### PR TITLE
stdbuf - basic version 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ PROGS       := \
   seq \
   shuf \
   sort \
+  stdbuf \
   sum \
   sync \
   tac \

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ ENABLE_LTO     ?= n
 ENABLE_STRIP   ?= n
 
 # Binaries
-RUSTC         ?= rustc
-CARGO         ?= cargo
-CC            ?= gcc
-RM            := rm
+RUSTC          ?= rustc
+CARGO          ?= cargo
+CC             ?= gcc
+RM             := rm
 
 # Install directories
-PREFIX        ?= /usr/local
-BINDIR        ?= /bin
-LIBDIR        ?= /lib
+PREFIX         ?= /usr/local
+BINDIR         ?= /bin
+LIBDIR         ?= /lib
 
 # This won't support any directory with spaces in its name, but you can just
 # make a symlink without spaces that points to the directory.
@@ -143,16 +143,16 @@ INSTALLEES  := \
 SYSTEM := $(shell uname)
 DYLIB_EXT := 
 ifeq ($(SYSTEM),Linux)
-	DYLIB_EXT    := so
+	DYLIB_EXT    := .so
 endif
 ifeq ($(SYSTEM),Darwin)
-	DYLIB_EXT    := dylib
+	DYLIB_EXT    := .dylib
 endif
 
 # Libaries to install
 LIBS :=
 ifneq (,$(findstring stdbuf, $(INSTALLEES)))
-LIBS += libstdbuf.$(DYLIB_EXT)
+LIBS += libstdbuf$(DYLIB_EXT)
 endif
 
 # Programs with usable tests
@@ -319,6 +319,10 @@ install-multicall: $(BUILDDIR)/uutils
 	for prog in $(INSTALLEES); do \
 		ln -s $(PROG_PREFIX)uutils $$prog; \
 	done
+	mkdir -p $(DESTDIR)$(PREFIX)$(LIBDIR)
+	for lib in $(LIBS); do \
+		install $(BUILDDIR)/$$lib $(DESTDIR)$(PREFIX)$(LIBDIR)/$$lib; \
+	done
 
 uninstall:
 	rm -f $(addprefix $(DESTDIR)$(PREFIX)$(BINDIR)/$(PROG_PREFIX),$(PROGS))
@@ -326,6 +330,7 @@ uninstall:
 
 uninstall-multicall:
 	rm -f $(addprefix $(DESTDIR)$(PREFIX)$(BINDIR)/,$(PROGS) $(PROG_PREFIX)uutils)
+	rm -f $(addprefix $(DESTDIR)$(PREFIX)$(LIBDIR)/,$(LIBS))
 
 # Test under the busybox testsuite
 $(BUILDDIR)/busybox: $(BUILDDIR)/uutils

--- a/src/stdbuf/libstdbuf.c
+++ b/src/stdbuf/libstdbuf.c
@@ -1,0 +1,7 @@
+#include "libstdbuf.h"
+
+void __attribute ((constructor))
+stdbuf_init (void)
+{
+	stdbuf();
+}

--- a/src/stdbuf/libstdbuf.h
+++ b/src/stdbuf/libstdbuf.h
@@ -1,0 +1,6 @@
+#ifndef UUTILS_LIBSTDBUF_H
+#define UUTILS_LIBSTDBUF_H
+
+void stdbuf(void);
+
+#endif

--- a/src/stdbuf/libstdbuf.rs
+++ b/src/stdbuf/libstdbuf.rs
@@ -1,6 +1,6 @@
 #![crate_name = "libstdbuf"]
 #![crate_type = "staticlib"]
-#![feature(macro_rules)]
+#![allow(unstable)]
 
 extern crate libc;
 use libc::{c_int, size_t, c_char, FILE, _IOFBF, _IONBF, _IOLBF, setvbuf};
@@ -8,6 +8,7 @@ use std::ptr;
 use std::os;
 
 #[path = "../common/util.rs"]
+#[macro_use]
 mod util;
 
 extern {
@@ -23,7 +24,7 @@ fn set_buffer(stream: *mut FILE, value: &str) {
         "0" => (_IONBF, 0 as size_t),
         "L" => (_IOLBF, 0 as size_t),
         input => {
-            let buff_size: uint = match from_str(input) {
+            let buff_size: usize = match input.parse() {
                 Some(num) => num,
                 None => crash!(1, "incorrect size of buffer!")
             };

--- a/src/stdbuf/libstdbuf.rs
+++ b/src/stdbuf/libstdbuf.rs
@@ -1,15 +1,22 @@
-#![crate_type = "dylib"]
+#![crate_name = "libstdbuf"]
+#![crate_type = "staticlib"]
+#![feature(macro_rules)]
 
 extern crate libc;
 use libc::{c_int, size_t, c_char, FILE, _IOFBF, _IONBF, _IOLBF, setvbuf};
 use std::ptr;
 use std::os;
 
+#[path = "../common/util.rs"]
+mod util;
+
 extern {
     static stdin: *mut FILE;
     static stdout: *mut FILE;
     static stderr: *mut FILE;
 }
+
+static NAME: &'static str = "libstdbuf";
 
 fn set_buffer(stream: *mut FILE, value: &str) {
     let (mode, size): (c_int, size_t) = match value {
@@ -18,7 +25,7 @@ fn set_buffer(stream: *mut FILE, value: &str) {
         input => {
             let buff_size: uint = match from_str(input) {
                 Some(num) => num,
-                None => panic!("incorrect size of buffer!")
+                None => crash!(1, "incorrect size of buffer!")
             };
             (_IOFBF, buff_size as size_t)
         }
@@ -30,7 +37,7 @@ fn set_buffer(stream: *mut FILE, value: &str) {
         res = libc::setvbuf(stream, buffer, mode, size);
     }
     if res != 0 {
-        panic!("error while calling setvbuf!");
+        crash!(res, "error while calling setvbuf!");
     }
 }
 

--- a/src/stdbuf/libstdbuf.rs
+++ b/src/stdbuf/libstdbuf.rs
@@ -1,0 +1,48 @@
+#![crate_type = "dylib"]
+
+extern crate libc;
+use libc::{c_int, size_t, c_char, FILE, _IOFBF, _IONBF, _IOLBF, setvbuf};
+use std::ptr;
+use std::os;
+
+extern {
+    static stdin: *mut FILE;
+    static stdout: *mut FILE;
+    static stderr: *mut FILE;
+}
+
+fn set_buffer(stream: *mut FILE, value: &str) {
+    let (mode, size): (c_int, size_t) = match value {
+        "0" => (_IONBF, 0 as size_t),
+        "L" => (_IOLBF, 0 as size_t),
+        input => {
+            let buff_size: uint = match from_str(input) {
+                Some(num) => num,
+                None => panic!("incorrect size of buffer!")
+            };
+            (_IOFBF, buff_size as size_t)
+        }
+    };
+    let mut res: c_int;
+    unsafe {
+        let buffer: *mut c_char = ptr::null_mut();
+        assert!(buffer.is_null());
+        res = libc::setvbuf(stream, buffer, mode, size);
+    }
+    if res != 0 {
+        panic!("error while calling setvbuf!");
+    }
+}
+
+#[no_mangle]
+pub extern fn stdbuf() {
+    if let Some(val) = os::getenv("_STDBUF_E") {
+        set_buffer(stderr, val.as_slice());
+    }
+    if let Some(val) = os::getenv("_STDBUF_I") {
+        set_buffer(stdin, val.as_slice());
+    }
+    if let Some(val) = os::getenv("_STDBUF_O") {
+        set_buffer(stdout, val.as_slice()); 
+    }
+}

--- a/src/stdbuf/prepare_libs.sh
+++ b/src/stdbuf/prepare_libs.sh
@@ -2,8 +2,8 @@
 
 cd $(dirname $0)
 rustc libstdbuf.rs
-gcc -c -Wall -Werror -fpic libstdbuf.c -L. -llibstdbuf.so
-gcc -shared -o libstdbuf.so libstdbuf.o
+gcc -c -Wall -Werror -fpic libstdbuf.c -L. -llibstdbuf.a
+gcc -shared -o libstdbuf.so -Wl,--whole-archive liblibstdbuf.a -Wl,--no-whole-archive libstdbuf.o -lpthread
 mv *.so ../../build/
 rm *.o
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":"$PWD"/../../build
+rm *.a

--- a/src/stdbuf/prepare_libs.sh
+++ b/src/stdbuf/prepare_libs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd $(dirname $0)
+rustc libstdbuf.rs
+gcc -c -Wall -Werror -fpic libstdbuf.c -L. -llibstdbuf.so
+gcc -shared -o libstdbuf.so libstdbuf.o
+mv *.so ../../build/
+rm *.o
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":"$PWD"/../../build

--- a/src/stdbuf/prepare_libs.sh
+++ b/src/stdbuf/prepare_libs.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-cd $(dirname $0)
-rustc libstdbuf.rs
-gcc -c -Wall -Werror -fpic libstdbuf.c -L. -llibstdbuf.a
-gcc -shared -o libstdbuf.so -Wl,--whole-archive liblibstdbuf.a -Wl,--no-whole-archive libstdbuf.o -lpthread
-mv *.so ../../build/
-rm *.o
-rm *.a

--- a/src/stdbuf/stdbuf.rs
+++ b/src/stdbuf/stdbuf.rs
@@ -1,0 +1,215 @@
+#![crate_name = "stdbuf"]
+
+/*
+* This file is part of the uutils coreutils package.
+*
+* (c) Dorota Kapturkiewicz <dokaptur@gmail.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+#![feature(macro_rules)]
+
+extern crate getopts;
+extern crate libc;
+use getopts::{optopt, optflag, getopts, usage, Matches, OptGroup};
+use std::io::process::{Command, StdioContainer};
+use std::iter::range_inclusive;
+use std::num::Int;
+
+#[path = "../common/util.rs"]
+mod util;
+
+static NAME: &'static str = "stdbuf";
+static VERSION: &'static str = "1.0.0";
+static LIBSTDBUF_PATH: &'static str = "liblibstdbuf.so libstdbuf.so"; 
+
+#[deriving(Show)]
+enum BufferType {
+    Default,
+    Line,
+    Size(u64)
+}
+
+#[deriving(Show)]
+struct ProgramOptions {
+    stdin: BufferType,
+    stdout: BufferType,
+    stderr: BufferType,
+}
+
+enum ErrMsg {
+    Retry,
+    Fatal
+}
+
+enum OkMsg {
+    Buffering,
+    Help,
+    Version
+}
+
+fn print_version() {
+    println!("{} version {}", NAME, VERSION);
+}
+
+fn print_usage(opts: &[OptGroup]) {
+    let brief = 
+        "Usage: stdbuf OPTION... COMMAND\n \
+        Run COMMAND, with modified buffering operations for its standard streams\n \
+        Mandatory arguments to long options are mandatory for short options too.";
+    let explanation = 
+        "If MODE is 'L' the corresponding stream will be line buffered.\n \
+        This option is invalid with standard input.\n\n \
+        If MODE is '0' the corresponding stream will be unbuffered.\n\n \
+        Otherwise MODE is a number which may be followed by one of the following:\n\n \
+        KB 1000, K 1024, MB 1000*1000, M 1024*1024, and so on for G, T, P, E, Z, Y.\n \
+        In this case the corresponding stream will be fully buffered with the buffer size set to MODE bytes.\n\n \
+        NOTE: If COMMAND adjusts the buffering of its standard streams ('tee' does for e.g.) then that will override \
+        corresponding settings changed by 'stdbuf'.\n \
+        Also some filters (like 'dd' and 'cat' etc.) don't use streams for I/O, \
+        and are thus unaffected by 'stdbuf' settings.\n";
+    println!("{}\n{}", getopts::usage(brief, opts), explanation);
+}
+
+fn parse_size(size: &str) -> Option<u64> {
+    let ext = size.trim_left_chars(|c: char| c.is_digit(10));
+    let num = size.trim_right_chars(|c: char| c.is_alphabetic());
+    let mut recovered = num.to_string();
+    recovered.push_str(ext);
+    if recovered.as_slice() != size {
+        return None;
+    }
+    let buf_size: u64 = match from_str(num) {
+        Some(m) => m,
+        None => return None,
+    };
+    let (power, base): (uint, u64) = match ext {
+        "" => (0, 0),
+        "KB" => (1, 1024),
+        "K" => (1, 1000),
+        "MB" => (2, 1024),
+        "M" => (2, 1000),
+        "GB" => (3, 1024),
+        "G" => (3, 1000),
+        "TB" => (4, 1024),
+        "T" => (4, 1000),
+        "PB" => (5, 1024),
+        "P" => (5, 1000),
+        "EB" => (6, 1024),
+        "E" => (6, 1000),
+        "ZB" => (7, 1024),
+        "Z" => (7, 1000),
+        "YB" => (8, 1024),
+        "Y" => (8, 1000),
+        _ => return None,
+    };
+    Some(buf_size * base.pow(power))
+}
+
+fn check_option(matches: &Matches, name: &str, modified: &mut bool) -> Option<BufferType> {
+    match matches.opt_str(name) {
+        Some(value) => {
+            *modified = true;
+            match value.as_slice() {
+                "L" => {
+                    if name == "input" {
+                        show_info!("stdbuf: line buffering stdin is meaningless");
+                        None
+                    } else {
+                        Some(BufferType::Line)
+                    }
+                },
+                x => {
+                    let size = match parse_size(x) {
+                        Some(m) => m,
+                        None => { show_error!("Invalid mode {}", x); return None }
+                    };
+                    Some(BufferType::Size(size))
+                },
+            }
+        },
+        None => Some(BufferType::Default),
+    }
+}
+
+fn parse_options(args: &[String], options: &mut ProgramOptions, optgrps: &[OptGroup]) -> Result<OkMsg, ErrMsg> {
+    let matches = match getopts(args, optgrps) {
+        Ok(m) => m,
+        Err(_) => return Err(ErrMsg::Retry)
+    };
+    if matches.opt_present("help") {
+        return Ok(OkMsg::Help);
+    }
+    if matches.opt_present("version") {
+        return Ok(OkMsg::Version);
+    }
+    let mut modified = false;
+    options.stdin = try!(check_option(&matches, "input", &mut modified).ok_or(ErrMsg::Fatal));
+    options.stdout = try!(check_option(&matches, "output", &mut modified).ok_or(ErrMsg::Fatal));
+    options.stderr = try!(check_option(&matches, "error", &mut modified).ok_or(ErrMsg::Fatal));
+
+    if matches.free.len() != 1 {
+        return Err(ErrMsg::Retry);
+    }
+    if !modified {
+        show_error!("stdbuf: you must specify a buffering mode option");
+        return Err(ErrMsg::Fatal);
+    }
+    Ok(OkMsg::Buffering)
+}
+
+fn set_command_env(command: &mut Command, buffer_name: &str, buffer_type: BufferType) {
+    match buffer_type {
+        BufferType::Size(m) => { command.env(buffer_name, m.to_string()); },
+        BufferType::Line => { command.env(buffer_name, "L"); },
+        BufferType::Default => {},
+    }
+}
+
+
+pub fn uumain(args: Vec<String>) -> int {
+    let optgrps = [
+        optopt("i", "input", "adjust standard input stream buffering", "MODE"),
+        optopt("o", "output", "adjust standard output stream buffering", "MODE"),
+        optopt("e", "error", "adjust standard error stream buffering", "MODE"),
+        optflag("", "help", "display this help and exit"),
+        optflag("", "version", "output version information and exit"),
+    ];
+    let mut options = ProgramOptions {stdin: BufferType::Default, stdout: BufferType::Default, stderr: BufferType::Default};
+    let mut command_idx = -1;
+    for i in range_inclusive(1, args.len()) {
+        match parse_options(args.slice(1, i), &mut options, &optgrps) {
+            Ok(OkMsg::Buffering) => {
+                command_idx = i-1;
+                break;
+            },
+            Ok(OkMsg::Help) => {
+                print_usage(&optgrps);
+                return 0;
+            },
+            Ok(OkMsg::Version) => {
+                print_version();
+                return 0;
+            },
+            Err(ErrMsg::Fatal) => break,
+            Err(ErrMsg::Retry) => continue,
+        }
+    };
+    if command_idx == -1 {
+        crash!(125, "Invalid options\nTry 'stdbuf --help' for more information.");
+    }
+    let ref command_name = args[command_idx];
+    let mut command = Command::new(command_name);
+    command.args(args.slice_from(command_idx+1)).env("LD_PRELOAD", LIBSTDBUF_PATH);
+    command.stdin(StdioContainer::InheritFd(0)).stdout(StdioContainer::InheritFd(1)).stderr(StdioContainer::InheritFd(2));
+    set_command_env(&mut command, "_STDBUF_I", options.stdin);
+    set_command_env(&mut command, "_STDBUF_O", options.stdout);
+    set_command_env(&mut command, "_STDBUF_E", options.stderr);
+    match command.spawn() {
+        Ok(_) => {},
+        Err(e) => crash!(1, "failed to execute process: {}", e),
+    };
+    0
+}
+


### PR DESCRIPTION
My first attempt to solve issue #434

This is very first and basic version of stdbuf working on Linux 86_x64. It assumes that user has GNU coreutils installed (and so libstdbuf.so from GNU in /lib/coreutils). It also works for the same programs GNU stdbuf works, that is programs written in C/C++ using default stdin/stdout/stderr objects from stdio.h library. 
To be honest, I don't know how to implement it for programms written in rust.

GNU uses LD_PRELOAD to link dynamically a shared library, which changes stdio.h objects before running the program itself, so buffors are being set properly. I know that rust allows to modify object returned by stdout() in current task by function set_stdout() (http://doc.rust-lang.org/nightly/std/io/stdio/fn.set_stdout.html), but I'm not sure if there is something like this preloading trick for rust.

And other methods that comes to my mind, like forking (spawning) process and buffering stdio from "outside" are useless, as stdbuf is mostly being used to make buffered programms unbuffered. And in this case I can do nothing "from outside".

I'm waiting for code review and some tips how to move it further!