### PR TITLE
quick Makefile tweak ; update chmod ; update chroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,13 @@ endef
 DEPLIBS := libc
 DEPPLUGS :=
 # now, add in deps in src/utilname/deps.mk
-$(foreach build,$(sort $(EXES) $(TESTS)),$(eval $(call DEP_INCLUDE,$(build))))
+# if we're testing, only consider the TESTS variable,
+# otherwise consider the EXES variable
+ifeq ($(MAKECMDGOALS),test)
+$(foreach build,$(TESTS),$(eval $(call DEP_INCLUDE,$(build))))
+else
+$(foreach build,$(sort $(TESTS) $(EXES)),$(eval $(call DEP_INCLUDE,$(build))))
+endif
 # uniqify deps
 DEPLIBS := $(sort $(DEPLIBS))
 DEPPLUGS := $(sort $(DEPPLUGS))
@@ -248,8 +254,8 @@ endef
 
 # Test exe built rules
 define TEST_BUILD
-test_$(1): $(TEMPDIR)/$(1)/$(1)_test $(BUILDDIR)/$(1)
-	$(call command,cp $(BUILDDIR)/$(1) $(TEMPDIR)/$(1) && cd $(TEMPDIR)/$(1) && $$<)
+test_$(1): $(BUILDDIR)/$(1) $(TEMPDIR)/$(1)/$(1)_test
+	$(call command,cp $(BUILDDIR)/$(1) $(TEMPDIR)/$(1) && cd $(TEMPDIR)/$(1) && $(TEMPDIR)/$(1)/$(1)_test)
 
 $(TEMPDIR)/$(1)/$(1)_test: $(TESTDIR)/$(1).rs | $(TEMPDIR)/$(1)
 	$(call command,$(RUSTC) $(RUSTCTESTFLAGS) $(DEP_EXTERN) --test -o $$@ $$<)

--- a/src/chroot/chroot.rs
+++ b/src/chroot/chroot.rs
@@ -1,5 +1,5 @@
 #![crate_name = "chroot"]
-#![feature(collections, core, old_io, os, old_path, rustc_private, std_misc)]
+#![feature(collections, rustc_private, path_ext)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -15,11 +15,12 @@ extern crate libc;
 
 use getopts::{optflag, optopt, getopts, usage};
 use c_types::{get_pw_from_args, get_group};
-use libc::funcs::posix88::unistd::{execvp, setuid, setgid};
+use libc::funcs::posix88::unistd::{execvp, setgid, setuid};
 use std::ffi::{CStr, CString};
+use std::fs::PathExt;
+use std::io::Write;
 use std::iter::FromIterator;
 use std::path::Path;
-use std::env;
 
 #[path = "../common/util.rs"] #[macro_use] mod util;
 #[path = "../common/c_types.rs"] mod c_types;
@@ -59,25 +60,25 @@ pub fn uumain(args: Vec<String>) -> i32 {
         Ok(m) => m,
         Err(f) => {
             show_error!("{}", f);
-            help_menu(program.as_slice(), &options);
+            help_menu(program, &options);
             return 1
         }
     };
 
     if opts.opt_present("V") { version(); return 0 }
-    if opts.opt_present("h") { help_menu(program.as_slice(), &options); return 0 }
+    if opts.opt_present("h") { help_menu(program, &options); return 0 }
 
     if opts.free.len() == 0 {
         println!("Missing operand: NEWROOT");
-        println!("Try `{} --help` for more information.", program.as_slice());
+        println!("Try `{} --help` for more information.", program);
         return 1
     }
 
     let default_shell: &'static str = "/bin/sh";
     let default_option: &'static str = "-i";
-    let user_shell = env::var("SHELL");
+    let user_shell = std::env::var("SHELL");
 
-    let newroot = Path::new(opts.free[0].as_slice());
+    let newroot = Path::new(&opts.free[0][..]);
     if !newroot.is_dir() {
         crash!(1, "cannot change root directory to `{}`: no such directory", newroot.display());
     }
@@ -85,12 +86,12 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let command: Vec<&str> = match opts.free.len() {
         1 => {
             let shell: &str = match user_shell {
-                None => default_shell,
-                Some(ref s) => s.as_slice()
+                Err(_) => default_shell,
+                Ok(ref s) => &s[..],
             };
             vec!(shell, default_option)
         }
-        _ => opts.free[1..opts.free.len()].iter().map(|x| x.as_slice()).collect()
+        _ => opts.free[1..opts.free.len()].iter().map(|x| &x[..]).collect()
     };
 
     set_context(&newroot, &opts);
@@ -110,32 +111,32 @@ fn set_context(root: &Path, options: &getopts::Matches) {
     let groups_str = options.opt_str("groups").unwrap_or_default();
     let userspec = match userspec_str {
         Some(ref u) => {
-            let s: Vec<&str> = u.as_slice().split(':').collect();
+            let s: Vec<&str> = u.split(':').collect();
             if s.len() != 2 {
-                crash!(1, "invalid userspec: `{}`", u.as_slice())
+                crash!(1, "invalid userspec: `{}`", u)
             };
             s
         }
         None => Vec::new()
     };
-    let user = if userspec.is_empty() { user_str.as_slice() } else { userspec[0].as_slice() };
-    let group = if userspec.is_empty() { group_str.as_slice() } else { userspec[1].as_slice() };
+    let user = if userspec.is_empty() { &user_str[..] } else { &userspec[0][..] };
+    let group = if userspec.is_empty() { &group_str[..] } else { &userspec[1][..] };
 
     enter_chroot(root);
 
-    set_groups_from_str(groups_str.as_slice());
-    set_main_group(group);
-    set_user(user);
+    set_groups_from_str(&groups_str[..]);
+    set_main_group(&group[..]);
+    set_user(&user[..]);
 }
 
 fn enter_chroot(root: &Path) {
     let root_str = root.display();
-    env::set_current_dir(root).unwrap();
+    std::env::set_current_dir(root).unwrap();
     let err = unsafe {
-        chroot(CString::new(b".").unwrap().as_bytes_with_nul().as_ptr() as *const libc::c_char)
+        chroot(CString::new(".".as_bytes()).unwrap().as_bytes_with_nul().as_ptr() as *const libc::c_char)
     };
     if err != 0 {
-        crash!(1, "cannot chroot to {}: {}", root_str, strerror(err).as_slice())
+        crash!(1, "cannot chroot to {}: {}", root_str, strerror(err))
     };
 }
 
@@ -147,7 +148,7 @@ fn set_main_group(group: &str) {
         };
         let err = unsafe { setgid(group_id) };
         if err != 0 {
-            crash!(1, "cannot set gid to {}: {}", group_id, strerror(err).as_slice())
+            crash!(1, "cannot set gid to {}: {}", group_id, strerror(err))
         }
     }
 }
@@ -156,7 +157,7 @@ fn set_main_group(group: &str) {
 fn set_groups(groups: Vec<libc::gid_t>) -> libc::c_int {
     unsafe {
         setgroups(groups.len() as libc::c_int,
-                  groups.as_slice().as_ptr())
+                  groups.as_ptr())
     }
 }
 
@@ -164,7 +165,7 @@ fn set_groups(groups: Vec<libc::gid_t>) -> libc::c_int {
 fn set_groups(groups: Vec<libc::gid_t>) -> libc::c_int {
     unsafe {
         setgroups(groups.len() as libc::size_t,
-                  groups.as_slice().as_ptr())
+                  groups.as_ptr())
     }
 }
 
@@ -179,7 +180,7 @@ fn set_groups_from_str(groups: &str) {
             );
         let err = set_groups(groups_vec);
         if err != 0 {
-            crash!(1, "cannot set groups: {}", strerror(err).as_slice())
+            crash!(1, "cannot set groups: {}", strerror(err))
         }
     }
 }
@@ -189,7 +190,7 @@ fn set_user(user: &str) {
         let user_id = get_pw_from_args(&vec!(String::from_str(user))).unwrap().pw_uid;
         let err = unsafe { setuid(user_id as libc::uid_t) };
         if err != 0 {
-            crash!(1, "cannot set user to {}: {}", user, strerror(err).as_slice())
+            crash!(1, "cannot set user to {}: {}", user, strerror(err))
         }
     }
 }


### PR DESCRIPTION
Three commits:

1. Tweak Makefile so that when the make goal is `test` it only considers the `TESTS` variable when building dependencies.

2. Updates in chmod. Works, but I suspect it will have issues with non-UTF-8 filenames. This was probably always the case, though.

3. Updates in chroot (and in `src/common/c_types.rs`). Two things here:

* For now, one of the fixes in c_types is slightly hacky (specifically: I commented out the `Copy` impls for several of the structs), but this will get fixed as necessary for other utils.

* The call to the chroot function seems to fail in some cases. I am still investigating this, but I ran out of time for now.