### PR TITLE
whoami fixes

### DIFF
--- a/src/whoami/platform/unix.rs
+++ b/src/whoami/platform/unix.rs
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+use std::io::{Result, Error};
 use ::libc;
 use self::c_types::{c_passwd, getpwuid};
 
@@ -16,14 +17,14 @@ extern {
     pub fn geteuid() -> libc::uid_t;
 }
 
-pub unsafe fn getusername() -> Result<String, String> {
+pub unsafe fn getusername() -> Result<String> {
     // Get effective user id
     let uid = geteuid();
 
     // Try to find username for uid
     let passwd: *const c_passwd = getpwuid(uid);
     if passwd.is_null() {
-        return Err(format!("cannot find name for user ID {}", uid))
+        return Err(Error::last_os_error())
     }
 
     // Extract username from passwd struct

--- a/src/whoami/platform/unix.rs
+++ b/src/whoami/platform/unix.rs
@@ -16,9 +16,10 @@ extern {
     pub fn geteuid() -> libc::uid_t;
 }
 
-pub unsafe fn getusername() -> String {
+pub unsafe fn getusername() -> Result<String, String> {
     let passwd: *const c_passwd = getpwuid(geteuid());
 
     let pw_name: *const libc::c_char = (*passwd).pw_name;
-    String::from_utf8_lossy(::std::ffi::CStr::from_ptr(pw_name).to_bytes()).to_string()
+    let username = String::from_utf8_lossy(::std::ffi::CStr::from_ptr(pw_name).to_bytes()).to_string();
+    Ok(username)
 }

--- a/src/whoami/platform/unix.rs
+++ b/src/whoami/platform/unix.rs
@@ -17,8 +17,16 @@ extern {
 }
 
 pub unsafe fn getusername() -> Result<String, String> {
-    let passwd: *const c_passwd = getpwuid(geteuid());
+    // Get effective user id
+    let uid = geteuid();
 
+    // Try to find username for uid
+    let passwd: *const c_passwd = getpwuid(uid);
+    if passwd.is_null() {
+        return Err(format!("cannot find name for user ID {}", uid))
+    }
+
+    // Extract username from passwd struct
     let pw_name: *const libc::c_char = (*passwd).pw_name;
     let username = String::from_utf8_lossy(::std::ffi::CStr::from_ptr(pw_name).to_bytes()).to_string();
     Ok(username)

--- a/src/whoami/platform/windows.rs
+++ b/src/whoami/platform/windows.rs
@@ -10,6 +10,8 @@
 extern crate winapi;
 extern crate advapi32;
 
+use std::io::{Result, Error};
+
 #[path = "../../common/wide.rs"] #[macro_use] mod wide;
 
 use std::mem;
@@ -18,11 +20,11 @@ use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use self::wide::FromWide;
 
-pub unsafe fn getusername() -> Result<String, String> {
+pub unsafe fn getusername() -> Result<String> {
     let mut buffer: [winapi::WCHAR; winapi::UNLEN as usize + 1] = mem::uninitialized();
     let mut len = buffer.len() as winapi::DWORD;
     if advapi32::GetUserNameW(buffer.as_mut_ptr(), &mut len) == 0 {
-        return Err("failed to get username".to_string())
+        return Err(Error::last_os_error())
     }
     let username = String::from_wide(&buffer[..len as usize - 1]);
     Ok(username)

--- a/src/whoami/platform/windows.rs
+++ b/src/whoami/platform/windows.rs
@@ -18,11 +18,12 @@ use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use self::wide::FromWide;
 
-pub unsafe fn getusername() -> String {
+pub unsafe fn getusername() -> Result<String, String> {
     let mut buffer: [winapi::WCHAR; winapi::UNLEN as usize + 1] = mem::uninitialized();
     let mut len = buffer.len() as winapi::DWORD;
     if advapi32::GetUserNameW(buffer.as_mut_ptr(), &mut len) == 0 {
-        crash!(1, "failed to get username");
+        return Err("failed to get username".to_string())
     }
-    String::from_wide(&buffer[..len as usize - 1])
+    let username = String::from_wide(&buffer[..len as usize - 1]);
+    Ok(username)
 }

--- a/src/whoami/whoami.rs
+++ b/src/whoami/whoami.rs
@@ -54,7 +54,9 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
 pub fn exec() {
     unsafe {
-        let username = platform::getusername();
-        println!("{}", username);
+        match platform::getusername() {
+            Ok(username) => println!("{}", username),
+            Err(msg) => crash!(libc::EXIT_FAILURE, "{}", msg),
+        }
     }
 }

--- a/src/whoami/whoami.rs
+++ b/src/whoami/whoami.rs
@@ -56,7 +56,10 @@ pub fn exec() {
     unsafe {
         match platform::getusername() {
             Ok(username) => println!("{}", username),
-            Err(msg) => crash!(libc::EXIT_FAILURE, "{}", msg),
+            Err(err) => match err.raw_os_error() {
+                Some(0) | None => crash!(1, "failed to get username"),
+                Some(_) => crash!(1, "failed to get username: {}", err),
+            }
         }
     }
 }


### PR DESCRIPTION
This PR does the following:

- Return status `libc::EXIT_FAILURE` instead of `1` on failures. This mimicks the GNU whoami implementation. Not sure what you think of it, if you want me to use `1` instead, let me know.
- The `getusername` functions now return a `Result<String, String>` instead of crashing directly
- Handle null pointer return value for `getpwuid()` on Linux

I don't have much experience doing systems stuff, so please check this PR carefully :) Also, I didn't try to compile it on Windows.

The error condition can be tested by doing this change (under the condition that a user with uid 1337 does not exist, of course):

```diff
diff --git a/src/whoami/platform/unix.rs b/src/whoami/platform/unix.rs
index d24d02e..e9c56a2 100644
--- a/src/whoami/platform/unix.rs
+++ b/src/whoami/platform/unix.rs
@@ -21,7 +21,7 @@ pub unsafe fn getusername() -> Result<String, String> {
     let uid = geteuid();
 
     // Try to find username for uid
-    let passwd: *const c_passwd = getpwuid(uid);
+    let passwd: *const c_passwd = getpwuid(1337 as libc::uid_t);
     if passwd.is_null() {
         return Err(format!("cannot find name for user ID {}", uid))
     }
```

Previously this resulted in a segfault.