### PR TITLE
test: fix namespace and broken test

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,7 +29,8 @@ pub fn main() {
     let mut map: UtilityMap = HashMap::new();\n".as_bytes()).unwrap();
     for krate in crates {
         match krate.as_ref() {
-            "false" | "true" | "test" => {},
+            "false" | "true" => {},
+            "test" => cf.write_all(format!("extern crate uu{krate};\n", krate=krate).as_bytes()).unwrap(),
             _ => cf.write_all(format!("extern crate {krate} as uu{krate};\n", krate=krate).as_bytes()).unwrap(),
         }
 
@@ -43,16 +44,12 @@ pub fn main() {
                               map.insert(\"sha384sum\", uuhashsum::uumain);
                               map.insert(\"sha512sum\", uuhashsum::uumain);\n".as_bytes()).unwrap();
             },
-            "true" => {
-                mf.write_all(format!("fn uu{}", krate).as_bytes()).unwrap();
-                mf.write_all("(_: Vec<String>) -> i32 { 0 }\n".as_bytes()).unwrap();
-                mf.write_all(format!("map.insert(\"{krate}\", uu{krate} as fn(Vec<String>) -> i32);\n", krate=krate).as_bytes()).unwrap();
-            }
-            "false" | "test" => {
-                mf.write_all(format!("fn uu{}", krate).as_bytes()).unwrap();
-                mf.write_all("(_: Vec<String>) -> i32 { 1 }\n".as_bytes()).unwrap();
-                mf.write_all(format!("map.insert(\"{krate}\", uu{krate} as fn(Vec<String>) -> i32);\n", krate=krate).as_bytes()).unwrap();
-            },
+            "false" =>
+                mf.write_all("fn uufalse(_: Vec<String>) -> i32 { 1 }
+                             map.insert(\"false\", uufalse as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
+            "true" =>
+                mf.write_all("fn uutrue(_: Vec<String>) -> i32 { 0 }
+                             map.insert(\"true\", uutrue as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
             _ => 
                 mf.write_all(format!("map.insert(\"{krate}\", uu{krate}::uumain as fn(Vec<String>) -> i32);\n", krate= krate).as_bytes()).unwrap(),
         }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="uutest"
-path="test.rs"
+name="test"
+path="main.rs"

--- a/src/test/main.rs
+++ b/src/test/main.rs
@@ -1,0 +1,5 @@
+extern crate uutest;
+
+fn main() {
+    std::process::exit(uutest::uumain(std::env::args().collect()));
+}

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -406,8 +406,3 @@ fn path(path: &[u8], cond: PathCondition) -> bool {
         PathCondition::Executable       => false, // TODO
     }
 }
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
-}


### PR DESCRIPTION
I separated test's main() into a separate file to override Cargo's
requirement for matching crate names. I had to update the build command
to use a special extern reference for test.

Current broken tests: cut readlink realpath relpath pwd

Fixes issues caused by #728.