### PR TITLE
ls: add short option for ignore

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -704,6 +704,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         )
         .arg(
             Arg::with_name(options::IGNORE)
+                .short("I")
                 .long(options::IGNORE)
                 .takes_value(true)
                 .multiple(true)


### PR DESCRIPTION
Small correction to my previous PR (https://github.com/uutils/coreutils/pull/2026), where I missed the short option `-I` for `--ignore`.