### PR TITLE
cat: range pattern now should use three dots.

### DIFF
--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -221,16 +221,16 @@ fn write_bytes(files: Vec<String>, number: NumberingMode, squeeze_blank: bool,
                     }
                 } else if show_nonprint {
                     let byte = match byte {
-                        128 .. 255 => {
+                        128 ... 255 => {
                             writer.write_str("M-").unwrap();
                             byte - 128
                         },
                         _ => byte,
                     };
                     match byte {
-                        0 .. 31 => writer.write(['^' as u8, byte + 64]),
-                        127     => writer.write(['^' as u8, byte - 64]),
-                        _       => writer.write_u8(byte),
+                        0 ... 31 => writer.write(['^' as u8, byte + 64]),
+                        127      => writer.write(['^' as u8, byte - 64]),
+                        _        => writer.write_u8(byte),
                     }
                 } else {
                     writer.write_u8(byte)


### PR DESCRIPTION
See rust-lang/rust@2f15dcd4d3865f9cc466637027eb02d5607b2bb7
