### PR TITLE
tests: refactor conventional TestScenario usage

### DIFF
--- a/tests/test_base64.rs
+++ b/tests/test_base64.rs
@@ -1,12 +1,15 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "base64";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_encode() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let input = "hello, world!";
-    ucmd.pipe_in(input)
+    new_ucmd()
+        .pipe_in(input)
         .succeeds()
         .stdout_only("aGVsbG8sIHdvcmxkIQ==\n");
 }
@@ -14,9 +17,9 @@ fn test_encode() {
 #[test]
 fn test_decode() {
     for decode_param in vec!["-d", "--decode"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
         let input = "aGVsbG8sIHdvcmxkIQ==";
-        ucmd.arg(decode_param)
+        new_ucmd()
+            .arg(decode_param)
             .pipe_in(input)
             .succeeds()
             .stdout_only("hello, world!");
@@ -25,9 +28,9 @@ fn test_decode() {
 
 #[test]
 fn test_garbage() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let input = "aGVsbG8sIHdvcmxkIQ==\0";
-    ucmd.arg("-d")
+    new_ucmd()
+        .arg("-d")
         .pipe_in(input)
         .fails()
         .stderr_only("base64: error: invalid character (Invalid character '0' at position 20)\n");
@@ -36,9 +39,10 @@ fn test_garbage() {
 #[test]
 fn test_ignore_garbage() {
     for ignore_garbage_param in vec!["-i", "--ignore-garbage"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
         let input = "aGVsbG8sIHdvcmxkIQ==\0";
-        ucmd.arg("-d").arg(ignore_garbage_param)
+        new_ucmd()
+            .arg("-d")
+            .arg(ignore_garbage_param)
             .pipe_in(input)
             .succeeds()
             .stdout_only("hello, world!");
@@ -48,9 +52,10 @@ fn test_ignore_garbage() {
 #[test]
 fn test_wrap() {
     for wrap_param in vec!["-w", "--wrap"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
         let input = "The quick brown fox jumps over the lazy dog.";
-        ucmd.arg(wrap_param).arg("20")
+        new_ucmd()
+            .arg(wrap_param)
+            .arg("20")
             .pipe_in(input)
             .succeeds()
             .stdout_only("VGhlIHF1aWNrIGJyb3du\nIGZveCBqdW1wcyBvdmVy\nIHRoZSBsYXp5IGRvZy4=\n");
@@ -60,8 +65,8 @@ fn test_wrap() {
 #[test]
 fn test_wrap_no_arg() {
     for wrap_param in vec!["-w", "--wrap"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.arg(wrap_param)
+        new_ucmd()
+            .arg(wrap_param)
             .fails()
             .stderr_only(
                 format!("base64: error: Argument to option '{}' missing.",
@@ -72,8 +77,8 @@ fn test_wrap_no_arg() {
 #[test]
 fn test_wrap_bad_arg() {
     for wrap_param in vec!["-w", "--wrap"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.arg(wrap_param).arg("b")
+        new_ucmd()
+            .arg(wrap_param).arg("b")
             .fails()
             .stderr_only("base64: error: Argument to option 'wrap' improperly formatted: invalid digit found in string");
     }

--- a/tests/test_basename.rs
+++ b/tests/test_basename.rs
@@ -1,10 +1,13 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "basename";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 fn expect_successful_stdout(input: Vec<&str>, expected: &str) {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let results = ucmd.args(&input).run();
+    let results = new_ucmd()
+        .args(&input).run();
     assert_empty_stderr!(results);
     assert!(results.success);
     assert_eq!(expected, results.stdout.trim_right());
@@ -35,8 +38,8 @@ fn test_dont_remove_suffix() {
 }
 
 fn expect_error(input: Vec<&str>, expected_stdout: &str) {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let results = ucmd.args(&input).run();
+    let results = new_ucmd()
+        .args(&input).run();
     assert!(!results.success);
     assert!(results.stderr.len() > 0);
     assert_eq!(expected_stdout, results.stdout.trim_right());

--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -1,11 +1,14 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "cat";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_output_multi_files_print_all_chars() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.args(&["alpha.txt", "256.txt", "-A", "-n"])
+    new_ucmd()
+        .args(&["alpha.txt", "256.txt", "-A", "-n"])
         .succeeds()
         .stdout_only("     1\tabcde$\n     2\tfghij$\n     3\tklmno$\n     4\tpqrst$\n     \
                 5\tuvwxyz$\n     6\t^@^A^B^C^D^E^F^G^H^I$\n     \
@@ -23,8 +26,8 @@ fn test_output_multi_files_print_all_chars() {
 #[test]
 fn test_stdin_show_nonprinting() {
     for same_param in vec!["-v", "--show-nonprinting"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&vec![same_param])
+        new_ucmd()
+            .args(&vec![same_param])
             .pipe_in("\t\0\n")
             .succeeds()
             .stdout_only("\t^@");
@@ -34,8 +37,8 @@ fn test_stdin_show_nonprinting() {
 #[test]
 fn test_stdin_show_tabs() {
     for same_param in vec!["-T", "--show-tabs"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&[same_param])
+        new_ucmd()
+            .args(&[same_param])
             .pipe_in("\t\0\n")
             .succeeds()
             .stdout_only("^I\0");
@@ -46,8 +49,8 @@ fn test_stdin_show_tabs() {
 #[test]
 fn test_stdin_show_ends() {
     for same_param in vec!["-E", "--show-ends"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&[same_param,"-"])
+        new_ucmd()
+            .args(&[same_param,"-"])
             .pipe_in("\t\0\n")
             .succeeds()
             .stdout_only("\t\0$");
@@ -57,8 +60,8 @@ fn test_stdin_show_ends() {
 #[test]
 fn test_stdin_show_all() {
     for same_param in vec!["-A", "--show-all"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&[same_param])
+        new_ucmd()
+            .args(&[same_param])
             .pipe_in("\t\0\n")
             .succeeds()
             .stdout_only("^I^@$");
@@ -67,8 +70,8 @@ fn test_stdin_show_all() {
 
 #[test]
 fn test_stdin_nonprinting_and_endofline() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.args(&["-e"])
+    new_ucmd()
+        .args(&["-e"])
         .pipe_in("\t\0\n")
         .succeeds()
         .stdout_only("\t^@$\n");
@@ -76,8 +79,8 @@ fn test_stdin_nonprinting_and_endofline() {
 
 #[test]
 fn test_stdin_nonprinting_and_tabs() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.args(&["-t"])
+    new_ucmd()
+        .args(&["-t"])
         .pipe_in("\t\0\n")
         .succeeds()
         .stdout_only("^I^@\n");
@@ -86,8 +89,8 @@ fn test_stdin_nonprinting_and_tabs() {
 #[test]
 fn test_stdin_squeeze_blank() {
     for same_param in vec!["-s", "--squeeze-blank"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.arg(same_param)
+        new_ucmd()
+            .arg(same_param)
             .pipe_in("\n\na\n\n\n\n\nb\n\n\n")
             .succeeds()
             .stdout_only("\na\n\nb\n\n");
@@ -97,8 +100,8 @@ fn test_stdin_squeeze_blank() {
 #[test]
 fn test_stdin_number_non_blank() {
     for same_param in vec!["-b", "--number-nonblank"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.arg(same_param)
+        new_ucmd()
+            .arg(same_param)
             .arg("-")
             .pipe_in("\na\nb\n\n\nc")
             .succeeds()
@@ -109,8 +112,8 @@ fn test_stdin_number_non_blank() {
 #[test]
 fn test_non_blank_overrides_number() {
     for same_param in vec!["-b", "--number-nonblank"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&[same_param, "-"])
+        new_ucmd()
+            .args(&[same_param, "-"])
             .pipe_in("\na\nb\n\n\nc")
             .succeeds()
             .stdout_only("\n     1\ta\n     2\tb\n\n\n     3\tc");
@@ -120,8 +123,8 @@ fn test_non_blank_overrides_number() {
 #[test]
 fn test_squeeze_blank_before_numbering() {
     for same_param in vec!["-s", "--squeeze-blank"] {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        ucmd.args(&[same_param, "-n", "-"])
+        new_ucmd()
+            .args(&[same_param, "-n", "-"])
             .pipe_in("a\n\n\nb")
             .succeeds()
             .stdout_only("     1\ta\n     2\t\n     3\tb");

--- a/tests/test_chmod.rs
+++ b/tests/test_chmod.rs
@@ -6,6 +6,12 @@ extern crate libc;
 use self::libc::umask;
 
 static UTIL_NAME: &'static str = "chmod";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
+
 static TEST_FILE: &'static str = "file";
 static REFERENCE_FILE: &'static str = "reference";
 static REFERENCE_PERMS: u32 = 0o247;
@@ -47,7 +53,7 @@ fn run_single_test(test: &TestCase, at: AtPath, mut ucmd: UCommand) {
 
 fn run_tests(tests: Vec<TestCase>) {
     for test in tests {
-        let (at, ucmd) = testing(UTIL_NAME);
+        let (at, ucmd) = at_and_ucmd();
         run_single_test(&test, at, ucmd);
     }
 }
@@ -129,7 +135,7 @@ fn test_chmod_reference_file() {
         TestCase{args: vec!{"--reference", REFERENCE_FILE, TEST_FILE}, before: 0o070, after: 0o247},
         TestCase{args: vec!{"a-w", "--reference", REFERENCE_FILE, TEST_FILE}, before: 0o070, after: 0o247},
     };
-    let (at, ucmd) = testing(UTIL_NAME);
+    let (at, ucmd) = at_and_ucmd();
     mkfile(&at.plus_as_string(REFERENCE_FILE), REFERENCE_PERMS);
     run_single_test(&tests[0], at, ucmd);
 }

--- a/tests/test_chown.rs
+++ b/tests/test_chown.rs
@@ -4,6 +4,9 @@ extern crate uu_chown;
 pub use self::uu_chown::*;
 
 static UTIL_NAME: &'static str = "chown";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[cfg(test)]
 mod test_passwd {
@@ -46,7 +49,7 @@ mod test_passwd {
 
 #[test]
 fn test_invalid_option() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-w").arg("-q").arg("/");
-    ucmd.fails();
+    new_ucmd()
+        .arg("-w").arg("-q").arg("/")
+        .fails();
 }

--- a/tests/test_cksum.rs
+++ b/tests/test_cksum.rs
@@ -1,36 +1,27 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "cksum";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_single_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("lorem_ipsum.txt").run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("single_file.expected"));
+    new_ucmd().arg("lorem_ipsum.txt")
+        .succeeds().stdout_is_fixture("single_file.expected");
 }
 
 #[test]
 fn test_multiple_files() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("lorem_ipsum.txt")
-                     .arg("alice_in_wonderland.txt")
-                     .run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("multiple_files.expected"));
+    new_ucmd()
+        .arg("lorem_ipsum.txt")
+        .arg("alice_in_wonderland.txt")
+        .succeeds().stdout_is_fixture("multiple_files.expected");
 }
 
 #[test]
 fn test_stdin() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let input = at.read("lorem_ipsum.txt");
-    let result = ucmd.run_piped_stdin(input);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("stdin.expected"));
+    new_ucmd()
+        .pipe_in_fixture("lorem_ipsum.txt")
+        .succeeds().stdout_is_fixture("stdin.expected");
 }

--- a/tests/test_comm.rs
+++ b/tests/test_comm.rs
@@ -1,12 +1,20 @@
-use common::util::testing;
+use common::util::*;
 use std::ffi::OsStr;
 
 static UTIL_NAME: &'static str = "comm";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 fn comm<A: AsRef<OsStr>, B: AsRef<str>>(args: &[A],
                                                        file_stdout_relpath_opt: Option<B>,
                                                        error_message_opt: Option<B>) {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let result = ucmd.args(args)
                      .run();
     assert!(result.success == error_message_opt.is_none());
@@ -146,8 +154,8 @@ fn unintuitive_default_behavior_1() {
 #[ignore] //bug? should help be stdout if not called via -h|--help?
 #[test]
 fn no_arguments() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run();
+    let result = new_ucmd()
+        .run();
     assert!(!result.success);
     assert!(result.stdout.len() == 0);
     assert!(result.stderr.len() > 0);
@@ -156,8 +164,8 @@ fn no_arguments() {
 #[ignore] //bug? should help be stdout if not called via -h|--help?
 #[test]
 fn one_argument() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("a").run();
+    let result = new_ucmd()
+        .arg("a").run();
     assert!(!result.success);
     assert!(result.stdout.len() == 0);
     assert!(result.stderr.len() > 0);

--- a/tests/test_cp.rs
+++ b/tests/test_cp.rs
@@ -1,5 +1,10 @@
 use common::util::*;
 static UTIL_NAME: &'static str = "cp";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 static TEST_HELLO_WORLD_SOURCE: &'static str = "hello_world.txt";
 static TEST_HELLO_WORLD_DEST: &'static str = "copy_of_hello_world.txt";
@@ -9,7 +14,7 @@ static TEST_COPY_FROM_FOLDER_FILE: &'static str = "hello_dir_with_file/hello_wor
 
 #[test]
 fn test_cp_cp() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     // Invoke our binary to make the copy.
     let result = ucmd.arg(TEST_HELLO_WORLD_SOURCE)
                      .arg(TEST_HELLO_WORLD_DEST)
@@ -25,11 +30,10 @@ fn test_cp_cp() {
 
 #[test]
 fn test_cp_with_dirs_t() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let (at, mut ucmd) = at_and_ucmd();
 
     //using -t option
-    let result_to_dir_t = ts.util_cmd()
+    let result_to_dir_t = ucmd
         .arg("-t")
         .arg(TEST_COPY_TO_FOLDER)
         .arg(TEST_HELLO_WORLD_SOURCE)
@@ -40,18 +44,18 @@ fn test_cp_with_dirs_t() {
 
 #[test]
 fn test_cp_with_dirs() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
 
     //using -t option
-    let result_to_dir = ts.util_cmd()
+    let result_to_dir = scene.ucmd()
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
         .run();
     assert!(result_to_dir.success);
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 
-    let result_from_dir = ts.util_cmd()
+    let result_from_dir = scene.ucmd()
         .arg(TEST_COPY_FROM_FOLDER_FILE)
         .arg(TEST_HELLO_WORLD_DEST)
         .run();

--- a/tests/test_cut.rs
+++ b/tests/test_cut.rs
@@ -1,57 +1,46 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "cut";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 static INPUT: &'static str = "lists.txt";
 
 
 #[test]
 fn test_prefix() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c", "-10", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lists_prefix.expected"));
+    new_ucmd().args(&["-c", "-10", INPUT]).run().stdout_is_fixture("lists_prefix.expected");
 }
 
 #[test]
 fn test_char_range() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c", "4-10", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lists_char_range.expected"));
+    new_ucmd().args(&["-c", "4-10", INPUT]).run().stdout_is_fixture("lists_char_range.expected");
 }
 
 #[test]
 fn test_column_to_end_of_line() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", ":", "-f", "5-", INPUT]).run();
-    assert_eq!(result.stdout,
-               at.read("lists_column_to_end_of_line.expected"));
+    new_ucmd().args(&["-d", ":", "-f", "5-", INPUT]).run().stdout_is_fixture("lists_column_to_end_of_line.expected");
 }
 
 #[test]
 fn test_specific_field() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", " ", "-f", "3", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lists_specific_field.expected"));
+    new_ucmd().args(&["-d", " ", "-f", "3", INPUT]).run().stdout_is_fixture("lists_specific_field.expected");
 }
 
 #[test]
 fn test_multiple_fields() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", ":", "-f", "1,3", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lists_multiple_fields.expected"));
+    new_ucmd().args(&["-d", ":", "-f", "1,3", INPUT]).run().stdout_is_fixture("lists_multiple_fields.expected");
 }
 
 #[test]
 fn test_tail() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", ":", "--complement", "-f", "1", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lists_tail.expected"));
+    new_ucmd().args(&["-d", ":", "--complement", "-f", "1", INPUT]).run().stdout_is_fixture("lists_tail.expected");
 }
 
 #[test]
 fn test_change_delimiter() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", ":", "--complement", "--output-delimiter=#", "-f", "1", INPUT])
-                     .run();
-    assert_eq!(result.stdout, at.read("lists_change_delimiter.expected"));
+    new_ucmd()
+        .args(&["-d", ":", "--complement", "--output-delimiter=#", "-f", "1", INPUT])
+        .run().stdout_is_fixture("lists_change_delimiter.expected");
 }

--- a/tests/test_dircolors.rs
+++ b/tests/test_dircolors.rs
@@ -4,6 +4,9 @@ use self::uu_dircolors::{StrUtils, guess_syntax, OutputFmt};
 use common::util::*;
 
 static UTIL_NAME: &'static str = "dircolors";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_shell_syntax() {
@@ -57,55 +60,46 @@ fn test_keywords() {
 
 #[test]
 fn test_internal_db() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-p");
-    let out = ucmd.run().stdout;
-    let filename = "internal.expected";
-    assert_eq!(out, at.read(filename));
+    new_ucmd()
+        .arg("-p")
+        .run()
+        .stdout_is_fixture("internal.expected");
 }
 
 #[test]
 fn test_bash_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-b");
-    let out = ucmd.env("TERM", "screen").run().stdout;
-    let filename = "bash_def.expected";
-    assert_eq!(out, at.read(filename));
+    new_ucmd().env("TERM", "screen").arg("-b").run().stdout_is_fixture("bash_def.expected");
 }
 
 #[test]
 fn test_csh_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-c");
-    let out = ucmd.env("TERM", "screen").run().stdout;
-    let filename = "csh_def.expected";
-    assert_eq!(out, at.read(filename));
+    new_ucmd().env("TERM", "screen").arg("-c").run().stdout_is_fixture("csh_def.expected");
 }
 
 #[test]
 fn test_no_env() {
     // no SHELL and TERM
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.fails();
+    new_ucmd()
+        .fails();
 }
 
 #[test]
 fn test_exclusive_option() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-cp");
-    ucmd.fails();
+    new_ucmd()
+        .arg("-cp")
+        .fails();
 }
 
 fn test_helper(file_name: &str, term: &str) {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-c").env("TERM", term);
-    let out = ucmd.arg(format!("{}.txt", file_name)).run().stdout;
-    let filename = format!("{}.csh.expected", file_name);
-    assert_eq!(out, at.read(&filename));
+    new_ucmd()
+        .env("TERM", term)
+        .arg("-c")
+        .arg(format!("{}.txt", file_name))
+        .run().stdout_is_fixture(format!("{}.csh.expected", file_name));
 
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-b").env("TERM", term);
-    let out = ucmd.arg(format!("{}.txt", file_name)).run().stdout;
-    let filename = format!("{}.sh.expected", file_name);
-    assert_eq!(out, at.read(&filename));
+    new_ucmd()
+        .env("TERM", term)
+        .arg("-b")
+        .arg(format!("{}.txt", file_name))
+        .run().stdout_is_fixture(format!("{}.sh.expected", file_name));
 }

--- a/tests/test_dirname.rs
+++ b/tests/test_dirname.rs
@@ -1,48 +1,46 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "dirname";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_path_with_trailing_slashes() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let dir = "/root/alpha/beta/gamma/delta/epsilon/omega//";
-    let out = ucmd.arg(dir).run().stdout;
+    let out = new_ucmd().arg(dir).run().stdout;
 
     assert_eq!(out.trim_right(), "/root/alpha/beta/gamma/delta/epsilon");
 }
 
 #[test]
 fn test_path_without_trailing_slashes() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let dir = "/root/alpha/beta/gamma/delta/epsilon/omega";
-    let out = ucmd.arg(dir).run().stdout;
+    let out = new_ucmd().arg(dir).run().stdout;
 
     assert_eq!(out.trim_right(), "/root/alpha/beta/gamma/delta/epsilon");
 }
 
 #[test]
 fn test_root() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let dir = "/";
-    let out = ucmd.arg(dir).run().stdout;
+    let out = new_ucmd().arg(dir).run().stdout;
 
     assert_eq!(out.trim_right(), "/");
 }
 
 #[test]
 fn test_pwd() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let dir = ".";
-    let out = ucmd.arg(dir).run().stdout;
+    let out = new_ucmd().arg(dir).run().stdout;
 
     assert_eq!(out.trim_right(), ".");
 }
 
 #[test]
 fn test_empty() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let dir = "";
-    let out = ucmd.arg(dir).run().stdout;
+    let out = new_ucmd().arg(dir).run().stdout;
 
     assert_eq!(out.trim_right(), ".");
 }

--- a/tests/test_echo.rs
+++ b/tests/test_echo.rs
@@ -1,36 +1,39 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "echo";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_default() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    assert_eq!(ucmd.run().stdout, "\n");
+    assert_eq!(new_ucmd()
+        .run().stdout, "\n");
 }
 
 #[test]
 fn test_no_trailing_newline() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-n")
-        .arg("hello_world");
-
-    assert_eq!(ucmd.run().stdout, "hello_world");
+    new_ucmd()
+        .arg("-n")
+        .arg("hello_world")
+        .run()
+        .stdout_is("hello_world");
 }
 
 #[test]
 fn test_enable_escapes() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-e")
-        .arg("\\\\\\t\\r");
-
-    assert_eq!(ucmd.run().stdout, "\\\t\r\n");
+    new_ucmd()
+        .arg("-e")
+        .arg("\\\\\\t\\r")
+        .run()
+        .stdout_is("\\\t\r\n");
 }
 
 #[test]
 fn test_disable_escapes() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-E")
-        .arg("\\b\\c\\e");
-
-    assert_eq!(ucmd.run().stdout, "\\b\\c\\e\n");
+    new_ucmd()
+        .arg("-E")
+        .arg("\\b\\c\\e")
+        .run()
+        .stdout_is("\\b\\c\\e\n");
 }

--- a/tests/test_env.rs
+++ b/tests/test_env.rs
@@ -1,19 +1,22 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "env";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_single_name_value_pair() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("FOO=bar").run().stdout;
+    let out = new_ucmd()
+        .arg("FOO=bar").run().stdout;
 
     assert!(out.lines().any(|line| line == "FOO=bar"));
 }
 
 #[test]
 fn test_multiple_name_value_pairs() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("FOO=bar")
+    let out = new_ucmd()
+        .arg("FOO=bar")
                   .arg("ABC=xyz")
                   .run()
                   .stdout;
@@ -24,16 +27,16 @@ fn test_multiple_name_value_pairs() {
 
 #[test]
 fn test_ignore_environment() {
-    let ts = TestSet::new(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
 
-    let out = ts.util_cmd()
+    let out = scene.ucmd()
                 .arg("-i")
                 .run()
                 .stdout;
 
     assert_eq!(out, "");
 
-    let out = ts.util_cmd()
+    let out = scene.ucmd()
                 .arg("-")
                 .run()
                 .stdout;
@@ -43,8 +46,8 @@ fn test_ignore_environment() {
 
 #[test]
 fn test_null_delimiter() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("-i")
+    let out = new_ucmd()
+                  .arg("-i")
                   .arg("--null")
                   .arg("FOO=bar")
                   .arg("ABC=xyz")
@@ -63,8 +66,8 @@ fn test_null_delimiter() {
 fn test_unset_variable() {
     // This test depends on the HOME variable being pre-defined by the
     // default shell
-    let out = TestSet::new(UTIL_NAME)
-                  .util_cmd_keepenv()
+    let out = TestScenario::new(UTIL_NAME)
+                  .ucmd_keepenv()
                   .arg("-u")
                   .arg("HOME")
                   .run()

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -1,51 +1,54 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "expr";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_simple_arithmetic() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["1", "+", "1"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["1", "+", "1"]).run().stdout;
     assert_eq!(out, "2\n");
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["1", "-", "1"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["1", "-", "1"]).run().stdout;
     assert_eq!(out, "0\n");
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["3", "*", "2"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["3", "*", "2"]).run().stdout;
     assert_eq!(out, "6\n");
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["4", "/", "2"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["4", "/", "2"]).run().stdout;
     assert_eq!(out, "2\n");
 }
 
 #[test]
 fn test_parenthesis() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["(", "1", "+", "1", ")", "*", "2"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["(", "1", "+", "1", ")", "*", "2"]).run().stdout;
     assert_eq!(out, "4\n");
 }
 
 #[test]
 fn test_or() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["0", "|", "foo"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["0", "|", "foo"]).run().stdout;
     assert_eq!(out, "foo\n");
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["foo", "|", "bar"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["foo", "|", "bar"]).run().stdout;
     assert_eq!(out, "foo\n");
 }
 
 #[test]
 fn test_and() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["foo", "&", "1"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["foo", "&", "1"]).run().stdout;
     assert_eq!(out, "foo\n");
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["", "&", "1"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["", "&", "1"]).run().stdout;
     assert_eq!(out, "0\n");
 }

--- a/tests/test_factor.rs
+++ b/tests/test_factor.rs
@@ -18,6 +18,9 @@ const LOG_PRIMES: f64 = 14.0;   // ceil(log2(NUM_PRIMES))
 const NUM_TESTS: usize = 100;
 
 static UTIL_NAME: &'static str = "factor";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_random() {
@@ -157,9 +160,8 @@ fn test_big_primes() {
 }
 
 fn run(instring: &[u8], outstring: &[u8]) {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     // now run factor
-    let out = ucmd.run_piped_stdin(instring).stdout;
+    let out = new_ucmd().run_piped_stdin(instring).stdout;
     assert_eq!(out, String::from_utf8(outstring.to_owned()).unwrap());
 }
 

--- a/tests/test_false.rs
+++ b/tests/test_false.rs
@@ -1,10 +1,13 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "false";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_exit_code() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_status = ucmd.run().success;
+    let exit_status = new_ucmd()
+        .run().success;
     assert_eq!(exit_status, false);
 }

--- a/tests/test_fold.rs
+++ b/tests/test_fold.rs
@@ -1,38 +1,35 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "fold";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_default_80_column_wrap() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("lorem_ipsum.txt")
-                  .run()
-                  .stdout;
-
-    assert_eq!(out, at.read("lorem_ipsum_80_column.expected"));
+    new_ucmd()
+        .arg("lorem_ipsum.txt")
+        .run()
+        .stdout_is_fixture("lorem_ipsum_80_column.expected");
 }
 
 #[test]
 fn test_40_column_hard_cutoff() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("-w")
-                  .arg("40")
-                  .arg("lorem_ipsum.txt")
-                  .run()
-                  .stdout;
-
-    assert_eq!(out, at.read("lorem_ipsum_40_column_hard.expected"));
+    new_ucmd()
+        .arg("-w")
+        .arg("40")
+        .arg("lorem_ipsum.txt")
+        .run()
+        .stdout_is_fixture("lorem_ipsum_40_column_hard.expected");
 }
 
 #[test]
 fn test_40_column_word_boundary() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("-s")
-                  .arg("-w")
-                  .arg("40")
-                  .arg("lorem_ipsum.txt")
-                  .run()
-                  .stdout;
-
-    assert_eq!(out, at.read("lorem_ipsum_40_column_word.expected"));
+    new_ucmd()
+        .arg("-s")
+        .arg("-w")
+        .arg("40")
+        .arg("lorem_ipsum.txt")
+        .run()
+        .stdout_is_fixture("lorem_ipsum_40_column_word.expected");
 }

--- a/tests/test_hashsum.rs
+++ b/tests/test_hashsum.rs
@@ -8,14 +8,19 @@ macro_rules! test_digest {
     ($($t:ident)*) => ($(
 
     mod $t {
-        use common::util::*;
+        use::common::util::*;
         static UTIL_NAME: &'static str = "hashsum";
+        fn at_and_ucmd() -> (AtPath, UCommand) {
+            let ts = TestScenario::new(UTIL_NAME);
+            let ucmd = ts.ucmd();
+            (ts.fixtures, ucmd)
+        }
         static DIGEST_ARG: &'static str = concat!("--", stringify!($t));
         static EXPECTED_FILE: &'static str = concat!(stringify!($t), ".expected");
 
         #[test]
         fn test_single_file() {
-            let (at, mut ucmd) = testing(UTIL_NAME);
+            let (at, mut ucmd) = at_and_ucmd();
             let result = ucmd.arg(DIGEST_ARG).arg("input.txt").run();
 
             assert_empty_stderr!(result);
@@ -25,7 +30,7 @@ macro_rules! test_digest {
 
         #[test]
         fn test_stdin() {
-            let (at, mut ucmd) = testing(UTIL_NAME);
+            let (at, mut ucmd) = at_and_ucmd();
             let input = at.read("input.txt");
             let result = ucmd.arg(DIGEST_ARG).run_piped_stdin(input);
 

--- a/tests/test_head.rs
+++ b/tests/test_head.rs
@@ -1,71 +1,74 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "head";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 static INPUT: &'static str = "lorem_ipsum.txt";
 
 #[test]
 fn test_stdin_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("lorem_ipsum_default.expected"));
+    new_ucmd()
+        .pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("lorem_ipsum_default.expected");
 }
 
 #[test]
 fn test_stdin_1_line_obsolete() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-1"])
-                     .run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("lorem_ipsum_1_line.expected"));
+    new_ucmd()
+        .args(&["-1"])
+        .pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
 #[test]
 fn test_stdin_1_line() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-n", "1"])
-                     .run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("lorem_ipsum_1_line.expected"));
+    new_ucmd()
+        .args(&["-n", "1"])
+        .pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
 #[test]
 fn test_stdin_5_chars() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c", "5"])
-                     .run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("lorem_ipsum_5_chars.expected"));
+    new_ucmd()
+        .args(&["-c", "5"])
+        .pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("lorem_ipsum_5_chars.expected");
 }
 
 #[test]
 fn test_single_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg(INPUT).run();
-    assert_eq!(result.stdout, at.read("lorem_ipsum_default.expected"));
+    new_ucmd()
+        .arg(INPUT)
+        .run().stdout_is_fixture("lorem_ipsum_default.expected");
 }
 
 #[test]
 fn test_single_1_line_obsolete() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-1", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lorem_ipsum_1_line.expected"));
+    new_ucmd()
+        .args(&["-1", INPUT])
+        .run().stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
 #[test]
 fn test_single_1_line() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-n", "1", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lorem_ipsum_1_line.expected"));
+    new_ucmd()
+        .args(&["-n", "1", INPUT])
+        .run().stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
 #[test]
 fn test_single_5_chars() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c", "5", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lorem_ipsum_5_chars.expected"));
+    new_ucmd()
+        .args(&["-c", "5", INPUT])
+        .run().stdout_is_fixture("lorem_ipsum_5_chars.expected");
 }
 
 #[test]
 fn test_verbose() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-v", INPUT]).run();
-    assert_eq!(result.stdout, at.read("lorem_ipsum_verbose.expected"));
+    new_ucmd()
+        .args(&["-v", INPUT])
+        .run().stdout_is_fixture("lorem_ipsum_verbose.expected");
 }

--- a/tests/test_install.rs
+++ b/tests/test_install.rs
@@ -9,10 +9,15 @@ use common::util::*;
 use std::os::unix::fs::PermissionsExt;
 
 static UTIL_NAME: &'static str = "install";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 #[test]
 fn test_install_help() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
 
     let result = ucmd.arg("--help").run();
 
@@ -24,7 +29,7 @@ fn test_install_help() {
 
 #[test]
 fn test_install_basic() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_install_target_dir_dir_a";
     let file1 = "test_install_target_dir_file_a1";
     let file2 = "test_install_target_dir_file_a2";
@@ -45,7 +50,7 @@ fn test_install_basic() {
 
 #[test]
 fn test_install_unimplemented_arg() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_install_target_dir_dir_b";
     let file = "test_install_target_dir_file_b";
     let context_arg = "--context";
@@ -62,7 +67,7 @@ fn test_install_unimplemented_arg() {
 
 #[test]
 fn test_install_component_directories() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let component1 = "test_install_target_dir_component_c1";
     let component2 = "test_install_target_dir_component_c2";
     let component3 = "test_install_target_dir_component_c3";
@@ -80,7 +85,7 @@ fn test_install_component_directories() {
 
 #[test]
 fn test_install_component_directories_failing() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let component = "test_install_target_dir_component_d1";
     let directories_arg = "-d";
 
@@ -93,7 +98,7 @@ fn test_install_component_directories_failing() {
 
 #[test]
 fn test_install_mode_numeric() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_install_target_dir_dir_e";
     let file = "test_install_target_dir_file_e";
     let mode_arg = "--mode=333";
@@ -114,7 +119,7 @@ fn test_install_mode_numeric() {
 
 #[test]
 fn test_install_mode_symbolic() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_install_target_dir_dir_f";
     let file = "test_install_target_dir_file_f";
     let mode_arg = "--mode=o+wx";
@@ -135,7 +140,7 @@ fn test_install_mode_symbolic() {
 
 #[test]
 fn test_install_mode_failing() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_install_target_dir_dir_g";
     let file = "test_install_target_dir_file_g";
     let mode_arg = "--mode=999";
@@ -154,7 +159,7 @@ fn test_install_mode_failing() {
 
 #[test]
 fn test_install_mode_directories() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let component = "test_install_target_dir_component_h";
     let directories_arg = "-d";
     let mode_arg = "--mode=333";

--- a/tests/test_link.rs
+++ b/tests/test_link.rs
@@ -3,10 +3,15 @@ extern crate libc;
 use common::util::*;
 
 static UTIL_NAME: &'static str = "link";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 #[test]
 fn test_link_existing_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_link_existing_file";
     let link = "test_link_existing_file_link";
 
@@ -25,7 +30,7 @@ fn test_link_existing_file() {
 
 #[test]
 fn test_link_no_circular() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let link = "test_link_no_circular";
 
     let result = ucmd.args(&[link, link]).run();
@@ -37,7 +42,7 @@ fn test_link_no_circular() {
 
 #[test]
 fn test_link_nonexistent_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_link_nonexistent_file";
     let link = "test_link_nonexistent_file_link";
 

--- a/tests/test_ln.rs
+++ b/tests/test_ln.rs
@@ -1,10 +1,15 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "ln";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 #[test]
 fn test_symlink_existing_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_symlink_existing_file";
     let link = "test_symlink_existing_file_link";
 
@@ -20,7 +25,7 @@ fn test_symlink_existing_file() {
 
 #[test]
 fn test_symlink_dangling_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_symlink_dangling_file";
     let link = "test_symlink_dangling_file_link";
 
@@ -34,7 +39,7 @@ fn test_symlink_dangling_file() {
 
 #[test]
 fn test_symlink_existing_directory() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_symlink_existing_dir";
     let link = "test_symlink_existing_dir_link";
 
@@ -50,7 +55,7 @@ fn test_symlink_existing_directory() {
 
 #[test]
 fn test_symlink_dangling_directory() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_symlink_dangling_dir";
     let link = "test_symlink_dangling_dir_link";
 
@@ -64,7 +69,7 @@ fn test_symlink_dangling_directory() {
 
 #[test]
 fn test_symlink_circular() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let link = "test_symlink_circular";
 
     let result = ucmd.args(&["-s", link]).run();
@@ -76,7 +81,7 @@ fn test_symlink_circular() {
 
 #[test]
 fn test_symlink_dont_overwrite() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_symlink_dont_overwrite";
     let link = "test_symlink_dont_overwrite_link";
 
@@ -92,7 +97,7 @@ fn test_symlink_dont_overwrite() {
 
 #[test]
 fn test_symlink_overwrite_force() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_symlink_overwrite_force_a";
     let file_b = "test_symlink_overwrite_force_b";
     let link = "test_symlink_overwrite_force_link";
@@ -111,15 +116,15 @@ fn test_symlink_overwrite_force() {
 
 #[test]
 fn test_symlink_interactive() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
     let file = "test_symlink_interactive_file";
     let link = "test_symlink_interactive_file_link";
 
     at.touch(file);
     at.touch(link);
 
-    let result1 = ts.util_cmd()
+    let result1 = scene.ucmd()
                     .args(&["-i", "-s", file, link])
                     .run_piped_stdin("n");
 
@@ -129,7 +134,7 @@ fn test_symlink_interactive() {
     assert!(at.file_exists(file));
     assert!(!at.is_symlink(link));
 
-    let result2 = ts.util_cmd()
+    let result2 = scene.ucmd()
                     .args(&["-i", "-s", file, link])
                     .run_piped_stdin("Yesh");
 
@@ -143,7 +148,7 @@ fn test_symlink_interactive() {
 
 #[test]
 fn test_symlink_simple_backup() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_symlink_simple_backup";
     let link = "test_symlink_simple_backup_link";
 
@@ -169,7 +174,7 @@ fn test_symlink_simple_backup() {
 
 #[test]
 fn test_symlink_custom_backup_suffix() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_symlink_custom_backup_suffix";
     let link = "test_symlink_custom_backup_suffix_link";
     let suffix = "super-suffix-of-the-century";
@@ -197,7 +202,7 @@ fn test_symlink_custom_backup_suffix() {
 
 #[test]
 fn test_symlink_backup_numbering() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_symlink_backup_numbering";
     let link = "test_symlink_backup_numbering_link";
 
@@ -223,7 +228,7 @@ fn test_symlink_backup_numbering() {
 
 #[test]
 fn test_symlink_existing_backup() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_symlink_existing_backup";
     let link = "test_symlink_existing_backup_link";
     let link_backup = "test_symlink_existing_backup_link.~1~";
@@ -257,7 +262,7 @@ fn test_symlink_existing_backup() {
 
 #[test]
 fn test_symlink_target_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_ln_target_dir_dir";
     let file_a = "test_ln_target_dir_file_a";
     let file_b = "test_ln_target_dir_file_b";
@@ -282,7 +287,7 @@ fn test_symlink_target_dir() {
 
 #[test]
 fn test_symlink_overwrite_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let path_a = "test_symlink_overwrite_dir_a";
     let path_b = "test_symlink_overwrite_dir_b";
 
@@ -301,7 +306,7 @@ fn test_symlink_overwrite_dir() {
 
 #[test]
 fn test_symlink_overwrite_nonempty_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let path_a = "test_symlink_overwrite_nonempty_dir_a";
     let path_b = "test_symlink_overwrite_nonempty_dir_b";
     let dummy = "test_symlink_overwrite_nonempty_dir_b/file";
@@ -328,7 +333,7 @@ fn test_symlink_overwrite_nonempty_dir() {
 
 #[test]
 fn test_symlink_errors() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_symlink_errors_dir";
     let file_a = "test_symlink_errors_file_a";
     let file_b = "test_symlink_errors_file_b";
@@ -348,21 +353,21 @@ fn test_symlink_errors() {
 
 #[test]
 fn test_symlink_verbose() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
     let file_a = "test_symlink_verbose_file_a";
     let file_b = "test_symlink_verbose_file_b";
 
     at.touch(file_a);
 
-    let result = ts.util_cmd().args(&["-v", file_a, file_b]).run();
+    let result = scene.ucmd().args(&["-v", file_a, file_b]).run();
     assert_empty_stderr!(result);
     assert_eq!(result.stdout, format!("'{}' -> '{}'\n", file_b, file_a));
     assert!(result.success);
 
     at.touch(file_b);
 
-    let result = ts.util_cmd().args(&["-v", "-b", file_a, file_b]).run();
+    let result = scene.ucmd().args(&["-v", "-b", file_a, file_b]).run();
     assert_empty_stderr!(result);
     assert_eq!(result.stdout,
                format!("'{}' -> '{}' (backup: '{}~')\n", file_b, file_a, file_b));

--- a/tests/test_ls.rs
+++ b/tests/test_ls.rs
@@ -1,12 +1,14 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "ls";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_ls_ls() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     
-    let result = ucmd.run();
+    let result = new_ucmd().run();
     
     let exit_success = result.success;
     assert_eq!(exit_success, true);

--- a/tests/test_mkdir.rs
+++ b/tests/test_mkdir.rs
@@ -1,6 +1,9 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "mkdir";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 static TEST_DIR1: &'static str = "mkdir_test1";
 static TEST_DIR2: &'static str = "mkdir_test2";
@@ -10,24 +13,24 @@ static TEST_DIR5: &'static str = "mkdir_test5/mkdir_test5_1";
 
 #[test]
 fn test_mkdir_mkdir() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_success = ucmd.arg(TEST_DIR1).run().success;
+    let exit_success = new_ucmd()
+        .arg(TEST_DIR1).run().success;
     assert_eq!(exit_success, true);
 }
 
 #[test]
 fn test_mkdir_dup_dir() {
-    let ts = TestSet::new(UTIL_NAME);
-    let exit_success = ts.util_cmd().arg(TEST_DIR2).run().success;
-    let exit_success2 = ts.util_cmd().arg(TEST_DIR2).run().success;
+    let scene = TestScenario::new(UTIL_NAME);
+    let exit_success = scene.ucmd().arg(TEST_DIR2).run().success;
+    let exit_success2 = scene.ucmd().arg(TEST_DIR2).run().success;
     assert!(exit_success);
     assert!(!exit_success2);
 }
 
 #[test]
 fn test_mkdir_mode() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_success = ucmd.arg("-m")
+    let exit_success = new_ucmd()
+                           .arg("-m")
                            .arg("755")
                            .arg(TEST_DIR3)
                            .run()
@@ -37,14 +40,14 @@ fn test_mkdir_mode() {
 
 #[test]
 fn test_mkdir_parent() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_success = ucmd.arg("-p").arg(TEST_DIR4).run().success;
+    let exit_success = new_ucmd()
+        .arg("-p").arg(TEST_DIR4).run().success;
     assert!(exit_success);
 }
 
 #[test]
 fn test_mkdir_no_parent() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_success = ucmd.arg(TEST_DIR5).run().success;
+    let exit_success = new_ucmd()
+        .arg(TEST_DIR5).run().success;
     assert!(!exit_success);
 }

--- a/tests/test_mktemp.rs
+++ b/tests/test_mktemp.rs
@@ -19,18 +19,18 @@ const TMPDIR: &'static str = "TMPDIR";
 
 #[test]
 fn test_mktemp_mktemp() {
-    let ts = TestSet::new(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
 
-    let pathname = ts.fixtures.as_string();
+    let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = ts.util_cmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE8).run().success;
+    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE1).run().success;
+    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE2).run().success;
+    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE3).run().success;
+    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE4).run().success;
+    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE5).run().success;
+    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE6).run().success;
+    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE7).run().success;
+    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE8).run().success;
 
 
     assert!(exit_success1);
@@ -45,18 +45,18 @@ fn test_mktemp_mktemp() {
 
 #[test]
 fn test_mktemp_make_temp_dir() {
-    let ts = TestSet::new(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
 
-    let pathname = ts.fixtures.as_string();
+    let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = ts.util_cmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE8).run().success;
+    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE1).run().success;
+    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE2).run().success;
+    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE3).run().success;
+    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE4).run().success;
+    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE5).run().success;
+    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE6).run().success;
+    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE7).run().success;
+    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE8).run().success;
 
     assert!(exit_success1);
     assert!(!exit_success2);
@@ -70,18 +70,18 @@ fn test_mktemp_make_temp_dir() {
 
 #[test]
 fn test_mktemp_dry_run() {
-    let ts = TestSet::new(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
 
-    let pathname = ts.fixtures.as_string();
+    let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = ts.util_cmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE8).run().success;
+    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE1).run().success;
+    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE2).run().success;
+    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE3).run().success;
+    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE4).run().success;
+    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE5).run().success;
+    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE6).run().success;
+    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE7).run().success;
+    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE8).run().success;
 
 
     assert!(exit_success1);
@@ -96,10 +96,10 @@ fn test_mktemp_dry_run() {
 
 #[test]
 fn test_mktemp_quiet() {
-    let ts = TestSet::new(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
 
-    let result1 = ts.util_cmd().arg("-p").arg("/definitely/not/exist/I/promise").arg("-q").run();
-    let result2 = ts.util_cmd().arg("-d").arg("-p").arg("/definitely/not/exist/I/promise").arg("-q").run();
+    let result1 = scene.ucmd().arg("-p").arg("/definitely/not/exist/I/promise").arg("-q").run();
+    let result2 = scene.ucmd().arg("-d").arg("-p").arg("/definitely/not/exist/I/promise").arg("-q").run();
 
     assert!(result1.stderr.is_empty() && result1.stdout.is_empty() && !result1.success);
     assert!(result2.stderr.is_empty() && result2.stdout.is_empty() && !result2.success);
@@ -107,18 +107,18 @@ fn test_mktemp_quiet() {
 
 #[test]
 fn test_mktemp_suffix() {
-    let ts = TestSet::new(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
 
-    let pathname = ts.fixtures.as_string();
+    let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = ts.util_cmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE8).run().success;
+    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE1).run().success;
+    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE2).run().success;
+    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE3).run().success;
+    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE4).run().success;
+    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE5).run().success;
+    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE6).run().success;
+    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE7).run().success;
+    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE8).run().success;
 
 
     assert!(exit_success1);
@@ -133,19 +133,19 @@ fn test_mktemp_suffix() {
 
 #[test]
 fn test_mktemp_tmpdir() {
-    let ts = TestSet::new(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
 
-   let path = TempDir::new_in(ts.fixtures.as_string(), UTIL_NAME).unwrap();
+   let path = TempDir::new_in(scene.fixtures.as_string(), UTIL_NAME).unwrap();
    let pathname = path.path().as_os_str();
 
-    let exit_success1 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = ts.util_cmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE8).run().success;
+    let exit_success1 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE1).run().success;
+    let exit_success2 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE2).run().success;
+    let exit_success3 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE3).run().success;
+    let exit_success4 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE4).run().success;
+    let exit_success5 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE5).run().success;
+    let exit_success6 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE6).run().success;
+    let exit_success7 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE7).run().success;
+    let exit_success8 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE8).run().success;
 
 
     assert!(exit_success1);

--- a/tests/test_mv.rs
+++ b/tests/test_mv.rs
@@ -8,10 +8,15 @@ use self::filetime::*;
 use common::util::*;
 
 static UTIL_NAME: &'static str = "mv";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 #[test]
 fn test_mv_rename_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir1 = "test_mv_rename_dir";
     let dir2 = "test_mv_rename_dir2";
 
@@ -26,7 +31,7 @@ fn test_mv_rename_dir() {
 
 #[test]
 fn test_mv_rename_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file1 = "test_mv_rename_file";
     let file2 = "test_mv_rename_file2";
 
@@ -41,7 +46,7 @@ fn test_mv_rename_file() {
 
 #[test]
 fn test_mv_move_file_into_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_mv_move_file_into_dir_dir";
     let file = "test_mv_move_file_into_dir_file";
 
@@ -57,8 +62,8 @@ fn test_mv_move_file_into_dir() {
 
 #[test]
 fn test_mv_strip_slashes() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
     let dir = "test_mv_strip_slashes_dir";
     let file = "test_mv_strip_slashes_file";
     let mut source = file.to_owned();
@@ -67,12 +72,12 @@ fn test_mv_strip_slashes() {
     at.mkdir(dir);
     at.touch(file);
 
-    let result = ts.util_cmd().arg(&source).arg(dir).run();
+    let result = scene.ucmd().arg(&source).arg(dir).run();
     assert!(!result.success);
 
     assert!(!at.file_exists(&format!("{}/{}", dir, file)));
 
-    let result = ts.util_cmd().arg("--strip-trailing-slashes").arg(source).arg(dir).run();
+    let result = scene.ucmd().arg("--strip-trailing-slashes").arg(source).arg(dir).run();
     assert_empty_stderr!(result);
     assert!(result.success);
 
@@ -81,7 +86,7 @@ fn test_mv_strip_slashes() {
 
 #[test]
 fn test_mv_multiple_files() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let target_dir = "test_mv_multiple_files_dir";
     let file_a = "test_mv_multiple_file_a";
     let file_b = "test_mv_multiple_file_b";
@@ -100,7 +105,7 @@ fn test_mv_multiple_files() {
 
 #[test]
 fn test_mv_multiple_folders() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let target_dir = "test_mv_multiple_dirs_dir";
     let dir_a = "test_mv_multiple_dir_a";
     let dir_b = "test_mv_multiple_dir_b";
@@ -119,8 +124,8 @@ fn test_mv_multiple_folders() {
 
 #[test]
 fn test_mv_interactive() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
     let file_a = "test_mv_interactive_file_a";
     let file_b = "test_mv_interactive_file_b";
 
@@ -128,7 +133,7 @@ fn test_mv_interactive() {
     at.touch(file_b);
 
 
-    let result1 = ts.util_cmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("n");
+    let result1 = scene.ucmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("n");
 
     assert_empty_stderr!(result1);
     assert!(result1.success);
@@ -137,7 +142,7 @@ fn test_mv_interactive() {
     assert!(at.file_exists(file_b));
 
 
-    let result2 = ts.util_cmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("Yesh");
+    let result2 = scene.ucmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("Yesh");
 
     assert_empty_stderr!(result2);
     assert!(result2.success);
@@ -148,7 +153,7 @@ fn test_mv_interactive() {
 
 #[test]
 fn test_mv_no_clobber() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_no_clobber_file_a";
     let file_b = "test_mv_no_clobber_file_b";
 
@@ -165,7 +170,7 @@ fn test_mv_no_clobber() {
 
 #[test]
 fn test_mv_replace_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_replace_file_a";
     let file_b = "test_mv_replace_file_b";
 
@@ -182,7 +187,7 @@ fn test_mv_replace_file() {
 
 #[test]
 fn test_mv_force_replace_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_force_replace_file_a";
     let file_b = "test_mv_force_replace_file_b";
 
@@ -199,7 +204,7 @@ fn test_mv_force_replace_file() {
 
 #[test]
 fn test_mv_simple_backup() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_simple_backup_file_a";
     let file_b = "test_mv_simple_backup_file_b";
 
@@ -217,7 +222,7 @@ fn test_mv_simple_backup() {
 
 #[test]
 fn test_mv_custom_backup_suffix() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_custom_backup_suffix_file_a";
     let file_b = "test_mv_custom_backup_suffix_file_b";
     let suffix = "super-suffix-of-the-century";
@@ -240,7 +245,7 @@ fn test_mv_custom_backup_suffix() {
 
 #[test]
 fn test_mv_backup_numbering() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_backup_numbering_file_a";
     let file_b = "test_mv_backup_numbering_file_b";
 
@@ -258,7 +263,7 @@ fn test_mv_backup_numbering() {
 
 #[test]
 fn test_mv_existing_backup() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_existing_backup_file_a";
     let file_b = "test_mv_existing_backup_file_b";
     let file_b_backup = "test_mv_existing_backup_file_b.~1~";
@@ -280,8 +285,8 @@ fn test_mv_existing_backup() {
 
 #[test]
 fn test_mv_update_option() {
-    let test_set = TestSet::new(UTIL_NAME);
-    let at = &test_set.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
     let file_a = "test_mv_update_option_file_a";
     let file_b = "test_mv_update_option_file_b";
 
@@ -293,7 +298,7 @@ fn test_mv_update_option() {
     filetime::set_file_times(at.plus_as_string(file_a), now, now).unwrap();
     filetime::set_file_times(at.plus_as_string(file_b), now, later).unwrap();
 
-    let result1 = test_set.util_cmd().arg("--update").arg(file_a).arg(file_b).run();
+    let result1 = scene.ucmd().arg("--update").arg(file_a).arg(file_b).run();
 
     assert_empty_stderr!(result1);
     assert!(result1.success);
@@ -301,7 +306,7 @@ fn test_mv_update_option() {
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
 
-    let result2 = test_set.util_cmd().arg("--update").arg(file_b).arg(file_a).run();
+    let result2 = scene.ucmd().arg("--update").arg(file_b).arg(file_a).run();
 
     assert_empty_stderr!(result2);
     assert!(result2.success);
@@ -312,7 +317,7 @@ fn test_mv_update_option() {
 
 #[test]
 fn test_mv_target_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_mv_target_dir_dir";
     let file_a = "test_mv_target_dir_file_a";
     let file_b = "test_mv_target_dir_file_b";
@@ -333,7 +338,7 @@ fn test_mv_target_dir() {
 
 #[test]
 fn test_mv_overwrite_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir_a = "test_mv_overwrite_dir_a";
     let dir_b = "test_mv_overwrite_dir_b";
 
@@ -350,7 +355,7 @@ fn test_mv_overwrite_dir() {
 
 #[test]
 fn test_mv_overwrite_nonempty_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir_a = "test_mv_overwrite_nonempty_dir_a";
     let dir_b = "test_mv_overwrite_nonempty_dir_b";
     let dummy = "test_mv_overwrite_nonempty_dir_b/file";
@@ -376,7 +381,7 @@ fn test_mv_overwrite_nonempty_dir() {
 
 #[test]
 fn test_mv_backup_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir_a = "test_mv_backup_dir_dir_a";
     let dir_b = "test_mv_backup_dir_dir_b";
 
@@ -399,8 +404,8 @@ fn test_mv_backup_dir() {
 
 #[test]
 fn test_mv_errors() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
     let dir = "test_mv_errors_dir";
     let file_a = "test_mv_errors_file_a";
     let file_b = "test_mv_errors_file_b";
@@ -410,7 +415,7 @@ fn test_mv_errors() {
 
     // $ mv -T -t a b
     // mv: cannot combine --target-directory (-t) and --no-target-directory (-T)
-    let result = ts.util_cmd().arg("-T").arg("-t").arg(dir).arg(file_a).arg(file_b).run();
+    let result = scene.ucmd().arg("-T").arg("-t").arg(dir).arg(file_a).arg(file_b).run();
     assert_eq!(result.stderr,
                "mv: error: cannot combine --target-directory (-t) and --no-target-directory \
                 (-T)\n");
@@ -420,7 +425,7 @@ fn test_mv_errors() {
     // $ at.touch file && at.mkdir dir
     // $ mv -T file dir
     // err == mv: cannot overwrite directory ‘dir’ with non-directory
-    let result = ts.util_cmd().arg("-T").arg(file_a).arg(dir).run();
+    let result = scene.ucmd().arg("-T").arg(file_a).arg(dir).run();
     assert_eq!(result.stderr,
                format!("mv: error: cannot overwrite directory ‘{}’ with non-directory\n",
                        dir));
@@ -429,15 +434,15 @@ fn test_mv_errors() {
     // $ at.mkdir dir && at.touch file
     // $ mv dir file
     // err == mv: cannot overwrite non-directory ‘file’ with directory ‘dir’
-    let result = ts.util_cmd().arg(dir).arg(file_a).run();
+    let result = scene.ucmd().arg(dir).arg(file_a).run();
     assert!(result.stderr.len() > 0);
     assert!(!result.success);
 }
 
 #[test]
 fn test_mv_verbose() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
     let dir = "test_mv_verbose_dir";
     let file_a = "test_mv_verbose_file_a";
     let file_b = "test_mv_verbose_file_b";
@@ -445,7 +450,7 @@ fn test_mv_verbose() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ts.util_cmd().arg("-v").arg(file_a).arg(file_b).run();
+    let result = scene.ucmd().arg("-v").arg(file_a).arg(file_b).run();
     assert_empty_stderr!(result);
     assert_eq!(result.stdout,
                format!("‘{}’ -> ‘{}’\n", file_a, file_b));
@@ -453,7 +458,7 @@ fn test_mv_verbose() {
 
 
     at.touch(file_a);
-    let result = ts.util_cmd().arg("-vb").arg(file_a).arg(file_b).run();
+    let result = scene.ucmd().arg("-vb").arg(file_a).arg(file_b).run();
     assert_empty_stderr!(result);
     assert_eq!(result.stdout,
                format!("‘{}’ -> ‘{}’ (backup: ‘{}~’)\n",

--- a/tests/test_nl.rs
+++ b/tests/test_nl.rs
@@ -1,25 +1,28 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "nl";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_stdin_nonewline() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin("No Newline".as_bytes());
+    let result = new_ucmd()
+        .run_piped_stdin("No Newline".as_bytes());
     assert_eq!(result.stdout, "     1\tNo Newline\n");
 }
 #[test]
 fn test_stdin_newline() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-s", "-", "-w", "1"])
+    let result = new_ucmd()
+        .args(&["-s", "-", "-w", "1"])
                      .run_piped_stdin("Line One\nLine Two\n".as_bytes());
     assert_eq!(result.stdout, "1-Line One\n2-Line Two\n");
 }
 
 #[test]
 fn test_padding_without_overflow() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-i", "1000", "-s", "x", "-n", "rz", "simple.txt"]).run();
+    let result = new_ucmd()
+        .args(&["-i", "1000", "-s", "x", "-n", "rz", "simple.txt"]).run();
     assert_eq!(result.stdout,
                "000001xL1\n001001xL2\n002001xL3\n003001xL4\n004001xL5\n005001xL6\n006001xL7\n0070\
                 01xL8\n008001xL9\n009001xL10\n010001xL11\n011001xL12\n012001xL13\n013001xL14\n014\
@@ -28,8 +31,8 @@ fn test_padding_without_overflow() {
 
 #[test]
 fn test_padding_with_overflow() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-i", "1000", "-s", "x", "-n", "rz", "-w", "4", "simple.txt"]).run();
+    let result = new_ucmd()
+        .args(&["-i", "1000", "-s", "x", "-n", "rz", "-w", "4", "simple.txt"]).run();
     assert_eq!(result.stdout,
                "0001xL1\n1001xL2\n2001xL3\n3001xL4\n4001xL5\n5001xL6\n6001xL7\n7001xL8\n8001xL9\n\
                 9001xL10\n10001xL11\n11001xL12\n12001xL13\n13001xL14\n14001xL15\n");
@@ -47,8 +50,8 @@ fn test_sections_and_styles() {
                                  |Followed by 4x empty\n\n\n\n\n9  |Nonempty\n10 |Nonempty\n11 \
                                  |Nonempty.\n")]
                                   .iter() {
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        let result = ucmd.args(&["-s", "|", "-n", "ln", "-w", "3", "-b", "a", "-l", "5", fixture])
+        let result = new_ucmd()
+            .args(&["-s", "|", "-n", "ln", "-w", "3", "-b", "a", "-l", "5", fixture])
                          .run();
         assert_eq!(result.stdout, output);
     }

--- a/tests/test_od.rs
+++ b/tests/test_od.rs
@@ -6,6 +6,9 @@ use std::fs::File;
 use std::fs::remove_file;
 
 static UTIL_NAME: &'static str = "od";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 // octal dump of 'abcdefghijklmnopqrstuvwxyz\n'
 static ALPHA_OUT: &'static str = "0000000    061141  062143  063145  064147  065151  066153  067155  070157\n0000020    071161  072163  073165  074167  075171  000012                \n0000033\n";
@@ -16,7 +19,6 @@ static ALPHA_OUT: &'static str = "0000000    061141  062143  063145  064147  065
 // Test that od can read one file and dump with default format
 #[test]
 fn test_file() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     use std::env;
     let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
@@ -30,7 +32,7 @@ fn test_file() {
         }
     }
 
-    let result = ucmd.arg(file.as_os_str()).run();
+    let result = new_ucmd().arg(file.as_os_str()).run();
 
     assert_empty_stderr!(result);
     assert!(result.success);
@@ -42,7 +44,6 @@ fn test_file() {
 // Test that od can read 2 files and concatenate the contents
 #[test]
 fn test_2files() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
     let file1 = tmpdir.join("test1");
@@ -60,7 +61,7 @@ fn test_2files() {
         }
     }
 
-    let result = ucmd.arg(file1.as_os_str()).arg(file2.as_os_str()).run();
+    let result = new_ucmd().arg(file1.as_os_str()).arg(file2.as_os_str()).run();
 
     assert_empty_stderr!(result);
     assert!(result.success);
@@ -73,12 +74,11 @@ fn test_2files() {
 // Test that od gives non-0 exit val for filename that dosen't exist.
 #[test]
 fn test_no_file() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
     let file = tmpdir.join("}surely'none'would'thus'a'file'name");
 
-    let result = ucmd.arg(file.as_os_str()).run();
+    let result = new_ucmd().arg(file.as_os_str()).run();
 
     assert!(!result.success);
 }
@@ -86,10 +86,9 @@ fn test_no_file() {
 // Test that od reads from stdin instead of a file
 #[test]
 fn test_from_stdin() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
 
     let input = "abcdefghijklmnopqrstuvwxyz\n";
-    let result = ucmd.run_piped_stdin(input.as_bytes());
+    let result = new_ucmd().run_piped_stdin(input.as_bytes());
 
     assert_empty_stderr!(result);
     assert!(result.success);
@@ -100,7 +99,6 @@ fn test_from_stdin() {
 // Test that od reads from stdin and also from files
 #[test]
 fn test_from_mixed() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
 
     let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
@@ -116,7 +114,7 @@ fn test_from_mixed() {
         }
     }
 
-    let result = ucmd.arg(file1.as_os_str()).arg("--").arg(file3.as_os_str()).run_piped_stdin(data2.as_bytes());
+    let result = new_ucmd().arg(file1.as_os_str()).arg("--").arg(file3.as_os_str()).run_piped_stdin(data2.as_bytes());
 
     assert_empty_stderr!(result);
     assert!(result.success);
@@ -126,10 +124,9 @@ fn test_from_mixed() {
 
 #[test]
 fn test_multiple_formats() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
 
     let input = "abcdefghijklmnopqrstuvwxyz\n";
-    let result = ucmd.arg("-c").arg("-b").run_piped_stdin(input.as_bytes());
+    let result = new_ucmd().arg("-c").arg("-b").run_piped_stdin(input.as_bytes());
 
     assert_empty_stderr!(result);
     assert!(result.success);
@@ -139,7 +136,6 @@ fn test_multiple_formats() {
 
 #[test]
 fn test_dec() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
 
 
     let input = [
@@ -151,7 +147,7 @@ fn test_dec() {
     	0x00u8,0x80u8,
     	0x01u8,0x80u8,];
     let expected_output = "0000000         0       1       2       3   32767  -32768  -32767        \n0000016\n";
-    let result = ucmd.arg("-i").run_piped_stdin(&input[..]);
+    let result = new_ucmd().arg("-i").run_piped_stdin(&input[..]);
 
     assert_empty_stderr!(result);
     assert!(result.success);
@@ -164,8 +160,8 @@ fn test_dec() {
 /*
 #[test]
 fn mit_die_umlauten_getesten() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin("Universität Tübingen".as_bytes());
+    let result = new_ucmd()
+        .run_piped_stdin("Universität Tübingen".as_bytes());
     assert_empty_stderr!(result);
     assert!(result.success);
     assert_eq!(result.stdout,

--- a/tests/test_paste.rs
+++ b/tests/test_paste.rs
@@ -1,16 +1,17 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "paste";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_combine_pairs_of_lines() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.arg("-s")
-                  .arg("-d")
-                  .arg("\t\n")
-                  .arg("html_colors.txt")
-                  .run()
-                  .stdout;
-
-    assert_eq!(out, at.read("html_colors.expected"));
+    new_ucmd()
+        .arg("-s")
+        .arg("-d")
+        .arg("\t\n")
+        .arg("html_colors.txt")
+        .run()
+        .stdout_is_fixture("html_colors.expected");
 }

--- a/tests/test_pathchk.rs
+++ b/tests/test_pathchk.rs
@@ -1,21 +1,24 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "pathchk";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_default_mode() {
     // test the default mode
     {
         // accept some reasonable default
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        let result = ucmd.args(&["abc/def"]).run();
+        let result = new_ucmd()
+            .args(&["abc/def"]).run();
         assert_eq!(result.stdout, "");
         assert!(result.success);
     }
     {
         // fail on long inputs
-        let (_, mut ucmd) = testing(UTIL_NAME);
-        let result = ucmd.args(&[repeat_str("test", 20000)]).run();
+        let result = new_ucmd()
+            .args(&[repeat_str("test", 20000)]).run();
         assert_eq!(result.stdout, "");
         assert!(!result.success);
     }

--- a/tests/test_pinky.rs
+++ b/tests/test_pinky.rs
@@ -1,6 +1,9 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "pinky";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 extern crate uu_pinky;
 pub use self::uu_pinky::*;
@@ -16,65 +19,54 @@ fn test_capitalize() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_long_format() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-l").arg("root");
-    let expected = "Login name: root                        In real life:  root\nDirectory: /root                        Shell:  /bin/bash\n\n";
-    assert_eq!(expected, ucmd.run().stdout);
+    new_ucmd()
+        .arg("-l").arg("root")
+        .run()
+        .stdout_is("Login name: root                        In real life:  root\nDirectory: /root                        Shell:  /bin/bash\n\n");
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-lb").arg("root");
-    let expected = "Login name: root                        In real life:  root\n\n";
-    assert_eq!(expected, ucmd.run().stdout);
+    new_ucmd()
+        .arg("-lb").arg("root")
+        .run()
+        .stdout_is("Login name: root                        In real life:  root\n\n");
 }
 
 #[test]
 #[cfg(target_os = "macos")]
 fn test_long_format() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-l").arg("root");
-    let expected = "Login name: root                        In real life:  System Administrator\nDirectory: /var/root                    Shell:  /bin/sh\n\n";
-    assert_eq!(expected, ucmd.run().stdout);
+    new_ucmd()
+        .arg("-l").arg("root")
+        .run()
+        .stdout_is("Login name: root                        In real life:  System Administrator\nDirectory: /var/root                    Shell:  /bin/sh\n\n");
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-lb").arg("root");
-    let expected = "Login name: root                        In real life:  System Administrator\n\n";
-    assert_eq!(expected, ucmd.run().stdout);
+    new_ucmd()
+        .arg("-lb").arg("root")
+        .run()
+        .stdout_is("Login name: root                        In real life:  System Administrator\n\n");
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 #[ignore]
 fn test_short_format() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
+    let scene = TestScenario::new(UTIL_NAME);
+    
     let args = ["-s"];
-    ucmd.args(&args);
-    assert_eq!(expected_result(&args), ucmd.run().stdout);
+    scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-f"];
-    ucmd.args(&args);
-    assert_eq!(expected_result(&args), ucmd.run().stdout);
+    scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-w"];
-    ucmd.args(&args);
-    assert_eq!(expected_result(&args), ucmd.run().stdout);
+    scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-i"];
-    ucmd.args(&args);
-    assert_eq!(expected_result(&args), ucmd.run().stdout);
+    scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
 
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-q"];
-    ucmd.args(&args);
-    assert_eq!(expected_result(&args), ucmd.run().stdout);
+    scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
 }
 
 #[cfg(target_os = "linux")]
 fn expected_result(args: &[&str]) -> String {
-    use std::process::Command;
-
-    let output = Command::new(UTIL_NAME).args(args).output().unwrap();
-    String::from_utf8_lossy(&output.stdout).into_owned()
+    TestScenario::new(UTIL_NAME).cmd(UTIL_NAME).args(args).run().stdout
 }

--- a/tests/test_printf.rs
+++ b/tests/test_printf.rs
@@ -1,10 +1,13 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "printf";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 fn expect_stdout(input: Vec<&str>, expected: &str) {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let results = ucmd.args(&input).run();
+    let results = new_ucmd()
+        .args(&input).run();
     // assert_empty_stderr!(result);
     // assert!(result.success);
     assert_eq!(expected, results.stdout);

--- a/tests/test_ptx.rs
+++ b/tests/test_ptx.rs
@@ -1,6 +1,9 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "ptx";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn gnu_ext_disabled_roff_no_ref() {
@@ -45,9 +48,5 @@ fn gnu_ext_disabled_ignore_and_only_file() {
 }
 
 fn test_ptx(opts: &Vec<&str>, expected: &str) {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(opts).arg("input").run();
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read(expected));
-    assert_empty_stderr!(&result);
+    new_ucmd().args(opts).arg("input").succeeds().stdout_only_fixture(expected);
 }

--- a/tests/test_pwd.rs
+++ b/tests/test_pwd.rs
@@ -1,10 +1,15 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "pwd";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 #[test]
 fn test_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let out = ucmd.run().stdout;
 
     let expected = at.root_dir_resolved();

--- a/tests/test_readlink.rs
+++ b/tests/test_readlink.rs
@@ -1,12 +1,20 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "readlink";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 static GIBBERISH: &'static str = "supercalifragilisticexpialidocious";
 
 #[test]
 fn test_canonicalize() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let out = ucmd.arg("-f")
                   .arg(".")
                   .run()
@@ -17,7 +25,7 @@ fn test_canonicalize() {
 
 #[test]
 fn test_canonicalize_existing() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let out = ucmd.arg("-e")
                   .arg(".")
                   .run()
@@ -28,7 +36,7 @@ fn test_canonicalize_existing() {
 
 #[test]
 fn test_canonicalize_missing() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let expected = path_concat!(at.root_dir_resolved(), GIBBERISH);
 
     let out = ucmd.arg("-m")
@@ -41,7 +49,7 @@ fn test_canonicalize_missing() {
 
 #[test]
 fn test_long_redirection_to_current_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     // Create a 256-character path to current directory
     let dir = path_concat!(".", ..128);
     let out = ucmd.arg("-n")
@@ -55,10 +63,10 @@ fn test_long_redirection_to_current_dir() {
 
 #[test]
 fn test_long_redirection_to_root() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     // Create a 255-character path to root
     let dir = path_concat!("..", ..85);
-    let out = ucmd.arg("-n")
+    let out = new_ucmd()
+                  .arg("-n")
                   .arg("-m")
                   .arg(dir)
                   .run()

--- a/tests/test_realpath.rs
+++ b/tests/test_realpath.rs
@@ -1,10 +1,18 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "realpath";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_current_directory() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let out = ucmd.arg(".").run().stdout;
 
     assert_eq!(out.trim_right(), at.root_dir_resolved());
@@ -12,7 +20,7 @@ fn test_current_directory() {
 
 #[test]
 fn test_long_redirection_to_current_dir() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     // Create a 256-character path to current directory
     let dir = path_concat!(".", ..128);
     let out = ucmd.arg(dir).run().stdout;
@@ -22,10 +30,9 @@ fn test_long_redirection_to_current_dir() {
 
 #[test]
 fn test_long_redirection_to_root() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     // Create a 255-character path to root
     let dir = path_concat!("..", ..85);
-    let out = ucmd.arg(dir).run().stdout;
+    let out = new_ucmd().arg(dir).run().stdout;
 
     assert_eq!(out.trim_right(), get_root_path());
 }

--- a/tests/test_rm.rs
+++ b/tests/test_rm.rs
@@ -1,10 +1,15 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "rm";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 #[test]
 fn test_rm_one_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_rm_one_file";
 
     at.touch(file);
@@ -18,7 +23,7 @@ fn test_rm_one_file() {
 
 #[test]
 fn test_rm_multiple_files() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_rm_multiple_file_a";
     let file_b = "test_rm_multiple_file_b";
 
@@ -35,8 +40,8 @@ fn test_rm_multiple_files() {
 
 #[test]
 fn test_rm_interactive() {
-    let ts = TestSet::new(UTIL_NAME);
-    let at = &ts.fixtures;
+    let scene = TestScenario::new(UTIL_NAME);
+    let at = &scene.fixtures;
 
     let file_a = "test_rm_interactive_file_a";
     let file_b = "test_rm_interactive_file_b";
@@ -44,7 +49,7 @@ fn test_rm_interactive() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result1 = ts.util_cmd()
+    let result1 = scene.ucmd()
                     .arg("-i")
                     .arg(file_a)
                     .arg(file_b)
@@ -55,7 +60,7 @@ fn test_rm_interactive() {
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
 
-    let result2 = ts.util_cmd()
+    let result2 = scene.ucmd()
                     .arg("-i")
                     .arg(file_a)
                     .arg(file_b)
@@ -69,7 +74,7 @@ fn test_rm_interactive() {
 
 #[test]
 fn test_rm_force() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_rm_force_a";
     let file_b = "test_rm_force_b";
 
@@ -86,7 +91,7 @@ fn test_rm_force() {
 
 #[test]
 fn test_rm_empty_directory() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rm_empty_directory";
 
     at.mkdir(dir);
@@ -100,7 +105,7 @@ fn test_rm_empty_directory() {
 
 #[test]
 fn test_rm_recursive() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rm_recursive_directory";
     let file_a = "test_rm_recursive_directory/test_rm_recursive_file_a";
     let file_b = "test_rm_recursive_directory/test_rm_recursive_file_b";
@@ -120,7 +125,7 @@ fn test_rm_recursive() {
 
 #[test]
 fn test_rm_errors() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rm_errors_directory";
     let file_a = "test_rm_errors_directory/test_rm_errors_file_a";
     let file_b = "test_rm_errors_directory/test_rm_errors_file_b";
@@ -140,7 +145,7 @@ fn test_rm_errors() {
 
 #[test]
 fn test_rm_verbose() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_rm_verbose_file_a";
     let file_b = "test_rm_verbose_file_b";
 

--- a/tests/test_rmdir.rs
+++ b/tests/test_rmdir.rs
@@ -3,10 +3,15 @@ extern crate libc;
 use common::util::*;
 
 static UTIL_NAME: &'static str = "rmdir";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 #[test]
 fn test_rmdir_empty_directory_no_parents() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rmdir_empty_no_parents";
 
     at.mkdir(dir);
@@ -21,7 +26,7 @@ fn test_rmdir_empty_directory_no_parents() {
 
 #[test]
 fn test_rmdir_empty_directory_with_parents() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rmdir_empty/with/parents";
 
     at.mkdir_all(dir);
@@ -36,7 +41,7 @@ fn test_rmdir_empty_directory_with_parents() {
 
 #[test]
 fn test_rmdir_nonempty_directory_no_parents() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rmdir_nonempty_no_parents";
     let file = "test_rmdir_nonempty_no_parents/foo";
 
@@ -57,7 +62,7 @@ fn test_rmdir_nonempty_directory_no_parents() {
 
 #[test]
 fn test_rmdir_nonempty_directory_with_parents() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rmdir_nonempty/with/parents";
     let file = "test_rmdir_nonempty/with/parents/foo";
 
@@ -80,7 +85,7 @@ fn test_rmdir_nonempty_directory_with_parents() {
 
 #[test]
 fn test_rmdir_ignore_nonempty_directory_no_parents() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rmdir_ignore_nonempty_no_parents";
     let file = "test_rmdir_ignore_nonempty_no_parents/foo";
 
@@ -99,7 +104,7 @@ fn test_rmdir_ignore_nonempty_directory_no_parents() {
 
 #[test]
 fn test_rmdir_ignore_nonempty_directory_with_parents() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_rmdir_ignore_nonempty/with/parents";
     let file = "test_rmdir_ignore_nonempty/with/parents/foo";
 

--- a/tests/test_seq.rs
+++ b/tests/test_seq.rs
@@ -1,31 +1,34 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "seq";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_count_up() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["10"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["10"]).run().stdout;
     assert_eq!(out, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n");
 }
 
 #[test]
 fn test_count_down() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["--", "5", "-1", "1"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["--", "5", "-1", "1"]).run().stdout;
     assert_eq!(out, "5\n4\n3\n2\n1\n");
 }
 
 #[test]
 fn test_separator_and_terminator() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["-s", ",", "-t", "!", "2", "6"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["-s", ",", "-t", "!", "2", "6"]).run().stdout;
     assert_eq!(out, "2,3,4,5,6!");
 }
 
 #[test]
 fn test_equalize_widths() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let out = ucmd.args(&["-w", "5", "10"]).run().stdout;
+    let out = new_ucmd()
+        .args(&["-w", "5", "10"]).run().stdout;
     assert_eq!(out, "05\n06\n07\n08\n09\n10\n");
 }

--- a/tests/test_sort.rs
+++ b/tests/test_sort.rs
@@ -2,6 +2,10 @@ use common::util::*;
 
 static UTIL_NAME: &'static str = "sort";
 
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
+
 #[test]
 fn test_numeric_floats_and_ints() {
     test_helper("numeric_floats_and_ints", "-n");
@@ -54,39 +58,27 @@ fn test_version() {
 
 #[test]
 fn test_multiple_files() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-n");
-    ucmd.arg("multiple_files1.txt");
-    ucmd.arg("multiple_files2.txt");
-    let res = ucmd.run();
-    assert_eq!(res.success, true);
-    assert_eq!(res.stdout, at.read("multiple_files.expected"));
+    new_ucmd()
+        .arg("-n")
+        .arg("multiple_files1.txt")
+        .arg("multiple_files2.txt")
+        .succeeds().stdout_is_fixture("multiple_files.expected");
 }
 
 #[test]
 fn test_check() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-c");
-    let res = ucmd.arg("check_fail.txt").run();
+    new_ucmd()
+        .arg("-c")
+        .arg("check_fail.txt")
+        .fails().stdout_is("sort: disorder in line 4\n");
 
-    assert_eq!(res.success, false);
-    assert_eq!(res.stdout, "sort: disorder in line 4\n");
-
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-c");
-    let res = ucmd.arg("multiple_files.expected").run();
-
-    assert_eq!(res.success, true);
-    assert_eq!(res.stdout, "");
+    new_ucmd()
+        .arg("-c")
+        .arg("multiple_files.expected")
+        .succeeds().stdout_is("");
 }
 
 fn test_helper(file_name: &str, args: &str) {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg(args);
-    let res = ucmd.arg(format!("{}{}", file_name, ".txt")).run();
-
-    assert_eq!(res.success, true);
-
-    let filename = format!("{}{}", file_name, ".expected");
-    assert_eq!(res.stdout, at.read(&filename));
+    new_ucmd().arg(args).arg(format!("{}{}", file_name, ".txt"))
+        .succeeds().stdout_is_fixture(format!("{}{}", file_name, ".expected"));
 }

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -9,6 +9,11 @@ use regex::Regex;
 use common::util::*;
 
 static UTIL_NAME: &'static str = "split";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 fn random_chars(n: usize) -> String {
     thread_rng().gen_ascii_chars().take(n).collect::<String>()
@@ -92,7 +97,7 @@ impl RandomFile {
 
 #[test]
 fn test_split_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let name = "split_default";
     let glob = Glob::new(&at, ".", r"x[:alpha:][:alpha:]$");
     RandomFile::new(&at, name).add_lines(2000);
@@ -103,7 +108,7 @@ fn test_split_default() {
 
 #[test]
 fn test_split_num_prefixed_chunks_by_bytes() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let name = "split_num_prefixed_chunks_by_bytes";
     let glob = Glob::new(&at, ".", r"a\d\d$");
     RandomFile::new(&at, name).add_bytes(10000);
@@ -114,7 +119,7 @@ fn test_split_num_prefixed_chunks_by_bytes() {
 
 #[test]
 fn test_split_str_prefixed_chunks_by_bytes() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let name = "split_str_prefixed_chunks_by_bytes";
     let glob = Glob::new(&at, ".", r"b[:alpha:][:alpha:]$");
     RandomFile::new(&at, name).add_bytes(10000);
@@ -125,7 +130,7 @@ fn test_split_str_prefixed_chunks_by_bytes() {
 
 #[test]
 fn test_split_num_prefixed_chunks_by_lines() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let name = "split_num_prefixed_chunks_by_lines";
     let glob = Glob::new(&at, ".", r"c\d\d$");
     RandomFile::new(&at, name).add_lines(10000);
@@ -136,7 +141,7 @@ fn test_split_num_prefixed_chunks_by_lines() {
 
 #[test]
 fn test_split_str_prefixed_chunks_by_lines() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let name = "split_str_prefixed_chunks_by_lines";
     let glob = Glob::new(&at, ".", r"d[:alpha:][:alpha:]$");
     RandomFile::new(&at, name).add_lines(10000);

--- a/tests/test_stat.rs
+++ b/tests/test_stat.rs
@@ -4,6 +4,9 @@ extern crate uu_stat;
 pub use self::uu_stat::*;
 
 static UTIL_NAME: &'static str = "stat";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[cfg(test)]
 mod test_fsext {
@@ -140,9 +143,8 @@ mod test_generate_tokens {
 
 #[test]
 fn test_invalid_option() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    ucmd.arg("-w").arg("-q").arg("/");
-    ucmd.fails();
+    new_ucmd()
+        .arg("-w").arg("-q").arg("/").fails();
 }
 
 #[cfg(target_os = "linux")]
@@ -155,82 +157,82 @@ const FS_FMTSTR: &'static str = "%a %b %c %d %f %i %l %n %s %S %t %T";
 #[test]
 #[cfg(target_os = "linux")]
 fn test_terse_fs_format() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-f", "-t", "/proc"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_fs_format() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-f", "-c", FS_FMTSTR, "/dev/shm"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_terse_normal_format() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-t", "/"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_normal_format() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-c", NORMAL_FMTSTR, "/boot"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_follow_symlink() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-L", "-c", DEV_FMTSTR, "/dev/cdrom"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_symlink() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-c", DEV_FMTSTR, "/dev/cdrom"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_char() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-c", DEV_FMTSTR, "/dev/zero"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_multi_files() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["-c", NORMAL_FMTSTR, "/dev", "/usr/lib", "/etc/fstab", "/var"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, expected_result(&args));
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_printf() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let args = ["--printf=123%-# 15q\\r\\\"\\\\\\a\\b\\e\\f\\v%+020.23m\\x12\\167\\132\\112\\n", "/"];
-    ucmd.args(&args);
-    assert_eq!(ucmd.run().stdout, "123?\r\"\\\x07\x08\x1B\x0C\x0B                   /\x12wZJ\n");
+    new_ucmd().args(&args)
+        .run()
+        .stdout_is(expected_result(&args));
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/test_stdbuf.rs
+++ b/tests/test_stdbuf.rs
@@ -1,13 +1,15 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "stdbuf";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_stdbuf_unbuffered_stdout() {
     if cfg!(target_os="linux") {
-        let (_, mut ucmd) = testing(UTIL_NAME);
         // This is a basic smoke test
-        let result = ucmd.args(&["-o0", "head"])
+        let result = new_ucmd().args(&["-o0", "head"])
                          .run_piped_stdin("The quick brown fox jumps over the lazy dog.");
         assert_eq!(result.stdout,
                    "The quick brown fox jumps over the lazy dog.");

--- a/tests/test_sum.rs
+++ b/tests/test_sum.rs
@@ -1,70 +1,52 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "sum";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_bsd_single_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("lorem_ipsum.txt").run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("bsd_single_file.expected"));
+    new_ucmd()
+        .arg("lorem_ipsum.txt")
+        .succeeds().stdout_only_fixture("bsd_single_file.expected");
 }
 
 #[test]
 fn test_bsd_multiple_files() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("lorem_ipsum.txt")
-                     .arg("alice_in_wonderland.txt")
-                     .run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("bsd_multiple_files.expected"));
+    new_ucmd()
+        .arg("lorem_ipsum.txt")
+        .arg("alice_in_wonderland.txt")
+        .succeeds().stdout_only_fixture("bsd_multiple_files.expected");
 }
 
 #[test]
 fn test_bsd_stdin() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let input = at.read("lorem_ipsum.txt");
-    let result = ucmd.run_piped_stdin(input);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("bsd_stdin.expected"));
+    new_ucmd()
+        .pipe_in_fixture("lorem_ipsum.txt")
+        .succeeds().stdout_only_fixture("bsd_stdin.expected");
 }
 
 #[test]
 fn test_sysv_single_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("-s").arg("lorem_ipsum.txt").run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("sysv_single_file.expected"));
+    new_ucmd()
+        .arg("-s").arg("lorem_ipsum.txt")
+        .succeeds().stdout_only_fixture("sysv_single_file.expected");
 }
 
 #[test]
 fn test_sysv_multiple_files() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("-s")
-                     .arg("lorem_ipsum.txt")
-                     .arg("alice_in_wonderland.txt")
-                     .run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("sysv_multiple_files.expected"));
+    new_ucmd()
+        .arg("-s")
+        .arg("lorem_ipsum.txt")
+        .arg("alice_in_wonderland.txt")
+        .succeeds().stdout_only_fixture("sysv_multiple_files.expected");
 }
 
 #[test]
 fn test_sysv_stdin() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let input = at.read("lorem_ipsum.txt");
-    let result = ucmd.arg("-s").run_piped_stdin(input);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, at.read("sysv_stdin.expected"));
+    new_ucmd()
+        .arg("-s")
+        .pipe_in_fixture("lorem_ipsum.txt")
+        .succeeds().stdout_only_fixture("sysv_stdin.expected");
 }

--- a/tests/test_tac.rs
+++ b/tests/test_tac.rs
@@ -1,45 +1,45 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "tac";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_stdin_default() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin("100\n200\n300\n400\n500");
+    let result = new_ucmd()
+        .run_piped_stdin("100\n200\n300\n400\n500");
     assert_eq!(result.stdout, "500400\n300\n200\n100\n");
 }
 
 #[test]
 fn test_stdin_non_newline_separator() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-s", ":"]).run_piped_stdin("100:200:300:400:500");
+    let result = new_ucmd()
+        .args(&["-s", ":"]).run_piped_stdin("100:200:300:400:500");
     assert_eq!(result.stdout, "500400:300:200:100:");
 }
 
 #[test]
 fn test_stdin_non_newline_separator_before() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-b", "-s", ":"]).run_piped_stdin("100:200:300:400:500");
+    let result = new_ucmd()
+        .args(&["-b", "-s", ":"]).run_piped_stdin("100:200:300:400:500");
     assert_eq!(result.stdout, "500:400:300:200:100");
 }
 
 #[test]
 fn test_single_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("prime_per_line.txt").run();
-    assert_eq!(result.stdout, at.read("prime_per_line.expected"));
+    new_ucmd().arg("prime_per_line.txt")
+        .run().stdout_is_fixture("prime_per_line.expected");
 }
 
 #[test]
 fn test_single_non_newline_separator() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-s", ":", "delimited_primes.txt"]).run();
-    assert_eq!(result.stdout, at.read("delimited_primes.expected"));
+    new_ucmd().args(&["-s", ":", "delimited_primes.txt"])
+        .run().stdout_is_fixture("delimited_primes.expected");
 }
 
 #[test]
 fn test_single_non_newline_separator_before() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-b", "-s", ":", "delimited_primes.txt"]).run();
-    assert_eq!(result.stdout, at.read("delimited_primes_before.expected"));
+    new_ucmd().args(&["-b", "-s", ":", "delimited_primes.txt"])
+        .run().stdout_is_fixture("delimited_primes_before.expected");
 }

--- a/tests/test_test.rs
+++ b/tests/test_test.rs
@@ -10,11 +10,14 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "test";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_op_prec_and_or_1() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_success = ucmd.arg(" ")
+    let exit_success = new_ucmd()
+                           .arg(" ")
                            .arg("-o")
                            .arg("")
                            .arg("-a")
@@ -26,8 +29,8 @@ fn test_op_prec_and_or_1() {
 
 #[test]
 fn test_op_prec_and_or_2() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_success = ucmd.arg("")
+    let exit_success = new_ucmd()
+                           .arg("")
                            .arg("-a")
                            .arg("")
                            .arg("-o")
@@ -41,8 +44,8 @@ fn test_op_prec_and_or_2() {
 
 #[test]
 fn test_or_as_filename() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_success = ucmd.arg("x")
+    let exit_success = new_ucmd()
+        .arg("x")
                            .arg("-a")
                            .arg("-z")
                            .arg("-o")

--- a/tests/test_touch.rs
+++ b/tests/test_touch.rs
@@ -5,6 +5,11 @@ use common::util::*;
 use self::filetime::FileTime;
 
 static UTIL_NAME: &'static str = "touch";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 fn get_file_times(at: &AtPath, path: &str) -> (FileTime, FileTime) {
     let m = at.metadata(path);
@@ -26,7 +31,7 @@ fn str_to_filetime(format: &str, s: &str) -> FileTime {
 
 #[test]
 fn test_touch_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_default_file";
 
     let result = ucmd.arg(file).run();
@@ -38,7 +43,7 @@ fn test_touch_default() {
 
 #[test]
 fn test_touch_no_create_file_absent() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_no_create_file_absent";
 
     let result = ucmd.arg("-c").arg(file).run();
@@ -50,7 +55,7 @@ fn test_touch_no_create_file_absent() {
 
 #[test]
 fn test_touch_no_create_file_exists() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_no_create_file_exists";
 
     at.touch(file);
@@ -65,7 +70,7 @@ fn test_touch_no_create_file_exists() {
 
 #[test]
 fn test_touch_set_mdhm_time() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_mdhm_time";
 
     let result = ucmd.args(&["-t", "01011234", file]).run();
@@ -85,7 +90,7 @@ fn test_touch_set_mdhm_time() {
 
 #[test]
 fn test_touch_set_mdhms_time() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_mdhms_time";
 
     let result = ucmd.args(&["-t", "01011234.56", file]).run();
@@ -105,7 +110,7 @@ fn test_touch_set_mdhms_time() {
 
 #[test]
 fn test_touch_set_ymdhm_time() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_ymdhm_time";
 
     let result = ucmd.args(&["-t", "1501011234", file]).run();
@@ -125,7 +130,7 @@ fn test_touch_set_ymdhm_time() {
 
 #[test]
 fn test_touch_set_ymdhms_time() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_ymdhms_time";
 
     let result = ucmd.args(&["-t", "1501011234.56", file]).run();
@@ -145,7 +150,7 @@ fn test_touch_set_ymdhms_time() {
 
 #[test]
 fn test_touch_set_cymdhm_time() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_cymdhm_time";
 
     let result = ucmd.args(&["-t", "201501011234", file]).run();
@@ -165,7 +170,7 @@ fn test_touch_set_cymdhm_time() {
 
 #[test]
 fn test_touch_set_cymdhms_time() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_cymdhms_time";
 
     let result = ucmd.args(&["-t", "201501011234.56", file]).run();
@@ -185,7 +190,7 @@ fn test_touch_set_cymdhms_time() {
 
 #[test]
 fn test_touch_set_only_atime() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_only_atime";
 
     let result = ucmd.args(&["-t", "201501011234", "-a", file]).run();
@@ -203,7 +208,7 @@ fn test_touch_set_only_atime() {
 
 #[test]
 fn test_touch_set_only_mtime() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_only_mtime";
 
     let result = ucmd.args(&["-t", "201501011234", "-m", file]).run();
@@ -221,7 +226,7 @@ fn test_touch_set_only_mtime() {
 
 #[test]
 fn test_touch_set_both() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_both";
 
     let result = ucmd.args(&["-t", "201501011234", "-a", "-m", file]).run();
@@ -241,7 +246,7 @@ fn test_touch_set_both() {
 
 #[test]
 fn test_touch_reference() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_touch_reference_a";
     let file_b = "test_touch_reference_b";
     let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
@@ -264,7 +269,7 @@ fn test_touch_reference() {
 
 #[test]
 fn test_touch_set_date() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_date";
 
     let result = ucmd.args(&["-d", "Thu Jan 01 12:34:00 2015", file]).run();

--- a/tests/test_tr.rs
+++ b/tests/test_tr.rs
@@ -1,39 +1,42 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "tr";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_toupper() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["a-z", "A-Z"]).run_piped_stdin("!abcd!");
+    let result = new_ucmd()
+        .args(&["a-z", "A-Z"]).run_piped_stdin("!abcd!");
     assert_eq!(result.stdout, "!ABCD!");
 }
 
 #[test]
 fn test_small_set2() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["0-9", "X"]).run_piped_stdin("@0123456789");
+    let result = new_ucmd()
+        .args(&["0-9", "X"]).run_piped_stdin("@0123456789");
     assert_eq!(result.stdout, "@XXXXXXXXXX");
 }
 
 #[test]
 fn test_unicode() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&[", ┬─┬", "╯︵┻━┻"])
+    let result = new_ucmd()
+        .args(&[", ┬─┬", "╯︵┻━┻"])
                      .run_piped_stdin("(,°□°）, ┬─┬".as_bytes());
     assert_eq!(result.stdout, "(╯°□°）╯︵┻━┻");
 }
 
 #[test]
 fn test_delete() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", "a-z"]).run_piped_stdin("aBcD");
+    let result = new_ucmd()
+        .args(&["-d", "a-z"]).run_piped_stdin("aBcD");
     assert_eq!(result.stdout, "BD");
 }
 
 #[test]
 fn test_delete_complement() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d", "-c", "a-z"]).run_piped_stdin("aBcD");
+    let result = new_ucmd()
+        .args(&["-d", "-c", "a-z"]).run_piped_stdin("aBcD");
     assert_eq!(result.stdout, "ac");
 }

--- a/tests/test_true.rs
+++ b/tests/test_true.rs
@@ -1,10 +1,13 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "true";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_exit_code() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let exit_status = ucmd.run().success;
+    let exit_status = new_ucmd()
+        .run().success;
     assert_eq!(exit_status, true);
 }

--- a/tests/test_truncate.rs
+++ b/tests/test_truncate.rs
@@ -2,13 +2,18 @@ use common::util::*;
 use std::io::{Seek, SeekFrom, Write};
 
 static UTIL_NAME: &'static str = "truncate";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
 
 static TFILE1: &'static str = "truncate_test_1";
 static TFILE2: &'static str = "truncate_test_2";
 
 #[test]
 fn test_increase_file_size() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let mut file = at.make_file(TFILE1);
     assert!(ucmd.args(&["-s", "+5K", TFILE1]).run().success);
 
@@ -18,7 +23,7 @@ fn test_increase_file_size() {
 
 #[test]
 fn test_decrease_file_size() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     assert!(ucmd.args(&["--size=-4", TFILE2]).run().success);

--- a/tests/test_tsort.rs
+++ b/tests/test_tsort.rs
@@ -1,17 +1,14 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "tsort";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_sort_call_graph() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let input = "call_graph.txt";
-    let output = "call_graph.expected";
-
-    let out = ucmd.arg(input)
-                  .run()
-                  .stdout;
-
-    assert_eq!(out,
-               String::from_utf8(at.read(output).into_bytes()).unwrap());
+    new_ucmd()
+        .arg("call_graph.txt")
+        .run()
+        .stdout_is_fixture("call_graph.expected");
 }

--- a/tests/test_unexpand.rs
+++ b/tests/test_unexpand.rs
@@ -1,68 +1,71 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "unexpand";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn unexpand_init_0() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t4"]).run_piped_stdin(" 1\n  2\n   3\n    4\n");
+    let result = new_ucmd()
+        .args(&["-t4"]).run_piped_stdin(" 1\n  2\n   3\n    4\n");
     assert_eq!(result.stdout, " 1\n  2\n   3\n\t4\n");
 }
 
 #[test]
 fn unexpand_init_1() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t4"]).run_piped_stdin("     5\n      6\n       7\n        8\n");
+    let result = new_ucmd()
+        .args(&["-t4"]).run_piped_stdin("     5\n      6\n       7\n        8\n");
     assert_eq!(result.stdout, "\t 5\n\t  6\n\t   7\n\t\t8\n");
 }
 
 #[test]
 fn unexpand_init_list_0() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t2,4"]).run_piped_stdin(" 1\n  2\n   3\n    4\n");
+    let result = new_ucmd()
+        .args(&["-t2,4"]).run_piped_stdin(" 1\n  2\n   3\n    4\n");
     assert_eq!(result.stdout, " 1\n\t2\n\t 3\n\t\t4\n");
 }
 
 #[test]
 fn unexpand_init_list_1() {
     // Once the list is exhausted, spaces are not converted anymore
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t2,4"]).run_piped_stdin("     5\n      6\n       7\n        8\n");
+    let result = new_ucmd()
+        .args(&["-t2,4"]).run_piped_stdin("     5\n      6\n       7\n        8\n");
     assert_eq!(result.stdout, "\t\t 5\n\t\t  6\n\t\t   7\n\t\t    8\n");
 }
 
 #[test]
 fn unexpand_aflag_0() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["--"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
+    let result = new_ucmd()
+        .args(&["--"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
     assert_eq!(result.stdout, "e     E\nf      F\ng       G\nh        H\n");
 }
 
 #[test]
 fn unexpand_aflag_1() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-a"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
+    let result = new_ucmd()
+        .args(&["-a"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
     assert_eq!(result.stdout, "e     E\nf      F\ng\tG\nh\t H\n");
 }
 
 #[test]
 fn unexpand_aflag_2() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t8"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
+    let result = new_ucmd()
+        .args(&["-t8"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
     assert_eq!(result.stdout, "e     E\nf      F\ng\tG\nh\t H\n");
 }
 
 #[test]
 fn unexpand_first_only_0() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t3"]).run_piped_stdin("        A     B");
+    let result = new_ucmd()
+        .args(&["-t3"]).run_piped_stdin("        A     B");
     assert_eq!(result.stdout, "\t\t  A\t  B");
 }
 
 #[test]
 fn unexpand_first_only_1() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t3", "--first-only"]).run_piped_stdin("        A     B");
+    let result = new_ucmd()
+        .args(&["-t3", "--first-only"]).run_piped_stdin("        A     B");
     assert_eq!(result.stdout, "\t\t  A     B");
 }
 
@@ -71,24 +74,24 @@ fn unexpand_trailing_space_0() {
     // evil
     // Individual spaces before fields starting with non blanks should not be
     // converted, unless they are at the beginning of the line.
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t4"]).run_piped_stdin("123 \t1\n123 1\n123 \n123 ");
+    let result = new_ucmd()
+        .args(&["-t4"]).run_piped_stdin("123 \t1\n123 1\n123 \n123 ");
     assert_eq!(result.stdout, "123\t\t1\n123 1\n123 \n123 ");
 }
 
 #[test]
 fn unexpand_trailing_space_1() {
     // super evil
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t1"]).run_piped_stdin(" abc d e  f  g ");
+    let result = new_ucmd()
+        .args(&["-t1"]).run_piped_stdin(" abc d e  f  g ");
     assert_eq!(result.stdout, "\tabc d e\t\tf\t\tg ");
 }
 
 #[test]
 fn unexpand_spaces_follow_tabs_0() {
     // The two first spaces can be included into the first tab.
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin("  \t\t   A");
+    let result = new_ucmd()
+        .run_piped_stdin("  \t\t   A");
     assert_eq!(result.stdout, "\t\t   A");
 }
 
@@ -100,14 +103,14 @@ fn unexpand_spaces_follow_tabs_1() {
     //    ' \t' -> '\t'         // second tabstop (4)
     //      ' ' -> '\t'         // third tabstop (5)
     // '  B \t' -> '  B \t'     // after the list is exhausted, nothing must change
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-t1,4,5"]).run_piped_stdin("a \t   B \t");
+    let result = new_ucmd()
+        .args(&["-t1,4,5"]).run_piped_stdin("a \t   B \t");
     assert_eq!(result.stdout, "a\t\t  B \t");
 }
 
 #[test]
 fn unexpand_spaces_after_fields() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-a"]).run_piped_stdin("   \t        A B C D             A\t\n");
+    let result = new_ucmd()
+        .args(&["-a"]).run_piped_stdin("   \t        A B C D             A\t\n");
     assert_eq!(result.stdout, "\t\tA B C D\t\t    A\t\n");
 }

--- a/tests/test_uniq.rs
+++ b/tests/test_uniq.rs
@@ -1,6 +1,9 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "uniq";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 static INPUT: &'static str = "sorted.txt";
 static SKIP_CHARS: &'static str = "skip-chars.txt";
@@ -8,84 +11,84 @@ static SKIP_FIELDS: &'static str = "skip-fields.txt";
 
 #[test]
 fn test_stdin_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("sorted-simple.expected"));
+    new_ucmd()
+        .pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("sorted-simple.expected");
 }
 
 #[test]
 fn test_single_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg(INPUT).run();
-    assert_eq!(result.stdout, at.read("sorted-simple.expected"));
+    new_ucmd()
+        .arg(INPUT)
+        .run().stdout_is_fixture("sorted-simple.expected");
 }
 
 #[test]
 fn test_stdin_counts() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c"]).run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("sorted-counts.expected"));
+    new_ucmd()
+        .args(&["-c"]).pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("sorted-counts.expected");
 }
 
 #[test]
 fn test_stdin_skip_1_char() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-s1"]).run_piped_stdin(at.read(SKIP_CHARS));
-    assert_eq!(result.stdout, at.read("skip-1-char.expected"));
+    new_ucmd()
+        .args(&["-s1"]).pipe_in_fixture(SKIP_CHARS)
+        .run().stdout_is_fixture("skip-1-char.expected");
 }
 
 #[test]
 fn test_stdin_skip_5_chars() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-s5"]).run_piped_stdin(at.read(SKIP_CHARS));
-    assert_eq!(result.stdout, at.read("skip-5-chars.expected"));
+    new_ucmd()
+        .args(&["-s5"]).pipe_in_fixture(SKIP_CHARS)
+        .run().stdout_is_fixture("skip-5-chars.expected");
 }
 
 #[test]
 fn test_stdin_skip_and_check_2_chars() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-s3", "-w2"]).run_piped_stdin(at.read(SKIP_CHARS));
-    assert_eq!(result.stdout, at.read("skip-3-check-2-chars.expected"));
+    new_ucmd()
+        .args(&["-s3", "-w2"]).pipe_in_fixture(SKIP_CHARS)
+        .run().stdout_is_fixture("skip-3-check-2-chars.expected");
 }
 
 #[test]
 fn test_stdin_skip_1_field() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-f2"]).run_piped_stdin(at.read(SKIP_FIELDS));
-    assert_eq!(result.stdout, at.read("skip-2-fields.expected"));
+    new_ucmd()
+        .args(&["-f2"]).pipe_in_fixture(SKIP_FIELDS)
+        .run().stdout_is_fixture("skip-2-fields.expected");
 }
 
 #[test]
 fn test_stdin_all_repeated() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["--all-repeated"]).run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("sorted-all-repeated.expected"));
+    new_ucmd()
+        .args(&["--all-repeated"]).pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("sorted-all-repeated.expected");
 }
 
 #[test]
 fn test_stdin_all_repeated_separate() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["--all-repeated", "separate"]).run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("sorted-all-repeated-separate.expected"));
+    new_ucmd()
+        .args(&["--all-repeated", "separate"]).pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("sorted-all-repeated-separate.expected");
 }
 
 #[test]
 fn test_stdin_all_repeated_prepend() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["--all-repeated", "prepend"]).run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("sorted-all-repeated-prepend.expected"));
+    new_ucmd()
+        .args(&["--all-repeated", "prepend"]).pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("sorted-all-repeated-prepend.expected");
 }
 
 #[test]
 fn test_stdin_unique_only() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-u"]).run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("sorted-unique-only.expected"));
+    new_ucmd()
+        .args(&["-u"]).pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("sorted-unique-only.expected");
 }
 
 #[test]
 fn test_stdin_repeated_only() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-d"]).run_piped_stdin(at.read(INPUT));
-    assert_eq!(result.stdout, at.read("sorted-repeated-only.expected"));
+    new_ucmd()
+        .args(&["-d"]).pipe_in_fixture(INPUT)
+        .run().stdout_is_fixture("sorted-repeated-only.expected");
 }

--- a/tests/test_unlink.rs
+++ b/tests/test_unlink.rs
@@ -1,10 +1,18 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "unlink";
+fn at_and_ucmd() -> (AtPath, UCommand) {
+    let ts = TestScenario::new(UTIL_NAME);
+    let ucmd = ts.ucmd();
+    (ts.fixtures, ucmd)
+}
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_unlink_file() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file = "test_unlink_file";
 
     at.touch(file);
@@ -18,7 +26,7 @@ fn test_unlink_file() {
 
 #[test]
 fn test_unlink_multiple_files() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_unlink_multiple_file_a";
     let file_b = "test_unlink_multiple_file_b";
 
@@ -34,7 +42,7 @@ fn test_unlink_multiple_files() {
 
 #[test]
 fn test_unlink_directory() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
+    let (at, mut ucmd) = at_and_ucmd();
     let dir = "test_unlink_empty_directory";
 
     at.mkdir(dir);
@@ -48,10 +56,9 @@ fn test_unlink_directory() {
 
 #[test]
 fn test_unlink_nonexistent() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
     let file = "test_unlink_nonexistent";
 
-    let result = ucmd.arg(file).run();
+    let result = new_ucmd().arg(file).run();
     assert_eq!(result.stderr,
                "unlink: error: Cannot stat 'test_unlink_nonexistent': No such file or directory \
                 (os error 2)\n");

--- a/tests/test_wc.rs
+++ b/tests/test_wc.rs
@@ -1,55 +1,55 @@
 use common::util::*;
 
 static UTIL_NAME: &'static str = "wc";
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
 
 #[test]
 fn test_stdin_default() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.run_piped_stdin(at.read("lorem_ipsum.txt"));
+    let result = new_ucmd().pipe_in_fixture("lorem_ipsum.txt").run();
     assert_eq!(result.stdout, "  13 109 772\n");
 }
 
 #[test]
 fn test_stdin_only_bytes() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c"]).run_piped_stdin(at.read("lorem_ipsum.txt"));
+    let result = new_ucmd().args(&["-c"]).pipe_in_fixture("lorem_ipsum.txt").run();
     assert_eq!(result.stdout, " 772\n");
 }
 
 #[test]
 fn test_stdin_all_counts() {
-    let (at, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c", "-m", "-l", "-L", "-w"])
-                     .run_piped_stdin(at.read("alice_in_wonderland.txt"));
+    let result = new_ucmd().args(&["-c", "-m", "-l", "-L", "-w"])
+                     .pipe_in_fixture("alice_in_wonderland.txt").run();
     assert_eq!(result.stdout, "   5  57 302 302  66\n");
 }
 
 #[test]
 fn test_single_default() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.arg("moby_dick.txt").run();
+    let result = new_ucmd()
+        .arg("moby_dick.txt").run();
     assert_eq!(result.stdout, "   18  204 1115 moby_dick.txt\n");
 }
 
 #[test]
 fn test_single_only_lines() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-l", "moby_dick.txt"]).run();
+    let result = new_ucmd()
+        .args(&["-l", "moby_dick.txt"]).run();
     assert_eq!(result.stdout, "   18 moby_dick.txt\n");
 }
 
 #[test]
 fn test_single_all_counts() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["-c", "-l", "-L", "-m", "-w", "alice_in_wonderland.txt"]).run();
+    let result = new_ucmd()
+        .args(&["-c", "-l", "-L", "-m", "-w", "alice_in_wonderland.txt"]).run();
     assert_eq!(result.stdout,
                "   5  57 302 302  66 alice_in_wonderland.txt\n");
 }
 
 #[test]
 fn test_multiple_default() {
-    let (_, mut ucmd) = testing(UTIL_NAME);
-    let result = ucmd.args(&["lorem_ipsum.txt", "moby_dick.txt", "alice_in_wonderland.txt"]).run();
+    let result = new_ucmd()
+        .args(&["lorem_ipsum.txt", "moby_dick.txt", "alice_in_wonderland.txt"]).run();
     assert_eq!(result.stdout,
                "   13  109  772 lorem_ipsum.txt\n   18  204 1115 moby_dick.txt\n    5   57  302 \
                 alice_in_wonderland.txt\n   36  370 2189 total\n");


### PR DESCRIPTION
# Refactor of conventional TestScenario usage

This is a rather large commit, so I've tried to give it a depth of documentation that will answer any questions and make browsing the code changes easier. 

You're probably fine just reading the summary though, and if you'd like the first few code blocks of "changes in depth" which help illustrate the benefit.

## Summary

### Purpose

The goal of this commit is to, through a group of intertwined changes:

 * **Reduce test boilerplate via project-wide conventions** - define a conventional module-level convenience function that makes single-line, <100 char tests viable without the use of convenience functions that are idiosyncratic to each test module.
 * **Improve readability through greater semantic clarity** - greater semantic clarity about the relation between TestScenario, AtPath, and UCommand without having to read util.rs

### Changes

Updates to individual integration tests

 * use proposed conventional approach to beginning tests where possible
 * use new convenience functions for using fixtures as arguments, stdin, or comparison points in tests (to enable use of main, conventional, single-line approach to beginning tests)
 * use new semantic struct, function, and instance names for TestScenario

Updates to integration test modules

 * add, as used, the proposed conventional module-level convenience functions

Updates to ```test/common/util.rs```

 * rename TestSet to be more semantically clear - in turn also changing its name and name of its instances in tests.
 * create convenience functions for semantic clarity and proposed conventional fixture approach
 * delete convenience functions obsoleted by proposed conventional method for beginning tests

## Changes in depth

### Updates to integration test functions

**Example: use proposed conventional approach to beginning tests where possible**

before
```rust
#[test]
fn test_something() {
    let (_, mut ucmd) = testing(UTIL_NAME)
    ucmd.arg(...).succeeds().stdout_only(...);
}
```

after
```rust
#[test]
fn test_something() {
    new_ucmd().arg(...).succeeds().stdout_only(...);
}
```

**Example: use new convenience functions for using fixtures as arguments, stdin, or comparison points in tests** (to enable use of main, conventional, single-line approach to beginning tests)

before
```rust
#[test]
fn test_one() {
    let (at, mut ucmd) = testing(UTIL_NAME);
    ucmd.arg(at.read("abc.txt")).succeeds().stdout_only("foobar");
}

#[test]
fn test_two() {
    let (at, mut ucmd) = testing(UTIL_NAME);
    ucmd.pipe_in(at.read("abc.txt")).succeeds().stdout_only("foobar");
}

#[test]
fn test_three() {
    let (at, mut ucmd) = testing(UTIL_NAME);
    ucmd.arg("woof").succeeds().stdout_only(at.read("bark.txt"));
}
```

after
```rust
#[test]
fn test_one() {
    new_ucmd().arg_fixture("abc.txt").succeeds().stdout_only("foobar");
}

#[test]
fn test_two() {
    new_ucmd().pipe_in_fixture("abc.txt").succeeds().stdout_only("foobar");
}

#[test]
fn test_three() {
    new_ucmd().arg("woof").succeeds().stdout_only_fixture("bark.txt");
}
```

**Example: use new semantic struct, function, and instance names for TestScenario**

As a reminder, the main use for binding the TestScenario within the test function is if the test is going to be executing more than one command (including commands that are the utility and those that are not)

before
```rust
#[test]
fn test_something() {
    let ts = TestSet::new(UTIL_NAME);
    ts.util_cmd().arg(...)...
    ...
}
```

after
```rust
#[test]
fn test_something() {
    let scene = TestScenario::new(UTIL_NAME);
    scene.ucmd().arg(...)...
    ...
}
```

### Updates to integration test modules

**proposed conventional module-level convenience functions**

In the same way that UTIL_NAME is a module-level convention, these functions build on that avoid each test in the module having to reference both UTIL_NAME and a convenience function.

if you use this function in a module which doesn't have this already defined, you would just copy this function below the ```UTIL_NAME``` declaration. If you can use either this module-level convenience function or the following module-level convenience function, use this one as, besides being more ubiquitous, it removes the need for a ```let```, two bindings, and an equal sign (as well as character length elsewhere).

```rust
fn new_ucmd() -> UCommand {
    TestScenario::new(UTIL_NAME).ucmd()
}
```

Even with the new fixture convenience functions seen above, certain utilities's tests (those which deal with file modification, filesystem attributes reading/modification, etc) will still want an AtPath instance to be available without a lot of boilerplate, and for these functions a conventional module-level convenience function is also available. Just copy and paste under the ```UTIL_NAME``` declaration if needed and not present.

```rust
fn at_and_ucmd() -> (AtPath, UCommand) {
    let ts = TestScenario::new(UTIL_NAME);
    let ucmd = ts.ucmd();
    (ts.fixtures, ucmd)
}
```

### Updates to test/common/util.rs

* ```TestSet``` is now ```TestScenario``` to better reflect its purpose, of setting up a scenario of a default environment with the provided fixtures for which commands will run in. For consistency with other references to instantiating ucmd, its method ```util_cmd``` is now ```ucmd``` and its method ```util_cmd_keepenv``` is now ```ucmd_keepenv```.

* The following fixture convenience functions have been added:

```rust
impl CommandResult {
    ...
    /// like stdout_is(...), but expects the contents of the file at the provided relative path
    pub fn stdout_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> Box<&CmdResult> { ... }

    /// like stderr_is(...), but expects the contents of the file at the provided relative path
    pub fn stderr_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> Box<&CmdResult> { ... }

    /// like stdout_only(...), but expects the contents of the file at the provided relative path
    pub fn stdout_only_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> Box<&CmdResult> { ... }

    /// like stderr_only(...), but expects the contents of the file at the provided relative path
    pub fn stderr_only_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> Box<&CmdResult> { ... }

    ...
}

impl UCommand {
    ...
    /// like arg(...), but uses the contents of the file at the provided relative path as the argument
    pub fn arg_fixture<S: AsRef<OsStr>>(&mut self, file_rel_path: S) -> Box<&mut UCommand> { ... }

    /// like pipe_in(...), but uses the contents of the file at the provided relative path as the piped in data
    pub fn pipe_in_fixture<S: AsRef<OsStr>>(&mut self, file_rel_path: S) -> Box<&mut UCommand> { ... }
    ...
}
```
* The following obsoleted convenience functions have been removed: ```testing(...)```, ```testset_and_ucommand(...)```

## Quantifying test length savings

You might be thinking, "How does this make tests shorter if the number of lines in this commit has increased?"

This commit results in an average test character length decrease of at least 5% (supporting data below; doesn't count whitespace, doesn't count length of functions the test calls). There are some upfront costs to this change, which amortized over our current tests makes the effective character length across util.rs and all test modules decrease around 2%. But we can expect that number to approach the average test length percentage decrease as we add more tests.

I say "at least" above, because the average test length decrease from this will probably be even more in time. Most current tests use the wordy old assert format (this was not changed as part of this commit), but as we transition to chained format we can expect to see this character difference being a greater percentage of the average test's length.

***supporting data***

running the following

```bash
alias count="sed -r 's/\s//g' | wc -m"
cat tests/test_*.rs tests/common/util.rs | count
```

results in the following for before the commit and after:
before
```
167555 total
```

after
```
164858 total
```

the data about the upfront costs that cause this gap to be only around 2% is extracted from the following:

 * ```cat tests/common/util.rs | count```: difference: ~1500
 * ```grep -ihA2 'fn new_ucmd' tests/*.rs | grep -vi '\-\-' | count```: ~2500
 * ```grep -ihA4 'fn at_and' tests/*.rs | grep -vi '\-\-' | count```: ~2000

In other words the amount of code that was in individual tests has been reduced around 8,700 characters, but this difference has been offset by 6000 upfront costs to add these convenience functions in most of the modules where applicable. This means that on average, new tests that are added will take 5% less characters thanthey would otherwise.

The reason this does not translate into line length is because when modifying existing tests, I made only the changes necessary to use the new format and avoided unnecessary stylistic changes. So for example, most lines of ```let (_, mut ucmd) = testing(UTIL_NAME);``` have been replaced with just ```new_ucmd()``` 
