### PR TITLE
Replace outdated time 0.1 dependancy with latest version of chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ dependencies = [
 name = "uu_du"
 version = "0.0.6"
 dependencies = [
- "time",
+ "chrono",
  "uucore",
  "uucore_procs",
  "winapi 0.3.9",

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/du.rs"
 
 [dependencies]
-time = "0.1.40"
+chrono = "0.4"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 winapi = { version="0.3", features=[] }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -11,7 +11,7 @@
 extern crate uucore;
 
 use chrono::prelude::DateTime;
-use chrono::{Local};
+use chrono::Local;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
@@ -24,7 +24,7 @@ use std::os::windows::fs::MetadataExt;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 use std::path::PathBuf;
-use std::time::{UNIX_EPOCH, Duration};
+use std::time::{Duration, UNIX_EPOCH};
 #[cfg(windows)]
 use winapi::shared::minwindef::{DWORD, LPVOID};
 #[cfg(windows)]

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -10,6 +10,8 @@
 #[macro_use]
 extern crate uucore;
 
+use chrono::prelude::DateTime;
+use chrono::{Local};
 use std::collections::HashSet;
 use std::env;
 use std::fs;
@@ -22,7 +24,7 @@ use std::os::windows::fs::MetadataExt;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 use std::path::PathBuf;
-use time::Timespec;
+use std::time::{UNIX_EPOCH, Duration};
 #[cfg(windows)]
 use winapi::shared::minwindef::{DWORD, LPVOID};
 #[cfg(windows)]
@@ -118,7 +120,7 @@ impl Stat {
 // https://doc.rust-lang.org/std/os/windows/fs/trait.MetadataExt.html#tymethod.creation_time
 // "The returned 64-bit value [...] which represents the number of 100-nanosecond intervals since January 1, 1601 (UTC)."
 fn windows_time_to_unix_time(win_time: u64) -> u64 {
-    win_time / 10_000 - 11_644_473_600_000
+    win_time / 10_000_000 - 11_644_473_600
 }
 
 #[cfg(windows)]
@@ -555,8 +557,8 @@ Try '{} --help' for more information.",
                     };
                     if matches.opt_present("time") {
                         let tm = {
-                            let (secs, nsecs) = {
-                                let time = match matches.opt_str("time") {
+                            let secs = {
+                                match matches.opt_str("time") {
                                     Some(s) => match &s[..] {
                                         "accessed" => stat.accessed,
                                         "created" => stat.created,
@@ -573,13 +575,12 @@ Try '{} --help' for more information.",
                                         }
                                     },
                                     None => stat.modified,
-                                };
-                                ((time / 1000) as i64, (time % 1000 * 1_000_000) as i32)
+                                }
                             };
-                            time::at(Timespec::new(secs, nsecs))
+                            DateTime::<Local>::from(UNIX_EPOCH + Duration::from_secs(secs))
                         };
                         if !summarize || index == len - 1 {
-                            let time_str = tm.strftime(time_format_str).unwrap();
+                            let time_str = tm.format(time_format_str).to_string();
                             print!(
                                 "{}\t{}\t{}{}",
                                 convert_size(size),

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -173,14 +173,12 @@ fn test_du_h_flag_empty_file() {
     assert_eq!(result.stdout, "0\tempty.txt\n");
 }
 
-// I don't have touch on windows so I can't run this test
-// if we port touch to windows then we can enable this test on windows
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "touch")]
 #[test]
 fn test_du_time() {
     let ts = TestScenario::new("du");
 
-    let touch = ts.cmd("touch").arg("-a").arg("-m").arg("-t").arg("201505150000").arg("date_test").run();
+    let touch = ts.ccmd("touch").arg("-a").arg("-m").arg("-t").arg("201505150000").arg("date_test").run();
     assert!(touch.success);
 
     let result = ts.ucmd().arg("--time").arg("date_test").run();

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -172,3 +172,23 @@ fn test_du_h_flag_empty_file() {
     assert_eq!(result.stderr, "");
     assert_eq!(result.stdout, "0\tempty.txt\n");
 }
+
+// I don't have touch on windows so I can't run this test
+// if we port touch to windows then we can enable this test on windows
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn test_du_time() {
+    let ts = TestScenario::new("du");
+
+    let touch = ts.cmd("touch").arg("-a").arg("-m").arg("-t").arg("201505150000").arg("date_test").run();
+    assert!(touch.success);
+
+    let result = ts.ucmd().arg("--time").arg("date_test").run();
+
+    // cleanup by removing test file
+    ts.cmd("rm").arg("date_test").run();
+
+    assert!(result.success);
+    assert_eq!(result.stderr, "");
+    assert_eq!(result.stdout, "0\t2015-05-15 00:00\tdate_test\n");
+}


### PR DESCRIPTION
I also noticed that times are being miscalculated on linux, so I fixed that.

Fixes #2042 and fixes #2043.