### PR TITLE
allow feature-gated integration tests for unimplemented functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ generic = [
   "yes",
 ]
 default = ["generic", "unix"]
+test_unimplemented = []
 
 [dependencies]
 uucore   = { path="src/uucore" }

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,13 @@ TEST_PROGS  := \
 TESTS       := \
 	$(sort $(filter $(UTILS),$(filter-out $(SKIP_UTILS),$(TEST_PROGS))))
 
+TEST_NO_FAIL_FAST :=
+TEST_SPEC_FEATURE := 
+ifneq ($(SPEC),)
+TEST_NO_FAIL_FAST :=--no-fail-fast
+TEST_SPEC_FEATURE := test_unimplemented
+endif
+
 define BUILD_EXE
 build_exe_$(1):
 	${CARGO} build ${CARGOFLAGS} ${PROFILE_CMD} -p $(1)
@@ -184,7 +191,7 @@ endef
 
 define TEST_INTEGRATION
 test_integration_$(1): build_exe_$(1)
-	${CARGO} test ${CARGOFLAGS} --test $(1) --features $(1) --no-default-features
+	${CARGO} test ${CARGOFLAGS} --test $(1) --features "$(1) $(TEST_SPEC_FEATURE)" --no-default-features $(TEST_NO_FAIL_FAST)
 endef
 
 define TEST_BUSYBOX

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ To test only a few of the available utilities:
 make UTILS='UTILITY_1 UTILITY_2' test
 ```
 
+To include tests for unimplemented behavior:
+```
+make UTILS='UTILITY_1 UTILITY_2' SPEC=y test
+```
+
 Run busybox tests
 -----------------
 

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ pub fn main() {
         if val == "1" && key.starts_with(feature_prefix) {
             let krate = key[feature_prefix.len()..].to_lowercase();
             match krate.as_ref() {
-                "default" | "unix" | "generic" => continue,
+                "default" | "unix" | "generic" | "test_unimplemented" => continue,
                 _ => {},
             }
             crates.push(krate.to_string());

--- a/tests/printf.rs
+++ b/tests/printf.rs
@@ -188,6 +188,18 @@ fn sub_num_dec_trunc() {
     expect_stdout(vec!["pi is ~ %g", "3.1415926535"], "pi is ~ 3.141593");
 }
 
+#[cfg_attr(not(feature="test_unimplemented"),ignore)]
+#[test]
+fn sub_num_hex_float_lower() {
+    expect_stdout(vec!["%a", ".875"], "0xep-4");
+}
+
+#[cfg_attr(not(feature="test_unimplemented"),ignore)]
+#[test]
+fn sub_num_hex_float_upper() {
+    expect_stdout(vec!["%A", ".875"], "0XEP-4");
+}
+
 #[test]
 fn sub_minwidth() {
     expect_stdout(vec!["hello %7s", "world"], "hello   world");


### PR DESCRIPTION
### Summary

Allows use of integration tests feature gated by the "unimplemented" feature e. g.
```
#[cfg(feature="unimplemented")]
#[test]
fn sub_num_hex_float_lower() {
    expect_stdout(vec!["%a", ".875"], "0xep-4");
}
```

Also adds make ```SPEC=y``` option (e.g. ```make UTILS='...' SPEC=y test```) that will include these tests and include the ```--no-fail-fast``` option.

### Motivation

#### Enable writing of integration tests at a mental distance from the implementation

Writing tests for implemented functionality only requires knowing which features are implemented which usually entails an intimate knowledge of the implementation

#### Enable eventual automatic enumeration of which features of a utility are implemented. 

Because good practice is to write integration tests for each feature implemented anyway, if we allow writing the tests before implementation, this allows us to express (through code and automatically through a nice-looking CI results page if desired) what features are and are not yet implemented without the need to, in addition to writing the inevitable tests, maintain a separate, outside-the-source-code checklist or set of issue tracking issues.

This would also be the first step if we wanted to eventually make very rough, ballpark automatic estimates of how close a utility is to completion; we could use these estimates to communicate to enthusiast end-users which utilities are most ready for them to try out and test.

#### Enable separate pull requests for tests and implementation while still demonstrating implementation in the implementation PR.

I have no preference on whether that's a convention or not, but this makes conventions like that possible. By providing an implementation of a feature (e.g. ```cat -n```) and simultaneously removing the "unimplemented" feature gate from the ```cat -n``` tests, if the PR passes tests it means the implementation is successful in regard to those tests.