### PR TITLE
Add non-UTF-8 support to utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 /src/*/gen_table
+/src/*/Cargo.lock
 /build/
 /tmp/
 /busybox/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 name = "rm"
 version = "0.0.1"
 dependencies = [
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rm/Cargo.toml
+++ b/src/rm/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_rm"
 path = "rm.rs"
 
 [dependencies]
-getopts = "0.2.14"
+clap = "2.25"
 walkdir = "1.0.7"
 remove_dir_all = "0.2"
 uucore = { path="../uucore" }

--- a/src/rm/main.rs
+++ b/src/rm/main.rs
@@ -1,5 +1,5 @@
 extern crate uu_rm;
 
 fn main() {
-    std::process::exit(uu_rm::uumain(std::env::args().collect()));
+    std::process::exit(uu_rm::uumain(std::env::args_os().collect()));
 }

--- a/src/rm/rm.rs
+++ b/src/rm/rm.rs
@@ -45,7 +45,7 @@ struct Options {
     verbose: bool
 }
 
-const AFTER_HELP: &'static str = "
+const AFTER_HELP: &'static str = "\
 By default, rm does not remove directories.  Use the --recursive (-r)
 option to remove each listed directory, too, along with all of its contents
 

--- a/src/sleep/Cargo.toml
+++ b/src/sleep/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_sleep"
 path = "sleep.rs"
 
 [dependencies]
-getopts = "0.2.14"
+clap = "2.25"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/sleep/main.rs
+++ b/src/sleep/main.rs
@@ -1,5 +1,5 @@
 extern crate uu_sleep;
 
 fn main() {
-    std::process::exit(uu_sleep::uumain(std::env::args().collect()));
+    std::process::exit(uu_sleep::uumain(std::env::args_os().collect()));
 }

--- a/src/sleep/sleep.rs
+++ b/src/sleep/sleep.rs
@@ -9,63 +9,50 @@
  * file that was distributed with this source code.
  */
 
-extern crate getopts;
+#[macro_use]
+extern crate clap;
 
 #[macro_use]
 extern crate uucore;
 
+use clap::{App, Arg};
+use std::ffi::{OsStr, OsString};
 use std::io::Write;
-use std::thread::{self};
+use std::thread;
 use std::time::Duration;
 
-static NAME: &'static str = "sleep";
-static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const AFTER_HELP: &'static str = "\
+SUFFIX may be 's' for seconds (the default), 'm' for minutes, 'h' for hours or
+'d' for days.  Unlike most implementations that require NUMBER be an integer,
+here NUMBER may be an arbitrary floating point number.  Given two or more
+arguments, pause for the amount of time specified by the sum of their values.
+";
 
-pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = getopts::Options::new();
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => {
-            show_error!("{}", f);
-            return 1;
-        }
-    };
+pub fn uumain(args: Vec<OsString>) -> i32 {
+    let matches = App::new(executable!(args))
+                          .version(crate_version!())
+                          .author("uutils developers (https://github.com/uutils)")
+                          .about("Pause for NUMBER seconds.")
+                          .after_help(AFTER_HELP)
+                          .arg(Arg::with_name("NUMBER[SUFFIX]")
+                               .help("The number of seconds to pause")
+                               .required(true)
+                               .index(1)
+                               .multiple(true))
+                          .get_matches_from(args);
 
-    if matches.opt_present("help") {
-        let msg = format!("{0} {1}
-
-Usage:
-  {0} NUMBER[SUFFIX]
-or
-  {0} OPTION
-
-Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
-'m' for minutes, 'h' for hours or 'd' for days.  Unlike most implementations
-that require NUMBER be an integer, here NUMBER may be an arbitrary floating
-point number.  Given two or more arguments, pause for the amount of time
-specified by the sum of their values.", NAME, VERSION);
-        print!("{}", opts.usage(&msg));
-    } else if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-    } else if matches.free.is_empty() {
-        show_error!("missing an argument");
-        show_error!("for help, try '{0} --help'", NAME);
-        return 1;
-    } else {
-        sleep(matches.free);
-    }
+    sleep(matches.values_of_os("NUMBER[SUFFIX]").unwrap().collect());
 
     0
 }
 
-fn sleep(args: Vec<String>) {
-    let sleep_dur = args.iter().fold(Duration::new(0, 0), |result, arg|
-        match uucore::parse_time::from_str(&arg[..]) {
+fn sleep(args: Vec<&OsStr>) {
+    let sleep_dur = args.iter().fold(Duration::new(0, 0), |result, arg| {
+        match uucore::parse_time::from_str(&arg.to_string_lossy()) {
             Ok(m) => m + result,
             Err(f) => crash!(1, "{}", f),
-        });
+        }
+    });
 
     thread::sleep(sleep_dur);
 }

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -5,6 +5,8 @@ authors = []
 
 [dependencies]
 getopts = "0.2.14"
+# Needed because AFAIK there is no easy way to print an OsStr
+os-str-generic = "0.2"
 time = { version = "0.1.38", optional = true }
 data-encoding = { version = "^1.1", optional = true }
 

--- a/src/uucore/lib.rs
+++ b/src/uucore/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "libc")]
 pub extern crate libc;
 
+pub extern crate os_str_generic;
+
 #[macro_use]
 mod macros;
 

--- a/src/uucore/macros.rs
+++ b/src/uucore/macros.rs
@@ -16,6 +16,10 @@ macro_rules! executable(
         } else {
             module
         }
+    });
+
+    ($args:expr) => ({
+        ::std::path::Path::new(&$args[0]).file_name().unwrap().to_string_lossy()
     })
 );
 
@@ -209,6 +213,47 @@ macro_rules! pipe_flush(
         }
     )
 );
+
+#[macro_export]
+macro_rules! os_bytes {
+    ($osstr:expr) => ({
+        use ::uucore::os_str_generic::OsStrGenericExt;
+
+        $osstr.elements().map(|x| x.raw()).collect::<Vec<_>>()
+    })
+}
+
+// we have this because byte_println! needs two writes
+#[macro_export]
+macro_rules! os_bytesln {
+    ($osstr:expr) => ({
+        use ::uucore::os_str_generic::OsStrGenericExt;
+
+        let mut bytes = os_bytes!($osstr);
+        bytes.push(::std::ffi::OsStr::new("\n").elements().next().unwrap().raw());
+        bytes
+    })
+}
+
+#[macro_export]
+macro_rules! byte_print {
+    ($bytes:expr) => ({
+        if let Err(f) = ::std::io::stdout().write($bytes) {
+            panic!(f.to_string());
+        }
+    })
+}
+
+// it is probably better to use os_bytesln! and then byte_print!
+#[macro_export]
+macro_rules! byte_println {
+    ($bytes:expr) => ({
+        use ::uucore::os_str_generic::OsStrGenericExt;
+
+        byte_print!($bytes);
+        byte_print!(&[::std::ffi::OsStr::new("\n").elements().next().unwrap().raw()]);
+    })
+}
 
 #[macro_export]
 macro_rules! safe_write(

--- a/src/whoami/Cargo.toml
+++ b/src/whoami/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_whoami"
 path = "whoami.rs"
 
 [dependencies]
-getopts = "0.2.14"
+clap = "2.25"
 winapi = "0.2.8"
 advapi32-sys = "0.2.0"
 

--- a/src/whoami/main.rs
+++ b/src/whoami/main.rs
@@ -1,5 +1,5 @@
 extern crate uu_whoami;
 
 fn main() {
-    std::process::exit(uu_whoami::uumain(std::env::args().collect()));
+    std::process::exit(uu_whoami::uumain(std::env::args_os().collect()));
 }

--- a/src/whoami/platform/unix.rs
+++ b/src/whoami/platform/unix.rs
@@ -9,11 +9,14 @@
  */
 
 use std::io::Result;
+use std::ffi::OsString;
 use uucore::libc::geteuid;
 use uucore::entries::uid2usr;
 
-pub unsafe fn getusername() -> Result<String> {
+pub unsafe fn getusername() -> Result<OsString> {
     // Get effective user id
     let uid = geteuid();
-    uid2usr(uid)
+    // XXX: uid2usr returns a String, which may or may not be fine given that I am not sure if
+    //      there are systems that allow non-utf8 characters in /etc/passwd
+    uid2usr(uid).map(|name| OsString::from(name))
 }

--- a/src/whoami/platform/windows.rs
+++ b/src/whoami/platform/windows.rs
@@ -12,15 +12,17 @@ extern crate advapi32;
 extern crate uucore;
 
 use std::io::{Error, Result};
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
 use std::mem;
 use uucore::wide::FromWide;
 
-pub unsafe fn getusername() -> Result<String> {
+pub unsafe fn getusername() -> Result<OsString> {
     let mut buffer: [winapi::WCHAR; winapi::UNLEN as usize + 1] = mem::uninitialized();
     let mut len = buffer.len() as winapi::DWORD;
     if advapi32::GetUserNameW(buffer.as_mut_ptr(), &mut len) == 0 {
         return Err(Error::last_os_error())
     }
-    let username = String::from_wide(&buffer[..len as usize - 1]);
+    let username = OsString::from_wide(&buffer[..len as usize - 1]);
     Ok(username)
 }

--- a/src/yes/Cargo.toml
+++ b/src/yes/Cargo.toml
@@ -8,7 +8,7 @@ name = "uu_yes"
 path = "yes.rs"
 
 [dependencies]
-getopts = "0.2.14"
+clap = "2.25"
 uucore = { path="../uucore" }
 
 [[bin]]

--- a/src/yes/main.rs
+++ b/src/yes/main.rs
@@ -1,5 +1,5 @@
 extern crate uu_yes;
 
 fn main() {
-    std::process::exit(uu_yes::uumain(std::env::args().collect()));
+    std::process::exit(uu_yes::uumain(std::env::args_os().collect()));
 }


### PR DESCRIPTION
### DO NOT MERGE YET!!!

I am planning on rewriting all the utils to have at least basic support for non-UTF-8 arguments and such, addressing #203, #554, #699, #1006, and #1050 (there may be more, but this is what I found after a quick check).  This pull request is to keep track of my progress.

Generally, adding support entails switching from `getopts` to `clap` and converting `String`-based arguments to `OsString`.  Some utilities require more in-depth changes as they either mess with the arguments or retrieve OS-specific data (which we currently convert to `String`s).

If anyone is interesting in helping, you should probably start from the top as I am pretty much starting from the end of the list.

## Progress (some utils are likely not marked):

* [ ] arch
* [ ] base32
* [ ] base64
* [ ] basename
* [ ] cat
* [ ] chgrp
* [ ] chmod
* [ ] chown
* [ ] chroot
* [ ] cksum
* [ ] comm
* [ ] cp
* [ ] cut
* [ ] dircolors
* [ ] dirname
* [ ] du
* [ ] echo
* [ ] env
* [ ] expand
* [ ] expr
* [ ] factor
* [ ] false
* [ ] fmt
* [ ] fold
* [ ] groups
* [ ] hashsum
* [ ] head
* [ ] hostid
* [ ] hostname
* [ ] id
* [ ] install
* [ ] kill
* [ ] link
* [ ] ln
* [ ] logname
* [ ] ls
* [ ] mkdir
* [ ] mkfifo
* [ ] mknod
* [ ] mktemp
* [ ] mv
* [ ] more (in progress, needs lots of work)
* [ ] nice
* [ ] nl
* [ ] nohup
* [ ] nproc
* [ ] od (almost complete, `--strings` and 128-bit datatypes are missing)
* [ ] paste
* [ ] pathchk
* [ ] pinky
* [ ] printenv
* [ ] printf
* [ ] ptx
* [ ] pwd
* [ ] readlink
* [ ] realpath
* [ ] relpath
* [x] rm (although `Path::display()` probably uses `to_string_lossy()` behind-the-scenes)
* [ ] rmdir
* [ ] seq
* [ ] shred
* [ ] shuf
* [x] sleep
* [ ] sort
* [ ] split
* [ ] stat
* [ ] stdbuf
* [ ] sum
* [ ] sync
* [ ] tac
* [ ] tail
* [ ] tee
* [ ] test
* [ ] timeout
* [ ] touch
* [ ] tr
* [ ] true
* [ ] truncate
* [ ] tsort
* [ ] tty
* [ ] uname
* [ ] unexpand
* [ ] uniq
* [ ] unlink
* [ ] uptime
* [ ] users
* [x] uutils
* [ ] wc
* [ ] who
* [x] whoami (not sure if username in `/etc/passwd` is ever non-UTF-8?)
* [x] yes