### PR TITLE
sort: refactor and add month sort

### DIFF
--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -217,19 +217,19 @@ fn human_numeric_size_compare(a: &String, b: &String) -> Ordering {
 
 #[derive(Eq, Ord, PartialEq, PartialOrd)]
 enum Month {
-    Unknown     = 0,
-    January     = 1,
-    February    = 2,
-    March       = 3,
-    April       = 4,
-    May         = 5,
-    June        = 6,
-    July        = 7,
-    August      = 8,
-    September   = 9,
-    October     = 10,
-    November    = 11,
-    December    = 12,
+    Unknown,
+    January,
+    February,
+    March,
+    April,
+    May,
+    June,
+    July,
+    August,
+    September,
+    October,
+    November,
+    December,
 }
 
 /// Parse the beginning string into a Month, returning Month::Unknown on errors.

--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -31,7 +31,7 @@ static THOUSANDS_SEP: char = ',';
 
 enum SortMode {
     Numeric,
-    HumanReadable,
+    HumanNumeric,
     Default,
 }
 
@@ -56,7 +56,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let mut opts = getopts::Options::new();
 
     opts.optflag("n", "numeric-sort", "compare according to string numerical value");
-    opts.optflag("H", "human-readable-sort", "compare according to human readable sizes, eg 1M > 100k");
+    opts.optflag("h", "human-numeric-sort", "compare according to human readable sizes, eg 1M > 100k");
     opts.optflag("r", "reverse", "reverse the output");
     opts.optflag("h", "help", "display this help and exit");
     opts.optflag("", "version", "output version information and exit");
@@ -88,8 +88,8 @@ With no FILE, or when FILE is -, read standard input.", NAME, VERSION);
 
     settings.mode = if matches.opt_present("numeric-sort") {
         SortMode::Numeric
-    } else if matches.opt_present("human-readable-sort") {
-        SortMode::HumanReadable
+    } else if matches.opt_present("human-numeric-sort") {
+        SortMode::HumanNumeric
     } else {
         SortMode::Default
     };
@@ -129,7 +129,7 @@ fn exec(files: Vec<String>, settings: &Settings) {
 
         match settings.mode {
             SortMode::Numeric => lines.sort_by(numeric_compare),
-            SortMode::HumanReadable => lines.sort_by(human_readable_size_compare),
+            SortMode::HumanNumeric => lines.sort_by(human_numeric_size_compare),
             SortMode::Default => lines.sort()
         }
 
@@ -174,7 +174,7 @@ fn numeric_compare(a: &String, b: &String) -> Ordering {
     }
 }
 
-fn human_readable_convert(a: &String) -> f64 {
+fn human_numeric_convert(a: &String) -> f64 {
     let int_iter = a.chars();
     let suffix_iter = a.chars();
     let int_str: String = int_iter.take_while(|c| c.is_numeric()).collect();
@@ -196,9 +196,9 @@ fn human_readable_convert(a: &String) -> f64 {
 
 /// Compare two strings as if they are human readable sizes.
 /// AKA 1M > 100k
-fn human_readable_size_compare(a: &String, b: &String) -> Ordering {
-    let fa = human_readable_convert(a);
-    let fb = human_readable_convert(b);
+fn human_numeric_size_compare(a: &String, b: &String) -> Ordering {
+    let fa = human_numeric_convert(a);
+    let fb = human_numeric_convert(b);
     if fa > fb {
         Ordering::Greater
     }

--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -148,11 +148,11 @@ fn exec(files: Vec<String>, settings: &Settings) {
 }
 
 /// Parse the beginning string into an f64, returning -inf instead of NaN on errors.
-fn permissive_f64_parse(a: &str) -> f64{
-    //Maybe should be split on non-digit, but then 10e100 won't parse properly.
-    //On the flip side, this will give NEG_INFINITY for "1,234", which might be OK
-    //because there's no way to handle both CSV and thousands separators without a new flag.
-    //GNU sort treats "1,234" as "1" in numeric, so maybe it's fine.
+fn permissive_f64_parse(a: &str) -> f64 {
+    // Maybe should be split on non-digit, but then 10e100 won't parse properly.
+    // On the flip side, this will give NEG_INFINITY for "1,234", which might be OK
+    // because there's no way to handle both CSV and thousands separators without a new flag.
+    // GNU sort treats "1,234" as "1" in numeric, so maybe it's fine.
     let sa: &str = a.split_whitespace().next().unwrap();
     match sa.parse::<f64>() {
         Ok(a) => a,
@@ -160,14 +160,14 @@ fn permissive_f64_parse(a: &str) -> f64{
     }
 }
 
-/// Compares two floating point numbers, with errors being assumned to be -inf.
+/// Compares two floating point numbers, with errors being assumed to be -inf.
 /// Stops coercing at the first whitespace char, so 1e2 will parse as 100 but 
 /// 1,000 will parse as -inf.
 fn numeric_compare(a: &String, b: &String) -> Ordering {
     let fa = permissive_f64_parse(a);
     let fb = permissive_f64_parse(b);
-    //f64::cmp isn't implemented because NaN messes with it
-    //but we sidestep that with permissive_f64_parse so just fake it
+    // f64::cmp isn't implemented because NaN messes with it
+    // but we sidestep that with permissive_f64_parse so just fake it
     if fa > fb {
         Ordering::Greater
     }

--- a/tests/fixtures/sort/month1.ans
+++ b/tests/fixtures/sort/month1.ans
@@ -1,0 +1,7 @@
+N/A Ut enim ad minim veniam, quis
+Jan Lorem ipsum dolor sit amet
+mar laboris nisi ut aliquip ex ea
+May sed do eiusmod tempor incididunt
+JUN nostrud exercitation ullamco
+Oct ut labore et dolore magna aliqua
+Dec consectetur adipiscing elit

--- a/tests/fixtures/sort/month1.txt
+++ b/tests/fixtures/sort/month1.txt
@@ -1,0 +1,7 @@
+Jan Lorem ipsum dolor sit amet
+Dec consectetur adipiscing elit
+May sed do eiusmod tempor incididunt
+Oct ut labore et dolore magna aliqua
+N/A Ut enim ad minim veniam, quis
+JUN nostrud exercitation ullamco
+mar laboris nisi ut aliquip ex ea

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -38,7 +38,7 @@ fn numeric6() {
 
 #[test]
 fn human1() {
-    test_helper(&String::from("human1"), &String::from("-H"));
+    test_helper(&String::from("human1"), &String::from("-h"));
 }
 
 #[test]

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -41,6 +41,11 @@ fn human1() {
     test_helper(&String::from("human1"), &String::from("-H"));
 }
 
+#[test]
+fn month1() {
+    test_helper(&String::from("month1"), &String::from("-M"));
+}
+
 fn numeric_helper(test_num: isize) {
     test_helper(&format!("numeric{}", test_num), &String::from("-n"))
 }


### PR DESCRIPTION
In addition to sorting by month, I moved the options into a dedicated settings struct for future enhancements. I also updated the flag for human-numeric sort to be in sync with GNU coreutils.