### PR TITLE
Add Windows CI support using AppVeyor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-uutils coreutils [![Build Status](https://api.travis-ci.org/uutils/coreutils.svg?branch=master)](https://travis-ci.org/uutils/coreutils)
+uutils coreutils
 ================
+
+[![Build Status](https://api.travis-ci.org/uutils/coreutils.svg?branch=master)](https://travis-ci.org/uutils/coreutils)
+[![Build status](https://ci.appveyor.com/api/projects/status/xhlsa439de5ogodp?svg=true)](https://ci.appveyor.com/project/jbcrail/coreutils-o0l0r)
 
 uutils is an attempt at writing universal (as in cross-platform) CLI
 utils in [Rust](http://www.rust-lang.org). This repo is to aggregate the GNU

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+platform:
+  - x64
+
+environment:
+  global:
+    MSYS2_BASEVER: 20150512
+    MSYS2_ARCH: x86_64
+    MBASH: msys64\usr\bin\sh --login -c
+
+  matrix:
+  - TARGET: i686-pc-windows-gnu
+
+install:
+  - appveyor DownloadFile "http://kent.dl.sourceforge.net/project/msys2/Base/%MSYS2_ARCH%/msys2-base-%MSYS2_ARCH%-%MSYS2_BASEVER%.tar.xz" -FileName "msys2.tar.xz"
+  - 7z x msys2.tar.xz
+  - 7z x msys2.tar > NUL
+  - call %MBASH% ""
+  - call %MBASH% "for i in {1..3}; do pacman --noconfirm -Suy mingw-w64-%MSYS2_ARCH%-{ragel,freetype,icu,gettext} libtool pkg-config gcc make autoconf automake perl && break || sleep 15; done"
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - SET PATH=%PATH%;C:\MinGW\bin
+  - rustc -V
+  - cargo -V
+
+build_script:
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make"
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make build-check"
+
+test_script:
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make test"
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make test-check"


### PR DESCRIPTION
Given the recent focus on the Windows build, I added CI support using AppVeyor. I installed MSYS2 and Rust in the Windows VM, and the initial build is functional but still fails.

Could someone review this? I'm a new to AppVeyor and building Rust programs on Windows so any help would be appreciated.

Here is the build for my coreutils fork: https://ci.appveyor.com/project/jbcrail/coreutils

/cc @retep998 @Arcterus 