### PR TITLE
Fix `make busytest`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -154,6 +154,33 @@ jobs:
       env:
         RUSTFLAGS: '-Awarnings'
 
+  busybox_test:
+    name: Busybox test suite
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { os: ubuntu-latest }
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install `rust` toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        profile: minimal # minimal component installation (ie, no documentation)
+    - name: "prepare busytest"
+      shell: bash
+      run: |
+        make prepare-busytest
+    - name: "run busybox testsuite"
+      shell: bash
+      run: |
+        bindir=$(pwd)/target/debug
+        cd tmp/busybox-*/testsuite
+        S=$(bindir=$bindir ./runtest) && printf "%s\n" "$S" || { printf "%s\n" "$S" | grep "FAIL:" | sed -e "s/FAIL: /::warning ::Test failure:/g" ; }
+
   build:
     name: Build
     runs-on: ${{ matrix.job.os }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -279,6 +279,8 @@ $(BUILDDIR)/busybox: busybox-src build-uutils $(BUILDDIR)/.config
 	cp $(BUILDDIR)/coreutils $(BUILDDIR)/busybox; \
 	chmod +x $@;
 
+prepare-busytest: $(BUILDDIR)/busybox
+
 ifeq ($(EXES),)
 busytest:
 else

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,7 +41,7 @@ PKG_BUILDDIR  := $(BUILDDIR)/deps
 DOCSDIR       := $(BASEDIR)/docs
 
 BUSYBOX_ROOT := $(BASEDIR)/tmp
-BUSYBOX_VER  := 1.24.1
+BUSYBOX_VER  := 1.32.1
 BUSYBOX_SRC  := $(BUSYBOX_ROOT)/busybox-$(BUSYBOX_VER)
 
 # Possible programs
@@ -228,7 +228,7 @@ endif
 
 define TEST_BUSYBOX
 test_busybox_$(1):
-	(cd $(BUSYBOX_SRC)/testsuite && bindir=$(BUILDDIR) ./runtest $(RUNTEST_ARGS) $(1) )
+	-(cd $(BUSYBOX_SRC)/testsuite && bindir=$(BUILDDIR) ./runtest $(RUNTEST_ARGS) $(1))
 endef
 
 # Output names
@@ -276,7 +276,7 @@ $(BUILDDIR)/.config: $(BASEDIR)/.busybox-config
 
 # Test under the busybox testsuite
 $(BUILDDIR)/busybox: busybox-src build-uutils $(BUILDDIR)/.config
-	cp $(BUILDDIR)/uutils $(BUILDDIR)/busybox; \
+	cp $(BUILDDIR)/coreutils $(BUILDDIR)/busybox; \
 	chmod +x $@;
 
 ifeq ($(EXES),)

--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -19,7 +19,7 @@ include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 fn usage<T>(utils: &UtilityMap<T>, name: &str) {
     println!("{} {} (multi-call binary)\n", name, VERSION);
     println!("Usage: {} [function [arguments...]]\n", name);
-    println!("Currently defined functions/utilities:\n");
+    println!("Currently defined functions:\n");
     #[allow(clippy::map_clone)]
     let mut utils: Vec<&str> = utils.keys().map(|&s| s).collect();
     utils.sort_unstable();


### PR DESCRIPTION
The binary was rename from uutils to coreutils in that commit
52ae491fcdd2cd9bd56fb56fae8270c399654dcd
but the makefile to run the busybox test wasn't updated

This commit update the makefile to use the correct binary name.
It also updates the busybox to the 1.32.1 version and fix the makefile
to run all the busybox tests instead of stopping after the first failed exe

This also change the main binary usage to match busybox. This allow to run the new busybox tests.
New busybox tests use an exact match on the usage string to find the list of defined functions. So without that change we had a `SKIPPED: cp (not built)` issue