### PR TITLE
maint/build ~ allow code coverage upload failures without breaking build

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -431,4 +431,4 @@ jobs:
         ## flags: IntegrationTests, UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
         flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
         name: codecov-umbrella
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
- code coverage upload failure becomes a warning instead of error