### PR TITLE
stat: fix `cargo clippy` complaint (unnecessary_sort_by)

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -485,7 +485,8 @@ impl Stater {
                 .filter_map(|line| line.split_whitespace().nth(1).map(ToOwned::to_owned))
                 .collect::<Vec<String>>();
             // Reverse sort. The longer comes first.
-            mount_list.sort_by(|a, b| b.cmp(a));
+            mount_list.sort();
+            mount_list.reverse();
             Some(mount_list)
         };
 


### PR DESCRIPTION
`cargo clippy` is complaining about using `Vec::sort_by(|a,b| b.cmp(a))` as a complicated closure (see [unnecessary_close_by](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by)). I'm not sure I agree, but this should be an equivalent construction which avoids the issue. [Benchmark comparison on StackOverflow](https://stackoverflow.com/a/60916195) shows no real difference in performance.

Alternatively, I can add a clippy allow exception for the offending line, but, of the two options, I'm inclined to this repair.

Thoughts/concerns?