### PR TITLE
Delay resolution of library symbols until runtime.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ ifeq ($(SYSTEM),Linux)
 endif
 ifeq ($(SYSTEM),Darwin)
 	DYLIB_EXT    := dylib
-	DYLIB_FLAGS  := -dynamiclib
+	DYLIB_FLAGS  := -dynamiclib -undefined dynamic_lookup
 endif
 
 # Libaries to install


### PR DESCRIPTION
This is needed for dynamic libraries on OS X. This was supposed to be part of #647, but it was left out.