### PR TITLE
Implemented 'expr' utility. (#381)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ all = [
     "echo",
     "env",
     "expand",
+    "expr",
     "factor",
     "false",
     "fmt",
@@ -96,6 +97,7 @@ du       = { optional=true, path="src/du" }
 echo     = { optional=true, path="src/echo" }
 env      = { optional=true, path="src/env" }
 expand   = { optional=true, path="src/expand" }
+expr     = { optional=true, path="src/expr" }
 factor   = { optional=true, path="src/factor" }
 false    = { optional=true, path="src/false" }
 fmt      = { optional=true, path="src/fmt" }

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ PROGS       := \
   echo \
   env \
   expand \
+  expr \
   factor \
   false \
   fmt \
@@ -144,7 +145,7 @@ INSTALLEES  := \
 
 # Shared library extension
 SYSTEM := $(shell uname)
-DYLIB_EXT := 
+DYLIB_EXT :=
 ifeq ($(SYSTEM),Linux)
 	DYLIB_EXT    := so
 	DYLIB_FLAGS  := -shared
@@ -324,7 +325,7 @@ $(BUILDDIR)/libstdbuf.$(DYLIB_EXT): $(SRCDIR)/stdbuf/libstdbuf.rs $(SRCDIR)/stdb
 	$(CC) -c -Wall -Werror -fPIC libstdbuf.c && \
 	$(CC) $(DYLIB_FLAGS) -o libstdbuf.$(DYLIB_EXT) liblibstdbuf.a libstdbuf.o && \
 	mv *.$(DYLIB_EXT) $(BUILDDIR) && $(RM) *.o && $(RM) *.a
-	
+
 $(BUILDDIR)/stdbuf: $(BUILDDIR)/libstdbuf.$(DYLIB_EXT)
 
 deps: $(BUILDDIR) $(SRCDIR)/cksum/crc_table.rs $(addprefix DEP_,$(DEPLIBS) $(DEPPLUGS))

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -1,0 +1,13 @@
+
+[package]
+name = "expr"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "expr"
+path = "expr.rs"
+
+[dependencies]
+getopts = "*"
+libc = "*"

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -1,0 +1,52 @@
+#![crate_name = "expr"]
+
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Roman Gafiyatullin <r.gafiyatullin@me.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+extern crate getopts;
+extern crate libc;
+
+#[path="../common/util.rs"]
+#[macro_use]
+mod util;
+mod tokens;
+mod syntax_tree;
+
+use std::io::{Write};
+
+static NAME: &'static str = "expr";
+// // FIXME: the following line is going to be needed once we can use getopts with this utility.
+// static VERSION: &'static str = "0.0.1";
+
+pub fn uumain(args: Vec<String>) -> i32 {
+	// For expr utility we do not want getopts.
+	// The following usage should work without escaping hyphens: `expr -15 = 1 +  2 \* \( 3 - -4 \)`
+
+	let token_strings = args[1..].to_vec();
+
+	match process_expr( &token_strings ) {
+		Ok( expr_result ) => print_expr_ok( &expr_result ),
+		Err( expr_error ) => print_expr_error( &expr_error )
+	}
+}
+
+fn process_expr( token_strings: &Vec<String> ) -> Result< String, String > {
+	let tokens = tokens::string_vec_to_tokens( &token_strings );
+	let ast = syntax_tree::tokens_to_ast( &tokens );
+	Result::Ok( ast.str_value() )
+}
+
+fn print_expr_ok( expr_result: &String ) -> i32 {
+	println!("{}", expr_result);
+	0
+}
+
+fn print_expr_error( expr_error: &String ) -> ! {
+	crash!(2, "expression evaluation error\n\t{}", expr_error)
+}

--- a/src/expr/syntax_tree.rs
+++ b/src/expr/syntax_tree.rs
@@ -1,0 +1,156 @@
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Roman Gafiyatullin <r.gafiyatullin@me.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+//!
+//! Here we employ shunting-yard algorithm for building AST from tokens according to operators' precedence and associativeness.
+//! * https://en.wikipedia.org/wiki/Shunting-yard_algorithm
+//!
+
+use std::io::{Write};
+use tokens::{Token, OpType};
+
+#[derive(Clone)]
+pub enum ASTNode {
+    Str{ value: String },
+    Int{ value: i64 },
+    Op{ operation: OpType, left: Box<ASTNode>, right: Box<ASTNode> }
+}
+
+impl ASTNode {
+    pub fn bool_value( self ) -> bool {
+        if self.int_value() == 0 { false }
+        else { true }
+    }
+    pub fn int_value( self ) -> i64 {
+        match self {
+            ASTNode::Int{ value: i } => i,
+            ASTNode::Str{ value: s } => crash!(2, "not a decimal number: '{}'", s),
+            ASTNode::Op{ operation: op_type, left: left_operand, right: right_operand } => {
+                match op_type {
+                    OpType::Plus => left_operand.int_value() + right_operand.int_value(),
+                    OpType::Minus => left_operand.int_value() - right_operand.int_value(),
+                    OpType::Mult => left_operand.int_value() * right_operand.int_value(),
+                    OpType::Div => left_operand.int_value() / right_operand.int_value(),
+                    OpType::Mod => left_operand.int_value() % right_operand.int_value(),
+                    OpType::Eq => if left_operand.int_value() == right_operand.int_value() { 1 } else { 0 },
+                    OpType::NEq => if left_operand.int_value() != right_operand.int_value() { 1 } else { 0 },
+                    OpType::Lt => if left_operand.int_value() < right_operand.int_value() { 1 } else { 0 },
+                    OpType::LtEq => if left_operand.int_value() <= right_operand.int_value() { 1 } else { 0 },
+                    OpType::Gt => if left_operand.int_value() > right_operand.int_value() { 1 } else { 0 },
+                    OpType::GtEq => if left_operand.int_value() >= right_operand.int_value() { 1 } else { 0 },
+                    OpType::And => if left_operand.bool_value() && right_operand.bool_value()  { 1 } else { 0 },
+                    OpType::Or => if left_operand.bool_value() || right_operand.bool_value()  { 1 } else { 0 },
+
+                    _ => crash!(2, "not implemented: '{:?}'", op_type)
+                }
+            }
+        }
+    }
+    pub fn str_value( self ) -> String {
+        match self {
+            ASTNode::Str{ value: s } => s,
+            ASTNode::Int{ value: i } => i.to_string(),
+            _ => self.int_value().to_string()
+        }
+    }
+}
+
+type TokenStack = Vec<Token>;
+
+pub fn tokens_to_ast( tokens: &Vec<Token> ) -> Box<ASTNode> {
+    let mut out_stack: TokenStack = Vec::new();
+    let mut op_stack: TokenStack = Vec::new();
+
+    for tok in tokens {
+        push_token_to_either_stack( tok.clone(), &mut out_stack, &mut op_stack );
+    }
+
+    move_rest_of_ops_to_out( &mut out_stack, &mut op_stack );
+    assert!( op_stack.is_empty() );
+
+    ast_from_stack( &mut out_stack )
+}
+
+fn ast_from_stack( out_stack: &mut TokenStack ) -> Box<ASTNode> {
+    match out_stack.pop() {
+        None => crash!(2, "syntax error (incomplete expression)"),
+
+        Some( Token::Str{ value: s } ) => Box::new( ASTNode::Str{ value: s } ),
+
+        Some( Token::Int{ value: s } ) => Box::new( ASTNode::Int{ value: s } ),
+
+        Some( Token::Op{ precedence: _, left_assoc: _, value: op_type } ) => {
+            let right = ast_from_stack( out_stack );
+            let left = ast_from_stack( out_stack );
+            Box::new( ASTNode::Op{ operation: op_type, left: left, right: right } )
+        }
+
+        Some( _ ) => panic!("Parenthesis on out_stack")
+    }
+}
+
+fn push_token_to_either_stack( tok: Token, out_stack: &mut TokenStack, op_stack: &mut TokenStack ) {
+    match tok {
+        Token::Int{ .. } => out_stack.push( tok ),
+        Token::Str{ .. } => out_stack.push( tok ),
+        Token::Op{ .. } =>
+            if op_stack.is_empty() { op_stack.push( tok ) }
+            else { push_op_to_stack( tok, out_stack, op_stack ) },
+        Token::ParOpen => op_stack.push( tok ),
+        Token::ParClose => move_till_match_paren( out_stack, op_stack )
+    }
+}
+
+
+fn push_op_to_stack( tok: Token, out_stack: &mut TokenStack, op_stack: &mut TokenStack ) {
+    if let Token::Op{ precedence: prec, left_assoc: la, .. } = tok {
+        loop {
+            match op_stack.last() {
+                None => break,
+                Some( &Token::ParOpen ) => {
+                    op_stack.push( tok.clone() );
+                    break
+                },
+
+                Some( &Token::Op{ precedence: prev_prec, .. } ) =>
+                    if la && prev_prec >= prec
+                    || !la && prev_prec > prec {
+                        out_stack.push( op_stack.pop().unwrap() )
+                    }
+                    else {
+                        op_stack.push( tok.clone() );
+                        break
+                    },
+
+                Some( _ ) => panic!("Non-operator on op_stack")
+            }
+        }
+    }
+}
+
+fn move_rest_of_ops_to_out( out_stack: &mut TokenStack, op_stack: &mut TokenStack ) {
+    loop {
+        match op_stack.pop() {
+            None => break,
+            Some( Token::ParOpen ) => crash!(2, "syntax error (Mismatched open-parenthesis)"),
+            Some( Token::ParClose ) => crash!(2, "syntax error (Mismatched close-parenthesis)"),
+            Some( other ) => out_stack.push( other )
+        }
+    }
+}
+
+fn move_till_match_paren( out_stack: &mut TokenStack, op_stack: &mut TokenStack ) {
+    loop {
+        match op_stack.pop() {
+            None => crash!(2, "syntax error (Mismatched close-parenthesis)"),
+            Some( Token::ParOpen ) => break,
+            Some( other ) => out_stack.push( other )
+        }
+    }
+}

--- a/src/expr/tokens.rs
+++ b/src/expr/tokens.rs
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Roman Gafiyatullin <r.gafiyatullin@me.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+//!
+//! The following tokens are present in the expr grammar:
+//! * integer literal;
+//! * string literal;
+//! * binary operators with 6 priorities.
+//!
+//! According to the man-page of expr we have expression split into tokens (each token -- separate CLI-argument).
+//! Hence all we need is to map the strings into the Token structures.
+//!
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OpType {
+    Colon,
+    Mult,
+    Div,
+    Mod,
+    Plus,
+    Minus,
+    Eq,
+    Gt,
+    GtEq,
+    Lt,
+    LtEq,
+    NEq,
+    And,
+    Or,
+    Cap
+}
+
+#[derive(Clone, PartialEq)]
+pub enum Token {
+    Int{ value: i64 },
+    Str{ value: String },
+    ParOpen,
+    ParClose,
+    Op{
+            precedence: u8,
+            left_assoc: bool,
+            value: OpType
+        }
+}
+
+pub fn string_vec_to_tokens( args: &Vec<String> ) -> Vec<Token> {
+    let mut out: Vec<Token> = Vec::with_capacity( args.len() );
+    for s in args {
+        match s.as_ref() {
+            "(" => out.push( Token::ParOpen ),
+            ")" => out.push( Token::ParClose ),
+
+            // The following one is added just to prove right-associativeness working
+            "^" => out.push( Token::Op{ left_assoc: false, precedence: 7, value: OpType::Cap } ),
+
+            ":" => out.push( Token::Op{ left_assoc: true, precedence: 6, value: OpType::Colon } ),
+
+            "*" => out.push( Token::Op{ left_assoc: true, precedence: 5, value: OpType::Mult } ),
+            "/" => out.push( Token::Op{ left_assoc: true, precedence: 5, value: OpType::Div } ),
+            "%" => out.push( Token::Op{ left_assoc: true, precedence: 5, value: OpType::Mod } ),
+
+            "+" => out.push( Token::Op{ left_assoc: true, precedence: 4, value: OpType::Plus } ),
+            "-" => out.push( Token::Op{ left_assoc: true, precedence: 4, value: OpType::Minus } ),
+
+            "=" => out.push( Token::Op{ left_assoc: true, precedence: 3, value: OpType::Eq } ),
+            ">" => out.push( Token::Op{ left_assoc: true, precedence: 3, value: OpType::Gt } ),
+            ">=" => out.push( Token::Op{ left_assoc: true, precedence: 3, value: OpType::GtEq } ),
+            "<" => out.push( Token::Op{ left_assoc: true, precedence: 3, value: OpType::Lt } ),
+            "<=" => out.push( Token::Op{ left_assoc: true, precedence: 3, value: OpType::LtEq } ),
+            "!=" => out.push( Token::Op{ left_assoc: true, precedence: 3, value: OpType::NEq } ),
+
+            "&" => out.push( Token::Op{ left_assoc: true, precedence: 2, value: OpType::And } ),
+
+            "|" => out.push( Token::Op{ left_assoc: true, precedence: 1, value: OpType::Or } ),
+
+            s => match s.parse::<i64>() {
+                    Ok( i ) => out.push( Token::Int{ value: i } ),
+                    Err( _ ) =>
+                        // panic!("Ouch! A string")
+                        out.push( Token::Str{ value: s.to_string() } )
+                },
+        }
+    }
+    out
+}


### PR DESCRIPTION
Supported operations -- *, /, %, -, +, &, |, <, >, =, !=, <=, >=
Not supported operations: :, ^ (not obligatory)
Operators: precedence (descending order):
     - ^
     - :
     - *, /, %
     - +, -
     - =, >, >=, <, <=, !=
     - &
     - |

^-operator is added just to make sure right-associative operators are analysed correctly.

Known issue:
    	as I am not sure how to make getopts work with arguments like '-2'
    	(which are supposed to denote negative integers)
    	getopts is not used altogether.
