### PR TITLE
Add Message templates

### DIFF
--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_arch"
 path = "arch.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/arch/arch.rs
+++ b/src/arch/arch.rs
@@ -9,14 +9,12 @@
  * file that was distributed with this source code.
  */
 
-extern crate getopts;
 extern crate libc;
 
 #[macro_use]
 extern crate uucore;
 
 use std::ffi::CStr;
-use std::io::Write;
 use std::mem::uninitialized;
 use uucore::c_types::utsname;
 
@@ -44,28 +42,15 @@ static NAME: &'static str = "arch";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
+    let mut opts = uucore::coreopts::CoreOptions::new();
+    let usage = opts.usage("Determine architecture name for current machine.");
+    opts.help(format!("
+{0} {1}
 
-    opts.optflag("", "help", "display this help and exit");
-    opts.optflag("", "version", "output version information and exit");
+{0}
 
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => crash!(1, "{}\nTry '{} --help' for more information.", f, NAME),
-    };
-
-    if matches.opt_present("help") {
-        println!("{} {}", NAME, VERSION);
-        println!("");
-        println!("Usage:");
-        println!("  {} [OPTIONS]...", NAME);
-        println!("");
-        print!("{}", opts.usage("Print machine architecture name."));
-        return 0;
-    } else if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
+{2}
+", NAME, VERSION, usage)).parse(args);
 
     let machine_arch = unsafe { get_machine_arch() };
     let mut output = String::new();

--- a/src/cut/Cargo.toml
+++ b/src/cut/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_cut"
 path = "cut.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -6,6 +6,7 @@ authors = []
 [dependencies]
 libc = "*"
 winapi = "*"
+getopts = "*"
 data-encoding = "^1.1"
 
 [lib]

--- a/src/uucore/coreopts.rs
+++ b/src/uucore/coreopts.rs
@@ -1,0 +1,53 @@
+extern crate getopts;
+use std::io::Write;
+
+pub struct CoreOptions {
+    pub options : getopts::Options,
+    longhelp : Option<String>
+}
+
+impl<'a> CoreOptions {
+    pub fn new() -> Self {
+        let mut ret = CoreOptions {
+            options : getopts::Options::new(),
+            longhelp : None
+        };
+        ret.options
+            .optflag("", "help", "print usage information")
+            .optflag("", "version", "print name and version number");
+        ret
+    }
+    pub fn optopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str) -> &mut CoreOptions {
+        self.options.optopt(short_name, long_name, desc, hint);
+        self
+    }
+    pub fn optflag(&mut self, short_name: &str, long_name: &str, desc: &str) -> &mut CoreOptions {
+        self.options.optflag(short_name, long_name, desc);
+        self
+    }
+    pub fn help<T: Into<String>>(&mut self, longhelp : T) -> &mut CoreOptions {
+        self.longhelp = Some(longhelp.into());
+        self
+    }
+    pub fn usage(&self, summary : &str) -> String {
+        self.options.usage(summary)
+    }
+    pub fn parse(&mut self, args : Vec<String>) -> getopts::Matches {
+        let matches = match self.options.parse(&args[1..]) {
+            Ok(m) => { Some(m) },
+            Err(f) => {
+                crash!(1, "{}", msg_invalid_input!(format!("{}", f)));
+            }
+        }.unwrap();
+        if matches.opt_present("help") {
+            exit!(match self.longhelp {
+                Some(ref lhelp) => { print!("{}", lhelp); 0}
+                None => 1
+            });
+        } else if matches.opt_present("version") {
+            print!("{}", msg_version!());
+            exit!(0);
+        }
+        matches
+    }
+}

--- a/src/uucore/lib.rs
+++ b/src/uucore/lib.rs
@@ -8,6 +8,7 @@ pub mod fs;
 pub mod parse_time;
 pub mod utf8;
 pub mod encoding;
+pub mod coreopts;
 
 #[cfg(unix)] pub mod c_types;
 #[cfg(unix)] pub mod process;

--- a/src/uucore/macros.rs
+++ b/src/uucore/macros.rs
@@ -239,3 +239,112 @@ macro_rules! safe_unwrap(
         }
     )
 );
+
+//-- message templates
+
+//-- message templates : general
+
+#[macro_export]
+macro_rules! snippet_list_join_oxford {
+    ($conjunction:expr, $valOne:expr, $valTwo:expr) => (
+        format!("{}, {} {}", $valOne, $conjunction, $valTwo)
+    );
+    ($conjunction:expr, $valOne:expr, $valTwo:expr $(, $remainingVals:expr)*) => (
+        format!("{}, {}", $valOne, snippet_list_join_inner!($conjunction, $valTwo $(, $remainingVals)*))
+    );
+}
+
+#[macro_export]
+macro_rules! snippet_list_join_or {
+    ($valOne:expr, $valTwo:expr) => (
+        format!("{} or {}", $valOne, $valTwo)
+    );
+    ($valOne:expr, $valTwo:expr $(, $remainingVals:expr)*) => (
+        format!("{}, {}", $valOne, snippet_list_join_oxford!("or", $valTwo $(, $remainingVals)*))
+    ); 
+}
+
+//-- message templates : help and version
+
+#[macro_export]
+macro_rules! msg_version {
+    () => (
+        format!("{} {}", executable!(), env!("CARGO_PKG_VERSION"))
+    )
+}
+
+//-- message templates : invalid input
+
+#[macro_export]
+macro_rules! msg_invalid_input { ($reason: expr) => (
+    format!("invalid input: {}", $reason) ); }
+
+#[macro_export]
+macro_rules! snippet_no_file_at_path { ($path:expr) => (
+    format!("nonexistent path {}", $path) ); }
+
+// -- message templates : invalid input : flag
+
+#[macro_export]
+macro_rules! msg_invalid_opt_use {
+    ($about:expr, $flag:expr) => (
+        msg_invalid_input!(format!("The '{}' option {}", $flag, $about))
+    );
+    ($about:expr, $longflag:expr, $shortflag:expr) => {
+        msg_invalid_input!(format!("The '{}' ('{}') option {}", $longflag, $shortflag, $about))
+    };
+}
+    
+#[macro_export]
+macro_rules! msg_opt_only_usable_if {
+    ($clause:expr, $flag:expr) => (
+        msg_invalid_opt_use!(format!("only usable if {}", $clause), $flag)
+    );
+    ($clause:expr, $longflag:expr, $shortflag:expr) => (
+        msg_invalid_opt_use!(format!("only usable if {}", $clause), $longflag, $shortflag)
+    );
+}
+
+#[macro_export]
+macro_rules! msg_opt_invalid_should_be {
+    ($expects:expr, $received:expr, $flag:expr) => (
+        msg_invalid_opt_use!(format!("expects {}, but was provided {}", $expects, $received), $flag)
+    );
+    ($expects:expr, $received:expr, $longflag:expr, $shortflag:expr) => (
+        msg_invalid_opt_use!(format!("expects {}, but was provided {}", $expects, $received), $longflag, $shortflag)
+    );
+}
+
+// -- message templates : invalid input : args
+
+#[macro_export]
+macro_rules! msg_arg_invalid_value { ($expects:expr, $received:expr) => (
+    msg_invalid_input!(format!("expects its argument to be {}, but was provided {}", $expects, $received)) ); }
+
+#[macro_export]
+macro_rules! msg_args_invalid_value { ($expects:expr, $received:expr) => (
+    msg_invalid_input!(format!("expects its arguments to be {}, but was provided {}", $expects, $received)) ); }
+
+#[macro_export]
+macro_rules! msg_args_nonexistent_file { ($received:expr) => (
+    msg_args_invalid_value!("paths to files", snippet_no_file_at_path!($received)));} 
+
+#[macro_export]
+macro_rules! msg_wrong_number_of_arguments { ($received:expr) => (
+    msg_args_invalid_value!("wrong number of arguments") ); }
+    
+// -- message templates : invalid input : input combinations 
+
+#[macro_export]
+macro_rules! msg_expects_one_of {
+    ($valOne:expr $(, $remainingVals:expr)*) => (
+        msg_invalid_input!(format!("expects one of {}", snippet_list_join_or!($valOne $(, $remainingVals)*))) 
+    ); 
+}
+
+#[macro_export]
+macro_rules! msg_expects_no_more_than_one_of {
+    ($valOne:expr $(, $remainingVals:expr)*) => (
+        msg_invalid_input!(format!("expects no more than one of {}", snippet_list_join_or!($valOne $(, $remainingVals)*))) ;
+    ); 
+}


### PR DESCRIPTION
This PR's first commit adds a group of Macros in ```uucore/macros.rs``` which we could call "Message Templates"

The second commit adds ```uucore::coreopts::CoreOptions```, a facet for ```getopts::Options``` that handles error output uniformly for option parsing failure cases. The reason it is a facet and not a function is to enable eventual uniformity in how option flags are displayed in error messages (for example, if we want to, for options with a shortform and longform, always display both forms when referencing a problem with an option, that is not possible with using just a function)

The third commit demonstrates CoreOption and Message Templates usage by making use of them in the ```cut``` implementation. I've added this and the following sample commit so that this PR does not add a completely unused technology to the repo without demonstration of its use.

The fourth commit is a simple example of CoreOption's usage in the ```arch``` utility impl.

### Use of Message Templates have the following advantages:

(1) **They reduce dev time spent of coming up with N creative ways to express the same problem (or digging through other Utils to try to determine/recall the typical way it is expressed).**
    
This is important enough to merit addition to uucore, because there is a large upcoming amount of work to be done in providing error messages to users, even for most messages that are already provided (see #818 ). Message templates are easy, drop-in messages for common problems, with message content that is original to uutils Coreutils.

(2) **Normalizing their use creates a more consistent UX design across uutils coreutils**
   
Wouldn't it be nice if the error message for "'-q' is not an option flag" looked basically the same for every utility. Since uutils coreutils are, aspirationally, programs that used in a ubiquitous everyday fashion, its a major asset in the eyes of users and distro creators if choosing Uutils provides a consistent, no-surprises user experience across many utilities on the system.
    
(3) **They reduce the surface of spelling mistakes.**
    
When people are using the same literal in format!()s in multiple locations, they can make a mistake in copy-and-pasting, and can make a spelling mistake if they elect to type it in instead of copy-and-pasting. 
    
Mistakes in copying literals can cause problems even if they would never be noticed by a user: they can prevent successful find-and-replace if a particular message is being changed across all utilities.
    
When people invoke templating functions or macros instead, the type system protects them from spelling mistakes, notifying them if there is use of an undefined template name.
    
***Design decisions***

This PR is in no way meant to set in stone the eventual text for a particular error message or to preclude any particular design decisions (such as avoiding getopts for a utility for performance or compatibility reasons) down the road. What it is trying to do is enable us to group error messages in a way that can be reasoned about and is enforced by the typesystem / build / CI.
    
So for example, if we find in the future that we want to use mostly functions instead of uniformly macros, (e.g. if testing binary size shows that it's much better for multicall binary size) all we would need to do is do a search and replace and we'd replace all of them.
