### PR TITLE
Move to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ to compile anywhere, and this is as good a way as any to try and learn it.
 Build Instructions
 ------------------
 
-NOTE: This currently requires the most current nightly build.
-
 To simply build all available utilities:
 ```
 make

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -1,5 +1,4 @@
 #![crate_name = "uu_fmt"]
-#![feature(str_char)]
 
 /*
  * This file is part of `fmt` from the uutils coreutils package.

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -1,5 +1,5 @@
 #![crate_name = "uu_fmt"]
-#![feature(str_char, unicode)]
+#![feature(str_char)]
 
 /*
  * This file is part of `fmt` from the uutils coreutils package.
@@ -11,7 +11,6 @@
  */
 
 extern crate getopts;
-extern crate rustc_unicode;
 extern crate unicode_width;
 
 #[macro_use]


### PR DESCRIPTION
Hi,

this patch fixes coreutils to compile on stable Rust by mostly following the recommendations given when removing the feature flags. In detail, that is:

* remove `fmt`s dependency on `rustc_unicode`. It wasn't using it anyways.
* Remove `CharRange` usage from `fmt` and use the recommended handling methods (`char_indices` and `chars`). These methods recently got deprecated, see https://github.com/rust-lang/rust/issues/27754, the struct is not committed to.
* Remove usage of io::Read::chars() in `tr`. The method is still under debate (https://github.com/rust-lang/rust/issues/27802). As a buffered reader is used anyways, I concluded that we could just read into a buffer and work on that. I'm rather unsure if this patch is super-clean, it's a bit late. All tests pass and I think logically, it's alright, I'm just pretty sure it could be expressed neater.

Best,
Florian, rust-community team


