### PR TITLE
travis: skip unsupported utils on stable/beta builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,4 @@ script:
   - cargo test --no-fail-fast
 matrix:
   allow_failures:
-    - rust: stable
-    - rust: beta
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
   - $HOME/.cargo
 sudo: false
 script:
+  - ./.travis_fixup.sh
   - cargo build
   - cargo test --no-fail-fast
 matrix:

--- a/.travis_fixup.sh
+++ b/.travis_fixup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if [ "$CI" != "true" ]; then
+	exit 1
+fi
+
+case "$TRAVIS_RUST_VERSION" in
+	"beta")
+		skip=$(grep skip_on_beta Cargo.toml | cut -d\" -f 2)
+		sed -i.org "/skip_on_beta/d" Cargo.toml
+		;;
+	"stable")
+		skip=$(grep -E "skip_on_beta|skip_on_stable" Cargo.toml | cut -d\" -f 2)
+		sed -i.org "/skip_on_beta/d" Cargo.toml
+		sed -i.org "/skip_on_stable/d" Cargo.toml
+		;;
+esac
+
+for x in $skip; do
+	if [ -f tests/$x.rs ]; then
+		mv tests/$x.rs tests/$x.rs.skip
+	fi
+done
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ generic = [
   "dirname",
   "echo",
   "env",
-  "expand",
+  "expand",	# skip_on_beta
   "expr",
   "factor",
   "false",
-  "fmt",
+  "fmt",	# skip_on_beta
   "fold",
   "hashsum",
   "head",
@@ -56,7 +56,7 @@ generic = [
   "od",
   "paste",
   "printenv",
-  "ptx",
+  "ptx",	# skip_on_stable
   "pwd",
   "readlink",
   "realpath",
@@ -75,11 +75,11 @@ generic = [
   "tail",
   "tee",
   "test",
-  "tr",
+  "tr",          # skip_on_beta
   "true",
   "truncate",
   "tsort",
-  "unexpand",
+  "unexpand",    # skip_on_beta
   "uniq",
   "wc",
   "whoami",


### PR DESCRIPTION
Kind of hacky but makes the stable/beta builds less useless.
Also useful to detect newly introduced reliance on the nightly.

Skipped utils: expand fmt tr unexpand