### PR TITLE
fixed panic! formatting for tests

### DIFF
--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -37,10 +37,10 @@ fn run_single_test(test: &TestCase, at: AtPath, mut ucmd: UCommand) {
     mkfile(&at.plus_as_string(TEST_FILE), test.before);
     let perms = at.metadata(TEST_FILE).permissions().mode();
     if perms != test.before {
-        panic!(format!(
+        panic!(
             "{}: expected: {:o} got: {:o}",
             "setting permissions on test files before actual test run failed", test.after, perms
-        ));
+        );
     }
 
     for arg in &test.args {
@@ -49,15 +49,15 @@ fn run_single_test(test: &TestCase, at: AtPath, mut ucmd: UCommand) {
     let r = ucmd.run();
     if !r.success {
         println!("{}", r.stderr);
-        panic!(format!("{:?}: failed", ucmd.raw));
+        panic!("{:?}: failed", ucmd.raw);
     }
 
     let perms = at.metadata(TEST_FILE).permissions().mode();
     if perms != test.after {
-        panic!(format!(
+        panic!(
             "{:?}: expected: {:o} got: {:o}",
             ucmd.raw, test.after, perms
-        ));
+        );
     }
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1038,7 +1038,7 @@ fn test_cp_one_file_system() {
         .arg("tmpfs")
         .arg(mountpoint_path)
         .run();
-    assert!(_r.code == Some(0), _r.stderr);
+    assert!(_r.code == Some(0), "{}", _r.stderr);
 
     at_src.touch(TEST_MOUNT_OTHER_FILESYSTEM_FILE);
 
@@ -1052,7 +1052,7 @@ fn test_cp_one_file_system() {
 
     // Ditch the mount before the asserts
     let _r = scene.cmd("umount").arg(mountpoint_path).run();
-    assert!(_r.code == Some(0), _r.stderr);
+    assert!(_r.code == Some(0), "{}", _r.stderr);
 
     assert!(result.success);
     assert!(!at_dst.file_exists(TEST_MOUNT_OTHER_FILESYSTEM_FILE));

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -98,7 +98,8 @@ fn test_head_count() {
     assert_eq!(result_seq.len(), repeat_limit, "Output is not limited");
     assert!(
         result_seq.iter().all(|x| input_seq.contains(x)),
-        format!("Output includes element not from input: {}", result)
+        "Output includes element not from input: {}",
+        result
     )
 }
 
@@ -133,13 +134,11 @@ fn test_repeat() {
     );
     assert!(
         result_seq.iter().all(|x| input_seq.contains(x)),
-        format!(
-            "Output includes element not from input: {:?}",
-            result_seq
-                .iter()
-                .filter(|x| !input_seq.contains(x))
-                .collect::<Vec<&i32>>()
-        )
+        "Output includes element not from input: {:?}",
+        result_seq
+            .iter()
+            .filter(|x| !input_seq.contains(x))
+            .collect::<Vec<&i32>>()
     )
 }
 

--- a/tests/common/macros.rs
+++ b/tests/common/macros.rs
@@ -5,7 +5,7 @@
 macro_rules! assert_empty_stderr(
     ($cond:expr) => (
         if $cond.stderr.len() > 0 {
-            panic!(format!("stderr: {}", $cond.stderr))
+            panic!("stderr: {}", $cond.stderr_str())
         }
     );
 );
@@ -17,7 +17,7 @@ macro_rules! assert_empty_stderr(
 macro_rules! assert_empty_stdout(
     ($cond:expr) => (
         if $cond.stdout.len() > 0 {
-            panic!(format!("stdout: {}", $cond.stdout))
+            panic!("stdout: {}", $cond.stdout_str())
         }
     );
 );
@@ -30,7 +30,7 @@ macro_rules! assert_no_error(
     ($cond:expr) => (
         assert!($cond.success);
         if $cond.stderr.len() > 0 {
-            panic!(format!("stderr: {}", $cond.stderr))
+            panic!("stderr: {}", $cond.stderr_str())
         }
     );
 );

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -658,7 +658,7 @@ impl UCommand {
     /// to the test environment directory.
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut UCommand {
         if self.has_run {
-            panic!(ALREADY_RUN);
+            panic!("{}", ALREADY_RUN);
         }
         self.comm_string.push_str(" ");
         self.comm_string.push_str(arg.as_ref().to_str().unwrap());
@@ -670,7 +670,7 @@ impl UCommand {
     /// to the test environment directory.
     pub fn args<S: AsRef<OsStr>>(&mut self, args: &[S]) -> &mut UCommand {
         if self.has_run {
-            panic!(MULTIPLE_STDIN_MEANINGLESS);
+            panic!("{}", MULTIPLE_STDIN_MEANINGLESS);
         }
         for s in args {
             self.comm_string.push_str(" ");
@@ -684,7 +684,7 @@ impl UCommand {
     /// provides stdinput to feed in to the command when spawned
     pub fn pipe_in<T: Into<Vec<u8>>>(&mut self, input: T) -> &mut UCommand {
         if self.stdin.is_some() {
-            panic!(MULTIPLE_STDIN_MEANINGLESS);
+            panic!("{}", MULTIPLE_STDIN_MEANINGLESS);
         }
         self.stdin = Some(input.into());
         self
@@ -702,7 +702,7 @@ impl UCommand {
         V: AsRef<OsStr>,
     {
         if self.has_run {
-            panic!(ALREADY_RUN);
+            panic!("{}", ALREADY_RUN);
         }
         self.raw.env(key, val);
         self
@@ -712,7 +712,7 @@ impl UCommand {
     /// child process immediately.
     pub fn run_no_wait(&mut self) -> Child {
         if self.has_run {
-            panic!(ALREADY_RUN);
+            panic!("{}", ALREADY_RUN);
         }
         self.has_run = true;
         log_info("run", &self.comm_string);


### PR DESCRIPTION
Fixed a bunch of 
```
warning: panic message is not a string literal
```
In the tests