### PR TITLE
tests/common: use more idiomatic asserts

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -65,7 +65,7 @@ impl CmdResult {
     /// 1. you can not know exactly what stdout will be
     /// or 2. you know that stdout will also be empty
     pub fn no_stderr(&self) -> Box<&CmdResult> {
-        assert!(self.stderr.len() == 0);
+        assert_eq!(0, self.stderr.len());
         Box::new(self)
     }
     
@@ -76,7 +76,7 @@ impl CmdResult {
     /// 1. you can not know exactly what stderr will be
     /// or 2. you know that stderr will also be empty
     pub fn no_stdout(&self) -> Box<&CmdResult> {
-        assert!(self.stdout.len() == 0);
+        assert_eq!(0, self.stdout.len());
         Box::new(self)
     }
 
@@ -84,7 +84,7 @@ impl CmdResult {
     /// passed in value, when both are trimmed of trailing whitespace
     /// stdout_only is a better choice unless stderr may or will be non-empty
     pub fn stdout_is<T: AsRef<str>>(&self, msg: T) -> Box<&CmdResult> {
-        assert!(self.stdout.trim_right() == String::from(msg.as_ref()).trim_right());
+        assert_eq!(String::from(msg.as_ref()).trim_right(), self.stdout.trim_right());
         Box::new(self)
     }
 
@@ -92,7 +92,7 @@ impl CmdResult {
     /// passed in value, when both are trimmed of trailing whitespace
     /// stderr_only is a better choice unless stdout may or will be non-empty
     pub fn stderr_is<T: AsRef<str>>(&self, msg: T) -> Box<&CmdResult> {
-        assert!(self.stderr.trim_right() == String::from(msg.as_ref()).trim_right());
+        assert_eq!(String::from(msg.as_ref()).trim_right(), self.stderr.trim_right());
         Box::new(self)
     }
 
@@ -114,7 +114,7 @@ impl CmdResult {
 
     pub fn fails_silently(&self) -> Box<&CmdResult> {
         assert!(!self.success);
-        assert!(self.stderr.len() == 0);
+        assert_eq!(0, self.stderr.len());
         Box::new(self)
     }
 }


### PR DESCRIPTION
This changes, where applicable, the ```assert!``` macros called by util.rs to the more idiomatic ```assert_eq!``` macro, with this change users will always be able to compare the results of a failed string equality test.