### PR TITLE
trivial windows fixes

### DIFF
--- a/src/ln/ln.rs
+++ b/src/ln/ln.rs
@@ -15,8 +15,8 @@ extern crate uucore;
 
 use std::fs;
 use std::io::{BufRead, BufReader, Result, stdin, Write};
-#[cfg(unix)] use std::os::unix::fs::symlink as symlink_file;
-#[cfg(windows)] use std::os::windows::fs::symlink_file;
+#[cfg(unix)] use std::os::unix::fs::symlink;
+#[cfg(windows)] use std::os::windows::fs::{symlink_file,symlink_dir};
 use std::path::{Path, PathBuf};
 
 static NAME: &'static str = "ln"; 
@@ -292,8 +292,16 @@ fn existing_backup_path(path: &PathBuf, suffix: &str) -> PathBuf {
     simple_backup_path(path, suffix)
 }
 
+#[cfg(windows)]
 pub fn symlink<P: AsRef<Path>>(src: P, dst: P) -> Result<()> {
-    symlink_file(src, dst)
+    if src.as_ref().is_dir()
+    {
+        symlink_dir(src,dst)
+    }
+    else
+    {
+        symlink_file(src,dst)
+    }
 }
 
 pub fn is_symlink<P: AsRef<Path>>(path: P) -> bool {

--- a/src/ls/ls.rs
+++ b/src/ls/ls.rs
@@ -147,7 +147,7 @@ fn list(options: getopts::Matches) {
 
         if p.is_dir() && !options.opt_present("d") {
             dir = true;
-            if !options.opt_present("L") {
+            if options.opt_present("l") && !(options.opt_present("L")) {
                 if let Ok(md) = p.symlink_metadata() {
                     if md.file_type().is_symlink() {
                         dir = false;
@@ -451,6 +451,21 @@ fn display_file_name(path: &Path,
             name.push('@');
         }
     }
+
+    if options.opt_present("long") && metadata.file_type().is_symlink() {
+        if let Ok(target) = path.read_link() {
+            // We don't bother updating width here because it's not used for long listings
+            let code = if target.exists() {
+                "fi"
+            } else {
+                "mi"
+            };
+            let target_name = target.to_string_lossy().to_string();
+            name.push_str(" -> ");
+            name.push_str(&target_name);
+        }
+    }
+
     name.into()
 }
 

--- a/src/ls/ls.rs
+++ b/src/ls/ls.rs
@@ -236,15 +236,21 @@ fn enter_directory(dir: &PathBuf, options: &getopts::Matches) {
     }
 
     let mut entries: Vec<_> = entries.iter().map(DirEntry::path).collect();
-
-    if options.opt_present("a") {
-        entries.push(dir.join("."));
-        entries.push(dir.join(".."));
-    }
-
     sort_entries(&mut entries, options);
 
-    display_items(&entries, Some(dir), options);
+
+
+    if options.opt_present("a") {
+        let mut display_entries = entries.clone();
+        display_entries.insert(0, dir.join(".."));
+        display_entries.insert(0, dir.join("."));
+        display_items(&display_entries, Some(dir), options);
+    }
+    else
+    {
+        display_items(&entries, Some(dir), options);
+    }
+
 
     if options.opt_present("R") {
         for e in entries.iter().filter(|p| p.is_dir()) {


### PR DESCRIPTION
ln: allow linking directories via symlinks on Windows
ls: more POSIX compliant symlink behavior
ls: fix -aR recursion

Attempting to use this (day to day) as a replacement for msys2 
revealed these issues quickly. ln -s would create a file no matter what
and ls wouldn't deal with symlinks the same as GNU ls or FreeBSD ls.
Probably more comprehensive unit tests are warranted, but these build,
pass the existing tests, and appear to work as-expected and are
modeled the same way as existing code.

Fairly certain there's a better way to fix the recursion than cloning,
but I'm still admittedly getting used to Rust. I didn't notice any problems
on excessively long paths (on Windows), though.

Symlink code also doesn't try to figure out a trailing slash yet with -l, but neither did the original.