### PR TITLE
rm: allow "-f" to be specified multiple times

### DIFF
--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -92,6 +92,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             Arg::with_name(OPT_FORCE)
             .short("f")
             .long(OPT_FORCE)
+            .multiple(true)
             .help("ignore nonexistent files and arguments, never prompt")
         )
         .arg(


### PR DESCRIPTION
This matches the behavior of GNU rm.

Fixes #1663.