### PR TITLE
fix(install) - Install was failing with '-m 0333'

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -146,7 +146,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .help("set permission mode (as in chmod), instead of rwxr-xr-x")
                 .value_name("MODE")
                 .takes_value(true)
-                .min_values(1)
         )
         .arg(
             Arg::with_name(OPT_OWNER)

--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -9,7 +9,7 @@
 
 pub fn parse_numeric(fperm: u32, mut mode: &str) -> Result<u32, String> {
     let (op, pos) = parse_op(mode, Some('='))?;
-    mode = mode[pos..].trim_start_matches('0');
+    mode = mode[pos..].trim().trim_start_matches('0');
     if mode.len() > 4 {
         Err(format!("mode is too large ({} > 7777)", mode))
     } else {


### PR DESCRIPTION
The parse_numeric was getting ' 0333' as input
and showing 'mode is too large ( 0333 > 7777)' as error

Syntax used: https://sources.debian.org/src/firebird3.0/3.0.7.33374.ds4-1/debian/functions.sh/?hl=145#L145