### PR TITLE
CI on OS X too. And cache .cargo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
   - stable
   - beta
   - nightly
+os:
+ - linux
+ - osx
 sudo: false
 script:
   - cargo build
@@ -11,3 +14,4 @@ matrix:
   allow_failures:
     - rust: stable
     - rust: beta
+    - os: osx


### PR DESCRIPTION
* Run CI on OS X
* Cache .cargo to make CI faster

I anticipate test under OS X will fail because OS X support of current coreutils is broken