### PR TITLE
Add a new makefile rule to check for test errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,4 +386,15 @@ build-check:
 		fi; \
 	done
 
+# This rule will test each program, ignore all output, and return pass
+# or fail depending on whether the test has errors.
+test-check:
+	@for prog in $(sort $(TEST_PROGS)); do \
+		make TEST="$$prog" test >/dev/null 2>&1; status=$$?; \
+		if [ $$status -eq 0 ]; \
+		then printf "%-10s\t\033[1;32mpass\033[00;m\n" $$prog; \
+		else printf "%-10s\t\033[1;31mfail\033[00;m\n" $$prog; \
+		fi; \
+	done
+
 .PHONY: $(TEMPDIR) all deps test distclean clean busytest install uninstall

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ To check all available utilities for build errors:
 make build-check
 ```
 
+To check all available tests for errors:
+```
+make test-check
+```
+
 Installation Instructions
 -------------------------
 


### PR DESCRIPTION
This rule will test each program, ignore all output, and return pass or fail depending on whether the test has errors. This is the equivalent of `make build-check`, but for tests.