### PR TITLE
Fix namespace collision for test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ all = [
     "tac",
     "tail",
     "tee",
-    "test_uu",
+    "test",
     "timeout",
     "touch",
     "tr",
@@ -143,7 +143,7 @@ sync     = { optional=true, path="src/sync" }
 tac      = { optional=true, path="src/tac" }
 tail     = { optional=true, path="src/tail" }
 tee      = { optional=true, path="src/tee" }
-test_uu  = { optional=true, path="src/test" }
+test     = { optional=true, path="src/test" }
 timeout  = { optional=true, path="src/timeout" }
 touch    = { optional=true, path="src/touch" }
 tr       = { optional=true, path="src/tr" }

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ PROGS       := \
   sync \
   tac \
   tee \
-  test_uu \
+  test \
   tr \
   true \
   truncate \
@@ -163,7 +163,7 @@ build_exe_$(1):
 endef
 
 define TEST_INTEGRATION
-test_integration_$(1):
+test_integration_$(1): build_exe_$(1)
 	${CARGO} test --test $(1) --features $(1) --no-default-features
 endef
 
@@ -206,11 +206,10 @@ use_default := 1
 
 $(foreach util,$(EXES),$(eval $(call BUILD_EXE,$(util))))
 
-build-uutils:
+build-uutils: $(addprefix build_exe_,$(EXES))
 	${CARGO} build --features "${EXES}" ${PROFILE_CMD} --no-default-features
 
-build: build-uutils $(addprefix build_exe_,$(EXES))
-	$(foreach util, ${EXES}, $(call build_pkg, ${util}))
+build: build-uutils
 
 $(foreach test,$(TESTS),$(eval $(call TEST_INTEGRATION,$(test))))
 $(foreach test,$(TESTS),$(eval $(call TEST_UNIT,$(test))))

--- a/build.rs
+++ b/build.rs
@@ -29,8 +29,7 @@ pub fn main() {
     let mut map: UtilityMap = HashMap::new();\n".as_bytes()).unwrap();
     for krate in crates {
         match krate.as_ref() {
-            "false" => {},
-            "true" => {},
+            "false" | "true" | "test" => {},
             _ => cf.write_all(format!("extern crate {krate} as uu{krate};\n", krate=krate).as_bytes()).unwrap(),
         }
 
@@ -44,12 +43,11 @@ pub fn main() {
                               map.insert(\"sha384sum\", uuhashsum::uumain);
                               map.insert(\"sha512sum\", uuhashsum::uumain);\n".as_bytes()).unwrap();
             },
-            "false" =>
-                mf.write_all("fn uufalse(_: Vec<String>) -> i32 { 1 }
-                             map.insert(\"false\", uufalse as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
-            "true" =>
-                mf.write_all("fn uutrue(_: Vec<String>) -> i32 { 0 }
-                             map.insert(\"true\", uutrue as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
+            "false" | "true" | "test" => {
+                mf.write_all(format!("fn uu{}", krate).as_bytes()).unwrap();
+                mf.write_all("(_: Vec<String>) -> i32 { 1 }\n".as_bytes()).unwrap();
+                mf.write_all(format!("map.insert(\"{krate}\", uu{krate} as fn(Vec<String>) -> i32);\n", krate=krate).as_bytes()).unwrap();
+            },
             _ => 
                 mf.write_all(format!("map.insert(\"{krate}\", uu{krate}::uumain as fn(Vec<String>) -> i32);\n", krate= krate).as_bytes()).unwrap(),
         }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "test_uu"
+name = "test"
 version = "0.0.1"
 authors = []
 
 [lib]
-name = "test_uu"
+name = "uutest"
 path = "test.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="test"
+name="uutest"
 path="test.rs"

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -1,4 +1,4 @@
-#![crate_name = "test_uu"]
+#![crate_name = "uutest"]
 
 /*
  * This file is part of the uutils coreutils package.

--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -20,21 +20,13 @@ static VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 
-fn name_sub(util_name: &str) -> &str {
-    match util_name {
-        "test" => "test_uu",
-        "test_uu" => "test",
-        x @ _ => x
-    }
-}
-
 fn usage(cmap: &UtilityMap) {
     println!("{} {}", NAME, VERSION);
     println!("");
     println!("Usage:");
     println!("  {} [util [arguments...]]\n", NAME);
     println!("Currently defined functions:");
-    let mut utils: Vec<&str> = cmap.keys().map(|&s| name_sub(s)).collect();
+    let mut utils: Vec<&str> = cmap.keys().map(|&s| s).collect();
     utils.sort();
     for util in utils.iter() {
         println!("\t{}", util);
@@ -72,7 +64,7 @@ fn main() {
         args.remove(0);
         let util = &args[0][..];
 
-        match umap.get(name_sub(util)) {
+        match umap.get(util) {
             Some(&uumain) => {
                 std::process::exit(uumain(args.clone()));
             }
@@ -81,7 +73,7 @@ fn main() {
                     // see if they want help on a specific util
                     if args.len() >= 2 {
                         let util = &args[1][..];
-                        match umap.get(name_sub(util)) {
+                        match umap.get(util) {
                             Some(&uumain) => {
                                 std::process::exit(uumain(vec![util.to_string(), "--help".to_string()]));
                             }


### PR DESCRIPTION
To avoid linking issues with Rust's libtest, the crate for the test utility was changed to `uutest`. However, the user doesn't need to see this so a few hoops were jumped through to make this transparent.

I also updated the make rules to build the individual features first and then uutils. This makes `make && make test` look more organized.