### PR TITLE
Use `$(MAKE)` variable for recursive invocations

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -260,7 +260,7 @@ build-uutils:
 	${CARGO} build ${CARGOFLAGS} --features "${EXES}" ${PROFILE_CMD} --no-default-features
 
 build-manpages:
-	cd $(DOCSDIR) && make man
+	cd $(DOCSDIR) && $(MAKE) man
 
 build: build-uutils build-pkgs build-manpages
 
@@ -293,7 +293,7 @@ endif
 
 clean:
 	$(RM) $(BUILDDIR)
-	cd $(DOCSDIR) && make clean
+	cd $(DOCSDIR) && $(MAKE) clean
 
 distclean: clean
 	$(CARGO) clean $(CARGOFLAGS) && $(CARGO) update $(CARGOFLAGS)


### PR DESCRIPTION
This ensures that docs Makefile is processed using the same binary as main one. See https://www.gnu.org/software/make/manual/html_node/Recursion.html#Recursion