### PR TITLE
Dirname: fix windows' failing test for absolute-path behavior (approach 2/2: platform-independent behavior)

### DIFF
--- a/src/dirname/dirname.rs
+++ b/src/dirname/dirname.rs
@@ -60,7 +60,7 @@ directory).", NAME, VERSION);
                     }
                 }
                 None => {
-                    if p.is_absolute() {
+                    if p.is_absolute() || path == "/" {
                         print!("/");
                     } else {
                         print!(".");


### PR DESCRIPTION
See: #824 