### PR TITLE
Refactor and simplify build for utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,5 +177,5 @@ rand="*"
 tempdir="*"
 
 [[bin]]
-name="uutils"
-path="src/uutils/uutils.rs"
+name = "uutils"
+path = "src/uutils/uutils.rs"

--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,6 @@ test_integration_$(1): build_exe_$(1)
 	${CARGO} test --test $(1) --features $(1) --no-default-features
 endef
 
-define TEST_UNIT
-test_unit_$(1):
-	${CARGO} test -p $(1)
-endef
-
 # Output names
 EXES        := \
   $(sort $(filter $(BUILD),$(filter-out $(DONT_BUILD),$(PROGS))))
@@ -213,9 +208,8 @@ build-uutils: $(addprefix build_exe_,$(EXES))
 build: build-uutils
 
 $(foreach test,$(TESTS),$(eval $(call TEST_INTEGRATION,$(test))))
-$(foreach test,$(TESTS),$(eval $(call TEST_UNIT,$(test))))
 
-test: $(addprefix test_integration_,$(TESTS)) $(addprefix test_unit_,$(TESTS))
+test: $(addprefix test_integration_,$(TESTS))
 
 clean:
 	$(RM) -rf $(BUILDDIR) 

--- a/build.rs
+++ b/build.rs
@@ -12,49 +12,43 @@ pub fn main() {
         if val == "1" && key.starts_with(feature_prefix) {
             let krate = key[feature_prefix.len()..].to_lowercase();
             match krate.as_ref() {
-            "default" | "unix" | "generic" => continue,
-            _ => {},
+                "default" | "unix" | "generic" => continue,
+                _ => {},
             }
             crates.push(krate.to_string());
         }
     }
     crates.sort();
+
     let mut cf = File::create(Path::new(&out_dir).join("uutils_crates.rs")).unwrap();
     let mut mf = File::create(Path::new(&out_dir).join("uutils_map.rs")).unwrap();
+
     mf.write_all("
     type UtilityMap = HashMap<&'static str, fn(Vec<String>) -> i32>;
 
     fn util_map() -> UtilityMap {
     let mut map: UtilityMap = HashMap::new();\n".as_bytes()).unwrap();
+
     for krate in crates {
-        match krate.as_ref() {
-            "false" | "true" => {},
-            "test" => cf.write_all(format!("extern crate uu{krate};\n", krate=krate).as_bytes()).unwrap(),
-            _ => cf.write_all(format!("extern crate {krate} as uu{krate};\n", krate=krate).as_bytes()).unwrap(),
-        }
+        cf.write_all(format!("extern crate uu_{krate};\n", krate=krate).as_bytes()).unwrap();
 
         match krate.as_ref() {
             "hashsum" => {
-                mf.write_all("map.insert(\"hashsum\", uuhashsum::uumain);
-                              map.insert(\"md5sum\", uuhashsum::uumain);
-                              map.insert(\"sha1sum\", uuhashsum::uumain);
-                              map.insert(\"sha224sum\", uuhashsum::uumain);
-                              map.insert(\"sha256sum\", uuhashsum::uumain);
-                              map.insert(\"sha384sum\", uuhashsum::uumain);
-                              map.insert(\"sha512sum\", uuhashsum::uumain);\n".as_bytes()).unwrap();
+                mf.write_all("map.insert(\"hashsum\", uu_hashsum::uumain);
+                              map.insert(\"md5sum\", uu_hashsum::uumain);
+                              map.insert(\"sha1sum\", uu_hashsum::uumain);
+                              map.insert(\"sha224sum\", uu_hashsum::uumain);
+                              map.insert(\"sha256sum\", uu_hashsum::uumain);
+                              map.insert(\"sha384sum\", uu_hashsum::uumain);
+                              map.insert(\"sha512sum\", uu_hashsum::uumain);\n".as_bytes()).unwrap();
             },
-            "false" =>
-                mf.write_all("fn uufalse(_: Vec<String>) -> i32 { 1 }
-                             map.insert(\"false\", uufalse as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
-            "true" =>
-                mf.write_all("fn uutrue(_: Vec<String>) -> i32 { 0 }
-                             map.insert(\"true\", uutrue as fn(Vec<String>) -> i32);\n".as_bytes()).unwrap(),
             _ => 
-                mf.write_all(format!("map.insert(\"{krate}\", uu{krate}::uumain as fn(Vec<String>) -> i32);\n", krate= krate).as_bytes()).unwrap(),
+                mf.write_all(format!("map.insert(\"{krate}\", uu_{krate}::uumain);\n", krate=krate).as_bytes()).unwrap(),
         }
     }
-    mf.write_all("map
-    }\n".as_bytes()).unwrap();
+
+    mf.write_all("map\n}\n".as_bytes()).unwrap();
+
     cf.flush().unwrap();
     mf.flush().unwrap();
 }

--- a/src/base64/Cargo.toml
+++ b/src/base64/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "base64"
+name = "uu_base64"
 path = "base64.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ rustc-serialize = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="base64"
-path="base64.rs"
+name = "base64"
+path = "main.rs"

--- a/src/base64/base64.rs
+++ b/src/base64/base64.rs
@@ -1,4 +1,4 @@
-#![crate_name = "base64"]
+#![crate_name = "uu_base64"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -158,9 +158,4 @@ fn help(opts: Options) {
 
 fn version() {
     println!("{} {}", NAME, VERSION);
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/base64/main.rs
+++ b/src/base64/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_base64;
+
+fn main() {
+    std::process::exit(uu_base64::uumain(std::env::args().collect()));
+}

--- a/src/basename/Cargo.toml
+++ b/src/basename/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "basename"
+name = "uu_basename"
 path = "basename.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="basename"
-path="basename.rs"
+name = "basename"
+path = "main.rs"

--- a/src/basename/basename.rs
+++ b/src/basename/basename.rs
@@ -1,4 +1,4 @@
-#![crate_name = "basename"]
+#![crate_name = "uu_basename"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -104,9 +104,4 @@ fn strip_suffix(name: &str, suffix: &str) -> String {
     }
 
     name.to_string()
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/basename/main.rs
+++ b/src/basename/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_basename;
+
+fn main() {
+    std::process::exit(uu_basename::uumain(std::env::args().collect()));
+}

--- a/src/cat/Cargo.toml
+++ b/src/cat/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "cat"
+name = "uu_cat"
 path = "cat.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="cat"
-path="cat.rs"
+name = "cat"
+path = "main.rs"

--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -1,4 +1,4 @@
-#![crate_name = "cat"]
+#![crate_name = "uu_cat"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -338,11 +338,4 @@ impl<'a, W: Write> Drop for UnsafeWriter<'a, W> {
     fn drop(&mut self) {
         let _ = self.flush_buf();
     }
-}
-
-/* vim: set ai ts=4 sw=4 sts=4 et : */
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/cat/main.rs
+++ b/src/cat/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_cat;
+
+fn main() {
+    std::process::exit(uu_cat::uumain(std::env::args().collect()));
+}

--- a/src/chmod/Cargo.toml
+++ b/src/chmod/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "chmod"
+name = "uu_chmod"
 path = "chmod.rs"
 
 [dependencies]
@@ -18,5 +18,5 @@ uucore = { path="../uucore" }
 walker = "*"
 
 [[bin]]
-name="chmod"
-path="chmod.rs"
+name = "chmod"
+path = "main.rs"

--- a/src/chmod/chmod.rs
+++ b/src/chmod/chmod.rs
@@ -1,4 +1,4 @@
-#![crate_name = "chmod"]
+#![crate_name = "uu_chmod"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -318,9 +318,4 @@ fn chmod_file(file: &Path, name: &str, changes: bool, quiet: bool, verbose: bool
     }
 
     Ok(())
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/chmod/main.rs
+++ b/src/chmod/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_chmod;
+
+fn main() {
+    std::process::exit(uu_chmod::uumain(std::env::args().collect()));
+}

--- a/src/chroot/Cargo.toml
+++ b/src/chroot/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "chroot"
+name = "uu_chroot"
 path = "chroot.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="chroot"
-path="chroot.rs"
+name = "chroot"
+path = "main.rs"

--- a/src/chroot/chroot.rs
+++ b/src/chroot/chroot.rs
@@ -1,4 +1,4 @@
-#![crate_name = "chroot"]
+#![crate_name = "uu_chroot"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -215,9 +215,4 @@ If COMMAND is not specified, it defaults to '$(SHELL) -i'.
 If $(SHELL) is not set, /bin/sh is used.", NAME, VERSION);
 
     print!("{}", options.usage(&msg));
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/chroot/main.rs
+++ b/src/chroot/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_chroot;
+
+fn main() {
+    std::process::exit(uu_chroot::uumain(std::env::args().collect()));
+}

--- a/src/cksum/Cargo.toml
+++ b/src/cksum/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "cksum"
+name = "uu_cksum"
 path = "cksum.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="cksum"
-path="cksum.rs"
+name = "cksum"
+path = "main.rs"

--- a/src/cksum/cksum.rs
+++ b/src/cksum/cksum.rs
@@ -1,4 +1,4 @@
-#![crate_name = "cksum"]
+#![crate_name = "uu_cksum"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -127,9 +127,4 @@ Print CRC and size for each file.", NAME, VERSION);
     }
 
     exit_code
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/cksum/main.rs
+++ b/src/cksum/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_cksum;
+
+fn main() {
+    std::process::exit(uu_cksum::uumain(std::env::args().collect()));
+}

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "comm"
+name = "uu_comm"
 path = "comm.rs"
 
 [dependencies]
@@ -12,5 +12,5 @@ getopts = "*"
 libc = "*"
 
 [[bin]]
-name="comm"
-path="comm.rs"
+name = "comm"
+path = "main.rs"

--- a/src/comm/comm.rs
+++ b/src/comm/comm.rs
@@ -1,4 +1,4 @@
-#![crate_name = "comm"]
+#![crate_name = "uu_comm"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -162,9 +162,4 @@ Compare sorted files line by line.", NAME, VERSION);
     comm(&mut f1, &mut f2, &matches);
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/comm/main.rs
+++ b/src/comm/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_comm;
+
+fn main() {
+    std::process::exit(uu_comm::uumain(std::env::args().collect()));
+}

--- a/src/cp/Cargo.toml
+++ b/src/cp/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "cp"
+name = "uu_cp"
 path = "cp.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="cp"
-path="cp.rs"
+name = "cp"
+path = "main.rs"

--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -1,4 +1,4 @@
-#![crate_name = "cp"]
+#![crate_name = "uu_cp"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -153,9 +153,4 @@ pub fn paths_refer_to_same_file(p1: &Path, p2: &Path) -> Result<bool> {
     let pathbuf2 = try!(canonicalize(p2, CanonicalizeMode::Normal));
 
     Ok(pathbuf1 == pathbuf2)
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/cp/main.rs
+++ b/src/cp/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_cp;
+
+fn main() {
+    std::process::exit(uu_cp::uumain(std::env::args().collect()));
+}

--- a/src/cut/Cargo.toml
+++ b/src/cut/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "cut"
+name = "uu_cut"
 path = "cut.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="cut"
-path="cut.rs"
+name = "cut"
+path = "main.rs"

--- a/src/cut/cut.rs
+++ b/src/cut/cut.rs
@@ -1,4 +1,4 @@
-#![crate_name = "cut"]
+#![crate_name = "uu_cut"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -538,9 +538,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
             1
         }
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/cut/main.rs
+++ b/src/cut/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_cut;
+
+fn main() {
+    std::process::exit(uu_cut::uumain(std::env::args().collect()));
+}

--- a/src/dirname/Cargo.toml
+++ b/src/dirname/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "dirname"
+name = "uu_dirname"
 path = "dirname.rs"
 
 [dependencies]
@@ -12,5 +12,5 @@ getopts = "*"
 libc = "*"
 
 [[bin]]
-name="dirname"
-path="dirname.rs"
+name = "dirname"
+path = "main.rs"

--- a/src/dirname/dirname.rs
+++ b/src/dirname/dirname.rs
@@ -1,4 +1,4 @@
-#![crate_name = "dirname"]
+#![crate_name = "uu_dirname"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -67,9 +67,4 @@ directory).", NAME, VERSION);
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/dirname/main.rs
+++ b/src/dirname/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_dirname;
+
+fn main() {
+    std::process::exit(uu_dirname::uumain(std::env::args().collect()));
+}

--- a/src/du/Cargo.toml
+++ b/src/du/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "du"
+name = "uu_du"
 path = "du.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ time = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="du"
-path="du.rs"
+name = "du"
+path = "main.rs"

--- a/src/du/du.rs
+++ b/src/du/du.rs
@@ -1,4 +1,4 @@
-#![crate_name = "du"]
+#![crate_name = "uu_du"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -394,9 +394,4 @@ Try '{} --help' for more information.", s, NAME);
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/du/main.rs
+++ b/src/du/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_du;
+
+fn main() {
+    std::process::exit(uu_du::uumain(std::env::args().collect()));
+}

--- a/src/echo/Cargo.toml
+++ b/src/echo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "echo"
+name = "uu_echo"
 path = "echo.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="echo"
-path="echo.rs"
+name = "echo"
+path = "main.rs"

--- a/src/echo/echo.rs
+++ b/src/echo/echo.rs
@@ -1,4 +1,4 @@
-#![crate_name = "echo"]
+#![crate_name = "uu_echo"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -250,9 +250,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/echo/main.rs
+++ b/src/echo/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_echo;
+
+fn main() {
+    std::process::exit(uu_echo::uumain(std::env::args().collect()));
+}

--- a/src/env/Cargo.toml
+++ b/src/env/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "env"
+name = "uu_env"
 path = "env.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="env"
-path="env.rs"
+name = "env"
+path = "main.rs"

--- a/src/env/env.rs
+++ b/src/env/env.rs
@@ -1,4 +1,4 @@
-#![crate_name = "env"]
+#![crate_name = "uu_env"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -203,9 +203,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(env::args().collect()));
 }

--- a/src/env/main.rs
+++ b/src/env/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_env;
+
+fn main() {
+    std::process::exit(uu_env::uumain(std::env::args().collect()));
+}

--- a/src/expand/Cargo.toml
+++ b/src/expand/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "expand"
+name = "uu_expand"
 path = "expand.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ unicode-width = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="expand"
-path="expand.rs"
+name = "expand"
+path = "main.rs"

--- a/src/expand/expand.rs
+++ b/src/expand/expand.rs
@@ -1,4 +1,4 @@
-#![crate_name = "expand"]
+#![crate_name = "uu_expand"]
 #![feature(unicode)]
 
 /*
@@ -240,9 +240,4 @@ fn expand(options: Options) {
             buf.truncate(0);    // clear the buffer
         }
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/expand/main.rs
+++ b/src/expand/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_expand;
+
+fn main() {
+    std::process::exit(uu_expand::uumain(std::env::args().collect()));
+}

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -1,11 +1,10 @@
-
 [package]
 name = "expr"
 version = "0.0.1"
 authors = []
 
 [lib]
-name = "expr"
+name = "uu_expr"
 path = "expr.rs"
 
 [dependencies]
@@ -14,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="expr"
-path="expr.rs"
+name = "expr"
+path = "main.rs"

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -1,4 +1,4 @@
-#![crate_name = "expr"]
+#![crate_name = "uu_expr"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -60,8 +60,6 @@ fn evaluate_ast( maybe_ast: Result<Box<syntax_tree::ASTNode>, String> ) -> Resul
 	if maybe_ast.is_err() { Err( maybe_ast.err().unwrap() ) }
 	else { maybe_ast.ok().unwrap().evaluate() }
 }
-
-
 
 fn maybe_handle_help_or_version( args: &Vec<String> ) -> bool {
 	if args.len() == 2 {
@@ -132,9 +130,4 @@ Environment variables:
 
 fn print_version() {
 	println!("{} {}", NAME, VERSION);
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/expr/main.rs
+++ b/src/expr/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_expr;
+
+fn main() {
+    std::process::exit(uu_expr::uumain(std::env::args().collect()));
+}

--- a/src/factor/Cargo.toml
+++ b/src/factor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "factor"
+name = "uu_factor"
 path = "factor.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ rand = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="factor"
-path="factor.rs"
+name = "factor"
+path = "main.rs"

--- a/src/factor/factor.rs
+++ b/src/factor/factor.rs
@@ -1,4 +1,4 @@
-#![crate_name = "factor"]
+#![crate_name = "uu_factor"]
 
 /*
 * This file is part of the uutils coreutils package.
@@ -199,9 +199,4 @@ read from standard input.", NAME, VERSION);
         }
     }
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/factor/main.rs
+++ b/src/factor/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_factor;
+
+fn main() {
+    std::process::exit(uu_factor::uumain(std::env::args().collect()));
+}

--- a/src/false/Cargo.toml
+++ b/src/false/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "false"
+name = "uu_false"
 path = "false.rs"
 
 [dependencies]
@@ -12,5 +12,5 @@ getopts = "*"
 libc = "*"
 
 [[bin]]
-name="false"
-path="false.rs"
+name = "false"
+path = "main.rs"

--- a/src/false/false.rs
+++ b/src/false/false.rs
@@ -1,4 +1,4 @@
-#![crate_name = "false"]
+#![crate_name = "uu_false"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -11,9 +11,4 @@
 
 pub fn uumain(_: Vec<String>) -> i32 {
     1
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/false/main.rs
+++ b/src/false/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_false;
+
+fn main() {
+    std::process::exit(uu_false::uumain(std::env::args().collect()));
+}

--- a/src/fmt/Cargo.toml
+++ b/src/fmt/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "fmt"
+name = "uu_fmt"
 path = "fmt.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ unicode-width = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="fmt"
-path="fmt.rs"
+name = "fmt"
+path = "main.rs"

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -1,4 +1,4 @@
-#![crate_name = "fmt"]
+#![crate_name = "uu_fmt"]
 #![feature(iter_cmp, str_char, unicode)]
 
 /*
@@ -218,9 +218,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/fmt/main.rs
+++ b/src/fmt/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_fmt;
+
+fn main() {
+    std::process::exit(uu_fmt::uumain(std::env::args().collect()));
+}

--- a/src/fold/Cargo.toml
+++ b/src/fold/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "fold"
+name = "uu_fold"
 path = "fold.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="fold"
-path="fold.rs"
+name = "fold"
+path = "main.rs"

--- a/src/fold/fold.rs
+++ b/src/fold/fold.rs
@@ -1,4 +1,4 @@
-#![crate_name = "fold"]
+#![crate_name = "uu_fold"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -218,9 +218,4 @@ fn rfind_whitespace(slice: &str) -> Option<usize> {
         }
     }
     None
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/fold/main.rs
+++ b/src/fold/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_fold;
+
+fn main() {
+    std::process::exit(uu_fold::uumain(std::env::args().collect()));
+}

--- a/src/groups/Cargo.toml
+++ b/src/groups/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "groups"
+name = "uu_groups"
 path = "groups.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="groups"
-path="groups.rs"
+name = "groups"
+path = "main.rs"

--- a/src/groups/groups.rs
+++ b/src/groups/groups.rs
@@ -1,4 +1,4 @@
-#![crate_name = "groups"]
+#![crate_name = "uu_groups"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -50,9 +50,4 @@ Prints the groups a user is in to standard output.", NAME, VERSION);
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/groups/main.rs
+++ b/src/groups/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_groups;
+
+fn main() {
+    std::process::exit(uu_groups::uumain(std::env::args().collect()));
+}

--- a/src/hashsum/Cargo.toml
+++ b/src/hashsum/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "hashsum"
+name = "uu_hashsum"
 path = "hashsum.rs"
 
 [dependencies]
@@ -16,5 +16,5 @@ rust-crypto = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="hashsum"
-path="hashsum.rs"
+name = "hashsum"
+path = "main.rs"

--- a/src/hashsum/hashsum.rs
+++ b/src/hashsum/hashsum.rs
@@ -1,4 +1,4 @@
-#![crate_name = "hashsum"]
+#![crate_name = "uu_hashsum"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -305,9 +305,4 @@ fn digest_reader<'a, T: Read>(digest: &mut Box<Digest+'a>, reader: &mut BufReade
     }
 
     Ok(digest.result_str())
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/hashsum/main.rs
+++ b/src/hashsum/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_hashsum;
+
+fn main() {
+    std::process::exit(uu_hashsum::uumain(std::env::args().collect()));
+}

--- a/src/head/Cargo.toml
+++ b/src/head/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "head"
+name = "uu_head"
 path = "head.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="head"
-path="head.rs"
+name = "head"
+path = "main.rs"

--- a/src/head/head.rs
+++ b/src/head/head.rs
@@ -1,4 +1,4 @@
-#![crate_name = "head"]
+#![crate_name = "uu_head"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -206,9 +206,4 @@ fn head<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> bool {
 
 fn version() {
     println!("{} {}", NAME, VERSION);
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/head/main.rs
+++ b/src/head/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_head;
+
+fn main() {
+    std::process::exit(uu_head::uumain(std::env::args().collect()));
+}

--- a/src/hostid/Cargo.toml
+++ b/src/hostid/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "hostid"
+name = "uu_hostid"
 path = "hostid.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="hostid"
-path="hostid.rs"
+name = "hostid"
+path = "main.rs"

--- a/src/hostid/hostid.rs
+++ b/src/hostid/hostid.rs
@@ -1,4 +1,4 @@
-#![crate_name = "hostid"]
+#![crate_name = "uu_hostid"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -86,9 +86,4 @@ fn hostid() {
 
     result &= 0xffffffff; 
     println!("{:0>8x}", result);
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/hostid/main.rs
+++ b/src/hostid/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_hostid;
+
+fn main() {
+    std::process::exit(uu_hostid::uumain(std::env::args().collect()));
+}

--- a/src/hostname/Cargo.toml
+++ b/src/hostname/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "hostname"
+name = "uu_hostname"
 path = "hostname.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="hostname"
-path="hostname.rs"
+name = "hostname"
+path = "main.rs"

--- a/src/hostname/hostname.rs
+++ b/src/hostname/hostname.rs
@@ -1,4 +1,4 @@
-#![crate_name = "hostname"]
+#![crate_name = "uu_hostname"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -173,9 +173,4 @@ fn xsethostname(name: &str) {
     if err != 0 {
         println!("Cannot set hostname to {}", name);
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/hostname/main.rs
+++ b/src/hostname/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_hostname;
+
+fn main() {
+    std::process::exit(uu_hostname::uumain(std::env::args().collect()));
+}

--- a/src/id/Cargo.toml
+++ b/src/id/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "id"
+name = "uu_id"
 path = "id.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="id"
-path="id.rs"
+name = "id"
+path = "main.rs"

--- a/src/id/id.rs
+++ b/src/id/id.rs
@@ -1,4 +1,4 @@
-#![crate_name = "id"]
+#![crate_name = "uu_id"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -393,9 +393,4 @@ fn id_print(possible_pw: Option<c_passwd>, p_euid: bool, p_egid: bool) {
     }
 
     println!("");
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/id/main.rs
+++ b/src/id/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_id;
+
+fn main() {
+    std::process::exit(uu_id::uumain(std::env::args().collect()));
+}

--- a/src/kill/Cargo.toml
+++ b/src/kill/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "kill"
+name = "uu_kill"
 path = "kill.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="kill"
-path="kill.rs"
+name = "kill"
+path = "main.rs"

--- a/src/kill/kill.rs
+++ b/src/kill/kill.rs
@@ -1,4 +1,4 @@
-#![crate_name = "kill"]
+#![crate_name = "uu_kill"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -184,9 +184,4 @@ fn kill(signalname: &str, pids: std::vec::Vec<String>) -> i32 {
         };
     }
     status
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/kill/main.rs
+++ b/src/kill/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_kill;
+
+fn main() {
+    std::process::exit(uu_kill::uumain(std::env::args().collect()));
+}

--- a/src/link/Cargo.toml
+++ b/src/link/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "link"
+name = "uu_link"
 path = "link.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="link"
-path="link.rs"
+name = "link"
+path = "main.rs"

--- a/src/link/link.rs
+++ b/src/link/link.rs
@@ -1,4 +1,4 @@
-#![crate_name = "link"]
+#![crate_name = "uu_link"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -62,9 +62,4 @@ Create a link named FILE2 to FILE1.", NAME, VERSION);
             1
         }
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/link/main.rs
+++ b/src/link/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_link;
+
+fn main() {
+    std::process::exit(uu_link::uumain(std::env::args().collect()));
+}

--- a/src/ln/Cargo.toml
+++ b/src/ln/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "ln"
+name = "uu_ln"
 path = "ln.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="ln"
-path="ln.rs"
+name = "ln"
+path = "main.rs"

--- a/src/ln/ln.rs
+++ b/src/ln/ln.rs
@@ -1,4 +1,4 @@
-#![crate_name = "ln"]
+#![crate_name = "uu_ln"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -325,9 +325,4 @@ pub fn is_symlink<P: AsRef<Path>>(path: P) -> bool {
         Ok(m) => m.file_type().is_symlink(),
         Err(_) => false
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/ln/main.rs
+++ b/src/ln/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_ln;
+
+fn main() {
+    std::process::exit(uu_ln::uumain(std::env::args().collect()));
+}

--- a/src/logname/Cargo.toml
+++ b/src/logname/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "logname"
+name = "uu_logname"
 path = "logname.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="logname"
-path="logname.rs"
+name = "logname"
+path = "main.rs"

--- a/src/logname/logname.rs
+++ b/src/logname/logname.rs
@@ -1,4 +1,4 @@
-#![crate_name = "logname"]
+#![crate_name = "uu_logname"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -79,9 +79,4 @@ fn exec() {
         Some(userlogin) => println!("{}", userlogin),
         None => println!("{}: no login name", NAME)
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/logname/main.rs
+++ b/src/logname/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_logname;
+
+fn main() {
+    std::process::exit(uu_logname::uumain(std::env::args().collect()));
+}

--- a/src/mkdir/Cargo.toml
+++ b/src/mkdir/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "mkdir"
+name = "uu_mkdir"
 path = "mkdir.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="mkdir"
-path="mkdir.rs"
+name = "mkdir"
+path = "main.rs"

--- a/src/mkdir/main.rs
+++ b/src/mkdir/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_mkdir;
+
+fn main() {
+    std::process::exit(uu_mkdir::uumain(std::env::args().collect()));
+}

--- a/src/mkdir/mkdir.rs
+++ b/src/mkdir/mkdir.rs
@@ -1,4 +1,4 @@
-#![crate_name = "mkdir"]
+#![crate_name = "uu_mkdir"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -154,9 +154,4 @@ fn mkdir(path: &Path, mode: u16, verbose: bool) -> i32 {
         0
     }
     chmod(path, mode)
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/mkfifo/Cargo.toml
+++ b/src/mkfifo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "mkfifo"
+name = "uu_mkfifo"
 path = "mkfifo.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="mkfifo"
-path="mkfifo.rs"
+name = "mkfifo"
+path = "main.rs"

--- a/src/mkfifo/main.rs
+++ b/src/mkfifo/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_mkfifo;
+
+fn main() {
+    std::process::exit(uu_mkfifo::uumain(std::env::args().collect()));
+}

--- a/src/mkfifo/mkfifo.rs
+++ b/src/mkfifo/mkfifo.rs
@@ -1,4 +1,4 @@
-#![crate_name = "mkfifo"]
+#![crate_name = "uu_mkfifo"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -75,9 +75,4 @@ Create a FIFO with the given name.", NAME, VERSION);
     }
 
     exit_status
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/mv/Cargo.toml
+++ b/src/mv/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "mv"
+name = "uu_mv"
 path = "mv.rs"
 
 [dependencies]
@@ -16,5 +16,5 @@ uucore = { path="../uucore" }
 time = "*"
 
 [[bin]]
-name="mv"
-path="mv.rs"
+name = "mv"
+path = "main.rs"

--- a/src/mv/main.rs
+++ b/src/mv/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_mv;
+
+fn main() {
+    std::process::exit(uu_mv::uumain(std::env::args().collect()));
+}

--- a/src/mv/mv.rs
+++ b/src/mv/mv.rs
@@ -1,4 +1,4 @@
-#![crate_name = "mv"]
+#![crate_name = "uu_mv"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -350,9 +350,4 @@ fn existing_backup_path(path: &PathBuf, suffix: &String) -> PathBuf {
         return numbered_backup_path(path);
     }
     simple_backup_path(path, suffix)
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/nice/Cargo.toml
+++ b/src/nice/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "nice"
+name = "uu_nice"
 path = "nice.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="nice"
-path="nice.rs"
+name = "nice"
+path = "main.rs"

--- a/src/nice/main.rs
+++ b/src/nice/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_nice;
+
+fn main() {
+    std::process::exit(uu_nice::uumain(std::env::args().collect()));
+}

--- a/src/nice/nice.rs
+++ b/src/nice/nice.rs
@@ -1,4 +1,4 @@
-#![crate_name = "nice"]
+#![crate_name = "uu_nice"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -108,9 +108,4 @@ process).", NAME, VERSION);
 
     show_error!("{}", Error::last_os_error());
     if Error::last_os_error().raw_os_error().unwrap() as c_int == libc::ENOENT { 127 } else { 126 }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/nl/Cargo.toml
+++ b/src/nl/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "nl"
+name = "uu_nl"
 path = "nl.rs"
 
 [dependencies]
@@ -17,5 +17,5 @@ regex-syntax = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="nl"
-path="nl.rs"
+name = "nl"
+path = "main.rs"

--- a/src/nl/main.rs
+++ b/src/nl/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_nl;
+
+fn main() {
+    std::process::exit(uu_nl::uumain(std::env::args().collect()));
+}

--- a/src/nl/nl.rs
+++ b/src/nl/nl.rs
@@ -1,4 +1,4 @@
-#![crate_name = "nl"]
+#![crate_name = "uu_nl"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -327,9 +327,4 @@ fn print_usage(opts: &getopts::Options) {
 
 fn version() {
     println!("{} {}", NAME, VERSION);
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/nohup/Cargo.toml
+++ b/src/nohup/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "nohup"
+name = "uu_nohup"
 path = "nohup.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="nohup"
-path="nohup.rs"
+name = "nohup"
+path = "main.rs"

--- a/src/nohup/main.rs
+++ b/src/nohup/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_nohup;
+
+fn main() {
+    std::process::exit(uu_nohup::uumain(std::env::args().collect()));
+}

--- a/src/nohup/nohup.rs
+++ b/src/nohup/nohup.rs
@@ -1,4 +1,4 @@
-#![crate_name = "nohup"]
+#![crate_name = "uu_nohup"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -140,9 +140,4 @@ or $HOME/nohup.out, if nohup.out open failed.
 If standard error is terminal, it'll be redirected to stdout.", NAME, VERSION);
 
     print!("{}", opts.usage(&msg));
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/nproc/Cargo.toml
+++ b/src/nproc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "nproc"
+name = "uu_nproc"
 path = "nproc.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ num_cpus = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="nproc"
-path="nproc.rs"
+name = "nproc"
+path = "main.rs"

--- a/src/nproc/main.rs
+++ b/src/nproc/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_nproc;
+
+fn main() {
+    std::process::exit(uu_nproc::uumain(std::env::args().collect()));
+}

--- a/src/nproc/nproc.rs
+++ b/src/nproc/nproc.rs
@@ -1,4 +1,4 @@
-#![crate_name = "nproc"]
+#![crate_name = "uu_nproc"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -83,9 +83,4 @@ Print the number of cores available to the current process.", NAME, VERSION);
     }
     println!("{}", cores);
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/od/Cargo.toml
+++ b/src/od/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "od"
+name = "uu_od"
 path = "od.rs"
 
 [dependencies]
@@ -12,5 +12,5 @@ getopts = "*"
 libc = "*"
 
 [[bin]]
-name="od"
-path="od.rs"
+name = "od"
+path = "main.rs"

--- a/src/od/main.rs
+++ b/src/od/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_od;
+
+fn main() {
+    std::process::exit(uu_od::uumain(std::env::args().collect()));
+}

--- a/src/od/od.rs
+++ b/src/od/od.rs
@@ -1,4 +1,4 @@
-#![crate_name = "od"]
+#![crate_name = "uu_od"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -123,9 +123,4 @@ fn print_with_radix(r: &Radix, x: usize) {
         Radix::Octal => print!("{:07o}", x),
         Radix::Binary => print!("{:07b}", x)
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/paste/Cargo.toml
+++ b/src/paste/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "paste"
+name = "uu_paste"
 path = "paste.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="paste"
-path="paste.rs"
+name = "paste"
+path = "main.rs"

--- a/src/paste/main.rs
+++ b/src/paste/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_paste;
+
+fn main() {
+    std::process::exit(uu_paste::uumain(std::env::args().collect()));
+}

--- a/src/paste/paste.rs
+++ b/src/paste/paste.rs
@@ -1,4 +1,4 @@
-#![crate_name = "paste"]
+#![crate_name = "uu_paste"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -126,9 +126,4 @@ fn unescape(s: String) -> String {
      .replace("\\t", "\t")
      .replace("\\\\", "\\")
      .replace("\\", "")
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/printenv/Cargo.toml
+++ b/src/printenv/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "printenv"
+name = "uu_printenv"
 path = "printenv.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="printenv"
-path="printenv.rs"
+name = "printenv"
+path = "main.rs"

--- a/src/printenv/main.rs
+++ b/src/printenv/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_printenv;
+
+fn main() {
+    std::process::exit(uu_printenv::uumain(std::env::args().collect()));
+}

--- a/src/printenv/printenv.rs
+++ b/src/printenv/printenv.rs
@@ -1,4 +1,4 @@
-#![crate_name = "printenv"]
+#![crate_name = "uu_printenv"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -74,9 +74,4 @@ pub fn exec(args: Vec<String>, separator: &str) {
             _ => ()
         }
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/ptx/Cargo.toml
+++ b/src/ptx/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "ptx"
+name = "uu_ptx"
 path = "ptx.rs"
 
 [dependencies]
@@ -17,5 +17,5 @@ regex = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="ptx"
-path="ptx.rs"
+name = "ptx"
+path = "main.rs"

--- a/src/ptx/main.rs
+++ b/src/ptx/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_ptx;
+
+fn main() {
+    std::process::exit(uu_ptx::uumain(std::env::args().collect()));
+}

--- a/src/ptx/ptx.rs
+++ b/src/ptx/ptx.rs
@@ -1,4 +1,4 @@
-#![crate_name = "ptx"]
+#![crate_name = "uu_ptx"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -559,9 +559,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
     write_traditional_output(&config, &file_map, &word_set, &output_file);
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/pwd/Cargo.toml
+++ b/src/pwd/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "pwd"
+name = "uu_pwd"
 path = "pwd.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="pwd"
-path="pwd.rs"
+name = "pwd"
+path = "main.rs"

--- a/src/pwd/main.rs
+++ b/src/pwd/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_pwd;
+
+fn main() {
+    std::process::exit(uu_pwd::uumain(std::env::args().collect()));
+}

--- a/src/pwd/pwd.rs
+++ b/src/pwd/pwd.rs
@@ -1,4 +1,4 @@
-#![crate_name = "pwd"]
+#![crate_name = "uu_pwd"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -49,9 +49,4 @@ Print the full filename of the current working directory.", NAME, VERSION);
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/readlink/Cargo.toml
+++ b/src/readlink/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "readlink"
+name = "uu_readlink"
 path = "readlink.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="readlink"
-path="readlink.rs"
+name = "readlink"
+path = "main.rs"

--- a/src/readlink/main.rs
+++ b/src/readlink/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_readlink;
+
+fn main() {
+    std::process::exit(uu_readlink::uumain(std::env::args().collect()));
+}

--- a/src/readlink/readlink.rs
+++ b/src/readlink/readlink.rs
@@ -1,4 +1,4 @@
-#![crate_name = "readlink"]
+#![crate_name = "uu_readlink"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -132,9 +132,4 @@ fn show_usage(opts: &getopts::Options) {
     println!("Usage: {0} [OPTION]... [FILE]...", NAME);
     print!("Print value of a symbolic link or canonical file name");
     print!("{}", opts.usage(""));
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/realpath/Cargo.toml
+++ b/src/realpath/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "realpath"
+name = "uu_realpath"
 path = "realpath.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="realpath"
-path="realpath.rs"
+name = "realpath"
+path = "main.rs"

--- a/src/realpath/main.rs
+++ b/src/realpath/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_realpath;
+
+fn main() {
+    std::process::exit(uu_realpath::uumain(std::env::args().collect()));
+}

--- a/src/realpath/realpath.rs
+++ b/src/realpath/realpath.rs
@@ -1,4 +1,4 @@
-#![crate_name= "realpath"]
+#![crate_name= "uu_realpath"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -134,9 +134,4 @@ fn show_usage(opts: &getopts::Options) {
             Each path component must exist or resolution will fail and non-zero exit status returned.\n\
             Each resolved FILENAME will be written to the standard output, one per line.")
     );
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/relpath/Cargo.toml
+++ b/src/relpath/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "relpath"
+name = "uu_relpath"
 path = "relpath.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="relpath"
-path="relpath.rs"
+name = "relpath"
+path = "main.rs"

--- a/src/relpath/main.rs
+++ b/src/relpath/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_relpath;
+
+fn main() {
+    std::process::exit(uu_relpath::uumain(std::env::args().collect()));
+}

--- a/src/relpath/relpath.rs
+++ b/src/relpath/relpath.rs
@@ -1,4 +1,4 @@
-#![crate_name = "relpath"]
+#![crate_name = "uu_relpath"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -99,9 +99,4 @@ fn show_usage(opts: &getopts::Options) {
             "Convert TO destination to the relative path from the FROM dir.\n\
             If FROM path is omitted, current working dir will be used.")
     );
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/rm/Cargo.toml
+++ b/src/rm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "rm"
+name = "uu_rm"
 path = "rm.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="rm"
-path="rm.rs"
+name = "rm"
+path = "main.rs"

--- a/src/rm/main.rs
+++ b/src/rm/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_rm;
+
+fn main() {
+    std::process::exit(uu_rm::uumain(std::env::args().collect()));
+}

--- a/src/rm/rm.rs
+++ b/src/rm/rm.rs
@@ -1,4 +1,4 @@
-#![crate_name = "rm"]
+#![crate_name = "uu_rm"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -284,9 +284,4 @@ fn prompt(msg: &str) -> bool {
         }
         _ => false,
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/rmdir/Cargo.toml
+++ b/src/rmdir/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "rmdir"
+name = "uu_rmdir"
 path = "rmdir.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="rmdir"
-path="rmdir.rs"
+name = "rmdir"
+path = "main.rs"

--- a/src/rmdir/main.rs
+++ b/src/rmdir/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_rmdir;
+
+fn main() {
+    std::process::exit(uu_rmdir::uumain(std::env::args().collect()));
+}

--- a/src/rmdir/rmdir.rs
+++ b/src/rmdir/rmdir.rs
@@ -1,4 +1,4 @@
-#![crate_name = "rmdir"]
+#![crate_name = "uu_rmdir"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -122,9 +122,4 @@ fn remove_dir(path: &Path, ignore: bool, verbose: bool) -> Result<(), i32> {
     }
 
     r
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/seq/Cargo.toml
+++ b/src/seq/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "seq"
+name = "uu_seq"
 path = "seq.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="seq"
-path="seq.rs"
+name = "seq"
+path = "main.rs"

--- a/src/seq/main.rs
+++ b/src/seq/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_seq;
+
+fn main() {
+    std::process::exit(uu_seq::uumain(std::env::args().collect()));
+}

--- a/src/seq/seq.rs
+++ b/src/seq/seq.rs
@@ -1,4 +1,4 @@
-#![crate_name = "seq"]
+#![crate_name = "uu_seq"]
 
 // TODO: Make -w flag work with decimals
 // TODO: Support -f flag
@@ -256,9 +256,4 @@ fn print_seq(first: f64, step: f64, last: f64, largest_dec: usize, separator: St
         pipe_print!("{}", terminator);
     }
     pipe_flush!();
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/shuf/Cargo.toml
+++ b/src/shuf/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "shuf"
+name = "uu_shuf"
 path = "shuf.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ rand = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="shuf"
-path="shuf.rs"
+name = "shuf"
+path = "main.rs"

--- a/src/shuf/main.rs
+++ b/src/shuf/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_shuf;
+
+fn main() {
+    std::process::exit(uu_shuf::uumain(std::env::args().collect()));
+}

--- a/src/shuf/shuf.rs
+++ b/src/shuf/shuf.rs
@@ -1,4 +1,4 @@
-#![crate_name = "shuf"]
+#![crate_name = "uu_shuf"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -265,9 +265,4 @@ impl WrappedRng {
             &mut WrappedRng::RngDefault(ref mut r) => r.next_u32() as usize,
         }
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/sleep/Cargo.toml
+++ b/src/sleep/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "sleep"
+name = "uu_sleep"
 path = "sleep.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="sleep"
-path="sleep.rs"
+name = "sleep"
+path = "main.rs"

--- a/src/sleep/main.rs
+++ b/src/sleep/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_sleep;
+
+fn main() {
+    std::process::exit(uu_sleep::uumain(std::env::args().collect()));
+}

--- a/src/sleep/sleep.rs
+++ b/src/sleep/sleep.rs
@@ -1,4 +1,4 @@
-#![crate_name = "sleep"]
+#![crate_name = "uu_sleep"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -75,9 +75,4 @@ fn sleep(args: Vec<String>) {
         (1000000.0 * sleep_time) as u32
     };
     thread::sleep(Duration::new(0, sleep_dur));
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/sort/Cargo.toml
+++ b/src/sort/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "sort"
+name = "uu_sort"
 path = "sort.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="sort"
-path="sort.rs"
+name = "sort"
+path = "main.rs"

--- a/src/sort/main.rs
+++ b/src/sort/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_sort;
+
+fn main() {
+    std::process::exit(uu_sort::uumain(std::env::args().collect()));
+}

--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -1,4 +1,4 @@
-#![crate_name = "sort"]
+#![crate_name = "uu_sort"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -203,9 +203,4 @@ fn open<'a>(path: &str) -> Option<(Box<Read + 'a>, bool)> {
             None
         },
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/split/Cargo.toml
+++ b/src/split/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "split"
+name = "uu_split"
 path = "split.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="split"
-path="split.rs"
+name = "split"
+path = "main.rs"

--- a/src/split/main.rs
+++ b/src/split/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_split;
+
+fn main() {
+    std::process::exit(uu_split::uumain(std::env::args().collect()));
+}

--- a/src/split/split.rs
+++ b/src/split/split.rs
@@ -1,4 +1,4 @@
-#![crate_name = "split"]
+#![crate_name = "uu_split"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -313,9 +313,4 @@ fn split(settings: &Settings) -> i32 {
         control.current_line = sl[advance..sl.chars().count()].to_string();
     }
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/stdbuf/Cargo.toml
+++ b/src/stdbuf/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "stdbuf"
+name = "uu_stdbuf"
 path = "stdbuf.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="stdbuf"
-path="stdbuf.rs"
+name = "stdbuf"
+path = "main.rs"

--- a/src/stdbuf/main.rs
+++ b/src/stdbuf/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_stdbuf;
+
+fn main() {
+    std::process::exit(uu_stdbuf::uumain(std::env::args().collect()));
+}

--- a/src/stdbuf/stdbuf.rs
+++ b/src/stdbuf/stdbuf.rs
@@ -1,4 +1,4 @@
-#![crate_name = "stdbuf"]
+#![crate_name = "uu_stdbuf"]
 
 /*
 * This file is part of the uutils coreutils package.
@@ -263,9 +263,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
         },
         Err(e) => crash!(1, "{}", e)
     };
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/sum/Cargo.toml
+++ b/src/sum/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "sum"
+name = "uu_sum"
 path = "sum.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="sum"
-path="sum.rs"
+name = "sum"
+path = "main.rs"

--- a/src/sum/main.rs
+++ b/src/sum/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_sum;
+
+fn main() {
+    std::process::exit(uu_sum::uumain(std::env::args().collect()));
+}

--- a/src/sum/sum.rs
+++ b/src/sum/sum.rs
@@ -1,4 +1,4 @@
-#![crate_name = "sum"]
+#![crate_name = "uu_sum"]
 
 /*
 * This file is part of the uutils coreutils package.
@@ -136,9 +136,4 @@ Checksum and count the blocks in a file.", NAME, VERSION);
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/sync/Cargo.toml
+++ b/src/sync/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "sync"
+name = "uu_sync"
 path = "sync.rs"
 
 [dependencies]
@@ -15,5 +15,5 @@ kernel32-sys = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="sync"
-path="sync.rs"
+name = "sync"
+path = "main.rs"

--- a/src/sync/main.rs
+++ b/src/sync/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_sync;
+
+fn main() {
+    std::process::exit(uu_sync::uumain(std::env::args().collect()));
+}

--- a/src/sync/sync.rs
+++ b/src/sync/sync.rs
@@ -1,4 +1,4 @@
-#![crate_name = "sync"]
+#![crate_name = "uu_sync"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -143,9 +143,4 @@ fn sync() -> isize {
     unsafe {
         platform::do_sync()
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/tac/Cargo.toml
+++ b/src/tac/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "tac"
+name = "uu_tac"
 path = "tac.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="tac"
-path="tac.rs"
+name = "tac"
+path = "main.rs"

--- a/src/tac/main.rs
+++ b/src/tac/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_tac;
+
+fn main() {
+    std::process::exit(uu_tac::uumain(std::env::args().collect()));
+}

--- a/src/tac/tac.rs
+++ b/src/tac/tac.rs
@@ -1,4 +1,4 @@
-#![crate_name = "tac"]
+#![crate_name = "uu_tac"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -145,9 +145,4 @@ fn show_line(out: &mut Stdout, sep: &[u8], dat: &[u8], before: bool) {
     if !before {
         out.write_all(sep).unwrap_or_else(|e| crash!(1, "failed to write to stdout: {}", e));
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/tail/Cargo.toml
+++ b/src/tail/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "tail"
+name = "uu_tail"
 path = "tail.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="tail"
-path="tail.rs"
+name = "tail"
+path = "main.rs"

--- a/src/tail/main.rs
+++ b/src/tail/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_tail;
+
+fn main() {
+    std::process::exit(uu_tail::uumain(std::env::args().collect()));
+}

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -1,4 +1,4 @@
-#![crate_name = "tail"]
+#![crate_name = "uu_tail"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -297,9 +297,4 @@ fn print_string<T: Write>(_: &mut T, s: &String) {
 
 fn version () {
     println!("{} {}", NAME, VERSION);
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/tee/Cargo.toml
+++ b/src/tee/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "tee"
+name = "uu_tee"
 path = "tee.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="tee"
-path="tee.rs"
+name = "tee"
+path = "main.rs"

--- a/src/tee/main.rs
+++ b/src/tee/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_tee;
+
+fn main() {
+    std::process::exit(uu_tee::uumain(std::env::args().collect()));
+}

--- a/src/tee/tee.rs
+++ b/src/tee/tee.rs
@@ -1,4 +1,4 @@
-#![crate_name = "tee"]
+#![crate_name = "uu_tee"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -170,9 +170,4 @@ impl Read for NamedReader {
 fn warn(message: &str) -> Error {
     eprintln!("{}: {}", NAME, message);
     Error::new(ErrorKind::Other, format!("{}: {}", NAME, message))
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "uutest"
+name = "uu_test"
 path = "test.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="test"
-path="main.rs"
+name = "test"
+path = "main.rs"

--- a/src/test/main.rs
+++ b/src/test/main.rs
@@ -1,5 +1,5 @@
-extern crate uutest;
+extern crate uu_test;
 
 fn main() {
-    std::process::exit(uutest::uumain(std::env::args().collect()));
+    std::process::exit(uu_test::uumain(std::env::args().collect()));
 }

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -1,4 +1,4 @@
-#![crate_name = "uutest"]
+#![crate_name = "uu_test"]
 
 /*
  * This file is part of the uutils coreutils package.

--- a/src/timeout/Cargo.toml
+++ b/src/timeout/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "timeout"
+name = "uu_timeout"
 path = "timeout.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ time = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="timeout"
-path="timeout.rs"
+name = "timeout"
+path = "main.rs"

--- a/src/timeout/main.rs
+++ b/src/timeout/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_timeout;
+
+fn main() {
+    std::process::exit(uu_timeout::uumain(std::env::args().collect()));
+}

--- a/src/timeout/timeout.rs
+++ b/src/timeout/timeout.rs
@@ -1,4 +1,4 @@
-#![crate_name = "timeout"]
+#![crate_name = "uu_timeout"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -146,9 +146,4 @@ fn timeout(cmdname: &str, args: &[String], duration: f64, signal: usize, kill_af
             ERR_EXIT_STATUS
         },
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/touch/Cargo.toml
+++ b/src/touch/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "touch"
+name = "uu_touch"
 path = "touch.rs"
 
 [dependencies]
@@ -15,5 +15,5 @@ time = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="touch"
-path="touch.rs"
+name = "touch"
+path = "main.rs"

--- a/src/touch/main.rs
+++ b/src/touch/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_touch;
+
+fn main() {
+    std::process::exit(uu_touch::uumain(std::env::args().collect()));
+}

--- a/src/touch/touch.rs
+++ b/src/touch/touch.rs
@@ -1,4 +1,4 @@
-#![crate_name = "touch"]
+#![crate_name = "uu_touch"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -202,10 +202,4 @@ fn parse_timestamp(s: &str) -> FileTime {
         Ok(tm) => local_tm_to_filetime!(to_local!(tm)),
         Err(e) => panic!("Unable to parse timestamp\n{}", e)
     }
-}
-
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/tr/Cargo.toml
+++ b/src/tr/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "tr"
+name = "uu_tr"
 path = "tr.rs"
 
 [dependencies]
@@ -15,5 +15,5 @@ vec_map = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="tr"
-path="tr.rs"
+name = "tr"
+path = "main.rs"

--- a/src/tr/main.rs
+++ b/src/tr/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_tr;
+
+fn main() {
+    std::process::exit(uu_tr::uumain(std::env::args().collect()));
+}

--- a/src/tr/tr.rs
+++ b/src/tr/tr.rs
@@ -1,4 +1,4 @@
-#![crate_name = "tr"]
+#![crate_name = "uu_tr"]
 #![feature(io)]
 
 /*
@@ -161,9 +161,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/true/Cargo.toml
+++ b/src/true/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "true"
+name = "uu_true"
 path = "true.rs"
 
 [dependencies]
@@ -12,5 +12,5 @@ getopts = "*"
 libc = "*"
 
 [[bin]]
-name="true"
-path="true.rs"
+name = "true"
+path = "main.rs"

--- a/src/true/main.rs
+++ b/src/true/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_true;
+
+fn main() {
+    std::process::exit(uu_true::uumain(std::env::args().collect()));
+}

--- a/src/true/true.rs
+++ b/src/true/true.rs
@@ -1,4 +1,4 @@
-#![crate_name= "true"]
+#![crate_name= "uu_true"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -9,12 +9,6 @@
  * file that was distributed with this source code.
  */
 
-
 pub fn uumain(_: Vec<String>) -> i32 {
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/truncate/Cargo.toml
+++ b/src/truncate/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "truncate"
+name = "uu_truncate"
 path = "truncate.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="truncate"
-path="truncate.rs"
+name = "truncate"
+path = "main.rs"

--- a/src/truncate/main.rs
+++ b/src/truncate/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_truncate;
+
+fn main() {
+    std::process::exit(uu_truncate::uumain(std::env::args().collect()));
+}

--- a/src/truncate/truncate.rs
+++ b/src/truncate/truncate.rs
@@ -1,4 +1,4 @@
-#![crate_name = "truncate"]
+#![crate_name = "uu_truncate"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -211,9 +211,4 @@ fn parse_size(size: &str) -> (u64, TruncateMode) {
         };
     }
     (number, mode)
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/tsort/Cargo.toml
+++ b/src/tsort/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "tsort"
+name = "uu_tsort"
 path = "tsort.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="tsort"
-path="tsort.rs"
+name = "tsort"
+path = "main.rs"

--- a/src/tsort/main.rs
+++ b/src/tsort/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_tsort;
+
+fn main() {
+    std::process::exit(uu_tsort::uumain(std::env::args().collect()));
+}

--- a/src/tsort/tsort.rs
+++ b/src/tsort/tsort.rs
@@ -1,4 +1,4 @@
-#![crate_name = "tsort"]
+#![crate_name = "uu_tsort"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -192,9 +192,4 @@ impl Graph {
         }
         true
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/tty/Cargo.toml
+++ b/src/tty/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "tty"
+name = "uu_tty"
 path = "tty.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="tty"
-path="tty.rs"
+name = "tty"
+path = "main.rs"

--- a/src/tty/main.rs
+++ b/src/tty/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_tty;
+
+fn main() {
+    std::process::exit(uu_tty::uumain(std::env::args().collect()));
+}

--- a/src/tty/tty.rs
+++ b/src/tty/tty.rs
@@ -1,4 +1,4 @@
-#![crate_name = "tty"]
+#![crate_name = "uu_tty"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -77,9 +77,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/uname/Cargo.toml
+++ b/src/uname/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "uname"
+name = "uu_uname"
 path = "uname.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="uname"
-path="uname.rs"
+name = "uname"
+path = "main.rs"

--- a/src/uname/main.rs
+++ b/src/uname/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_uname;
+
+fn main() {
+    std::process::exit(uu_uname::uumain(std::env::args().collect()));
+}

--- a/src/uname/uname.rs
+++ b/src/uname/uname.rs
@@ -1,4 +1,4 @@
-#![crate_name = "uname"]
+#![crate_name = "uu_uname"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -105,9 +105,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     println!("{}", output.trim());
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/unexpand/Cargo.toml
+++ b/src/unexpand/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "unexpand"
+name = "uu_unexpand"
 path = "unexpand.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ unicode-width = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="unexpand"
-path="unexpand.rs"
+name = "unexpand"
+path = "main.rs"

--- a/src/unexpand/main.rs
+++ b/src/unexpand/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_unexpand;
+
+fn main() {
+    std::process::exit(uu_unexpand::uumain(std::env::args().collect()));
+}

--- a/src/unexpand/unexpand.rs
+++ b/src/unexpand/unexpand.rs
@@ -1,4 +1,4 @@
-#![crate_name = "unexpand"]
+#![crate_name = "uu_unexpand"]
 #![feature(unicode)]
 
 /*
@@ -279,9 +279,4 @@ fn unexpand(options: Options) {
         }
     }
     pipe_flush!(output);
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/uniq/Cargo.toml
+++ b/src/uniq/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "uniq"
+name = "uu_uniq"
 path = "uniq.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="uniq"
-path="uniq.rs"
+name = "uniq"
+path = "main.rs"

--- a/src/uniq/main.rs
+++ b/src/uniq/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_uniq;
+
+fn main() {
+    std::process::exit(uu_uniq::uumain(std::env::args().collect()));
+}

--- a/src/uniq/uniq.rs
+++ b/src/uniq/uniq.rs
@@ -1,4 +1,4 @@
-#![crate_name = "uniq"]
+#![crate_name = "uu_uniq"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -238,9 +238,4 @@ fn open_output_file(out_file_name: String) -> BufWriter<Box<Write+'static>> {
         Box::new(w) as Box<Write>
     };
     BufWriter::new(out_file)
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/unlink/Cargo.toml
+++ b/src/unlink/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "unlink"
+name = "uu_unlink"
 path = "unlink.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="unlink"
-path="unlink.rs"
+name = "unlink"
+path = "main.rs"

--- a/src/unlink/main.rs
+++ b/src/unlink/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_unlink;
+
+fn main() {
+    std::process::exit(uu_unlink::uumain(std::env::args().collect()));
+}

--- a/src/unlink/unlink.rs
+++ b/src/unlink/unlink.rs
@@ -1,4 +1,4 @@
-#![crate_name = "unlink"]
+#![crate_name = "uu_unlink"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -89,9 +89,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     0
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/uptime/Cargo.toml
+++ b/src/uptime/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "uptime"
+name = "uu_uptime"
 path = "uptime.rs"
 
 [dependencies]
@@ -14,5 +14,5 @@ time = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="uptime"
-path="uptime.rs"
+name = "uptime"
+path = "main.rs"

--- a/src/uptime/main.rs
+++ b/src/uptime/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_uptime;
+
+fn main() {
+    std::process::exit(uu_uptime::uumain(std::env::args().collect()));
+}

--- a/src/uptime/uptime.rs
+++ b/src/uptime/uptime.rs
@@ -1,4 +1,4 @@
-#![crate_name = "uptime"]
+#![crate_name = "uu_uptime"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -201,9 +201,4 @@ fn print_uptime(upsecs: i64) {
     else {
         print!("up  {:2}:{:02}, ", uphours, upmins);
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/users/Cargo.toml
+++ b/src/users/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "users"
+name = "uu_users"
 path = "users.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="users"
-path="users.rs"
+name = "users"
+path = "main.rs"

--- a/src/users/main.rs
+++ b/src/users/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_users;
+
+fn main() {
+    std::process::exit(uu_users::uumain(std::env::args().collect()));
+}

--- a/src/users/users.rs
+++ b/src/users/users.rs
@@ -1,4 +1,4 @@
-#![crate_name = "users"]
+#![crate_name = "uu_users"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -115,9 +115,4 @@ fn exec(filename: &str) {
         users.sort();
         println!("{}", users.join(" "));
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/uucore/macros.rs
+++ b/src/uucore/macros.rs
@@ -8,9 +8,21 @@
  */
 
 #[macro_export]
+macro_rules! executable(
+    () => ({
+        let module = module_path!();
+        if &module[0..3] == "uu_" {
+            &module[3..]
+        } else {
+            module
+        }
+    })
+);
+
+#[macro_export]
 macro_rules! show_error(
     ($($args:tt)+) => ({
-        pipe_write!(&mut ::std::io::stderr(), "{}: error: ", module_path!());
+        pipe_write!(&mut ::std::io::stderr(), "{}: error: ", executable!());
         pipe_writeln!(&mut ::std::io::stderr(), $($args)+);
     })
 );
@@ -18,7 +30,7 @@ macro_rules! show_error(
 #[macro_export]
 macro_rules! show_warning(
     ($($args:tt)+) => ({
-        pipe_write!(&mut ::std::io::stderr(), "{}: warning: ", module_path!());
+        pipe_write!(&mut ::std::io::stderr(), "{}: warning: ", executable!());
         pipe_writeln!(&mut ::std::io::stderr(), $($args)+);
     })
 );
@@ -26,7 +38,7 @@ macro_rules! show_warning(
 #[macro_export]
 macro_rules! show_info(
     ($($args:tt)+) => ({
-        pipe_write!(&mut ::std::io::stderr(), "{}: ", module_path!());
+        pipe_write!(&mut ::std::io::stderr(), "{}: ", executable!());
         pipe_writeln!(&mut ::std::io::stderr(), $($args)+);
     })
 );

--- a/src/wc/Cargo.toml
+++ b/src/wc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "wc"
+name = "uu_wc"
 path = "wc.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="wc"
-path="wc.rs"
+name = "wc"
+path = "main.rs"

--- a/src/wc/main.rs
+++ b/src/wc/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_wc;
+
+fn main() {
+    std::process::exit(uu_wc::uumain(std::env::args().collect()));
+}

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -1,4 +1,4 @@
-#![crate_name = "wc"]
+#![crate_name = "uu_wc"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -276,9 +276,4 @@ fn open(path: &str) -> StdResult<BufReader<Box<Read+'static>>, i32> {
             Err(1)
         }
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/whoami/Cargo.toml
+++ b/src/whoami/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "whoami"
+name = "uu_whoami"
 path = "whoami.rs"
 
 [dependencies]
@@ -15,5 +15,5 @@ advapi32-sys = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="whoami"
-path="whoami.rs"
+name = "whoami"
+path = "main.rs"

--- a/src/whoami/main.rs
+++ b/src/whoami/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_whoami;
+
+fn main() {
+    std::process::exit(uu_whoami::uumain(std::env::args().collect()));
+}

--- a/src/whoami/whoami.rs
+++ b/src/whoami/whoami.rs
@@ -1,4 +1,4 @@
-#![crate_name = "whoami"]
+#![crate_name = "uu_whoami"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -64,9 +64,4 @@ pub fn exec() {
             }
         }
     }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }

--- a/src/yes/Cargo.toml
+++ b/src/yes/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = []
 
 [lib]
-name = "yes"
+name = "uu_yes"
 path = "yes.rs"
 
 [dependencies]
@@ -13,5 +13,5 @@ libc = "*"
 uucore = { path="../uucore" }
 
 [[bin]]
-name="yes"
-path="yes.rs"
+name = "yes"
+path = "main.rs"

--- a/src/yes/main.rs
+++ b/src/yes/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_yes;
+
+fn main() {
+    std::process::exit(uu_yes::uumain(std::env::args().collect()));
+}

--- a/src/yes/yes.rs
+++ b/src/yes/yes.rs
@@ -1,4 +1,4 @@
-#![crate_name = "yes"]
+#![crate_name = "uu_yes"]
 
 /*
  * This file is part of the uutils coreutils package.
@@ -59,9 +59,4 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
 pub fn exec(string: &str) {
     while pipe_println!("{}", string) { }
-}
-
-#[allow(dead_code)]
-fn main() {
-    std::process::exit(uumain(std::env::args().collect()));
 }


### PR DESCRIPTION
For coreutils, there are two build artifacts:

  1. multicall executable (each utility is a separate static library)
  2. individual utilities (still separate library with main wrapper)

To avoid namespace collision, each utility crate is defined as `uu_{CMD}`. The end user only sees the original utility name. This simplifies build.rs, but doesn't eliminate the need for it. At least, there are fewer odd cases.

Also, the thin wrapper for the main() function is no longer contained in the crate. It has been separated into a dedicated file. This was necessary to work around Cargo's need for the crate name attribute to match the name in the respective Cargo.toml.