### PR TITLE
perf/factor ~ deduplicate divisors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1641,7 @@ dependencies = [
  "quickcheck 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.4 (git+https://github.com/uutils/uucore.git?branch=canary)",
  "uucore_procs 0.0.4 (git+https://github.com/uutils/uucore.git?branch=canary)",
 ]
@@ -2679,6 +2685,7 @@ dependencies = [
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
 "checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
+"checksum smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,6 +328,7 @@ pin_same-file = { version="1.0.4, < 1.0.6", package="same-file" } ## same-file v
 pin_winapi-util = { version="0.1.2, < 0.1.3", package="winapi-util" } ## winapi-util v0.1.3 has compiler errors for MinRustV v1.32.0, expects 1.34
 
 [dev-dependencies]
+conv = "0.3"
 filetime = "0.2"
 libc = "0.2"
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,7 +330,7 @@ pin_winapi-util = { version="0.1.2, < 0.1.3", package="winapi-util" } ## winapi-
 [dev-dependencies]
 filetime = "0.2"
 libc = "0.2"
-rand = "0.6"
+rand = "0.7"
 regex = "1.0"
 tempfile = "3.1"
 time = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,6 +332,7 @@ filetime = "0.2"
 libc = "0.2"
 rand = "0.7"
 regex = "1.0"
+sha1 = { version="0.6", features=["std"] }
 tempfile = "3.1"
 time = "0.1"
 unindent = "0.1"

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2" # used in src/numerics.rs, which is included by build.rs
 [dependencies]
 num-traits = "0.2"
 rand = { version="0.7", features=["small_rng"] }
+smallvec = { version="0.6.13, < 1.0" }
 uucore = { version="0.0.4", package="uucore", git="https://github.com/uutils/uucore.git", branch="canary" }
 uucore_procs = { version="0.0.4", package="uucore_procs", git="https://github.com/uutils/uucore.git", branch="canary" }
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -173,24 +173,30 @@ pub fn factor(num: u64) -> Factors {
                 let mut tmp = Decomposition::one();
                 non_trivial_gcd = false;
                 for i in 0..gcd_queue.0.len() - 1 {
-                    let (a, e_a) = gcd_queue.0[i];
-                    let (b, e_b) = gcd_queue.0[i + 1];
+                    let (mut a, e_a) = gcd_queue.0[i];
+                    let (mut b, e_b) = gcd_queue.0[i + 1];
+
+                    if a == 1 {
+                        continue;
+                    }
 
                     let g = gcd(a, b);
                     if g != 1 {
                         non_trivial_gcd = true;
-                        tmp.add(a / g, e_a);
-                        tmp.add(g, e_a + e_b);
-                        if i + 1 == gcd_queue.0.len() {
-                            tmp.add(b / g, e_b)
-                        } else {
-                            gcd_queue.0[i + 1] = (b / g, e_b);
-                        }
-                    } else {
+                        a /= g;
+                        b /= g;
+                    }
+                    if a != 1 {
                         tmp.add(a, e_a);
-                        if i + 1 == gcd_queue.0.len() - 1 {
-                            tmp.add(b, e_b)
-                        }
+                    }
+                    if g != 1 {
+                        tmp.add(g, e_a + e_b);
+                    }
+
+                    if i + 1 != gcd_queue.0.len() - 1 {
+                        gcd_queue.0[i + 1].0 = b;
+                    } else if b != 1 {
+                        tmp.add(b, e_b);
                     }
                 }
                 gcd_queue = tmp;

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -7,7 +7,6 @@
 
 extern crate rand;
 
-use std::cell::RefCell;
 use std::fmt;
 
 use crate::numeric::{Arithmetic, Montgomery};
@@ -61,31 +60,8 @@ impl PartialEq for Decomposition {
 
         true
     }
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct Decomposition(BTreeMap<u64, Exponent>);
-
-impl Decomposition {
-    fn one() -> Decomposition {
-        Decomposition(BTreeMap::new())
-    }
-
-    fn add(&mut self, factor: u64, exp: Exponent) {
-        debug_assert!(exp > 0);
-        let n = *self.0.get(&factor).unwrap_or(&0);
-        self.0.insert(factor, exp + n);
-    }
-
-    #[cfg(test)]
-    fn product(&self) -> u64 {
-        self.0
-            .iter()
-            .fold(1, |acc, (p, exp)| acc * p.pow(*exp as u32))
-    }
 }
 impl Eq for Decomposition {}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Factors(RefCell<Decomposition>);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Factors(Decomposition);
@@ -112,7 +88,10 @@ impl Factors {
 
 impl fmt::Display for Factors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (p, exp) in (self.0).0.iter() {
+        let mut v = (self.0).0.clone();
+        v.sort_unstable();
+
+        for (p, exp) in v.iter() {
             for _ in 0..*exp {
                 write!(f, " {}", p)?
             }

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn factor_recombines_strong_pseudoprime() {
         // This is a strong pseudoprime (wrt. miller_rabin::BASIS)
-        //  and triggered a bug in rho::factor's codepath handling
+        //  and triggered a bug in rho::factor's code path handling
         //  miller_rabbin::Result::Composite
         let pseudoprime = 17179869183;
         for _ in 0..20 {
@@ -300,7 +300,7 @@ impl quickcheck::Arbitrary for Factors {
         let mut n = u64::MAX;
 
         // Adam Kalai's algorithm for generating uniformly-distributed
-        // integers and their factorisation.
+        // integers and their factorization.
         //
         // See Generating Random Factored Numbers, Easily, J. Cryptology (2003)
         'attempt: loop {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -7,6 +7,7 @@
 
 extern crate rand;
 
+use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::fmt;
 
@@ -16,11 +17,16 @@ use crate::{miller_rabin, rho, table};
 type Exponent = u8;
 
 #[derive(Clone, Debug)]
-struct Decomposition(Vec<(u64, Exponent)>);
+struct Decomposition(SmallVec<[(u64, Exponent); NUM_FACTORS_INLINE]>);
+
+// The number of factors to inline directly into a `Decomposition` object.
+// As a consequence of the Erdős–Kac theorem, the average number of prime
+//  factors of integers < 10²⁵ ≃ 2⁸³ is 4, so we can use that value.
+const NUM_FACTORS_INLINE: usize = 4;
 
 impl Decomposition {
     fn one() -> Decomposition {
-        Decomposition(Vec::new())
+        Decomposition(SmallVec::new())
     }
 
     fn add(&mut self, factor: u64, exp: Exponent) {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -169,10 +169,16 @@ pub fn factor(num: u64) -> Factors {
 
         if let Some(divisor) = find_factor(factor) {
             let mut gcd_queue = Decomposition::one();
-            gcd_queue.add(divisor, exp);
-            gcd_queue.add(factor / divisor, exp);
 
-            let mut non_trivial_gcd = true;
+            let quotient = factor / divisor;
+            if quotient == divisor {
+                gcd_queue.add(divisor, exp + 1);
+            } else {
+                gcd_queue.add(divisor, exp);
+                gcd_queue.add(quotient, exp);
+            }
+
+            let mut non_trivial_gcd = quotient != divisor;
             while non_trivial_gcd {
                 debug_assert_eq!(factor, gcd_queue.product());
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -225,9 +225,31 @@ mod tests {
     use quickcheck::quickcheck;
 
     #[test]
+    fn factor_correctly_recombines_prior_test_failures() {
+        let prior_failures = [
+            // * integers with duplicate factors (ie, N.pow(M))
+            4566769_u64, // == 2137.pow(2)
+            2044854919485649_u64,
+            18446739546814299361_u64,
+            18446738440860217487_u64,
+            18446736729316206481_u64,
+        ];
+        assert!(prior_failures.iter().all(|i| factor(*i).product() == *i));
+    }
+
+    #[test]
     fn factor_recombines_small() {
         assert!((1..10_000)
             .map(|i| 2 * i + 1)
+            .all(|i| factor(i).product() == i));
+    }
+
+    #[test]
+    fn factor_recombines_small_squares() {
+        // factor(18446736729316206481) == 4294966441 ** 2 ; causes debug_assert fault for repeated decomposition factor in add()
+        // ToDO: explain/combine with factor_18446736729316206481 and factor_18446739546814299361 tests
+        assert!((1..10_000)
+            .map(|i| (2 * i + 1) * (2 * i + 1))
             .all(|i| factor(i).product() == i));
     }
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -140,10 +140,10 @@ pub fn factor(num: u64) -> Factors {
     }
 
     let mut n = num;
-    let z = num.trailing_zeros();
-    if z > 0 {
-        factors.add(2, z as Exponent);
-        n >>= z;
+    let n_zeros = num.trailing_zeros();
+    if n_zeros > 0 {
+        factors.add(2, n_zeros as Exponent);
+        n >>= n_zeros;
     }
     debug_assert_eq!(num, n * factors.product());
 
@@ -165,22 +165,22 @@ pub fn factor(num: u64) -> Factors {
         // Check correctness invariant
         debug_assert_eq!(num, factors.product() * dec.product());
 
-        let (f, e) = dec.pop().unwrap();
+        let (factor, exp) = dec.pop().unwrap();
 
-        if let Some(d) = find_factor(f) {
+        if let Some(divisor) = find_factor(factor) {
             let mut gcd_queue = Decomposition::one();
-            gcd_queue.add(d, e);
-            gcd_queue.add(f / d, e);
+            gcd_queue.add(divisor, exp);
+            gcd_queue.add(factor / divisor, exp);
 
             let mut non_trivial_gcd = true;
             while non_trivial_gcd {
-                debug_assert_eq!(f, gcd_queue.product());
+                debug_assert_eq!(factor, gcd_queue.product());
 
                 let mut tmp = Decomposition::one();
                 non_trivial_gcd = false;
                 for i in 0..gcd_queue.0.len() - 1 {
-                    let (mut a, e_a) = gcd_queue.0[i];
-                    let (mut b, e_b) = gcd_queue.0[i + 1];
+                    let (mut a, exp_a) = gcd_queue.0[i];
+                    let (mut b, exp_b) = gcd_queue.0[i + 1];
 
                     if a == 1 {
                         continue;
@@ -193,26 +193,26 @@ pub fn factor(num: u64) -> Factors {
                         b /= g;
                     }
                     if a != 1 {
-                        tmp.add(a, e_a);
+                        tmp.add(a, exp_a);
                     }
                     if g != 1 {
-                        tmp.add(g, e_a + e_b);
+                        tmp.add(g, exp_a + exp_b);
                     }
 
                     if i + 1 != gcd_queue.0.len() - 1 {
                         gcd_queue.0[i + 1].0 = b;
                     } else if b != 1 {
-                        tmp.add(b, e_b);
+                        tmp.add(b, exp_b);
                     }
                 }
                 gcd_queue = tmp;
             }
 
-            debug_assert_eq!(f, gcd_queue.product());
+            debug_assert_eq!(factor, gcd_queue.product());
             dec.0.extend(gcd_queue.0);
         } else {
-            // f is prime
-            factors.add(f, e);
+            // factor is prime
+            factors.add(factor, exp);
         }
     }
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -171,19 +171,19 @@ pub fn factor(num: u64) -> Factors {
             let mut gcd_queue = Decomposition::one();
 
             let quotient = factor / divisor;
-            if quotient == divisor {
+            let mut trivial_gcd = quotient == divisor;
+            if trivial_gcd {
                 gcd_queue.add(divisor, exp + 1);
             } else {
                 gcd_queue.add(divisor, exp);
                 gcd_queue.add(quotient, exp);
             }
 
-            let mut non_trivial_gcd = quotient != divisor;
-            while non_trivial_gcd {
+            while !trivial_gcd {
                 debug_assert_eq!(factor, gcd_queue.product());
 
                 let mut tmp = Decomposition::one();
-                non_trivial_gcd = false;
+                trivial_gcd = true;
                 for i in 0..gcd_queue.0.len() - 1 {
                     let (mut a, exp_a) = gcd_queue.0[i];
                     let (mut b, exp_b) = gcd_queue.0[i + 1];
@@ -194,7 +194,7 @@ pub fn factor(num: u64) -> Factors {
 
                     let g = gcd(a, b);
                     if g != 1 {
-                        non_trivial_gcd = true;
+                        trivial_gcd = false;
                         a /= g;
                         b /= g;
                     }

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -7,6 +7,7 @@
 
 extern crate rand;
 
+use std::cell::RefCell;
 use std::fmt;
 
 use crate::numeric::{Arithmetic, Montgomery};
@@ -64,16 +65,16 @@ impl PartialEq for Decomposition {
 impl Eq for Decomposition {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Factors(Decomposition);
+pub struct Factors(RefCell<Decomposition>);
 
 impl Factors {
     pub fn one() -> Factors {
-        Factors(Decomposition::one())
+        Factors(RefCell::new(Decomposition::one()))
     }
 
     pub fn add(&mut self, prime: u64, exp: Exponent) {
         debug_assert!(miller_rabin::is_prime(prime));
-        self.0.add(prime, exp)
+        self.0.borrow_mut().add(prime, exp)
     }
 
     pub fn push(&mut self, prime: u64) {
@@ -82,13 +83,13 @@ impl Factors {
 
     #[cfg(test)]
     fn product(&self) -> u64 {
-        self.0.product()
+        self.0.borrow().product()
     }
 }
 
 impl fmt::Display for Factors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut v = (self.0).0.clone();
+        let v = &mut (self.0).borrow_mut().0;
         v.sort_unstable();
 
         for (p, exp) in v.iter() {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -25,12 +25,10 @@ impl Decomposition {
 
     fn add(&mut self, factor: u64, exp: Exponent) {
         debug_assert!(exp > 0);
+        // Assert the factor doesn't already exist in the Decomposition object
+        debug_assert_eq!(self.0.iter_mut().find(|(f, _)| *f == factor), None);
 
-        if let Some((_, e)) = self.0.iter_mut().find(|(f, _)| *f == factor) {
-            *e += exp;
-        } else {
-            self.0.push((factor, exp))
-        }
+        self.0.push((factor, exp))
     }
 
     fn is_one(&self) -> bool {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -20,9 +20,9 @@ type Exponent = u8;
 struct Decomposition(SmallVec<[(u64, Exponent); NUM_FACTORS_INLINE]>);
 
 // The number of factors to inline directly into a `Decomposition` object.
-// As a consequence of the Erdős–Kac theorem, the average number of prime
-//  factors of integers < 10²⁵ ≃ 2⁸³ is 4, so we can use that value.
-const NUM_FACTORS_INLINE: usize = 4;
+// As a consequence of the Erdős–Kac theorem, the average number of prime factors
+// of integers < 10²⁵ ≃ 2⁸³ is 4, so we can use a slightly higher value.
+const NUM_FACTORS_INLINE: usize = 5;
 
 impl Decomposition {
     fn one() -> Decomposition {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -61,6 +61,9 @@ impl PartialEq for Decomposition {
 
         true
     }
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Factors {
+    f: BTreeMap<u64, Exponent>,
 }
 impl Eq for Decomposition {}
 

--- a/src/uu/factor/src/numeric/gcd.rs
+++ b/src/uu/factor/src/numeric/gcd.rs
@@ -79,7 +79,11 @@ mod tests {
         fn divisor(a: u64, b: u64) -> bool {
             // Test that gcd(a, b) divides a and b
             let g = gcd(a, b);
-            (g != 0 && a % g == 0 && b % g == 0) || (g == 0 && a == 0 && b == 0)
+            if g != 0 {
+                a % g == 0 && b % g == 0
+            } else {
+                a == 0 && b == 0 // for g == 0
+            }
         }
 
         fn commutative(a: u64, b: u64) -> bool {

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -14,7 +14,8 @@ use crate::Factors;
 
 include!(concat!(env!("OUT_DIR"), "/prime_table.rs"));
 
-pub(crate) fn factor(mut num: u64, mut factors: Factors) -> (Factors, u64) {
+pub(crate) fn factor(n: &mut u64, factors: &mut Factors) {
+    let mut num = *n;
     for &(prime, inv, ceil) in P_INVS_U64 {
         if num == 1 {
             break;
@@ -42,5 +43,5 @@ pub(crate) fn factor(mut num: u64, mut factors: Factors) -> (Factors, u64) {
         }
     }
 
-    (factors, num)
+    *n = num;
 }

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -22,6 +22,27 @@ const LOG_PRIMES: f64 = 14.0; // ceil(log2(NUM_PRIMES))
 const NUM_TESTS: usize = 100;
 
 #[test]
+fn test_first_100000_integers() {
+    extern crate sha1;
+
+    let n_integers = 100_000;
+    let mut instring = String::new();
+    for i in 0..=n_integers {
+        instring.push_str(&(format!("{} ", i))[..]);
+    }
+
+    println!("STDIN='{}'", instring);
+    let result = new_ucmd!().pipe_in(instring.as_bytes()).run();
+    let stdout = result.stdout;
+
+    assert!(result.success);
+
+    // `seq 0 100000 | factor | sha1sum` => "4ed2d8403934fa1c76fe4b84c5d4b8850299c359"
+    let hash_check = sha1::Sha1::from(stdout.as_bytes()).hexdigest();
+    assert_eq!(hash_check, "4ed2d8403934fa1c76fe4b84c5d4b8850299c359");
+}
+
+#[test]
 fn test_random() {
     let primes = Sieve::primes().take(NUM_PRIMES).collect::<Vec<u64>>();
 

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -6,6 +6,7 @@
 // that was distributed with this source code.
 
 use crate::common::util::*;
+use std::time::SystemTime;
 
 #[path = "../../src/uu/factor/sieve.rs"]
 mod sieve;
@@ -13,7 +14,7 @@ use self::sieve::Sieve;
 
 extern crate rand;
 use self::rand::distributions::{Distribution, Uniform};
-use self::rand::{rngs::SmallRng, FromEntropy, Rng};
+use self::rand::{rngs::SmallRng, Rng, SeedableRng};
 
 const NUM_PRIMES: usize = 10000;
 const LOG_PRIMES: f64 = 14.0; // ceil(log2(NUM_PRIMES))
@@ -24,8 +25,13 @@ const NUM_TESTS: usize = 100;
 fn test_random() {
     let primes = Sieve::primes().take(NUM_PRIMES).collect::<Vec<u64>>();
 
-    let mut rng = SmallRng::from_entropy();
-    println!("(seed) rng={:?}", rng);
+    let rng_seed = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    println!("rng_seed={:?}", rng_seed);
+
+    let mut rng = SmallRng::seed_from_u64(rng_seed);
     let mut rand_gt = move |min: u64| {
         let mut product = 1u64;
         let mut factors = Vec::new();
@@ -73,8 +79,12 @@ fn test_random() {
 
 #[test]
 fn test_random_big() {
-    let mut rng = SmallRng::from_entropy();
-    println!("(seed) rng={:?}", rng);
+    let rng_seed = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    println!("rng_seed={:?}", rng_seed);
+    let mut rng = SmallRng::seed_from_u64(rng_seed);
     let bitrange_1 = Uniform::new(14usize, 51);
     let mut rand_64 = move || {
         // first, choose a random number of bits for the first factor
@@ -161,6 +171,8 @@ fn test_big_primes() {
 }
 
 fn run(instring: &[u8], outstring: &[u8]) {
+    println!("STDIN='{}'", String::from_utf8_lossy(instring));
+    println!("STDOUT(expected)='{}'", String::from_utf8_lossy(outstring));
     // now run factor
     new_ucmd!()
         .pipe_in(instring)

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -10,15 +10,15 @@ use std::time::SystemTime;
 
 #[path = "../../src/uu/factor/sieve.rs"]
 mod sieve;
-use self::sieve::Sieve;
 
+extern crate conv;
 extern crate rand;
+
 use self::rand::distributions::{Distribution, Uniform};
 use self::rand::{rngs::SmallRng, Rng, SeedableRng};
+use self::sieve::Sieve;
 
 const NUM_PRIMES: usize = 10000;
-const LOG_PRIMES: f64 = 14.0; // ceil(log2(NUM_PRIMES))
-
 const NUM_TESTS: usize = 100;
 
 #[test]
@@ -44,6 +44,9 @@ fn test_first_100000_integers() {
 
 #[test]
 fn test_random() {
+    use conv::prelude::*;
+
+    let log_num_primes = f64::value_from(NUM_PRIMES).unwrap().log2().ceil();
     let primes = Sieve::primes().take(NUM_PRIMES).collect::<Vec<u64>>();
 
     let rng_seed = SystemTime::now()
@@ -51,16 +54,16 @@ fn test_random() {
         .unwrap()
         .as_secs();
     println!("rng_seed={:?}", rng_seed);
-
     let mut rng = SmallRng::seed_from_u64(rng_seed);
+
     let mut rand_gt = move |min: u64| {
-        let mut product = 1u64;
+        let mut product = 1_u64;
         let mut factors = Vec::new();
         while product < min {
             // log distribution---higher probability for lower numbers
             let factor;
             loop {
-                let next = rng.gen_range(0f64, LOG_PRIMES).exp2().floor() as usize;
+                let next = rng.gen_range(0_f64, log_num_primes).exp2().floor() as usize;
                 if next < NUM_PRIMES {
                     factor = primes[next];
                     break;
@@ -106,7 +109,8 @@ fn test_random_big() {
         .as_secs();
     println!("rng_seed={:?}", rng_seed);
     let mut rng = SmallRng::seed_from_u64(rng_seed);
-    let bitrange_1 = Uniform::new(14usize, 51);
+
+    let bitrange_1 = Uniform::new(14_usize, 51);
     let mut rand_64 = move || {
         // first, choose a random number of bits for the first factor
         let f_bit_1 = bitrange_1.sample(&mut rng);
@@ -116,11 +120,11 @@ fn test_random_big() {
         // we will have a number of additional factors equal to nfacts + 1
         // where nfacts is in [0, floor(rem/14) )  NOTE half-open interval
         // Each prime factor is at least 14 bits, hence floor(rem/14)
-        let nfacts = Uniform::new(0usize, rem / 14).sample(&mut rng);
+        let nfacts = Uniform::new(0_usize, rem / 14).sample(&mut rng);
         // we have to distribute extrabits among the (nfacts + 1) values
         let extrabits = rem - (nfacts + 1) * 14;
         // (remember, a Range is a half-open interval)
-        let extrarange = Uniform::new(0usize, extrabits + 1);
+        let extrarange = Uniform::new(0_usize, extrabits + 1);
 
         // to generate an even split of this range, generate n-1 random elements
         // in the range, add the desired total value to the end, sort this list,
@@ -147,7 +151,7 @@ fn test_random_big() {
         let f_bits = f_bits;
 
         let mut nbits = 0;
-        let mut product = 1u64;
+        let mut product = 1_u64;
         let mut factors = Vec::new();
         for bit in f_bits {
             assert!(bit < 37);


### PR DESCRIPTION
- [x] Refactor (eheh) the `factor()` function and `Factors` datastructure
- [x] Introduce `Decomposition`, a representation of divisor multisets, common to `factor()` and `Factors`.
- [x] Optimise `Decomposition`, first by switching to a flat vector representation, then by using `smallvec` to stack-allocate the space in most cases.
- [x] Optimise the `fmt` implementation for `Factors`, avoiding a data copy to sort the factors.
- [x] Use a GCD-powered algorithm to decompose numbers into coprime factors, whenever a new factor is found.
       This is marked WiP, as the implementation is rather ugly and leaves some performance on the table.
- [x] Optimise `Decomposition` again, knowing we do not ever add the same factor twice (so we can skip looking for it)