### PR TITLE
date: add more tests for setting (alt. formats)

### DIFF
--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -177,3 +177,42 @@ fn test_date_set_mac_unavailable() {
         .stderr
         .starts_with("date: setting the date is not supported by macOS"));
 }
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn test_date_set_valid_2() {
+    if get_effective_uid() == 0 {
+        let (_, mut ucmd) = at_and_ucmd!();
+        let result = ucmd
+            .arg("--set")
+            .arg("Sat 20 Mar 2021 14:53:01 AWST")
+            .succeeds();
+        result.no_stdout().no_stderr();
+    }
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn test_date_set_valid_3() {
+    if get_effective_uid() == 0 {
+        let (_, mut ucmd) = at_and_ucmd!();
+        let result = ucmd
+            .arg("--set")
+            .arg("Sat 20 Mar 2021 14:53:01") // Local timezone
+            .succeeds();
+        result.no_stdout().no_stderr();
+    }
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn test_date_set_valid_4() {
+    if get_effective_uid() == 0 {
+        let (_, mut ucmd) = at_and_ucmd!();
+        let result = ucmd
+            .arg("--set")
+            .arg("2020-03-11 21:45:00") // Local timezone
+            .succeeds();
+        result.no_stdout().no_stderr();
+    }
+}


### PR DESCRIPTION
Follow on from PR #1798 to put in tests for different date formats that are not handled yet.