### PR TITLE
Fix sync and whoami on windows.

### DIFF
--- a/src/whoami/whoami.rs
+++ b/src/whoami/whoami.rs
@@ -56,8 +56,8 @@ mod platform {
 
     #[allow(unused_unsafe)]
     pub unsafe fn getusername() -> String {
-        let buffer: [libc::c_char, ..2048] = mem::uninitialized();   // XXX: it may be possible that this isn't long enough.  I don't know
-        if !GetUserNameA(buffer.as_ptr(), &(buffer.len() as libc::uint32_t)) == 0 {
+        let mut buffer: [libc::c_char, ..2048] = mem::uninitialized();   // XXX: it may be possible that this isn't long enough.  I don't know
+        if !GetUserNameA(buffer.as_mut_ptr(), &mut (buffer.len() as libc::uint32_t)) == 0 {
             crash!(1, "username is too long");
         }
         str::raw::from_c_str(buffer.as_ptr())


### PR DESCRIPTION
Fixed compile errors on MinGW, mainly mutable reference errors.

In sync.rs, for some reason "use std::ptr::null" doesn't work unless it's inside the windows "mod platform {" block - is that a compiler bug or defined behavior?

There are still some deprecated code warnings in sync.rs concerning the use of str::to_c_str, but I'm not sure how to fix them without resorting to transmute
