### PR TITLE
tests: normalize around chaining asserts

### DIFF
--- a/tests/test_comm.rs
+++ b/tests/test_comm.rs
@@ -1,105 +1,82 @@
 use common::util::*;
-use std::ffi::OsStr;
 
 static UTIL_NAME: &'static str = "comm";
-fn at_and_ucmd() -> (AtPath, UCommand) {
-    let ts = TestScenario::new(UTIL_NAME);
-    let ucmd = ts.ucmd();
-    (ts.fixtures, ucmd)
-}
 fn new_ucmd() -> UCommand {
     TestScenario::new(UTIL_NAME).ucmd()
 }
 
-fn comm<A: AsRef<OsStr>, B: AsRef<str>>(args: &[A],
-                                                       file_stdout_relpath_opt: Option<B>,
-                                                       error_message_opt: Option<B>) {
-    let (at, mut ucmd) = at_and_ucmd();
-    let result = ucmd.args(args)
-                     .run();
-    assert!(result.success == error_message_opt.is_none());
-    if let Some(_) = error_message_opt {
-        assert!(result.stderr.len() > 0);
-        // assert!(result.stderr.trim_right() == s);
-    } else {
-        assert!(result.stderr.len() == 0);
-    }
-    if let Some(file_stdout_relpath) = file_stdout_relpath_opt {
-        assert!(result.stdout == at.read(file_stdout_relpath.as_ref()))
-    }
-}
-
 #[test]
 fn ab_no_args() {
-    comm(&["a", "b"], Some("ab.expected"), None);
+    new_ucmd().args(&["a", "b"]).succeeds().stdout_only_fixture("ab.expected");
 }
 
 #[test]
 fn ab_dash_one() {
-    comm(&["a", "b", "-1"], Some("ab1.expected"), None);
+    new_ucmd().args(&["a", "b", "-1"]).succeeds().stdout_only_fixture("ab1.expected");
 }
 
 #[test]
 fn ab_dash_two() {
-    comm(&["a", "b", "-2"], Some("ab2.expected"), None);
+    new_ucmd().args(&["a", "b", "-2"]).succeeds().stdout_only_fixture("ab2.expected");
 }
 
 #[test]
 fn ab_dash_three() {
-    comm(&["a", "b", "-3"], Some("ab3.expected"), None);
+    new_ucmd().args(&["a", "b", "-3"]).succeeds().stdout_only_fixture("ab3.expected");
 }
 
 #[test]
 fn aempty() {
-    comm(&["a", "empty"], Some("aempty.expected"), None);
+    new_ucmd().args(&["a", "empty"]).succeeds().stdout_only_fixture("aempty.expected");
 }
 
 #[test]
 fn emptyempty() {
-    comm(&["empty", "empty"], Some("emptyempty.expected"), None);
+    new_ucmd().args(&["empty", "empty"]).succeeds().stdout_only_fixture("emptyempty.expected");
 }
 
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn output_delimiter() {
-    comm(&["--output-delimiter=word", "a", "b"],
-               Some("ab_delimiter_word.expected"),
-               None);
+    new_ucmd().args(&["--output-delimiter=word", "a", "b"])
+              .succeeds().stdout_only_fixture("ab_delimiter_word.expected");
 }
 
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn output_delimiter_require_arg() {
-    comm(&["--output-delimiter=", "a", "b"],
-               None,
-               Some("error to be defined"));
+    new_ucmd().args(&["--output-delimiter=", "a", "b"])
+              .fails().stderr_only("error to be defined");
 }
 
 // even though (info) documentation suggests this is an option
 // in latest GNU Coreutils comm, it actually is not.
 // this test is essentially an alarm in case someone well-intendingly
 // implements it.
+//marked as unimplemented as error message not set yet.
+#[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn zero_terminated() {
     for param in vec!["-z", "--zero-terminated"] {
-        comm(&[param, "a", "b"], None, Some("error to be defined"));
+        new_ucmd().args(&[param, "a", "b"]).fails().stderr_only("error to be defined");
     }
 }
 
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn check_order() {
-    comm(&["--check-order", "bad_order_1", "bad_order_2"],
-               Some("bad_order12.check_order.expected"),
-               Some("error to be defined"));
+    new_ucmd().args(&["--check-order", "bad_order_1", "bad_order_2"])
+              .fails()
+              .stdout_is_fixture("bad_order12.check_order.expected")
+              .stderr_is("error to be defined");
 }
 
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn nocheck_order() {
-    comm(&["--nocheck-order", "bad_order_1", "bad_order_2"],
-               Some("bad_order12.nocheck_order.expected"),
-               None);
+    new_ucmd().args(&["--nocheck-order", "bad_order_1", "bad_order_2"])
+              .succeeds()
+              .stdout_only_fixture("bad_order12.nocheck_order.expected");
 }
 
 // when neither --check-order nor --no-check-order is provided,
@@ -108,7 +85,7 @@ fn nocheck_order() {
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn defaultcheck_order() {
-    comm(&["a", "bad_order_1"], None, Some("error to be defined"));
+    new_ucmd().args(&["a", "bad_order_1"]).fails().stderr_only("error to be defined");
 }
 
 // * the first: if both files are not in order, the default behavior is the only
@@ -120,17 +97,17 @@ fn defaultcheck_order() {
 
 #[test]
 fn defaultcheck_order_identical_bad_order_files() {
-    comm(&["bad_order_1", "bad_order_1"],
-               Some("bad_order11.defaultcheck_order.expected"),
-               None);
+    new_ucmd().args(&["bad_order_1", "bad_order_1"])
+              .succeeds().stdout_only_fixture("bad_order11.defaultcheck_order.expected");
 }
 
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn defaultcheck_order_two_different_bad_order_files() {
-    comm(&["bad_order_1", "bad_order_2"],
-               Some("bad_order12.nocheck_order.expected"),
-               Some("error to be defined"));
+    new_ucmd().args(&["bad_order_1", "bad_order_2"])
+              .fails()
+              .stdout_is_fixture("bad_order12.nocheck_order.expected")
+              .stderr_is("error to be defined");
 }
 
 // * the third: (it is not know whether this is a bug or not)
@@ -146,27 +123,18 @@ fn defaultcheck_order_two_different_bad_order_files() {
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn unintuitive_default_behavior_1() {
-    comm(&["defaultcheck_unintuitive_1", "defaultcheck_unintuitive_2"],
-               Some("defaultcheck_unintuitive.expected"),
-               None);
+    new_ucmd().args(&["defaultcheck_unintuitive_1", "defaultcheck_unintuitive_2"])
+              .succeeds().stdout_only_fixture("defaultcheck_unintuitive.expected");
 }
 
 #[ignore] //bug? should help be stdout if not called via -h|--help?
 #[test]
 fn no_arguments() {
-    let result = new_ucmd()
-        .run();
-    assert!(!result.success);
-    assert!(result.stdout.len() == 0);
-    assert!(result.stderr.len() > 0);
+    new_ucmd().fails().no_stdout().no_stderr();
 }
 
 #[ignore] //bug? should help be stdout if not called via -h|--help?
 #[test]
 fn one_argument() {
-    let result = new_ucmd()
-        .arg("a").run();
-    assert!(!result.success);
-    assert!(result.stdout.len() == 0);
-    assert!(result.stderr.len() > 0);
+    new_ucmd().arg("a").fails().no_stdout().no_stderr();
 }

--- a/tests/test_dirname.rs
+++ b/tests/test_dirname.rs
@@ -7,40 +7,27 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_path_with_trailing_slashes() {
-    let dir = "/root/alpha/beta/gamma/delta/epsilon/omega//";
-    let out = new_ucmd().arg(dir).run().stdout;
-
-    assert_eq!(out.trim_right(), "/root/alpha/beta/gamma/delta/epsilon");
+    new_ucmd().arg("/root/alpha/beta/gamma/delta/epsilon/omega//")
+        .run().stdout_is("/root/alpha/beta/gamma/delta/epsilon");
 }
 
 #[test]
 fn test_path_without_trailing_slashes() {
-    let dir = "/root/alpha/beta/gamma/delta/epsilon/omega";
-    let out = new_ucmd().arg(dir).run().stdout;
-
-    assert_eq!(out.trim_right(), "/root/alpha/beta/gamma/delta/epsilon");
+    new_ucmd().arg("/root/alpha/beta/gamma/delta/epsilon/omega")
+        .run().stdout_is("/root/alpha/beta/gamma/delta/epsilon");
 }
 
 #[test]
 fn test_root() {
-    let dir = "/";
-    let out = new_ucmd().arg(dir).run().stdout;
-
-    assert_eq!(out.trim_right(), "/");
+    new_ucmd().arg("/").run().stdout_is("/");
 }
 
 #[test]
 fn test_pwd() {
-    let dir = ".";
-    let out = new_ucmd().arg(dir).run().stdout;
-
-    assert_eq!(out.trim_right(), ".");
+    new_ucmd().arg(".").run().stdout_is(".");
 }
 
 #[test]
 fn test_empty() {
-    let dir = "";
-    let out = new_ucmd().arg(dir).run().stdout;
-
-    assert_eq!(out.trim_right(), ".");
+    new_ucmd().arg("").run().stdout_is(".");
 }

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -7,48 +7,30 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_simple_arithmetic() {
-    let out = new_ucmd()
-        .args(&["1", "+", "1"]).run().stdout;
-    assert_eq!(out, "2\n");
+    new_ucmd().args(&["1", "+", "1"]).run().stdout_is("2\n");
 
-    let out = new_ucmd()
-        .args(&["1", "-", "1"]).run().stdout;
-    assert_eq!(out, "0\n");
+    new_ucmd().args(&["1", "-", "1"]).run().stdout_is("0\n");
 
-    let out = new_ucmd()
-        .args(&["3", "*", "2"]).run().stdout;
-    assert_eq!(out, "6\n");
+    new_ucmd().args(&["3", "*", "2"]).run().stdout_is("6\n");
 
-    let out = new_ucmd()
-        .args(&["4", "/", "2"]).run().stdout;
-    assert_eq!(out, "2\n");
+    new_ucmd().args(&["4", "/", "2"]).run().stdout_is("2\n");
 }
 
 #[test]
 fn test_parenthesis() {
-    let out = new_ucmd()
-        .args(&["(", "1", "+", "1", ")", "*", "2"]).run().stdout;
-    assert_eq!(out, "4\n");
+    new_ucmd().args(&["(", "1", "+", "1", ")", "*", "2"]).run().stdout_is("4\n");
 }
 
 #[test]
 fn test_or() {
-    let out = new_ucmd()
-        .args(&["0", "|", "foo"]).run().stdout;
-    assert_eq!(out, "foo\n");
+    new_ucmd().args(&["0", "|", "foo"]).run().stdout_is("foo\n");
 
-    let out = new_ucmd()
-        .args(&["foo", "|", "bar"]).run().stdout;
-    assert_eq!(out, "foo\n");
+    new_ucmd().args(&["foo", "|", "bar"]).run().stdout_is("foo\n");
 }
 
 #[test]
 fn test_and() {
-    let out = new_ucmd()
-        .args(&["foo", "&", "1"]).run().stdout;
-    assert_eq!(out, "foo\n");
+    new_ucmd().args(&["foo", "&", "1"]).run().stdout_is("foo\n");
 
-    let out = new_ucmd()
-        .args(&["", "&", "1"]).run().stdout;
-    assert_eq!(out, "0\n");
+    new_ucmd().args(&["", "&", "1"]).run().stdout_is("0\n");
 }

--- a/tests/test_factor.rs
+++ b/tests/test_factor.rs
@@ -166,8 +166,7 @@ fn test_big_primes() {
 
 fn run(instring: &[u8], outstring: &[u8]) {
     // now run factor
-    let out = new_ucmd().run_piped_stdin(instring).stdout;
-    assert_eq!(out, String::from_utf8(outstring.to_owned()).unwrap());
+    new_ucmd().pipe_in(instring).run().stdout_is(String::from_utf8(outstring.to_owned()).unwrap());
 }
 
 const PRIMES_BY_BITS: &'static [&'static [u64]] = &[PRIMES14, PRIMES15, PRIMES16, PRIMES17,

--- a/tests/test_false.rs
+++ b/tests/test_false.rs
@@ -7,7 +7,5 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_exit_code() {
-    let exit_status = new_ucmd()
-        .run().success;
-    assert_eq!(exit_status, false);
+    new_ucmd().fails();
 }

--- a/tests/test_fold.rs
+++ b/tests/test_fold.rs
@@ -16,9 +16,7 @@ fn test_default_80_column_wrap() {
 #[test]
 fn test_40_column_hard_cutoff() {
     new_ucmd()
-        .arg("-w")
-        .arg("40")
-        .arg("lorem_ipsum.txt")
+        .args(&["-w", "40", "lorem_ipsum.txt"])
         .run()
         .stdout_is_fixture("lorem_ipsum_40_column_hard.expected");
 }
@@ -26,10 +24,7 @@ fn test_40_column_hard_cutoff() {
 #[test]
 fn test_40_column_word_boundary() {
     new_ucmd()
-        .arg("-s")
-        .arg("-w")
-        .arg("40")
-        .arg("lorem_ipsum.txt")
+        .args(&["-s", "-w", "40", "lorem_ipsum.txt"])
         .run()
         .stdout_is_fixture("lorem_ipsum_40_column_word.expected");
 }

--- a/tests/test_hashsum.rs
+++ b/tests/test_hashsum.rs
@@ -21,22 +21,16 @@ macro_rules! test_digest {
         #[test]
         fn test_single_file() {
             let (at, mut ucmd) = at_and_ucmd();
-            let result = ucmd.arg(DIGEST_ARG).arg("input.txt").run();
-
-            assert_empty_stderr!(result);
-            assert!(result.success);
-            assert_eq!(get_hash!(result.stdout), at.read(EXPECTED_FILE));
+            assert_eq!(at.read(EXPECTED_FILE),
+                       get_hash!(ucmd.arg(DIGEST_ARG).arg("input.txt").succeeds().no_stderr().stdout));
         }
 
         #[test]
         fn test_stdin() {
             let (at, mut ucmd) = at_and_ucmd();
             let input = at.read("input.txt");
-            let result = ucmd.arg(DIGEST_ARG).run_piped_stdin(input);
-
-            assert_empty_stderr!(result);
-            assert!(result.success);
-            assert_eq!(get_hash!(result.stdout), at.read(EXPECTED_FILE));
+            assert_eq!(at.read(EXPECTED_FILE),
+                       get_hash!(ucmd.arg(DIGEST_ARG).pipe_in(input).succeeds().no_stderr().stdout));
         }
     }
     )*)

--- a/tests/test_install.rs
+++ b/tests/test_install.rs
@@ -12,12 +12,8 @@ fn at_and_ucmd() -> (AtPath, UCommand) {
 fn test_install_help() {
     let (_, mut ucmd) = at_and_ucmd();
 
-    let result = ucmd.arg("--help").run();
-
-    assert!(result.success);
-    assert_empty_stderr!(result);
-
-    assert!(result.stdout.contains("Usage:"));
+    assert!(
+        ucmd.arg("--help").succeeds().no_stderr().stdout.contains("Usage:"));
 }
 
 #[test]
@@ -30,10 +26,7 @@ fn test_install_basic() {
     at.touch(file1);
     at.touch(file2);
     at.mkdir(dir);
-    let result = ucmd.arg(file1).arg(file2).arg(dir).run();
-
-    assert!(result.success);
-    assert_empty_stderr!(result);
+    ucmd.arg(file1).arg(file2).arg(dir).succeeds().no_stderr();
 
     assert!(at.file_exists(file1));
     assert!(at.file_exists(file2));
@@ -50,10 +43,8 @@ fn test_install_unimplemented_arg() {
 
     at.touch(file);
     at.mkdir(dir);
-    let result = ucmd.arg(context_arg).arg(file).arg(dir).run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("Unimplemented"));
+    assert!(ucmd.arg(context_arg).arg(file).arg(dir)
+            .fails().stderr.contains("Unimplemented"));
 
     assert!(!at.file_exists(&format!("{}/{}", dir, file)));
 }
@@ -66,10 +57,8 @@ fn test_install_component_directories() {
     let component3 = "test_install_target_dir_component_c3";
     let directories_arg = "-d";
 
-    let result = ucmd.arg(directories_arg).arg(component1).arg(component2).arg(component3).run();
-
-    assert!(result.success);
-    assert_empty_stderr!(result);
+    ucmd.args(&[directories_arg, component1, component2, component3])
+        .succeeds().no_stderr();
 
     assert!(at.dir_exists(component1));
     assert!(at.dir_exists(component2));
@@ -83,10 +72,8 @@ fn test_install_component_directories_failing() {
     let directories_arg = "-d";
 
     at.mkdir(component);
-    let result = ucmd.arg(directories_arg).arg(component).run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("File exists"));
+    assert!(ucmd.arg(directories_arg).arg(component)
+            .fails().stderr.contains("File exists"));
 }
 
 #[test]
@@ -98,10 +85,7 @@ fn test_install_mode_numeric() {
 
     at.touch(file);
     at.mkdir(dir);
-    let result = ucmd.arg(file).arg(dir).arg(mode_arg).run();
-
-    assert!(result.success);
-    assert_empty_stderr!(result);
+    ucmd.arg(file).arg(dir).arg(mode_arg).succeeds().no_stderr();
 
     let dest_file = &format!("{}/{}", dir, file);
     assert!(at.file_exists(file));
@@ -119,10 +103,7 @@ fn test_install_mode_symbolic() {
 
     at.touch(file);
     at.mkdir(dir);
-    let result = ucmd.arg(file).arg(dir).arg(mode_arg).run();
-
-    assert!(result.success);
-    assert_empty_stderr!(result);
+    ucmd.arg(file).arg(dir).arg(mode_arg).succeeds().no_stderr();
 
     let dest_file = &format!("{}/{}", dir, file);
     assert!(at.file_exists(file));
@@ -140,10 +121,8 @@ fn test_install_mode_failing() {
 
     at.touch(file);
     at.mkdir(dir);
-    let result = ucmd.arg(file).arg(dir).arg(mode_arg).run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("Invalid mode string: numeric parsing error"));
+    assert!(ucmd.arg(file).arg(dir).arg(mode_arg)
+            .fails().stderr.contains("Invalid mode string: numeric parsing error"));
 
     let dest_file = &format!("{}/{}", dir, file);
     assert!(at.file_exists(file));
@@ -157,10 +136,7 @@ fn test_install_mode_directories() {
     let directories_arg = "-d";
     let mode_arg = "--mode=333";
 
-    let result = ucmd.arg(directories_arg).arg(component).arg(mode_arg).run();
-
-    assert!(result.success);
-    assert_empty_stderr!(result);
+    ucmd.arg(directories_arg).arg(component).arg(mode_arg).succeeds().no_stderr();
 
     assert!(at.dir_exists(component));
     let permissions = at.metadata(component).permissions();

--- a/tests/test_link.rs
+++ b/tests/test_link.rs
@@ -17,10 +17,7 @@ fn test_link_existing_file() {
     at.write(file, "foobar");
     assert!(at.file_exists(file));
 
-    let result = ucmd.args(&[file, link]).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&[file, link]).succeeds().no_stderr();
     assert!(at.file_exists(file));
     assert!(at.file_exists(link));
     assert_eq!(at.read(file), at.read(link));
@@ -31,10 +28,8 @@ fn test_link_no_circular() {
     let (at, mut ucmd) = at_and_ucmd();
     let link = "test_link_no_circular";
 
-    let result = ucmd.args(&[link, link]).run();
-    assert_eq!(result.stderr,
-               "link: error: No such file or directory (os error 2)\n");
-    assert!(!result.success);
+    ucmd.args(&[link, link]).fails()
+        .stderr_is("link: error: No such file or directory (os error 2)\n");
     assert!(!at.file_exists(link));
 }
 
@@ -44,10 +39,8 @@ fn test_link_nonexistent_file() {
     let file = "test_link_nonexistent_file";
     let link = "test_link_nonexistent_file_link";
 
-    let result = ucmd.args(&[file, link]).run();
-    assert_eq!(result.stderr,
-               "link: error: No such file or directory (os error 2)\n");
-    assert!(!result.success);
+    ucmd.args(&[file, link]).fails()
+        .stderr_is("link: error: No such file or directory (os error 2)\n");
     assert!(!at.file_exists(file));
     assert!(!at.file_exists(link));
 }

--- a/tests/test_ln.rs
+++ b/tests/test_ln.rs
@@ -15,9 +15,8 @@ fn test_symlink_existing_file() {
 
     at.touch(file);
 
-    let result = ucmd.args(&["-s", file, link]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", file, link]).succeeds().no_stderr();
+    
     assert!(at.file_exists(file));
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), file);
@@ -29,9 +28,7 @@ fn test_symlink_dangling_file() {
     let file = "test_symlink_dangling_file";
     let link = "test_symlink_dangling_file_link";
 
-    let result = ucmd.args(&["-s", file, link]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", file, link]).succeeds().no_stderr();
     assert!(!at.file_exists(file));
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), file);
@@ -45,9 +42,7 @@ fn test_symlink_existing_directory() {
 
     at.mkdir(dir);
 
-    let result = ucmd.args(&["-s", dir, link]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", dir, link]).succeeds().no_stderr();
     assert!(at.dir_exists(dir));
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), dir);
@@ -59,9 +54,7 @@ fn test_symlink_dangling_directory() {
     let dir = "test_symlink_dangling_dir";
     let link = "test_symlink_dangling_dir_link";
 
-    let result = ucmd.args(&["-s", dir, link]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", dir, link]).succeeds().no_stderr();
     assert!(!at.dir_exists(dir));
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), dir);
@@ -72,9 +65,7 @@ fn test_symlink_circular() {
     let (at, mut ucmd) = at_and_ucmd();
     let link = "test_symlink_circular";
 
-    let result = ucmd.args(&["-s", link]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", link]).succeeds().no_stderr();
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), link);
 }
@@ -88,8 +79,7 @@ fn test_symlink_dont_overwrite() {
     at.touch(file);
     at.touch(link);
 
-    let result = ucmd.args(&["-s", file, link]).run();
-    assert!(!result.success);
+    ucmd.args(&["-s", file, link]).fails();
     assert!(at.file_exists(file));
     assert!(at.file_exists(link));
     assert!(!at.is_symlink(link));
@@ -108,8 +98,7 @@ fn test_symlink_overwrite_force() {
     assert_eq!(at.resolve_link(link), file_a);
 
     // Force overwrite of existing symlink
-    let result = ucmd.args(&["--force", "-s", file_b, link]).run();
-    assert!(result.success);
+    ucmd.args(&["--force", "-s", file_b, link]).succeeds();
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), file_b);
 }
@@ -124,22 +113,16 @@ fn test_symlink_interactive() {
     at.touch(file);
     at.touch(link);
 
-    let result1 = scene.ucmd()
-                    .args(&["-i", "-s", file, link])
-                    .run_piped_stdin("n");
-
-    assert_empty_stderr!(result1);
-    assert!(result1.success);
+    scene.ucmd()
+        .args(&["-i", "-s", file, link])
+        .pipe_in("n").succeeds().no_stderr();
 
     assert!(at.file_exists(file));
     assert!(!at.is_symlink(link));
 
-    let result2 = scene.ucmd()
-                    .args(&["-i", "-s", file, link])
-                    .run_piped_stdin("Yesh");
-
-    assert_empty_stderr!(result2);
-    assert!(result2.success);
+    scene.ucmd()
+        .args(&["-i", "-s", file, link])
+        .pipe_in("Yesh").succeeds().no_stderr();
 
     assert!(at.file_exists(file));
     assert!(at.is_symlink(link));
@@ -158,10 +141,8 @@ fn test_symlink_simple_backup() {
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), file);
 
-    let result = ucmd.args(&["-b", "-s", file, link]).run();
+    ucmd.args(&["-b", "-s", file, link]).succeeds().no_stderr();
 
-    assert_empty_stderr!(result);
-    assert!(result.success);
     assert!(at.file_exists(file));
 
     assert!(at.is_symlink(link));
@@ -186,10 +167,7 @@ fn test_symlink_custom_backup_suffix() {
     assert_eq!(at.resolve_link(link), file);
 
     let arg = &format!("--suffix={}", suffix);
-    let result = ucmd.args(&["-b", arg, "-s", file, link]).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-b", arg, "-s", file, link]).succeeds().no_stderr();
     assert!(at.file_exists(file));
 
     assert!(at.is_symlink(link));
@@ -212,10 +190,7 @@ fn test_symlink_backup_numbering() {
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), file);
 
-    let result = ucmd.args(&["-s", "--backup=t", file, link]).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", "--backup=t", file, link]).succeeds().no_stderr();
     assert!(at.file_exists(file));
 
     assert!(at.is_symlink(link));
@@ -247,10 +222,7 @@ fn test_symlink_existing_backup() {
     assert!(at.is_symlink(link_backup));
     assert_eq!(at.resolve_link(link_backup), file);
 
-    let result = ucmd.args(&["-s", "--backup=nil", file, link]).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", "--backup=nil", file, link]).succeeds().no_stderr();
     assert!(at.file_exists(file));
 
     assert!(at.is_symlink(link_backup));
@@ -271,10 +243,7 @@ fn test_symlink_target_dir() {
     at.touch(file_b);
     at.mkdir(dir);
 
-    let result = ucmd.args(&["-s", "-t", dir, file_a, file_b]).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", "-t", dir, file_a, file_b]).succeeds().no_stderr();
 
     let file_a_link = &format!("{}/{}", dir, file_a);
     assert!(at.is_symlink(file_a_link));
@@ -294,10 +263,7 @@ fn test_symlink_overwrite_dir() {
     at.touch(path_a);
     at.mkdir(path_b);
 
-    let result = ucmd.args(&["-s", "-T", path_a, path_b]).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-s", "-T", path_a, path_b]).succeeds().no_stderr();
 
     assert!(at.file_exists(path_a));
     assert!(at.is_symlink(path_b));
@@ -315,18 +281,15 @@ fn test_symlink_overwrite_nonempty_dir() {
     at.mkdir(path_b);
     at.touch(dummy);
 
-    let result = ucmd.args(&["-v", "-T", "-s", path_a, path_b]).run();
-
     // Not same error as GNU; the error message is a Rust builtin
     // TODO: test (and implement) correct error message (or at least decide whether to do so)
     // Current: "ln: error: Directory not empty (os error 66)"
     // GNU:     "ln: cannot link 'a' to 'b': Directory not empty"
-    assert!(result.stderr.len() > 0);
-
+    
     // Verbose output for the link should not be shown on failure
-    assert!(result.stdout.len() == 0);
+    assert!(ucmd.args(&["-v", "-T", "-s", path_a, path_b])
+            .fails().no_stdout().stderr.len() > 0);
 
-    assert!(!result.success);
     assert!(at.file_exists(path_a));
     assert!(at.dir_exists(path_b));
 }
@@ -344,11 +307,9 @@ fn test_symlink_errors() {
 
     // $ ln -T -t a b
     // ln: cannot combine --target-directory (-t) and --no-target-directory (-T)
-    let result = ucmd.args(&["-T", "-t", dir, file_a, file_b]).run();
-    assert_eq!(result.stderr,
-               "ln: error: cannot combine --target-directory (-t) and --no-target-directory \
+    ucmd.args(&["-T", "-t", dir, file_a, file_b]).fails()
+        .stderr_is("ln: error: cannot combine --target-directory (-t) and --no-target-directory \
                 (-T)\n");
-    assert!(!result.success);
 }
 
 #[test]
@@ -360,16 +321,11 @@ fn test_symlink_verbose() {
 
     at.touch(file_a);
 
-    let result = scene.ucmd().args(&["-v", file_a, file_b]).run();
-    assert_empty_stderr!(result);
-    assert_eq!(result.stdout, format!("'{}' -> '{}'\n", file_b, file_a));
-    assert!(result.success);
+    scene.ucmd().args(&["-v", file_a, file_b])
+        .succeeds().stdout_only(format!("'{}' -> '{}'\n", file_b, file_a));
 
     at.touch(file_b);
 
-    let result = scene.ucmd().args(&["-v", "-b", file_a, file_b]).run();
-    assert_empty_stderr!(result);
-    assert_eq!(result.stdout,
-               format!("'{}' -> '{}' (backup: '{}~')\n", file_b, file_a, file_b));
-    assert!(result.success);
+    scene.ucmd().args(&["-v", "-b", file_a, file_b])
+        .succeeds().stdout_only(format!("'{}' -> '{}' (backup: '{}~')\n", file_b, file_a, file_b));
 }

--- a/tests/test_ls.rs
+++ b/tests/test_ls.rs
@@ -7,9 +7,5 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_ls_ls() {
-    
-    let result = new_ucmd().run();
-    
-    let exit_success = result.success;
-    assert_eq!(exit_success, true);
+    new_ucmd().succeeds();
 }

--- a/tests/test_mkdir.rs
+++ b/tests/test_mkdir.rs
@@ -13,41 +13,31 @@ static TEST_DIR5: &'static str = "mkdir_test5/mkdir_test5_1";
 
 #[test]
 fn test_mkdir_mkdir() {
-    let exit_success = new_ucmd()
-        .arg(TEST_DIR1).run().success;
-    assert_eq!(exit_success, true);
+    new_ucmd().arg(TEST_DIR1).succeeds();
 }
 
 #[test]
 fn test_mkdir_dup_dir() {
     let scene = TestScenario::new(UTIL_NAME);
-    let exit_success = scene.ucmd().arg(TEST_DIR2).run().success;
-    let exit_success2 = scene.ucmd().arg(TEST_DIR2).run().success;
-    assert!(exit_success);
-    assert!(!exit_success2);
+    scene.ucmd().arg(TEST_DIR2).succeeds();
+    scene.ucmd().arg(TEST_DIR2).fails();
 }
 
 #[test]
 fn test_mkdir_mode() {
-    let exit_success = new_ucmd()
-                           .arg("-m")
-                           .arg("755")
-                           .arg(TEST_DIR3)
-                           .run()
-                           .success;
-    assert!(exit_success);
+    new_ucmd()
+        .arg("-m")
+        .arg("755")
+        .arg(TEST_DIR3)
+        .succeeds();
 }
 
 #[test]
 fn test_mkdir_parent() {
-    let exit_success = new_ucmd()
-        .arg("-p").arg(TEST_DIR4).run().success;
-    assert!(exit_success);
+    new_ucmd().arg("-p").arg(TEST_DIR4).succeeds();
 }
 
 #[test]
 fn test_mkdir_no_parent() {
-    let exit_success = new_ucmd()
-        .arg(TEST_DIR5).run().success;
-    assert!(!exit_success);
+    new_ucmd().arg(TEST_DIR5).fails();
 }

--- a/tests/test_mktemp.rs
+++ b/tests/test_mktemp.rs
@@ -24,24 +24,14 @@ fn test_mktemp_mktemp() {
 
     let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE8).run().success;
-
-
-    assert!(exit_success1);
-    assert!(!exit_success2);
-    assert!(!exit_success3);
-    assert!(!exit_success4);
-    assert!(exit_success5);
-    assert!(exit_success6);
-    assert!(exit_success7);
-    assert!(!exit_success8);
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE1).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE2).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE3).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE4).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE5).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE6).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE7).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg(TEST_TEMPLATE8).fails();
 }
 
 #[test]
@@ -50,23 +40,14 @@ fn test_mktemp_make_temp_dir() {
 
     let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE8).run().success;
-
-    assert!(exit_success1);
-    assert!(!exit_success2);
-    assert!(!exit_success3);
-    assert!(!exit_success4);
-    assert!(exit_success5);
-    assert!(exit_success6);
-    assert!(exit_success7);
-    assert!(!exit_success8);
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE1).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE2).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE3).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE4).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE5).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE6).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE7).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-d").arg(TEST_TEMPLATE8).fails();
 }
 
 #[test]
@@ -75,35 +56,25 @@ fn test_mktemp_dry_run() {
 
     let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE8).run().success;
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE1).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE2).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE3).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE4).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE5).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE6).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE7).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("-u").arg(TEST_TEMPLATE8).fails();
 
-
-    assert!(exit_success1);
-    assert!(!exit_success2);
-    assert!(!exit_success3);
-    assert!(!exit_success4);
-    assert!(exit_success5);
-    assert!(exit_success6);
-    assert!(exit_success7);
-    assert!(!exit_success8);
 }
 
 #[test]
 fn test_mktemp_quiet() {
     let scene = TestScenario::new(UTIL_NAME);
 
-    let result1 = scene.ucmd().arg("-p").arg("/definitely/not/exist/I/promise").arg("-q").run();
-    let result2 = scene.ucmd().arg("-d").arg("-p").arg("/definitely/not/exist/I/promise").arg("-q").run();
-
-    assert!(result1.stderr.is_empty() && result1.stdout.is_empty() && !result1.success);
-    assert!(result2.stderr.is_empty() && result2.stdout.is_empty() && !result2.success);
+    scene.ucmd().arg("-p").arg("/definitely/not/exist/I/promise").arg("-q")
+        .fails().no_stdout().no_stderr();
+    scene.ucmd().arg("-d").arg("-p").arg("/definitely/not/exist/I/promise").arg("-q")
+        .fails().no_stdout().no_stderr();
 }
 
 #[test]
@@ -112,49 +83,29 @@ fn test_mktemp_suffix() {
 
     let pathname = scene.fixtures.as_string();
 
-    let exit_success1 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE8).run().success;
-
-
-    assert!(exit_success1);
-    assert!(!exit_success2);
-    assert!(!exit_success3);
-    assert!(!exit_success4);
-    assert!(exit_success5);
-    assert!(!exit_success6);
-    assert!(!exit_success7);
-    assert!(!exit_success8);
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE1).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE2).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE3).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE4).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE5).succeeds();
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE6).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE7).fails();
+    scene.ucmd().env(TMPDIR, &pathname).arg("--suffix").arg("suf").arg(TEST_TEMPLATE8).fails();
 }
 
 #[test]
 fn test_mktemp_tmpdir() {
     let scene = TestScenario::new(UTIL_NAME);
 
-   let path = TempDir::new_in(scene.fixtures.as_string(), UTIL_NAME).unwrap();
-   let pathname = path.path().as_os_str();
+    let path = TempDir::new_in(scene.fixtures.as_string(), UTIL_NAME).unwrap();
+    let pathname = path.path().as_os_str();
 
-    let exit_success1 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE1).run().success;
-    let exit_success2 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE2).run().success;
-    let exit_success3 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE3).run().success;
-    let exit_success4 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE4).run().success;
-    let exit_success5 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE5).run().success;
-    let exit_success6 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE6).run().success;
-    let exit_success7 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE7).run().success;
-    let exit_success8 = scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE8).run().success;
-
-
-    assert!(exit_success1);
-    assert!(!exit_success2);
-    assert!(!exit_success3);
-    assert!(!exit_success4);
-    assert!(exit_success5);
-    assert!(exit_success6);
-    assert!(exit_success7);
-    assert!(!exit_success8);
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE1).succeeds();
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE2).fails();
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE3).fails();
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE4).fails();
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE5).succeeds();
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE6).succeeds();
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE7).succeeds();
+    scene.ucmd().arg("-p").arg(pathname).arg(TEST_TEMPLATE8).fails();
 }

--- a/tests/test_mv.rs
+++ b/tests/test_mv.rs
@@ -19,9 +19,7 @@ fn test_mv_rename_dir() {
 
     at.mkdir(dir1);
 
-    let result = ucmd.arg(dir1).arg(dir2).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(dir1).arg(dir2).succeeds().no_stderr();
 
     assert!(at.dir_exists(dir2));
 }
@@ -34,10 +32,7 @@ fn test_mv_rename_file() {
 
     at.touch(file1);
 
-    let result = ucmd.arg(file1).arg(file2).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
-
+    ucmd.arg(file1).arg(file2).succeeds().no_stderr();
     assert!(at.file_exists(file2));
 }
 
@@ -50,9 +45,7 @@ fn test_mv_move_file_into_dir() {
     at.mkdir(dir);
     at.touch(file);
 
-    let result = ucmd.arg(file).arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(file).arg(dir).succeeds().no_stderr();
 
     assert!(at.file_exists(&format!("{}/{}", dir, file)));
 }
@@ -69,14 +62,11 @@ fn test_mv_strip_slashes() {
     at.mkdir(dir);
     at.touch(file);
 
-    let result = scene.ucmd().arg(&source).arg(dir).run();
-    assert!(!result.success);
+    scene.ucmd().arg(&source).arg(dir).fails();
 
     assert!(!at.file_exists(&format!("{}/{}", dir, file)));
 
-    let result = scene.ucmd().arg("--strip-trailing-slashes").arg(source).arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    scene.ucmd().arg("--strip-trailing-slashes").arg(source).arg(dir).succeeds().no_stderr();
 
     assert!(at.file_exists(&format!("{}/{}", dir, file)));
 }
@@ -92,9 +82,7 @@ fn test_mv_multiple_files() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg(file_a).arg(file_b).arg(target_dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(file_a).arg(file_b).arg(target_dir).succeeds().no_stderr();
 
     assert!(at.file_exists(&format!("{}/{}", target_dir, file_a)));
     assert!(at.file_exists(&format!("{}/{}", target_dir, file_b)));
@@ -111,9 +99,7 @@ fn test_mv_multiple_folders() {
     at.mkdir(dir_a);
     at.mkdir(dir_b);
 
-    let result = ucmd.arg(dir_a).arg(dir_b).arg(target_dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(dir_a).arg(dir_b).arg(target_dir).succeeds().no_stderr();
 
     assert!(at.dir_exists(&format!("{}/{}", target_dir, dir_a)));
     assert!(at.dir_exists(&format!("{}/{}", target_dir, dir_b)));
@@ -130,19 +116,13 @@ fn test_mv_interactive() {
     at.touch(file_b);
 
 
-    let result1 = scene.ucmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("n");
-
-    assert_empty_stderr!(result1);
-    assert!(result1.success);
+    scene.ucmd().arg("-i").arg(file_a).arg(file_b).pipe_in("n").succeeds().no_stderr();
 
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
 
 
-    let result2 = scene.ucmd().arg("-i").arg(file_a).arg(file_b).run_piped_stdin("Yesh");
-
-    assert_empty_stderr!(result2);
-    assert!(result2.success);
+    scene.ucmd().arg("-i").arg(file_a).arg(file_b).pipe_in("Yesh").succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -157,9 +137,7 @@ fn test_mv_no_clobber() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg("-n").arg(file_a).arg(file_b).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-n").arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -174,9 +152,7 @@ fn test_mv_replace_file() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg(file_a).arg(file_b).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -191,9 +167,7 @@ fn test_mv_force_replace_file() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg("--force").arg(file_a).arg(file_b).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("--force").arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -207,10 +181,7 @@ fn test_mv_simple_backup() {
 
     at.touch(file_a);
     at.touch(file_b);
-    let result = ucmd.arg("-b").arg(file_a).arg(file_b).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-b").arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -226,14 +197,11 @@ fn test_mv_custom_backup_suffix() {
 
     at.touch(file_a);
     at.touch(file_b);
-    let result = ucmd.arg("-b")
-                     .arg(format!("--suffix={}", suffix))
-                     .arg(file_a)
-                     .arg(file_b)
-                     .run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-b")
+        .arg(format!("--suffix={}", suffix))
+        .arg(file_a)
+        .arg(file_b)
+        .succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -248,10 +216,7 @@ fn test_mv_backup_numbering() {
 
     at.touch(file_a);
     at.touch(file_b);
-    let result = ucmd.arg("--backup=t").arg(file_a).arg(file_b).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("--backup=t").arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -269,10 +234,7 @@ fn test_mv_existing_backup() {
     at.touch(file_a);
     at.touch(file_b);
     at.touch(file_b_backup);
-    let result = ucmd.arg("--backup=nil").arg(file_a).arg(file_b).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("--backup=nil").arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -295,18 +257,12 @@ fn test_mv_update_option() {
     filetime::set_file_times(at.plus_as_string(file_a), now, now).unwrap();
     filetime::set_file_times(at.plus_as_string(file_b), now, later).unwrap();
 
-    let result1 = scene.ucmd().arg("--update").arg(file_a).arg(file_b).run();
-
-    assert_empty_stderr!(result1);
-    assert!(result1.success);
+    scene.ucmd().arg("--update").arg(file_a).arg(file_b).run();
 
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
 
-    let result2 = scene.ucmd().arg("--update").arg(file_b).arg(file_a).run();
-
-    assert_empty_stderr!(result2);
-    assert!(result2.success);
+    scene.ucmd().arg("--update").arg(file_b).arg(file_a).succeeds().no_stderr();
 
     assert!(at.file_exists(file_a));
     assert!(!at.file_exists(file_b));
@@ -322,10 +278,7 @@ fn test_mv_target_dir() {
     at.touch(file_a);
     at.touch(file_b);
     at.mkdir(dir);
-    let result = ucmd.arg("-t").arg(dir).arg(file_a).arg(file_b).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-t").arg(dir).arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(!at.file_exists(file_b));
@@ -341,10 +294,7 @@ fn test_mv_overwrite_dir() {
 
     at.mkdir(dir_a);
     at.mkdir(dir_b);
-    let result = ucmd.arg("-T").arg(dir_a).arg(dir_b).run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-T").arg(dir_a).arg(dir_b).succeeds().no_stderr();
 
     assert!(!at.dir_exists(dir_a));
     assert!(at.dir_exists(dir_b));
@@ -360,18 +310,14 @@ fn test_mv_overwrite_nonempty_dir() {
     at.mkdir(dir_a);
     at.mkdir(dir_b);
     at.touch(dummy);
-    let result = ucmd.arg("-vT").arg(dir_a).arg(dir_b).run();
-
     // Not same error as GNU; the error message is a rust builtin
     // TODO: test (and implement) correct error message (or at least decide whether to do so)
     // Current: "mv: error: couldn't rename path (Directory not empty; from=a; to=b)"
     // GNU:     "mv: cannot move ‘a’ to ‘b’: Directory not empty"
-    assert!(result.stderr.len() > 0);
 
     // Verbose output for the move should not be shown on failure
-    assert!(result.stdout.len() == 0);
+    assert!(ucmd.arg("-vT").arg(dir_a).arg(dir_b).fails().no_stdout().stderr.len() > 0);
 
-    assert!(!result.success);
     assert!(at.dir_exists(dir_a));
     assert!(at.dir_exists(dir_b));
 }
@@ -384,15 +330,11 @@ fn test_mv_backup_dir() {
 
     at.mkdir(dir_a);
     at.mkdir(dir_b);
-    let result = ucmd.arg("-vbT").arg(dir_a).arg(dir_b).run();
-
-    assert_empty_stderr!(result);
-    assert_eq!(result.stdout,
-               format!("‘{}’ -> ‘{}’ (backup: ‘{}~’)\n",
+    ucmd.arg("-vbT").arg(dir_a).arg(dir_b).succeeds()
+        .stdout_only(format!("‘{}’ -> ‘{}’ (backup: ‘{}~’)\n",
                        dir_a,
                        dir_b,
                        dir_b));
-    assert!(result.success);
 
     assert!(!at.dir_exists(dir_a));
     assert!(at.dir_exists(dir_b));
@@ -412,28 +354,21 @@ fn test_mv_errors() {
 
     // $ mv -T -t a b
     // mv: cannot combine --target-directory (-t) and --no-target-directory (-T)
-    let result = scene.ucmd().arg("-T").arg("-t").arg(dir).arg(file_a).arg(file_b).run();
-    assert_eq!(result.stderr,
-               "mv: error: cannot combine --target-directory (-t) and --no-target-directory \
+    scene.ucmd().arg("-T").arg("-t").arg(dir).arg(file_a).arg(file_b).fails()
+    .stderr_is("mv: error: cannot combine --target-directory (-t) and --no-target-directory \
                 (-T)\n");
-    assert!(!result.success);
-
 
     // $ at.touch file && at.mkdir dir
     // $ mv -T file dir
     // err == mv: cannot overwrite directory ‘dir’ with non-directory
-    let result = scene.ucmd().arg("-T").arg(file_a).arg(dir).run();
-    assert_eq!(result.stderr,
-               format!("mv: error: cannot overwrite directory ‘{}’ with non-directory\n",
+    scene.ucmd().arg("-T").arg(file_a).arg(dir).fails()
+    .stderr_is(format!("mv: error: cannot overwrite directory ‘{}’ with non-directory\n",
                        dir));
-    assert!(!result.success);
 
     // $ at.mkdir dir && at.touch file
     // $ mv dir file
     // err == mv: cannot overwrite non-directory ‘file’ with directory ‘dir’
-    let result = scene.ucmd().arg(dir).arg(file_a).run();
-    assert!(result.stderr.len() > 0);
-    assert!(!result.success);
+    assert!(scene.ucmd().arg(dir).arg(file_a).fails().stderr.len() > 0);
 }
 
 #[test]
@@ -447,22 +382,15 @@ fn test_mv_verbose() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = scene.ucmd().arg("-v").arg(file_a).arg(file_b).run();
-    assert_empty_stderr!(result);
-    assert_eq!(result.stdout,
-               format!("‘{}’ -> ‘{}’\n", file_a, file_b));
-    assert!(result.success);
-
+    scene.ucmd().arg("-v").arg(file_a).arg(file_b).succeeds()
+       .stdout_only(format!("‘{}’ -> ‘{}’\n", file_a, file_b));
 
     at.touch(file_a);
-    let result = scene.ucmd().arg("-vb").arg(file_a).arg(file_b).run();
-    assert_empty_stderr!(result);
-    assert_eq!(result.stdout,
-               format!("‘{}’ -> ‘{}’ (backup: ‘{}~’)\n",
-                       file_a,
-                       file_b,
-                       file_b));
-    assert!(result.success);
+    scene.ucmd().arg("-vb").arg(file_a).arg(file_b).succeeds()
+        .stdout_only(format!("‘{}’ -> ‘{}’ (backup: ‘{}~’)\n",
+                             file_a,
+                             file_b,
+                             file_b));
 }
 
 // Todo:

--- a/tests/test_nl.rs
+++ b/tests/test_nl.rs
@@ -7,23 +7,22 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_stdin_nonewline() {
-    let result = new_ucmd()
-        .run_piped_stdin("No Newline".as_bytes());
-    assert_eq!(result.stdout, "     1\tNo Newline\n");
+    new_ucmd().pipe_in("No Newline").run().stdout_is("     1\tNo Newline\n");
 }
 #[test]
 fn test_stdin_newline() {
-    let result = new_ucmd()
+    new_ucmd()
         .args(&["-s", "-", "-w", "1"])
-                     .run_piped_stdin("Line One\nLine Two\n".as_bytes());
-    assert_eq!(result.stdout, "1-Line One\n2-Line Two\n");
+        .pipe_in("Line One\nLine Two\n")
+        .run()
+        .stdout_is("1-Line One\n2-Line Two\n");
 }
 
 #[test]
 fn test_padding_without_overflow() {
-    let result = new_ucmd()
-        .args(&["-i", "1000", "-s", "x", "-n", "rz", "simple.txt"]).run();
-    assert_eq!(result.stdout,
+    new_ucmd()
+        .args(&["-i", "1000", "-s", "x", "-n", "rz", "simple.txt"]).run()
+        .stdout_is(
                "000001xL1\n001001xL2\n002001xL3\n003001xL4\n004001xL5\n005001xL6\n006001xL7\n0070\
                 01xL8\n008001xL9\n009001xL10\n010001xL11\n011001xL12\n012001xL13\n013001xL14\n014\
                 001xL15\n");
@@ -31,9 +30,9 @@ fn test_padding_without_overflow() {
 
 #[test]
 fn test_padding_with_overflow() {
-    let result = new_ucmd()
-        .args(&["-i", "1000", "-s", "x", "-n", "rz", "-w", "4", "simple.txt"]).run();
-    assert_eq!(result.stdout,
+    new_ucmd()
+        .args(&["-i", "1000", "-s", "x", "-n", "rz", "-w", "4", "simple.txt"]).run()
+        .stdout_is(
                "0001xL1\n1001xL2\n2001xL3\n3001xL4\n4001xL5\n5001xL6\n6001xL7\n7001xL8\n8001xL9\n\
                 9001xL10\n10001xL11\n11001xL12\n12001xL13\n13001xL14\n14001xL15\n");
 }
@@ -50,9 +49,9 @@ fn test_sections_and_styles() {
                                  |Followed by 4x empty\n\n\n\n\n9  |Nonempty\n10 |Nonempty\n11 \
                                  |Nonempty.\n")]
                                   .iter() {
-        let result = new_ucmd()
+        new_ucmd()
             .args(&["-s", "|", "-n", "ln", "-w", "3", "-b", "a", "-l", "5", fixture])
-                         .run();
-        assert_eq!(result.stdout, output);
+            .run()
+            .stdout_is(output);
     }
 }

--- a/tests/test_paste.rs
+++ b/tests/test_paste.rs
@@ -8,10 +8,7 @@ fn new_ucmd() -> UCommand {
 #[test]
 fn test_combine_pairs_of_lines() {
     new_ucmd()
-        .arg("-s")
-        .arg("-d")
-        .arg("\t\n")
-        .arg("html_colors.txt")
+        .args(&["-s", "-d", "\t\n", "html_colors.txt"])
         .run()
         .stdout_is_fixture("html_colors.expected");
 }

--- a/tests/test_pathchk.rs
+++ b/tests/test_pathchk.rs
@@ -8,18 +8,10 @@ fn new_ucmd() -> UCommand {
 #[test]
 fn test_default_mode() {
     // test the default mode
-    {
-        // accept some reasonable default
-        let result = new_ucmd()
-            .args(&["abc/def"]).run();
-        assert_eq!(result.stdout, "");
-        assert!(result.success);
-    }
-    {
-        // fail on long inputs
-        let result = new_ucmd()
-            .args(&[repeat_str("test", 20000)]).run();
-        assert_eq!(result.stdout, "");
-        assert!(!result.success);
-    }
+
+    // accept some reasonable default
+    new_ucmd().args(&["abc/def"]).succeeds().no_stdout();
+
+    // fail on long inputs
+    new_ucmd().args(&[repeat_str("test", 20000)]).fails().no_stdout();
 }

--- a/tests/test_printf.rs
+++ b/tests/test_printf.rs
@@ -5,288 +5,279 @@ fn new_ucmd() -> UCommand {
     TestScenario::new(UTIL_NAME).ucmd()
 }
 
-fn expect_stdout(input: Vec<&str>, expected: &str) {
-    let results = new_ucmd()
-        .args(&input).run();
-    // assert_empty_stderr!(result);
-    // assert!(result.success);
-    assert_eq!(expected, results.stdout);
-}
-
 #[test]
 fn basic_literal() {
-    expect_stdout(vec!["hello world"], "hello world");
+    new_ucmd().args(&["hello world"]).succeeds().stdout_only("hello world");
 }
 
 #[test]
 fn escaped_tab() {
-    expect_stdout(vec!["hello\\t world"], "hello\t world");
+    new_ucmd().args(&["hello\\t world"]).succeeds().stdout_only("hello\t world");
 }
 
 #[test]
 fn escaped_newline() {
-    expect_stdout(vec!["hello\\n world"], "hello\n world");
+    new_ucmd().args(&["hello\\n world"]).succeeds().stdout_only("hello\n world");
 }
 
 #[test]
 fn escaped_slash() {
-    expect_stdout(vec!["hello\\\\ world"], "hello\\ world");
+    new_ucmd().args(&["hello\\\\ world"]).succeeds().stdout_only("hello\\ world");
 }
 
 #[test]
 fn escaped_hex() {
-    expect_stdout(vec!["\\x41"], "A");
+    new_ucmd().args(&["\\x41"]).succeeds().stdout_only("A");
 }
 
 #[test]
 fn escaped_octal() {
-    expect_stdout(vec!["\\101"], "A");
+    new_ucmd().args(&["\\101"]).succeeds().stdout_only("A");
 }
 
 #[test]
 fn escaped_unicode_fourdigit() {
-    expect_stdout(vec!["\\u0125"], "ĥ");
+    new_ucmd().args(&["\\u0125"]).succeeds().stdout_only("ĥ");
 }
 
 #[test]
 fn escaped_unicode_eightdigit() {
-    expect_stdout(vec!["\\U00000125"], "ĥ");
+    new_ucmd().args(&["\\U00000125"]).succeeds().stdout_only("ĥ");
 }
 
 #[test]
 fn escaped_percent_sign() {
-    expect_stdout(vec!["hello%% world"], "hello% world");
+    new_ucmd().args(&["hello%% world"]).succeeds().stdout_only("hello% world");
 }
 
 #[test]
 fn escaped_unrecognized() {
-    expect_stdout(vec!["c\\d"], "c\\d");
+    new_ucmd().args(&["c\\d"]).succeeds().stdout_only("c\\d");
 }
 
 #[test]
 fn sub_string() {
-    expect_stdout(vec!["hello %s", "world"], "hello world");
+    new_ucmd().args(&["hello %s", "world"]).succeeds().stdout_only("hello world");
 }
 
 #[test]
 fn sub_multifield() {
-    expect_stdout(vec!["%s %s", "hello", "world"], "hello world");
+    new_ucmd().args(&["%s %s", "hello", "world"]).succeeds().stdout_only("hello world");
 }
 
 #[test]
 fn sub_repeat_formatstr() {
-    expect_stdout(vec!["%s.", "hello", "world"], "hello.world.");
+    new_ucmd().args(&["%s.", "hello", "world"]).succeeds().stdout_only("hello.world.");
 }
 
 #[test]
 fn sub_string_ignore_escapes() {
-    expect_stdout(vec!["hello %s", "\\tworld"], "hello \\tworld");
+    new_ucmd().args(&["hello %s", "\\tworld"]).succeeds().stdout_only("hello \\tworld");
 }
 
 #[test]
 fn sub_bstring_handle_escapes() {
-    expect_stdout(vec!["hello %b", "\\tworld"], "hello \tworld");
+    new_ucmd().args(&["hello %b", "\\tworld"]).succeeds().stdout_only("hello \tworld");
 }
 
 #[test]
 fn sub_bstring_ignore_subs() {
-    expect_stdout(vec!["hello %b", "world %% %i"], "hello world %% %i");
+    new_ucmd().args(&["hello %b", "world %% %i"]).succeeds().stdout_only("hello world %% %i");
 }
 
 #[test]
 fn sub_char() {
-    expect_stdout(vec!["the letter %c", "A"], "the letter A");
+    new_ucmd().args(&["the letter %c", "A"]).succeeds().stdout_only("the letter A");
 }
 
 #[test]
 fn sub_num_int() {
-    expect_stdout(vec!["twenty is %i", "20"], "twenty is 20");
+    new_ucmd().args(&["twenty is %i", "20"]).succeeds().stdout_only("twenty is 20");
 }
 
 #[test]
 fn sub_num_int_minwidth() {
-    expect_stdout(vec!["twenty is %1i", "20"], "twenty is 20");
+    new_ucmd().args(&["twenty is %1i", "20"]).succeeds().stdout_only("twenty is 20");
 }
 
 #[test]
 fn sub_num_int_neg() {
-    expect_stdout(vec!["neg. twenty is %i", "-20"], "neg. twenty is -20");
+    new_ucmd().args(&["neg. twenty is %i", "-20"]).succeeds().stdout_only("neg. twenty is -20");
 }
 
 #[test]
 fn sub_num_int_oct_in() {
-    expect_stdout(vec!["twenty is %i", "024"], "twenty is 20");
+    new_ucmd().args(&["twenty is %i", "024"]).succeeds().stdout_only("twenty is 20");
 }
 
 #[test]
 fn sub_num_int_oct_in_neg() {
-    expect_stdout(vec!["neg. twenty is %i", "-024"], "neg. twenty is -20");
+    new_ucmd().args(&["neg. twenty is %i", "-024"]).succeeds().stdout_only("neg. twenty is -20");
 }
 
 #[test]
 fn sub_num_int_hex_in() {
-    expect_stdout(vec!["twenty is %i", "0x14"], "twenty is 20");
+    new_ucmd().args(&["twenty is %i", "0x14"]).succeeds().stdout_only("twenty is 20");
 }
 
 #[test]
 fn sub_num_int_hex_in_neg() {
-    expect_stdout(vec!["neg. twenty is %i", "-0x14"], "neg. twenty is -20");
+    new_ucmd().args(&["neg. twenty is %i", "-0x14"]).succeeds().stdout_only("neg. twenty is -20");
 }
 
 #[test]
 fn sub_num_int_charconst_in() {
-    expect_stdout(vec!["ninetyseven is %i", "'a"], "ninetyseven is 97");
+    new_ucmd().args(&["ninetyseven is %i", "'a"]).succeeds().stdout_only("ninetyseven is 97");
 }
 
 #[test]
 fn sub_num_uint() {
-    expect_stdout(vec!["twenty is %u", "20"], "twenty is 20");
+    new_ucmd().args(&["twenty is %u", "20"]).succeeds().stdout_only("twenty is 20");
 }
 
 #[test]
 fn sub_num_octal() {
-    expect_stdout(vec!["twenty in octal is %o", "20"], "twenty in octal is 24");
+    new_ucmd().args(&["twenty in octal is %o", "20"]).succeeds().stdout_only("twenty in octal is 24");
 }
 
 #[test]
 fn sub_num_hex_lower() {
-    expect_stdout(vec!["thirty in hex is %x", "30"], "thirty in hex is 1e");
+    new_ucmd().args(&["thirty in hex is %x", "30"]).succeeds().stdout_only("thirty in hex is 1e");
 }
 
 #[test]
 fn sub_num_hex_upper() {
-    expect_stdout(vec!["thirty in hex is %X", "30"], "thirty in hex is 1E");
+    new_ucmd().args(&["thirty in hex is %X", "30"]).succeeds().stdout_only("thirty in hex is 1E");
 }
 
 #[test]
 fn sub_num_float() {
-    expect_stdout(vec!["twenty is %f", "20"], "twenty is 20.000000");
+    new_ucmd().args(&["twenty is %f", "20"]).succeeds().stdout_only("twenty is 20.000000");
 }
 
 #[test]
 fn sub_num_float_round() {
-    expect_stdout(vec!["two is %f", "1.9999995"], "two is 2.000000");
+    new_ucmd().args(&["two is %f", "1.9999995"]).succeeds().stdout_only("two is 2.000000");
 }
 
 #[test]
 fn sub_num_sci_lower() {
-    expect_stdout(vec!["twenty is %e", "20"], "twenty is 2.000000e+01");
+    new_ucmd().args(&["twenty is %e", "20"]).succeeds().stdout_only("twenty is 2.000000e+01");
 }
 
 #[test]
 fn sub_num_sci_upper() {
-    expect_stdout(vec!["twenty is %E", "20"], "twenty is 2.000000E+01");
+    new_ucmd().args(&["twenty is %E", "20"]).succeeds().stdout_only("twenty is 2.000000E+01");
 }
 
 #[test]
 fn sub_num_sci_trunc() {
-    expect_stdout(vec!["pi is ~ %e", "3.1415926535"], "pi is ~ 3.141593e+00");
+    new_ucmd().args(&["pi is ~ %e", "3.1415926535"]).succeeds().stdout_only("pi is ~ 3.141593e+00");
 }
 
 #[test]
 fn sub_num_dec_trunc() {
-    expect_stdout(vec!["pi is ~ %g", "3.1415926535"], "pi is ~ 3.141593");
+    new_ucmd().args(&["pi is ~ %g", "3.1415926535"]).succeeds().stdout_only("pi is ~ 3.141593");
 }
 
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn sub_num_hex_float_lower() {
-    expect_stdout(vec!["%a", ".875"], "0xep-4");
+    new_ucmd().args(&["%a", ".875"]).succeeds().stdout_only("0xep-4");
 }
 
 #[cfg_attr(not(feature="test_unimplemented"),ignore)]
 #[test]
 fn sub_num_hex_float_upper() {
-    expect_stdout(vec!["%A", ".875"], "0XEP-4");
+    new_ucmd().args(&["%A", ".875"]).succeeds().stdout_only("0XEP-4");
 }
 
 #[test]
 fn sub_minwidth() {
-    expect_stdout(vec!["hello %7s", "world"], "hello   world");
+    new_ucmd().args(&["hello %7s", "world"]).succeeds().stdout_only("hello   world");
 }
 
 #[test]
 fn sub_minwidth_negative() {
-    expect_stdout(vec!["hello %-7s", "world"], "hello world  ");
+    new_ucmd().args(&["hello %-7s", "world"]).succeeds().stdout_only("hello world  ");
 }
 
 #[test]
 fn sub_str_max_chars_input() {
-    expect_stdout(vec!["hello %7.2s", "world"], "hello      wo");
+    new_ucmd().args(&["hello %7.2s", "world"]).succeeds().stdout_only("hello      wo");
 }
 
 #[test]
 fn sub_int_decimal() {
-    expect_stdout(vec!["%0.i", "11"], "11");
+    new_ucmd().args(&["%0.i", "11"]).succeeds().stdout_only("11");
 }
 
 #[test]
 fn sub_int_leading_zeroes() {
-    expect_stdout(vec!["%.4i", "11"], "0011");
+    new_ucmd().args(&["%.4i", "11"]).succeeds().stdout_only("0011");
 }
 
 #[test]
 fn sub_int_leading_zeroes_prio() {
-    expect_stdout(vec!["%5.4i", "11"], " 0011");
+    new_ucmd().args(&["%5.4i", "11"]).succeeds().stdout_only(" 0011");
 }
 
 #[test]
 fn sub_float_dec_places() {
-    expect_stdout(vec!["pi is ~ %.11f", "3.1415926535"],
-                  "pi is ~ 3.14159265350");
+    new_ucmd().args(&["pi is ~ %.11f", "3.1415926535"]).succeeds().stdout_only("pi is ~ 3.14159265350");
 }
 
 #[test]
 fn sub_float_hex_in() {
-    expect_stdout(vec!["%f", "0xF1.1F"], "241.121094");
+    new_ucmd().args(&["%f", "0xF1.1F"]).succeeds().stdout_only("241.121094");
 }
 
 #[test]
 fn sub_float_no_octal_in() {
-    expect_stdout(vec!["%f", "077"], "77.000000");
+    new_ucmd().args(&["%f", "077"]).succeeds().stdout_only("77.000000");
 }
 
 #[test]
 fn sub_any_asterisk_firstparam() {
-    expect_stdout(vec!["%*i", "3", "11", "4", "12"], " 11  12");
+    new_ucmd().args(&["%*i", "3", "11", "4", "12"]).succeeds().stdout_only(" 11  12");
 }
 
 #[test]
 fn sub_any_asterisk_second_param() {
-    expect_stdout(vec!["%.*i", "3", "11", "4", "12"], "0110012");
+    new_ucmd().args(&["%.*i", "3", "11", "4", "12"]).succeeds().stdout_only("0110012");
 }
 
 #[test]
 fn sub_any_asterisk_both_params() {
-    expect_stdout(vec!["%*.*i", "4", "3", "11", "5", "4", "12"], " 011 0012");
+    new_ucmd().args(&["%*.*i", "4", "3", "11", "5", "4", "12"]).succeeds().stdout_only(" 011 0012");
 }
 
 #[test]
 fn sub_any_asterisk_octal_arg() {
-    expect_stdout(vec!["%.*i", "011", "12345678"], "012345678");
+    new_ucmd().args(&["%.*i", "011", "12345678"]).succeeds().stdout_only("012345678");
 }
 
 #[test]
 fn sub_any_asterisk_hex_arg() {
-    expect_stdout(vec!["%.*i", "0xA", "123456789"], "0123456789");
+    new_ucmd().args(&["%.*i", "0xA", "123456789"]).succeeds().stdout_only("0123456789");
 }
 
 #[test]
 fn sub_any_specifiers_no_params() {
-    expect_stdout(vec!["%ztlhLji", "3"], "3");
+    new_ucmd().args(&["%ztlhLji", "3"]).succeeds().stdout_only("3");
 }
 
 #[test]
 fn sub_any_specifiers_after_first_param() {
-    expect_stdout(vec!["%0ztlhLji", "3"], "3");
+    new_ucmd().args(&["%0ztlhLji", "3"]).succeeds().stdout_only("3");
 }
 
 #[test]
 fn sub_any_specifiers_after_period() {
-    expect_stdout(vec!["%0.ztlhLji", "3"], "3");
+    new_ucmd().args(&["%0.ztlhLji", "3"]).succeeds().stdout_only("3");
 }
 
 #[test]
 fn sub_any_specifiers_after_second_param() {
-    expect_stdout(vec!["%0.0ztlhLji", "3"], "3");
+    new_ucmd().args(&["%0.0ztlhLji", "3"]).succeeds().stdout_only("3");
 }

--- a/tests/test_ptx.rs
+++ b/tests/test_ptx.rs
@@ -7,46 +7,42 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn gnu_ext_disabled_roff_no_ref() {
-    let opts = vec!["-G", "-R"];
-    test_ptx(&opts, "gnu_ext_disabled_roff_no_ref.expected");
+    new_ucmd().args(&["-G", "-R", "input"])
+        .succeeds().stdout_only_fixture("gnu_ext_disabled_roff_no_ref.expected");
 }
 
 #[test]
 fn gnu_ext_disabled_roff_input_ref() {
-    let opts = vec!["-G", "-r", "-R"];
-    test_ptx(&opts, "gnu_ext_disabled_roff_input_ref.expected");
+    new_ucmd().args(&["-G", "-r", "-R", "input"])
+        .succeeds().stdout_only_fixture("gnu_ext_disabled_roff_input_ref.expected");
 }
 
 #[test]
 fn gnu_ext_disabled_roff_auto_ref() {
-    let opts = vec!["-G", "-A", "-R"];
-    test_ptx(&opts, "gnu_ext_disabled_roff_auto_ref.expected");
+    new_ucmd().args(&["-G", "-A", "-R", "input"])
+        .succeeds().stdout_only_fixture("gnu_ext_disabled_roff_auto_ref.expected");
 }
 
 #[test]
 fn gnu_ext_disabled_tex_no_ref() {
-    let opts = vec!["-G", "-T", "-R"];
-    test_ptx(&opts, "gnu_ext_disabled_tex_no_ref.expected");
+    new_ucmd().args(&["-G", "-T", "-R", "input"])
+        .succeeds().stdout_only_fixture("gnu_ext_disabled_tex_no_ref.expected");
 }
 
 #[test]
 fn gnu_ext_disabled_tex_input_ref() {
-    let opts = vec!["-G", "-T", "-r", "-R"];
-    test_ptx(&opts, "gnu_ext_disabled_tex_input_ref.expected");
+    new_ucmd().args(&["-G", "-T", "-r", "-R", "input"])
+        .succeeds().stdout_only_fixture("gnu_ext_disabled_tex_input_ref.expected");
 }
 
 #[test]
 fn gnu_ext_disabled_tex_auto_ref() {
-    let opts = vec!["-G", "-T", "-A", "-R"];
-    test_ptx(&opts, "gnu_ext_disabled_tex_auto_ref.expected");
+    new_ucmd().args(&["-G", "-T", "-A", "-R", "input"])
+        .succeeds().stdout_only_fixture("gnu_ext_disabled_tex_auto_ref.expected");
 }
 
 #[test]
 fn gnu_ext_disabled_ignore_and_only_file() {
-    let opts = vec!["-G", "-o", "only", "-i", "ignore"];
-    test_ptx(&opts, "gnu_ext_disabled_ignore_and_only_file.expected");
-}
-
-fn test_ptx(opts: &Vec<&str>, expected: &str) {
-    new_ucmd().args(opts).arg("input").succeeds().stdout_only_fixture(expected);
+    new_ucmd().args(&["-G", "-o", "only", "-i", "ignore", "input"])
+        .succeeds().stdout_only_fixture("gnu_ext_disabled_ignore_and_only_file.expected");
 }

--- a/tests/test_pwd.rs
+++ b/tests/test_pwd.rs
@@ -10,8 +10,5 @@ fn at_and_ucmd() -> (AtPath, UCommand) {
 #[test]
 fn test_default() {
     let (at, mut ucmd) = at_and_ucmd();
-    let out = ucmd.run().stdout;
-
-    let expected = at.root_dir_resolved();
-    assert_eq!(out.trim_right(), expected);
+    ucmd.run().stdout_is(at.root_dir_resolved());
 }

--- a/tests/test_readlink.rs
+++ b/tests/test_readlink.rs
@@ -15,36 +15,29 @@ static GIBBERISH: &'static str = "supercalifragilisticexpialidocious";
 #[test]
 fn test_canonicalize() {
     let (at, mut ucmd) = at_and_ucmd();
-    let out = ucmd.arg("-f")
-                  .arg(".")
-                  .run()
-                  .stdout;
-
-    assert_eq!(out.trim_right(), at.root_dir_resolved());
+    ucmd.arg("-f")
+        .arg(".")
+        .run()
+        .stdout_is(at.root_dir_resolved());
 }
 
 #[test]
 fn test_canonicalize_existing() {
     let (at, mut ucmd) = at_and_ucmd();
-    let out = ucmd.arg("-e")
-                  .arg(".")
-                  .run()
-                  .stdout;
-
-    assert_eq!(out.trim_right(), at.root_dir_resolved());
+    ucmd.arg("-e")
+        .arg(".")
+        .run()
+        .stdout_is(at.root_dir_resolved());
 }
 
 #[test]
 fn test_canonicalize_missing() {
     let (at, mut ucmd) = at_and_ucmd();
     let expected = path_concat!(at.root_dir_resolved(), GIBBERISH);
-
-    let out = ucmd.arg("-m")
-                  .arg(GIBBERISH)
-                  .run()
-                  .stdout;
-
-    assert_eq!(out.trim_right(), expected);
+    ucmd.arg("-m")
+        .arg(GIBBERISH)
+        .run()
+        .stdout_is(expected);
 }
 
 #[test]
@@ -52,25 +45,21 @@ fn test_long_redirection_to_current_dir() {
     let (at, mut ucmd) = at_and_ucmd();
     // Create a 256-character path to current directory
     let dir = path_concat!(".", ..128);
-    let out = ucmd.arg("-n")
-                  .arg("-m")
-                  .arg(dir)
-                  .run()
-                  .stdout;
-
-    assert_eq!(out, at.root_dir_resolved());
+    ucmd.arg("-n")
+        .arg("-m")
+        .arg(dir)
+        .run()
+        .stdout_is(at.root_dir_resolved());
 }
 
 #[test]
 fn test_long_redirection_to_root() {
     // Create a 255-character path to root
     let dir = path_concat!("..", ..85);
-    let out = new_ucmd()
-                  .arg("-n")
-                  .arg("-m")
-                  .arg(dir)
-                  .run()
-                  .stdout;
-
-    assert_eq!(out, get_root_path());
+    new_ucmd()
+        .arg("-n")
+        .arg("-m")
+        .arg(dir)
+        .run()
+        .stdout_is(get_root_path());
 }

--- a/tests/test_realpath.rs
+++ b/tests/test_realpath.rs
@@ -13,9 +13,7 @@ fn new_ucmd() -> UCommand {
 #[test]
 fn test_current_directory() {
     let (at, mut ucmd) = at_and_ucmd();
-    let out = ucmd.arg(".").run().stdout;
-
-    assert_eq!(out.trim_right(), at.root_dir_resolved());
+    ucmd.arg(".").run().stdout_is(at.root_dir_resolved());
 }
 
 #[test]
@@ -23,16 +21,12 @@ fn test_long_redirection_to_current_dir() {
     let (at, mut ucmd) = at_and_ucmd();
     // Create a 256-character path to current directory
     let dir = path_concat!(".", ..128);
-    let out = ucmd.arg(dir).run().stdout;
-
-    assert_eq!(out.trim_right(), at.root_dir_resolved());
+    ucmd.arg(dir).run().stdout_is(at.root_dir_resolved());
 }
 
 #[test]
 fn test_long_redirection_to_root() {
     // Create a 255-character path to root
     let dir = path_concat!("..", ..85);
-    let out = new_ucmd().arg(dir).run().stdout;
-
-    assert_eq!(out.trim_right(), get_root_path());
+    new_ucmd().arg(dir).run().stdout_is(get_root_path());
 }

--- a/tests/test_rm.rs
+++ b/tests/test_rm.rs
@@ -14,9 +14,7 @@ fn test_rm_one_file() {
 
     at.touch(file);
 
-    let result = ucmd.arg(file).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(file).succeeds().no_stderr();
 
     assert!(!at.file_exists(file));
 }
@@ -30,9 +28,7 @@ fn test_rm_multiple_files() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg(file_a).arg(file_b).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(file_a).arg(file_b).succeeds().no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(!at.file_exists(file_b));
@@ -49,24 +45,22 @@ fn test_rm_interactive() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result1 = scene.ucmd()
-                    .arg("-i")
-                    .arg(file_a)
-                    .arg(file_b)
-                    .run_piped_stdin("n");
-
-    assert!(result1.success);
+    scene.ucmd()
+        .arg("-i")
+        .arg(file_a)
+        .arg(file_b)
+        .pipe_in("n")
+        .succeeds();
 
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
 
-    let result2 = scene.ucmd()
-                    .arg("-i")
-                    .arg(file_a)
-                    .arg(file_b)
-                    .run_piped_stdin("Yesh");
-
-    assert!(result2.success);
+    scene.ucmd()
+        .arg("-i")
+        .arg(file_a)
+        .arg(file_b)
+        .pipe_in("Yesh")
+        .succeeds();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -78,12 +72,11 @@ fn test_rm_force() {
     let file_a = "test_rm_force_a";
     let file_b = "test_rm_force_b";
 
-    let result = ucmd.arg("-f")
-                     .arg(file_a)
-                     .arg(file_b)
-                     .run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-f")
+        .arg(file_a)
+        .arg(file_b)
+        .succeeds()
+        .no_stderr();
 
     assert!(!at.file_exists(file_a));
     assert!(!at.file_exists(file_b));
@@ -96,9 +89,7 @@ fn test_rm_empty_directory() {
 
     at.mkdir(dir);
 
-    let result = ucmd.arg("-d").arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-d").arg(dir).succeeds().no_stderr();
 
     assert!(!at.dir_exists(dir));
 }
@@ -114,9 +105,7 @@ fn test_rm_recursive() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg("-r").arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-r").arg(dir).succeeds().no_stderr();
 
     assert!(!at.dir_exists(dir));
     assert!(!at.file_exists(file_a));
@@ -136,11 +125,9 @@ fn test_rm_errors() {
 
     // $ rm test_rm_errors_directory
     // rm: error: could not remove directory 'test_rm_errors_directory' (did you mean to pass '-r'?)
-    let result = ucmd.arg(dir).run();
-    assert_eq!(result.stderr,
-               "rm: error: could not remove directory 'test_rm_errors_directory' (did you mean \
+    ucmd.arg(dir).fails()
+        .stderr_is("rm: error: could not remove directory 'test_rm_errors_directory' (did you mean \
                 to pass '-r'?)\n");
-    assert!(!result.success);
 }
 
 #[test]
@@ -152,9 +139,6 @@ fn test_rm_verbose() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg("-v").arg(file_a).arg(file_b).run();
-    assert_empty_stderr!(result);
-    assert_eq!(result.stdout,
-               format!("removed '{}'\nremoved '{}'\n", file_a, file_b));
-    assert!(result.success);
+    ucmd.arg("-v").arg(file_a).arg(file_b).succeeds()
+        .stdout_only(format!("removed '{}'\nremoved '{}'\n", file_a, file_b));
 }

--- a/tests/test_rmdir.rs
+++ b/tests/test_rmdir.rs
@@ -15,9 +15,7 @@ fn test_rmdir_empty_directory_no_parents() {
     at.mkdir(dir);
     assert!(at.dir_exists(dir));
 
-    let result = ucmd.arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(dir).succeeds().no_stderr();
 
     assert!(!at.dir_exists(dir));
 }
@@ -30,9 +28,7 @@ fn test_rmdir_empty_directory_with_parents() {
     at.mkdir_all(dir);
     assert!(at.dir_exists(dir));
 
-    let result = ucmd.arg("-p").arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-p").arg(dir).succeeds().no_stderr();
 
     assert!(!at.dir_exists(dir));
 }
@@ -49,11 +45,9 @@ fn test_rmdir_nonempty_directory_no_parents() {
     at.touch(file);
     assert!(at.file_exists(file));
 
-    let result = ucmd.arg(dir).run();
-    assert_eq!(result.stderr,
-               "rmdir: error: failed to remove 'test_rmdir_nonempty_no_parents': Directory not \
+    ucmd.arg(dir).fails()
+        .stderr_is("rmdir: error: failed to remove 'test_rmdir_nonempty_no_parents': Directory not \
                 empty\n");
-    assert!(!result.success);
 
     assert!(at.dir_exists(dir));
 }
@@ -70,13 +64,12 @@ fn test_rmdir_nonempty_directory_with_parents() {
     at.touch(file);
     assert!(at.file_exists(file));
 
-    let result = ucmd.arg("-p").arg(dir).run();
-    assert_eq!(result.stderr,
+    ucmd.arg("-p").arg(dir).fails()
+        .stderr_is(
                "rmdir: error: failed to remove 'test_rmdir_nonempty/with/parents': Directory not \
                 empty\nrmdir: error: failed to remove 'test_rmdir_nonempty/with': Directory not \
                 empty\nrmdir: error: failed to remove 'test_rmdir_nonempty': Directory not \
                 empty\n");
-    assert!(!result.success);
 
     assert!(at.dir_exists(dir));
 }
@@ -93,9 +86,7 @@ fn test_rmdir_ignore_nonempty_directory_no_parents() {
     at.touch(file);
     assert!(at.file_exists(file));
 
-    let result = ucmd.arg("--ignore-fail-on-non-empty").arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("--ignore-fail-on-non-empty").arg(dir).succeeds().no_stderr();
 
     assert!(at.dir_exists(dir));
 }
@@ -112,9 +103,7 @@ fn test_rmdir_ignore_nonempty_directory_with_parents() {
     at.touch(file);
     assert!(at.file_exists(file));
 
-    let result = ucmd.arg("--ignore-fail-on-non-empty").arg("-p").arg(dir).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("--ignore-fail-on-non-empty").arg("-p").arg(dir).succeeds().no_stderr();
 
     assert!(at.dir_exists(dir));
 }

--- a/tests/test_seq.rs
+++ b/tests/test_seq.rs
@@ -7,28 +7,24 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_count_up() {
-    let out = new_ucmd()
-        .args(&["10"]).run().stdout;
-    assert_eq!(out, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n");
+    new_ucmd()
+        .args(&["10"]).run().stdout_is("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n");
 }
 
 #[test]
 fn test_count_down() {
-    let out = new_ucmd()
-        .args(&["--", "5", "-1", "1"]).run().stdout;
-    assert_eq!(out, "5\n4\n3\n2\n1\n");
+    new_ucmd()
+        .args(&["--", "5", "-1", "1"]).run().stdout_is("5\n4\n3\n2\n1\n");
 }
 
 #[test]
 fn test_separator_and_terminator() {
-    let out = new_ucmd()
-        .args(&["-s", ",", "-t", "!", "2", "6"]).run().stdout;
-    assert_eq!(out, "2,3,4,5,6!");
+    new_ucmd()
+        .args(&["-s", ",", "-t", "!", "2", "6"]).run().stdout_is("2,3,4,5,6!");
 }
 
 #[test]
 fn test_equalize_widths() {
-    let out = new_ucmd()
-        .args(&["-w", "5", "10"]).run().stdout;
-    assert_eq!(out, "05\n06\n07\n08\n09\n10\n");
+    new_ucmd()
+        .args(&["-w", "5", "10"]).run().stdout_is("05\n06\n07\n08\n09\n10\n");
 }

--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -2,7 +2,7 @@ extern crate rand;
 extern crate regex;
 
 use std::fs::{File, read_dir};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::Path;
 use self::rand::{Rng, thread_rng};
 use self::regex::Regex;
@@ -101,7 +101,7 @@ fn test_split_default() {
     let name = "split_default";
     let glob = Glob::new(&at, ".", r"x[:alpha:][:alpha:]$");
     RandomFile::new(&at, name).add_lines(2000);
-    assert!(ucmd.args(&[name]).run().success);
+    ucmd.args(&[name]).succeeds();
     assert_eq!(glob.count(), 2);
     assert_eq!(glob.collate(), at.read(name).into_bytes());
 }
@@ -112,7 +112,7 @@ fn test_split_num_prefixed_chunks_by_bytes() {
     let name = "split_num_prefixed_chunks_by_bytes";
     let glob = Glob::new(&at, ".", r"a\d\d$");
     RandomFile::new(&at, name).add_bytes(10000);
-    assert!(ucmd.args(&["-d", "-b", "1000", name, "a"]).run().success);
+    ucmd.args(&["-d", "-b", "1000", name, "a"]).succeeds();
     assert_eq!(glob.count(), 10);
     assert_eq!(glob.collate(), at.read(name).into_bytes());
 }
@@ -123,7 +123,7 @@ fn test_split_str_prefixed_chunks_by_bytes() {
     let name = "split_str_prefixed_chunks_by_bytes";
     let glob = Glob::new(&at, ".", r"b[:alpha:][:alpha:]$");
     RandomFile::new(&at, name).add_bytes(10000);
-    assert!(ucmd.args(&["-b", "1000", name, "b"]).run().success);
+    ucmd.args(&["-b", "1000", name, "b"]).succeeds();
     assert_eq!(glob.count(), 10);
     assert_eq!(glob.collate(), at.read(name).into_bytes());
 }
@@ -134,7 +134,7 @@ fn test_split_num_prefixed_chunks_by_lines() {
     let name = "split_num_prefixed_chunks_by_lines";
     let glob = Glob::new(&at, ".", r"c\d\d$");
     RandomFile::new(&at, name).add_lines(10000);
-    assert!(ucmd.args(&["-d", "-l", "1000", name, "c"]).run().success);
+    ucmd.args(&["-d", "-l", "1000", name, "c"]).succeeds();
     assert_eq!(glob.count(), 10);
     assert_eq!(glob.collate(), at.read(name).into_bytes());
 }
@@ -145,7 +145,7 @@ fn test_split_str_prefixed_chunks_by_lines() {
     let name = "split_str_prefixed_chunks_by_lines";
     let glob = Glob::new(&at, ".", r"d[:alpha:][:alpha:]$");
     RandomFile::new(&at, name).add_lines(10000);
-    assert!(ucmd.args(&["-l", "1000", name, "d"]).run().success);
+    ucmd.args(&["-l", "1000", name, "d"]).succeeds();
     assert_eq!(glob.count(), 10);
     assert_eq!(glob.collate(), at.read(name).into_bytes());
 }

--- a/tests/test_stdbuf.rs
+++ b/tests/test_stdbuf.rs
@@ -9,9 +9,8 @@ fn new_ucmd() -> UCommand {
 fn test_stdbuf_unbuffered_stdout() {
     if cfg!(target_os="linux") {
         // This is a basic smoke test
-        let result = new_ucmd().args(&["-o0", "head"])
-                         .run_piped_stdin("The quick brown fox jumps over the lazy dog.");
-        assert_eq!(result.stdout,
-                   "The quick brown fox jumps over the lazy dog.");
+        new_ucmd().args(&["-o0", "head"])
+            .pipe_in("The quick brown fox jumps over the lazy dog.").run()
+            .stdout_is("The quick brown fox jumps over the lazy dog.");
     }
 }

--- a/tests/test_tac.rs
+++ b/tests/test_tac.rs
@@ -7,23 +7,28 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_stdin_default() {
-    let result = new_ucmd()
-        .run_piped_stdin("100\n200\n300\n400\n500");
-    assert_eq!(result.stdout, "500400\n300\n200\n100\n");
+    new_ucmd()
+        .pipe_in("100\n200\n300\n400\n500")
+        .run()
+        .stdout_is("500400\n300\n200\n100\n");
 }
 
 #[test]
 fn test_stdin_non_newline_separator() {
-    let result = new_ucmd()
-        .args(&["-s", ":"]).run_piped_stdin("100:200:300:400:500");
-    assert_eq!(result.stdout, "500400:300:200:100:");
+    new_ucmd()
+        .args(&["-s", ":"])
+        .pipe_in("100:200:300:400:500")
+        .run()
+        .stdout_is("500400:300:200:100:");
 }
 
 #[test]
 fn test_stdin_non_newline_separator_before() {
-    let result = new_ucmd()
-        .args(&["-b", "-s", ":"]).run_piped_stdin("100:200:300:400:500");
-    assert_eq!(result.stdout, "500:400:300:200:100");
+    new_ucmd()
+        .args(&["-b", "-s", ":"])
+        .pipe_in("100:200:300:400:500")
+        .run()
+        .stdout_is("500:400:300:200:100");
 }
 
 #[test]

--- a/tests/test_tail.rs
+++ b/tests/test_tail.rs
@@ -110,8 +110,7 @@ fn test_single_big_args() {
     }
     big_expected.flush().expect("Could not flush EXPECTED_FILE");
 
-    let result = ucmd.arg(FILE).arg("-n").arg(format!("{}", N_ARG)).run();
-    assert_eq!(result.stdout, at.read(EXPECTED_FILE));
+    ucmd.arg(FILE).arg("-n").arg(format!("{}", N_ARG)).run().stdout_is(at.read(EXPECTED_FILE));
 }
 
 #[test]
@@ -214,6 +213,5 @@ fn test_lines_with_size_suffix() {
     }
     big_expected.flush().expect("Could not flush EXPECTED_FILE");
 
-    let result = ucmd.arg(FILE).arg("-n").arg("2K").run();
-    assert_eq!(result.stdout, at.read(EXPECTED_FILE));
+    ucmd.arg(FILE).arg("-n").arg("2K").run().stdout_is_fixture(EXPECTED_FILE);
 }

--- a/tests/test_test.rs
+++ b/tests/test_test.rs
@@ -16,40 +16,21 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_op_prec_and_or_1() {
-    let exit_success = new_ucmd()
-                           .arg(" ")
-                           .arg("-o")
-                           .arg("")
-                           .arg("-a")
-                           .arg("")
-                           .run()
-                           .success;
-    assert!(exit_success);
+    new_ucmd()
+        .args(&[" ", "-o", "", "-a", ""])
+        .succeeds();
 }
 
 #[test]
 fn test_op_prec_and_or_2() {
-    let exit_success = new_ucmd()
-                           .arg("")
-                           .arg("-a")
-                           .arg("")
-                           .arg("-o")
-                           .arg(" ")
-                           .arg("-a")
-                           .arg(" ")
-                           .run()
-                           .success;
-    assert!(exit_success);
+    new_ucmd()
+        .args(&["", "-a", "", "-o", " ", "-a", " "])
+        .succeeds();
 }
 
 #[test]
 fn test_or_as_filename() {
-    let exit_success = new_ucmd()
-        .arg("x")
-                           .arg("-a")
-                           .arg("-z")
-                           .arg("-o")
-                           .run()
-                           .success;
-    assert!(!exit_success);
+    new_ucmd()
+        .args(&["x", "-a", "-z", "-o"])
+        .fails();
 }

--- a/tests/test_touch.rs
+++ b/tests/test_touch.rs
@@ -34,9 +34,8 @@ fn test_touch_default() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_default_file";
 
-    let result = ucmd.arg(file).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(file).succeeds().no_stderr();
+    
 
     assert!(at.file_exists(file));
 }
@@ -46,9 +45,7 @@ fn test_touch_no_create_file_absent() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_no_create_file_absent";
 
-    let result = ucmd.arg("-c").arg(file).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-c").arg(file).succeeds().no_stderr();
 
     assert!(!at.file_exists(file));
 }
@@ -61,9 +58,7 @@ fn test_touch_no_create_file_exists() {
     at.touch(file);
     assert!(at.file_exists(file));
 
-    let result = ucmd.arg("-c").arg(file).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg("-c").arg(file).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 }
@@ -73,9 +68,7 @@ fn test_touch_set_mdhm_time() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_mdhm_time";
 
-    let result = ucmd.args(&["-t", "01011234", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "01011234", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -93,9 +86,7 @@ fn test_touch_set_mdhms_time() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_mdhms_time";
 
-    let result = ucmd.args(&["-t", "01011234.56", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "01011234.56", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -113,9 +104,7 @@ fn test_touch_set_ymdhm_time() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_ymdhm_time";
 
-    let result = ucmd.args(&["-t", "1501011234", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "1501011234", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -133,9 +122,7 @@ fn test_touch_set_ymdhms_time() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_ymdhms_time";
 
-    let result = ucmd.args(&["-t", "1501011234.56", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "1501011234.56", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -153,9 +140,7 @@ fn test_touch_set_cymdhm_time() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_cymdhm_time";
 
-    let result = ucmd.args(&["-t", "201501011234", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "201501011234", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -173,9 +158,7 @@ fn test_touch_set_cymdhms_time() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_cymdhms_time";
 
-    let result = ucmd.args(&["-t", "201501011234.56", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "201501011234.56", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -193,9 +176,7 @@ fn test_touch_set_only_atime() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_only_atime";
 
-    let result = ucmd.args(&["-t", "201501011234", "-a", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "201501011234", "-a", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -211,9 +192,7 @@ fn test_touch_set_only_mtime() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_only_mtime";
 
-    let result = ucmd.args(&["-t", "201501011234", "-m", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "201501011234", "-m", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -229,9 +208,7 @@ fn test_touch_set_both() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_both";
 
-    let result = ucmd.args(&["-t", "201501011234", "-a", "-m", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-t", "201501011234", "-a", "-m", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 
@@ -255,9 +232,7 @@ fn test_touch_reference() {
     set_file_times(&at, file_a, start_of_year, start_of_year);
     assert!(at.file_exists(file_a));
 
-    let result = ucmd.args(&["-r", file_a, file_b]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-r", file_a, file_b]).succeeds().no_stderr();
 
     assert!(at.file_exists(file_b));
 
@@ -272,9 +247,7 @@ fn test_touch_set_date() {
     let (at, mut ucmd) = at_and_ucmd();
     let file = "test_touch_set_date";
 
-    let result = ucmd.args(&["-d", "Thu Jan 01 12:34:00 2015", file]).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.args(&["-d", "Thu Jan 01 12:34:00 2015", file]).succeeds().no_stderr();
 
     assert!(at.file_exists(file));
 

--- a/tests/test_tr.rs
+++ b/tests/test_tr.rs
@@ -7,36 +7,32 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_toupper() {
-    let result = new_ucmd()
-        .args(&["a-z", "A-Z"]).run_piped_stdin("!abcd!");
-    assert_eq!(result.stdout, "!ABCD!");
+    new_ucmd()
+        .args(&["a-z", "A-Z"]).pipe_in("!abcd!").run().stdout_is("!ABCD!");
 }
 
 #[test]
 fn test_small_set2() {
-    let result = new_ucmd()
-        .args(&["0-9", "X"]).run_piped_stdin("@0123456789");
-    assert_eq!(result.stdout, "@XXXXXXXXXX");
+    new_ucmd()
+        .args(&["0-9", "X"]).pipe_in("@0123456789").run().stdout_is("@XXXXXXXXXX");
 }
 
 #[test]
 fn test_unicode() {
-    let result = new_ucmd()
+    new_ucmd()
         .args(&[", ┬─┬", "╯︵┻━┻"])
-                     .run_piped_stdin("(,°□°）, ┬─┬".as_bytes());
-    assert_eq!(result.stdout, "(╯°□°）╯︵┻━┻");
+        .pipe_in("(,°□°）, ┬─┬").run()
+        .stdout_is("(╯°□°）╯︵┻━┻");
 }
 
 #[test]
 fn test_delete() {
-    let result = new_ucmd()
-        .args(&["-d", "a-z"]).run_piped_stdin("aBcD");
-    assert_eq!(result.stdout, "BD");
+    new_ucmd()
+        .args(&["-d", "a-z"]).pipe_in("aBcD").run().stdout_is("BD");
 }
 
 #[test]
 fn test_delete_complement() {
-    let result = new_ucmd()
-        .args(&["-d", "-c", "a-z"]).run_piped_stdin("aBcD");
-    assert_eq!(result.stdout, "ac");
+    new_ucmd()
+        .args(&["-d", "-c", "a-z"]).pipe_in("aBcD").run().stdout_is("ac");
 }

--- a/tests/test_true.rs
+++ b/tests/test_true.rs
@@ -7,7 +7,5 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_exit_code() {
-    let exit_status = new_ucmd()
-        .run().success;
-    assert_eq!(exit_status, true);
+    new_ucmd().succeeds();
 }

--- a/tests/test_truncate.rs
+++ b/tests/test_truncate.rs
@@ -15,7 +15,7 @@ static TFILE2: &'static str = "truncate_test_2";
 fn test_increase_file_size() {
     let (at, mut ucmd) = at_and_ucmd();
     let mut file = at.make_file(TFILE1);
-    assert!(ucmd.args(&["-s", "+5K", TFILE1]).run().success);
+    ucmd.args(&["-s", "+5K", TFILE1]).succeeds();
 
     file.seek(SeekFrom::End(0)).unwrap();
     assert!(file.seek(SeekFrom::Current(0)).unwrap() == 5 * 1024);
@@ -26,7 +26,7 @@ fn test_decrease_file_size() {
     let (at, mut ucmd) = at_and_ucmd();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
-    assert!(ucmd.args(&["--size=-4", TFILE2]).run().success);
+    ucmd.args(&["--size=-4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
     assert!(file.seek(SeekFrom::Current(0)).unwrap() == 6);
 }

--- a/tests/test_unexpand.rs
+++ b/tests/test_unexpand.rs
@@ -7,66 +7,66 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn unexpand_init_0() {
-    let result = new_ucmd()
-        .args(&["-t4"]).run_piped_stdin(" 1\n  2\n   3\n    4\n");
-    assert_eq!(result.stdout, " 1\n  2\n   3\n\t4\n");
+    new_ucmd()
+        .args(&["-t4"]).pipe_in(" 1\n  2\n   3\n    4\n")
+        .run().stdout_is(" 1\n  2\n   3\n\t4\n");
 }
 
 #[test]
 fn unexpand_init_1() {
-    let result = new_ucmd()
-        .args(&["-t4"]).run_piped_stdin("     5\n      6\n       7\n        8\n");
-    assert_eq!(result.stdout, "\t 5\n\t  6\n\t   7\n\t\t8\n");
+    new_ucmd()
+        .args(&["-t4"]).pipe_in("     5\n      6\n       7\n        8\n")
+        .run().stdout_is("\t 5\n\t  6\n\t   7\n\t\t8\n");
 }
 
 #[test]
 fn unexpand_init_list_0() {
-    let result = new_ucmd()
-        .args(&["-t2,4"]).run_piped_stdin(" 1\n  2\n   3\n    4\n");
-    assert_eq!(result.stdout, " 1\n\t2\n\t 3\n\t\t4\n");
+    new_ucmd()
+        .args(&["-t2,4"]).pipe_in(" 1\n  2\n   3\n    4\n")
+        .run().stdout_is(" 1\n\t2\n\t 3\n\t\t4\n");
 }
 
 #[test]
 fn unexpand_init_list_1() {
     // Once the list is exhausted, spaces are not converted anymore
-    let result = new_ucmd()
-        .args(&["-t2,4"]).run_piped_stdin("     5\n      6\n       7\n        8\n");
-    assert_eq!(result.stdout, "\t\t 5\n\t\t  6\n\t\t   7\n\t\t    8\n");
+    new_ucmd()
+        .args(&["-t2,4"]).pipe_in("     5\n      6\n       7\n        8\n")
+        .run().stdout_is("\t\t 5\n\t\t  6\n\t\t   7\n\t\t    8\n");
 }
 
 #[test]
 fn unexpand_aflag_0() {
-    let result = new_ucmd()
-        .args(&["--"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
-    assert_eq!(result.stdout, "e     E\nf      F\ng       G\nh        H\n");
+    new_ucmd()
+        .args(&["--"]).pipe_in("e     E\nf      F\ng       G\nh        H\n")
+        .run().stdout_is("e     E\nf      F\ng       G\nh        H\n");
 }
 
 #[test]
 fn unexpand_aflag_1() {
-    let result = new_ucmd()
-        .args(&["-a"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
-    assert_eq!(result.stdout, "e     E\nf      F\ng\tG\nh\t H\n");
+    new_ucmd()
+        .args(&["-a"]).pipe_in("e     E\nf      F\ng       G\nh        H\n")
+        .run().stdout_is("e     E\nf      F\ng\tG\nh\t H\n");
 }
 
 #[test]
 fn unexpand_aflag_2() {
-    let result = new_ucmd()
-        .args(&["-t8"]).run_piped_stdin("e     E\nf      F\ng       G\nh        H\n");
-    assert_eq!(result.stdout, "e     E\nf      F\ng\tG\nh\t H\n");
+    new_ucmd()
+        .args(&["-t8"]).pipe_in("e     E\nf      F\ng       G\nh        H\n")
+        .run().stdout_is("e     E\nf      F\ng\tG\nh\t H\n");
 }
 
 #[test]
 fn unexpand_first_only_0() {
-    let result = new_ucmd()
-        .args(&["-t3"]).run_piped_stdin("        A     B");
-    assert_eq!(result.stdout, "\t\t  A\t  B");
+    new_ucmd()
+        .args(&["-t3"]).pipe_in("        A     B")
+        .run().stdout_is("\t\t  A\t  B");
 }
 
 #[test]
 fn unexpand_first_only_1() {
-    let result = new_ucmd()
-        .args(&["-t3", "--first-only"]).run_piped_stdin("        A     B");
-    assert_eq!(result.stdout, "\t\t  A     B");
+    new_ucmd()
+        .args(&["-t3", "--first-only"]).pipe_in("        A     B")
+        .run().stdout_is("\t\t  A     B");
 }
 
 #[test]
@@ -74,25 +74,25 @@ fn unexpand_trailing_space_0() {
     // evil
     // Individual spaces before fields starting with non blanks should not be
     // converted, unless they are at the beginning of the line.
-    let result = new_ucmd()
-        .args(&["-t4"]).run_piped_stdin("123 \t1\n123 1\n123 \n123 ");
-    assert_eq!(result.stdout, "123\t\t1\n123 1\n123 \n123 ");
+    new_ucmd()
+        .args(&["-t4"]).pipe_in("123 \t1\n123 1\n123 \n123 ")
+        .run().stdout_is("123\t\t1\n123 1\n123 \n123 ");
 }
 
 #[test]
 fn unexpand_trailing_space_1() {
     // super evil
-    let result = new_ucmd()
-        .args(&["-t1"]).run_piped_stdin(" abc d e  f  g ");
-    assert_eq!(result.stdout, "\tabc d e\t\tf\t\tg ");
+    new_ucmd()
+        .args(&["-t1"]).pipe_in(" abc d e  f  g ")
+        .run().stdout_is("\tabc d e\t\tf\t\tg ");
 }
 
 #[test]
 fn unexpand_spaces_follow_tabs_0() {
     // The two first spaces can be included into the first tab.
-    let result = new_ucmd()
-        .run_piped_stdin("  \t\t   A");
-    assert_eq!(result.stdout, "\t\t   A");
+    new_ucmd()
+        .pipe_in("  \t\t   A")
+        .run().stdout_is("\t\t   A");
 }
 
 #[test]
@@ -103,14 +103,14 @@ fn unexpand_spaces_follow_tabs_1() {
     //    ' \t' -> '\t'         // second tabstop (4)
     //      ' ' -> '\t'         // third tabstop (5)
     // '  B \t' -> '  B \t'     // after the list is exhausted, nothing must change
-    let result = new_ucmd()
-        .args(&["-t1,4,5"]).run_piped_stdin("a \t   B \t");
-    assert_eq!(result.stdout, "a\t\t  B \t");
+    new_ucmd()
+        .args(&["-t1,4,5"]).pipe_in("a \t   B \t")
+        .run().stdout_is("a\t\t  B \t");
 }
 
 #[test]
 fn unexpand_spaces_after_fields() {
-    let result = new_ucmd()
-        .args(&["-a"]).run_piped_stdin("   \t        A B C D             A\t\n");
-    assert_eq!(result.stdout, "\t\tA B C D\t\t    A\t\n");
+    new_ucmd()
+        .args(&["-a"]).pipe_in("   \t        A B C D             A\t\n")
+        .run().stdout_is("\t\tA B C D\t\t    A\t\n");
 }

--- a/tests/test_unlink.rs
+++ b/tests/test_unlink.rs
@@ -17,9 +17,7 @@ fn test_unlink_file() {
 
     at.touch(file);
 
-    let result = ucmd.arg(file).run();
-    assert_empty_stderr!(result);
-    assert!(result.success);
+    ucmd.arg(file).succeeds().no_stderr();
 
     assert!(!at.file_exists(file));
 }
@@ -33,11 +31,9 @@ fn test_unlink_multiple_files() {
     at.touch(file_a);
     at.touch(file_b);
 
-    let result = ucmd.arg(file_a).arg(file_b).run();
-    assert_eq!(result.stderr,
-               "unlink: error: extra operand: 'test_unlink_multiple_file_b'\nTry 'unlink --help' \
+    ucmd.arg(file_a).arg(file_b).fails()
+        .stderr_is("unlink: error: extra operand: 'test_unlink_multiple_file_b'\nTry 'unlink --help' \
                 for more information.\n");
-    assert!(!result.success);
 }
 
 #[test]
@@ -47,20 +43,16 @@ fn test_unlink_directory() {
 
     at.mkdir(dir);
 
-    let result = ucmd.arg(dir).run();
-    assert_eq!(result.stderr,
-               "unlink: error: cannot unlink 'test_unlink_empty_directory': Not a regular file \
+    ucmd.arg(dir).fails()
+        .stderr_is("unlink: error: cannot unlink 'test_unlink_empty_directory': Not a regular file \
                 or symlink\n");
-    assert!(!result.success);
 }
 
 #[test]
 fn test_unlink_nonexistent() {
     let file = "test_unlink_nonexistent";
 
-    let result = new_ucmd().arg(file).run();
-    assert_eq!(result.stderr,
-               "unlink: error: Cannot stat 'test_unlink_nonexistent': No such file or directory \
+    new_ucmd().arg(file).fails()
+        .stderr_is("unlink: error: Cannot stat 'test_unlink_nonexistent': No such file or directory \
                 (os error 2)\n");
-    assert!(!result.success);
 }

--- a/tests/test_wc.rs
+++ b/tests/test_wc.rs
@@ -7,50 +7,48 @@ fn new_ucmd() -> UCommand {
 
 #[test]
 fn test_stdin_default() {
-    let result = new_ucmd().pipe_in_fixture("lorem_ipsum.txt").run();
-    assert_eq!(result.stdout, "  13 109 772\n");
+    new_ucmd().pipe_in_fixture("lorem_ipsum.txt")
+        .run().stdout_is("  13 109 772\n");
 }
 
 #[test]
 fn test_stdin_only_bytes() {
-    let result = new_ucmd().args(&["-c"]).pipe_in_fixture("lorem_ipsum.txt").run();
-    assert_eq!(result.stdout, " 772\n");
+    new_ucmd().args(&["-c"]).pipe_in_fixture("lorem_ipsum.txt")
+        .run().stdout_is(" 772\n");
 }
 
 #[test]
 fn test_stdin_all_counts() {
-    let result = new_ucmd().args(&["-c", "-m", "-l", "-L", "-w"])
-                     .pipe_in_fixture("alice_in_wonderland.txt").run();
-    assert_eq!(result.stdout, "   5  57 302 302  66\n");
+    new_ucmd().args(&["-c", "-m", "-l", "-L", "-w"])
+        .pipe_in_fixture("alice_in_wonderland.txt")
+        .run()
+        .stdout_is("   5  57 302 302  66\n");
 }
 
 #[test]
 fn test_single_default() {
-    let result = new_ucmd()
-        .arg("moby_dick.txt").run();
-    assert_eq!(result.stdout, "   18  204 1115 moby_dick.txt\n");
+    new_ucmd()
+        .arg("moby_dick.txt").run().stdout_is("   18  204 1115 moby_dick.txt\n");
 }
 
 #[test]
 fn test_single_only_lines() {
-    let result = new_ucmd()
-        .args(&["-l", "moby_dick.txt"]).run();
-    assert_eq!(result.stdout, "   18 moby_dick.txt\n");
+    new_ucmd()
+        .args(&["-l", "moby_dick.txt"]).run().stdout_is("   18 moby_dick.txt\n");
 }
 
 #[test]
 fn test_single_all_counts() {
-    let result = new_ucmd()
-        .args(&["-c", "-l", "-L", "-m", "-w", "alice_in_wonderland.txt"]).run();
-    assert_eq!(result.stdout,
-               "   5  57 302 302  66 alice_in_wonderland.txt\n");
+    new_ucmd()
+        .args(&["-c", "-l", "-L", "-m", "-w", "alice_in_wonderland.txt"]).run()
+        .stdout_is("   5  57 302 302  66 alice_in_wonderland.txt\n");
 }
 
 #[test]
 fn test_multiple_default() {
-    let result = new_ucmd()
-        .args(&["lorem_ipsum.txt", "moby_dick.txt", "alice_in_wonderland.txt"]).run();
-    assert_eq!(result.stdout,
+    new_ucmd()
+        .args(&["lorem_ipsum.txt", "moby_dick.txt", "alice_in_wonderland.txt"]).run()
+        .stdout_is(
                "   13  109  772 lorem_ipsum.txt\n   18  204 1115 moby_dick.txt\n    5   57  302 \
                 alice_in_wonderland.txt\n   36  370 2189 total\n");
 }

--- a/tests/test_who.rs
+++ b/tests/test_who.rs
@@ -2,87 +2,75 @@ use common::util::*;
 
 static UTIL_NAME: &'static str = "who";
 
+fn new_ucmd() -> UCommand {
+    TestScenario::new(UTIL_NAME).ucmd()
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn test_count() {
-    for opt in ["-q", "--count"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-q", "--count"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn test_boot() {
-    for opt in ["-b", "--boot"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-b", "--boot"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn test_heading() {
-    for opt in ["-H"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-H"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn test_short() {
-    for opt in ["-s", "--short"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-s", "--short"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn test_login() {
-    for opt in ["-l", "--login"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-l", "--login"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn test_m() {
-    for opt in ["-m"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-m"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn test_dead() {
-    for opt in ["-d", "--dead"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-d", "--dead"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn test_all() {
-    for opt in ["-a", "--all"].into_iter() {
-        let scene = TestScenario::new(UTIL_NAME);
-        let args = [*opt];
-        scene.ucmd().args(&args).run().stdout_is(expected_result(&args));
+    for opt in vec!["-a", "--all"] {
+        new_ucmd().arg(opt).run().stdout_is(expected_result(opt));
     }
 }
 
 #[cfg(target_os = "linux")]
-fn expected_result(args: &[&str]) -> String {
-    TestScenario::new(UTIL_NAME).cmd_keepenv(UTIL_NAME).args(args).run().stdout
+fn expected_result(arg: &str) -> String {
+    TestScenario::new(UTIL_NAME).cmd_keepenv(UTIL_NAME).args(&[arg]).run().stdout
 }


### PR DESCRIPTION
This commit improves the brevity and consistency of integration tests by refactoring multiple tests to use chaining asserts and idiomatic use of UCommand

#### 1.Consistency

Some test modules currently use "module-idiosyncratic" convenience functions that provide only, or little more than, plugging the arguments into expected stdout, stderr, etc. By "module-idiosyncratic" I just mean their naming, parameters, and behavior are particular to their test module.  

Previously, these convenience functions offered a major brevity gain, but with the arrival of both chaining asserts and the ```new_ucmd()``` convention, this advantage has been reduced and is now outweighed by the following benefits of using UCommand directly:

* When someone opens up a test file to investigate a failing test, they immediately understand the command inputs and expected outputs, even if they haven't read this test file in the last week.
* Devs adding tests no longer have to mentally "context switch" to the particular module-specific style of calling tests in this module, a style that is not truly necessary.
* UCommand is more naturally readable. We obviously can't expect to always achieve natural readability for all tests, but where we can achieve it it's a big win in terms of converting skeptics to users, distributors or advocates. When we have naturally readable tests we can point skeptics to them to show them in an intuitively understandable way that we're as feature as we say we are. 

 E.g. Someone who wants to see for themselves that our ```basename``` implements all the features of Gnu ```basename``` will probably understand ```new_ucmd().args(&["/foo/bar/baz", "baz"]).succeeds().stdout_only( "baz")```even if they don't know rust or any programming languages. And the text shows everything that's being tested (exit code, stdout, stderr).

#### 2. Brevity

Chaining asserts take up far less characters than even the use of the assert_eq! macros as can be seen from the linecount. This is visible from the linecount change and character count change.

```bash
alias count="sed -r 's/\s//g' | wc -m"
cat tests/test_*.rs | count
#before: ~156000
#after:  ~147000
```