### PR TITLE
Remove the unnecessary conversion of os::args() ret val

### DIFF
--- a/hostid/hostid.rs
+++ b/hostid/hostid.rs
@@ -50,7 +50,7 @@ extern {
 }
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
 
     let opts = [
         optflag("", "help", "display this help and exit"),

--- a/md5sum/md5sum.rs
+++ b/md5sum/md5sum.rs
@@ -28,7 +28,7 @@ static NAME: &'static str = "md5sum";
 static VERSION: &'static str = "1.0.0";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
 
     let program = args.get(0).clone();
 

--- a/mkdir/mkdir.rs
+++ b/mkdir/mkdir.rs
@@ -29,7 +29,7 @@ static VERSION: &'static str = "1.0.0";
  * Handles option parsing
  */
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
 
     let opts = ~[
         // Linux-specific options, not implemented

--- a/paste/paste.rs
+++ b/paste/paste.rs
@@ -24,7 +24,7 @@ static NAME: &'static str = "paste";
 static VERSION: &'static str = "1.0.0";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
 
     let opts = ~[

--- a/printenv/printenv.rs
+++ b/printenv/printenv.rs
@@ -25,7 +25,7 @@ mod util;
 static NAME: &'static str = "printenv";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
     let opts = ~[
         getopts::optflag("0", "null", "end each output line with 0 byte rather than newline"),

--- a/pwd/pwd.rs
+++ b/pwd/pwd.rs
@@ -24,7 +24,7 @@ static NAME: &'static str = "pwd";
 static VERSION: &'static str = "1.0.0";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
     let opts = ~[
         getopts::optflag("", "help", "display this help and exit"),

--- a/rm/rm.rs
+++ b/rm/rm.rs
@@ -30,7 +30,7 @@ enum InteractiveMode {
 static NAME: &'static str = "rm";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
 
     // TODO: make getopts support -R in addition to -r

--- a/rmdir/rmdir.rs
+++ b/rmdir/rmdir.rs
@@ -23,7 +23,7 @@ mod util;
 static NAME: &'static str = "rmdir";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
 
     let opts = ~[

--- a/seq/seq.rs
+++ b/seq/seq.rs
@@ -34,7 +34,7 @@ fn escape_sequences(s: &str) -> String {
 }
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let opts = ~[
         getopts::optopt("s", "separator", "Separator character (defaults to \\n)", ""),
         getopts::optopt("t", "terminator", "Terminator character (defaults to separator)", ""),

--- a/sleep/sleep.rs
+++ b/sleep/sleep.rs
@@ -24,7 +24,7 @@ mod util;
 static NAME: &'static str = "sleep";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
 
     let opts = ~[

--- a/tac/tac.rs
+++ b/tac/tac.rs
@@ -24,7 +24,7 @@ static NAME: &'static str = "tac";
 static VERSION: &'static str = "1.0.0";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
 
     let opts = ~[

--- a/tr/tr.rs
+++ b/tr/tr.rs
@@ -147,7 +147,7 @@ fn usage(opts: &[OptGroup]) {
 }
 
 pub fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let opts = [
         getopts::optflag("c", "complement", "use the complement of SET1"),
         getopts::optflag("C", "", "same as -c"),

--- a/truncate/truncate.rs
+++ b/truncate/truncate.rs
@@ -47,7 +47,7 @@ enum TruncateMode {
 static NAME: &'static str = "truncate";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
 
     let opts = ~[

--- a/tty/tty.rs
+++ b/tty/tty.rs
@@ -35,7 +35,7 @@ extern {
 static NAME: &'static str = "tty";
 
 fn main () {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
 
     let options = [
         optflag("s", "silent", "print nothing, only return an exit status")

--- a/uname/uname.rs
+++ b/uname/uname.rs
@@ -52,7 +52,7 @@ unsafe fn getuname() -> utsrust {
 static NAME: &'static str = "uname";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).as_slice();
     let opts = ~[
         getopts::optflag("h", "help", "display this help and exit"),

--- a/unlink/unlink.rs
+++ b/unlink/unlink.rs
@@ -27,7 +27,7 @@ mod util;
 static NAME: &'static str = "unlink";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
     let opts = ~[
         getopts::optflag("h", "help", "display this help and exit"),

--- a/uptime/uptime.rs
+++ b/uptime/uptime.rs
@@ -48,7 +48,7 @@ extern {
 }
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
     let opts = ~[
         getopts::optflag("v", "version", "output version information and exit"),

--- a/users/users.rs
+++ b/users/users.rs
@@ -48,7 +48,7 @@ extern {
 static NAME: &'static str = "users";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).as_slice();
     let opts = ~[
         getopts::optflag("h", "help", "display this help and exit"),

--- a/wc/wc.rs
+++ b/wc/wc.rs
@@ -34,7 +34,7 @@ struct Result {
 static NAME: &'static str = "wc";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
     let opts = ~[
         getopts::optflag("c", "bytes", "print the byte counts"),

--- a/whoami/whoami.rs
+++ b/whoami/whoami.rs
@@ -42,7 +42,7 @@ unsafe fn getusername() -> String {
 static NAME: &'static str = "whoami";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).as_slice();
     let opts = ~[
         getopts::optflag("h", "help", "display this help and exit"),

--- a/yes/yes.rs
+++ b/yes/yes.rs
@@ -25,7 +25,7 @@ mod util;
 static NAME: &'static str = "yes";
 
 fn main() {
-    let args: Vec<String> = os::args().iter().map(|x| x.to_strbuf()).collect();
+    let args = os::args();
     let program = args.get(0).clone();
     let opts = ~[
         getopts::optflag("h", "help", "display this help and exit"),


### PR DESCRIPTION
Missed these in 46b9d6d78e6e2dca07364414fe086ea31fa4e57d
