### PR TITLE
cksum: use clap for argument management

### DIFF
--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/cksum.rs"
 
 [dependencies]
+clap = "2.33"
 libc = "0.2.42"
 uucore = { version=">=0.0.7", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }


### PR DESCRIPTION
While adding tests to cksum, i found cksum wasn't using clap, there is a very small need for clap in cksum (it is very small) but it is great for general consistency.