### PR TITLE
make: fix busybox script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ ensure-builddir:
 
 # Test under the busybox testsuite
 $(BUILDDIR)/busybox: busybox-src ensure-builddir
-	echo '#!/bin/bash\n$(PKG_BUILDDIR)./$$1 $${@:2}' > $@; \
+	echo -e '#!/bin/bash\n$(PKG_BUILDDIR)./$$1 $${@:2}' > $@; \
 	chmod +x $@;
 
 # This is a busybox-specific config file their test suite wants to parse.


### PR DESCRIPTION
The generated script fails to execute due to escaped newlines.

/src/uutils/tmp/busybox-1.24.1/testsuite/basename/basename-works: /src/uutils/target/debug/busybox: /bin/bash\n/src/uutils/target/debug//deps/./$1: bad interpreter: No such file or directory