### PR TITLE
cat: --squeeze-blank keeps up to one blank line

### DIFF
--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -101,6 +101,7 @@ fn write_lines(files: Vec<String>, number: NumberingMode, squeeze_blank: bool,
         let mut out_buf = [0; 1024 * 64];
         let mut writer = UnsafeWriter::new(&mut out_buf[..], stdout());
         let mut at_line_start = true;
+        let mut one_blank_kept = false;
         while let Ok(n) = reader.read(&mut in_buf) {
             if n == 0 { break }
 
@@ -113,7 +114,8 @@ fn write_lines(files: Vec<String>, number: NumberingMode, squeeze_blank: bool,
                     None => break,
                 };
                 if in_buf[pos] == '\n' as u8 {
-                    if !at_line_start || !squeeze_blank {
+                    if !at_line_start || !squeeze_blank || !one_blank_kept {
+                        one_blank_kept = true;
                         if at_line_start && number == NumberingMode::NumberAll {
                             (write!(&mut writer, "{0:6}\t", line_counter)).unwrap();
                             line_counter += 1;
@@ -128,6 +130,8 @@ fn write_lines(files: Vec<String>, number: NumberingMode, squeeze_blank: bool,
                     }
                     at_line_start = true;
                     continue;
+                } else if one_blank_kept {
+                    one_blank_kept = false;
                 }
                 if at_line_start && number != NumberingMode::NumberNone {
                     (write!(&mut writer, "{0:6}\t", line_counter)).unwrap();


### PR DESCRIPTION
minor fix, matches the behavior of GNU ```cat --squeeze-blank``` to keep up to 1 blank line in a row for all groups of blank lines

```printf "a\n\n\nb\n" | cat -s```

now results in:

```
a

b
```