### PR TITLE
 Add cross build targeting Redox to Travis CI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-redox]
+linker = "x86_64-unknown-redox-gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,15 @@ matrix:
     - rust: nightly
       os: osx
       env: FEATURES=nightly
+    - rust: nightly
+      os: linux
+      env: FEATURES=nightly,redox CC=x86_64-unknown-redox-gcc CARGO_ARGS='--no-default-features --target=x86_64-unknown-redox' REDOX=1
 cache:
  directories:
   - $HOME/.cargo
-sudo: false
+sudo: true
+before_install:
+  - if [ $REDOX ]; then ./.travis/redox-toolchain.sh; fi
 script:
-  - cargo build --features "$FEATURES"
-  - cargo test --features "$FEATURES" --no-fail-fast
+  - cargo build $CARGO_ARGS --features "$FEATURES"
+  - if [ ! $REDOX ]; then cargo test $CARGO_ARGS --features "$FEATURES" --no-fail-fast; fi

--- a/.travis/redox-toolchain.sh
+++ b/.travis/redox-toolchain.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+rustup target add x86_64-unknown-redox
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AA12E97F0881517F
+sudo add-apt-repository 'deb https://static.redox-os.org/toolchain/apt /'
+sudo apt-get update -qq
+sudo apt-get install -y x86-64-unknown-redox-gcc


### PR DESCRIPTION
It is helpful to make sure things are building on Redox, though It's understandable if you don't want Redox breaking CI.

I ran `cargo update` since Redox required newer versions of a dependency or two.