### PR TITLE
wc: fix leading spaces on println!

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -278,7 +278,7 @@ fn print_stats(settings: &Settings, result: &Result, max_width: usize) {
     }
 
     if result.title != "-" {
-        println!(" {}", result.title);
+        println!("{}", result.title);
     } else {
         println!();
     }


### PR DESCRIPTION
This is a resolution to issue #1894 (https://github.com/uutils/coreutils/issues/1894). `wc`/`wc -l` would print out an extra 2 spaces before the actual result, and this was a pretty basic fix.