### PR TITLE
Standardize display of utility name and version.

### DIFF
--- a/src/chmod/chmod.rs
+++ b/src/chmod/chmod.rs
@@ -48,7 +48,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         Err(f) => { crash!(1, "{}", f) }
     };
     if matches.opt_present("help") {
-        let msg = format!("{name} v{version}
+        let msg = format!("{name} {version}
 
 Usage:
   {program} [OPTION]... MODE[,MODE]... FILE...
@@ -63,7 +63,7 @@ Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.",
         print!("{}", opts.usage(&msg));
         return 0;
     } else if matches.opt_present("version") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
     } else if matches.free.is_empty() && matches.opt_present("reference") || matches.free.len() < 2 {
         show_error!("missing an argument");
         show_error!("for help, try '{} --help'", NAME);

--- a/src/chroot/chroot.rs
+++ b/src/chroot/chroot.rs
@@ -202,11 +202,11 @@ fn set_user(user: &str) {
 }
 
 fn version() {
-    println!("{} v{}", NAME, VERSION)
+    println!("{} {}", NAME, VERSION)
 }
 
 fn help_menu(options: Options) {
-    let msg = format!("{0} v{1}
+    let msg = format!("{0} {1}
 
 Usage:
   {0} [OPTION]... NEWROOT [COMMAND [ARG]...]

--- a/src/du/du.rs
+++ b/src/du/du.rs
@@ -210,7 +210,7 @@ ers of 1000).",
                  usage = opts.usage("Summarize disk usage of each FILE, recursively for directories."));
         return 0;
     } else if matches.opt_present("version") {
-        println!("{} version: {}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/env/env.rs
+++ b/src/env/env.rs
@@ -21,6 +21,9 @@ use std::process::Command;
 #[macro_use]
 mod util;
 
+static NAME: &'static str = "env";
+static VERSION: &'static str = "1.0.0";
+
 struct options {
     ignore_env: bool,
     null: bool,
@@ -29,8 +32,8 @@ struct options {
     program: Vec<String>
 }
 
-fn usage(prog: &str) {
-    println!("Usage: {} [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]", prog);
+fn usage() {
+    println!("Usage: {} [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]", NAME);
     println!("Set each NAME to VALUE in the environment and run COMMAND\n");
     println!("Possible options are:");
     println!("  -i --ignore-environment\t start with an empty environment");
@@ -42,7 +45,7 @@ fn usage(prog: &str) {
 }
 
 fn version() {
-    println!("env 1.0.0");
+    println!("{} {}", NAME, VERSION);
 }
 
 // print name=value env pairs on screen
@@ -54,8 +57,6 @@ fn print_env(null: bool) {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let prog = &args[0];
-
     // to handle arguments the same way than GNU env, we can't use getopts
     let mut opts = Box::new(options {
         ignore_env: false,
@@ -94,7 +95,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
             }
         } else if opt.starts_with("--") {
             match opt.as_ref() {
-                "--help" => { usage(prog); return 0; }
+                "--help" => { usage(); return 0; }
                 "--version" => { version(); return 0; }
 
                 "--ignore-environment" => opts.ignore_env = true,
@@ -103,14 +104,14 @@ pub fn uumain(args: Vec<String>) -> i32 {
                     let var = iter.next();
 
                     match var {
-                        None => println!("{}: this option requires an argument: {}", prog, opt),
+                        None => println!("{}: this option requires an argument: {}", NAME, opt),
                         Some(s) => opts.unsets.push(s.to_string())
                     }
                 }
 
                 _ => {
-                    println!("{}: invalid option \"{}\"", prog, *opt);
-                    println!("Type \"{} --help\" for detailed informations", prog);
+                    println!("{}: invalid option \"{}\"", NAME, *opt);
+                    println!("Type \"{} --help\" for detailed informations", NAME);
                     return 1;
                 }
             }
@@ -128,7 +129,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
             for c in chars {
                 // short versions of options
                 match c {
-                    'h' => { usage(prog); return 0; }
+                    'h' => { usage(); return 0; }
                     'V' => { version(); return 0; }
                     'i' => opts.ignore_env = true,
                     '0' => opts.null = true,
@@ -136,13 +137,13 @@ pub fn uumain(args: Vec<String>) -> i32 {
                         let var = iter.next();
 
                         match var {
-                            None => println!("{}: this option requires an argument: {}", prog, opt),
+                            None => println!("{}: this option requires an argument: {}", NAME, opt),
                             Some(s) => opts.unsets.push(s.to_string())
                         }
                     }
                     _ => {
-                        println!("{}: illegal option -- {}", prog, c);
-                        println!("Type \"{} --help\" for detailed informations", prog);
+                        println!("{}: illegal option -- {}", NAME, c);
+                        println!("Type \"{} --help\" for detailed informations", NAME);
                         return 1;
                     }
                 }

--- a/src/expand/expand.rs
+++ b/src/expand/expand.rs
@@ -117,7 +117,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("V") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -94,7 +94,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("V") || matches.opt_present("h") {
-        println!("uutils {} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0
     }
 

--- a/src/fold/fold.rs
+++ b/src/fold/fold.rs
@@ -40,14 +40,14 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("h") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
         println!("  {} [OPTION]... [FILE]...", NAME);
         println!("");
         print!("{}", opts.usage("Writes each file (or standard input if no files are given) to standard output whilst breaking long lines"));
     } else if matches.opt_present("V") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
     } else {
         let bytes = matches.opt_present("b");
         let spaces = matches.opt_present("s");

--- a/src/groups/groups.rs
+++ b/src/groups/groups.rs
@@ -34,9 +34,9 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("version") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
     } else if matches.opt_present("help") {
-        let msg = format!("{0} v{1}
+        let msg = format!("{0} {1}
 
 Usage:
   {0} [OPTION]... [USER]...

--- a/src/hashsum/hashsum.rs
+++ b/src/hashsum/hashsum.rs
@@ -138,7 +138,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 }
 
 fn version() {
-    pipe_println!("{} v{}", NAME, VERSION);
+    pipe_println!("{} {}", NAME, VERSION);
 }
 
 fn usage(program: &str, binary_name: &str, opts: &getopts::Options) {
@@ -148,7 +148,7 @@ fn usage(program: &str, binary_name: &str, opts: &getopts::Options) {
         format!("  {} {{--md5|--sha1|--sha224|--sha256|--sha384|--sha512}} [OPTION]... [FILE]...", program)
     };
 
-    let msg = format!("{} v{}
+    let msg = format!("{} {}
 
 Usage:
 {}

--- a/src/head/head.rs
+++ b/src/head/head.rs
@@ -179,5 +179,5 @@ fn head<T: Read>(reader: &mut BufReader<T>, count: usize, use_bytes: bool) -> bo
 }
 
 fn version() {
-    println!("{} version {}", NAME, VERSION);
+    println!("{} {}", NAME, VERSION);
 }

--- a/src/mkdir/mkdir.rs
+++ b/src/mkdir/mkdir.rs
@@ -50,7 +50,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         return 0;
     }
     if matches.opt_present("version") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
     let verbose = matches.opt_present("verbose");
@@ -79,7 +79,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 }
 
 fn print_help(opts: &getopts::Options) {
-    println!("{} v{} - make a new directory with the given path", NAME, VERSION);
+    println!("{} {}", NAME, VERSION);
     println!("");
     println!("Usage:");
     print!("{}", opts.usage("Create the given DIRECTORY(ies) if they do not exist"));

--- a/src/mv/mv.rs
+++ b/src/mv/mv.rs
@@ -106,7 +106,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
                 "none" | "off"     => BackupMode::NoBackup,
                 x => {
                     show_error!("invalid argument ‘{}’ for ‘backup type’\n\
-                                Try 'mv --help' for more information.", x);
+                                Try '{} --help' for more information.", x, NAME);
                     return 1;
                 }
             }
@@ -117,7 +117,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     if overwrite_mode == OverwriteMode::NoClobber && backup_mode != BackupMode::NoBackup {
         show_error!("options --backup and --no-clobber are mutually exclusive\n\
-                    Try 'mv --help' for more information.");
+                    Try '{} --help' for more information.", NAME);
         return 1;
     }
 
@@ -126,7 +126,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
             Some(x) => x,
             None => {
                 show_error!("option '--suffix' requires an argument\n\
-                            Try 'mv --help' for more information.");
+                            Try '{} --help' for more information.", NAME);
                 return 1;
             }
         }
@@ -180,7 +180,7 @@ fn exec(files: &[PathBuf], b: Behaviour) -> i32 {
     match files {
         [] | [_] => {
             show_error!("missing file operand\n\
-                        Try 'mv --help' for more information.");
+                        Try '{} --help' for more information.", NAME);
             return 1;
         },
         [ref source, ref target] => {
@@ -220,7 +220,7 @@ fn exec(files: &[PathBuf], b: Behaviour) -> i32 {
         fs => {
             if b.no_target_dir {
                 show_error!("mv: extra operand ‘{}’\n\
-                            Try 'mv --help' for more information.", fs[2].display());
+                            Try '{} --help' for more information.", fs[2].display(), NAME);
                 return 1;
             }
             let target_dir = fs.last().unwrap();

--- a/src/nice/nice.rs
+++ b/src/nice/nice.rs
@@ -47,12 +47,12 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("version") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 
     if matches.opt_present("help") {
-        let msg = format!("{0} v{1}
+        let msg = format!("{0} {1}
 
 Usage:
   {0} [OPTIONS] [COMMAND [ARGS]]

--- a/src/nl/nl.rs
+++ b/src/nl/nl.rs
@@ -324,5 +324,5 @@ fn print_usage(opts: &getopts::Options) {
 }
 
 fn version() {
-    println!("{} version {}", NAME, VERSION);
+    println!("{} {}", NAME, VERSION);
 }

--- a/src/nohup/nohup.rs
+++ b/src/nohup/nohup.rs
@@ -53,7 +53,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     };
 
-    if matches.opt_present("V") { println!("{} v{}", NAME, VERSION); return 0 }
+    if matches.opt_present("V") { println!("{} {}", NAME, VERSION); return 0 }
     if matches.opt_present("h") { show_usage(&opts); return 0 }
 
     if matches.free.len() == 0 {
@@ -133,7 +133,7 @@ fn find_stdout() -> File {
 }
 
 fn show_usage(opts: &getopts::Options) {
-    let msg = format!("{0} v{1}
+    let msg = format!("{0} {1}
 
 Usage:
   {0} COMMAND [ARG]...

--- a/src/pwd/pwd.rs
+++ b/src/pwd/pwd.rs
@@ -44,7 +44,7 @@ Usage:
 Print the full filename of the current working directory.", NAME, VERSION);
         print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
-        println!("{} version: {}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
     } else {
         println!("{}", env::current_dir().unwrap().display());
     }

--- a/src/readlink/readlink.rs
+++ b/src/readlink/readlink.rs
@@ -156,7 +156,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("version") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/realpath/realpath.rs
+++ b/src/realpath/realpath.rs
@@ -116,7 +116,7 @@ fn resolve_path(path: &str, strip: bool, zero: bool, quiet: bool) -> bool {
 }
 
 fn version() {
-    println!("{} v{}", NAME, VERSION)
+    println!("{} {}", NAME, VERSION)
 }
 
 fn show_usage(opts: &getopts::Options) {

--- a/src/relpath/relpath.rs
+++ b/src/relpath/relpath.rs
@@ -84,7 +84,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 }
 
 fn version() {
-    println!("{} v{}", NAME, VERSION)
+    println!("{} {}", NAME, VERSION)
 }
 
 fn show_usage(opts: &getopts::Options) {

--- a/src/shuf/shuf.rs
+++ b/src/shuf/shuf.rs
@@ -50,7 +50,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     };
     if matches.opt_present("help") {
-        let msg = format!("{0} v{1}
+        let msg = format!("{0} {1}
 
 Usage:
   {0} [OPTION]... [FILE]
@@ -61,7 +61,7 @@ Write a random permutation of the input lines to standard output.
 With no FILE, or when FILE is -, read standard input.", NAME, VERSION);
         print!("{}", opts.usage(&msg));
     } else if matches.opt_present("version") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
     } else {
         let echo = matches.opt_present("echo");
         let mode = match matches.opt_str("input-range") {

--- a/src/split/split.rs
+++ b/src/split/split.rs
@@ -42,7 +42,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("h") {
-        let msg = format!("{0} v{1}
+        let msg = format!("{0} {1}
 
 Usage:
   {0} [OPTION]... [INPUT [PREFIX]]
@@ -56,7 +56,7 @@ size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is
     }
 
     if matches.opt_present("V") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/stdbuf/stdbuf.rs
+++ b/src/stdbuf/stdbuf.rs
@@ -68,7 +68,7 @@ fn preload_strings() -> (&'static str, &'static str) {
 }
 
 fn print_version() {
-    println!("{} version {}", NAME, VERSION);
+    println!("{} {}", NAME, VERSION);
 }
 
 fn print_usage(opts: &Options) {

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -296,5 +296,5 @@ fn print_string<T: Write>(_: &mut T, s: &String) {
 }
 
 fn version () {
-    println!("{} v{}", NAME, VERSION);
+    println!("{} {}", NAME, VERSION);
 }

--- a/src/timeout/timeout.rs
+++ b/src/timeout/timeout.rs
@@ -53,14 +53,14 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     };
     if matches.opt_present("help") {
-        print!("{} v{}
+        print!("{} {}
 
 Usage:
   {} [OPTION] DURATION COMMAND [ARG]...
 
 {}", NAME, VERSION, program, getopts::usage("Start COMMAND, and kill it if still running after DURATION.", &opts));
     } else if matches.opt_present("version") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
     } else if matches.free.len() < 2 {
         show_error!("missing an argument");
         show_error!("for help, try '{0} --help'", program);

--- a/src/tsort/tsort.rs
+++ b/src/tsort/tsort.rs
@@ -37,7 +37,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("h") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         println!("");
         println!("Usage:");
         println!("  {} [OPTIONS] FILE", NAME);
@@ -47,7 +47,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("V") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 

--- a/src/unexpand/unexpand.rs
+++ b/src/unexpand/unexpand.rs
@@ -100,7 +100,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if matches.opt_present("help") {
-        println!("{} v{}\n", NAME, VERSION);
+        println!("{} {}\n", NAME, VERSION);
         println!("Usage: {} [OPTION]... [FILE]...\n", NAME);
         println!("{}", opts.usage(
             "Convert blanks in each FILE to tabs, writing to standard output.\n\
@@ -109,7 +109,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     if matches.opt_present("V") {
-        println!("{} v{}", NAME, VERSION);
+        println!("{} {}", NAME, VERSION);
         return 0;
     }
 


### PR DESCRIPTION
All utilities should now use the format "{name} {version}" when the version is printed.