### PR TITLE
Move contributing section into separate file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+Contributing to coreutils
+=========================
+
+Contributions are very welcome, and should target Rust's master branch until
+Rust 1.0 is released. You may *claim* an item on the to-do list by following
+these steps:
+
+1. Open an issue named "Implement [the utility of your choice]", e.g. "Implement ls"
+2. State that you are working on this utility.
+3. Develop the utility.
+4. Add integration tests.
+5. Add the reference to your utility into Cargo.toml and Makefile.
+6. Remove utility from the to-do list in the README.
+7. Submit a pull request and close the issue.
+
+The steps above imply that, before starting to work on a utility, you should search the issues to make sure no one else is working on it.

--- a/README.md
+++ b/README.md
@@ -113,18 +113,7 @@ make TEST='UTILITY_1 UTILITY_2' test
 Contribute
 ----------
 
-Contributions are very welcome, and should target Rust's master branch until
-Rust 1.0 is released. You may *claim* an item on the to-do list by following
-these steps:
-
-1. Open an issue named "Implement [the utility of your choice]", e.g. "Implement ls"
-2. State that you are working on this utility.
-3. Develop the utility.
-4. Add the reference to your utility into uutils/uutils.rs (required for multibinary).
-5. Remove utility from the to-do list on this README.
-6. Submit a pull request and close the issue.
-
-The steps above imply that, before starting to work on a utility, you should search the issues to make sure no one else is working on it.
+To contribute to coreutils, please see [CONTRIBUTING](CONTRIBUTING.md).
 
 To do
 -----


### PR DESCRIPTION
GitHub uses CONTRIBUTING.md as the basis for a message to someone
creating a new issue. I made a few changes to modernize the contribution
section, but there's still room for updates.