### PR TITLE
tests/tee: implemented tests for tee

### DIFF
--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -1,1 +1,102 @@
-// ToDO: add tests
+use crate::common::util::*;
+
+// tests for basic tee functionality.
+// inspired by:
+// https://github.com/coreutils/coreutils/tests/misc/tee.sh
+
+#[test]
+fn test_tee_processing_multiple_operands() {
+    // POSIX says: "Processing of at least 13 file operands shall be supported."
+
+    let content = "tee_sample_content";
+    for &n in [1, 2, 12, 13].iter() {
+        let files = (1..=n).map(|x| x.to_string()).collect::<Vec<_>>();
+        let (at, mut ucmd) = at_and_ucmd!();
+
+        ucmd.args(&files)
+            .pipe_in(content)
+            .succeeds()
+            .stdout_is(content);
+
+        for file in files.iter() {
+            assert!(at.file_exists(file));
+            assert_eq!(at.read(file), content);
+        }
+    }
+}
+
+#[test]
+fn test_tee_treat_minus_as_filename() {
+    // Ensure tee treats '-' as the name of a file, as mandated by POSIX.
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    let content = "tee_sample_content";
+    let file = "-";
+
+    ucmd.arg("-").pipe_in(content).succeeds().stdout_is(content);
+
+    assert!(at.file_exists(file));
+    assert_eq!(at.read(file), content);
+}
+
+#[test]
+fn test_tee_append() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let content = "tee_sample_content";
+    let file = "tee_out";
+
+    at.touch(file);
+    at.write(file, content);
+    assert_eq!(at.read(file), content);
+
+    ucmd.arg("-a")
+        .arg(file)
+        .pipe_in(content)
+        .succeeds()
+        .stdout_is(content);
+    assert!(at.file_exists(file));
+    assert_eq!(at.read(file), content.repeat(2));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_tee_no_more_writeable_stdout() {
+    let (_at, mut ucmd) = at_and_ucmd!();
+    let content = (1..=10)
+        .map(|x| format!("{}\n", x.to_string()))
+        .collect::<String>();
+    let file_out = "tee_file_out";
+
+    let _result = ucmd
+        .arg("/dev/full")
+        .arg(file_out)
+        .pipe_in(&content[..])
+        .fails();
+
+    // TODO: comment in after https://github.com/uutils/coreutils/issues/1805 is fixed
+    // assert_eq!(at.read(file_out), content);
+    // assert!(result.stdout.contains(&content));
+    // assert!(result.stderr.contains("No space left on device"));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_tee_no_more_writeable_stdin() {
+    let (_at, mut ucmd) = at_and_ucmd!();
+    let _content = (1..=10)
+        .map(|x| format!("{}\n", x.to_string()))
+        .collect::<String>();
+    let file_out_a = "tee_file_out_a";
+    let file_out_b = "tee_file_out_b";
+
+    let _result = ucmd
+        .arg(file_out_a)
+        .arg(file_out_b)
+        .pipe_in("/dev/full")
+        .succeeds(); // TODO: expected to succeed currently; change to fails() when required
+
+    // TODO: comment in after https://github.com/uutils/coreutils/issues/1805 is fixed
+    // assert_eq!(at.read(file_out_a), content);
+    // assert_eq!(at.read(file_out_b), content);
+    // assert!(result.stderr.contains("No space left on device"));
+}


### PR DESCRIPTION
These tests are ported from `https://github.com/coreutils/coreutils/tests/misc/tee.sh`.

Issue #1793 asked to add tests for tee.
There are tests in `tee.sh` that I could not port over because I don't know how to handle `timeouts` and `dd` in tests.

These are the tests I managed to port over:
- processing_multiple_operands
- treat_minus_as_filename
- append
- no_more_writeable_stdout
- no_more_writeable_stdin

The last two tests fail because rust's tee stdout/stderr differ from GNU's tee stdout/stderr if either of them is `/dev/full`.
I will open an issue for this at #1805