### PR TITLE
GNU sync implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,17 +43,18 @@ PROGS       := \
   tail \
 
 UNIX_PROGS := \
+  groups \
   hostid \
   hostname \
+  id \
   kill \
   logname \
-  users \
-  whoami \
+  sync \
   tty \
-  groups \
-  id \
+  uname \
   uptime \
-  uname
+  users \
+  whoami
 
 ifneq ($(OS),Windows_NT)
 	PROGS    := $(PROGS) $(UNIX_PROGS)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ To do
 - stat
 - stdbuf
 - stty (in progress)
-- sync
 - tail (not all features implemented)
 - test
 - timeout

--- a/sync/sync.rs
+++ b/sync/sync.rs
@@ -1,0 +1,66 @@
+#![crate_id(name="sync", vers="1.0.0", author="Alexander Fomin")]
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Alexander Fomin <xander.fomin@ya.ru>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+ /* Last synced with: sync (GNU coreutils) 8.13 */
+
+extern crate getopts;
+extern crate libc;
+
+use std::os;
+use getopts::{optflag, getopts, usage};
+
+extern {
+    fn sync() -> libc::c_void;
+}
+
+#[allow(dead_code)]
+fn main () { os::set_exit_status(uumain(os::args())); }
+
+pub fn uumain(args: Vec<String>) -> int {
+    let program = args.get(0);
+
+    let options = [
+        optflag("h", "help", "display this help and exit"),
+        optflag("V", "version", "output version information and exit")
+    ];
+
+    let matches = match getopts(args.tail(), options) {
+        Ok(m) => { m }
+        _ => { help(program.as_slice(), options); return 0 }
+    };
+
+    if matches.opt_present("h") {
+        help(program.as_slice(), options);
+        return 0
+    }
+
+    if matches.opt_present("V") {
+        version();
+        return 0
+    }
+
+    unsafe {
+        sync()
+    };
+
+    0
+}
+
+fn version() {
+    println!("sync (uutils) 1.0.0");
+    println!("The MIT License");
+    println!("");
+    println!("Author -- Alexander Fomin.");
+}
+
+fn help(program: &str, options: &[getopts::OptGroup]) {
+    println!("Usage: {:s} [OPTION]", program);
+    print!("{:s}", usage("Force changed blocks to disk, update the super block.", options));
+}


### PR DESCRIPTION
1) GNU coreutils **sync** implemented.
2) **UNIX_PROGS** in Makefile sorted in alphabetical order.

N.B.: I have a draft implementation on **sync** for Windows which is based on **Sysinternals Sync** by Mark Russinovich and its **flushvol** analogue by Eugene Muzychenko. However, that draft implementation heavily depends on **kernel32** library; moreover, it requires administrative privileges (UNIX/Linux systems don't require any CAP_SYS_\* for issuing **sync()** syscall). Let me know if when we Windows implementation.
