### PR TITLE
yes: use 16 KiB rather than 8 KiB for the buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,8 @@ version = "0.0.1"
 dependencies = [
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 
@@ -1430,6 +1432,7 @@ dependencies = [
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/yes/Cargo.toml
+++ b/src/yes/Cargo.toml
@@ -13,6 +13,10 @@ path = "yes.rs"
 clap = "2.31"
 uucore = { path = "../uucore" }
 
+[features]
+latency = []
+default = []
+
 [[bin]]
 name = "yes"
 path = "../../uumain.rs"

--- a/src/yes/yes.rs
+++ b/src/yes/yes.rs
@@ -55,21 +55,31 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
 
     let mut buffer = [0; BUF_SIZE];
-    let bytes = if string.len() < BUF_SIZE / 2 {
-        let mut size = 0;
-        while size < BUF_SIZE - string.len() {
-            let (_, right) = buffer.split_at_mut(size);
-            right[..string.len()].copy_from_slice(string.as_bytes());
-            size += string.len();
-        }
-        &buffer[..size]
-    } else {
-        string.as_bytes()
-    };
+    let bytes = prepare_buffer(&string, &mut buffer);
 
     exec(bytes);
 
     0
+}
+
+#[cfg(not(feature = "latency"))]
+fn prepare_buffer<'a>(input: &'a str, buffer: &'a mut [u8; BUF_SIZE]) -> &'a [u8] {
+    if input.len() < BUF_SIZE / 2 {
+        let mut size = 0;
+        while size < BUF_SIZE - input.len() {
+            let (_, right) = buffer.split_at_mut(size);
+            right[..input.len()].copy_from_slice(input.as_bytes());
+            size += input.len();
+        }
+        &buffer[..size]
+    } else {
+        input.as_bytes()
+    }
+}
+
+#[cfg(feature = "latency")]
+fn prepare_buffer<'a>(input: &'a str, _buffer: &'a mut [u8; BUF_SIZE]) -> &'a [u8] {
+    input.as_bytes()
 }
 
 pub fn exec(bytes: &[u8]) {

--- a/src/yes/yes.rs
+++ b/src/yes/yes.rs
@@ -23,7 +23,9 @@ use std::io::{self, Write};
 // force a re-build whenever Cargo.toml changes
 const _CARGO_TOML: &'static str = include_str!("Cargo.toml");
 
-const BUF_SIZE: usize = 8192;
+// it's possible that using a smaller or larger buffer might provide better performance on some
+// systems, but honestly this is good enough
+const BUF_SIZE: usize = 16 * 1024;
 
 pub fn uumain(args: Vec<String>) -> i32 {
     let app = app_from_crate!().arg(Arg::with_name("STRING").index(1).multiple(true));


### PR DESCRIPTION
This bumped the speed past GNU `yes` on my Mac.  I now get something like 4.30 GiB/s for ours compared to around 1 GiB/s for the GNU version.