### PR TITLE
ls: only print colors if stdout is a tty

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -619,7 +619,7 @@ fn display_file_name(
     let mut width = UnicodeWidthStr::width(&*name);
 
     let color = match options.opt_str("color") {
-        None => stdout_isatty(),
+        None => atty::is(atty::Stream::Stdout),
         Some(val) => match val.as_ref() {
             "always" | "yes" | "force" => true,
             "auto" | "tty" | "if-tty" => stdout_isatty(),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -619,7 +619,7 @@ fn display_file_name(
     let mut width = UnicodeWidthStr::width(&*name);
 
     let color = match options.opt_str("color") {
-        None => true,
+        None => stdout_isatty(),
         Some(val) => match val.as_ref() {
             "always" | "yes" | "force" => true,
             "auto" | "tty" | "if-tty" => stdout_isatty(),


### PR DESCRIPTION
Previously if no --color argument was input, we would always print
colors in the output. This breaks `configure` scripts which run `ls`
and then compare the output against what they expect to see, since the
left side has ANSI escape sequences and the right side doesn't.

Instead, only print escape sequences if a TTY is present, or if
`--color=always` is specified.

Fixes #1638.