### PR TITLE
Fix build failure for systems with a non-64-bit time_t.

### DIFF
--- a/uptime/uptime.rs
+++ b/uptime/uptime.rs
@@ -165,7 +165,7 @@ fn get_uptime(boot_time: Option<time_t>) -> i64 {
         _ => return match boot_time {
                 Some(t) => {
                     let now = unsafe { time(null()) };
-                    (now - t) * 100 // Return in ms
+                    ((now - t) * 100) as i64 // Return in ms
                 },
                 _ => -1
              }


### PR DESCRIPTION
On my system (Linux i686), `time_t` is 32 bits long, which causes a compile error as it is returned (through a call to `time`) as an `i64`. A cast fixes this.
