### PR TITLE
Flush pending stdout writes.

### DIFF
--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -22,6 +22,10 @@ use libc::consts::os::posix88::STDIN_FILENO;
 use libc::funcs::posix88::unistd::isatty;
 use libc::types::os::arch::c95::c_int;
 
+#[path = "../common/util.rs"]
+#[macro_use]
+mod util;
+
 static NAME: &'static str = "cat";
 static VERSION: &'static str = "1.0.0";
 
@@ -252,6 +256,7 @@ fn exec(files: Vec<String>, number: NumberingMode, show_nonprint: bool,
     } else {
         write_fast(files);
     }
+    pipe_flush!();
 }
 
 fn open(path: &str) -> Option<(Box<Read>, bool)> {

--- a/src/readlink/readlink.rs
+++ b/src/readlink/readlink.rs
@@ -227,6 +227,7 @@ fn show(path: &PathBuf, no_newline: bool, use_zero: bool) {
     } else {
         println!("{}", path);
     }
+    pipe_flush!();
 }
 
 fn show_usage(opts: &getopts::Options) {

--- a/src/tr/tr.rs
+++ b/src/tr/tr.rs
@@ -59,6 +59,7 @@ fn delete<'a>(set: ExpandSet<'a>, complement: bool) {
     }
     if buf.len() > 0 {
         safe_unwrap!(stdout.write_all(&buf[..].as_bytes()));
+        pipe_flush!();
     }
 }
 
@@ -94,6 +95,7 @@ fn tr<'a>(set1: ExpandSet<'a>, mut set2: ExpandSet<'a>) {
     }
     if buf.len() > 0 {
         safe_unwrap!(stdout.write_all(&buf[..].as_bytes()));
+        pipe_flush!();
     }
 }
 

--- a/src/unexpand/unexpand.rs
+++ b/src/unexpand/unexpand.rs
@@ -279,4 +279,5 @@ fn unexpand(options: Options) {
             buf.truncate(0);    // clear out the buffer
         }
     }
+    pipe_flush!(output);
 }


### PR DESCRIPTION
This was needed to ensure all writes to stdout were printed. Several tests failed because this wasn't happening.