### PR TITLE
Fixed wc -L no end of line LF bug

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -212,11 +212,7 @@ fn wc(files: Vec<String>, settings: &Settings) -> StdResult<(), i32> {
                 char_count += current_char_count;
                 if current_char_count > longest_line_length {
                     // -L is a GNU 'wc' extension so same behavior on LF
-                    if ends_lf {
-                        longest_line_length = current_char_count - 1;
-                    } else {
-                        longest_line_length = current_char_count;
-                    }
+                    longest_line_length = current_char_count - (ends_lf as usize);
                 }
             }
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -177,7 +177,7 @@ fn wc(files: Vec<String>, settings: &Settings) -> StdResult<(), i32> {
         let mut char_count: usize = 0;
         let mut longest_line_length: usize = 0;
         let mut raw_line = Vec::new();
-
+        let mut ends_lf: bool;
         // reading from a TTY seems to raise a condition on, rather than return Some(0) like a file.
         // hence the option wrapped in a result here
         while match reader.read_until(LF, &mut raw_line) {
@@ -189,7 +189,8 @@ fn wc(files: Vec<String>, settings: &Settings) -> StdResult<(), i32> {
             _ => false,
         } {
             // GNU 'wc' only counts lines that end in LF as lines
-            if *raw_line.last().unwrap() == LF {
+            ends_lf = *raw_line.last().unwrap() == LF;
+            if ends_lf {
                 line_count += 1;
             }
 
@@ -209,11 +210,13 @@ fn wc(files: Vec<String>, settings: &Settings) -> StdResult<(), i32> {
                     }
                 }
                 char_count += current_char_count;
-
                 if current_char_count > longest_line_length {
-                    // we subtract one here because `line.len()` includes the LF
-                    // matches GNU 'wc' behavior
-                    longest_line_length = current_char_count - 1;
+                    // -L is a GNU 'wc' extension so same behavior on LF
+                    if ends_lf {
+                        longest_line_length = current_char_count - 1;
+                    } else {
+                        longest_line_length = current_char_count;
+                    }
                 }
             }
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -190,9 +190,7 @@ fn wc(files: Vec<String>, settings: &Settings) -> StdResult<(), i32> {
         } {
             // GNU 'wc' only counts lines that end in LF as lines
             ends_lf = *raw_line.last().unwrap() == LF;
-            if ends_lf {
-                line_count += 1;
-            }
+            line_count += ends_lf as usize;
 
             byte_count += raw_line.len();
 

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -9,6 +9,15 @@ fn test_stdin_default() {
 }
 
 #[test]
+fn test_stdin_line_len_regression() {
+    new_ucmd!()
+        .args(&["-L"])
+        .pipe_in("\n123456")
+        .run()
+        .stdout_is(" 6\n");
+}
+
+#[test]
 fn test_stdin_only_bytes() {
     new_ucmd!()
         .args(&["-c"])


### PR DESCRIPTION
uu_wc -L (count the number of characters in a line) is a GNU extension. I fixed the failing test case from the GNU test suite where the last line of the file does not end in a LF.