### PR TITLE
stat: fix test on travis

### DIFF
--- a/tests/test_stat.rs
+++ b/tests/test_stat.rs
@@ -207,7 +207,7 @@ fn test_symlink() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_char() {
-    let args = ["-c", DEV_FMTSTR, "/dev/zero"];
+    let args = ["-c", DEV_FMTSTR, "/dev/pts/ptmx"];
     new_ucmd!().args(&args)
         .run()
         .stdout_is(expected_result(&args));


### PR DESCRIPTION
See also #996 for diagnostics.

The travis builds on linux run inside a docker container. It looks like travis has changed the containers some time ago. Now all builds on linux fail because gnu stat does not detect the bind-mount of /dev/zero. This causes the output to be different, and the test to fail.

I assume `test_char` is meant to test a character special file in `/dev`. This PR uses `/dev/pts/ptmx` instead, both stat versions agree about it's output.

See https://travis-ci.org/wimh/coreutils/builds/177738828 where I added some additional logging.
