### PR TITLE
Add a new makefile rule to check for build errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,4 +374,15 @@ busytest: $(BUILDDIR)/busybox $(BUILDDIR)/.config
 	(cd $(BUSYBOX_SRC)/testsuite && bindir=$(BUILDDIR) ./runtest $(RUNTEST_ARGS))
 endif
 
+# This rule will build each program, ignore all output, and return pass
+# or fail depending on whether the build has errors.
+build-check:
+	@for prog in $(sort $(PROGS)); do \
+		make BUILD="$$prog" >/dev/null 2>&1; status=$$?; \
+		if [ $$status -eq 0 ]; \
+		then printf "%-10s\t\033[1;32mpass\033[00;m\n" $$prog; \
+		else printf "%-10s\t\033[1;31mfail\033[00;m\n" $$prog; \
+		fi; \
+	done
+
 .PHONY: $(TEMPDIR) all deps test distclean clean busytest install uninstall

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ To build with LTO and stripping:
 make ENABLE_LTO=y ENABLE_STRIP=y
 ```
 
+To check all available utilities for build errors:
+```
+make build-check
+```
+
 Installation Instructions
 -------------------------
 


### PR DESCRIPTION
This rule will build each program, ignore all output, and return pass or fail depending on whether the build has errors. This is helpful for finding out which programs need to be fixed when a new Rust nightly build inevitably breaks everything.

This would be deprecated by changing the Makefile to not exit on the first program that doesn't build properly, but this seemed useful enough for inclusion.