### PR TITLE
cp: implement --strip-trailing-slashes

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -480,6 +480,24 @@ fn test_cp_no_deref() {
 }
 
 #[test]
+fn test_cp_strip_trailing_slashes() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    //using --strip-trailing-slashes option
+    let result = ucmd
+        .arg("--strip-trailing-slashes")
+        .arg(format!("{}/", TEST_HELLO_WORLD_SOURCE))
+        .arg(TEST_HELLO_WORLD_DEST)
+        .run();
+
+    // Check that the exit code represents a successful copy.
+    assert!(result.success);
+
+    // Check the content of the destination file that was copied.
+    assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
+}
+
+#[test]
 // For now, disable the test on Windows. Symlinks aren't well support on Windows.
 // It works on Unix for now and it works locally when run from a powershell
 #[cfg(not(windows))]


### PR DESCRIPTION
Adds support for the `--strip-trailing-slashes` flag for `cp` (#1761).

I've based the implementation on the `--strip-trailing-slashes` flag for `mv`, which [uses `.components().as_path()`](https://github.com/uutils/coreutils/blob/2dcc60d624b672c6100e28808fb6ac20e391a0b7/src/uu/mv/src/mv.rs#L200) to perform the normalization.