### PR TITLE
fix "`mv` fails transfers between dirs"

### DIFF
--- a/src/mv/mv.rs
+++ b/src/mv/mv.rs
@@ -306,7 +306,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &PathBuf, b: &Behaviour) -
 
     let mut all_successful = true;
     for sourcepath in files.iter() {
-        let targetpath = match sourcepath.as_os_str().to_str() {
+        let targetpath = match sourcepath.file_name() {
             Some(name) => target_dir.join(name),
             None => {
                 show_error!(

--- a/src/mv/mv.rs
+++ b/src/mv/mv.rs
@@ -358,11 +358,11 @@ fn rename(from: &PathBuf, to: &PathBuf, b: &Behaviour) -> Result<()> {
             BackupMode::ExistingBackup => Some(existing_backup_path(to, &b.suffix)),
         };
         if let Some(ref p) = backup_path {
-            try!(fs::rename(to, p));
+            fs::rename(to, p)?;
         }
 
         if b.update {
-            if try!(try!(fs::metadata(from)).modified()) <= try!(try!(fs::metadata(to)).modified())
+            if fs::metadata(from)?.modified()? <= fs::metadata(to)?.modified()?
             {
                 return Ok(());
             }
@@ -374,14 +374,14 @@ fn rename(from: &PathBuf, to: &PathBuf, b: &Behaviour) -> Result<()> {
         // normalize behavior between *nix and windows
         if from.is_dir() {
             if is_empty_dir(to) {
-                try!(fs::remove_dir(to))
+                fs::remove_dir(to)?
             } else {
                 return Err(std::io::Error::new(std::io::ErrorKind::Other, "Directory not empty"));
             }
         }
     }
 
-    try!(fs::rename(from, to));
+    fs::rename(from, to)?;
 
     if b.verbose {
         print!("‘{}’ -> ‘{}’", from.display(), to.display());

--- a/src/mv/mv.rs
+++ b/src/mv/mv.rs
@@ -257,7 +257,10 @@ fn exec(files: &[PathBuf], b: Behaviour) -> i32 {
 
                     return match rename(source, target, &b) {
                         Err(e) => {
-                            show_error!("{}", e);
+                            show_error!(
+                                "cannot move ‘{}’ to ‘{}’: {}",
+                                source.display(), target.display(), e
+                            );
                             1
                         }
                         _ => 0,

--- a/tests/test_mv.rs
+++ b/tests/test_mv.rs
@@ -368,8 +368,7 @@ fn test_mv_errors() {
     // $ mv -T -t a b
     // mv: cannot combine --target-directory (-t) and --no-target-directory (-T)
     scene.ucmd().arg("-T").arg("-t").arg(dir).arg(file_a).arg(file_b).fails()
-    .stderr_is("mv: error: cannot combine --target-directory (-t) and --no-target-directory \
-                (-T)\n");
+    .stderr_is("mv: error: cannot combine --target-directory (-t) and --no-target-directory (-T)\n");
 
     // $ at.touch file && at.mkdir dir
     // $ mv -T file dir

--- a/tests/test_mv.rs
+++ b/tests/test_mv.rs
@@ -45,6 +45,25 @@ fn test_mv_move_file_into_dir() {
 }
 
 #[test]
+fn test_mv_move_file_between_dirs() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir1 = "test_mv_move_file_between_dirs_dir1";
+    let dir2 = "test_mv_move_file_between_dirs_dir2";
+    let file = "test_mv_move_file_between_dirs_file";
+
+    at.mkdir(dir1);
+    at.mkdir(dir2);
+    at.touch(&format!("{}/{}", dir1, file));
+
+    assert!(at.file_exists(&format!("{}/{}", dir1, file)));
+
+    ucmd.arg(&format!("{}/{}", dir1, file)).arg(dir2).succeeds().no_stderr();
+
+    assert!(!at.file_exists(&format!("{}/{}", dir1, file)));
+    assert!(at.file_exists(&format!("{}/{}", dir2, file)));
+}
+
+#[test]
 fn test_mv_strip_slashes() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -23,7 +23,6 @@ unix_only! {
     "chown", test_chown;
     "chgrp", test_chgrp;
     "install", test_install;
-    "mv", test_mv;
     "pathchk", test_pathchk;
     "pinky", test_pinky;
     "stdbuf", test_stdbuf;
@@ -68,6 +67,7 @@ generic! {
     "ls", test_ls;
     "mkdir", test_mkdir;
     "mktemp", test_mktemp;
+    "mv", test_mv;
     "numfmt", test_numfmt;
     "nl", test_nl;
     "od", test_od;


### PR DESCRIPTION
* includes test which demonstrates the problem 

Note that this is on top of the improved testing introduced in [PR#1281](https://github.com/uutils/coreutils/pull/1281).