### PR TITLE
Miscellaneous `tail` related commits

### DIFF
--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -272,6 +272,8 @@ fn follow<T: Read>(mut reader: BufReader<T>, settings: &Settings) {
 fn backwards_thru_file<F>(file: &mut File, size: u64, buf: &mut Vec<u8>, should_stop: &mut F)
     where F: FnMut(u8) -> bool
 {
+    assert!(buf.len() >= BLOCK_SIZE as usize);
+
     let max_blocks_to_read = (size as f64 / BLOCK_SIZE as f64).ceil() as usize;
 
     for block_idx in 0..max_blocks_to_read {
@@ -280,13 +282,6 @@ fn backwards_thru_file<F>(file: &mut File, size: u64, buf: &mut Vec<u8>, should_
         } else {
             BLOCK_SIZE
         };
-
-        // Ensure that the buffer is filled and zeroed, if needed.
-        if buf.len() < (block_size as usize) {
-            for _ in buf.len()..(block_size as usize) {
-                buf.push(0);
-            }
-        }
 
         // Seek backwards by the next block, read the full block into
         // `buf`, and then seek back to the start of the block again.
@@ -327,7 +322,7 @@ fn bounded_tail(mut file: File, settings: &Settings) {
         return;
     }
 
-    let mut buf = Vec::with_capacity(BLOCK_SIZE as usize);
+    let mut buf = vec![0; BLOCK_SIZE as usize];
 
     // Find the position in the file to start printing from.
     match settings.mode {

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -336,11 +336,8 @@ fn bounded_tail(mut file: File, settings: &Settings) {
                 }
             });
         },
-        FilterMode::Bytes(mut count) => {
-            backwards_thru_file(&mut file, size, &mut buf, &mut |_| {
-                count -= 1;
-                count == 0
-            });
+        FilterMode::Bytes(count) => {
+            file.seek(SeekFrom::End(-(count as i64))).unwrap();
         },
     }
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -5,6 +5,7 @@ extern crate tempdir;
 use std::env;
 use std::fs::{self, File};
 use std::io::{Read, Write, Result};
+use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
 use std::os::unix::fs::symlink as symlink_file;
 #[cfg(windows)]
@@ -28,7 +29,7 @@ static ALREADY_RUN: &'static str = " you have already run this UCommand, if you 
                                     another command in the same test, use TestSet::new instead of \
                                     testing();";
 static MULTIPLE_STDIN_MEANINGLESS: &'static str = "Ucommand is designed around a typical use case of: provide args and input stream -> spawn process -> block until completion -> return output streams. For verifying that a particular section of the input stream is what causes a particular behavior, use the Command type directly.";
-    
+
 #[macro_export]
 macro_rules! assert_empty_stderr(
     ($cond:expr) => (
@@ -122,6 +123,40 @@ pub fn recursive_copy(src: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// A scoped, temporary file that is removed upon drop.
+pub struct ScopedFile {
+    path: PathBuf,
+    file: File,
+}
+
+impl ScopedFile {
+    fn new(path: PathBuf, file: File) -> ScopedFile {
+        ScopedFile {
+            path: path,
+            file: file
+        }
+    }
+}
+
+impl Deref for ScopedFile {
+    type Target = File;
+    fn deref(&self) -> &File {
+        &self.file
+    }
+}
+
+impl DerefMut for ScopedFile {
+    fn deref_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+}
+
+impl Drop for ScopedFile {
+    fn drop(&mut self) {
+        fs::remove_file(&self.path).unwrap();
+    }
+}
+
 pub struct AtPath {
     pub subdir: PathBuf,
 }
@@ -184,6 +219,9 @@ impl AtPath {
             Ok(f) => f,
             Err(e) => panic!("{}", e),
         }
+    }
+    pub fn make_scoped_file(&self, name: &str) -> ScopedFile {
+        ScopedFile::new(self.plus(name), self.make_file(name))
     }
     pub fn touch(&self, file: &str) {
         log_info("touch", self.plus_as_string(file));
@@ -393,7 +431,7 @@ impl UCommand {
                     .stderr(Stdio::piped())
                     .spawn()
                     .unwrap();
-                
+
                 result.stdin
                     .take()
                     .unwrap_or_else(
@@ -401,8 +439,8 @@ impl UCommand {
                             "Could not take child process stdin"))
                     .write_all(&input)
                     .unwrap_or_else(|e| panic!("{}", e));
-                
-                result.wait_with_output().unwrap()        
+
+                result.wait_with_output().unwrap()
             }
             None => {
                 self.raw.output().unwrap()

--- a/tests/tail.rs
+++ b/tests/tail.rs
@@ -24,6 +24,13 @@ fn test_single_default() {
 }
 
 #[test]
+fn test_n_greater_than_number_of_lines() {
+    let (at, mut ucmd) = testing(UTIL_NAME);
+    let result = ucmd.arg("-n").arg("99999999").arg(FOOBAR_TXT).run();
+    assert_eq!(result.stdout, at.read(FOOBAR_TXT));
+}
+
+#[test]
 fn test_single_big_args() {
     const FILE: &'static str = "single_big_args.txt";
     const EXPECTED_FILE: &'static str = "single_big_args_expected.txt";

--- a/tests/tail.rs
+++ b/tests/tail.rs
@@ -7,19 +7,19 @@ use common::util::*;
 
 static UTIL_NAME: &'static str = "tail";
 
-static INPUT: &'static str = "foobar.txt";
+static FOOBAR_TXT: &'static str = "foobar.txt";
 
 #[test]
 fn test_stdin_default() {
     let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin(at.read(INPUT));
+    let result = ucmd.run_piped_stdin(at.read(FOOBAR_TXT));
     assert_eq!(result.stdout, at.read("foobar_stdin_default.expected"));
 }
 
 #[test]
 fn test_single_default() {
     let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg(INPUT).run();
+    let result = ucmd.arg(FOOBAR_TXT).run();
     assert_eq!(result.stdout, at.read("foobar_single_default.expected"));
 }
 
@@ -51,14 +51,14 @@ fn test_single_big_args() {
 #[test]
 fn test_bytes_single() {
     let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("-c").arg("10").arg(INPUT).run();
+    let result = ucmd.arg("-c").arg("10").arg(FOOBAR_TXT).run();
     assert_eq!(result.stdout, at.read("foobar_bytes_single.expected"));
 }
 
 #[test]
 fn test_bytes_stdin() {
     let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("-c").arg("13").run_piped_stdin(at.read(INPUT));
+    let result = ucmd.arg("-c").arg("13").run_piped_stdin(at.read(FOOBAR_TXT));
     assert_eq!(result.stdout, at.read("foobar_bytes_stdin.expected"));
 }
 


### PR DESCRIPTION
* Test when `-n` is larger than the number of lines in the file
* Rename `INPUT` to `FOOBAR_TXT` as there are more than one inputs
* Add a test for tail'ing large files in bytes mode
* Refactor the `test_single_big_args` test to use `ScopedFile`
* Create the `ScopedFile` type for temporary files in tests
* When tailing a file in bytes mode, seek directly to the specified byte
* Pre-fill the buffer with zeroes

See each commit and commit message for more details.