### PR TITLE
ls: fix --color flag

### DIFF
--- a/src/ls/Cargo.toml
+++ b/src/ls/Cargo.toml
@@ -10,6 +10,7 @@ path = "ls.rs"
 
 [dependencies]
 getopts = "0.2.18"
+isatty = "0.1"
 number_prefix = "0.2.8"
 term_grid = "0.1.5"
 termsize = "0.1.6"

--- a/src/ls/ls.rs
+++ b/src/ls/ls.rs
@@ -158,7 +158,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
              directory.  This is especially useful when listing very large directories, \
              since not doing any sorting can be noticeably faster.",
         )
-        .optflag("", "color", "Color output based on file type.")
+        .optflagopt("", "color", "Color output based on file type.", "always|auto|never")
         .parse(args);
 
     list(matches);
@@ -611,7 +611,14 @@ fn display_file_name(
     }
     let mut width = UnicodeWidthStr::width(&*name);
 
-    let color = options.opt_present("color");
+    let color = match options.opt_str("color") {
+        None => true,
+        Some(val) => match val.as_ref() {
+            "always" | "yes" | "force" => true,
+            "auto" | "tty" | "if-tty" => true, /* TODO */
+            "never" | "no" | "none" | _ => false,
+        },
+    };
     let classify = options.opt_present("classify");
     let ext;
 

--- a/src/ls/ls.rs
+++ b/src/ls/ls.rs
@@ -14,6 +14,8 @@ extern crate termsize;
 extern crate time;
 extern crate unicode_width;
 extern crate number_prefix;
+extern crate isatty;
+use isatty::stdout_isatty;
 use number_prefix::{Standalone, Prefixed, decimal_prefix};
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 use time::{strftime, Timespec};
@@ -615,7 +617,7 @@ fn display_file_name(
         None => true,
         Some(val) => match val.as_ref() {
             "always" | "yes" | "force" => true,
-            "auto" | "tty" | "if-tty" => true, /* TODO */
+            "auto" | "tty" | "if-tty" => stdout_isatty(),
             "never" | "no" | "none" | _ => false,
         },
     };

--- a/tests/test_ls.rs
+++ b/tests/test_ls.rs
@@ -11,3 +11,10 @@ fn test_ls_ls_i() {
     new_ucmd!().arg("-i").succeeds();
     new_ucmd!().arg("-il").succeeds();
 }
+
+#[test]
+fn test_ls_ls_color() {
+    new_ucmd!().arg("--color").succeeds();
+    new_ucmd!().arg("--color=always").succeeds();
+    new_ucmd!().arg("--color=never").succeeds();
+}


### PR DESCRIPTION
Hi,

The --color flag did not accept argument like it should have.

I've split this into two commits because I use an additional crate: isatty
Depending on whether you want it, feel free to discard that part, or merge the two commits.

Best regards,