### PR TITLE
uptime: error when uptime cannot be found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,6 +1695,7 @@ name = "uptime"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1",
 ]
 

--- a/src/uptime/Cargo.toml
+++ b/src/uptime/Cargo.toml
@@ -10,6 +10,7 @@ path = "uptime.rs"
 
 [dependencies]
 getopts = "0.2.14"
+time = "0.1.38"
 
 [dependencies.uucore]
 path = "../uucore"


### PR DESCRIPTION
I believe this fixes #1195.  `uptime` will also now compile on Windows, although it doesn't work correctly (missing load averages and the number of users is always 0).