### PR TITLE
tail: suppress headers when --quiet flag is used

### DIFF
--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -79,6 +79,8 @@ pub fn uumain(args: Vec<String>) -> i32 {
     opts.optflag("h", "help", "help");
     opts.optflag("V", "version", "version");
     opts.optflag("v", "verbose", "always output headers giving file names");
+    // TODO: --silent flag as alias to --quiet
+    opts.optflag("q", "quiet", "never output headers giving file names");
 
     let given_options = match opts.parse(&args) {
         Ok (m) => { m }
@@ -165,6 +167,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     let verbose = given_options.opt_present("v");
+    let quiet = given_options.opt_present("q");
 
     let files = given_options.free;
 
@@ -172,16 +175,12 @@ pub fn uumain(args: Vec<String>) -> i32 {
         let mut buffer = BufReader::new(stdin());
         unbounded_tail(&mut buffer, &settings);
     } else {
-        let mut multiple = false;
+        let multiple = files.len() > 1;
         let mut first_header = true;
         let mut readers = Vec::new();
 
-        if files.len() > 1 {
-            multiple = true;
-        }
-
         for filename in &files {
-            if multiple || verbose {
+            if (multiple || verbose) && !quiet {
                 if !first_header { println!(""); }
                 println!("==> {} <==", filename);
             }

--- a/tests/fixtures/tail/foobar_multiple_quiet.expected
+++ b/tests/fixtures/tail/foobar_multiple_quiet.expected
@@ -1,0 +1,12 @@
+dos
+tres
+quattro
+cinco
+seis
+siette
+ocho
+nueve
+diez
+once
+un
+deux

--- a/tests/test_tail.rs
+++ b/tests/test_tail.rs
@@ -245,3 +245,19 @@ fn test_lines_with_size_suffix() {
 
     ucmd.arg(FILE).arg("-n").arg("2K").run().stdout_is_fixture(EXPECTED_FILE);
 }
+
+#[test]
+fn test_multiple_input_files() {
+    new_ucmd!().arg(FOOBAR_TXT).arg(FOOBAR_2_TXT).run().stdout_is_fixture("foobar_follow_multiple.expected");
+}
+
+#[test]
+fn test_multiple_input_files_with_suppressed_headers() {
+    new_ucmd!().arg(FOOBAR_TXT).arg(FOOBAR_2_TXT).arg("-q").run().stdout_is_fixture("foobar_multiple_quiet.expected");
+}
+
+#[test]
+fn test_multiple_input_quiet_flag_overrides_verbose_flag_for_suppressing_headers() {
+    // TODO: actually the later one should win, i.e. -qv should lead to headers being printed, -vq to them being suppressed
+    new_ucmd!().arg(FOOBAR_TXT).arg(FOOBAR_2_TXT).arg("-q").arg("-v").run().stdout_is_fixture("foobar_multiple_quiet.expected");
+}


### PR DESCRIPTION
A first stab at adding the `--quiet` flag to `tail`.

As mentioned in the TODOs the `--silent` alias is missing so far. Not sure how (and if) this is possible with getopts. If clap can do this it might be a good reason to move forward with #1006?

Another open point is taking the position of `-q` and `-v` into account. Again, not sure if this is even possible with getopts...