### PR TITLE
Alignment consistency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,42 @@
 # Binaries
-RUSTC				?=	rustc
-RM					=	rm
+RUSTC       ?= rustc
+RM          := rm
 
 # Flags
-RUSTCFLAGS			:=
-RMFLAGS				:=
+RUSTCFLAGS  :=
+RMFLAGS     :=
 
 # Output names
-EXES				:=	false printenv true yes cat whoami
-TESTS				:=	cat
+EXES        := false printenv true yes cat whoami
+TESTS       := cat
 
 # Utils stuff
-EXES_PATHS			:=	$(addprefix build/,$(EXES))
-
-command				=	sh -c '$(1)'
+EXES_PATHS  := $(addprefix build/,$(EXES))
+command     := sh -c '$(1)'
 
 # Main exe build rule
 define EXE_BUILD
-build/$(1):			$(1)/$(1).rs
+build/$(1): $(1)/$(1).rs
 	$(call command,$(RUSTC) $(RUSTCFLAGS) -o build/$(1) $(1)/$(1).rs)
 endef
 
 # Test exe built rules
 define TEST_BUILD
-test_$(1):			tmp/$(1)_test
+test_$(1): tmp/$(1)_test
 	$(call command,tmp/$(1)_test)
 
-tmp/$(1)_test:	$(1)/test.rs
+tmp/$(1)_test: $(1)/test.rs
 	$(RUSTC) $(RUSTCFLAGS) -o tmp/$(1)_test $(1)/test.rs
 endef
 
 # Main rules
-all:				build $(EXES_PATHS)
+all: build $(EXES_PATHS)
 
-test:				tmp $(addprefix test_,$(TESTS))
-	rm -rf tmp
+test: tmp $(addprefix test_,$(TESTS))
+	$(RM) -rf tmp
 
 clean:
-	rm -rf build tmp
+	$(RM) -rf build tmp
 
 build:
 	mkdir build
@@ -49,4 +48,5 @@ tmp:
 $(foreach exe,$(EXES),$(eval $(call EXE_BUILD,$(exe))))
 $(foreach test,$(TESTS),$(eval $(call TEST_BUILD,$(test))))
 
-.PHONY:				all test clean
+.PHONY: all test clean
+


### PR DESCRIPTION
- cleans up alignment inconsistency
- removes superfluous tabs (they aren't necessary everywhere)
- built-in variables where possible
