### PR TITLE
Implement: "wc: Don't read() if we only need to count number of bytes"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,6 +906,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nl"
 version = "0.0.1"
 dependencies = [
@@ -2052,6 +2064,8 @@ name = "wc"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2196,6 +2210,7 @@ dependencies = [
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
+"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47e49f6982987135c5e9620ab317623e723bd06738fd85377e8d55f57c8b6487"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"

--- a/src/wc/Cargo.toml
+++ b/src/wc/Cargo.toml
@@ -12,6 +12,10 @@ path = "wc.rs"
 getopts = "0.2.18"
 uucore = "0.0.1"
 
+[target.'cfg(unix)'.dependencies]
+nix = "0.14.0"
+libc = "0.2"
+
 [[bin]]
 name = "wc"
 path = "../../uumain.rs"

--- a/src/wc/Cargo.toml
+++ b/src/wc/Cargo.toml
@@ -10,6 +10,7 @@ path = "wc.rs"
 
 [dependencies]
 getopts = "0.2.18"
+quick-error = "1.2.2"
 uucore = "0.0.1"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -142,7 +142,7 @@ impl AddAssign for WordCount {
 }
 
 impl WordCount {
-    fn with_title(self, title: String) -> TitledWordCount {
+    fn with_title<'a>(self, title: &'a str) -> TitledWordCount<'a> {
         return TitledWordCount {
             title: title,
             count: self,
@@ -155,8 +155,8 @@ impl WordCount {
 /// The reason we don't simply include title in the `WordCount` struct is that
 /// it would result in unneccesary copying of `String`.
 #[derive(Debug, Default, Clone)]
-struct TitledWordCount {
-    title: String,
+struct TitledWordCount<'a> {
+    title: &'a str,
     count: WordCount,
 }
 
@@ -398,7 +398,7 @@ fn wc(files: Vec<String>, settings: &Settings) -> WcResult<()> {
             || settings.show_max_line_length
             || settings.show_words));
 
-    for path in files {
+    for path in &files {
         let word_count =
             word_count_from_path(&path, only_need_to_count_bytes).unwrap_or_else(|err| {
                 eprintln!("{}", err);
@@ -415,7 +415,7 @@ fn wc(files: Vec<String>, settings: &Settings) -> WcResult<()> {
     }
 
     if num_files > 1 {
-        let total_result = total_word_count.with_title("total".to_owned());
+        let total_result = total_word_count.with_title("total");
         print_stats(settings, &total_result, max_width);
     }
 

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -48,15 +48,15 @@ quick_error! {
     #[derive(Debug)]
     enum WcError {
         /// Wrapper for io::Error with no context
-        InputOutput(err: io::Error) {
-            display("cat: {0}", err)
+        InputOutput(error: io::Error) {
+            display("wc: {}", error)
             from()
-            cause(err)
+            cause(error)
         }
 
         /// At least one error was encountered in reading or writing
         EncounteredErrors(count: usize) {
-            display("cat: encountered {0} errors", count)
+            display("wc: Encountered {} errors", count)
         }
 
         /// Denotes an error caused by trying to `wc` a directory

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -322,10 +322,19 @@ fn word_count_from_path(path: &String, only_count_bytes: bool) -> WordCount {
         let fpath = Path::new(path);
         if fpath.is_dir() {
             show_info!("{}: is a directory", path);
+        } else {
+            match File::open(path) {
+                Ok(mut reader) => {
+                    return word_count_from_reader(&mut reader, only_count_bytes);
+                }
+                Err(err) => {
+                    show_info!("{}: error when opening while: {}", path, err)
+                }
+            }
         }
-        let mut reader = File::open(path).unwrap();
-        return word_count_from_reader(&mut reader, only_count_bytes);
     }
+
+    WordCount::default()
 }
 
 fn wc(files: Vec<String>, settings: &Settings) -> StdResult<(), i32> {


### PR DESCRIPTION
See #1351

## Benchmarks for splice (28x faster!)
```
[arni][~/OpenSource/coreutils][wc-fstat]% hyperfine "fcat /tmp/largefile | target/release/wc -c" --warmup 10
Benchmark #1: fcat /tmp/largefile | target/release/wc -c
  Time (mean ± σ):      6.007 s ±  0.044 s    [User: 5.639 s, System: 1.018 s]
  Range (min … max):    5.964 s …  6.116 s    10 runs

[arni][~/OpenSource/coreutils][wc-fstat]% cargo build -p wc --release
   Compiling wc v0.0.1 (/sdb/OpenSource/coreutils/src/wc)
    Finished release [optimized] target(s) in 1.38s
[arni][~/OpenSource/coreutils][wc-fstat]% hyperfine "fcat /tmp/largefile | target/release/wc -c" --warmup 10
Benchmark #1: fcat /tmp/largefile | target/release/wc -c
  Time (mean ± σ):     211.3 ms ±   3.2 ms    [User: 53.1 ms, System: 324.2 ms]
  Range (min … max):   205.0 ms … 216.7 ms    14 runs
```