### PR TITLE
travis: bump rust to 1.33.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
-    - rust: 1.32.0
+    - rust: 1.33.0
       env: FEATURES=unix
     # - rust: stable
     #   os: linux


### PR DESCRIPTION
Follow-up to #1724 where the minimum Rust version was bumped to v1.33.0

I'm not too sure this is wanted, but I'll leave it here