### PR TITLE
Added a check to see if the input file/path that ls is run on when us…

### DIFF
--- a/src/ls/ls.rs
+++ b/src/ls/ls.rs
@@ -160,7 +160,7 @@ fn list(options: getopts::Matches) {
             dir = true;
             if options.opt_present("l") && !(options.opt_present("L")) {
                 if let Ok(md) = p.symlink_metadata() {
-                    if md.file_type().is_symlink() {
+                    if md.file_type().is_symlink() && !p.ends_with( "/" ) {
                         dir = false;
                     }
                 }


### PR DESCRIPTION
…ing -l or other long options, that if the path part ends with '/' then it does not show it as a soft-link if it is a soft-link but, instead shows the directory contents of the directory the soft-link points to - see https://github.com/uutils/coreutils/issues/1093