### PR TITLE
fix(more) Return a proper error message when no argument is provided

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -41,6 +41,12 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 pub fn uumain(args: Vec<String>) -> i32 {
     let mut opts = Options::new();
 
+    // FixME: fail without panic for now; but `more` should work with no arguments (ie, for piped input)
+    if args.len() < 2 {
+        println!("{}: incorrect usage", args[0]);
+        return 1;
+    }
+
     opts.optflag("h", "help", "display this help and exit");
     opts.optflag("v", "version", "output version information and exit");
 

--- a/tests/test_more.rs
+++ b/tests/test_more.rs
@@ -1,0 +1,8 @@
+use common::util::*;
+
+#[test]
+fn test_more_no_arg() {
+    let (_, mut ucmd) = at_and_ucmd!();
+    let result = ucmd.run();
+    assert!(!result.success);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -75,6 +75,7 @@ generic! {
     "ls", test_ls;
     "mkdir", test_mkdir;
     "mktemp", test_mktemp;
+    "more", test_more;
     "mv", test_mv;
     "numfmt", test_numfmt;
     "nl", test_nl;


### PR DESCRIPTION
Fix #1509