### PR TITLE
Cleanup: Fix grammar in "cp" macro comments.

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -112,7 +112,7 @@ macro_rules! or_continue(
     })
 );
 
-/// Prompts the user yes/no and returns `true` they if successfully
+/// Prompts the user yes/no and returns `true` if they successfully
 /// answered yes.
 macro_rules! prompt_yes(
     ($($args:tt)+) => ({


### PR DESCRIPTION
Replaced "they if" with "if they" in the comments above the "prompt_yes" macro.