### PR TITLE
documentation for usual macros

### DIFF
--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -5,6 +5,9 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+/// Deduce the name of the binary from the current source code filename.
+///
+/// e.g.: `src/uu/cp/src/cp.rs` -> `cp`
 #[macro_export]
 macro_rules! executable(
     () => ({
@@ -18,6 +21,7 @@ macro_rules! executable(
     })
 );
 
+/// Show an error to stderr in a silimar style to GNU coreutils.
 #[macro_export]
 macro_rules! show_error(
     ($($args:tt)+) => ({
@@ -26,6 +30,7 @@ macro_rules! show_error(
     })
 );
 
+/// Show a warning to stderr in a silimar style to GNU coreutils.
 #[macro_export]
 macro_rules! show_warning(
     ($($args:tt)+) => ({
@@ -34,6 +39,7 @@ macro_rules! show_warning(
     })
 );
 
+/// Show an info message to stderr in a silimar style to GNU coreutils.
 #[macro_export]
 macro_rules! show_info(
     ($($args:tt)+) => ({
@@ -42,6 +48,7 @@ macro_rules! show_info(
     })
 );
 
+/// Show a bad inocation help message in a similar style to GNU coreutils.
 #[macro_export]
 macro_rules! show_usage_error(
     ($($args:tt)+) => ({
@@ -51,6 +58,7 @@ macro_rules! show_usage_error(
     })
 );
 
+/// Display the provided error message, then `exit()` with the provided exit code
 #[macro_export]
 macro_rules! crash(
     ($exit_code:expr, $($args:tt)+) => ({
@@ -59,6 +67,7 @@ macro_rules! crash(
     })
 );
 
+/// Calls `exit()` with the provided exit code.
 #[macro_export]
 macro_rules! exit(
     ($exit_code:expr) => ({
@@ -66,6 +75,8 @@ macro_rules! exit(
     })
 );
 
+/// Unwraps the Result. Instead of panicking, it exists the program with the
+/// provided exit code.
 #[macro_export]
 macro_rules! crash_if_err(
     ($exit_code:expr, $exp:expr) => (
@@ -76,6 +87,9 @@ macro_rules! crash_if_err(
     )
 );
 
+/// Unwraps the Result. Instead of panicking, it shows the error and then
+/// returns from the function with the provided exit code.
+/// Assumes the current function returns an i32 value.
 #[macro_export]
 macro_rules! return_if_err(
     ($exit_code:expr, $exp:expr) => (
@@ -109,6 +123,8 @@ macro_rules! safe_writeln(
     )
 );
 
+/// Unwraps the Result. Instead of panicking, it exists the program with exit
+/// code 1.
 #[macro_export]
 macro_rules! safe_unwrap(
     ($exp:expr) => (

--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -9,7 +9,7 @@ fn test_default_mode() {
 
     // fail on long inputs
     new_ucmd!()
-        .args(&[repeat_str("test", 20000)])
+        .args(&["test".repeat(20000)])
         .fails()
         .no_stdout();
 }

--- a/tests/common/macros.rs
+++ b/tests/common/macros.rs
@@ -1,3 +1,6 @@
+/// Assertion helper macro for [`CmdResult`] types
+///
+/// [`CmdResult`]: crate::tests::common::util::CmdResult
 #[macro_export]
 macro_rules! assert_empty_stderr(
     ($cond:expr) => (
@@ -7,6 +10,9 @@ macro_rules! assert_empty_stderr(
     );
 );
 
+/// Assertion helper macro for [`CmdResult`] types
+///
+/// [`CmdResult`]: crate::tests::common::util::CmdResult
 #[macro_export]
 macro_rules! assert_empty_stdout(
     ($cond:expr) => (
@@ -16,6 +22,9 @@ macro_rules! assert_empty_stdout(
     );
 );
 
+/// Assertion helper macro for [`CmdResult`] types
+///
+/// [`CmdResult`]: crate::tests::common::util::CmdResult
 #[macro_export]
 macro_rules! assert_no_error(
     ($cond:expr) => (
@@ -26,6 +35,7 @@ macro_rules! assert_no_error(
     );
 );
 
+/// Platform-independent helper for constructing a PathBuf from individual elements
 #[macro_export]
 macro_rules! path_concat {
     ($e:expr, ..$n:expr) => {{
@@ -47,6 +57,9 @@ macro_rules! path_concat {
     }};
 }
 
+/// Deduce the name of the test binary from the test filename.
+///
+/// e.g.: `tests/by-util/test_cat.rs` -> `cat`
 #[macro_export]
 macro_rules! util_name {
     () => {
@@ -54,6 +67,16 @@ macro_rules! util_name {
     };
 }
 
+/// Convenience macro for acquiring a [`UCommand`] builder.
+///
+/// Returns the following:
+/// - a [`UCommand`] builder for invoking the binary to be tested
+///
+/// This macro is intended for quick, single-call tests. For more complex tests
+/// that require multiple invocations of the tested binary, see [`TestScenario`]
+///
+/// [`UCommand`]: crate::tests::common::util::UCommand
+/// [`TestScenario]: crate::tests::common::util::TestScenario
 #[macro_export]
 macro_rules! new_ucmd {
     () => {
@@ -61,6 +84,18 @@ macro_rules! new_ucmd {
     };
 }
 
+/// Convenience macro for acquiring a [`UCommand`] builder and a test path.
+///
+/// Returns a tuple containing the following:
+/// - an [`AsPath`] that points to a unique temporary test directory
+/// - a [`UCommand`] builder for invoking the binary to be tested
+///
+/// This macro is intended for quick, single-call tests. For more complex tests
+/// that require multiple invocations of the tested binary, see [`TestScenario`]
+///
+/// [`UCommand`]: crate::tests::common::util::UCommand
+/// [`AsPath`]: crate::tests::common::util::AsPath
+/// [`TestScenario]: crate::tests::common::util::TestScenario
 #[macro_export]
 macro_rules! at_and_ucmd {
     () => {{


### PR DESCRIPTION
resolves #1132 

- removed repeat_str helper as it's now part of std
- added docstrings for usual macros and test utils
- added `allow(dead_code)` in tests/utils.rs to reduce warnings when testing individual utilities

I've stated repeatedly that some macros/methods treat paths as relative to a unique test directory, since some tests seem to have been written with the assumption that the test directory was shared across tests.