### PR TITLE
factor: reduce number of random tests

### DIFF
--- a/test/factor.rs
+++ b/test/factor.rs
@@ -22,7 +22,7 @@ mod sieve;
 const NUM_PRIMES: usize = 10000;
 const LOG_PRIMES: f64 = 14.0;   // ceil(log2(NUM_PRIMES))
 
-const NUM_TESTS: usize = 1000;
+const NUM_TESTS: usize = 100;
 const PROGNAME: &'static str = "./factor";
 
 #[test]


### PR DESCRIPTION
The current test runs for ~1min on a fast machine which seems to be a bit
excessive. (Or maybe there is a performance problem?)