### PR TITLE
shred: remove usage of Vec::set_len()

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -16,6 +16,7 @@ use std::io;
 use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 #[macro_use]
 extern crate uucore;
@@ -119,6 +120,7 @@ struct BytesGenerator<'a> {
     exact: bool, // if false, every block's size is block_size
     gen_type: PassType<'a>,
     rng: Option<RefCell<ThreadRng>>,
+    bytes: Rc<RefCell<Vec<u8>>>,
 }
 
 impl<'a> BytesGenerator<'a> {
@@ -128,6 +130,9 @@ impl<'a> BytesGenerator<'a> {
             _ => None,
         };
 
+        let bytes = Vec::with_capacity(BLOCK_SIZE);
+        let bytes = Rc::new(RefCell::new(bytes));
+
         BytesGenerator {
             total_bytes,
             bytes_generated: Cell::new(0u64),
@@ -135,25 +140,39 @@ impl<'a> BytesGenerator<'a> {
             exact,
             gen_type,
             rng,
+            bytes,
         }
+    }
+
+    pub fn reset(&mut self, total_bytes: u64, gen_type: PassType<'a>) {
+        if let PassType::Random = gen_type {
+            if self.rng.is_none() {
+                self.rng = Some(RefCell::new(rand::thread_rng()));
+            }
+        }
+
+        self.total_bytes = total_bytes;
+        self.gen_type = gen_type;
+
+        self.bytes_generated.set(0);
     }
 }
 
 impl<'a> Iterator for BytesGenerator<'a> {
-    type Item = Box<[u8]>;
+    type Item = Rc<RefCell<Vec<u8>>>;
 
-    fn next(&mut self) -> Option<Box<[u8]>> {
+    fn next(&mut self) -> Option<Self::Item> {
         // We go over the total_bytes limit when !self.exact and total_bytes isn't a multiple
         // of self.block_size
         if self.bytes_generated.get() >= self.total_bytes {
             return None;
         }
 
-        let this_block_size: usize = {
+        let this_block_size = {
             if !self.exact {
                 self.block_size
             } else {
-                let bytes_left: u64 = self.total_bytes - self.bytes_generated.get();
+                let bytes_left = self.total_bytes - self.bytes_generated.get();
                 if bytes_left >= self.block_size as u64 {
                     self.block_size
                 } else {
@@ -162,19 +181,20 @@ impl<'a> Iterator for BytesGenerator<'a> {
             }
         };
 
-        let mut bytes: Vec<u8> = Vec::with_capacity(this_block_size);
+        let mut bytes = self.bytes.borrow_mut();
 
         match self.gen_type {
             PassType::Random => {
-                // This is ok because the vector was
-                // allocated with the same capacity
-                unsafe {
-                    bytes.set_len(this_block_size);
+                if bytes.len() != this_block_size {
+                    bytes.resize(this_block_size, 0);
                 }
+
                 let mut rng = self.rng.as_ref().unwrap().borrow_mut();
                 rng.fill(&mut bytes[..]);
             }
             PassType::Pattern(pattern) => {
+                bytes.truncate(0);
+
                 let skip = {
                     if self.bytes_generated.get() == 0 {
                         0
@@ -183,6 +203,7 @@ impl<'a> Iterator for BytesGenerator<'a> {
                     }
                 };
                 // Same range as 0..this_block_size but we start with the right index
+                // TODO: copy ranges rather than a byte at a time to improve performance
                 for i in skip..this_block_size + skip {
                     let index = i % pattern.len();
                     bytes.push(pattern[index]);
@@ -193,7 +214,7 @@ impl<'a> Iterator for BytesGenerator<'a> {
         let new_bytes_generated = self.bytes_generated.get() + this_block_size as u64;
         self.bytes_generated.set(new_bytes_generated);
 
-        Some(bytes.into_boxed_slice())
+        Some(self.bytes.clone())
     }
 }
 
@@ -443,6 +464,10 @@ fn wipe_file(
             .open(path)
             .expect("Failed to open file for writing");
 
+        // NOTE: it does not really matter what we set for total_bytes and gen_type here, so just
+        //       use bogus values
+        let mut generator = BytesGenerator::new(0, PassType::Pattern(&[]), exact);
+
         for (i, pass_type) in pass_sequence.iter().enumerate() {
             if verbose {
                 let pass_name: String = pass_name(*pass_type);
@@ -467,7 +492,7 @@ fn wipe_file(
                 }
             }
             // size is an optional argument for exactly how many bytes we want to shred
-            do_pass(&mut file, path, *pass_type, size, exact).expect("File write pass failed");
+            do_pass(&mut file, path, &mut generator, *pass_type, size).expect("File write pass failed");
             // Ignore failed writes; just keep trying
         }
     }
@@ -477,22 +502,22 @@ fn wipe_file(
     }
 }
 
-fn do_pass(
+fn do_pass<'a>(
     file: &mut File,
     path: &Path,
-    generator_type: PassType,
+    generator: &mut BytesGenerator<'a>,
+    generator_type: PassType<'a>,
     given_file_size: Option<u64>,
-    exact: bool,
 ) -> Result<(), io::Error> {
     file.seek(SeekFrom::Start(0))?;
 
     // Use the given size or the whole file if not specified
     let size: u64 = given_file_size.unwrap_or(get_file_size(path)?);
 
-    let generator = BytesGenerator::new(size, generator_type, exact);
+    generator.reset(size, generator_type);
 
     for block in generator {
-        file.write_all(&*block)?;
+        file.write_all(&block.borrow()[..])?;
     }
 
     file.sync_data()?;

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -492,7 +492,8 @@ fn wipe_file(
                 }
             }
             // size is an optional argument for exactly how many bytes we want to shred
-            do_pass(&mut file, path, &mut generator, *pass_type, size).expect("File write pass failed");
+            do_pass(&mut file, path, &mut generator, *pass_type, size)
+                .expect("File write pass failed");
             // Ignore failed writes; just keep trying
         }
     }


### PR DESCRIPTION
This PR removes usage of `Vec::set_len()` (#1729).  It also avoids allocating a new `Vec` every time `BytesGenerator` iterates, so it is most likely actually faster than before.  Note that there is still quite a bit of room for improvement in terms of performance ~(_e.g._ copying entire patterns rather than pushing them to the `Vec` one byte at a time)~ and readability.

There is at least one more instance of `Vec::set_len()` that needs to be fixed (it's in `od` again).  We may want to simply review our usage of `unsafe` in general, as I imagine some of the cruft that's built up over the years can be removed.