### PR TITLE
uucore: don't follow symlinks when examining them (fixes #799)

### DIFF
--- a/src/uucore/fs.rs
+++ b/src/uucore/fs.rs
@@ -31,7 +31,7 @@ fn resolve<P: AsRef<Path>>(original: P) -> Result<PathBuf> {
             return Err(Error::new(ErrorKind::InvalidInput, "maximum links followed"));
         }
 
-        match fs::metadata(&result) {
+        match fs::symlink_metadata(&result) {
             Err(e) => return Err(e),
             Ok(ref m) if !m.file_type().is_symlink() => break,
             Ok(..) => {


### PR DESCRIPTION
We were apparently resolving symlinks when examining metadata, so files were never considered to be symlinks.