### PR TITLE
mkdir: trying to create existing dir is fine

### DIFF
--- a/src/mkdir/mkdir.rs
+++ b/src/mkdir/mkdir.rs
@@ -119,14 +119,11 @@ fn exec(dirs: Vec<String>, recursive: bool, mode: u16, verbose: bool) -> i32 {
  * Wrapper to catch errors, return 1 if failed
  */
 fn mkdir(path: &Path, mode: u16, verbose: bool) -> i32 {
-    if path.exists() {
-        show_info!("cannot create directory '{}': File exists", path.display());
-        return 1;
-    }
-
-    if let Err(e) = fs::create_dir(path) {
-        show_info!("{}: {}", path.display(), e.to_string());
-        return 1;
+    if !path.exists() {
+        if let Err(e) = fs::create_dir(path) {
+            show_info!("{}: {}", path.display(), e.to_string());
+            return 1;
+        }
     }
 
     if verbose {

--- a/tests/test_mkdir.rs
+++ b/tests/test_mkdir.rs
@@ -16,7 +16,7 @@ fn test_mkdir_mkdir() {
 fn test_mkdir_dup_dir() {
     let scene = TestScenario::new(util_name!());
     scene.ucmd().arg(TEST_DIR2).succeeds();
-    scene.ucmd().arg(TEST_DIR2).fails();
+    scene.ucmd().arg(TEST_DIR2).succeeds();
 }
 
 #[test]
@@ -30,7 +30,9 @@ fn test_mkdir_mode() {
 
 #[test]
 fn test_mkdir_parent() {
-    new_ucmd!().arg("-p").arg(TEST_DIR4).succeeds();
+    let scene = TestScenario::new(util_name!());
+    scene.ucmd().arg("-p").arg(TEST_DIR4).succeeds();
+    scene.ucmd().arg("-p").arg(TEST_DIR4).succeeds();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1017.

test_mkdir_dup_dir asserted that creating an existing directory is an
error, but that's not how GNU coreutils behaves. This has been reported
in #121, but wasn't fixed (only the `-p` case was).