### PR TITLE
more ergonomic testing

### DIFF
--- a/tests/ln.rs
+++ b/tests/ln.rs
@@ -126,7 +126,7 @@ fn test_symlink_interactive() {
 
     let result1 = ts.util_cmd()
                     .args(&["-i", "-s", file, link])
-                    .run_piped_stdin(b"n");
+                    .run_piped_stdin("n");
 
     assert_empty_stderr!(result1);
     assert!(result1.success);
@@ -136,7 +136,7 @@ fn test_symlink_interactive() {
 
     let result2 = ts.util_cmd()
                     .args(&["-i", "-s", file, link])
-                    .run_piped_stdin(b"Yesh");
+                    .run_piped_stdin("Yesh");
 
     assert_empty_stderr!(result2);
     assert!(result2.success);

--- a/tests/mv.rs
+++ b/tests/mv.rs
@@ -131,7 +131,7 @@ fn test_mv_interactive() {
     at.touch(file_b);
 
 
-    let result1 = ts.util_cmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin(b"n");
+    let result1 = ts.util_cmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("n");
 
     assert_empty_stderr!(result1);
     assert!(result1.success);
@@ -140,7 +140,7 @@ fn test_mv_interactive() {
     assert!(at.file_exists(file_b));
 
 
-    let result2 = ts.util_cmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin(b"Yesh");
+    let result2 = ts.util_cmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("Yesh");
 
     assert_empty_stderr!(result2);
     assert!(result2.success);

--- a/tests/rm.rs
+++ b/tests/rm.rs
@@ -51,7 +51,7 @@ fn test_rm_interactive() {
                     .arg("-i")
                     .arg(file_a)
                     .arg(file_b)
-                    .run_piped_stdin(b"n");
+                    .run_piped_stdin("n");
 
     assert!(result1.success);
 
@@ -62,7 +62,7 @@ fn test_rm_interactive() {
                     .arg("-i")
                     .arg(file_a)
                     .arg(file_b)
-                    .run_piped_stdin(b"Yesh");
+                    .run_piped_stdin("Yesh");
 
     assert!(result2.success);
 

--- a/tests/tr.rs
+++ b/tests/tr.rs
@@ -10,14 +10,14 @@ static UTIL_NAME: &'static str = "tr";
 #[test]
 fn test_toupper() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["a-z", "A-Z"]).run_piped_stdin(b"!abcd!");
+    let result = ucmd.args(&["a-z", "A-Z"]).run_piped_stdin("!abcd!");
     assert_eq!(result.stdout, "!ABCD!");
 }
 
 #[test]
 fn test_small_set2() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["0-9", "X"]).run_piped_stdin(b"@0123456789");
+    let result = ucmd.args(&["0-9", "X"]).run_piped_stdin("@0123456789");
     assert_eq!(result.stdout, "@XXXXXXXXXX");
 }
 
@@ -32,13 +32,13 @@ fn test_unicode() {
 #[test]
 fn test_delete() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", "a-z"]).run_piped_stdin(b"aBcD");
+    let result = ucmd.args(&["-d", "a-z"]).run_piped_stdin("aBcD");
     assert_eq!(result.stdout, "BD");
 }
 
 #[test]
 fn test_delete_complement() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", "-c", "a-z"]).run_piped_stdin(b"aBcD");
+    let result = ucmd.args(&["-d", "-c", "a-z"]).run_piped_stdin("aBcD");
     assert_eq!(result.stdout, "ac");
 }


### PR DESCRIPTION
## Summary

A set of additional convenience functions, and one breaking change, to the testing utility module to make testing more ergonomic, and more consistent across tests (e.g. avoiding the possibility of each test class developing their own convenience functions that does basically the same things but may have minor differences).

The ergonomic jumps here are made from the repetition that we know we will generally be making assertions on the result of this command we are running, rather than another variable. And because this command helper is only being run in a test context, we know already when using it that we will be making assertions.

## General use case

In the general use case, there are benefits in the sense that most of what we are asserting is very standardized, so if we can standardize around particular names for those assertions (rather than boolean expressions or having differently named convenience functions) we can correctly understand what is being asserted, without jumping around the file, while still having tests that are very quickly readable and easily comparable.

##### Before:
```rust
let (_, mut ucmd) = testing(UTIL_NAME);
let result = ucmd.args(vec!["%b", "\\\\"])
                 .run();

assert!(result.success);
assert_empty_stderr!(result);
assert!(result.stdout == "\\")
```

##### After:
```rust
let (_, ucmd) = testing(UTIL_NAME);
ucmd.args(vec!["%b", "\\\\"])
    .succeeds()
    .stdout_only("\\");
```

### Specialized use cases

Specialized use cases is where these features really shine, because it means you can have terse functions that require varying input formats (stdin? stdin+args? args?) and output expectations in many different places without having to write additional, convenience functions in each module for each combination.

#### Stdin and args
##### Before:
```rust
    let (_, ucmd) = testing(UTIL_NAME);
    let result = ucmd.arg("-T")
                     .run_piped_stdin(b"\t");
   
    assert!(result.success);
    assert_empty_stderr!(result);
    assert!(result.stdout.trim_right() == "^I")
```

##### After:
```rust
    let (_, ucmd) = testing(UTIL_NAME);
    ucmd.arg("-T")
        .piped_in("\t")
        .succeeds()
        .stdout_only("^I");
```

#### failure, standard error, and standard output
##### Before:
```rust
    let (_, ucmd) = testing(UTIL_NAME);
    let result = ucmd.arg("'a%f'")
                     .arg("4.1a3")
                     .run();
   
    assert!(!result.success);
    assert!(result.stderr.trim_right() == expected_stderr);
    assert!(result.stdout.trim_right() == expected_stdout);
```
##### After:
```rust
    let (_, ucmd) = testing(UTIL_NAME);
    ucmd.arg("'a%f'")
        .arg("4.1a3")
        .fails()
        .stderr_is(expected_stderr)
        .stdout_is(expected_stdout);
```
#### Convenience functions:

meaning here abstractions over very common use cases in a very brief way limited to that use case.

##### Before (with module-level convenience functions)

This clocks in at 71 characters and still communicates exactly what the input behavior is and what it's asserting.  It takes a second to figure out which argument supposed to be stdin and which is supposed to be stdout.

```rust
    piped_in_success_stdout_only(vec!["-n", "-T"],":\t", "    1\t:^T");
```


##### Before (with module-level convenience macro)

This clocks in at 67 characters and still communicates exactly what it's *asserting*, but now it takes a second to recognize what the input behavior is, and which strings represent stdin, stdout, and arguments.

```
    piped_in_success_stdout_only!("    1\t:^T", ":\t", "-n", "-T");
```

##### After (with module-level convenience macro)

As you can see, it's not always shorter than specialized convenience functions - this is 75 characters long. But the idea is to achieve brevity that, when not better, is always at least close without needing to write/maintain multiple convenience functions per module for different input and assertion configurations.

```rust
    ucmd!("-n", "-T").piped_in(":\t"),succeeds().stdout_only("    1\t:^T");
```

This is a convenience macro because it's only usable in situations where if you make use of the fixtures temporary directory it's only during the utility call.

### Breaking change

To allow storing the stdin value before running, forces a choice in the storing function (afaik, if anyone can come up with a way around this let me know) between accepting by zero-copy either a

1. a ``` vec<u8>``` and sized ```[u8, T]``` arrays through a reference stored in  the UCommand struct's field with a lifetime, 
2. a moved in unsized ```vec<u8>``` or anything with ```Into<vec<u8>>``` (like ```&str```, String). 

I fell on the side of option two because option one made the util.rs code more complex and less readable due to the lifetime specifier. But if you'd like, I'm happy to revise this PR towards option one.

For principle of least surprise between run_piped_in and piped_in's args, I changed run_piped_ins' signature as well, and changed situations where a size array was passed in. There were about around a dozen calls using sized arrays in the tests directory.

This may result in technically slower tests, but I don't think in the range of noticability within the forseeable future.