### PR TITLE
Fix du --apparent-size on ext4 and MacOS

### DIFF
--- a/src/du/du.rs
+++ b/src/du/du.rs
@@ -394,7 +394,7 @@ Try '{} --help' for more information.",
                 let len = len.unwrap();
                 for (index, stat) in iter.enumerate() {
                     let size = if matches.opt_present("apparent-size") {
-                        stat.nlink * stat.size
+                        stat.size
                     } else if matches.opt_present("b") {
                         stat.size
                     } else {


### PR DESCRIPTION
All credit goes to @JJJollyjim in this PR https://github.com/uutils/coreutils/pull/1294, but that PR needs to be rebased over master to be mergeable and hasn't been after multiple weeks.