### PR TITLE
Add/polish `cargo make` tasks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -266,6 +266,11 @@ description = "`cargo fmt` lint report"
 command = "cargo"
 args = ["fmt", "--", "--check"]
 
+[tasks.action-spellcheck-codespell]
+description = "`codespell` spellcheck repository"
+command = "codespell" # (from `pip install codespell`)
+args = [".", "--skip=*/.git,./target,./tests/fixtures", "--ignore-words-list=mut,od"]
+
 [tasks.action-test_quiet]
 description = "Test (in `--quiet` mode)"
 command = "cargo"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -121,6 +121,12 @@ category = "[project]"
 command = "cargo"
 args = [ "make", "--list-all-steps" ]
 
+[tasks.install]
+description = "Install project binary (to \"$HOME/.cargo/bin\")"
+category = "[project]"
+command = "cargo"
+args = ["install", "--path", "."]
+
 [tasks.lint]
 description = "Lint report"
 category = "[project]"
@@ -151,6 +157,12 @@ dependencies = [
     "action-test_quiet",
     "core::post-test",
 ]
+
+[tasks.uninstall]
+description = "Remove project binary (from \"$HOME/.cargo/bin\")"
+category = "[project]"
+command = "cargo"
+args = ["uninstall"]
 
 [tasks.util]
 alias = "utils"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,6 @@
 # spell-checker:ignore (cargo-make) duckscript macos
 # spell-checker:ignore (rust) clippy
+# spell-checker:ignore (uutils) uutil uutils
 
 [config]
 min_version = "0.26.2"
@@ -155,7 +156,7 @@ dependencies = [
 alias = "utils"
 
 [tasks.utils]
-description = "Build (individual) utilities; usage: `cargo make (util | utils) [UTIL_NAME..]`"
+description = "Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME..]`"
 category = "[project]"
 dependencies = [
 	"core::pre-build",
@@ -163,6 +164,12 @@ dependencies = [
     "action-build-utils",
     "core::post-build",
 ]
+
+[tasks.uutil]
+alias = "utils"
+
+[tasks.uutils]
+alias = "utils"
 
 ### actions
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -84,7 +84,7 @@ set_env CARGO_MAKE_TASK_BUILD_UTILS_ARGS "${args}"
 ### tasks
 
 [tasks.default]
-description = "Build and Test"
+description = "## *DEFAULT* Build and test project"
 category = "[project]"
 dependencies = [
 	"action-build-debug",
@@ -92,7 +92,7 @@ dependencies = [
 ]
 
 [tasks.build]
-description = "Build"
+description = "## Build project"
 category = "[project]"
 dependencies = [
 	"core::pre-build",
@@ -101,7 +101,7 @@ dependencies = [
 ]
 
 [tasks.build-features]
-description = "Build (with features); usage: `cargo make (build-features | features) FEATURE..`"
+description = "## Build (with features); usage: `cargo make (build-features | features) FEATURE...`"
 category = "[project]"
 dependencies = [
 	"core::pre-build",
@@ -113,7 +113,7 @@ dependencies = [
 alias = "build-features"
 
 [tasks.format]
-description = "Format"
+description = "## Format code files (with `cargo fmt`)"
 category = "[project]"
 dependencies = [
 	"action-format",
@@ -122,19 +122,20 @@ dependencies = [
 ]
 
 [tasks.help]
-description = "Help"
+description = "## Display help"
 category = "[project]"
-command = "cargo"
-args = [ "make", "--list-all-steps" ]
+dependencies = [
+	"action-display-help",
+]
 
 [tasks.install]
-description = "Install project binary (to \"$HOME/.cargo/bin\")"
+description = "## Install project binary (to $HOME/.cargo/bin)"
 category = "[project]"
 command = "cargo"
 args = ["install", "--path", "."]
 
 [tasks.lint]
-description = "Lint report"
+description = "## Display lint report"
 category = "[project]"
 dependencies = [
 	"action-clippy",
@@ -143,11 +144,9 @@ dependencies = [
 
 [tasks.release]
 alias = "build"
-description = "Build"
-category = "[project]"
 
 [tasks.test]
-description = "Test"
+description = "## Run project tests"
 category = "[project]"
 dependencies = [
 	"core::pre-test",
@@ -156,7 +155,7 @@ dependencies = [
 ]
 
 [tasks.test-terse]
-description = "Test (with terse/summary output)"
+description = "## Run project tests (with terse/summary output)"
 category = "[project]"
 dependencies = [
 	"core::pre-test",
@@ -165,7 +164,7 @@ dependencies = [
 ]
 
 [tasks.uninstall]
-description = "Remove project binary (from \"$HOME/.cargo/bin\")"
+description = "## Remove project binary (from $HOME/.cargo/bin)"
 category = "[project]"
 command = "cargo"
 args = ["uninstall"]
@@ -174,7 +173,7 @@ args = ["uninstall"]
 alias = "utils"
 
 [tasks.utils]
-description = "Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME..]`"
+description = "## Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME...]`"
 category = "[project]"
 dependencies = [
 	"core::pre-build",
@@ -279,3 +278,41 @@ args = [".", "--skip=*/.git,./target,./tests/fixtures", "--ignore-words-list=mut
 description = "Test (in `--quiet` mode)"
 command = "cargo"
 args = ["test", "--quiet", "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )"]
+
+[tasks.action-display-help]
+script_runner = "@duckscript"
+script = [
+'''
+	echo ""
+	echo "usage: `cargo make TARGET [ARGS...]`"
+	echo ""
+	echo "TARGETs:"
+	echo ""
+	result = exec "cargo" make --list-all-steps
+	# set_env CARGO_MAKE_VAR_UTILS ${result.stdout}
+	# echo ${result.stdout}
+	lines = split ${result.stdout} "\n"
+	# echo ${lines}
+	for line in ${lines}
+		if not is_empty ${line}
+			if contains ${line} " - ##"
+				line_segments = split ${line} " - ##"
+				desc = array_pop ${line_segments}
+				desc = trim ${desc}
+				target = array_pop ${line_segments}
+				target = trim ${target}
+				l = length ${target}
+				r = range 0 20
+				spacing = set ""
+				for i in ${r}
+					if greater_than ${i} ${l}
+						spacing = set "${spacing} "
+					end_if
+				end
+				echo ${target}${spacing}${desc}
+			end_if
+		end_if
+	end
+	echo ""
+'''
+]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -113,6 +113,8 @@ description = "Format"
 category = "[project]"
 dependencies = [
 	"action-format",
+	"action-determine-tests",
+	"action-format-tests",
 ]
 
 [tasks.help]
@@ -230,15 +232,34 @@ set_env CARGO_MAKE_TASK_BUILD_UTILS_ARGS "${package_options}"
 '''
 ]
 
+[tasks.action-determine-tests]
+script_runner = "@duckscript"
+script = [
+'''
+test_files = glob_array tests/**/*.rs
+for file in ${test_files}
+	if is_empty "${tests}"
+		tests = set "${file}"
+	else
+		tests = set "${tests} ${file}"
+	end_if
+end
+set_env CARGO_MAKE_VAR_TESTS "${tests}"
+'''
+]
+
 [tasks.action-format]
 description = "`cargo fmt`"
 command = "cargo"
 args = ["fmt"]
 
-[tasks.action-fmt]
-description = "`cargo fmt`"
+[tasks.action-format-tests]
+description = "`cargo fmt` tests"
 command = "cargo"
-args = ["fmt"]
+args = ["fmt", "--", "@@split(CARGO_MAKE_VAR_TESTS, )"]
+
+[tasks.action-fmt]
+alias = "action-format"
 
 [tasks.action-fmt_report]
 description = "`cargo fmt` lint report"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -84,30 +84,42 @@ set_env CARGO_MAKE_TASK_BUILD_UTILS_ARGS "${args}"
 ### tasks
 
 [tasks.default]
-description = "## *DEFAULT* Build and test project"
+description = "## *DEFAULT* Build (debug-mode) and test project"
 category = "[project]"
 dependencies = [
 	"action-build-debug",
     "test-terse",
 ]
 
+##
+
 [tasks.build]
-description = "## Build project"
+description = "## Build (release-mode) project"
 category = "[project]"
 dependencies = [
 	"core::pre-build",
-    "action-build",
+    "action-build-release",
     "core::post-build",
 ]
 
+[tasks.build-debug]
+description = "## Build (debug-mode) project"
+category = "[project]"
+dependencies = [
+	"action-build-debug",
+]
+
 [tasks.build-features]
-description = "## Build (with features); usage: `cargo make (build-features | features) FEATURE...`"
+description = "## Build (with features; release-mode) project; usage: `cargo make (build-features | features) FEATURE...`"
 category = "[project]"
 dependencies = [
 	"core::pre-build",
     "action-build-features",
     "core::post-build",
 ]
+
+[tasks.debug]
+alias = "build-debug"
 
 [tasks.features]
 alias = "build-features"
@@ -173,7 +185,7 @@ args = ["uninstall"]
 alias = "utils"
 
 [tasks.utils]
-description = "## Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME...]`"
+description = "## Build (individual; release-mode) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME...]`"
 category = "[project]"
 dependencies = [
 	"core::pre-build",
@@ -190,7 +202,7 @@ alias = "utils"
 
 ### actions
 
-[tasks.action-build]
+[tasks.action-build-release]
 description = "`cargo build --release`"
 command = "cargo"
 args = ["build", "--release", "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )" ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,18 +5,22 @@
 [config]
 min_version = "0.26.2"
 default_to_workspace = false
-init_task = "_init"
+init_task = "_init_task"
 
 [config.modify_core_tasks]
 namespace = "core"
 
 ### initialization
 
-[tasks._init]
-private = true
-run_task = "_init_"
+### * note: the task executed from 'init_task' ignores dependencies; workaround is to run a secondary task via 'run_task'
 
-[tasks._init_]
+[tasks._init_task]
+# dependencies are unavailable
+# * delegate (via 'run_task') to "real" initialization task ('_init') with full capabilities
+private = true
+run_task = "_init"
+
+[tasks._init]
 private = true
 dependencies = [
 	"_init-vars",


### PR DESCRIPTION
This PR includes some additional tasks for `cargo make` and some polish on some existing tasks, especially `cargo make help`. 

- `cargo make help` output ...

```shell
[cargo-make] INFO - cargo make 0.30.6
[cargo-make] INFO - Project: uutils
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: help
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: _init_task
[cargo-make] INFO - Running Task: _init-vars
[cargo-make] INFO - Running Task: _init
[cargo-make] INFO - Running Task: action-display-help

usage: `cargo make TARGET [ARGS...]`

TARGETs:

build              Build project
build-features     Build (with features); usage: `cargo make (build-features | features) FEATURE...`
default            *DEFAULT* Build and test project
features           Build (with features); usage: `cargo make (build-features | features) FEATURE...`
format             Format code files (with `cargo fmt`)
help               Display help
install            Install project binary (to $HOME/.cargo/bin)
lint               Display lint report
release            Build project
test               Run project tests
test-terse         Run project tests (with terse/summary output)
uninstall          Remove project binary (from $HOME/.cargo/bin)
util               Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME...]`
utils              Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME...]`
uutil              Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME...]`
uutils             Build (individual) utilities; usage: `cargo make (util | utils | uutil | uutils) [UTIL_NAME...]`

[cargo-make] INFO - Running Task: help
[cargo-make] INFO - Build Done in 0 seconds.
```

I've added a couple of more dev-centric tasks, as well. And I'm including some preliminary support for `codespell` in the `action-spellcheck-codespell` task. Better support for that one, and tying it to `lint`, will have to wait a while until I have time to think about how to handle the case of a missing `codespell` executable.

The README needs some documentation updates, as well. I'll have to get to that in a couple of weeks. I've got too many other PRs in-progress, here and for `clap`, at the moment.
