### PR TITLE
Group OPT_ARGUMENTS into mods

### DIFF
--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -40,10 +40,10 @@ pub mod options {
     }
     pub mod dereference {
         pub static DEREFERENCE: &str = "dereference";
-        pub static NO_DEREFERENCE: &str = "no-dereference"; // not actually read?
+        pub static NO_DEREFERENCE: &str = "no-dereference";
     }
     pub static FROM: &str = "from";
-    pub static RECURSIVE: &str = "recursive"; // TODO(felipel) recursive, reference, traverse related?
+    pub static RECURSIVE: &str = "recursive";
     pub mod traverse {
         pub static TRAVERSE: &str = "H";
         pub static NO_TRAVERSE: &str = "P";

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -27,20 +27,30 @@ use std::path::Path;
 static ABOUT: &str = "change file owner and group";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
-static OPT_CHANGES: &str = "changes";
-static OPT_DEREFERENCE: &str = "dereference";
-static OPT_NO_DEREFERENCE: &str = "no-dereference";
-static OPT_FROM: &str = "from";
-static OPT_PRESERVE_ROOT: &str = "preserve-root";
-static OPT_NO_PRESERVE_ROOT: &str = "no-preserve-root";
-static OPT_QUIET: &str = "quiet";
-static OPT_RECURSIVE: &str = "recursive";
-static OPT_REFERENCE: &str = "reference";
-static OPT_SILENT: &str = "silent";
-static OPT_TRAVERSE: &str = "H";
-static OPT_NO_TRAVERSE: &str = "P";
-static OPT_TRAVERSE_EVERY: &str = "L";
-static OPT_VERBOSE: &str = "verbose";
+pub mod options {
+    pub mod verbosity {
+        pub static CHANGES: &str = "changes";
+        pub static QUIET: &str = "quiet";
+        pub static SILENT: &str = "silent";
+        pub static VERBOSE: &str = "verbose";
+    }
+    pub mod preserve_root {
+        pub static PRESERVE: &str = "preserve-root";
+        pub static NO_PRESERVE: &str = "no-preserve-root";
+    }
+    pub mod dereference {
+        pub static DEREFERENCE: &str = "dereference";
+        pub static NO_DEREFERENCE: &str = "no-dereference"; // not actually read?
+    }
+    pub static FROM: &str = "from";
+    pub static RECURSIVE: &str = "recursive"; // TODO(felipel) recursive, reference, traverse related?
+    pub mod traverse {
+        pub static TRAVERSE: &str = "H";
+        pub static NO_TRAVERSE: &str = "P";
+        pub static EVERY: &str = "L";
+    }
+    pub static REFERENCE: &str = "reference";
+}
 
 static ARG_OWNER: &str = "owner";
 static ARG_FILES: &str = "files";
@@ -66,80 +76,80 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .about(ABOUT)
         .usage(&usage[..])
         .arg(
-            Arg::with_name(OPT_CHANGES)
+            Arg::with_name(options::verbosity::CHANGES)
                 .short("c")
-                .long(OPT_CHANGES)
+                .long(options::verbosity::CHANGES)
                 .help("like verbose but report only when a change is made"),
         )
-        .arg(Arg::with_name(OPT_DEREFERENCE).long(OPT_DEREFERENCE).help(
+        .arg(Arg::with_name(options::dereference::DEREFERENCE).long(options::dereference::DEREFERENCE).help(
             "affect the referent of each symbolic link (this is the default), rather than the symbolic link itself",
         ))
         .arg(
-            Arg::with_name(OPT_NO_DEREFERENCE)
+            Arg::with_name(options::dereference::NO_DEREFERENCE)
                 .short("h")
-                .long(OPT_NO_DEREFERENCE)
+                .long(options::dereference::NO_DEREFERENCE)
                 .help(
                     "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)",
                 ),
         )
         .arg(
-            Arg::with_name(OPT_FROM)
-                .long(OPT_FROM)
+            Arg::with_name(options::FROM)
+                .long(options::FROM)
                 .help(
                     "change the owner and/or group of each file only if its current owner and/or group match those specified here. Either may be omitted, in which case a match is not required for the omitted attribute",
                 )
                 .value_name("CURRENT_OWNER:CURRENT_GROUP"),
         )
         .arg(
-            Arg::with_name(OPT_PRESERVE_ROOT)
-                .long(OPT_PRESERVE_ROOT)
+            Arg::with_name(options::preserve_root::PRESERVE)
+                .long(options::preserve_root::PRESERVE)
                 .help("fail to operate recursively on '/'"),
         )
         .arg(
-            Arg::with_name(OPT_NO_PRESERVE_ROOT)
-                .long(OPT_NO_PRESERVE_ROOT)
+            Arg::with_name(options::preserve_root::NO_PRESERVE)
+                .long(options::preserve_root::NO_PRESERVE)
                 .help("do not treat '/' specially (the default)"),
         )
         .arg(
-            Arg::with_name(OPT_QUIET)
-                .long(OPT_QUIET)
+            Arg::with_name(options::verbosity::QUIET)
+                .long(options::verbosity::QUIET)
                 .help("suppress most error messages"),
         )
         .arg(
-            Arg::with_name(OPT_RECURSIVE)
+            Arg::with_name(options::RECURSIVE)
                 .short("R")
-                .long(OPT_RECURSIVE)
+                .long(options::RECURSIVE)
                 .help("operate on files and directories recursively"),
         )
         .arg(
-            Arg::with_name(OPT_REFERENCE)
-                .long(OPT_REFERENCE)
+            Arg::with_name(options::REFERENCE)
+                .long(options::REFERENCE)
                 .help("use RFILE's owner and group rather than specifying OWNER:GROUP values")
                 .value_name("RFILE")
                 .min_values(1),
         )
-        .arg(Arg::with_name(OPT_SILENT).short("f").long(OPT_SILENT))
+        .arg(Arg::with_name(options::verbosity::SILENT).short("f").long(options::verbosity::SILENT))
         .arg(
-            Arg::with_name(OPT_TRAVERSE)
-                .short(OPT_TRAVERSE)
+            Arg::with_name(options::traverse::TRAVERSE)
+                .short(options::traverse::TRAVERSE)
                 .help("if a command line argument is a symbolic link to a directory, traverse it")
-                .overrides_with_all(&[OPT_TRAVERSE_EVERY, OPT_NO_TRAVERSE]),
+                .overrides_with_all(&[options::traverse::EVERY, options::traverse::NO_TRAVERSE]),
         )
         .arg(
-            Arg::with_name(OPT_TRAVERSE_EVERY)
-                .short(OPT_TRAVERSE_EVERY)
+            Arg::with_name(options::traverse::EVERY)
+                .short(options::traverse::EVERY)
                 .help("traverse every symbolic link to a directory encountered")
-                .overrides_with_all(&[OPT_TRAVERSE, OPT_NO_TRAVERSE]),
+                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::NO_TRAVERSE]),
         )
         .arg(
-            Arg::with_name(OPT_NO_TRAVERSE)
-                .short(OPT_NO_TRAVERSE)
+            Arg::with_name(options::traverse::NO_TRAVERSE)
+                .short(options::traverse::NO_TRAVERSE)
                 .help("do not traverse any symbolic links (default)")
-                .overrides_with_all(&[OPT_TRAVERSE, OPT_TRAVERSE_EVERY]),
+                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::EVERY]),
         )
         .arg(
-            Arg::with_name(OPT_VERBOSE)
-                .long(OPT_VERBOSE)
+            Arg::with_name(options::verbosity::VERBOSE)
+                .long(options::verbosity::VERBOSE)
                 .help("output a diagnostic for every file processed"),
         )
         .arg(
@@ -166,23 +176,23 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 
-    let preserve_root = matches.is_present(OPT_PRESERVE_ROOT);
+    let preserve_root = matches.is_present(options::preserve_root::PRESERVE);
 
-    let mut derefer = if matches.is_present(OPT_NO_DEREFERENCE) {
+    let mut derefer = if matches.is_present(options::dereference::NO_DEREFERENCE) {
         1
     } else {
         0
     };
 
-    let mut bit_flag = if matches.is_present(OPT_TRAVERSE) {
+    let mut bit_flag = if matches.is_present(options::traverse::TRAVERSE) {
         FTS_COMFOLLOW | FTS_PHYSICAL
-    } else if matches.is_present(OPT_TRAVERSE_EVERY) {
+    } else if matches.is_present(options::traverse::EVERY) {
         FTS_LOGICAL
     } else {
         FTS_PHYSICAL
     };
 
-    let recursive = matches.is_present(OPT_RECURSIVE);
+    let recursive = matches.is_present(options::RECURSIVE);
     if recursive {
         if bit_flag == FTS_PHYSICAL {
             if derefer == 1 {
@@ -195,17 +205,19 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         bit_flag = FTS_PHYSICAL;
     }
 
-    let verbosity = if matches.is_present(OPT_CHANGES) {
+    let verbosity = if matches.is_present(options::verbosity::CHANGES) {
         Verbosity::Changes
-    } else if matches.is_present(OPT_SILENT) || matches.is_present(OPT_QUIET) {
+    } else if matches.is_present(options::verbosity::SILENT)
+        || matches.is_present(options::verbosity::QUIET)
+    {
         Verbosity::Silent
-    } else if matches.is_present(OPT_VERBOSE) {
+    } else if matches.is_present(options::verbosity::VERBOSE) {
         Verbosity::Verbose
     } else {
         Verbosity::Normal
     };
 
-    let filter = if let Some(spec) = matches.value_of(OPT_FROM) {
+    let filter = if let Some(spec) = matches.value_of(options::FROM) {
         match parse_spec(&spec) {
             Ok((Some(uid), None)) => IfFrom::User(uid),
             Ok((None, Some(gid))) => IfFrom::Group(gid),
@@ -222,7 +234,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let dest_uid: Option<u32>;
     let dest_gid: Option<u32>;
-    if let Some(file) = matches.value_of(OPT_REFERENCE) {
+    if let Some(file) = matches.value_of(options::REFERENCE) {
         match fs::metadata(&file) {
             Ok(meta) => {
                 dest_gid = Some(meta.gid());

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -87,11 +87,13 @@ macro_rules! print_adjusted {
 static ABOUT: &str = "Display file or file system status.";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
-static OPT_DEREFERENCE: &str = "dereference";
-static OPT_FILE_SYSTEM: &str = "file-system";
-static OPT_FORMAT: &str = "format";
-static OPT_PRINTF: &str = "printf";
-static OPT_TERSE: &str = "terse";
+pub mod options {
+    pub static DEREFERENCE: &str = "dereference";
+    pub static FILE_SYSTEM: &str = "file-system";
+    pub static FORMAT: &str = "format";
+    pub static PRINTF: &str = "printf";
+    pub static TERSE: &str = "terse";
+}
 
 static ARG_FILES: &str = "files";
 
@@ -464,15 +466,17 @@ impl Stater {
             .map(|v| v.map(ToString::to_string).collect())
             .unwrap_or_default();
 
-        let fmtstr = if matches.is_present(OPT_PRINTF) {
-            matches.value_of(OPT_PRINTF).expect("Invalid format string")
+        let fmtstr = if matches.is_present(options::PRINTF) {
+            matches
+                .value_of(options::PRINTF)
+                .expect("Invalid format string")
         } else {
-            matches.value_of(OPT_FORMAT).unwrap_or("")
+            matches.value_of(options::FORMAT).unwrap_or("")
         };
 
-        let use_printf = matches.is_present(OPT_PRINTF);
-        let terse = matches.is_present(OPT_TERSE);
-        let showfs = matches.is_present(OPT_FILE_SYSTEM);
+        let use_printf = matches.is_present(options::PRINTF);
+        let terse = matches.is_present(options::TERSE);
+        let showfs = matches.is_present(options::FILE_SYSTEM);
 
         let default_tokens = if fmtstr.is_empty() {
             Stater::generate_tokens(&Stater::default_fmt(showfs, terse, false), use_printf).unwrap()
@@ -501,7 +505,7 @@ impl Stater {
         };
 
         Ok(Stater {
-            follow: matches.is_present(OPT_DEREFERENCE),
+            follow: matches.is_present(options::DEREFERENCE),
             showfs,
             from_user: !fmtstr.is_empty(),
             files,
@@ -955,27 +959,27 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .usage(&usage[..])
         .after_help(&long_usage[..])
         .arg(
-            Arg::with_name(OPT_DEREFERENCE)
+            Arg::with_name(options::DEREFERENCE)
                 .short("L")
-                .long(OPT_DEREFERENCE)
+                .long(options::DEREFERENCE)
                 .help("follow links"),
         )
         .arg(
-            Arg::with_name(OPT_FILE_SYSTEM)
+            Arg::with_name(options::FILE_SYSTEM)
                 .short("f")
-                .long(OPT_FILE_SYSTEM)
+                .long(options::FILE_SYSTEM)
                 .help("display file system status instead of file status"),
         )
         .arg(
-            Arg::with_name(OPT_TERSE)
+            Arg::with_name(options::TERSE)
                 .short("t")
-                .long(OPT_TERSE)
+                .long(options::TERSE)
                 .help("print the information in terse form"),
         )
         .arg(
-            Arg::with_name(OPT_FORMAT)
+            Arg::with_name(options::FORMAT)
                 .short("c")
-                .long(OPT_FORMAT)
+                .long(options::FORMAT)
                 .help(
                     "use the specified FORMAT instead of the default;
  output a newline after each use of FORMAT",
@@ -983,8 +987,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .value_name("FORMAT"),
         )
         .arg(
-            Arg::with_name(OPT_PRINTF)
-                .long(OPT_PRINTF)
+            Arg::with_name(options::PRINTF)
+                .long(options::PRINTF)
                 .value_name("FORMAT")
                 .help(
                     "like --format, but interpret backslash escapes,

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -19,8 +19,10 @@ static EXIT_ERR: i32 = 1;
 
 static ABOUT: &str = "Synchronize cached writes to persistent storage";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
-static OPT_FILE_SYSTEM: &str = "file-system";
-static OPT_DATA: &str = "data";
+pub mod options {
+    pub static FILE_SYSTEM: &str = "file-system";
+    pub static DATA: &str = "data";
+}
 
 static ARG_FILES: &str = "files";
 
@@ -170,17 +172,17 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .about(ABOUT)
         .usage(&usage[..])
         .arg(
-            Arg::with_name(OPT_FILE_SYSTEM)
+            Arg::with_name(options::FILE_SYSTEM)
                 .short("f")
-                .long(OPT_FILE_SYSTEM)
-                .conflicts_with(OPT_DATA)
+                .long(options::FILE_SYSTEM)
+                .conflicts_with(options::DATA)
                 .help("sync the file systems that contain the files (Linux and Windows only)"),
         )
         .arg(
-            Arg::with_name(OPT_DATA)
+            Arg::with_name(options::DATA)
                 .short("d")
-                .long(OPT_DATA)
-                .conflicts_with(OPT_FILE_SYSTEM)
+                .long(options::DATA)
+                .conflicts_with(options::FILE_SYSTEM)
                 .help("sync only file data, no unneeded metadata (Linux only)"),
         )
         .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
@@ -197,10 +199,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         }
     }
 
-    if matches.is_present(OPT_FILE_SYSTEM) {
+    if matches.is_present(options::FILE_SYSTEM) {
         #[cfg(any(target_os = "linux", target_os = "windows"))]
         syncfs(files);
-    } else if matches.is_present(OPT_DATA) {
+    } else if matches.is_present(options::DATA) {
         #[cfg(target_os = "linux")]
         fdatasync(files);
     } else {

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -29,10 +29,12 @@ enum TruncateMode {
 static ABOUT: &str = "Shrink or extend the size of each file to the specified size.";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
-static OPT_IO_BLOCKS: &str = "io-blocks";
-static OPT_NO_CREATE: &str = "no-create";
-static OPT_REFERENCE: &str = "reference";
-static OPT_SIZE: &str = "size";
+pub mod options {
+    pub static IO_BLOCKS: &str = "io-blocks";
+    pub static NO_CREATE: &str = "no-create";
+    pub static REFERENCE: &str = "reference";
+    pub static SIZE: &str = "size";
+}
 
 static ARG_FILES: &str = "files";
 
@@ -72,26 +74,26 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .usage(&usage[..])
         .after_help(&long_usage[..])
         .arg(
-            Arg::with_name(OPT_IO_BLOCKS)
+            Arg::with_name(options::IO_BLOCKS)
             .short("o")
-            .long(OPT_IO_BLOCKS)
+            .long(options::IO_BLOCKS)
             .help("treat SIZE as the number of I/O blocks of the file rather than bytes (NOT IMPLEMENTED)")
         )
         .arg(
-            Arg::with_name(OPT_NO_CREATE)
+            Arg::with_name(options::NO_CREATE)
             .short("c")
-            .long(OPT_NO_CREATE)
+            .long(options::NO_CREATE)
             .help("do not create files that do not exist")
         )
         .arg(
-            Arg::with_name(OPT_REFERENCE)
+            Arg::with_name(options::REFERENCE)
             .short("r")
-            .long(OPT_REFERENCE)
+            .long(options::REFERENCE)
             .help("base the size of each file on the size of RFILE")
             .value_name("RFILE")
         )
         .arg(
-            Arg::with_name(OPT_SIZE)
+            Arg::with_name(options::SIZE)
             .short("s")
             .long("size")
             .help("set or adjust the size of each file according to SIZE, which is in bytes unless --io-blocks is specified")
@@ -109,10 +111,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         show_error!("Missing an argument");
         return 1;
     } else {
-        let io_blocks = matches.is_present(OPT_IO_BLOCKS);
-        let no_create = matches.is_present(OPT_NO_CREATE);
-        let reference = matches.value_of(OPT_REFERENCE).map(String::from);
-        let size = matches.value_of(OPT_SIZE).map(String::from);
+        let io_blocks = matches.is_present(options::IO_BLOCKS);
+        let no_create = matches.is_present(options::NO_CREATE);
+        let reference = matches.value_of(options::REFERENCE).map(String::from);
+        let size = matches.value_of(options::SIZE).map(String::from);
         if reference.is_none() && size.is_none() {
             crash!(1, "you must specify either --reference or --size");
         } else {

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -19,19 +19,17 @@ use platform_info::*;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const ABOUT: &str = "Print certain system information.  With no OPTION, same as -s.";
 
-const OPT_ALL: &str = "all";
-const OPT_KERNELNAME: &str = "kernel-name";
-const OPT_NODENAME: &str = "nodename";
-const OPT_KERNELVERSION: &str = "kernel-version";
-const OPT_KERNELRELEASE: &str = "kernel-release";
-const OPT_MACHINE: &str = "machine";
-const OPT_PROCESSOR: &str = "processor";
-const OPT_HWPLATFORM: &str = "hardware-platform";
-
-//FIXME: unimplemented options
-//const OPT_PROCESSOR: &'static str = "processor";
-//const OPT_HWPLATFORM: &'static str = "hardware-platform";
-const OPT_OS: &str = "operating-system";
+pub mod options {
+    pub static ALL: &str = "all";
+    pub static KERNELNAME: &str = "kernel-name";
+    pub static NODENAME: &str = "nodename";
+    pub static KERNELVERSION: &str = "kernel-version";
+    pub static KERNELRELEASE: &str = "kernel-release";
+    pub static MACHINE: &str = "machine";
+    pub static PROCESSOR: &str = "processor";
+    pub static HWPLATFORM: &str = "hardware-platform";
+    pub static OS: &str = "operating-system";
+}
 
 #[cfg(target_os = "linux")]
 const HOST_OS: &str = "GNU/Linux";
@@ -54,58 +52,58 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .version(VERSION)
         .about(ABOUT)
         .usage(&usage[..])
-        .arg(Arg::with_name(OPT_ALL)
+        .arg(Arg::with_name(options::ALL)
             .short("a")
-            .long(OPT_ALL)
+            .long(options::ALL)
             .help("Behave as though all of the options -mnrsv were specified."))
-        .arg(Arg::with_name(OPT_KERNELNAME)
+        .arg(Arg::with_name(options::KERNELNAME)
             .short("s")
-            .long(OPT_KERNELNAME)
+            .long(options::KERNELNAME)
             .alias("sysname") // Obsolescent option in GNU uname
             .help("print the kernel name."))
-        .arg(Arg::with_name(OPT_NODENAME)
+        .arg(Arg::with_name(options::NODENAME)
             .short("n")
-            .long(OPT_NODENAME)
+            .long(options::NODENAME)
             .help("print the nodename (the nodename may be a name that the system is known by to a communications network)."))
-        .arg(Arg::with_name(OPT_KERNELRELEASE)
+        .arg(Arg::with_name(options::KERNELRELEASE)
             .short("r")
-            .long(OPT_KERNELRELEASE)
+            .long(options::KERNELRELEASE)
             .alias("release") // Obsolescent option in GNU uname
             .help("print the operating system release."))
-        .arg(Arg::with_name(OPT_KERNELVERSION)
+        .arg(Arg::with_name(options::KERNELVERSION)
             .short("v")
-            .long(OPT_KERNELVERSION)
+            .long(options::KERNELVERSION)
             .help("print the operating system version."))
-        .arg(Arg::with_name(OPT_HWPLATFORM)
+        .arg(Arg::with_name(options::HWPLATFORM)
             .short("i")
-            .long(OPT_HWPLATFORM)
+            .long(options::HWPLATFORM)
             .help("print the hardware platform (non-portable)"))
-        .arg(Arg::with_name(OPT_MACHINE)
+        .arg(Arg::with_name(options::MACHINE)
             .short("m")
-            .long(OPT_MACHINE)
+            .long(options::MACHINE)
             .help("print the machine hardware name."))
-        .arg(Arg::with_name(OPT_PROCESSOR)
+        .arg(Arg::with_name(options::PROCESSOR)
             .short("p")
-            .long(OPT_PROCESSOR)
+            .long(options::PROCESSOR)
             .help("print the processor type (non-portable)"))
-        .arg(Arg::with_name(OPT_OS)
+        .arg(Arg::with_name(options::OS)
             .short("o")
-            .long(OPT_OS)
+            .long(options::OS)
             .help("print the operating system name."))
         .get_matches_from(args);
 
     let uname = return_if_err!(1, PlatformInfo::new());
     let mut output = String::new();
 
-    let all = matches.is_present(OPT_ALL);
-    let kernelname = matches.is_present(OPT_KERNELNAME);
-    let nodename = matches.is_present(OPT_NODENAME);
-    let kernelrelease = matches.is_present(OPT_KERNELRELEASE);
-    let kernelversion = matches.is_present(OPT_KERNELVERSION);
-    let machine = matches.is_present(OPT_MACHINE);
-    let processor = matches.is_present(OPT_PROCESSOR);
-    let hwplatform = matches.is_present(OPT_HWPLATFORM);
-    let os = matches.is_present(OPT_OS);
+    let all = matches.is_present(options::ALL);
+    let kernelname = matches.is_present(options::KERNELNAME);
+    let nodename = matches.is_present(options::NODENAME);
+    let kernelrelease = matches.is_present(options::KERNELRELEASE);
+    let kernelversion = matches.is_present(options::KERNELVERSION);
+    let machine = matches.is_present(options::MACHINE);
+    let processor = matches.is_present(options::PROCESSOR);
+    let hwplatform = matches.is_present(options::HWPLATFORM);
+    let os = matches.is_present(options::OS);
 
     let none = !(all
         || kernelname

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -16,15 +16,17 @@ use std::str::FromStr;
 
 static ABOUT: &str = "Report or omit repeated lines.";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
-static OPT_ALL_REPEATED: &str = "all-repeated";
-static OPT_CHECK_CHARS: &str = "check-chars";
-static OPT_COUNT: &str = "count";
-static OPT_IGNORE_CASE: &str = "ignore-case";
-static OPT_REPEATED: &str = "repeated";
-static OPT_SKIP_FIELDS: &str = "skip-fields";
-static OPT_SKIP_CHARS: &str = "skip-chars";
-static OPT_UNIQUE: &str = "unique";
-static OPT_ZERO_TERMINATED: &str = "zero-terminated";
+pub mod options {
+    pub static ALL_REPEATED: &str = "all-repeated";
+    pub static CHECK_CHARS: &str = "check-chars";
+    pub static COUNT: &str = "count";
+    pub static IGNORE_CASE: &str = "ignore-case";
+    pub static REPEATED: &str = "repeated";
+    pub static SKIP_FIELDS: &str = "skip-fields";
+    pub static SKIP_CHARS: &str = "skip-chars";
+    pub static UNIQUE: &str = "unique";
+    pub static ZERO_TERMINATED: &str = "zero-terminated";
+}
 
 static ARG_FILES: &str = "files";
 
@@ -233,63 +235,63 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .usage(&usage[..])
         .after_help(&long_usage[..])
         .arg(
-            Arg::with_name(OPT_ALL_REPEATED)
+            Arg::with_name(options::ALL_REPEATED)
                 .short("D")
-                .long(OPT_ALL_REPEATED)
+                .long(options::ALL_REPEATED)
                 .possible_values(&["none", "prepend", "separate"])
                 .help("print all duplicate lines. Delimiting is done with blank lines")
                 .value_name("delimit-method")
                 .default_value("none"),
         )
         .arg(
-            Arg::with_name(OPT_CHECK_CHARS)
+            Arg::with_name(options::CHECK_CHARS)
                 .short("w")
-                .long(OPT_CHECK_CHARS)
+                .long(options::CHECK_CHARS)
                 .help("compare no more than N characters in lines")
                 .value_name("N"),
         )
         .arg(
-            Arg::with_name(OPT_COUNT)
+            Arg::with_name(options::COUNT)
                 .short("c")
-                .long(OPT_COUNT)
+                .long(options::COUNT)
                 .help("prefix lines by the number of occurrences"),
         )
         .arg(
-            Arg::with_name(OPT_IGNORE_CASE)
+            Arg::with_name(options::IGNORE_CASE)
                 .short("i")
-                .long(OPT_IGNORE_CASE)
+                .long(options::IGNORE_CASE)
                 .help("ignore differences in case when comparing"),
         )
         .arg(
-            Arg::with_name(OPT_REPEATED)
+            Arg::with_name(options::REPEATED)
                 .short("d")
-                .long(OPT_REPEATED)
+                .long(options::REPEATED)
                 .help("only print duplicate lines"),
         )
         .arg(
-            Arg::with_name(OPT_SKIP_CHARS)
+            Arg::with_name(options::SKIP_CHARS)
                 .short("s")
-                .long(OPT_SKIP_CHARS)
+                .long(options::SKIP_CHARS)
                 .help("avoid comparing the first N characters")
                 .value_name("N"),
         )
         .arg(
-            Arg::with_name(OPT_SKIP_FIELDS)
+            Arg::with_name(options::SKIP_FIELDS)
                 .short("f")
-                .long(OPT_SKIP_FIELDS)
+                .long(options::SKIP_FIELDS)
                 .help("avoid comparing the first N fields")
                 .value_name("N"),
         )
         .arg(
-            Arg::with_name(OPT_UNIQUE)
+            Arg::with_name(options::UNIQUE)
                 .short("u")
-                .long(OPT_UNIQUE)
+                .long(options::UNIQUE)
                 .help("only print unique lines"),
         )
         .arg(
-            Arg::with_name(OPT_ZERO_TERMINATED)
+            Arg::with_name(options::ZERO_TERMINATED)
                 .short("z")
-                .long(OPT_ZERO_TERMINATED)
+                .long(options::ZERO_TERMINATED)
                 .help("end lines with 0 byte, not newline"),
         )
         .arg(
@@ -316,11 +318,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     };
 
     let uniq = Uniq {
-        repeats_only: matches.is_present(OPT_REPEATED)
-            || matches.occurrences_of(OPT_ALL_REPEATED) > 0,
-        uniques_only: matches.is_present(OPT_UNIQUE),
-        all_repeated: matches.occurrences_of(OPT_ALL_REPEATED) > 0,
-        delimiters: match matches.value_of(OPT_ALL_REPEATED).map(String::from) {
+        repeats_only: matches.is_present(options::REPEATED)
+            || matches.occurrences_of(options::ALL_REPEATED) > 0,
+        uniques_only: matches.is_present(options::UNIQUE),
+        all_repeated: matches.occurrences_of(options::ALL_REPEATED) > 0,
+        delimiters: match matches.value_of(options::ALL_REPEATED).map(String::from) {
             Some(ref opt_arg) if opt_arg != "none" => match &(*opt_arg.as_str()) {
                 "prepend" => Delimiters::Prepend,
                 "separate" => Delimiters::Separate,
@@ -328,12 +330,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             },
             _ => Delimiters::None,
         },
-        show_counts: matches.is_present(OPT_COUNT),
-        skip_fields: opt_parsed(OPT_SKIP_FIELDS, &matches),
-        slice_start: opt_parsed(OPT_SKIP_CHARS, &matches),
-        slice_stop: opt_parsed(OPT_CHECK_CHARS, &matches),
-        ignore_case: matches.is_present(OPT_IGNORE_CASE),
-        zero_terminated: matches.is_present(OPT_ZERO_TERMINATED),
+        show_counts: matches.is_present(options::COUNT),
+        skip_fields: opt_parsed(options::SKIP_FIELDS, &matches),
+        slice_start: opt_parsed(options::SKIP_CHARS, &matches),
+        slice_stop: opt_parsed(options::CHECK_CHARS, &matches),
+        ignore_case: matches.is_present(options::IGNORE_CASE),
+        zero_terminated: matches.is_present(options::ZERO_TERMINATED),
     };
     uniq.print_uniq(
         &mut open_input_file(in_file_name),

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -21,7 +21,9 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = "Display the current time, the length of time the system has been up,\n\
 the number of users on the system, and the average number of jobs\n\
 in the run queue over the last 1, 5 and 15 minutes.";
-static OPT_SINCE: &str = "since";
+pub mod options {
+    pub static SINCE: &str = "since";
+}
 
 #[cfg(unix)]
 use uucore::libc::getloadavg;
@@ -42,9 +44,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .about(ABOUT)
         .usage(&usage[..])
         .arg(
-            Arg::with_name(OPT_SINCE)
+            Arg::with_name(options::SINCE)
                 .short("s")
-                .long(OPT_SINCE)
+                .long(options::SINCE)
                 .help("system up since"),
         )
         .get_matches_from(args);
@@ -56,7 +58,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
         1
     } else {
-        if matches.is_present(OPT_SINCE) {
+        if matches.is_present(options::SINCE) {
             let initial_date = Local.timestamp(Utc::now().timestamp() - uptime, 0);
             println!("{}", initial_date.format("%Y-%m-%d %H:%M:%S"));
             return 0;

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -29,11 +29,11 @@ struct Settings {
 impl Settings {
     fn new(matches: &ArgMatches) -> Settings {
         let settings = Settings {
-            show_bytes: matches.is_present(OPT_BYTES),
-            show_chars: matches.is_present(OPT_CHAR),
-            show_lines: matches.is_present(OPT_LINES),
-            show_words: matches.is_present(OPT_WORDS),
-            show_max_line_length: matches.is_present(OPT_MAX_LINE_LENGTH),
+            show_bytes: matches.is_present(options::BYTES),
+            show_chars: matches.is_present(options::CHAR),
+            show_lines: matches.is_present(options::LINES),
+            show_words: matches.is_present(options::WORDS),
+            show_max_line_length: matches.is_present(options::MAX_LINE_LENGTH),
         };
 
         if settings.show_bytes
@@ -68,11 +68,13 @@ static ABOUT: &str = "Display newline, word, and byte counts for each FILE, and 
 more than one FILE is specified.";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
-static OPT_BYTES: &str = "bytes";
-static OPT_CHAR: &str = "chars";
-static OPT_LINES: &str = "lines";
-static OPT_MAX_LINE_LENGTH: &str = "max-line-length";
-static OPT_WORDS: &str = "words";
+pub mod options {
+    pub static BYTES: &str = "bytes";
+    pub static CHAR: &str = "chars";
+    pub static LINES: &str = "lines";
+    pub static MAX_LINE_LENGTH: &str = "max-line-length";
+    pub static WORDS: &str = "words";
+}
 
 static ARG_FILES: &str = "files";
 
@@ -92,33 +94,33 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .about(ABOUT)
         .usage(&usage[..])
         .arg(
-            Arg::with_name(OPT_BYTES)
+            Arg::with_name(options::BYTES)
                 .short("c")
-                .long(OPT_BYTES)
+                .long(options::BYTES)
                 .help("print the byte counts"),
         )
         .arg(
-            Arg::with_name(OPT_CHAR)
+            Arg::with_name(options::CHAR)
                 .short("m")
-                .long(OPT_CHAR)
+                .long(options::CHAR)
                 .help("print the character counts"),
         )
         .arg(
-            Arg::with_name(OPT_LINES)
+            Arg::with_name(options::LINES)
                 .short("l")
-                .long(OPT_LINES)
+                .long(options::LINES)
                 .help("print the newline counts"),
         )
         .arg(
-            Arg::with_name(OPT_MAX_LINE_LENGTH)
+            Arg::with_name(options::MAX_LINE_LENGTH)
                 .short("L")
-                .long(OPT_MAX_LINE_LENGTH)
+                .long(options::MAX_LINE_LENGTH)
                 .help("print the length of the longest line"),
         )
         .arg(
-            Arg::with_name(OPT_WORDS)
+            Arg::with_name(options::WORDS)
                 .short("w")
-                .long(OPT_WORDS)
+                .long(options::WORDS)
                 .help("print the word counts"),
         )
         .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))


### PR DESCRIPTION
Group `OPT_SOME_CLI_OPTION` into `options::SOME_CLI_OPTION`

This pull request does not intend to end all re-ordering of options, but rather establish a norm to follow in all tools/commands.

I'm grouping several related options into sub-mods. They can be improved by pointing them out here, in this PR, or later in the future