### PR TITLE
travis: switch to cargo build/test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rust:
   - nightly
 sudo: false
 script:
-  - make
-  - make test
+  - cargo build
+  - cargo test --no-fail-fast
 matrix:
   allow_failures:
     - rust: stable


### PR DESCRIPTION
`make test` used to run all tests but exited with 0 unless the last test
failed. So failures where hidden from travis. 

With 2d41e664 `make test` fails with an error exit code on the first test
failure. This is better than before, but it hides newly introduced failures.

`cargo test --no-fail-fast` runs all tests and if any of the tests fails exits
with an error. So if travis reports a failed check, we at least can skim the
travis log to ensure no new failures are introduced.