### PR TITLE
Add installation instructions for NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Set install parent directory (default value is /usr/local):
 $ make PREFIX=/my/path install
 ```
 
+### NixOS ###
+
+The [standard package set](https://nixos.org/nixpkgs/manual/) of [NixOS](https://nixos.org/)
+provides this package out of the box since 18.03:
+
+```
+nix-env -iA nixos.uutils-coreutils
+```
+
 Uninstallation Instructions
 ---------------------------
 


### PR DESCRIPTION
The package set `nixpkgs`, NixOS relies on provides `uutils-coreutils`
out of the box since 18.03/unstable.

See https://github.com/NixOS/nixpkgs/pull/34840