### PR TITLE
rm: Remove symlinks to directories without -r

### DIFF
--- a/src/rm/rm.rs
+++ b/src/rm/rm.rs
@@ -129,7 +129,7 @@ fn remove(files: Vec<String>, force: bool, interactive: InteractiveMode, one_fs:
         let filename = &filename[..];
         let file = Path::new(filename);
         if file.exists() {
-            if file.is_dir() {
+            if file.symlink_metadata().unwrap().is_dir() {
                 if recursive && (filename != "/" || !preserve_root) {
                     if interactive != InteractiveMode::InteractiveAlways {
                         if let Err(e) = fs::remove_dir_all(file) {

--- a/src/rm/rm.rs
+++ b/src/rm/rm.rs
@@ -129,7 +129,15 @@ fn remove(files: Vec<String>, force: bool, interactive: InteractiveMode, one_fs:
         let filename = &filename[..];
         let file = Path::new(filename);
         if file.exists() {
-            if file.symlink_metadata().unwrap().is_dir() {
+            let is_dir = match file.symlink_metadata() {
+                Ok(metadata) => metadata.is_dir(),
+                Err(e) => {
+                    had_err = true;
+                    show_error!("could not read metadata of '{}': {}", filename, e);
+                    continue;
+                }
+            };
+            if is_dir {
                 if recursive && (filename != "/" || !preserve_root) {
                     if interactive != InteractiveMode::InteractiveAlways {
                         if let Err(e) = fs::remove_dir_all(file) {

--- a/tests/test_rm.rs
+++ b/tests/test_rm.rs
@@ -136,3 +136,15 @@ fn test_rm_verbose() {
     ucmd.arg("-v").arg(file_a).arg(file_b).succeeds()
         .stdout_only(format!("removed '{}'\nremoved '{}'\n", file_a, file_b));
 }
+
+#[test]
+fn test_rm_dir_symlink() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir = "test_rm_dir_symlink_dir";
+    let link = "test_rm_dir_symlink_link";
+
+    at.mkdir(dir);
+    at.symlink(dir, link);
+
+    ucmd.arg(link).succeeds();
+}


### PR DESCRIPTION
Path::is_dir follows symlinks so it returns true for symlinks
to directories. Use symlink_metadata instead so you can remove
symlinks to directories without -r flag.