### PR TITLE
Basic Cargo based build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,268 +1,162 @@
-[project]
-name = "uutils-coreutils"
+[package]
+name = "uutils"
 version = "0.0.1"
 authors = []
+build = "build.rs"
+
+[features]
+default = ["all"]
+all = [
+    "base64",
+    "basename",
+    "cat",
+    "chmod",
+    "chroot",
+    "cksum",
+    "comm",
+    "cp",
+    "cut",
+    "dirname",
+    "du",
+    "echo",
+    "env",
+    "expand",
+    "factor",
+    "false",
+    "fmt",
+    "fold",
+    "groups",
+    "hashsum",
+    "head",
+    "hostid",
+    "hostname",
+    "id",
+    "kill",
+    "link",
+    "ln",
+    "logname",
+    "mkdir",
+    "mkfifo",
+    "mv",
+    "nice",
+    "nl",
+    "nohup",
+    "nproc",
+    "od",
+    "paste",
+    "printenv",
+    "ptx",
+    "pwd",
+    "readlink",
+    "realpath",
+    "relpath",
+    "rm",
+    "rmdir",
+    "seq",
+    "shuf",
+    "sleep",
+    "sort",
+    "split",
+    "sum",
+    "sync",
+    "tac",
+    "tail",
+    "tee",
+    "test",
+    "timeout",
+    "touch",
+    "tr",
+    "true",
+    "truncate",
+    "tsort",
+    "tty",
+    "uname",
+    "unexpand",
+    "uniq",
+    "unlink",
+    "uptime",
+    "users",
+    "wc",
+    "whoami",
+    "yes",
+]
+
+[dependencies]
+base64   = { optional=true, path="src/base64" }
+basename = { optional=true, path="src/basename" }
+cat      = { optional=true, path="src/cat" }
+chmod    = { optional=true, path="src/chmod" }
+chroot   = { optional=true, path="src/chroot" }
+cksum    = { optional=true, path="src/cksum" }
+comm     = { optional=true, path="src/comm" }
+cp       = { optional=true, path="src/cp" }
+cut      = { optional=true, path="src/cut" }
+dirname  = { optional=true, path="src/dirname" }
+du       = { optional=true, path="src/du" }
+echo     = { optional=true, path="src/echo" }
+env      = { optional=true, path="src/env" }
+expand   = { optional=true, path="src/expand" }
+factor   = { optional=true, path="src/factor" }
+false    = { optional=true, path="src/false" }
+fmt      = { optional=true, path="src/fmt" }
+fold     = { optional=true, path="src/fold" }
+groups   = { optional=true, path="src/groups" }
+hashsum  = { optional=true, path="src/hashsum" }
+head     = { optional=true, path="src/head" }
+hostid   = { optional=true, path="src/hostid" }
+hostname = { optional=true, path="src/hostname" }
+id       = { optional=true, path="src/id" }
+kill     = { optional=true, path="src/kill" }
+link     = { optional=true, path="src/link" }
+ln       = { optional=true, path="src/ln" }
+logname  = { optional=true, path="src/logname" }
+mkdir    = { optional=true, path="src/mkdir" }
+mkfifo   = { optional=true, path="src/mkfifo" }
+mv       = { optional=true, path="src/mv" }
+nice     = { optional=true, path="src/nice" }
+nl       = { optional=true, path="src/nl" }
+nohup    = { optional=true, path="src/nohup" }
+nproc    = { optional=true, path="src/nproc" }
+od       = { optional=true, path="src/od" }
+paste    = { optional=true, path="src/paste" }
+printenv = { optional=true, path="src/printenv" }
+ptx      = { optional=true, path="src/ptx" }
+pwd      = { optional=true, path="src/pwd" }
+readlink = { optional=true, path="src/readlink" }
+realpath = { optional=true, path="src/realpath" }
+relpath  = { optional=true, path="src/relpath" }
+rm       = { optional=true, path="src/rm" }
+rmdir    = { optional=true, path="src/rmdir" }
+seq      = { optional=true, path="src/seq" }
+shuf     = { optional=true, path="src/shuf" }
+sleep    = { optional=true, path="src/sleep" }
+sort     = { optional=true, path="src/sort" }
+split    = { optional=true, path="src/split" }
+sum      = { optional=true, path="src/sum" }
+sync     = { optional=true, path="src/sync" }
+tac      = { optional=true, path="src/tac" }
+tail     = { optional=true, path="src/tail" }
+tee      = { optional=true, path="src/tee" }
+test     = { optional=true, path="src/test" }
+timeout  = { optional=true, path="src/timeout" }
+touch    = { optional=true, path="src/touch" }
+tr       = { optional=true, path="src/tr" }
+true     = { optional=true, path="src/true" }
+truncate = { optional=true, path="src/truncate" }
+tsort    = { optional=true, path="src/tsort" }
+tty      = { optional=true, path="src/tty" }
+uname    = { optional=true, path="src/uname" }
+unexpand = { optional=true, path="src/unexpand" }
+uniq     = { optional=true, path="src/uniq" }
+unlink   = { optional=true, path="src/unlink" }
+uptime   = { optional=true, path="src/uptime" }
+users    = { optional=true, path="src/users" }
+wc       = { optional=true, path="src/wc" }
+whoami   = { optional=true, path="src/whoami" }
+yes      = { optional=true, path="src/yes" }
+
+
+[[bin]]
+name="uutils"
+path="src/uutils/uutils_cargo.rs"
 
-[[bin]]
-name = "base64"
-path = "base64/base64.rs"
-
-[[bin]]
-name = "basename"
-path = "basename/basename.rs"
-
-[[bin]]
-name = "cat"
-path = "cat/cat.rs"
-
-[[bin]]
-name = "chmod"
-path = "chmod/chmod.rs"
-
-[[bin]]
-name = "chroot"
-path = "chroot/chroot.rs"
-
-[[bin]]
-name = "cksum"
-path = "cksum/cksum.rs"
-
-[[bin]]
-name = "comm"
-path = "comm/comm.rs"
-
-[[bin]]
-name = "cp"
-path = "cp/cp.rs"
-
-[[bin]]
-name = "cut"
-path = "cut/cut.rs"
-
-[[bin]]
-name = "dirname"
-path = "dirname/dirname.rs"
-
-[[bin]]
-name = "du"
-path = "du/du.rs"
-
-[[bin]]
-name = "echo"
-path = "echo/echo.rs"
-
-[[bin]]
-name = "env"
-path = "env/env.rs"
-
-[[bin]]
-name = "expand"
-path = "expand/expand.rs"
-
-[[bin]]
-name = "factor"
-path = "factor/factor.rs"
-
-[[bin]]
-name = "false"
-path = "false/false.rs"
-
-[[bin]]
-name = "fmt"
-path = "fmt/fmt.rs"
-
-[[bin]]
-name = "fold"
-path = "fold/fold.rs"
-
-[[bin]]
-name = "groups"
-path = "groups/groups.rs"
-
-[[bin]]
-name = "hashsum"
-path = "hashsum/hashsum.rs"
-
-[[bin]]
-name = "head"
-path = "head/head.rs"
-
-[[bin]]
-name = "hostid"
-path = "hostid/hostid.rs"
-
-[[bin]]
-name = "hostname"
-path = "hostname/hostname.rs"
-
-[[bin]]
-name = "id"
-path = "id/id.rs"
-
-[[bin]]
-name = "kill"
-path = "kill/kill.rs"
-
-[[bin]]
-name = "link"
-path = "link/link.rs"
-
-[[bin]]
-name = "logname"
-path = "logname/logname.rs"
-
-[[bin]]
-name = "mkdir"
-path = "mkdir/mkdir.rs"
-
-[[bin]]
-name = "mv"
-path = "mv/mv.rs"
-
-[[bin]]
-name = "mkfifo"
-path = "mkfifo/mkfifo.rs"
-
-[[bin]]
-name = "nl"
-path = "nl/nl.rs"
-
-[[bin]]
-name = "nohup"
-path = "nohup/nohup.rs"
-
-[[bin]]
-name = "paste"
-path = "paste/paste.rs"
-
-[[bin]]
-name = "printenv"
-path = "printenv/printenv.rs"
-
-[[bin]]
-name = "pwd"
-path = "pwd/pwd.rs"
-
-[[bin]]
-name = "realpath"
-path = "realpath/realpath.rs"
-
-[[bin]]
-name = "relpath"
-path = "relpath/relpath.rs"
-
-[[bin]]
-name = "rm"
-path = "rm/rm.rs"
-
-[[bin]]
-name = "rmdir"
-path = "rmdir/rmdir.rs"
-
-[[bin]]
-name = "seq"
-path = "seq/seq.rs"
-
-[[bin]]
-name = "shuf"
-path = "shuf/shuf.rs"
-
-[[bin]]
-name = "sleep"
-path = "sleep/sleep.rs"
-
-[[bin]]
-name = "sort"
-path = "sort/sort.rs"
-
-[[bin]]
-name = "split"
-path = "split/split.rs"
-
-[[bin]]
-name = "sum"
-path = "sum/sum.rs"
-
-[[bin]]
-name = "sync"
-path = "sync/sync.rs"
-
-[[bin]]
-name = "tac"
-path = "tac/tac.rs"
-
-[[bin]]
-name = "tail"
-path = "tail/tail.rs"
-
-[[bin]]
-name = "tee"
-path = "tee/tee.rs"
-
-[[bin]]
-name = "test"
-path = "test/test.rs"
-
-[[bin]]
-name = "timeout"
-path = "timeout/timeout.rs"
-
-[[bin]]
-name = "touch"
-path = "touch/touch.rs"
-
-[[bin]]
-name = "tr"
-path = "tr/tr.rs"
-
-[[bin]]
-name = "true"
-path = "true/true.rs"
-
-[[bin]]
-name = "truncate"
-path = "truncate/truncate.rs"
-
-[[bin]]
-name = "tsort"
-path = "tsort/tsort.rs"
-
-[[bin]]
-name = "tty"
-path = "tty/tty.rs"
-
-[[bin]]
-name = "uname"
-path = "uname/uname.rs"
-
-[[bin]]
-name = "unexpand"
-path = "unexpand/unexpand.rs"
-
-[[bin]]
-name = "uniq"
-path = "uniq/uniq.rs"
-
-[[bin]]
-name = "unlink"
-path = "unlink/unlink.rs"
-
-[[bin]]
-name = "uptime"
-path = "uptime/uptime.rs"
-
-[[bin]]
-name = "users"
-path = "users/users.rs"
-
-[[bin]]
-name = "wc"
-path = "wc/wc.rs"
-
-[[bin]]
-name = "whoami"
-path = "whoami/whoami.rs"
-
-[[bin]]
-name = "yes"
-path = "yes/yes.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,61 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+pub fn main() {
+    let feature_prefix = "CARGO_FEATURE_";
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    let mut crates = Vec::new();
+    for (key, val) in env::vars() {
+        if val == "1" && key.starts_with(feature_prefix) {
+            let krate = key[feature_prefix.len()..].to_lowercase();
+            match krate.as_ref() {
+            "default" => continue,
+            "all" => continue,
+            _ => {},
+            }
+            crates.push(krate.to_string());
+        }
+    }
+    crates.sort();
+    let mut cf = File::create(Path::new(&out_dir).join("uutils_crates.rs")).unwrap();
+    let mut mf = File::create(Path::new(&out_dir).join("uutils_map.rs")).unwrap();
+    mf.write_all("
+    type UtilityMap = HashMap<&'static str, fn(Vec<String>) -> i32>;
+
+    fn util_map() -> UtilityMap {
+    let mut map: UtilityMap = HashMap::new();\n".as_bytes()).unwrap();
+    for krate in crates {
+        match krate.as_ref() {
+            "false" => continue,
+            "true" => continue,
+            _ => cf.write_all(format!("extern crate {krate} as uu{krate};\n", krate=krate).as_bytes()).unwrap(),
+        }
+
+        match krate.as_ref() {
+            "hashsum" => {
+                mf.write_all("map.insert(\"hashsum\", uuhashsum::uumain);
+                              map.insert(\"md5sum\", uuhashsum::uumain);
+                              map.insert(\"sha1sum\", uuhashsum::uumain);
+                              map.insert(\"sha224sum\", uuhashsum::uumain);
+                              map.insert(\"sha256sum\", uuhashsum::uumain);
+                              map.insert(\"sha384sum\", uuhashsum::uumain);
+                              map.insert(\"sha512sum\", uuhashsum::uumain);\n".as_bytes()).unwrap();
+            },
+            "false" =>
+                mf.write_all("fn uufalse(_: Vec<String>) -> i32 { 1 }
+                             map.insert(\"false\", uufalse as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
+            "true" =>
+                mf.write_all("fn uutrue(_: Vec<String>) -> i32 { 0 }
+                             map.insert(\"true\", uutrue as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
+            _ => 
+                mf.write_all(format!("map.insert(\"{krate}\", uu{krate}::uumain as fn(Vec<String>) -> i32);\n", krate= krate).as_bytes()).unwrap(),
+        }
+    }
+    mf.write_all("map
+    }\n".as_bytes()).unwrap();
+    cf.flush().unwrap();
+    mf.flush().unwrap();
+}

--- a/src/base64/Cargo.toml
+++ b/src/base64/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "base64"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "base64"
+path = "base64.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+rustc-serialize = "*"

--- a/src/basename/Cargo.toml
+++ b/src/basename/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "basename"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "basename"
+path = "basename.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/cat/Cargo.toml
+++ b/src/cat/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "cat"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "cat"
+path = "cat.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/chmod/Cargo.toml
+++ b/src/chmod/Cargo.toml
@@ -1,0 +1,18 @@
+
+[package]
+name = "chmod"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "chmod"
+path = "chmod.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+aho-corasick = "*"
+memchr = "*"
+regex = "*"
+regex-syntax = "*"
+walker = "*"

--- a/src/chroot/Cargo.toml
+++ b/src/chroot/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "chroot"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "chroot"
+path = "chroot.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/cksum/Cargo.toml
+++ b/src/cksum/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "cksum"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "cksum"
+path = "cksum.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "comm"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "comm"
+path = "comm.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/cp/Cargo.toml
+++ b/src/cp/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "cp"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "cp"
+path = "cp.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/cut/Cargo.toml
+++ b/src/cut/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "cut"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "cut"
+path = "cut.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/dirname/Cargo.toml
+++ b/src/dirname/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "dirname"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "dirname"
+path = "dirname.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/du/Cargo.toml
+++ b/src/du/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "du"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "du"
+path = "du.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+time = "*"

--- a/src/echo/Cargo.toml
+++ b/src/echo/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "echo"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "echo"
+path = "echo.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/env/Cargo.toml
+++ b/src/env/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "env"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "env"
+path = "env.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/expand/Cargo.toml
+++ b/src/expand/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "expand"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "expand"
+path = "expand.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+unicode-width = "*"

--- a/src/factor/Cargo.toml
+++ b/src/factor/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "factor"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "factor"
+path = "factor.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+rand = "*"

--- a/src/false/Cargo.toml
+++ b/src/false/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "false"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "false"
+path = "false.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/fmt/Cargo.toml
+++ b/src/fmt/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "fmt"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "fmt"
+path = "fmt.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+unicode-width = "*"

--- a/src/fold/Cargo.toml
+++ b/src/fold/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "fold"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "fold"
+path = "fold.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/groups/Cargo.toml
+++ b/src/groups/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "groups"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "groups"
+path = "groups.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/hashsum/Cargo.toml
+++ b/src/hashsum/Cargo.toml
@@ -1,0 +1,16 @@
+
+[package]
+name = "hashsum"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "hashsum"
+path = "hashsum.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+regex = "*"
+regex-syntax = "*"
+rust-crypto = "*"

--- a/src/head/Cargo.toml
+++ b/src/head/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "head"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "head"
+path = "head.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/hostid/Cargo.toml
+++ b/src/hostid/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "hostid"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "hostid"
+path = "hostid.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/hostname/Cargo.toml
+++ b/src/hostname/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "hostname"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "hostname"
+path = "hostname.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/id/Cargo.toml
+++ b/src/id/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "id"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "id"
+path = "id.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/kill/Cargo.toml
+++ b/src/kill/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "kill"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "kill"
+path = "kill.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/link/Cargo.toml
+++ b/src/link/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "link"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "link"
+path = "link.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/ln/Cargo.toml
+++ b/src/ln/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "ln"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "ln"
+path = "ln.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/logname/Cargo.toml
+++ b/src/logname/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "logname"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "logname"
+path = "logname.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/mkdir/Cargo.toml
+++ b/src/mkdir/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "mkdir"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "mkdir"
+path = "mkdir.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/mkfifo/Cargo.toml
+++ b/src/mkfifo/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "mkfifo"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "mkfifo"
+path = "mkfifo.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/mv/Cargo.toml
+++ b/src/mv/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "mv"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "mv"
+path = "mv.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/nice/Cargo.toml
+++ b/src/nice/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "nice"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "nice"
+path = "nice.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/nl/Cargo.toml
+++ b/src/nl/Cargo.toml
@@ -1,0 +1,17 @@
+
+[package]
+name = "nl"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "nl"
+path = "nl.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+aho-corasick = "*"
+memchr = "*"
+regex = "*"
+regex-syntax = "*"

--- a/src/nohup/Cargo.toml
+++ b/src/nohup/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "nohup"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "nohup"
+path = "nohup.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/nproc/Cargo.toml
+++ b/src/nproc/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "nproc"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "nproc"
+path = "nproc.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+num_cpus = "*"

--- a/src/od/Cargo.toml
+++ b/src/od/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "od"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "od"
+path = "od.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/paste/Cargo.toml
+++ b/src/paste/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "paste"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "paste"
+path = "paste.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/printenv/Cargo.toml
+++ b/src/printenv/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "printenv"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "printenv"
+path = "printenv.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/ptx/Cargo.toml
+++ b/src/ptx/Cargo.toml
@@ -1,0 +1,17 @@
+
+[package]
+name = "ptx"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "ptx"
+path = "ptx.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+aho-corasick = "*"
+memchr = "*"
+regex-syntax = "*"
+regex = "*"

--- a/src/pwd/Cargo.toml
+++ b/src/pwd/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "pwd"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "pwd"
+path = "pwd.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/readlink/Cargo.toml
+++ b/src/readlink/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "readlink"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "readlink"
+path = "readlink.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/realpath/Cargo.toml
+++ b/src/realpath/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "realpath"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "realpath"
+path = "realpath.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/relpath/Cargo.toml
+++ b/src/relpath/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "relpath"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "relpath"
+path = "relpath.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/rm/Cargo.toml
+++ b/src/rm/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "rm"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "rm"
+path = "rm.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/rmdir/Cargo.toml
+++ b/src/rmdir/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "rmdir"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "rmdir"
+path = "rmdir.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/seq/Cargo.toml
+++ b/src/seq/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "seq"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "seq"
+path = "seq.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/shuf/Cargo.toml
+++ b/src/shuf/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "shuf"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "shuf"
+path = "shuf.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+rand = "*"

--- a/src/sleep/Cargo.toml
+++ b/src/sleep/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "sleep"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "sleep"
+path = "sleep.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/sort/Cargo.toml
+++ b/src/sort/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "sort"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "sort"
+path = "sort.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/split/Cargo.toml
+++ b/src/split/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "split"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "split"
+path = "split.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/sum/Cargo.toml
+++ b/src/sum/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "sum"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "sum"
+path = "sum.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/sync/Cargo.toml
+++ b/src/sync/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "sync"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "sync"
+path = "sync.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/tac/Cargo.toml
+++ b/src/tac/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "tac"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "tac"
+path = "tac.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/tail/Cargo.toml
+++ b/src/tail/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "tail"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "tail"
+path = "tail.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/tee/Cargo.toml
+++ b/src/tee/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "tee"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "tee"
+path = "tee.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "test"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "test"
+path = "test.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/timeout/Cargo.toml
+++ b/src/timeout/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "timeout"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "timeout"
+path = "timeout.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+time = "*"

--- a/src/touch/Cargo.toml
+++ b/src/touch/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "touch"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "touch"
+path = "touch.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+time = "*"

--- a/src/touch/Cargo.toml
+++ b/src/touch/Cargo.toml
@@ -9,6 +9,7 @@ name = "touch"
 path = "touch.rs"
 
 [dependencies]
+filetime = "*"
 getopts = "*"
 libc = "*"
 time = "*"

--- a/src/tr/Cargo.toml
+++ b/src/tr/Cargo.toml
@@ -1,0 +1,15 @@
+
+[package]
+name = "tr"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "tr"
+path = "tr.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+bit-set = "*"
+vec_map = "*"

--- a/src/true/Cargo.toml
+++ b/src/true/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "true"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "true"
+path = "true.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/truncate/Cargo.toml
+++ b/src/truncate/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "truncate"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "truncate"
+path = "truncate.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/tsort/Cargo.toml
+++ b/src/tsort/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "tsort"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "tsort"
+path = "tsort.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/tty/Cargo.toml
+++ b/src/tty/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "tty"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "tty"
+path = "tty.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/uname/Cargo.toml
+++ b/src/uname/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "uname"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "uname"
+path = "uname.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/unexpand/Cargo.toml
+++ b/src/unexpand/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "unexpand"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "unexpand"
+path = "unexpand.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+unicode-width = "*"

--- a/src/uniq/Cargo.toml
+++ b/src/uniq/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "uniq"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "uniq"
+path = "uniq.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/unlink/Cargo.toml
+++ b/src/unlink/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "unlink"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "unlink"
+path = "unlink.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/uptime/Cargo.toml
+++ b/src/uptime/Cargo.toml
@@ -1,0 +1,14 @@
+
+[package]
+name = "uptime"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "uptime"
+path = "uptime.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"
+time = "*"

--- a/src/users/Cargo.toml
+++ b/src/users/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "users"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "users"
+path = "users.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/uutils/uutils_cargo.rs
+++ b/src/uutils/uutils_cargo.rs
@@ -1,0 +1,99 @@
+#![crate_name = "uutils"]
+
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Michael Gehring <mg@ebfe.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+include!(concat!(env!("OUT_DIR"), "/uutils_crates.rs"));
+
+use std::env;
+use std::collections::hash_map::HashMap;
+use std::path::Path;
+
+static NAME: &'static str = "uutils";
+static VERSION: &'static str = "0.0.1";
+
+include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
+
+fn usage(cmap: &UtilityMap) {
+    println!("{} {}", NAME, VERSION);
+    println!("");
+    println!("Usage:");
+    println!("  {} [util [arguments...]]\n", NAME);
+    println!("Currently defined functions:");
+    let mut utils: Vec<&str> = cmap.keys().map(|&s| s).collect();
+    utils.sort();
+    for util in utils.iter() {
+        println!("\t{}", util);
+    }
+}
+
+fn main() {
+    let umap = util_map();
+    let mut args : Vec<String> = env::args().collect();
+
+    // try binary name as util name.
+    let args0 = args[0].clone();
+    let binary = Path::new(&args0[..]);
+    let binary_as_util = binary.file_name().unwrap().to_str().unwrap();
+
+    match umap.get(binary_as_util) {
+        Some(&uumain) => {
+            std::process::exit(uumain(args));
+        }
+        None => (),
+    }
+
+    if binary_as_util.ends_with("uutils") || binary_as_util.starts_with("uutils") ||
+        binary_as_util.ends_with("busybox") || binary_as_util.starts_with("busybox") {
+            // uutils can be called as either "uutils", "busybox"
+            // "uutils-suffix" or "busybox-suffix". Not sure
+            // what busybox uses the -suffix pattern for.
+    } else {
+        println!("{}: applet not found", binary_as_util);
+        std::process::exit(1);
+    }
+
+    // try first arg as util name.
+    if args.len() >= 2 {
+        args.remove(0);
+        let util = &args[0][..];
+
+        match umap.get(util) {
+            Some(&uumain) => {
+                std::process::exit(uumain(args.clone()));
+            }
+            None => {
+                if &args[0][..] == "--help" {
+                    // see if they want help on a specific util
+                    if args.len() >= 2 {
+                        let util = &args[1][..];
+                        match umap.get(util) {
+                            Some(&uumain) => {
+                                std::process::exit(uumain(vec![util.to_string(), "--help".to_string()]));
+                            }
+                            None => {
+                                println!("{}: applet not found", util);
+                                std::process::exit(1);
+                            }
+                        }
+                    }
+                    usage(&umap);
+                    std::process::exit(0);
+                } else {
+                    println!("{}: applet not found", util);
+                    std::process::exit(1);
+                }
+            }
+        }
+    } else {
+        // no arguments provided
+        usage(&umap);
+        std::process::exit(0);
+    }
+}

--- a/src/wc/Cargo.toml
+++ b/src/wc/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "wc"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "wc"
+path = "wc.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/whoami/Cargo.toml
+++ b/src/whoami/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "whoami"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "whoami"
+path = "whoami.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/yes/Cargo.toml
+++ b/src/yes/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "yes"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "yes"
+path = "yes.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"


### PR DESCRIPTION
Builds the uutils multicall binary containing all utils (except stdbuf)
by default. To only build a subset
    `cargo --no-default-features --features "<utils>"`
can be used.

Whats missing is building the standalone binaries and a mechanism to
automatically disable the build of unix only utils on windows.

Maybe a step towards fixing #655.