### PR TITLE
fold: preserve blank lines

### DIFF
--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -100,7 +100,10 @@ fn fold(filenames: Vec<String>, bytes: bool, spaces: bool, width: usize) {
 fn fold_file<T: Read>(file: BufReader<T>, bytes: bool, spaces: bool, width: usize) {
     for line_result in file.lines() {
         let mut line = safe_unwrap!(line_result);
-        if bytes {
+
+        if line.is_empty() {
+            println!();
+        } else if bytes {
             let len = line.len();
             let mut i = 0;
             while i < len {

--- a/tests/by-util/test_fold.rs
+++ b/tests/by-util/test_fold.rs
@@ -25,9 +25,35 @@ fn test_40_column_word_boundary() {
 }
 
 #[test]
-fn test_default_warp_with_newlines() {
+fn test_default_wrap_with_newlines() {
     new_ucmd!()
         .arg("lorem_ipsum_new_line.txt")
         .run()
         .stdout_is_fixture("lorem_ipsum_new_line_80_column.expected");
+}
+
+#[test]
+fn test_should_preserve_empty_lines() {
+    new_ucmd!().pipe_in("\n").succeeds().stdout_is("\n");
+
+    new_ucmd!()
+        .arg("-w1")
+        .pipe_in("0\n1\n\n2\n\n\n")
+        .succeeds()
+        .stdout_is("0\n1\n\n2\n\n\n");
+}
+
+#[test]
+fn test_word_boundary_split_should_preserve_empty_lines() {
+    new_ucmd!()
+        .arg("-s")
+        .pipe_in("\n")
+        .succeeds()
+        .stdout_is("\n");
+
+    new_ucmd!()
+        .args(&["-w1", "-s"])
+        .pipe_in("0\n1\n\n2\n\n\n")
+        .succeeds()
+        .stdout_is("0\n1\n\n2\n\n\n");
 }


### PR DESCRIPTION
Update `fold` to preserve blank lines in the input stream as GNU does:

```
$ echo -ne '0\n1\n\n2\n\n\n-----' | fold
0
1

2


-----
```