### PR TITLE
cut: make chars mode use byte mode behavior

### DIFF
--- a/tests/test_cut.rs
+++ b/tests/test_cut.rs
@@ -33,7 +33,6 @@ fn test_byte_sequence() {
     }
 }
 
-#[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn test_char_sequence() {
     for param in vec!["-c", "--characters"] {


### PR DESCRIPTION
This is the same behavior that GNU coreutils currently has for cut: it is not UTF-8 aware, the use of the ```--characters/-c``` option is essentially an alias for the ```--bytes``` option. If it does change in the future to become UTF-8 aware we can go back through version control and revive this code. 