### PR TITLE
tests: feature-complete cat integration tests

### DIFF
--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -8,10 +8,9 @@ fn test_output_multi_files_print_all_chars() {
     ucmd.arg("alpha.txt")
         .arg("256.txt")
         .arg("-A")
-        .arg("-n");
-
-    assert_eq!(ucmd.run().stdout,
-               "     1\tabcde$\n     2\tfghij$\n     3\tklmno$\n     4\tpqrst$\n     \
+        .arg("-n")
+        .succeeds()
+        .stdout_only("     1\tabcde$\n     2\tfghij$\n     3\tklmno$\n     4\tpqrst$\n     \
                 5\tuvwxyz$\n     6\t^@^A^B^C^D^E^F^G^H^I$\n     \
                 7\t^K^L^M^N^O^P^Q^R^S^T^U^V^W^X^Y^Z^[^\\^]^^^_ \
                 !\"#$%&\'()*+,-./0123456789:;\
@@ -25,32 +24,109 @@ fn test_output_multi_files_print_all_chars() {
 }
 
 #[test]
-fn test_stdin_show_all() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("-A")
-                  .run_piped_stdin("\x00\x01\x02".as_bytes())
-                  .stdout;
+fn test_stdin_show_nonprinting() {
+    for same_param in vec!["-v", "--show-nonprinting"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.args(&vec![same_param])
+            .pipe_in("\t\0\n")
+            .succeeds()
+            .stdout_only("\t^@");
+    }
+}
 
-    assert_eq!(out, "^@^A^B");
+#[test]
+fn test_stdin_show_tabs() {
+    for same_param in vec!["-T", "--show-tabs"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.args(&vec![same_param])
+            .pipe_in("\t\0\n")
+            .succeeds()
+            .stdout_only("^I\0");
+    }
+}
+
+
+#[test]
+fn test_stdin_show_ends() {
+    for same_param in vec!["-E", "--show-ends"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.args(&vec![same_param,"-"])
+            .pipe_in("\t\0\n")
+            .succeeds()
+            .stdout_only("\t\0$");
+    }
+}
+
+#[test]
+fn test_stdin_show_all() {
+    for same_param in vec!["-A", "--show-all"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.args(&vec![same_param])
+            .pipe_in("\t\0\n")
+            .succeeds()
+            .stdout_only("^I^@$");
+    }
+}
+
+#[test]
+fn test_stdin_nonprinting_and_endofline() {
+    let (_, mut ucmd) = testing(UTIL_NAME);
+    ucmd.args(&vec!["-e"])
+        .pipe_in("\t\0\n")
+        .succeeds()
+        .stdout_only("\t^@$\n");
+}
+
+#[test]
+fn test_stdin_nonprinting_and_tabs() {
+    let (_, mut ucmd) = testing(UTIL_NAME);
+    ucmd.args(&vec!["-t"])
+        .pipe_in("\t\0\n")
+        .succeeds()
+        .stdout_only("^I^@\n");
 }
 
 #[test]
 fn test_stdin_squeeze_blank() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("--squeeze-blank")
-                  .run_piped_stdin("\n\na\n\n\n\n\nb\n\n\n".as_bytes())
-                  .stdout;
-
-    assert_eq!(out, "\na\n\nb\n\n");
+    for same_param in vec!["-s", "--squeeze-blank"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.arg(same_param)
+            .pipe_in("\n\na\n\n\n\n\nb\n\n\n".as_bytes())
+            .succeeds()
+            .stdout_only("\na\n\nb\n\n");
+    }
 }
 
 #[test]
 fn test_stdin_number_non_blank() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("-b")
-                  .arg("-")
-                  .run_piped_stdin("\na\nb\n\n\nc".as_bytes())
-                  .stdout;
+    for same_param in vec!["-b", "--number-nonblank"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.arg(same_param)
+            .arg("-")
+            .pipe_in("\na\nb\n\n\nc".as_bytes())
+            .succeeds()
+            .stdout_only("\n     1\ta\n     2\tb\n\n\n     3\tc");
+    }
+}
 
-    assert_eq!(out, "\n     1\ta\n     2\tb\n\n\n     3\tc");
+#[test]
+fn test_non_blank_overrides_number() {
+    for same_param in vec!["-b", "--number-nonblank"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.args(&vec![same_param, "-"])
+            .pipe_in("\na\nb\n\n\nc".as_bytes())
+            .succeeds()
+            .stdout_only("\n     1\ta\n     2\tb\n\n\n     3\tc");
+    }    
+}
+
+#[test]
+fn test_squeeze_blank_before_numbering() {
+    for same_param in vec!["-s", "--squeeze-blank"] {
+        let (_, mut ucmd) = testing(UTIL_NAME);
+        ucmd.args(&vec![same_param, "-n", "-"])
+            .pipe_in("a\n\n\nb")
+            .succeeds()
+            .stdout_only("     1\ta\n     2\t\n     3\tb");
+    }
 }


### PR DESCRIPTION
With these additions, the tests should now cover at least one example case of every flag of ```cat```, including the status code result and an empty stderr.