### PR TITLE
fix "`cp` always creates backup"

### DIFF
--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -579,7 +579,7 @@ impl Options {
         let recursive = matches.is_present(OPT_RECURSIVE) || matches.is_present(OPT_RECURSIVE_ALIAS)
             || matches.is_present(OPT_ARCHIVE);
 
-        let backup = matches.is_present(OPT_BACKUP) || matches.is_present(OPT_SUFFIX);
+        let backup = matches.is_present(OPT_BACKUP) || (matches.occurrences_of(OPT_SUFFIX) > 0);
 
         // Parse target directory options
         let no_target_dir = matches.is_present(OPT_NO_TARGET_DIRECTORY);

--- a/tests/test_cp.rs
+++ b/tests/test_cp.rs
@@ -32,6 +32,23 @@ fn test_cp_cp() {
 
 
 #[test]
+fn test_cp_existing_target() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let result = ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_EXISTING_FILE)
+        .run();
+
+    assert!(result.success);
+
+    // Check the content of the destination file
+    assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
+
+    // No backup should have been created
+    assert!(!at.file_exists(&*format!("{}~", TEST_EXISTING_FILE)));
+}
+
+
+#[test]
 fn test_cp_duplicate_files() {
     let (at, mut ucmd) = at_and_ucmd!();
     let result = ucmd.arg(TEST_HELLO_WORLD_SOURCE)


### PR DESCRIPTION
* includes test which demonstrates the problem 

Note that this is on top of the improved testing introduced in [PR#1281](https://github.com/uutils/coreutils/pull/1281).