### PR TITLE
muted test not for windows and added windows temp file convention

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -25,7 +25,11 @@ mod tempdir;
 
 static ABOUT: &str = "create a temporary file or directory.";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(unix)]
 static DEFAULT_TEMPLATE: &str = "tmp.XXXXXXXXXX";
+#[cfg(windows)]
+static DEFAULT_TEMPLATE: &str = "XXXXXXXXXX.tmp";
 
 static OPT_DIRECTORY: &str = "directory";
 static OPT_DRY_RUN: &str = "dry-run";

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -26,10 +26,7 @@ mod tempdir;
 static ABOUT: &str = "create a temporary file or directory.";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[cfg(unix)]
 static DEFAULT_TEMPLATE: &str = "tmp.XXXXXXXXXX";
-#[cfg(windows)]
-static DEFAULT_TEMPLATE: &str = "XXXXXXXXXX.tmp";
 
 static OPT_DIRECTORY: &str = "directory";
 static OPT_DRY_RUN: &str = "dry-run";

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -285,7 +285,7 @@ fn test_ls_ls_color() {
     scene.ucmd().arg("--color=never").arg("z").succeeds();
 }
 
-#[cfg(not(target_os = "macos"))] // Truncate not available on mac
+#[cfg(not(any(target_os = "macos", target_os = "windows")))] // Truncate not available on mac or win
 #[test]
 fn test_ls_human() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
Fixed the first failure in https://github.com/uutils/coreutils/issues/1747 is due to the truncate command not existing in powershell.

Also changed the default 'mktemp' template to the windows filename convention of XXXXXXX.tmp.