### PR TITLE
Fold backspace and carriage return

### DIFF
--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -232,13 +232,9 @@ fn fold_file<T: Read>(mut file: BufReader<T>, spaces: bool, width: usize) {
                     last_space = if spaces { Some(char_count) } else { None };
                 }
                 '\x08' => {
-                    // FIXME: does not match GNU's handling of backspace
                     if col_count > 0 {
                         col_count -= 1;
-                        char_count -= 1;
-                        output.truncate(char_count);
                     }
-                    continue;
                 }
                 '\r' => {
                     // FIXME: does not match GNU's handling of carriage return
@@ -258,7 +254,7 @@ fn fold_file<T: Read>(mut file: BufReader<T>, spaces: bool, width: usize) {
             char_count += 1;
         }
 
-        if col_count > 0 {
+        if char_count > 0 {
             print!("{}", output);
             output.truncate(0);
         }

--- a/tests/by-util/test_fold.rs
+++ b/tests/by-util/test_fold.rs
@@ -285,6 +285,34 @@ fn test_backspace_is_not_word_boundary() {
         .stdout_is("foobar\x086789a\nbcdef");
 }
 
+#[test]
+fn test_carriage_return_should_be_preserved() {
+    new_ucmd!().pipe_in("\r").succeeds().stdout_is("\r");
+}
+
+#[test]
+fn test_carriage_return_overwrriten_char_should_be_preserved() {
+    new_ucmd!().pipe_in("x\ry").succeeds().stdout_is("x\ry");
+}
+
+#[test]
+fn test_carriage_return_should_reset_column_count() {
+    new_ucmd!()
+        .arg("-w6")
+        .pipe_in("12345\r123456789abcdef")
+        .succeeds()
+        .stdout_is("12345\r123456\n789abc\ndef");
+}
+
+#[test]
+fn test_carriage_return_is_not_word_boundary() {
+    new_ucmd!()
+        .args(&["-w6", "-s"])
+        .pipe_in("fizz\rbuzz\rfizzbuzz")
+        .succeeds()
+        .stdout_is("fizz\rbuzz\rfizzbu\nzz");
+}
+
 //
 // bytewise tests
 
@@ -469,4 +497,40 @@ fn test_bytewise_backspace_is_not_word_boundary() {
         .pipe_in("foobar\x0889abcdef")
         .succeeds()
         .stdout_is("foobar\x0889a\nbcdef");
+}
+
+#[test]
+fn test_bytewise_carriage_return_should_be_preserved() {
+    new_ucmd!()
+        .arg("-b")
+        .pipe_in("\r")
+        .succeeds()
+        .stdout_is("\r");
+}
+
+#[test]
+fn test_bytewise_carriage_return_overwrriten_char_should_be_preserved() {
+    new_ucmd!()
+        .arg("-b")
+        .pipe_in("x\ry")
+        .succeeds()
+        .stdout_is("x\ry");
+}
+
+#[test]
+fn test_bytewise_carriage_return_should_not_reset_column_count() {
+    new_ucmd!()
+        .args(&["-w6", "-b"])
+        .pipe_in("12345\r123456789abcdef")
+        .succeeds()
+        .stdout_is("12345\r\n123456\n789abc\ndef");
+}
+
+#[test]
+fn test_bytewise_carriage_return_is_not_word_boundary() {
+    new_ucmd!()
+        .args(&["-w6", "-s", "-b"])
+        .pipe_in("fizz\rbuzz\rfizzbuzz")
+        .succeeds()
+        .stdout_is("fizz\rb\nuzz\rfi\nzzbuzz");
 }

--- a/tests/by-util/test_fold.rs
+++ b/tests/by-util/test_fold.rs
@@ -248,6 +248,43 @@ fn test_fold_at_word_boundary_only_whitespace_preserve_final_newline() {
         .stdout_is("  \n  \n");
 }
 
+#[test]
+fn test_backspace_should_be_preserved() {
+    new_ucmd!().pipe_in("\x08").succeeds().stdout_is("\x08");
+}
+
+#[test]
+fn test_backspaced_char_should_be_preserved() {
+    new_ucmd!().pipe_in("x\x08").succeeds().stdout_is("x\x08");
+}
+
+#[test]
+fn test_backspace_should_decrease_column_count() {
+    new_ucmd!()
+        .arg("-w2")
+        .pipe_in("1\x08345")
+        .succeeds()
+        .stdout_is("1\x0834\n5");
+}
+
+#[test]
+fn test_backspace_should_not_decrease_column_count_past_zero() {
+    new_ucmd!()
+        .arg("-w2")
+        .pipe_in("1\x08\x083456")
+        .succeeds()
+        .stdout_is("1\x08\x0834\n56");
+}
+
+#[test]
+fn test_backspace_is_not_word_boundary() {
+    new_ucmd!()
+        .args(&["-w10", "-s"])
+        .pipe_in("foobar\x086789abcdef")
+        .succeeds()
+        .stdout_is("foobar\x086789a\nbcdef");
+}
+
 //
 // bytewise tests
 
@@ -396,4 +433,40 @@ fn test_bytewise_fold_at_word_boundary_only_whitespace_preserve_final_newline() 
         .pipe_in("    \n")
         .succeeds()
         .stdout_is("  \n  \n");
+}
+
+#[test]
+fn test_bytewise_backspace_should_be_preserved() {
+    new_ucmd!()
+        .arg("-b")
+        .pipe_in("\x08")
+        .succeeds()
+        .stdout_is("\x08");
+}
+
+#[test]
+fn test_bytewise_backspaced_char_should_be_preserved() {
+    new_ucmd!()
+        .arg("-b")
+        .pipe_in("x\x08")
+        .succeeds()
+        .stdout_is("x\x08");
+}
+
+#[test]
+fn test_bytewise_backspace_should_not_decrease_column_count() {
+    new_ucmd!()
+        .args(&["-w2", "-b"])
+        .pipe_in("1\x08345")
+        .succeeds()
+        .stdout_is("1\x08\n34\n5");
+}
+
+#[test]
+fn test_bytewise_backspace_is_not_word_boundary() {
+    new_ucmd!()
+        .args(&["-w10", "-s", "-b"])
+        .pipe_in("foobar\x0889abcdef")
+        .succeeds()
+        .stdout_is("foobar\x0889a\nbcdef");
 }


### PR DESCRIPTION
GNU `fold` does not remove characters from the input stream:

```
$ echo -ne 'x\b' | fold | xxd
00000000: 7808                                     x.
$ echo -ne 'x\ry' | fold | xxd
00000000: 780d 79                                  x.y
```

Backspaces and carriage returns are preserved, but simply change the column counters for folding. Here is an example where a backspace decreases the column count by 1

```
$ echo -ne 'foobar\b6789abcdef' | fold -w10 -s
fooba6789a
bcdef
```
so the input for folding purposes is `fooba6789abcdef` and `fold` inserts a newline after the character `a` in the tenth column; the `r\b` pair still appear in the output:

```
$ echo -ne 'foobar\b6789abcdef' | fold -w10 -s | xxd
00000000: 666f 6f62 6172 0836 3738 3961 0a62 6364  foobar.6789a.bcd
00000010: 6566                                     ef
```

By changing the `\r` to a space we can also see that `fold` does not consider backspace to be a word boundary separator:

```
$ echo -ne 'foobar 6789abcdef' | fold -w10 -s
foobar
6789abcdef
```