### PR TITLE
fix(mv): Allow move across file systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +915,7 @@ dependencies = [
 name = "mv"
 version = "0.0.1"
 dependencies = [
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.2 (git+https://github.com/uutils/uucore/?tag=0.0.2)",
 ]
@@ -2237,6 +2243,7 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8c63033fcba1f51ef744505b3cad42510432b904c062afa67ad7ece008429d"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "72327b15c228bfe31f1390f93dd5e9279587f0463836393c9df719ce62a3e450"

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/mv.rs"
 [dependencies]
 getopts = "0.2.18"
 uucore = "0.0.2"
+fs_extra = "1.1.0"
 
 [[bin]]
 name = "mv"


### PR DESCRIPTION
Closes: #1411

I can confirm that it fixes the problem for me.

```
$ touch 1413.patch
$ ./target/debug/uutils mv 1413.patch /external
mv: error: mv: cannot move ‘1413.patch’ to ‘/external/1413.patch’: Invalid cross-device link (os error 18)
```
With the patch:
```
$ ./target/debug/uutils mv 1413.patch /external 
$ ls -al /external/1413.patch
-rw-r--r-- 1 sylvestre sylvestre 1419 mai   24 12:25 /external/1413.patch
```