### PR TITLE
base64/base64.rs: Fix build error with rust-0.10

### DIFF
--- a/base64/base64.rs
+++ b/base64/base64.rs
@@ -105,7 +105,7 @@ fn decode(input: &mut Reader, ignore_garbage: bool) {
             out.flush();
         }
         Err(s) => {
-            error!("error: {:s}", s);
+            error!("error: {}", s.to_str());
             fail!()
         }
     }


### PR DESCRIPTION
Hi,

I use rust from [master branch](www.github.com/mozilla/rust) and I've some trouble when I build coreutils.

So I fixed build error with this simple pull request, but I don't know if you use the lastest rust version.
