### PR TITLE
Add macro to manually flush a writer.

### DIFF
--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -163,6 +163,34 @@ macro_rules! pipe_writeln(
 );
 
 #[macro_export]
+macro_rules! pipe_flush(
+    () => (
+        match ::std::io::stdout().flush() {
+            Ok(_) => true,
+            Err(f) => {
+                if f.kind() == ::std::io::ErrorKind::BrokenPipe {
+                    false
+                } else {
+                    panic!("{}", f)
+                }
+            }
+        }
+    );
+    ($fd:expr) => (
+        match $fd.flush() {
+            Ok(_) => true,
+            Err(f) => {
+                if f.kind() == ::std::io::ErrorKind::BrokenPipe {
+                    false
+                } else {
+                    panic!("{}", f)
+                }
+            }
+        }
+    )
+);
+
+#[macro_export]
 macro_rules! safe_write(
     ($fd:expr, $($args:tt)+) => (
         match write!($fd, $($args)+) {

--- a/src/echo/echo.rs
+++ b/src/echo/echo.rs
@@ -12,10 +12,11 @@
 extern crate getopts;
 extern crate libc;
 
-use std::io::{stdout, Write};
+use std::io::Write;
 use std::str::from_utf8;
 
 #[path = "../common/util.rs"]
+#[macro_use]
 mod util;
 
 #[allow(dead_code)]
@@ -244,7 +245,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if options.newline {
-        let _ = stdout().flush();
+        pipe_flush!();
     } else {
         println!("")
     }

--- a/src/env/env.rs
+++ b/src/env/env.rs
@@ -14,7 +14,12 @@
 #![allow(non_camel_case_types)]
 
 use std::env;
+use std::io::Write;
 use std::process::Command;
+
+#[path = "../common/util.rs"]
+#[macro_use]
+mod util;
 
 struct options {
     ignore_env: bool,
@@ -194,6 +199,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     } else {
         // no program provided
         print_env(opts.null);
+        pipe_flush!();
     }
 
     0

--- a/src/seq/seq.rs
+++ b/src/seq/seq.rs
@@ -256,4 +256,5 @@ fn print_seq(first: f64, step: f64, last: f64, largest_dec: usize, separator: St
     if (first >= last && step < 0f64) || (first <= last && step > 0f64) {
         pipe_print!("{}", terminator);
     }
+    pipe_flush!();
 }


### PR DESCRIPTION
I built upon the pipe_* macros, adding pipe_flush!() to flush an optional writer (default to stdout if no writer is given).

It turns out standard output is buffered by default, so non-newline-terminated strings are not printed when a program terminates.