### PR TITLE
link: normalize file-not-found error message across platforms

### DIFF
--- a/src/link/link.rs
+++ b/src/link/link.rs
@@ -17,9 +17,17 @@ extern crate uucore;
 use std::fs::hard_link;
 use std::io::Write;
 use std::path::Path;
+use std::io::Error;
 
 static NAME: &'static str = "link";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+pub fn normalize_error_message(e: Error) -> String {
+    match e.raw_os_error() {
+        Some(2) => { String::from("No such file or directory (os error 2)") }
+        _ => { format!("{}", e) }
+    }
+}
 
 pub fn uumain(args: Vec<String>) -> i32 {
     let mut opts = getopts::Options::new();
@@ -58,7 +66,7 @@ Create a link named FILE2 to FILE1.", NAME, VERSION);
     match hard_link(old, new) {
         Ok(_) => 0,
         Err(err) => {
-            show_error!("{}", err);
+            show_error!("{}",normalize_error_message(err));
             1
         }
     }


### PR DESCRIPTION
As can be seen from this [this appveyor console](https://ci.appveyor.com/project/nathanross/coreutils/build/1.0.3) another reason the appveyor tests are currently failing is because ```link``` returns two different error messages for the same error scenario.

This is because link directs to the stderr the string value of ```std::fs::hard_link``` whose returned error message varies by platform for the same scenario, because these are the os error messages retrieved from the respective libc calls.

This commit changes the implementation to return the error message specified in the test for that error scenario on all platforms. That this resolves the issue on windows is demonstrated in [this appveyor console](https://ci.appveyor.com/project/nathanross/coreutils) of a separate branch that includes both this commit and one of the dirname prs' commits.