### PR TITLE
pathchk: refuse empty path

### DIFF
--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -230,16 +230,16 @@ fn check_default(path: &[String]) -> bool {
 
 // check whether a path is or if other problems arise
 fn check_searchable(path: &str) -> bool {
-    // we use lstat, just like the original implementation
+    // we use lstat and reject the empty file name
+    // just like the original implementation
     match fs::symlink_metadata(path) {
         Ok(_) => true,
         Err(e) => {
-            if e.kind() == ErrorKind::NotFound {
-                true
-            } else {
+            if e.kind() != ErrorKind::NotFound || path.len() == 0 {
                 writeln!(&mut std::io::stderr(), "{}", e);
-                false
-            }
+                return false
+            };
+            true
         }
     }
 }


### PR DESCRIPTION
Hi!

While looking at https://github.com/uutils/coreutils/issues/1855 I noticed that patchchk behavior was different from GNU coreutils pathchk when the path is empty (patchchk accepts it while the GNU version refuses it). I changed the code to match GNU source.

This is my first contribution, please tell me if I need to change anything. If this goes well I'll start working on tests for pathchk.