### PR TITLE
ls: On Windows don't display files hidden by NTFS

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -256,14 +256,12 @@ fn sort_entries(entries: &mut Vec<PathBuf>, options: &getopts::Matches) {
 }
 
 fn is_hidden(file_path: &DirEntry) -> std::io::Result<bool> {
-    let metadata = fs::metadata(file_path.path())?;
-    let attr = metadata.file_attributes();
-
-
     #[cfg(unix)]
     return Ok(file_path.file_name().to_string_lossy().starts_with('.'));
 
     #[cfg(windows)]
+    let metadata = fs::metadata(file_path.path())?;
+    let attr = metadata.file_attributes();
     return Ok(((attr & 0x2) > 0) || file_path.file_name().to_string_lossy().starts_with('.'));
 }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -256,19 +256,15 @@ fn sort_entries(entries: &mut Vec<PathBuf>, options: &getopts::Matches) {
 }
 
 #[cfg(windows)]
-fn ntfs_hidden(path: &DirEntry) -> std::io::Result<bool> {
-    let metadata = fs::metadata(path.path())?;
+fn is_hidden(file_path: &DirEntry) -> std::io::Result<bool> {
+    let metadata = fs::metadata(file_path.path())?;
     let attr = metadata.file_attributes();
-    return Ok((attr & 0x2) > 0);
+    return Ok(((attr & 0x2) > 0) || file_path.file_name().to_string_lossy().starts_with('.'));
 }
 
+#[cfg(unix)]
 fn is_hidden(file_path: &DirEntry) -> std::io::Result<bool> {
-    if file_path.file_name().to_string_lossy().starts_with('.') {
-        return Ok(true);
-    }
-
-    #[cfg(windows)]
-    return ntfs_hidden(file_path);
+    return Ok(file_path.file_name().to_string_lossy().starts_with('.'));
 }
 
 #[cfg(windows)]

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -259,12 +259,12 @@ fn sort_entries(entries: &mut Vec<PathBuf>, options: &getopts::Matches) {
 fn is_hidden(file_path: &DirEntry) -> std::io::Result<bool> {
     let metadata = fs::metadata(file_path.path())?;
     let attr = metadata.file_attributes();
-    return Ok(((attr & 0x2) > 0) || file_path.file_name().to_string_lossy().starts_with('.'));
+    Ok(((attr & 0x2) > 0) || file_path.file_name().to_string_lossy().starts_with('.'))
 }
 
 #[cfg(unix)]
 fn is_hidden(file_path: &DirEntry) -> std::io::Result<bool> {
-    return Ok(file_path.file_name().to_string_lossy().starts_with('.'));
+    Ok(file_path.file_name().to_string_lossy().starts_with('.'))
 }
 
 #[cfg(windows)]

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -296,13 +296,15 @@ fn should_display(entry: &DirEntry, options: &getopts::Matches) -> bool {
     let ffi_name = entry.file_name();
     let name = ffi_name.to_string_lossy();
     let hidden_by_ntfs = is_hidden(&entry.path()).unwrap();
-    if !options.opt_present("a") && !options.opt_present("A") && name.starts_with('.') || hidden_by_ntfs {
+    if !options.opt_present("a") && !options.opt_present("A") && name.starts_with('.')
+        || hidden_by_ntfs
+    {
         return false;
     }
     if options.opt_present("B") && name.ends_with('~') {
         return false;
     }
-    return true
+    return true;
 }
 
 #[cfg(unix)]
@@ -315,7 +317,7 @@ fn should_display(entry: &DirEntry, options: &getopts::Matches) -> bool {
     if options.opt_present("B") && name.ends_with('~') {
         return false;
     }
-    return true
+    return true;
 }
 
 fn enter_directory(dir: &PathBuf, options: &getopts::Matches) {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -260,11 +260,7 @@ fn is_hidden(file_path: &std::path::PathBuf) -> std::io::Result<bool> {
     let metadata = fs::metadata(file_path)?;
     let attr = metadata.file_attributes();
 
-    if (attr & 0x2) > 0 {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+    Ok((attr & 0x2) > 0)
 }
 
 #[cfg(windows)]

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -296,8 +296,8 @@ fn should_display(entry: &DirEntry, options: &getopts::Matches) -> bool {
     let ffi_name = entry.file_name();
     let name = ffi_name.to_string_lossy();
     let hidden_by_ntfs = is_hidden(&entry.path()).unwrap();
-    if !options.opt_present("a") && !options.opt_present("A") && name.starts_with('.')
-        || hidden_by_ntfs
+    if !options.opt_present("a") && !options.opt_present("A") && (name.starts_with('.')
+        || hidden_by_ntfs)
     {
         return false;
     }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -295,22 +295,31 @@ fn sort_entries(entries: &mut Vec<PathBuf>, options: &getopts::Matches) {
     }
 }
 
+#[cfg(windows)]
 fn should_display(entry: &DirEntry, options: &getopts::Matches) -> bool {
     let ffi_name = entry.file_name();
     let name = ffi_name.to_string_lossy();
-    #[cfg(windows)]
     let hidden_by_ntfs = is_hidden(&entry.path()).unwrap();
     if !options.opt_present("a") && !options.opt_present("A") && name.starts_with('.') || hidden_by_ntfs {
         return false;
     }
-    #[cfg(unix)]
+    if options.opt_present("B") && name.ends_with('~') {
+        return false;
+    }
+    return true
+}
+
+#[cfg(unix)]
+fn should_display(entry: &DirEntry, options: &getopts::Matches) -> bool {
+    let ffi_name = entry.file_name();
+    let name = ffi_name.to_string_lossy();
     if !options.opt_present("a") && !options.opt_present("A") && name.starts_with('.') {
         return false;
     }
     if options.opt_present("B") && name.ends_with('~') {
         return false;
     }
-    true
+    return true
 }
 
 fn enter_directory(dir: &PathBuf, options: &getopts::Matches) {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -160,7 +160,7 @@ fn test_ls_order_size() {
     println!("stdout = {:?}", result.stdout);
     assert!(result.success);
     #[cfg(not(windows))]
-    assert_eq!(result.stdout, "test-1\ntest-2\ntest-3\ntest-4\tp");
+    assert_eq!(result.stdout, "test-1\ntest-2\ntest-3\ntest-4\n");
     #[cfg(windows)]
     assert_eq!(result.stdout, "test-1  test-2  test-3  test-4\n");
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -160,7 +160,7 @@ fn test_ls_order_size() {
     println!("stdout = {:?}", result.stdout);
     assert!(result.success);
     #[cfg(not(windows))]
-    assert_eq!(result.stdout, "test-1\ntest-2\ntest-3\ntest-4\n");
+    assert_eq!(result.stdout, "test-1\ntest-2\ntest-3\ntest-4\tp");
     #[cfg(windows)]
     assert_eq!(result.stdout, "test-1  test-2  test-3  test-4\n");
 }
@@ -309,4 +309,24 @@ fn test_ls_human() {
     println!("stdout = {:?}", result.stdout);
     assert!(result.success);
     assert!(result.stdout.contains("1.02M"));
+}
+
+#[cfg(windows)]
+#[test]
+fn test_ls_hidden_windows() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    let file = "hiddenWindowsFileNoDot";
+    at.touch(file);
+    // hide the file
+    scene.cmd("attrib").arg("+h").arg("+S").arg("+r").arg(file).run();
+    let result = scene.ucmd().run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    let result = scene.ucmd().arg("-a").run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    assert!(result.stdout.contains(file));
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -319,7 +319,13 @@ fn test_ls_hidden_windows() {
     let file = "hiddenWindowsFileNoDot";
     at.touch(file);
     // hide the file
-    scene.cmd("attrib").arg("+h").arg("+S").arg("+r").arg(file).run();
+    scene
+        .cmd("attrib")
+        .arg("+h")
+        .arg("+S")
+        .arg("+r")
+        .arg(file)
+        .run();
     let result = scene.ucmd().run();
     println!("stderr = {:?}", result.stderr);
     println!("stdout = {:?}", result.stdout);


### PR DESCRIPTION
This little check, allows us to hide the files that
shouldn't be shown on the listing on Windows operating
systems.

Just like the "dot" in UNIX based operating systems
Windows uses its own file attributes to determine if a file
is hidden or not.

The lack of support for this option is normally an annoyance
for many users, this commit adds full support for this feature.

Here is a little example of this issue:

Before the patch: 
![image](https://user-images.githubusercontent.com/38844659/102658915-23d6f580-413e-11eb-9ea2-98020f2ea2d5.png)

As you may see, there are some files named: 
`NTUSER.DAT{fa492542-3fc7-11eb-9272-e44a63569703}.TM.blf`, etc

That are supposed to be hidden under the NTFS filesystem, after the patch:
![image](https://user-images.githubusercontent.com/38844659/102659280-c55e4700-413e-11eb-852a-c0259c587d36.png)

As you can see, the files are now properly hidden, allowing for a much cleaner user experience, that fits right into the operating system.

This annoyance is pretty normal, among Windows users and has been requested on other coreutils projects:
´
[Example with git bash](https://superuser.com/questions/650322/ignore-ntuser-dat-files-when-ls-on-git-bash)
[Feature request on WSL](https://github.com/microsoft/WSL/issues/459)

