### PR TITLE
Tests: minor refactor for dryness of base64 and cat tests

### DIFF
--- a/tests/test_base64.rs
+++ b/tests/test_base64.rs
@@ -6,8 +6,8 @@ static UTIL_NAME: &'static str = "base64";
 fn test_encode() {
     let (_, mut ucmd) = testing(UTIL_NAME);
     let input = "hello, world!";
-    ucmd.run_piped_stdin(input.as_bytes())
-        .success()
+    ucmd.pipe_in(input)
+        .succeeds()
         .stdout_only("aGVsbG8sIHdvcmxkIQ==\n");
 }
 
@@ -16,8 +16,9 @@ fn test_decode() {
     for decode_param in vec!["-d", "--decode"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
         let input = "aGVsbG8sIHdvcmxkIQ==";
-        ucmd.arg(decode_param).run_piped_stdin(input.as_bytes())
-            .success()
+        ucmd.arg(decode_param)
+            .pipe_in(input)
+            .succeeds()
             .stdout_only("hello, world!");
     }
 }
@@ -26,8 +27,9 @@ fn test_decode() {
 fn test_garbage() {
     let (_, mut ucmd) = testing(UTIL_NAME);
     let input = "aGVsbG8sIHdvcmxkIQ==\0";
-    ucmd.arg("-d").run_piped_stdin(input.as_bytes())
-        .failure()
+    ucmd.arg("-d")
+        .pipe_in(input)
+        .fails()
         .stderr_only("base64: error: invalid character (Invalid character '0' at position 20)\n");
 }
 
@@ -36,8 +38,9 @@ fn test_ignore_garbage() {
     for ignore_garbage_param in vec!["-i", "--ignore-garbage"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
         let input = "aGVsbG8sIHdvcmxkIQ==\0";
-        ucmd.arg("-d").arg(ignore_garbage_param).run_piped_stdin(input.as_bytes())
-            .success()
+        ucmd.arg("-d").arg(ignore_garbage_param)
+            .pipe_in(input)
+            .succeeds()
             .stdout_only("hello, world!");
     }
 }
@@ -47,8 +50,9 @@ fn test_wrap() {
     for wrap_param in vec!["-w", "--wrap"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
         let input = "The quick brown fox jumps over the lazy dog.";
-        ucmd.arg(wrap_param).arg("20").run_piped_stdin(input.as_bytes())
-            .success()
+        ucmd.arg(wrap_param).arg("20")
+            .pipe_in(input)
+            .succeeds()
             .stdout_only("VGhlIHF1aWNrIGJyb3du\nIGZveCBqdW1wcyBvdmVy\nIHRoZSBsYXp5IGRvZy4=\n");
     }
 }
@@ -57,8 +61,8 @@ fn test_wrap() {
 fn test_wrap_no_arg() {
     for wrap_param in vec!["-w", "--wrap"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.arg(wrap_param).run()
-            .failure()
+        ucmd.arg(wrap_param)
+            .fails()
             .stderr_only(
                 format!("base64: error: Argument to option '{}' missing.",
                         if wrap_param == "-w" { "w" } else { "wrap" }));
@@ -69,8 +73,8 @@ fn test_wrap_no_arg() {
 fn test_wrap_bad_arg() {
     for wrap_param in vec!["-w", "--wrap"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.arg(wrap_param).arg("b").run()
-            .failure()
+        ucmd.arg(wrap_param).arg("b")
+            .fails()
             .stderr_only("base64: error: Argument to option 'wrap' improperly formatted: invalid digit found in string");
     }
 }

--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -5,10 +5,7 @@ static UTIL_NAME: &'static str = "cat";
 #[test]
 fn test_output_multi_files_print_all_chars() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("alpha.txt")
-        .arg("256.txt")
-        .arg("-A")
-        .arg("-n")
+    ucmd.args(&["alpha.txt", "256.txt", "-A", "-n"])
         .succeeds()
         .stdout_only("     1\tabcde$\n     2\tfghij$\n     3\tklmno$\n     4\tpqrst$\n     \
                 5\tuvwxyz$\n     6\t^@^A^B^C^D^E^F^G^H^I$\n     \
@@ -38,7 +35,7 @@ fn test_stdin_show_nonprinting() {
 fn test_stdin_show_tabs() {
     for same_param in vec!["-T", "--show-tabs"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&vec![same_param])
+        ucmd.args(&[same_param])
             .pipe_in("\t\0\n")
             .succeeds()
             .stdout_only("^I\0");
@@ -50,7 +47,7 @@ fn test_stdin_show_tabs() {
 fn test_stdin_show_ends() {
     for same_param in vec!["-E", "--show-ends"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&vec![same_param,"-"])
+        ucmd.args(&[same_param,"-"])
             .pipe_in("\t\0\n")
             .succeeds()
             .stdout_only("\t\0$");
@@ -61,7 +58,7 @@ fn test_stdin_show_ends() {
 fn test_stdin_show_all() {
     for same_param in vec!["-A", "--show-all"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&vec![same_param])
+        ucmd.args(&[same_param])
             .pipe_in("\t\0\n")
             .succeeds()
             .stdout_only("^I^@$");
@@ -71,7 +68,7 @@ fn test_stdin_show_all() {
 #[test]
 fn test_stdin_nonprinting_and_endofline() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.args(&vec!["-e"])
+    ucmd.args(&["-e"])
         .pipe_in("\t\0\n")
         .succeeds()
         .stdout_only("\t^@$\n");
@@ -80,7 +77,7 @@ fn test_stdin_nonprinting_and_endofline() {
 #[test]
 fn test_stdin_nonprinting_and_tabs() {
     let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.args(&vec!["-t"])
+    ucmd.args(&["-t"])
         .pipe_in("\t\0\n")
         .succeeds()
         .stdout_only("^I^@\n");
@@ -91,7 +88,7 @@ fn test_stdin_squeeze_blank() {
     for same_param in vec!["-s", "--squeeze-blank"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
         ucmd.arg(same_param)
-            .pipe_in("\n\na\n\n\n\n\nb\n\n\n".as_bytes())
+            .pipe_in("\n\na\n\n\n\n\nb\n\n\n")
             .succeeds()
             .stdout_only("\na\n\nb\n\n");
     }
@@ -103,7 +100,7 @@ fn test_stdin_number_non_blank() {
         let (_, mut ucmd) = testing(UTIL_NAME);
         ucmd.arg(same_param)
             .arg("-")
-            .pipe_in("\na\nb\n\n\nc".as_bytes())
+            .pipe_in("\na\nb\n\n\nc")
             .succeeds()
             .stdout_only("\n     1\ta\n     2\tb\n\n\n     3\tc");
     }
@@ -113,8 +110,8 @@ fn test_stdin_number_non_blank() {
 fn test_non_blank_overrides_number() {
     for same_param in vec!["-b", "--number-nonblank"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&vec![same_param, "-"])
-            .pipe_in("\na\nb\n\n\nc".as_bytes())
+        ucmd.args(&[same_param, "-"])
+            .pipe_in("\na\nb\n\n\nc")
             .succeeds()
             .stdout_only("\n     1\ta\n     2\tb\n\n\n     3\tc");
     }    
@@ -124,7 +121,7 @@ fn test_non_blank_overrides_number() {
 fn test_squeeze_blank_before_numbering() {
     for same_param in vec!["-s", "--squeeze-blank"] {
         let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&vec![same_param, "-n", "-"])
+        ucmd.args(&[same_param, "-n", "-"])
             .pipe_in("a\n\n\nb")
             .succeeds()
             .stdout_only("     1\ta\n     2\t\n     3\tb");


### PR DESCRIPTION
- remove extraneous uses of ```run``` or ```run_piped_stdin```
- remove extraneous uses of ```vec!```
- remove extraneous uses of ```as_bytes``` (```run_piped_stdin``` and ```pipe_in``` both now use ```Into<Vec<u8>>```)
- remove an extraneous use of >2 ```arg``` calls for the same command instead of ```args```