### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Installation Instructions
 
 Likewise, installing can simply be done using:
 ```bash
-$ cargo install
+$ cargo install --path .
 ```
 
 This command will install uutils into Cargo's *bin* folder (*e.g.* `$HOME/.cargo/bin`).


### PR DESCRIPTION
error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.