### PR TITLE
base64: tolerate non-utf8 encoded inputs

### DIFF
--- a/src/base64/base_common.rs
+++ b/src/base64/base_common.rs
@@ -12,7 +12,7 @@ use uucore;
 use uucore::encoding::{wrap_print, Data, Format};
 
 use std::fs::File;
-use std::io::{stdin, BufReader, Read};
+use std::io::{Write, stdout, stdin, BufReader, Read};
 use std::path::Path;
 
 pub fn execute(
@@ -84,7 +84,12 @@ fn handle_input<R: Read>(
         wrap_print(&data, encoded);
     } else {
         match data.decode() {
-            Ok(s) => print!("{}", String::from_utf8(s).unwrap()),
+            Ok(s) => {
+                if stdout().write_all(&s).is_err() {
+                    // on windows console, writing invalid utf8 returns an error
+                    crash!(1, "Cannot write non-utf8 data");
+                }
+            },
             Err(_) => crash!(1, "invalid input"),
         }
     }


### PR DESCRIPTION
For inputs that are valid base64 but that encode non-utf8 strings (like
garbage), base64 panicks when trying to unwrap the result from
String::from_utf8().
Instead of interpreting the byte stream as utf8, simply dump the raw
bytes to stdout.

Since the test assert that all io is valid utf8, this does not come with
a unit test. See run() in tests/common/utils.rs.

Eg.
"gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo=" -> ">(Iľ^Z\/S"