### PR TITLE
README: Moved 'date' into the 'Semi-Done' section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,16 +152,16 @@ Utilities
 |-----------|-----------|--------|
 | arch      | cp        | chcon  |
 | base32    | expr (no regular expressions) | csplit |
-| base64    | install   | date   |
-| basename  | ls        | dd     |
-| cat       | more      | df     |
-| chgrp     | od (`--strings` and 128-bit data types missing) | join |
-| chmod     | printf    | numfmt |
-| chown     | sort      | pr     |
-| chroot    | split     | runcon |
-| cksum     | tail      | stty   |
+| base64    | install   | dd     |
+| basename  | ls        | df     |
+| cat       | more      | join   |
+| chgrp     | od (`--strings` and 128-bit data types missing) | numfmt |
+| chmod     | printf    | pr     |
+| chown     | sort      | runcon |
+| chroot    | split     | stty   |
+| cksum     | tail      |        |
 | comm      | test      |        |
-| cut       |           |        |
+| cut       | date      |        |
 | dircolors |           |        |
 | dirname   |           |        |
 | du        |           |        |


### PR DESCRIPTION
'date' has been partially implemented into the coreutils. According to
[this](https://github.com/uutils/coreutils/pull/1029) I decided to move 'date' into the 'Semi-Done' section from the
readme utilities chart.