### PR TITLE
od: remove Vec::set_len() usage in InputDecoder

### DIFF
--- a/src/uu/od/src/inputdecoder.rs
+++ b/src/uu/od/src/inputdecoder.rs
@@ -38,10 +38,7 @@ impl<'a, I> InputDecoder<'a, I> {
         peek_length: usize,
         byte_order: ByteOrder,
     ) -> InputDecoder<I> {
-        let mut bytes: Vec<u8> = Vec::with_capacity(normal_length + peek_length);
-        unsafe {
-            bytes.set_len(normal_length + peek_length);
-        } // fast but uninitialized
+        let bytes = vec![0; normal_length + peek_length];
 
         InputDecoder {
             input,


### PR DESCRIPTION
This removes the last usage of `Vec::set_len()` with undefined behavior (AFAIK).  Zero-initializing the `Vec` isn't much of an issue here as it is only created once (over the course of the entire program) and the actual amount of allocated memory should be rather small (usually at least).

See #1729 for more info on the undefined behavior.