### PR TITLE
Dirname: fix windows' failing test for absolute-path behavior (approach 1/2: platform-dependent behavior)

### DIFF
--- a/src/dirname/dirname.rs
+++ b/src/dirname/dirname.rs
@@ -61,7 +61,7 @@ directory).", NAME, VERSION);
                 }
                 None => {
                     if p.is_absolute() {
-                        print!("/");
+                        print!("{}", path);
                     } else {
                         print!(".");
                     }

--- a/tests/dirname.rs
+++ b/tests/dirname.rs
@@ -5,32 +5,41 @@ use common::util::*;
 
 static UTIL_NAME: &'static str = "dirname";
 
+#[cfg(windows)]
+static FS_ROOT_EXAMPLE: &'static str = "a:\\";
+#[cfg(not(windows))]
+static FS_ROOT_EXAMPLE: &'static str = "/";
+
+#[cfg(windows)]
+static DIRNAME_SEPARATOR: &'static str = "\\";
+#[cfg(not(windows))]
+static DIRNAME_SEPARATOR: &'static str = "/";
 
 #[test]
 fn test_path_with_trailing_slashes() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let dir = "/root/alpha/beta/gamma/delta/epsilon/omega//";
+    let dir = format!("{0}root{1}alpha{1}beta{1}gamma{1}delta{1}epsilon{1}omega{1}{1}", FS_ROOT_EXAMPLE, DIRNAME_SEPARATOR);
     let out = ucmd.arg(dir).run().stdout;
 
-    assert_eq!(out.trim_right(), "/root/alpha/beta/gamma/delta/epsilon");
+    assert_eq!(out.trim_right(), format!("{0}root{1}alpha{1}beta{1}gamma{1}delta{1}epsilon", FS_ROOT_EXAMPLE, DIRNAME_SEPARATOR));
 }
 
 #[test]
 fn test_path_without_trailing_slashes() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let dir = "/root/alpha/beta/gamma/delta/epsilon/omega";
+    let dir = format!("{0}root{1}alpha{1}beta{1}gamma{1}delta{1}epsilon{1}omega", FS_ROOT_EXAMPLE, DIRNAME_SEPARATOR);
     let out = ucmd.arg(dir).run().stdout;
 
-    assert_eq!(out.trim_right(), "/root/alpha/beta/gamma/delta/epsilon");
+    assert_eq!(out.trim_right(), format!("{0}root{1}alpha{1}beta{1}gamma{1}delta{1}epsilon", FS_ROOT_EXAMPLE, DIRNAME_SEPARATOR));
 }
 
 #[test]
 fn test_root() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let dir = "/";
+    let dir = FS_ROOT_EXAMPLE;
     let out = ucmd.arg(dir).run().stdout;
 
-    assert_eq!(out.trim_right(), "/");
+    assert_eq!(out.trim_right(), FS_ROOT_EXAMPLE);
 }
 
 #[test]


### PR DESCRIPTION
One of the reasons the appveyor build is currently failing is because [the dirname test for the root directory doesn't work](https://ci.appveyor.com/project/Arcterus/coreutils/build/1.0.67). Any correction to this failure would imply an answer to a question raised by making dirname cross-platform: how dirname should function on windows' platforms. I've made the test pass in accordance with two different possible development directions in two separate PRs, and have no real opinion about which direction is best.

**Approach 1 out of 2: platform-dependent behavior** (this pr):

([demonstration of dirname tests passing for this pr](https://ci.appveyor.com/project/nathanross/coreutils/build/1.0.1))

```dirname /a/b/c```

Works as you might expect only on unix-like OSes, but is expected to be treated on windows (where the path could not possibly exist) the way a backward slash version would work on unix. Instead, windows' dirname is expected to treat absolute paths possible on windows, and only those possible on windows, in a similar way that we'd normally expect dirname to work with unix-like OS paths

**benefit of this approach**
* consistent with other binaries that accept paths for windows, in that when run on windows they will imaginably only accept absolute paths that are possible on windows. Dirname would probably be the only binary in uutils coreutils with this behavior, which might be unintuitive.
* walks around the issue of undecidability in situations where someone has made a filename with a backslash in a unix-like OS and someone references it relatively. (not a very common problem though)

**Approach 2 out of 2: platform-independent behavior** (#825)

([demonstration of dirname tests passing for this pr](https://ci.appveyor.com/project/nathanross/coreutils/build/1.0.3))

```dirname /a/b/c```

works the same on windows-like OSes unix-like OSes. This approach makes no decision as to whether or not windows format paths will also be supported in the future and whether on all or specific platforms, just that unix-like OS paths are, and are supported on every platform.

**benefit of this approach**
* dirname does not actually do filesystem operations or check if a path exists or is possible, it's essentially a text utility, so it's really unclear how much concrete benefit there is (backslashes in filenames aside) to the end user to restricting them to only being able to obtain the dirname of paths to when they're running the binary on a platform that could use that path.