### PR TITLE
Start using Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,29 @@ matrix:
     - rust: nightly
       os: linux
       env: FEATURES=nightly,redox CC=x86_64-unknown-redox-gcc CARGO_ARGS='--no-default-features --target=x86_64-unknown-redox' REDOX=1
+
 cache:
- directories:
-  - $HOME/.cargo
+  directories:
+    - $HOME/.cargo
+
 sudo: true
+
 before_install:
   - if [ $REDOX ]; then ./.travis/redox-toolchain.sh; fi
+
 script:
   - cargo build $CARGO_ARGS --features "$FEATURES"
   - if [ ! $REDOX ]; then cargo test $CARGO_ARGS --features "$FEATURES" --no-fail-fast; fi
+
+addons:
+  apt:
+    packages:
+      - libssl-dev
+
+after_success: |
+  if [ "$TRAVIS_OS_NAME" = linux -a "$TRAVIS_RUST_VERSION" = stable ]; then
+    bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+    cargo tarpaulin --out Xml
+    bash <(curl -s https://codecov.io/bash)
+  fi
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ uutils coreutils
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/uutils/coreutils/blob/master/LICENSE)
 [![Build Status](https://api.travis-ci.org/uutils/coreutils.svg?branch=master)](https://travis-ci.org/uutils/coreutils)
 [![Build status](https://ci.appveyor.com/api/projects/status/787ltcxgy86r20le?svg=true)](https://ci.appveyor.com/project/Arcterus/coreutils)
+[![codecov](https://codecov.io/gh/uutils/coreutils/branch/master/graph/badge.svg)](https://codecov.io/gh/uutils/coreutils)
 [![LOC](https://tokei.rs/b1/github/uutils/coreutils?category=code)](https://github.com/Aaronepower/tokei)
 
 uutils is an attempt at writing universal (as in cross-platform) CLI


### PR DESCRIPTION
The coverage is generated using Tarpaulin (which seems somewhat inaccurate but is a lot easier to set up than kcov).