### PR TITLE
sort: fix panic on write to closed pipe

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -550,10 +550,7 @@ where
 
     for line in iter {
         let str = format!("{}\n", line);
-        if let Err(e) = file.write_all(str.as_bytes()) {
-            show_error!("sort: {0}", e.to_string());
-            panic!("Write failed");
-        }
+        crash_if_err!(1, file.write_all(str.as_bytes()))
     }
 }
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -119,6 +119,19 @@ fn test_merge_reversed() {
 }
 
 #[test]
+fn test_pipe() {
+    // TODO: issue 1608 reports a panic when we attempt to read from stdin,
+    // which was closed by the other side of the pipe. This test does not
+    // protect against regressions in that case; we should add one at some
+    // point.
+    new_ucmd!()
+        .pipe_in("one\ntwo\nfour")
+        .succeeds()
+        .stdout_is("four\none\ntwo\n")
+        .stderr_is("");
+}
+
+#[test]
 fn test_check() {
     new_ucmd!()
         .arg("-c")


### PR DESCRIPTION
If the output of sort is piped to another program that closes the file
descriptor, sort currently panics. The GNU coreutils is able to handle
this case.

Replacing panic with crash_if_err reports the closed pipe and exits
with a return code, which seems like the correct behavior. Tested on
my Mac and the panic disappears.