### PR TITLE
Fix deprecation warnings with latest rust nightly

### DIFF
--- a/src/base64/base64.rs
+++ b/src/base64/base64.rs
@@ -66,7 +66,7 @@ pub fn uumain(args: Vec<String>) -> int {
     };
     let ignore_garbage = matches.opt_present("ignore-garbage");
     let line_wrap = match matches.opt_str("wrap") {
-        Some(s) => match from_str(s.as_slice()) {
+        Some(s) => match s.parse() {
             Some(s) => s,
             None => {
                 error!("error: {}", "Argument to option 'wrap' improperly formatted.");

--- a/src/basename/basename.rs
+++ b/src/basename/basename.rs
@@ -13,6 +13,7 @@
 extern crate getopts;
 extern crate libc;
 
+use std::borrow::ToOwned;
 use std::io::{print, println};
 
 #[path = "../common/util.rs"]
@@ -99,12 +100,12 @@ fn strip_dir(fullname: &str) -> String {
 
 fn strip_suffix(name: &str, suffix: &str) -> String {
     if name == suffix {
-        return name.into_string();
+        return name.to_owned();
     }
 
     if name.ends_with(suffix) {
-        return name.slice_to(name.len() - suffix.len()).into_string();
+        return name.slice_to(name.len() - suffix.len()).to_owned();
     }
 
-    name.into_string()
+    name.to_owned()
 }

--- a/src/common/c_types.rs
+++ b/src/common/c_types.rs
@@ -119,7 +119,7 @@ pub fn get_pw_from_args(free: &Vec<String>) -> Option<c_passwd> {
 
         // Passed user as id
         if username.chars().all(|c| c.is_digit(10)) {
-            let id = from_str::<u32>(username).unwrap();
+            let id = username.parse::<u32>().unwrap();
             let pw_pointer = unsafe { getpwuid(id as uid_t) };
 
             if pw_pointer.is_not_null() {
@@ -146,7 +146,7 @@ pub fn get_pw_from_args(free: &Vec<String>) -> Option<c_passwd> {
 
 pub fn get_group(groupname: &str) -> Option<c_group> {
     let group = if groupname.chars().all(|c| c.is_digit(10)) {
-        unsafe { getgrgid(from_str::<gid_t>(groupname).unwrap()) }
+        unsafe { getgrgid(groupname.parse().unwrap()) }
     } else {
         unsafe { getgrnam(groupname.to_c_str().into_inner() as *const c_char) }
     };

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -28,7 +28,7 @@ pub fn from_str(string: &str) -> Result<f64, String> {
             }
         }
     };
-    match ::std::str::from_str::<f64>(numstr) {
+    match numstr.parse::<f64>() {
         Some(m) => Ok(m * times as f64),
         None => Err(format!("invalid time interval '{}'", string))
     }

--- a/src/kill/kill.rs
+++ b/src/kill/kill.rs
@@ -19,7 +19,6 @@ extern crate serialize;
 
 #[phase(plugin, link)] extern crate log;
 
-use std::str::from_str;
 use std::io::process::Process;
 
 use getopts::{
@@ -109,7 +108,7 @@ fn handle_obsolete(mut args: Vec<String>) -> (Vec<String>, Option<String>) {
         let slice: &str = unsafe { std::mem::transmute(args[i].as_slice()) };
         if slice.char_at(0) == '-' && slice.len() > 1 && slice.char_at(1).is_digit(10) {
             let val = slice.slice_from(1);
-            match from_str(val) {
+            match val.parse() {
                 Some(num) => {
                     if signals::is_signal(num) {
                         args.remove(i);
@@ -194,7 +193,7 @@ fn kill(signalname: &str, pids: std::vec::Vec<String>) -> int {
         None => crash!(EXIT_ERR, "unknown signal name {}", signalname)
     };
     for pid in pids.iter() {
-        match from_str::<i32>(pid.as_slice()) {
+        match pid.as_slice().parse() {
             Some(x) => {
                 let result = Process::kill(x, signal_value as int);
                 match result {

--- a/src/nice/nice.rs
+++ b/src/nice/nice.rs
@@ -79,7 +79,7 @@ pub fn uumain(args: Vec<String>) -> int {
                                  Try \"{} --help\" for more information.", args[0]);
                     return 125;
                 }
-                match from_str(nstr.as_slice()) {
+                match nstr.as_slice().parse() {
                     Some(num) => num,
                     None => {
                         show_error!("\"{}\" is not a valid number", nstr);

--- a/src/tty/tty.rs
+++ b/src/tty/tty.rs
@@ -52,7 +52,7 @@ pub fn uumain(args: Vec<String>) -> int {
     let tty = unsafe { String::from_raw_buf(ttyname(libc::STDIN_FILENO) as *const u8) };
 
     if !silent {
-        if !tty.as_slice().is_whitespace() {
+        if !tty.as_slice().chars().all(|c| c.is_whitespace()) {
             println(tty.as_slice());
         } else {
             println!("not a tty");

--- a/src/uptime/uptime.rs
+++ b/src/uptime/uptime.rs
@@ -21,7 +21,6 @@ extern crate "time" as rtime;
 use std::mem::transmute;
 use std::io::{print, File};
 use std::ptr::null;
-use std::str::from_str;
 use libc::{time_t, c_double, c_int, c_char};
 use utmpx::*;
 
@@ -182,7 +181,7 @@ fn get_uptime(boot_time: Option<time_t>) -> i64 {
     };
 
     match uptime_text.as_slice().words().next() {
-        Some(s) => match from_str(s.replace(".", "").as_slice()) {
+        Some(s) => match s.replace(".", "").as_slice().parse() {
                     Some(n) => n,
                     None => -1
                    },


### PR DESCRIPTION
- from_str() -> parse()
- into_string() -> to_owned()