### PR TITLE
uucore: Start testing uucore

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,4 +11,4 @@ task:
     - cargo build
   test_script:
     - . $HOME/.cargo/env
-    - cargo test
+    - cargo test -p uucore -p coreutils

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -150,7 +150,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --features "feat_os_unix"
+        args: --features "feat_os_unix" -p uucore -p coreutils
       env:
         RUSTFLAGS: '-Awarnings'
 
@@ -536,6 +536,17 @@ jobs:
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo "-puu_${u}"; done;)"
         echo set-output name=UTILITY_LIST::${UTILITY_LIST}
         echo ::set-output name=CARGO_UTILITY_LIST_OPTIONS::${CARGO_UTILITY_LIST_OPTIONS}
+    - name: Test uucore
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast -p uucore
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTC_WRAPPER: ''
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+        RUSTDOCFLAGS: '-Cpanic=abort'
+        # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Test
       uses: actions-rs/cargo@v1
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
 
 script:
   - cargo build $CARGO_ARGS --features "$FEATURES"
-  - if [ ! $REDOX ]; then cargo test $CARGO_ARGS --features "$FEATURES" --no-fail-fast; fi
+  - if [ ! $REDOX ]; then cargo test $CARGO_ARGS -p uucore -p coreutils --features "$FEATURES" --no-fail-fast; fi
   - if [ -n "$TEST_INSTALL" ]; then mkdir installdir_test; DESTDIR=installdir_test make install; [ `ls installdir_test/usr/local/bin | wc -l` -gt 0 ]; fi
 
 addons:

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ If you would prefer to test a select few utilities:
 $ cargo test --features "chmod mv tail" --no-default-features
 ```
 
+If you also want to test the core utilities:
+```bash
+$ cargo test  -p uucore -p coreutils
+```
+
 To debug:
 ```bash
 $ gdb --args target/debug/coreutils ls


### PR DESCRIPTION
Before this change we never ran tests on uucore itself
meaning that is was not possible to test
functions of the shared core, only their usage
in the different binaries

This change adds running uucore to our ci, which will increase coverage for the few doctests that exist

and is extracted from #1988 where first tests for uucore will be introduced
