### PR TITLE
factor: Refactor and optimise the `Factors` datastructure

### DIFF
--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -7,6 +7,7 @@
 
 extern crate rand;
 
+use std::cell::RefCell;
 use std::fmt;
 
 use crate::numeric::{Arithmetic, Montgomery};
@@ -64,16 +65,16 @@ impl PartialEq for Decomposition {
 impl Eq for Decomposition {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Factors(Decomposition);
+pub struct Factors(RefCell<Decomposition>);
 
 impl Factors {
     pub fn one() -> Factors {
-        Factors(Decomposition::one())
+        Factors(RefCell::new(Decomposition::one()))
     }
 
     pub fn add(&mut self, prime: u64, exp: Exponent) {
         debug_assert!(miller_rabin::is_prime(prime));
-        self.0.add(prime, exp)
+        self.0.borrow_mut().add(prime, exp)
     }
 
     pub fn push(&mut self, prime: u64) {
@@ -82,13 +83,13 @@ impl Factors {
 
     #[cfg(test)]
     fn product(&self) -> u64 {
-        self.0.product()
+        self.0.borrow().product()
     }
 }
 
 impl fmt::Display for Factors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut v = (self.0).0.clone();
+        let v = &mut (self.0).borrow_mut().0;
         v.sort_unstable();
 
         for (p, exp) in v.iter() {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -13,9 +13,11 @@ use std::fmt;
 use crate::numeric::{Arithmetic, Montgomery};
 use crate::{miller_rabin, rho, table};
 
+type Exponent = u8;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Factors {
-    f: BTreeMap<u64, u8>,
+    f: BTreeMap<u64, Exponent>,
 }
 
 impl Factors {
@@ -23,7 +25,7 @@ impl Factors {
         Factors { f: BTreeMap::new() }
     }
 
-    pub fn add(&mut self, prime: u64, exp: u8) {
+    pub fn add(&mut self, prime: u64, exp: Exponent) {
         debug_assert!(miller_rabin::is_prime(prime));
         debug_assert!(exp > 0);
         let n = *self.f.get(&prime).unwrap_or(&0);
@@ -95,7 +97,7 @@ pub fn factor(mut n: u64) -> Factors {
 
     let z = n.trailing_zeros();
     if z > 0 {
-        factors.add(2, z as u8);
+        factors.add(2, z as Exponent);
         n >>= z;
     }
 


### PR DESCRIPTION
- [x] Extract the divisors multiset abstraction to a `Decomposition` struct.
- [x] Make it use a flat vector representation.
- [x] Inline them on the stack in most cases, with `smallvec`.
- [x] Optimise away a copy in the `fmt` implementation of `Factors`.

This set of changes is extracted from #1571.  Approx. 12% faster than `master`.