### PR TITLE
factor: Avoid most heap allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1641,7 @@ dependencies = [
  "quickcheck 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uucore 0.0.4 (git+https://github.com/uutils/uucore.git?branch=canary)",
  "uucore_procs 0.0.4 (git+https://github.com/uutils/uucore.git?branch=canary)",
 ]
@@ -2679,6 +2685,7 @@ dependencies = [
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
 "checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
+"checksum smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2" # used in src/numerics.rs, which is included by build.rs
 [dependencies]
 num-traits = "0.2"
 rand = { version="0.7", features=["small_rng"] }
+smallvec = "1.4"
 uucore = { version="0.0.4", package="uucore", git="https://github.com/uutils/uucore.git", branch="canary" }
 uucore_procs = { version="0.0.4", package="uucore_procs", git="https://github.com/uutils/uucore.git", branch="canary" }
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -7,6 +7,7 @@
 
 extern crate rand;
 
+use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::fmt;
 
@@ -16,11 +17,16 @@ use crate::{miller_rabin, rho, table};
 type Exponent = u8;
 
 #[derive(Clone, Debug)]
-struct Decomposition(Vec<(u64, Exponent)>);
+struct Decomposition(SmallVec<[(u64, Exponent); NUM_FACTORS_INLINE]>);
+
+// The number of factors to inline directly into a `Decomposition` object.
+// As a consequence of the Erdős–Kac theorem, the average number of prime
+//  factors of integers < 10²⁵ ≃ 2⁸³ is 4, so we can use that value.
+const NUM_FACTORS_INLINE: usize = 4;
 
 impl Decomposition {
     fn one() -> Decomposition {
-        Decomposition(Vec::new())
+        Decomposition(SmallVec::new())
     }
 
     fn add(&mut self, factor: u64, exp: Exponent) {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -7,6 +7,7 @@
 
 extern crate rand;
 
+use std::cell::RefCell;
 use std::fmt;
 
 use crate::numeric::{Arithmetic, Montgomery};
@@ -64,16 +65,16 @@ impl PartialEq for Decomposition {
 impl Eq for Decomposition {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Factors(Decomposition);
+pub struct Factors(RefCell<Decomposition>);
 
 impl Factors {
     pub fn one() -> Factors {
-        Factors(Decomposition::one())
+        Factors(RefCell::new(Decomposition::one()))
     }
 
     pub fn add(&mut self, prime: u64, exp: Exponent) {
         debug_assert!(miller_rabin::is_prime(prime));
-        self.0.add(prime, exp)
+        self.0.borrow_mut().add(prime, exp)
     }
 
     pub fn push(&mut self, prime: u64) {
@@ -82,13 +83,13 @@ impl Factors {
 
     #[cfg(test)]
     fn product(&self) -> u64 {
-        self.0.product()
+        self.0.borrow().product()
     }
 }
 
 impl fmt::Display for Factors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut v = (self.0).0.clone();
+        let v = &mut (self.0).borrow_mut().0;
         v.sort_unstable();
 
         for (p, exp) in v.iter() {

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -13,9 +13,11 @@ use std::fmt;
 use crate::numeric::{Arithmetic, Montgomery};
 use crate::{miller_rabin, rho, table};
 
+type Exponent = u8;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Factors {
-    f: BTreeMap<u64, u8>,
+    f: BTreeMap<u64, Exponent>,
 }
 
 impl Factors {
@@ -23,7 +25,7 @@ impl Factors {
         Factors { f: BTreeMap::new() }
     }
 
-    pub fn add(&mut self, prime: u64, exp: u8) {
+    pub fn add(&mut self, prime: u64, exp: Exponent) {
         debug_assert!(miller_rabin::is_prime(prime));
         debug_assert!(exp > 0);
         let n = *self.f.get(&prime).unwrap_or(&0);
@@ -95,7 +97,7 @@ pub fn factor(mut n: u64) -> Factors {
 
     let z = n.trailing_zeros();
     if z > 0 {
-        factors.add(2, z as u8);
+        factors.add(2, z as Exponent);
         n >>= z;
     }
 


### PR DESCRIPTION
Uses `smallvec` instead of `Vec` in `Decomposition`, sized to the average number of (co)prime factors (4) for integers < 2⁸³.  Extracted from #1572.