### PR TITLE
Expand `CmdResult`'s API 

### DIFF
--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -14,7 +14,7 @@ fn test_utf8() {
         .args(&["-lwmcL"])
         .pipe_in_fixture("UTF_8_test.txt")
         .run()
-        .stdout_is(" 0 0 0 0 0\n");
+        .stdout_is("   300  4969 22781 22213    79\n");
     // GNU returns "  300  2086 22219 22781    79"
     // TODO: we should fix that to match GNU's behavior
 }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -64,7 +64,7 @@ fn read_scenario_fixture<S: AsRef<OsStr>>(tmpd: &Option<Rc<TempDir>>, file_rel_p
 #[derive(Debug)]
 pub struct CmdResult {
     //tmpd is used for convenience functions for asserts against fixtures
-    pub tmpd: Option<Rc<TempDir>>,
+    tmpd: Option<Rc<TempDir>>,
     /// exit status for command (if there is one)
     pub code: Option<i32>,
     /// zero-exit from running the Command?

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -197,7 +197,6 @@ impl CmdResult {
         Box::new(self)
     }
 
-
     /// like stdout_is(...), but expects the contents of the file at the provided relative path
     pub fn stdout_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> Box<&CmdResult> {
         let contents = read_scenario_fixture(&self.tmpd, file_rel_path);

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -127,7 +127,7 @@ impl CmdResult {
         self.code.expect("Program must be run first")
     }
 
-    /// Retunrs the program's TempDir
+    /// Returns the program's TempDir
     /// Panics if not present
     pub fn tmpd(&self) -> Rc<TempDir> {
         match &self.tmpd {
@@ -144,21 +144,21 @@ impl CmdResult {
     }
 
     /// asserts that the command resulted in a success (zero) status code
-    pub fn success(&self) -> Box<&CmdResult> {
+    pub fn success(&self) -> &CmdResult {
         assert!(self.success);
-        Box::new(self)
+        self
     }
 
     /// asserts that the command resulted in a failure (non-zero) status code
-    pub fn failure(&self) -> Box<&CmdResult> {
+    pub fn failure(&self) -> &CmdResult {
         assert!(!self.success);
-        Box::new(self)
+        self
     }
 
     /// asserts that the command's exit code is the same as the given one
-    pub fn status_code(&self, code: i32) -> Box<&CmdResult> {
+    pub fn status_code(&self, code: i32) -> &CmdResult {
         assert!(self.code == Some(code));
-        Box::new(self)
+        self
     }
 
     /// asserts that the command resulted in empty (zero-length) stderr stream output
@@ -166,9 +166,9 @@ impl CmdResult {
     /// but you might find yourself using this function if
     /// 1. you can not know exactly what stdout will be
     /// or 2. you know that stdout will also be empty
-    pub fn no_stderr(&self) -> Box<&CmdResult> {
+    pub fn no_stderr(&self) -> &CmdResult {
         assert!(self.stderr.is_empty());
-        Box::new(self)
+        self
     }
 
     /// asserts that the command resulted in empty (zero-length) stderr stream output
@@ -177,28 +177,28 @@ impl CmdResult {
     /// but you might find yourself using this function if
     /// 1. you can not know exactly what stderr will be
     /// or 2. you know that stderr will also be empty
-    pub fn no_stdout(&self) -> Box<&CmdResult> {
+    pub fn no_stdout(&self) -> &CmdResult {
         assert!(self.stdout.is_empty());
-        Box::new(self)
+        self
     }
 
     /// asserts that the command resulted in stdout stream output that equals the
     /// passed in value, trailing whitespace are kept to force strict comparison (#1235)
     /// stdout_only is a better choice unless stderr may or will be non-empty
-    pub fn stdout_is<T: AsRef<str>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stdout_is<T: AsRef<str>>(&self, msg: T) -> &CmdResult {
         assert_eq!(self.stdout, String::from(msg.as_ref()));
-        Box::new(self)
+        self
     }
 
     /// asserts that the command resulted in stdout stream output,
     /// whose bytes equal those of the passed in slice
-    pub fn stdout_is_bytes<T: AsRef<[u8]>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stdout_is_bytes<T: AsRef<[u8]>>(&self, msg: T) -> &CmdResult {
         assert_eq!(self.stdout.as_bytes(), msg.as_ref());
-        Box::new(self)
+        self
     }
 
     /// like stdout_is(...), but expects the contents of the file at the provided relative path
-    pub fn stdout_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> Box<&CmdResult> {
+    pub fn stdout_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &CmdResult {
         let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
         self.stdout_is_bytes(contents)
     }
@@ -206,26 +206,26 @@ impl CmdResult {
     /// asserts that the command resulted in stderr stream output that equals the
     /// passed in value, when both are trimmed of trailing whitespace
     /// stderr_only is a better choice unless stdout may or will be non-empty
-    pub fn stderr_is<T: AsRef<str>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stderr_is<T: AsRef<str>>(&self, msg: T) -> &CmdResult {
         assert_eq!(
             self.stderr.trim_end(),
             String::from(msg.as_ref()).trim_end()
         );
-        Box::new(self)
+        self
     }
 
     /// asserts that the command resulted in stderr stream output,
     /// whose bytes equal those of the passed in slice
-    pub fn stderr_is_bytes<T: AsRef<[u8]>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stderr_is_bytes<T: AsRef<[u8]>>(&self, msg: T) -> &CmdResult {
         assert_eq!(self.stderr.as_bytes(), msg.as_ref());
-        Box::new(self)
+        self
     }
 
     /// asserts that
     /// 1. the command resulted in stdout stream output that equals the
     /// passed in value, when both are trimmed of trailing whitespace
     /// and 2. the command resulted in empty (zero-length) stderr stream output
-    pub fn stdout_only<T: AsRef<str>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stdout_only<T: AsRef<str>>(&self, msg: T) -> &CmdResult {
         self.no_stderr().stdout_is(msg)
     }
 
@@ -233,12 +233,12 @@ impl CmdResult {
     /// 1.  the command resulted in a stdout stream whose bytes
     ///     equal those of the passed in value
     /// 2.  the command resulted in an empty stderr stream
-    pub fn stdout_only_bytes<T: AsRef<[u8]>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stdout_only_bytes<T: AsRef<[u8]>>(&self, msg: T) -> &CmdResult {
         self.no_stderr().stdout_is_bytes(msg)
     }
 
     /// like stdout_only(...), but expects the contents of the file at the provided relative path
-    pub fn stdout_only_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> Box<&CmdResult> {
+    pub fn stdout_only_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &CmdResult {
         let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
         self.stdout_only_bytes(contents)
     }
@@ -247,7 +247,7 @@ impl CmdResult {
     /// 1. the command resulted in stderr stream output that equals the
     /// passed in value, when both are trimmed of trailing whitespace
     /// and 2. the command resulted in empty (zero-length) stdout stream output
-    pub fn stderr_only<T: AsRef<str>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stderr_only<T: AsRef<str>>(&self, msg: T) -> &CmdResult {
         self.no_stdout().stderr_is(msg)
     }
 
@@ -255,24 +255,24 @@ impl CmdResult {
     /// 1.  the command resulted in a stderr stream whose bytes equal the ones
     ///     of the passed value
     /// 2.  the command resulted in an empty stdout stream
-    pub fn stderr_only_bytes<T: AsRef<[u8]>>(&self, msg: T) -> Box<&CmdResult> {
+    pub fn stderr_only_bytes<T: AsRef<[u8]>>(&self, msg: T) -> &CmdResult {
         self.no_stderr().stderr_is_bytes(msg)
     }
 
-    pub fn fails_silently(&self) -> Box<&CmdResult> {
+    pub fn fails_silently(&self) -> &CmdResult {
         assert!(!self.success);
         assert!(self.stderr.is_empty());
-        Box::new(self)
+        self
     }
 
-    pub fn stdout_contains<T: AsRef<str>>(&self, cmp: T) -> Box<&CmdResult> {
+    pub fn stdout_contains<T: AsRef<str>>(&self, cmp: T) -> &CmdResult {
         assert!(self.stdout_str().contains(cmp.as_ref()));
-        Box::new(self)
+        self
     }
 
-    pub fn stderr_contains<T: AsRef<str>>(&self, cmp: &T) -> Box<&CmdResult> {
+    pub fn stderr_contains<T: AsRef<str>>(&self, cmp: &T) -> &CmdResult {
         assert!(self.stderr_str().contains(cmp.as_ref()));
-        Box::new(self)
+        self
     }
 }
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -653,19 +653,19 @@ impl UCommand {
 
     /// Add a parameter to the invocation. Path arguments are treated relative
     /// to the test environment directory.
-    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> Box<&mut UCommand> {
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut UCommand {
         if self.has_run {
             panic!(ALREADY_RUN);
         }
         self.comm_string.push_str(" ");
         self.comm_string.push_str(arg.as_ref().to_str().unwrap());
         self.raw.arg(arg.as_ref());
-        Box::new(self)
+        self
     }
 
     /// Add multiple parameters to the invocation. Path arguments are treated relative
     /// to the test environment directory.
-    pub fn args<S: AsRef<OsStr>>(&mut self, args: &[S]) -> Box<&mut UCommand> {
+    pub fn args<S: AsRef<OsStr>>(&mut self, args: &[S]) -> &mut UCommand {
         if self.has_run {
             panic!(MULTIPLE_STDIN_MEANINGLESS);
         }
@@ -675,25 +675,25 @@ impl UCommand {
         }
 
         self.raw.args(args.as_ref());
-        Box::new(self)
+        self
     }
 
     /// provides stdinput to feed in to the command when spawned
-    pub fn pipe_in<T: Into<Vec<u8>>>(&mut self, input: T) -> Box<&mut UCommand> {
+    pub fn pipe_in<T: Into<Vec<u8>>>(&mut self, input: T) -> &mut UCommand {
         if self.stdin.is_some() {
             panic!(MULTIPLE_STDIN_MEANINGLESS);
         }
         self.stdin = Some(input.into());
-        Box::new(self)
+        self
     }
 
     /// like pipe_in(...), but uses the contents of the file at the provided relative path as the piped in data
-    pub fn pipe_in_fixture<S: AsRef<OsStr>>(&mut self, file_rel_path: S) -> Box<&mut UCommand> {
+    pub fn pipe_in_fixture<S: AsRef<OsStr>>(&mut self, file_rel_path: S) -> &mut UCommand {
         let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
         self.pipe_in(contents)
     }
 
-    pub fn env<K, V>(&mut self, key: K, val: V) -> Box<&mut UCommand>
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut UCommand
     where
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
@@ -702,7 +702,7 @@ impl UCommand {
             panic!(ALREADY_RUN);
         }
         self.raw.env(key, val);
-        Box::new(self)
+        self
     }
 
     /// Spawns the command, feeds the stdin if any, and returns the


### PR DESCRIPTION
This PR adds a bunch of useful functions & byte/string getters for the CmdResult struct.
It also adds methods to rw+ items in an `AtPath`.

Now, we need to refactor tests to use this API (together with `stdout_is` for example instead of manual asserts, and `succeeds` instead of `assert!(result.success)`. Once that is done, we can 

1. Change the type of `stderr`/`stdout` in `CmdResult` to `Vec<u8>` 
2. Make the fields private (to avoid this whole mess in the future)
3. Finally be able to test our utils for non-utf8 reliance! Will close #1916 
