### PR TITLE
tail: implement --pid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,8 +942,10 @@ name = "tail"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/tail/Cargo.toml
+++ b/src/tail/Cargo.toml
@@ -9,7 +9,9 @@ path = "tail.rs"
 
 [dependencies]
 getopts = "*"
+kernel32-sys = "*"
 libc = "*"
+winapi = "*"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/tail/README.md
+++ b/src/tail/README.md
@@ -4,7 +4,6 @@ Rudimentary tail implementation.
 
 ### Flags with features
 * `--max-unchanged-stats` : with `--follow=name`, reopen a FILE which has not changed size after N (default 5) iterations  to see if it has been unlinked or renamed (this is the usual case of rotated log files).  With inotify, this option is rarely useful.
-* `--pid` : with `-f`, terminate after process ID, PID dies
 * `--quiet` : never output headers giving file names
 * `--retry` : keep trying to open a file even when it is or becomes inaccessible; useful when follow‐ing by name, i.e., with `--follow=name`
 

--- a/src/tail/platform/mod.rs
+++ b/src/tail/platform/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Alexander Batischev <eual.jp@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#[cfg(unix)]
+pub use self::unix::{Pid, supports_pid_checks, ProcessChecker};
+
+#[cfg(windows)]
+pub use self::windows::{Pid, supports_pid_checks, ProcessChecker};
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(windows)]
+mod windows;

--- a/src/tail/platform/unix.rs
+++ b/src/tail/platform/unix.rs
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Alexander Batischev <eual.jp@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+extern crate libc;
+
+use std::io::Error;
+
+pub type Pid = libc::pid_t;
+
+pub struct ProcessChecker { pid: self::Pid }
+
+impl ProcessChecker {
+    pub fn new(process_id: self::Pid) -> ProcessChecker {
+        ProcessChecker { pid: process_id }
+    }
+
+    // Borrowing mutably to be aligned with Windows implementation
+    pub fn is_dead(&mut self) -> bool {
+        unsafe {
+            libc::kill(self.pid, 0) != 0 && get_errno() != libc::EPERM
+        }
+    }
+}
+
+impl Drop for ProcessChecker {
+    fn drop(&mut self) {
+    }
+}
+
+pub fn supports_pid_checks(pid: self::Pid) -> bool {
+    unsafe {
+        !(libc::kill(pid, 0) != 0 && get_errno() == libc::ENOSYS)
+    }
+}
+
+#[inline]
+fn get_errno() -> i32 {
+    Error::last_os_error().raw_os_error().unwrap()
+}

--- a/src/tail/platform/windows.rs
+++ b/src/tail/platform/windows.rs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Alexander Batischev <eual.jp@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+extern crate winapi;
+extern crate kernel32;
+
+use self::kernel32::{OpenProcess, CloseHandle, WaitForSingleObject};
+use self::winapi::minwindef::DWORD;
+use self::winapi::winbase::{WAIT_OBJECT_0, WAIT_FAILED};
+use self::winapi::winnt::{HANDLE, SYNCHRONIZE};
+
+pub type Pid = DWORD;
+
+pub struct ProcessChecker {
+    dead: bool,
+    handle: HANDLE
+}
+
+impl ProcessChecker {
+    pub fn new(process_id: self::Pid) -> ProcessChecker {
+        #[allow(non_snake_case)]
+        let FALSE = 0i32;
+        let h = unsafe {
+            OpenProcess(SYNCHRONIZE, FALSE, process_id as DWORD)
+        };
+        ProcessChecker { dead: h.is_null(), handle: h }
+    }
+
+    pub fn is_dead(&mut self) -> bool {
+        if !self.dead {
+            self.dead = unsafe {
+                let status = WaitForSingleObject(self.handle, 0);
+                status == WAIT_OBJECT_0 || status == WAIT_FAILED
+            }
+        }
+
+        self.dead
+    }
+}
+
+impl Drop for ProcessChecker {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+pub fn supports_pid_checks(_pid: self::Pid) -> bool {
+    true
+}


### PR DESCRIPTION
GNU coreutils have one more use-case for `--pid`, actually, but it doesn't apply to us because we don't support inotify:

```
  -s, --sleep-interval=N   with -f, sleep for approximately N seconds
                             (default 1.0) between iterations;
                             with inotify and --pid=P, check process P at
                             least once every N seconds
```