### PR TITLE
DRYer code and more UX consistency through use of coreopts 

### DIFF
--- a/src/base32/Cargo.toml
+++ b/src/base32/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_base32"
 path = "base32.rs"
 
 [dependencies]
-getopts = "*"
 uucore = { path="../uucore" }
 
 [dependencies.clippy]

--- a/src/base32/base32.rs
+++ b/src/base32/base32.rs
@@ -8,46 +8,38 @@
 
 #![crate_name = "uu_base32"]
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 use uucore::encoding::{Data, Format, wrap_print};
 
-use getopts::Options;
 use std::fs::File;
 use std::io::{BufReader, Read, stdin, Write};
 use std::path::Path;
 
-static NAME: &'static str = "base32";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTION]... [FILE]"; 
+static SUMMARY: &'static str = "Base32 encode or decode FILE, or standard input, to standard output."; 
+static LONG_HELP: &'static str = "
+ With no FILE, or when FILE is -, read standard input.
+
+ The data are encoded as described for the base32 alphabet in RFC
+ 4648. When decoding, the input may contain newlines in addition
+ to the bytes of the formal base32 alphabet. Use --ignore-garbage
+ to attempt to recover from any other non-alphabet bytes in the
+ encoded stream.
+";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = Options::new();
-    opts.optflag("d", "decode", "decode data");
-    opts.optflag("i",
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optflag("d", "decode", "decode data")
+        .optflag("i",
                  "ignore-garbage",
-                 "when decoding, ignore non-alphabetic characters");
-    opts.optopt("w",
+                 "when decoding, ignore non-alphabetic characters")
+        .optopt("w",
                 "wrap",
                 "wrap encoded lines after COLS character (default 76, 0 to disable wrapping)",
-                "COLS");
-    opts.optflag("", "help", "display this help text and exit");
-    opts.optflag("", "version", "output version information and exit");
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(e) => {
-            disp_err!("{}", e);
-            return 1;
-        }
-    };
-
-    if matches.opt_present("help") {
-        return help(&opts);
-    } else if matches.opt_present("version") {
-        return version();
-    }
-
+                "COLS")
+        .parse(args);
+    
     let line_wrap = match matches.opt_str("wrap") {
         Some(s) => {
             match s.parse() {
@@ -86,25 +78,5 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     }
 
-    0
-}
-
-fn help(opts: &Options) -> i32 {
-    let msg = format!("Usage: {} [OPTION]... [FILE]\n\n\
-    Base32 encode or decode FILE, or standard input, to standard output.\n\
-    With no FILE, or when FILE is -, read standard input.\n\n\
-    The data are encoded as described for the base32 alphabet in RFC \
-    4648.\nWhen decoding, the input may contain newlines in addition \
-    to the bytes of the formal\nbase32 alphabet. Use --ignore-garbage \
-    to attempt to recover from any other\nnon-alphabet bytes in the \
-    encoded stream.",
-                      NAME);
-
-    print!("{}", opts.usage(&msg));
-    0
-}
-
-fn version() -> i32 {
-    println!("{} {}", NAME, VERSION);
     0
 }

--- a/src/base64/Cargo.toml
+++ b/src/base64/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_base64"
 path = "base64.rs"
 
 [dependencies]
-getopts = "*"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/base64/base64.rs
+++ b/src/base64/base64.rs
@@ -9,45 +9,38 @@
 // that was distributed with this source code.
 //
 
-extern crate getopts;
 
 #[macro_use]
 extern crate uucore;
 use uucore::encoding::{Data, Format, wrap_print};
 
-use getopts::Options;
 use std::fs::File;
 use std::io::{BufReader, Read, stdin, Write};
 use std::path::Path;
 
-static NAME: &'static str = "base64";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTION]... [FILE]"; 
+static SUMMARY: &'static str = "Base64 encode or decode FILE, or standard input, to standard output."; 
+static LONG_HELP: &'static str = "
+ With no FILE, or when FILE is -, read standard input.
+
+ The data are encoded as described for the base64 alphabet in RFC
+ 3548. When decoding, the input may contain newlines in addition
+ to the bytes of the formal base64 alphabet. Use --ignore-garbage
+ to attempt to recover from any other non-alphabet bytes in the
+ encoded stream.
+";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = Options::new();
-    opts.optflag("d", "decode", "decode data");
-    opts.optflag("i",
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optflag("d", "decode", "decode data")
+        .optflag("i",
                  "ignore-garbage",
-                 "when decoding, ignore non-alphabetic characters");
-    opts.optopt("w",
+                 "when decoding, ignore non-alphabetic characters")
+        .optopt("w",
                 "wrap",
                 "wrap encoded lines after COLS character (default 76, 0 to disable wrapping)",
-                "COLS");
-    opts.optflag("", "help", "display this help text and exit");
-    opts.optflag("", "version", "output version information and exit");
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(e) => {
-            disp_err!("{}", e);
-            return 1;
-        }
-    };
-
-    if matches.opt_present("help") {
-        return help(&opts);
-    } else if matches.opt_present("version") {
-        return version();
-    }
+                "COLS")
+        .parse(args);
 
     let line_wrap = match matches.opt_str("wrap") {
         Some(s) => {
@@ -87,25 +80,5 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     }
 
-    0
-}
-
-fn help(opts: &Options) -> i32 {
-    let msg = format!("Usage: {} [OPTION]... [FILE]\n\n\
-    Base64 encode or decode FILE, or standard input, to standard output.\n\
-    With no FILE, or when FILE is -, read standard input.\n\n\
-    The data are encoded as described for the base64 alphabet in RFC \
-    3548. When\ndecoding, the input may contain newlines in addition \
-    to the bytes of the formal\nbase64 alphabet. Use --ignore-garbage \
-    to attempt to recover from any other\nnon-alphabet bytes in the \
-    encoded stream.",
-                      NAME);
-
-    print!("{}", opts.usage(&msg));
-    0
-}
-
-fn version() -> i32 {
-    println!("{} {}", NAME, VERSION);
     0
 }

--- a/src/basename/Cargo.toml
+++ b/src/basename/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_basename"
 path = "basename.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/cat/Cargo.toml
+++ b/src/cat/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_cat"
 path = "cat.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -11,53 +11,35 @@
 
 /* last synced with: cat (GNU coreutils) 8.13 */
 
-extern crate getopts;
 extern crate libc;
 
 #[macro_use]
 extern crate uucore;
 
-use getopts::Options;
 use std::fs::File;
 use std::intrinsics::{copy_nonoverlapping};
 use std::io::{stdout, stdin, stderr, Write, Read, Result};
 use uucore::fs::is_stdin_interactive;
 
-static NAME: &'static str = "cat";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTION]... [FILE]..."; 
+static SUMMARY: &'static str = "Concatenate FILE(s), or standard input, to standard output
+ With no FILE, or when FILE is -, read standard input."; 
+static LONG_HELP: &'static str = ""; 
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = Options::new();
-    opts.optflag("A", "show-all", "equivalent to -vET");
-    opts.optflag("b", "number-nonblank",
-                 "number nonempty output lines, overrides -n");
-    opts.optflag("e", "", "equivalent to -vE");
-    opts.optflag("E", "show-ends", "display $ at end of each line");
-    opts.optflag("n", "number", "number all output lines");
-    opts.optflag("s", "squeeze-blank", "suppress repeated empty output lines");
-    opts.optflag("t", "", "equivalent to -vT");
-    opts.optflag("T", "show-tabs", "display TAB characters as ^I");
-    opts.optflag("v", "show-nonprinting",
-                 "use ^ and M- notation, except for LF (\\n) and TAB (\\t)");
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => panic!("Invalid options\n{}", f)
-    };
-    if matches.opt_present("help") {
-        let msg = format!("{} {}\n\n\
-        Usage:\n  {0} [OPTION]... [FILE]...\n\n\
-        Concatenate FILE(s), or standard input, to standard output.\n\n\
-        With no FILE, or when FILE is -, read standard input.", NAME, VERSION);
-
-        print!("{}", opts.usage(&msg));
-        return 0;
-    }
-    if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optflag("A", "show-all", "equivalent to -vET")
+        .optflag("b", "number-nonblank",
+                 "number nonempty output lines, overrides -n")
+        .optflag("e", "", "equivalent to -vE")
+        .optflag("E", "show-ends", "display $ at end of each line")
+        .optflag("n", "number", "number all output lines")
+        .optflag("s", "squeeze-blank", "suppress repeated empty output lines")
+        .optflag("t", "", "equivalent to -vT")
+        .optflag("T", "show-tabs", "display TAB characters as ^I")
+        .optflag("v", "show-nonprinting",
+                 "use ^ and M- notation, except for LF (\\n) and TAB (\\t)")
+        .parse(args);
 
     let number_mode = if matches.opt_present("b") {
         NumberingMode::NumberNonEmpty

--- a/src/chmod/Cargo.toml
+++ b/src/chmod/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_chmod"
 path = "chmod.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 walker = "*"

--- a/src/chown/chown.rs
+++ b/src/chown/chown.rs
@@ -42,38 +42,35 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let mut opts = new_coreopts!(SYNTAX, SUMMARY, "");
     opts.optflag("c",
                  "changes",
-                 "like verbose but report only when a change is made");
-    opts.optflag("f", "silent", "");
-    opts.optflag("", "quiet", "suppress most error messages");
-    opts.optflag("v",
+                 "like verbose but report only when a change is made")
+        .optflag("f", "silent", "")
+        .optflag("", "quiet", "suppress most error messages")
+        .optflag("v",
                  "verbose",
-                 "output a diagnostic for every file processed");
-    opts.optflag("", "dereference", "affect the referent of each symbolic link (this is the default), rather than the symbolic link itself");
-    opts.optflag("h", "no-dereference", "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)");
+                 "output a diagnostic for every file processed")
+        .optflag("", "dereference", "affect the referent of each symbolic link (this is the default), rather than the symbolic link itself")
+        .optflag("h", "no-dereference", "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)")
 
-    opts.optopt("", "from", "change the owner and/or group of each file only if its current owner and/or group match those specified here. Either may be omitted, in which case a match is not required for the omitted attribute", "CURRENT_OWNER:CURRENT_GROUP");
-    opts.optopt("",
+        .optopt("", "from", "change the owner and/or group of each file only if its current owner and/or group match those specified here. Either may be omitted, in which case a match is not required for the omitted attribute", "CURRENT_OWNER:CURRENT_GROUP")
+        .optopt("",
                 "reference",
                 "use RFILE's owner and group rather than specifying OWNER:GROUP values",
-                "RFILE");
-
-    opts.optflag("",
+                "RFILE")
+        .optflag("",
                  "no-preserve-root",
-                 "do not treat '/' specially (the default)");
-    opts.optflag("", "preserve-root", "fail to operate recursively on '/'");
+                 "do not treat '/' specially (the default)")
+        .optflag("", "preserve-root", "fail to operate recursively on '/'")
 
-    opts.optflag("R",
+        .optflag("R",
                  "recursive",
-                 "operate on files and directories recursively");
-    opts.optflag("H",
+                 "operate on files and directories recursively")
+        .optflag("H",
                  "",
-                 "if a command line argument is a symbolic link to a directory, traverse it");
-    opts.optflag("L",
+                 "if a command line argument is a symbolic link to a directory, traverse it")
+        .optflag("L",
                  "",
-                 "traverse every symbolic link to a directory encountered");
-    opts.optflag("P", "", "do not traverse any symbolic links (default)");
-
-    let matches = opts.parse(args.clone());
+                 "traverse every symbolic link to a directory encountered")
+        .optflag("P", "", "do not traverse any symbolic links (default)");
 
     let mut bit_flag = FTS_PHYSICAL;
     let mut preserve_root = false;
@@ -100,6 +97,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     }
 
+    let matches = opts.parse(args);
     let recursive = matches.opt_present("recursive");
     if recursive {
         if bit_flag == FTS_PHYSICAL {

--- a/src/cksum/Cargo.toml
+++ b/src/cksum/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_cksum"
 path = "cksum.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/cksum/cksum.rs
+++ b/src/cksum/cksum.rs
@@ -9,12 +9,10 @@
  * file that was distributed with this source code.
  */
 
-extern crate getopts;
 
 #[macro_use]
 extern crate uucore;
 
-use getopts::Options;
 use std::fs::File;
 use std::io::{self, stdin, Read, Write, BufReader};
 #[cfg(not(windows))]
@@ -25,8 +23,9 @@ use crc_table::CRC_TABLE;
 
 mod crc_table;
 
-static NAME: &'static str = "cksum";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTIONS] [FILE]..."; 
+static SUMMARY: &'static str = "Print CRC and size for each file"; 
+static LONG_HELP: &'static str = ""; 
 
 #[inline]
 fn crc_update(crc: u32, input: u8) -> u32 {
@@ -88,31 +87,8 @@ fn cksum(fname: &str) -> io::Result<(u32, usize)> {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = Options::new();
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(err) => panic!("{}", err),
-    };
-
-    if matches.opt_present("help") {
-        let msg = format!("{0} {1}
-
-Usage:
-  {0} [OPTIONS] [FILE]...
-
-Print CRC and size for each file.", NAME, VERSION);
-
-        print!("{}", opts.usage(&msg));
-        return 0;
-    }
-
-    if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .parse(args);
 
     let files = matches.free;
 

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -8,8 +8,9 @@ name = "uu_comm"
 path = "comm.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
+getopts = "*"
+uucore = { path="../uucore" }
 
 [[bin]]
 name = "comm"

--- a/src/comm/comm.rs
+++ b/src/comm/comm.rs
@@ -11,14 +11,17 @@
 
 extern crate getopts;
 
-use getopts::Options;
+#[macro_use]
+extern crate uucore;
+
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, stdin, Stdin};
 use std::path::Path;
 
-static NAME: &'static str = "comm";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTIONS] FILE1 FILE2"; 
+static SUMMARY: &'static str = "Compare sorted files line by line"; 
+static LONG_HELP: &'static str = ""; 
 
 fn mkdelim(col: usize, opts: &getopts::Matches) -> String {
     let mut s = String::new();
@@ -122,39 +125,12 @@ fn open_file(name: &str) -> io::Result<LineReader> {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = Options::new();
-    opts.optflag("1", "", "suppress column 1 (lines uniq to FILE1)");
-    opts.optflag("2", "", "suppress column 2 (lines uniq to FILE2)");
-    opts.optflag("3", "", "suppress column 3 (lines that appear in both files)");
-    opts.optopt("", "output-delimiter", "separate columns with STR", "STR");
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(err) => panic!("{}", err),
-    };
-
-    if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
-
-    if matches.opt_present("help") || matches.free.len() != 2 {
-        let msg = format!("{0} {1}
-
-Usage:
-  {0} [OPTIONS] FILE1 FILE2
-
-Compare sorted files line by line.", NAME, VERSION);
-
-        print!("{}", opts.usage(&msg));
-
-        if matches.free.len() != 2 {
-            return 1;
-        }
-        return 0;
-    }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optflag("1", "", "suppress column 1 (lines uniq to FILE1)")
+        .optflag("2", "", "suppress column 2 (lines uniq to FILE2)")
+        .optflag("3", "", "suppress column 3 (lines that appear in both files)")
+        .optopt("", "output-delimiter", "separate columns with STR", "STR")
+        .parse(args);
 
     let mut f1 = open_file(matches.free[0].as_ref()).unwrap();
     let mut f2 = open_file(matches.free[1].as_ref()).unwrap();

--- a/src/cut/cut.rs
+++ b/src/cut/cut.rs
@@ -291,7 +291,7 @@ fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> i32 
     match opts.out_delimeter {
         Some(ref o_delim) => {
             return cut_fields_delimiter(reader, ranges, &opts.delimiter,
-                                        opts.only_delimited, newline_char, o_delim);
+                                            opts.only_delimited, newline_char, o_delim)
         }
         None => ()
     }
@@ -417,18 +417,17 @@ fn cut_files(mut filenames: Vec<String>, mode: Mode) -> i32 {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP);
-    opts.optopt("b", "bytes", "filter byte columns from the input source", "sequence");
-    opts.optopt("c", "characters", "alias for character mode", "sequence");
-    opts.optopt("d", "delimiter", "specify the delimiter character that separates fields in the input source. Defaults to Tab.", "delimiter");
-    opts.optopt("f", "fields", "filter field columns from the input source", "sequence");
-    opts.optflag("n", "", "legacy option - has no effect.");
-    opts.optflag("", "complement", "invert the filter - instead of displaying only the filtered columns, display all but those columns");
-    opts.optflag("s", "only-delimited", "in field mode, only print lines which contain the delimiter");
-    opts.optflag("z", "zero-terminated", "instead of filtering columns based on line, filter columns based on \\0 (NULL character)");
-    opts.optopt("", "output-delimiter", "in field mode, replace the delimiter in output lines with this option's argument", "new delimiter");
-    let matches = opts.parse(args);
-
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optopt("b", "bytes", "filter byte columns from the input source", "sequence")
+        .optopt("c", "characters", "alias for character mode", "sequence")
+        .optopt("d", "delimiter", "specify the delimiter character that separates fields in the input source. Defaults to Tab.", "delimiter")
+        .optopt("f", "fields", "filter field columns from the input source", "sequence")
+        .optflag("n", "", "legacy option - has no effect.")
+        .optflag("", "complement", "invert the filter - instead of displaying only the filtered columns, display all but those columns")
+        .optflag("s", "only-delimited", "in field mode, only print lines which contain the delimiter")
+        .optflag("z", "zero-terminated", "instead of filtering columns based on line, filter columns based on \\0 (NULL character)")
+        .optopt("", "output-delimiter", "in field mode, replace the delimiter in output lines with this option's argument", "new delimiter")
+        .parse(args);
     let complement = matches.opt_present("complement");
 
     let mode_parse = match (matches.opt_str("bytes"),

--- a/src/dircolors/Cargo.toml
+++ b/src/dircolors/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_dircolors"
 path = "dircolors.rs"
 
 [dependencies]
-getopts = "*"
 glob = "*"
 libc = "*"
 uucore = { path="../uucore" }

--- a/src/dirname/Cargo.toml
+++ b/src/dirname/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_dirname"
 path = "dirname.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
+uucore = { path="../uucore" }
 
 [[bin]]
 name = "dirname"

--- a/src/dirname/dirname.rs
+++ b/src/dirname/dirname.rs
@@ -9,42 +9,24 @@
  * file that was distributed with this source code.
  */
 
-extern crate getopts;
+#[macro_use]
+extern crate uucore;
 
 use std::path::Path;
 
-static NAME: &'static str = "dirname";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static NAME: &'static str = "dirname"; 
+static SYNTAX: &'static str = "[OPTION] NAME..."; 
+static SUMMARY: &'static str = "strip last component from file name"; 
+static LONG_HELP: &'static str = "
+ Output each NAME with its last non-slash component and trailing slashes
+ removed; if NAME contains no /'s, output '.' (meaning the current
+ directory).
+"; 
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
-    opts.optflag("z", "zero", "separate output with NUL rather than newline");
-    opts.optflag("", "help", "display this help and exit");
-    opts.optflag("", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => panic!("Invalid options\n{}", f)
-    };
-
-    if matches.opt_present("help") {
-        let msg = format!("{0} {1} - strip last component from file name
-
-Usage:
-  {0} [OPTION] NAME...
-
-Output each NAME with its last non-slash component and trailing slashes
-removed; if NAME contains no  /'s,  output  '.'  (meaning  the  current
-directory).", NAME, VERSION);
-
-        print!("{}", opts.usage(&msg));
-        return 0;
-    }
-
-    if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optflag("z", "zero", "separate output with NUL rather than newline")
+        .parse(args);
 
     let separator = if matches.opt_present("zero") {"\0"} else {"\n"};
 

--- a/src/du/Cargo.toml
+++ b/src/du/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_du"
 path = "du.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 time = "*"
 uucore = { path="../uucore" }

--- a/src/echo/Cargo.toml
+++ b/src/echo/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_echo"
 path = "echo.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/env/Cargo.toml
+++ b/src/env/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_env"
 path = "env.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/expand/Cargo.toml
+++ b/src/expand/Cargo.toml
@@ -8,9 +8,9 @@ name = "uu_expand"
 path = "expand.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 unicode-width = "*"
+getopts = "*"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/expand/expand.rs
+++ b/src/expand/expand.rs
@@ -11,9 +11,9 @@
  * file that was distributed with this source code.
  */
 
-extern crate getopts;
 extern crate libc;
 extern crate unicode_width;
+extern crate getopts;
 
 #[macro_use]
 extern crate uucore;
@@ -24,8 +24,10 @@ use std::iter::repeat;
 use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 
-static NAME: &'static str = "expand";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTION]... [FILE]..."; 
+static SUMMARY: &'static str = "Convert tabs in each FILE to spaces, writing to standard output.
+ With no FILE, or when FILE is -, read standard input."; 
+static LONG_HELP: &'static str = "";
 
 static DEFAULT_TABSTOP: usize = 8;
 
@@ -89,32 +91,12 @@ impl Options {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
-
-    opts.optflag("i", "initial", "do not convert tabs after non blanks");
-    opts.optopt("t", "tabs", "have tabs NUMBER characters apart, not 8", "NUMBER");
-    opts.optopt("t", "tabs", "use comma separated list of explicit tab positions", "LIST");
-    opts.optflag("U", "no-utf8", "interpret input file as 8-bit ASCII rather than UTF-8");
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => crash!(1, "{}", f)
-    };
-
-    if matches.opt_present("help") {
-        println!("Usage: {} [OPTION]... [FILE]...", NAME);
-        println!("{}", opts.usage(
-            "Convert tabs in each FILE to spaces, writing to standard output.\n\
-            With no FILE, or when FILE is -, read standard input."));
-        return 0;
-    }
-
-    if matches.opt_present("V") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optflag("i", "initial", "do not convert tabs after non blanks")
+        .optopt("t", "tabs", "have tabs NUMBER characters apart, not 8", "NUMBER")
+        .optopt("t", "tabs", "use comma separated list of explicit tab positions", "LIST")
+        .optflag("U", "no-utf8", "interpret input file as 8-bit ASCII rather than UTF-8")
+        .parse(args);
 
     expand(Options::new(matches));
 

--- a/src/factor/Cargo.toml
+++ b/src/factor/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_factor"
 path = "factor.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 rand = "*"
 uucore = { path="../uucore" }

--- a/src/factor/factor.rs
+++ b/src/factor/factor.rs
@@ -13,7 +13,6 @@
 * that was distributed with this source code.
 */
 
-extern crate getopts;
 extern crate libc;
 extern crate rand;
 
@@ -31,8 +30,10 @@ use std::mem::swap;
 mod numeric;
 mod prime_table;
 
-static NAME: &'static str = "factor";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTION] [NUMBER]..."; 
+static SUMMARY: &'static str = "Print the prime factors of the given number(s).
+ If none are specified, read from standard input."; 
+static LONG_HELP: &'static str = ""; 
 
 fn rho_pollard_pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
     if num < 1 << 63 {
@@ -158,33 +159,8 @@ fn print_factors_str(num_str: &str) {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
-    opts.optflag("h", "help", "show this help message");
-    opts.optflag("v", "version", "print the version and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => crash!(1, "Invalid options\n{}", f)
-    };
-
-    if matches.opt_present("help") {
-        let msg = format!("{0} {1}
-
-Usage:
-\t{0} [NUMBER]...
-\t{0} [OPTION]
-
-Print the prime factors of the given number(s). If none are specified,
-read from standard input.", NAME, VERSION);
-
-        print!("{}", opts.usage(&msg));
-        return 1;
-    }
-
-    if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .parse(args);
 
     if matches.free.is_empty() {
         for line in BufReader::new(stdin()).lines() {

--- a/src/fmt/Cargo.toml
+++ b/src/fmt/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_fmt"
 path = "fmt.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 unicode-width = "*"
 uucore = { path="../uucore" }

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-extern crate getopts;
 extern crate unicode_width;
 
 #[macro_use]
@@ -35,8 +34,9 @@ mod linebreak;
 mod parasplit;
 
 // program's NAME and VERSION are used for -V and -h
-static NAME: &'static str = "fmt";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTION]... [FILE]..."; 
+static SUMMARY: &'static str = "Reformat paragraphs from input files (or stdin) to stdout.";
+static LONG_HELP: &'static str = "";
 
 pub type FileOrStdReader = BufReader<Box<Read+'static>>;
 pub struct FmtOptions {
@@ -58,43 +58,21 @@ pub struct FmtOptions {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
-
-    opts.optflag("c", "crown-margin", "First and second line of paragraph may have different indentations, in which case the first line's indentation is preserved, and each subsequent line's indentation matches the second line.");
-    opts.optflag("t", "tagged-paragraph", "Like -c, except that the first and second line of a paragraph *must* have different indentation or they are treated as separate paragraphs.");
-    opts.optflag("m", "preserve-headers", "Attempt to detect and preserve mail headers in the input. Be careful when combining this flag with -p.");
-    opts.optflag("s", "split-only", "Split lines only, do not reflow.");
-    opts.optflag("u", "uniform-spacing", "Insert exactly one space between words, and two between sentences. Sentence breaks in the input are detected as [?!.] followed by two spaces or a newline; other punctuation is not interpreted as a sentence break.");
-
-    opts.optopt("p", "prefix", "Reformat only lines beginning with PREFIX, reattaching PREFIX to reformatted lines. Unless -x is specified, leading whitespace will be ignored when matching PREFIX.", "PREFIX");
-    opts.optopt("P", "skip-prefix", "Do not reformat lines beginning with PSKIP. Unless -X is specified, leading whitespace will be ignored when matching PSKIP", "PSKIP");
-
-    opts.optflag("x", "exact-prefix", "PREFIX must match at the beginning of the line with no preceding whitespace.");
-    opts.optflag("X", "exact-skip-prefix", "PSKIP must match at the beginning of the line with no preceding whitespace.");
-
-    opts.optopt("w", "width", "Fill output lines up to a maximum of WIDTH columns, default 79.", "WIDTH");
-    opts.optopt("g", "goal", "Goal width, default ~0.94*WIDTH. Must be less than WIDTH.", "GOAL");
-
-    opts.optflag("q", "quick", "Break lines more quickly at the expense of a potentially more ragged appearance.");
-
-    opts.optopt("T", "tab-width", "Treat tabs as TABWIDTH spaces for determining line length, default 8. Note that this is used only for calculating line lengths; tabs are preserved in the output.", "TABWIDTH");
-
-    opts.optflag("V", "version", "Output version information and exit.");
-    opts.optflag("h", "help", "Display this help message and exit.");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => crash!(1, "{}\nTry `{} --help' for more information.", f, NAME)
-    };
-
-    if matches.opt_present("h") {
-        println!("Usage: {} [OPTION]... [FILE]...\n\n{}", NAME, opts.usage("Reformat paragraphs from input files (or stdin) to stdout."));
-    }
-
-    if matches.opt_present("V") || matches.opt_present("h") {
-        println!("{} {}", NAME, VERSION);
-        return 0
-    }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optflag("c", "crown-margin", "First and second line of paragraph may have different indentations, in which case the first line's indentation is preserved, and each subsequent line's indentation matches the second line.")
+        .optflag("t", "tagged-paragraph", "Like -c, except that the first and second line of a paragraph *must* have different indentation or they are treated as separate paragraphs.")
+        .optflag("m", "preserve-headers", "Attempt to detect and preserve mail headers in the input. Be careful when combining this flag with -p.")
+        .optflag("s", "split-only", "Split lines only, do not reflow.")
+        .optflag("u", "uniform-spacing", "Insert exactly one space between words, and two between sentences. Sentence breaks in the input are detected as [?!.] followed by two spaces or a newline; other punctuation is not interpreted as a sentence break.")
+        .optopt("p", "prefix", "Reformat only lines beginning with PREFIX, reattaching PREFIX to reformatted lines. Unless -x is specified, leading whitespace will be ignored when matching PREFIX.", "PREFIX")
+        .optopt("P", "skip-prefix", "Do not reformat lines beginning with PSKIP. Unless -X is specified, leading whitespace will be ignored when matching PSKIP", "PSKIP")
+        .optflag("x", "exact-prefix", "PREFIX must match at the beginning of the line with no preceding whitespace.")
+        .optflag("X", "exact-skip-prefix", "PSKIP must match at the beginning of the line with no preceding whitespace.")
+        .optopt("w", "width", "Fill output lines up to a maximum of WIDTH columns, default 79.", "WIDTH")
+        .optopt("g", "goal", "Goal width, default ~0.94*WIDTH. Must be less than WIDTH.", "GOAL")
+        .optflag("q", "quick", "Break lines more quickly at the expense of a potentially more ragged appearance.")
+        .optopt("T", "tab-width", "Treat tabs as TABWIDTH spaces for determining line length, default 8. Note that this is used only for calculating line lengths; tabs are preserved in the output.", "TABWIDTH")
+        .parse(args);
 
     let mut fmt_opts = FmtOptions {
         crown           : false,

--- a/src/fold/Cargo.toml
+++ b/src/fold/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_fold"
 path = "fold.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/groups/groups.rs
+++ b/src/groups/groups.rs
@@ -19,8 +19,8 @@ static SYNTAX: &'static str = "[user]";
 static SUMMARY: &'static str = "display current group names";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = new_coreopts!(SYNTAX, SUMMARY, "");
-    let matches = opts.parse(args);
+    let matches = new_coreopts!(SYNTAX, SUMMARY, "")
+          .parse(args);
 
     if matches.free.is_empty() {
         println!("{}", get_groups().unwrap().iter().map(|&g| gid2grp(g).unwrap()).collect::<Vec<_>>().join(" "));

--- a/src/head/head.rs
+++ b/src/head/head.rs
@@ -21,8 +21,9 @@ use std::fs::File;
 use std::path::Path;
 use std::str::from_utf8;
 
-static NAME: &'static str = "head";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "";
+static SUMMARY: &'static str = "";
+static LONG_HELP: &'static str = "";
 
 enum FilterMode {
     Bytes(usize),
@@ -47,35 +48,19 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let mut settings: Settings = Default::default();
 
     // handle obsolete -number syntax
-    let options = match obsolete(&args[1..]) {
+    let new_args = match obsolete(&args[0..]) {
         (args, Some(n)) => { settings.mode = FilterMode::Lines(n); args },
         (args, None) => args
     };
 
-    let args = options;
-
-    let mut opts = getopts::Options::new();
-
-    opts.optopt("c", "bytes", "Print the first K bytes.  With the leading '-', print all but the last K bytes", "[-]K");
-    opts.optopt("n", "lines", "Print the first K lines.  With the leading '-', print all but the last K lines", "[-]K");
-    opts.optflag("q", "quiet", "never print headers giving file names");
-    opts.optflag("v", "verbose", "always print headers giving file names");
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args) {
-        Ok (m) => { m }
-        Err(_) => {
-            println!("{}", opts.usage(""));
-            return 1;
-        }
-    };
-
-    if matches.opt_present("h") {
-        println!("{}", opts.usage(""));
-        return 0;
-    }
-    if matches.opt_present("V") { version(); return 0 }
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .optopt("c", "bytes", "Print the first K bytes.  With the leading '-', print all but the last K bytes", "[-]K")
+        .optopt("n", "lines", "Print the first K lines.  With the leading '-', print all but the last K lines", "[-]K")
+        .optflag("q", "quiet", "never print headers giving file names")
+        .optflag("v", "verbose", "always print headers giving file names")
+        .optflag("h", "help", "display this help and exit")
+        .optflag("V", "version", "output version information and exit")
+        .parse(new_args);
 
     let use_bytes = matches.opt_present("c");
 
@@ -155,7 +140,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 // getopts works correctly.
 fn obsolete(options: &[String]) -> (Vec<String>, Option<usize>) {
     let mut options: Vec<String> = options.to_vec();
-    let mut a = 0;
+    let mut a = 1;
     let b = options.len();
 
     while a < b {
@@ -202,8 +187,4 @@ fn head<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> bool {
         }
     }
     true
-}
-
-fn version() {
-    println!("{} {}", NAME, VERSION);
 }

--- a/src/hostid/Cargo.toml
+++ b/src/hostid/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_hostid"
 path = "hostid.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/hostid/hostid.rs
+++ b/src/hostid/hostid.rs
@@ -9,7 +9,6 @@
  * that was distributed with this source code.
  */
 
-extern crate getopts;
 extern crate libc;
 
 #[macro_use]
@@ -17,10 +16,9 @@ extern crate uucore;
 
 use libc::c_long;
 
-static NAME: &'static str = "hostid";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
-
-static EXIT_ERR: i32 = 1;
+static SYNTAX: &'static str = "[options]"; 
+static SUMMARY: &'static str = ""; 
+static LONG_HELP: &'static str = ""; 
 
 pub enum Mode {
     HostId,
@@ -34,42 +32,10 @@ extern {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
-    opts.optflag("", "help", "display this help and exit");
-    opts.optflag("", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(_) => {
-            help(&opts);
-            return EXIT_ERR;
-        },
-    };
-
-    let mode = if matches.opt_present("version") {
-        Mode::Version
-    } else if matches.opt_present("help") {
-        Mode::Help
-    } else {
-        Mode::HostId
-    };
-
-    match mode {
-        Mode::HostId  => hostid(),
-        Mode::Help    => help(&opts),
-        Mode::Version => version(),
-    }
-
+    new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .parse(args);
+    hostid();
     0
-}
-
-fn version() {
-    println!("{} {}", NAME, VERSION);
-}
-
-fn help(opts: &getopts::Options) {
-    let msg = format!("Usage:\n {} [options]", NAME);
-    print!("{}", opts.usage(&msg));
 }
 
 fn hostid() {

--- a/src/hostname/Cargo.toml
+++ b/src/hostname/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_hostname"
 path = "hostname.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/kill/Cargo.toml
+++ b/src/kill/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_kill"
 path = "kill.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/link/Cargo.toml
+++ b/src/link/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_link"
 path = "link.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/link/link.rs
+++ b/src/link/link.rs
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 
@@ -19,8 +17,9 @@ use std::io::Write;
 use std::path::Path;
 use std::io::Error;
 
-static NAME: &'static str = "link";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = "[OPTIONS] FILE1 FILE2"; 
+static SUMMARY: &'static str = "Create a link named FILE2 to FILE1"; 
+static LONG_HELP: &'static str = ""; 
 
 pub fn normalize_error_message(e: Error) -> String {
     match e.raw_os_error() {
@@ -30,34 +29,10 @@ pub fn normalize_error_message(e: Error) -> String {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
-
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(err) => panic!("{}", err),
-    };
-
-    if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
-
-    if matches.opt_present("help") || matches.free.len() != 2 {
-        let msg = format!("{0} {1}
-
-Usage:
-  {0} [OPTIONS] FILE1 FILE2
-
-Create a link named FILE2 to FILE1.", NAME, VERSION);
-
-        println!("{}", opts.usage(&msg));
-        if matches.free.len() != 2 {
-            return 1;
-        }
-        return 0;
+    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+        .parse(args);
+    if matches.free.len() != 2 {
+        crash!(1, "{}", msg_wrong_number_of_arguments!(2));
     }
 
     let old = Path::new(&matches.free[0]);

--- a/src/ln/Cargo.toml
+++ b/src/ln/Cargo.toml
@@ -8,7 +8,6 @@ name = "uu_ln"
 path = "ln.rs"
 
 [dependencies]
-getopts = "*"
 libc = "*"
 uucore = { path="../uucore" }
 

--- a/src/logname/logname.rs
+++ b/src/logname/logname.rs
@@ -11,7 +11,6 @@
 
 /* last synced with: logname (GNU coreutils) 8.22 */
 
-extern crate getopts;
 extern crate libc;
 
 #[macro_use]
@@ -36,38 +35,12 @@ fn get_userlogin() -> Option<String> {
     }
 }
 
-static NAME: &'static str = "logname";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static SYNTAX: &'static str = ""; 
+static SUMMARY: &'static str = "Print user's login name"; 
+static LONG_HELP: &'static str = ""; 
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    //
-    // Argument parsing
-    //
-    let mut opts = getopts::Options::new();
-
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => crash!(1, "Invalid options\n{}", f)
-    };
-
-    if matches.opt_present("help") {
-        let msg = format!("{0} {1}
-
-Usage:
-  {0}
-
-Print user's login name.", NAME, VERSION);
-
-        print!("{}", opts.usage(&msg));
-        return 0;
-    }
-    if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-        return 0;
-    }
+    new_coreopts!(SYNTAX, SUMMARY, LONG_HELP).parse(args);
 
     exec();
 
@@ -77,6 +50,6 @@ Print user's login name.", NAME, VERSION);
 fn exec() {
     match get_userlogin() {
         Some(userlogin) => println!("{}", userlogin),
-        None => println!("{}: no login name", NAME)
+        None => show_error!("no login name")
     }
 }

--- a/src/ls/ls.rs
+++ b/src/ls/ls.rs
@@ -27,7 +27,6 @@ extern crate uucore;
 use uucore::libc::{S_ISUID, S_ISGID, S_ISVTX, S_IRUSR, S_IWUSR, S_IXUSR, S_IRGRP, S_IWGRP, S_IXGRP,
                    S_IROTH, S_IWOTH, S_IXOTH, mode_t};
 
-use getopts::Options;
 use std::fs;
 use std::fs::{DirEntry, FileType, Metadata};
 use std::path::{Path, PathBuf};
@@ -44,15 +43,13 @@ use unicode_width::UnicodeWidthStr;
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
 
-#[derive(Copy, Clone, PartialEq)]
-enum Mode {
-    Help,
-    Version,
-    List,
-}
-
-static NAME: &'static str = "ls";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static NAME: &'static str = "ls"; 
+static SUMMARY: &'static str = ""; 
+static LONG_HELP: &'static str = "
+ By default, ls will list the files and contents of any directories on 
+ the command line, expect that it will ignore files and directories 
+ whose names start with '.'
+"; 
 
 static DEFAULT_COLORS: &'static str = "rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:";
 
@@ -76,103 +73,63 @@ lazy_static! {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = Options::new();
-
-    opts.optflag("", "help", "display this help and exit");
-    opts.optflag("", "version", "output version information and exit");
-
-    opts.optflag("a",
+    let syntax = format!("[OPTION]... DIRECTORY
+ {0} [OPTION]... [FILE]...", NAME);
+    let matches = new_coreopts!(&syntax, SUMMARY, LONG_HELP)
+        .optflag("a",
                  "all",
-                 "Do not ignore hidden files (files with names that start with '.').");
-    opts.optflag("A",
+                 "Do not ignore hidden files (files with names that start with '.').")
+        .optflag("A",
                  "almost-all",
                  "In a directory, do not ignore all file names that start with '.', only ignore \
-                  '.' and '..'.");
-    opts.optflag("c",
+                  '.' and '..'.")
+        .optflag("c",
                  "",
                  "If the long listing format (e.g., -l, -o) is being used, print the status \
                  change time (the ‘ctime’ in the inode) instead of the modification time. When \
                  explicitly sorting by time (--sort=time or -t) or when not using a long listing \
-                 format, sort according to the status change time.");
-    opts.optflag("d",
+                 format, sort according to the status change time.")
+        .optflag("d",
                  "directory",
                  "Only list the names of directories, rather than listing directory contents. \
                   This will not follow symbolic links unless one of `--dereference-command-line \
                   (-H)`, `--dereference (-L)`, or `--dereference-command-line-symlink-to-dir` is \
-                  specified.");
-    opts.optflag("F",
+                  specified.")
+        .optflag("F",
                  "classify",
                  "Append a character to each file name indicating the file type. Also, for \
                  regular files that are executable, append '*'. The file type indicators are \
                  '/' for directories, '@' for symbolic links, '|' for FIFOs, '=' for sockets, \
-                 '>' for doors, and nothing for regular files.");
-    opts.optflag("h",
+                 '>' for doors, and nothing for regular files.")
+        .optflag("h",
                  "human-readable",
-                 "Print human readable file sizes (e.g. 1K 234M 56G).");
-    opts.optflag("L",
+                 "Print human readable file sizes (e.g. 1K 234M 56G).")
+        .optflag("L",
                  "dereference",
                  "When showing file information for a symbolic link, show information for the \
-                 file the link references rather than the link itself.");
-    opts.optflag("l", "long", "Display detailed information.");
-    opts.optflag("r",
+                 file the link references rather than the link itself.")
+        .optflag("l", "long", "Display detailed information.")
+        .optflag("r",
                  "reverse",
                  "Reverse whatever the sorting method is--e.g., list files in reverse \
-                 alphabetical order, youngest first, smallest first, or whatever.");
-    opts.optflag("R",
+                 alphabetical order, youngest first, smallest first, or whatever.")
+        .optflag("R",
                  "recursive",
-                 "List the contents of all directories recursively.");
-    opts.optflag("S", "", "Sort by file size, largest first.");
-    opts.optflag("t",
+                 "List the contents of all directories recursively.")
+        .optflag("S", "", "Sort by file size, largest first.")
+        .optflag("t",
                  "",
-                 "Sort by modification time (the 'mtime' in the inode), newest first.");
-    opts.optflag("U",
+                 "Sort by modification time (the 'mtime' in the inode), newest first.")
+        .optflag("U",
                  "",
                  "Do not sort; list the files in whatever order they are stored in the \
                  directory.  This is especially useful when listing very large directories, \
-                 since not doing any sorting can be noticeably faster.");
-    opts.optflag("", "color", "Color output based on file type.");
+                 since not doing any sorting can be noticeably faster.")
+        .optflag("", "color", "Color output based on file type.")
+        .parse(args);
 
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(e) => {
-            disp_err!("{}", e);
-            return 1;
-        }
-    };
-
-    let mode = if matches.opt_present("version") {
-        Mode::Version
-    } else if matches.opt_present("help") {
-        Mode::Help
-    } else {
-        Mode::List
-    };
-
-    match mode {
-        Mode::Version => version(),
-        Mode::Help => help(),
-        Mode::List => list(matches),
-    }
-
+    list(matches);
     0
-}
-
-fn version() {
-    println!("{} {}", NAME, VERSION);
-}
-
-fn help() {
-    let msg = format!("{0} {1}\n\n\
-                       Usage:  {0} [OPTION]... DIRECTORY\n \
-                          or:  {0} [OPTION]... [FILE]...\n \
-                       \n \
-                       By default, ls will list the files and contents of any directories on \
-                       the command line, expect that it will ignore files and directories \
-                       whose names start with '.'. \n\
-                       \n",
-                      NAME,
-                      VERSION);
-    println!("{}", msg);
 }
 
 fn list(options: getopts::Matches) {

--- a/src/uucore/coreopts.rs
+++ b/src/uucore/coreopts.rs
@@ -41,7 +41,9 @@ impl<'a> CoreOptions<'a> {
         let matches = match self.options.parse(&args[1..]) {
             Ok(m) => { Some(m) },
             Err(f) => {
-                crash!(1, "{}", f);
+                pipe_write!(&mut ::std::io::stderr(), "{}: error: ", self.help_text.name);
+                pipe_writeln!(&mut ::std::io::stderr(), "{}", f);
+                ::std::process::exit(1);
             }
         }.unwrap();
         if matches.opt_present("help") {

--- a/src/uucore/coreopts.rs
+++ b/src/uucore/coreopts.rs
@@ -26,12 +26,16 @@ impl<'a> CoreOptions<'a> {
             .optflag("", "version", "print name and version number");
         ret
     }
-    pub fn optopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str) -> &mut CoreOptions<'a> {
-        self.options.optopt(short_name, long_name, desc, hint);
+    pub fn optflagopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str) -> &mut CoreOptions<'a> {
+        self.options.optflagopt(short_name, long_name, desc, hint);
         self
     }
     pub fn optflag(&mut self, short_name: &str, long_name: &str, desc: &str) -> &mut CoreOptions<'a> {
         self.options.optflag(short_name, long_name, desc);
+        self
+    }
+    pub fn optopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str) -> &mut CoreOptions<'a> {
+        self.options.optopt(short_name, long_name, desc, hint);
         self
     }
     pub fn usage(&self, summary : &str) -> String {

--- a/src/uucore/macros.rs
+++ b/src/uucore/macros.rs
@@ -327,8 +327,21 @@ macro_rules! msg_args_nonexistent_file { ($received:expr) => (
     msg_args_invalid_value!("paths to files", snippet_no_file_at_path!($received)));}
 
 #[macro_export]
-macro_rules! msg_wrong_number_of_arguments { () => (
-    msg_args_invalid_value!("wrong number of arguments") ); }
+macro_rules! msg_wrong_number_of_arguments {
+    () => (
+        msg_args_invalid_value!("wrong number of arguments")
+    );
+    ($min:expr, $max:expr) => (
+        msg_args_invalid_value!(format!("expects {}-{} arguments", $min, $max))
+    );
+    ($exact:expr) => (
+        if $exact == 1 {
+            msg_args_invalid_value!("expects 1 argument")
+        } else {
+            msg_args_invalid_value!(format!("expects {} arguments", $exact))
+        }
+    );
+}
 
 // -- message templates : invalid input : input combinations
 

--- a/tests/test_base32.rs
+++ b/tests/test_base32.rs
@@ -76,7 +76,7 @@ fn test_wrap_no_arg() {
         new_ucmd()
             .arg(wrap_param)
             .fails()
-            .stderr_only(format!("base32: Argument to option '{}' missing.\nTry 'base32 --help' for more information.\n",
+            .stderr_only(format!("base32: error: Argument to option '{}' missing.\n",
                                  if wrap_param == "-w" { "w" } else { "wrap" }));
     }
 }

--- a/tests/test_base64.rs
+++ b/tests/test_base64.rs
@@ -68,7 +68,7 @@ fn test_wrap_no_arg() {
         new_ucmd()
             .arg(wrap_param)
             .fails()
-            .stderr_only(format!("base64: Argument to option '{}' missing.\nTry 'base64 --help' for more information.\n",
+            .stderr_only(format!("base64: error: Argument to option '{}' missing.\n",
                                  if wrap_param == "-w" { "w" } else { "wrap" }));
     }
 }

--- a/tests/test_install.rs
+++ b/tests/test_install.rs
@@ -13,7 +13,7 @@ fn test_install_help() {
     let (_, mut ucmd) = at_and_ucmd();
 
     assert!(
-        ucmd.arg("--help").succeeds().no_stderr().stdout.contains("Usage:"));
+        ucmd.arg("--help").succeeds().no_stderr().stdout.contains("Options:"));
 }
 
 #[test]


### PR DESCRIPTION
This applies Coreopts through (most of) the utilities with names A through L so as to remove redundant boilerplate (this PR results in a net removal of ~12000 non-whitespace chars) and to make another incremental movement towards resolution of #818 and #83 . I'm breaking this into two PRs (A-L, M-Z) because of the number of lines to review and to limit this half's exposure to rebase conflicts while I work on the second half.

The following additional commits are made to support these changes

- in A through L utilities where coreopts is already used, its usage is made slightly more dryer so as to be consistent with utilities where it is being newly applied here.
- A bugfix and two minor functionality additions are added between uucore/coreopts.rs and uucore/macros.rs