### PR TITLE
more: fix build on windows

### DIFF
--- a/src/more/Cargo.toml
+++ b/src/more/Cargo.toml
@@ -10,8 +10,10 @@ path = "more.rs"
 [dependencies]
 getopts = "*"
 libc = "*"
-nix = "*"
 uucore = { path="../uucore" }
+
+[target."cfg(unix)".dependencies]
+nix = "*"
 
 [[bin]]
 name = "more"


### PR DESCRIPTION
see also #990; the build of more fails on windows. [nix](https://crates.io/crates/nix) is the reason. As it does not contain any windows specific code, I moved all related code to two functions and added dummy functions to call on windows.

error message on my test system:
```
w@w7 ~/coreutils/src/more
$ rustup show
Default host: x86_64-pc-windows-gnu

stable-x86_64-pc-windows-gnu (default)
rustc 1.12.0 (3191fbae9 2016-09-23)

w@w7 ~/coreutils/src/more
$ cargo build
   Compiling more v0.0.1 (file:///C:/cygwin/home/w/coreutils/src/more)
error[E0432]: unresolved import `nix::sys::termios`. Could not find `sys` in `nix`
  --> more.rs:22:5
   |
22 | use nix::sys::termios;
   |     ^^^^^^^^^^^^^^^^^

error: aborting due to previous error

error: Could not compile `more`.

To learn more, run the command again with --verbose.
```