### PR TITLE
Use Less Memory and Fix Text Mode on Windows/UNIX  #303

### DIFF
--- a/hashsum/hashsum.rs
+++ b/hashsum/hashsum.rs
@@ -23,7 +23,6 @@ use std::io::stdio::stdin_raw;
 use std::io::BufferedReader;
 use std::io::IoError;
 use std::io::EndOfFile;
-use std::os;
 use regex::Regex;
 use crypto::digest::Digest;
 use crypto::md5::Md5;


### PR DESCRIPTION
The following are changed to fix #303:
1. hashsum pulls 512 KB chunks of the file into memory. This ends up taking 1 MB with a secondary buffer allocated for windows. hashsum is now able to hash files larger than the computer's available memory.
2. Text no longer transforms to UTF-8. This allows hashing to work on binary files without specifying text mode. On Windows, it converts a Windows newline '\r\n' to the standard newline '\n'.
3. Set default modes: Windows uses binary by default, text otherwise.

Tested above claims on Windows 7/Ubuntu 14.04.
