### PR TITLE
Temporary fix for errors in testing

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,10 @@ use std::io::Write;
 use std::path::Path;
 
 pub fn main() {
+    if let Ok(profile) = env::var("PROFILE") {
+        println!("cargo:rustc-cfg=build={:?}", profile);
+    }
+
     let feature_prefix = "CARGO_FEATURE_";
     let out_dir = env::var("OUT_DIR").unwrap();
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -374,7 +374,15 @@ impl TestScenario {
                 // Instead of hardcoding the path relative to the current
                 // directory, use Cargo's OUT_DIR to find path to executable.
                 // This allows tests to be run using profiles other than debug.
-                let target_dir = path_concat!(env::var("OUT_DIR").unwrap(), "..", "..", "..", PROGNAME);
+                // let target_dir = path_concat!(env::var("OUT_DIR").unwrap(), "..", "..", "..", PROGNAME);
+                let target_dir;
+                // FIXME: $OUT_DIR is not set by nightly cargo
+                // See also: https://github.com/rust-lang/cargo/issues/3368
+                if cfg!(build = "release") {
+                    target_dir = path_concat!(env!("CARGO_MANIFEST_DIR"), "target", "release", PROGNAME);
+                } else {
+                    target_dir = path_concat!(env!("CARGO_MANIFEST_DIR"), "target", "debug", PROGNAME);
+                }
                 PathBuf::from(AtPath::new(Path::new(&target_dir)).root_dir_resolved())
             },
             util_name: String::from(util_name),


### PR DESCRIPTION
The errors were caused by the missing env $OUT_DIR which should be set by
cargo. 

[Related issue](https://github.com/rust-lang/cargo/issues/3368)