### PR TITLE
bug(cp): like gnu/cp, don't show any message when --no-clobber is used

### DIFF
--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -12,6 +12,8 @@ extern crate uucore;
 use std::fs::OpenOptions;
 use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
 use uucore::libc;
 
 static NAME: &str = "tee";

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -255,7 +255,40 @@ fn test_cp_arg_no_clobber() {
 
     assert!(result.success);
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "How are you?\n");
-    assert!(result.stderr.contains("Not overwriting"));
+}
+
+#[test]
+fn test_cp_arg_no_clobber_twice() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("source.txt");
+    let result = scene
+        .ucmd()
+        .arg("--no-clobber")
+        .arg("source.txt")
+        .arg("dest.txt")
+        .run();
+
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    assert!(result.stderr.is_empty());
+    assert_eq!(at.read("source.txt"), "");
+
+    at.append("source.txt", "some-content");
+    let result = scene
+        .ucmd()
+        .arg("--no-clobber")
+        .arg("source.txt")
+        .arg("dest.txt")
+        .run();
+
+    assert!(result.success);
+    assert_eq!(at.read("source.txt"), "some-content");
+    // Should be empty as the "no-clobber" should keep
+    // the previous version
+    assert_eq!(at.read("dest.txt"), "");
+    assert!(!result.stderr.contains("Not overwriting"));
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -289,18 +289,21 @@ fn test_ls_ls_color() {
 #[test]
 fn test_ls_human() {
     let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
     let file = "test_human";
     let result = scene.cmd("truncate").arg("-s").arg("+1000").arg(file).run();
     println!("stderr = {:?}", result.stderr);
     println!("stdout = {:?}", result.stdout);
-    assert!(result.success);
     let result = scene.ucmd().arg("-hl").arg(file).run();
     println!("stderr = {:?}", result.stderr);
     println!("stdout = {:?}", result.stdout);
     assert!(result.success);
     assert!(result.stdout.contains("1.00K"));
-    let result = scene.cmd("truncate").arg("-s").arg("+1000k").arg(file).run();
+    scene
+        .cmd("truncate")
+        .arg("-s")
+        .arg("+1000k")
+        .arg(file)
+        .run();
     let result = scene.ucmd().arg("-hl").arg(file).run();
     println!("stderr = {:?}", result.stderr);
     println!("stdout = {:?}", result.stdout);


### PR DESCRIPTION
Simple example:
```

touch bar
rm -rf /tmp/foo
mkdir -p /tmp/foo
cp -pnL -v bar /tmp/foo
echo $?
cp -pnL -v bar /tmp/foo
echo $?

rm -rf /tmp/foo
mkdir -p /tmp/foo
./target/debug/coreutils cp -pnL -v bar /tmp/foo
echo $?
./target/debug/coreutils cp -pnL bar /tmp/foo
echo $?
```