### PR TITLE
Remove trait shim needed before Path stabilized

### DIFF
--- a/src/chmod/chmod.rs
+++ b/src/chmod/chmod.rs
@@ -28,7 +28,6 @@ use std::ffi::CString;
 use std::io::{Error, Write};
 use std::mem;
 use std::path::Path;
-use uucore::fs::UUPathExt;
 use walker::Walker;
 
 const NAME: &'static str = "chmod";
@@ -149,8 +148,8 @@ fn chmod(files: Vec<String>, changes: bool, quiet: bool, verbose: bool, preserve
     for filename in files.iter() {
         let filename = &filename[..];
         let file = Path::new(filename);
-        if file.uu_exists() {
-            if file.uu_is_dir() {
+        if file.exists() {
+            if file.is_dir() {
                 if !preserve_root || filename != "/" {
                     if recursive {
                         let walk_dir = match Walker::new(&file) {
@@ -273,7 +272,7 @@ fn chmod_file(file: &Path, name: &str, changes: bool, quiet: bool, verbose: bool
                             'w' => rwx |= 0o002,
                             'x' => rwx |= 0o001,
                             'X' => {
-                                if file.uu_is_dir() || (fperm & 0o0111) != 0 {
+                                if file.is_dir() || (fperm & 0o0111) != 0 {
                                     rwx |= 0o001;
                                 }
                             }

--- a/src/chroot/chroot.rs
+++ b/src/chroot/chroot.rs
@@ -23,7 +23,6 @@ use std::iter::FromIterator;
 use std::path::Path;
 use std::process::Command;
 use uucore::c_types::{get_pw_from_args, get_group};
-use uucore::fs::UUPathExt;
 
 extern {
     fn chroot(path: *const libc::c_char) -> libc::c_int;
@@ -77,7 +76,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let user_shell = std::env::var("SHELL");
 
     let newroot = Path::new(&matches.free[0][..]);
-    if !newroot.uu_is_dir() {
+    if !newroot.is_dir() {
         crash!(1, "cannot change root directory to `{}`: no such directory", newroot.display());
     }
 

--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -18,7 +18,7 @@ use getopts::Options;
 use std::fs;
 use std::io::{ErrorKind, Result, Write};
 use std::path::Path;
-use uucore::fs::{canonicalize, CanonicalizeMode, UUPathExt};
+use uucore::fs::{canonicalize, CanonicalizeMode};
 
 #[derive(Clone, Eq, PartialEq)]
 pub enum Mode {
@@ -118,7 +118,7 @@ fn copy(matches: getopts::Matches) {
             panic!();
         }
     } else {
-        if !dest.uu_is_dir() {
+        if !dest.is_dir() {
             show_error!("TARGET must be a directory");
             panic!();
         }
@@ -126,7 +126,7 @@ fn copy(matches: getopts::Matches) {
         for src in sources.iter() {
             let source = Path::new(&src);
 
-            if !source.uu_is_file() {
+            if !source.is_file() {
                 show_error!("\"{}\" is not a file", source.display());
                 continue;
             }

--- a/src/cut/cut.rs
+++ b/src/cut/cut.rs
@@ -18,7 +18,6 @@ extern crate uucore;
 use std::fs::File;
 use std::io::{stdout, stdin, BufRead, BufReader, Read, Stdout, Write};
 use std::path::Path;
-use uucore::fs::UUPathExt;
 
 use ranges::Range;
 use searcher::Searcher;
@@ -379,7 +378,7 @@ fn cut_files(mut filenames: Vec<String>, mode: Mode) -> i32 {
         } else {
             let path = Path::new(&filename[..]);
 
-            if !path.uu_exists() {
+            if !path.exists() {
                 show_error!("{}: No such file or directory", filename);
                 continue
             }

--- a/src/ln/ln.rs
+++ b/src/ln/ln.rs
@@ -19,7 +19,6 @@ use std::io::{BufRead, BufReader, Result, stdin, Write};
 #[cfg(unix)] use std::os::unix::fs::symlink as symlink_file;
 #[cfg(windows)] use std::os::windows::fs::symlink_file;
 use std::path::{Path, PathBuf};
-use uucore::fs::UUPathExt;
 
 static NAME: &'static str = "ln";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -200,7 +199,7 @@ fn exec(files: &[PathBuf], settings: &Settings) -> i32 {
 }
 
 fn link_files_in_dir(files: &[PathBuf], target_dir: &PathBuf, settings: &Settings) -> i32 {
-    if !target_dir.uu_is_dir() {
+    if !target_dir.is_dir() {
         show_error!("target '{}' is not a directory", target_dir.display());
         return 1;
     }
@@ -232,13 +231,13 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &PathBuf, settings: &Setting
 fn link(src: &PathBuf, dst: &PathBuf, settings: &Settings) -> Result<()> {
     let mut backup_path = None;
 
-    if dst.uu_is_dir() {
+    if dst.is_dir() {
         if settings.no_target_dir {
             try!(fs::remove_dir(dst));
         }
     }
 
-    if is_symlink(dst) || dst.uu_exists() {
+    if is_symlink(dst) || dst.exists() {
         match settings.overwrite {
             OverwriteMode::NoClobber => {},
             OverwriteMode::Interactive => {
@@ -301,7 +300,7 @@ fn numbered_backup_path(path: &PathBuf) -> PathBuf {
     let mut i: u64 = 1;
     loop {
         let new_path = simple_backup_path(path, &format!(".~{}~", i));
-        if !new_path.uu_exists() {
+        if !new_path.exists() {
             return new_path;
         }
         i += 1;
@@ -310,7 +309,7 @@ fn numbered_backup_path(path: &PathBuf) -> PathBuf {
 
 fn existing_backup_path(path: &PathBuf, suffix: &String) -> PathBuf {
     let test_path = simple_backup_path(path, &".~1~".to_string());
-    if test_path.uu_exists() {
+    if test_path.exists() {
         return numbered_backup_path(path);
     }
     simple_backup_path(path, suffix)

--- a/src/mkdir/mkdir.rs
+++ b/src/mkdir/mkdir.rs
@@ -18,7 +18,6 @@ extern crate uucore;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use uucore::fs::UUPathExt;
 
 static NAME: &'static str = "mkdir";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -100,7 +99,7 @@ fn exec(dirs: Vec<String>, recursive: bool, mode: u16, verbose: bool) -> i32 {
         } else {
             match path.parent() {
                 Some(parent) => {
-                    if parent != empty && !parent.uu_exists() {
+                    if parent != empty && !parent.exists() {
                         show_info!("cannot create directory '{}': No such file or directory", path.display());
                         status = 1;
                     } else {
@@ -120,7 +119,7 @@ fn exec(dirs: Vec<String>, recursive: bool, mode: u16, verbose: bool) -> i32 {
  * Wrapper to catch errors, return 1 if failed
  */
 fn mkdir(path: &Path, mode: u16, verbose: bool) -> i32 {
-    if path.uu_exists() {
+    if path.exists() {
         show_info!("cannot create directory '{}': File exists", path.display());
         return 1;
     }

--- a/src/mv/mv.rs
+++ b/src/mv/mv.rs
@@ -20,7 +20,6 @@ use std::fs;
 use std::io::{BufRead, BufReader, Result, stdin, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-use uucore::fs::UUPathExt;
 
 static NAME: &'static str = "mv";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -195,14 +194,14 @@ fn exec(files: &[PathBuf], b: Behaviour) -> i32 {
         2 => {
             let ref source = files[0];
             let ref target = files[1];
-            if !source.uu_exists() {
+            if !source.exists() {
                 show_error!("cannot stat ‘{}’: No such file or directory", source.display());
                 return 1;
             }
 
-            if target.uu_is_dir() {
+            if target.is_dir() {
                 if b.no_target_dir {
-                    if !source.uu_is_dir() {
+                    if !source.is_dir() {
                         show_error!("cannot overwrite directory ‘{}’ with non-directory",
                             target.display());
                         return 1;
@@ -242,7 +241,7 @@ fn exec(files: &[PathBuf], b: Behaviour) -> i32 {
 }
 
 fn move_files_into_dir(files: &[PathBuf], target_dir: &PathBuf, b: &Behaviour) -> i32 {
-    if !target_dir.uu_is_dir() {
+    if !target_dir.is_dir() {
         show_error!("target ‘{}’ is not a directory", target_dir.display());
         return 1;
     }
@@ -275,7 +274,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &PathBuf, b: &Behaviour) -
 fn rename(from: &PathBuf, to: &PathBuf, b: &Behaviour) -> Result<()> {
     let mut backup_path = None;
 
-    if to.uu_exists() {
+    if to.exists() {
         match b.overwrite {
             OverwriteMode::NoClobber => return Ok(()),
             OverwriteMode::Interactive => {
@@ -337,7 +336,7 @@ fn numbered_backup_path(path: &PathBuf) -> PathBuf {
     let mut i: u64 = 1;
     loop {
         let new_path = simple_backup_path(path, &format!(".~{}~", i));
-        if !new_path.uu_exists() {
+        if !new_path.exists() {
             return new_path;
         }
         i = i + 1;
@@ -346,7 +345,7 @@ fn numbered_backup_path(path: &PathBuf) -> PathBuf {
 
 fn existing_backup_path(path: &PathBuf, suffix: &String) -> PathBuf {
     let test_path = simple_backup_path(path, &".~1~".to_string());
-    if test_path.uu_exists() {
+    if test_path.exists() {
         return numbered_backup_path(path);
     }
     simple_backup_path(path, suffix)

--- a/src/rm/rm.rs
+++ b/src/rm/rm.rs
@@ -20,7 +20,6 @@ use std::fs;
 use std::io::{stdin, stderr, BufRead, Write};
 use std::ops::BitOr;
 use std::path::{Path, PathBuf};
-use uucore::fs::UUPathExt;
 
 #[derive(Eq, PartialEq, Clone, Copy)]
 enum InteractiveMode {
@@ -130,8 +129,8 @@ fn remove(files: Vec<String>, force: bool, interactive: InteractiveMode, one_fs:
     for filename in files.iter() {
         let filename = &filename[..];
         let file = Path::new(filename);
-        if file.uu_exists() {
-            if file.uu_is_dir() {
+        if file.exists() {
+            if file.is_dir() {
                 if recursive && (filename != "/" || !preserve_root) {
                     if interactive != InteractiveMode::InteractiveAlways {
                         match fs::remove_dir_all(file) {

--- a/src/stdbuf/stdbuf.rs
+++ b/src/stdbuf/stdbuf.rs
@@ -20,7 +20,7 @@ use std::io::{self, Write};
 use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
 use std::process::Command;
-use uucore::fs::{canonicalize, CanonicalizeMode, UUPathExt};
+use uucore::fs::{canonicalize, CanonicalizeMode};
 
 static NAME: &'static str = "stdbuf";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -201,7 +201,7 @@ fn get_preload_env() -> (String, String) {
     // First search for library in directory of executable.
     let mut path = exe_path().unwrap_or_else(|_| crash!(1, "Impossible to fetch the path of this executable."));
     path.push(libstdbuf.clone());
-    if path.uu_exists() {
+    if path.exists() {
         match path.as_os_str().to_str() {
             Some(s) => { return (preload.to_string(), s.to_string()); },
             None => crash!(1, "Error while converting path.")

--- a/src/touch/touch.rs
+++ b/src/touch/touch.rs
@@ -21,7 +21,6 @@ use filetime::*;
 use std::fs::{self, File};
 use std::io::{Error, Write};
 use std::path::Path;
-use uucore::fs::UUPathExt;
 
 static NAME: &'static str = "touch";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -108,7 +107,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     for filename in matches.free.iter() {
         let path = &filename[..];
 
-        if !Path::new(path).uu_exists() {
+        if !Path::new(path).exists() {
             // no-dereference included here for compatibility
             if matches.opts_present(&["no-create".to_string(), "no-dereference".to_string()]) {
                 continue;

--- a/src/uucore/fs.rs
+++ b/src/uucore/fs.rs
@@ -7,42 +7,12 @@
  * file that was distributed with this source code.
  */
 
-// Based on the pattern using by Cargo, I created a shim over the
-// standard PathExt trait, so that the unstable path methods could
-// be backported to stable (<= 1.1). This will likely be dropped
-// when the path trait stabilizes.
-
 #[cfg(unix)]
 use super::libc;
 use std::env;
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
 use std::path::{Component, Path, PathBuf};
-
-pub trait UUPathExt {
-    fn uu_exists(&self) -> bool;
-    fn uu_is_file(&self) -> bool;
-    fn uu_is_dir(&self) -> bool;
-    fn uu_metadata(&self) -> Result<fs::Metadata>;
-}
-
-impl UUPathExt for Path {
-    fn uu_exists(&self) -> bool {
-        fs::metadata(self).is_ok()
-    }
-
-    fn uu_is_file(&self) -> bool {
-        fs::metadata(self).map(|m| m.is_file()).unwrap_or(false)
-    }
-
-    fn uu_is_dir(&self) -> bool {
-        fs::metadata(self).map(|m| m.is_dir()).unwrap_or(false)
-    }
-
-    fn uu_metadata(&self) -> Result<fs::Metadata> {
-        fs::metadata(self)
-    }
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CanonicalizeMode {

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -22,7 +22,6 @@ use std::io::{stdin, BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::result::Result as StdResult;
 use std::str::from_utf8;
-use uucore::fs::UUPathExt;
 
 struct Settings {
     show_bytes: bool,
@@ -263,7 +262,7 @@ fn open(path: &str) -> StdResult<BufReader<Box<Read+'static>>, i32> {
     }
 
     let fpath = Path::new(path);
-    if fpath.uu_is_dir() {
+    if fpath.is_dir() {
         show_info!("{}: is a directory", path);
     }
     match File::open(&fpath) {


### PR DESCRIPTION
Now that Path has stabilized in Rust 1.5, I removed the UUPathExt trait
needed to support stable, beta, and nightly.