### PR TITLE
Add busybox test functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ To test only a few of the available utilities:
 make TEST='UTILITY_1 UTILITY_2' test
 ```
 
+Run busybox tests
+-----------------
+
+This testing functionality is only available on *nix operating systems
+
+To run busybox's tests for all utilities for which busybox has tests
+```
+make busytest
+```
+
+To run busybox's tests for a few of the available utilities
+```
+make BUSYTEST='UTILITY_1 UTILITY_2' busytest
+```
+
+To pass an argument like "-v" to the busybox test runtime
+```
+make BUSYTEST='UTILITY_1 UTILITY_2' RUNTEST_ARGS='-v' busytest
+```
+
 Contribute
 ----------
 

--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -49,12 +49,7 @@ fn main() {
         None => (),
     }
 
-    if binary_as_util.ends_with("uutils") || binary_as_util.starts_with("uutils") ||
-        binary_as_util.ends_with("busybox") || binary_as_util.starts_with("busybox") {
-            // uutils can be called as either "uutils", "busybox"
-            // "uutils-suffix" or "busybox-suffix". Not sure
-            // what busybox uses the -suffix pattern for.
-    } else {
+    if !(binary_as_util.ends_with("uutils") || binary_as_util.starts_with("uutils")) {
         println!("{}: applet not found", binary_as_util);
         std::process::exit(1);
     }


### PR DESCRIPTION
A make task to run busybox tests for utiltiies has been added back, with some changes.

Changes:

1. the busybox tests are now run from busybox source that is automatically downloaded and unpacked into a subdir of the repo's ```tmp``` folder
2. utilities to run busybox tests for is now determined by the ```BUSYTEST``` make variable (analogous to ```BUILD``` and ```TEST```) - the RUNTEST_ARG make variable still exists.
3. Busybox tests now run against a bash shim, instead of the ```uutils``` binary
 * Because of this, running ```make busytest``` will, like running ```make test```, not create or clobber the ```uutils``` binary

fixes #742 