### PR TITLE
factor: Add/update copyright notices as necessary

### DIFF
--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -1,10 +1,7 @@
 // * This file is part of the uutils coreutils package.
 // *
-// * (c) T. Jameson Little <t.jameson.little@gmail.com>
-// * (c) Wiktor Kuropatwa <wiktor.kuropatwa@gmail.com>
-// *     * 2015-02-23 ~ added Pollard rho method implementation
-// * (c) kwantam <kwantam@gmail.com>
-// *     * 2015-04-29 ~ sped up trial division by adding table of prime inverses
+// * (c) 2014 T. Jameson Little <t.jameson.little@gmail.com>
+// * (c) 2020 nicoo <nicoo@debian.org>
 // *
 // * For the full copyright and license information, please view the LICENSE file
 // * that was distributed with this source code.

--- a/src/uu/factor/src/numeric.rs
+++ b/src/uu/factor/src/numeric.rs
@@ -1,8 +1,7 @@
 // * This file is part of the uutils coreutils package.
 // *
-// * (c) Wiktor Kuropatwa <wiktor.kuropatwa@gmail.com>
-// * (c) kwantam <kwantam@gmail.com>
-// *     * 20150507 ~ added big_ routines to prevent overflow when num > 2^63
+// * (c) 2015 Wiktor Kuropatwa <wiktor.kuropatwa@gmail.com>
+// * (c) 2020 nicoo            <nicoo@debian.org>
 // *
 // * For the full copyright and license information, please view the LICENSE file
 // * that was distributed with this source code.

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -1,3 +1,11 @@
+// * This file is part of the uutils coreutils package.
+// *
+// * (c) 2015 Wiktor Kuropatwa <wiktor.kuropatwa@gmail.com>
+// * (c) 2020 nicoo <nicoo@debian.org>
+// *
+// * For the full copyright and license information, please view the LICENSE file
+// * that was distributed with this source code.
+
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::SmallRng;
 use rand::{thread_rng, SeedableRng};

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -1,3 +1,11 @@
+// * This file is part of the uutils coreutils package.
+// *
+// * (c) 2015 kwantam <kwantam@gmail.com>
+// * (c) 2020 nicoo   <nicoo@debian.org>
+// *
+// * For the full copyright and license information, please view the LICENSE file
+// * that was distributed with this source code.
+
 // spell-checker: ignore (ToDO) INVS
 
 use std::num::Wrapping;


### PR DESCRIPTION
I discovered yesterday that I accidentally failed to update/preserve those when
moving code around (#1525), deleting code (#1529), or adding my own
contributions.

This rectifies it, also adding years (based on git history) for all copyright
lines; I took the liberty not to track the individual changes for which
copyright is claimed, since that information is in git and tacking it by hand
would get out-of-hand very quickly.