### PR TITLE
ptx: ignore empty regex

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -95,12 +95,21 @@ impl WordFilter {
         if matches.opt_present("b") {
             crash!(1, "-b not implemented yet");
         }
-        let reg = if matches.opt_present("W") {
-            matches.opt_str("W").expect("parsing options failed!")
-        } else if config.gnu_ext {
-            "\\w+".to_owned()
+        // Ignore empty string regex from cmd-line-args
+        let arg_reg: Option<String> = if matches.opt_present("W") {
+            matches.opt_str("W").filter(|reg| !reg.is_empty())
         } else {
-            "[^ \t\n]+".to_owned()
+            None
+        };
+        let reg = match arg_reg {
+            Some(arg_reg) => arg_reg,
+            None => {
+                if config.gnu_ext {
+                    "\\w+".to_owned()
+                } else {
+                    "[^ \t\n]+".to_owned()
+                }
+            }
         };
         WordFilter {
             only_specified: o,

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -9,6 +9,14 @@ fn gnu_ext_disabled_roff_no_ref() {
 }
 
 #[test]
+fn gnu_ext_disabled_roff_no_ref_empty_word_regexp() {
+    new_ucmd!()
+        .args(&["-G", "-R", "-W", "", "input"])
+        .succeeds()
+        .stdout_only_fixture("gnu_ext_disabled_roff_no_ref.expected");
+}
+
+#[test]
 fn gnu_ext_disabled_roff_input_ref() {
     new_ucmd!()
         .args(&["-G", "-r", "-R", "input"])

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -17,6 +17,14 @@ fn gnu_ext_disabled_roff_no_ref_empty_word_regexp() {
 }
 
 #[test]
+fn gnu_ext_disabled_roff_no_ref_word_regexp_exc_space() {
+    new_ucmd!()
+        .args(&["-G", "-R", "-W", "[^\t\n]+", "input"])
+        .succeeds()
+        .stdout_only_fixture("gnu_ext_disabled_roff_no_ref_word_regexp_exc_space.expected");
+}
+
+#[test]
 fn gnu_ext_disabled_roff_input_ref() {
     new_ucmd!()
         .args(&["-G", "-r", "-R", "input"])

--- a/tests/fixtures/ptx/gnu_ext_disabled_roff_no_ref_word_regexp_exc_space.expected
+++ b/tests/fixtures/ptx/gnu_ext_disabled_roff_no_ref_word_regexp_exc_space.expected
@@ -1,0 +1,7 @@
+.xx "" "" """quotes"", for roff" ""
+.xx "" "" "and some other like %a, b#, c$c" ""
+.xx "" "" "hello world!" ""
+.xx "" "" "let's check special characters:" ""
+.xx "" "" "maybe also~or^" ""
+.xx "" "" "oh, and back\slash" ""
+.xx "" "" "{brackets} for tex" ""


### PR DESCRIPTION
GNU manpages for the `-W` option say. "An empty regexp is equivalent to not using this option."

Here's a patch that implements that. If somebody does #1753 they will likely need to know about this PR.