### PR TITLE
cat: fix tests

### DIFF
--- a/cat/test.rs
+++ b/cat/test.rs
@@ -5,7 +5,7 @@ fn test_output_multi_files_print_all_chars() {
     let prog = run::process_output("build/cat",
                                    [~"cat/fixtures/alpha.txt", ~"cat/fixtures/256.txt",
                                     ~"-A", ~"-n"]).unwrap();
-    let out = str::from_utf8_owned(prog.output);
+    let out = str::from_utf8_owned(prog.output).unwrap();
     assert_eq!(out,
                ~"     1\tabcde$\n     2\tfghij$\n     3\tklmno$\n     4\tpqrst$\n     5\tuvwxyz$\n     6\t^@^A^B^C^D^E^F^G^H^I$\n     7\t^K^L^M^N^O^P^Q^R^S^T^U^V^W^X^Y^Z^[^\\^]^^^_ !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~^?M-^@M-^AM-^BM-^CM-^DM-^EM-^FM-^GM-^HM-^IM-^JM-^KM-^LM-^MM-^NM-^OM-^PM-^QM-^RM-^SM-^TM-^UM-^VM-^WM-^XM-^YM-^ZM-^[M-^\\M-^]M-^^M-^_M- M-!M-\"M-#M-$M-%M-&M-\'M-(M-)M-*M-+M-,M--M-.M-/M-0M-1M-2M-3M-4M-5M-6M-7M-8M-9M-:M-;M-<M-=M->M-?M-@M-AM-BM-CM-DM-EM-FM-GM-HM-IM-JM-KM-LM-MM-NM-OM-PM-QM-RM-SM-TM-UM-VM-WM-XM-YM-ZM-[M-\\M-]M-^M-_M-`M-aM-bM-cM-dM-eM-fM-gM-hM-iM-jM-kM-lM-mM-nM-oM-pM-qM-rM-sM-tM-uM-vM-wM-xM-yM-zM-{M-|M-}M-~M-^?");
 }
@@ -17,7 +17,7 @@ fn test_stdin_squeeze() {
     prog.input().write(bytes!("\x00\x01\x02"));
     prog.close_input();
 
-    let out = str::from_utf8_owned(prog.finish_with_output().output);
+    let out = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
     assert_eq!(out, ~"^@^A^B");
 }
 
@@ -28,6 +28,6 @@ fn test_stdin_number_non_blank() {
     prog.input().write(bytes!("\na\nb\n\n\nc"));
     prog.close_input();
 
-    let out = str::from_utf8_owned(prog.finish_with_output().output);
+    let out = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
     assert_eq!(out, ~"\n     1\ta\n     2\tb\n\n\n     3\tc");
 }


### PR DESCRIPTION
This should update `cat`'s tests for the latest Rust.
