### PR TITLE
mv: cleanup the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ To do
 * [x] mkfifo
 * [x] mknod
 * [x] mktemp
-* [ ] mv (almost done, one more option)
+* [x] mv
 * [x] nice
 * [x] nl
 * [x] nohup

--- a/src/mv/Cargo.toml
+++ b/src/mv/Cargo.toml
@@ -9,11 +9,10 @@ path = "mv.rs"
 
 [dependencies]
 getopts = "*"
-libc = "*"
-uucore = { path="../uucore" }
 
-[dev-dependencies]
-time = "*"
+[dependencies.uucore]
+path = "../uucore"
+default-features = false
 
 [[bin]]
 name = "mv"

--- a/tests/test_mv.rs
+++ b/tests/test_mv.rs
@@ -209,6 +209,25 @@ fn test_mv_custom_backup_suffix() {
 }
 
 #[test]
+fn test_mv_custom_backup_suffix_via_env() {
+    let (at, mut ucmd) = at_and_ucmd();
+    let file_a = "test_mv_custom_backup_suffix_file_a";
+    let file_b = "test_mv_custom_backup_suffix_file_b";
+    let suffix = "super-suffix-of-the-century";
+    at.touch(file_a);
+    at.touch(file_b);
+    ucmd.arg("-b")
+        .env("SIMPLE_BACKUP_SUFFIX", suffix)
+        .arg(file_a)
+        .arg(file_b)
+        .succeeds().no_stderr();
+
+    assert!(!at.file_exists(file_a));
+    assert!(at.file_exists(file_b));
+    assert!(at.file_exists(&format!("{}{}", file_b, suffix)));
+}
+
+#[test]
 fn test_mv_backup_numbering() {
     let (at, mut ucmd) = at_and_ucmd();
     let file_a = "test_mv_backup_numbering_file_a";


### PR DESCRIPTION
The unimplemented option of `mv` is `-Z/--context` which is a Linux-specific option and I *guess* it can be ignored for the time being.