### PR TITLE
Replace unstable set_exit_status() with exit().

### DIFF
--- a/mkmain.rs
+++ b/mkmain.rs
@@ -1,17 +1,15 @@
-#![feature(exit_status)]
 use std::env;
 use std::io::Write;
 use std::fs::File;
 
 static TEMPLATE: &'static str = "\
-#![feature(exit_status)]
 extern crate @UTIL_CRATE@ as uu@UTIL_CRATE@;
 
 use std::env;
 use uu@UTIL_CRATE@::uumain;
 
 fn main() {
-    env::set_exit_status(uumain(env::args().collect()));
+    std::process::exit(uumain(env::args().collect()));
 }
 ";
 
@@ -19,8 +17,7 @@ fn main() {
     let args : Vec<String> = env::args().collect();
     if args.len() != 3 {
         println!("usage: mkbuild <crate> <outfile>");
-        env::set_exit_status(1);
-        return;
+        std::process::exit(1);
     }
 
     let crat    = match &args[1][..] {

--- a/mkuutils.rs
+++ b/mkuutils.rs
@@ -1,5 +1,3 @@
-#![feature(exit_status)]
-
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -8,8 +6,7 @@ fn main() {
     let args : Vec<String> = env::args().collect();
     if args.len() < 3 {
         println!("usage: mkuutils <outfile> <crates>");
-        env::set_exit_status(1);
-        return;
+        std::process::exit(1);
     }
 
     let mut crates = String::new();

--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -1,5 +1,5 @@
 #![crate_name = "uutils"]
-#![feature(exit_status, rustc_private)]
+#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -53,7 +53,7 @@ fn main() {
 
     match umap.get(binary_as_util) {
         Some(&uumain) => {
-            env::set_exit_status(uumain(args));
+            std::process::exit(uumain(args));
             return
         }
         None => (),
@@ -66,7 +66,7 @@ fn main() {
             // what busybox uses the -suffix pattern for.
     } else {
         println!("{}: applet not found", binary_as_util);
-        env::set_exit_status(1);
+        std::process::exit(1);
         return
     }
 
@@ -77,7 +77,7 @@ fn main() {
 
         match umap.get(util) {
             Some(&uumain) => {
-                env::set_exit_status(uumain(args.clone()));
+                std::process::exit(uumain(args.clone()));
                 return
             }
             None => {
@@ -87,22 +87,22 @@ fn main() {
                         let util = &args[1][..];
                         match umap.get(util) {
                             Some(&uumain) => {
-                                env::set_exit_status(uumain(vec![util.to_string(), "--help".to_string()]));
+                                std::process::exit(uumain(vec![util.to_string(), "--help".to_string()]));
                                 return
                             }
                             None => {
                                 println!("{}: applet not found", util);
-                                env::set_exit_status(1);
+                                std::process::exit(1);
                                 return
                             }
                         }
                     }
                     usage(&umap);
-                    env::set_exit_status(0);
+                    std::process::exit(0);
                     return
                 } else {
                     println!("{}: applet not found", util);
-                    env::set_exit_status(1);
+                    std::process::exit(1);
                     return
                 }
             }
@@ -110,7 +110,7 @@ fn main() {
     } else {
         // no arguments provided
         usage(&umap);
-        env::set_exit_status(0);
+        std::process::exit(0);
         return
     }
 }


### PR DESCRIPTION
With the 1.0 release, unstable features are causing build errors. I replaced references to std::env::set_exit_status() with std::process::exit().