### PR TITLE
ls: show/hide control chars

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1163,6 +1163,24 @@ fn test_ls_quoting_style() {
         }
 
         for (arg, correct) in &[
+            ("--quoting-style=literal", "one?two"),
+            ("-N", "one?two"),
+            ("--literal", "one?two"),
+            ("--quoting-style=shell", "one?two"),
+            ("--quoting-style=shell-always", "'one?two'"),
+        ] {
+            let result = scene
+                .ucmd()
+                .arg(arg)
+                .arg("--hide-control-chars")
+                .arg("one\ntwo")
+                .run();
+            println!("stderr = {:?}", result.stderr);
+            println!("stdout = {:?}", result.stdout);
+            assert_eq!(result.stdout, format!("{}\n", correct));
+        }
+
+        for (arg, correct) in &[
             ("--quoting-style=literal", "one\ntwo"),
             ("-N", "one\ntwo"),
             ("--literal", "one\ntwo"),

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1142,9 +1142,9 @@ fn test_ls_quoting_style() {
         assert_eq!(result.stdout, "'one'$'\\n''two'\n");
 
         for (arg, correct) in &[
-            ("--quoting-style=literal", "one\ntwo"),
-            ("-N", "one\ntwo"),
-            ("--literal", "one\ntwo"),
+            ("--quoting-style=literal", "one?two"),
+            ("-N", "one?two"),
+            ("--literal", "one?two"),
             ("--quoting-style=c", "\"one\\ntwo\""),
             ("-Q", "\"one\\ntwo\""),
             ("--quote-name", "\"one\\ntwo\""),
@@ -1157,6 +1157,24 @@ fn test_ls_quoting_style() {
             ("--quoting-style=shell-always", "'one?two'"),
         ] {
             let result = scene.ucmd().arg(arg).arg("one\ntwo").run();
+            println!("stderr = {:?}", result.stderr);
+            println!("stdout = {:?}", result.stdout);
+            assert_eq!(result.stdout, format!("{}\n", correct));
+        }
+
+        for (arg, correct) in &[
+            ("--quoting-style=literal", "one\ntwo"),
+            ("-N", "one\ntwo"),
+            ("--literal", "one\ntwo"),
+            ("--quoting-style=shell", "one\ntwo"),
+            ("--quoting-style=shell-always", "'one\ntwo'"),
+        ] {
+            let result = scene
+                .ucmd()
+                .arg(arg)
+                .arg("--show-control-chars")
+                .arg("one\ntwo")
+                .run();
             println!("stderr = {:?}", result.stderr);
             println!("stdout = {:?}", result.stdout);
             assert_eq!(result.stdout, format!("{}\n", correct));


### PR DESCRIPTION
Implements the flags:
- `-q` & `--hide-control-chars`
- `--show-control-chars`

The former is now the default and replaces any control character with a `?`, the second just shows them as is.

One thing I couldn't figure out was this line from the GNU docs for the `-q` flag:
> This is the default if the output is a terminal and the program is `ls`.

In what circumstances would the program not be `ls` and how could we perform the same check? If anyone knows how to do this, please let me know and I'll update the PR, otherwise I'll make an issue about this.