### PR TITLE
appveyor: add cache of mingw download

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.2/threads-win32/dwarf/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z/download
     MINGW_ARCHIVE: i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
     MINGW_DIR: mingw32
+    DIR_TEMP_MINGW: C:\cached\mingw
   - TARGET: x86_64-pc-windows-gnu
     MSYS_BITS: 64
 
@@ -16,9 +17,16 @@ install:
   # Use the system msys if we can
   - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
 
-  # download a custom compiler otherwise
-  - if defined MINGW_ARCHIVE appveyor DownloadFile "%MINGW_URL%" -FileName "%MINGW_ARCHIVE%"
-  - if defined MINGW_ARCHIVE 7z x -y "%MINGW_ARCHIVE%" > nul
+  - ps: >-
+      if ((Test-Path Env:\MINGW_ARCHIVE) -and -not (Test-Path "${env:DIR_TEMP_MINGW}\${env:MINGW_ARCHIVE}")) {
+        if (Test-Path "${env:DIR_TEMP_MINGW}") {
+          rm -Recurse ${env:DIR_TEMP_MINGW}\*;
+        }
+        New-Item -ItemType Directory -Force -Path ${env:DIR_TEMP_MINGW} | Out-Null;
+        $download_loc = ${env:MINGW_URL};
+        Start-FileDownload $download_loc -FileName "${env:DIR_TEMP_MINGW}\${env:MINGW_ARCHIVE}";
+      }
+  - if defined MINGW_ARCHIVE 7z x -y "%DIR_TEMP_MINGW%\%MINGW_ARCHIVE%" > nul
   - if defined MINGW_ARCHIVE set PATH=%CD%\%MINGW_DIR%\bin;C:\msys64\usr\bin;%PATH%
 
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
@@ -34,3 +42,6 @@ build: false
 
 test_script:
   - cargo test --no-fail-fast --features "nightly generic" --no-default-features
+
+cache:
+  - c:\cached


### PR DESCRIPTION
As per discussion in #943

What appveyor now does in regard to installing mingw.

* if in 386 GNU, checks if the mingw version specified in the environment var exists at the cached location
* if it is not, it wipes the cached location if it exists, makes a new directory there and any necessary parent directories, and downloads the specified version of mingw
* then the the extraction of binaries continues as normal, only referencing the archive in a different location now.

It is probably possible to extract, and then remove the archive, and just have the extracted directory be cached instead of the installer. That could be a possible future upgrade, but I'm not sure it would be worth the complexity cost.