### PR TITLE
fix fmt's behavior for blank prefixed lines

### DIFF
--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -206,7 +206,10 @@ pub fn uumain(args: Vec<String>) -> i32 {
         let p_stream = ParagraphStream::new(&fmt_opts, &mut fp);
         for para_result in p_stream {
             match para_result {
-                Err(s) => silent_unwrap!(ostream.write_all(s.as_bytes())),
+                Err(s) => {
+                    silent_unwrap!(ostream.write_all(s.as_bytes()));
+                    silent_unwrap!(ostream.write_all("\n".as_bytes()));
+                },
                 Ok(para) => break_lines(&para, &fmt_opts, &mut ostream)
             }
         }

--- a/src/fmt/parasplit.rs
+++ b/src/fmt/parasplit.rs
@@ -100,11 +100,9 @@ impl<'a> FileLines<'a> {
         if !exact {
             // we do it this way rather than byte indexing to support unicode whitespace chars
             for (i, char) in line.char_indices() {
-                if char.is_whitespace() {
-                    if line[i..].starts_with(pfx) {
-                        return (true, i);
-                    }
-                } else {
+                if line[i..].starts_with(pfx) {
+                    return (true, i);
+                } else if !char.is_whitespace() {
                     break;
                 }
             }
@@ -157,7 +155,7 @@ impl<'a> Iterator for FileLines<'a> {
         // Err(true) indicates that this was a linebreak,
         // which is important to know when detecting mail headers
         if n.chars().all(|c| c.is_whitespace()) {
-            return Some(Line::NoFormatLine("\n".to_owned(), true));
+            return Some(Line::NoFormatLine("".to_owned(), true));
         }
 
         // if this line does not match the prefix,


### PR DESCRIPTION
Current behavior of `fmt` is broken when processing empty, prefixed lines with the -p option. This change fixes that.

Here's an example of what was wrong before:

```
[user@host]$ fmt -w 80 -p\>
  >
  >  asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf
^D
  >  >  asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf
```

Correct output is:

```
  >
  >  asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf
```

`fmt` needs some tests. I thought I'd written some once, but either I have a bad memory or they've disappeared. I'll try to find some time to write new ones, but it probably won't be any time soon, so it's probably not worthwhile to put them in the same PR as the above fix.