### PR TITLE
Some more test refactors for #1982

### DIFF
--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -1,106 +1,108 @@
 use crate::common::util::*;
 
 #[test]
-fn test_current_directory() {
+fn test_realpath_current_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let actual = ucmd.arg(".").run().stdout;
     let expect = at.root_dir_resolved() + "\n";
-    println!("actual: {:?}", actual);
-    println!("expect: {:?}", expect);
-    assert_eq!(actual, expect);
+    ucmd.arg(".").succeeds().stdout_is(expect);
 }
 
 #[test]
-fn test_long_redirection_to_current_dir() {
+fn test_realpath_long_redirection_to_current_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     // Create a 256-character path to current directory
     let dir = path_concat!(".", ..128);
-    let actual = ucmd.arg(dir).run().stdout;
     let expect = at.root_dir_resolved() + "\n";
-    println!("actual: {:?}", actual);
-    println!("expect: {:?}", expect);
-    assert_eq!(actual, expect);
+    ucmd.arg(dir).succeeds().stdout_is(expect);
 }
 
 #[test]
-fn test_long_redirection_to_root() {
+fn test_realpath_long_redirection_to_root() {
     // Create a 255-character path to root
     let dir = path_concat!("..", ..85);
-    let actual = new_ucmd!().arg(dir).run().stdout;
     let expect = get_root_path().to_owned() + "\n";
-    println!("actual: {:?}", actual);
-    println!("expect: {:?}", expect);
-    assert_eq!(actual, expect);
+    new_ucmd!().arg(dir).succeeds().stdout_is(expect);
 }
 
 #[test]
-fn test_file_and_links() {
+fn test_realpath_file_and_links() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     at.touch("foo");
     at.symlink_file("foo", "bar");
 
-    let actual = scene.ucmd().arg("foo").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("foo\n"));
-
-    let actual = scene.ucmd().arg("bar").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("foo\n"));
+    scene.ucmd().arg("foo").succeeds().stdout_contains("foo\n");
+    scene.ucmd().arg("bar").succeeds().stdout_contains("foo\n");
 }
 
 #[test]
-fn test_file_and_links_zero() {
+fn test_realpath_file_and_links_zero() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     at.touch("foo");
     at.symlink_file("foo", "bar");
 
-    let actual = scene.ucmd().arg("foo").arg("-z").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("foo"));
-    assert!(!actual.contains("\n"));
+    scene
+        .ucmd()
+        .arg("foo")
+        .arg("-z")
+        .succeeds()
+        .stdout_contains("foo\u{0}");
 
-    let actual = scene.ucmd().arg("bar").arg("-z").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("foo"));
-    assert!(!actual.contains("\n"));
+    scene
+        .ucmd()
+        .arg("bar")
+        .arg("-z")
+        .succeeds()
+        .stdout_contains("foo\u{0}");
 }
 
 #[test]
-fn test_file_and_links_strip() {
+fn test_realpath_file_and_links_strip() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     at.touch("foo");
     at.symlink_file("foo", "bar");
 
-    let actual = scene.ucmd().arg("foo").arg("-s").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("foo\n"));
+    scene
+        .ucmd()
+        .arg("foo")
+        .arg("-s")
+        .succeeds()
+        .stdout_contains("foo\n");
 
-    let actual = scene.ucmd().arg("bar").arg("-s").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("bar\n"));
+    scene
+        .ucmd()
+        .arg("bar")
+        .arg("-s")
+        .succeeds()
+        .stdout_contains("bar\n");
 }
 
 #[test]
-fn test_file_and_links_strip_zero() {
+fn test_realpath_file_and_links_strip_zero() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     at.touch("foo");
     at.symlink_file("foo", "bar");
 
-    let actual = scene.ucmd().arg("foo").arg("-s").arg("-z").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("foo"));
-    assert!(!actual.contains("\n"));
+    scene
+        .ucmd()
+        .arg("foo")
+        .arg("-s")
+        .arg("-z")
+        .succeeds()
+        .stdout_contains("foo\u{0}");
 
-    let actual = scene.ucmd().arg("bar").arg("-s").arg("-z").run().stdout;
-    println!("actual: {:?}", actual);
-    assert!(actual.contains("bar"));
-    assert!(!actual.contains("\n"));
+    scene
+        .ucmd()
+        .arg("bar")
+        .arg("-s")
+        .arg("-z")
+        .succeeds()
+        .stdout_contains("bar\u{0}");
 }

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -15,14 +15,12 @@ fn test_rm_one_file() {
 #[test]
 fn test_rm_failed() {
     let (_at, mut ucmd) = at_and_ucmd!();
-    let file = "test_rm_one_file";
+    let file = "test_rm_one_file"; // Doesn't exist
 
-    let result = ucmd.arg(file).fails(); // Doesn't exist
-
-    assert!(result.stderr.contains(&format!(
+    ucmd.arg(file).fails().stderr_contains(&format!(
         "cannot remove '{}': No such file or directory",
         file
-    )));
+    ));
 }
 
 #[test]
@@ -145,10 +143,10 @@ fn test_rm_non_empty_directory() {
     at.mkdir(dir);
     at.touch(file_a);
 
-    let result = ucmd.arg("-d").arg(dir).fails();
-    assert!(result
-        .stderr
-        .contains(&format!("cannot remove '{}': Directory not empty", dir)));
+    ucmd.arg("-d")
+        .arg(dir)
+        .fails()
+        .stderr_contains(&format!("cannot remove '{}': Directory not empty", dir));
     assert!(at.file_exists(file_a));
     assert!(at.dir_exists(dir));
 }
@@ -178,11 +176,9 @@ fn test_rm_directory_without_flag() {
 
     at.mkdir(dir);
 
-    let result = ucmd.arg(dir).fails();
-    println!("{}", result.stderr);
-    assert!(result
-        .stderr
-        .contains(&format!("cannot remove '{}': Is a directory", dir)));
+    ucmd.arg(dir)
+        .fails()
+        .stderr_contains(&format!("cannot remove '{}': Is a directory", dir));
 }
 
 #[test]
@@ -229,10 +225,11 @@ fn test_rm_symlink_dir() {
     at.mkdir(dir);
     at.symlink_dir(dir, link);
 
-    let result = scene.ucmd().arg(link).fails();
-    assert!(result
-        .stderr
-        .contains(&format!("cannot remove '{}': Is a directory", link)));
+    scene
+        .ucmd()
+        .arg(link)
+        .fails()
+        .stderr_contains(&format!("cannot remove '{}': Is a directory", link));
 
     assert!(at.dir_exists(link));
 

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -68,15 +68,14 @@ fn test_tee_no_more_writeable_1() {
         .collect::<String>();
     let file_out = "tee_file_out";
 
-    let result = ucmd
-        .arg("/dev/full")
+    ucmd.arg("/dev/full")
         .arg(file_out)
         .pipe_in(&content[..])
-        .fails();
+        .fails()
+        .stdout_contains(&content)
+        .stderr_contains(&"No space left on device");
 
     assert_eq!(at.read(file_out), content);
-    assert!(result.stdout.contains(&content));
-    assert!(result.stderr.contains("No space left on device"));
 }
 
 #[test]


### PR DESCRIPTION
part of the ongoing effort in #1982
The tests are still the same but don't access the fields of CmdResult

* I omitted extra `println` since it's [planned](https://github.com/uutils/coreutils/issues/1982#issuecomment-811808890) to do these automatically.
* I renamed some tests to be coherent with the naming scheme.
* I changed `run` to `succeeds` since that's [recommended](https://github.com/uutils/coreutils/blob/9bb588d69ad8a230cfcbd267e8a276ca88e442f2/tests/common/util.rs#L741)