### PR TITLE
ls: Implements extension sorting

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1165,9 +1165,10 @@ fn sort_entries(entries: &mut Vec<PathData>, config: &Config) {
         Sort::Name => entries.sort_by_cached_key(|k| k.file_name.to_lowercase()),
         Sort::Version => entries.sort_by(|k, j| version_cmp::version_cmp(&k.p_buf, &j.p_buf)),
         Sort::Extension => entries.sort_by(|a, b| {
-            a.extension()
-                .cmp(&b.extension())
-                .then(a.file_stem().cmp(&b.file_stem()))
+            a.p_buf
+                .extension()
+                .cmp(&b.p_buf.extension())
+                .then(a.p_buf.file_stem().cmp(&b.p_buf.file_stem()))
         }),
         Sort::None => {}
     }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1167,7 +1167,7 @@ fn sort_entries(entries: &mut Vec<PathData>, config: &Config) {
         Sort::Extension => entries.sort_by(|a, b| {
             a.extension()
                 .cmp(&b.extension())
-                .then(a.to_string_lossy().cmp(&b.to_string_lossy()))
+                .then(a.file_stem().cmp(&b.file_stem()))
         }),
         Sort::None => {}
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1681,3 +1681,57 @@ fn test_ls_deref_command_line_dir() {
 
     assert!(!result.stdout_str().ends_with("sym_dir"));
 }
+
+#[test]
+fn test_ls_sort_extension() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    for filename in &[
+        "file1",
+        "file2",
+        "anotherFile",
+        ".hidden",
+        ".file.1",
+        ".file.2",
+        "file.1",
+        "file.2",
+        "anotherFile.1",
+        "anotherFile.2",
+        "file.ext",
+        "file.debug",
+        "anotherFile.ext",
+        "anotherFile.debug",
+    ] {
+        at.touch(filename);
+    }
+
+    let expected = vec![
+        ".",
+        "..",
+        ".hidden",    
+        "anotherFile",
+        "file1",
+        "file2",
+        ".file.1",
+        "anotherFile.1",
+        "file.1",
+        ".file.2",
+        "anotherFile.2",
+        "file.2",
+        "anotherFile.debug",
+        "file.debug",
+        "anotherFile.ext",
+        "file.ext",
+        "", // because of '\n' at the end of the output
+    ];
+
+    let result = scene.ucmd().arg("-1aX").run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert_eq!(result.stdout.split('\n').collect::<Vec<_>>(), expected,);
+
+    let result = scene.ucmd().arg("-1a").arg("--sort=extension").run();
+    println!("stderr = {:?}", result.stderr);
+    println!("stdout = {:?}", result.stdout);
+    assert_eq!(result.stdout.split('\n').collect::<Vec<_>>(), expected,);
+}

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1726,12 +1726,8 @@ fn test_ls_sort_extension() {
     ];
 
     let result = scene.ucmd().arg("-1aX").run();
-    println!("stderr = {:?}", result.stderr);
-    println!("stdout = {:?}", result.stdout);
-    assert_eq!(result.stdout.split('\n').collect::<Vec<_>>(), expected,);
+    assert_eq!(result.stdout_str().split('\n').collect::<Vec<_>>(), expected,);
 
     let result = scene.ucmd().arg("-1a").arg("--sort=extension").run();
-    println!("stderr = {:?}", result.stderr);
-    println!("stdout = {:?}", result.stdout);
-    assert_eq!(result.stdout.split('\n').collect::<Vec<_>>(), expected,);
+    assert_eq!(result.stdout_str().split('\n').collect::<Vec<_>>(), expected,);
 }


### PR DESCRIPTION
Added implementation (and small test) for extension sorting with ls.
Fixes #1880 

There is some difference to the behavior of my ls on ubuntu, especially when it comes to the behavior of hidden directories and files, this implementation does not treat hidden files (with a leading .) as extensions, whereas my system's /usr/bin/ls does. 

Not sure on the pro's and con's about that and would like to discuss.