### PR TITLE
du: rewrite to use (mostly) working multithreaded directory walker (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +398,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cut"
 version = "0.0.1"
 dependencies = [
@@ -438,6 +507,10 @@ dependencies = [
 name = "du"
 version = "0.0.1"
 dependencies = [
+ "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evmap 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -470,6 +543,15 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "evmap"
+version = "5.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hashbrown 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -601,6 +683,11 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hashbrown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hashsum"
 version = "0.0.1"
 dependencies = [
@@ -623,6 +710,14 @@ version = "0.0.1"
 dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -802,6 +897,11 @@ dependencies = [
 [[package]]
 name = "memchr"
 version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1383,6 +1483,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1637,26 @@ dependencies = [
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "structopt"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "sum"
@@ -1802,6 +1927,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
@@ -2126,6 +2256,7 @@ dependencies = [
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f106c02a3604afcdc0df5d36cc47b44b55917dbaf3d808f71c163a0ddba64637"
@@ -2153,10 +2284,17 @@ dependencies = [
 "checksum cpp_syn 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8cd649bf5b3804d92fe12a60c7698f5a538a6033ed8a668bf5241d4d4f1644e"
 "checksum cpp_synmap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "897e4f9cdbe2874edd3ffe53718ee5d8b89e2a970057b2c93d3214104f2e90b6"
 "checksum cpp_synom 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc8da5694233b646150c785118f77835ad0a49680c7f312a10ef30957c67b6d"
+"checksum crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b14492071ca110999a20bf90e3833406d5d66bfd93b4e52ec9539025ff43fe0d"
+"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
+"checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
+"checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
+"checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
+"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum evmap 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "df2a1ffa17c0e88c8900ae2d994b3ddae7f8d4fa908f5bc93cad72deca6301e9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -2167,6 +2305,8 @@ dependencies = [
 "checksum getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "72327b15c228bfe31f1390f93dd5e9279587f0463836393c9df719ce62a3e450"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9353c2a89d550b58fa0061d8ed8d002a7d8cdf2494eb0e432859bd3a9e543836"
+"checksum hashbrown 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "570178d5e4952010d138b0f1d581271ff3a02406d990f887d1e87e3d6e43b0ac"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4bac95d9aa0624e7b78187d6fb8ab012b41d9f6f54b1bcb61e61c4845f8357ec"
@@ -2180,6 +2320,7 @@ dependencies = [
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47e49f6982987135c5e9620ab317623e723bd06738fd85377e8d55f57c8b6487"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -2224,6 +2365,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
@@ -2234,6 +2376,8 @@ dependencies = [
 "checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
+"checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
@@ -2249,6 +2393,7 @@ dependencies = [
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/src/du/Cargo.toml
+++ b/src/du/Cargo.toml
@@ -3,12 +3,17 @@ name = "du"
 version = "0.0.1"
 authors = []
 build = "../../mkmain.rs"
+edition = "2018"
 
 [lib]
 name = "uu_du"
 path = "du.rs"
 
 [dependencies]
+crossbeam = "0.7"
+evmap = "5.0"
+num_cpus = "1.10"
+structopt = "0.2"
 time = "0.1.40"
 uucore = "0.0.1"
 

--- a/src/du/du.rs
+++ b/src/du/du.rs
@@ -4,24 +4,24 @@
  * This file is part of the uutils coreutils package.
  *
  * (c) Derek Chiang <derekchiang93@gmail.com>
+ * (c) Alex Lyon <arcterus@mail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-extern crate time;
+extern crate structopt;
 
 #[macro_use]
 extern crate uucore;
 
-use std::collections::HashSet;
 use std::env;
-use std::fs;
-use std::io::{stderr, Result, Write};
-use std::iter;
-use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
-use time::Timespec;
+use structopt::{StructOpt, clap::{AppSettings, arg_enum}};
+
+use walker::DuWalker;
+
+mod walker;
 
 const NAME: &str = "du";
 const SUMMARY: &str = "estimate file space usage";
@@ -36,222 +36,128 @@ const LONG_HELP: &str = "
  ers of 1000).
 ";
 
-// TODO: Suport Z & Y (currently limited by size of u64)
-const UNITS: [(char, u32); 6] = [('E', 6), ('P', 5), ('T', 4), ('G', 3), ('M', 2), ('K', 1)];
+const UNITS: [(char, u32); 8] = [('Y', 8), ('Z', 7), ('E', 6), ('P', 5), ('T', 4), ('G', 3), ('M', 2), ('K', 1)];
 
+arg_enum! {
+    #[derive(Debug, Clone, Copy)]
+    enum TimeStrategy {
+        Atime,
+        Access,
+        Use,
+        Ctime,
+        Status,
+    }
+}
+
+arg_enum! {
+    #[derive(Debug, Clone, Copy)]
+    enum TimeFormat {
+        FullIso,
+        LongIso,
+        Iso,
+    }
+}
+
+#[derive(StructOpt, Debug)]
+struct SizeFormat {
+    /// Print sizes in human readable format (e.g., 1K 234M 2G)
+    #[structopt(short = "h", long = "human-readable")]
+    human_readable: bool,
+
+    /// Like -h, but use powers of 1000 not 1024
+    #[structopt(long = "si", raw(overrides_with = r#""human-readable""#))]
+    si: bool,
+}
+
+#[derive(StructOpt, Debug)]
+struct BlockSize {
+    /// Scale sizes by SIZE before printing them.  For example, '-BM' prints sizes in units of
+    /// 1,048,576 bytes.  See SIZE format below
+    #[structopt(short = "B", long = "block-size", parse(try_from_str = "unit_string_to_number"))]
+    block_size: Option<u128>,
+
+    /// Like --block-size=1K
+    #[structopt(short = "k", overrides_with = r#""mega""#)]
+    kilo: bool,
+
+    /// Like --block-size=1M
+    #[structopt(short = "m", overrides_with = r#""kilo""#)]
+    mega: bool,
+}
+
+// FIXME: check for all needed overrides/conflicts
+#[derive(StructOpt, Debug)]
+#[structopt(raw(name = "NAME", setting = "AppSettings::AllArgsOverrideSelf"))]
 struct Options {
+    /// Write counts for all files, not just directories
+    #[structopt(short = "a", long = "all", conflicts_with = "summarize")]
     all: bool,
-    program_name: String,
-    max_depth: Option<usize>,
+
+    /// Print apparent sizes, rather than disk usage.  Although the apparent size is usually
+    /// smaller, it may be larger due to holes in ('sparse') files, internal fragmentation,
+    /// indirect blocks, and the like
+    #[structopt(long = "apparent-size")]
+    apparent_size: bool,
+
+    #[structopt(flatten)]
+    block_size: BlockSize,
+
+    #[structopt(flatten)]
+    size_format: SizeFormat,
+
+    // XXX: it would be nice if there's a way to set this automatically
+    /// Equivalent to '--apparent-size --block-size=1'
+    #[structopt(short = "b", long = "bytes", raw(overrides_with = r#""block_size""#))]
+    bytes: bool,
+
+    /// Produce a grand total
+    #[structopt(short = "c", long = "total")]
     total: bool,
+
+    /// Count sizes many times if hard-linked
+    #[structopt(short = "l", long = "count-links")]
+    count_links: bool,
+
+    /// End each output line with 0 byte rather than newline
+    #[structopt(short = "0", long = "null")]
+    null: bool,
+
+    /// Do not include the size of subdirectories
+    #[structopt(short = "S", long = "separate-dirs")]
     separate_dirs: bool,
+
+    /// Display only a total for each argument
+    #[structopt(short = "s", long = "summarize", conflicts_with = "max_depth")]
+    summarize: bool,
+
+    /// Print the total for a directory (or file, with --all) only if it is N or fewer levels below
+    /// the command line argument; --max-depth=0 is the same as --summarize
+    #[structopt(short = "d", long = "max-depth", parse(try_from_str))]
+    max_depth: Option<usize>,
+
+    // FIXME: this is broken, needs to handle case where no option is given (i.e. just "--time" is given), which
+    //        should make the time strategy use mtime instead of atime/ctime
+    /// Show time of the last modification of any file in the directory, or any of its
+    /// subdirectories.  If WORD is given, show time as WORD instead of modification time: atime,
+    /// access, use, ctime or status
+    #[structopt(long = "time", raw(possible_values = "&TimeStrategy::variants()"), case_insensitive = true)]
+    time: Option<TimeStrategy>,
+
+    // FIXME: need to implement +FORMAT
+    /// Show times using style STYLE: full-iso, long-iso, iso, +FORMAT (where FORMAT is interpreted
+    /// like 'date'; the +FORMAT functionality is NOT IMPLEMENTED)
+    #[structopt(long = "time-style", min_values = 0, raw(possible_values = "&TimeFormat::variants()"), case_insensitive = true)]
+    time_style: Option<TimeFormat>,
+
+    /// Search through directories using COUNT threads.  If COUNT is 0, the default number of
+    /// threads will be used
+    #[structopt(long = "thread-count", default_value = "0", parse(try_from_str))]
+    thread_count: usize,
+
+    #[structopt(multiple = true, parse(from_os_str))]
+    files: Vec<PathBuf>,
 }
 
-struct Stat {
-    path: PathBuf,
-    is_dir: bool,
-    size: u64,
-    blocks: u64,
-    inode: u64,
-    created: u64,
-    accessed: u64,
-    modified: u64,
-}
-
-impl Stat {
-    fn new(path: PathBuf) -> Result<Stat> {
-        let metadata = fs::symlink_metadata(&path)?;
-        Ok(Stat {
-            path,
-            is_dir: metadata.is_dir(),
-            size: metadata.len(),
-            blocks: metadata.blocks() as u64,
-            inode: metadata.ino() as u64,
-            created: metadata.mtime() as u64,
-            accessed: metadata.atime() as u64,
-            modified: metadata.mtime() as u64,
-        })
-    }
-}
-
-fn unit_string_to_number(s: &str) -> Option<u64> {
-    let mut offset = 0;
-    let mut s_chars = s.chars().rev();
-
-    let (mut ch, multiple) = match s_chars.next() {
-        Some('B') | Some('b') => ('B', 1000u64),
-        Some(ch) => (ch, 1024u64),
-        None => return None,
-    };
-    if ch == 'B' {
-        ch = s_chars.next()?;
-        offset += 1;
-    }
-    ch = ch.to_ascii_uppercase();
-
-    let unit = UNITS
-        .iter()
-        .rev()
-        .find(|&&(unit_ch, _)| unit_ch == ch)
-        .map(|&(_, val)| {
-            // we found a match, so increment offset
-            offset += 1;
-            val
-        })
-        .or_else(|| if multiple == 1024 { Some(0) } else { None })?;
-
-    let number = s[..s.len() - offset].parse::<u64>().ok()?;
-
-    Some(number * multiple.pow(unit))
-}
-
-fn translate_to_pure_number(s: &Option<String>) -> Option<u64> {
-    match *s {
-        Some(ref s) => unit_string_to_number(s),
-        None => None,
-    }
-}
-
-fn read_block_size(s: Option<String>) -> u64 {
-    match translate_to_pure_number(&s) {
-        Some(v) => v,
-        None => {
-            if let Some(value) = s {
-                show_error!("invalid --block-size argument '{}'", value);
-            };
-
-            for env_var in &["DU_BLOCK_SIZE", "BLOCK_SIZE", "BLOCKSIZE"] {
-                if let Some(quantity) = translate_to_pure_number(&env::var(env_var).ok()) {
-                    return quantity;
-                }
-            }
-
-            if env::var("POSIXLY_CORRECT").is_ok() {
-                512
-            } else {
-                1024
-            }
-        }
-    }
-}
-
-// this takes `my_stat` to avoid having to stat files multiple times.
-// XXX: this should use the impl Trait return type when it is stabilized
-fn du(
-    mut my_stat: Stat,
-    options: &Options,
-    depth: usize,
-    inodes: &mut HashSet<u64>,
-) -> Box<DoubleEndedIterator<Item = Stat>> {
-    let mut stats = vec![];
-    let mut futures = vec![];
-
-    if my_stat.is_dir {
-        let read = match fs::read_dir(&my_stat.path) {
-            Ok(read) => read,
-            Err(e) => {
-                safe_writeln!(
-                    stderr(),
-                    "{}: cannot read directory ‘{}‘: {}",
-                    options.program_name,
-                    my_stat.path.display(),
-                    e
-                );
-                return Box::new(iter::once(my_stat));
-            }
-        };
-
-        for f in read {
-            match f {
-                Ok(entry) => {
-                    match Stat::new(entry.path()) {
-                        Ok(this_stat) => {
-                            if this_stat.is_dir {
-                                futures.push(du(this_stat, options, depth + 1, inodes));
-                            } else {
-                                if inodes.contains(&this_stat.inode) {
-                                    continue;
-                                }
-                                inodes.insert(this_stat.inode);
-                                my_stat.size += this_stat.size;
-                                my_stat.blocks += this_stat.blocks;
-                                if options.all {
-                                    stats.push(this_stat);
-                                }
-                            }
-                        }
-                        Err(error) => show_error!("{}", error),
-                    }
-                }
-                Err(error) => show_error!("{}", error),
-            }
-        }
-    }
-
-    stats.extend(futures.into_iter().flat_map(|val| val).rev().filter_map(
-        |stat| {
-            if !options.separate_dirs && stat.path.parent().unwrap() == my_stat.path {
-                my_stat.size += stat.size;
-                my_stat.blocks += stat.blocks;
-            }
-            if options.max_depth == None || depth < options.max_depth.unwrap() {
-                Some(stat)
-            } else {
-                None
-            }
-        },
-    ));
-    stats.push(my_stat);
-    Box::new(stats.into_iter())
-}
-
-fn convert_size_human(size: u64, multiplier: u64, _block_size: u64) -> String {
-    for &(unit, power) in &UNITS {
-        let limit = multiplier.pow(power);
-        if size >= limit {
-            return format!("{:.1}{}", (size as f64) / (limit as f64), unit);
-        }
-    }
-    format!("{}B", size)
-}
-
-fn convert_size_b(size: u64, _multiplier: u64, _block_size: u64) -> String {
-    format!("{}", ((size as f64) / (1 as f64)).ceil())
-}
-
-fn convert_size_k(size: u64, multiplier: u64, _block_size: u64) -> String {
-    format!("{}", ((size as f64) / (multiplier as f64)).ceil())
-}
-
-fn convert_size_m(size: u64, multiplier: u64, _block_size: u64) -> String {
-    format!("{}", ((size as f64) / ((multiplier * multiplier) as f64)).ceil())
-}
-
-fn convert_size_other(size: u64, _multiplier: u64, block_size: u64) -> String {
-    format!("{}", ((size as f64) / (block_size as f64)).ceil())
-}
-
-pub fn uumain(args: Vec<String>) -> i32 {
-    let syntax = format!(
-        "[OPTION]... [FILE]...
- {0} [OPTION]... --files0-from=F",
-        NAME
-    );
-    let matches = new_coreopts!(&syntax, SUMMARY, LONG_HELP)
-    // In task
-        .optflag("a", "all", " write counts for all files, not just directories")
-    // In main
-        .optflag("", "apparent-size", "print apparent sizes,  rather  than  disk  usage
-            although  the apparent  size is usually smaller, it may be larger due to holes
-            in ('sparse') files, internal  fragmentation,  indirect  blocks, and the like")
-    // In main
-        .optopt("B", "block-size", "scale sizes  by  SIZE before printing them.
-            E.g., '-BM' prints sizes in units of 1,048,576 bytes.  See SIZE format below.",
-            "SIZE")
-    // In main
-        .optflag("b", "bytes", "equivalent to '--apparent-size --block-size=1'")
-    // In main
-        .optflag("c", "total", "produce a grand total")
     // In task
     // opts.optflag("D", "dereference-args", "dereference only symlinks that are listed
     //     on the command line"),
@@ -261,90 +167,130 @@ pub fn uumain(args: Vec<String>) -> i32 {
     //                   If F is - then read names from standard input", "F"),
     // // In task
     // opts.optflag("H", "", "equivalent to --dereference-args (-D)"),
-    // In main
-        .optflag("h", "human-readable", "print sizes in human readable format (e.g., 1K 234M 2G)")
-    // In main
-        .optflag("", "si", "like -h, but use powers of 1000 not 1024")
-    // In main
-        .optflag("k", "", "like --block-size=1K")
-    // In task
-        .optflag("l", "count-links", "count sizes many times if hard linked")
-    // // In main
-        .optflag("m", "", "like --block-size=1M")
     // // In task
     // opts.optflag("L", "dereference", "dereference all symbolic links"),
     // // In task
     // opts.optflag("P", "no-dereference", "don't follow any symbolic links (this is the default)"),
-    // // In main
-        .optflag("0", "null", "end each output line with 0 byte rather than newline")
-    // In main
-        .optflag("S", "separate-dirs", "do not include size of subdirectories")
-    // In main
-        .optflag("s", "summarize", "display only a total for each argument")
     // // In task
     // opts.optflag("x", "one-file-system", "skip directories on different file systems"),
     // // In task
     // opts.optopt("X", "exclude-from", "exclude files that match any pattern in FILE", "FILE"),
     // // In task
     // opts.optopt("", "exclude", "exclude files that match PATTERN", "PATTERN"),
-    // In main
-        .optopt("d", "max-depth", "print the total for a directory (or file, with --all)
-            only if it is N or fewer levels below the command
-            line argument;  --max-depth=0 is the same as --summarize", "N")
-    // In main
-        .optflagopt("", "time", "show time of the last modification of any file in the
-            directory, or any of its subdirectories.  If WORD is given, show time as WORD instead
-            of modification time: atime, access, use, ctime or status", "WORD")
-    // In main
-        .optopt("", "time-style", "show times using style STYLE:
-            full-iso, long-iso, iso, +FORMAT FORMAT is interpreted like 'date'", "STYLE")
-        .parse(args);
 
-    let summarize = matches.opt_present("summarize");
-
-    let max_depth_str = matches.opt_str("max-depth");
-    let max_depth = max_depth_str.as_ref().and_then(|s| s.parse::<usize>().ok());
-    match (max_depth_str, max_depth) {
-        (Some(ref s), _) if summarize => {
-            show_error!("summarizing conflicts with --max-depth={}", *s);
-            return 1;
+fn retrieve_default_block_size() -> u128 {
+    for env_var in &["DU_BLOCK_SIZE", "BLOCK_SIZE", "BLOCKSIZE"] {
+        if let Some(quantity) = translate_to_pure_number(&env::var(env_var).ok()) {
+            return quantity;
         }
-        (Some(ref s), None) => {
-            show_error!("invalid maximum depth '{}'", *s);
-            return 1;
-        }
-        (Some(_), Some(_)) | (None, _) => { /* valid */ }
     }
 
-    let options = Options {
-        all: matches.opt_present("all"),
-        program_name: NAME.to_owned(),
-        max_depth,
-        total: matches.opt_present("total"),
-        separate_dirs: matches.opt_present("S"),
-    };
-
-    let strs = if matches.free.is_empty() {
-        vec!["./".to_owned()]
+    if env::var("POSIXLY_CORRECT").is_ok() {
+        512
     } else {
-        matches.free.clone()
+        1024
+    }
+}
+
+fn split_number_and_scale(s: &str, idx: usize) -> Option<(&str, u128)> {
+    let (number_s, suffix) = s.split_at(idx);
+
+    let first_ch = suffix.chars().next()?.to_ascii_uppercase();
+
+    // search for the unit (e.g. the "K" in "KiB") in the given suffix
+    let unit = UNITS
+        .iter()
+        .rev()
+        .find_map(|&(unit_ch, val)| {
+            if unit_ch == first_ch {
+                Some(val)
+            } else {
+                None
+            }
+        });
+
+    let scale = if let Some(unit) = unit {
+        // check for multiplier modifiers
+        let multiple: u128 = match &suffix[1..] {
+            "iB" | "" => 1024,
+            "B" | "b" => 1000,
+            _ => return None,
+        };
+        multiple.pow(unit)
+    } else if first_ch == 'B' && suffix.len() == 1 {
+        1000
+    } else {
+        return None
     };
 
-    let block_size = read_block_size(matches.opt_str("block-size"));
+    Some((number_s, scale))
+}
 
-    let multiplier: u64 = if matches.opt_present("si") {
+fn unit_string_to_number(s: &str) -> Result<u128, String> {
+    let (number_s, scale) = match s.rfind(|ch: char| ch.is_digit(10)) {
+        Some(idx) if idx + 1 < s.len() => split_number_and_scale(s, idx + 1)
+            .ok_or_else(|| format!("invalid suffix: {}", &s[idx + 1..]))?,
+        _ => (s, 1),
+    };
+
+    let number = number_s.parse::<u128>().map_err(|e| format!("{}", e))?;
+
+    Ok(number * scale)
+}
+
+fn translate_to_pure_number(s: &Option<String>) -> Option<u128> {
+    s.as_ref().and_then(|s| unit_string_to_number(&s).ok())
+}
+
+fn convert_size_human(size: u64, multiplier: u64, _block_size: u128) -> String {
+    for &(unit, power) in &UNITS {
+        let limit = multiplier.pow(power);
+        if size >= limit {
+            return format!("{:.1}{}", (size as f64) / (limit as f64), unit);
+        }
+    }
+    format!("{}B", size)
+}
+
+fn convert_size_b(size: u64, _multiplier: u64, _block_size: u128) -> String {
+    format!("{}", ((size as f64) / (1 as f64)).ceil())
+}
+
+fn convert_size_k(size: u64, multiplier: u64, _block_size: u128) -> String {
+    format!("{}", ((size as f64) / (multiplier as f64)).ceil())
+}
+
+fn convert_size_m(size: u64, multiplier: u64, _block_size: u128) -> String {
+    format!("{}", ((size as f64) / ((multiplier * multiplier) as f64)).ceil())
+}
+
+fn convert_size_other(size: u64, _multiplier: u64, block_size: u128) -> String {
+    format!("{}", ((size as f64) / (block_size as f64)).ceil())
+}
+
+pub fn uumain(args: Vec<String>) -> i32 {
+    let mut options = Options::from_iter(args);
+
+    if options.files.is_empty() {
+        // FIXME: does this print correctly if we drop the trailing slash?
+        options.files.push(PathBuf::from("./"));
+    }
+
+    let block_size = options.block_size.block_size.unwrap_or_else(retrieve_default_block_size);
+
+    let multiplier: u64 = if options.size_format.si {
         1000
     } else {
         1024
     };
     let convert_size_fn = {
-        if matches.opt_present("human-readable") || matches.opt_present("si") {
+        if options.size_format.human_readable || options.size_format.si {
             convert_size_human        
-        } else if matches.opt_present("b") {
+        } else if options.bytes {
             convert_size_b
-        } else if matches.opt_present("k") {
+        } else if options.block_size.kilo {
             convert_size_k
-        } else if matches.opt_present("m") {
+        } else if options.block_size.mega {
             convert_size_m
         } else {
             convert_size_other
@@ -352,106 +298,26 @@ pub fn uumain(args: Vec<String>) -> i32 {
     };
     let convert_size = |size| convert_size_fn(size, multiplier, block_size);
 
-    let time_format_str = match matches.opt_str("time-style") {
-        Some(s) => {
-            match &s[..] {
-                "full-iso" => "%Y-%m-%d %H:%M:%S.%f %z",
-                "long-iso" => "%Y-%m-%d %H:%M",
-                "iso" => "%Y-%m-%d",
-                _ => {
-                    show_error!(
-                        "invalid argument '{}' for 'time style'
-Valid arguments are:
-- 'full-iso'
-- 'long-iso'
-- 'iso'
-Try '{} --help' for more information.",
-                        s,
-                        NAME
-                    );
-                    return 1;
-                }
-            }
-        }
-        None => "%Y-%m-%d %H:%M",
-    };
-
-    let line_separator = if matches.opt_present("0") { "\0" } else { "\n" };
+    let line_separator = if options.null { "\0" } else { "\n" };
 
     let mut grand_total = 0;
-    for path_str in strs {
-        let path = PathBuf::from(&path_str);
-        match Stat::new(path) {
-            Ok(stat) => {
-                let mut inodes: HashSet<u64> = HashSet::new();
+    for path in &options.files {
+        // FIXME: obviously needs cleanup, as does all the command-line parsing stuff
+        // FIXME: figure out how not to clone this
 
-                let iter = du(stat, &options, 0, &mut inodes);
-                let (_, len) = iter.size_hint();
-                let len = len.unwrap();
-                for (index, stat) in iter.enumerate() {
-                    let size = if matches.opt_present("apparent-size") {
-                        stat.size
-                    } else if matches.opt_present("b") {
-                        stat.size
-                    } else {
-                        // C's stat is such that each block is assume to be 512 bytes
-                        // See: http://linux.die.net/man/2/stat
-                        stat.blocks * 512
-                    };
-                    if matches.opt_present("time") {
-                        let tm = {
-                            let (secs, nsecs) = {
-                                let time = match matches.opt_str("time") {
-                                    Some(s) => {
-                                        match &s[..] {
-                                            "accessed" => stat.accessed,
-                                            "created" => stat.created,
-                                            "modified" => stat.modified,
-                                            _ => {
-                                                show_error!(
-                                                    "invalid argument 'modified' for '--time'
-    Valid arguments are:
-      - 'accessed', 'created', 'modified'
-    Try '{} --help' for more information.",
-                                                    NAME
-                                                );
-                                                return 1;
-                                            }
-                                        }
-                                    }
-                                    None => stat.modified,
-                                };
-                                ((time / 1000) as i64, (time % 1000 * 1_000_000) as i32)
-                            };
-                            time::at(Timespec::new(secs, nsecs))
-                        };
-                        if !summarize || index == len - 1 {
-                            let time_str = tm.strftime(time_format_str).unwrap();
-                            print!(
-                                "{}\t{}\t{}{}",
-                                convert_size(size),
-                                time_str,
-                                stat.path.display(),
-                                line_separator
-                            );
-                        }
-                    } else if !summarize || index == len - 1 {
-                        print!(
-                            "{}\t{}{}",
-                            convert_size(size),
-                            stat.path.display(),
-                            line_separator
-                        );
-                    }
-                    if options.total && index == (len - 1) {
-                        // The last element will be the total size of the the path under
-                        // path_str.  We add it to the grand total.
-                        grand_total += size;
-                    }
-                }
-            }
+        // FIXME!!!!: this does not work if the given path is a file, not a directory
+        let walker = match DuWalker::new(path.clone(), &options, convert_size) {
+            Ok(walker) => walker,
+            // XXX: should we actually show the error?
             Err(_) => {
-                show_error!("{}: {}", path_str, "No such file or directory");
+                show_error!("{}: {}", path.display(), "No such file or directory");
+                continue;
+            }
+        };
+
+        if let Some(size) = walker.run() {
+            if options.total {
+                grand_total += size;
             }
         }
     }

--- a/src/du/walker.rs
+++ b/src/du/walker.rs
@@ -1,0 +1,592 @@
+use crate::{Options, TimeFormat, TimeStrategy};
+
+use crossbeam::channel;
+use time::Timespec;
+
+use std::collections::{HashSet, HashMap};
+use std::collections::hash_map::Entry as HashMapEntry;
+use std::fs::{self, DirEntry, Metadata};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::os::unix::fs::MetadataExt;
+use std::sync::{Arc, Mutex};
+
+// XXX: this has not been tuned much at all
+const MAX_MESSAGES: usize = 1024 * 64;
+const MAX_DEFAULT_THREADS: usize = 8;
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+struct FileID {
+    device: u64,
+    inode: u64,
+}
+
+impl From<&Metadata> for FileID {
+    fn from(metadata: &Metadata) -> FileID {
+        FileID {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct Stat {
+    size: u64,
+    blocks: u64,
+    /// Either time of last status change, access, or modification for file
+    time: u64,
+}
+
+impl Stat {
+    fn new(metadata: &Metadata, options: &Options) -> Stat {
+        // FIXME: this doesn't work quite right because "--time" is not handled
+        let time = match options.time {
+            Some(strat) => match strat {
+                // time of last status change for file
+                TimeStrategy::Ctime | TimeStrategy::Status | TimeStrategy::Use => metadata.ctime(),
+                // time of last access for file
+                TimeStrategy::Atime | TimeStrategy::Access => metadata.atime(),
+            },
+            // time of last modification for file
+            None => metadata.mtime()
+        } as u64;
+
+        Stat {
+            size: metadata.len(),
+            blocks: metadata.blocks() as u64,
+            time,
+        }
+    }
+}
+
+// NOTE: this is non-commutative because "time" will be the same as that of self
+impl Add for Stat {
+    type Output = Stat;
+
+    fn add(self, other: Stat) -> Stat {
+        Stat {
+            size: self.size + other.size,
+            blocks: self.blocks + other.blocks,
+            time: self.time,
+        }
+    }
+}
+
+// NOTE: same as for Add
+impl AddAssign for Stat {
+    fn add_assign(&mut self, other: Stat) {
+        *self = *self + other;
+    }
+}
+
+// NOTE: same as for Add
+impl Sub for Stat {
+    type Output = Stat;
+
+    fn sub(self, other: Stat) -> Stat {
+        Stat {
+            size: self.size - other.size,
+            blocks: self.blocks - other.blocks,
+            time: self.time,
+        }
+    }
+}
+
+// NOTE: same as for Add
+impl SubAssign for Stat {
+    fn sub_assign(&mut self, other: Stat) {
+        *self = *self - other;
+    }
+}
+
+// XXX: should try to reduce the size of the messages
+enum IoMessage {
+    RegisterParent {
+        dir_id: FileID,
+        parent_id: Option<FileID>,
+        path: PathBuf,
+        stat: Stat,
+        subdir_count: usize,
+        depth: usize,
+    },
+    FinishedFiles {
+        files: Vec<(PathBuf, Stat)>,
+    },
+    FinishedDir {
+        path: PathBuf,
+        stat: Stat,
+        parent_id: Option<FileID>,
+        depth: usize,
+    },
+    CouldNotReadDir {
+        path: PathBuf,
+        stat: Stat,
+        parent_id: Option<FileID>,
+        depth: usize,
+        err: io::Error,
+    },
+    FailedToGetMetadata {
+        path: PathBuf,
+        err: io::Error,
+    },
+    InvalidEntry {
+        err: io::Error,
+    },
+}
+
+enum TraversalMessage {
+    Subdir {
+        path: PathBuf,
+        metadata: Metadata,
+        parent_id: Option<FileID>,
+        depth: usize,
+    },
+    Done,
+}
+
+pub(crate) struct DuWalker<'a, F: Send + Sync + Fn(u64) -> String> {
+    path: PathBuf,
+    metadata: Metadata,
+    convert_size: F,
+    options: &'a Options,
+    thread_count: usize,
+}
+
+// XXX: it would be great to keep the threads running after run() (and take &self or something
+//      instead of self) so we don't have to spin them up again when we begin trawling through
+//      the directories
+impl<'a, F: Send + Sync + Fn(u64) -> String> DuWalker<'a, F> {
+    pub fn new(path: PathBuf, options: &'a Options, convert_size: F) -> io::Result<Self> {
+        // XXX: maybe this should be given a path and metadata?  only work for directories?
+        let metadata = fs::symlink_metadata(&path)?;
+
+        let mut thread_count = options.thread_count;
+        if thread_count == 0 {
+            thread_count = num_cpus::get().min(MAX_DEFAULT_THREADS);
+        }
+        if thread_count > 1 {
+            // the current thread should already be taking up one of the threads
+            thread_count -= 1;
+        }
+
+        Ok(Self {
+            path,
+            metadata,
+            options,
+            convert_size,
+            thread_count,
+        })
+    }
+
+    pub fn run(self) -> Option<u64> {
+        // XXX: should probably test if unbounded or bounded work better
+        let (io_tx, io_rx) = channel::bounded(MAX_MESSAGES);
+        let (subdir_tx, subdir_rx) = channel::unbounded();
+
+        let path = self.path;
+        let options = self.options;
+        let metadata = self.metadata;
+        let convert_size = self.convert_size;
+        let thread_count = self.thread_count;
+
+        let ids = Arc::new(Mutex::new(HashSet::new()));
+
+        // TODO: check if the given file is NOT a directory, if so, either just print the data for
+        //       the file by spawning the IoWorker and NOT spawning the TraversalWorkers, or just
+        //       print directly
+
+        crossbeam::scope(|s| {
+            // FIXME: the number of threads should perhaps be less than the number of cpus?  i/o bound
+            for _ in 0..thread_count {
+                s.spawn(|_| {
+                    let worker = TraversalWorker::new(options, ids.clone(), &subdir_rx, &subdir_tx, &io_tx);
+                    worker.walk();
+
+                    // if we get here we need to send another "Done" message to ensure all the
+                    // threads exit
+                    subdir_tx.send(TraversalMessage::Done);
+                });
+            }
+
+            subdir_tx.send(TraversalMessage::Subdir {
+                path: path.clone(),
+                metadata,
+                parent_id: None,
+                depth: 0,
+            });
+
+            // XXX: not sure but it might be best to spawn several IoWorkers and synchronize them
+            //      somehow (or just limit the number of TraversalWorkers to prevent them from just
+            //      flooding the IoWorker with data)
+            let io_worker = IoWorker::new(path, io_rx, options, convert_size);
+            let maybe_stat = io_worker.run();
+
+            subdir_tx.send(TraversalMessage::Done);
+
+            maybe_stat.map(|stat| stat.size)
+        }).unwrap()
+    }
+}
+
+struct TraversalWorker<'a> {
+    subdir_rx: &'a channel::Receiver<TraversalMessage>,
+    subdir_tx: &'a channel::Sender<TraversalMessage>,
+    io_tx: &'a channel::Sender<IoMessage>,
+
+    options: &'a Options,
+    ids: Arc<Mutex<HashSet<FileID>>>,
+}
+
+// FIXME: i believe this overflows due to the large amount of data stored and the continuous
+//        recursion.  one way around this might be to create another set of channels so we
+//        can just push subdirectories into the write channel to be processed by another thread
+//        waiting for data from a read channel.  unsure how to handle ids and the FinishedDir
+//        message in this case, however
+impl<'a> TraversalWorker<'a> {
+    pub fn new(options: &'a Options, ids: Arc<Mutex<HashSet<FileID>>>, subdir_rx: &'a channel::Receiver<TraversalMessage>, subdir_tx: &'a channel::Sender<TraversalMessage>, io_tx: &'a channel::Sender<IoMessage>) -> Self {
+        Self {
+            subdir_rx,
+            subdir_tx,
+            io_tx,
+
+            options,
+            ids,
+        }
+    }
+
+    pub fn walk(mut self) {
+        for msg in self.subdir_rx {
+            match msg {
+                TraversalMessage::Subdir { path, metadata, parent_id, depth } => {            
+                    if let Err(msg) = self.walk_helper(path, metadata, parent_id, depth) {
+                        self.io_tx.send(msg);
+                    }
+                }
+                TraversalMessage::Done => break,
+            }
+        }
+    }
+
+    fn walk_helper(&mut self, path: PathBuf, metadata: Metadata, parent_id: Option<FileID>, depth: usize) -> Result<(), IoMessage> {
+        let mut stat = Stat::new(&metadata, self.options);
+
+        // FIXME: avoid this clone
+        let dir_iter = fs::read_dir(&path)
+            .map_err(|e| IoMessage::CouldNotReadDir {
+                path: path.clone(),
+                stat,
+                parent_id,
+                depth,
+                err: e
+            })?;
+
+        let mut dirs = vec![];
+        let mut possible_dups = vec![];
+        let mut files = if self.options.all {
+            vec![]
+        } else {
+            Vec::with_capacity(0)
+        };
+
+        for f in dir_iter {
+            match self.handle_entry(f, &mut dirs, &mut possible_dups, &mut files) {
+                Ok(Some(file_stat)) => {
+                    stat += file_stat;
+                }
+                Ok(None) => {}
+                Err(msg) => {
+                    self.io_tx.send(msg);
+                }
+            }
+        }
+
+        // XXX: this likely hinders performance, so it would be nice to have some sort of lockfree
+        //      hashset
+        {
+            let mut ids = self.ids.lock().unwrap();
+            for (dup_id, dup_stat) in possible_dups {
+                if !ids.insert(dup_id) {
+                    // this was indeed a file we have already seen, adjust the directory's stat
+                    // accordingly
+                    stat -= dup_stat;
+                }
+            }
+        }
+
+        // send the files in the current directory off to be displayed if "--all" was given and the
+        // depth is fine
+        if files.len() > 0 && is_valid_depth(self.options, depth) {
+            self.io_tx.send(IoMessage::FinishedFiles { files });
+        }
+
+        if dirs.len() > 0 {
+            let dir_id = FileID::from(&metadata);
+            self.io_tx.send(IoMessage::RegisterParent {
+                dir_id,
+                parent_id,
+                path,
+                stat,
+                subdir_count: dirs.len(),
+                depth,
+            });
+
+            for (dir_path, dir_metadata) in dirs {
+                self.subdir_tx.send(TraversalMessage::Subdir {
+                    path: dir_path,
+                    metadata: dir_metadata,
+                    parent_id: Some(dir_id),
+                    depth: depth + 1,
+                });
+            }
+        } else {
+            self.io_tx.send(IoMessage::FinishedDir {
+                path,
+                stat,
+                parent_id,
+                depth,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn handle_entry(
+        &mut self,
+        f: io::Result<DirEntry>,
+        dirs: &mut Vec<(PathBuf, Metadata)>,
+        possible_dups: &mut Vec<(FileID, Stat)>,
+        files: &mut Vec<(PathBuf, Stat)>,
+    ) -> Result<Option<Stat>, IoMessage> {
+        let entry = f.map_err(|e| IoMessage::InvalidEntry { err: e })?;
+
+        let metadata = entry.metadata()
+            .map_err(|e| IoMessage::FailedToGetMetadata {
+                path: entry.path(),
+                err: e,
+            })?;
+
+        if metadata.is_dir() {
+            dirs.push((entry.path(), metadata));
+
+            Ok(None)
+        } else {
+            let file_stat = Stat::new(&metadata, self.options);
+
+            // NOTE: pushing here for later rather than checking the HashSet to try to avoid some
+            //       lock contention (if we had a lockfree HashSet, we could probably perform the
+            //       check here)
+            if metadata.is_file() && metadata.nlink() > 1 {
+                let file_id = FileID::from(&metadata);
+                possible_dups.push((file_id, file_stat));
+            }
+
+            if self.options.all {
+                files.push((entry.path(), file_stat));
+            }
+
+            Ok(Some(file_stat))
+        }
+    }
+}
+
+struct IoWorker<'a, F: Fn(u64) -> String> {
+    root_path: PathBuf,
+    rx: Option<channel::Receiver<IoMessage>>,
+    options: &'a Options,
+    convert_size: F,
+    time_format_str: &'static str,
+    line_separator: &'static str,
+
+    parents: HashMap<FileID, (Option<FileID>, PathBuf, Stat, usize, usize)>,
+    last_stat: Option<Stat>,
+}
+
+impl<'a, F: Fn(u64) -> String> IoWorker<'a, F> {
+    pub fn new(root_path: PathBuf, rx: channel::Receiver<IoMessage>, options: &'a Options, convert_size: F) -> Self {
+        // FIXME: when we accept +FORMAT input, this will have the potential to error probably
+        //        we could just validate when parsing command-line arguments using a clap validator
+        //        potentially to alleviate this issue
+        let time_format_str = options.time_style
+            .map(|style| match style {
+                TimeFormat::FullIso => "%Y-%m-%d %H:%M:%S.%f %z",
+                TimeFormat::LongIso => "%Y-%m-%d %H:%M",
+                TimeFormat::Iso => "%Y-%m-%d",
+            })
+            .unwrap_or("%Y-%m-%d %H:%M");
+
+        // FIXME: currently specified in two places
+        let line_separator = if options.null { "\0" } else { "\n" };
+
+        Self {
+            root_path,
+            rx: Some(rx),
+            options,
+            convert_size,
+            time_format_str,
+            line_separator,
+
+            parents: HashMap::new(),
+            last_stat: None,
+        }
+    }
+
+    pub fn run(mut self) -> Option<Stat> {
+        let stderr_raw = io::stderr();
+        let mut stderr = stderr_raw.lock();
+
+        let stdout_raw = io::stdout();
+        let mut stdout = stdout_raw.lock();
+
+        // NOTE: these branches need to be as fast as possible to ensure they keep up with the
+        //       TraversalWorkers
+        for msg in self.rx.take().unwrap() {
+            match msg {
+                IoMessage::RegisterParent { dir_id, parent_id, path, stat, subdir_count, depth } => {
+                    self.parents.insert(dir_id, (parent_id, path, stat, subdir_count, depth));
+                }
+                IoMessage::FinishedDir { path, stat, parent_id, depth } => {
+                    // display directory info
+                    if is_valid_depth(self.options, depth) {
+                        self.display_entry_info(&mut stdout, &path, &stat);
+                    }
+
+                    // let the parent directory know that its subdirectory finished processing
+                    if self.update_parent(&mut stdout, path, stat, parent_id, depth) {
+                        break;
+                    }
+                }
+                IoMessage::FinishedFiles { files } => {
+                    for (file_path, file_stat) in files {
+                        self.display_entry_info(&mut stdout, &file_path, &file_stat);
+                    }
+                }
+                IoMessage::CouldNotReadDir { path, stat, parent_id, depth, err } => {
+                    safe_writeln!(
+                        stderr,
+                        "{}: cannot read directory ‘{}‘: {}",
+                        //options.program_name,
+                        crate::NAME,
+                        path.display(),
+                        err
+                    );
+
+                    // let the parent directory know that its subdirectory finished processing (in
+                    // this case by failing to be read)
+                    if self.update_parent(&mut stdout, path, stat, parent_id, depth) {
+                        break;
+                    }
+                }
+                IoMessage::FailedToGetMetadata { path, err } => {
+                    safe_writeln!(
+                        stderr,
+                        "{}: failed to retrieve metadata for '{}': {}",
+                        crate::NAME,
+                        path.display(),
+                        err
+                    );
+                }
+                IoMessage::InvalidEntry { err } => {
+                    safe_writeln!(
+                        stderr,
+                        "{}: could not read directory entry: {}",
+                        crate::NAME,
+                        err
+                    );
+                }
+            }
+        }
+
+        self.last_stat
+    }
+
+    // XXX: atm, true is done with everything, false is continue
+    fn update_parent<W: Write>(&mut self, output: &mut W, path: PathBuf, mut stat: Stat, parent_id: Option<FileID>, depth: usize) -> bool {
+        if let Some(mut parent_id) = parent_id {
+            // check if all the subdirectories in the parent directory have been processed
+            // and display stuff for the parent directory if so.  need to loop in case we
+            // finish another directory's contents after doing so
+            while let HashMapEntry::Occupied(mut entry) = self.parents.entry(parent_id) {
+                let (_, _, ref mut parent_stat, ref mut subdir_count, _) = entry.get_mut();
+
+                if !self.options.separate_dirs {
+                    *parent_stat += stat;
+                }
+
+                self.last_stat = Some(*parent_stat);
+
+                if *subdir_count > 1 {
+                    *subdir_count -= 1;
+                    break;
+                } else {
+                    // we have finished processing everything in the parent directory, so display
+                    // the parent directory as well
+                    let (_, (new_parent, parent_path, parent_stat, _, parent_depth)) = entry.remove_entry();
+
+                    match new_parent {
+                        // the parent directory also has a parent directory (the grandparent
+                        // directory), so update that one as well
+                        Some(new_parent) => {
+                            if is_valid_depth(self.options, parent_depth) {
+                                self.display_entry_info(output, &parent_path, &parent_stat);
+                            }
+
+                            parent_id = new_parent;
+                            stat = parent_stat;
+                        }
+                        None => {
+                            // this is the root directory
+                            self.display_entry_info(output, &parent_path, &parent_stat);
+                            return true;
+                        },
+                    }
+                }
+            }
+
+            false
+        } else {
+            // NOTE: i believe this only occurs if the given directory has no subdirectories
+            // this is the root directory
+            if self.options.summarize {
+                if let Some(ref stat) = self.last_stat {
+                    self.display_entry_info(output, &self.root_path, stat);
+                }
+            }
+
+            true
+        }
+    }
+
+    // XXX: this function is questionable and may be contributing to the system-dependent errors
+    fn entry_size(&self, entry_stat: &Stat) -> u64 {
+        if self.options.apparent_size || self.options.bytes {
+            entry_stat.size
+        } else {
+            // C's stat is such that each block is assume to be 512 bytes
+            // See: http://linux.die.net/man/2/stat
+            entry_stat.blocks * 512
+        }
+    }
+
+    fn display_entry_info<W: Write>(&self, output: &mut W, path: &Path, entry_stat: &Stat) {
+        let size = self.entry_size(entry_stat);
+
+        write!(output, "{}\t", (self.convert_size)(size));
+        
+        if let Some(_) = self.options.time {
+            let secs = (entry_stat.time / 1000) as i64;
+            let nsecs = (entry_stat.time % 1000 * 1_000_000) as i32;
+            let tm = time::at(Timespec::new(secs, nsecs));
+
+            let time_str = tm.strftime(self.time_format_str).unwrap();
+            write!(output, "{}\t", time_str);
+        }
+
+        write!(output, "{}{}", path.display(), self.line_separator);
+    }
+}
+
+fn is_valid_depth(options: &Options, depth: usize) -> bool {
+    !options.summarize && (options.max_depth == None || depth <= options.max_depth.unwrap())
+}

--- a/src/env/env.rs
+++ b/src/env/env.rs
@@ -3,6 +3,7 @@
  * This file is part of the uutils coreutils package.
  *
  * (c) Jordi Boggiano <j.boggiano@seld.be>
+ * (c) Alex Lyon <arcterus@mail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -123,6 +124,7 @@ fn create_app() -> App<'static, 'static> {
         .usage(USAGE)
         .after_help(AFTER_HELP)
         .setting(AppSettings::AllowExternalSubcommands)
+        .setting(AppSettings::AllArgsOverrideSelf)
         .arg(Arg::with_name("ignore-environment")
             .short("i")
             .long("ignore-environment")
@@ -223,7 +225,7 @@ fn run_env(args: Vec<String>) -> Result<(), i32> {
     }
 
     // set specified env vars
-    for &(ref name, ref val) in &opts.sets {
+    for &(name, val) in &opts.sets {
         // FIXME: set_var() panics if name is an empty string
         env::set_var(name, val);
     }


### PR DESCRIPTION
### DO NOT MERGE YET!

This is a mostly working rewrite of `du` using `crossbeam` and `structopt` (although I am strongly considering switching to `clap` by itself because I am finding it difficult to get `structopt` to do what I want).  There are a few issues mentioned in #1377, and a few features (such as processing files given on the command-line that are *not* directories) are currently broken.  I am probably going to go through and try to clean up the code some more as well.

However, at this point, I think the code is more or less ready for some feedback if anyone has any.  I am considering adding a flag (or maybe an environment variable?  `POSIXLY_CORRECT` or `GNULY_CORRECT` might work for this) that just resets `du` into (mostly) normal single-threaded behavior, sort of like the `--thread-count` flag I added.

Also, note that I included a couple minor changes to `env` in this commit (one of which is adding my name to the authors, because I refactored pretty much the entire thing).

## Benchmarks

I have some (very unscientific) benchmarks made by running the new version of `du`, the old version of `du`, GNU `du`, and `diskus` on a very large directory on a very overloaded 2012 MacBook Pro.

#### new `du`
```bash
$ time target/release/uutils du -s ~
du: cannot read directory ‘/Users/alex/Library/Preferences/KDE‘: Permission denied (os error 13)
426662684	/Users/alex
target/release/uutils du -s ~  15.49s user 168.16s system 215% cpu 1:25.16 total
```

#### old `du`
```bash
$ time target/release/uutils du -s ~
du: cannot read directory ‘/Users/alex/Library/Preferences/KDE‘: Permission denied (os error 13)
du: cannot read directory ‘/Users/alex/Desktop/coreutils/tmp/coreutils-8.24/gt-deep-1.sh.evGP/t/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k/k‘: Too many open files (os error 24)
426661732	/Users/alex
target/release/uutils du -s ~  13.29s user 110.63s system 51% cpu 4:00.89 total
```

#### GNU `du`
```bash
$ time gdu -s ~
gdu: cannot read directory '/Users/alex/Library/Preferences/KDE': Permission denied
426663172	/Users/alex
gdu -s ~  6.90s user 98.50s system 47% cpu 3:43.24 total
```

#### `diskus`
```bash
$ time diskus ~

thread '<unknown>' has overflowed its stack
fatal runtime error: stack overflow
zsh: abort      diskus ~
diskus ~  1.86s user 27.79s system 428% cpu 6.913 total
```

You'll notice that while `diskus` obviously crashed, the sizes output by the three variations of `du` differ, which is obviously an issue.  I'll try to track down what the cause is, but it may take a bit of time.