### PR TITLE
ptx: delete getopts dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,6 @@ version = "0.0.4"
 dependencies = [
  "aho-corasick 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/uu/ptx/Cargo.toml
+++ b/src/uu/ptx/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/ptx.rs"
 [dependencies]
 clap = "2.33"
 aho-corasick = "0.7.3"
-getopts = "0.2.18"
 libc = "0.2.42"
 memchr = "2.2.0"
 regex = "1.0.1"


### PR DESCRIPTION
I forgot to delete it in https://github.com/uutils/coreutils/pull/1893, thanks for the reminder @sylvestre .)