### PR TITLE
cat: Add tests for the case of no options

### DIFF
--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -4,6 +4,34 @@ extern crate unix_socket;
 use crate::common::util::*;
 
 #[test]
+fn test_no_options() {
+    for fixture in &["empty.txt", "alpha.txt", "nonewline.txt"] {
+        // Give fixture through command line file argument
+        new_ucmd!()
+            .args(&[fixture])
+            .succeeds()
+            .stdout_is_fixture(fixture);
+        // Give fixture through stdin
+        new_ucmd!()
+            .pipe_in_fixture(fixture)
+            .succeeds()
+            .stdout_is_fixture(fixture);
+    }
+}
+
+#[test]
+fn test_no_options_big_input() {
+    let mut data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7];
+    while data.len() < 1024 * 128 {
+        new_ucmd!()
+            .pipe_in(data.clone())
+            .succeeds()
+            .stdout_is_bytes(&data);
+        data.extend_from_slice(&data.clone());
+    }
+}
+
+#[test]
 fn test_output_multi_files_print_all_chars() {
     new_ucmd!()
         .args(&["alpha.txt", "256.txt", "-A", "-n"])


### PR DESCRIPTION
Funnily enough, none of the previous tests covered the case where cat is called with no options (the most common case). See https://codecov.io/gh/uutils/coreutils/src/master/src/uu/cat/src/cat.rs