### PR TITLE
Add comments for deprecated connect().

### DIFF
--- a/src/echo/echo.rs
+++ b/src/echo/echo.rs
@@ -174,6 +174,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     if !free.is_empty() {
+        // NB: Using deprecated connect() until Rust 1.3 becomes stable.
         let string = free.connect(" ");
         if options.escape {
             let mut prev_was_slash = false;

--- a/src/users/users.rs
+++ b/src/users/users.rs
@@ -117,6 +117,7 @@ fn exec(filename: &str) {
 
     if users.len() > 0 {
         users.sort();
+        // NB: Using deprecated connect() until Rust 1.3 becomes stable.
         println!("{}", users.connect(" "));
     }
 }

--- a/src/yes/yes.rs
+++ b/src/yes/yes.rs
@@ -50,6 +50,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let string = if matches.free.is_empty() {
         "y".to_string()
     } else {
+        // NB: Using deprecated connect() until Rust 1.3 becomes stable.
         matches.free.connect(" ")
     };
 


### PR DESCRIPTION
We are using connect() instead of join() until Rust 1.3 is stable. Currently, connect() is just a thin wrapper over join(). Keeping the deprecated method allows us to build on all releases.

Fixes concerns about #676.