### PR TITLE
ci: fix appveyor cargo test call

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,4 +33,4 @@ artifacts:
 build: false
 
 test_script:
-  - cargo test --no-fail-fast --features nightly generic --no-default-features
+  - cargo test --no-fail-fast --features "nightly generic" --no-default-features


### PR DESCRIPTION
If you're testing multiple features with cargo and do not wrap them in quotes, no tests are run