### PR TITLE
Allow failure on Rust 1.0.0 (broken right now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ script:
   - make test
   - make build-check
   - make test-check
+matrix:
+  allow_failures:
+    - rust: 1.0.0


### PR DESCRIPTION
It looks like the Travis build has been broken for a long time, that's a shame.

I have a PR (#641) fixing timeout.rs, so that the Travis build on nightly succeeds; this PR makes it so that the build isn't red because of the failure on 1.0.0.