### PR TITLE
tail: add spaces after hashes

### DIFF
--- a/src/tail/README.md
+++ b/src/tail/README.md
@@ -1,14 +1,13 @@
 Rudimentary tail implementation.
 
-##Missing features:
+## Missing features:
 
 ### Flags with features
 * `--max-unchanged-stats` : with `--follow=name`, reopen a FILE which has not changed size after N (default 5) iterations  to see if it has been unlinked or renamed (this is the usual case of rotated log files).  With inotify, this option is rarely useful.
-* `--quiet` : never output headers giving file names
 * `--retry` : keep trying to open a file even when it is or becomes inaccessible; useful when follow‐ing by name, i.e., with `--follow=name`
 
 ### Others
 The current implementation does not handle `-` as an alias for stdin.
 
-##Possible optimizations:
+## Possible optimizations:
 * Don't read the whole file if not using `-f` and input is regular file. Read in chunks from the end going backwards, reading each individual chunk forward.

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -79,8 +79,8 @@ pub fn uumain(args: Vec<String>) -> i32 {
     opts.optflag("h", "help", "help");
     opts.optflag("V", "version", "version");
     opts.optflag("v", "verbose", "always output headers giving file names");
-    // TODO: --silent flag as alias to --quiet
     opts.optflag("q", "quiet", "never output headers giving file names");
+    opts.optflag("", "silent", "synonym of --quiet");
 
     let given_options = match opts.parse(&args) {
         Ok (m) => { m }
@@ -167,7 +167,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     }
 
     let verbose = given_options.opt_present("v");
-    let quiet = given_options.opt_present("q");
+    let quiet = given_options.opt_present("q") || given_options.opt_present("silent");
 
     let files = given_options.free;
 
@@ -181,7 +181,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
         for filename in &files {
             if (multiple || verbose) && !quiet {
-                if !first_header { println!(""); }
+                if !first_header { println!(); }
                 println!("==> {} <==", filename);
             }
             first_header = false;


### PR DESCRIPTION
Add spaces after title hashes to correct formatting.