### PR TITLE
ls: --hide and --ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "globset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,7 +1962,7 @@ version = "0.0.6"
 dependencies = [
  "atty",
  "clap",
- "glob 0.3.0",
+ "globset",
  "lazy_static",
  "number_prefix",
  "term_grid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,7 @@ version = "0.0.6"
 dependencies = [
  "atty",
  "clap",
+ "glob 0.3.0",
  "lazy_static",
  "number_prefix",
  "term_grid",

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -22,6 +22,7 @@ term_grid = "0.1.5"
 termsize = "0.1.6"
 time = "0.1.40"
 unicode-width = "0.1.5"
+glob = "0.3.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -22,7 +22,7 @@ term_grid = "0.1.5"
 termsize = "0.1.6"
 time = "0.1.40"
 unicode-width = "0.1.5"
-glob = "0.3.0"
+globset = "0.4.6"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -449,7 +449,7 @@ impl Config {
         for pattern in options.values_of(options::IGNORE).into_iter().flatten() {
             match glob::Pattern::new(pattern) {
                 Ok(p) => ignore_patterns.push(p),
-                Err(_) => show_error!("Invalid pattern for ignore: '{}'", pattern),
+                Err(_) => show_warning!("Invalid pattern for ignore: '{}'", pattern),
             }
         }
 
@@ -457,7 +457,7 @@ impl Config {
             for pattern in options.values_of(options::HIDE).into_iter().flatten() {
                 match glob::Pattern::new(pattern) {
                     Ok(p) => ignore_patterns.push(p),
-                    Err(_) => show_error!("Invalid pattern for hide: '{}'", pattern),
+                    Err(_) => show_warning!("Invalid pattern for hide: '{}'", pattern),
                 }
             }
         }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -449,7 +449,7 @@ impl Config {
         for pattern in options.values_of(options::IGNORE).into_iter().flatten() {
             match glob::Pattern::new(pattern) {
                 Ok(p) => ignore_patterns.push(p),
-                Err(e) => show_error!("{}", e),
+                Err(_) => show_error!("Invalid pattern for ignore: '{}'", pattern),
             }
         }
 
@@ -457,7 +457,7 @@ impl Config {
             for pattern in options.values_of(options::HIDE).into_iter().flatten() {
                 match glob::Pattern::new(pattern) {
                     Ok(p) => ignore_patterns.push(p),
-                    Err(e) => show_error!("{}", e),
+                    Err(_) => show_error!("Invalid pattern for hide: '{}'", pattern),
                 }
             }
         }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1209,3 +1209,83 @@ fn test_ls_quoting_style() {
         assert_eq!(result.stdout, format!("{}\n", correct));
     }
 }
+
+#[test]
+fn test_ls_ignore_hide() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.touch("README.md");
+    at.touch("CONTRIBUTING.md");
+    at.touch("some_other_file");
+    at.touch("READMECAREFULLY.md");
+
+    scene.ucmd().arg("--hide").arg("*").succeeds().stdout_is("");
+
+    scene
+        .ucmd()
+        .arg("--ignore")
+        .arg("*")
+        .succeeds()
+        .stdout_is("");
+
+    scene
+        .ucmd()
+        .arg("--ignore")
+        .arg("irrelevant pattern")
+        .succeeds()
+        .stdout_is("CONTRIBUTING.md\nREADME.md\nREADMECAREFULLY.md\nsome_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("--ignore")
+        .arg("README*.md")
+        .succeeds()
+        .stdout_is("CONTRIBUTING.md\nsome_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("--hide")
+        .arg("README*.md")
+        .succeeds()
+        .stdout_is("CONTRIBUTING.md\nsome_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("--ignore")
+        .arg("*.md")
+        .succeeds()
+        .stdout_is("some_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("-a")
+        .arg("--ignore")
+        .arg("*.md")
+        .succeeds()
+        .stdout_is(".\n..\nsome_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("-a")
+        .arg("--hide")
+        .arg("*.md")
+        .succeeds()
+        .stdout_is(".\n..\nCONTRIBUTING.md\nREADME.md\nREADMECAREFULLY.md\nsome_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("-A")
+        .arg("--ignore")
+        .arg("*.md")
+        .succeeds()
+        .stdout_is("some_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("-A")
+        .arg("--hide")
+        .arg("*.md")
+        .succeeds()
+        .stdout_is("CONTRIBUTING.md\nREADME.md\nREADMECAREFULLY.md\nsome_other_file\n");
+}

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1288,4 +1288,29 @@ fn test_ls_ignore_hide() {
         .arg("*.md")
         .succeeds()
         .stdout_is("CONTRIBUTING.md\nREADME.md\nREADMECAREFULLY.md\nsome_other_file\n");
+
+    // Stacking multiple patterns
+    scene
+        .ucmd()
+        .arg("--ignore")
+        .arg("README*")
+        .arg("--ignore")
+        .arg("CONTRIBUTING*")
+        .succeeds()
+        .stdout_is("some_other_file\n");
+
+    // Invalid patterns
+    scene
+        .ucmd()
+        .arg("--ignore")
+        .arg("READ[ME")
+        .succeeds()
+        .stderr_contains(&"Invalid pattern");
+
+    scene
+        .ucmd()
+        .arg("--ignore")
+        .arg("READ[ME")
+        .succeeds()
+        .stderr_contains(&"Invalid pattern");
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1315,6 +1315,26 @@ fn test_ls_ignore_hide() {
         .succeeds()
         .stdout_is("some_other_file\n");
 
+    scene
+        .ucmd()
+        .arg("--hide")
+        .arg("README*")
+        .arg("--ignore")
+        .arg("CONTRIBUTING*")
+        .arg("-1")
+        .succeeds()
+        .stdout_is("some_other_file\n");
+
+    scene
+        .ucmd()
+        .arg("--hide")
+        .arg("README*")
+        .arg("--hide")
+        .arg("CONTRIBUTING*")
+        .arg("-1")
+        .succeeds()
+        .stdout_is("some_other_file\n");
+
     // Invalid patterns
     scene
         .ucmd()
@@ -1326,7 +1346,7 @@ fn test_ls_ignore_hide() {
 
     scene
         .ucmd()
-        .arg("--ignore")
+        .arg("--hide")
         .arg("READ[ME")
         .arg("-1")
         .succeeds()

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1220,12 +1220,19 @@ fn test_ls_ignore_hide() {
     at.touch("some_other_file");
     at.touch("READMECAREFULLY.md");
 
-    scene.ucmd().arg("--hide").arg("*").succeeds().stdout_is("");
+    scene
+        .ucmd()
+        .arg("--hide")
+        .arg("*")
+        .arg("-1")
+        .succeeds()
+        .stdout_is("");
 
     scene
         .ucmd()
         .arg("--ignore")
         .arg("*")
+        .arg("-1")
         .succeeds()
         .stdout_is("");
 
@@ -1233,6 +1240,7 @@ fn test_ls_ignore_hide() {
         .ucmd()
         .arg("--ignore")
         .arg("irrelevant pattern")
+        .arg("-1")
         .succeeds()
         .stdout_is("CONTRIBUTING.md\nREADME.md\nREADMECAREFULLY.md\nsome_other_file\n");
 
@@ -1240,6 +1248,7 @@ fn test_ls_ignore_hide() {
         .ucmd()
         .arg("--ignore")
         .arg("README*.md")
+        .arg("-1")
         .succeeds()
         .stdout_is("CONTRIBUTING.md\nsome_other_file\n");
 
@@ -1247,6 +1256,7 @@ fn test_ls_ignore_hide() {
         .ucmd()
         .arg("--hide")
         .arg("README*.md")
+        .arg("-1")
         .succeeds()
         .stdout_is("CONTRIBUTING.md\nsome_other_file\n");
 
@@ -1254,6 +1264,7 @@ fn test_ls_ignore_hide() {
         .ucmd()
         .arg("--ignore")
         .arg("*.md")
+        .arg("-1")
         .succeeds()
         .stdout_is("some_other_file\n");
 
@@ -1262,6 +1273,7 @@ fn test_ls_ignore_hide() {
         .arg("-a")
         .arg("--ignore")
         .arg("*.md")
+        .arg("-1")
         .succeeds()
         .stdout_is(".\n..\nsome_other_file\n");
 
@@ -1270,6 +1282,7 @@ fn test_ls_ignore_hide() {
         .arg("-a")
         .arg("--hide")
         .arg("*.md")
+        .arg("-1")
         .succeeds()
         .stdout_is(".\n..\nCONTRIBUTING.md\nREADME.md\nREADMECAREFULLY.md\nsome_other_file\n");
 
@@ -1278,6 +1291,7 @@ fn test_ls_ignore_hide() {
         .arg("-A")
         .arg("--ignore")
         .arg("*.md")
+        .arg("-1")
         .succeeds()
         .stdout_is("some_other_file\n");
 
@@ -1286,6 +1300,7 @@ fn test_ls_ignore_hide() {
         .arg("-A")
         .arg("--hide")
         .arg("*.md")
+        .arg("-1")
         .succeeds()
         .stdout_is("CONTRIBUTING.md\nREADME.md\nREADMECAREFULLY.md\nsome_other_file\n");
 
@@ -1296,6 +1311,7 @@ fn test_ls_ignore_hide() {
         .arg("README*")
         .arg("--ignore")
         .arg("CONTRIBUTING*")
+        .arg("-1")
         .succeeds()
         .stdout_is("some_other_file\n");
 
@@ -1304,6 +1320,7 @@ fn test_ls_ignore_hide() {
         .ucmd()
         .arg("--ignore")
         .arg("READ[ME")
+        .arg("-1")
         .succeeds()
         .stderr_contains(&"Invalid pattern");
 
@@ -1311,6 +1328,7 @@ fn test_ls_ignore_hide() {
         .ucmd()
         .arg("--ignore")
         .arg("READ[ME")
+        .arg("-1")
         .succeeds()
         .stderr_contains(&"Invalid pattern");
 }


### PR DESCRIPTION
Implements `--ignore` and `--hide`, which both hide files matching a shell paths, except that `--hide` does not work when `-A` or `-a` is used. The options can also be used multiple times to specifiy multiple patterns. I've also refactored the `--ignore-backups` options  to be essentially a shorthand for `--ignore='*~' --ignore='.*~'`.

GNU does not show any errors or warnings for invalid patterns, but I thought it might be nice to at least show a warning.