### PR TITLE
show_error macro now uses a function instead of constant

### DIFF
--- a/common/util.rs
+++ b/common/util.rs
@@ -9,11 +9,13 @@
 
 #[macro_escape];
 
+pub fn program_name () -> &'static str { ::NAME }
+
 #[macro_export]
 macro_rules! show_error(
     ($exitcode:expr, $($args:expr),+) => ({
         ::std::os::set_exit_status($exitcode);
-        safe_write!(&mut ::std::io::stderr(), "{}: error: ", NAME);
+        safe_write!(&mut ::std::io::stderr(), "{}: error: ", ::util::program_name());
         safe_writeln!(&mut ::std::io::stderr(), $($args),+);
     })
 )


### PR DESCRIPTION
Proposal for https://github.com/uutils/coreutils/issues/112
