### PR TITLE
Remove some useless BufReader wrappers around stdin

### DIFF
--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -42,7 +42,7 @@ use clap::{App, Arg, ArgMatches};
 use quick_error::ResultExt;
 use std::collections::HashSet;
 use std::fs;
-use std::io::{stdin, stdout, BufRead, BufReader, Write};
+use std::io::{stdin, stdout, Write};
 use std::io;
 use std::path::{Path, PathBuf, StripPrefixError};
 use std::str::FromStr;
@@ -123,7 +123,7 @@ macro_rules! prompt_yes(
         print!(" [y/N]: ");
         crash_if_err!(1, stdout().flush());
         let mut s = String::new();
-        match BufReader::new(stdin()).read_line(&mut s) {
+        match stdin().read_line(&mut s) {
             Ok(_) => match s.char_indices().nth(0) {
                 Some((_, x)) => x == 'y' || x == 'Y',
                 _ => false

--- a/src/factor/factor.rs
+++ b/src/factor/factor.rs
@@ -23,7 +23,7 @@ use rand::distributions::{Distribution, Uniform};
 use rand::{SeedableRng, thread_rng};
 use rand::rngs::SmallRng;
 use std::cmp::{max, min};
-use std::io::{stdin, BufRead, BufReader};
+use std::io::{stdin, BufRead};
 use std::num::Wrapping;
 use std::mem::swap;
 
@@ -163,7 +163,8 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let matches = new_coreopts!(SYNTAX, SUMMARY, LONG_HELP).parse(args);
 
     if matches.free.is_empty() {
-        for line in BufReader::new(stdin()).lines() {
+        let stdin = stdin();
+        for line in stdin.lock().lines() {
             for number in line.unwrap().split_whitespace() {
                 print_factors_str(number);
             }

--- a/src/ln/ln.rs
+++ b/src/ln/ln.rs
@@ -13,7 +13,7 @@
 extern crate uucore;
 
 use std::fs;
-use std::io::{stdin, BufRead, BufReader, Result};
+use std::io::{stdin, Result};
 #[cfg(any(unix, target_os = "redox"))]
 use std::os::unix::fs::symlink;
 #[cfg(windows)]
@@ -303,7 +303,7 @@ fn link(src: &PathBuf, dst: &PathBuf, settings: &Settings) -> Result<()> {
 
 fn read_yes() -> bool {
     let mut s = String::new();
-    match BufReader::new(stdin()).read_line(&mut s) {
+    match stdin().read_line(&mut s) {
         Ok(_) => match s.char_indices().nth(0) {
             Some((_, x)) => x == 'y' || x == 'Y',
             _ => false,

--- a/src/mv/mv.rs
+++ b/src/mv/mv.rs
@@ -16,7 +16,7 @@ extern crate uucore;
 
 use std::fs;
 use std::env;
-use std::io::{stdin, BufRead, BufReader, Result};
+use std::io::{stdin, Result};
 use std::path::{Path, PathBuf};
 
 static NAME: &str = "mv";
@@ -374,7 +374,7 @@ fn rename(from: &PathBuf, to: &PathBuf, b: &Behaviour) -> Result<()> {
 
 fn read_yes() -> bool {
     let mut s = String::new();
-    match BufReader::new(stdin()).read_line(&mut s) {
+    match stdin().read_line(&mut s) {
         Ok(_) => match s.chars().nth(0) {
             Some(x) => x == 'y' || x == 'Y',
             _ => false,


### PR DESCRIPTION
This fixes, in part only, #1103.

I’m willing to remove the other useless `BufReader` wrappers, but I am too much of a Rust newbie to know how to do that properly. I need some help.

In, for instance, `base32.rs`, it’d be easy to do:

```rust
     let input = if matches.free.is_empty() || &matches.free[0][..] == "-" {
-        BufReader::new(Box::new(stdin()) as Box<Read>)
+        Box::new(stdin()) as Box<Read>
     } else {
         let path = Path::new(matches.free[0].as_str());
         let file_buf = safe_unwrap!(File::open(&path));
-        BufReader::new(Box::new(file_buf) as Box<Read>)
+        Box::new(BufReader::new(file_buf))
     };
```

This compiles. But then some repetitive hence excessive mutex locking/unlocking is going to take place.

`base32.rs` delegates to `decode()/encode()` in `encoding.rs`. There, `read_to_end()` is called.
If I understand https://doc.rust-lang.org/src/std/io/mod.rs.html#365-394 correctly, `read_to_end()`
calls `read()`, potentially several times. And each time, the mutex has to be taken then released.
See https://www.reddit.com/r/rust/comments/3rj54u/how_can_i_read_char_by_char_from_stdin/cwpojn1/

So it’d be better to acquire the mutex lock explicitely beforehand, doing something like:

```rust
+    let std_input; // declare this here to make the compiler happy
     let input = if matches.free.is_empty() || &matches.free[0][..] == "-" {
-        BufReader::new(Box::new(stdin()) as Box<Read>)
+        std_input = stdin();
+        Box::new(std_input.lock()) as Box<Read>
     } else {
         let path = Path::new(matches.free[0].as_str());
         let file_buf = safe_unwrap!(File::open(&path));
-        BufReader::new(Box::new(file_buf) as Box<Read>)
+        Box::new(BufReader::new(file_buf))
     };
```

This compiles, but this is ugly (the stupid `std_input` upfront declaration).

Ugly is one thing, losing the fight with the borrow checker is another.
Take `cat.rs`. It does not explicitely lock either (but it should). But then if you do:

```rust
     if path == "-" {
         let stdin = stdin();
         return Ok(InputHandle {
-            reader: Box::new(stdin) as Box<Read>,
+            reader: Box::new(stdin.lock()) as Box<Read>,
             is_interactive: is_stdin_interactive(),
         });
     }
```

The compiler is not happy, and I don’t know to please it.

Maybe it’d be better just to wait for non-lexical lifetimes to be implemented? 
See https://github.com/rust-lang/rust/issues/33520 https://github.com/rust-lang/rfcs/issues/811  https://github.com/rust-lang/rust/issues/43234

Please let me know what you think.
