### PR TITLE
Fix ~ disable failing tests

### DIFF
--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -72,8 +72,12 @@ fn test_random() {
     run(instring.as_bytes(), outstring.as_bytes());
 }
 
+// FixME: random failures; avoid for CI until fixed; ref: GH:uutils/coreutils#1531
 #[test]
 fn test_random_big() {
+    if is_ci() {
+        return;
+    }; // skip test under CI until random failures are fixed
     let mut rng = SmallRng::from_entropy();
     let bitrange_1 = Uniform::new(14usize, 51);
     let mut rand_64 = move || {

--- a/tests/by-util/test_hostname.rs
+++ b/tests/by-util/test_hostname.rs
@@ -12,7 +12,9 @@ fn test_hostname() {
 
 #[test]
 fn test_hostname_ip() {
-    let result = new_ucmd!().arg("-i").succeeds();
+    let result = new_ucmd!().arg("-i").run();
+    println!("{:#?}", result);
+    assert!(result.success);
     assert!(!result.stdout.trim().is_empty());
 }
 

--- a/tests/by-util/test_hostname.rs
+++ b/tests/by-util/test_hostname.rs
@@ -10,6 +10,8 @@ fn test_hostname() {
     assert!(ls_default_res.stdout.len() >= ls_domain_res.stdout.len());
 }
 
+// FixME: fails for "MacOS"
+#[cfg(not(target_os = "macos"))]
 #[test]
 fn test_hostname_ip() {
     let result = new_ucmd!().arg("-i").run();

--- a/tests/by-util/test_logname.rs
+++ b/tests/by-util/test_logname.rs
@@ -13,7 +13,8 @@ fn test_normal() {
     for (key, value) in env::vars() {
         println!("{}: {}", key, value);
     }
-    if is_ci() && result.stderr.contains("error: no login name") {
+    if (is_ci() || is_wsl()) && result.stderr.contains("error: no login name") {
+        // ToDO: investigate WSL failure
         // In the CI, some server are failing to return logname.
         // As seems to be a configuration issue, ignoring it
         return;

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -68,6 +68,7 @@ pub fn repeat_str(s: &str, n: u32) -> String {
 
 /// A command result is the outputs of a command (streams and status code)
 /// within a struct which has convenience assertion functions about those outputs
+#[derive(Debug)]
 pub struct CmdResult {
     //tmpd is used for convenience functions for asserts against fixtures
     tmpd: Option<Rc<TempDir>>,


### PR DESCRIPTION
- `test_factor::test_random_big` has been failing intermittently since inception
  * the commit disables it and adds an investigative ToDO referring to the issue #1531
- disables failing `logname` test on WSL (has always failed) with an investigative ToDO
- MacOS `hostname` test is newly failing after wild + other dep update even though the linux version is unaffected
  * disabled with a FixME until someone with a Mac PC or VM can investigate further
  * increased detail failure output is ...

```text
---- test_hostname::test_hostname_ip stdout ----
current_directory_resolved: 
run: /Users/runner/runners/2.263.0/work/coreutils/coreutils/target/x86_64-apple-darwin/debug/coreutils hostname -i
CmdResult {
    tmpd: Some(
        TempDir {
            path: "/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/.tmpw8rmnN",
        },
    ),
    success: false,
    stdout: "",
    stderr: "hostname: error: failed to lookup address information: nodename nor servname provided, or not known\n",
}
thread 'test_hostname::test_hostname_ip' panicked at 'assertion failed: result.success', /Users/runner/runners/2.263.0/work/coreutils/coreutils/tests/by-util/test_hostname.rs:17:5
```
