### PR TITLE
pin dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,8 +36,8 @@ dependencies = [
  "id 0.0.1",
  "install 0.0.1",
  "kill 0.0.1",
- "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "link 0.0.1",
  "ln 0.0.1",
  "logname 0.0.1",
@@ -82,7 +82,7 @@ dependencies = [
  "tee 0.0.1",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "test 0.0.1",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "timeout 0.0.1",
  "touch 0.0.1",
  "tr 0.0.1",
@@ -123,6 +123,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,7 +148,17 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -170,17 +188,12 @@ name = "bit-set"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -189,22 +202,27 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
-version = "0.5.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cat"
 version = "0.0.1"
 dependencies = [
- "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -212,14 +230,14 @@ name = "chgrp"
 version = "0.0.1"
 dependencies = [
  "uucore 0.0.1",
- "walkdir 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chmod"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
  "walker 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -238,8 +256,8 @@ name = "chrono"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,23 +272,24 @@ dependencies = [
 name = "cksum"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
 [[package]]
 name = "clap"
-version = "2.20.0"
+version = "2.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -278,7 +297,7 @@ name = "comm"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -287,8 +306,9 @@ name = "cp"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -300,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -308,7 +328,7 @@ name = "date"
 version = "0.0.1"
 dependencies = [
  "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -324,7 +344,7 @@ dependencies = [
 name = "dirname"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -332,7 +352,7 @@ dependencies = [
 name = "du"
 version = "0.0.1"
 dependencies = [
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -345,14 +365,14 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -369,7 +389,7 @@ dependencies = [
 name = "expr"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -390,17 +410,22 @@ name = "filetime"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fmt"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fold"
@@ -411,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.3.40"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -433,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -441,11 +466,11 @@ name = "hashsum"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -453,7 +478,7 @@ dependencies = [
 name = "head"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -461,7 +486,7 @@ dependencies = [
 name = "hostid"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -469,7 +494,7 @@ dependencies = [
 name = "hostname"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -485,16 +510,16 @@ name = "install"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.5.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -510,30 +535,30 @@ dependencies = [
 name = "kill"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "0.2.2"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.18"
-source = "git+https://github.com/rust-lang/libc.git#fb8587d327ca0a14edbaf7c1656c580efee156d2"
+version = "0.2.26"
+source = "git+https://github.com/rust-lang/libc.git#c43c0770db6b85ade0b70009464603ff9be4b37d"
 
 [[package]]
 name = "libc"
-version = "0.2.18"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "link"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -541,7 +566,7 @@ dependencies = [
 name = "ln"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -549,7 +574,7 @@ dependencies = [
 name = "logname"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -558,11 +583,11 @@ name = "ls"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty-bytes 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_grid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termsize 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
@@ -572,7 +597,15 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -580,7 +613,7 @@ name = "mkdir"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -589,7 +622,7 @@ name = "mkfifo"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -598,7 +631,7 @@ name = "mknod"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -608,7 +641,7 @@ version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -617,7 +650,7 @@ name = "more"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -634,20 +667,18 @@ name = "nice"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
 [[package]]
 name = "nix"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -655,12 +686,12 @@ dependencies = [
 name = "nl"
 version = "0.0.1"
 dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -669,7 +700,7 @@ name = "nohup"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -678,59 +709,59 @@ name = "nproc"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
 [[package]]
 name = "num"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.33"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.5.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "od"
 version = "0.0.1"
 dependencies = [
- "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "half 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -747,7 +778,7 @@ name = "pathchk"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -764,7 +795,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -779,7 +810,7 @@ dependencies = [
 name = "printf"
 version = "0.0.1"
 dependencies = [
- "itertools 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -787,12 +818,12 @@ dependencies = [
 name = "ptx"
 version = "0.0.1"
 dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -806,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -814,7 +845,7 @@ name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -822,7 +853,7 @@ name = "readlink"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -836,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.17"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -852,8 +883,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -885,16 +933,16 @@ name = "rust-crypto"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -906,26 +954,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "semver-parser 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "semver-parser"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "seq"
@@ -941,9 +994,9 @@ version = "0.0.1"
 dependencies = [
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -969,8 +1022,8 @@ name = "sort"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -987,7 +1040,7 @@ name = "stat"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1018,7 +1071,7 @@ version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1037,7 +1090,7 @@ version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1047,7 +1100,7 @@ name = "tee"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1061,11 +1114,11 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1081,11 +1134,11 @@ dependencies = [
 
 [[package]]
 name = "term_size"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1096,7 +1149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1104,8 +1157,17 @@ dependencies = [
 name = "test"
 version = "0.0.1"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1114,7 +1176,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1126,13 +1188,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
-version = "0.1.36"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1141,8 +1212,8 @@ name = "timeout"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1152,7 +1223,7 @@ version = "0.0.1"
 dependencies = [
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1161,6 +1232,7 @@ name = "tr"
 version = "0.0.1"
 dependencies = [
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
@@ -1190,7 +1262,7 @@ name = "tty"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1238,8 +1310,8 @@ name = "unix_socket"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1247,8 +1319,16 @@ name = "unlink"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1273,18 +1353,23 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uucore"
 version = "0.0.1"
 dependencies = [
- "data-encoding 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "data-encoding 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (git+https://github.com/rust-lang/libc.git)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (git+https://github.com/rust-lang/libc.git)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "vec_map"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1303,10 +1388,11 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "1.0.3"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1361,65 +1447,76 @@ dependencies = [
 [metadata]
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0fd4c0631f06448cc45a6bbb3b710ebb7ff8ccb96a0800c994afe23a70d5df2"
+"checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
-"checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
-"checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
+"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "158b0bd7d75cbb6bf9c25967a48a2e9f77da95876b858eadfabaa99cd069de6e"
-"checksum clap 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1cb22651881e6379f4492d0d572ecb8022faef8c8aaae285bb18cb307bfa30"
-"checksum data-encoding 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f13f03d68d1906eb3222536f5756953e30de4dff4417e5d428414fb8edb26723"
-"checksum either 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2b503c86dad62aaf414ecf2b8c527439abedb3f8d812537f0b12bfd6f32a91"
+"checksum clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "867a885995b4184be051b70a592d4d70e32d7a188db6e8dff626af286a962771"
+"checksum data-encoding 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d867ddbf09de0b73e09ec798972fb7f870495a0893f6f736c1855448c5a56789"
+"checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
-"checksum gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "872db9e59486ef2b14f8e8c10e9ef02de2bccef6363d7f34835dedb386b3d950"
+"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
+"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum half 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d07978d54bfc4102f0656a19b2a6b8af375dd6a09db587920d03ea35195d844"
-"checksum itertools 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8e8d6f7e00ae9fd6ad3075412717c706d823cebc4a2f127ae43c1744452a087a"
+"checksum half 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63d68db75012a85555434ee079e7e6337931f87a087ab2988becbadf64673a7f"
+"checksum itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "772a0928a97246167d59a2a4729df5871f1327ab8b36fd24c4224b229cb47b99"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
-"checksum libc 0.2.18 (git+https://github.com/rust-lang/libc.git)" = "<none>"
-"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum libc 0.2.26 (git+https://github.com/rust-lang/libc.git)" = "<none>"
+"checksum libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "30885bcb161cf67054244d10d4a7f4835ffd58773bc72e07d35fecf472295503"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
-"checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
-"checksum num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "21e4df1098d1d797d27ef0c69c178c3fab64941559b290fcae198e0825c9c8b5"
-"checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
-"checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
-"checksum num_cpus 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6e850c7f35c3de263e6094e819f6b4b9c09190ff4438fc6dec1aef1568547bc"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47e49f6982987135c5e9620ab317623e723bd06738fd85377e8d55f57c8b6487"
+"checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
+"checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
+"checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
+"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
 "checksum pretty-bytes 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3095b93999fae14b4e0bb661c53875a441d9058b7b1a7ba2dfebc104d3776349"
-"checksum quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0aad603e8d7fb67da22dbdf1f4b826ce8829e406124109e73cf1b2454b93a71c"
+"checksum quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c36987d4978eb1be2e422b1e0423a557923a5c3e7e6f31d5699e9aafaefa469"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
-"checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
+"checksum redox_syscall 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "9df6a71a1e67be2104410736b2389fb8e383c1d7e9e792d629ff13c02867147a"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-"checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
-"checksum semver-parser 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e88e43a5a74dd2a11707f9c21dfd4a423c66bd871df813227bb0a3e78f3a1ae9"
+"checksum semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fdd61b85a0fa777f7fb7c454b9189b2941b110d1385ce84d7f76efdf1606a85"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
-"checksum tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9270837a93bad1b1dac18fe67e786b3c960513af86231f6f4f57fddd594ff0c8"
+"checksum tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3213fd2b7ed87e39306737ccfac04b1233b57a33ca64cfbf52f2ffaa2b765e2f"
 "checksum term_grid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc202875496cf72a683a1ecd66f0742a830e73c202bdbd21867d73dfaac8343"
-"checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
+"checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum termsize 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3a225cb94c3630aabd2e289cad545679dd38b5f4891524e92da1be10aae6e4e8"
+"checksum textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f86300c3e7416ee233abd7cda890c492007a3980f941f79185c753a701257167"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-"checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
+"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
+"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unindent 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3508be0ce1bacc38d579b69bffb4b8d469f5af0c388ff4890b2b294e61671ffe"
 "checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
-"checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
-"checksum walkdir 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dd7c16466ecc507c7cb5988db03e6eab4aaeab89a5c37a29251fcfd3ac9b7afe"
+"checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
 "checksum walker 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0488b82b198ac3588ba688f5e56cbd53e0b6dad64f075e67c15647e54aac610"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,17 +238,17 @@ whoami   = { optional=true, path="src/whoami" }
 yes      = { optional=true, path="src/yes" }
 
 [dev-dependencies]
-time = "*"
-filetime = "*"
-libc = "*"
-regex="*"
-rand="*"
-tempdir="*"
-unindent="*"
-lazy_static = "*"
+time = "0.1.38"
+filetime = "0.1.10"
+libc = "0.2.26"
+regex = "0.1.80"
+rand = "0.3.15"
+tempdir = "0.3.5"
+unindent = "0.1.0"
+lazy_static = "0.2.2"
 
 [target.'cfg(unix)'.dev-dependencies]
-unix_socket = "*"
+unix_socket = "0.5.0"
 
 [[bin]]
 name = "uutils"

--- a/src/base32/Cargo.toml
+++ b/src/base32/Cargo.toml
@@ -11,7 +11,7 @@ path = "base32.rs"
 uucore = { path="../uucore" }
 
 [dependencies.clippy]
-version = "*"
+version = "0.0.143"
 optional = true
 
 [[bin]]

--- a/src/chgrp/Cargo.toml
+++ b/src/chgrp/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_chgrp"
 path = "chgrp.rs"
 
 [dependencies]
-walkdir = "*"
+walkdir = "1.0.7"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/chmod/Cargo.toml
+++ b/src/chmod/Cargo.toml
@@ -8,9 +8,9 @@ name = "uu_chmod"
 path = "chmod.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
-walker = "*"
+walker = "1.0.0"
 
 [[bin]]
 name = "chmod"

--- a/src/chown/Cargo.toml
+++ b/src/chown/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_chown"
 path = "chown.rs"
 
 [dependencies]
-glob = "*"
+glob = "0.2.11"
 walkdir = "0.1"
 
 [dependencies.uucore]
@@ -17,7 +17,7 @@ default-features = false
 features = ["entries", "fs"]
 
 [dependencies.clippy]
-version = "*"
+version = "0.0.143"
 optional = true
 
 [[bin]]

--- a/src/chroot/Cargo.toml
+++ b/src/chroot/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_chroot"
 path = "chroot.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/cksum/Cargo.toml
+++ b/src/cksum/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_cksum"
 path = "cksum.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_comm"
 path = "comm.rs"
 
 [dependencies]
-libc = "*"
-getopts = "*"
+libc = "0.2.26"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/cp/Cargo.toml
+++ b/src/cp/Cargo.toml
@@ -8,10 +8,10 @@ name = "uu_cp"
 path = "cp.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
-walkdir = "*"
+walkdir = "1.0.7"
 
 [[bin]]
 name = "cp"

--- a/src/date/Cargo.toml
+++ b/src/date/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_date"
 path = "date.rs"
 
 [dependencies]
-chrono = "*"
-clap = "*"
+chrono = "0.3.0"
+clap = "2.24.1"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/date/main.rs
+++ b/src/date/main.rs
@@ -1,4 +1,4 @@
-extern crate uu_echo;
+extern crate uu_date;
 
 fn main() {
     std::process::exit(uu_date::uumain(std::env::args().collect()));

--- a/src/dircolors/Cargo.toml
+++ b/src/dircolors/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_dircolors"
 path = "dircolors.rs"
 
 [dependencies]
-glob = "*"
+glob = "0.2.11"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/dirname/Cargo.toml
+++ b/src/dirname/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_dirname"
 path = "dirname.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/du/Cargo.toml
+++ b/src/du/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_du"
 path = "du.rs"
 
 [dependencies]
-time = "*"
+time = "0.1.38"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/env/Cargo.toml
+++ b/src/env/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_env"
 path = "env.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/expand/Cargo.toml
+++ b/src/expand/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_expand"
 path = "expand.rs"
 
 [dependencies]
-unicode-width = "*"
-getopts = "*"
+unicode-width = "0.1.4"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_expr"
 path = "expr.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/factor/Cargo.toml
+++ b/src/factor/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_factor"
 path = "factor.rs"
 
 [dependencies]
-rand = "*"
+rand = "0.3.15"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/fmt/Cargo.toml
+++ b/src/fmt/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_fmt"
 path = "fmt.rs"
 
 [dependencies]
-libc = "*"
-unicode-width = "*"
+libc = "0.2.26"
+unicode-width = "0.1.4"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/hashsum/Cargo.toml
+++ b/src/hashsum/Cargo.toml
@@ -8,12 +8,12 @@ name = "uu_hashsum"
 path = "hashsum.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
-regex = "*"
-regex-syntax = "*"
-rust-crypto = "*"
-rustc-serialize = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
+regex = "0.1.80"
+regex-syntax = "0.4.1"
+rust-crypto = "0.2.36"
+rustc-serialize = "0.3.24"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/head/Cargo.toml
+++ b/src/head/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_head"
 path = "head.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/hostid/Cargo.toml
+++ b/src/hostid/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_hostid"
 path = "hostid.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/hostname/Cargo.toml
+++ b/src/hostname/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_hostname"
 path = "hostname.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/install/Cargo.toml
+++ b/src/install/Cargo.toml
@@ -8,12 +8,12 @@ name = "uu_install"
 path = "install.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 libc = ">= 0.2"
 uucore = { path="../uucore" }
 
 [dev-dependencies]
-time = "*"
+time = "0.1.38"
 
 [[bin]]
 name = "install"

--- a/src/kill/Cargo.toml
+++ b/src/kill/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_kill"
 path = "kill.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/link/Cargo.toml
+++ b/src/link/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_link"
 path = "link.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/ln/Cargo.toml
+++ b/src/ln/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_ln"
 path = "ln.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/logname/Cargo.toml
+++ b/src/logname/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_logname"
 path = "logname.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/ls/Cargo.toml
+++ b/src/ls/Cargo.toml
@@ -8,13 +8,13 @@ name = "uu_ls"
 path = "ls.rs"
 
 [dependencies]
-getopts = "*"
-pretty-bytes = "*"
-term_grid = "*"
-termsize = "*"
-time = "*"
-lazy_static = "*"
-unicode-width = "*"
+getopts = "0.2.14"
+pretty-bytes = "0.2.1"
+term_grid = "0.1.5"
+termsize = "0.1.4"
+time = "0.1.38"
+lazy_static = "0.2.8"
+unicode-width = "0.1.4"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/mkdir/Cargo.toml
+++ b/src/mkdir/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_mkdir"
 path = "mkdir.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/mkfifo/Cargo.toml
+++ b/src/mkfifo/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_mkfifo"
 path = "mkfifo.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/mknod/Cargo.toml
+++ b/src/mknod/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_mknod"
 path = "mknod.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 libc = "^0.2.4"
 uucore = { path="../uucore" }
 

--- a/src/mktemp/Cargo.toml
+++ b/src/mktemp/Cargo.toml
@@ -9,9 +9,9 @@ path = "mktemp.rs"
 
 [dependencies]
 uucore = { path="../uucore" }
-getopts = "*"
+getopts = "0.2.14"
 rand = "0.3"
-tempfile = "*"
+tempfile = "2.1.5"
 
 [[bin]]
 name = "mktemp"

--- a/src/more/Cargo.toml
+++ b/src/more/Cargo.toml
@@ -8,11 +8,11 @@ name = "uu_more"
 path = "more.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [target.'cfg(all(unix, not(target_os = "fuchsia")))'.dependencies]
-nix = "*"
+nix = "0.8.1"
 
 [[bin]]
 name = "more"

--- a/src/mv/Cargo.toml
+++ b/src/mv/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_mv"
 path = "mv.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/nice/Cargo.toml
+++ b/src/nice/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_nice"
 path = "nice.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/nl/Cargo.toml
+++ b/src/nl/Cargo.toml
@@ -8,12 +8,12 @@ name = "uu_nl"
 path = "nl.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
-aho-corasick = "*"
-memchr = "*"
-regex = "*"
-regex-syntax = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
+aho-corasick = "0.6.3"
+memchr = "1.0.1"
+regex = "0.2.2"
+regex-syntax = "0.4.1"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/nohup/Cargo.toml
+++ b/src/nohup/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_nohup"
 path = "nohup.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/nproc/Cargo.toml
+++ b/src/nproc/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_nproc"
 path = "nproc.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 num_cpus = "1.5"
 uucore = { path="../uucore" }
 

--- a/src/od/Cargo.toml
+++ b/src/od/Cargo.toml
@@ -8,10 +8,10 @@ name = "uu_od"
 path = "od.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
-byteorder = "*"
-half = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
+byteorder = "1.1.0"
+half = "1.0.0"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/paste/Cargo.toml
+++ b/src/paste/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_paste"
 path = "paste.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/pathchk/Cargo.toml
+++ b/src/pathchk/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_pathchk"
 path = "pathchk.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/printenv/Cargo.toml
+++ b/src/printenv/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_printenv"
 path = "printenv.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/printf/Cargo.toml
+++ b/src/printf/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_printf"
 path = "printf.rs"
 
 [dependencies]
-"itertools" = "*"
+"itertools" = "0.6.0"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/printf/printf.rs
+++ b/src/printf/printf.rs
@@ -3,13 +3,12 @@
 #![allow(dead_code)]
 
 extern crate itertools;
+extern crate uucore;
 
 mod cli;
 mod memo;
 mod tokenize;
 
-#[macro_use]
-extern crate uucore;
 
 static NAME: &'static str = "printf";
 static VERSION: &'static str = "0.0.1";
@@ -39,12 +38,12 @@ static LONGHELP_BODY: &'static str = "
   ESCAPE SEQUENCES
 
   The following escape sequences, organized here in alphabetical order,
-  will print the corresponding character literal:    
+  will print the corresponding character literal:
 
   \"   double quote
 
   \\\\    backslash
-   
+
   \\a  alert (BEL)
 
   \\b  backspace
@@ -64,7 +63,7 @@ static LONGHELP_BODY: &'static str = "
   \\v  vertical tab
 
   \\NNN byte with value expressed in octal value NNN (1 to 3 digits)
-        values greater than 256 will be treated 
+        values greater than 256 will be treated
 
   \\xHH byte with value expressed in hexadecimal value NN (1 to 2 digits)
 
@@ -80,14 +79,14 @@ static LONGHELP_BODY: &'static str = "
 
   Fields
 
-  %s - string 
-  %b - string parsed for literals 
+  %s - string
+  %b - string parsed for literals
     second parameter is max length
 
   %c - char
     no second parameter
 
-  %i or %d - 64-bit integer 
+  %i or %d - 64-bit integer
   %u - 64 bit unsigned integer
   %x or %X - 64-bit unsigned integer as hex
   %o - 64-bit unsigned integer as octal
@@ -97,7 +96,7 @@ static LONGHELP_BODY: &'static str = "
   %f or %F - decimal floating point value
   %e or %E - scientific notation floating point value
   %g or %G - shorter of specially interpreted decimal or SciNote floating point value.
-    second parameter is 
+    second parameter is
       -max places after decimal point for floating point output
       -max number of significant digits for scientific notation output
 
@@ -108,7 +107,7 @@ static LONGHELP_BODY: &'static str = "
   printf '%4.3i' 7
   has a first parameter of 4
      and a second parameter of 3
-  will result in ' 007' 
+  will result in ' 007'
 
   printf '%.1s' abcde
   has no first parameter
@@ -121,7 +120,7 @@ static LONGHELP_BODY: &'static str = "
   will result in  '   q'
 
   The first parameter of a field is the minimum width to pad the output to
-   if the output is less than this absolute value of this width, 
+   if the output is less than this absolute value of this width,
    it will be padded with leading spaces, or, if the argument is negative,
    with trailing spaces. the default is zero.
 
@@ -132,7 +131,7 @@ static LONGHELP_BODY: &'static str = "
     0 (e.g. 010) - interpret argument as octal (integer output fields only)
     0x (e.g. 0xABC) - interpret argument as hex (numeric output fields only)
     \' (e.g. \'a) - interpret argument as a character constant
-    
+
   HOW TO USE SUBSTITUTIONS
 
   Substitutions are used to pass additional argument(s) into the FORMAT string, to be formatted a
@@ -140,14 +139,14 @@ static LONGHELP_BODY: &'static str = "
 
       printf 'the letter %X comes before the letter %X' 10 11
 
-  will print 
-   
-     'the letter A comes before the letter B' 
+  will print
+
+     'the letter A comes before the letter B'
 
   because the substitution field %X means
   'take an integer argument and write it as a hexadecimal number'
 
-  Passing more arguments than are in the format string will cause the format string to be 
+  Passing more arguments than are in the format string will cause the format string to be
    repeated for the remaining substitutions
 
      printf 'it is %i F in %s \n' 22 Portland 25 Boston 27 New York
@@ -160,18 +159,18 @@ static LONGHELP_BODY: &'static str = "
      '
   If a format string is printed but there are less arguments remaining
    than there are substitution fields, substitution fields without
-   an argument will default to empty strings, or for numeric fields 
+   an argument will default to empty strings, or for numeric fields
    the value 0
 
   AVAILABLE SUBSTITUTIONS
 
-  This program, like GNU coreutils printf, 
-  interprets a modified subset of the POSIX C printf spec, 
-  a quick reference to substitutions is below. 
+  This program, like GNU coreutils printf,
+  interprets a modified subset of the POSIX C printf spec,
+  a quick reference to substitutions is below.
 
    STRING SUBSTITUTIONS
-    All string fields have a 'max width' parameter 
-    %.3s means 'print no more than three characters of the original input' 
+    All string fields have a 'max width' parameter
+    %.3s means 'print no more than three characters of the original input'
 
    %s - string
 
@@ -193,7 +192,7 @@ static LONGHELP_BODY: &'static str = "
     %.4i means an integer which if it is less than 4 digits in length,
     is padded with leading zeros until it is 4 digits in length.
 
-   %d or %i - 64-bit integer 
+   %d or %i - 64-bit integer
 
    %u - 64 bit unsigned integer
 
@@ -202,7 +201,7 @@ static LONGHELP_BODY: &'static str = "
 
    %o - 64 bit unsigned integer printed in octal (base 8)
 
-   FLOATING POINT SUBSTITUTIONS 
+   FLOATING POINT SUBSTITUTIONS
 
     All floating point fields have a 'max decimal places / max significant digits' parameter
     %.10f means a decimal floating point with 7 decimal places past 0
@@ -212,7 +211,7 @@ static LONGHELP_BODY: &'static str = "
     Like with GNU coreutils, the value after the decimal point is these outputs is parsed as a double first before being rendered to text. For both implementations do not expect meaningful precision past the 18th decimal place. When using a number of decimal places that is 18 or higher, you can expect variation in output between GNU coreutils printf and this printf at the 18th decimal place of +/- 1
 
    %f - floating point value presented in decimal, truncated and displayed to 6 decimal places by default.
-        There is not past-double behavior parity with Coreutils printf, values are not estimated or adjusted beyond input values. 
+        There is not past-double behavior parity with Coreutils printf, values are not estimated or adjusted beyond input values.
 
    %e or %E - floating point value presented in scientific notation
             7 significant digits by default
@@ -225,9 +224,9 @@ static LONGHELP_BODY: &'static str = "
             Sci Note has 6 significant digits by default
             Trailing zeroes are removed
             Instead of being truncated, digit after last is rounded
- 
-   Like other behavior in this utility, the design choices of floating point 
-    behavior in this utility is selected to reproduce in exact 
+
+   Like other behavior in this utility, the design choices of floating point
+    behavior in this utility is selected to reproduce in exact
     the behavior of GNU coreutils' printf from an inputs and outputs standpoint.
 
   USING PARAMETERS
@@ -239,8 +238,8 @@ static LONGHELP_BODY: &'static str = "
      leading spaces
    The 2nd parameter is proceeded by a dot.
    You do not have to use parameters
-   
-  SPECIAL FORMS OF INPUT 
+
+  SPECIAL FORMS OF INPUT
    For numeric input, the following additional forms of input are accepted besides decimal:
 
     Octal (only with integer): if the argument begins with a 0 the proceeding characters
@@ -255,13 +254,13 @@ static LONGHELP_BODY: &'static str = "
       of the next character will be interpreted as an 8-bit unsigned integer. If there are
       additional bytes, they will throw an error (unless the environment variable POSIXLY_CORRECt is set)
 
-WRITTEN BY : 
+WRITTEN BY :
   Nathan E. Ross, et al. for the uutils project
 
-MORE INFO : 
+MORE INFO :
   https://github.com/uutils/coreutils
 
-COPYRIGHT : 
+COPYRIGHT :
   Copyright 2015 uutils project.
   Licensed under the MIT License, please see LICENSE file for details
 
@@ -279,7 +278,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     if formatstr == "--help" {
         print!("{} {}", LONGHELP_LEAD, LONGHELP_BODY);
     } else if formatstr == "--version" {
-        println!("{} {}", NAME, VERSION);        
+        println!("{} {}", NAME, VERSION);
     } else {
         let printf_args = &args[2..];
         memo::Memo::run_all(formatstr, printf_args);

--- a/src/ptx/Cargo.toml
+++ b/src/ptx/Cargo.toml
@@ -8,12 +8,12 @@ name = "uu_ptx"
 path = "ptx.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
-aho-corasick = "*"
-memchr = "*"
-regex-syntax = "*"
-regex = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
+aho-corasick = "0.6.3"
+memchr = "1.0.1"
+regex-syntax = "0.4.1"
+regex = "0.1.80"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/pwd/Cargo.toml
+++ b/src/pwd/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_pwd"
 path = "pwd.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/readlink/Cargo.toml
+++ b/src/readlink/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_readlink"
 path = "readlink.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/realpath/Cargo.toml
+++ b/src/realpath/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_realpath"
 path = "realpath.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/relpath/Cargo.toml
+++ b/src/relpath/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_relpath"
 path = "relpath.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/rm/Cargo.toml
+++ b/src/rm/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_rm"
 path = "rm.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/rmdir/Cargo.toml
+++ b/src/rmdir/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_rmdir"
 path = "rmdir.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/seq/Cargo.toml
+++ b/src/seq/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_seq"
 path = "seq.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/shred/Cargo.toml
+++ b/src/shred/Cargo.toml
@@ -9,10 +9,10 @@ path = "shred.rs"
 
 [dependencies]
 rand = "0.3"
-filetime = "*"
-getopts = "*"
-libc = "*"
-time = "*"
+filetime = "0.1.10"
+getopts = "0.2.14"
+libc = "0.2.26"
+time = "0.1.38"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/shuf/Cargo.toml
+++ b/src/shuf/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_shuf"
 path = "shuf.rs"
 
 [dependencies]
-getopts = "*"
-rand = "*"
+getopts = "0.2.14"
+rand = "0.3.15"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/sleep/Cargo.toml
+++ b/src/sleep/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_sleep"
 path = "sleep.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/sort/Cargo.toml
+++ b/src/sort/Cargo.toml
@@ -8,9 +8,9 @@ name = "uu_sort"
 path = "sort.rs"
 
 [dependencies]
-getopts = "*"
-semver = "*"
-itertools = "*"
+getopts = "0.2.14"
+semver = "0.7.0"
+itertools = "0.6.0"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -16,7 +16,6 @@ extern crate semver;
 
 #[macro_use]
 extern crate uucore;
-#[macro_use]
 extern crate itertools;
 
 use std::cmp::Ordering;

--- a/src/split/Cargo.toml
+++ b/src/split/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_split"
 path = "split.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/stat/Cargo.toml
+++ b/src/stat/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_stat"
 path = "stat.rs"
 
 [dependencies]
-getopts = "*"
-time = "*"
+getopts = "0.2.14"
+time = "0.1.38"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/stdbuf/Cargo.toml
+++ b/src/stdbuf/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_stdbuf"
 path = "stdbuf.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/sum/Cargo.toml
+++ b/src/sum/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_sum"
 path = "sum.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/sync/Cargo.toml
+++ b/src/sync/Cargo.toml
@@ -8,10 +8,10 @@ name = "uu_sync"
 path = "sync.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
-winapi = "*"
-kernel32-sys = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
+winapi = "0.2.8"
+kernel32-sys = "0.2.2"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/sync/sync.rs
+++ b/src/sync/sync.rs
@@ -14,7 +14,11 @@
 extern crate getopts;
 extern crate libc;
 
+#[cfg(windows)]
 #[macro_use]
+extern crate uucore;
+
+#[cfg(not(windows))]
 extern crate uucore;
 
 static NAME: &'static str = "sync";

--- a/src/tac/Cargo.toml
+++ b/src/tac/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_tac"
 path = "tac.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/tail/Cargo.toml
+++ b/src/tail/Cargo.toml
@@ -8,10 +8,10 @@ name = "uu_tail"
 path = "tail.rs"
 
 [dependencies]
-getopts = "*"
-kernel32-sys = "*"
-libc = "*"
-winapi = "*"
+getopts = "0.2.14"
+kernel32-sys = "0.2.2"
+libc = "0.2.26"
+winapi = "0.2.8"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/tee/Cargo.toml
+++ b/src/tee/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_tee"
 path = "tee.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_test"
 path = "test.rs"
 
 [dependencies]
-libc = "*"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/timeout/Cargo.toml
+++ b/src/timeout/Cargo.toml
@@ -8,9 +8,9 @@ name = "uu_timeout"
 path = "timeout.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
-time = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
+time = "0.1.38"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/touch/Cargo.toml
+++ b/src/touch/Cargo.toml
@@ -8,9 +8,9 @@ name = "uu_touch"
 path = "touch.rs"
 
 [dependencies]
-filetime = "*"
-getopts = "*"
-time = "*"
+filetime = "0.1.10"
+getopts = "0.2.14"
+time = "0.1.38"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/tr/Cargo.toml
+++ b/src/tr/Cargo.toml
@@ -8,9 +8,9 @@ name = "uu_tr"
 path = "tr.rs"
 
 [dependencies]
-getopts = "*"
-bit-set = "*"
-fnv = "*"
+getopts = "0.2.14"
+bit-set = "0.4.0"
+fnv = "1.0.5"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/truncate/Cargo.toml
+++ b/src/truncate/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_truncate"
 path = "truncate.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/tsort/Cargo.toml
+++ b/src/tsort/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_tsort"
 path = "tsort.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/tty/Cargo.toml
+++ b/src/tty/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_tty"
 path = "tty.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/unexpand/Cargo.toml
+++ b/src/unexpand/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_unexpand"
 path = "unexpand.rs"
 
 [dependencies]
-getopts = "*"
-unicode-width = "*"
+getopts = "0.2.14"
+unicode-width = "0.1.4"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/uniq/Cargo.toml
+++ b/src/uniq/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_uniq"
 path = "uniq.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 
 [dependencies.uucore]
 path="../uucore"

--- a/src/unlink/Cargo.toml
+++ b/src/unlink/Cargo.toml
@@ -8,8 +8,8 @@ name = "uu_unlink"
 path = "unlink.rs"
 
 [dependencies]
-getopts = "*"
-libc = "*"
+getopts = "0.2.14"
+libc = "0.2.26"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/uptime/Cargo.toml
+++ b/src/uptime/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_uptime"
 path = "uptime.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/users/Cargo.toml
+++ b/src/users/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_users"
 path = "users.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 
 [dependencies.uucore]
 default-features = false

--- a/src/users/users.rs
+++ b/src/users/users.rs
@@ -16,9 +16,8 @@
 #![allow(dead_code)]
 
 extern crate getopts;
-
-#[macro_use]
 extern crate uucore;
+
 use uucore::utmpx::*;
 
 use getopts::Options;

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.0.1"
 authors = []
 
 [dependencies]
-getopts = "*"
-time = { version = "*", optional = true }
+getopts = "0.2.14"
+time = { version = "0.1.38", optional = true }
 data-encoding = { version = "^1.1", optional = true }
 
 [dependencies.libc]

--- a/src/wc/Cargo.toml
+++ b/src/wc/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_wc"
 path = "wc.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/who/Cargo.toml
+++ b/src/who/Cargo.toml
@@ -13,7 +13,7 @@ default-features = false
 features = ["utmpx"]
 
 [dependencies.clippy]
-version = "*"
+version = "0.0.143"
 optional = true
 
 [[bin]]

--- a/src/whoami/Cargo.toml
+++ b/src/whoami/Cargo.toml
@@ -8,9 +8,9 @@ name = "uu_whoami"
 path = "whoami.rs"
 
 [dependencies]
-getopts = "*"
-winapi = "*"
-advapi32-sys = "*"
+getopts = "0.2.14"
+winapi = "0.2.8"
+advapi32-sys = "0.2.0"
 
 [dependencies.uucore]
 path = "../uucore"

--- a/src/yes/Cargo.toml
+++ b/src/yes/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_yes"
 path = "yes.rs"
 
 [dependencies]
-getopts = "*"
+getopts = "0.2.14"
 uucore = { path="../uucore" }
 
 [[bin]]


### PR DESCRIPTION
Pins dependencies in all utilities.

Fixes failing master build

addendum: removes warnings for unused `#[macro_use]`, trailing whitespace