### PR TITLE
nohup, timeout: allow subcommands to use flags

### DIFF
--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -37,6 +37,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let args = args.collect_str();
 
     let mut opts = getopts::Options::new();
+    opts.parsing_style(getopts::ParsingStyle::StopAtFirstFree);
 
     opts.optflag("h", "help", "Show help and exit");
     opts.optflag("V", "version", "Show version and exit");

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -26,6 +26,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let program = args[0].clone();
 
     let mut opts = getopts::Options::new();
+    opts.parsing_style(getopts::ParsingStyle::StopAtFirstFree);
     opts.optflag(
         "",
         "preserve-status",


### PR DESCRIPTION
This should resolve #1613.  Both of these utilities need to be switched to `clap` at some point.