### PR TITLE
sort: add "dictionary-order" flag.

### DIFF
--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -48,8 +48,8 @@ struct Settings {
     stable: bool,
     unique: bool,
     check: bool,
-    ignore_case: bool,
     compare_fns: Vec<fn(&String, &String) -> Ordering>,
+    transform_fns: Vec<fn(&String) -> String>,
 }
 
 impl Default for Settings {
@@ -62,8 +62,8 @@ impl Default for Settings {
             stable: false,
             unique: false,
             check: false,
-            ignore_case: false,
             compare_fns: Vec::new(),
+            transform_fns: Vec::new(),
         }
     }
 }
@@ -152,6 +152,11 @@ pub fn uumain(args: Vec<String>) -> i32 {
     let mut opts = getopts::Options::new();
 
     opts.optflag(
+        "d",
+        "dictionary-order",
+        "consider only blanks and alphanumeric characters",
+    );
+    opts.optflag(
         "f",
         "ignore-case",
         "fold lower case to upper case characters",
@@ -239,7 +244,13 @@ With no FILE, or when FILE is -, read standard input.",
     settings.stable = matches.opt_present("stable");
     settings.unique = matches.opt_present("unique");
     settings.check = matches.opt_present("check");
-    settings.ignore_case = matches.opt_present("ignore-case");
+
+    if matches.opt_present("dictionary-order") {
+        settings.transform_fns.push(remove_nondictionary_chars);
+    }
+    if matches.opt_present("ignore-case") {
+        settings.transform_fns.push(|s| s.to_uppercase());
+    }
 
     let mut files = matches.free;
     if files.is_empty() {
@@ -348,17 +359,25 @@ fn exec_check_file(lines: Lines<BufReader<Box<dyn Read>>>, settings: &Settings) 
     }
 }
 
+fn transform(line: &String, settings: &Settings) -> String {
+    let mut transformed = line.to_string();
+    for transform_fn in &settings.transform_fns {
+        transformed = transform_fn(&transformed);
+    }
+
+    transformed
+}
+
 fn sort_by(lines: &mut Vec<String>, settings: &Settings) {
     lines.sort_by(|a, b| compare_by(a, b, &settings))
 }
 
 fn compare_by(a: &String, b: &String, settings: &Settings) -> Ordering {
-    // Convert to uppercase if necessary
-    let (a_upper, b_upper): (String, String);
-    let (a, b) = if settings.ignore_case {
-        a_upper = a.to_uppercase();
-        b_upper = b.to_uppercase();
-        (&a_upper, &b_upper)
+    let (a_transformed, b_transformed): (String, String);
+    let (a, b) = if settings.transform_fns.len() > 0 {
+        a_transformed = transform(&a, &settings);
+        b_transformed = transform(&b, &settings);
+        (&a_transformed, &b_transformed)
     } else {
         (a, b)
     };
@@ -500,6 +519,15 @@ fn version_compare(a: &String, b: &String) -> Ordering {
     } else {
         Ordering::Equal
     }
+}
+
+fn remove_nondictionary_chars(s: &String) -> String {
+    // Using 'is_ascii_whitespace()' instead of 'is_whitespace()', because it
+    // uses only symbols compatible with UNIX sort (space, tab, newline).
+    // 'is_whitespace()' uses more symbols as whitespaces (e.g. vertical tab).
+    s.chars()
+        .filter(|c| c.is_alphanumeric() || c.is_ascii_whitespace())
+        .collect::<String>()
 }
 
 fn print_sorted<S, T: Iterator<Item = S>>(iter: T, outfile: &Option<String>)

--- a/src/sort/sort.rs
+++ b/src/sort/sort.rs
@@ -16,15 +16,15 @@ extern crate itertools;
 #[macro_use]
 extern crate uucore;
 
+use itertools::Itertools;
+use semver::Version;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Lines, Read, Write};
 use std::mem::replace;
 use std::path::Path;
-use uucore::fs::is_stdin_interactive;
-use semver::Version;
-use itertools::Itertools; // for Iterator::dedup()
+use uucore::fs::is_stdin_interactive; // for Iterator::dedup()
 
 static NAME: &str = "sort";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -385,13 +385,11 @@ fn permissive_f64_parse(a: &str) -> f64 {
     // GNU sort treats "NaN" as non-number in numeric, so it needs special care.
     match a.split_whitespace().next() {
         None => std::f64::NEG_INFINITY,
-        Some(sa) => {
-            match sa.parse::<f64>() {
-                Ok(a) if a.is_nan() => std::f64::NEG_INFINITY,
-                Ok(a) => a,
-                Err(_) => std::f64::NEG_INFINITY,
-            }
-        }
+        Some(sa) => match sa.parse::<f64>() {
+            Ok(a) if a.is_nan() => std::f64::NEG_INFINITY,
+            Ok(a) => a,
+            Err(_) => std::f64::NEG_INFINITY,
+        },
     }
 }
 
@@ -465,7 +463,8 @@ enum Month {
 
 /// Parse the beginning string into a Month, returning Month::Unknown on errors.
 fn month_parse(line: &String) -> Month {
-    match line.split_whitespace()
+    match line
+        .split_whitespace()
         .next()
         .unwrap()
         .to_uppercase()

--- a/tests/fixtures/sort/dictionary_order.expected
+++ b/tests/fixtures/sort/dictionary_order.expected
@@ -1,0 +1,3 @@
+bbb
+./bbc
+bbd

--- a/tests/fixtures/sort/dictionary_order.txt
+++ b/tests/fixtures/sort/dictionary_order.txt
@@ -1,0 +1,3 @@
+./bbc
+bbd
+bbb

--- a/tests/test_sort.rs
+++ b/tests/test_sort.rs
@@ -68,6 +68,11 @@ fn test_ignore_case() {
 }
 
 #[test]
+fn test_dictionary_order() {
+    test_helper("dictionary_order", "-d");
+}
+
+#[test]
 fn test_multiple_files() {
     new_ucmd!()
         .arg("-n")


### PR DESCRIPTION
Adds support of `-d` as in [`sort` manual](http://man7.org/linux/man-pages/man1/sort.1.html)
```
-d, --dictionary-order
           consider only blanks and alphanumeric characters
```

Behaviour is slightly different though as this implementation uses ALL alphanumeric symbols while GNU one uses only ASCII ones.