### PR TITLE
env: refactor and move away from pre-1.0 Rust conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "env"
 version = "0.0.1"
 dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/env/Cargo.toml
+++ b/src/env/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "env"
 version = "0.0.1"
-authors = []
+authors = ["uutils developers"]
+description = "Set each NAME to VALUE in the environment and run COMMAND"
 build = "../../mkmain.rs"
+edition = "2018"
 
 [lib]
 name = "uu_env"
 path = "env.rs"
 
 [dependencies]
+clap = "2.33"
 libc = "0.2.42"
 uucore = "0.0.1"
 rust-ini = "0.13.0"

--- a/src/env/env.rs
+++ b/src/env/env.rs
@@ -110,7 +110,7 @@ fn build_command<'a, 'b>(args: &'a mut Vec<&'b str>) -> (Cow<'b, str>, &'a [&'b 
     args.insert(0, "/d/c");
     let progname = env::var("ComSpec")
         .map(Cow::from)
-        .unwrap_or_else(|| Cow::from("cmd"));
+        .unwrap_or_else(|_| Cow::from("cmd"));
 
     (progname, &args[..])
 }

--- a/tests/test_env.rs
+++ b/tests/test_env.rs
@@ -2,7 +2,7 @@ use common::util::*;
 
 #[test]
 fn test_env_help() {
-    assert!(new_ucmd!().arg("--help").succeeds().no_stderr().stdout.contains("Options:"));
+    assert!(new_ucmd!().arg("--help").succeeds().no_stderr().stdout.contains("OPTIONS:"));
 }
 
 #[test]


### PR DESCRIPTION
One small step towards #1358.  Apparently we were boxing `Options`, which I assume was leftover from when `Box` was `~`, so this code was very much in need of an update.