### PR TITLE
uniq: utf-8 issues

### DIFF
--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -79,22 +79,19 @@ impl Uniq {
 
     fn skip_fields<'a>(&self, line: &'a str) -> &'a str {
         if let Some(skip_fields) = self.skip_fields {
-            if line.split_whitespace().count() > skip_fields {
-                let mut field = 0;
-                let mut i = 0;
-                while field < skip_fields && i < line.len() {
-                    while i < line.len() && line.chars().nth(i).unwrap().is_whitespace() {
-                        i += 1;
-                    }
-                    while i < line.len() && !line.chars().nth(i).unwrap().is_whitespace() {
-                        i += 1;
-                    }
-                    field += 1;
+            let mut i = 0;
+            let mut char_indices = line.char_indices();
+            for _ in 0..skip_fields {
+                if char_indices.find(|(_, c)| !c.is_whitespace()) == None {
+                    return "";
                 }
-                &line[i..]
-            } else {
-                ""
+                match char_indices.find(|(_, c)| c.is_whitespace()) {
+                    None => return "",
+
+                    Some((next_field_i, _)) => i = next_field_i,
+                }
             }
+            &line[i..]
         } else {
             line
         }

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -138,3 +138,12 @@ fn test_stdin_zero_terminated() {
         .run()
         .stdout_is_fixture("sorted-zero-terminated.expected");
 }
+
+#[test]
+fn test_invalid_utf8() {
+    new_ucmd!()
+        .arg("not-utf8-sequence.txt")
+        .run()
+        .failure()
+        .stderr_only("uniq: error: invalid utf-8 sequence of 1 bytes from index 0");
+}

--- a/tests/fixtures/uniq/not-utf8-sequence.txt
+++ b/tests/fixtures/uniq/not-utf8-sequence.txt
@@ -1,0 +1,2 @@
+Next line contains two bytes - 0xCC and 0xCD - which are not a valid utf-8 sequence
+ÌÍ

--- a/tests/fixtures/uniq/skip-2-fields.expected
+++ b/tests/fixtures/uniq/skip-2-fields.expected
@@ -1,2 +1,2 @@
-	  aaa  aa  a
+	  aaa  ⟪⟫  a
 aa  a

--- a/tests/fixtures/uniq/skip-fields.txt
+++ b/tests/fixtures/uniq/skip-fields.txt
@@ -1,4 +1,4 @@
-	  aaa  aa  a
+	  aaa  ⟪⟫  a
 	  ZZZ     aa  a
 ZZZ     aa  a
 	  ZZZ     bb  a


### PR DESCRIPTION
This fixes 2 issues I found with handling of utf-8 input in `uniq`:

- Invalid utf-8 sequence in input was causing panics
- Multi-byte code points were handled incorrectly in `skip_fields` causing incorrect results or panics in some cases.