### PR TITLE
Fix busybox seq formatting test

### DIFF
--- a/src/seq/seq.rs
+++ b/src/seq/seq.rs
@@ -196,6 +196,9 @@ pub fn uumain(args: Vec<String>) -> i32 {
             Err(s) => { show_error!("{}", s); return 1; }
         }
     };
+    if largest_dec > 0 {
+        largest_dec -= 1;
+    }
     let separator = escape_sequences(&options.separator[..]);
     let terminator = match options.terminator {
         Some(term) => escape_sequences(&term[..]),
@@ -219,7 +222,7 @@ fn print_seq(first: f64, step: f64, last: f64, largest_dec: usize, separator: St
     let mut i = 0isize;
     let mut value = first + i as f64 * step;
     while !done_printing(value, step, last) {
-        let istr = value.to_string();
+        let istr = format!("{:.*}", largest_dec, value);
         let ilen = istr.len();
         let before_dec = istr.find('.').unwrap_or(ilen);
         if pad && before_dec < padding {
@@ -230,20 +233,6 @@ fn print_seq(first: f64, step: f64, last: f64, largest_dec: usize, separator: St
             }
         }
         pipe_print!("{}", istr);
-        let mut idec = ilen - before_dec;
-        if idec < largest_dec {
-            if idec == 0 {
-                if !pipe_print!(".") {
-                    return;
-                }
-                idec += 1;
-            }
-            for _ in idec..largest_dec {
-                if !pipe_print!("0") {
-                    return;
-                }
-            }
-        }
         i += 1;
         value = first + i as f64 * step;
         if !done_printing(value, step, last) {


### PR DESCRIPTION
I simplified formatting code for seq a bit and fixed a mismatch in busybox test that occurred due to default float formatting. I.e.
```
echo -ne '' | seq .7 -.9 -2.2
FAIL: seq count by -.9
--- expected	2015-12-26 15:58:44.242175239 +0300
+++ actual	2015-12-26 15:58:44.244175239 +0300
@@ -1,4 +1,4 @@
 0.7
--0.2
+-0.20000000000000007
 -1.1
 -2.0
```