### PR TITLE
ls - improve the error management + add tests

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -367,7 +367,7 @@ fn display_items(items: &[PathBuf], strip: Option<&Path>, options: &getopts::Mat
                 match md {
                     Err(e) => {
                         let filename = get_file_name(i, strip);
-                        show_error!("{}: {}", filename, e);
+                        show_error!("'{}': {}", filename, e);
                         None
                     }
                     Ok(md) => Some(display_file_name(&i, strip, &md, options)),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -168,11 +168,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         )
         .parse(args);
 
-    list(matches);
-    0
+    list(matches)
 }
 
-fn list(options: getopts::Matches) {
+fn list(options: getopts::Matches) -> i32 {
     let locs: Vec<String> = if options.free.is_empty() {
         vec![String::from(".")]
     } else {
@@ -181,8 +180,16 @@ fn list(options: getopts::Matches) {
 
     let mut files = Vec::<PathBuf>::new();
     let mut dirs = Vec::<PathBuf>::new();
+    let mut has_failed = false;
     for loc in locs {
         let p = PathBuf::from(&loc);
+        if !p.exists() {
+            show_error!("'{}': {}", &loc, "No such file or directory");
+            // We found an error, the return code of ls should not be 0
+            // And no need to continue the execution
+            has_failed = true;
+            continue;
+        }
         let mut dir = false;
 
         if p.is_dir() && !options.opt_present("d") {
@@ -210,6 +217,11 @@ fn list(options: getopts::Matches) {
             println!("\n{}:", dir.to_string_lossy());
         }
         enter_directory(&dir, &options);
+    }
+    if has_failed {
+        1
+    } else {
+        0
     }
 }
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -46,6 +46,36 @@ fn test_ls_files_dirs() {
 }
 
 #[test]
+fn test_ls_recursive() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("a");
+    at.mkdir("a/b");
+    at.mkdir("a/b/c");
+    at.mkdir("z");
+    at.touch(&at.plus_as_string("a/a"));
+    at.touch(&at.plus_as_string("a/b/b"));
+
+    scene.ucmd().arg("a").succeeds();
+    scene.ucmd().arg("a/a").succeeds();
+    let result = scene
+        .ucmd()
+        .arg("--color=never")
+        .arg("-R")
+        .arg("a")
+        .arg("z")
+        .succeeds();
+
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    if cfg!(target_os = "windows") {
+        assert!(result.stdout.contains("a\\b:\nb"));
+    } else {
+        assert!(result.stdout.contains("a/b:\nb"));
+    }
+}
+
+#[test]
 fn test_ls_ls_color() {
     new_ucmd!().arg("--color").succeeds();
     new_ucmd!().arg("--color=always").succeeds();

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -12,6 +12,40 @@ fn test_ls_ls_i() {
 }
 
 #[test]
+fn test_ls_non_existing() {
+    new_ucmd!().arg("doesntexist").fails();
+}
+
+#[test]
+fn test_ls_files_dirs() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("a");
+    at.mkdir("a/b");
+    at.mkdir("a/b/c");
+    at.mkdir("z");
+    at.touch(&at.plus_as_string("a/a"));
+    at.touch(&at.plus_as_string("a/b/b"));
+
+    scene.ucmd().arg("a").succeeds();
+    scene.ucmd().arg("a/a").succeeds();
+    scene.ucmd().arg("a").arg("z").succeeds();
+
+    let result = scene.ucmd().arg("doesntexist").fails();
+    // Doesn't exist
+    assert!(result
+        .stderr
+        .contains("error: 'doesntexist': No such file or directory"));
+
+    let result = scene.ucmd().arg("a").arg("doesntexist").fails();
+    // One exists, the other doesn't
+    assert!(result
+        .stderr
+        .contains("error: 'doesntexist': No such file or directory"));
+    assert!(result.stdout.contains("a:"));
+}
+
+#[test]
 fn test_ls_ls_color() {
     new_ucmd!().arg("--color").succeeds();
     new_ucmd!().arg("--color=always").succeeds();


### PR DESCRIPTION
When a file doesn't exist, exit early and fails ls
    
Currently, running
```
$ ls doesntexist
```
will return 0
while it should return 1
    
Ditto for
```
$ ls doesntexist a
```