### PR TITLE
Fix OS X build errors for stdbuf.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,11 @@ SYSTEM := $(shell uname)
 DYLIB_EXT := 
 ifeq ($(SYSTEM),Linux)
 	DYLIB_EXT    := so
+	DYLIB_FLAGS  := -shared
 endif
 ifeq ($(SYSTEM),Darwin)
 	DYLIB_EXT    := dylib
+	DYLIB_FLAGS  := -dynamiclib
 endif
 
 # Libaries to install
@@ -310,8 +312,8 @@ $(BUILDDIR)/uutils: $(SRCDIR)/uutils/uutils.rs $(BUILDDIR)/mkuutils $(RLIB_PATHS
 $(BUILDDIR)/libstdbuf.$(DYLIB_EXT): $(SRCDIR)/stdbuf/libstdbuf.rs $(SRCDIR)/stdbuf/libstdbuf.c $(SRCDIR)/stdbuf/libstdbuf.h | $(BUILDDIR)
 	cd $(SRCDIR)/stdbuf && \
 	$(RUSTC) libstdbuf.rs && \
-	$(CC) -c -Wall -Werror -fpic libstdbuf.c -L. -llibstdbuf.a && \
-	$(CC) -shared -o libstdbuf.$(DYLIB_EXT) -Wl,--whole-archive liblibstdbuf.a -Wl,--no-whole-archive libstdbuf.o -lpthread && \
+	$(CC) -c -Wall -Werror -fPIC libstdbuf.c && \
+	$(CC) $(DYLIB_FLAGS) -o libstdbuf.$(DYLIB_EXT) liblibstdbuf.a libstdbuf.o && \
 	mv *.$(DYLIB_EXT) $(BUILDDIR) && $(RM) *.o && $(RM) *.a
 	
 $(BUILDDIR)/stdbuf: $(BUILDDIR)/libstdbuf.$(DYLIB_EXT)

--- a/src/stdbuf/libstdbuf.rs
+++ b/src/stdbuf/libstdbuf.rs
@@ -33,7 +33,7 @@ fn set_buffer(stream: *mut FILE, value: &str) {
             (_IOFBF, buff_size as size_t)
         }
     };
-    let mut res: c_int;
+    let res: c_int;
     unsafe {
         let buffer: *mut c_char = ptr::null_mut();
         assert!(buffer.is_null());

--- a/src/stdbuf/stdbuf.rs
+++ b/src/stdbuf/stdbuf.rs
@@ -59,7 +59,7 @@ fn preload_strings() -> (&'static str, &'static str) {
 
 #[cfg(target_os = "macos")]
 fn preload_strings() -> (&'static str, &'static str) { 
-    ("DYLD_INSERT_LIBRARIES", ".dylib")
+    ("DYLD_LIBRARY_PATH", ".dylib")
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]


### PR DESCRIPTION
I removed several unused linker flags and replaced extern C reference to standard I/O with Rust's libc constants. I also removed an unused variable mutation.