### PR TITLE
Fix build for tee (Reader.eof())

### DIFF
--- a/tee/tee.rs
+++ b/tee/tee.rs
@@ -139,10 +139,6 @@ impl Reader for NamedReader {
         }).inside(|| self.inner.read(buf)))
 
     }
-
-    fn eof(&mut self) -> bool {
-        self.inner.eof()
-    }
 }
 
 fn with_path<T>(path: &Path, cb: || -> T) -> T {


### PR DESCRIPTION
From https://github.com/mozilla/rust/pull/11376
