### PR TITLE
rm: Remove invalid symlinks

### DIFF
--- a/tests/test_rm.rs
+++ b/tests/test_rm.rs
@@ -148,3 +148,13 @@ fn test_rm_dir_symlink() {
 
     ucmd.arg(link).succeeds();
 }
+
+#[test]
+fn test_rm_invalid_symlink() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let link = "test_rm_invalid_symlink";
+
+    at.symlink(link, link);
+
+    ucmd.arg(link).succeeds();
+}


### PR DESCRIPTION
Checking with file.exists() was not good for this purpose as
Path::exists() returns false for invalid symlinks.