### PR TITLE
cp: fix argument parsing

### DIFF
--- a/cp/cp.rs
+++ b/cp/cp.rs
@@ -83,7 +83,7 @@ fn copy(matches: getopts::Matches) {
         fail!()
     } else {
         // All but the last argument:
-        matches.free.slice(0, matches.free.len() - 2).iter()
+        matches.free.slice(0, matches.free.len() - 1).iter()
             .map(|arg| Path::new(arg.clone())).collect()
     };
     let dest = if matches.free.len() < 2 {


### PR DESCRIPTION
```
$ echo foo > a
$ build/cp a b
task '<main>' failed at 'assertion failed: sources.len() >= 1', cp/cp.rs:97
```
