### PR TITLE
paste: support multi-stdin

### DIFF
--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -2,8 +2,23 @@ use crate::common::util::*;
 
 #[test]
 fn test_combine_pairs_of_lines() {
-    new_ucmd!()
-        .args(&["-s", "-d", "\t\n", "html_colors.txt"])
-        .run()
-        .stdout_is_fixture("html_colors.expected");
+    for s in vec!["-s", "--serial"] {
+        for d in vec!["-d", "--delimiters"] {
+            new_ucmd!()
+                .args(&[s, d, "\t\n", "html_colors.txt"])
+                .run()
+                .stdout_is_fixture("html_colors.expected");
+        }
+    }
+}
+
+#[test]
+fn test_multi_stdin() {
+    for d in vec!["-d", "--delimiters"] {
+        new_ucmd!()
+            .args(&[d, "\t\n", "-", "-"])
+            .pipe_in_fixture("html_colors.txt")
+            .succeeds()
+            .stdout_is_fixture("html_colors.expected");
+    }
 }


### PR DESCRIPTION
- added `-` as the default input, since `paste` reads stdin if no file
is provided
- `paste` also supports providing `-` multiple times
- added a test for it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uutils/coreutils/1791)
<!-- Reviewable:end -->
