### PR TITLE
dirname: move to clap, write to stderr on errors 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,7 @@ dependencies = [
 name = "uu_dirname"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "libc",
  "uucore",
  "uucore_procs",

--- a/src/uu/dirname/Cargo.toml
+++ b/src/uu/dirname/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/dirname.rs"
 
 [dependencies]
+clap = "2.33"
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -8,32 +8,57 @@
 #[macro_use]
 extern crate uucore;
 
+use clap::{App, Arg};
 use std::path::Path;
 
 static NAME: &str = "dirname";
 static SYNTAX: &str = "[OPTION] NAME...";
 static SUMMARY: &str = "strip last component from file name";
+static VERSION: &str = env!("CARGO_PKG_VERSION");
 static LONG_HELP: &str = "
  Output each NAME with its last non-slash component and trailing slashes
  removed; if NAME contains no /'s, output '.' (meaning the current
  directory).
 ";
 
+mod options {
+    pub const ZERO: &str = "zero";
+    pub const DIR: &str = "dir";
+}
+
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let args = args.collect_str();
 
-    let matches = app!(SYNTAX, SUMMARY, LONG_HELP)
-        .optflag("z", "zero", "separate output with NUL rather than newline")
-        .parse(args);
+    let matches = App::new(executable!())
+        .name(NAME)
+        .usage(SYNTAX)
+        .about(SUMMARY)
+        .after_help(LONG_HELP)
+        .version(VERSION)
+        .arg(
+            Arg::with_name(options::ZERO)
+                .short(options::ZERO)
+                .short("z")
+                .takes_value(false)
+                .help("separate output with NUL rather than newline"),
+        )
+        .arg(Arg::with_name(options::DIR).hidden(true).multiple(true))
+        .get_matches_from(args);
 
-    let separator = if matches.opt_present("zero") {
+    let separator = if matches.is_present(options::ZERO) {
         "\0"
     } else {
         "\n"
     };
 
-    if !matches.free.is_empty() {
-        for path in &matches.free {
+    let dirnames: Vec<String> = matches
+        .values_of(options::DIR)
+        .unwrap_or_default()
+        .map(str::to_owned)
+        .collect();
+
+    if !dirnames.is_empty() {
+        for path in dirnames.iter() {
             let p = Path::new(path);
             match p.parent() {
                 Some(d) => {
@@ -54,8 +79,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             print!("{}", separator);
         }
     } else {
-        println!("{0}: missing operand", NAME);
-        println!("Try '{0} --help' for more information.", NAME);
+        show_usage_error!("missing operand");
         return 1;
     }
 


### PR DESCRIPTION
This PR includes these changes for dirname: 

* moved to clap
* fixed writing to stdout instead of stderr in missing operand

