### PR TITLE
who: fix build on raspberry pi 2

### DIFF
--- a/src/who/who.rs
+++ b/src/who/who.rs
@@ -12,7 +12,7 @@
 #[macro_use]
 extern crate uucore;
 use uucore::utmpx::{self, time, Utmpx};
-use uucore::libc::{STDIN_FILENO, time_t, ttyname, S_IWGRP};
+use uucore::libc::{STDIN_FILENO, ttyname, S_IWGRP};
 
 use std::borrow::Cow;
 use std::io::prelude::*;
@@ -244,7 +244,7 @@ struct Who {
     args: Vec<String>,
 }
 
-fn idle_string<'a>(when: time_t, boottime: time_t) -> Cow<'a, str> {
+fn idle_string<'a>(when: i64, boottime: i64) -> Cow<'a, str> {
     thread_local! {
         static NOW: time::Tm = time::now()
     }


### PR DESCRIPTION
`who` fails to compile on a raspberry pi 2. This commit fixed that.

`idle_string` was using `time_t`. But it is called with the result of [`meta.atime()`](https://doc.rust-lang.org/std/os/unix/fs/trait.MetadataExt.html#tymethod.atime), which returns an `i64`. And it is compared with [`n.to_timespec().sec`](https://doc.rust-lang.org/time/time/struct.Timespec.html), which is also an `i64`. So it seems appropriate to use `i64` instead of `time_t`.
