### PR TITLE
Fix stdbuf regression.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ TEST_PROGS  := \
   seq \
   sort \
   split \
+  stdbuf \
   tac \
   test \
   tr \

--- a/src/stdbuf/stdbuf.rs
+++ b/src/stdbuf/stdbuf.rs
@@ -225,7 +225,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     let mut options = ProgramOptions {stdin: BufferType::Default, stdout: BufferType::Default, stderr: BufferType::Default};
     let mut command_idx = -1;
-    for i in 1 .. args.len()-1 {
+    for i in 1 .. args.len()+1 {
         match parse_options(&args[1 .. i], &mut options, &opts) {
             Ok(OkMsg::Buffering) => {
                 command_idx = i - 1;

--- a/test/stdbuf.rs
+++ b/test/stdbuf.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+use util::*;
+
+static PROGNAME: &'static str = "./stdbuf";
+
+#[path = "common/util.rs"]
+#[macro_use]
+mod util;
+
+#[test]
+fn test_stdbuf_unbuffered_stdout() {
+    // This is a basic smoke test
+    let mut cmd = Command::new(PROGNAME);
+    let result = run_piped_stdin(&mut cmd.args(&["-o0", "head"]), "The quick brown fox jumps over the lazy dog.");
+    assert_eq!(result.stdout, "The quick brown fox jumps over the lazy dog.");
+}


### PR DESCRIPTION
When replacing range_inclusive(), I introduced a bug when parsing arguments. I added a smoke test to prevent basic regressions in the future.