### PR TITLE
*nix install script and appveyor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,19 @@ To install only a few of the available utilities:
 make INSTALL='UTILITY_1 UTILITY_2' install
 ```
 
-To install every program with a prefix:
+To install every program with a prefix (e.g. uu-echo uu-cat):
 ```
 make PROG_PREFIX=PREFIX_GOES_HERE install
 ```
 
 To install the multicall binary:
 ```
-make install-multicall
+make MULTICALL=y install
+```
+
+Set install parent directory (default value is /usr/local):
+```
+make PREFIX=/my/path install
 ```
 
 Uninstallation Instructions
@@ -89,7 +94,12 @@ make PROG_PREFIX=PREFIX_GOES_HERE uninstall
 
 To uninstall the multicall binary:
 ```
-make uninstall-multicall
+make MULTICALL=y uninstall
+```
+
+To uninstall from a custom parent directory:
+```
+make PREFIX=/my/path uninstall
 ```
 
 Test Instructions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,14 @@ install:
   - cargo -V
 
 build_script:
-  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make"
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make PROFILE='release' build"
+  - 7z a -tzip uutils.zip .\target\release\deps\*.exe
+ 
+artifacts:
+  - path: uutils.zip
+    name: zipfile
+  - path: target\release\uutils.exe
+    name: uutils.exe
 
 test_script:
   - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+platform:
+  - x64
+
+environment:
+  global:
+    MSYS2_BASEVER: 20150512
+    MSYS2_ARCH: x86_64
+    MBASH: msys64\usr\bin\sh --login -c
+
+  matrix:
+  - TARGET: i686-pc-windows-gnu
+
+install:
+  - appveyor DownloadFile "http://kent.dl.sourceforge.net/project/msys2/Base/%MSYS2_ARCH%/msys2-base-%MSYS2_ARCH%-%MSYS2_BASEVER%.tar.xz" -FileName "msys2.tar.xz"
+  - 7z x msys2.tar.xz
+  - 7z x msys2.tar > NUL
+  - call %MBASH% ""
+  - call %MBASH% "for i in {1..3}; do pacman --noconfirm -Suy mingw-w64-%MSYS2_ARCH%-{ragel,freetype,icu,gettext} libtool pkg-config gcc make autoconf automake perl && break || sleep 15; done"
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - SET PATH=%PATH%;C:\MinGW\bin
+  - rustc -V
+  - cargo -V
+
+build_script:
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make"
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make build-check"
+
+test_script:
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make test"
+  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make test-check"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,6 @@ install:
 
 build_script:
   - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make"
-  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make build-check"
 
 test_script:
   - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make test"
-  - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER; PATH=$PATH:/mingw64/bin:/mingw32/bin; exec 0</dev/null; make test-check"

--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -49,14 +49,26 @@ fn main() {
         None => (),
     }
 
-    if !(binary_as_util.ends_with("uutils") || binary_as_util.starts_with("uutils")) {
-        println!("{}: applet not found", binary_as_util);
-        std::process::exit(1);
+    if binary_as_util.ends_with("uutils") || binary_as_util.starts_with("uutils") {
+        args.remove(0);
+    } else {
+        let mut found = false;
+        for util in umap.keys() {
+            if binary_as_util.ends_with(util) {
+                args[0] = util.clone().to_owned();
+                found = true;
+                break;
+            }
+        }
+        if ! found {
+            println!("{}: applet not found", binary_as_util);
+            std::process::exit(1);
+        }
     }
 
     // try first arg as util name.
-    if args.len() >= 2 {
-        args.remove(0);
+    if args.len() >= 1 {
+
         let util = &args[0][..];
 
         match umap.get(util) {

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -16,7 +16,13 @@ use std::ffi::OsStr;
 use self::tempdir::TempDir;
 use std::rc::Rc;
 
+#[cfg(windows)]
+static PROGNAME: &'static str = "target\\debug\\uutils.exe";
+#[cfg(windows)]
+static FIXTURES_DIR: &'static str = "tests\\fixtures";
+#[cfg(not(windows))]
 static PROGNAME: &'static str = "target/debug/uutils";
+#[cfg(not(windows))]
 static FIXTURES_DIR: &'static str = "tests/fixtures";
 static ALREADY_RUN: &'static str = " you have already run this UCommand, if you want to run \
                                     another command in the same test, use TestSet::new instead of \


### PR DESCRIPTION
Key changes

1. Appveyor script now creates downloadable artifacts (zip of single call binaries, and multicall binary) on test success
2. Installed multicall utilities can now be prefixed using PROG_PREFIX make param
3. Utilities are only built during install if they are going to be installed

Additional minor changes described in commit notes for "fixes for linux install" commit (d99d5c1)