### PR TITLE
tail: fix bug when following /dev/stdin

### DIFF
--- a/tests/test_tail.rs
+++ b/tests/test_tail.rs
@@ -80,13 +80,7 @@ fn test_follow_multiple() {
 
 #[test]
 fn test_follow_stdin() {
-    let (at, mut ucmd) = at_and_ucmd();
-    let mut child = ucmd.arg("-f").pipe_in(at.read(FOOBAR_TXT)).run_no_wait();
-
-    let expected = at.read("follow_stdin.expected");
-    assert_eq!(read_size(&mut child, expected.len()), expected);
-
-    child.kill().unwrap();
+    new_ucmd().arg("-f").pipe_in_fixture(FOOBAR_TXT).run().stdout_is_fixture("follow_stdin.expected");
 }
 
 #[test]


### PR DESCRIPTION
main panics when following /dev/stdin since /dev/stdin is not seekable.
Check to see if file is seekable and use unbounded_seek if not.

Also tail should ignore `-f` if no files are passed.