### PR TITLE
Fix broken build for serialize crate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ define CRATE_BUILD
 -include $(BUILDDIR)/$(1).d
 
 $(BUILDDIR)/$($(1)_RLIB): $(SRCDIR)/$(1)/$(1).rs | $(BUILDDIR) deps
-	$(RUSTC) $(RUSTCLIBFLAGS) --extern libc=$(BUILDDIR)/liblibc.rlib --extern time=$(BUILDDIR)/libtime.rlib --extern rand=$(BUILDDIR)/librand.rlib --extern regex=$(BUILDDIR)/libregex.rlib --extern serialize=$(BUILDDIR)/librustc-serialize.rlib --crate-type rlib --emit link,dep-info $$< --out-dir $(BUILDDIR)
+	$(RUSTC) $(RUSTCLIBFLAGS) --extern libc=$(BUILDDIR)/liblibc.rlib --extern time=$(BUILDDIR)/libtime.rlib --extern rand=$(BUILDDIR)/librand.rlib --extern regex=$(BUILDDIR)/libregex.rlib --extern serialize=$(BUILDDIR)/librustc_serialize.rlib --crate-type rlib --emit link,dep-info $$< --out-dir $(BUILDDIR)
 endef
 
 # Aliases build rule
@@ -259,7 +259,7 @@ $(BUILDDIR)/stdbuf: $(BUILDDIR)/libstdbuf.$(DYLIB_EXT)
 $(BUILDDIR)/.rust-crypto: | $(BUILDDIR)
 	cd $(BASEDIR)/deps/rust-crypto && $(CARGO) build --release
 	cp -r $(BASEDIR)/deps/rust-crypto/target/release/deps/librand*.rlib $(BUILDDIR)/librand.rlib
-	cp -r $(BASEDIR)/deps/rust-crypto/target/release/deps/librustc_serialize*.rlib $(BUILDDIR)/librustc-serialize.rlib
+	cp -r $(BASEDIR)/deps/rust-crypto/target/release/deps/librustc_serialize*.rlib $(BUILDDIR)/librustc_serialize.rlib
 	cp -r $(BASEDIR)/deps/rust-crypto/target/release/deps/libtime*.rlib $(BUILDDIR)/libtime.rlib
 	cp -r $(BASEDIR)/deps/rust-crypto/target/release/deps/liblibc*.rlib $(BUILDDIR)/liblibc.rlib
 	cp -r $(BASEDIR)/deps/rust-crypto/target/release/libcrypto*.rlib $(BUILDDIR)/libcrypto.rlib


### PR DESCRIPTION
After building the serialize crate, the rlib was copied to the build
directory using a hyphen in the library name ('librustc-serialize').
It seems that Rust expects an underscore instead.