### PR TITLE
Fix `cargo clippy` warnings

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -25,7 +25,7 @@ fn usage<T>(utils: &UtilityMap<T>, name: &str) {
     println!("Currently defined functions/utilities:\n");
     #[allow(clippy::map_clone)]
     let mut utils: Vec<&str> = utils.keys().map(|&s| s).collect();
-    utils.sort();
+    utils.sort_unstable();
     let display_list = utils.join(", ");
     let width = cmp::min(textwrap::termwidth(), 100) - 4 * 2; // (opinion/heuristic) max 100 chars wide with 4 character side indentions
     println!(

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -29,7 +29,7 @@ static LONG_HELP: &str = "";
 static DEFAULT_TABSTOP: usize = 8;
 
 fn tabstops_parse(s: String) -> Vec<usize> {
-    let words = s.split(',').collect::<Vec<&str>>();
+    let words = s.split(',');
 
     let nums = words
         .into_iter()

--- a/src/uu/expr/src/tokens.rs
+++ b/src/uu/expr/src/tokens.rs
@@ -63,6 +63,8 @@ impl Token {
         }
     }
     fn is_a_close_paren(&self) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
+        // `matches!(...)` macro not stabilized until rust v1.42
         match *self {
             Token::ParClose => true,
             _ => false,

--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -264,6 +264,8 @@ impl<'a> ParagraphStream<'a> {
                     return false;
                 }
 
+                #[allow(clippy::match_like_matches_macro)]
+                // `matches!(...)` macro not stabilized until rust v1.42
                 l_slice[..colon_posn].chars().all(|x| match x as usize {
                     y if y < 33 || y > 126 => false,
                     _ => true,
@@ -539,6 +541,8 @@ impl<'a> WordSplit<'a> {
     }
 
     fn is_punctuation(c: char) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
+        // `matches!(...)` macro not stabilized until rust v1.42
         match c {
             '!' | '.' | '?' => true,
             _ => false,

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -57,6 +57,8 @@ struct Options {
 }
 
 fn is_custom_binary(program: &str) -> bool {
+    #[allow(clippy::match_like_matches_macro)]
+    // `matches!(...)` macro not stabilized until rust v1.42
     match program {
         "md5sum" | "sha1sum" | "sha224sum" | "sha256sum" | "sha384sum" | "sha512sum"
         | "sha3sum" | "sha3-224sum" | "sha3-256sum" | "sha3-384sum" | "sha3-512sum"

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -85,6 +85,8 @@ fn od_format_type(type_char: FormatType, byte_size: u8) -> Option<FormatterItemI
 }
 
 fn od_argument_with_option(ch: char) -> bool {
+    #[allow(clippy::match_like_matches_macro)]
+    // `matches!(...)` macro not stabilized until rust v1.42
     match ch {
         'A' | 'j' | 'N' | 'S' | 'w' => true,
         _ => false,

--- a/src/uu/printf/src/tokenize/sub.rs
+++ b/src/uu/printf/src/tokenize/sub.rs
@@ -163,8 +163,8 @@ impl SubParser {
             'b', 'c', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'i', 'o', 's', 'u', 'x', 'X',
         ];
         let mut specifiers = vec!['h', 'j', 'l', 'L', 't', 'z'];
-        legal_fields.sort();
-        specifiers.sort();
+        legal_fields.sort_unstable();
+        specifiers.sort_unstable();
 
         // divide substitution from %([0-9]+)?(.[0-9+])?([a-zA-Z])
         // into min_width, second_field, field_char

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -302,6 +302,8 @@ fn prompt(msg: &str) -> bool {
     let stdin = stdin();
     let mut stdin = stdin.lock();
 
+    #[allow(clippy::match_like_matches_macro)]
+    // `matches!(...)` macro not stabilized until rust v1.42
     match stdin.read_until(b'\n', &mut buf) {
         Ok(x) if x > 0 => match buf[0] {
             b'y' | b'Y' => true,

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -69,10 +69,7 @@ struct FilenameGenerator {
 
 impl FilenameGenerator {
     fn new(name_len: usize) -> FilenameGenerator {
-        let mut indices: Vec<usize> = Vec::new();
-        for _ in 0..name_len {
-            indices.push(0);
-        }
+        let indices: Vec<usize> = vec![0; name_len];
         FilenameGenerator {
             name_len,
             nameset_indices: RefCell::new(indices),

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -26,7 +26,7 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_TABSTOP: usize = 8;
 
 fn tabstops_parse(s: String) -> Vec<usize> {
-    let words = s.split(',').collect::<Vec<&str>>();
+    let words = s.split(',');
 
     let nums = words
         .into_iter()


### PR DESCRIPTION
This PR fixes new warnings due to updated rust/clippy version(s).