### PR TITLE
timeout: Moved argument parsing to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,7 @@ dependencies = [
 name = "uu_timeout"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "getopts",
  "libc",
  "uucore",

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -45,7 +45,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .short("b")
                 .help(
                     "count using bytes rather than columns (meaning control characters \
-             such as newline are not treated specially)",
+                     such as newline are not treated specially)",
                 )
                 .takes_value(false),
         )

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -80,7 +80,8 @@ fn print_version() {
 fn print_usage(opts: &Options) {
     let brief = "Run COMMAND, with modified buffering operations for its standard streams\n \
                  Mandatory arguments to long options are mandatory for short options too.";
-    let explanation = "If MODE is 'L' the corresponding stream will be line buffered.\n \
+    let explanation =
+        "If MODE is 'L' the corresponding stream will be line buffered.\n \
          This option is invalid with standard input.\n\n \
          If MODE is '0' the corresponding stream will be unbuffered.\n\n \
          Otherwise MODE is a number which may be followed by one of the following:\n\n \

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -15,10 +15,12 @@ edition = "2018"
 path = "src/timeout.rs"
 
 [dependencies]
+clap = "2.33"
 getopts = "0.2.18"
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["parse_time", "process", "signals"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
+
 
 [[bin]]
 name = "timeout"

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -79,11 +79,11 @@ impl Config {
         let foreground = options.is_present(options::FOREGROUND);
 
         let command: String = options.value_of(options::COMMAND).unwrap().to_string();
-        let command_args: Vec<String> = options
-            .values_of(options::ARGS)
-            .unwrap()
-            .map(|x| x.to_owned())
-            .collect();
+
+        let command_args: Vec<String> = match options.values_of(options::ARGS) {
+            Some(values) => values.map(|x| x.to_owned()).collect(),
+            None => vec![],
+        };
 
         Config {
             foreground,
@@ -137,7 +137,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .required(true)
         )
         .arg(
-            Arg::with_name(options::ARGS).required(true).multiple(true)
+            Arg::with_name(options::ARGS).multiple(true)
         )
         .setting(AppSettings::TrailingVarArg);
 


### PR DESCRIPTION
Changed from optparse to clap.

None of the logic within timeout has been changed, which could use some
refactoring,

Closes Issue: https://github.com/uutils/coreutils/issues/1934