### PR TITLE
Add pre-commit hook + run fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# https://pre-commit.com
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: cargo-check
+      - id: clippy
+      - id: fmt

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -227,12 +227,19 @@ impl Config {
         // options, but manually whether they have an index that's greater than
         // the other format options. If so, we set the appropriate format.
         if format != Format::Long {
-            let idx = options.indices_of(opt).map(|x| x.max().unwrap()).unwrap_or(0);    
-            if [options::format::LONG_NO_OWNER, options::format::LONG_NO_GROUP, options::format::LONG_NUMERIC_UID_GID]
-                .iter()
-                .flat_map(|opt| options.indices_of(opt))
-                .flatten()
-                .any(|i| i >= idx)
+            let idx = options
+                .indices_of(opt)
+                .map(|x| x.max().unwrap())
+                .unwrap_or(0);
+            if [
+                options::format::LONG_NO_OWNER,
+                options::format::LONG_NO_GROUP,
+                options::format::LONG_NUMERIC_UID_GID,
+            ]
+            .iter()
+            .flat_map(|opt| options.indices_of(opt))
+            .flatten()
+            .any(|i| i >= idx)
             {
                 format = Format::Long;
             } else {
@@ -243,7 +250,6 @@ impl Config {
                 }
             }
         }
-        
 
         let files = if options.is_present(options::files::ALL) {
             Files::All
@@ -659,7 +665,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 file the link references rather than the link itself.",
                 ),
         )
-        
         .arg(
             Arg::with_name(options::REVERSE)
                 .short("r")

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -9,10 +9,10 @@
 extern crate uucore;
 
 use clap::{App, Arg};
+use retain_mut::RetainMut;
 use std::fs::OpenOptions;
 use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
 use std::path::{Path, PathBuf};
-use retain_mut::RetainMut;
 
 #[cfg(unix)]
 use uucore::libc;
@@ -98,19 +98,19 @@ fn tee(options: Options) -> Result<()> {
         .files
         .clone()
         .into_iter()
-        .map(|file|
-            NamedWriter {
-                name: file.clone(),
-                inner: open(file, options.append),
-            }
-        )
+        .map(|file| NamedWriter {
+            name: file.clone(),
+            inner: open(file, options.append),
+        })
         .collect();
 
-
-    writers.insert(0, NamedWriter {
-        name: "'standard output'".to_owned(),
-        inner: Box::new(stdout()),
-    });
+    writers.insert(
+        0,
+        NamedWriter {
+            name: "'standard output'".to_owned(),
+            inner: Box::new(stdout()),
+        },
+    );
 
     let mut output = MultiWriter::new(writers);
     let input = &mut NamedReader {
@@ -119,8 +119,7 @@ fn tee(options: Options) -> Result<()> {
 
     // TODO: replaced generic 'copy' call to be able to stop copying
     // if all outputs are closed (due to errors)
-    if copy(input, &mut output).is_err() || output.flush().is_err() ||
-            output.error_occured() {
+    if copy(input, &mut output).is_err() || output.flush().is_err() || output.error_occured() {
         Err(Error::new(ErrorKind::Other, ""))
     } else {
         Ok(())
@@ -150,7 +149,7 @@ struct MultiWriter {
 }
 
 impl MultiWriter {
-    fn new (writers: Vec<NamedWriter>) -> Self {
+    fn new(writers: Vec<NamedWriter>) -> Self {
         Self {
             initial_len: writers.len(),
             writers,
@@ -170,7 +169,7 @@ impl Write for MultiWriter {
                     show_info!("{}: {}", writer.name, f.to_string());
                     false
                 }
-                _ => true
+                _ => true,
             }
         });
         Ok(buf.len())
@@ -184,7 +183,7 @@ impl Write for MultiWriter {
                     show_info!("{}: {}", writer.name, f.to_string());
                     false
                 }
-                _ => true
+                _ => true,
             }
         });
         Ok(())

--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -38,10 +38,7 @@ fn test_posix_mode() {
 
     // fail on long path
     new_ucmd!()
-        .args(&[
-            "-p",
-            &"dir".repeat(libc::PATH_MAX as usize + 1).as_str(),
-        ])
+        .args(&["-p", &"dir".repeat(libc::PATH_MAX as usize + 1).as_str()])
         .fails()
         .no_stdout();
 
@@ -79,10 +76,7 @@ fn test_posix_special() {
 
     // fail on long path
     new_ucmd!()
-        .args(&[
-            "-P",
-            &"dir".repeat(libc::PATH_MAX as usize + 1).as_str(),
-        ])
+        .args(&["-P", &"dir".repeat(libc::PATH_MAX as usize + 1).as_str()])
         .fails()
         .no_stdout();
 
@@ -107,7 +101,10 @@ fn test_posix_all() {
     // test the posix special mode
 
     // accept some reasonable default
-    new_ucmd!().args(&["-p", "-P", "dir/file"]).succeeds().no_stdout();
+    new_ucmd!()
+        .args(&["-p", "-P", "dir/file"])
+        .succeeds()
+        .no_stdout();
 
     // accept non-leading hyphen
     new_ucmd!()
@@ -136,10 +133,16 @@ fn test_posix_all() {
         .no_stdout();
 
     // fail on non-portable chars
-    new_ucmd!().args(&["-p", "-P", "dir#/$file"]).fails().no_stdout();
+    new_ucmd!()
+        .args(&["-p", "-P", "dir#/$file"])
+        .fails()
+        .no_stdout();
 
     // fail on leading hyphen char
-    new_ucmd!().args(&["-p", "-P", "dir/-file"]).fails().no_stdout();
+    new_ucmd!()
+        .args(&["-p", "-P", "dir/-file"])
+        .fails()
+        .no_stdout();
 
     // fail on empty path
     new_ucmd!().args(&["-p", "-P", ""]).fails().no_stdout();
@@ -149,8 +152,5 @@ fn test_posix_all() {
 fn test_args_parsing() {
     // fail on no args
     let empty_args: [String; 0] = [];
-    new_ucmd!()
-        .args(&empty_args)
-        .fails()
-        .no_stdout();
+    new_ucmd!().args(&empty_args).fails().no_stdout();
 }

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -177,7 +177,7 @@ fn test_rm_directory_without_flag() {
     let dir = "test_rm_directory_without_flag_dir";
 
     at.mkdir(dir);
-  
+
     let result = ucmd.arg(dir).fails();
     println!("{}", result.stderr);
     assert!(result


### PR DESCRIPTION
See #1920 

This is a minimal `pre-commit` config, to run `cargo check`, `clippy` and `rustfmt`.

I also ran `pre-commit run -a` to add some rustfmt changes.

There are plenty of other checks that we could add, for example `shellcheck` generates warning for some shell scripts, `prettier` can autoformat yaml or markdown files, but I wanted to keep minimal for a first addition.