### PR TITLE
Separate file operand logic into uucore

### DIFF
--- a/src/tail/README.md
+++ b/src/tail/README.md
@@ -6,8 +6,5 @@ Rudimentary tail implementation.
 * `--max-unchanged-stats` : with `--follow=name`, reopen a FILE which has not changed size after N (default 5) iterations  to see if it has been unlinked or renamed (this is the usual case of rotated log files).  With inotify, this option is rarely useful.
 * `--retry` : keep trying to open a file even when it is or becomes inaccessible; useful when follow‐ing by name, i.e., with `--follow=name`
 
-### Others
-The current implementation does not handle `-` as an alias for stdin.
-
 ## Possible optimizations:
 * Don't read the whole file if not using `-f` and input is regular file. Read in chunks from the end going backwards, reading each individual chunk forward.

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -187,7 +187,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     let files = given_options.free;
 
-    if files.is_empty() {
+    if files.is_empty() || &files[0] == "-" {
         let mut buffer = BufReader::new(stdin());
         unbounded_tail(&mut buffer, &settings);
     } else {

--- a/src/tail/tail.rs
+++ b/src/tail/tail.rs
@@ -187,7 +187,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     let files = given_options.free;
 
-    if files.is_empty() || &files[0] == "-" {
+    if uucore::coreopts::is_stdin(&files) {
         let mut buffer = BufReader::new(stdin());
         unbounded_tail(&mut buffer, &settings);
     } else {

--- a/src/uucore/coreopts.rs
+++ b/src/uucore/coreopts.rs
@@ -139,3 +139,8 @@ macro_rules! new_coreopts {
         })
     );
 }
+
+#[inline]
+pub fn is_stdin(files: &Vec<String>) -> bool {
+    files.is_empty() || &files[0] == "-"
+}

--- a/src/uucore/coreopts.rs
+++ b/src/uucore/coreopts.rs
@@ -144,3 +144,30 @@ macro_rules! new_coreopts {
 pub fn is_stdin(files: &Vec<String>) -> bool {
     files.is_empty() || &files[0] == "-"
 }
+
+#[cfg(test)]
+mod tests {
+    use super::is_stdin;
+
+    macro_rules! vec_of_strings {
+        ($($x:expr),*) => (vec![$($x.to_string()),*]);
+    }
+
+    #[test]
+    fn test_is_stdin_with_files() {
+        let files = vec_of_strings!["foo/bar", "baz"];
+        assert!(!is_stdin(&files));
+    }
+
+    #[test]
+    fn test_is_stdin_without_files() {
+        let files = Vec::new();
+        assert!(is_stdin(&files));
+    }
+
+    #[test]
+    fn test_is_stdin_with_operand() {
+        let files = vec_of_strings!["-"];
+        assert!(is_stdin(&files));
+    }
+}

--- a/tests/test_tail.rs
+++ b/tests/test_tail.rs
@@ -19,6 +19,11 @@ fn test_stdin_default() {
 }
 
 #[test]
+fn test_file_operand_default() {
+    new_ucmd!().arg("-").pipe_in_fixture(FOOBAR_TXT).run().stdout_is_fixture("foobar_stdin_default.expected");
+}
+
+#[test]
 fn test_single_default() {
     new_ucmd!().arg(FOOBAR_TXT).run().stdout_is_fixture("foobar_single_default.expected");
 }


### PR DESCRIPTION
This pull request includes the changes from \#1324, which are included so that the stdin checking functionality is used in the codebase. As there are no guidelines for contributing to uucore, I am making this pull-request as an RFC on using uucore to implement such functionality in this way.