### PR TITLE
Add missing lib.name for uucore

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -10,3 +10,4 @@ winapi = "*"
 
 [lib]
 path = "lib.rs"
+name = "uucore"


### PR DESCRIPTION
Fix build on Linux

Built with `rustc 1.7.0`

Fix  #838