### PR TITLE
maint/CICD ~ fix FreeBSD build on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,11 @@
-freebsd_instance:
-  image: freebsd-12-0-release-amd64
-
 task:
-  name: stable x86_64-unknown-freebsd
+  name: stable x86_64-unknown-freebsd-12
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
   setup_script:
     - pkg install -y curl gmake
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y
+    - sh rustup.sh -y --profile=minimal
   build_script:
     - . $HOME/.cargo/env
     - cargo build


### PR DESCRIPTION
- update FreeBSD image used to 'freebsd-12-1-release-amd64'

.# [why]

FreeBSD 12.0-RELEASE became designated as end-of-life on February 29, 2020 (removing
access to any packages for installation [eg, `curl` and `gmake`, required here], and
causing setup errors for the Cirrus CI build).

ref: <https://www.freebsd.org/security/unsupported.html>
ref: <https://www.ixsystems.com/community/threads/pkg-problem-cant-install-or-update-packages-in-11-2-u7.82368> @@ <https://web.archive.org/web/20200407230115/https://www.ixsystems.com/community/threads/pkg-problem-cant-install-or-update-packages-in-11-2-u7.82368>