### PR TITLE
Relax the dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,14 +292,14 @@ yes      = { optional=true, path="src/uu/yes" }
 backtrace = ">= 0.3.3, <= 0.3.30"
 
 [dev-dependencies]
-filetime = "0.2.5"
-lazy_static = "1.3.0"
-libc = "0.2.62"
-rand = "0.6.5"
-regex = "1.0.3"
-tempdir = "0.3.7"
-time = "0.1.42"
-unindent = "0.1.3"
+filetime = "0.2"
+lazy_static = "1.3"
+libc = "0.2"
+rand = "0.6"
+regex = "1.0"
+tempdir = "0.3"
+time = "0.1"
+unindent = "0.1"
 
 [target.'cfg(unix)'.dev-dependencies]
 # FIXME: this should use the normal users crate, but it conflicts with the users utility


### PR DESCRIPTION
Makes the life of packagers easier

Cargo will use the most recent version when building locally anyway
