### PR TITLE
Partial implemantion of date.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "comm 0.0.1",
  "cp 0.0.1",
  "cut 0.0.1",
+ "date 0.0.1",
  "dircolors 0.0.1",
  "dirname 0.0.1",
  "du 0.0.1",
@@ -81,7 +82,7 @@ dependencies = [
  "tee 0.0.1",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "test 0.0.1",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "timeout 0.0.1",
  "touch 0.0.1",
  "tr 0.0.1",
@@ -120,6 +121,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ansi_term"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arch"
@@ -178,6 +184,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "chroot"
 version = "0.0.1"
 dependencies = [
@@ -236,6 +256,21 @@ version = "0.0.1"
 dependencies = [
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
+]
+
+[[package]]
+name = "clap"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -269,6 +304,15 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "date"
+version = "0.0.1"
+dependencies = [
+ "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uucore 0.0.1",
+]
+
+[[package]]
 name = "dircolors"
 version = "0.0.1"
 dependencies = [
@@ -288,7 +332,7 @@ dependencies = [
 name = "du"
 version = "0.0.1"
 dependencies = [
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -317,7 +361,7 @@ name = "expand"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -354,7 +398,7 @@ name = "fmt"
 version = "0.0.1"
 dependencies = [
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -518,8 +562,8 @@ dependencies = [
  "pretty-bytes 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_grid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termsize 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -638,6 +682,38 @@ dependencies = [
  "num_cpus 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
+
+[[package]]
+name = "num"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
@@ -759,6 +835,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "regex"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,7 +889,7 @@ dependencies = [
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -862,7 +943,7 @@ dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -906,7 +987,7 @@ name = "stat"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -917,6 +998,11 @@ dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sum"
@@ -990,7 +1076,17 @@ name = "term_grid"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1031,11 +1127,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1045,7 +1142,7 @@ version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1055,7 +1152,7 @@ version = "0.0.1"
 dependencies = [
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1109,13 +1206,18 @@ name = "unexpand"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1177,8 +1279,13 @@ dependencies = [
  "data-encoding 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (git+https://github.com/rust-lang/libc.git)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "void"
@@ -1254,12 +1361,16 @@ dependencies = [
 [metadata]
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0fd4c0631f06448cc45a6bbb3b710ebb7ff8ccb96a0800c994afe23a70d5df2"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
+"checksum chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "158b0bd7d75cbb6bf9c25967a48a2e9f77da95876b858eadfabaa99cd069de6e"
+"checksum clap 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1cb22651881e6379f4492d0d572ecb8022faef8c8aaae285bb18cb307bfa30"
 "checksum data-encoding 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f13f03d68d1906eb3222536f5756953e30de4dff4417e5d428414fb8edb26723"
 "checksum either 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2b503c86dad62aaf414ecf2b8c527439abedb3f8d812537f0b12bfd6f32a91"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
@@ -1274,10 +1385,15 @@ dependencies = [
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
+"checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
+"checksum num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "21e4df1098d1d797d27ef0c69c178c3fab64941559b290fcae198e0825c9c8b5"
+"checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
+"checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum num_cpus 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55aabf4e2d6271a2e4e4c0f2ea1f5b07cc589cc1a9e9213013b54a76678ca4f3"
 "checksum pretty-bytes 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3095b93999fae14b4e0bb661c53875a441d9058b7b1a7ba2dfebc104d3776349"
 "checksum quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0aad603e8d7fb67da22dbdf1f4b826ce8829e406124109e73cf1b2454b93a71c"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
@@ -1286,17 +1402,21 @@ dependencies = [
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
 "checksum semver-parser 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e88e43a5a74dd2a11707f9c21dfd4a423c66bd871df813227bb0a3e78f3a1ae9"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9270837a93bad1b1dac18fe67e786b3c960513af86231f6f4f57fddd594ff0c8"
 "checksum term_grid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc202875496cf72a683a1ecd66f0742a830e73c202bdbd21867d73dfaac8343"
+"checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum termsize 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3a225cb94c3630aabd2e289cad545679dd38b5f4891524e92da1be10aae6e4e8"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-"checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
-"checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
+"checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
+"checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unindent 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3508be0ce1bacc38d579b69bffb4b8d469f5af0c388ff4890b2b294e61671ffe"
 "checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
 "checksum walkdir 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dd7c16466ecc507c7cb5988db03e6eab4aaeab89a5c37a29251fcfd3ac9b7afe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ redox = [
   "comm",
   "cp",
   "cut",
+  "date",
   "dircolors",
   "dirname",
   "echo",
@@ -157,6 +158,7 @@ cksum    = { optional=true, path="src/cksum" }
 comm     = { optional=true, path="src/comm" }
 cp       = { optional=true, path="src/cp" }
 cut      = { optional=true, path="src/cut" }
+date     = { optional=true, path="src/date" }
 dircolors= { optional=true, path="src/dircolors" }
 dirname  = { optional=true, path="src/dirname" }
 du       = { optional=true, path="src/du" }

--- a/src/date/Cargo.toml
+++ b/src/date/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "date"
+version = "0.0.1"
+authors = []
+
+[lib]
+name = "uu_date"
+path = "date.rs"
+
+[dependencies]
+chrono = "*"
+clap = "*"
+uucore = { path="../uucore" }
+
+[[bin]]
+name = "date"
+path = "main.rs"

--- a/src/date/date.rs
+++ b/src/date/date.rs
@@ -1,0 +1,283 @@
+#![crate_name = "uu_date"]
+
+/*
+ * This file is part of the uutils coreutils package.
+ *
+ * (c) Anthony Deschamps <anthony.j.deschamps@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+extern crate chrono;
+#[macro_use]
+extern crate clap;
+extern crate uucore;
+
+use chrono::{DateTime, FixedOffset, Offset, Local};
+use chrono::offset::utc::UTC;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+// Options
+const DATE: &'static str = "date";
+const HOURS: &'static str = "hours";
+const MINUTES: &'static str = "minutes";
+const SECONDS: &'static str = "seconds";
+const NS: &'static str = "ns";
+
+// Help strings
+
+static ISO_8601_HELP_STRING: &'static str = "output date/time in ISO 8601 format.
+ FMT='date' for date only (the default),
+ 'hours', 'minutes', 'seconds', or 'ns'
+ for date and time to the indicated precision.
+ Example: 2006-08-14T02:34:56-06:00";
+
+static RFC_2822_HELP_STRING: &'static str = "output date and time in RFC 2822 format.
+ Example: Mon, 14 Aug 2006 02:34:56 -0600";
+
+static RFC_3339_HELP_STRING: &'static str = "output date/time in RFC 3339 format.
+ FMT='date', 'seconds', or 'ns'
+ for date and time to the indicated precision.
+ Example: 2006-08-14 02:34:56-06:00";
+
+/// Settings for this program, parsed from the command line
+struct Settings {
+    utc: bool,
+    format: Format,
+    date_source: DateSource,
+    set_to: Option<DateTime<FixedOffset>>,
+}
+
+/// Various ways of displaying the date
+enum Format {
+    Iso8601(Iso8601Format),
+    Rfc2822,
+    Rfc3339(Rfc3339Format),
+    Custom(String),
+    Default,
+}
+
+/// Various places that dates can come from
+enum DateSource {
+    Now,
+    Custom(String),
+    File(PathBuf),
+}
+
+enum Iso8601Format {
+    Date,
+    Hours,
+    Minutes,
+    Seconds,
+    Ns,
+}
+
+impl<'a> From<&'a str> for Iso8601Format {
+    fn from(s: &str) -> Self {
+        match s {
+            HOURS => Iso8601Format::Hours,
+            MINUTES => Iso8601Format::Minutes,
+            SECONDS => Iso8601Format::Seconds,
+            NS => Iso8601Format::Ns,
+            DATE => Iso8601Format::Date,
+            // Should be caught by clap
+            _ => panic!("Invalid format: {}", s),
+        }
+    }
+}
+
+enum Rfc3339Format {
+    Date,
+    Seconds,
+    Ns,
+}
+
+impl<'a> From<&'a str> for Rfc3339Format {
+    fn from(s: &str) -> Self {
+        match s {
+            DATE => Rfc3339Format::Date,
+            SECONDS => Rfc3339Format::Seconds,
+            NS => Rfc3339Format::Ns,
+            // Should be caught by clap
+            _ => panic!("Invalid format: {}", s),
+        }
+    }
+}
+
+pub fn uumain(args: Vec<String>) -> i32 {
+
+    let settings = parse_cli(args);
+
+    if let Some(_time) = settings.set_to {
+        unimplemented!();
+        // Probably need to use this syscall:
+        // https://doc.rust-lang.org/libc/i686-unknown-linux-gnu/libc/fn.clock_settime.html
+
+    } else {
+        // Declare a file here because it needs to outlive the `dates` iterator.
+        let file: File;
+
+        // Get the current time, either in the local time zone or UTC.
+        let now: DateTime<FixedOffset> = match settings.utc {
+            true => {
+                let now = UTC::now();
+                now.with_timezone(&now.offset().fix())
+            }
+            false => {
+                let now = Local::now();
+                now.with_timezone(now.offset())
+            }
+        };
+
+        /// Parse a `String` into a `DateTime`.
+        /// If it fails, return a tuple of the `String` along with its `ParseError`.
+        fn parse_date(s: String)
+                      -> Result<DateTime<FixedOffset>, (String, chrono::format::ParseError)> {
+            // TODO: The GNU date command can parse a wide variety of inputs.
+            s.parse().map_err(|e| (s, e))
+        }
+
+        // Iterate over all dates - whether it's a single date or a file.
+        let dates: Box<Iterator<Item = _>> = match settings.date_source {
+            DateSource::Custom(ref input) => {
+                let date = parse_date(input.clone());
+                let iter = std::iter::once(date);
+                Box::new(iter)
+            }
+            DateSource::File(ref path) => {
+                file = File::open(path).unwrap();
+                let lines = BufReader::new(file).lines();
+                let iter = lines.filter_map(Result::ok).map(parse_date);
+                Box::new(iter)
+            }
+            DateSource::Now => {
+                let iter = std::iter::once(Ok(now));
+                Box::new(iter)
+            }
+        };
+
+        let format_string = make_format_string(&settings);
+
+        // Format all the dates
+        for date in dates {
+            match date {
+                Ok(date) => {
+                    let formatted = date.format(format_string);
+                    println!("{}", formatted);
+                }
+                Err((input, _err)) => {
+                    println!("date: invalid date '{}'", input);
+                }
+            }
+        }
+    }
+
+    0
+}
+
+
+/// Handle command line arguments.
+fn parse_cli(args: Vec<String>) -> Settings {
+    let matches = clap_app!(
+        date =>
+            (@group dates =>
+             (@arg date: -d --date [STRING]
+              "display time described by STRING, not 'now'")
+             (@arg file: -f --file [DATEFILE]
+              "like --date; once for each line of DATEFILE"))
+
+            (@group format =>
+             (@arg iso_8601: -I --("iso-8601") <FMT>
+              possible_value[date hours minutes seconds ns]
+              #{0, 1}
+              ISO_8601_HELP_STRING)
+             (@arg rfc_2822: -R --("rfc-2822")
+              RFC_2822_HELP_STRING)
+             (@arg rfc_3339: --("rfc-3339") <FMT>
+              possible_value[date seconds ns]
+              RFC_3339_HELP_STRING)
+             (@arg custom_format: +takes_value {
+                 |s| match s.starts_with("+") {
+                     true => Ok(()),
+                     false => Err(String::from("Date formats must start with a '+' character"))
+                 }
+             }))
+
+            (@arg debug: --debug
+             "annotate the parsed date, and warn about questionable usage to stderr")
+            (@arg reference: -r --reference [FILE]
+             "display the last modification time of FILE")
+            (@arg set: -s --set [STRING]
+             "set time described by STRING")
+            (@arg utc: -u --utc --universal
+             "print or set Coordinated Universal Time (UTC)"))
+
+    // TODO: Decide whether this is appropriate.
+    //   The GNU date command has an explanation of all formatting options,
+    //   but the `chrono` crate has a few differences (most notably, the %Z option)
+    // (after_help: include_str!("usage.txt")))
+        .get_matches_from(args);
+
+
+    let format = if let Some(form) = matches.value_of("custom_format") {
+        let form = form[1..].into();
+        Format::Custom(form)
+    } else if let Some(fmt) = matches.values_of("iso_8601").map(|mut iter| {
+                                                                    iter.next()
+                                                                        .unwrap_or(DATE)
+                                                                        .into()
+                                                                }) {
+        Format::Iso8601(fmt)
+    } else if matches.is_present("rfc_2822") {
+        Format::Rfc2822
+    } else if let Some(fmt) = matches.value_of("rfc_3339").map(Into::into) {
+        Format::Rfc3339(fmt)
+    } else {
+        Format::Default
+    };
+
+    let date_source = if let Some(date) = matches.value_of("date") {
+        DateSource::Custom(date.into())
+    } else if let Some(file) = matches.value_of("file") {
+        DateSource::File(file.into())
+    } else {
+        DateSource::Now
+    };
+
+    Settings {
+        utc: matches.is_present("utc"),
+        format: format,
+        date_source: date_source,
+        // TODO: Handle this option:
+        set_to: None,
+    }
+}
+
+
+/// Return the appropriate format string for the given settings.
+fn make_format_string(settings: &Settings) -> &str {
+    match settings.format {
+        Format::Iso8601(ref fmt) => {
+            match fmt {
+                &Iso8601Format::Date => "%F",
+                &Iso8601Format::Hours => "%FT%H%:z",
+                &Iso8601Format::Minutes => "%FT%H:%M%:z",
+                &Iso8601Format::Seconds => "%FT%T%:z",
+                &Iso8601Format::Ns => "%FT%T,%f%:z",
+            }
+        }
+        Format::Rfc2822 => "%a, %d %h %Y %T %z",
+        Format::Rfc3339(ref fmt) => {
+            match fmt {
+                &Rfc3339Format::Date => "%F",
+                &Rfc3339Format::Seconds => "%F %T%:z",
+                &Rfc3339Format::Ns => "%F %T.%f%:z",
+            }
+        }
+        Format::Custom(ref fmt) => fmt,
+        Format::Default => "%c",
+    }
+}

--- a/src/date/main.rs
+++ b/src/date/main.rs
@@ -1,0 +1,5 @@
+extern crate uu_echo;
+
+fn main() {
+    std::process::exit(uu_date::uumain(std::env::args().collect()));
+}

--- a/src/date/usage.txt
+++ b/src/date/usage.txt
@@ -1,0 +1,72 @@
+FORMAT controls the output.  Interpreted sequences are:
+
+  %%   a literal %
+  %a   locale's abbreviated weekday name (e.g., Sun)
+  %A   locale's full weekday name (e.g., Sunday)
+  %b   locale's abbreviated month name (e.g., Jan)
+  %B   locale's full month name (e.g., January)
+  %c   locale's date and time (e.g., Thu Mar  3 23:05:25 2005)
+  %C   century; like %Y, except omit last two digits (e.g., 20)
+  %d   day of month (e.g., 01)
+  %D   date; same as %m/%d/%y
+  %e   day of month, space padded; same as %_d
+  %F   full date; same as %Y-%m-%d
+  %g   last two digits of year of ISO week number (see %G)
+  %G   year of ISO week number (see %V); normally useful only with %V
+  %h   same as %b
+  %H   hour (00..23)
+  %I   hour (01..12)
+  %j   day of year (001..366)
+  %k   hour, space padded ( 0..23); same as %_H
+  %l   hour, space padded ( 1..12); same as %_I
+  %m   month (01..12)
+  %M   minute (00..59)
+  %n   a newline
+  %N   nanoseconds (000000000..999999999)
+  %p   locale's equivalent of either AM or PM; blank if not known
+  %P   like %p, but lower case
+  %q   quarter of year (1..4)
+  %r   locale's 12-hour clock time (e.g., 11:11:04 PM)
+  %R   24-hour hour and minute; same as %H:%M
+  %s   seconds since 1970-01-01 00:00:00 UTC
+  %S   second (00..60)
+  %t   a tab
+  %T   time; same as %H:%M:%S
+  %u   day of week (1..7); 1 is Monday
+  %U   week number of year, with Sunday as first day of week (00..53)
+  %V   ISO week number, with Monday as first day of week (01..53)
+  %w   day of week (0..6); 0 is Sunday
+  %W   week number of year, with Monday as first day of week (00..53)
+  %x   locale's date representation (e.g., 12/31/99)
+  %X   locale's time representation (e.g., 23:13:48)
+  %y   last two digits of year (00..99)
+  %Y   year
+  %z   +hhmm numeric time zone (e.g., -0400)
+  %:z  +hh:mm numeric time zone (e.g., -04:00)
+  %::z  +hh:mm:ss numeric time zone (e.g., -04:00:00)
+  %:::z  numeric time zone with : to necessary precision (e.g., -04, +05:30)
+  %Z   alphabetic time zone abbreviation (e.g., EDT)
+
+By default, date pads numeric fields with zeroes.
+The following optional flags may follow '%':
+
+  -  (hyphen) do not pad the field
+  _  (underscore) pad with spaces
+  0  (zero) pad with zeros
+  ^  use upper case if possible
+  #  use opposite case if possible
+
+After any flags comes an optional field width, as a decimal number;
+then an optional modifier, which is either
+E to use the locale's alternate representations if available, or
+O to use the locale's alternate numeric symbols if available.
+
+Examples:
+Convert seconds since the epoch (1970-01-01 UTC) to a date
+  $ date --date='@2147483647'
+
+Show the time on the west coast of the US (use tzselect(1) to find TZ)
+  $ TZ='America/Los_Angeles' date
+
+Show the local time for 9AM next Friday on the west coast of the US
+  $ date --date='TZ="America/Los_Angeles" 09:00 next Fri'


### PR DESCRIPTION
Here's a partial implementation of `date`.

Things that work:
- Printing the current date/time in UTC or local time
- Command line arguments
- Printing in various formats (standard formats and user supplied format string)
- Reading from a file

Things that don't work:
- Handling the variety of ways in which the GNU `date` program parses string input ("next week", "yesterday", etc)
- Setting the system clock (need to be able to parse the time first)
- Printing the name of the time zone

I don't have any tests yet. I'm not quite sure how to approach them, since most of the things this program does depend on the system clock.