### PR TITLE
od: fix --address-radix interpretation and minor cleanups

### DIFF
--- a/src/od/od.rs
+++ b/src/od/od.rs
@@ -38,7 +38,7 @@ pub fn uumain(args: Vec<String>) -> isize {
                           specified."),
                         "BYTES"),
         getopts::optflag("h", "help", "display this help and exit."),
-        getopts::optflag("v", "version", "output version information and exit."),
+        getopts::optflag("", "version", "output version information and exit."),
     ];
 
     let matches = match getopts::getopts(args.tail(), &opts) {

--- a/src/od/od.rs
+++ b/src/od/od.rs
@@ -51,18 +51,17 @@ pub fn uumain(args: Vec<String>) -> isize {
         Err(f) => { panic!("Invalid -A/--address-radix\n{}", f) }
     };
 
-    let mut fname;
-    match args.last() {
-        Some(n) => fname = n,
-        None    => { panic!("Need fname for now") ; }
+    let fname = match args.last() {
+        Some(n) => n,
+        None => { panic!("Need fname for now") ; }
     };
 
-    main(input_offset_base, fname.clone());
+    main(input_offset_base, fname.as_slice());
 
     0
 }
 
-fn main(input_offset_base: Radix, fname: String) {
+fn main(input_offset_base: Radix, fname: &str) {
     let mut f = match File::open(&Path::new(fname)) {
         Ok(f) => f,
         Err(e) => panic!("file error: {}", e)


### PR DESCRIPTION
The initial draft written by @benhirsch24 misinterpreted the -A/--address-radix flag. This flag should control the printing of the file offsets (the leftmost field of the output), not the printing of the values in the output bytes. See the POSIX spec for od:

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/od.html

You can also verify this by running any standard od on any input whatsoever.

This PR implements an initial fix for this defect. A few preparatory cleanups I made related to fixing this bug are rolled into this PR as well.