### PR TITLE
Changes as suggested for #766

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,13 @@ CARGO  ?= cargo
 CARGOFLAGS ?=
 
 # Install directories
-DESTDIR ?= /usr/local
+PREFIX ?= /usr/local
+DESTDIR ?= 
 BINDIR ?= /bin
 LIBDIR ?= /lib
 
-INSTALLDIR_BIN=$(DESTDIR)$(BINDIR)
-INSTALLDIR_LIB=$(DESTDIR)$(LIBDIR)
+INSTALLDIR_BIN=$(DESTDIR)$(PREFIX)$(BINDIR)
+INSTALLDIR_LIB=$(DESTDIR)$(PREFIX)$(LIBDIR)
 
 #prefix to apply to uutils binary and all tool binaries
 PROG_PREFIX ?=

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 PROFILE         ?= debug
 ifneq (,$(filter install, $(MAKECMDGOALS)))
 override PROFILE:=release
-override BUILD:=INSTALL
-override DONT_BUILD:=DONT_INSTALL
+override BUILD:=$(INSTALL)
+override DONT_BUILD:=$(DONT_INSTALL)
 endif
 
 MULTICALL       ?= n

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,12 @@ CARGO  ?= cargo
 CARGOFLAGS ?=
 
 # Install directories
-FS_ROOT ?= /
-PREFIX ?= /usr/local
+DESTDIR ?= /usr/local
 BINDIR ?= /bin
 LIBDIR ?= /lib
 
-INSTALLDIR_BIN=$(FS_ROOT)$(PREFIX)$(BINDIR)
-INSTALLDIR_LIB=$(FS_ROOT)$(PREFIX)$(LIBDIR)
+INSTALLDIR_BIN=$(DESTDIR)$(BINDIR)
+INSTALLDIR_LIB=$(DESTDIR)$(LIBDIR)
 
 #prefix to apply to uutils binary and all tool binaries
 PROG_PREFIX ?=
@@ -274,10 +273,9 @@ distclean: clean
 # TODO: figure out if there is way for prefixes to work with the symlinks
 install: build 
 	mkdir -p $(INSTALLDIR_BIN)
-	rm -f $(addprefix $(INSTALLDIR_BIN)/$(PROG_PREFIX),$(INSTALLEES))
 ifeq (${MULTICALL}, y)
 	install $(BUILDDIR)/uutils $(INSTALLDIR_BIN)/$(PROG_PREFIX)uutils
-	$(foreach prog, $(INSTALLEES), cd $(INSTALLDIR_BIN) && ln -s $(PROG_PREFIX)uutils $(PROG_PREFIX)$(prog);)
+	$(foreach prog, $(INSTALLEES), cd $(INSTALLDIR_BIN) && ln -fs $(PROG_PREFIX)uutils $(PROG_PREFIX)$(prog);)
 else
 	$(foreach prog, $(INSTALLEES), \
 		install $(PKG_BUILDDIR)/$(prog) $(INSTALLDIR_BIN)/$(PROG_PREFIX)$(prog);)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ make MULTICALL=y install
 
 Set install parent directory (default value is /usr/local):
 ```
-make PREFIX=/my/path install
+make DESTDIR=/my/path install
 ```
 
 Uninstallation Instructions
@@ -99,7 +99,7 @@ make MULTICALL=y uninstall
 
 To uninstall from a custom parent directory:
 ```
-make PREFIX=/my/path uninstall
+make DESTDIR=/my/path uninstall
 ```
 
 Test Instructions


### PR DESCRIPTION
changes as suggested for #766 by @ebfe 

remove split of destdir into two params
use ```ln -f``` option to clobber old binaries rather than unnecessary rm