### PR TITLE
Refactor check for standard stream interactivity.

### DIFF
--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -17,12 +17,11 @@ extern crate libc;
 #[macro_use]
 extern crate uucore;
 
-use libc::STDIN_FILENO;
-use libc::{c_int, isatty};
 use getopts::Options;
 use std::fs::File;
 use std::intrinsics::{copy_nonoverlapping};
 use std::io::{stdout, stdin, stderr, Write, Read, Result};
+use uucore::fs::is_stdin_interactive;
 
 static NAME: &'static str = "cat";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -260,8 +259,7 @@ fn exec(files: Vec<String>, number: NumberingMode, show_nonprint: bool,
 fn open(path: &str) -> Option<(Box<Read>, bool)> {
     if path == "-" {
         let stdin = stdin();
-        let interactive = unsafe { isatty(STDIN_FILENO) } != 0 as c_int;
-        return Some((Box::new(stdin) as Box<Read>, interactive));
+        return Some((Box::new(stdin) as Box<Read>, is_stdin_interactive()));
     }
 
     match File::open(path) {

--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -17,12 +17,11 @@ extern crate libc;
 #[macro_use]
 extern crate uucore;
 
-use libc::STDIN_FILENO;
-use libc::{c_int, isatty};
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, stdin, Write};
 use std::path::Path;
+use uucore::fs::is_stdin_interactive;
 
 static NAME: &'static str = "sort";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -194,8 +193,7 @@ fn print_sorted<S, T: Iterator<Item=S>>(iter: T) where S: std::fmt::Display {
 fn open<'a>(path: &str) -> Option<(Box<Read + 'a>, bool)> {
     if path == "-" {
         let stdin = stdin();
-        let interactive = unsafe { isatty(STDIN_FILENO) } != 0 as c_int;
-        return Some((Box::new(stdin) as Box<Read>, interactive));
+        return Some((Box::new(stdin) as Box<Read>, is_stdin_interactive()));
     }
 
     match File::open(Path::new(path)) {

--- a/src/tty/tty.rs
+++ b/src/tty/tty.rs
@@ -19,10 +19,10 @@ extern crate uucore;
 
 use std::ffi::CStr;
 use std::io::Write;
+use uucore::fs::is_stdin_interactive;
 
 extern {
     fn ttyname(filedesc: libc::c_int) -> *const libc::c_char;
-    fn isatty(filedesc: libc::c_int) -> libc::c_int;
 }
 
 static NAME: &'static str = "tty";
@@ -69,12 +69,10 @@ pub fn uumain(args: Vec<String>) -> i32 {
             }
         }
 
-        return unsafe {
-            if isatty(libc::STDIN_FILENO) == 1 {
-                libc::EXIT_SUCCESS
-            } else {
-                libc::EXIT_FAILURE
-            }
+        return if is_stdin_interactive() {
+            libc::EXIT_SUCCESS
+        } else {
+            libc::EXIT_FAILURE
         };
     }
 

--- a/src/uucore/fs.rs
+++ b/src/uucore/fs.rs
@@ -12,6 +12,7 @@
 // be backported to stable (<= 1.1). This will likely be dropped
 // when the path trait stabilizes.
 
+use ::libc;
 use std::env;
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
@@ -141,4 +142,34 @@ pub fn canonicalize<P: AsRef<Path>>(original: P, can_mode: CanonicalizeMode) -> 
         }
     }
     Ok(result)
+}
+
+#[cfg(unix)]
+pub fn is_stdin_interactive() -> bool {
+    unsafe { libc::isatty(libc::STDIN_FILENO) == 1 }
+}
+
+#[cfg(windows)]
+pub fn is_stdin_interactive() -> bool {
+    0
+}
+
+#[cfg(unix)]
+pub fn is_stdout_interactive() -> bool {
+    unsafe { libc::isatty(libc::STDOUT_FILENO) == 1 }
+}
+
+#[cfg(windows)]
+pub fn is_stdout_interactive() -> bool {
+    0
+}
+
+#[cfg(unix)]
+pub fn is_stderr_interactive() -> bool {
+    unsafe { libc::isatty(libc::STDERR_FILENO) == 1 }
+}
+
+#[cfg(windows)]
+pub fn is_stderr_interactive() -> bool {
+    0
 }


### PR DESCRIPTION
Since several utilities check if the standard streams are interactive, I
moved this into the uucore::fs library as is_std*_interactive(). I also
added Windows support for these methods, which only return false (or at
least until someone finds a way to support this).