### PR TITLE
Fix "panic message is not a string literal" warnings

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -382,7 +382,7 @@ fn follow<T: Read>(readers: &mut [BufReader<T>], filenames: &[String], settings:
                         }
                         print!("{}", datum);
                     }
-                    Err(err) => panic!(err),
+                    Err(err) => panic!("{}", err),
                 }
             }
         }
@@ -509,7 +509,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) {
                             ringbuf.push_back(datum);
                         }
                     }
-                    Err(err) => panic!(err),
+                    Err(err) => panic!("{}", err),
                 }
             }
             let mut stdout = stdout();
@@ -540,7 +540,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) {
                             ringbuf.push_back(datum[0]);
                         }
                     }
-                    Err(err) => panic!(err),
+                    Err(err) => panic!("{}", err),
                 }
             }
             let mut stdout = stdout();

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -56,10 +56,10 @@ pub fn main(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut expr = match expr {
         syn::Expr::Lit(expr_lit) => match expr_lit.lit {
             syn::Lit::Str(ref lit_str) => lit_str.parse::<syn::ExprPath>().unwrap(),
-            _ => panic!(ARG_PANIC_TEXT),
+            _ => panic!("{}", ARG_PANIC_TEXT),
         },
         syn::Expr::Path(expr_path) => expr_path,
-        _ => panic!(ARG_PANIC_TEXT),
+        _ => panic!("{}", ARG_PANIC_TEXT),
     };
     proc_dbg!(&expr);
 


### PR DESCRIPTION
New in Rust 1.51.

Closes #1914