### PR TITLE
expand: flush output buffer

### DIFF
--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -244,10 +244,10 @@ fn expand(options: Options) {
                     }
                 }
 
-                safe_unwrap!(output.flush());
                 byte += nbytes; // advance the pointer
             }
 
+            safe_unwrap!(output.flush());
             buf.truncate(0); // clear the buffer
         }
     }

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -244,6 +244,7 @@ fn expand(options: Options) {
                     }
                 }
 
+                safe_unwrap!(output.flush());
                 byte += nbytes; // advance the pointer
             }
 

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -324,6 +324,7 @@ fn unexpand(options: Options) {
 
             // write out anything remaining
             write_tabs(&mut output, ts, scol, col, pctype == Tab, init, true);
+            safe_unwrap!(output.flush());
             buf.truncate(0); // clear out the buffer
         }
     }


### PR DESCRIPTION
Hi,
I noticed that when I used expand on stdin, the output wasn't immediately printed on the screen after I pressed the enter key. The output was printed only after <ctrl-d> (EOF) was pressed.