### PR TITLE
uucore: fix potential use-after-free in utmpx iterator

### DIFF
--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -242,9 +242,10 @@ impl UtmpxIter {
     ///
     /// If not set, default record file will be used(file path depends on the target OS)
     pub fn read_from(self, f: &str) -> Self {
-        // FixME: discuss and revise a rewrite which is correct and satisfies clippy/rustc
-        #[allow(clippy::temporary_cstring_as_ptr)]
-        let res = unsafe { utmpxname(CString::new(f).unwrap().as_ptr()) };
+        let res = unsafe {
+            let cstr = CString::new(f).unwrap();
+            utmpxname(cstr.as_ptr())
+        };
         if res != 0 {
             println!("Warning: {}", IOError::last_os_error());
         }


### PR DESCRIPTION
From what I can tell (the man page is not very useful here), `utmpxname()` uses `strdup()` to copy the string, so it's fine that it is freed afterwards.