### PR TITLE
du error output should match GNU

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -15,7 +15,7 @@ use chrono::Local;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
-use std::io::{stderr, Result, Write};
+use std::io::{ErrorKind, Result, stderr, Write};
 use std::iter;
 #[cfg(not(windows))]
 use std::os::unix::fs::MetadataExt;
@@ -296,7 +296,13 @@ fn du(
                             }
                         }
                     }
-                    Err(error) => show_error!("{}", error),
+                    Err(error) => match error.kind() {
+                        ErrorKind::PermissionDenied => {
+                            let description = format!("cannot access '{}'",entry.path().as_os_str().to_str().unwrap_or("<Un-printable path>"));
+                            let error_message = "Permission denied";
+                            show_error_custom_description!(description, "{}", error_message) }
+                        _ => show_error!("{}", error),
+                    }
                 },
                 Err(error) => show_error!("{}", error),
             }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -15,7 +15,7 @@ use chrono::Local;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
-use std::io::{ErrorKind, Result, stderr, Write};
+use std::io::{stderr, ErrorKind, Result, Write};
 use std::iter;
 #[cfg(not(windows))]
 use std::os::unix::fs::MetadataExt;
@@ -298,11 +298,19 @@ fn du(
                     }
                     Err(error) => match error.kind() {
                         ErrorKind::PermissionDenied => {
-                            let description = format!("cannot access '{}'",entry.path().as_os_str().to_str().unwrap_or("<Un-printable path>"));
+                            let description = format!(
+                                "cannot access '{}'",
+                                entry
+                                    .path()
+                                    .as_os_str()
+                                    .to_str()
+                                    .unwrap_or("<Un-printable path>")
+                            );
                             let error_message = "Permission denied";
-                            show_error_custom_description!(description, "{}", error_message) }
+                            show_error_custom_description!(description, "{}", error_message)
+                        }
                         _ => show_error!("{}", error),
-                    }
+                    },
                 },
                 Err(error) => show_error!("{}", error),
             }

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -32,6 +32,15 @@ macro_rules! show_error(
 
 /// Show a warning to stderr in a silimar style to GNU coreutils.
 #[macro_export]
+macro_rules! show_error_custom_description (
+    ($err:expr,$($args:tt)+) => ({
+        eprint!("{}: {}: ", executable!(), $err);
+        eprintln!($($args)+);
+    })
+);
+
+
+#[macro_export]
 macro_rules! show_warning(
     ($($args:tt)+) => ({
         eprint!("{}: warning: ", executable!());

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -39,7 +39,6 @@ macro_rules! show_error_custom_description (
     })
 );
 
-
 #[macro_export]
 macro_rules! show_warning(
     ($($args:tt)+) => ({


### PR DESCRIPTION
Fixes #1770

* Created a new error macro which allows the customization of the
  "error:" string part
* Match the du output based on the type of error encountered. Can extend
  to handling other errors I guess.

I'm pretty new to rust, so interested in feedback on this. I did contemplate changing the signature of the `show_error` macro, but it seemed less complex to create a new macro allowing the customization of the `error:` string part. Also, I'm not wild about hardcoding the `Permission denied` string, but it seemed the simplest thing to do.
