### PR TITLE
factor: Faster modular arithmetic with the Montgomery transform

### DIFF
--- a/src/uu/factor/build.rs
+++ b/src/uu/factor/build.rs
@@ -58,7 +58,7 @@ fn main() {
     let mut x = primes.next().unwrap();
     for next in primes {
         // format the table
-        let outstr = format!("({}, {}, {}),", x, inv_mod_u64(x), u64::MAX / x);
+        let outstr = format!("({}, {}, {}),", x, inv_mod_u64(x), std::u64::MAX / x);
         if cols + outstr.len() > MAX_WIDTH {
             write!(file, "\n    {}", outstr).unwrap();
             cols = 4 + outstr.len();

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -39,7 +39,7 @@ impl Factors {
     }
 
     fn add(&mut self, prime: u64, exp: u8) {
-        assert!(exp > 0);
+        debug_assert!(exp > 0);
         let n = *self.f.get(&prime).unwrap_or(&0);
         self.f.insert(prime, exp + n);
     }

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -47,6 +47,13 @@ impl Factors {
     fn push(&mut self, prime: u64) {
         self.add(prime, 1)
     }
+
+    #[cfg(test)]
+    fn product(&self) -> u64 {
+        self.f
+            .iter()
+            .fold(1, |acc, (p, exp)| acc * p.pow(*exp as u32))
+    }
 }
 
 impl ops::MulAssign<Factors> for Factors {
@@ -131,4 +138,23 @@ pub fn uumain(args: Vec<String>) -> i32 {
         }
     }
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::factor;
+
+    #[test]
+    fn factor_recombines_small() {
+        assert!((1..10_000)
+            .map(|i| 2 * i + 1)
+            .all(|i| factor(i).product() == i));
+    }
+
+    #[test]
+    fn factor_recombines_overflowing() {
+        assert!((0..250)
+            .map(|i| 2 * i + 2u64.pow(32) + 1)
+            .all(|i| factor(i).product() == i));
+    }
 }

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -38,6 +38,9 @@ pub(crate) fn test<A: Arithmetic>(m: A) -> Result {
     let i = (n - 1).trailing_zeros();
     let r = (n - 1) >> i;
 
+    let one = m.one();
+    let minus_one = m.minus_one();
+
     for _a in BASIS.iter() {
         let _a = _a % n;
         if _a == 0 {
@@ -55,21 +58,21 @@ pub(crate) fn test<A: Arithmetic>(m: A) -> Result {
             for _ in 0..i {
                 y = m.mul(y, y)
             }
-            if y != m.one() {
+            if y != one {
                 return Pseudoprime;
             };
         }
 
-        if x == m.one() || x == m.minus_one() {
+        if x == one || x == minus_one {
             break;
         }
 
         loop {
             let y = m.mul(x, x);
-            if y == m.one() {
+            if y == one {
                 return Composite(gcd(m.to_u64(x) - 1, m.modulus()));
             }
-            if y == m.minus_one() {
+            if y == minus_one {
                 // This basis element is not a witness of `n` being composite.
                 // Keep looking.
                 break;

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -88,3 +88,21 @@ pub(crate) fn is_prime(n: u64) -> bool {
     }
     .is_prime()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::is_prime;
+    const LARGEST_U64_PRIME: u64 = 0xFFFFFFFFFFFFFFC5;
+
+    #[test]
+    fn largest_prime() {
+        assert!(is_prime(LARGEST_U64_PRIME));
+    }
+
+    #[test]
+    fn first_primes() {
+        use crate::table::{NEXT_PRIME, P_INVS_U64};
+        assert!(P_INVS_U64.iter().all(|(p, _, _)| is_prime(*p)));
+        assert!(is_prime(NEXT_PRIME));
+    }
+}

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -40,12 +40,15 @@ pub(crate) trait Arithmetic: Copy + Sized {
         }
 
         // Check that r (reduced back to the usual representation) equals
-        // a^b % n, unless the latter computation overflows
-        debug_assert!(self
-            .to_u64(_a)
-            .checked_pow(_b as u32)
-            .map(|r| r % self.modulus() == self.to_u64(result))
-            .unwrap_or(true));
+        //  a^b % n, unless the latter computation overflows
+        // Temporarily commented-out, as there u64::checked_pow is not available
+        //  on the minimum supported Rust version, nor is an appropriate method
+        //  for compiling the check conditionally.
+        //debug_assert!(self
+        //    .to_u64(_a)
+        //    .checked_pow(_b as u32)
+        //    .map(|r| r % self.modulus() == self.to_u64(result))
+        //    .unwrap_or(true));
 
         result
     }
@@ -165,7 +168,7 @@ pub(crate) fn inv_mod_u64(a: u64) -> u64 {
             // special case when we're just starting out
             // This works because we know that
             // a does not divide 2^64, so floor(2^64 / a) == floor((2^64-1) / a);
-            u64::MAX
+            std::u64::MAX
         } else {
             r
         } / newr;

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -173,12 +173,12 @@ pub(crate) fn inv_mod_u64(a: u64) -> u64 {
             r
         } / newr;
 
-        let (tp, Wrapping(newtp)) = (newt, Wrapping(t) - (Wrapping(quot) * Wrapping(newt)));
-        t = tp;
+        let newtp = t.wrapping_sub(quot.wrapping_mul(newt));
+        t = newt;
         newt = newtp;
 
-        let (rp, Wrapping(newrp)) = (newr, Wrapping(r) - (Wrapping(quot) * Wrapping(newr)));
-        r = rp;
+        let newrp = r.wrapping_sub(quot.wrapping_mul(newr));
+        r = newr;
         newr = newrp;
     }
 

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -9,7 +9,10 @@
 
 use std::mem::swap;
 
-pub fn gcd(mut a: u64, mut b: u64) -> u64 {
+// This is incorrectly reported as dead code,
+//  presumably when included in build.rs.
+#[allow(dead_code)]
+pub(crate) fn gcd(mut a: u64, mut b: u64) -> u64 {
     while b > 0 {
         a %= b;
         swap(&mut a, &mut b);

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -80,16 +80,16 @@ impl Montgomery {
         let (xnm, overflow) = (x as u128).overflowing_add(nm); // x + n*m
         debug_assert_eq!(xnm % (1 << 64), 0);
 
-        if !overflow {
-            let y = (xnm >> 64) as u64 + overflow as u64; // (x + n*m) / R
-            if y >= *n {
-                y - n
-            } else {
-                y
-            }
+        // (x + n*m) / R
+        // in case of overflow, this is (2¹²⁸ + xnm)/2⁶⁴ - n = xnm/2⁶⁴ + (2⁶⁴ - n)
+        let y =
+            (xnm >> 64) as u64 +
+            if !overflow { 0 } else { n.wrapping_neg() };
+
+        if y >= *n {
+            y - n
         } else {
-            // y = (2¹²⁸ + xnm)/2⁶⁴ - n = xnm/2⁶⁴ + (2⁶⁴ - n)
-            (xnm >> 64) as u64 + n.wrapping_neg()
+            y
         }
     }
 }

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -8,7 +8,6 @@
 // * that was distributed with this source code.
 
 use std::mem::swap;
-use std::num::Wrapping;
 
 pub fn gcd(mut a: u64, mut b: u64) -> u64 {
     while b > 0 {
@@ -89,7 +88,7 @@ impl Montgomery {
 impl Arithmetic for Montgomery {
     // Montgomery transform, R=2⁶⁴
     // Provides fast arithmetic mod n (n odd, u64)
-    type I = Wrapping<u64>;
+    type I = u64;
 
     fn new(n: u64) -> Self {
         let a = inv_mod_u64(n).wrapping_neg();
@@ -104,13 +103,13 @@ impl Arithmetic for Montgomery {
     fn from_u64(&self, x: u64) -> Self::I {
         // TODO: optimise!
         assert!(x < self.n);
-        let r = Wrapping((((x as u128) << 64) % self.n as u128) as u64);
+        let r = (((x as u128) << 64) % self.n as u128) as u64;
         debug_assert_eq!(x, self.to_u64(r));
         r
     }
 
     fn to_u64(&self, n: Self::I) -> u64 {
-        self.reduce(n.0)
+        self.reduce(n)
     }
 
     fn add(&self, a: Self::I, b: Self::I) -> Self::I {
@@ -134,7 +133,7 @@ impl Arithmetic for Montgomery {
     }
 
     fn mul(&self, a: Self::I, b: Self::I) -> Self::I {
-        let r = Wrapping(self.reduce((a * b).0));
+        let r = self.reduce(a.wrapping_mul(b));
 
         // Check that r (reduced back to the usual representation) equals
         // a*b % n

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -82,9 +82,7 @@ impl Montgomery {
 
         // (x + n*m) / R
         // in case of overflow, this is (2¹²⁸ + xnm)/2⁶⁴ - n = xnm/2⁶⁴ + (2⁶⁴ - n)
-        let y =
-            (xnm >> 64) as u64 +
-            if !overflow { 0 } else { n.wrapping_neg() };
+        let y = (xnm >> 64) as u64 + if !overflow { 0 } else { n.wrapping_neg() };
 
         if y >= *n {
             y - n

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -3,9 +3,9 @@ use rand::rngs::SmallRng;
 use rand::{thread_rng, SeedableRng};
 use std::cmp::{max, min};
 
-use crate::{Factors,miller_rabin};
 use crate::miller_rabin::Result::*;
 use crate::numeric::*;
+use crate::{miller_rabin, Factors};
 
 fn find_divisor<A: Arithmetic>(n: A) -> u64 {
     #![allow(clippy::many_single_char_names)]

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -3,19 +3,19 @@ use rand::rngs::SmallRng;
 use rand::{thread_rng, SeedableRng};
 use std::cmp::{max, min};
 
+use crate::{Factors,miller_rabin};
 use crate::miller_rabin::Result::*;
 use crate::numeric::*;
-use crate::{miller_rabin, Factors};
 
-fn find_divisor<A: Arithmetic>(n: u64) -> u64 {
+fn find_divisor<A: Arithmetic>(n: A) -> u64 {
     #![allow(clippy::many_single_char_names)]
     let mut rand = {
-        let range = Uniform::new(1, n);
+        let range = Uniform::new(1, n.modulus());
         let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
-        move || range.sample(&mut rng)
+        move || n.from_u64(range.sample(&mut rng))
     };
 
-    let quadratic = |a, b| move |x| A::add(A::mul(a, A::mul(x, x, n), n), b, n);
+    let quadratic = |a, b| move |x| n.add(n.mul(a, n.mul(x, x)), b);
 
     loop {
         let f = quadratic(rand(), rand());
@@ -25,8 +25,12 @@ fn find_divisor<A: Arithmetic>(n: u64) -> u64 {
         loop {
             x = f(x);
             y = f(f(y));
-            let d = gcd(n, max(x, y) - min(x, y));
-            if d == n {
+            let d = {
+                let _x = n.to_u64(x);
+                let _y = n.to_u64(y);
+                gcd(n.modulus(), max(_x, _y) - min(_x, _y))
+            };
+            if d == n.modulus() {
                 // Failure, retry with a different quadratic
                 break;
             } else if d > 1 {
@@ -39,11 +43,8 @@ fn find_divisor<A: Arithmetic>(n: u64) -> u64 {
 fn _factor<A: Arithmetic>(mut num: u64) -> Factors {
     // Shadow the name, so the recursion automatically goes from “Big” arithmetic to small.
     let _factor = |n| {
-        if n < 1 << 63 {
-            _factor::<Small>(n)
-        } else {
-            _factor::<A>(n)
-        }
+        // TODO: Optimise with 32 and 64b versions
+        _factor::<A>(n)
     };
 
     let mut factors = Factors::new();
@@ -51,7 +52,8 @@ fn _factor<A: Arithmetic>(mut num: u64) -> Factors {
         return factors;
     }
 
-    match miller_rabin::test::<A>(num) {
+    let n = A::new(num);
+    match miller_rabin::test::<A>(n) {
         Prime => {
             factors.push(num);
             return factors;
@@ -65,16 +67,12 @@ fn _factor<A: Arithmetic>(mut num: u64) -> Factors {
         Pseudoprime => {}
     };
 
-    let divisor = find_divisor::<A>(num);
+    let divisor = find_divisor::<A>(n);
     factors *= _factor(divisor);
     factors *= _factor(num / divisor);
     factors
 }
 
 pub(crate) fn factor(n: u64) -> Factors {
-    if n < 1 << 63 {
-        _factor::<Small>(n)
-    } else {
-        _factor::<Big>(n)
-    }
+    _factor::<Montgomery>(n)
 }


### PR DESCRIPTION
This can probably be optimised further, but as of commit 4851619d this is already ~2.43 times faster as previously, taking ~3.55s for all integers from 2 to 10⁶.

- [x] Add tests to `factor::{factor,miller_rabin}`.
- [x] Rework the `Arithmetic` trait, implement the Montgomery transform on 64b integers (requires 128b integers for some intermediate values)
- [x] Add consistency checks with `debug_assert!`

A further optimisation would be to make the `Montgomery` implementation generic, and add a 32b variant. Moreover, a 32b variant could use a shorter basis in the Miller-Rabin primality test (either [3 witnesses], or a [single witness depending on n]).

[3 witnesses]: https://miller-rabin.appspot.com/#records
[single witness depending on n]: http://ceur-ws.org/Vol-1326/020-Forisek.pdf

This seems however out-of-scope for this PR. Moreover, such an optimisation would be currently premature, and its impact hard to measure: after this change, `factor` only spends ~10% of its time in the Miller-Rabin primality test, and another ~10% in Pollard's ρ algorithm, versus ~35% in `table::factor` and ~25% printing the factorisations (!)