### PR TITLE
Fix type mismatch error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-vec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -901,7 +901,7 @@ dependencies = [
 name = "tr"
 version = "0.0.1"
 dependencies = [
- "bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",

--- a/src/tr/tr.rs
+++ b/src/tr/tr.rs
@@ -43,9 +43,9 @@ fn delete(set: ExpandSet, complement: bool) {
 
     let is_allowed = |c : char| {
         if complement {
-            bset.contains(&(c as usize))
+            bset.contains(c as usize)
         } else {
-            !bset.contains(&(c as usize))
+            !bset.contains(c as usize)
         }
     };
 


### PR DESCRIPTION
The `bit_set` cargo changed `contains()` to only accept the parameter by value instead of reference.