### PR TITLE
Fix the test test_terse_normal_format on Linux by testing -t on /dev

### DIFF
--- a/tests/test_stat.rs
+++ b/tests/test_stat.rs
@@ -171,7 +171,7 @@ fn test_fs_format() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_terse_normal_format() {
-    let args = ["-t", "/"];
+    let args = ["-t", "/dev"];
     new_ucmd!().args(&args)
         .run()
         .stdout_is(expected_result(&args));


### PR DESCRIPTION
On linux, / might not have the Birth date.
It causes this test to fail.
Example:
```
% LANG=C stat /|grep Birth
 Birth: -
% target/debug/uutils stat  /|grep Birth
 Birth: 1972-10-19 04:34:25.547884339 +0100
```