### PR TITLE
Switch to external getopts cargo (part 1).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,8 @@ define DEP_INCLUDE
 -include $(SRCDIR)/$(1)/deps.mk
 endef
 # we always depend on libc because common/util does
-DEPLIBS := libc
+# we also depend on getopts since all utilities support command-line arguments
+DEPLIBS := libc getopts
 DEPPLUGS :=
 # now, add in deps in src/utilname/deps.mk
 # if we're testing, only consider the TESTS variable,

--- a/deps/Cargo.toml
+++ b/deps/Cargo.toml
@@ -7,6 +7,7 @@ name = "null"
 
 [dependencies]
 libc = "0.1.7"
+getopts = "0.2.11"
 num_cpus = "*"
 rand = "0.3.8"
 regex = "0.1.30"

--- a/src/basename/basename.rs
+++ b/src/basename/basename.rs
@@ -1,5 +1,4 @@
 #![crate_name = "basename"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -13,6 +12,7 @@
 extern crate getopts;
 extern crate libc;
 
+use getopts::Options;
 use std::io::Write;
 use std::path::{is_separator, PathBuf};
 
@@ -24,47 +24,43 @@ static NAME: &'static str = "basename";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = strip_dir(&args[0]);
-
     //
     // Argument parsing
     //
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m)  => m,
         Err(f) => crash!(1, "Invalid options\n{}", f)
     };
 
     if matches.opt_present("help") {
-        println!("Usage: {0} NAME [SUFFIX]", program);
-        println!("  or: {0} OPTION", program);
-        println!("Print NAME with any leading directory components removed.");
-        println!("If specified, also remove a trailing SUFFIX.");
+        let msg = format!("Usage: {0} NAME [SUFFIX]\n   or: {0} OPTION\n\n\
+        Print NAME with any leading directory components removed.\n\
+        If specified, also remove a trailing SUFFIX.", NAME);
 
-        print!("{}", getopts::usage("", &opts));
+        print!("{}", opts.usage(&msg));
 
         return 0;
     }
 
     if matches.opt_present("version") {
-        println!("{} {}", program, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 
     // too few arguments
     if args.len() < 2 {
-        println!("{}: {}", program, "missing operand");
-        println!("Try '{} --help' for more information.", program);
+        println!("{}: {}", NAME, "missing operand");
+        println!("Try '{} --help' for more information.", NAME);
         return 1;
     }
     // too many arguments
     else if args.len() > 3 {
-        println!("{}: extra operand '{}'", program, args[3]);
-        println!("Try '{} --help' for more information.", program);
+        println!("{}: extra operand '{}'", NAME, args[3]);
+        println!("Try '{} --help' for more information.", NAME);
         return 1;
     }
 

--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -1,5 +1,4 @@
 #![crate_name = "cat"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -15,49 +14,47 @@
 extern crate getopts;
 extern crate libc;
 
+use getopts::Options;
 use std::fs::File;
-use std::io::{stdout, stdin, stderr, Write, Read};
-use std::io::Result;
 use std::intrinsics::{copy_nonoverlapping};
+use std::io::{stdout, stdin, stderr, Write, Read, Result};
 use libc::consts::os::posix88::STDIN_FILENO;
 use libc::funcs::posix88::unistd::isatty;
 use libc::types::os::arch::c95::c_int;
 
+static NAME: &'static str = "cat";
+static VERSION: &'static str = "1.0.0";
+
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0];
-    let opts = [
-        getopts::optflag("A", "show-all", "equivalent to -vET"),
-        getopts::optflag("b", "number-nonblank",
-                         "number nonempty output lines, overrides -n"),
-        getopts::optflag("e", "", "equivalent to -vE"),
-        getopts::optflag("E", "show-ends", "display $ at end of each line"),
-        getopts::optflag("n", "number", "number all output lines"),
-        getopts::optflag("s", "squeeze-blank", "suppress repeated empty output lines"),
-        getopts::optflag("t", "", "equivalent to -vT"),
-        getopts::optflag("T", "show-tabs", "display TAB characters as ^I"),
-        getopts::optflag("v", "show-nonprinting",
-                         "use ^ and M- notation, except for LF (\\n) and TAB (\\t)"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = Options::new();
+    opts.optflag("A", "show-all", "equivalent to -vET");
+    opts.optflag("b", "number-nonblank",
+                 "number nonempty output lines, overrides -n");
+    opts.optflag("e", "", "equivalent to -vE");
+    opts.optflag("E", "show-ends", "display $ at end of each line");
+    opts.optflag("n", "number", "number all output lines");
+    opts.optflag("s", "squeeze-blank", "suppress repeated empty output lines");
+    opts.optflag("t", "", "equivalent to -vT");
+    opts.optflag("T", "show-tabs", "display TAB characters as ^I");
+    opts.optflag("v", "show-nonprinting",
+                 "use ^ and M- notation, except for LF (\\n) and TAB (\\t)");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!("Invalid options\n{}", f)
     };
     if matches.opt_present("help") {
-        println!("cat 1.0.0");
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION]... [FILE]...", program);
-        println!("");
-        print!("{}", &getopts::usage("Concatenate FILE(s), or standard input, to \
-                             standard output.", &opts)[..]);
-        println!("");
-        println!("With no FILE, or when FILE is -, read standard input.");
+        let msg = format!("{} {}\n\n\
+        Usage:\n  {0} [OPTION]... [FILE]...\n\n\
+        Concatenate FILE(s), or standard input, to standard output.\n\n\
+        With no FILE, or when FILE is -, read standard input.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
         return 0;
     }
     if matches.opt_present("version") {
-        println!("cat 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/cksum/cksum.rs
+++ b/src/cksum/cksum.rs
@@ -1,5 +1,4 @@
 #![crate_name = "cksum"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -12,10 +11,11 @@
 
 extern crate getopts;
 
-use std::io::{self, stdin, Read, Write, BufReader};
-use std::path::Path;
+use getopts::Options;
 use std::fs::File;
+use std::io::{self, stdin, Read, Write, BufReader};
 use std::mem;
+use std::path::Path;
 
 use crc_table::CRC_TABLE;
 
@@ -77,23 +77,24 @@ fn cksum(fname: &str) -> io::Result<(u32, usize)> {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(err) => panic!("{}", err),
     };
 
     if matches.opt_present("help") {
-        println!("{} {}", NAME, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {} [OPTIONS] [FILE]...", NAME);
-        println!("");
-        println!("{}", getopts::usage("Print CRC and size for each file.", opts.as_ref()));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTIONS] [FILE]...
+
+Print CRC and size for each file.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
         return 0;
     }
 

--- a/src/dirname/dirname.rs
+++ b/src/dirname/dirname.rs
@@ -1,5 +1,4 @@
 #![crate_name = "dirname"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -14,35 +13,36 @@ extern crate getopts;
 
 use std::path::Path;
 
+static NAME: &'static str = "dirname";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
-    let opts = [
-        getopts::optflag("z", "zero", "separate output with NUL rather than newline"),
-        getopts::optflag("", "help", "display this help and exit"),
-        getopts::optflag("", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
+    opts.optflag("z", "zero", "separate output with NUL rather than newline");
+    opts.optflag("", "help", "display this help and exit");
+    opts.optflag("", "version", "output version information and exit");
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!("Invalid options\n{}", f)
     };
 
     if matches.opt_present("help") {
-        println!("dirname {} - strip last component from file name", VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION] NAME...", program);
-        println!("");
-        print!("{}", getopts::usage("Output each NAME with its last non-slash component and trailing slashes
+        let msg = format!("{0} {1} - strip last component from file name
+
+Usage:
+  {0} [OPTION] NAME...
+
+Output each NAME with its last non-slash component and trailing slashes
 removed; if NAME contains no  /'s,  output  '.'  (meaning  the  current
-directory).", &opts));
+directory).", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
         return 0;
     }
 
     if matches.opt_present("version") {
-        println!("dirname version: {}", VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 
@@ -61,8 +61,8 @@ directory).", &opts));
             print!("{}", separator);
         }
     } else {
-        println!("{0}: missing operand", program);
-        println!("Try '{0} --help' for more information.", program);
+        println!("{0}: missing operand", NAME);
+        println!("Try '{0} --help' for more information.", NAME);
         return 1;
     }
 

--- a/src/echo/echo.rs
+++ b/src/echo/echo.rs
@@ -1,5 +1,4 @@
 #![crate_name = "echo"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -79,11 +78,10 @@ fn convert_str(string: &[u8], index: usize, base: u32) -> (char, usize) {
 
 fn parse_options(args: Vec<String>, options: &mut EchoOptions) -> Option<Vec<String>> {
     let mut echo_args = vec!();
-    let program = args[0].clone();
     'argloop: for arg in args.into_iter().skip(1) {
         match arg.as_ref() {
             "--help" | "-h" => {
-                print_help(&program);
+                print_help();
                 return None;
             }
             "--version" | "-V" => {
@@ -99,7 +97,7 @@ fn parse_options(args: Vec<String>, options: &mut EchoOptions) -> Option<Vec<Str
                     for ch in arg.chars().skip(1) {
                         match ch {
                             'h' => {
-                                print_help(&program);
+                                print_help();
                                 return None;
                             }
                             'V' => {
@@ -125,22 +123,22 @@ fn parse_options(args: Vec<String>, options: &mut EchoOptions) -> Option<Vec<Str
     Some(echo_args)
 }
 
-fn print_help(program: &String) {
-    let opts = [
-        getopts::optflag("n", "", "do not output the trailing newline"),
-        getopts::optflag("e", "", "enable interpretation of backslash escapes"),
-        getopts::optflag("E", "", "disable interpretation of backslash escapes (default)"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
-    println!("echo {} - display a line of text", VERSION);
-    println!("");
-    println!("Usage:");
-    println!("  {0} [SHORT-OPTION]... [STRING]...", *program);
-    println!("  {0} LONG-OPTION", *program);
-    println!("");
-    println!("{}", getopts::usage("Echo the STRING(s) to standard output.", &opts));
-    println!("{}", "If -e is in effect, the following sequences are recognized:
+fn print_help() {
+    let mut opts = getopts::Options::new();
+    opts.optflag("n", "", "do not output the trailing newline");
+    opts.optflag("e", "", "enable interpretation of backslash escapes");
+    opts.optflag("E", "", "disable interpretation of backslash escapes (default)");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let msg = format!("{0} {1} - display a line of text
+
+Usage:
+  {0} [SHORT-OPTION]... [STRING]...
+  {0} LONG-OPTION
+
+Echo the STRING(s) to standard output.
+If -e is in effect, the following sequences are recognized:
 
 \\\\      backslash
 \\a      alert (BEL)
@@ -153,11 +151,13 @@ fn print_help(program: &String) {
 \\t      horizontal tab
 \\v      vertical tab
 \\0NNN   byte with octal value NNN (1 to 3 digits)
-\\xHH    byte with hexadecimal value HH (1 to 2 digits)");
+\\xHH    byte with hexadecimal value HH (1 to 2 digits)", NAME, VERSION);
+
+    print!("{}", opts.usage(&msg));
 }
 
 fn print_version() {
-    println!("echo version: {}", VERSION);
+    println!("{} {}", NAME, VERSION);
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {

--- a/src/factor/factor.rs
+++ b/src/factor/factor.rs
@@ -1,5 +1,4 @@
 #![crate_name = "factor"]
-#![feature(rustc_private)]
 
 /*
 * This file is part of the uutils coreutils package.
@@ -20,12 +19,12 @@ extern crate rand;
 
 use numeric::*;
 use prime_table::P_INVS_U64;
+use rand::weak_rng;
+use rand::distributions::{Range, IndependentSample};
 use std::cmp::{max, min};
 use std::io::{stdin, BufRead, BufReader, Write};
 use std::num::Wrapping;
 use std::mem::swap;
-use rand::weak_rng;
-use rand::distributions::{Range, IndependentSample};
 
 #[path="../common/util.rs"]
 #[macro_use]
@@ -33,8 +32,8 @@ mod util;
 mod numeric;
 mod prime_table;
 
-static VERSION: &'static str = "1.0.0";
 static NAME: &'static str = "factor";
+static VERSION: &'static str = "1.0.0";
 
 fn rho_pollard_pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
     if num < 1 << 63 {
@@ -157,33 +156,31 @@ fn print_factors_str(num_str: &str) {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "show this help message"),
-        getopts::optflag("v", "version", "print the version and exit"),
-    ];
+    let mut opts = getopts::Options::new();
+    opts.optflag("h", "help", "show this help message");
+    opts.optflag("v", "version", "print the version and exit");
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "Invalid options\n{}", f)
     };
 
     if matches.opt_present("help") {
-        print!("{program} {version}\n\
-                \n\
-                Usage:\n\
-                \t{program} [NUMBER]...\n\
-                \t{program} [OPTION]\n\
-                \n\
-                {usage}",
-                program = &args[0][..],
-                version = VERSION, 
-                usage = getopts::usage("Print the prime factors of the given number(s). \
-                                        If none are specified, read from standard input.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+\t{0} [NUMBER]...
+\t{0} [OPTION]
+
+Print the prime factors of the given number(s). If none are specified,
+read from standard input.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
         return 1;
     }
 
     if matches.opt_present("version") {
-        println!("{} {}", &args[0][..], VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/groups/groups.rs
+++ b/src/groups/groups.rs
@@ -1,5 +1,4 @@
 #![crate_name = "groups"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -13,7 +12,6 @@
 extern crate getopts;
 
 use c_types::{get_pw_from_args, group};
-use getopts::{getopts, optflag, usage};
 use std::io::Write;
 
 #[path = "../common/util.rs"] #[macro_use]  mod util;
@@ -23,14 +21,11 @@ static NAME: &'static str = "groups";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
+    let mut opts = getopts::Options::new();
+    opts.optflag("h", "help", "display this help menu and exit");
+    opts.optflag("V", "version", "display version information and exit");
 
-    let options = [
-        optflag("h", "help", "display this help menu and exit"),
-        optflag("V", "version", "display version information and exit")
-    ];
-
-    let matches = match getopts(&args[1..], &options) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => { m },
         Err(f) => {
             show_error!("{}", f);
@@ -41,10 +36,14 @@ pub fn uumain(args: Vec<String>) -> i32 {
     if matches.opt_present("version") {
         println!("{} v{}", NAME, VERSION);
     } else if matches.opt_present("help") {
-        print!("{} v{}\n\n\
-                Usage:\n  \
-                  {} [OPTION]... [USER]...\n\n\
-                {}", NAME, VERSION, program, usage("Prints the groups a user is in to standard output.", &options));
+        let msg = format!("{0} v{1}
+
+Usage:
+  {0} [OPTION]... [USER]...
+
+Prints the groups a user is in to standard output.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
     } else {
         group(get_pw_from_args(&matches.free), true);
     }

--- a/src/hostid/hostid.rs
+++ b/src/hostid/hostid.rs
@@ -1,5 +1,4 @@
 #![crate_name = "hostid"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -11,20 +10,16 @@
  */
 
 extern crate getopts;
-extern crate serialize;
 extern crate libc;
-#[macro_use] extern crate log;
 
-use getopts::{getopts, optflag, usage};
-use libc::{c_long};
-use std::io::Write;
+use libc::c_long;
 
 #[path = "../common/util.rs"]
 #[macro_use]
 mod util;
 
-static NAME:     &'static str = "hostid";
-static VERSION:  &'static str = "0.0.1";
+static NAME: &'static str = "hostid";
+static VERSION: &'static str = "0.0.1";
 
 static EXIT_ERR: i32 = 1;
 
@@ -34,23 +29,20 @@ pub enum Mode {
     Version,
 }
 
-//currently rust libc interface doesn't include gethostid
+// currently rust libc interface doesn't include gethostid
 extern {
     pub fn gethostid() -> c_long;
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        optflag("", "help", "display this help and exit"),
-        optflag("", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
+    opts.optflag("", "help", "display this help and exit");
+    opts.optflag("", "version", "output version information and exit");
 
-    let usage = usage("[options]", &opts);
-
-    let matches = match getopts(&args[1..], &opts) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(e) => {
-            show_error!("{}\n{}", e,  get_help_text(NAME, usage.as_ref()));
+        Err(_) => {
+            help(&opts);
             return EXIT_ERR;
         },
     };
@@ -65,7 +57,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     match mode {
         Mode::HostId  => hostid(),
-        Mode::Help    => help(NAME, usage.as_ref()),
+        Mode::Help    => help(&opts),
         Mode::Version => version(),
     }
 
@@ -76,12 +68,9 @@ fn version() {
     println!("{} {}", NAME, VERSION);
 }
 
-fn get_help_text(progname: &str, usage: &str) -> String {
-    format!("Usage: \n {0} {1}", progname, usage)
-}
-
-fn help(progname: &str, usage: &str) {
-    println!("{}", get_help_text(progname, usage));
+fn help(opts: &getopts::Options) {
+    let msg = format!("Usage:\n {} [options]", NAME);
+    print!("{}", opts.usage(&msg));
 }
 
 fn hostid() {

--- a/src/link/link.rs
+++ b/src/link/link.rs
@@ -1,5 +1,4 @@
 #![crate_name = "link"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -12,24 +11,24 @@
 
 extern crate getopts;
 
-use std::io::Write;
 use std::fs::hard_link;
+use std::io::Write;
 use std::path::Path;
 
 #[path="../common/util.rs"]
 #[macro_use]
 mod util;
 
-static NAME : &'static str = "link";
-static VERSION : &'static str = "1.0.0";
+static NAME: &'static str = "link";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(err) => panic!("{}", err),
     };
@@ -40,12 +39,14 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("help") || matches.free.len() != 2 {
-        println!("{} {}", NAME, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {} [OPTIONS] FILE1 FILE2", NAME);
-        println!("");
-        print!("{}", getopts::usage("Create a link named FILE2 to FILE1.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTIONS] FILE1 FILE2
+  
+Create a link named FILE2 to FILE1.", NAME, VERSION);
+
+        println!("{}", opts.usage(&msg));
         if matches.free.len() != 2 {
             return 1;
         }

--- a/src/logname/logname.rs
+++ b/src/logname/logname.rs
@@ -1,5 +1,4 @@
 #![crate_name = "logname"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -39,37 +38,33 @@ fn get_userlogin() -> Option<String> {
 static NAME: &'static str = "logname";
 static VERSION: &'static str = "1.0.0";
 
-fn version() {
-    println!("{} {}", NAME, VERSION);
-}
-
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
-
     //
     // Argument parsing
     //
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "Invalid options\n{}", f)
     };
 
     if matches.opt_present("help") {
-        version();
-        println!("");
-        println!("Usage:");
-        println!("  {}", program);
-        println!("");
-        print!("{}", getopts::usage("print user's login name", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0}
+
+Print user's login name.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
         return 0;
     }
     if matches.opt_present("version") {
-        version();
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/mkfifo/mkfifo.rs
+++ b/src/mkfifo/mkfifo.rs
@@ -1,5 +1,4 @@
 #![crate_name = "mkfifo"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -13,25 +12,25 @@
 extern crate getopts;
 extern crate libc;
 
+use libc::funcs::posix88::stat_::mkfifo;
 use std::ffi::CString;
 use std::io::{Error, Write};
-use libc::funcs::posix88::stat_::mkfifo;
 
 #[path = "../common/util.rs"]
 #[macro_use]
 mod util;
 
-static NAME : &'static str = "mkfifo";
-static VERSION : &'static str = "1.0.0";
+static NAME: &'static str = "mkfifo";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optopt("m", "mode", "file permissions for the fifo", "(default 0666)"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optopt("m", "mode", "file permissions for the fifo", "(default 0666)");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(err) => panic!("{}", err),
     };
@@ -42,12 +41,14 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("help") || matches.free.is_empty() {
-        println!("{} {}", NAME, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {} [OPTIONS] NAME...", NAME);
-        println!("");
-        print!("{}", getopts::usage("Create a FIFO with the given name.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTIONS] NAME...
+
+Create a FIFO with the given name.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
         if matches.free.is_empty() {
             return 1;
         }

--- a/src/nice/nice.rs
+++ b/src/nice/nice.rs
@@ -1,5 +1,4 @@
 #![crate_name = "nice"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -13,9 +12,9 @@
 extern crate getopts;
 extern crate libc;
 
+use libc::{c_char, c_int, execvp};
 use std::ffi::CString;
 use std::io::{Error, Write};
-use libc::{c_char, c_int, execvp};
 
 const NAME: &'static str = "nice";
 const VERSION: &'static str = "1.0.0";
@@ -33,13 +32,13 @@ extern {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optopt("n", "adjustment", "add N to the niceness (default is 10)", "N"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optopt("n", "adjustment", "add N to the niceness (default is 10)", "N");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(err) => {
             show_error!("{}", err);
@@ -47,66 +46,67 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     };
 
-    if matches.opt_present("version") || matches.opt_present("help") {
+    if matches.opt_present("version") {
         println!("{} v{}", NAME, VERSION);
-        if matches.opt_present("help") {
-            let usage = getopts::usage("Run COMMAND with an adjusted niceness, \
-                                        which affects process scheduling.\n\
-                                        With no COMMAND, print the current \
-                                        niceness.  Niceness values range from \
-                                        at\nleast -20 (most favorable to the \
-                                        process) to 19 (least favorable to the\
-                                        \nprocess).", &opts);
-            println!("");
-            println!("Usage:");
-            println!("  {} [OPTIONS] [COMMAND [ARGS]]", NAME);
-            println!("");
-            print!("{}", usage);
-        }
-        0
-    } else {
-        let mut niceness = unsafe { getpriority(PRIO_PROCESS, 0) };
-        if Error::last_os_error().raw_os_error().unwrap() != 0 {
-            show_error!("{}", Error::last_os_error());
-            return 125;
-        }
+        return 0;
+    }
 
-        let adjustment = match matches.opt_str("adjustment") {
-            Some(nstr) => {
-                if matches.free.len() == 0 {
-                    show_error!("A command must be given with an adjustment.
-                                 Try \"{} --help\" for more information.", args[0]);
+    if matches.opt_present("help") {
+        let msg = format!("{0} v{1}
+
+Usage:
+  {0} [OPTIONS] [COMMAND [ARGS]]
+
+Run COMMAND with an adjusted niceness, which affects process scheduling.
+With no COMMAND, print the current niceness.  Niceness values range from at
+least -20 (most favorable to the process) to 19 (least favorable to the
+process).", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
+        return 0;
+    }
+
+    let mut niceness = unsafe { getpriority(PRIO_PROCESS, 0) };
+    if Error::last_os_error().raw_os_error().unwrap() != 0 {
+        show_error!("{}", Error::last_os_error());
+        return 125;
+    }
+
+    let adjustment = match matches.opt_str("adjustment") {
+        Some(nstr) => {
+            if matches.free.len() == 0 {
+                show_error!("A command must be given with an adjustment.
+                                Try \"{} --help\" for more information.", args[0]);
+                return 125;
+            }
+            match nstr.parse() {
+                Ok(num) => num,
+                Err(e)=> {
+                    show_error!("\"{}\" is not a valid number: {}", nstr, e);
                     return 125;
                 }
-                match nstr.parse() {
-                    Ok(num) => num,
-                    Err(e)=> {
-                        show_error!("\"{}\" is not a valid number: {}", nstr, e);
-                        return 125;
-                    }
-                }
-            },
-            None => {
-                if matches.free.len() == 0 {
-                    println!("{}", niceness);
-                    return 0;
-                }
-                10 as c_int
             }
-        };
-
-        niceness += adjustment;
-        unsafe { setpriority(PRIO_PROCESS, 0, niceness); }
-        if Error::last_os_error().raw_os_error().unwrap() != 0 {
-            show_warning!("{}", Error::last_os_error());
+        },
+        None => {
+            if matches.free.len() == 0 {
+                println!("{}", niceness);
+                return 0;
+            }
+            10 as c_int
         }
+    };
 
-        let cstrs: Vec<CString> = matches.free.iter().map(|x| CString::new(x.as_bytes()).unwrap()).collect();
-        let mut args: Vec<*const c_char> = cstrs.iter().map(|s| s.as_ptr()).collect();
-        args.push(0 as *const c_char);
-        unsafe { execvp(args[0], args.as_mut_ptr()); }
-
-        show_error!("{}", Error::last_os_error());
-        if Error::last_os_error().raw_os_error().unwrap() as c_int == libc::ENOENT { 127 } else { 126 }
+    niceness += adjustment;
+    unsafe { setpriority(PRIO_PROCESS, 0, niceness); }
+    if Error::last_os_error().raw_os_error().unwrap() != 0 {
+        show_warning!("{}", Error::last_os_error());
     }
+
+    let cstrs: Vec<CString> = matches.free.iter().map(|x| CString::new(x.as_bytes()).unwrap()).collect();
+    let mut args: Vec<*const c_char> = cstrs.iter().map(|s| s.as_ptr()).collect();
+    args.push(0 as *const c_char);
+    unsafe { execvp(args[0], args.as_mut_ptr()); }
+
+    show_error!("{}", Error::last_os_error());
+    if Error::last_os_error().raw_os_error().unwrap() as c_int == libc::ENOENT { 127 } else { 126 }
 }

--- a/src/nl/nl.rs
+++ b/src/nl/nl.rs
@@ -14,11 +14,11 @@
 extern crate getopts;
 extern crate regex;
 
+use getopts::{getopts, optflag, OptGroup, optopt, usage};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, stdin, Write};
 use std::iter::repeat;
 use std::path::Path;
-use getopts::{getopts, optflag, OptGroup, optopt, usage};
 
 #[path="../common/util.rs"]
 #[macro_use]

--- a/src/nproc/nproc.rs
+++ b/src/nproc/nproc.rs
@@ -1,5 +1,4 @@
 #![crate_name = "nproc"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -24,14 +23,14 @@ static VERSION : &'static str = "0.0.0";
 mod util;
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("", "all", "print the number of cores available to the system"),
-        getopts::optopt("", "ignore", "ignore up to N cores", "N"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("", "all", "print the number of cores available to the system");
+    opts.optopt("", "ignore", "ignore up to N cores", "N");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(err) => {
             show_error!("{}", err);
@@ -45,12 +44,14 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("help") {
-        println!("{} {}", NAME, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {} [OPTIONS]...", NAME);
-        println!("");
-        print!("{}", getopts::usage("Print the number of cores available to the current process.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTIONS]...
+
+Print the number of cores available to the current process.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
         return 0;
     }
 

--- a/src/od/od.rs
+++ b/src/od/od.rs
@@ -1,5 +1,4 @@
 #![crate_name = "od"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -21,28 +20,28 @@ use std::path::Path;
 enum Radix { Decimal, Hexadecimal, Octal, Binary }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optopt("A", "address-radix",
-                        "Select the base in which file offsets are printed.", "RADIX"),
-        getopts::optopt("j", "skip-bytes",
-                        "Skip bytes input bytes before formatting and writing.", "BYTES"),
-        getopts::optopt("N", "read-bytes",
-                        "limit dump to BYTES input bytes", "BYTES"),
-        getopts::optopt("S", "strings",
-                        ("output strings of at least BYTES graphic chars. 3 is assumed when \
-                          BYTES is not specified."),
-                        "BYTES"),
-        getopts::optopt("t", "format", "select output format or formats", "TYPE"),
-        getopts::optflag("v", "output-duplicates", "do not use * to mark line suppression"),
-        getopts::optopt("w", "width",
-                        ("output BYTES bytes per output line. 32 is implied when BYTES is not \
-                          specified."),
-                        "BYTES"),
-        getopts::optflag("h", "help", "display this help and exit."),
-        getopts::optflag("", "version", "output version information and exit."),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optopt("A", "address-radix",
+                "Select the base in which file offsets are printed.", "RADIX");
+    opts.optopt("j", "skip-bytes",
+                "Skip bytes input bytes before formatting and writing.", "BYTES");
+    opts.optopt("N", "read-bytes",
+                "limit dump to BYTES input bytes", "BYTES");
+    opts.optopt("S", "strings",
+                ("output strings of at least BYTES graphic chars. 3 is assumed when \
+                 BYTES is not specified."),
+                "BYTES");
+    opts.optopt("t", "format", "select output format or formats", "TYPE");
+    opts.optflag("v", "output-duplicates", "do not use * to mark line suppression");
+    opts.optopt("w", "width",
+                ("output BYTES bytes per output line. 32 is implied when BYTES is not \
+                 specified."),
+                "BYTES");
+    opts.optflag("h", "help", "display this help and exit.");
+    opts.optflag("", "version", "output version information and exit.");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!("Invalid options\n{}", f)
     };

--- a/src/paste/paste.rs
+++ b/src/paste/paste.rs
@@ -1,5 +1,4 @@
 #![crate_name = "paste"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -26,25 +25,27 @@ static NAME: &'static str = "paste";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0];
+    let mut opts = getopts::Options::new();
 
-    let opts = [
-        getopts::optflag("s", "serial", "paste one file at a time instead of in parallel"),
-        getopts::optopt("d", "delimiters", "reuse characters from LIST instead of TABs", "LIST"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("s", "serial", "paste one file at a time instead of in parallel");
+    opts.optopt("d", "delimiters", "reuse characters from LIST instead of TABs", "LIST");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(e) => crash!(1, "{}", e)
     };
+
     if matches.opt_present("help") {
-        println!("{} {}", NAME, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION]... [FILE]...", program);
-        println!("");
-        print!("{}", getopts::usage("Write lines consisting of the sequentially corresponding lines from each FILE, separated by TABs, to standard output.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTION]... [FILE]...
+
+Write lines consisting of the sequentially corresponding lines from each
+FILE, separated by TABs, to standard output.", NAME, VERSION);
+        print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
         println!("{} {}", NAME, VERSION);
     } else {

--- a/src/printenv/printenv.rs
+++ b/src/printenv/printenv.rs
@@ -1,5 +1,4 @@
 #![crate_name = "printenv"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -23,31 +22,31 @@ use std::io::Write;
 mod util;
 
 static NAME: &'static str = "printenv";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
-    let opts = [
-        getopts::optflag("0", "null", "end each output line with 0 byte rather than newline"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = getopts::Options::new();
+    opts.optflag("0", "null", "end each output line with 0 byte rather than newline");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             crash!(1, "Invalid options\n{}", f)
         }
     };
     if matches.opt_present("help") {
-        println!("printenv 1.0.0");
-        println!("");
-        println!("Usage:");
-        println!("  {0} [VARIABLE]... [OPTION]...", program);
-        println!("");
-        print!("{}", getopts::usage("Prints the given environment VARIABLE(s), otherwise prints them all.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [VARIABLE]... [OPTION]...
+
+Prints the given environment VARIABLE(s), otherwise prints them all.", NAME, VERSION);
+        print!("{}", opts.usage(&msg)); 
         return 0;
     }
     if matches.opt_present("version") {
-        println!("printenv 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
     let mut separator = "\n";

--- a/src/pwd/pwd.rs
+++ b/src/pwd/pwd.rs
@@ -1,5 +1,4 @@
 #![crate_name = "pwd"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -24,13 +23,12 @@ static NAME: &'static str = "pwd";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
-    let opts = [
-        getopts::optflag("", "help", "display this help and exit"),
-        getopts::optflag("", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("", "help", "display this help and exit");
+    opts.optflag("", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             crash!(1, "Invalid options\n{}", f)
@@ -38,14 +36,15 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("help") {
-        println!("pwd {}", VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION]...", program);
-        println!("");
-        print!("{}", getopts::usage("Print the full filename of the current working directory.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTION]...
+
+Print the full filename of the current working directory.", NAME, VERSION);
+        print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
-        println!("pwd version: {}", VERSION);
+        println!("{} version: {}", NAME, VERSION);
     } else {
         println!("{}", env::current_dir().unwrap().display());
     }

--- a/src/rmdir/rmdir.rs
+++ b/src/rmdir/rmdir.rs
@@ -1,5 +1,4 @@
 #![crate_name = "rmdir"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -13,27 +12,27 @@
 extern crate getopts;
 extern crate libc;
 
-use std::path::Path;
-use std::io::Write;
 use std::fs;
+use std::io::Write;
+use std::path::Path;
 
 #[path = "../common/util.rs"]
 #[macro_use]
 mod util;
 
 static NAME: &'static str = "rmdir";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
+    let mut opts = getopts::Options::new();
 
-    let opts = [
-        getopts::optflag("", "ignore-fail-on-non-empty", "ignore each failure that is solely because a directory is non-empty"),
-        getopts::optflag("p", "parents", "remove DIRECTORY and its ancestors; e.g., 'rmdir -p a/b/c' is similar to rmdir a/b/c a/b a"),
-        getopts::optflag("v", "verbose", "output a diagnostic for every directory processed"),
-        getopts::optflag("h", "help", "print this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("", "ignore-fail-on-non-empty", "ignore each failure that is solely because a directory is non-empty");
+    opts.optflag("p", "parents", "remove DIRECTORY and its ancestors; e.g., 'rmdir -p a/b/c' is similar to rmdir a/b/c a/b a");
+    opts.optflag("v", "verbose", "output a diagnostic for every directory processed");
+    opts.optflag("h", "help", "print this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             show_error!("{}", f);
@@ -42,17 +41,18 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("help") {
-        println!("rmdir 1.0.0");
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION]... DIRECTORY...", program);
-        println!("");
-        println!("{}", &getopts::usage("Remove the DIRECTORY(ies), if they are empty.", &opts)[..]);
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTION]... DIRECTORY...
+
+Remove the DIRECTORY(ies), if they are empty.", NAME, VERSION);
+        print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
-        println!("rmdir 1.0.0");
+        println!("{} {}", NAME, VERSION);
     } else if matches.free.is_empty() {
         show_error!("missing an argument");
-        show_error!("for help, try '{0} --help'", program);
+        show_error!("for help, try '{0} --help'", NAME);
         return 1;
     } else {
         let ignore = matches.opt_present("ignore-fail-on-non-empty");

--- a/src/shuf/shuf.rs
+++ b/src/shuf/shuf.rs
@@ -1,5 +1,4 @@
 #![crate_name = "shuf"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -14,8 +13,8 @@ extern crate getopts;
 extern crate libc;
 extern crate rand;
 
-use rand::read::ReadRng;
 use rand::{Rng, ThreadRng};
+use rand::read::ReadRng;
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use std::usize::MAX as MAX_USIZE;
@@ -34,34 +33,33 @@ static NAME: &'static str = "shuf";
 static VERSION: &'static str = "0.0.1";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("e", "echo", "treat each ARG as an input line"),
-        getopts::optopt("i", "input-range", "treat each number LO through HI as an input line", "LO-HI"),
-        getopts::optopt("n", "head-count", "output at most COUNT lines", "COUNT"),
-        getopts::optopt("o", "output", "write result to FILE instead of standard output", "FILE"),
-        getopts::optopt("", "random-source", "get random bytes from FILE", "FILE"),
-        getopts::optflag("r", "repeat", "output lines can be repeated"),
-        getopts::optflag("z", "zero-terminated", "end lines with 0 byte, not newline"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
-    let mut matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = getopts::Options::new();
+    opts.optflag("e", "echo", "treat each ARG as an input line");
+    opts.optopt("i", "input-range", "treat each number LO through HI as an input line", "LO-HI");
+    opts.optopt("n", "head-count", "output at most COUNT lines", "COUNT");
+    opts.optopt("o", "output", "write result to FILE instead of standard output", "FILE");
+    opts.optopt("", "random-source", "get random bytes from FILE", "FILE");
+    opts.optflag("r", "repeat", "output lines can be repeated");
+    opts.optflag("z", "zero-terminated", "end lines with 0 byte, not newline");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+    let mut matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             crash!(1, "{}", f)
         }
     };
     if matches.opt_present("help") {
-        println!("{name} v{version}
+        let msg = format!("{0} v{1}
 
 Usage:
-  {prog} [OPTION]... [FILE]
-  {prog} -e [OPTION]... [ARG]...
-  {prog} -i LO-HI [OPTION]...\n
-{usage}
-With no FILE, or when FILE is -, read standard input.",
-                 name = NAME, version = VERSION, prog = &args[0][..],
-                 usage = getopts::usage("Write a random permutation of the input lines to standard output.", &opts));
+  {0} [OPTION]... [FILE]
+  {0} -e [OPTION]... [ARG]...
+  {0} -i LO-HI [OPTION]...
+
+Write a random permutation of the input lines to standard output.
+With no FILE, or when FILE is -, read standard input.", NAME, VERSION);
+        print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
         println!("{} v{}", NAME, VERSION);
     } else {

--- a/src/sleep/sleep.rs
+++ b/src/sleep/sleep.rs
@@ -1,5 +1,4 @@
 #![crate_name = "sleep"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -25,13 +24,13 @@ mod util;
 mod time;
 
 static NAME: &'static str = "sleep";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = getopts::Options::new();
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             show_error!("{}", f);
@@ -40,23 +39,24 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("help") {
-        println!("sleep 1.0.0");
-        println!("");
-        println!("Usage:");
-        println!("  {0} NUMBER[SUFFIX]", &args[0][..]);
-        println!("or");
-        println!("  {0} OPTION", &args[0][..]);
-        println!("");
-        println!("{}", getopts::usage("Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} NUMBER[SUFFIX]
+or
+  {0} OPTION
+
+Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
 'm' for minutes, 'h' for hours or 'd' for days.  Unlike most implementations
 that require NUMBER be an integer, here NUMBER may be an arbitrary floating
 point number.  Given two or more arguments, pause for the amount of time
-specified by the sum of their values.", &opts));
+specified by the sum of their values.", NAME, VERSION);
+        print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
-        println!("sleep 1.0.0");
+        println!("{} {}", NAME, VERSION);
     } else if matches.free.is_empty() {
         show_error!("missing an argument");
-        show_error!("for help, try '{0} --help'", &args[0][..]);
+        show_error!("for help, try '{0} --help'", NAME);
         return 1;
     } else {
         sleep(matches.free);
@@ -79,5 +79,3 @@ fn sleep(args: Vec<String>) {
     };
     sleep_ms(sleep_dur);
 }
-
-

--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -1,5 +1,4 @@
 #![crate_name = "sort"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -29,35 +28,40 @@ use std::str::Chars;
 mod util;
 
 static NAME: &'static str = "sort";
-static VERSION:  &'static str = "0.0.1";
+static VERSION: &'static str = "0.0.1";
 
 static DECIMAL_PT: char = '.';
 static THOUSANDS_SEP: char = ',';
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("n", "numeric-sort", "compare according to string numerical value"),
-        getopts::optflag("r", "reverse", "reverse the output"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("n", "numeric-sort", "compare according to string numerical value");
+    opts.optflag("r", "reverse", "reverse the output");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "Invalid options\n{}", f)
     };
     if matches.opt_present("help") {
-        println!("Usage: {0} [OPTION]... [FILE]...", args[0]);
-        println!("Write the sorted concatenation of all FILE(s) to standard output.");
-        println!("");
-        print!("{}", getopts::usage("Mandatory arguments for long options are mandatory for short options too.", &opts));
-        println!("");
-        println!("With no FILE, or when FILE is -, read standard input.");
+        let msg = format!("{0} {1}
+
+Usage:
+ {0} [OPTION]... [FILE]...
+
+Write the sorted concatenation of all FILE(s) to standard output.
+
+Mandatory arguments for long options are mandatory for short options too.
+
+With no FILE, or when FILE is -, read standard input.", NAME, VERSION);
+        print!("{}", opts.usage(&msg));
         return 0;
     }
 
     if matches.opt_present("version") {
-        println!("sort 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 
@@ -172,4 +176,3 @@ fn open<'a>(path: &str) -> Option<(Box<Read + 'a>, bool)> {
         },
     }
 }
-

--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -1,5 +1,4 @@
 #![crate_name = "uutils"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -9,8 +8,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
-extern crate getopts;
 
 @CRATES@
 
@@ -54,7 +51,6 @@ fn main() {
     match umap.get(binary_as_util) {
         Some(&uumain) => {
             std::process::exit(uumain(args));
-            return
         }
         None => (),
     }
@@ -67,7 +63,6 @@ fn main() {
     } else {
         println!("{}: applet not found", binary_as_util);
         std::process::exit(1);
-        return
     }
 
     // try first arg as util name.
@@ -78,7 +73,6 @@ fn main() {
         match umap.get(util) {
             Some(&uumain) => {
                 std::process::exit(uumain(args.clone()));
-                return
             }
             None => {
                 if &args[0][..] == "--help" {
@@ -88,22 +82,18 @@ fn main() {
                         match umap.get(util) {
                             Some(&uumain) => {
                                 std::process::exit(uumain(vec![util.to_string(), "--help".to_string()]));
-                                return
                             }
                             None => {
                                 println!("{}: applet not found", util);
                                 std::process::exit(1);
-                                return
                             }
                         }
                     }
                     usage(&umap);
                     std::process::exit(0);
-                    return
                 } else {
                     println!("{}: applet not found", util);
                     std::process::exit(1);
-                    return
                 }
             }
         }
@@ -111,6 +101,5 @@ fn main() {
         // no arguments provided
         usage(&umap);
         std::process::exit(0);
-        return
     }
 }


### PR DESCRIPTION
I switched over to the getopts crate on crates.io, instead of Rust's private implementation. This will allow coreutils to build for Rust 1.0.

I'm splitting the updates into several commits for easier reviewing.