### PR TITLE
chmod: rewrite mode parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mkdir 0.0.1",
  "mkfifo 0.0.1",
+ "mktemp 0.0.1",
  "mv 0.0.1",
  "nice 0.0.1",
  "nl 0.0.1",
@@ -468,6 +469,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mktemp"
+version = "0.0.1"
+dependencies = [
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 1.1.3 (git+https://github.com/Stebalien/tempfile.git)",
+ "uucore 0.0.1",
+]
+
+[[package]]
 name = "mv"
 version = "0.0.1"
 dependencies = [
@@ -832,6 +844,17 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "1.1.3"
+source = "git+https://github.com/Stebalien/tempfile.git#34e42b9fdd931ad694900b0afd7c7553a4ac8dd0"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tests/chmod.rs
+++ b/tests/chmod.rs
@@ -58,9 +58,9 @@ fn test_chmod_octal() {
         // TestCase{args: vec!{"-0700", TEST_FILE}, before: 0o700, after: 0o000},
         // TestCase{args: vec!{"-0070", TEST_FILE}, before: 0o060, after: 0o000},
         // TestCase{args: vec!{"-0007", TEST_FILE}, before: 0o001, after: 0o000},
-        // TestCase{args: vec!{"+0100", TEST_FILE}, before: 0o600, after: 0o700},
-        // TestCase{args: vec!{"+0020", TEST_FILE}, before: 0o050, after: 0o070},
-        // TestCase{args: vec!{"+0004", TEST_FILE}, before: 0o003, after: 0o007},
+        TestCase{args: vec!{"+0100", TEST_FILE}, before: 0o600, after: 0o700},
+        TestCase{args: vec!{"+0020", TEST_FILE}, before: 0o050, after: 0o070},
+        TestCase{args: vec!{"+0004", TEST_FILE}, before: 0o003, after: 0o007},
     };
     run_tests(tests);
 }


### PR DESCRIPTION
I rewrote the monstrosity that was the former mode parser.  At the moment, I have fixed `+octal`, but `-octal` is still not working because of getopts (see #788).  I have also re-enabled the tests that now pass.