### PR TITLE
ls: long format author, group and owner

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -178,13 +178,16 @@ struct LongFormat {
 impl Config {
     fn from(options: clap::ArgMatches) -> Config {
         let (mut format, opt) = if let Some(format_) = options.value_of(options::FORMAT) {
-            (match format_ {
-                "long" | "verbose" => Format::Long,
-                "single-column" => Format::OneLine,
-                "columns" | "vertical" => Format::Columns,
-                // below should never happen as clap already restricts the values.
-                _ => unreachable!("Invalid field for --format"),
-            }, options::FORMAT)
+            (
+                match format_ {
+                    "long" | "verbose" => Format::Long,
+                    "single-column" => Format::OneLine,
+                    "columns" | "vertical" => Format::Columns,
+                    // below should never happen as clap already restricts the values.
+                    _ => unreachable!("Invalid field for --format"),
+                },
+                options::FORMAT,
+            )
         } else if options.is_present(options::format::LONG) {
             (Format::Long, options::format::LONG)
         } else {
@@ -203,15 +206,19 @@ impl Config {
         // actually makes it distinct from the --format=singe-column option,
         // which always applies.
         //
-        // The idea here is to not let these options override with the other 
+        // The idea here is to not let these options override with the other
         // options, but manually check the last index they occur. If this index
         // is larger than the index for the other format options, we apply the
         // long format.
         match options.indices_of(opt).map(|x| x.max().unwrap()) {
-            None => if options.is_present(options::format::LONG_NO_GROUP) || options.is_present(options::format::LONG_NO_OWNER) {
-                format = Format::Long;
-            } else if options.is_present(options::format::ONELINE) {
-                format = Format::OneLine;
+            None => {
+                if options.is_present(options::format::LONG_NO_GROUP)
+                    || options.is_present(options::format::LONG_NO_OWNER)
+                {
+                    format = Format::Long;
+                } else if options.is_present(options::format::ONELINE) {
+                    format = Format::OneLine;
+                }
             }
             Some(mut idx) => {
                 if let Some(indices) = options.indices_of(options::format::LONG_NO_OWNER) {
@@ -425,7 +432,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     options::TIME,
                     options::time::ACCESS,
                     options::time::CHANGE,
-                ]),                
+                ])
         )
         .arg(
             Arg::with_name(options::time::ACCESS)
@@ -505,7 +512,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .long(options::AUTHOR)
                 .help("Show author in long format. On the supported platforms, the author \
                 always matches the file owner.")
-                
         )
         // Other Flags
         .arg(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -832,24 +832,36 @@ fn display_item_long(
         Ok(md) => md,
     };
 
+    if config.inode {
+        print!("{} ", get_inode(&md));
+    }
+
+    print!(
+        "{}{} {}",
+        display_file_type(md.file_type()),
+        display_permissions(&md),
+        pad_left(display_symlink_count(&md), max_links),
+    );
+
+    if config.long.owner {
+        print!(" {}", display_uname(&md, config));
+    }
+
+    if config.long.group {
+        print!(" {}", display_group(&md, config));
+    }
+
+    // Author is only different from owner on GNU/Hurd, so we reuse
+    // the owner, since GNU/Hurd is not currently supported by Rust.
+    if config.long.author {
+        print!(" {}", display_uname(&md, config));
+    }
+
     println!(
-        "{}",
-        vec![
-            config.inode.then(|| get_inode(&md)),
-            Some(format!("{}{}",
-                display_file_type(md.file_type()),
-                display_permissions(&md),
-            )),
-            Some(pad_left(display_symlink_count(&md), max_links)),
-            config.long.owner.then(|| display_uname(&md, config)),
-            config.long.group.then(|| display_group(&md, config)),
-            // Author is only different from owner on GNU/Hurd, so we reuse
-            // the owner, since GNU/Hurd is not currently supported by Rust.
-            config.long.author.then(|| display_uname(&md, config)),
-            Some(pad_left(display_file_size(&md, config), max_size)),
-            Some(display_date(&md, config)),
-            Some(display_file_name(&item, strip, &md, config).contents)
-        ].into_iter().filter_map(|x| x).collect::<Vec<_>>().join(" ")
+        " {} {} {}",
+        pad_left(display_file_size(&md, config), max_size),
+        display_date(&md, config),
+        display_file_name(&item, strip, &md, config).contents,
     );
 }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -833,8 +833,10 @@ fn display_item_long(
     };
 
     #[cfg(unix)]
-    if config.inode {
-        print!("{} ", get_inode(&md));
+    {
+        if config.inode {
+            print!("{} ", get_inode(&md));
+        }
     }
 
     print!(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1071,7 +1071,7 @@ fn display_file_name(
 ) -> Cell {
     let mut name = get_file_name(path, strip);
     if config.format != Format::Long && config.inode {
-        name = get_inode(metadata) + &name;
+        name = get_inode(metadata) + " " + &name;
     }
     let mut width = UnicodeWidthStr::width(&*name);
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -314,23 +314,51 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     options::format::COLUMNS,
                     options::format::ONELINE,
                     options::format::LONG,
+                    options::format::LONG_NO_GROUP,
+                    options::format::LONG_NO_OWNER,
                 ]),
         )
         .arg(
             Arg::with_name(options::format::COLUMNS)
                 .short(options::format::COLUMNS)
                 .help("Display the files in columns.")
+                .overrides_with_all(&[
+                    options::FORMAT,
+                    options::format::COLUMNS,
+                    options::format::ONELINE,
+                    options::format::LONG,
+                    options::format::LONG_NO_GROUP,
+                    options::format::LONG_NO_OWNER,
+                ]),
         )
+        // Detail in the GNU implementation that is replicated here:
+        // The -1 option does not override the -l option, because
+        // the -l already does "1 file per line".
+        // This actually makes -1 different from 
+        // --format=single-column, which does override -l.
         .arg(
             Arg::with_name(options::format::ONELINE)
                 .short(options::format::ONELINE)
                 .help("List one file per line.")
+                .overrides_with_all(&[
+                    options::FORMAT,
+                    options::format::COLUMNS,
+                    options::format::ONELINE,
+                ]),
         )
+        // -l, -g, -o should not override each other:
+        // i.e. -glo should hide both owner and group.
         .arg(
             Arg::with_name(options::format::LONG)
                 .short("l")
                 .long(options::format::LONG)
                 .help("Display detailed information.")
+                .overrides_with_all(&[
+                    options::FORMAT,
+                    options::format::COLUMNS,
+                    options::format::ONELINE,
+                    options::format::LONG,
+                ]),
         )
         .arg(
             Arg::with_name(options::format::LONG_NO_GROUP)
@@ -379,8 +407,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .help("If the long listing format (e.g., -l, -o) is being used, print the status \
                 change time (the ‘ctime’ in the inode) instead of the modification time. When \
                 explicitly sorting by time (--sort=time or -t) or when not using a long listing \
-                format, sort according to the status change time.",
-        ))
+                format, sort according to the status change time.")
+                .overrides_with_all(&[
+                    options::TIME,
+                    options::time::ACCESS,
+                    options::time::CHANGE,
+                ]),                
+        )
         .arg(
             Arg::with_name(options::time::ACCESS)
                 .short(options::time::ACCESS)
@@ -388,6 +421,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 access time instead of the modification time. When explicitly sorting by time \
                 (--sort=time or -t) or when not using a long listing format, sort according to the \
                 access time.")
+                .overrides_with_all(&[
+                    options::TIME,
+                    options::time::ACCESS,
+                    options::time::CHANGE,
+                ])
         )
 
         // Sort arguments
@@ -409,12 +447,24 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .arg(
             Arg::with_name(options::sort::SIZE)
                 .short(options::sort::SIZE)
-                .help("Sort by file size, largest first."),
+                .help("Sort by file size, largest first.")
+                .overrides_with_all(&[
+                    options::SORT,
+                    options::sort::SIZE,
+                    options::sort::TIME,
+                    options::sort::NONE,
+                ])
         )
         .arg(
             Arg::with_name(options::sort::TIME)
                 .short(options::sort::TIME)
-                .help("Sort by modification time (the 'mtime' in the inode), newest first."),
+                .help("Sort by modification time (the 'mtime' in the inode), newest first.")
+                .overrides_with_all(&[
+                    options::SORT,
+                    options::sort::SIZE,
+                    options::sort::TIME,
+                    options::sort::NONE,
+                ])
         )
         .arg(
             Arg::with_name(options::sort::NONE)
@@ -422,6 +472,14 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .help("Do not sort; list the files in whatever order they are stored in the \
                 directory.  This is especially useful when listing very large directories, \
                 since not doing any sorting can be noticeably faster.")
+                .overrides_with_all(&[
+                    options::SORT,
+                    options::sort::SIZE,
+                    options::sort::TIME,
+                    options::sort::NONE,
+                ])
+        )
+
         // Long format options
         .arg(
             Arg::with_name(options::NO_GROUP)

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -832,6 +832,7 @@ fn display_item_long(
         Ok(md) => md,
     };
 
+    #[cfg(unix)]
     if config.inode {
         print!("{} ", get_inode(&md));
     }
@@ -868,11 +869,6 @@ fn display_item_long(
 #[cfg(unix)]
 fn get_inode(metadata: &Metadata) -> String {
     format!("{:8}", metadata.ino())
-}
-
-#[cfg(not(unix))]
-fn get_inode(_metadata: &Metadata) -> String {
-    "".to_string()
 }
 
 // Currently getpwuid is `linux` target only. If it's broken out into
@@ -956,7 +952,7 @@ fn format_prefixed(prefixed: NumberPrefix<f64>) -> String {
         NumberPrefix::Standalone(bytes) => bytes.to_string(),
         NumberPrefix::Prefixed(prefix, bytes) => {
             // Remove the "i" from "Ki", "Mi", etc. if present
-            let prefix_str = prefix.symbol().trim_end_matches("i");
+            let prefix_str = prefix.symbol().trim_end_matches('i');
 
             // Check whether we get more than 10 if we round up to the first decimal
             // because we want do display 9.81 as "9.9", not as "10".
@@ -1008,10 +1004,6 @@ fn display_file_name(
     config: &Config,
 ) -> Cell {
     let mut name = get_file_name(path, strip);
-
-    if config.format == Format::Long {
-        name = get_inode(metadata, config) + &name;
-    }
 
     if config.classify {
         let file_type = metadata.file_type();

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -131,20 +131,19 @@ fn test_ls_long_formats() {
     at.touch(&at.plus_as_string("test-long-formats"));
 
     // Regex for three names, so all of author, group and owner
-    let re_three = Regex::new(r"[xrw-]{9} \d ([_a-z][-0-9_a-z]+ ){3}").unwrap();
+    let re_three = Regex::new(r"[xrw-]{9} \d ([-0-9_a-z]+ ){3}0").unwrap();
 
     // Regex for two names, either:
     // - group and owner
     // - author and owner
     // - author and group
-    let re_two = Regex::new(r"[xrw-]{9} \d ([_a-z][-0-9_a-z]+ ){2}").unwrap();
+    let re_two = Regex::new(r"[xrw-]{9} \d ([-0-9_a-z]+ ){2}0").unwrap();
 
     // Regex for one name: author, group or owner
-    let re_one = Regex::new(r"[xrw-]{9} \d [_a-z][-0-9_a-z]+ ").unwrap();
+    let re_one = Regex::new(r"[xrw-]{9} \d [-0-9_a-z]+ 0").unwrap();
 
-    // Regex for no names.
-    // Names cannot start with a number, so the second \d will only match the file size
-    let re_zero = Regex::new(r"[xrw-]{9} \d \d").unwrap();
+    // Regex for no names
+    let re_zero = Regex::new(r"[xrw-]{9} \d 0").unwrap();
 
     let result = scene
         .ucmd()

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -166,10 +166,10 @@ fn test_ls_long_formats() {
     assert!(re_three.is_match(&result.stdout));
 
     for arg in &[
-        "-l", // only group and owner
-        "-g --author", // only author and group
-        "-o --author", // only author and owner
-        "-lG --author", // only author and owner
+        "-l",                     // only group and owner
+        "-g --author",            // only author and group
+        "-o --author",            // only author and owner
+        "-lG --author",           // only author and owner
         "-l --no-group --author", // only author and owner
     ] {
         let result = scene
@@ -183,14 +183,14 @@ fn test_ls_long_formats() {
     }
 
     for arg in &[
-        "-g", // only group
-        "-gl", // only group
-        "-o", // only owner
-        "-ol", // only owner
-        "-oG", // only owner
-        "-lG", // only owner
+        "-g",            // only group
+        "-gl",           // only group
+        "-o",            // only owner
+        "-ol",           // only owner
+        "-oG",           // only owner
+        "-lG",           // only owner
         "-l --no-group", // only owner
-        "-gG --author", // only author
+        "-gG --author",  // only author
     ] {
         let result = scene
             .ucmd()


### PR DESCRIPTION
This PR adds the options to customize what information is shown in long format regarding author, group & owner. Specifically it adds:
- `--author`: shows the author, which is always the same as the owner. GNU has this feature because GNU/Hurd supports a difference between author and owner, but I don't think Rust supports GNU/Hurd, so I just used the owner.
- `-G` & `--no-group`: hide the group information.
- `-o`: hide the group and use long format (equivalent to `-lG`).
- `-g`: hide the owner and use long format.

The `-o` and `-g` options have some interesting behaviour that I had to account for. Some examples:
- `-og` hides both group and owner.
- `-ol` still hides the group. Same behaviour with variations such as `-o --format=long`, `-gl`, `-g --format=long` and `-ogl`.
- They even retain some information when overridden by another format: `-oCl` (or `-o --format=vertical --format=long`) still hides the group.

My previous solution for handling the behaviour where `-l1` shows the long format did not fit with these additions, so I had to rewrite that as well.

The tests only cover the how many names (author, group and owner) are present in the output, so it can't distinguish between, for example, author & group and group & owner.