### PR TITLE
factor::numeric::gcd: Refactor `divisor` test

### DIFF
--- a/src/uu/factor/src/numeric/gcd.rs
+++ b/src/uu/factor/src/numeric/gcd.rs
@@ -76,14 +76,13 @@ mod tests {
             gcd(0, a) == a
         }
 
-        fn divisor(a: u64, b: u64) -> bool {
-            // Test that gcd(a, b) divides a and b
+        fn divisor(a: u64, b: u64) -> () {
+            // Test that gcd(a, b) divides a and b, unless a == b == 0
+            if a == 0 && b == 0 { return; }
+
             let g = gcd(a, b);
-            if g != 0 {
-                a % g == 0 && b % g == 0
-            } else {
-                a == 0 && b == 0 // for g == 0
-            }
+            assert_eq!(a % g, 0);
+            assert_eq!(b % g, 0);
         }
 
         fn commutative(a: u64, b: u64) -> bool {


### PR DESCRIPTION
Should be clearer; does not handle the `gcd(0, 0)` case, which is already covered by the `zero` test.