### PR TITLE
refactor: remove import of AsciiExt

### DIFF
--- a/src/hashsum/hashsum.rs
+++ b/src/hashsum/hashsum.rs
@@ -32,6 +32,7 @@ use regex::Regex;
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shake256};
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read, stdin};

--- a/src/pinky/pinky.rs
+++ b/src/pinky/pinky.rs
@@ -155,6 +155,7 @@ pub trait Capitalize {
 
 impl Capitalize for str {
     fn capitalize(&self) -> String {
+        #[allow(unused_imports)]
         use std::ascii::AsciiExt;
         self.char_indices().fold(String::with_capacity(self.len()), |mut acc, x| {
             if x.0 != 0 {

--- a/src/truncate/truncate.rs
+++ b/src/truncate/truncate.rs
@@ -14,6 +14,7 @@ extern crate getopts;
 #[macro_use]
 extern crate uucore;
 
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 use std::fs::{File, metadata, OpenOptions};
 use std::io::Result;

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -15,6 +15,8 @@ extern crate getopts;
 extern crate uucore;
 
 use getopts::{Matches, Options};
+
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};


### PR DESCRIPTION
Since 1.23 stable no need to import AsciiExt explicitly.