### PR TITLE
bug(install) - install -d can be run on an existing directory

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -363,14 +363,12 @@ fn directory(paths: Vec<String>, b: Behavior) -> i32 {
         for directory in paths.iter() {
             let path = Path::new(directory);
 
-            if path.exists() {
-                show_info!("cannot create directory '{}': File exists", path.display());
-                all_successful = false;
-            }
-
-            if let Err(e) = fs::create_dir(directory) {
-                show_info!("{}: {}", path.display(), e.to_string());
-                all_successful = false;
+            // if the path already exist, don't try to create it again
+            if !path.exists() {
+                if let Err(e) = fs::create_dir(directory) {
+                    show_info!("{}: {}", path.display(), e.to_string());
+                    all_successful = false;
+                }
             }
 
             if mode::chmod(&path, b.mode()).is_err() {

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -32,6 +32,18 @@ fn test_install_basic() {
 }
 
 #[test]
+fn test_install_twice_dir() {
+    let dir = "test_install_target_dir_dir_a";
+    let scene = TestScenario::new(util_name!());
+
+    scene.ucmd().arg("-d").arg(dir).succeeds();
+    scene.ucmd().arg("-d").arg(dir).succeeds();
+    let at = &scene.fixtures;
+
+    assert!(at.dir_exists(dir));
+}
+
+#[test]
 fn test_install_failing_not_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file1 = "test_install_target_dir_file_a1";
@@ -85,21 +97,6 @@ fn test_install_component_directories() {
     assert!(at.dir_exists(component1));
     assert!(at.dir_exists(component2));
     assert!(at.dir_exists(component3));
-}
-
-#[test]
-fn test_install_component_directories_failing() {
-    let (at, mut ucmd) = at_and_ucmd!();
-    let component = "test_install_target_dir_component_d1";
-    let directories_arg = "-d";
-
-    at.mkdir(component);
-    assert!(ucmd
-        .arg(directories_arg)
-        .arg(component)
-        .fails()
-        .stderr
-        .contains("File exists"));
 }
 
 #[test]


### PR DESCRIPTION
GNU:
```
$ install -d foo
$ install -d foo
```

Rust:
```
$ install -d foo
$ install -d foo
install: cannot create directory 'foo': File exists
install: foo: File exists (os error 17)
```
