### PR TITLE
refactor: use HELP name across programs

### DIFF
--- a/src/arch/arch.rs
+++ b/src/arch/arch.rs
@@ -15,10 +15,10 @@ use uucore::utsname::Uname;
 
 static SYNTAX: &'static str = "";
 static SUMMARY: &'static str = "Determine architecture name for current machine.";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    new_coreopts!(SYNTAX, SUMMARY, LONG_HELP).parse(args);
+    new_coreopts!(SYNTAX, SUMMARY, HELP).parse(args);
     let uts = Uname::new();
     println!("{}", uts.machine().trim());
     0

--- a/src/base32/base32.rs
+++ b/src/base32/base32.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 
 static SYNTAX: &'static str = "[OPTION]... [FILE]";
 static SUMMARY: &'static str = "Base32 encode or decode FILE, or standard input, to standard output.";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  With no FILE, or when FILE is -, read standard input.
 
  The data are encoded as described for the base32 alphabet in RFC
@@ -29,7 +29,7 @@ static LONG_HELP: &'static str = "
 ";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("d", "decode", "decode data")
         .optflag("i",
                  "ignore-garbage",

--- a/src/base64/base64.rs
+++ b/src/base64/base64.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 
 static SYNTAX: &'static str = "[OPTION]... [FILE]";
 static SUMMARY: &'static str = "Base64 encode or decode FILE, or standard input, to standard output.";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  With no FILE, or when FILE is -, read standard input.
 
  The data are encoded as described for the base64 alphabet in RFC
@@ -31,7 +31,7 @@ static LONG_HELP: &'static str = "
 ";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("d", "decode", "decode data")
         .optflag("i",
                  "ignore-garbage",

--- a/src/basename/basename.rs
+++ b/src/basename/basename.rs
@@ -18,13 +18,13 @@ static NAME: &'static str = "basename";
 static SYNTAX: &'static str = "NAME [SUFFIX]";
 static SUMMARY: &'static str = "Print NAME with any leading directory components removed
  If specified, also remove a trailing SUFFIX";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 pub fn uumain(args: Vec<String>) -> i32 {
     //
     // Argument parsing
     //
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("a", "multiple", "Support more than one argument. Treat every argument as a name.")
         .optopt("s", "suffix", "Remove a trailing suffix. This option implies the -a option.", "SUFFIX")
         .optflag("z", "zero", "Output a zero byte (ASCII NUL) at the end of each line, rather than a newline.")

--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -31,7 +31,7 @@ use uucore::fs::is_stdin_interactive;
 static SYNTAX: &'static str = "[OPTION]... [FILE]...";
 static SUMMARY: &'static str = "Concatenate FILE(s), or standard input, to standard output
  With no FILE, or when FILE is -, read standard input.";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 
 #[derive(PartialEq)]
@@ -126,7 +126,7 @@ type CatResult<T> = Result<T, CatError>;
 
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("A", "show-all", "equivalent to -vET")
         .optflag("b",
                  "number-nonblank",

--- a/src/chmod/chmod.rs
+++ b/src/chmod/chmod.rs
@@ -26,7 +26,7 @@ use uucore::mode;
 const NAME: &'static str = "chmod";
 static SUMMARY: &'static str = "Change the mode of each FILE to MODE.
  With --reference, change the mode of each FILE to that of RFILE.";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.
 ";
 
@@ -34,7 +34,7 @@ pub fn uumain(mut args: Vec<String>) -> i32 {
     let syntax = format!("[OPTION]... MODE[,MODE]... FILE...
  {0} [OPTION]... OCTAL-MODE FILE...
  {0} [OPTION]... --reference=RFILE FILE...", NAME);
-    let mut opts = new_coreopts!(&syntax, SUMMARY, LONG_HELP);
+    let mut opts = new_coreopts!(&syntax, SUMMARY, HELP);
     opts.optflag("c", "changes", "like verbose but report only when a change is made (unimplemented)")
         .optflag("f", "quiet", "suppress most error messages (unimplemented)") // TODO: support --silent
         .optflag("v", "verbose", "output a diagnostic for every file processed (unimplemented)")

--- a/src/chroot/chroot.rs
+++ b/src/chroot/chroot.rs
@@ -26,13 +26,13 @@ use std::process::Command;
 static NAME: &'static str = "chroot";
 static SYNTAX: &'static str = "[OPTION]... NEWROOT [COMMAND [ARG]...]";
 static SUMMARY: &'static str = "Run COMMAND with root directory set to NEWROOT.";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  If COMMAND is not specified, it defaults to '$(SHELL) -i'.
  If $(SHELL) is not set, /bin/sh is used.
 ";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optopt("u", "user", "User (ID or name) to switch before running the program", "USER")
         .optopt("g", "group", "Group (ID or name) to switch to", "GROUP")
         .optopt("G", "groups", "Comma-separated list of groups to switch to", "GROUP1,GROUP2...")

--- a/src/cksum/cksum.rs
+++ b/src/cksum/cksum.rs
@@ -23,7 +23,7 @@ include!(concat!(env!("OUT_DIR"), "/crc_table.rs"));
 
 static SYNTAX: &'static str = "[OPTIONS] [FILE]...";
 static SUMMARY: &'static str = "Print CRC and size for each file";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 #[inline]
 fn crc_update(crc: u32, input: u8) -> u32 {
@@ -85,7 +85,7 @@ fn cksum(fname: &str) -> io::Result<(u32, usize)> {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .parse(args);
 
     let files = matches.free;

--- a/src/comm/comm.rs
+++ b/src/comm/comm.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 
 static SYNTAX: &'static str = "[OPTIONS] FILE1 FILE2"; 
 static SUMMARY: &'static str = "Compare sorted files line by line"; 
-static LONG_HELP: &'static str = ""; 
+static HELP: &'static str = "";
 
 fn mkdelim(col: usize, opts: &getopts::Matches) -> String {
     let mut s = String::new();
@@ -125,7 +125,7 @@ fn open_file(name: &str) -> io::Result<LineReader> {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("1", "", "suppress column 1 (lines uniq to FILE1)")
         .optflag("2", "", "suppress column 2 (lines uniq to FILE2)")
         .optflag("3", "", "suppress column 3 (lines that appear in both files)")

--- a/src/cut/cut.rs
+++ b/src/cut/cut.rs
@@ -25,7 +25,7 @@ mod searcher;
 
 static SYNTAX: &'static str = "[-d] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+";
 static SUMMARY: &'static str = "Prints specified byte or field columns from each line of stdin or the input files";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  Each call must specify a mode (what to use for columns),
  a sequence (which columns to print), and provide a data source
 
@@ -415,7 +415,7 @@ fn cut_files(mut filenames: Vec<String>, mode: Mode) -> i32 {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optopt("b", "bytes", "filter byte columns from the input source", "sequence")
         .optopt("c", "characters", "alias for character mode", "sequence")
         .optopt("d", "delimiter", "specify the delimiter character that separates fields in the input source. Defaults to Tab.", "delimiter")

--- a/src/dircolors/dircolors.rs
+++ b/src/dircolors/dircolors.rs
@@ -20,7 +20,7 @@ use std::env;
 
 static SYNTAX: &'static str = "[OPTION]... [FILE]";
 static SUMMARY: &'static str = "Output commands to set the LS_COLORS environment variable.";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  If FILE is specified, read it to determine which colors to use for which
  file types and extensions.  Otherwise, a precompiled database is used.
  For details on the format of these files, run 'dircolors --print-database'
@@ -56,7 +56,7 @@ pub fn guess_syntax() -> OutputFmt {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("b", "sh", "output Bourne shell code to set LS_COLORS")
         .optflag("",
                  "bourne-shell",

--- a/src/dirname/dirname.rs
+++ b/src/dirname/dirname.rs
@@ -17,14 +17,14 @@ use std::path::Path;
 static NAME: &'static str = "dirname"; 
 static SYNTAX: &'static str = "[OPTION] NAME..."; 
 static SUMMARY: &'static str = "strip last component from file name"; 
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  Output each NAME with its last non-slash component and trailing slashes
  removed; if NAME contains no /'s, output '.' (meaning the current
  directory).
 "; 
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("z", "zero", "separate output with NUL rather than newline")
         .parse(args);
 

--- a/src/du/du.rs
+++ b/src/du/du.rs
@@ -23,7 +23,7 @@ use time::Timespec;
 
 const NAME: &'static str = "du";
 const SUMMARY: &'static str = "estimate file space usage";
-const LONG_HELP: &'static str = "
+const HELP: &'static str = "
  Display  values  are  in  units  of  the  first  available  SIZE from
  --block-size,  and the DU_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environ‐
  ment variables.  Otherwise, units default to  1024  bytes  (or  512  if
@@ -120,7 +120,7 @@ fn du(mut my_stat: Stat, options: &Options, depth: usize)
 pub fn uumain(args: Vec<String>) -> i32 {
     let syntax = format!("[OPTION]... [FILE]...
  {0} [OPTION]... --files0-from=F", NAME);
-    let matches = new_coreopts!(&syntax, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(&syntax, SUMMARY, HELP)
     // In task
         .optflag("a", "all", " write counts for all files, not just directories")
     // In main

--- a/src/env/env.rs
+++ b/src/env/env.rs
@@ -23,7 +23,7 @@ use std::process::Command;
 static NAME: &'static str = "env";
 static SYNTAX: &'static str = "[OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]";
 static SUMMARY: &'static str = "Set each NAME to VALUE in the environment and run COMMAND";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  A mere - implies -i. If no COMMAND, print the resulting environment
 ";
 
@@ -44,7 +44,7 @@ fn print_env(null: bool) {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let mut core_opts = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP);
+    let mut core_opts = new_coreopts!(SYNTAX, SUMMARY, HELP);
     core_opts.optflag("i", "ignore-environment", "start with an empty environment")
         .optflag("0", "null", "end each output line with a 0 byte rather than newline")
         .optopt("u", "unset", "remove variable from the environment", "NAME");

--- a/src/expand/expand.rs
+++ b/src/expand/expand.rs
@@ -26,7 +26,7 @@ use unicode_width::UnicodeWidthChar;
 static SYNTAX: &'static str = "[OPTION]... [FILE]..."; 
 static SUMMARY: &'static str = "Convert tabs in each FILE to spaces, writing to standard output.
  With no FILE, or when FILE is -, read standard input."; 
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 static DEFAULT_TABSTOP: usize = 8;
 
@@ -90,7 +90,7 @@ impl Options {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("i", "initial", "do not convert tabs after non blanks")
         .optopt("t", "tabs", "have tabs NUMBER characters apart, not 8", "NUMBER")
         .optopt("t", "tabs", "use comma separated list of explicit tab positions", "LIST")

--- a/src/factor/factor.rs
+++ b/src/factor/factor.rs
@@ -32,7 +32,7 @@ include!(concat!(env!("OUT_DIR"), "/prime_table.rs"));
 static SYNTAX: &'static str = "[OPTION] [NUMBER]...";
 static SUMMARY: &'static str = "Print the prime factors of the given number(s).
  If none are specified, read from standard input.";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 fn rho_pollard_pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
     if num < 1 << 63 {
@@ -158,7 +158,7 @@ fn print_factors_str(num_str: &str) {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .parse(args);
 
     if matches.free.is_empty() {

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -36,7 +36,7 @@ mod parasplit;
 // program's NAME and VERSION are used for -V and -h
 static SYNTAX: &'static str = "[OPTION]... [FILE]..."; 
 static SUMMARY: &'static str = "Reformat paragraphs from input files (or stdin) to stdout.";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 pub type FileOrStdReader = BufReader<Box<Read+'static>>;
 pub struct FmtOptions {
@@ -58,7 +58,7 @@ pub struct FmtOptions {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("c", "crown-margin", "First and second line of paragraph may have different indentations, in which case the first line's indentation is preserved, and each subsequent line's indentation matches the second line.")
         .optflag("t", "tagged-paragraph", "Like -c, except that the first and second line of a paragraph *must* have different indentation or they are treated as separate paragraphs.")
         .optflag("m", "preserve-headers", "Attempt to detect and preserve mail headers in the input. Be careful when combining this flag with -p.")

--- a/src/fold/fold.rs
+++ b/src/fold/fold.rs
@@ -19,11 +19,11 @@ use std::path::Path;
 static SYNTAX: &'static str = "[OPTION]... [FILE]...";
 static SUMMARY: &'static str = "Writes each file (or standard input if no files are given)
  to standard output whilst breaking long lines";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 pub fn uumain(args: Vec<String>) -> i32 {
     let (args, obs_width) = handle_obsolete(&args[..]);
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("b", "bytes", "count using bytes rather than columns (meaning control characters such as newline are not treated specially)")
         .optflag("s", "spaces", "break lines at word boundaries rather than a hard cut-off")
         .optopt("w", "width", "set WIDTH as the maximum line width rather than 80", "WIDTH")

--- a/src/head/head.rs
+++ b/src/head/head.rs
@@ -21,7 +21,7 @@ use std::str::from_utf8;
 
 static SYNTAX: &'static str = "";
 static SUMMARY: &'static str = "";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 enum FilterMode {
     Bytes(usize),
@@ -51,7 +51,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         (args, None) => args
     };
 
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optopt("c", "bytes", "Print the first K bytes.  With the leading '-', print all but the last K bytes", "[-]K")
         .optopt("n", "lines", "Print the first K lines.  With the leading '-', print all but the last K lines", "[-]K")
         .optflag("q", "quiet", "never print headers giving file names")

--- a/src/hostid/hostid.rs
+++ b/src/hostid/hostid.rs
@@ -18,7 +18,7 @@ use libc::c_long;
 
 static SYNTAX: &'static str = "[options]"; 
 static SUMMARY: &'static str = ""; 
-static LONG_HELP: &'static str = ""; 
+static HELP: &'static str = "";
 
 pub enum Mode {
     HostId,
@@ -32,7 +32,7 @@ extern {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    new_coreopts!(SYNTAX, SUMMARY, HELP)
         .parse(args);
     hostid();
     0

--- a/src/hostname/hostname.rs
+++ b/src/hostname/hostname.rs
@@ -25,7 +25,7 @@ use std::net::ToSocketAddrs;
 
 static SYNTAX: &'static str = "[OPTION]... [HOSTNAME]";
 static SUMMARY: &'static str = "Print or set the system's host name.";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 extern {
     fn gethostname(name: *mut libc::c_char, namelen: libc::size_t) -> libc::c_int;
@@ -42,7 +42,7 @@ extern {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optflag("d", "domain", "Display the name of the DNS domain if possible")
         .optflag("i", "ip-address", "Display the network address(es) of the host")
         .optflag("f", "fqdn", "Display the FQDN (Fully Qualified Domain Name) (default)")   // TODO: support --long

--- a/src/install/install.rs
+++ b/src/install/install.rs
@@ -24,7 +24,7 @@ use std::result::Result;
 static NAME: &'static str = "install";
 static SUMMARY: &'static str = "Copy SOURCE to DEST or multiple SOURCE(s) to the existing
  DIRECTORY, while setting permission modes and owner/group";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 const DEFAULT_MODE: u32 = 755;
 
@@ -100,7 +100,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 fn parse_opts(args: Vec<String>) -> getopts::Matches {
     let syntax = format!("SOURCE DEST
  {} SOURCE... DIRECTORY", NAME);
-     new_coreopts!(&syntax, SUMMARY, LONG_HELP)
+     new_coreopts!(&syntax, SUMMARY, HELP)
     // TODO implement flag
         .optflagopt("",  "backup", "(unimplemented) make a backup of each existing destination\n \
                                     file", "CONTROL")

--- a/src/kill/kill.rs
+++ b/src/kill/kill.rs
@@ -20,7 +20,7 @@ use uucore::signals::ALL_SIGNALS;
 
 static SYNTAX: &'static str = "[options] <pid> [...]";
 static SUMMARY: &'static str = "";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 static EXIT_OK:  i32 = 0;
 static EXIT_ERR: i32 = 1;
@@ -34,7 +34,7 @@ pub enum Mode {
 
 pub fn uumain(args: Vec<String>) -> i32 {
     let (args, obs_signal) = handle_obsolete(args);
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .optopt("s", "signal", "specify the <signal> to be sent", "SIGNAL")
         .optflagopt("l", "list", "list all signal names, or convert one to a name", "LIST")
         .optflag("L", "table", "list all signal names in a nice table")

--- a/src/link/link.rs
+++ b/src/link/link.rs
@@ -18,7 +18,7 @@ use std::io::Error;
 
 static SYNTAX: &'static str = "[OPTIONS] FILE1 FILE2";
 static SUMMARY: &'static str = "Create a link named FILE2 to FILE1";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 pub fn normalize_error_message(e: Error) -> String {
     match e.raw_os_error() {
@@ -28,7 +28,7 @@ pub fn normalize_error_message(e: Error) -> String {
 }
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(SYNTAX, SUMMARY, HELP)
         .parse(args);
     if matches.free.len() != 2 {
         crash!(1, "{}", msg_wrong_number_of_arguments!(2));

--- a/src/ln/ln.rs
+++ b/src/ln/ln.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 
 static NAME: &'static str = "ln";
 static SUMMARY: &'static str = "";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  In the 1st form, create a link to TARGET with the name LINK_NAME.
  In the 2nd form, create a link to TARGET in the current directory.
  In the 3rd and 4th forms, create links to each TARGET in DIRECTORY.
@@ -62,7 +62,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
  {0} [OPTION]... TARGET                  (2nd form)
  {0} [OPTION]... TARGET... DIRECTORY     (3rd form)
  {0} [OPTION]... -t DIRECTORY TARGET...  (4th form)", NAME);
-    let matches = new_coreopts!(&syntax, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(&syntax, SUMMARY, HELP)
         .optflag("b", "", "make a backup of each file that would otherwise be overwritten or removed")
         .optflagopt("", "backup", "make a backup of each file that would otherwise be overwritten or removed", "METHOD")
     // TODO: opts.optflag("d", "directory", "allow users with appropriate privileges to attempt to make hard links to directories");

--- a/src/logname/logname.rs
+++ b/src/logname/logname.rs
@@ -36,10 +36,10 @@ fn get_userlogin() -> Option<String> {
 
 static SYNTAX: &'static str = "";
 static SUMMARY: &'static str = "Print user's login name";
-static LONG_HELP: &'static str = "";
+static HELP: &'static str = "";
 
 pub fn uumain(args: Vec<String>) -> i32 {
-    new_coreopts!(SYNTAX, SUMMARY, LONG_HELP).parse(args);
+    new_coreopts!(SYNTAX, SUMMARY, HELP).parse(args);
 
     exec();
 

--- a/src/ls/ls.rs
+++ b/src/ls/ls.rs
@@ -46,7 +46,7 @@ use std::os::windows::fs::MetadataExt;
 
 static NAME: &'static str = "ls";
 static SUMMARY: &'static str = "";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
  By default, ls will list the files and contents of any directories on
  the command line, expect that it will ignore files and directories
  whose names start with '.'
@@ -78,7 +78,7 @@ lazy_static! {
 pub fn uumain(args: Vec<String>) -> i32 {
     let syntax = format!("[OPTION]... DIRECTORY
  {0} [OPTION]... [FILE]...", NAME);
-    let matches = new_coreopts!(&syntax, SUMMARY, LONG_HELP)
+    let matches = new_coreopts!(&syntax, SUMMARY, HELP)
         .optflag("a",
                  "all",
                  "Do not ignore hidden files (files with names that start with '.').")

--- a/src/who/who.rs
+++ b/src/who/who.rs
@@ -21,7 +21,7 @@ use std::os::unix::fs::MetadataExt;
 
 static SYNTAX: &'static str = "[OPTION]... [ FILE | ARG1 ARG2 ]";
 static SUMMARY: &'static str = "Print information about users who are currently logged in.";
-static LONG_HELP: &'static str = "
+static HELP: &'static str = "
   -a, --all         same as -b -d --login -p -r -t -T -u
   -b, --boot        time of last system boot
   -d, --dead        print dead processes
@@ -47,7 +47,7 @@ If ARG1 ARG2 given, -m presumed: 'am i' or 'mom likes' are usual.
 
 pub fn uumain(args: Vec<String>) -> i32 {
 
-    let mut opts = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP);
+    let mut opts = new_coreopts!(SYNTAX, SUMMARY, HELP);
     opts.optflag("a", "all", "same as -b -d --login -p -r -t -T -u");
     opts.optflag("b", "boot", "time of last system boot");
     opts.optflag("d", "dead", "print dead processes");


### PR DESCRIPTION
Changed LONG_HELP and HELP to only HELP across programs.