### PR TITLE
add functionality to od

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ TEST_PROGS  := \
 	mktemp \
 	mv \
 	nl \
+	od \
 	paste \
 	printf \
 	ptx \

--- a/src/od/od.rs
+++ b/src/od/od.rs
@@ -61,6 +61,9 @@ pub fn uumain(args: Vec<String>) -> i32 {
     0
 }
 
+const LINEBYTES:usize = 16;
+const WORDBYTES:usize = 2;
+
 fn odfunc(input_offset_base: &Radix, fname: &str) {
     let mut f = match File::open(Path::new(fname)) {
         Ok(f) => f,
@@ -68,29 +71,37 @@ fn odfunc(input_offset_base: &Radix, fname: &str) {
     };
 
     let mut addr = 0;
-    let bytes = &mut [b'\x00'; 16];
-    loop {
+    let bytes = &mut [b'\x00'; LINEBYTES];
+    loop { // print each line
+        print_with_radix(input_offset_base, addr); // print offset
         match f.read(bytes) {
             Ok(0) => {
-                print_with_radix(input_offset_base, addr);
                 print!("\n");
                 break;
             }
             Ok(n) => {
-                print_with_radix(input_offset_base, addr);
+                print!("  "); // 4 spaces after offset - we print 2 more before each word
+                 
                 for b in 0 .. n / mem::size_of::<u16>() {
                     let bs = &bytes[(2 * b) .. (2 * b + 2)];
                     let p: u16 = (bs[1] as u16) << 8 | bs[0] as u16;
-                    print!(" {:06o}", p);
+                    print!("  {:06o}", p);
                 }
                 if n % mem::size_of::<u16>() == 1 {
-                    print!(" {:06o}", bytes[n - 1]);
+                    print!("  {:06o}", bytes[n - 1]);
                 }
+
+                // Add extra spaces to pad out the short, presumably last, line.
+                if n<LINEBYTES {
+                    // calc # of items we did not print, must be short at least WORDBYTES to be missing any.
+                    let words_short = (LINEBYTES-n)/WORDBYTES; 
+                    print!("{:>width$}", "", width=(words_short)*(6+2));
+                }
+
                 print!("\n");
                 addr += n;
             },
             Err(_) => {
-                print_with_radix(input_offset_base, addr);
                 break;
             }
         };
@@ -118,7 +129,7 @@ fn parse_radix(radix_str: Option<String>) -> Result<Radix, &'static str> {
         }
     }
 }
-
+ 
 fn print_with_radix(r: &Radix, x: usize) {
     // TODO(keunwoo): field widths should be based on sizeof(x), or chosen dynamically based on the
     // expected range of address values.  Binary in particular is not great here.

--- a/tests/od.rs
+++ b/tests/od.rs
@@ -20,7 +20,8 @@ static ALPHA_OUT: &'static str = "0000000    061141  062143  063145  064147  065
 #[test]
 fn test_file() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let temp = env::var("TMPDIR").unwrap_or_else(|_| env::var("TEMP").unwrap());
+    use std::env;
+    let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
     let file = tmpdir.join("test");
      
@@ -45,7 +46,7 @@ fn test_file() {
 #[test]
 fn test_2files() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let temp = env::var("TMPDIR").unwrap_or_else(|_| env::var("TEMP").unwrap());
+    let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
     let file1 = tmpdir.join("test1");
     let file2 = tmpdir.join("test2");
@@ -76,7 +77,7 @@ fn test_2files() {
 #[test]
 fn test_no_file() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    let temp = env::var("TMPDIR").unwrap_or_else(|_| env::var("TEMP").unwrap());
+    let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
     let file = tmpdir.join("}surely'none'would'thus'a'file'name");
      
@@ -104,7 +105,7 @@ fn test_from_stdin() {
 fn test_from_mixed() {
     let (_, mut ucmd) = testing(UTIL_NAME);
 
-    let temp = env::var("TMPDIR").unwrap_or_else(|_| env::var("TEMP").unwrap());
+    let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
     let file1 = tmpdir.join("test-1");
     let file3 = tmpdir.join("test-3");

--- a/tests/od.rs
+++ b/tests/od.rs
@@ -1,0 +1,87 @@
+#[macro_use]
+mod common;
+ 
+use common::util::*;
+use std::path::Path;
+use std::env;
+use std::io::Write;
+use std::fs::File;
+use std::fs::remove_file;
+ 
+static UTIL_NAME: &'static str = "od";
+ 
+// octal dump of 'abcdefghijklmnopqrstuvwxyz\n'
+static ALPHA_OUT: &'static str = "0000000    061141  062143  063145  064147  065151  066153  067155  070157\n0000020    071161  072163  073165  074167  075171  000012                \n0000033\n";
+ 
+// XXX We could do a better job of ensuring that we have a fresh temp dir to ourself,
+// not a general one ful of other proc's leftovers. 
+ 
+// Test that od can read one file and dump with default format 
+#[test]
+fn test_file() {
+    let (_, mut ucmd) = testing(UTIL_NAME);
+    let temp = env::var("TMPDIR").unwrap_or_else(|_| env::var("TEMP").unwrap());
+    let tmpdir = Path::new(&temp);
+    let file = tmpdir.join("test");
+     
+    {
+        let mut f = File::create(&file).unwrap();
+        match f.write_all(b"abcdefghijklmnopqrstuvwxyz\n") {
+            Err(_)  => panic!("Test setup failed - could not write file"),
+            _ => {}
+        }
+    }
+     
+    let result = ucmd.arg(file.as_os_str()).run();
+ 
+    assert_empty_stderr!(result);
+    assert!(result.success);
+    assert_eq!(result.stdout, ALPHA_OUT);
+     
+    let _ = remove_file(file);
+}
+ 
+// Test that od can read 2 files and concatenate the contents
+#[test]
+fn test_2files() {
+    let (_, mut ucmd) = testing(UTIL_NAME);
+    let temp = env::var("TMPDIR").unwrap_or_else(|_| env::var("TEMP").unwrap());
+    let tmpdir = Path::new(&temp);
+    let file1 = tmpdir.join("test1");
+    let file2 = tmpdir.join("test2");
+     
+    for &(n,a) in [(1,"a"), (2,"b")].iter() {
+        println!("number: {} letter:{}", n, a);
+     }
+         
+    for &(path,data)in &[(&file1, "abcdefghijklmnop"),(&file2, "qrstuvwxyz\n")] {
+        let mut f = File::create(&path).unwrap();
+        match f.write_all(data.as_bytes()) {
+            Err(_)  => panic!("Test setup failed - could not write file"),
+            _ => {}
+        }
+    }
+     
+    let result = ucmd.arg(file1.as_os_str()).arg(file2.as_os_str()).run();
+ 
+    assert_empty_stderr!(result);
+    assert!(result.success);
+    assert_eq!(result.stdout, ALPHA_OUT);
+     
+    let _ = remove_file(file1);
+    let _ = remove_file(file2);
+}
+
+// Test that od gives non-0 exit val for filename that dosen't exist.   
+#[test]
+fn test_no_file() {
+    let (_, mut ucmd) = testing(UTIL_NAME);
+    let temp = env::var("TMPDIR").unwrap_or_else(|_| env::var("TEMP").unwrap());
+    let tmpdir = Path::new(&temp);
+    let file = tmpdir.join("}surely'none'would'thus'a'file'name");
+     
+    let result = ucmd.arg(file.as_os_str()).run();
+     
+    assert!(!result.success);
+ 
+}


### PR DESCRIPTION
Adds features, all from origial `od` that were missing: 

- add extra spaces to output to match format of origial `od`

- accept multiple files as input, concatenating

- accept stdin as, either when no args or as arg '--' 

- create first tests for these features

There are still missing flags, but if no missing flags are given, output should match origial `od` exactly if no error, or very close if error. (For instance rust's file not found error is a little longer) 
