### PR TITLE
Allow build to fail on Redox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 matrix:
+  fast_finish: true
   include:
     - rust: stable
       os: linux
@@ -19,6 +20,10 @@ matrix:
     - rust: nightly
       os: osx
       env: FEATURES=nightly
+    - rust: nightly
+      os: linux
+      env: FEATURES=nightly,redox CC=x86_64-unknown-redox-gcc CARGO_ARGS='--no-default-features --target=x86_64-unknown-redox' REDOX=1
+  allow_failures:
     - rust: nightly
       os: linux
       env: FEATURES=nightly,redox CC=x86_64-unknown-redox-gcc CARGO_ARGS='--no-default-features --target=x86_64-unknown-redox' REDOX=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,13 +19,13 @@ environment:
     MSYS_BITS: 64
 
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin;C:\MinGW\bin
 
   # Use the system msys if we can
   - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
 
   - ps: >-
+      Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe";
       if ((Test-Path Env:\MINGW_ARCHIVE) -and -not (Test-Path "${env:DIR_TEMP_MINGW}\${env:MINGW_ARCHIVE}")) {
         if (Test-Path "${env:DIR_TEMP_MINGW}") {
           rm -Recurse ${env:DIR_TEMP_MINGW}\*;


### PR DESCRIPTION
This should allow the build to pass (as it is always a linking error when using `x86_64-unknown-redox-gcc` on Travis).  Also, this will hopefully help fix spurious errors on Appveyor when trying to download the Rust compiler.

~If the Appveyor build doesn't start at some point, don't merge this.  I will have to see what is wrong if so.  It seems to work if I start the build manually, so I am pretty sure the issue is unrelated to my changes.~