### PR TITLE
Fix for legacy Windows versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,15 @@ unix = [
   "generic"
 ]
 windows = ["generic"]
+windows_legacy = [
+  "arch",
+  "nproc",
+  "sync",
+  "touch",
+  "whoami",
+
+  "redox_generic"
+  ]
 # Feature "fuchsia" contains the exclusive list of utilities
 # that can be compiled and run on Fuchsia. Should be built
 # with --no-default-features when selecting this feature.

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ pub fn main() {
         if val == "1" && key.starts_with(feature_prefix) {
             let krate = key[feature_prefix.len()..].to_lowercase();
             match krate.as_ref() {
-                "default" | "unix" | "redox" | "redox_generic" | "fuchsia" | "generic" | "windows"
+                "default" | "unix" | "redox" | "redox_generic" | "fuchsia" | "generic" | "windows" | "windows_legacy"
                 | "nightly" | "test_unimplemented" => continue,
                 _ => {}
             }

--- a/src/cp/cp.rs
+++ b/src/cp/cp.rs
@@ -29,7 +29,7 @@ extern crate kernel32;
 #[cfg(windows)]
 use kernel32::GetFileInformationByHandle;
 #[cfg(windows)]
-use kernel32::CreateFile2;
+use kernel32::CreateFileW;
 #[cfg(windows)]
 extern crate winapi;
 
@@ -731,10 +731,12 @@ fn preserve_hardlinks(
                 #[cfg(windows)]
                 {
                     let stat = mem::uninitialized();
-                    let handle = CreateFile2(
+                    let handle = CreateFileW(
                         src_path.as_ptr() as *const u16,
                         winapi::um::winnt::GENERIC_READ,
                         winapi::um::winnt::FILE_SHARE_READ,
+                        std::ptr::null_mut(),
+                        0,
                         0,
                         std::ptr::null_mut(),
                     );


### PR DESCRIPTION
Allows older windows versions to build, using feature="windows_legacy".

- use `CreateFileW` instead of `CreateFile2`
- disable `hostname` build (current implementation isn't compatible with older Windows version)