### PR TITLE
Added some functionality and tests to cp

### DIFF
--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -36,6 +36,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     opts.optflag("h", "help", "display this help and exit");
     opts.optflag("v", "version", "output version information and exit");
     opts.optopt("t", "target-directory", "copy all SOURCE arguments into DIRECTORY", "DEST");
+    opts.optflag("T", "no-target-directory", "Treat DEST as a regular file and not a directory");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -99,7 +100,7 @@ fn copy(matches: getopts::Matches) {
         //the argument to the -t/--target-directory= options
         let path = Path::new(&dest_str);
         if !path.is_dir() && matches.opt_present("target-directory") {
-            show_error!("Argument to -t/--target-directory must be a directory");
+            show_error!("Target {} is not a directory", matches.opt_str("target-directory").unwrap());
             panic!()
         } else {
             path
@@ -108,6 +109,10 @@ fn copy(matches: getopts::Matches) {
     };
 
     assert!(sources.len() >= 1);
+    if matches.opt_present("no-target-directory") && dest.is_dir() {
+        show_error!("Can't overwrite directory {} with non-directory", dest.display());
+        panic!()
+    }
 
     if sources.len() == 1 {
         let source = Path::new(&sources[0]);

--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -34,9 +34,10 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let mut opts = Options::new();
 
     opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("v", "version", "output version information and exit");
+    opts.optflag("", "version", "output version information and exit");
     opts.optopt("t", "target-directory", "copy all SOURCE arguments into DIRECTORY", "DEST");
     opts.optflag("T", "no-target-directory", "Treat DEST as a regular file and not a directory");
+    opts.optflag("v", "verbose", "explicitly state what is being done");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -45,7 +46,6 @@ pub fn uumain(args: Vec<String>) -> i32 {
             panic!()
         },
     };
-
     let usage = opts.usage("Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.");
     let mode = if matches.opt_present("version") {
         Mode::Version
@@ -79,7 +79,7 @@ fn help(usage: &str) {
 }
 
 fn copy(matches: getopts::Matches) {
-
+    let verbose = matches.opt_present("verbose");
     let sources: Vec<String> = if matches.free.is_empty() {
         show_error!("Missing SOURCE or DEST argument. Try --help.");
         panic!()
@@ -136,6 +136,9 @@ fn copy(matches: getopts::Matches) {
         if dest.is_dir() {
             full_dest.push(source.file_name().unwrap()); //the destination path is the destination
         } // directory + the file name we're copying
+        if verbose {
+            println!("{} -> {}", source.display(), full_dest.display());
+        }
         if let Err(err) = fs::copy(source, full_dest) {
             show_error!("{}", err);
             panic!();
@@ -157,7 +160,9 @@ fn copy(matches: getopts::Matches) {
 
             full_dest.push(source.file_name().unwrap());
 
-            println!("{}", full_dest.display());
+            if verbose {
+                println!("{} -> {}", source.display(), full_dest.display());
+            }
 
             let io_result = fs::copy(source, full_dest);
 

--- a/tests/fixtures/cp/hello_dir_with_file/hello_world.txt
+++ b/tests/fixtures/cp/hello_dir_with_file/hello_world.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/tests/test_cp.rs
+++ b/tests/test_cp.rs
@@ -1,9 +1,11 @@
 use common::util::*;
-
 static UTIL_NAME: &'static str = "cp";
 
 static TEST_HELLO_WORLD_SOURCE: &'static str = "hello_world.txt";
 static TEST_HELLO_WORLD_DEST: &'static str = "copy_of_hello_world.txt";
+static TEST_COPY_TO_FOLDER: &'static str = "hello_dir/";
+static TEST_COPY_TO_FOLDER_FILE: &'static str = "hello_dir/hello_world.txt";
+static TEST_COPY_FROM_FOLDER_FILE: &'static str = "hello_dir_with_file/hello_world.txt";
 
 #[test]
 fn test_cp_cp() {
@@ -15,8 +17,44 @@ fn test_cp_cp() {
 
     // Check that the exit code represents a successful copy.
     let exit_success = result.success;
-    assert_eq!(exit_success, true);
+    assert!(exit_success);
 
     // Check the content of the destination file that was copied.
+    assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
+}
+
+#[test]
+fn test_cp_with_dirs_t() {
+    let ts = TestSet::new(UTIL_NAME);
+    let at = &ts.fixtures;
+
+    //using -t option
+    let result_to_dir_t = ts.util_cmd()
+        .arg("-t")
+        .arg(TEST_COPY_TO_FOLDER)
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .run();
+    assert!(result_to_dir_t.success);
+    assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
+}
+
+#[test]
+fn test_cp_with_dirs() {
+    let ts = TestSet::new(UTIL_NAME);
+    let at = &ts.fixtures;
+
+    //using -t option
+    let result_to_dir_t = ts.util_cmd()
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_COPY_TO_FOLDER)
+        .run();
+    assert!(result_to_dir_t.success);
+    assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
+
+    let result_from_dir_t = ts.util_cmd()
+        .arg(TEST_COPY_FROM_FOLDER_FILE)
+        .arg(TEST_HELLO_WORLD_DEST)
+        .run();
+    assert!(result_from_dir_t.success);
     assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
 }

--- a/tests/test_cp.rs
+++ b/tests/test_cp.rs
@@ -44,17 +44,17 @@ fn test_cp_with_dirs() {
     let at = &ts.fixtures;
 
     //using -t option
-    let result_to_dir_t = ts.util_cmd()
+    let result_to_dir = ts.util_cmd()
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
         .run();
-    assert!(result_to_dir_t.success);
+    assert!(result_to_dir.success);
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 
-    let result_from_dir_t = ts.util_cmd()
+    let result_from_dir = ts.util_cmd()
         .arg(TEST_COPY_FROM_FOLDER_FILE)
         .arg(TEST_HELLO_WORLD_DEST)
         .run();
-    assert!(result_from_dir_t.success);
+    assert!(result_from_dir.success);
     assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
 }


### PR DESCRIPTION
I added the following flags to cp:  
* -v/--verbose  
* -t/--target-directory  
* -T/--no-target-directory  

And created two tests to verify that files are copied into and out of folders correctly.  
These tests helped find a bug, which I fixed (when copying files from a directory other than cwd, the destination files would be named after the entire path given, and not the file name itself)  
I'm not sure whether to "adopt" cd, because I'm just a beginner and someone more experienced might be a better fit for this, and get things done more quickly, but I'll work on this as much as I can.