### PR TITLE
Tests run using makefile skip separately building binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build_exe_$(1):
 endef
 
 define TEST_INTEGRATION
-test_integration_$(1): build_exe_$(1)
+test_integration_$(1):
 	${CARGO} test ${CARGOFLAGS} --features "$(1) $(TEST_SPEC_FEATURE)" --no-default-features $(TEST_NO_FAIL_FAST)
 endef
 


### PR DESCRIPTION
Currently the README.md advises users to continue to use the makefile for running tests. 

This commit makes running tests via make faster by removing an extraneous binary build that previously occurred prior to each test.