### PR TITLE
mv: ensure line prints

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -380,7 +380,7 @@ fn rename(from: &PathBuf, to: &PathBuf, b: &Behavior) -> io::Result<()> {
         match b.overwrite {
             OverwriteMode::NoClobber => return Ok(()),
             OverwriteMode::Interactive => {
-                print!("{}: overwrite ‘{}’? ", executable!(), to.display());
+                println!("{}: overwrite ‘{}’? ", executable!(), to.display());
                 if !read_yes() {
                     return Ok(());
                 }


### PR DESCRIPTION
Previously this used `print` instead of `println`, and as a result the
prompt would never appear and the command would hang. The Rust docs
note this about print:

> Note that stdout is frequently line-buffered by default so it may be
> necessary to use io::stdout().flush() to ensure the output is emitted
> immediately.

Changing to `println` fixes the issue.

Fixes #1889.