### PR TITLE
fix(cksum): check metadata of the path 

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -153,7 +153,7 @@ fn cksum(fname: &str) -> io::Result<(u32, usize)> {
                     "No such file or directory",
                 ));
             };
-            file = File::open(&Path::new(fname))?;
+            file = File::open(&path)?;
             Box::new(BufReader::new(file))
         }
     };

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -140,6 +140,19 @@ fn cksum(fname: &str) -> io::Result<(u32, usize)> {
     let mut rd: Box<dyn Read> = match fname {
         "-" => Box::new(stdin()),
         _ => {
+            let path = &Path::new(fname);
+            if path.is_dir() {
+                return Err(std::io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Is a directory",
+                ));
+            };
+            if !path.metadata().is_ok() {
+                return Err(std::io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "No such file or directory",
+                ));
+            };
             file = File::open(&Path::new(fname))?;
             Box::new(BufReader::new(file))
         }


### PR DESCRIPTION
addition to: https://github.com/uutils/coreutils/pull/1923 

https://github.com/uutils/coreutils/pull/1923 kept failing for freebsd, there was no precheck for file metadata before  this pr addresses that. 