### PR TITLE
cp: enable setting timestamps

### DIFF
--- a/src/cp/Cargo.toml
+++ b/src/cp/Cargo.toml
@@ -17,6 +17,7 @@ walkdir = "1.0.7"
 clap = "2.20.0"
 quick-error = "1.1.0"
 uucore = { path="../uucore" }
+filetime = "0.1.10"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ioctl-sys = "0.5.2"

--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -787,9 +787,9 @@ fn copy_attribute(source: &Path, dest: &Path, attribute: &Attribute) -> CopyResu
         },
         Attribute::Timestamps => {
             let metadata = fs::metadata(source).context(context)?;
-            let mtime = FileTime::from_last_modification_time(&metadata);
             let atime = FileTime::from_last_access_time(&metadata);
-            set_file_times(dest, mtime, atime)?;
+            let mtime = FileTime::from_last_modification_time(&metadata);
+            set_file_times(dest, atime, mtime)?;
         },
         Attribute::Context    => return Err(Error::NotImplemented("preserving context not implemented".to_string())),
         Attribute::Links      => return Err(Error::NotImplemented("preserving links not implemented".to_string())),


### PR DESCRIPTION
This is better than the method used in https://github.com/uutils/coreutils/pull/1066, since it uses the filetime crate, which is more portable than direct libc calls.