### PR TITLE
fix 32-bit kernel uptime error

### DIFF
--- a/src/uptime/uptime.rs
+++ b/src/uptime/uptime.rs
@@ -174,7 +174,8 @@ fn get_uptime(boot_time: Option<time_t>) -> i64 {
         _ => return match boot_time {
                 Some(t) => {
                     let now = rtime::get_time().sec;
-                    ((now - t) * 100) as i64 // Return in ms
+                    let time = t.to_i64().unwrap();
+                    ((now - time) * 100) as i64 // Return in ms
                 },
                 _ => -1
              }


### PR DESCRIPTION
I get an error on 32-bit virtual machine
error: mismatched types: expected `i64`, found `i32` (expected i64,
found i32)
