### PR TITLE
uname: change trim_left() to trim()

### DIFF
--- a/src/uname/uname.rs
+++ b/src/uname/uname.rs
@@ -105,7 +105,7 @@ pub fn uumain(args: Vec<String>) -> isize {
         output.push_str(uname.machine.as_slice());
         output.push_str(" ");
     }
-    println!("{}", output.as_slice().trim_left());
+    println!("{}", output.as_slice().trim());
 
     0
 }


### PR DESCRIPTION
Otherwise all options have a space at the end, causing a warning in grml zsh config, and who knows what else.