### PR TITLE
tty: Move from getopts to clap

### DIFF
--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/tty.rs"
 
 [dependencies]
-getopts = "0.2.18"
+clap = "2.33"
 libc = "0.2.42"
 uucore = { version=">=0.0.7", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -12,6 +12,7 @@
 #[macro_use]
 extern crate uucore;
 
+use clap::{App, Arg};
 use std::ffi::CStr;
 use uucore::fs::is_stdin_interactive;
 
@@ -19,61 +20,57 @@ extern "C" {
     fn ttyname(filedesc: libc::c_int) -> *const libc::c_char;
 }
 
-static NAME: &str = "tty";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
+static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
+
+mod options {
+    pub const SILENT: &str = "silent";
+}
+
+fn get_usage() -> String {
+    format!("{0} [OPTION]...", executable!())
+}
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let args = args.collect_str();
+    let usage = get_usage();
 
-    let mut opts = getopts::Options::new();
+    let matches = App::new(executable!())
+        .version(VERSION)
+        .about(ABOUT)
+        .usage(&usage[..])
+        .arg(
+            Arg::with_name(options::SILENT)
+                .long(options::SILENT)
+                .alias("quiet")
+                .short("s")
+                .help("print nothing, only return an exit status")
+                .required(false),
+        )
+        .get_matches_from(args);
 
-    opts.optflag("s", "silent", "print nothing, only return an exit status");
-    opts.optflag("h", "help", "display this help and exit");
-    opts.optflag("V", "version", "output version information and exit");
+    let silent = matches.is_present(options::SILENT);
 
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => crash!(2, "{}", f),
+    let tty = unsafe {
+        let ptr = ttyname(libc::STDIN_FILENO);
+        if !ptr.is_null() {
+            String::from_utf8_lossy(CStr::from_ptr(ptr).to_bytes()).to_string()
+        } else {
+            "".to_owned()
+        }
     };
 
-    if matches.opt_present("help") {
-        println!("{} {}", NAME, VERSION);
-        println!();
-        println!("Usage:");
-        println!("  {} [OPTION]...", NAME);
-        println!();
-        print!(
-            "{}",
-            opts.usage("Print the file name of the terminal connected to standard input.")
-        );
-    } else if matches.opt_present("version") {
-        println!("{} {}", NAME, VERSION);
-    } else {
-        let silent = matches.opt_present("s");
-
-        let tty = unsafe {
-            let ptr = ttyname(libc::STDIN_FILENO);
-            if !ptr.is_null() {
-                String::from_utf8_lossy(CStr::from_ptr(ptr).to_bytes()).to_string()
-            } else {
-                "".to_owned()
-            }
-        };
-
-        if !silent {
-            if !tty.chars().all(|c| c.is_whitespace()) {
-                println!("{}", tty);
-            } else {
-                println!("not a tty");
-            }
-        }
-
-        return if is_stdin_interactive() {
-            libc::EXIT_SUCCESS
+    if !silent {
+        if !tty.chars().all(|c| c.is_whitespace()) {
+            println!("{}", tty);
         } else {
-            libc::EXIT_FAILURE
-        };
+            println!("not a tty");
+        }
     }
 
-    0
+    return if is_stdin_interactive() {
+        libc::EXIT_SUCCESS
+    } else {
+        libc::EXIT_FAILURE
+    };
 }

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -42,7 +42,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .arg(
             Arg::with_name(options::SILENT)
                 .long(options::SILENT)
-                .alias("quiet")
+                .visible_alias("quiet")
                 .short("s")
                 .help("print nothing, only return an exit status")
                 .required(false),

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -16,10 +16,6 @@ use clap::{App, Arg};
 use std::ffi::CStr;
 use uucore::fs::is_stdin_interactive;
 
-extern "C" {
-    fn ttyname(filedesc: libc::c_int) -> *const libc::c_char;
-}
-
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
 
@@ -51,8 +47,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let silent = matches.is_present(options::SILENT);
 
+    // Call libc function ttyname
     let tty = unsafe {
-        let ptr = ttyname(libc::STDIN_FILENO);
+        let ptr = libc::ttyname(libc::STDIN_FILENO);
         if !ptr.is_null() {
             String::from_utf8_lossy(CStr::from_ptr(ptr).to_bytes()).to_string()
         } else {

--- a/tests/by-util/test_tty.rs
+++ b/tests/by-util/test_tty.rs
@@ -1,1 +1,57 @@
-// ToDO: add tests
+use crate::common::util::*;
+
+#[test]
+#[cfg(not(windows))]
+fn test_dev_null() {
+    new_ucmd!()
+        .pipe_in("</dev/null")
+        .fails()
+        .stdout_is("not a tty\n");
+}
+
+#[test]
+#[cfg(not(windows))]
+fn test_dev_null_silent() {
+    new_ucmd!()
+        .args(&["-s"])
+        .pipe_in("</dev/null")
+        .fails()
+        .stdout_is("");
+}
+
+#[test]
+fn test_close_stdin() {
+    new_ucmd!().pipe_in("<&-").fails().stdout_is("not a tty\n");
+}
+
+#[test]
+fn test_close_stdin_silent() {
+    new_ucmd!()
+        .args(&["-s"])
+        .pipe_in("<&-")
+        .fails()
+        .stdout_is("");
+}
+
+#[test]
+fn test_close_stdin_silent_long() {
+    new_ucmd!()
+        .args(&["--silent"])
+        .pipe_in("<&-")
+        .fails()
+        .stdout_is("");
+}
+
+#[test]
+fn test_close_stdin_silent_alias() {
+    new_ucmd!()
+        .args(&["--quiet"])
+        .pipe_in("<&-")
+        .fails()
+        .stdout_is("");
+}
+
+#[test]
+fn test_wrong_argument() {
+    new_ucmd!().args(&["a"]).fails();
+}


### PR DESCRIPTION
I replaced getopts with clap for tty.
I also added some tests, but I wasn't able to write a succeeding one.
I'm not sure, if all tests run on all operating systems. Maybe some `#[cfg(not(windows))]` have to be added.

Fixes #1935.