### PR TITLE
Update for latest Rust and fixed up id for Linux

### DIFF
--- a/base64/base64.rs
+++ b/base64/base64.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod serialize;
-extern mod getopts;
+extern crate serialize;
+extern crate getopts;
 
 use std::char;
 use std::io::{println, File, stdin, stdout};

--- a/basename/basename.rs
+++ b/basename/basename.rs
@@ -10,8 +10,8 @@
  * file that was distributed with this source code.
  */
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::io::{print, println};
 use std::os;

--- a/cat/cat.rs
+++ b/cat/cat.rs
@@ -12,8 +12,8 @@
 
 /* last synced with: cat (GNU coreutils) 8.13 */
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::{print, stdin, stdout, File};

--- a/dirname/dirname.rs
+++ b/dirname/dirname.rs
@@ -9,8 +9,8 @@
  * file that was distributed with this source code.
  */
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::print;

--- a/echo/echo.rs
+++ b/echo/echo.rs
@@ -10,8 +10,8 @@
  * file that was distributed with this source code.
  */
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::{print, println};

--- a/hostname/hostname.rs
+++ b/hostname/hostname.rs
@@ -12,8 +12,8 @@
  * https://www.opensource.apple.com/source/shell_cmds/shell_cmds-170/hostname/hostname.c?txt
  */
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::{os,libc,vec,str};
 use getopts::{optflag, getopts, usage};

--- a/mkdir/mkdir.rs
+++ b/mkdir/mkdir.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::fs;

--- a/printenv/printenv.rs
+++ b/printenv/printenv.rs
@@ -13,8 +13,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::print;

--- a/pwd/pwd.rs
+++ b/pwd/pwd.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::print;

--- a/rm/rm.rs
+++ b/rm/rm.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::{print, stdin, stdio, fs, BufferedReader};

--- a/rmdir/rmdir.rs
+++ b/rmdir/rmdir.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::{print, fs};

--- a/seq/seq.rs
+++ b/seq/seq.rs
@@ -5,8 +5,8 @@
 // TODO: Make -w flag work with decimals
 // TODO: Support -f flag
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::cmp::max;

--- a/sleep/sleep.rs
+++ b/sleep/sleep.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::num;
 use std::cast;

--- a/tee/tee.rs
+++ b/tee/tee.rs
@@ -10,8 +10,8 @@
  * file that was distributed with this source code.
  */
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::io::{println, stdin, stdout, Append, File, Truncate, Write};
 use std::io::{IoResult};

--- a/truncate/truncate.rs
+++ b/truncate/truncate.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::io::{File, Open, ReadWrite, fs};
 use std::os;
@@ -108,7 +108,7 @@ file based on its current size:
     }
 }
 
-fn truncate(no_create: bool, io_blocks: bool, reference: Option<~str>, size: Option<~str>, filenames: ~[~str]) {
+fn truncate(no_create: bool, _: bool, reference: Option<~str>, size: Option<~str>, filenames: ~[~str]) {
     let (refsize, mode) = match reference {
         Some(rfilename) => {
             let rfile = match File::open(&Path::new(rfilename.clone())) {

--- a/tty/tty.rs
+++ b/tty/tty.rs
@@ -16,8 +16,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::{libc,str,os};
 use std::io::println;

--- a/users/users.rs
+++ b/users/users.rs
@@ -16,8 +16,8 @@
 
 #[feature(macro_rules, globs)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::io::print;
 use std::cast;

--- a/wc/wc.rs
+++ b/wc/wc.rs
@@ -11,8 +11,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::str::from_utf8;

--- a/whoami/whoami.rs
+++ b/whoami/whoami.rs
@@ -13,8 +13,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::io::print;
 use std::os;

--- a/yes/yes.rs
+++ b/yes/yes.rs
@@ -13,8 +13,8 @@
 
 #[feature(macro_rules)];
 
-extern mod extra;
-extern mod getopts;
+extern crate extra;
+extern crate getopts;
 
 use std::os;
 use std::io::{print, println};


### PR DESCRIPTION
`id` used getaudit, which is a BSD system call that is unavailable on Linux.
