### PR TITLE
Consistency with GNU version of `du` when doing `du -h` on an empty file

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -305,6 +305,9 @@ fn convert_size_human(size: u64, multiplier: u64, _block_size: u64) -> String {
             return format!("{:.1}{}", (size as f64) / (limit as f64), unit);
         }
     }
+    if size == 0 {
+        return format!("0");
+    }
     format!("{}B", size)
 }
 

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -162,3 +162,13 @@ fn _du_d_flag(s: String) {
         assert_eq!(s, "8\t./subdir\n8\t./\n");
     }
 }
+
+#[test]
+fn test_du_h_flag_empty_file() {
+    let ts = TestScenario::new("du");
+
+    let result = ts.ucmd().arg("-h").arg("empty.txt").run();
+    assert!(result.success);
+    assert_eq!(result.stderr, "");
+    assert_eq!(result.stdout, "0\tempty.txt\n");
+}


### PR DESCRIPTION
Fixes #1999