### PR TITLE
uptime: match the gnu version output

### DIFF
--- a/src/uptime/uptime.rs
+++ b/src/uptime/uptime.rs
@@ -139,9 +139,9 @@ fn process_utmpx() -> (Option<time_t>, usize) {
 
 fn print_nusers(nusers: usize) {
     if nusers == 1 {
-        print!("1 user, ");
+        print!("1 user,  ");
     } else if nusers > 1 {
-        print!("{} users, ", nusers);
+        print!("{} users,  ", nusers);
     }
 }
 
@@ -190,9 +190,9 @@ fn print_uptime(upsecs: i64) {
     let uphours = (upsecs - (updays * 86400)) / 3600;
     let upmins = (upsecs - (updays * 86400) - (uphours * 3600)) / 60;
     if updays == 1 {
-        print!("up {:1} day, {:2}:{:02}, ", updays, uphours, upmins);
+        print!("up {:1} day, {:2}:{:02},  ", updays, uphours, upmins);
     } else if updays > 1 {
-        print!("up {:1} days, {:2}:{:02}, ", updays, uphours, upmins);
+        print!("up {:1} days, {:2}:{:02},  ", updays, uphours, upmins);
     } else {
         print!("up  {:2}:{:02}, ", uphours, upmins);
     }


### PR DESCRIPTION
This version:
` 22:59:49 up 10 days, 11:38, 1 user, load average: 4.07, 2.95, 2.40`
GNU:
` 23:00:05 up 10 days, 11:38,  1 user,  load average: 4.18, 3.03, 2.44`

https://github.com/coreutils/coreutils/blob/master/src/uptime.c#L149
https://github.com/coreutils/coreutils/blob/master/src/uptime.c#L161

This patch provides the same output