### PR TITLE
Revert #1571 “perf/factor ~ deduplicate divisors”

### DIFF
--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -14,8 +14,7 @@ use crate::Factors;
 
 include!(concat!(env!("OUT_DIR"), "/prime_table.rs"));
 
-pub(crate) fn factor(n: &mut u64, factors: &mut Factors) {
-    let mut num = *n;
+pub(crate) fn factor(mut num: u64, mut factors: Factors) -> (Factors, u64) {
     for &(prime, inv, ceil) in P_INVS_U64 {
         if num == 1 {
             break;
@@ -43,5 +42,5 @@ pub(crate) fn factor(n: &mut u64, factors: &mut Factors) {
         }
     }
 
-    *n = num;
+    (factors, num)
 }


### PR DESCRIPTION
It was a draft PR, not ready for merging, and its premature inclusion caused repeated issues, see 368f47381b7441ddb23bb7460417e0d1ce33e330 & friends.

This reverts commits 3743a3e1e7a87bdd0ea7b923dc42386bfc14ccd5, ce218e01b6fcfadf4a9e55348d98f36dafff6c6b, and b7b0c76b8ea60297b43777d17d7322d1d45a9e91.

Close #1841.
