### PR TITLE
.gitattributes: treat tests/fixtures/** as binary data

### DIFF
--- a/tests/fixtures/.gitattributes
+++ b/tests/fixtures/.gitattributes
@@ -1,0 +1,1 @@
+* -text diff


### PR DESCRIPTION
This prevents line ending conversion to CRLF by git under Windows.

Without this patch tests on cat (or anything using tests/fixtures) are failing on Windows machine and git with default settings. AppVeyor seems to be ok (probably core.autocrlf is not set to 'true' there)