### PR TITLE
Add -o/--operating-system flag

### DIFF
--- a/src/uname/uname.rs
+++ b/src/uname/uname.rs
@@ -63,7 +63,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
             .short("s")
             .long(OPT_KERNELNAME)
             .alias("sysname") // Obsolescent option in GNU uname
-            .help("print the operating system name."))
+            .help("print the kernel name."))
         .arg(Arg::with_name(OPT_NODENAME)
             .short("n")
             .long(OPT_NODENAME)
@@ -91,6 +91,10 @@ pub fn uumain(args: Vec<String>) -> i32 {
             .short("m")
             .long(OPT_MACHINE)
             .help("print the machine hardware name."))
+        .arg(Arg::with_name(OPT_OS)
+            .short("o")
+            .long(OPT_OS)
+            .help("print the operating system name."))
         .get_matches_from(&args);
 
     let argc = args.len();


### PR DESCRIPTION
The code for the flag already existed it had just not been added to the argument parsing. Replace "print the operating system name." in -s help text with "print the kernel name." so the -o option can use the previous -s help text.