### PR TITLE
tests/chmod: don't make assumptions about umask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "id 0.0.1",
  "install 0.0.1",
  "kill 0.0.1",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "link 0.0.1",
  "ln 0.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ regex="*"
 rand="*"
 tempdir="*"
 unindent="*"
+lazy_static = "*"
 
 [[bin]]
 name = "uutils"

--- a/tests/test_chmod.rs
+++ b/tests/test_chmod.rs
@@ -1,6 +1,7 @@
 use common::util::*;
 use std::fs::{metadata, OpenOptions, set_permissions};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::sync::Mutex;
 
 extern crate libc;
 use self::libc::umask;
@@ -9,6 +10,9 @@ use self::libc::umask;
 static TEST_FILE: &'static str = "file";
 static REFERENCE_FILE: &'static str = "reference";
 static REFERENCE_PERMS: u32 = 0o247;
+lazy_static! {
+    static ref UMASK_MUTEX: Mutex<()> = Mutex::new(());
+}
 
 struct TestCase {
     args: Vec<&'static str>,
@@ -70,6 +74,8 @@ fn test_chmod_octal() {
 
 #[test]
 fn test_chmod_ugoa() {
+    let _guard = UMASK_MUTEX.lock();
+
     let last = unsafe {
         umask(0)
     };
@@ -117,6 +123,8 @@ fn test_chmod_ugo_copy() {
 
 #[test]
 fn test_chmod_many_options() {
+    let _guard = UMASK_MUTEX.lock();
+
     let original_umask = unsafe {
         umask(0)
     };

--- a/tests/test_chmod.rs
+++ b/tests/test_chmod.rs
@@ -117,10 +117,16 @@ fn test_chmod_ugo_copy() {
 
 #[test]
 fn test_chmod_many_options() {
+    let original_umask = unsafe {
+        umask(0)
+    };
     let tests = vec!{
         TestCase{args: vec!{"-r,a+w", TEST_FILE}, before: 0o444, after: 0o222},
     };
     run_tests(tests);
+    unsafe {
+        umask(original_umask);
+    }
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 mod common;
 
+#[macro_use]
+extern crate lazy_static;
+
 // For conditional compilation
 macro_rules! unix_only {
     ($($fea:expr, $m:ident);+) => {


### PR DESCRIPTION
`test_chmod_many_options` relied on user's umask not denying read access for anyone. 022, which is the default umask for many, indeed allows read access for everyone. I'm using 027, which disallows read for everyone but owner and group. This made tests fail.

Now tests set and reset umask, ensuring checks are run in a reliable, predictable environment.

`test_chmod_ugoa` already tests chmod's behaviour with different umasks, so it's sufficient to run this test with one particular umask.