### PR TITLE
Performance improvements for factor

### DIFF
--- a/src/uu/factor/build.rs
+++ b/src/uu/factor/build.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use std::u64::MAX as MAX_U64;
 
 #[cfg(test)]
-use numeric::is_prime;
+use miller_rabin::is_prime;
 
 #[cfg(test)]
 #[path = "src/numeric.rs"]

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -100,7 +100,11 @@ fn factor(mut n: u64) -> Factors {
 
     let (f, n) = table::factor(n);
     factors *= f;
-    factors *= rho::factor(n);
+
+    if n >= table::NEXT_PRIME {
+        factors *= rho::factor(n);
+    }
+
     factors
 }
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -23,9 +23,12 @@ use rand::distributions::{Distribution, Uniform};
 use rand::rngs::SmallRng;
 use rand::{thread_rng, SeedableRng};
 use std::cmp::{max, min};
+use std::collections::HashMap;
+use std::fmt;
 use std::io::{stdin, BufRead};
 use std::mem::swap;
 use std::num::Wrapping;
+use std::ops;
 
 mod numeric;
 
@@ -36,20 +39,64 @@ static SUMMARY: &str = "Print the prime factors of the given number(s).
  If none are specified, read from standard input.";
 static LONG_HELP: &str = "";
 
-fn rho_pollard_pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
-    if num < 1 << 63 {
-        (sm_mul(a, sm_mul(x, x, num), num) + b) % num
-    } else {
-        big_add(big_mul(a, big_mul(x, x, num), num), b, num)
-    }
-}
-
 fn gcd(mut a: u64, mut b: u64) -> u64 {
     while b > 0 {
         a %= b;
         swap(&mut a, &mut b);
     }
     a
+}
+
+struct Factors {
+    f: HashMap<u64, u8>,
+}
+
+impl Factors {
+    fn new() -> Factors {
+        Factors { f: HashMap::new() }
+    }
+
+    fn add(&mut self, prime: u64, exp: u8) {
+        assert!(exp > 0);
+        self.f.insert(prime, exp + self.f.get(&prime).unwrap_or(&0));
+    }
+
+    fn push(&mut self, prime: u64) {
+        self.add(prime, 1)
+    }
+}
+
+impl ops::MulAssign<Factors> for Factors {
+    fn mul_assign(&mut self, other: Factors) {
+        for (prime, exp) in &other.f {
+            self.add(*prime, *exp);
+        }
+    }
+}
+
+impl fmt::Display for Factors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: Use a representation with efficient in-order iteration
+        let mut primes: Vec<&u64> = self.f.keys().collect();
+        primes.sort();
+
+        for p in primes {
+            for _ in 0..self.f[&p] {
+                write!(f, " {}", p)?
+            }
+        }
+
+        Ok(())
+    }
+}
+
+
+fn rho_pollard_pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
+    if num < 1 << 63 {
+        (sm_mul(a, sm_mul(x, x, num), num) + b) % num
+    } else {
+        big_add(big_mul(a, big_mul(x, x, num), num), b, num)
+    }
 }
 
 fn rho_pollard_find_divisor(num: u64) -> u64 {
@@ -78,31 +125,39 @@ fn rho_pollard_find_divisor(num: u64) -> u64 {
     }
 }
 
-fn rho_pollard_factor(num: u64, factors: &mut Vec<u64>) {
+fn rho_pollard_factor(num: u64, factors: &mut Factors) {
     if is_prime(num) {
         factors.push(num);
         return;
     }
+
     let divisor = rho_pollard_find_divisor(num);
     rho_pollard_factor(divisor, factors);
     rho_pollard_factor(num / divisor, factors);
 }
 
-fn table_division(mut num: u64, factors: &mut Vec<u64>) {
+fn table_division(mut num: u64) -> Factors {
+    let mut factors = Factors::new();
+
     if num < 2 {
-        return;
+        factors.push(num);
+        return factors
     }
+
     while num % 2 == 0 {
         num /= 2;
         factors.push(2);
     }
+
     if num == 1 {
-        return;
+        return factors;
     }
+
     if is_prime(num) {
         factors.push(num);
-        return;
+        return factors;
     }
+
     for &(prime, inv, ceil) in P_INVS_U64 {
         if num == 1 {
             break;
@@ -120,7 +175,7 @@ fn table_division(mut num: u64, factors: &mut Vec<u64>) {
                 factors.push(prime);
                 if is_prime(num) {
                     factors.push(num);
-                    return;
+                    return factors;
                 }
             } else {
                 break;
@@ -136,21 +191,13 @@ fn table_division(mut num: u64, factors: &mut Vec<u64>) {
     //trial_division_slow(num, factors);
     //} else if num > 1 {
     // number is still greater than 1, but not so big that we have to worry
-    rho_pollard_factor(num, factors);
+    rho_pollard_factor(num, &mut factors);
+    factors
     //}
 }
 
 fn print_factors(num: u64) {
-    print!("{}:", num);
-
-    let mut factors = Vec::new();
-    // we always start with table division, and go from there
-    table_division(num, &mut factors);
-    factors.sort();
-
-    for fac in &factors {
-        print!(" {}", fac);
-    }
+    print!("{}:{}", num, table_division(num));
     println!();
 }
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -93,11 +93,6 @@ fn factor(mut n: u64) -> Factors {
         return factors;
     }
 
-    if numeric::is_prime(n) {
-        factors.push(n);
-        return factors;
-    }
-
     let (f, n) = table::factor(n);
     factors *= f;
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -87,7 +87,7 @@ fn factor(mut n: u64) -> Factors {
     let z = n.trailing_zeros();
     if z > 0 {
         factors.add(2, z as u8);
-        n = n >> z;
+        n >>= z;
     }
 
     if n == 1 {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -23,6 +23,7 @@ use std::fmt;
 use std::io::{stdin, BufRead};
 use std::ops;
 
+mod miller_rabin;
 mod numeric;
 mod rho;
 mod table;

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -44,7 +44,8 @@ impl Factors {
 
     fn add(&mut self, prime: u64, exp: u8) {
         assert!(exp > 0);
-        self.f.insert(prime, exp + self.f.get(&prime).unwrap_or(&0));
+        let n = *self.f.get(&prime).unwrap_or(&0);
+        self.f.insert(prime, exp + n);
     }
 
     fn push(&mut self, prime: u64) {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -83,9 +83,10 @@ fn factor(mut n: u64) -> Factors {
         return factors;
     }
 
-    while n % 2 == 0 {
-        n /= 2;
-        factors.push(2);
+    let z = n.trailing_zeros();
+    if z > 0 {
+        factors.add(2, z as u8);
+        n = n >> z;
     }
 
     if n == 1 {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -18,34 +18,19 @@ extern crate rand;
 #[macro_use]
 extern crate uucore;
 
-use numeric::*;
-use rand::distributions::{Distribution, Uniform};
-use rand::rngs::SmallRng;
-use rand::{thread_rng, SeedableRng};
-use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{stdin, BufRead};
-use std::mem::swap;
-use std::num::Wrapping;
 use std::ops;
 
 mod numeric;
-
-include!(concat!(env!("OUT_DIR"), "/prime_table.rs"));
+mod rho;
+mod table;
 
 static SYNTAX: &str = "[OPTION] [NUMBER]...";
 static SUMMARY: &str = "Print the prime factors of the given number(s).
  If none are specified, read from standard input.";
 static LONG_HELP: &str = "";
-
-fn gcd(mut a: u64, mut b: u64) -> u64 {
-    while b > 0 {
-        a %= b;
-        swap(&mut a, &mut b);
-    }
-    a
-}
 
 struct Factors {
     f: HashMap<u64, u8>,
@@ -90,114 +75,36 @@ impl fmt::Display for Factors {
     }
 }
 
-
-fn rho_pollard_pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
-    if num < 1 << 63 {
-        (sm_mul(a, sm_mul(x, x, num), num) + b) % num
-    } else {
-        big_add(big_mul(a, big_mul(x, x, num), num), b, num)
-    }
-}
-
-fn rho_pollard_find_divisor(num: u64) -> u64 {
-    #![allow(clippy::many_single_char_names)]
-    let range = Uniform::new(1, num);
-    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
-    let mut x = range.sample(&mut rng);
-    let mut y = x;
-    let mut a = range.sample(&mut rng);
-    let mut b = range.sample(&mut rng);
-
-    loop {
-        x = rho_pollard_pseudorandom_function(x, a, b, num);
-        y = rho_pollard_pseudorandom_function(y, a, b, num);
-        y = rho_pollard_pseudorandom_function(y, a, b, num);
-        let d = gcd(num, max(x, y) - min(x, y));
-        if d == num {
-            // Failure, retry with different function
-            x = range.sample(&mut rng);
-            y = x;
-            a = range.sample(&mut rng);
-            b = range.sample(&mut rng);
-        } else if d > 1 {
-            return d;
-        }
-    }
-}
-
-fn rho_pollard_factor(num: u64, factors: &mut Factors) {
-    if is_prime(num) {
-        factors.push(num);
-        return;
-    }
-
-    let divisor = rho_pollard_find_divisor(num);
-    rho_pollard_factor(divisor, factors);
-    rho_pollard_factor(num / divisor, factors);
-}
-
-fn table_division(mut num: u64) -> Factors {
+fn factor(mut n: u64) -> Factors {
     let mut factors = Factors::new();
 
-    if num < 2 {
-        factors.push(num);
-        return factors
+    if n < 2 {
+        factors.push(n);
+        return factors;
     }
 
-    while num % 2 == 0 {
-        num /= 2;
+    while n % 2 == 0 {
+        n /= 2;
         factors.push(2);
     }
 
-    if num == 1 {
+    if n == 1 {
         return factors;
     }
 
-    if is_prime(num) {
-        factors.push(num);
+    if numeric::is_prime(n) {
+        factors.push(n);
         return factors;
     }
 
-    for &(prime, inv, ceil) in P_INVS_U64 {
-        if num == 1 {
-            break;
-        }
-
-        // inv = prime^-1 mod 2^64
-        // ceil = floor((2^64-1) / prime)
-        // if (num * inv) mod 2^64 <= ceil, then prime divides num
-        // See http://math.stackexchange.com/questions/1251327/
-        // for a nice explanation.
-        loop {
-            let Wrapping(x) = Wrapping(num) * Wrapping(inv); // x = num * inv mod 2^64
-            if x <= ceil {
-                num = x;
-                factors.push(prime);
-                if is_prime(num) {
-                    factors.push(num);
-                    return factors;
-                }
-            } else {
-                break;
-            }
-        }
-    }
-
-    // do we still have more factoring to do?
-    // Decide whether to use Pollard Rho or slow divisibility based on
-    // number's size:
-    //if num >= 1 << 63 {
-    // number is too big to use rho pollard without overflowing
-    //trial_division_slow(num, factors);
-    //} else if num > 1 {
-    // number is still greater than 1, but not so big that we have to worry
-    rho_pollard_factor(num, &mut factors);
+    let (f, n) = table::factor(n);
+    factors *= f;
+    factors *= rho::factor(n);
     factors
-    //}
 }
 
 fn print_factors(num: u64) {
-    print!("{}:{}", num, table_division(num));
+    print!("{}:{}", num, factor(num));
     println!();
 }
 

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -2,6 +2,7 @@ use crate::numeric::*;
 
 // Small set of bases for the Miller-Rabin prime test, valid for all 64b integers;
 //  discovered by Jim Sinclair on 2011-04-20, see miller-rabin.appspot.com
+#[allow(clippy::unreadable_literal)]
 const BASIS: [u64; 7] = [2, 325, 9375, 28178, 450775, 9780504, 1795265022];
 
 #[derive(Eq, PartialEq)]
@@ -13,7 +14,7 @@ pub(crate) enum Result {
 
 impl Result {
     pub(crate) fn is_prime(&self) -> bool {
-        return *self == Result::Prime;
+        *self == Result::Prime
     }
 }
 
@@ -29,8 +30,7 @@ pub(crate) fn test(n: u64) -> Result {
         return if n == 2 { Prime } else { Composite(2) };
     }
 
-    let d = (n - 1).trailing_zeros();
-    let r = (n - 1) >> d;
+    let r = (n - 1) >> (n - 1).trailing_zeros();
 
     let mul = if n < 1 << 63 {
         sm_mul as fn(u64, u64, u64) -> u64

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -4,14 +4,29 @@ use crate::numeric::*;
 //  discovered by Jim Sinclair on 2011-04-20, see miller-rabin.appspot.com
 const BASIS: [u64; 7] = [2, 325, 9375, 28178, 450775, 9780504, 1795265022];
 
+#[derive(Eq, PartialEq)]
+pub(crate) enum Result {
+    Prime,
+    Pseudoprime,
+    Composite(u64),
+}
+
+impl Result {
+    pub(crate) fn is_prime(&self) -> bool {
+        return *self == Result::Prime;
+    }
+}
+
 // Deterministic Miller-Rabin primality-checking algorithm, adapted to extract
 // (some) dividers; it will fail to factor strong pseudoprimes.
-pub(crate) fn is_prime(n: u64) -> bool {
+pub(crate) fn test(n: u64) -> Result {
+    use self::Result::*;
+
     if n < 2 {
-        return false;
+        return Pseudoprime;
     }
     if n % 2 == 0 {
-        return n == 2;
+        return if n == 2 { Prime } else { Composite(2) };
     }
 
     let d = (n - 1).trailing_zeros();
@@ -30,7 +45,7 @@ pub(crate) fn is_prime(n: u64) -> bool {
         }
 
         if pow(x, n - 1, n, mul) != 1 {
-            return false;
+            return Pseudoprime;
         }
         x = pow(x, r, n, mul);
         if x == 1 || x == n - 1 {
@@ -40,7 +55,7 @@ pub(crate) fn is_prime(n: u64) -> bool {
         loop {
             let y = mul(x, x, n);
             if y == 1 {
-                return false;
+                return Composite(gcd(x - 1, n));
             }
             if y == n - 1 {
                 // This basis element is not a witness of `n` being composite.
@@ -51,5 +66,11 @@ pub(crate) fn is_prime(n: u64) -> bool {
         }
     }
 
-    true
+    Prime
+}
+
+// Used by build.rs' tests
+#[allow(dead_code)]
+pub(crate) fn is_prime(n: u64) -> bool {
+    test(n).is_prime()
 }

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -1,0 +1,52 @@
+use crate::numeric::*;
+
+fn witness(mut a: u64, exponent: u64, m: u64) -> bool {
+    if a == 0 {
+        return false;
+    }
+
+    let mul = if m < 1 << 63 {
+        sm_mul as fn(u64, u64, u64) -> u64
+    } else {
+        big_mul as fn(u64, u64, u64) -> u64
+    };
+
+    if pow(a, m - 1, m, mul) != 1 {
+        return true;
+    }
+    a = pow(a, exponent, m, mul);
+    if a == 1 {
+        return false;
+    }
+    loop {
+        if a == 1 {
+            return true;
+        }
+        if a == m - 1 {
+            return false;
+        }
+        a = mul(a, a, m);
+    }
+}
+
+// Deterministic Miller-Rabin primality-checking algorithm, adapted to extract
+// (some) dividers; it will fail to factor strong pseudoprimes.
+pub(crate) fn is_prime(num: u64) -> bool {
+    if num < 2 {
+        return false;
+    }
+    if num % 2 == 0 {
+        return num == 2;
+    }
+    let mut exponent = num - 1;
+    while exponent & 1 == 0 {
+        exponent >>= 1;
+    }
+
+    // These witnesses detect all composites up to at least 2^64.
+    // Discovered by Jim Sinclair, according to http://miller-rabin.appspot.com
+    let witnesses = [2, 325, 9_375, 28_178, 450_775, 9_780_504, 1_795_265_022];
+    !witnesses
+        .iter()
+        .any(|&wit| witness(wit % num, exponent, num))
+}

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -1,52 +1,55 @@
 use crate::numeric::*;
 
-fn witness(mut a: u64, exponent: u64, m: u64) -> bool {
-    if a == 0 {
+// Small set of bases for the Miller-Rabin prime test, valid for all 64b integers;
+//  discovered by Jim Sinclair on 2011-04-20, see miller-rabin.appspot.com
+const BASIS: [u64; 7] = [2, 325, 9375, 28178, 450775, 9780504, 1795265022];
+
+// Deterministic Miller-Rabin primality-checking algorithm, adapted to extract
+// (some) dividers; it will fail to factor strong pseudoprimes.
+pub(crate) fn is_prime(n: u64) -> bool {
+    if n < 2 {
         return false;
     }
+    if n % 2 == 0 {
+        return n == 2;
+    }
 
-    let mul = if m < 1 << 63 {
+    let d = (n - 1).trailing_zeros();
+    let r = (n - 1) >> d;
+
+    let mul = if n < 1 << 63 {
         sm_mul as fn(u64, u64, u64) -> u64
     } else {
         big_mul as fn(u64, u64, u64) -> u64
     };
 
-    if pow(a, m - 1, m, mul) != 1 {
-        return true;
-    }
-    a = pow(a, exponent, m, mul);
-    if a == 1 {
-        return false;
-    }
-    loop {
-        if a == 1 {
-            return true;
+    for a in BASIS.iter() {
+        let mut x = a % n;
+        if x == 0 {
+            break;
         }
-        if a == m - 1 {
+
+        if pow(x, n - 1, n, mul) != 1 {
             return false;
         }
-        a = mul(a, a, m);
-    }
-}
+        x = pow(x, r, n, mul);
+        if x == 1 || x == n - 1 {
+            break;
+        }
 
-// Deterministic Miller-Rabin primality-checking algorithm, adapted to extract
-// (some) dividers; it will fail to factor strong pseudoprimes.
-pub(crate) fn is_prime(num: u64) -> bool {
-    if num < 2 {
-        return false;
-    }
-    if num % 2 == 0 {
-        return num == 2;
-    }
-    let mut exponent = num - 1;
-    while exponent & 1 == 0 {
-        exponent >>= 1;
+        loop {
+            let y = mul(x, x, n);
+            if y == 1 {
+                return false;
+            }
+            if y == n - 1 {
+                // This basis element is not a witness of `n` being composite.
+                // Keep looking.
+                break;
+            }
+            x = y;
+        }
     }
 
-    // These witnesses detect all composites up to at least 2^64.
-    // Discovered by Jim Sinclair, according to http://miller-rabin.appspot.com
-    let witnesses = [2, 325, 9_375, 28_178, 450_775, 9_780_504, 1_795_265_022];
-    !witnesses
-        .iter()
-        .any(|&wit| witness(wit % num, exponent, num))
+    true
 }

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -9,8 +9,17 @@
 * that was distributed with this source code.
 */
 
+use std::mem::swap;
 use std::num::Wrapping;
 use std::u64::MAX as MAX_U64;
+
+pub fn gcd(mut a: u64, mut b: u64) -> u64 {
+    while b > 0 {
+        a %= b;
+        swap(&mut a, &mut b);
+    }
+    a
+}
 
 pub fn big_add(a: u64, b: u64, m: u64) -> u64 {
     let Wrapping(msb_mod_m) = Wrapping(MAX_U64) - Wrapping(m) + Wrapping(1);

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -21,71 +21,87 @@ pub fn gcd(mut a: u64, mut b: u64) -> u64 {
     a
 }
 
-pub fn big_add(a: u64, b: u64, m: u64) -> u64 {
-    let Wrapping(msb_mod_m) = Wrapping(MAX_U64) - Wrapping(m) + Wrapping(1);
-    let msb_mod_m = msb_mod_m % m;
+pub(crate) trait Arithmetic {
+    fn add(a: u64, b: u64, modulus: u64) -> u64;
+    fn mul(a: u64, b: u64, modulus: u64) -> u64;
 
-    let Wrapping(res) = Wrapping(a) + Wrapping(b);
-    if b <= MAX_U64 - a {
-        res
-    } else {
-        (res + msb_mod_m) % m
+    fn pow(mut a: u64, mut b: u64, m: u64) -> u64 {
+        let mut result = 1;
+        while b > 0 {
+            if b & 1 != 0 {
+                result = Self::mul(result, a, m);
+            }
+            a = Self::mul(a, a, m);
+            b >>= 1;
+        }
+        result
     }
 }
 
-// computes (a + b) % m using the russian peasant algorithm
-// CAUTION: Will overflow if m >= 2^63
-pub fn sm_mul(mut a: u64, mut b: u64, m: u64) -> u64 {
-    let mut result = 0;
-    while b > 0 {
-        if b & 1 != 0 {
-            result = (result + a) % m;
-        }
-        a = (a << 1) % m;
-        b >>= 1;
-    }
-    result
-}
+pub(crate) struct Big {}
 
-// computes (a + b) % m using the russian peasant algorithm
-// Only necessary when m >= 2^63; otherwise, just wastes time.
-pub fn big_mul(mut a: u64, mut b: u64, m: u64) -> u64 {
-    // precompute 2^64 mod m, since we expect to wrap
-    let Wrapping(msb_mod_m) = Wrapping(MAX_U64) - Wrapping(m) + Wrapping(1);
-    let msb_mod_m = msb_mod_m % m;
+impl Arithmetic for Big {
+    fn add(a: u64, b: u64, m: u64) -> u64 {
+        let Wrapping(msb_mod_m) = Wrapping(MAX_U64) - Wrapping(m) + Wrapping(1);
+        let msb_mod_m = msb_mod_m % m;
 
-    let mut result = 0;
-    while b > 0 {
-        if b & 1 != 0 {
-            let Wrapping(next_res) = Wrapping(result) + Wrapping(a);
-            let next_res = next_res % m;
-            result = if result <= MAX_U64 - a {
-                next_res
-            } else {
-                (next_res + msb_mod_m) % m
-            };
-        }
-        let Wrapping(next_a) = Wrapping(a) << 1;
-        let next_a = next_a % m;
-        a = if a < 1 << 63 {
-            next_a
+        let Wrapping(res) = Wrapping(a) + Wrapping(b);
+        if b <= MAX_U64 - a {
+            res
         } else {
-            (next_a + msb_mod_m) % m
-        };
-        b >>= 1;
+            (res + msb_mod_m) % m
+        }
     }
-    result
+
+    // computes (a + b) % m using the russian peasant algorithm
+    // Only necessary when m >= 2^63; otherwise, just wastes time.
+    fn mul(mut a: u64, mut b: u64, m: u64) -> u64 {
+        // precompute 2^64 mod m, since we expect to wrap
+        let Wrapping(msb_mod_m) = Wrapping(MAX_U64) - Wrapping(m) + Wrapping(1);
+        let msb_mod_m = msb_mod_m % m;
+
+        let mut result = 0;
+        while b > 0 {
+            if b & 1 != 0 {
+                let Wrapping(next_res) = Wrapping(result) + Wrapping(a);
+                let next_res = next_res % m;
+                result = if result <= MAX_U64 - a {
+                    next_res
+                } else {
+                    (next_res + msb_mod_m) % m
+                };
+            }
+            let Wrapping(next_a) = Wrapping(a) << 1;
+            let next_a = next_a % m;
+            a = if a < 1 << 63 {
+                next_a
+            } else {
+                (next_a + msb_mod_m) % m
+            };
+            b >>= 1;
+        }
+        result
+    }
 }
 
-// computes a.pow(b) % m
-pub(crate) fn pow(mut a: u64, mut b: u64, m: u64, mul: fn(u64, u64, u64) -> u64) -> u64 {
-    let mut result = 1;
-    while b > 0 {
-        if b & 1 != 0 {
-            result = mul(result, a, m);
+pub(crate) struct Small {}
+
+impl Arithmetic for Small {
+    // computes (a + b) % m using the russian peasant algorithm
+    // CAUTION: Will overflow if m >= 2^63
+    fn mul(mut a: u64, mut b: u64, m: u64) -> u64 {
+        let mut result = 0;
+        while b > 0 {
+            if b & 1 != 0 {
+                result = (result + a) % m;
+            }
+            a = (a << 1) % m;
+            b >>= 1;
         }
-        a = mul(a, a, m);
-        b >>= 1;
+        result
     }
-    result
+
+    fn add(a: u64, b: u64, m: u64) -> u64 {
+        (a + b) % m
+    }
 }

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -6,36 +6,31 @@ use rand::rngs::SmallRng;
 use rand::{thread_rng, SeedableRng};
 use std::cmp::{max, min};
 
-fn pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
-    if num < 1 << 63 {
-        (sm_mul(a, sm_mul(x, x, num), num) + b) % num
-    } else {
-        big_add(big_mul(a, big_mul(x, x, num), num), b, num)
-    }
-}
-
-fn find_divisor(num: u64) -> u64 {
+fn find_divisor<A: Arithmetic>(n: u64) -> u64 {
     #![allow(clippy::many_single_char_names)]
-    let range = Uniform::new(1, num);
-    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
-    let mut x = range.sample(&mut rng);
-    let mut y = x;
-    let mut a = range.sample(&mut rng);
-    let mut b = range.sample(&mut rng);
+    let mut rand = {
+        let range = Uniform::new(1, n);
+        let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+        move || range.sample(&mut rng)
+    };
+
+    let quadratic = |a, b| move |x| A::add(A::mul(a, A::mul(x, x, n), n), b, n);
 
     loop {
-        x = pseudorandom_function(x, a, b, num);
-        y = pseudorandom_function(y, a, b, num);
-        y = pseudorandom_function(y, a, b, num);
-        let d = gcd(num, max(x, y) - min(x, y));
-        if d == num {
-            // Failure, retry with different function
-            x = range.sample(&mut rng);
-            y = x;
-            a = range.sample(&mut rng);
-            b = range.sample(&mut rng);
-        } else if d > 1 {
-            return d;
+        let f = quadratic(rand(), rand());
+        let mut x = rand();
+        let mut y = x;
+
+        loop {
+            x = f(x);
+            y = f(f(y));
+            let d = gcd(n, max(x, y) - min(x, y));
+            if d == n {
+                // Failure, retry with a different quadratic
+                break;
+            } else if d > 1 {
+                return d;
+            }
         }
     }
 }
@@ -46,7 +41,11 @@ pub(crate) fn factor(mut num: u64) -> Factors {
         return factors;
     }
 
-    match miller_rabin::test(num) {
+    match if num < 1 << 63 {
+        miller_rabin::test::<Small>(num)
+    } else {
+        miller_rabin::test::<Big>(num)
+    } {
         Prime => {
             factors.push(num);
             return factors;
@@ -60,7 +59,11 @@ pub(crate) fn factor(mut num: u64) -> Factors {
         Pseudoprime => {}
     };
 
-    let divisor = find_divisor(num);
+    let divisor = if num < 1 << 63 {
+        find_divisor::<Small>(num)
+    } else {
+        find_divisor::<Big>(num)
+    };
     factors *= factor(divisor);
     factors *= factor(num / divisor);
     factors

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -1,3 +1,4 @@
+use crate::miller_rabin::Result::*;
 use crate::{miller_rabin, Factors};
 use numeric::*;
 use rand::distributions::{Distribution, Uniform};
@@ -39,16 +40,25 @@ fn find_divisor(num: u64) -> u64 {
     }
 }
 
-pub(crate) fn factor(num: u64) -> Factors {
+pub(crate) fn factor(mut num: u64) -> Factors {
     let mut factors = Factors::new();
     if num == 1 {
         return factors;
     }
 
-    if miller_rabin::is_prime(num) {
-        factors.push(num);
-        return factors;
-    }
+    match miller_rabin::test(num) {
+        Prime => {
+            factors.push(num);
+            return factors;
+        }
+
+        Composite(d) => {
+            num = num / d;
+            factors *= factor(d);
+        }
+
+        Pseudoprime => {}
+    };
 
     let divisor = find_divisor(num);
     factors *= factor(divisor);

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -1,4 +1,4 @@
-use crate::Factors;
+use crate::{miller_rabin, Factors};
 use numeric::*;
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::SmallRng;
@@ -41,8 +41,11 @@ fn find_divisor(num: u64) -> u64 {
 
 pub(crate) fn factor(num: u64) -> Factors {
     let mut factors = Factors::new();
-    if num == 1 { return factors; }
-    if is_prime(num) {
+    if num == 1 {
+        return factors;
+    }
+
+    if miller_rabin::is_prime(num) {
         factors.push(num);
         return factors;
     }

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -1,0 +1,54 @@
+use crate::Factors;
+use numeric::*;
+use rand::distributions::{Distribution, Uniform};
+use rand::rngs::SmallRng;
+use rand::{thread_rng, SeedableRng};
+use std::cmp::{max, min};
+
+fn pseudorandom_function(x: u64, a: u64, b: u64, num: u64) -> u64 {
+    if num < 1 << 63 {
+        (sm_mul(a, sm_mul(x, x, num), num) + b) % num
+    } else {
+        big_add(big_mul(a, big_mul(x, x, num), num), b, num)
+    }
+}
+
+fn find_divisor(num: u64) -> u64 {
+    #![allow(clippy::many_single_char_names)]
+    let range = Uniform::new(1, num);
+    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+    let mut x = range.sample(&mut rng);
+    let mut y = x;
+    let mut a = range.sample(&mut rng);
+    let mut b = range.sample(&mut rng);
+
+    loop {
+        x = pseudorandom_function(x, a, b, num);
+        y = pseudorandom_function(y, a, b, num);
+        y = pseudorandom_function(y, a, b, num);
+        let d = gcd(num, max(x, y) - min(x, y));
+        if d == num {
+            // Failure, retry with different function
+            x = range.sample(&mut rng);
+            y = x;
+            a = range.sample(&mut rng);
+            b = range.sample(&mut rng);
+        } else if d > 1 {
+            return d;
+        }
+    }
+}
+
+pub(crate) fn factor(num: u64) -> Factors {
+    let mut factors = Factors::new();
+    if num == 1 { return factors; }
+    if is_prime(num) {
+        factors.push(num);
+        return factors;
+    }
+
+    let divisor = find_divisor(num);
+    factors *= factor(divisor);
+    factors *= factor(num / divisor);
+    factors
+}

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -53,7 +53,7 @@ pub(crate) fn factor(mut num: u64) -> Factors {
         }
 
         Composite(d) => {
-            num = num / d;
+            num /= d;
             factors *= factor(d);
         }
 

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -1,5 +1,4 @@
 use crate::Factors;
-use numeric::*;
 use std::num::Wrapping;
 
 include!(concat!(env!("OUT_DIR"), "/prime_table.rs"));
@@ -14,17 +13,15 @@ pub(crate) fn factor(mut num: u64) -> (Factors, u64) {
         // inv = prime^-1 mod 2^64
         // ceil = floor((2^64-1) / prime)
         // if (num * inv) mod 2^64 <= ceil, then prime divides num
-        // See http://math.stackexchange.com/questions/1251327/
+        // See https://math.stackexchange.com/questions/1251327/
         // for a nice explanation.
         loop {
-            let Wrapping(x) = Wrapping(num) * Wrapping(inv); // x = num * inv mod 2^64
+            let Wrapping(x) = Wrapping(num) * Wrapping(inv);
+
+            // While prime divides num
             if x <= ceil {
                 num = x;
                 factors.push(prime);
-                if is_prime(num) {
-                    factors.push(num);
-                    return (factors, 1);
-                }
             } else {
                 break;
             }

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -1,0 +1,44 @@
+use crate::Factors;
+use numeric::*;
+use std::num::Wrapping;
+
+include!(concat!(env!("OUT_DIR"), "/prime_table.rs"));
+
+pub(crate) fn factor(mut num: u64) -> (Factors, u64) {
+    let mut factors = Factors::new();
+    for &(prime, inv, ceil) in P_INVS_U64 {
+        if num == 1 {
+            break;
+        }
+
+        // inv = prime^-1 mod 2^64
+        // ceil = floor((2^64-1) / prime)
+        // if (num * inv) mod 2^64 <= ceil, then prime divides num
+        // See http://math.stackexchange.com/questions/1251327/
+        // for a nice explanation.
+        loop {
+            let Wrapping(x) = Wrapping(num) * Wrapping(inv); // x = num * inv mod 2^64
+            if x <= ceil {
+                num = x;
+                factors.push(prime);
+                if is_prime(num) {
+                    factors.push(num);
+                    return (factors, 1);
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    // do we still have more factoring to do?
+    // Decide whether to use Pollard Rho or slow divisibility based on
+    // number's size:
+    //if num >= 1 << 63 {
+    // number is too big to use rho pollard without overflowing
+    //trial_division_slow(num, factors);
+    //} else if num > 1 {
+    // number is still greater than 1, but not so big that we have to worry
+    (factors, num)
+    //}
+}

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -28,14 +28,5 @@ pub(crate) fn factor(mut num: u64) -> (Factors, u64) {
         }
     }
 
-    // do we still have more factoring to do?
-    // Decide whether to use Pollard Rho or slow divisibility based on
-    // number's size:
-    //if num >= 1 << 63 {
-    // number is too big to use rho pollard without overflowing
-    //trial_division_slow(num, factors);
-    //} else if num > 1 {
-    // number is still greater than 1, but not so big that we have to worry
     (factors, num)
-    //}
 }


### PR DESCRIPTION
First pass at fixing #1456: after those changes, `factor` is 4× faster, and
“only” 48× slower than the GNU implementation (when factoring all numbers from 2
to 10⁶).

- Replaced the `Vec` of factors with a datatype that only stores each prime once
- Moved each algorithm (table-based, Pollard's rho, and Miller-Rabin) to its own module, and decoupled them.
- Removed unecessary calls to `is_prime` (~50% of the perf. gain)
- Replaced iterated division by 2 with `u64::trailing_zeros`
- Refactored and optimized the Miller-Rabin primality test, extracted dividers from the result (the other half of the performance gain)