### PR TITLE
od: refactor tests for #1982

### DIFF
--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -21,6 +21,7 @@ static ALPHA_OUT: &'static str = "
 // Test that od can read one file and dump with default format
 #[test]
 fn test_file() {
+    // TODO: Can this be replaced by AtPath?
     use std::env;
     let temp = env::temp_dir();
     let tmpdir = Path::new(&temp);
@@ -33,15 +34,12 @@ fn test_file() {
         }
     }
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg(file.as_os_str())
-        .run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, unindent(ALPHA_OUT));
-
+        .succeeds()
+        .no_stderr()
+        .stdout_is(unindent(ALPHA_OUT));
     let _ = remove_file(file);
 }
 
@@ -64,16 +62,14 @@ fn test_2files() {
         }
     }
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg(file1.as_os_str())
         .arg(file2.as_os_str())
-        .run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, unindent(ALPHA_OUT));
-
+        .succeeds()
+        .no_stderr()
+        .stdout_is(unindent(ALPHA_OUT));
+    // TODO: Handle errors?
     let _ = remove_file(file1);
     let _ = remove_file(file2);
 }
@@ -85,22 +81,19 @@ fn test_no_file() {
     let tmpdir = Path::new(&temp);
     let file = tmpdir.join("}surely'none'would'thus'a'file'name");
 
-    let result = new_ucmd!().arg(file.as_os_str()).run();
-
-    assert!(!result.success);
+    new_ucmd!().arg(file.as_os_str()).fails();
 }
 
 // Test that od reads from stdin instead of a file
 #[test]
 fn test_from_stdin() {
     let input = "abcdefghijklmnopqrstuvwxyz\n";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, unindent(ALPHA_OUT));
+        .run_piped_stdin(input.as_bytes())
+        .success()
+        .no_stderr()
+        .stdout_is(unindent(ALPHA_OUT));
 }
 
 // Test that od reads from stdin and also from files
@@ -119,40 +112,35 @@ fn test_from_mixed() {
         }
     }
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg(file1.as_os_str())
         .arg("-")
         .arg(file3.as_os_str())
-        .run_piped_stdin(data2.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, unindent(ALPHA_OUT));
+        .run_piped_stdin(data2.as_bytes())
+        .success()
+        .no_stderr()
+        .stdout_is(unindent(ALPHA_OUT));
 }
 
 #[test]
 fn test_multiple_formats() {
     let input = "abcdefghijklmnopqrstuvwxyz\n";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-c")
         .arg("-b")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin(input.as_bytes())
+        .success()
+        .no_stderr()
+        .stdout_is(unindent(
             "
             0000000   a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p
                     141 142 143 144 145 146 147 150 151 152 153 154 155 156 157 160
             0000020   q   r   s   t   u   v   w   x   y   z  \\n
                     161 162 163 164 165 166 167 170 171 172 012
             0000033
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
@@ -166,14 +154,13 @@ fn test_dec() {
             0000016
             ",
     );
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-s")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -185,14 +172,13 @@ fn test_hex16() {
             0000011
             ",
     );
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-x")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -204,14 +190,13 @@ fn test_hex32() {
             0000011
             ",
     );
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-X")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -232,15 +217,14 @@ fn test_f16() {
             0000016
             ",
     );
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-tf2")
         .arg("-w8")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -261,14 +245,13 @@ fn test_f32() {
             0000034
             ",
     );
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-f")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -291,36 +274,31 @@ fn test_f64() {
             0000050
             ",
     );
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-F")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
 fn test_multibyte() {
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-c")
         .arg("-w12")
-        .run_piped_stdin("Universität Tübingen \u{1B000}".as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin("Universität Tübingen \u{1B000}".as_bytes())
+        .success()
+        .no_stderr()
+        .stdout_is(unindent(
             "
             0000000   U   n   i   v   e   r   s   i   t   ä  **   t
             0000014       T   ü  **   b   i   n   g   e   n       \u{1B000}
             0000030  **  **  **
             0000033
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
@@ -334,11 +312,13 @@ fn test_width() {
             ",
     );
 
-    let result = new_ucmd!().arg("-w4").arg("-v").run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+    new_ucmd!()
+        .arg("-w4")
+        .arg("-v")
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -352,14 +332,13 @@ fn test_invalid_width() {
             ",
     );
 
-    let result = new_ucmd!().arg("-w5").arg("-v").run_piped_stdin(&input[..]);
-
-    assert_eq!(
-        result.stderr,
-        "od: warning: invalid width 5; using 2 instead\n"
-    );
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+    new_ucmd!()
+        .arg("-w5")
+        .arg("-v")
+        .run_piped_stdin(&input[..])
+        .success()
+        .stderr_is_bytes("od: warning: invalid width 5; using 2 instead\n".as_bytes())
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -373,14 +352,13 @@ fn test_zero_width() {
             ",
     );
 
-    let result = new_ucmd!().arg("-w0").arg("-v").run_piped_stdin(&input[..]);
-
-    assert_eq!(
-        result.stderr,
-        "od: warning: invalid width 0; using 2 instead\n"
-    );
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+    new_ucmd!()
+        .arg("-w0")
+        .arg("-v")
+        .run_piped_stdin(&input[..])
+        .success()
+        .stderr_is_bytes("od: warning: invalid width 0; using 2 instead\n".as_bytes())
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -392,11 +370,12 @@ fn test_width_without_value() {
             0000050
             ");
 
-    let result = new_ucmd!().arg("-w").run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+    new_ucmd!()
+        .arg("-w")
+        .run_piped_stdin(&input[..])
+        .success()
+        .no_stderr()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -421,15 +400,14 @@ fn test_suppress_duplicates() {
             ",
     );
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-w4")
         .arg("-O")
         .arg("-x")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -446,17 +424,16 @@ fn test_big_endian() {
         ",
     );
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=big")
         .arg("-F")
         .arg("-f")
         .arg("-X")
         .arg("-x")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -474,16 +451,15 @@ fn test_alignment_Xxa() {
     );
 
     // in this case the width of the -a (8-bit) determines the alignment for the other fields
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-X")
         .arg("-x")
         .arg("-a")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -500,15 +476,14 @@ fn test_alignment_Fx() {
     );
 
     // in this case the width of the -F (64-bit) determines the alignment for the other field
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("-F")
         .arg("-x")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -528,16 +503,15 @@ fn test_maxuint() {
             ",
     );
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--format=o8")
         .arg("-Oobtu8")
         .arg("-Dd")
         .arg("--format=u1")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -553,15 +527,14 @@ fn test_hex_offset() {
             ",
     );
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-Ax")
         .arg("-X")
         .arg("-X")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -577,15 +550,14 @@ fn test_dec_offset() {
             ",
     );
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-Ad")
         .arg("-X")
         .arg("-X")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
@@ -594,66 +566,57 @@ fn test_no_offset() {
     const LINE: &'static str = " 00000000 00000000 00000000 00000000\n";
     let expected_output = [LINE, LINE, LINE, LINE].join("");
 
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-An")
         .arg("-X")
         .arg("-X")
-        .run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, expected_output);
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(expected_output);
 }
 
 #[test]
 fn test_invalid_offset() {
-    let result = new_ucmd!().arg("-Ab").run();
-
-    assert!(!result.success);
+    new_ucmd!().arg("-Ab").fails();
 }
 
 #[test]
 fn test_skip_bytes() {
     let input = "abcdefghijklmnopq";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-c")
         .arg("--skip-bytes=5")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
             "
             0000005   f   g   h   i   j   k   l   m   n   o   p   q
             0000021
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
 fn test_skip_bytes_error() {
     let input = "12345";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--skip-bytes=10")
-        .run_piped_stdin(input.as_bytes());
-
-    assert!(!result.success);
+        .run_piped_stdin(input.as_bytes())
+        .failure();
 }
 
 #[test]
 fn test_read_bytes() {
     let input = "abcdefghijklmnopqrstuvwxyz\n12345678";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--endian=little")
         .arg("--read-bytes=27")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(result.stdout, unindent(ALPHA_OUT));
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(ALPHA_OUT));
 }
 
 #[test]
@@ -662,13 +625,12 @@ fn test_ascii_dump() {
         0x00, 0x01, 0x0a, 0x0d, 0x10, 0x1f, 0x20, 0x61, 0x62, 0x63, 0x7d, 0x7e, 0x7f, 0x80, 0x90,
         0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0xff,
     ];
-    let result = new_ucmd!().arg("-tx1zacz").run_piped_stdin(&input[..]);
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+    new_ucmd!()
+        .arg("-tx1zacz")
+        .run_piped_stdin(&input[..])
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
             r"
             0000000  00  01  0a  0d  10  1f  20  61  62  63  7d  7e  7f  80  90  a0  >...... abc}~....<
                     nul soh  nl  cr dle  us  sp   a   b   c   }   ~ del nul dle  sp
@@ -677,9 +639,8 @@ fn test_ascii_dump() {
                       0   @   P   `   p del
                      ** 300 320 340 360 377                                          >......<
             0000026
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
@@ -687,159 +648,136 @@ fn test_filename_parsing() {
     // files "a" and "x" both exists, but are no filenames in the commandline below
     // "-f" must be treated as a filename, it contains the text: minus lowercase f
     // so "-f" should not be interpreted as a formatting option.
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--format")
         .arg("a")
         .arg("-A")
         .arg("x")
         .arg("--")
         .arg("-f")
-        .run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .succeeds()
+        .no_stderr()
+        .stdout_is(unindent(
             "
             000000   m   i   n   u   s  sp   l   o   w   e   r   c   a   s   e  sp
             000010   f  nl
             000012
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
 fn test_stdin_offset() {
     let input = "abcdefghijklmnopq";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-c")
         .arg("+5")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
             "
             0000005   f   g   h   i   j   k   l   m   n   o   p   q
             0000021
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
 fn test_file_offset() {
-    let result = new_ucmd!().arg("-c").arg("--").arg("-f").arg("10").run();
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+    new_ucmd!()
+        .arg("-c")
+        .arg("--")
+        .arg("-f")
+        .arg("10")
+        .succeeds()
+        .no_stderr()
+        .stdout_is(unindent(
             r"
             0000010   w   e   r   c   a   s   e       f  \n
             0000022
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
 fn test_traditional() {
     // note gnu od does not align both lines
     let input = "abcdefghijklmnopq";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--traditional")
         .arg("-a")
         .arg("-c")
         .arg("-")
         .arg("10")
         .arg("0")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
             r"
             0000010 (0000000)   i   j   k   l   m   n   o   p   q
                                 i   j   k   l   m   n   o   p   q
             0000021 (0000011)
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
 fn test_traditional_with_skip_bytes_override() {
     // --skip-bytes is ignored in this case
     let input = "abcdefghijklmnop";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--traditional")
         .arg("--skip-bytes=10")
         .arg("-c")
         .arg("0")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
             r"
             0000000   a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p
             0000020
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
 fn test_traditional_with_skip_bytes_non_override() {
     // no offset specified in the traditional way, so --skip-bytes is used
     let input = "abcdefghijklmnop";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--traditional")
         .arg("--skip-bytes=10")
         .arg("-c")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
             r"
             0000012   k   l   m   n   o   p
             0000020
-            "
-        )
-    );
+            ",
+        ));
 }
 
 #[test]
 fn test_traditional_error() {
     // file "0" exists - don't fail on that, but --traditional only accepts a single input
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("--traditional")
         .arg("0")
         .arg("0")
         .arg("0")
         .arg("0")
-        .run();
-
-    assert!(!result.success);
+        .fails();
 }
 
 #[test]
 fn test_traditional_only_label() {
     let input = "abcdefghijklmnopqrstuvwxyz";
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("-An")
         .arg("--traditional")
         .arg("-a")
@@ -847,20 +785,16 @@ fn test_traditional_only_label() {
         .arg("-")
         .arg("10")
         .arg("0x10")
-        .run_piped_stdin(input.as_bytes());
-
-    assert_empty_stderr!(result);
-    assert!(result.success);
-    assert_eq!(
-        result.stdout,
-        unindent(
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
             r"
             (0000020)   i   j   k   l   m   n   o   p   q   r   s   t   u   v   w   x
                         i   j   k   l   m   n   o   p   q   r   s   t   u   v   w   x
             (0000040)   y   z
                         y   z
             (0000042)
-            "
-        )
-    );
+            ",
+        ));
 }


### PR DESCRIPTION
part of the ongoing effort in #1982
The tests are still the same but don't access the fields of `CmdResult`