### PR TITLE
head: unwrap IoResult before printing

### DIFF
--- a/head/head.rs
+++ b/head/head.rs
@@ -127,7 +127,7 @@ fn obsolete (options: &[String]) -> (Vec<String>, Option<uint>) {
 }
 
 fn head<T: Reader> (reader: &mut BufferedReader<T>, line_count:uint) {
-    for line in reader.lines().take(line_count) { print!("{}", line); }
+    for line in reader.lines().take(line_count) { print!("{}", line.unwrap()); }
 }
 
 fn version () {


### PR DESCRIPTION
```
$ build/head README.md 
Ok(uutils coreutils [![Build Status](https://travis-ci.org/uutils/coreutils.png?branch=master)](https://travis-ci.org/uutils/coreutils)
)Ok(================
)Ok(
)Ok(uutils is an attempt at writing universal (as in cross-platform) CLI
)Ok(utils in [Rust](http://rust-lang.org). This repo is to aggregate the GNU
)Ok(coreutils rewrites.
)Ok(
)Ok(Why?
)Ok(----
)Ok(
```
