### PR TITLE
Fix failure to print stdout for echo.

### DIFF
--- a/src/echo/echo.rs
+++ b/src/echo/echo.rs
@@ -12,6 +12,7 @@
 extern crate getopts;
 extern crate libc;
 
+use std::io::{stdout, Write};
 use std::str::from_utf8;
 
 #[path = "../common/util.rs"]
@@ -242,7 +243,9 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     }
 
-    if !options.newline {
+    if options.newline {
+        let _ = stdout().flush();
+    } else {
         println!("")
     }
 


### PR DESCRIPTION
Upon program termination, pending stdout writes were not automatically flushed. When newlines are disabled, I force a flush to stdout.