### PR TITLE
head: Ignore known-failing tests introduced in #1579

### DIFF
--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -87,11 +87,13 @@ fn test_verbose() {
 }
 
 #[test]
+#[ignore]
 fn test_spams_newline() {
     new_ucmd!().pipe_in("a").succeeds().stdout_is("a\n");
 }
 
 #[test]
+#[ignore]
 fn test_unsupported_byte_syntax() {
     new_ucmd!()
         .args(&["-1c"])
@@ -103,6 +105,7 @@ fn test_unsupported_byte_syntax() {
 }
 
 #[test]
+#[ignore]
 fn test_unsupported_line_syntax() {
     new_ucmd!()
         .args(&["-n", "2048m"])
@@ -114,6 +117,7 @@ fn test_unsupported_line_syntax() {
 }
 
 #[test]
+#[ignore]
 fn test_unsupported_zero_terminated_syntax() {
     new_ucmd!()
         .args(&["-z -n 1"])
@@ -124,6 +128,7 @@ fn test_unsupported_zero_terminated_syntax() {
 }
 
 #[test]
+#[ignore]
 fn test_unsupported_zero_terminated_syntax_2() {
     new_ucmd!()
         .args(&["-z -n 2"])
@@ -134,6 +139,7 @@ fn test_unsupported_zero_terminated_syntax_2() {
 }
 
 #[test]
+#[ignore]
 fn test_unsupported_negative_byte_syntax() {
     new_ucmd!()
         .args(&["--bytes=-2"])
@@ -144,6 +150,7 @@ fn test_unsupported_negative_byte_syntax() {
 }
 
 #[test]
+#[ignore]
 fn test_bug_in_negative_zero_lines() {
     new_ucmd!()
         .args(&["--lines=-0"])


### PR DESCRIPTION
This caused tests to fail on all unrelated work.
In particular, CI went red for all pull requests.