### PR TITLE
Follow stdin

### DIFF
--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -172,7 +172,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
 
         if settings.follow {
-            follow(readers, &files, &settings);
+            follow(&mut readers[..], &files[..], &settings);
         }
     }
 
@@ -304,7 +304,7 @@ fn obsolete(options: &[String]) -> (Vec<String>, Option<u64>) {
 /// block read at a time.
 const BLOCK_SIZE: u64 = 1 << 16;
 
-fn follow<T: Read>(mut readers: Vec<BufReader<T>>, filenames: &Vec<String>, settings: &Settings) {
+fn follow<T: Read>(readers: &mut [BufReader<T>], filenames: &[String], settings: &Settings) {
     assert!(settings.follow);
     let mut last = readers.len() - 1;
 
@@ -482,10 +482,8 @@ fn unbounded_tail<T: Read>(mut reader: BufReader<T>, settings: &Settings) {
         }
     }
 
-    // TODO: make following stdin work with the new follow() signature
-    // maybe wrap stdin in a 1-element vec?
     if settings.follow {
-        //follow(reader, settings);
+        follow(&mut [reader], &["stdin".to_string()], settings);
     }
 }
 

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -319,8 +319,7 @@ fn follow<T: Read>(mut readers: Vec<BufReader<T>>, filenames: &Vec<String>, sett
                     Ok(0) => break,
                     Ok(_) => {
                         if i != last {
-                            println!("");
-                            println!("==> {} <==", filenames[i]);
+                            println!("\n==> {} <==", filenames[i]);
                             last = i;
                         }
                         print!("{}", datum);

--- a/tests/fixtures/tail/follow_stdin.expected
+++ b/tests/fixtures/tail/follow_stdin.expected
@@ -1,0 +1,10 @@
+dos
+tres
+quattro
+cinco
+seis
+siette
+ocho
+nueve
+diez
+once

--- a/tests/test_tail.rs
+++ b/tests/test_tail.rs
@@ -2,7 +2,7 @@ extern crate uu_tail;
 
 use common::util::*;
 use std::char::from_digit;
-use std::io::{Read, Write};
+use std::io::Write;
 use uu_tail::parse_size;
 
 static UTIL_NAME: &'static str = "tail";
@@ -72,6 +72,17 @@ fn test_follow_multiple() {
     let second_append = "doce\ntrece\n";
     let expected = at.read("foobar_follow_multiple_appended.expected");
     at.append(FOOBAR_TXT, second_append);
+    assert_eq!(read_size(&mut child, expected.len()), expected);
+
+    child.kill().unwrap();
+}
+
+#[test]
+fn test_follow_stdin() {
+    let (at, mut ucmd) = testing(UTIL_NAME);
+    let mut child = ucmd.arg("-f").pipe_in(at.read(FOOBAR_TXT)).run_no_wait();
+
+    let expected = at.read("follow_stdin.expected");
     assert_eq!(read_size(&mut child, expected.len()), expected);
 
     child.kill().unwrap();


### PR DESCRIPTION
Brings back the `follow()` call when reading from stdin. (issue #891)