### PR TITLE
Remove most of the 'extern crate'

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -5,9 +5,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-extern crate textwrap;
-extern crate uucore;
-
 use std::cmp;
 use std::collections::hash_map::HashMap;
 use std::ffi::OsString;

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -6,7 +6,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-extern crate platform_info;
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -7,10 +7,6 @@
 
 // spell-checker:ignore (ToDO) Chmoder cmode fmode fperm fref ugoa RFILE RFILE's
 
-#[cfg(unix)]
-extern crate libc;
-extern crate walkdir;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -14,10 +14,8 @@ use uucore::fs::resolve_relative_path;
 use uucore::libc::{gid_t, uid_t};
 use uucore::perms::{wrap_chown, Verbosity};
 
-extern crate clap;
 use clap::{App, Arg};
 
-extern crate walkdir;
 use walkdir::WalkDir;
 
 use std::fs::{self, Metadata};

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -8,8 +8,6 @@
 
 // spell-checker:ignore (ToDO) NEWROOT Userspec pstatus
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 use uucore::entries;

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) delim mkdelim
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -10,22 +10,14 @@
 
 // spell-checker:ignore (ToDO) ficlone linkgs lstat nlink nlinks pathbuf reflink strs xattrs
 
-extern crate clap;
-extern crate filetime;
 #[cfg(target_os = "linux")]
 #[macro_use]
 extern crate ioctl_sys;
-extern crate libc;
 #[macro_use]
 extern crate quick_error;
 #[macro_use]
 extern crate uucore;
-extern crate walkdir;
-#[cfg(unix)]
-extern crate xattr;
 
-#[cfg(windows)]
-extern crate winapi;
 #[cfg(windows)]
 use winapi::um::fileapi::CreateFileW;
 #[cfg(windows)]

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -4,8 +4,6 @@
 extern crate failure;
 #[macro_use]
 extern crate uucore;
-extern crate getopts;
-extern crate regex;
 use getopts::Matches;
 use regex::Regex;
 use std::cmp::Ordering;

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -9,9 +9,6 @@
 // spell-checker:ignore (format) MMDDhhmm
 // spell-checker:ignore (ToDO) DATEFILE
 
-extern crate chrono;
-
-extern crate clap;
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -9,17 +9,11 @@
 // spell-checker:ignore (ToDO) mountinfo mtab BLOCKSIZE getmntinfo fobj mptr noatime Iused overmounted
 // spell-checker:ignore (libc/fs) asyncreads asyncwrites autofs bavail bfree bsize charspare cifs debugfs devfs devpts ffree frsize fsid fstypename fusectl inode inodes iosize kernfs mntbufp mntfromname mntonname mqueue namemax pipefs smbfs statfs statvfs subfs syncreads syncwrites sysfs wcslen
 
-extern crate clap;
-extern crate libc;
-extern crate number_prefix;
-
 #[macro_use]
 extern crate uucore;
 
 use clap::{App, Arg};
 
-#[cfg(windows)]
-extern crate winapi;
 #[cfg(windows)]
 use winapi::um::errhandlingapi::GetLastError;
 #[cfg(windows)]

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) clrtoeol dircolors eightbit endcode fnmatch leftcode multihardlink rightcode setenv sgid suid
 
-extern crate glob;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) BLOCKSIZE inode inodes ment strs
 
-extern crate time;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) ctype cwidth iflag nbytes nspaces nums tspaces uflag
 
-extern crate getopts;
-extern crate unicode_width;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -5,7 +5,6 @@
 //* For the full copyright and license information, please view the LICENSE
 //* file that was distributed with this source code.
 
-extern crate onig;
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -5,8 +5,6 @@
 // * For the full copyright and license information, please view the LICENSE file
 // * that was distributed with this source code.
 
-extern crate rand;
-
 use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::fmt;

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) PSKIP linebreak ostream parasplit tabwidth xanti xprefix
 
-extern crate unicode_width;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -12,7 +12,6 @@
 extern crate uucore;
 use uucore::entries::{get_groups, gid2grp, Locate, Passwd};
 
-extern crate clap;
 use clap::{App, Arg};
 
 static VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -11,14 +11,6 @@
 
 #[macro_use]
 extern crate clap;
-extern crate blake2_rfc;
-extern crate hex;
-extern crate md5;
-extern crate regex;
-extern crate regex_syntax;
-extern crate sha1;
-extern crate sha2;
-extern crate sha3;
 
 #[macro_use]
 extern crate uucore;

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) gethostid
 
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -7,12 +7,6 @@
 
 // spell-checker:ignore (ToDO) MAKEWORD addrs hashset
 
-extern crate clap;
-extern crate hostname;
-extern crate libc;
-#[cfg(windows)]
-extern crate winapi;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -15,8 +15,6 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) rwxr sourcepath targetpath
 
-extern crate clap;
-extern crate libc;
-
 mod mode;
 
 #[macro_use]

--- a/src/uu/install/src/mode.rs
+++ b/src/uu/install/src/mode.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 use std::fs;
 use std::path::Path;
 #[cfg(not(windows))]

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) autoformat FILENUM whitespaces pairable unpairable nocheck
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) signalname pids
 
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -9,8 +9,6 @@
 
 // spell-checker:ignore (ToDO) getlogin userlogin
 
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -7,15 +7,6 @@
 
 // spell-checker:ignore (ToDO) cpio svgz webm somegroup nlink rmvb xspf
 
-extern crate getopts;
-#[cfg(unix)]
-extern crate isatty;
-extern crate number_prefix;
-extern crate term_grid;
-extern crate termsize;
-extern crate time;
-extern crate unicode_width;
-
 #[cfg(unix)]
 #[macro_use]
 extern crate lazy_static;

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -5,8 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate getopts;
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) parsemode makedev sysmacros makenod newmode perror IFBLK IFCHR IFIFO
 
-extern crate getopts;
-extern crate libc;
-
 mod parsemode;
 
 #[macro_use]

--- a/src/uu/mknod/src/parsemode.rs
+++ b/src/uu/mknod/src/parsemode.rs
@@ -1,6 +1,5 @@
 // spell-checker:ignore (ToDO) fperm
 
-extern crate libc;
 use libc::{mode_t, S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOTH, S_IWUSR};
 
 use uucore::mode;

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -8,10 +8,6 @@
 
 // spell-checker:ignore (ToDO) tempfile tempdir SUFF TMPDIR tmpname
 
-extern crate getopts;
-extern crate rand;
-extern crate tempfile;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/mktemp/src/tempdir.rs
+++ b/src/uu/mktemp/src/tempdir.rs
@@ -2,7 +2,6 @@
 
 // Mainly taken from crate `tempdir`
 
-extern crate rand;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) lflag ICANON tcgetattr tcsetattr TCSADRAIN
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -8,9 +8,6 @@
 
 // spell-checker:ignore (ToDO) sourcepath targetpath
 
-extern crate clap;
-extern crate fs_extra;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) getpriority execvp setpriority nstr PRIO cstrs ENOENT
 
-extern crate getopts;
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -1,8 +1,5 @@
 // spell-checker:ignore (ToDO) conv
 
-extern crate getopts;
-extern crate regex;
-
 // parse_style parses a style string into a NumberingStyle.
 fn parse_style(chars: &[char]) -> Result<crate::NumberingStyle, String> {
     if chars.len() == 1 && chars[0] == 'a' {

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -8,12 +8,6 @@
 
 // spell-checker:ignore (ToDO) corasick memchr
 
-extern crate aho_corasick;
-extern crate getopts;
-extern crate memchr;
-extern crate regex;
-extern crate regex_syntax;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) execvp SIGHUP cproc vprocmgr cstrs homeout
 
-extern crate getopts;
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -7,12 +7,6 @@
 
 // spell-checker:ignore (ToDO) NPROCESSORS nprocs numstr threadstr sysconf
 
-extern crate clap;
-extern crate num_cpus;
-
-#[cfg(unix)]
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -5,8 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate getopts;
-
 use getopts::{Matches, Options};
 use std::fmt;
 use std::io::BufRead;

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -7,10 +7,6 @@
 
 // spell-checker:ignore (ToDO) formatteriteminfo inputdecoder inputoffset mockstream nrofbytes partialreader odfunc multifile exitcode
 
-extern crate byteorder;
-extern crate getopts;
-extern crate half;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) delim
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) lstat
 
-extern crate getopts;
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -7,8 +7,6 @@
 
 /* last synced with: printenv (GNU coreutils) 8.13 */
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -3,9 +3,6 @@
 // spell-checker:ignore (change!) each's
 // spell-checker:ignore (ToDO) LONGHELP FORMATSTRING templating parameterizing formatstr
 
-extern crate itertools;
-extern crate uucore;
-
 mod cli;
 mod memo;
 mod tokenize;

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -7,12 +7,6 @@
 
 // spell-checker:ignore (ToDOs) corasick memchr Roff trunc oset iset
 
-extern crate aho_corasick;
-extern crate getopts;
-extern crate memchr;
-extern crate regex;
-extern crate regex_syntax;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -5,8 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) errno
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) retcode
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) subpath absto absfrom absbase
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -7,10 +7,6 @@
 
 // spell-checker:ignore (ToDO) bitor ulong
 
-extern crate clap;
-extern crate remove_dir_all;
-extern crate walkdir;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -5,8 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -3,8 +3,6 @@
 
 // spell-checker:ignore (ToDO) istr chiter argptr ilen
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -8,9 +8,6 @@
 
 // spell-checker:ignore (ToDO) NAMESET FILESIZE fstab coeff journaling writeback REiser journaled
 
-extern crate getopts;
-extern crate rand;
-
 use rand::{Rng, ThreadRng};
 use std::cell::{Cell, RefCell};
 use std::fs;

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) cmdline evec seps rvec fdata
 
-extern crate getopts;
-extern crate rand;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -5,8 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -7,11 +7,6 @@
 #![allow(dead_code)]
 
 // spell-checker:ignore (ToDO) outfile nondictionary
-
-extern crate clap;
-extern crate semver;
-
-extern crate itertools;
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) PREFIXaa
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) mtab fsext showfs otype fmtstr prec ftype blocksize nlink rdev fnodes fsid namelen blksize inodes fstype iosize statfs gnulib NBLOCKSIZE
 
-extern crate clap;
-
 #[macro_use]
 mod fsext;
 pub use crate::fsext::*;

--- a/src/uu/stdbuf/src/libstdbuf/build.rs
+++ b/src/uu/stdbuf/src/libstdbuf/build.rs
@@ -1,7 +1,5 @@
 // spell-checker:ignore (ToDO) libstdbuf
 
-extern crate cpp_build;
-
 use cpp_build::Config;
 
 fn main() {

--- a/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
+++ b/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
@@ -2,7 +2,6 @@
 
 #[macro_use]
 extern crate cpp;
-extern crate libc;
 
 #[macro_use]
 extern crate uucore;

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) tempdir dyld dylib dragonflybsd optgrps libstdbuf
 
-extern crate getopts;
-extern crate tempfile;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) sysv
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -7,7 +7,6 @@
 
 /* Last synced with: sync (GNU coreutils) 8.13 */
 
-extern crate clap;
 extern crate libc;
 
 #[macro_use]

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) sbytes slen
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/tail/src/platform/redox.rs
+++ b/src/uu/tail/src/platform/redox.rs
@@ -1,7 +1,5 @@
 // spell-checker:ignore (ToDO) ENOSYS EPERM
 
-extern crate syscall;
-
 use self::syscall::{Error, ENOSYS, EPERM};
 
 pub type Pid = usize;

--- a/src/uu/tail/src/platform/unix.rs
+++ b/src/uu/tail/src/platform/unix.rs
@@ -9,8 +9,6 @@
 
 // spell-checker:ignore (ToDO) errno EPERM ENOSYS
 
-extern crate libc;
-
 use std::io::Error;
 
 pub type Pid = libc::pid_t;

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) seekable seek'd tail'ing ringbuffer ringbuf
 
-extern crate getopts;
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -5,10 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate getopts;
-
-extern crate uucore;
-
 use std::fs::OpenOptions;
 use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
 use std::path::{Path, PathBuf};

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -7,10 +7,6 @@
 
 // spell-checker:ignore (ToDO) retval paren prec subprec cond
 
-extern crate libc;
-#[cfg(target_os = "redox")]
-extern crate syscall;
-
 use std::collections::HashMap;
 use std::str::from_utf8;
 

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -7,10 +7,6 @@
 
 // spell-checker:ignore (ToDO) tstr sigstr cmdname setpgid
 
-extern crate getopts;
-extern crate libc;
-extern crate time;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -8,9 +8,7 @@
 
 // spell-checker:ignore (ToDO) filetime strptime utcoff strs datetime MMDDhhmm
 
-extern crate clap;
 pub extern crate filetime;
-extern crate time;
 
 #[macro_use]
 extern crate uucore;

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -10,10 +10,6 @@
 
 // spell-checker:ignore (ToDO) allocs bset dflag cflag sflag tflag
 
-extern crate bit_set;
-extern crate fnv;
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore (ToDO) RFILE refsize rfilename fsize tsize
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -6,8 +6,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate getopts;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) ttyname filedesc
 
-extern crate getopts;
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -10,8 +10,6 @@
 
 // spell-checker:ignore (ToDO) nodename kernelname kernelrelease kernelversion sysname hwplatform mnrsv
 
-extern crate clap;
-extern crate platform_info;
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) nums aflag uflag scol prevtab amode ctype cwidth nbytes lastcol pctype
 
-extern crate getopts;
-extern crate unicode_width;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -5,8 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate clap;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) lstat IFLNK IFMT IFREG
 
-extern crate getopts;
-extern crate libc;
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -10,10 +10,6 @@
 
 // spell-checker:ignore (ToDO) getloadavg upsecs updays nusers loadavg boottime uphours upmins
 
-extern crate chrono;
-extern crate clap;
-extern crate time;
-
 use chrono::{Local, TimeZone, Utc};
 use clap::{App, Arg};
 

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -10,7 +10,6 @@
 // Allow dead code here in order to keep all fields, constants here, for consistency.
 #![allow(dead_code)]
 
-extern crate clap;
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -7,7 +7,6 @@
 
 // spell-checker:ignore (ToDO) fpath
 
-extern crate clap;
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/whoami/src/platform/windows.rs
+++ b/src/uu/whoami/src/platform/windows.rs
@@ -9,8 +9,6 @@
 
 // spell-checker:ignore (ToDO) advapi lmcons winnt getusername WCHAR UNLEN
 
-extern crate advapi32;
-extern crate uucore;
 extern crate winapi;
 
 use self::winapi::shared::lmcons;

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -6,11 +6,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-#[cfg(windows)]
-extern crate dunce;
-#[cfg(target_os = "redox")]
-extern crate termion;
-
 #[cfg(unix)]
 use libc::{
     mode_t, S_IRGRP, S_IROTH, S_IRUSR, S_ISGID, S_ISUID, S_ISVTX, S_IWGRP, S_IWOTH, S_IWUSR,

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -3,10 +3,6 @@
 // Copyright (C) ~ Alex Lyon <arcterus@mail.com>
 // Copyright (C) ~ Roy Ivy III <rivy.dev@gmail.com>; MIT license
 
-//## external crates
-
-extern crate wild;
-
 // * feature-gated external crates
 #[cfg(feature = "failure")]
 extern crate failure;

--- a/src/uucore/src/lib/mods/coreopts.rs
+++ b/src/uucore/src/lib/mods/coreopts.rs
@@ -1,5 +1,3 @@
-extern crate getopts;
-
 pub struct HelpText<'a> {
     pub name: &'a str,
     pub version: &'a str,


### PR DESCRIPTION
Not necessary anymore. See:
https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html#no-more-extern-crate