### PR TITLE
expand: replace getopts with clap

### DIFF
--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/expand.rs"
 
 [dependencies]
-getopts = "0.2.18"
+clap = "2.33"
 unicode-width = "0.1.5"
 uucore = { version=">=0.0.7", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -23,6 +23,13 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = "Convert tabs in each FILE to spaces, writing to standard output.
  With no FILE, or when FILE is -, read standard input.";
 
+pub mod options {
+    pub static TABS: &str = "tabs";
+    pub static INITIAL: &str = "initial";
+    pub static NO_UTF8: &str = "no-utf8";
+    pub static FILES: &str = "FILES";
+}
+
 static LONG_HELP: &str = "";
 
 static DEFAULT_TABSTOP: usize = 8;
@@ -65,13 +72,13 @@ struct Options {
 
 impl Options {
     fn new(matches: &ArgMatches) -> Options {
-        let tabstops = match matches.value_of("tabstops") {
+        let tabstops = match matches.value_of(options::TABS) {
             Some(s) => tabstops_parse(s.to_string()),
             None => vec![DEFAULT_TABSTOP],
         };
 
-        let iflag = matches.is_present("iflag");
-        let uflag = !matches.is_present("uflag");
+        let iflag = matches.is_present(options::INITIAL);
+        let uflag = !matches.is_present(options::NO_UTF8);
 
         // avoid allocations when dumping out long sequences of spaces
         // by precomputing the longest string of spaces we will ever need
@@ -86,7 +93,7 @@ impl Options {
             .unwrap(); // length of tabstops is guaranteed >= 1
         let tspaces = repeat(' ').take(nspaces).collect();
 
-        let files: Vec<String> = match matches.values_of("files") {
+        let files: Vec<String> = match matches.values_of(options::FILES) {
             Some(s) => s.map(|v| v.to_string()).collect(),
             None => vec!["-".to_owned()],
         };
@@ -109,23 +116,29 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .usage(&usage[..])
         .after_help(LONG_HELP)
         .arg(
-            Arg::with_name("iflag")
-                .long("initial")
+            Arg::with_name(options::INITIAL)
+                .long(options::INITIAL)
                 .short("i")
                 .help("do not convert tabs after non blanks"),
         )
         .arg(
-            Arg::with_name("tabstops")
-                .long("tabs")
+            Arg::with_name(options::TABS)
+                .long(options::TABS)
                 .short("t")
                 .value_name("N, LIST")
                 .takes_value(true)
                 .help("have tabs N characters apart, not 8 or use comma separated list of explicit tab positions"),
         )
         .arg(
-            Arg::with_name("uflags").long("no-utf8").short("U").help("interpret input file as 8-bit ASCII rather than UTF-8"),
+            Arg::with_name(options::NO_UTF8)
+                .long(options::NO_UTF8)
+                .short("U")
+                .help("interpret input file as 8-bit ASCII rather than UTF-8"),
         ).arg(
-            Arg::with_name("files").multiple(true).hidden(true).takes_value(true)
+            Arg::with_name(options::FILES)
+                .multiple(true)
+                .hidden(true)
+                .takes_value(true)
         )
         .get_matches_from(args);
 

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -46,3 +46,13 @@ fn test_with_space() {
     assert!(result.success);
     assert!(result.stdout.contains("    return"));
 }
+
+#[test]
+fn test_with_multiple_files() {
+    let (_, mut ucmd) = at_and_ucmd!();
+
+    let result = ucmd.arg("with-spaces.txt").arg("with-tab.txt").run();
+    assert!(result.success);
+    assert!(result.stdout.contains("    return"));
+    assert!(result.stdout.contains("        "));
+}


### PR DESCRIPTION
expand has one odd behavior that allows two format for tabstop

From expand --help
```
-t, --tabs=N     have tabs N characters apart, not 8
-t, --tabs=LIST  use comma separated list of tab positions
```

This patch use one `value_name("N, LIST")` for tabstop and
deal with above behavior in `parse_tabstop`.

Close #1795