### PR TITLE
tr: use FnvHashMap instead of default HashMap backed by SipHasher

### DIFF
--- a/src/tr/Cargo.toml
+++ b/src/tr/Cargo.toml
@@ -10,6 +10,7 @@ path = "tr.rs"
 [dependencies]
 getopts = "*"
 bit-set = "*"
+fnv = "*"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/tr/tr.rs
+++ b/src/tr/tr.rs
@@ -14,6 +14,7 @@
 
 extern crate bit_set;
 extern crate getopts;
+extern crate fnv;
 
 #[macro_use]
 extern crate uucore;
@@ -21,7 +22,7 @@ extern crate uucore;
 use bit_set::BitSet;
 use getopts::Options;
 use std::io::{stdin, stdout, BufRead, BufWriter, Write};
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 use expand::ExpandSet;
 
@@ -65,8 +66,7 @@ fn delete(set: ExpandSet, complement: bool) {
 }
 
 fn tr<'a>(set1: ExpandSet<'a>, mut set2: ExpandSet<'a>) {
-    //let mut map = VecMap::new();
-    let mut map = HashMap::new();
+    let mut map = FnvHashMap::default();
     let stdin = stdin();
     let mut locked_stdin = stdin.lock();
     let mut buffered_stdout = BufWriter::new(stdout());


### PR DESCRIPTION
FnvHashMap is much faster for small inputs like intergers, and we literally have a hashmap with chars as keys in tr. This reduces runtime for tr in substitution mode from 40 seconds to 30 seconds on my 1.7Gb unicode test file.

Using FnvHashSet instead of BitSet in tr delete mode did not measuarably impact performance, so I did not convert it. I have also grepped for "Hash" and checked if using FnvHash made sense in other places; it did conceptually, but did not result in measurable performance improvements, so I did not convert those.

This adds dependency on the `fnv` crate, but it's quite mature and even used inside `rustc` itself, so that should not be a problem.