### PR TITLE
Minor changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,11 +207,6 @@ build_exe_$(1):
 	${CARGO} build ${CARGOFLAGS} ${PROFILE_CMD} -p $(1)
 endef
 
-define TEST_INTEGRATION
-test_integration_$(1):
-	${CARGO} test ${CARGOFLAGS} --features "$(1) $(TEST_SPEC_FEATURE)" --no-default-features $(TEST_NO_FAIL_FAST)
-endef
-
 define TEST_BUSYBOX
 test_busybox_$(1):
 	(cd $(BUSYBOX_SRC)/testsuite && bindir=$(BUILDDIR) ./runtest $(RUNTEST_ARGS) $(1) )
@@ -255,10 +250,10 @@ build-uutils:
 
 build: build-uutils build-pkgs
 
-$(foreach test,$(TESTS),$(eval $(call TEST_INTEGRATION,$(test))))
 $(foreach test,$(filter-out $(SKIP_UTILS),$(PROGS)),$(eval $(call TEST_BUSYBOX,$(test))))
 
-test: $(addprefix test_integration_,$(TESTS))
+test:
+	${CARGO} test ${CARGOFLAGS} --features "$(TESTS) $(TEST_SPEC_FEATURE)" --no-default-features $(TEST_NO_FAIL_FAST)
 
 busybox-src:
 	if [ ! -e $(BUSYBOX_SRC) ]; then \

--- a/README.md
+++ b/README.md
@@ -148,15 +148,21 @@ To do
 -----
 
 - chcon
+- runcon
+- base32
+- md5sum
+- sha1sum
+- sha224sum
+- sha256sum
+- sha384sum
+- sha512sum
 - chgrp
-- copy
 - cp (not much done)
 - csplit
 - date
 - dd
 - df
 - expr (almost done, no regular expressions)
-- getlimits
 - join
 - ls
 - mv (almost done, one more option)
@@ -164,9 +170,6 @@ To do
 - od (in progress, needs lots of work)
 - pr
 - printf
-- remove
-- runcon
-- setuidgid
 - sort (a couple of options implemented)
 - split (a couple of missing options)
 - stty


### PR DESCRIPTION
The previous runs of `make UTILS='stat dircolors ...etc.' test` would compile multiple times, which is somewhat inefficient.

In addition, I updated the TODO list on README according to the [online manual](https://www.gnu.org/software/coreutils/manual/coreutils.html). BTW, are we going to implement chcon/runcon which are related to SELinux context? 