### PR TITLE
Make 'yes' 1000 times faster.

### DIFF
--- a/src/yes/yes.rs
+++ b/src/yes/yes.rs
@@ -22,6 +22,8 @@ use std::io::Write;
 static NAME: &'static str = "yes";
 static VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
+const BUF_SIZE: usize = 8192;
+
 pub fn uumain(args: Vec<String>) -> i32 {
     let mut opts = Options::new();
 
@@ -51,7 +53,13 @@ pub fn uumain(args: Vec<String>) -> i32 {
         matches.free.join(" ")
     };
 
-    exec(&string[..]);
+    let mut multistring = string.clone();
+    while multistring.len() < BUF_SIZE - string.len() - 1 {
+        multistring.push_str("\n");
+        multistring.push_str(&string);
+    }
+
+    exec(&multistring[..]);
 
     0
 }


### PR DESCRIPTION
See #1085.

On my computer, it makes coreutils' yes go from 3MB/s to 4GB/s. As a comparison, GNU yes is at 5GB/s.