### PR TITLE
coreopts: display package name instead of module path

### DIFF
--- a/src/arch/arch.rs
+++ b/src/arch/arch.rs
@@ -42,7 +42,7 @@ static NAME: &'static str = "arch";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = uucore::coreopts::CoreOptions::new();
+    let mut opts = uucore::coreopts::CoreOptions::new(NAME);
     let usage = opts.usage("Determine architecture name for current machine.");
     opts.help(format!("
 {0} {1}

--- a/src/cut/cut.rs
+++ b/src/cut/cut.rs
@@ -58,7 +58,7 @@ fn cut_bytes<R: Read>(reader: R, ranges: &[Range], opts: &Options) -> i32 {
     use buffer::Bytes::Select;
     use buffer::Bytes::Selected::*;
 
-    let newline_char = 
+    let newline_char =
         if opts.zero_terminated { b'\0' } else { b'\n' };
     let mut buf_read = buffer::ByteReader::new(reader, newline_char);
     let mut out = stdout();
@@ -277,7 +277,7 @@ fn cut_fields_delimiter<R: Read>(reader: R, ranges: &[Range], delim: &str, only_
 }
 
 fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> i32 {
-    let newline_char = 
+    let newline_char =
         if opts.zero_terminated { b'\0' } else { b'\n' };
     match opts.out_delimeter {
         Some(ref o_delim) => {
@@ -408,7 +408,7 @@ fn cut_files(mut filenames: Vec<String>, mode: Mode) -> i32 {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = uucore::coreopts::CoreOptions::new();
+    let mut opts = uucore::coreopts::CoreOptions::new(NAME);
 
     opts.optopt("b", "bytes", "filter byte columns from the input source", "sequence");
     opts.optopt("c", "characters", "alias for character mode", "sequence");
@@ -429,7 +429,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
  Reference
 
- Each call must specify a mode (what to use for columns), 
+ Each call must specify a mode (what to use for columns),
  a sequence (which columns to print), and provide a data source
 
  Specifying a mode
@@ -444,69 +444,69 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     A sequence is a group of 1 or more numbers or inclusive ranges separated
     by a commas.
-    
+
     cut -f 2,5-7 some_file.txt
     will display the 2nd, 5th, 6th, and 7th field for each source line
-    
+
     Ranges can extend to the end of the row by excluding the the second number
 
     cut -f 3- some_file.txt
     will display the 3rd field and all fields after for each source line
-    
+
     The first number of a range can be excluded, and this is effectively the
     same as using 1 as the first number: it causes the range to begin at the
     first column. Ranges can also display a single column
-    
+
     cut -f 1,3-5 some_file.txt
     will display the 1st, 3rd, 4th, and 5th field for each source line
 
     The --complement option, when used, inverts the effect of the sequence
-    
+
     cut --complement -f 4-6 some_file.txt
     will display the every field but the 4th, 5th, and 6th
-    
+
  Specifying a data source
 
     If no sourcefile arguments are specified, stdin is used as the source of
     lines to print
-    
+
     If sourcefile arguments are specified, stdin is ignored and all files are
     read in consecutively if a sourcefile is not successfully read, a warning
     will print to stderr, and the eventual status code will be 1, but cut
     will continue to read through proceeding sourcefiles
-    
-    To print columns from both STDIN and a file argument, use - (dash) as a 
+
+    To print columns from both STDIN and a file argument, use - (dash) as a
     sourcefile argument to represent stdin.
 
  Field Mode options
 
     The fields in each line are identified by a delimiter (separator)
-    
+
     Set the delimiter
         Set the delimiter which separates fields in the file using the
         --delimiter (-d) option. Setting the delimiter is optional.
         If not set, a default delimiter of Tab will be used.
-    
+
     Optionally Filter based on delimiter
-        If the --only-delimited (-s) flag is provided, only lines which 
+        If the --only-delimited (-s) flag is provided, only lines which
         contain the delimiter will be printed
-    
+
     Replace the delimiter
         If the --output-delimiter option is provided, the argument used for
         it will replace the delimiter character in each line printed. This is
-        useful for transforming tabular data - e.g. to convert a CSV to a 
+        useful for transforming tabular data - e.g. to convert a CSV to a
         TSV (tab-separated file)
-        
+
  Line endings
-    
+
     When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
-    'line ending' character (both for the purposes of reading lines and 
+    'line ending' character (both for the purposes of reading lines and
     separating printed lines) instead of \\n (newline). This is useful for
     tabular data where some of the cells may contain newlines
-    
+
     echo 'ab\\0cd' | cut -z -c 1
     will result in 'a\\0c\\0'
-    
+
 ", NAME, VERSION, usage));
     let matches = opts.parse(args);
 

--- a/src/uucore/coreopts.rs
+++ b/src/uucore/coreopts.rs
@@ -3,14 +3,16 @@ use std::io::Write;
 
 pub struct CoreOptions {
     pub options : getopts::Options,
+    pkgname: &'static str,
     longhelp : Option<String>
 }
 
 impl<'a> CoreOptions {
-    pub fn new() -> Self {
+    pub fn new(name: &'static str) -> Self {
         let mut ret = CoreOptions {
             options : getopts::Options::new(),
-            longhelp : None
+            pkgname: name,
+            longhelp: None
         };
         ret.options
             .optflag("", "help", "print usage information")
@@ -36,16 +38,18 @@ impl<'a> CoreOptions {
         let matches = match self.options.parse(&args[1..]) {
             Ok(m) => { Some(m) },
             Err(f) => {
-                crash!(1, "{}", msg_invalid_input!(format!("{}", f)));
+                eprintln!("{}: {}", self.pkgname, f);
+                eprintln!("Try '{} --help' for more information.", self.pkgname);
+                exit!(1)
             }
         }.unwrap();
         if matches.opt_present("help") {
             exit!(match self.longhelp {
-                Some(ref lhelp) => { print!("{}", lhelp); 0}
+                Some(ref lhelp) => { println!("{}", lhelp); 0}
                 None => 1
             });
         } else if matches.opt_present("version") {
-            print!("{}", msg_version!());
+            println!("{} {}", self.pkgname, env!("CARGO_PKG_VERSION"));
             exit!(0);
         }
         matches

--- a/src/uucore/macros.rs
+++ b/src/uucore/macros.rs
@@ -261,7 +261,7 @@ macro_rules! snippet_list_join_or {
     );
     ($valOne:expr, $valTwo:expr $(, $remainingVals:expr)*) => (
         format!("{}, {}", $valOne, snippet_list_join_oxford!("or", $valTwo $(, $remainingVals)*))
-    ); 
+    );
 }
 
 //-- message templates : help and version
@@ -294,7 +294,7 @@ macro_rules! msg_invalid_opt_use {
         msg_invalid_input!(format!("The '{}' ('{}') option {}", $longflag, $shortflag, $about))
     };
 }
-    
+
 #[macro_export]
 macro_rules! msg_opt_only_usable_if {
     ($clause:expr, $flag:expr) => (
@@ -327,24 +327,24 @@ macro_rules! msg_args_invalid_value { ($expects:expr, $received:expr) => (
 
 #[macro_export]
 macro_rules! msg_args_nonexistent_file { ($received:expr) => (
-    msg_args_invalid_value!("paths to files", snippet_no_file_at_path!($received)));} 
+    msg_args_invalid_value!("paths to files", snippet_no_file_at_path!($received)));}
 
 #[macro_export]
 macro_rules! msg_wrong_number_of_arguments { ($received:expr) => (
     msg_args_invalid_value!("wrong number of arguments") ); }
-    
-// -- message templates : invalid input : input combinations 
+
+// -- message templates : invalid input : input combinations
 
 #[macro_export]
 macro_rules! msg_expects_one_of {
     ($valOne:expr $(, $remainingVals:expr)*) => (
-        msg_invalid_input!(format!("expects one of {}", snippet_list_join_or!($valOne $(, $remainingVals)*))) 
-    ); 
+        msg_invalid_input!(format!("expects one of {}", snippet_list_join_or!($valOne $(, $remainingVals)*)))
+    );
 }
 
 #[macro_export]
 macro_rules! msg_expects_no_more_than_one_of {
     ($valOne:expr $(, $remainingVals:expr)*) => (
         msg_invalid_input!(format!("expects no more than one of {}", snippet_list_join_or!($valOne $(, $remainingVals)*))) ;
-    ); 
+    );
 }


### PR DESCRIPTION
Using uucore::coreopts, `<prog> --version` will print out:
```
uucore::coreopts 0.0.1
```
because of the `executable!()` macro.

I decided to pass the program name to `CoreOptions` to fix this problem.