### PR TITLE
Switch to external getopts cargo (part 3).

### DIFF
--- a/src/cut/cut.rs
+++ b/src/cut/cut.rs
@@ -1,5 +1,5 @@
 #![crate_name = "cut"]
-#![feature(collections, path_ext, rustc_private)]
+#![feature(collections, path_ext)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -16,7 +16,6 @@ extern crate libc;
 use std::fs::{File, PathExt};
 use std::io::{stdout, stdin, BufRead, BufReader, Read, Stdout, Write};
 use std::path::Path;
-use getopts::{optopt, optflag, getopts, usage};
 
 use ranges::Range;
 use searcher::Searcher;
@@ -405,20 +404,20 @@ fn cut_files(mut filenames: Vec<String>, mode: Mode) -> i32 {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        optopt("b", "bytes", "select only these bytes", "LIST"),
-        optopt("c", "characters", "select only these characters", "LIST"),
-        optopt("d", "delimiter", "use DELIM instead of TAB for field delimiter", "DELIM"),
-        optopt("f", "fields", "select only these fields;  also print any line that contains no delimiter character, unless the -s option is specified", "LIST"),
-        optflag("n", "", "(ignored)"),
-        optflag("", "complement", "complement the set of selected bytes, characters or fields"),
-        optflag("s", "only-delimited", "do not print lines not containing delimiters"),
-        optopt("", "output-delimiter", "use STRING as the output delimiter the default is to use the input delimiter", "STRING"),
-        optflag("", "help", "display this help and exit"),
-        optflag("", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts(&args[1..], &opts) {
+    opts.optopt("b", "bytes", "select only these bytes", "LIST");
+    opts.optopt("c", "characters", "select only these characters", "LIST");
+    opts.optopt("d", "delimiter", "use DELIM instead of TAB for field delimiter", "DELIM");
+    opts.optopt("f", "fields", "select only these fields;  also print any line that contains no delimiter character, unless the -s option is specified", "LIST");
+    opts.optflag("n", "", "(ignored)");
+    opts.optflag("", "complement", "complement the set of selected bytes, characters or fields");
+    opts.optflag("s", "only-delimited", "do not print lines not containing delimiters");
+    opts.optopt("", "output-delimiter", "use STRING as the output delimiter the default is to use the input delimiter", "STRING");
+    opts.optflag("", "help", "display this help and exit");
+    opts.optflag("", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             show_error!("Invalid options\n{}", f);
@@ -427,10 +426,12 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("help") {
-        println!("Usage:");
-        println!("  {0} OPTION... [FILE]...", args[0]);
+        println!("{} {}", NAME, VERSION);
         println!("");
-        println!("{}", &usage("Print selected parts of lines from each FILE to standard output.", &opts)[..]);
+        println!("Usage:");
+        println!("  {0} OPTION... [FILE]...", NAME);
+        println!("");
+        println!("{}", opts.usage("Print selected parts of lines from each FILE to standard output."));
         println!("");
         println!("Use one, and only one of -b, -c or -f.  Each LIST is made up of one");
         println!("range, or many ranges separated by commas.  Selected input is written");

--- a/src/du/du.rs
+++ b/src/du/du.rs
@@ -1,5 +1,5 @@
 #![crate_name = "du"]
-#![feature(collections, fs_time, metadata_ext, rustc_private, std_misc)]
+#![feature(fs_time, metadata_ext, std_misc)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -115,73 +115,72 @@ fn du(path: &PathBuf, mut my_stat: Stat, options: Arc<Options>, depth: usize) ->
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0];
-    let opts = [
-        // In task
-        getopts::optflag("a", "all", " write counts for all files, not just directories"),
-        // In main
-        getopts::optflag("", "apparent-size", "print apparent sizes,  rather  than  disk  usage;
-            although  the apparent  size is usually smaller, it may be larger due to holes
-            in ('sparse') files, internal  fragmentation,  indirect  blocks, and the like"),
-        // In main
-        getopts::optopt("B", "block-size", "scale sizes  by  SIZE before printing them.
-            E.g., '-BM' prints sizes in units of 1,048,576 bytes.  See SIZE format below.",
-            "SIZE"),
-        // In main
-        getopts::optflag("b", "bytes", "equivalent to '--apparent-size --block-size=1'"),
-        // In main
-        getopts::optflag("c", "total", "produce a grand total"),
-        // In task
-        // getopts::optflag("D", "dereference-args", "dereference only symlinks that are listed
-        //     on the command line"),
-        // In main
-        // getopts::optopt("", "files0-from", "summarize disk usage of the NUL-terminated file
-        //                   names specified in file F;
-        //                   If F is - then read names from standard input", "F"),
-        // // In task
-        // getopts::optflag("H", "", "equivalent to --dereference-args (-D)"),
-        // In main
-        getopts::optflag("h", "human-readable", "print sizes in human readable format (e.g., 1K 234M 2G)"),
-        // In main
-        getopts::optflag("", "si", "like -h, but use powers of 1000 not 1024"),
-        // In main
-        getopts::optflag("k", "", "like --block-size=1K"),
-        // In task
-        getopts::optflag("l", "count-links", "count sizes many times if hard linked"),
-        // // In main
-        getopts::optflag("m", "", "like --block-size=1M"),
-        // // In task
-        // getopts::optflag("L", "dereference", "dereference all symbolic links"),
-        // // In task
-        // getopts::optflag("P", "no-dereference", "don't follow any symbolic links (this is the default)"),
-        // // In main
-        getopts::optflag("0", "null", "end each output line with 0 byte rather than newline"),
-        // In main
-        getopts::optflag("S", "separate-dirs", "do not include size of subdirectories"),
-        // In main
-        getopts::optflag("s", "summarize", "display only a total for each argument"),
-        // // In task
-        // getopts::optflag("x", "one-file-system", "skip directories on different file systems"),
-        // // In task
-        // getopts::optopt("X", "exclude-from", "exclude files that match any pattern in FILE", "FILE"),
-        // // In task
-        // getopts::optopt("", "exclude", "exclude files that match PATTERN", "PATTERN"),
-        // In main
-        getopts::optopt("d", "max-depth", "print the total for a directory (or file, with --all)
-            only if it is N or fewer levels below the command
-            line argument;  --max-depth=0 is the same as --summarize", "N"),
-        // In main
-        getopts::optflagopt("", "time", "show time of the last modification of any file in the
-            directory, or any of its subdirectories.  If WORD is given, show time as WORD instead of modification time:
-            atime, access, use, ctime or status", "WORD"),
-        // In main
-        getopts::optopt("", "time-style", "show times using style STYLE:
-            full-iso, long-iso, iso, +FORMAT FORMAT is interpreted like 'date'", "STYLE"),
-        getopts::optflag("", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(args.tail(), &opts) {
+    // In task
+    opts.optflag("a", "all", " write counts for all files, not just directories");
+    // In main
+    opts.optflag("", "apparent-size", "print apparent sizes,  rather  than  disk  usage;
+            although  the apparent  size is usually smaller, it may be larger due to holes
+            in ('sparse') files, internal  fragmentation,  indirect  blocks, and the like");
+    // In main
+    opts.optopt("B", "block-size", "scale sizes  by  SIZE before printing them.
+            E.g., '-BM' prints sizes in units of 1,048,576 bytes.  See SIZE format below.",
+            "SIZE");
+    // In main
+    opts.optflag("b", "bytes", "equivalent to '--apparent-size --block-size=1'");
+    // In main
+    opts.optflag("c", "total", "produce a grand total");
+    // In task
+    // opts.optflag("D", "dereference-args", "dereference only symlinks that are listed
+    //     on the command line"),
+    // In main
+    // opts.optopt("", "files0-from", "summarize disk usage of the NUL-terminated file
+    //                   names specified in file F;
+    //                   If F is - then read names from standard input", "F"),
+    // // In task
+    // opts.optflag("H", "", "equivalent to --dereference-args (-D)"),
+    // In main
+    opts.optflag("h", "human-readable", "print sizes in human readable format (e.g., 1K 234M 2G)");
+    // In main
+    opts.optflag("", "si", "like -h, but use powers of 1000 not 1024");
+    // In main
+    opts.optflag("k", "", "like --block-size=1K");
+    // In task
+    opts.optflag("l", "count-links", "count sizes many times if hard linked");
+    // // In main
+    opts.optflag("m", "", "like --block-size=1M");
+    // // In task
+    // opts.optflag("L", "dereference", "dereference all symbolic links"),
+    // // In task
+    // opts.optflag("P", "no-dereference", "don't follow any symbolic links (this is the default)"),
+    // // In main
+    opts.optflag("0", "null", "end each output line with 0 byte rather than newline");
+    // In main
+    opts.optflag("S", "separate-dirs", "do not include size of subdirectories");
+    // In main
+    opts.optflag("s", "summarize", "display only a total for each argument");
+    // // In task
+    // opts.optflag("x", "one-file-system", "skip directories on different file systems"),
+    // // In task
+    // opts.optopt("X", "exclude-from", "exclude files that match any pattern in FILE", "FILE"),
+    // // In task
+    // opts.optopt("", "exclude", "exclude files that match PATTERN", "PATTERN"),
+    // In main
+    opts.optopt("d", "max-depth", "print the total for a directory (or file, with --all)
+            only if it is N or fewer levels below the command
+            line argument;  --max-depth=0 is the same as --summarize", "N");
+    // In main
+    opts.optflagopt("", "time", "show time of the last modification of any file in the
+            directory, or any of its subdirectories.  If WORD is given, show time as WORD instead of modification time:
+            atime, access, use, ctime or status", "WORD");
+    // In main
+    opts.optopt("", "time-style", "show times using style STYLE:
+            full-iso, long-iso, iso, +FORMAT FORMAT is interpreted like 'date'", "STYLE");
+    opts.optflag("", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
             show_error!("Invalid options\n{}", f);
@@ -206,12 +205,12 @@ POSIXLY_CORRECT is set).
 SIZE  is  an  integer and optional unit (example: 10M is 10*1024*1024).
 Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB, ...  (pow‐
 ers of 1000).",
-                 program = program,
+                 program = NAME,
                  version = VERSION,
-                 usage = getopts::usage("Summarize disk usage of each FILE, recursively for directories.", &opts));
+                 usage = opts.usage("Summarize disk usage of each FILE, recursively for directories."));
         return 0;
     } else if matches.opt_present("version") {
-        println!("{} version: {}", program, VERSION);
+        println!("{} version: {}", NAME, VERSION);
         return 0;
     }
 
@@ -233,7 +232,7 @@ ers of 1000).",
 
     let options = Options {
         all: matches.opt_present("all"),
-        program_name: program.to_string(),
+        program_name: NAME.to_string(),
         max_depth: max_depth,
         total: matches.opt_present("total"),
         separate_dirs: matches.opt_present("S"),
@@ -320,7 +319,7 @@ Valid arguments are:
 - 'full-iso'
 - 'long-iso'
 - 'iso'
-Try '{} --help' for more information.", s, program);
+Try '{} --help' for more information.", s, NAME);
                     return 1;
                 }
             }
@@ -358,7 +357,7 @@ Try '{} --help' for more information.", s, program);
                                     show_error!("invalid argument 'modified' for '--time'
     Valid arguments are:
       - 'accessed', 'created', 'modified'
-    Try '{} --help' for more information.", program);
+    Try '{} --help' for more information.", NAME);
                                     return 1;
                                 }
                             },

--- a/src/expand/expand.rs
+++ b/src/expand/expand.rs
@@ -1,5 +1,5 @@
 #![crate_name = "expand"]
-#![feature(rustc_private, unicode)]
+#![feature(unicode)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -94,25 +94,25 @@ impl Options {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("i", "initial", "do not convert tabs after non blanks"),
-        getopts::optopt("t", "tabs", "have tabs NUMBER characters apart, not 8", "NUMBER"),
-        getopts::optopt("t", "tabs", "use comma separated list of explicit tab positions", "LIST"),
-        getopts::optflag("U", "no-utf8", "interpret input file as 8-bit ASCII rather than UTF-8"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("i", "initial", "do not convert tabs after non blanks");
+    opts.optopt("t", "tabs", "have tabs NUMBER characters apart, not 8", "NUMBER");
+    opts.optopt("t", "tabs", "use comma separated list of explicit tab positions", "LIST");
+    opts.optflag("U", "no-utf8", "interpret input file as 8-bit ASCII rather than UTF-8");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f)
     };
 
     if matches.opt_present("help") {
         println!("Usage: {} [OPTION]... [FILE]...", NAME);
-        println!("{}", getopts::usage(
+        println!("{}", opts.usage(
             "Convert tabs in each FILE to spaces, writing to standard output.\n\
-            With no FILE, or when FILE is -, read standard input.", &opts));
+            With no FILE, or when FILE is -, read standard input."));
         return 0;
     }
 

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -1,5 +1,5 @@
 #![crate_name = "fmt"]
-#![feature(rustc_private,str_char,unicode,core)]
+#![feature(core, str_char, unicode)]
 
 /*
  * This file is part of `fmt` from the uutils coreutils package.
@@ -60,38 +60,37 @@ pub struct FmtOptions {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
+    let mut opts = getopts::Options::new();
 
-    let opts = [
-        getopts::optflag("c", "crown-margin", "First and second line of paragraph may have different indentations, in which case the first line's indentation is preserved, and each subsequent line's indentation matches the second line."),
-        getopts::optflag("t", "tagged-paragraph", "Like -c, except that the first and second line of a paragraph *must* have different indentation or they are treated as separate paragraphs."),
-        getopts::optflag("m", "preserve-headers", "Attempt to detect and preserve mail headers in the input. Be careful when combining this flag with -p."),
-        getopts::optflag("s", "split-only", "Split lines only, do not reflow."),
-        getopts::optflag("u", "uniform-spacing", "Insert exactly one space between words, and two between sentences. Sentence breaks in the input are detected as [?!.] followed by two spaces or a newline; other punctuation is not interpreted as a sentence break."),
+    opts.optflag("c", "crown-margin", "First and second line of paragraph may have different indentations, in which case the first line's indentation is preserved, and each subsequent line's indentation matches the second line.");
+    opts.optflag("t", "tagged-paragraph", "Like -c, except that the first and second line of a paragraph *must* have different indentation or they are treated as separate paragraphs.");
+    opts.optflag("m", "preserve-headers", "Attempt to detect and preserve mail headers in the input. Be careful when combining this flag with -p.");
+    opts.optflag("s", "split-only", "Split lines only, do not reflow.");
+    opts.optflag("u", "uniform-spacing", "Insert exactly one space between words, and two between sentences. Sentence breaks in the input are detected as [?!.] followed by two spaces or a newline; other punctuation is not interpreted as a sentence break.");
 
-        getopts::optopt("p", "prefix", "Reformat only lines beginning with PREFIX, reattaching PREFIX to reformatted lines. Unless -x is specified, leading whitespace will be ignored when matching PREFIX.", "PREFIX"),
-        getopts::optopt("P", "skip-prefix", "Do not reformat lines beginning with PSKIP. Unless -X is specified, leading whitespace will be ignored when matching PSKIP", "PSKIP"),
+    opts.optopt("p", "prefix", "Reformat only lines beginning with PREFIX, reattaching PREFIX to reformatted lines. Unless -x is specified, leading whitespace will be ignored when matching PREFIX.", "PREFIX");
+    opts.optopt("P", "skip-prefix", "Do not reformat lines beginning with PSKIP. Unless -X is specified, leading whitespace will be ignored when matching PSKIP", "PSKIP");
 
-        getopts::optflag("x", "exact-prefix", "PREFIX must match at the beginning of the line with no preceding whitespace."),
-        getopts::optflag("X", "exact-skip-prefix", "PSKIP must match at the beginning of the line with no preceding whitespace."),
+    opts.optflag("x", "exact-prefix", "PREFIX must match at the beginning of the line with no preceding whitespace.");
+    opts.optflag("X", "exact-skip-prefix", "PSKIP must match at the beginning of the line with no preceding whitespace.");
 
-        getopts::optopt("w", "width", "Fill output lines up to a maximum of WIDTH columns, default 79.", "WIDTH"),
-        getopts::optopt("g", "goal", "Goal width, default ~0.94*WIDTH. Must be less than WIDTH.", "GOAL"),
+    opts.optopt("w", "width", "Fill output lines up to a maximum of WIDTH columns, default 79.", "WIDTH");
+    opts.optopt("g", "goal", "Goal width, default ~0.94*WIDTH. Must be less than WIDTH.", "GOAL");
 
-        getopts::optflag("q", "quick", "Break lines more quickly at the expense of a potentially more ragged appearance."),
+    opts.optflag("q", "quick", "Break lines more quickly at the expense of a potentially more ragged appearance.");
 
-        getopts::optopt("T", "tab-width", "Treat tabs as TABWIDTH spaces for determining line length, default 8. Note that this is used only for calculating line lengths; tabs are preserved in the output.", "TABWIDTH"),
+    opts.optopt("T", "tab-width", "Treat tabs as TABWIDTH spaces for determining line length, default 8. Note that this is used only for calculating line lengths; tabs are preserved in the output.", "TABWIDTH");
 
-        getopts::optflag("V", "version", "Output version information and exit."),
-        getopts::optflag("h", "help", "Display this help message and exit.")
-            ];
+    opts.optflag("V", "version", "Output version information and exit.");
+    opts.optflag("h", "help", "Display this help message and exit.");
 
-    let matches = match getopts::getopts(&args[1..], &opts[..]) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => crash!(1, "{}\nTry `{} --help' for more information.", f, args[0])
+        Err(f) => crash!(1, "{}\nTry `{} --help' for more information.", f, NAME)
     };
 
     if matches.opt_present("h") {
-        print_usage(&(args[0])[..], &opts[..], "");
+        println!("Usage: {} [OPTION]... [FILE]...\n\n{}", NAME, opts.usage("Reformat paragraphs from input files (or stdin) to stdout."));
     }
 
     if matches.opt_present("V") || matches.opt_present("h") {
@@ -219,8 +218,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     0
-}
-
-fn print_usage(arg0: &str, opts: &[getopts::OptGroup], errmsg: &str) {
-    println!("Usage: {} [OPTION]... [FILE]...\n\n{}{}", arg0, getopts::usage("Reformat paragraphs from input files (or stdin) to stdout.", opts), errmsg);
 }

--- a/src/fold/fold.rs
+++ b/src/fold/fold.rs
@@ -1,5 +1,5 @@
 #![crate_name = "fold"]
-#![feature(collections, rustc_private)]
+#![feature(collections)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -26,17 +26,15 @@ static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
     let (args, obs_width) = handle_obsolete(&args[..]);
-    let program = args[0].clone();
+    let mut opts = getopts::Options::new();
 
-    let opts = [
-        getopts::optflag("b", "bytes", "count using bytes rather than columns (meaning control characters such as newline are not treated specially)"),
-        getopts::optflag("s", "spaces", "break lines at word boundaries rather than a hard cut-off"),
-        getopts::optopt("w", "width", "set WIDTH as the maximum line width rather than 80", "WIDTH"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
+    opts.optflag("b", "bytes", "count using bytes rather than columns (meaning control characters such as newline are not treated specially)");
+    opts.optflag("s", "spaces", "break lines at word boundaries rather than a hard cut-off");
+    opts.optopt("w", "width", "set WIDTH as the maximum line width rather than 80", "WIDTH");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f)
     };
@@ -45,9 +43,9 @@ pub fn uumain(args: Vec<String>) -> i32 {
         println!("{} v{}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {} [OPTION]... [FILE]...", program);
+        println!("  {} [OPTION]... [FILE]...", NAME);
         println!("");
-        print!("{}", getopts::usage("Writes each file (or standard input if no files are given) to standard output whilst breaking long lines", &opts));
+        print!("{}", opts.usage("Writes each file (or standard input if no files are given) to standard output whilst breaking long lines"));
     } else if matches.opt_present("V") {
         println!("{} v{}", NAME, VERSION);
     } else {

--- a/src/head/head.rs
+++ b/src/head/head.rs
@@ -1,5 +1,4 @@
 #![crate_name = "head"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -18,13 +17,13 @@ use std::io::{BufRead, BufReader, Read, stdin, Write};
 use std::fs::File;
 use std::path::Path;
 use std::str::from_utf8;
-use getopts::{optopt, optflag, getopts, usage};
 
 #[path = "../common/util.rs"]
 #[macro_use]
 mod util;
 
 static NAME: &'static str = "head";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
     let mut line_count = 10usize;
@@ -38,23 +37,23 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     let args = options;
 
-    let possible_options = [
-        optopt("c", "bytes", "Print the first K bytes.  With the leading '-', print all but the last K bytes", "[-]K"),
-        optopt("n", "lines", "Print the first K lines.  With the leading '-', print all but the last K lines", "[-]K"),
-        optflag("h", "help", "help"),
-        optflag("V", "version", "version")
-    ];
+    let mut opts = getopts::Options::new();
 
-    let given_options = match getopts(args.as_ref(), &possible_options) {
+    opts.optopt("c", "bytes", "Print the first K bytes.  With the leading '-', print all but the last K bytes", "[-]K");
+    opts.optopt("n", "lines", "Print the first K lines.  With the leading '-', print all but the last K lines", "[-]K");
+    opts.optflag("h", "help", "help");
+    opts.optflag("V", "version", "version");
+
+    let given_options = match opts.parse(&args) {
         Ok (m) => { m }
         Err(_) => {
-            println!("{}", usage(NAME, &possible_options));
+            println!("{}", opts.usage(""));
             return 1;
         }
     };
 
     if given_options.opt_present("h") {
-        println!("{}", usage(NAME, &possible_options));
+        println!("{}", opts.usage(""));
         return 0;
     }
     if given_options.opt_present("V") { version(); return 0 }
@@ -180,5 +179,5 @@ fn head<T: Read>(reader: &mut BufReader<T>, count: usize, use_bytes: bool) -> bo
 }
 
 fn version() {
-    println!("head version 1.0.0");
+    println!("{} version {}", NAME, VERSION);
 }

--- a/src/mkdir/mkdir.rs
+++ b/src/mkdir/mkdir.rs
@@ -1,5 +1,5 @@
 #![crate_name = "mkdir"]
-#![feature(path_ext, rustc_private)]
+#![feature(path_ext)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -29,23 +29,20 @@ static VERSION: &'static str = "1.0.0";
  * Handles option parsing
  */
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        // Linux-specific options, not implemented
-        // getopts::optflag("Z", "context", "set SELinux secutiry context" +
-        // " of each created directory to CTX"),
-        getopts::optopt("m", "mode", "set file mode", "755"),
-        getopts::optflag("p", "parents", "make parent directories as needed"),
-        getopts::optflag("v", "verbose",
-                        "print a message for each printed directory"),
-        getopts::optflag("h", "help", "display this help"),
-        getopts::optflag("V", "version", "display this version")
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    // Linux-specific options, not implemented
+    // opts.optflag("Z", "context", "set SELinux secutiry context" +
+    // " of each created directory to CTX"),
+    opts.optopt("m", "mode", "set file mode", "755");
+    opts.optflag("p", "parents", "make parent directories as needed");
+    opts.optflag("v", "verbose", "print a message for each printed directory");
+    opts.optflag("h", "help", "display this help");
+    opts.optflag("V", "version", "display this version");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => {
-            crash!(1, "Invalid options\n{}", f);
-        }
+        Err(f) => crash!(1, "Invalid options\n{}", f)
     };
 
     if args.len() == 1 || matches.opt_present("help") {
@@ -53,7 +50,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         return 0;
     }
     if matches.opt_present("version") {
-        println!("mkdir v{}", VERSION);
+        println!("{} v{}", NAME, VERSION);
         return 0;
     }
     let verbose = matches.opt_present("verbose");
@@ -81,11 +78,11 @@ pub fn uumain(args: Vec<String>) -> i32 {
     exec(dirs, recursive, mode, verbose)
 }
 
-fn print_help(opts: &[getopts::OptGroup]) {
-    println!("mkdir v{} - make a new directory with the given path", VERSION);
+fn print_help(opts: &getopts::Options) {
+    println!("{} v{} - make a new directory with the given path", NAME, VERSION);
     println!("");
     println!("Usage:");
-    print!("{}", getopts::usage("Create the given DIRECTORY(ies) if they do not exist", opts));
+    print!("{}", opts.usage("Create the given DIRECTORY(ies) if they do not exist"));
 }
 
 /**

--- a/src/readlink/readlink.rs
+++ b/src/readlink/readlink.rs
@@ -1,5 +1,5 @@
 #![crate_name = "readlink"]
-#![feature(file_type, rustc_private)]
+#![feature(file_type)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -12,7 +12,6 @@
 
 extern crate getopts;
 
-use getopts::{getopts, optflag, OptGroup, usage};
 use std::env;
 use std::fs::{metadata, read_link};
 use std::io::{Error, ErrorKind, Result, Write};
@@ -128,32 +127,31 @@ fn canonicalize(original: &PathBuf, can_mode: &CanonicalizeMode) -> Result<PathB
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0];
-    let opts = [
-        optflag("f", "canonicalize",
-                "canonicalize by following every symlink in every component of the \
-                 given name recursively; all but the last component must exist"),
-        optflag("e", "canonicalize-existing",
-                "canonicalize by following every symlink in every component of the \
-                 given name recursively, all components must exist"),
-        optflag("m", "canonicalize-missing",
-                "canonicalize by following every symlink in every component of the \
-                 given name recursively, without requirements on components existence"),
-        optflag("n", "no-newline", "do not output the trailing delimiter"),
-        optflag("q", "quiet", "suppress most error messages"),
-        optflag("s", "silent", "suppress most error messages"),
-        optflag("v", "verbose", "report error message"),
-        optflag("z", "zero", "separate output with NUL rather than newline"),
-        optflag("", "help", "display this help and exit"),
-        optflag("", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts(&args[1..], &opts) {
+    opts.optflag("f", "canonicalize",
+                 "canonicalize by following every symlink in every component of the \
+                  given name recursively; all but the last component must exist");
+    opts.optflag("e", "canonicalize-existing",
+                 "canonicalize by following every symlink in every component of the \
+                  given name recursively, all components must exist");
+    opts.optflag("m", "canonicalize-missing",
+                 "canonicalize by following every symlink in every component of the \
+                  given name recursively, without requirements on components existence");
+    opts.optflag("n", "no-newline", "do not output the trailing delimiter");
+    opts.optflag("q", "quiet", "suppress most error messages");
+    opts.optflag("s", "silent", "suppress most error messages");
+    opts.optflag("v", "verbose", "report error message");
+    opts.optflag("z", "zero", "separate output with NUL rather than newline");
+    opts.optflag("", "help", "display this help and exit");
+    opts.optflag("", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "Invalid options\n{}", f)
     };
     if matches.opt_present("help") {
-        show_usage(program, &opts);
+        show_usage(&opts);
         return 0;
     }
 
@@ -182,12 +180,12 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     let files = matches.free;
     if files.len() == 0 {
-        crash!(1, "missing operand\nTry {} --help for more information", program);
+        crash!(1, "missing operand\nTry {} --help for more information", NAME);
     }
 
     if no_newline && files.len() > 1 {
         if !silent {
-            eprintln!("{}: ignoring --no-newline with multiple arguments", program);
+            eprintln!("{}: ignoring --no-newline with multiple arguments", NAME);
             no_newline = false;
         }
     }
@@ -231,8 +229,10 @@ fn show(path: &PathBuf, no_newline: bool, use_zero: bool) {
     }
 }
 
-fn show_usage(program: &str, opts: &[OptGroup]) {
-    println!("Usage: {0} [OPTION]... [FILE]...", program);
+fn show_usage(opts: &getopts::Options) {
+    println!("{} {}", NAME, VERSION);
+    println!("");
+    println!("Usage: {0} [OPTION]... [FILE]...", NAME);
     print!("Print value of a symbolic link or canonical file name");
-    print!("{}", usage("", opts));
+    print!("{}", opts.usage(""));
 }

--- a/src/rm/rm.rs
+++ b/src/rm/rm.rs
@@ -1,5 +1,5 @@
 #![crate_name = "rm"]
-#![feature(file_type, dir_entry_ext, path_ext, rustc_private)]
+#![feature(file_type, dir_entry_ext, path_ext)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -31,36 +31,36 @@ enum InteractiveMode {
 }
 
 static NAME: &'static str = "rm";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
     // TODO: make getopts support -R in addition to -r
-    let opts = [
-        getopts::optflag("f", "force", "ignore nonexistent files and arguments, never prompt"),
-        getopts::optflag("i", "", "prompt before every removal"),
-        getopts::optflag("I", "", "prompt once before removing more than three files, or when removing recursively.  Less intrusive than -i, while still giving some protection against most mistakes"),
-        getopts::optflagopt("", "interactive", "prompt according to WHEN: never, once (-I), or always (-i).  Without WHEN, prompts always", "WHEN"),
-        getopts::optflag("", "one-file-system", "when removing a hierarchy recursively, skip any directory that is on a file system different from that of the corresponding command line argument (NOT IMPLEMENTED)"),
-        getopts::optflag("", "no-preserve-root", "do not treat '/' specially"),
-        getopts::optflag("", "preserve-root", "do not remove '/' (default)"),
-        getopts::optflag("r", "recursive", "remove directories and their contents recursively"),
-        getopts::optflag("d", "dir", "remove empty directories"),
-        getopts::optflag("v", "verbose", "explain what is being done"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit")
-    ];
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    let mut opts = getopts::Options::new();
+
+    opts.optflag("f", "force", "ignore nonexistent files and arguments, never prompt");
+    opts.optflag("i", "", "prompt before every removal");
+    opts.optflag("I", "", "prompt once before removing more than three files, or when removing recursively.  Less intrusive than -i, while still giving some protection against most mistakes");
+    opts.optflagopt("", "interactive", "prompt according to WHEN: never, once (-I), or always (-i).  Without WHEN, prompts always", "WHEN");
+    opts.optflag("", "one-file-system", "when removing a hierarchy recursively, skip any directory that is on a file system different from that of the corresponding command line argument (NOT IMPLEMENTED)");
+    opts.optflag("", "no-preserve-root", "do not treat '/' specially");
+    opts.optflag("", "preserve-root", "do not remove '/' (default)");
+    opts.optflag("r", "recursive", "remove directories and their contents recursively");
+    opts.optflag("d", "dir", "remove empty directories");
+    opts.optflag("v", "verbose", "explain what is being done");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => {
-            crash!(1, "{}", f)
-        }
+        Err(f) => crash!(1, "{}", f)
     };
     if matches.opt_present("help") {
-        println!("rm 1.0.0");
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
-        println!("  {0} [OPTION]... [FILE]...", &args[0][..]);
+        println!("  {0} [OPTION]... [FILE]...", NAME);
         println!("");
-        println!("{}", &getopts::usage("Remove (unlink) the FILE(s).", &opts)[..]);
+        println!("{}", opts.usage("Remove (unlink) the FILE(s)."));
         println!("By default, rm does not remove directories.  Use the --recursive (-r)");
         println!("option to remove each listed directory, too, along with all of its contents");
         println!("");
@@ -74,10 +74,10 @@ pub fn uumain(args: Vec<String>) -> i32 {
         println!("some of its contents, given sufficient expertise and/or time.  For greater");
         println!("assurance that the contents are truly unrecoverable, consider using shred.");
     } else if matches.opt_present("version") {
-        println!("rm 1.0.0");
+        println!("{} {}", NAME, VERSION);
     } else if matches.free.is_empty() {
         show_error!("missing an argument");
-        show_error!("for help, try '{0} --help'", &args[0][..]);
+        show_error!("for help, try '{0} --help'", NAME);
         return 1;
     } else {
         let force = matches.opt_present("force");

--- a/src/seq/seq.rs
+++ b/src/seq/seq.rs
@@ -1,5 +1,4 @@
 #![crate_name = "seq"]
-#![feature(rustc_private)]
 
 // TODO: Make -w flag work with decimals
 // TODO: Support -f flag
@@ -15,6 +14,7 @@ use std::io::Write;
 mod util;
 
 static NAME: &'static str = "seq";
+static VERSION: &'static str = "1.0.0";
 
 #[derive(Clone)]
 struct SeqOptions {
@@ -34,19 +34,18 @@ fn parse_float(mut s: &str) -> Result<f64, String> {
 }
 
 fn escape_sequences(s: &str) -> String {
-    s.replace("\\n", "\n").
-        replace("\\t", "\t")
+    s.replace("\\n", "\n")
+     .replace("\\t", "\t")
 }
 
 fn parse_options(args: Vec<String>, options: &mut SeqOptions) -> Result<Vec<String>, i32> {
     let mut seq_args = vec!();
-    let program = args[0].clone();
     let mut iter = args.into_iter().skip(1);
     loop {
         match iter.next() {
             Some(arg) => match &arg[..] {
                 "--help" | "-h" => {
-                    print_help(&program);
+                    print_help();
                     return Err(0);
                 }
                 "--version" | "-V" => {
@@ -80,7 +79,7 @@ fn parse_options(args: Vec<String>, options: &mut SeqOptions) -> Result<Vec<Stri
                         while match chiter.next() { Some(m) => { ch = m; true } None => false } {
                             match ch {
                                 'h' => {
-                                    print_help(&program);
+                                    print_help();
                                     return Err(0);
                                 }
                                 'V' => {
@@ -130,25 +129,25 @@ fn parse_options(args: Vec<String>, options: &mut SeqOptions) -> Result<Vec<Stri
     Ok(seq_args)
 }
 
-fn print_help(program: &String) {
-    let opts = [
-        getopts::optopt("s", "separator", "Separator character (defaults to \\n)", ""),
-        getopts::optopt("t", "terminator", "Terminator character (defaults to separator)", ""),
-        getopts::optflag("w", "widths", "Equalize widths of all numbers by padding with zeros"),
-        getopts::optflag("h", "help", "print this help text and exit"),
-        getopts::optflag("V", "version", "print version and exit"),
-    ];
-    println!("seq 1.0.0\n");
-    println!("Usage:\n  {} [-w] [-s string] [-t string] [first [step]] last\n", *program);
-    println!("{}", getopts::usage("Print sequences of numbers", &opts));
+fn print_help() {
+    let mut opts = getopts::Options::new();
+
+    opts.optopt("s", "separator", "Separator character (defaults to \\n)", "");
+    opts.optopt("t", "terminator", "Terminator character (defaults to separator)", "");
+    opts.optflag("w", "widths", "Equalize widths of all numbers by padding with zeros");
+    opts.optflag("h", "help", "print this help text and exit");
+    opts.optflag("V", "version", "print version and exit");
+
+    println!("{} {}\n", NAME, VERSION);
+    println!("Usage:\n  {} [-w] [-s string] [-t string] [first [step]] last\n", NAME);
+    println!("{}", opts.usage("Print sequences of numbers"));
 }
 
 fn print_version() {
-    println!("seq 1.0.0\n");
+    println!("{} {}", NAME, VERSION);
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = args[0].clone();
     let mut options = SeqOptions {
         separator: "\n".to_string(),
         terminator: None,
@@ -160,7 +159,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
     if free.len() < 1 || free.len() > 3 {
         crash!(1, "too {} operands.\nTry '{} --help' for more information.",
-               if free.len() < 1 { "few" } else { "many" }, program);
+               if free.len() < 1 { "few" } else { "many" }, NAME);
     }
     let mut largest_dec = 0;
     let mut padding = 0;

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -1,5 +1,4 @@
 #![crate_name = "tail"]
-#![feature(rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -13,7 +12,6 @@
 
 extern crate getopts;
 
-use getopts::{optopt, optflag, getopts, usage};
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, stdin, stdout, Write};
@@ -43,25 +41,25 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     let args = options;
 
-    let possible_options = [
-        optopt("c", "bytes", "Number of bytes to print", "k"),
-        optopt("n", "lines", "Number of lines to print", "k"),
-        optflag("f", "follow", "Print the file as it grows"),
-        optopt("s", "sleep-interval", "Number or seconds to sleep between polling the file when running with -f", "n"),
-        optflag("h", "help", "help"),
-        optflag("V", "version", "version"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let given_options = match getopts(args.as_ref(), &possible_options) {
+    opts.optopt("c", "bytes", "Number of bytes to print", "k");
+    opts.optopt("n", "lines", "Number of lines to print", "k");
+    opts.optflag("f", "follow", "Print the file as it grows");
+    opts.optopt("s", "sleep-interval", "Number or seconds to sleep between polling the file when running with -f", "n");
+    opts.optflag("h", "help", "help");
+    opts.optflag("V", "version", "version");
+
+    let given_options = match opts.parse(&args) {
         Ok (m) => { m }
         Err(_) => {
-            println!("{}", usage(NAME, &possible_options));
+            println!("{}", opts.usage(""));
             return 1;
         }
     };
 
     if given_options.opt_present("h") {
-        println!("{}", usage(NAME, &possible_options));
+        println!("{}", opts.usage(""));
         return 0;
     }
     if given_options.opt_present("V") { version(); return 0 }

--- a/src/touch/touch.rs
+++ b/src/touch/touch.rs
@@ -1,5 +1,5 @@
 #![crate_name = "touch"]
-#![feature(rustc_private, path_ext, fs_time)]
+#![feature(fs_time, path_ext)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -10,15 +10,14 @@
  * that was distributed with this source code.
  */
 
-extern crate libc;
 extern crate getopts;
+extern crate libc;
 extern crate time;
 
 use libc::types::os::arch::c95::c_char;
 use libc::types::os::arch::posix01::stat as stat_t;
 use libc::funcs::posix88::stat_::stat as c_stat;
 use libc::funcs::posix01::stat_::lstat as c_lstat;
-
 use std::fs::{set_file_times, File, PathExt};
 use std::io::{Error, Write};
 use std::mem::uninitialized;
@@ -32,23 +31,23 @@ static NAME: &'static str = "touch";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("a", "",               "change only the access time"),
-        getopts::optflag("c", "no-create",      "do not create any files"),
-        getopts::optopt( "d", "date",           "parse argument and use it instead of current time", "STRING"),
-        getopts::optflag("h", "no-dereference", "affect each symbolic link instead of any referenced file \
-                                                 (only for systems that can change the timestamps of a symlink)"),
-        getopts::optflag("m", "",               "change only the modification time"),
-        getopts::optopt( "r", "reference",      "use this file's times instead of the current time", "FILE"),
-        getopts::optopt( "t", "",               "use [[CC]YY]MMDDhhmm[.ss] instead of the current time", "STAMP"),
-        getopts::optopt( "",  "time",           "change only the specified time: \"access\", \"atime\", or \
-                                                 \"use\" are equivalent to -a; \"modify\" or \"mtime\" are \
-                                                 equivalent to -m", "WORD"),
-        getopts::optflag("h", "help",           "display this help and exit"),
-        getopts::optflag("V", "version",        "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("a", "",               "change only the access time");
+    opts.optflag("c", "no-create",      "do not create any files");
+    opts.optopt( "d", "date",           "parse argument and use it instead of current time", "STRING");
+    opts.optflag("h", "no-dereference", "affect each symbolic link instead of any referenced file \
+                                         (only for systems that can change the timestamps of a symlink)");
+    opts.optflag("m", "",               "change only the modification time");
+    opts.optopt( "r", "reference",      "use this file's times instead of the current time", "FILE");
+    opts.optopt( "t", "",               "use [[CC]YY]MMDDhhmm[.ss] instead of the current time", "STAMP");
+    opts.optopt( "",  "time",           "change only the specified time: \"access\", \"atime\", or \
+                                         \"use\" are equivalent to -a; \"modify\" or \"mtime\" are \
+                                         equivalent to -m", "WORD");
+    opts.optflag("h", "help",           "display this help and exit");
+    opts.optflag("V", "version",        "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m)  => m,
         Err(e) => panic!("Invalid options\n{}", e)
     };
@@ -63,8 +62,8 @@ pub fn uumain(args: Vec<String>) -> i32 {
         println!("");
         println!("Usage: {} [OPTION]... FILE...", NAME);
         println!("");
-        println!("{}", getopts::usage("Update the access and modification times of \
-                                         each FILE to the current time.", &opts));
+        println!("{}", opts.usage("Update the access and modification times of \
+                                   each FILE to the current time."));
         if matches.free.is_empty() {
             return 1;
         }

--- a/src/tr/tr.rs
+++ b/src/tr/tr.rs
@@ -1,5 +1,5 @@
 #![crate_name = "tr"]
-#![feature(io, rustc_private)]
+#![feature(io)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -14,9 +14,10 @@
 
 extern crate getopts;
 
-use getopts::OptGroup;
+use getopts::Options;
 use std::collections::{BitSet, VecMap};
 use std::io::{stdin, stdout, BufReader, Read, Write};
+
 use expand::ExpandSet;
 
 #[path="../common/util.rs"]
@@ -25,8 +26,8 @@ mod util;
 
 mod expand;
 
-static NAME : &'static str = "tr";
-static VERSION : &'static str = "1.0.0";
+static NAME: &'static str = "tr";
+static VERSION: &'static str = "1.0.0";
 const BUFFER_LEN: usize = 1024;
 
 fn delete<'a>(set: ExpandSet<'a>, complement: bool) {
@@ -96,25 +97,25 @@ fn tr<'a>(set1: ExpandSet<'a>, mut set2: ExpandSet<'a>) {
     }
 }
 
-fn usage(opts: &[OptGroup]) {
+fn usage(opts: &Options) {
     println!("{} {}", NAME, VERSION);
     println!("");
     println!("Usage:");
     println!("  {} [OPTIONS] SET1 [SET2]", NAME);
     println!("");
-    println!("{}", getopts::usage("Translate or delete characters.", opts));
+    println!("{}", opts.usage("Translate or delete characters."));
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("c", "complement", "use the complement of SET1"),
-        getopts::optflag("C", "", "same as -c"),
-        getopts::optflag("d", "delete", "delete characters in SET1"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("c", "complement", "use the complement of SET1");
+    opts.optflag("C", "", "same as -c");
+    opts.optflag("d", "delete", "delete characters in SET1");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(err) => {
             show_error!("{}", err);

--- a/src/tsort/tsort.rs
+++ b/src/tsort/tsort.rs
@@ -1,5 +1,4 @@
 #![crate_name = "tsort"]
-#![feature(collections, rustc_private)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -27,12 +26,12 @@ static NAME: &'static str = "tsort";
 static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(args.tail(), &opts) {
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f)
     };
@@ -43,7 +42,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         println!("Usage:");
         println!("  {} [OPTIONS] FILE", NAME);
         println!("");
-        println!("{}", getopts::usage("Topological sort the strings in FILE. Strings are defined as any sequence of tokens separated by whitespace (tab, space, or newline). If FILE is not passed in, stdin is used instead.", &opts));
+        println!("{}", opts.usage("Topological sort the strings in FILE. Strings are defined as any sequence of tokens separated by whitespace (tab, space, or newline). If FILE is not passed in, stdin is used instead."));
         return 0;
     }
 

--- a/src/unexpand/unexpand.rs
+++ b/src/unexpand/unexpand.rs
@@ -1,5 +1,5 @@
 #![crate_name = "unexpand"]
-#![feature(rustc_private, unicode)]
+#![feature(unicode)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -84,26 +84,27 @@ impl Options {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let opts = [
-        getopts::optflag("a", "all", "convert all blanks, instead of just initial blanks"),
-        getopts::optflag("", "first-only", "convert only leading sequences of blanks (overrides -a)"),
-        getopts::optopt("t", "tabs", "have tabs N characters apart instead of 8 (enables -a)", "N"),
-        getopts::optopt("t", "tabs", "use comma separated LIST of tab positions (enables -a)", "LIST"),
-        getopts::optflag("U", "no-utf8", "interpret input file as 8-bit ASCII rather than UTF-8"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = getopts::Options::new();
 
-    let matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("a", "all", "convert all blanks, instead of just initial blanks");
+    opts.optflag("", "first-only", "convert only leading sequences of blanks (overrides -a)");
+    opts.optopt("t", "tabs", "have tabs N characters apart instead of 8 (enables -a)", "N");
+    opts.optopt("t", "tabs", "use comma separated LIST of tab positions (enables -a)", "LIST");
+    opts.optflag("U", "no-utf8", "interpret input file as 8-bit ASCII rather than UTF-8");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => crash!(1, "{}", f)
     };
 
     if matches.opt_present("help") {
-        println!("Usage: {} [OPTION]... [FILE]...", NAME);
-        println!("{}", getopts::usage(
+        println!("{} v{}\n", NAME, VERSION);
+        println!("Usage: {} [OPTION]... [FILE]...\n", NAME);
+        println!("{}", opts.usage(
             "Convert blanks in each FILE to tabs, writing to standard output.\n\
-            With no FILE, or when FILE is -, read standard input.", &opts));
+            With no FILE, or when FILE is -, read standard input."));
         return 0;
     }
 

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -1,5 +1,5 @@
 #![crate_name = "wc"]
-#![feature(rustc_private, path_ext)]
+#![feature(path_ext)]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -13,8 +13,7 @@
 extern crate getopts;
 extern crate libc;
 
-use getopts::Matches;
-
+use getopts::{Matches, Options};
 use std::ascii::AsciiExt;
 use std::fs::{File, PathExt};
 use std::io::{stdin, BufRead, BufReader, Read, Write};
@@ -36,37 +35,37 @@ struct Result {
 }
 
 static NAME: &'static str = "wc";
+static VERSION: &'static str = "1.0.0";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let program = &args[0][..];
-    let opts = [
-        getopts::optflag("c", "bytes", "print the byte counts"),
-        getopts::optflag("m", "chars", "print the character counts"),
-        getopts::optflag("l", "lines", "print the newline counts"),
-        getopts::optflag("L", "max-line-length", "print the length of the longest line"),
-        getopts::optflag("w", "words", "print the word counts"),
-        getopts::optflag("h", "help", "display this help and exit"),
-        getopts::optflag("V", "version", "output version information and exit"),
-    ];
+    let mut opts = Options::new();
 
-    let mut matches = match getopts::getopts(&args[1..], &opts) {
+    opts.optflag("c", "bytes", "print the byte counts");
+    opts.optflag("m", "chars", "print the character counts");
+    opts.optflag("l", "lines", "print the newline counts");
+    opts.optflag("L", "max-line-length", "print the length of the longest line");
+    opts.optflag("w", "words", "print the word counts");
+    opts.optflag("h", "help", "display this help and exit");
+    opts.optflag("V", "version", "output version information and exit");
+
+    let mut matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => {
-            crash!(1, "Invalid options\n{}", f)
-        }
+        Err(f) => crash!(1, "Invalid options\n{}", f)
     };
 
     if matches.opt_present("help") {
-        println!("Usage:");
-        println!("  {0} [OPTION]... [FILE]...", program);
+        println!("{} {}", NAME, VERSION);
         println!("");
-        println!("{}", getopts::usage("Print newline, word and byte counts for each FILE", &opts));
+        println!("Usage:");
+        println!("  {0} [OPTION]... [FILE]...", NAME);
+        println!("");
+        println!("{}", opts.usage("Print newline, word and byte counts for each FILE"));
         println!("With no FILE, or when FILE is -, read standard input.");
         return 0;
     }
 
     if matches.opt_present("version") {
-        println!("wc 1.0.0");
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 


### PR DESCRIPTION
I switched over to the getopts crate on crates.io, instead of Rust's private implementation. This will allow coreutils to build for Rust 1.0.

I'm splitting the updates into several commits for easier reviewing.