### PR TITLE
Make `id` build with Rust 1.0.

### DIFF
--- a/deps/Cargo.toml
+++ b/deps/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.0.0"
 name = "null"
 
 [dependencies]
+getopts = "0.2.11"
 libc = "0.1.7"
 num_cpus = "*"
 rand = "0.3.8"

--- a/src/base64/base64.rs
+++ b/src/base64/base64.rs
@@ -1,5 +1,4 @@
 #![crate_name = "base64"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -21,12 +20,7 @@ use std::fs::File;
 use std::io::{BufReader, Read, stdin, stdout, Write};
 use std::path::Path;
 
-use getopts::{
-    getopts,
-    optflag,
-    optopt,
-    usage
-};
+use getopts::Options;
 use serialize::base64;
 use serialize::base64::{FromBase64, ToBase64};
 
@@ -39,16 +33,15 @@ static NAME: &'static str = "base64";
 pub type FileOrStdReader = BufReader<Box<Read+'static>>;
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        optflag("d", "decode", "decode data"),
-        optflag("i", "ignore-garbage", "when decoding, ignore non-alphabetic characters"),
-        optopt("w", "wrap",
+    let mut opts = Options::new();
+    opts.optflag("d", "decode", "decode data");
+    opts.optflag("i", "ignore-garbage", "when decoding, ignore non-alphabetic characters");
+    opts.optopt("w", "wrap",
             "wrap encoded lines after COLS character (default 76, 0 to disable wrapping)", "COLS"
-        ),
-        optflag("h", "help", "display this help text and exit"),
-        optflag("V", "version", "output version information and exit")
-    ];
-    let matches = match getopts(&args[1..], &opts) {
+        );
+    opts.optflag("h", "help", "display this help text and exit");
+    opts.optflag("V", "version", "output version information and exit");
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(e) => {
             crash!(1, "error: {}", e);
@@ -56,7 +49,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     let progname = args[0].clone();
-    let usage = usage("Base64 encode or decode FILE, or standard input, to standard output.", &opts);
+    let usage = opts.usage("Base64 encode or decode FILE, or standard input, to standard output.");
     let mode = if matches.opt_present("help") {
         Mode::Help
     } else if matches.opt_present("version") {

--- a/src/base64/deps.mk
+++ b/src/base64/deps.mk
@@ -1,1 +1,3 @@
+DEPLIBS += getopts
+DEPLIBS += log
 DEPLIBS += rustc-serialize

--- a/src/id/deps.mk
+++ b/src/id/deps.mk
@@ -1,0 +1,1 @@
+DEPLIBS += getopts

--- a/src/id/id.rs
+++ b/src/id/id.rs
@@ -1,5 +1,4 @@
 #![crate_name = "id"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -27,7 +26,7 @@ use libc::{
     getuid
 };
 use libc::funcs::posix88::unistd::{getegid, geteuid, getlogin};
-use getopts::{getopts, optflag, usage};
+use getopts::Options;
 use c_types::{
     c_passwd,
     c_group,
@@ -89,28 +88,27 @@ static NAME: &'static str = "id";
 pub fn uumain(args: Vec<String>) -> i32 {
     let args_t = &args[1..];
 
-    let options = [
-        optflag("h", "", "Show help"),
-        optflag("A", "", "Display the process audit (not available on Linux)"),
-        optflag("G", "", "Display the different group IDs"),
-        optflag("g", "", "Display the effective group ID as a number"),
-        optflag("n", "", "Display the name of the user or group ID for the -G, -g and -u options"),
-        optflag("P", "", "Display the id as a password file entry"),
-        optflag("p", "", "Make the output human-readable"),
-        optflag("r", "", "Display the real ID for the -g and -u options"),
-        optflag("u", "", "Display the effective user ID as a number")
-    ];
+    let mut options = Options::new();
+    options.optflag("h", "", "Show help");
+    options.optflag("A", "", "Display the process audit (not available on Linux)");
+    options.optflag("G", "", "Display the different group IDs");
+    options.optflag("g", "", "Display the effective group ID as a number");
+    options.optflag("n", "", "Display the name of the user or group ID for the -G, -g and -u options");
+    options.optflag("P", "", "Display the id as a password file entry");
+    options.optflag("p", "", "Make the output human-readable");
+    options.optflag("r", "", "Display the real ID for the -g and -u options");
+    options.optflag("u", "", "Display the effective user ID as a number");
 
-    let matches = match getopts(args_t, &options) {
+    let matches = match options.parse(args_t) {
         Ok(m) => { m },
         Err(_) => {
-            println!("{}", usage(NAME, &options));
+            println!("{}", options.usage(NAME));
             return 1;
         }
     };
 
     if matches.opt_present("h") {
-        println!("{}", usage(NAME, &options));
+        println!("{}", options.usage(NAME));
         return 0;
     }
 

--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -51,7 +51,6 @@ fn main() {
     match umap.get(binary_as_util) {
         Some(&uumain) => {
             std::process::exit(uumain(args));
-            return
         }
         None => (),
     }
@@ -64,7 +63,6 @@ fn main() {
     } else {
         println!("{}: applet not found", binary_as_util);
         std::process::exit(1);
-        return
     }
 
     // try first arg as util name.
@@ -75,7 +73,6 @@ fn main() {
         match umap.get(util) {
             Some(&uumain) => {
                 std::process::exit(uumain(args.clone()));
-                return
             }
             None => {
                 if &args[0][..] == "--help" {
@@ -85,22 +82,18 @@ fn main() {
                         match umap.get(util) {
                             Some(&uumain) => {
                                 std::process::exit(uumain(vec![util.to_string(), "--help".to_string()]));
-                                return
                             }
                             None => {
                                 println!("{}: applet not found", util);
                                 std::process::exit(1);
-                                return
                             }
                         }
                     }
                     usage(&umap);
                     std::process::exit(0);
-                    return
                 } else {
                     println!("{}: applet not found", util);
                     std::process::exit(1);
-                    return
                 }
             }
         }
@@ -108,6 +101,5 @@ fn main() {
         // no arguments provided
         usage(&umap);
         std::process::exit(0);
-        return
     }
 }

--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -1,5 +1,4 @@
 #![crate_name = "uutils"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -9,8 +8,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
-extern crate getopts;
 
 @CRATES@
 


### PR DESCRIPTION
Make "make BUILD=id" work with Rust 1.0.
* Remove rustc_private
* Switch to getopts from crates.io

If these changes are ok, I'll plod away and get a few more working with 1.0.