### PR TITLE
cut: fix off-by-one error for range calculation

### DIFF
--- a/src/cut/ranges.rs
+++ b/src/cut/ranges.rs
@@ -37,7 +37,7 @@ impl FromStr for Range {
             }
             (Some(n), Some(m)) if m.len() == 0 => {
                 if let Ok(low) = n.parse::<usize>() {
-                    if low > 0 { Ok(Range{ low: low, high: MAX}) } else { Err(field) }
+                    if low > 0 { Ok(Range{ low: low, high: MAX - 1}) } else { Err(field) }
                 } else {
                     Err(inval)
                 }
@@ -118,10 +118,10 @@ pub fn complement(ranges: &Vec<Range>) -> Vec<Range> {
                 }
             }
             (Some(last), None) => {
-                if last.high < usize::MAX {
+                if last.high < usize::MAX - 1 {
                     complements.push(Range {
                                         low: last.high + 1,
-                                        high: usize::MAX
+                                        high: usize::MAX - 1
                                      });
                 }
             }


### PR DESCRIPTION
When determining the range from which to select portions of a line, the
upper limit of the range is a usize. The maximum upper value is
usize::MAX, but at one point this value is incremented, causing an
overflow. By setting the maximum upper value to usize::MAX-1, the bug is
averted. Since the upper limit of the range is an index (thus, ranging
from 0 to 2^64-1 for 64-bit platforms), the maximum usize should not be
reached.