### PR TITLE
Port 'tail' to Redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ generic = [
   "hostname",
   "nproc",
   "sync",
-  "tail",
   "whoami",
   "redox_generic"
 ]
@@ -129,6 +128,7 @@ redox_generic = [
   "split",
   "sum",
   "tac",
+  "tail",
   "tee",
   "test",
   "tr",

--- a/src/tail/Cargo.toml
+++ b/src/tail/Cargo.toml
@@ -15,6 +15,9 @@ libc = "0.2.26"
 winapi = "0.3"
 uucore = { path="../uucore" }
 
+[target.'cfg(target_os = "redox")'.dependencies]
+redox_syscall = "0.1"
+
 [[bin]]
 name = "tail"
 path = "../../uumain.rs"

--- a/src/tail/platform/mod.rs
+++ b/src/tail/platform/mod.rs
@@ -13,8 +13,14 @@ pub use self::unix::{supports_pid_checks, Pid, ProcessChecker};
 #[cfg(windows)]
 pub use self::windows::{supports_pid_checks, Pid, ProcessChecker};
 
+#[cfg(target_os = "redox")]
+pub use self::redox::{supports_pid_checks, Pid, ProcessChecker};
+
 #[cfg(unix)]
 mod unix;
 
 #[cfg(windows)]
 mod windows;
+
+#[cfg(target_os = "redox")]
+mod redox;

--- a/src/tail/platform/redox.rs
+++ b/src/tail/platform/redox.rs
@@ -1,0 +1,25 @@
+extern crate syscall;
+
+use self::syscall::{Error, EPERM, ENOSYS};
+
+pub type Pid = usize;
+
+pub struct ProcessChecker {
+    pid: self::Pid,
+}
+
+impl ProcessChecker {
+    pub fn new(process_id: self::Pid) -> ProcessChecker {
+        ProcessChecker { pid: process_id }
+    }
+
+    // Borrowing mutably to be aligned with Windows implementation
+    pub fn is_dead(&mut self) -> bool {
+        let res = syscall::kill(self.pid, 0);
+        res != Ok(0) && res != Err(Error::new(EPERM))
+    }
+}
+
+pub fn supports_pid_checks(pid: self::Pid) -> bool {
+    true
+}


### PR DESCRIPTION
This requires https://github.com/redox-os/kernel/pull/86 to work correctly (it builds and runs fine without that, but the `--pid` feature won't work without that kernel change).