### PR TITLE
stdbuf: move from getopts to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 name = "uu_stdbuf"
 version = "0.0.6"
 dependencies = [
- "getopts",
+ "clap",
  "tempfile",
  "uu_stdbuf_libstdbuf",
  "uucore",

--- a/src/uu/stdbuf/Cargo.toml
+++ b/src/uu/stdbuf/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/stdbuf.rs"
 
 [dependencies]
-getopts = "0.2.18"
+clap = "2.33"
 tempfile = "3.1"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -1,13 +1,71 @@
+#[cfg(not(target_os = "windows"))]
 use crate::common::util::*;
 
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn test_stdbuf_unbuffered_stdout() {
-    if cfg!(target_os = "linux") {
-        // This is a basic smoke test
-        new_ucmd!()
-            .args(&["-o0", "head"])
-            .pipe_in("The quick brown fox jumps over the lazy dog.")
-            .run()
-            .stdout_is("The quick brown fox jumps over the lazy dog.");
-    }
+    // This is a basic smoke test
+    new_ucmd!()
+        .args(&["-o0", "head"])
+        .pipe_in("The quick brown fox jumps over the lazy dog.")
+        .run()
+        .stdout_is("The quick brown fox jumps over the lazy dog.");
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn test_stdbuf_line_buffered_stdout() {
+    new_ucmd!()
+        .args(&["-oL", "head"])
+        .pipe_in("The quick brown fox jumps over the lazy dog.")
+        .run()
+        .stdout_is("The quick brown fox jumps over the lazy dog.");
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn test_stdbuf_no_buffer_option_fails() {
+    new_ucmd!()
+        .args(&["head"])
+        .pipe_in("The quick brown fox jumps over the lazy dog.")
+        .fails()
+        .stderr_is(
+            "error: The following required arguments were not provided:\n    \
+            --error <MODE>\n    \
+            --input <MODE>\n    \
+            --output <MODE>\n\n\
+            USAGE:\n    \
+            stdbuf OPTION... COMMAND\n\n\
+            For more information try --help",
+        );
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn test_stdbuf_trailing_var_arg() {
+    new_ucmd!()
+        .args(&["-i", "1024", "tail", "-1"])
+        .pipe_in("The quick brown fox\njumps over the lazy dog.")
+        .run()
+        .stdout_is("jumps over the lazy dog.");
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn test_stdbuf_line_buffering_stdin_fails() {
+    new_ucmd!()
+        .args(&["-i", "L", "head"])
+        .pipe_in("The quick brown fox jumps over the lazy dog.")
+        .fails()
+        .stderr_is("stdbuf: error: line buffering stdin is meaningless\nTry 'stdbuf --help' for more information.");
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn test_stdbuf_invalid_mode_fails() {
+    new_ucmd!()
+        .args(&["-i", "1024R", "head"])
+        .pipe_in("The quick brown fox jumps over the lazy dog.")
+        .fails()
+        .stderr_is("stdbuf: error: invalid mode 1024R\nTry 'stdbuf --help' for more information.");
 }


### PR DESCRIPTION
I'm unsure about how closely the behavior of the GNU original should be mimicked when checking options:
* is it okay to just use claps default message in case no MODE option is set?
* when attempting line buffering stdin, stdbuf prints `Try 'stdbuf --help' for more information.` but not when an invalid mode is set. The current uutils implementations prints it in any case. Should this behavior be kept or should it behave like the GNU implementation?

And lastly, should I add integration tests or should this be done in a seperate issue?

closes #1930 