### PR TITLE
Fix comparison of empty string to numeric f64 sort

### DIFF
--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -383,11 +383,15 @@ fn permissive_f64_parse(a: &str) -> f64 {
     // because there's no way to handle both CSV and thousands separators without a new flag.
     // GNU sort treats "1,234" as "1" in numeric, so maybe it's fine.
     // GNU sort treats "NaN" as non-number in numeric, so it needs special care.
-    let sa: &str = a.split_whitespace().next().unwrap();
-    match sa.parse::<f64>() {
-        Ok(a) if a.is_nan() => std::f64::NEG_INFINITY,
-        Ok(a) => a,
-        Err(_) => std::f64::NEG_INFINITY,
+    match a.split_whitespace().next() {
+        None => std::f64::NEG_INFINITY,
+        Some(sa) => {
+            match sa.parse::<f64>() {
+                Ok(a) if a.is_nan() => std::f64::NEG_INFINITY,
+                Ok(a) => a,
+                Err(_) => std::f64::NEG_INFINITY,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Taking a look at issue #1282 the problem appears to be that the empty line is failing the numeric comparison. This change ensures that if we are not passed any value it will still properly return the expected result.