### PR TITLE
cat: fix for numbered lines w/ no trailing newline

### DIFF
--- a/tests/fixtures/cat/nonewline.txt
+++ b/tests/fixtures/cat/nonewline.txt
@@ -1,0 +1,1 @@
+text without a trailing newline

--- a/tests/test_cat.rs
+++ b/tests/test_cat.rs
@@ -23,6 +23,15 @@ fn test_output_multi_files_print_all_chars() {
 }
 
 #[test]
+fn test_numbered_lines_no_trailing_newline() {
+    new_ucmd!()
+        .args(&["nonewline.txt", "alpha.txt", "-n"])
+        .succeeds()
+        .stdout_only("     1\ttext without a trailing newlineabcde\n     2\tfghij\n     \
+                3\tklmno\n     4\tpqrst\n     5\tuvwxyz\n");
+}
+
+#[test]
 fn test_stdin_show_nonprinting() {
     for same_param in vec!["-v", "--show-nonprinting"] {
         new_ucmd!()


### PR DESCRIPTION
Make `at_line_start` persist between printing each file. This fixes an
issue when numbering lines in the output and one of the input files
does not have a trailing newline.

#### Before:

```
❯ cat -n tests/fixtures/cat/nonewline.txt tests/fixtures/cat/alpha.txt
     1	text without a trailing newline     2	abcde
     3	fghij
     4	klmno
     5	pqrst
     6	uvwxyz
```

#### After:

```
❯ cat -n tests/fixtures/cat/nonewline.txt tests/fixtures/cat/alpha.txt
     1	text without a trailing newlineabcde
     2	fghij
     3	klmno
     4	pqrst
     5	uvwxyz
```