### PR TITLE
Add configuration for Codecov to prevent it from failing builds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        # TODO: when the embedding interface is complete, this should be
+        #       changed to something more reasonable, like 1%
+        threshold: 50%


### PR DESCRIPTION
This can be merged after ensuring that the build in fact does not fail.