### PR TITLE
touch: use an ArgGroup for sources and turn macros into functions

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -22,6 +22,8 @@ use std::path::Path;
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = "Update the access and modification times of each FILE to the current time.";
 pub mod options {
+    // Both SOURCES and sources are needed as we need to be able to refer to the ArgGroup.
+    pub static SOURCES: &str = "sources";
     pub mod sources {
         pub static DATE: &str = "date";
         pub static REFERENCE: &str = "reference";
@@ -121,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .takes_value(true)
                 .min_values(1),
         )
-        .group(ArgGroup::with_name("sources").args(&[
+        .group(ArgGroup::with_name(options::SOURCES).args(&[
             options::sources::CURRENT,
             options::sources::DATE,
             options::sources::REFERENCE,
@@ -172,7 +174,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             };
 
             // Minor optimization: if no reference time was specified, we're done.
-            if !matches.is_present("sources") {
+            if !matches.is_present(options::SOURCES) {
                 continue;
             }
         }

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -204,6 +204,44 @@ fn test_touch_set_only_mtime_failed() {
 }
 
 #[test]
+fn test_touch_set_both_time_and_reference() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let ref_file = "test_touch_reference";
+    let file = "test_touch_set_both_time_and_reference";
+
+    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+
+    at.touch(ref_file);
+    set_file_times(&at, ref_file, start_of_year, start_of_year);
+    assert!(at.file_exists(ref_file));
+
+    ucmd.args(&["-t", "2015010112342", "-r", ref_file]).fails();
+}
+
+#[test]
+fn test_touch_set_both_date_and_reference() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let ref_file = "test_touch_reference";
+    let file = "test_touch_set_both_date_and_reference";
+
+    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+
+    at.touch(ref_file);
+    set_file_times(&at, ref_file, start_of_year, start_of_year);
+    assert!(at.file_exists(ref_file));
+
+    ucmd.args(&["-d", "Thu Jan 01 12:34:00 2015", "-r", ref_file]).fails();
+}
+
+#[test]
+fn test_touch_set_both_time_and_date() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_both_time_and_date";
+
+    ucmd.args(&["-t", "2015010112342", "-d", "Thu Jan 01 12:34:00 2015", file]).fails();
+}
+
+#[test]
 fn test_touch_set_only_mtime() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_set_only_mtime";

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -215,7 +215,8 @@ fn test_touch_set_both_time_and_reference() {
     set_file_times(&at, ref_file, start_of_year, start_of_year);
     assert!(at.file_exists(ref_file));
 
-    ucmd.args(&["-t", "2015010112342", "-r", ref_file]).fails();
+    ucmd.args(&["-t", "2015010112342", "-r", ref_file, file])
+        .fails();
 }
 
 #[test]
@@ -230,15 +231,23 @@ fn test_touch_set_both_date_and_reference() {
     set_file_times(&at, ref_file, start_of_year, start_of_year);
     assert!(at.file_exists(ref_file));
 
-    ucmd.args(&["-d", "Thu Jan 01 12:34:00 2015", "-r", ref_file]).fails();
+    ucmd.args(&["-d", "Thu Jan 01 12:34:00 2015", "-r", ref_file, file])
+        .fails();
 }
 
 #[test]
 fn test_touch_set_both_time_and_date() {
-    let (at, mut ucmd) = at_and_ucmd!();
+    let (_at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_set_both_time_and_date";
 
-    ucmd.args(&["-t", "2015010112342", "-d", "Thu Jan 01 12:34:00 2015", file]).fails();
+    ucmd.args(&[
+        "-t",
+        "2015010112342",
+        "-d",
+        "Thu Jan 01 12:34:00 2015",
+        file,
+    ])
+    .fails();
 }
 
 #[test]


### PR DESCRIPTION
There are three mutually exclusive arguments in `touch` to specify the time that should be set: `time`, `date` and `current`. This PR removes the manual check that ensures that only one of these is present in favor of using a `clap::ArgGroup`. I have also added tests for the cases where multiple of these arguments are passed.

Finally, there were the macros `to_local!` and `local_tm_to_filetime` that I turned into functions.