### PR TITLE
numfmt: Add support for --delimiter and --field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,17 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "isatty"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itertools"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +795,7 @@ name = "ls"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -975,6 +987,7 @@ name = "numfmt"
 version = "0.0.1"
 dependencies = [
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2184,6 +2197,7 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4bac95d9aa0624e7b78187d6fb8ab012b41d9f6f54b1bcb61e61c4845f8357ec"
 "checksum ioctl-sys 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2c4b26352496eaaa8ca7cfa9bd99e93419d3f7983dc6e99c2a35fe9e33504a"
+"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"

--- a/src/numfmt/Cargo.toml
+++ b/src/numfmt/Cargo.toml
@@ -11,6 +11,7 @@ path = "numfmt.rs"
 [dependencies]
 getopts = "0.2.18"
 uucore = "0.0.1"
+regex = "1.0.1"
 
 [[bin]]
 name = "numfmt"

--- a/tests/test_numfmt.rs
+++ b/tests/test_numfmt.rs
@@ -145,3 +145,37 @@ fn test_si_to_iec() {
         .run()
         .stdout_is("13.9T\n");
 }
+
+#[test]
+fn test_delim_with_field() {
+    new_ucmd!()
+        .args(&["--field=3", "--header", "--to=si"])
+        .pipe_in("total 164
+-rw-r--r--  1  2911 Feb 11 14:15 build.rs
+-rw-r--r--  1 90347 Mar  3 14:30 Cargo.lock
+-rw-r--r--  1  7034 Feb 11 14:15 Cargo.toml
+-rw-r--r--  1  2018 Feb 11 14:15 CONTRIBUTING.md
+drwxr-xr-x  2  4096 Feb 11 14:15 docs")
+        .run()
+        .stdout_is("total 164
+-rw-r--r--  1  2.9K Feb 11 14:15 build.rs
+-rw-r--r--  1 90.3K Mar  3 14:30 Cargo.lock
+-rw-r--r--  1  7.0K Feb 11 14:15 Cargo.toml
+-rw-r--r--  1  2.0K Feb 11 14:15 CONTRIBUTING.md
+drwxr-xr-x  2  4.1K Feb 11 14:15 docs
+");
+
+
+    new_ucmd!()
+        .args(&["--field=2-4", "--header=2", "--to=si"])
+        .pipe_in("
+Filesystem                                     1B-blocks         Used     Available Use% Mounted on
+udev                                         33560113152            0   33560113152   0% /dev
+tmpfs                                         6726156288      2158592    6723997696   1% /run")
+        .run()
+        .stdout_is("
+Filesystem                                     1B-blocks         Used     Available Use% Mounted on
+udev                                               33.6G            0         33.6G   0% /dev
+tmpfs                                               6.7G         2.2M          6.7G   1% /run
+");
+}


### PR DESCRIPTION
Adds support for --delimiter field with support for default delimiter
parsing which is useful for piping in the output of utilities like ls
and df into numfmt.
--field argument support cut style arguments N-M which allows user to
specify which columns to apply conversion logic to. Useful for parsing
lines which contain a mix of numeric and non-numeric fields (like ls
-al)