### PR TITLE
Begin switching everything from getopts to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,7 +1928,7 @@ dependencies = [
 name = "yes"
 version = "0.0.1"
 dependencies = [
- "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,7 +1882,7 @@ name = "whoami"
 version = "0.0.1"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -10,10 +10,7 @@ path = "arch.rs"
 
 [dependencies]
 platform-info = { git = "https://github.com/uutils/platform-info" }
-
-[dependencies.uucore]
-path = "../uucore"
-default-features = false
+uucore = { path = "../uucore" }
 
 [[bin]]
 name = "arch"

--- a/src/base32/Cargo.toml
+++ b/src/base32/Cargo.toml
@@ -8,8 +8,9 @@ build = "../../mkmain.rs"
 name = "uu_base32"
 path = "base32.rs"
 
-[dependencies]
-uucore = { path="../uucore" }
+[dependencies.uucore]
+path = "../uucore"
+features = ["encoding"]
 
 [dependencies.clippy]
 version = "0.0.143"

--- a/src/base64/Cargo.toml
+++ b/src/base64/Cargo.toml
@@ -8,8 +8,9 @@ build = "../../mkmain.rs"
 name = "uu_base64"
 path = "base64.rs"
 
-[dependencies]
-uucore = { path="../uucore" }
+[dependencies.uucore]
+path = "../uucore"
+features = ["encoding"]
 
 [[bin]]
 name = "base64"

--- a/src/cat/Cargo.toml
+++ b/src/cat/Cargo.toml
@@ -10,7 +10,10 @@ path = "cat.rs"
 
 [dependencies]
 quick-error = "1.1.0"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [target.'cfg(unix)'.dependencies]
 unix_socket = "0.5.0"

--- a/src/chgrp/Cargo.toml
+++ b/src/chgrp/Cargo.toml
@@ -13,7 +13,6 @@ walkdir = "1.0.7"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries", "fs"]
 
 [[bin]]

--- a/src/chmod/Cargo.toml
+++ b/src/chmod/Cargo.toml
@@ -10,8 +10,11 @@ path = "chmod.rs"
 
 [dependencies]
 libc = "0.2.26"
-uucore = { path="../uucore" }
 walker = "1.0.0"
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["mode"]
 
 [[bin]]
 name = "chmod"

--- a/src/chown/Cargo.toml
+++ b/src/chown/Cargo.toml
@@ -14,7 +14,6 @@ walkdir = "0.1"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries", "fs"]
 
 [dependencies.clippy]

--- a/src/chroot/Cargo.toml
+++ b/src/chroot/Cargo.toml
@@ -13,7 +13,6 @@ getopts = "0.2.14"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries"]
 
 [[bin]]

--- a/src/cp/Cargo.toml
+++ b/src/cp/Cargo.toml
@@ -17,8 +17,11 @@ libc = "0.2.26"
 walkdir = "1.0.7"
 clap = "2.20.0"
 quick-error = "1.1.0"
-uucore = { path="../uucore" }
 filetime = "0.1"
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ioctl-sys = "0.5.2"

--- a/src/env/env.rs
+++ b/src/env/env.rs
@@ -9,7 +9,6 @@
  */
 
 /* last synced with: env (GNU coreutils) 8.13 */
-#![allow(non_camel_case_types)]
 
 #[macro_use]
 extern crate uucore;
@@ -25,7 +24,7 @@ static LONG_HELP: &'static str = "
  A mere - implies -i. If no COMMAND, print the resulting environment
 ";
 
-struct options {
+struct Options {
     ignore_env: bool,
     null: bool,
     unsets: Vec<String>,
@@ -52,7 +51,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         )
         .optopt("u", "unset", "remove variable from the environment", "NAME");
 
-    let mut opts = Box::new(options {
+    let mut opts = Box::new(Options {
         ignore_env: false,
         null: false,
         unsets: vec![],

--- a/src/groups/Cargo.toml
+++ b/src/groups/Cargo.toml
@@ -10,7 +10,6 @@ path = "groups.rs"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries"]
 
 [[bin]]

--- a/src/id/Cargo.toml
+++ b/src/id/Cargo.toml
@@ -10,7 +10,6 @@ path = "id.rs"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries", "process"]
 
 [[bin]]

--- a/src/kill/Cargo.toml
+++ b/src/kill/Cargo.toml
@@ -10,7 +10,10 @@ path = "kill.rs"
 
 [dependencies]
 libc = "0.2.26"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["signals"]
 
 [[bin]]
 name = "kill"

--- a/src/ls/Cargo.toml
+++ b/src/ls/Cargo.toml
@@ -19,7 +19,6 @@ unicode-width = "0.1.4"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries"]
 
 [[bin]]

--- a/src/nohup/Cargo.toml
+++ b/src/nohup/Cargo.toml
@@ -11,7 +11,10 @@ path = "nohup.rs"
 [dependencies]
 getopts = "0.2.14"
 libc = "0.2.26"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [[bin]]
 name = "nohup"

--- a/src/pinky/Cargo.toml
+++ b/src/pinky/Cargo.toml
@@ -10,7 +10,6 @@ path = "pinky.rs"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["utmpx", "entries"]
 
 [[bin]]

--- a/src/readlink/Cargo.toml
+++ b/src/readlink/Cargo.toml
@@ -11,7 +11,10 @@ path = "readlink.rs"
 [dependencies]
 getopts = "0.2.14"
 libc = "0.2.26"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [[bin]]
 name = "readlink"

--- a/src/realpath/Cargo.toml
+++ b/src/realpath/Cargo.toml
@@ -10,7 +10,10 @@ path = "realpath.rs"
 
 [dependencies]
 getopts = "0.2.14"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [[bin]]
 name = "realpath"

--- a/src/relpath/Cargo.toml
+++ b/src/relpath/Cargo.toml
@@ -10,7 +10,10 @@ path = "relpath.rs"
 
 [dependencies]
 getopts = "0.2.14"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [[bin]]
 name = "relpath"

--- a/src/sleep/Cargo.toml
+++ b/src/sleep/Cargo.toml
@@ -10,7 +10,10 @@ path = "sleep.rs"
 
 [dependencies]
 getopts = "0.2.14"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["parse_time"]
 
 [[bin]]
 name = "sleep"

--- a/src/sort/Cargo.toml
+++ b/src/sort/Cargo.toml
@@ -12,7 +12,10 @@ path = "sort.rs"
 getopts = "0.2.14"
 semver = "0.7.0"
 itertools = "0.6.0"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [[bin]]
 name = "sort"

--- a/src/stat/Cargo.toml
+++ b/src/stat/Cargo.toml
@@ -14,7 +14,6 @@ time = "0.1.38"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries"]
 
 [[bin]]

--- a/src/sync/Cargo.toml
+++ b/src/sync/Cargo.toml
@@ -13,7 +13,10 @@ getopts = "0.2.14"
 libc = "0.2.26"
 winapi = { version = "0.3", features = ["handleapi", "winerror"] }
 kernel32-sys = "0.2.2"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["wide"]
 
 [[bin]]
 name = "sync"

--- a/src/timeout/Cargo.toml
+++ b/src/timeout/Cargo.toml
@@ -12,7 +12,10 @@ path = "timeout.rs"
 getopts = "0.2.14"
 libc = "0.2.26"
 time = "0.1.38"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["parse_time", "process"]
 
 [[bin]]
 name = "timeout"

--- a/src/touch/Cargo.toml
+++ b/src/touch/Cargo.toml
@@ -15,7 +15,6 @@ time = "0.1.38"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["libc"]
 
 [[bin]]

--- a/src/tr/Cargo.toml
+++ b/src/tr/Cargo.toml
@@ -12,10 +12,7 @@ path = "tr.rs"
 getopts = "0.2.14"
 bit-set = "0.4.0"
 fnv = "1.0.5"
-
-[dependencies.uucore]
-path = "../uucore"
-default-features = false
+uucore = { path = "../uucore" }
 
 [[bin]]
 name = "tr"

--- a/src/tty/Cargo.toml
+++ b/src/tty/Cargo.toml
@@ -11,7 +11,10 @@ path = "tty.rs"
 [dependencies]
 getopts = "0.2.14"
 libc = "0.2.26"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["fs"]
 
 [[bin]]
 name = "tty"

--- a/src/uname/Cargo.toml
+++ b/src/uname/Cargo.toml
@@ -11,10 +11,7 @@ path = "uname.rs"
 [dependencies]
 clap = "2.20.0"
 platform-info = { git = "https://github.com/uutils/platform-info" }
-
-[dependencies.uucore]
-path = "../uucore"
-default-features = false
+uucore = { path = "../uucore" }
 
 [[bin]]
 name = "uname"

--- a/src/unexpand/Cargo.toml
+++ b/src/unexpand/Cargo.toml
@@ -11,7 +11,10 @@ path = "unexpand.rs"
 [dependencies]
 getopts = "0.2.14"
 unicode-width = "0.1.4"
-uucore = { path="../uucore" }
+
+[dependencies.uucore]
+path = "../uucore"
+features = ["utf8"]
 
 [[bin]]
 name = "unexpand"

--- a/src/uniq/Cargo.toml
+++ b/src/uniq/Cargo.toml
@@ -10,10 +10,7 @@ path = "uniq.rs"
 
 [dependencies]
 getopts = "0.2.14"
-
-[dependencies.uucore]
-path="../uucore"
-default-features = false
+uucore = { path = "../uucore" }
 
 [[bin]]
 name = "uniq"

--- a/src/uptime/Cargo.toml
+++ b/src/uptime/Cargo.toml
@@ -13,7 +13,6 @@ getopts = "0.2.14"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["utmpx"]
 
 [[bin]]

--- a/src/users/Cargo.toml
+++ b/src/users/Cargo.toml
@@ -12,7 +12,6 @@ path = "users.rs"
 getopts = "0.2.14"
 
 [dependencies.uucore]
-default-features = false
 features = ["utmpx"]
 path = "../uucore"
 

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -20,7 +20,7 @@ process = ["libc"]
 signals = []
 entries = ["libc"]
 wide = []
-default = ["fs", "libc", "utf8", "encoding", "parse_time", "mode", "utmpx", "process", "entries", "signals", "wide"]
+default = []
 
 [lib]
 path = "lib.rs"

--- a/src/who/Cargo.toml
+++ b/src/who/Cargo.toml
@@ -10,7 +10,6 @@ path = "who.rs"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["utmpx"]
 
 [dependencies.clippy]

--- a/src/whoami/Cargo.toml
+++ b/src/whoami/Cargo.toml
@@ -2,6 +2,7 @@
 name = "whoami"
 version = "0.0.1"
 authors = []
+description = "Print effective user ID."
 build = "../../mkmain.rs"
 
 [lib]
@@ -9,14 +10,14 @@ name = "uu_whoami"
 path = "whoami.rs"
 
 [dependencies]
-getopts = "0.2.14"
+clap = "2.31"
 winapi = { version = "0.3", features = ["lmcons"] }
 advapi32-sys = "0.2.0"
 
 [dependencies.uucore]
 path = "../uucore"
 default-features = false
-features = ["entries"]
+features = ["entries", "wide"]
 
 [[bin]]
 name = "whoami"

--- a/src/whoami/Cargo.toml
+++ b/src/whoami/Cargo.toml
@@ -16,7 +16,6 @@ advapi32-sys = "0.2.0"
 
 [dependencies.uucore]
 path = "../uucore"
-default-features = false
 features = ["entries", "wide"]
 
 [[bin]]

--- a/src/yes/Cargo.toml
+++ b/src/yes/Cargo.toml
@@ -11,10 +11,7 @@ path = "yes.rs"
 
 [dependencies]
 clap = "2.31"
-
-[dependencies.uucore]
-path = "../uucore"
-default-features = false
+uucore = { path = "../uucore" }
 
 [[bin]]
 name = "yes"

--- a/src/yes/Cargo.toml
+++ b/src/yes/Cargo.toml
@@ -2,6 +2,7 @@
 name = "yes"
 version = "0.0.1"
 authors = []
+description = "Repeatedly output a line with all specified STRING(s), or 'y'."
 build = "../../mkmain.rs"
 
 [lib]
@@ -9,8 +10,11 @@ name = "uu_yes"
 path = "yes.rs"
 
 [dependencies]
-getopts = "0.2.14"
-uucore = { path="../uucore" }
+clap = "2.31"
+
+[dependencies.uucore]
+path = "../uucore"
+default-features = false
 
 [[bin]]
 name = "yes"


### PR DESCRIPTION
I have begun removing all `getopts`-related code in favor of using `clap`.  Currently, I am in the process of converting everything using `coreopts` to purely using `clap`.

In addition, I made some general changes regarding `uucore` and tried to improve `yes`.

Also note that, on error, the output of `yes` is now slightly broken (there is an extra `error: `).  This issue has been fixed on my local machine, but I will push this after finishing the conversion of the `coreopts` programs to `clap`.