### PR TITLE
uname: change sysname flag to kernel-name

### DIFF
--- a/src/uname/Cargo.toml
+++ b/src/uname/Cargo.toml
@@ -8,6 +8,9 @@ build = "../../mkmain.rs"
 name = "uu_uname"
 path = "uname.rs"
 
+[dependencies]
+clap = "2.20.0"
+
 [dependencies.uucore]
 path = "../uucore"
 default-features = false

--- a/src/uname/uname.rs
+++ b/src/uname/uname.rs
@@ -37,7 +37,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     opts.optflag("a",
                  "all",
                  "Behave as though all of the options -mnrsv were specified.");
-    opts.optflag("s", "sysname", "print the operating system name.");
+    opts.optflag("s", "kernel-name", "print the operating system name.");
     opts.optflag("n", "nodename", "print the nodename (the nodename may be a name that the system is known by to a communications network).");
     opts.optflag("r", "kernel-release", "print the operating system release.");
     opts.optflag("v", "kernel-version", "print the operating system version.");

--- a/src/uname/uname.rs
+++ b/src/uname/uname.rs
@@ -13,10 +13,25 @@
 
 #[macro_use]
 extern crate uucore;
+extern crate clap;
+
+use clap::{Arg, App};
 use uucore::utsname::Uname;
 
-static SYNTAX: &'static str = "[OPTION]...";
-static SUMMARY: &'static str = "Print certain system information.  With no OPTION, same as -s.";
+static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+static ABOUT: &'static str = "Print certain system information.  With no OPTION, same as -s.";
+
+static OPT_ALL: &'static str = "all";
+static OPT_KERNELNAME: &'static str = "kernel-name";
+static OPT_NODENAME: &'static str = "nodename";
+static OPT_KERNELVERSION: &'static str = "kernel-version";
+static OPT_KERNELRELEASE: &'static str = "kernel-release";
+static OPT_MACHINE: &'static str = "machine";
+
+//FIXME: unimplemented options
+//static OPT_PROCESSOR: &'static str = "processor";
+//static OPT_HWPLATFORM: &'static str = "hardware-platform";
+static OPT_OS: &'static str = "operating-system";
 
 #[cfg(target_os = "linux")]
 static HOST_OS: &'static str = "GNU/Linux";
@@ -32,48 +47,76 @@ static HOST_OS: &'static str = "Darwin";
 static HOST_OS: &'static str = "Fuchsia";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut opts = new_coreopts!(SYNTAX, SUMMARY, "");
 
-    opts.optflag("a",
-                 "all",
-                 "Behave as though all of the options -mnrsv were specified.");
-    opts.optflag("s", "kernel-name", "print the operating system name.");
-    opts.optflag("n", "nodename", "print the nodename (the nodename may be a name that the system is known by to a communications network).");
-    opts.optflag("r", "kernel-release", "print the operating system release.");
-    opts.optflag("v", "kernel-version", "print the operating system version.");
-    opts.optflag("m", "machine", "print the machine hardware name.");
+    let usage = format!("{} [OPTION]...", executable!());
+    let matches = App::new(executable!())
+        .version(VERSION)
+        .about(ABOUT)
+        .usage(&usage[..])
+        .arg(Arg::with_name(OPT_ALL)
+            .short("a")
+            .long(OPT_ALL)
+            .help("Behave as though all of the options -mnrsv were specified."))
+        .arg(Arg::with_name(OPT_KERNELNAME)
+            .short("s")
+            .long(OPT_KERNELNAME)
+            .alias("sysname") // Obsolescent option in GNU uname
+            .help("print the operating system name.")
+        .arg(Arg::with_name(OPT_NODENAME)
+            .short("n")
+            .long(OPT_NODENAME)
+            .help("print the nodename (the nodename may be a name that the system is known by to a communications network)."))
+        .arg(Arg::with_name(OPT_KERNELRELEASE)
+            .short("r")
+            .long(OPT_KERNELRELEASE)
+            .alias("release") // Obsolescent option in GNU uname
+            .help("print the operating system release."))
+        .arg(Arg::with_name(OPT_KERNELVERSION)
+            .short("v")
+            .long(OPT_KERNELVERSION)
+            .help("print the operating system version."))
 
-    // FIXME: Unimplemented
-    // opts.optflag("p", "processor", "print the machine processor architecture name.");
-    // opts.optflag("i", "hardware-platform", "print the hardware platform.");
+        //FIXME: unimplemented options
+        // .arg(Arg::with_name(OPT_PROCESSOR)
+        //     .short("p")
+        //     .long(OPT_PROCESSOR)
+        //     .help("print the processor type (non-portable)"))
+        // .arg(Arg::with_name(OPT_HWPLATFORM)
+        //     .short("i")
+        //     .long(OPT_HWPLATFORM)
+        //     .help("print the hardware platform (non-portable)"))
+        .arg(Arg::with_name(OPT_MACHINE)
+            .short("m")
+            .long(OPT_MACHINE)
+            .help("print the machine hardware name."))
+        .get_matches_from(&args);
 
-    opts.optflag("o", "operating-system", "print the operating system");
     let argc = args.len();
-    let matches = opts.parse(args);
     let uname = Uname::new();
     let mut output = String::new();
-    if matches.opt_present("sysname") || matches.opt_present("all") || argc == 1 {
+
+    if matches.is_present(OPT_KERNELNAME) || matches.is_present(OPT_ALL) || argc == 1 {
         output.push_str(uname.sysname().as_ref());
         output.push_str(" ");
     }
 
-    if matches.opt_present("nodename") || matches.opt_present("all") {
+    if matches.is_present(OPT_NODENAME) || matches.is_present(OPT_ALL) {
         output.push_str(uname.nodename().as_ref());
         output.push_str(" ");
     }
-    if matches.opt_present("kernel-release") || matches.opt_present("all") {
+    if matches.is_present(OPT_KERNELRELEASE) || matches.is_present(OPT_ALL) {
         output.push_str(uname.release().as_ref());
         output.push_str(" ");
     }
-    if matches.opt_present("kernel-version") || matches.opt_present("all") {
+    if matches.is_present(OPT_KERNELVERSION) || matches.is_present(OPT_ALL) {
         output.push_str(uname.version().as_ref());
         output.push_str(" ");
     }
-    if matches.opt_present("machine") || matches.opt_present("all") {
+    if matches.is_present(OPT_MACHINE) || matches.is_present(OPT_ALL) {
         output.push_str(uname.machine().as_ref());
         output.push_str(" ");
     }
-    if matches.opt_present("operating-system") || matches.opt_present("all") {
+    if matches.is_present(OPT_OS) || matches.is_present(OPT_ALL) {
         output.push_str(HOST_OS);
         output.push_str(" ");
     }

--- a/src/uname/uname.rs
+++ b/src/uname/uname.rs
@@ -61,7 +61,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
             .short("s")
             .long(OPT_KERNELNAME)
             .alias("sysname") // Obsolescent option in GNU uname
-            .help("print the operating system name.")
+            .help("print the operating system name."))
         .arg(Arg::with_name(OPT_NODENAME)
             .short("n")
             .long(OPT_NODENAME)


### PR DESCRIPTION
The --sysname flag in GNU uname was deprecated in 2002 and replaced by --kernel-name.