### PR TITLE
Switch to external getopts cargo (part 2).

### DIFF
--- a/src/split/split.rs
+++ b/src/split/split.rs
@@ -1,5 +1,4 @@
 #![crate_name = "split"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -26,31 +25,33 @@ static NAME: &'static str = "split";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optopt("a", "suffix-length", "use suffixes of length N (default 2)", "N"),
-        getopts::optopt("b", "bytes", "put SIZE bytes per output file", "SIZE"),
-        getopts::optopt("C", "line-bytes", "put at most SIZE bytes of lines per output file", "SIZE"),
-        getopts::optflag("d", "numeric-suffixes", "use numeric suffixes instead of alphabetic"),
-        getopts::optopt("l", "lines", "put NUMBER lines per output file", "NUMBER"),
-        getopts::optflag("", "verbose", "print a diagnostic just before each output file is opened"),
-        getopts::optflag("h", "help", "display help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optopt("a", "suffix-length", "use suffixes of length N (default 2)", "N");
+    opts.optopt("b", "bytes", "put SIZE bytes per output file", "SIZE");
+    opts.optopt("C", "line-bytes", "put at most SIZE bytes of lines per output file", "SIZE");
+    opts.optflag("d", "numeric-suffixes", "use numeric suffixes instead of alphabetic");
+    opts.optopt("l", "lines", "put NUMBER lines per output file", "NUMBER");
+    opts.optflag("", "verbose", "print a diagnostic just before each output file is opened");
+    opts.optflag("h", "help", "display help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f)
     };
 
     if matches.opt_present("h") {
-        println!("{} v{}", NAME, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION]... [INPUT [PREFIX]]", NAME);
-        println!("");
-        print!("{}", getopts::usage("Output fixed-size pieces of INPUT to PREFIXaa, PREFIX ab, ...; default size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is -, read standard input." , &opts));
-        println!("");
-        println!("SIZE may have a multiplier suffix: b for 512, k for 1K, m for 1 Meg.");
+        let msg = format!("{0} v{1}
+
+Usage:
+  {0} [OPTION]... [INPUT [PREFIX]]
+
+Output fixed-size pieces of INPUT to PREFIXaa, PREFIX ab, ...; default
+size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is
+-, read standard input.", NAME, VERSION);
+
+        println!("{}\nSIZE may have a multiplier suffix: b for 512, k for 1K, m for 1 Meg.", opts.usage(&msg));
         return 0;
     }
 

--- a/src/sum/sum.rs
+++ b/src/sum/sum.rs
@@ -1,5 +1,4 @@
 #![crate_name = "sum"]
-#![feature(rustc_private)]
 
 /*
 * This file is part of the uutils coreutils package.
@@ -21,8 +20,8 @@ use std::path::Path;
 #[macro_use]
 mod util;
 
-static VERSION: &'static str = "1.0.0";
 static NAME: &'static str = "sum";
+static VERSION: &'static str = "1.0.0";
 
 fn bsd_sum(mut reader: Box<Read>) -> (usize, u16) {
     let mut buf = [0; 1024];
@@ -78,32 +77,30 @@ fn open(name: &str) -> Result<Box<Read>> {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0];
-    let opts = [
-        getopts::optflag("r", "", "use the BSD compatible algorithm (default)"),
-        getopts::optflag("s", "sysv", "use System V compatible algorithm"),
-        getopts::optflag("h", "help", "show this help message"),
-        getopts::optflag("v", "version", "print the version and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("r", "", "use the BSD compatible algorithm (default)");
+    opts.optflag("s", "sysv", "use System V compatible algorithm");
+    opts.optflag("h", "help", "show this help message");
+    opts.optflag("v", "version", "print the version and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "Invalid options\n{}", f)
     };
 
     if matches.opt_present("help") {
-        println!("{} {}", program, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION]... [FILE]...", program);
-        println!("");
-        print!("{}", getopts::usage("checksum and count the blocks in a file", &opts));
-        println!("");
-        println!("With no FILE, or when  FILE is -, read standard input.");
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTION]... [FILE]...
+
+Checksum and count the blocks in a file.", NAME, VERSION);
+        println!("{}\nWith no FILE, or when  FILE is -, read standard input.", opts.usage(&msg));
         return 0;
     }
     if matches.opt_present("version") {
-        println!("{} {}", program, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/sync/sync.rs
+++ b/src/sync/sync.rs
@@ -1,5 +1,4 @@
 #![crate_name = "sync"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -14,8 +13,6 @@
 
 extern crate getopts;
 extern crate libc;
-
-use getopts::{optflag, getopts, usage};
 
 #[path = "../common/util.rs"] #[macro_use] mod util;
 
@@ -141,20 +138,18 @@ mod platform {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0][..];
+    let mut opts = getopts::Options::new();
 
-    let options = [
-        optflag("h", "help", "display this help and exit"),
-        optflag("V", "version", "output version information and exit")
-    ];
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
 
-    let matches = match getopts(&args[1..], &options) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => { m }
-        _ => { help(program, &options); return 1 }
+        _ => { help(&opts); return 1 }
     };
 
     if matches.opt_present("h") {
-        help(program, &options);
+        help(&opts);
         return 0
     }
 
@@ -174,9 +169,15 @@ fn version() {
     println!("Author -- Alexander Fomin.");
 }
 
-fn help(program: &str, options: &[getopts::OptGroup]) {
-    println!("Usage: {} [OPTION]", program);
-    print!("{}", usage("Force changed blocks to disk, update the super block.", options));
+fn help(opts: &getopts::Options) {
+    let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTION]
+
+Force changed blocks to disk, update the super block.", NAME, VERSION);
+
+    print!("{}", opts.usage(&msg));
 }
 
 fn sync() -> isize {

--- a/src/tac/tac.rs
+++ b/src/tac/tac.rs
@@ -1,5 +1,4 @@
 #![crate_name = "tac"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -14,7 +13,7 @@ extern crate getopts;
 extern crate libc;
 
 use std::fs::File;
-use std::io::{stdin, stdout, BufReader, Read, Stdout, Write};
+use std::io::{BufReader, Read, stdin, stdout, Stdout, Write};
 
 #[path = "../common/util.rs"]
 #[macro_use]
@@ -24,26 +23,29 @@ static NAME: &'static str = "tac";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("b", "before", "attach the separator before instead of after"),
-        getopts::optflag("r", "regex", "interpret the sequence as a regular expression (NOT IMPLEMENTED)"),
-        getopts::optopt("s", "separator", "use STRING as the separator instead of newline", "STRING"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = getopts::Options::new();
+
+    opts.optflag("b", "before", "attach the separator before instead of after");
+    opts.optflag("r", "regex", "interpret the sequence as a regular expression (NOT IMPLEMENTED)");
+    opts.optopt("s", "separator", "use STRING as the separator instead of newline", "STRING");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f)
     };
     if matches.opt_present("help") {
-        println!("tac {}", VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {0} [OPTION]... [FILE]...", &args[0][..]);
-        println!("");
-        print!("{}", getopts::usage("Write each file to standard output, last line first.", &opts));
+        let msg = format!("{0} {1}
+
+Usage:
+  {0} [OPTION]... [FILE]...
+
+Write each file to standard output, last line first.", NAME, VERSION);
+
+        print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
-        println!("tac {}", VERSION);
+        println!("{} {}", NAME, VERSION);
     } else {
         let before = matches.opt_present("b");
         let regex = matches.opt_present("r");

--- a/src/truncate/truncate.rs
+++ b/src/truncate/truncate.rs
@@ -1,5 +1,4 @@
 #![crate_name = "truncate"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -34,32 +33,30 @@ enum TruncateMode {
 }
 
 static NAME: &'static str = "truncate";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
+    let mut opts = getopts::Options::new();
 
-    let opts = [
-        getopts::optflag("c", "no-create", "do not create files that do not exist"),
-        getopts::optflag("o", "io-blocks", "treat SIZE as the number of I/O blocks of the file rather than bytes (NOT IMPLEMENTED)"),
-        getopts::optopt("r", "reference", "base the size of each file on the size of RFILE", "RFILE"),
-        getopts::optopt("s", "size", "set or adjust the size of each file according to SIZE, which is in bytes unless --io-blocks is specified", "SIZE"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("c", "no-create", "do not create files that do not exist");
+    opts.optflag("o", "io-blocks", "treat SIZE as the number of I/O blocks of the file rather than bytes (NOT IMPLEMENTED)");
+    opts.optopt("r", "reference", "base the size of each file on the size of RFILE", "RFILE");
+    opts.optopt("s", "size", "set or adjust the size of each file according to SIZE, which is in bytes unless --io-blocks is specified", "SIZE");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => {
-            crash!(1, "{}", f)
-        }
+        Err(f) => { crash!(1, "{}", f) }
     };
 
     if matches.opt_present("help") {
-        println!("truncate 1.0.0");
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {0} [OPTION]... FILE...", program);
+        println!("  {} [OPTION]... FILE...", NAME);
         println!("");
-        print!("{}", getopts::usage("Shrink or extend the size of each file to the specified size.", &opts));
+        print!("{}", opts.usage("Shrink or extend the size of each file to the specified size."));
         print!("
 SIZE is an integer with an optional prefix and optional unit.
 The available units (K, M, G, T, P, E, Z, and Y) use the following format:
@@ -79,7 +76,7 @@ file based on its current size:
     '%'  => round up to multiple of
 ");
     } else if matches.opt_present("version") {
-        println!("truncate 1.0.0");
+        println!("{} {}", NAME, VERSION);
     } else if matches.free.is_empty() {
         show_error!("missing an argument");
         return 1;
@@ -100,7 +97,6 @@ file based on its current size:
 
     0
 }
-
 
 fn truncate(no_create: bool, _: bool, reference: Option<String>, size: Option<String>, filenames: Vec<String>) -> Result<()> {
     let (refsize, mode) = match reference {

--- a/src/tty/tty.rs
+++ b/src/tty/tty.rs
@@ -1,5 +1,4 @@
 #![crate_name = "tty"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -15,7 +14,6 @@
 extern crate getopts;
 extern crate libc;
 
-use getopts::{getopts, optflag};
 use std::ffi::CStr;
 use std::io::Write;
 
@@ -32,23 +30,24 @@ static NAME: &'static str = "tty";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let options = [
-        optflag("s", "silent", "print nothing, only return an exit status"),
-        optflag("h", "help", "display this help and exit"),
-        optflag("V", "version", "output version information and exit")
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts(&args[1..], &options) {
+    opts.optflag("s", "silent", "print nothing, only return an exit status");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => {
-            crash!(2, "{}", f)
-        }
+        Err(f) => { crash!(2, "{}", f) }
     };
 
     if matches.opt_present("help") {
-        let usage = getopts::usage("Print the file name of the terminal connected to standard input.", &options);
-
-        println!("Usage: {} [OPTION]...\n{}", NAME, usage);
+        println!("{} {}", NAME, VERSION);
+        println!("");
+        println!("Usage:");
+        println!("  {} [OPTION]...", NAME);
+        println!("");
+        print!("{}", opts.usage("Print the file name of the terminal connected to standard input."));
     } else if matches.opt_present("version") {
         println!("{} {}", NAME, VERSION);
     } else {

--- a/src/uname/uname.rs
+++ b/src/uname/uname.rs
@@ -1,5 +1,4 @@
 #![crate_name = "uname"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -15,10 +14,10 @@
 extern crate getopts;
 extern crate libc;
 
+use c_types::utsname;
 use std::ffi::CStr;
 use std::io::Write;
 use std::mem::uninitialized;
-use c_types::utsname;
 
 #[path = "../common/util.rs"] #[macro_use] mod util;
 #[path = "../common/c_types.rs"] mod c_types;
@@ -51,31 +50,32 @@ unsafe fn getuname() -> Uts {
     }
 }
 
-
 static NAME: &'static str = "uname";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("a", "all", "Behave as though all of the options -mnrsv were specified."),
-        getopts::optflag("m", "machine", "print the machine hardware name."),
-        getopts::optflag("n", "nodename", "print the nodename (the nodename may be a name that the system is known by to a communications network)."),
-        getopts::optflag("p", "processor", "print the machine processor architecture name."),
-        getopts::optflag("r", "release", "print the operating system release."),
-        getopts::optflag("s", "sysname", "print the operating system name."),
-        getopts::optflag("v", "version", "print the operating system version."),
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = getopts::Options::new();
+
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("a", "all", "Behave as though all of the options -mnrsv were specified.");
+    opts.optflag("m", "machine", "print the machine hardware name.");
+    opts.optflag("n", "nodename", "print the nodename (the nodename may be a name that the system is known by to a communications network).");
+    opts.optflag("p", "processor", "print the machine processor architecture name.");
+    opts.optflag("r", "release", "print the operating system release.");
+    opts.optflag("s", "sysname", "print the operating system name.");
+    opts.optflag("v", "version", "print the operating system version.");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f),
     };
     if matches.opt_present("help") {
-        println!("uname 1.0.0");
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {}", args[0]);
+        println!("  {} [OPTIONS]", NAME);
         println!("");
-        println!("{}", getopts::usage("The uname utility writes symbols representing one or more system characteristics to the standard output.", &opts));
+        print!("{}", opts.usage("The uname utility writes symbols representing one or more system characteristics to the standard output."));
         return 0;
     }
     let uname = unsafe { getuname() };

--- a/src/unlink/unlink.rs
+++ b/src/unlink/unlink.rs
@@ -1,5 +1,4 @@
 #![crate_name = "unlink"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -15,53 +14,52 @@
 extern crate getopts;
 extern crate libc;
 
+use getopts::Options;
 use libc::consts::os::posix88::{S_IFMT, S_IFLNK, S_IFREG};
-use libc::types::os::arch::c95::c_char;
-use libc::types::os::arch::posix01::stat;
 use libc::funcs::posix01::stat_::lstat;
 use libc::funcs::posix88::unistd::unlink;
-
-use std::mem::uninitialized;
+use libc::types::os::arch::c95::c_char;
+use libc::types::os::arch::posix01::stat;
 use std::io::{Error, ErrorKind, Write};
+use std::mem::uninitialized;
 
 #[path = "../common/util.rs"]
 #[macro_use]
 mod util;
 
 static NAME: &'static str = "unlink";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => {
-            crash!(1, "invalid options\n{}", f)
-        }
+        Err(f) => crash!(1, "invalid options\n{}", f)
     };
 
     if matches.opt_present("help") {
-        println!("unlink 1.0.0");
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {0} [FILE]... [OPTION]...", args[0]);
+        println!("  {} [FILE]... [OPTION]...", NAME);
         println!("");
-        println!("{}", getopts::usage("Unlink the file at [FILE].", &opts));
+        println!("{}", opts.usage("Unlink the file at [FILE]."));
         return 0;
     }
 
     if matches.opt_present("version") {
-        println!("unlink 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 
     if matches.free.len() == 0 {
-        crash!(1, "missing operand\nTry '{0} --help' for more information.", args[0]);
+        crash!(1, "missing operand\nTry '{0} --help' for more information.", NAME);
     } else if matches.free.len() > 1 {
-        crash!(1, "extra operand: '{1}'\nTry '{0} --help' for more information.", args[0], matches.free[1]);
+        crash!(1, "extra operand: '{1}'\nTry '{0} --help' for more information.", NAME, matches.free[1]);
     }
 
     let st_mode = {

--- a/src/users/users.rs
+++ b/src/users/users.rs
@@ -1,5 +1,4 @@
 #![crate_name = "users"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -18,6 +17,7 @@
 extern crate getopts;
 extern crate libc;
 
+use getopts::Options;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::ptr;
@@ -50,30 +50,31 @@ unsafe extern fn utmpxname(_file: *const libc::c_char) -> libc::c_int {
 }
 
 static NAME: &'static str = "users";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => panic!("{}", f),
     };
 
     if matches.opt_present("help") {
-        println!("users 1.0.0");
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {} [OPTION]... [FILE]", args[0]);
+        println!("  {} [OPTION]... [FILE]", NAME);
         println!("");
-        println!("{}", getopts::usage("Output who is currently logged in according to FILE.", &opts));
+        println!("{}", opts.usage("Output who is currently logged in according to FILE."));
         return 0;
     }
 
     if matches.opt_present("version") {
-        println!("users 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/whoami/whoami.rs
+++ b/src/whoami/whoami.rs
@@ -1,5 +1,4 @@
 #![crate_name = "whoami"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -15,33 +14,36 @@
 extern crate getopts;
 extern crate libc;
 
+use getopts::Options;
 use std::io::Write;
 
 #[path = "../common/util.rs"] #[macro_use] mod util;
 mod platform;
 
 static NAME: &'static str = "whoami";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = Options::new();
+
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f),
     };
     if matches.opt_present("help") {
-        println!("whoami 1.0.0");
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {}", args[0]);
+        println!("  {} [OPTIONS]", NAME);
         println!("");
-        println!("{}", getopts::usage("print effective userid", &opts));
+        println!("{}", opts.usage("print effective userid"));
         return 0;
     }
     if matches.opt_present("version") {
-        println!("whoami 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/yes/yes.rs
+++ b/src/yes/yes.rs
@@ -1,5 +1,4 @@
 #![crate_name = "yes"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -15,6 +14,7 @@
 extern crate getopts;
 extern crate libc;
 
+use getopts::Options;
 use std::io::Write;
 
 #[path = "../common/util.rs"]
@@ -22,30 +22,29 @@ use std::io::Write;
 mod util;
 
 static NAME: &'static str = "yes";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0];
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = Options::new();
+
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => {
-            crash!(1, "invalid options\n{}", f)
-        }
+        Err(f) => crash!(1, "invalid options\n{}", f)
     };
     if matches.opt_present("help") {
-        println!("yes 1.0.0");
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {0} [STRING]... [OPTION]...", program);
+        println!("  {0} [STRING]... [OPTION]...", NAME);
         println!("");
-        print!("{}", getopts::usage("Repeatedly output a line with all specified STRING(s), or 'y'.", &opts));
+        print!("{}", opts.usage("Repeatedly output a line with all specified STRING(s), or 'y'."));
         return 0;
     }
     if matches.opt_present("version") {
-        println!("yes 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
     let string = if matches.free.is_empty() {


### PR DESCRIPTION
I switched over to the getopts crate on crates.io, instead of Rust's private implementation. This will allow coreutils to build for Rust 1.0.

I'm splitting the updates into several commits for easier reviewing.