### PR TITLE
test_install: Add sleeps

### DIFF
--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -453,7 +453,6 @@ fn test_install_copy_then_compare_file() {
 
 #[test]
 #[cfg(target_os = "linux")]
-#[ignore]
 fn test_install_copy_then_compare_file_with_extra_mode() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2,6 +2,7 @@ use crate::common::util::*;
 use filetime::FileTime;
 use rust_users::*;
 use std::os::unix::fs::PermissionsExt;
+use std::thread::sleep;
 
 #[test]
 fn test_install_help() {
@@ -471,6 +472,7 @@ fn test_install_copy_then_compare_file_with_extra_mode() {
 
     let mut file2_meta = at.metadata(file2);
     let before = FileTime::from_last_modification_time(&file2_meta);
+    sleep(std::time::Duration::from_millis(1000));
 
     scene
         .ucmd()
@@ -486,6 +488,8 @@ fn test_install_copy_then_compare_file_with_extra_mode() {
     let after_install_sticky = FileTime::from_last_modification_time(&file2_meta);
 
     assert!(before != after_install_sticky);
+
+    sleep(std::time::Duration::from_millis(1000));
 
     // dest file still 1644, so need_copy ought to return `true`
     scene

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2,6 +2,7 @@ use crate::common::util::*;
 use filetime::FileTime;
 use rust_users::*;
 use std::os::unix::fs::PermissionsExt;
+#[cfg(target_os = "linux")]
 use std::thread::sleep;
 
 #[test]


### PR DESCRIPTION
To ensure timestamps don't match. Fixes #1927.