### PR TITLE
sleep: move from getopts to clap #1735

### DIFF
--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/sleep.rs"
 
 [dependencies]
-getopts = "0.2.18"
+clap = "2.33"
 uucore = { version=">=0.0.7", package="uucore", path="../../uucore", features=["parse_time"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -26,7 +26,7 @@ mod options {
 }
 
 fn get_usage() -> String {
-    format!("{0} [NUMBER]<SUFFIX> \n  or\n    {0} [OPTION]", executable!())
+    format!("{0} {1}[SUFFIX]... \n    {0} OPTION", executable!(), options::NUMBER)
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -41,9 +41,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             Arg::with_name(options::NUMBER)
                 .long(options::NUMBER)
                 .help("pause for NUMBER seconds")
-                .value_name("DURATION")
+                .value_name(options::NUMBER)
                 .index(1)
                 .multiple(true)
+                .required(true)
         ).get_matches_from(args);
     
     if let Some(values) = matches.values_of(options::NUMBER) {

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -11,55 +11,50 @@ extern crate uucore;
 use std::thread;
 use std::time::Duration;
 
-static NAME: &str = "sleep";
+use clap::{App, Arg};
+
 static VERSION: &str = env!("CARGO_PKG_VERSION");
-
-pub fn uumain(args: impl uucore::Args) -> i32 {
-    let args = args.collect_str();
-
-    let mut opts = getopts::Options::new();
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
-
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => {
-            show_error!("{}", f);
-            return 1;
-        }
-    };
-
-    if matches.opt_present("help") {
-        let msg = format!(
-            "{0} {1}
-
-Usage:
-  {0} NUMBER[SUFFIX]
-or
-  {0} OPTION
-
-Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
+static ABOUT: &str = "Pause for NUMBER seconds.";
+static LONG_HELP: &str = "Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
 'm' for minutes, 'h' for hours or 'd' for days.  Unlike most implementations
 that require NUMBER be an integer, here NUMBER may be an arbitrary floating
 point number.  Given two or more arguments, pause for the amount of time
-specified by the sum of their values.",
-            NAME, VERSION
-        );
-        print!("{}", opts.usage(&msg));
-    } else if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-    } else if matches.free.is_empty() {
-        show_error!("missing an argument");
-        show_error!("for help, try '{0} --help'", NAME);
-        return 1;
-    } else {
-        sleep(matches.free);
-    }
+specified by the sum of their values.";
 
+mod options {
+    pub const NUMBER: &str = "NUMBER";
+}
+
+fn get_usage() -> String {
+    format!("{0} [NUMBER]<SUFFIX> \n  or\n    {0} [OPTION]", executable!())
+}
+
+pub fn uumain(args: impl uucore::Args) -> i32 {
+    let usage = get_usage();
+
+    let matches = App::new(executable!())
+        .version(VERSION)
+        .about(ABOUT)
+        .usage(&usage[..])
+        .after_help(LONG_HELP)
+        .arg(
+            Arg::with_name(options::NUMBER)
+                .long(options::NUMBER)
+                .help("pause for NUMBER seconds")
+                .value_name("DURATION")
+                .index(1)
+                .multiple(true)
+        ).get_matches_from(args);
+    
+    if let Some(values) = matches.values_of(options::NUMBER) {
+        let numbers = values.collect();
+        sleep(numbers);
+    }
+    
     0
 }
 
-fn sleep(args: Vec<String>) {
+fn sleep(args: Vec<&str>) {
     let sleep_dur =
         args.iter().fold(
             Duration::new(0, 0),

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -26,7 +26,11 @@ mod options {
 }
 
 fn get_usage() -> String {
-    format!("{0} {1}[SUFFIX]... \n    {0} OPTION", executable!(), options::NUMBER)
+    format!(
+        "{0} {1}[SUFFIX]... \n    {0} OPTION",
+        executable!(),
+        options::NUMBER
+    )
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -44,14 +48,15 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .value_name(options::NUMBER)
                 .index(1)
                 .multiple(true)
-                .required(true)
-        ).get_matches_from(args);
-    
+                .required(true),
+        )
+        .get_matches_from(args);
+
     if let Some(values) = matches.values_of(options::NUMBER) {
         let numbers = values.collect();
         sleep(numbers);
     }
-    
+
     0
 }
 

--- a/tests/by-util/test_sleep.rs
+++ b/tests/by-util/test_sleep.rs
@@ -1,1 +1,47 @@
-// ToDO: add tests
+use crate::common::util::*;
+
+use std::time::{Duration, Instant};
+
+#[test]
+fn test_sleep_no_suffix() {
+    let millis_100 = Duration::from_millis(100);
+    let before_test = Instant::now();
+
+    new_ucmd!().args(&["0.1"]).succeeds().stdout_only("");
+
+    let duration = before_test.elapsed();
+    assert!(duration >= millis_100);
+}
+
+#[test]
+fn test_sleep_s_suffix() {
+    let millis_100 = Duration::from_millis(100);
+    let before_test = Instant::now();
+
+    new_ucmd!().args(&["0.1s"]).succeeds().stdout_only("");
+
+    let duration = before_test.elapsed();
+    assert!(duration >= millis_100);
+}
+
+#[test]
+fn test_sleep_m_suffix() {
+    let millis_600 = Duration::from_millis(600);
+    let before_test = Instant::now();
+
+    new_ucmd!().args(&["0.01m"]).succeeds().stdout_only("");
+
+    let duration = before_test.elapsed();
+    assert!(duration >= millis_600);
+}
+
+#[test]
+fn test_sleep_h_suffix() {
+    let millis_360 = Duration::from_millis(360);
+    let before_test = Instant::now();
+
+    new_ucmd!().args(&["0.0001h"]).succeeds().stdout_only("");
+
+    let duration = before_test.elapsed();
+    assert!(duration >= millis_360);
+}


### PR DESCRIPTION
Fixes #1735.

This request replaces getopts with clap for the sleep binary.
It does not introduce tests.