### PR TITLE
tests/cp ~ disable intermittent failures on MacOS (includes FixME comments)

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -112,6 +112,8 @@ fn test_cp_multiple_files() {
 }
 
 #[test]
+// FixME: for MacOS, this has intermittent failures; track repair progress at GH:uutils/coreutils/issues/1590
+#[cfg(not(macos))]
 fn test_cp_recurse() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -141,6 +143,8 @@ fn test_cp_with_dirs_t() {
 }
 
 #[test]
+// FixME: for MacOS, this has intermittent failures; track repair progress at GH:uutils/coreutils/issues/1590
+#[cfg(not(macos))]
 fn test_cp_with_dirs() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
- track repair progress at uutils/coreutils#1590