### PR TITLE
make: always build multicall binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ install:
 script:
   - make
   - make test
-  - make MULTICALL=1

--- a/README.md
+++ b/README.md
@@ -34,11 +34,6 @@ To build only a few of the available utilities:
 make BUILD='UTILITY_1 UTILITY_2'
 ```
 
-To build the multicall binary (_i.e._ BusyBox-like binary):
-```
-make MULTICALL=1
-```
-
 Installation Instructions
 -------------------------
 
@@ -57,12 +52,7 @@ To install only a few of the available utilities:
 make INSTALL='UTILITY_1 UTILITY_2' install
 ```
 
-To install the multicall binary:
-```
-make MULTICALL=1 install
-```
-
-To install every program (other than the multicall binary) with a prefix:
+To install every program with a prefix:
 ```
 make PROG_PREFIX=PREFIX_GOES_HERE install
 ```
@@ -75,12 +65,7 @@ To uninstall all utilities:
 make uninstall
 ```
 
-To uninstall the multicall binary:
-```
-make MULTICALL=1 uninstall
-```
-
-To uninstall every program (other than the multicall binary) with a set prefix:
+To uninstall every program with a set prefix:
 ```
 make PROG_PREFIX=PREFIX_GOES_HERE uninstall
 ```

--- a/base64/base64.rs
+++ b/base64/base64.rs
@@ -18,7 +18,6 @@ extern crate libc;
 #[phase(plugin, link)] extern crate log;
 
 use std::io::{println, File, stdin, stdout};
-use std::os;
 use std::str;
 
 use getopts::{
@@ -91,9 +90,6 @@ pub fn uumain(args: Vec<String>) -> int {
 
     0
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 fn decode(input: &mut Reader, ignore_garbage: bool) {
     let mut to_decode = match input.read_to_str() {

--- a/basename/basename.rs
+++ b/basename/basename.rs
@@ -14,7 +14,6 @@ extern crate getopts;
 extern crate libc;
 
 use std::io::{print, println};
-use std::os;
 use std::str::StrSlice;
 
 #[path = "../common/util.rs"]
@@ -22,9 +21,6 @@ mod util;
 
 static NAME: &'static str = "basename";
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = strip_dir(args.get(0).as_slice());

--- a/cat/cat.rs
+++ b/cat/cat.rs
@@ -14,14 +14,10 @@
 
 extern crate getopts;
 
-use std::os;
 use std::io::{print, File};
 use std::io::stdio::{stdout_raw, stdin_raw, stderr};
 use std::io::{IoResult};
 use std::ptr::{copy_nonoverlapping_memory};
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).as_slice();

--- a/chroot/chroot.rs
+++ b/chroot/chroot.rs
@@ -36,9 +36,6 @@ extern {
 static NAME: &'static str = "chroot";
 static VERSION: &'static str = "1.0.0";
 
-#[allow(dead_code)]
-fn main () { std::os::set_exit_status(uumain(std::os::args())); }
-
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0);
 

--- a/cksum/cksum.rs
+++ b/cksum/cksum.rs
@@ -14,7 +14,6 @@ extern crate getopts;
 
 use std::io::{BufferedReader, EndOfFile, File, IoError, IoResult, print};
 use std::io::stdio::stdin;
-use std::os;
 
 #[path="../common/util.rs"]
 mod util;
@@ -76,9 +75,6 @@ fn open_file(name: &str) -> IoResult<Box<Reader>> {
         }
     }
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); } 
 
 pub fn uumain(args: Vec<String>) -> int {
     let opts = [

--- a/comm/comm.rs
+++ b/comm/comm.rs
@@ -15,7 +15,6 @@ use std::cmp::Ord;
 use std::io::{BufferedReader, IoResult, print};
 use std::io::fs::File;
 use std::io::stdio::stdin;
-use std::os;
 use std::path::Path;
 
 static NAME : &'static str = "comm";
@@ -93,9 +92,6 @@ fn open_file(name: &str) -> IoResult<Box<Buffer>> {
         }
     }
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let opts = [

--- a/cp/cp.rs
+++ b/cp/cp.rs
@@ -31,9 +31,6 @@ pub enum Mode {
     Version,
 }
 
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
-
 pub fn uumain(args: Vec<String>) -> int {
     let opts = [
         optflag("h", "help", "display this help and exit"),

--- a/dirname/dirname.rs
+++ b/dirname/dirname.rs
@@ -11,13 +11,9 @@
 
 extern crate getopts;
 
-use std::os;
 use std::io::print;
 
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/du/du.rs
+++ b/du/du.rs
@@ -16,7 +16,6 @@ extern crate getopts;
 extern crate libc;
 extern crate time;
 
-use std::os;
 use std::io::{stderr, fs, FileStat, TypeDirectory};
 use std::option::Option;
 use std::path::Path;
@@ -88,9 +87,6 @@ fn du(path: &Path, mut my_stat: Stat,
 
     stats
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).as_slice();

--- a/echo/echo.rs
+++ b/echo/echo.rs
@@ -13,7 +13,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io::{print, println};
 use std::uint;
 
@@ -162,9 +161,6 @@ fn print_help(program: &String) {
 fn print_version() {
     println!("echo version: {:s}", VERSION);
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let mut options = EchoOptions {

--- a/env/env.rs
+++ b/env/env.rs
@@ -13,8 +13,6 @@
 
 #![allow(non_camel_case_types)]
 
-use std::os;
-
 struct options {
     ignore_env: bool,
     null: bool,
@@ -52,9 +50,6 @@ fn print_env(null: bool) {
         );
     }
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let prog = args.get(0).as_slice();

--- a/factor/factor.rs
+++ b/factor/factor.rs
@@ -14,7 +14,6 @@ extern crate getopts;
 extern crate libc;
 
 use std::u64;
-use std::os;
 use std::vec::{Vec};
 use std::io::{stdin};
 
@@ -63,9 +62,6 @@ fn print_factors_str(num_str: &str) {
     };
     print_factors(num);
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).as_slice();

--- a/false/false.rs
+++ b/false/false.rs
@@ -1,4 +1,4 @@
-#![crate_id(name="false", vers="1.0.0", author="Seldaek")]
+#![crate_id = "uufalse#1.0.0"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -9,6 +9,6 @@
  * file that was distributed with this source code.
  */
 
-fn main() {
-    std::os::set_exit_status(1);
+pub fn uumain(_: Vec<String>) -> int  {
+	1
 }

--- a/fmt/fmt.rs
+++ b/fmt/fmt.rs
@@ -15,7 +15,6 @@ extern crate getopts;
 
 use std::io::{BufferedReader, BufferedWriter, File, IoResult};
 use std::io::stdio::{stdin_raw, stdout_raw};
-use std::os;
 use linebreak::break_lines;
 use parasplit::ParagraphStream;
 
@@ -53,9 +52,6 @@ struct FmtOptions {
     goal            : uint,
     tabwidth        : uint,
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())) }
 
 pub fn uumain(args: Vec<String>) -> int {
 

--- a/fold/fold.rs
+++ b/fold/fold.rs
@@ -17,7 +17,6 @@ extern crate libc;
 use std::io;
 use std::io::fs::File;
 use std::io::BufferedReader;
-use std::os;
 use std::uint;
 
 #[path = "../common/util.rs"]
@@ -25,9 +24,6 @@ mod util;
 
 static NAME: &'static str = "fold";
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
 

--- a/groups/groups.rs
+++ b/groups/groups.rs
@@ -12,7 +12,6 @@
 
 extern crate getopts;
 
-use std::os;
 use getopts::{
     optflag,
     getopts,
@@ -25,9 +24,6 @@ use c_types::{get_pw_from_args, group};
 
 static NAME: &'static str = "groups";
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main () { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/hashsum/hashsum.rs
+++ b/hashsum/hashsum.rs
@@ -21,7 +21,6 @@ extern crate getopts;
 use std::io::fs::File;
 use std::io::stdio::stdin_raw;
 use std::io::BufferedReader;
-use std::os;
 use regex::Regex;
 use crypto::digest::Digest;
 use crypto::md5::Md5;
@@ -87,9 +86,6 @@ fn detect_algo(program: &str, matches: &getopts::Matches) -> (&str, Box<Digest>)
         }
     }
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/head/head.rs
+++ b/head/head.rs
@@ -12,7 +12,6 @@
 
 extern crate getopts;
 
-use std::os;
 use std::char;
 use std::io::{stdin};
 use std::io::BufferedReader;
@@ -21,9 +20,6 @@ use std::path::Path;
 use getopts::{optopt, optflag, getopts, usage};
 
 static PROGRAM: &'static str = "head";
-
-#[allow(dead_code)]
-fn main () { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let mut line_count = 10u;

--- a/hostid/hostid.rs
+++ b/hostid/hostid.rs
@@ -20,8 +20,6 @@ extern crate libc;
 
 #[phase(plugin, link)] extern crate log;
 
-use std::os;
-
 use getopts::{
     getopts,
     optflag,
@@ -48,9 +46,6 @@ pub enum Mode {
 extern {
     pub fn gethostid() -> c_long;
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
 

--- a/hostname/hostname.rs
+++ b/hostname/hostname.rs
@@ -15,7 +15,7 @@
 extern crate getopts;
 extern crate libc;
 
-use std::{os,str};
+use std::str;
 use getopts::{optflag, getopts, usage};
 
 extern {
@@ -31,9 +31,6 @@ extern {
 extern {
     fn sethostname(name: *libc::c_char, namelen: libc::size_t) -> libc::c_int;
 }
-
-#[allow(dead_code)]
-fn main () { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0);

--- a/id/id.rs
+++ b/id/id.rs
@@ -18,7 +18,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::ptr::read;
 use libc::{
     uid_t,
@@ -82,9 +81,6 @@ extern {
 }
 
 static NAME: &'static str = "id";
-
-#[allow(dead_code)]
-fn main () { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let args_t = args.tail();

--- a/kill/kill.rs
+++ b/kill/kill.rs
@@ -19,7 +19,6 @@ extern crate serialize;
 
 #[phase(plugin, link)] extern crate log;
 
-use std::os;
 use std::from_str::from_str;
 use std::io::process::Process;
 
@@ -51,9 +50,6 @@ pub enum Mode {
     Help,
     Version,
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
 

--- a/link/link.rs
+++ b/link/link.rs
@@ -13,7 +13,6 @@
 extern crate getopts;
 
 use std::io::fs::link;
-use std::os;
 use std::path::Path;
 
 #[path="../common/util.rs"]
@@ -21,9 +20,6 @@ mod util;
 
 static NAME : &'static str = "link";
 static VERSION : &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let opts = [

--- a/logname/logname.rs
+++ b/logname/logname.rs
@@ -19,7 +19,6 @@ extern crate getopts;
 extern crate libc;
 
 use std::io::print;
-use std::os;
 use std::str;
 use libc::c_char;
 
@@ -42,9 +41,6 @@ static VERSION: &'static str = "1.0.0";
 fn version() {
     println!("{} {}", NAME, VERSION);
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/mkdir/mkdir.rs
+++ b/mkdir/mkdir.rs
@@ -14,7 +14,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io::fs;
 use std::io::FilePermission;
 use std::num::strconv;
@@ -28,9 +27,6 @@ static VERSION: &'static str = "1.0.0";
 /**
  * Handles option parsing
  */
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
-
 pub fn uumain(args: Vec<String>) -> int {
 
     let opts = [

--- a/mkfifo/mkfifo.rs
+++ b/mkfifo/mkfifo.rs
@@ -23,9 +23,6 @@ mod util;
 static NAME : &'static str = "mkfifo";
 static VERSION : &'static str = "1.0.0";
 
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
-
 pub fn uumain(args: Vec<String>) -> int {
     let opts = [
         getopts::optopt("m", "mode", "file permissions for the fifo", "(default 0666)"),

--- a/mkmain.rs
+++ b/mkmain.rs
@@ -1,0 +1,40 @@
+use std::io::{File, Truncate, ReadWrite};
+use std::os;
+use std::path::Path;
+use std::str::replace;
+
+static TEMPLATE : &'static str = r"
+extern crate @UTIL_CRATE@;
+
+use std::os;
+use @UTIL_CRATE@::uumain;
+
+fn main() {
+    os::set_exit_status(uumain(os::args()));
+}
+";
+
+fn main() {
+    let args = os::args();
+    if args.len() != 3 {
+        println!("usage: mkbuild <crate> <outfile>");
+        os::set_exit_status(1);
+        return;
+    }
+
+    let crat = match args.get(1).as_slice() {
+        "true" => "uutrue",
+        "false" => "uufalse",
+        "sync" => "uusync",
+        s => s.clone(),
+    };
+    let outfile  = args.get(2).as_slice();
+
+    let main = std::str::replace(TEMPLATE, "@UTIL_CRATE@", crat);
+    let mut out = File::open_mode(&Path::new(outfile), Truncate, ReadWrite);
+
+    match out.write(main.as_bytes()) {
+        Err(e) => fail!("{}", e),
+        _ => (),
+    }
+}

--- a/nl/nl.rs
+++ b/nl/nl.rs
@@ -16,7 +16,6 @@ extern crate regex_macros;
 extern crate regex;
 extern crate getopts;
 
-use std::os;
 use std::io::{stdin};
 use std::io::BufferedReader;
 use std::io::fs::File;
@@ -73,11 +72,6 @@ enum NumberFormat {
     Left,
     Right,
     RightZero,
-}
-
-#[allow(dead_code)]
-fn main () {
-  os::set_exit_status(uumain(os::args()));
 }
 
 pub fn uumain(args: Vec<String>) -> int {

--- a/paste/paste.rs
+++ b/paste/paste.rs
@@ -15,16 +15,12 @@ extern crate getopts;
 extern crate libc;
 
 use std::io;
-use std::os;
 
 #[path = "../common/util.rs"]
 mod util;
 
 static NAME: &'static str = "paste";
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/printenv/printenv.rs
+++ b/printenv/printenv.rs
@@ -24,9 +24,6 @@ mod util;
 
 static NAME: &'static str = "printenv";
 
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
-
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();
     let opts = [

--- a/pwd/pwd.rs
+++ b/pwd/pwd.rs
@@ -14,7 +14,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io::print;
 
 #[path = "../common/util.rs"]
@@ -22,9 +21,6 @@ mod util;
 
 static NAME: &'static str = "pwd";
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/rm/rm.rs
+++ b/rm/rm.rs
@@ -14,7 +14,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io::{print, stdin, stdio, fs, BufferedReader};
 
 #[path = "../common/util.rs"]
@@ -28,9 +27,6 @@ enum InteractiveMode {
 }
 
 static NAME: &'static str = "rm";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/rmdir/rmdir.rs
+++ b/rmdir/rmdir.rs
@@ -14,16 +14,12 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io::{print, fs};
 
 #[path = "../common/util.rs"]
 mod util;
 
 static NAME: &'static str = "rmdir";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/seq/seq.rs
+++ b/seq/seq.rs
@@ -10,7 +10,6 @@ extern crate libc;
 
 use std::cmp;
 use std::io;
-use std::os;
 
 #[path = "../common/util.rs"]
 mod util;
@@ -158,9 +157,6 @@ fn print_help(program: &String) {
 fn print_version() {
     println!("seq 1.0.0\n");
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/sleep/sleep.rs
+++ b/sleep/sleep.rs
@@ -15,7 +15,6 @@ extern crate getopts;
 extern crate libc;
 
 use std::f64;
-use std::os;
 use std::io::{print, timer};
 use std::u64;
 
@@ -23,9 +22,6 @@ use std::u64;
 mod util;
 
 static NAME: &'static str = "sleep";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/sum/sum.rs
+++ b/sum/sum.rs
@@ -13,7 +13,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io::{File, IoResult, print};
 use std::io::stdio::{stdin_raw};
 
@@ -75,9 +74,6 @@ fn open(name: &str) -> IoResult<Box<Reader>> {
 		}
 	}
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).as_slice();

--- a/sync/sync.rs
+++ b/sync/sync.rs
@@ -15,7 +15,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use getopts::{optflag, getopts, usage};
 
 #[path = "../common/util.rs"] mod util;
@@ -135,11 +134,6 @@ mod platform {
         0
     }
 }
-
-static NAME: &'static str = "sync";
-
-#[allow(dead_code)]
-fn main () { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0);

--- a/tac/tac.rs
+++ b/tac/tac.rs
@@ -15,16 +15,12 @@ extern crate getopts;
 extern crate libc;
 
 use std::io;
-use std::os;
 
 #[path = "../common/util.rs"]
 mod util;
 
 static NAME: &'static str = "tac";
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/tail/tail.rs
+++ b/tail/tail.rs
@@ -11,7 +11,6 @@
 
 extern crate getopts;
 
-use std::os;
 use std::char;
 use std::io::{stdin};
 use std::io::BufferedReader;
@@ -23,9 +22,6 @@ use std::collections::ringbuf::RingBuf;
 use std::io::timer::sleep;
 
 static PROGRAM: &'static str = "tail";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let mut line_count = 10u;

--- a/tee/tee.rs
+++ b/tee/tee.rs
@@ -24,9 +24,6 @@ use getopts::{getopts, optflag, usage};
 static NAME: &'static str = "tee";
 static VERSION: &'static str = "1.0.0";
 
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
-
 pub fn uumain(args: Vec<String>) -> int {
     match options(args.as_slice()).and_then(exec) {
         Ok(_) => 0,

--- a/touch/touch.rs
+++ b/touch/touch.rs
@@ -14,16 +14,12 @@ extern crate getopts;
 extern crate time;
 
 use std::io::File;
-use std::os;
 
 #[path = "../common/util.rs"]
 mod util;
 
 static NAME: &'static str = "touch";
 static VERSION: &'static str = "1.0.0";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let opts = [

--- a/tr/tr.rs
+++ b/tr/tr.rs
@@ -20,7 +20,6 @@ use std::char::from_u32;
 use std::io::print;
 use std::io::stdio::{stdin,stdout};
 use std::iter::FromIterator;
-use std::os;
 use std::vec::Vec;
 
 #[path="../common/util.rs"]
@@ -145,9 +144,6 @@ fn usage(opts: &[OptGroup]) {
         println!("");
         print(getopts::usage("Translate or delete characters.", opts).as_slice());
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let opts = [

--- a/true/true.rs
+++ b/true/true.rs
@@ -1,4 +1,4 @@
-#![crate_id(name="true", vers="1.0.0", author="Seldaek")]
+#![crate_id = "uutrue#1.0.0"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -9,5 +9,6 @@
  * file that was distributed with this source code.
  */
 
-fn main() {
+pub fn uumain(_: Vec<String>) -> int {
+	0
 }

--- a/truncate/truncate.rs
+++ b/truncate/truncate.rs
@@ -15,7 +15,6 @@ extern crate getopts;
 extern crate libc;
 
 use std::io::{File, Open, ReadWrite, fs};
-use std::os;
 use std::u64;
 
 #[path = "../common/util.rs"]
@@ -33,9 +32,6 @@ enum TruncateMode {
 }
 
 static NAME: &'static str = "truncate";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/tty/tty.rs
+++ b/tty/tty.rs
@@ -19,7 +19,7 @@
 extern crate getopts;
 extern crate libc;
 
-use std::{str,os};
+use std::str;
 use std::io::println;
 use std::io::stdio::stderr;
 use getopts::{optflag,getopts};
@@ -33,9 +33,6 @@ extern {
 }
 
 static NAME: &'static str = "tty";
-
-#[allow(dead_code)]
-fn main () { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let options = [

--- a/uname/uname.rs
+++ b/uname/uname.rs
@@ -17,7 +17,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::mem::uninitialized;
 use std::io::print;
 use std::str::raw::from_c_str;
@@ -50,9 +49,6 @@ unsafe fn getuname() -> utsrust {
 
 
 static NAME: &'static str = "uname";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).as_slice();

--- a/unlink/unlink.rs
+++ b/unlink/unlink.rs
@@ -16,7 +16,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io;
 use std::io::fs;
 use std::io::print;
@@ -25,9 +24,6 @@ use std::io::print;
 mod util;
 
 static NAME: &'static str = "unlink";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/uptime/uptime.rs
+++ b/uptime/uptime.rs
@@ -17,7 +17,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::mem::transmute;
 use std::io::{print, File};
 use std::ptr::null;
@@ -46,9 +45,6 @@ extern {
 
     fn utmpxname(file: *c_char) -> c_int;
 }
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/users/users.rs
+++ b/users/users.rs
@@ -21,7 +21,6 @@ extern crate libc;
 
 use std::io::print;
 use std::mem;
-use std::os;
 use std::ptr;
 use std::str;
 use utmpx::*;
@@ -46,9 +45,6 @@ extern {
 }
 
 static NAME: &'static str = "users";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).as_slice();

--- a/wc/wc.rs
+++ b/wc/wc.rs
@@ -14,7 +14,6 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::str::from_utf8;
 use std::io::{print, stdin, File, BufferedReader};
 use StdResult = std::result::Result;
@@ -33,9 +32,6 @@ struct Result {
 }
 
 static NAME: &'static str = "wc";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();

--- a/whoami/whoami.rs
+++ b/whoami/whoami.rs
@@ -19,7 +19,6 @@ extern crate getopts;
 extern crate libc;
 
 use std::io::print;
-use std::os;
 
 #[path = "../common/util.rs"] mod util;
 
@@ -66,9 +65,6 @@ mod platform {
 }
 
 static NAME: &'static str = "whoami";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).as_slice();

--- a/yes/yes.rs
+++ b/yes/yes.rs
@@ -16,16 +16,12 @@
 extern crate getopts;
 extern crate libc;
 
-use std::os;
 use std::io::{print, println};
 
 #[path = "../common/util.rs"]
 mod util;
 
 static NAME: &'static str = "yes";
-
-#[allow(dead_code)]
-fn main() { os::set_exit_status(uumain(os::args())); }
 
 pub fn uumain(args: Vec<String>) -> int {
     let program = args.get(0).clone();


### PR DESCRIPTION
This first speeds up the crate build rules by removing the `rust --crate-file-name` invocations. Then removes the MULTICALL=1 switch so that `uutils` is always build. To avoid compiling everything twice the main() function of each util is split into a separate file that links the util crate and calls uumain.
