### PR TITLE
Tests for `tail -c <bytes>`

### DIFF
--- a/tests/fixtures/tail/foobar_bytes_single.expected
+++ b/tests/fixtures/tail/foobar_bytes_single.expected
@@ -1,0 +1,2 @@
+diez
+once

--- a/tests/fixtures/tail/foobar_bytes_stdin.expected
+++ b/tests/fixtures/tail/foobar_bytes_stdin.expected
@@ -1,0 +1,3 @@
+ve
+diez
+once

--- a/tests/tail.rs
+++ b/tests/tail.rs
@@ -57,3 +57,10 @@ fn test_single_big_args() {
     assert_eq!(result.stdout, at.read(BIG_EXPECTED));
     cleanup_big_test_files(&at);
 }
+
+#[test]
+fn test_bytes_single() {
+    let (at, mut ucmd) = testing(UTIL_NAME);
+    let result = ucmd.arg("-c").arg("10").arg(INPUT).run();
+    assert_eq!(result.stdout, at.read("foobar_bytes_single.expected"));
+}

--- a/tests/tail.rs
+++ b/tests/tail.rs
@@ -64,3 +64,10 @@ fn test_bytes_single() {
     let result = ucmd.arg("-c").arg("10").arg(INPUT).run();
     assert_eq!(result.stdout, at.read("foobar_bytes_single.expected"));
 }
+
+#[test]
+fn test_bytes_stdin() {
+    let (at, mut ucmd) = testing(UTIL_NAME);
+    let result = ucmd.arg("-c").arg("13").run_piped_stdin(at.read(INPUT));
+    assert_eq!(result.stdout, at.read("foobar_bytes_stdin.expected"));
+}


### PR DESCRIPTION
I noticed that there weren't any tests for tailing bytes rather than lines, so I whipped up some simple sanity tests.