### PR TITLE
Fix build errors on Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 
 [features]
 unix = [
+  "chmod",
   "chroot",
   "du",
   "groups",
@@ -31,7 +32,6 @@ generic = [
   "base64",
   "basename",
   "cat",
-  "chmod",
   "cksum",
   "comm",
   "cp",

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ PROGS       := \
   base64 \
   basename \
   cat \
-  chmod \
   cksum \
   comm \
   cp \
@@ -81,6 +80,7 @@ PROGS       := \
   whoami
 
 UNIX_PROGS := \
+  chmod \
   chroot \
   du \
   groups \

--- a/src/mv/Cargo.toml
+++ b/src/mv/Cargo.toml
@@ -14,6 +14,7 @@ uucore = { path="../uucore" }
 
 [dev-dependencies]
 time = "*"
+
 [[bin]]
 name="mv"
 path="mv.rs"

--- a/src/sync/Cargo.toml
+++ b/src/sync/Cargo.toml
@@ -10,6 +10,8 @@ path = "sync.rs"
 [dependencies]
 getopts = "*"
 libc = "*"
+winapi = "*"
+kernel32-sys = "*"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -6,6 +6,7 @@ authors = []
 [dependencies]
 libc = "*"
 time = "*"
+winapi = "*"
 
 [lib]
 path = "lib.rs"

--- a/src/uucore/fs.rs
+++ b/src/uucore/fs.rs
@@ -12,7 +12,8 @@
 // be backported to stable (<= 1.1). This will likely be dropped
 // when the path trait stabilizes.
 
-use ::libc;
+#[cfg(unix)]
+use super::libc;
 use std::env;
 use std::fs;
 use std::io::{Error, ErrorKind, Result};

--- a/src/uucore/fs.rs
+++ b/src/uucore/fs.rs
@@ -151,7 +151,7 @@ pub fn is_stdin_interactive() -> bool {
 
 #[cfg(windows)]
 pub fn is_stdin_interactive() -> bool {
-    0
+    false
 }
 
 #[cfg(unix)]
@@ -161,7 +161,7 @@ pub fn is_stdout_interactive() -> bool {
 
 #[cfg(windows)]
 pub fn is_stdout_interactive() -> bool {
-    0
+    false
 }
 
 #[cfg(unix)]
@@ -171,5 +171,5 @@ pub fn is_stderr_interactive() -> bool {
 
 #[cfg(windows)]
 pub fn is_stderr_interactive() -> bool {
-    0
+    false
 }

--- a/src/uucore/lib.rs
+++ b/src/uucore/lib.rs
@@ -1,5 +1,6 @@
 extern crate libc;
 extern crate time;
+#[cfg(windows)] extern crate winapi;
 
 #[macro_use]
 mod macros;

--- a/src/whoami/Cargo.toml
+++ b/src/whoami/Cargo.toml
@@ -10,6 +10,8 @@ path = "whoami.rs"
 [dependencies]
 getopts = "*"
 libc = "*"
+winapi = "*"
+advapi32-sys = "*"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/whoami/platform/windows.rs
+++ b/src/whoami/platform/windows.rs
@@ -11,8 +11,7 @@ extern crate winapi;
 extern crate advapi32;
 extern crate uucore;
 
-use std::ffi::OsString;
-use std::io::{Error, Result, Write};
+use std::io::{Error, Result};
 use std::mem;
 use std::os::windows::ffi::OsStringExt;
 use uucore::wide::FromWide;


### PR DESCRIPTION
The build now works on the following targets (tests still fail):

  * x86_64-pc-windows-msvc
  * i686-pc-windows-msvc