### PR TITLE
ls: --si flag and more compatible size formatting

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -428,28 +428,94 @@ fn test_ls_ls_color() {
 
 #[cfg(not(any(target_vendor = "apple", target_os = "windows")))] // Truncate not available on mac or win
 #[test]
-fn test_ls_human() {
+fn test_ls_human_si() {
     let scene = TestScenario::new(util_name!());
-    let file = "test_human";
-    let result = scene.cmd("truncate").arg("-s").arg("+1000").arg(file).run();
+    let file1 = "test_human-1";
+    let result = scene
+        .cmd("truncate")
+        .arg("-s")
+        .arg("+1000")
+        .arg(file1)
+        .run();
     println!("stderr = {:?}", result.stderr);
     println!("stdout = {:?}", result.stdout);
-    let result = scene.ucmd().arg("-hl").arg(file).run();
+
+    let result = scene.ucmd().arg("-hl").arg(file1).run();
     println!("stderr = {:?}", result.stderr);
     println!("stdout = {:?}", result.stdout);
     assert!(result.success);
-    assert!(result.stdout.contains("1.00K"));
+    assert!(result.stdout.contains(" 1000 "));
+
+    let result = scene.ucmd().arg("-l").arg("--si").arg(file1).run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    assert!(result.stdout.contains(" 1.0k "));
+
     scene
         .cmd("truncate")
         .arg("-s")
         .arg("+1000k")
-        .arg(file)
+        .arg(file1)
         .run();
-    let result = scene.ucmd().arg("-hl").arg(file).run();
+
+    let result = scene.ucmd().arg("-hl").arg(file1).run();
     println!("stderr = {:?}", result.stderr);
     println!("stdout = {:?}", result.stdout);
     assert!(result.success);
-    assert!(result.stdout.contains("1.02M"));
+    assert!(result.stdout.contains(" 1001K "));
+
+    let result = scene.ucmd().arg("-l").arg("--si").arg(file1).run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    assert!(result.stdout.contains(" 1.1M "));
+
+    let file2 = "test-human-2";
+    let result = scene
+        .cmd("truncate")
+        .arg("-s")
+        .arg("+12300k")
+        .arg(file2)
+        .run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    let result = scene.ucmd().arg("-hl").arg(file2).run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    // GNU rounds up, so we must too.
+    assert!(result.stdout.contains(" 13M "));
+
+    let result = scene.ucmd().arg("-l").arg("--si").arg(file2).run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    // GNU rounds up, so we must too.
+    assert!(result.stdout.contains(" 13M "));
+
+    let file3 = "test-human-3";
+    let result = scene
+        .cmd("truncate")
+        .arg("-s")
+        .arg("+9999")
+        .arg(file3)
+        .run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+
+    let result = scene.ucmd().arg("-hl").arg(file3).run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    assert!(result.stdout.contains(" 9.8K "));
+
+    let result = scene.ucmd().arg("-l").arg("--si").arg(file3).run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert!(result.success);
+    assert!(result.stdout.contains(" 10k "));
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
There was a mistake that `--human-readable` and `-h` used decimal prefixes (kilo, mega, etc.) instead of binary prefixes (kibi, mebi, etc.). So `--si` was added for decimal prefixes.

Second, there are a few peculiarities with how GNU `ls` formats the sizes:
1. They only show a single decimal place if the size is less than 10. Previous behaviour was to always include two decimal places.
2. Sizes are always rounded up. Previous behaviour was to do normal rounding.
3. They never show the "B" for bytes, e.g. they show `K` instead of `KB`.
3. There is no `i` for prefixes such as  `Ki` and `Mi`.
4. The prefix for kibi is `K`, while the prefix for kilo is `k`.

Below are some examples of this behaviour (from GNU ls) with some annotations. I've used the same file sizes for the tests.
```
$ ls -lh
total 0
-rw-r--r-- 1 terts terts  1000 19 mrt 14:21 file1
-rw-r--r-- 1 terts terts 1001K 19 mrt 14:21 file2 <-- not Ki, but K
-rw-r--r-- 1 terts terts   13M 19 mrt 14:21 file3 <-- no decimal place
-rw-r--r-- 1 terts terts  9,8K 19 mrt 14:39 file4 <-- one decimal place
$ ls -l --si
total 0
-rw-r--r-- 1 terts terts 1,0k 19 mrt 14:21 file1 <-- k instead of K
-rw-r--r-- 1 terts terts 1,1M 19 mrt 14:21 file2 <-- size is 1.025MB, therefore it is rounded up
-rw-r--r-- 1 terts terts  13M 19 mrt 14:21 file3
-rw-r--r-- 1 terts terts  10k 19 mrt 14:39 file4
$ ls -l
total 0
-rw-r--r-- 1 terts terts     1000 19 mrt 14:21 file1
-rw-r--r-- 1 terts terts  1025000 19 mrt 14:21 file2
-rw-r--r-- 1 terts terts 12595200 19 mrt 14:21 file3
-rw-r--r-- 1 terts terts     9999 19 mrt 14:39 file4
```
> Note: the output above uses comma's for decimal places, because my computer is set to the dutch locale.

For completeness, the previous output of this `ls`:
```
$ coreutils ls -lh
-rw-r--r-- 1 terts terts  1.00K 2021-03-19 14:21 file1
-rw-r--r-- 1 terts terts  1.02M 2021-03-19 14:21 file2
-rw-r--r-- 1 terts terts 12.60M 2021-03-19 14:21 file3
-rw-r--r-- 1 terts terts 10.00K 2021-03-19 14:39 file4
```

and the output with this PR:
```
$ coreutils ls -lh
-rw-r--r-- 1 terts terts  1000 2021-03-19 14:21 file1
-rw-r--r-- 1 terts terts 1001K 2021-03-19 14:21 file2
-rw-r--r-- 1 terts terts   13M 2021-03-19 14:21 file3
-rw-r--r-- 1 terts terts  9.8K 2021-03-19 14:39 file4
$ coreutils ls -l --si
-rw-r--r-- 1 terts terts 1.0k 2021-03-19 14:21 file1
-rw-r--r-- 1 terts terts 1.1M 2021-03-19 14:21 file2
-rw-r--r-- 1 terts terts  13M 2021-03-19 14:21 file3
-rw-r--r-- 1 terts terts  10k 2021-03-19 14:39 file4
```