### PR TITLE
tests/echo: complete tests except for --help and --version

### DIFF
--- a/tests/test_echo.rs
+++ b/tests/test_echo.rs
@@ -7,33 +7,82 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_default() {
-    assert_eq!(new_ucmd()
-        .run().stdout, "\n");
+    //CmdResult.stdout_only(...) trims trailing newlines
+    assert_eq!("hi\n", new_ucmd().arg("hi").succeeds().no_stderr().stdout);
 }
 
 #[test]
 fn test_no_trailing_newline() {
-    new_ucmd()
-        .arg("-n")
-        .arg("hello_world")
-        .run()
-        .stdout_is("hello_world");
+    //CmdResult.stdout_only(...) trims trailing newlines
+    assert_eq!("hi", new_ucmd().arg("-n").arg("hi").succeeds().no_stderr().stdout);
 }
 
 #[test]
-fn test_enable_escapes() {
-    new_ucmd()
-        .arg("-e")
-        .arg("\\\\\\t\\r")
-        .run()
-        .stdout_is("\\\t\r\n");
+fn test_escape_alert() {
+    new_ucmd().args(&["-e", "\\a"]).succeeds().stdout_only("\x07\n");
+}
+
+#[test]
+fn test_escape_backslash() {
+    new_ucmd().args(&["-e", "\\\\"]).succeeds().stdout_only("\\\n");
+}
+
+#[test]
+fn test_escape_backspace() {
+    new_ucmd().args(&["-e", "\\b"]).succeeds().stdout_only("\x08\n");
+}
+
+#[test]
+fn test_escape_carriage_return() {
+    new_ucmd().args(&["-e", "\\r"]).succeeds().stdout_only("\r\n");
+}
+
+#[test]
+fn test_escape_escape() {
+    new_ucmd().args(&["-e", "\\e"]).succeeds().stdout_only("\x1B\n");
+}
+
+#[test]
+fn test_escape_form_feed() {
+    new_ucmd().args(&["-e", "\\f"]).succeeds().stdout_only("\x0C\n");
+}
+
+#[test]
+fn test_escape_hex() {
+    new_ucmd().args(&["-e", "\\x41"]).succeeds().stdout_only("A");
+}
+
+#[test]
+fn test_escape_newline() {
+    new_ucmd().args(&["-e", "\\na"]).succeeds().stdout_only("\na");
+}
+
+#[test]
+fn test_escape_no_further_output() {
+    new_ucmd().args(&["-e", "a\\cb"]).succeeds().stdout_only("a\n");
+}
+
+#[test]
+fn test_escape_octal() {
+    new_ucmd().args(&["-e", "\\0100"]).succeeds().stdout_only("@");
+}
+
+#[test]
+fn test_escape_tab() {
+    new_ucmd().args(&["-e", "\\t"]).succeeds().stdout_only("\t\n");
+}
+
+#[test]
+fn test_escape_vertical_tab() {
+    new_ucmd().args(&["-e", "\\v"]).succeeds().stdout_only("\x0B\n");
 }
 
 #[test]
 fn test_disable_escapes() {
+    let input_str = "\\a \\\\ \\b \\r \\e \\f \\x41 \\n a\\cb \\u0100 \\t \\v";
     new_ucmd()
         .arg("-E")
-        .arg("\\b\\c\\e")
-        .run()
-        .stdout_is("\\b\\c\\e\n");
+        .arg(input_str)
+        .succeeds()
+        .stdout_only(format!("{}\n", input_str));
 }


### PR DESCRIPTION
I don't know of any failure cases for echo, so I think with this commit, echo is tested as feature complete, except for the question of whether --help and --version should print a help and version message.

One stylistic choice of this commit is to break up escape tests into separate tests to explicitly document which character is being tested so that readers of the test can understand without cross-referencing another document. 

This choice is not very dry, however, so I could be easily convinced to keep it in the old format of all one test, possibly with using comments.