### PR TITLE
factor::miller_rabin: Add missing copyright header in source file

### DIFF
--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -1,3 +1,10 @@
+// * This file is part of the uutils coreutils package.
+// *
+// * (c) 2020 nicoo <nicoo@debian.org>
+// *
+// * For the full copyright and license information, please view the LICENSE file
+// * that was distributed with this source code.
+
 // spell-checker:ignore (URL) appspot
 
 use crate::numeric::*;


### PR DESCRIPTION
I just noticed it was missing  >_>'