### PR TITLE
Add the 'dyn' keyword where necessary

### DIFF
--- a/src/cat/cat.rs
+++ b/src/cat/cat.rs
@@ -100,7 +100,7 @@ struct OutputOptions {
 
 /// Represents an open file handle, stream, or other device
 struct InputHandle {
-    reader: Box<Read>,
+    reader: Box<dyn Read>,
     is_interactive: bool,
 }
 
@@ -241,7 +241,7 @@ fn open(path: &str) -> CatResult<InputHandle> {
     if path == "-" {
         let stdin = stdin();
         return Ok(InputHandle {
-            reader: Box::new(stdin) as Box<Read>,
+            reader: Box::new(stdin) as Box<dyn Read>,
             is_interactive: is_stdin_interactive(),
         });
     }
@@ -253,14 +253,14 @@ fn open(path: &str) -> CatResult<InputHandle> {
             let socket = UnixStream::connect(path).context(path)?;
             socket.shutdown(Shutdown::Write).context(path)?;
             Ok(InputHandle {
-                reader: Box::new(socket) as Box<Read>,
+                reader: Box::new(socket) as Box<dyn Read>,
                 is_interactive: false,
             })
         }
         _ => {
             let file = File::open(path).context(path)?;
             Ok(InputHandle {
-                reader: Box::new(file) as Box<Read>,
+                reader: Box::new(file) as Box<dyn Read>,
                 is_interactive: false,
             })
         }

--- a/src/cksum/cksum.rs
+++ b/src/cksum/cksum.rs
@@ -55,7 +55,7 @@ fn cksum(fname: &str) -> io::Result<(u32, usize)> {
     let mut size = 0usize;
 
     let file;
-    let mut rd: Box<Read> = match fname {
+    let mut rd: Box<dyn Read> = match fname {
         "-" => Box::new(stdin()),
         _ => {
             file = File::open(&Path::new(fname))?;

--- a/src/date/date.rs
+++ b/src/date/date.rs
@@ -137,7 +137,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
 
         // Iterate over all dates - whether it's a single date or a file.
-        let dates: Box<Iterator<Item = _>> = match settings.date_source {
+        let dates: Box<dyn Iterator<Item = _>> = match settings.date_source {
             DateSource::Custom(ref input) => {
                 let date = parse_date(input.clone());
                 let iter = std::iter::once(date);

--- a/src/du/du.rs
+++ b/src/du/du.rs
@@ -142,7 +142,7 @@ fn du(
     options: &Options,
     depth: usize,
     inodes: &mut HashSet<u64>,
-) -> Box<DoubleEndedIterator<Item = Stat>> {
+) -> Box<dyn DoubleEndedIterator<Item = Stat>> {
     let mut stats = vec![];
     let mut futures = vec![];
 

--- a/src/expand/expand.rs
+++ b/src/expand/expand.rs
@@ -128,16 +128,16 @@ pub fn uumain(args: Vec<String>) -> i32 {
     0
 }
 
-fn open(path: String) -> BufReader<Box<Read + 'static>> {
+fn open(path: String) -> BufReader<Box<dyn Read + 'static>> {
     let file_buf;
     if path == "-" {
-        BufReader::new(Box::new(stdin()) as Box<Read>)
+        BufReader::new(Box::new(stdin()) as Box<dyn Read>)
     } else {
         file_buf = match File::open(&path[..]) {
             Ok(a) => a,
             Err(e) => crash!(1, "{}: {}\n", &path[..], e),
         };
-        BufReader::new(Box::new(file_buf) as Box<Read>)
+        BufReader::new(Box::new(file_buf) as Box<dyn Read>)
     }
 }
 

--- a/src/fmt/fmt.rs
+++ b/src/fmt/fmt.rs
@@ -38,7 +38,7 @@ static SYNTAX: &str = "[OPTION]... [FILE]...";
 static SUMMARY: &str = "Reformat paragraphs from input files (or stdin) to stdout.";
 static LONG_HELP: &str = "";
 
-pub type FileOrStdReader = BufReader<Box<Read + 'static>>;
+pub type FileOrStdReader = BufReader<Box<dyn Read + 'static>>;
 pub struct FmtOptions {
     crown: bool,
     tagged: bool,
@@ -179,9 +179,9 @@ pub fn uumain(args: Vec<String>) -> i32 {
 
     for i in files.iter().map(|x| &x[..]) {
         let mut fp = match i {
-            "-" => BufReader::new(Box::new(stdin()) as Box<Read + 'static>),
+            "-" => BufReader::new(Box::new(stdin()) as Box<dyn Read + 'static>),
             _ => match File::open(i) {
-                Ok(f) => BufReader::new(Box::new(f) as Box<Read + 'static>),
+                Ok(f) => BufReader::new(Box::new(f) as Box<dyn Read + 'static>),
                 Err(e) => {
                     show_warning!("{}: {}", i, e);
                     continue;

--- a/src/fold/fold.rs
+++ b/src/fold/fold.rs
@@ -89,10 +89,10 @@ fn fold(filenames: Vec<String>, bytes: bool, spaces: bool, width: usize) {
         let mut file_buf;
         let buffer = BufReader::new(if filename == "-" {
             stdin_buf = stdin();
-            &mut stdin_buf as &mut Read
+            &mut stdin_buf as &mut dyn Read
         } else {
             file_buf = safe_unwrap!(File::open(Path::new(filename)));
-            &mut file_buf as &mut Read
+            &mut file_buf as &mut dyn Read
         });
         fold_file(buffer, bytes, spaces, width);
     }

--- a/src/hashsum/hashsum.rs
+++ b/src/hashsum/hashsum.rs
@@ -51,23 +51,23 @@ fn is_custom_binary(program: &str) -> bool {
 fn detect_algo(
     program: &str,
     matches: &getopts::Matches,
-) -> (&'static str, Box<Digest + 'static>, usize) {
-    let mut alg: Option<Box<Digest>> = None;
+) -> (&'static str, Box<dyn Digest + 'static>, usize) {
+    let mut alg: Option<Box<dyn Digest>> = None;
     let mut name: &'static str = "";
     let mut output_bits = 0;
     match program {
-        "md5sum" => ("MD5", Box::new(Md5::new()) as Box<Digest>, 128),
-        "sha1sum" => ("SHA1", Box::new(Sha1::new()) as Box<Digest>, 160),
-        "sha224sum" => ("SHA224", Box::new(Sha224::new()) as Box<Digest>, 224),
-        "sha256sum" => ("SHA256", Box::new(Sha256::new()) as Box<Digest>, 256),
-        "sha384sum" => ("SHA384", Box::new(Sha384::new()) as Box<Digest>, 384),
-        "sha512sum" => ("SHA512", Box::new(Sha512::new()) as Box<Digest>, 512),
+        "md5sum" => ("MD5", Box::new(Md5::new()) as Box<dyn Digest>, 128),
+        "sha1sum" => ("SHA1", Box::new(Sha1::new()) as Box<dyn Digest>, 160),
+        "sha224sum" => ("SHA224", Box::new(Sha224::new()) as Box<dyn Digest>, 224),
+        "sha256sum" => ("SHA256", Box::new(Sha256::new()) as Box<dyn Digest>, 256),
+        "sha384sum" => ("SHA384", Box::new(Sha384::new()) as Box<dyn Digest>, 384),
+        "sha512sum" => ("SHA512", Box::new(Sha512::new()) as Box<dyn Digest>, 512),
         "sha3sum" => match matches.opt_str("bits") {
             Some(bits_str) => match usize::from_str_radix(&bits_str, 10) {
-                Ok(224) => ("SHA3-224", Box::new(Sha3_224::new()) as Box<Digest>, 224),
-                Ok(256) => ("SHA3-256", Box::new(Sha3_256::new()) as Box<Digest>, 256),
-                Ok(384) => ("SHA3-384", Box::new(Sha3_384::new()) as Box<Digest>, 384),
-                Ok(512) => ("SHA3-512", Box::new(Sha3_512::new()) as Box<Digest>, 512),
+                Ok(224) => ("SHA3-224", Box::new(Sha3_224::new()) as Box<dyn Digest>, 224),
+                Ok(256) => ("SHA3-256", Box::new(Sha3_256::new()) as Box<dyn Digest>, 256),
+                Ok(384) => ("SHA3-384", Box::new(Sha3_384::new()) as Box<dyn Digest>, 384),
+                Ok(512) => ("SHA3-512", Box::new(Sha3_512::new()) as Box<dyn Digest>, 512),
                 Ok(_) => crash!(
                     1,
                     "Invalid output size for SHA3 (expected 224, 256, 384, or 512)"
@@ -76,20 +76,20 @@ fn detect_algo(
             },
             None => crash!(1, "--bits required for SHA3"),
         },
-        "sha3-224sum" => ("SHA3-224", Box::new(Sha3_224::new()) as Box<Digest>, 224),
-        "sha3-256sum" => ("SHA3-256", Box::new(Sha3_256::new()) as Box<Digest>, 256),
-        "sha3-384sum" => ("SHA3-384", Box::new(Sha3_384::new()) as Box<Digest>, 384),
-        "sha3-512sum" => ("SHA3-512", Box::new(Sha3_512::new()) as Box<Digest>, 512),
+        "sha3-224sum" => ("SHA3-224", Box::new(Sha3_224::new()) as Box<dyn Digest>, 224),
+        "sha3-256sum" => ("SHA3-256", Box::new(Sha3_256::new()) as Box<dyn Digest>, 256),
+        "sha3-384sum" => ("SHA3-384", Box::new(Sha3_384::new()) as Box<dyn Digest>, 384),
+        "sha3-512sum" => ("SHA3-512", Box::new(Sha3_512::new()) as Box<dyn Digest>, 512),
         "shake128sum" => match matches.opt_str("bits") {
             Some(bits_str) => match usize::from_str_radix(&bits_str, 10) {
-                Ok(bits) => ("SHAKE128", Box::new(Shake128::new()) as Box<Digest>, bits),
+                Ok(bits) => ("SHAKE128", Box::new(Shake128::new()) as Box<dyn Digest>, bits),
                 Err(err) => crash!(1, "{}", err),
             },
             None => crash!(1, "--bits required for SHAKE-128"),
         },
         "shake256sum" => match matches.opt_str("bits") {
             Some(bits_str) => match usize::from_str_radix(&bits_str, 10) {
-                Ok(bits) => ("SHAKE256", Box::new(Shake256::new()) as Box<Digest>, bits),
+                Ok(bits) => ("SHAKE256", Box::new(Shake256::new()) as Box<dyn Digest>, bits),
                 Err(err) => crash!(1, "{}", err),
             },
             None => crash!(1, "--bits required for SHAKE-256"),
@@ -127,22 +127,22 @@ fn detect_algo(
                         Some(bits_str) => match usize::from_str_radix(&bits_str, 10) {
                             Ok(224) => set_or_crash(
                                 "SHA3-224",
-                                Box::new(Sha3_224::new()) as Box<Digest>,
+                                Box::new(Sha3_224::new()) as Box<dyn Digest>,
                                 224,
                             ),
                             Ok(256) => set_or_crash(
                                 "SHA3-256",
-                                Box::new(Sha3_256::new()) as Box<Digest>,
+                                Box::new(Sha3_256::new()) as Box<dyn Digest>,
                                 256,
                             ),
                             Ok(384) => set_or_crash(
                                 "SHA3-384",
-                                Box::new(Sha3_384::new()) as Box<Digest>,
+                                Box::new(Sha3_384::new()) as Box<dyn Digest>,
                                 384,
                             ),
                             Ok(512) => set_or_crash(
                                 "SHA3-512",
-                                Box::new(Sha3_512::new()) as Box<Digest>,
+                                Box::new(Sha3_512::new()) as Box<dyn Digest>,
                                 512,
                             ),
                             Ok(_) => crash!(
@@ -369,7 +369,7 @@ Compute and check message digests.",
 
 fn hashsum(
     algoname: &str,
-    mut digest: Box<Digest>,
+    mut digest: Box<dyn Digest>,
     files: Vec<String>,
     binary: bool,
     check: bool,
@@ -389,10 +389,10 @@ fn hashsum(
         let file_buf;
         let mut file = BufReader::new(if filename == "-" {
             stdin_buf = stdin();
-            Box::new(stdin_buf) as Box<Read>
+            Box::new(stdin_buf) as Box<dyn Read>
         } else {
             file_buf = safe_unwrap!(File::open(filename));
-            Box::new(file_buf) as Box<Read>
+            Box::new(file_buf) as Box<dyn Read>
         });
         if check {
             // Set up Regexes for line validation and parsing
@@ -440,7 +440,7 @@ fn hashsum(
                     },
                 };
                 let f = safe_unwrap!(File::open(ck_filename));
-                let mut ckf = BufReader::new(Box::new(f) as Box<Read>);
+                let mut ckf = BufReader::new(Box::new(f) as Box<dyn Read>);
                 let real_sum = safe_unwrap!(digest_reader(
                     &mut digest,
                     &mut ckf,
@@ -482,7 +482,7 @@ fn hashsum(
 }
 
 fn digest_reader<'a, T: Read>(
-    digest: &mut Box<Digest + 'a>,
+    digest: &mut Box<dyn Digest + 'a>,
     reader: &mut BufReader<T>,
     binary: bool,
     output_bits: usize,

--- a/src/join/join.rs
+++ b/src/join/join.rs
@@ -235,7 +235,7 @@ struct State<'a> {
     file_name: &'a str,
     file_num: FileNum,
     print_unpaired: bool,
-    lines: Lines<Box<BufRead + 'a>>,
+    lines: Lines<Box<dyn BufRead + 'a>>,
     seq: Vec<Line>,
     max_fields: Option<usize>,
     line_num: usize,
@@ -251,10 +251,10 @@ impl<'a> State<'a> {
         print_unpaired: FileNum,
     ) -> State<'a> {
         let f = if name == "-" {
-            Box::new(stdin.lock()) as Box<BufRead>
+            Box::new(stdin.lock()) as Box<dyn BufRead>
         } else {
             match File::open(name) {
-                Ok(file) => Box::new(BufReader::new(file)) as Box<BufRead>,
+                Ok(file) => Box::new(BufReader::new(file)) as Box<dyn BufRead>,
                 Err(err) => crash!(1, "{}: {}", name, err),
             }
         };

--- a/src/od/multifilereader.rs
+++ b/src/od/multifilereader.rs
@@ -8,13 +8,13 @@ pub enum InputSource<'a> {
     FileName(&'a str),
     Stdin,
     #[allow(dead_code)]
-    Stream(Box<io::Read>),
+    Stream(Box<dyn io::Read>),
 }
 
 // MultifileReader - concatenate all our input, file or stdin.
 pub struct MultifileReader<'a> {
     ni: Vec<InputSource<'a>>,
-    curr_file: Option<Box<io::Read>>,
+    curr_file: Option<Box<dyn io::Read>>,
     any_err: bool,
 }
 

--- a/src/od/output_info.rs
+++ b/src/od/output_info.rs
@@ -138,7 +138,7 @@ impl OutputInfo {
     /// This algorithm assumes the size of all types is a power of 2 (1, 2, 4, 8, 16, ...)
     /// Increase MAX_BYTES_PER_UNIT to allow larger types.
     fn calculate_alignment(
-        sf: &TypeSizeInfo,
+        sf: &dyn TypeSizeInfo,
         byte_size_block: usize,
         print_width_block: usize,
     ) -> [usize; MAX_BYTES_PER_UNIT] {

--- a/src/od/parse_inputs.rs
+++ b/src/od/parse_inputs.rs
@@ -38,7 +38,7 @@ pub enum CommandLineInputs {
 /// Offset and label are specified in bytes.
 /// '-' is used as filename if stdin is meant. This is also returned if
 /// there is no input, as stdin is the default input.
-pub fn parse_inputs(matches: &CommandLineOpts) -> Result<CommandLineInputs, String> {
+pub fn parse_inputs(matches: &dyn CommandLineOpts) -> Result<CommandLineInputs, String> {
     let mut input_strings: Vec<String> = matches.inputs();
 
     if matches.opts_present(&["traditional"]) {

--- a/src/paste/paste.rs
+++ b/src/paste/paste.rs
@@ -68,14 +68,14 @@ FILE, separated by TABs, to standard output.",
 }
 
 fn paste(filenames: Vec<String>, serial: bool, delimiters: String) {
-    let mut files: Vec<BufReader<Box<Read>>> = filenames
+    let mut files: Vec<BufReader<Box<dyn Read>>> = filenames
         .into_iter()
         .map(|name| {
             BufReader::new(if name == "-" {
-                Box::new(stdin()) as Box<Read>
+                Box::new(stdin()) as Box<dyn Read>
             } else {
                 let r = crash_if_err!(1, File::open(Path::new(&name)));
-                Box::new(r) as Box<Read>
+                Box::new(r) as Box<dyn Read>
             })
         })
         .collect();

--- a/src/printf/memo.rs
+++ b/src/printf/memo.rs
@@ -14,7 +14,7 @@ use tokenize::unescaped_text::UnescapedText;
 use tokenize::sub::Sub;
 
 pub struct Memo {
-    tokens: Vec<Box<Token>>,
+    tokens: Vec<Box<dyn Token>>,
 }
 
 fn warn_excess_args(first_arg: &str) {
@@ -27,7 +27,7 @@ fn warn_excess_args(first_arg: &str) {
 impl Memo {
     pub fn new(pf_string: &String, pf_args_it: &mut Peekable<Iter<String>>) -> Memo {
         let mut pm = Memo { tokens: Vec::new() };
-        let mut tmp_token: Option<Box<Token>>;
+        let mut tmp_token: Option<Box<dyn Token>>;
         let mut it = put_back_n(pf_string.chars());
         let mut has_sub = false;
         loop {

--- a/src/printf/tokenize/num_format/formatters/base_conv/mod.rs
+++ b/src/printf/tokenize/num_format/formatters/base_conv/mod.rs
@@ -240,7 +240,7 @@ pub fn base_conv_float(src: &Vec<u8>, radix_src: u8, radix_dest: u8) -> f64 {
     r
 }
 
-pub fn str_to_arrnum(src: &str, radix_def_src: &RadixDef) -> Vec<u8> {
+pub fn str_to_arrnum(src: &str, radix_def_src: &dyn RadixDef) -> Vec<u8> {
     let mut intermed_in: Vec<u8> = Vec::new();
     for c in src.chars() {
         match radix_def_src.from_char(c) {
@@ -253,7 +253,7 @@ pub fn str_to_arrnum(src: &str, radix_def_src: &RadixDef) -> Vec<u8> {
     intermed_in
 }
 
-pub fn arrnum_to_str(src: &Vec<u8>, radix_def_dest: &RadixDef) -> String {
+pub fn arrnum_to_str(src: &Vec<u8>, radix_def_dest: &dyn RadixDef) -> String {
     let mut str_out = String::new();
     for u in src.iter() {
         match radix_def_dest.from_u8(u.clone()) {
@@ -267,7 +267,11 @@ pub fn arrnum_to_str(src: &Vec<u8>, radix_def_dest: &RadixDef) -> String {
 }
 
 #[allow(unused_variables)]
-pub fn base_conv_str(src: &str, radix_def_src: &RadixDef, radix_def_dest: &RadixDef) -> String {
+pub fn base_conv_str(
+    src: &str,
+    radix_def_src: &dyn RadixDef,
+    radix_def_dest: &dyn RadixDef,
+) -> String {
     let intermed_in: Vec<u8> = str_to_arrnum(src, radix_def_src);
     let intermed_out = base_conv_vec(
         &intermed_in,

--- a/src/printf/tokenize/num_format/num_format.rs
+++ b/src/printf/tokenize/num_format/num_format.rs
@@ -210,7 +210,7 @@ pub fn num_format(field: &FormatField, in_str_opt: Option<&String>) -> Option<St
     // see formatter.rs for more details
 
     // to do switch to static dispatch
-    let fmtr: Box<Formatter> = match *field.field_type {
+    let fmtr: Box<dyn Formatter> = match *field.field_type {
         FieldType::Intf => Box::new(Intf::new()),
         FieldType::Floatf => Box::new(Floatf::new()),
         FieldType::CninetyNineHexFloatf => Box::new(CninetyNineHexFloatf::new()),

--- a/src/printf/tokenize/sub.rs
+++ b/src/printf/tokenize/sub.rs
@@ -116,20 +116,20 @@ impl SubParser {
     fn from_it(
         it: &mut PutBackN<Chars>,
         args: &mut Peekable<Iter<String>>,
-    ) -> Option<Box<token::Token>> {
+    ) -> Option<Box<dyn token::Token>> {
         let mut parser = SubParser::new();
         if parser.sub_vals_retrieved(it) {
-            let t: Box<token::Token> = SubParser::build_token(parser);
+            let t: Box<dyn token::Token> = SubParser::build_token(parser);
             t.print(args);
             Some(t)
         } else {
             None
         }
     }
-    fn build_token(parser: SubParser) -> Box<token::Token> {
+    fn build_token(parser: SubParser) -> Box<dyn token::Token> {
         // not a self method so as to allow move of subparser vals.
         // return new Sub struct as token
-        let t: Box<token::Token> = Box::new(Sub::new(
+        let t: Box<dyn token::Token> = Box::new(Sub::new(
             if parser.min_width_is_asterisk {
                 CanAsterisk::Asterisk
             } else {
@@ -317,7 +317,7 @@ impl token::Tokenizer for Sub {
     fn from_it(
         it: &mut PutBackN<Chars>,
         args: &mut Peekable<Iter<String>>,
-    ) -> Option<Box<token::Token>> {
+    ) -> Option<Box<dyn token::Token>> {
         SubParser::from_it(it, args)
     }
 }

--- a/src/printf/tokenize/token.rs
+++ b/src/printf/tokenize/token.rs
@@ -1,10 +1,9 @@
 //! Traits and enums dealing with Tokenization of printf Format String
-#[allow(unused_must_use)]
-
-use std::iter::Peekable;
-use std::str::Chars;
-use std::slice::Iter;
 use itertools::PutBackN;
+#[allow(unused_must_use)]
+use std::iter::Peekable;
+use std::slice::Iter;
+use std::str::Chars;
 
 // A token object is an object that can print the expected output
 // of a contiguous segment of the format string, and
@@ -26,5 +25,8 @@ pub trait Token {
 // a number of arguments equal to the number of argument-using tokens
 
 pub trait Tokenizer {
-    fn from_it(it: &mut PutBackN<Chars>, args: &mut Peekable<Iter<String>>) -> Option<Box<Token>>;
+    fn from_it(
+        it: &mut PutBackN<Chars>,
+        args: &mut Peekable<Iter<String>>,
+    ) -> Option<Box<dyn Token>>;
 }

--- a/src/printf/tokenize/unescaped_text.rs
+++ b/src/printf/tokenize/unescaped_text.rs
@@ -3,14 +3,14 @@
 //! and escaped character literals (of allowed escapes),
 //! into an unescaped text byte array
 
-use std::iter::Peekable;
-use std::slice::Iter;
-use std::str::Chars;
-use std::char::from_u32;
-use std::process::exit;
+use super::token;
 use cli;
 use itertools::PutBackN;
-use super::token;
+use std::char::from_u32;
+use std::iter::Peekable;
+use std::process::exit;
+use std::slice::Iter;
+use std::str::Chars;
 
 pub struct UnescapedText(Vec<u8>);
 impl UnescapedText {
@@ -173,7 +173,10 @@ impl UnescapedText {
     // and return a wrapper around a Vec<u8> of unescaped bytes
     // break on encounter of sub symbol ('%[^%]') unless called
     // through %b subst.
-    pub fn from_it_core(it: &mut PutBackN<Chars>, subs_mode: bool) -> Option<Box<token::Token>> {
+    pub fn from_it_core(
+        it: &mut PutBackN<Chars>,
+        subs_mode: bool,
+    ) -> Option<Box<dyn token::Token>> {
         let mut addchar = false;
         let mut new_text = UnescapedText::new();
         let mut tmp_str = String::new();
@@ -241,7 +244,7 @@ impl token::Tokenizer for UnescapedText {
     fn from_it(
         it: &mut PutBackN<Chars>,
         args: &mut Peekable<Iter<String>>,
-    ) -> Option<Box<token::Token>> {
+    ) -> Option<Box<dyn token::Token>> {
         UnescapedText::from_it_core(it, false)
     }
 }

--- a/src/ptx/ptx.rs
+++ b/src/ptx/ptx.rs
@@ -200,7 +200,7 @@ fn read_input(input_files: &[String], config: &Config) -> HashMap<String, (Vec<S
     }
     let mut lines_so_far: usize = 0;
     for filename in files {
-        let reader: BufReader<Box<Read>> = BufReader::new(if filename == "-" {
+        let reader: BufReader<Box<dyn Read>> = BufReader::new(if filename == "-" {
             Box::new(stdin())
         } else {
             let file = crash_if_err!(1, File::open(filename));
@@ -470,7 +470,7 @@ fn write_traditional_output(
     words: &BTreeSet<WordRef>,
     output_filename: &str,
 ) {
-    let mut writer: BufWriter<Box<Write>> = BufWriter::new(if output_filename == "-" {
+    let mut writer: BufWriter<Box<dyn Write>> = BufWriter::new(if output_filename == "-" {
         Box::new(stdout())
     } else {
         let file = crash_if_err!(1, File::create(output_filename));

--- a/src/shuf/shuf.rs
+++ b/src/shuf/shuf.rs
@@ -147,10 +147,10 @@ With no FILE, or when FILE is -, read standard input.",
 
 fn read_input_file(filename: &str) -> Vec<u8> {
     let mut file = BufReader::new(if filename == "-" {
-        Box::new(stdin()) as Box<Read>
+        Box::new(stdin()) as Box<dyn Read>
     } else {
         match File::open(filename) {
-            Ok(f) => Box::new(f) as Box<Read>,
+            Ok(f) => Box::new(f) as Box<dyn Read>,
             Err(e) => crash!(1, "failed to open '{}': {}", filename, e),
         }
     });
@@ -206,9 +206,9 @@ fn shuf_bytes(
     random: Option<String>,
 ) {
     let mut output = BufWriter::new(match output {
-        None => Box::new(stdout()) as Box<Write>,
+        None => Box::new(stdout()) as Box<dyn Write>,
         Some(s) => match File::create(&s[..]) {
-            Ok(f) => Box::new(f) as Box<Write>,
+            Ok(f) => Box::new(f) as Box<dyn Write>,
             Err(e) => crash!(1, "failed to open '{}' for writing: {}", &s[..], e),
         },
     });

--- a/src/sum/sum.rs
+++ b/src/sum/sum.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 static NAME: &str = "sum";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn bsd_sum(mut reader: Box<Read>) -> (usize, u16) {
+fn bsd_sum(mut reader: Box<dyn Read>) -> (usize, u16) {
     let mut buf = [0; 1024];
     let mut blocks_read = 0;
     let mut checksum: u16 = 0;
@@ -41,7 +41,7 @@ fn bsd_sum(mut reader: Box<Read>) -> (usize, u16) {
     (blocks_read, checksum)
 }
 
-fn sysv_sum(mut reader: Box<Read>) -> (usize, u16) {
+fn sysv_sum(mut reader: Box<dyn Read>) -> (usize, u16) {
     let mut buf = [0; 512];
     let mut blocks_read = 0;
     let mut ret = 0u32;
@@ -64,12 +64,12 @@ fn sysv_sum(mut reader: Box<Read>) -> (usize, u16) {
     (blocks_read, ret as u16)
 }
 
-fn open(name: &str) -> Result<Box<Read>> {
+fn open(name: &str) -> Result<Box<dyn Read>> {
     match name {
-        "-" => Ok(Box::new(stdin()) as Box<Read>),
+        "-" => Ok(Box::new(stdin()) as Box<dyn Read>),
         _ => {
             let f = File::open(&Path::new(name))?;
-            Ok(Box::new(f) as Box<Read>)
+            Ok(Box::new(f) as Box<dyn Read>)
         }
     }
 }

--- a/src/tac/tac.rs
+++ b/src/tac/tac.rs
@@ -91,10 +91,10 @@ fn tac(filenames: Vec<String>, before: bool, _: bool, separator: &str) {
 
     for filename in &filenames {
         let mut file = BufReader::new(if filename == "-" {
-            Box::new(stdin()) as Box<Read>
+            Box::new(stdin()) as Box<dyn Read>
         } else {
             match File::open(filename) {
-                Ok(f) => Box::new(f) as Box<Read>,
+                Ok(f) => Box::new(f) as Box<dyn Read>,
                 Err(e) => {
                     show_warning!("failed to open '{}' for reading: {}", filename, e);
                     continue;

--- a/src/tr/tr.rs
+++ b/src/tr/tr.rs
@@ -20,9 +20,9 @@ extern crate getopts;
 extern crate uucore;
 
 use bit_set::BitSet;
+use fnv::FnvHashMap;
 use getopts::Options;
 use std::io::{stdin, stdout, BufRead, BufWriter, Write};
-use fnv::FnvHashMap;
 
 use expand::ExpandSet;
 
@@ -145,7 +145,11 @@ impl SymbolTranslator for TranslateOperation {
     }
 }
 
-fn translate_input<T: SymbolTranslator>(input: &mut BufRead, output: &mut Write, translator: T) {
+fn translate_input<T: SymbolTranslator>(
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+    translator: T,
+) {
     let mut buf = String::with_capacity(BUFFER_LEN + 4);
     let mut output_buf = String::with_capacity(BUFFER_LEN + 4);
 

--- a/src/tsort/tsort.rs
+++ b/src/tsort/tsort.rs
@@ -62,7 +62,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let mut file_buf;
     let mut reader = BufReader::new(if input == "-" {
         stdin_buf = stdin();
-        &mut stdin_buf as &mut Read
+        &mut stdin_buf as &mut dyn Read
     } else {
         file_buf = match File::open(Path::new(&input)) {
             Ok(a) => a,
@@ -71,7 +71,7 @@ pub fn uumain(args: Vec<String>) -> i32 {
                 return 1;
             }
         };
-        &mut file_buf as &mut Read
+        &mut file_buf as &mut dyn Read
     });
 
     let mut g = Graph::new();

--- a/src/unexpand/unexpand.rs
+++ b/src/unexpand/unexpand.rs
@@ -145,16 +145,16 @@ pub fn uumain(args: Vec<String>) -> i32 {
     0
 }
 
-fn open(path: String) -> BufReader<Box<Read + 'static>> {
+fn open(path: String) -> BufReader<Box<dyn Read + 'static>> {
     let file_buf;
     if path == "-" {
-        BufReader::new(Box::new(stdin()) as Box<Read>)
+        BufReader::new(Box::new(stdin()) as Box<dyn Read>)
     } else {
         file_buf = match File::open(&path[..]) {
             Ok(a) => a,
             Err(e) => crash!(1, "{}: {}", &path[..], e),
         };
-        BufReader::new(Box::new(file_buf) as Box<Read>)
+        BufReader::new(Box::new(file_buf) as Box<dyn Read>)
     }
 }
 

--- a/src/uniq/uniq.rs
+++ b/src/uniq/uniq.rs
@@ -111,7 +111,7 @@ impl Uniq {
 
     fn cmp_key<F>(&self, line: &str, mut closure: F) -> bool
     where
-        F: FnMut(&mut Iterator<Item = char>) -> bool,
+        F: FnMut(&mut dyn Iterator<Item = char>) -> bool,
     {
         let fields_to_check = self.skip_fields(line);
         let len = fields_to_check.len();
@@ -307,26 +307,26 @@ pub fn uumain(args: Vec<String>) -> i32 {
     0
 }
 
-fn open_input_file(in_file_name: String) -> BufReader<Box<Read + 'static>> {
+fn open_input_file(in_file_name: String) -> BufReader<Box<dyn Read + 'static>> {
     let in_file = if in_file_name == "-" {
-        Box::new(stdin()) as Box<Read>
+        Box::new(stdin()) as Box<dyn Read>
     } else {
         let path = Path::new(&in_file_name[..]);
         let in_file = File::open(&path);
         let r = crash_if_err!(1, in_file);
-        Box::new(r) as Box<Read>
+        Box::new(r) as Box<dyn Read>
     };
     BufReader::new(in_file)
 }
 
-fn open_output_file(out_file_name: String) -> BufWriter<Box<Write + 'static>> {
+fn open_output_file(out_file_name: String) -> BufWriter<Box<dyn Write + 'static>> {
     let out_file = if out_file_name == "-" {
-        Box::new(stdout()) as Box<Write>
+        Box::new(stdout()) as Box<dyn Write>
     } else {
         let path = Path::new(&out_file_name[..]);
         let in_file = File::create(&path);
         let w = crash_if_err!(1, in_file);
-        Box::new(w) as Box<Write>
+        Box::new(w) as Box<dyn Write>
     };
     BufWriter::new(out_file)
 }

--- a/src/wc/wc.rs
+++ b/src/wc/wc.rs
@@ -258,9 +258,9 @@ fn print_stats(settings: &Settings, result: &Result, max_width: usize) {
     }
 }
 
-fn open(path: &str) -> StdResult<BufReader<Box<Read + 'static>>, i32> {
+fn open(path: &str) -> StdResult<BufReader<Box<dyn Read + 'static>>, i32> {
     if "-" == path {
-        let reader = Box::new(stdin()) as Box<Read>;
+        let reader = Box::new(stdin()) as Box<dyn Read>;
         return Ok(BufReader::new(reader));
     }
 
@@ -270,7 +270,7 @@ fn open(path: &str) -> StdResult<BufReader<Box<Read + 'static>>, i32> {
     }
     match File::open(&fpath) {
         Ok(fd) => {
-            let reader = Box::new(fd) as Box<Read>;
+            let reader = Box::new(fd) as Box<dyn Read>;
             Ok(BufReader::new(reader))
         }
         Err(e) => {


### PR DESCRIPTION
The keyword is needed for trait objects and is intended to improve
readability.
https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html