### PR TITLE
numfmt: implement --field

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -14,11 +14,10 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, Read, Stdout, Write};
 use std::path::Path;
 
-use self::ranges::Range;
 use self::searcher::Searcher;
+use uucore::ranges::Range;
 
 mod buffer;
-mod ranges;
 mod searcher;
 
 static SYNTAX: &str =
@@ -125,7 +124,7 @@ enum Mode {
 
 fn list_to_ranges(list: &str, complement: bool) -> Result<Vec<Range>, String> {
     if complement {
-        Range::from_list(list).map(|r| ranges::complement(&r))
+        Range::from_list(list).map(|r| uucore::ranges::complement(&r))
     } else {
         Range::from_list(list)
     }

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -27,6 +27,7 @@ mod mods; // core cross-platform modules
 // * cross-platform modules
 pub use crate::mods::coreopts;
 pub use crate::mods::panic;
+pub use crate::mods::ranges;
 
 // * feature-gated modules
 #[cfg(feature = "encoding")]

--- a/src/uucore/src/lib/mods.rs
+++ b/src/uucore/src/lib/mods.rs
@@ -2,3 +2,4 @@
 
 pub mod coreopts;
 pub mod panic;
+pub mod ranges;

--- a/src/uucore/src/lib/mods/ranges.rs
+++ b/src/uucore/src/lib/mods/ranges.rs
@@ -144,3 +144,31 @@ pub fn complement(ranges: &[Range]) -> Vec<Range> {
 
     complements
 }
+
+/// Test if at least one of the given Ranges contain the supplied value.
+///
+/// Examples:
+///
+/// ```
+/// let ranges = uucore::ranges::Range::from_list("11,2,6-8").unwrap();
+///
+/// assert!(!uucore::ranges::contain(&ranges, 0));
+/// assert!(!uucore::ranges::contain(&ranges, 1));
+/// assert!(!uucore::ranges::contain(&ranges, 5));
+/// assert!(!uucore::ranges::contain(&ranges, 10));
+///
+/// assert!(uucore::ranges::contain(&ranges, 2));
+/// assert!(uucore::ranges::contain(&ranges, 6));
+/// assert!(uucore::ranges::contain(&ranges, 7));
+/// assert!(uucore::ranges::contain(&ranges, 8));
+/// assert!(uucore::ranges::contain(&ranges, 11));
+/// ```
+pub fn contain(ranges: &[Range], n: usize) -> bool {
+    for range in ranges {
+        if n >= range.low && n <= range.high {
+            return true;
+        }
+    }
+
+    false
+}

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -315,3 +315,71 @@ fn test_to_iec_i_should_truncate_output() {
         .succeeds()
         .stdout_is_fixture("gnutest_iec-i_result.txt");
 }
+
+#[test]
+fn test_format_selected_field() {
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "3", "1K 2K 3K"])
+        .succeeds()
+        .stdout_only("1K 2K 3000\n");
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "2", "1K 2K 3K"])
+        .succeeds()
+        .stdout_only("1K 2000 3K\n");
+}
+
+#[test]
+fn test_format_selected_fields() {
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "1,4,3", "1K 2K 3K 4K 5K 6K"])
+        .succeeds()
+        .stdout_only("1000 2K 3000 4000 5K 6K\n");
+}
+
+#[test]
+fn test_should_succeed_if_selected_field_out_of_range() {
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "9", "1K 2K 3K"])
+        .succeeds()
+        .stdout_only("1K 2K 3K\n");
+}
+
+#[test]
+fn test_format_selected_field_range() {
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "2-5", "1K 2K 3K 4K 5K 6K"])
+        .succeeds()
+        .stdout_only("1K 2000 3000 4000 5000 6K\n");
+}
+
+#[test]
+fn test_should_succeed_if_range_out_of_bounds() {
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "5-10", "1K 2K 3K 4K 5K 6K"])
+        .succeeds()
+        .stdout_only("1K 2K 3K 4K 5000 6000\n");
+}
+
+#[test]
+fn test_implied_initial_field_value() {
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "-2", "1K 2K 3K"])
+        .succeeds()
+        .stdout_only("1000 2000 3K\n");
+
+    // same as above but with the equal sign
+    new_ucmd!()
+        .args(&["--from=auto", "--field=-2", "1K 2K 3K"])
+        .succeeds()
+        .stdout_only("1000 2000 3K\n");
+}
+
+#[test]
+fn test_field_df_example() {
+    // df -B1 | numfmt --header --field 2-4 --to=si
+    new_ucmd!()
+        .args(&["--header", "--field", "2-4", "--to=si"])
+        .pipe_in_fixture("df_input.txt")
+        .succeeds()
+        .stdout_is_fixture("df_expected.txt");
+}

--- a/tests/fixtures/numfmt/df_expected.txt
+++ b/tests/fixtures/numfmt/df_expected.txt
@@ -1,0 +1,8 @@
+Filesystem                1B-blocks         Used    Available Use% Mounted on
+udev                           8.2G            0         8.2G   0% /dev
+tmpfs                          1.7G         2.1M         1.7G   1% /run
+/dev/nvme0n1p2                 1.1T         433G         523G  46% /
+tmpfs                          8.3G         145M         8.1G   2% /dev/shm
+tmpfs                          5.3M         4.1K         5.3M   1% /run/lock
+tmpfs                          8.3G            0         8.3G   0% /sys/fs/cgroup
+/dev/nvme0n1p1                 536M         8.2M         528M   2% /boot/efi

--- a/tests/fixtures/numfmt/df_input.txt
+++ b/tests/fixtures/numfmt/df_input.txt
@@ -1,0 +1,8 @@
+Filesystem                1B-blocks         Used    Available Use% Mounted on
+udev                     8192688128            0   8192688128   0% /dev
+tmpfs                    1643331584      2015232   1641316352   1% /run
+/dev/nvme0n1p2        1006530654208 432716689408 522613624832  46% /
+tmpfs                    8216649728    144437248   8072212480   2% /dev/shm
+tmpfs                       5242880         4096      5238784   1% /run/lock
+tmpfs                    8216649728            0   8216649728   0% /sys/fs/cgroup
+/dev/nvme0n1p1            535805952      8175616    527630336   2% /boot/efi


### PR DESCRIPTION
Add field selection to `numfmt`, allowing the user to select an alternate field to format, a list of alternate fields, a range of fields, or any combination of individual fields and ranges.

This PR takes a different approach from the earlier PR (#1454): the range support in `cut` was already nicely factored out of the main implementation, so this PR relocates `cut`'s range handling to `uucore` and reuses it for `numfmt`.
