### PR TITLE
echo: allow leading hyphens  

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -117,6 +117,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let matches = App::new(executable!())
         .name(NAME)
+        // TrailingVarArg specifies the final positional argument is a VarArg
+        // and it doesn't attempts the parse any further args.
+        // Final argument must have multiple(true) or the usage string equivalent.
         .setting(clap::AppSettings::TrailingVarArg)
         .setting(clap::AppSettings::AllowLeadingHyphen)
         .version(VERSION)

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -117,6 +117,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let matches = App::new(executable!())
         .name(NAME)
+        .setting(clap::AppSettings::TrailingVarArg)
+        .setting(clap::AppSettings::AllowLeadingHyphen)
         .version(VERSION)
         .usage(SYNTAX)
         .about(SUMMARY)

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -173,3 +173,25 @@ fn test_disable_escapes() {
         .succeeds()
         .stdout_only(format!("{}\n", input_str));
 }
+
+#[test]
+fn test_hyphen_value() {
+    new_ucmd!().arg("-abc").succeeds().stdout_is("-abc\n");
+}
+
+#[test]
+fn test_multiple_hyphen_values() {
+    new_ucmd!()
+        .args(&["-abc", "-def", "-edf"])
+        .succeeds()
+        .stdout_is("-abc -def -edf\n");
+}
+
+#[test]
+fn test_hyphen_values_inside_string() {
+    new_ucmd!()
+        .arg("'\"\n'CXXFLAGS=-g -O2'\n\"'")
+        .succeeds()
+        .stdout
+        .contains("CXXFLAGS");
+}

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -195,3 +195,36 @@ fn test_hyphen_values_inside_string() {
         .stdout
         .contains("CXXFLAGS");
 }
+
+#[test]
+fn test_hyphen_values_at_start() {
+    let result = new_ucmd!()
+        .arg("-E")
+        .arg("-test")
+        .arg("araba")
+        .arg("-merci")
+        .run();
+
+    assert!(result.success);
+    assert_eq!(false, result.stdout.contains("-E"));
+    assert_eq!(result.stdout, "-test araba -merci\n");
+}
+
+#[test]
+fn test_hyphen_values_between() {
+    let result = new_ucmd!().arg("test").arg("-E").arg("araba").run();
+
+    assert!(result.success);
+    assert_eq!(result.stdout, "test -E araba\n");
+
+    let result = new_ucmd!()
+        .arg("dumdum ")
+        .arg("dum dum dum")
+        .arg("-e")
+        .arg("dum")
+        .run();
+
+    assert!(result.success);
+    assert_eq!(result.stdout, "dumdum  dum dum dum -e dum\n");
+    assert_eq!(true, result.stdout.contains("-e"));
+}


### PR DESCRIPTION
This is a two line change, but it fixes: https://github.com/uutils/coreutils/issues/1873 by allowing the leading hyphens and trailing var arg.

