### PR TITLE
uutils: Replace file_name with file_stem in symlink applet detection.

### DIFF
--- a/src/uutils/uutils.rs
+++ b/src/uutils/uutils.rs
@@ -45,7 +45,7 @@ fn main() {
     // try binary name as util name.
     let args0 = args[0].clone();
     let binary = Path::new(&args0[..]);
-    let binary_as_util = binary.file_name().unwrap().to_str().unwrap();
+    let binary_as_util = binary.file_stem().unwrap().to_str().unwrap();
 
     if let Some(&uumain) = umap.get(binary_as_util) {
         std::process::exit(uumain(args));


### PR DESCRIPTION
This can get confused on Windows with powershell, where it passes .exe
for symlinks.

closes #1241 