### PR TITLE
cat: Put splice code in separate file, handle more failures

### DIFF
--- a/src/uu/cat/src/splice.rs
+++ b/src/uu/cat/src/splice.rs
@@ -1,0 +1,91 @@
+use super::{CatResult, InputHandle};
+
+use nix::fcntl::{splice, SpliceFFlags};
+use nix::unistd::{self, pipe};
+use std::io::Read;
+use std::os::unix::io::RawFd;
+
+const BUF_SIZE: usize = 1024 * 16;
+
+/// This function is called from `write_fast()` on Linux and Android. The
+/// function `splice()` is used to move data between two file descriptors
+/// without copying between kernel- and userspace. This results in a large
+/// speedup.
+///
+/// The `bool` in the result value indicates if we need to fall back to normal
+/// copying or not. False means we don't have to.
+#[inline]
+pub(super) fn write_fast_using_splice<R: Read>(
+    handle: &mut InputHandle<R>,
+    write_fd: RawFd,
+) -> CatResult<bool> {
+    let (pipe_rd, pipe_wr) = match pipe() {
+        Ok(r) => r,
+        Err(_) => {
+            // It is very rare that creating a pipe fails, but it can happen.
+            return Ok(true);
+        }
+    };
+
+    loop {
+        match splice(
+            handle.file_descriptor,
+            None,
+            pipe_wr,
+            None,
+            BUF_SIZE,
+            SpliceFFlags::empty(),
+        ) {
+            Ok(n) => {
+                if n == 0 {
+                    return Ok(false);
+                }
+                if splice_exact(pipe_rd, write_fd, n).is_err() {
+                    // If the first splice manages to copy to the intermediate
+                    // pipe, but the second splice to stdout fails for some reason
+                    // we can recover by copying the data that we have from the
+                    // intermediate pipe to stdout using normal read/write. Then
+                    // we tell the caller to fall back.
+                    copy_exact(pipe_rd, write_fd, n)?;
+                    return Ok(true);
+                }
+            }
+            Err(_) => {
+                return Ok(true);
+            }
+        }
+    }
+}
+
+/// Splice wrapper which handles short writes.
+#[inline]
+fn splice_exact(read_fd: RawFd, write_fd: RawFd, num_bytes: usize) -> nix::Result<()> {
+    let mut left = num_bytes;
+    loop {
+        let written = splice(read_fd, None, write_fd, None, left, SpliceFFlags::empty())?;
+        left -= written;
+        if left == 0 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Caller must ensure that `num_bytes <= BUF_SIZE`, otherwise this function
+/// will panic. The way we use this function in `write_fast_using_splice`
+/// above is safe because `splice` is set to write at most `BUF_SIZE` to the
+/// pipe.
+#[inline]
+fn copy_exact(read_fd: RawFd, write_fd: RawFd, num_bytes: usize) -> nix::Result<()> {
+    let mut left = num_bytes;
+    let mut buf = [0; BUF_SIZE];
+    loop {
+        let read = unistd::read(read_fd, &mut buf[..left])?;
+        let written = unistd::write(write_fd, &mut buf[..read])?;
+        left -= written;
+        if left == 0 {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -689,8 +689,11 @@ pub struct UCommand {
     comm_string: String,
     tmpd: Option<Rc<TempDir>>,
     has_run: bool,
-    stdin: Option<Vec<u8>>,
     ignore_stdin_write_error: bool,
+    stdin: Option<Stdio>,
+    stdout: Option<Stdio>,
+    stderr: Option<Stdio>,
+    bytes_into_stdin: Option<Vec<u8>>,
 }
 
 impl UCommand {
@@ -719,8 +722,11 @@ impl UCommand {
                 cmd
             },
             comm_string: String::from(arg.as_ref().to_str().unwrap()),
-            stdin: None,
             ignore_stdin_write_error: false,
+            bytes_into_stdin: None,
+            stdin: None,
+            stdout: None,
+            stderr: None,
         }
     }
 
@@ -729,6 +735,21 @@ impl UCommand {
         let mut ucmd: UCommand = UCommand::new(arg.as_ref(), tmpd_path_buf, env_clear);
         ucmd.tmpd = Some(tmpd);
         ucmd
+    }
+
+    pub fn set_stdin<T: Into<Stdio>>(&mut self, stdin: T) -> &mut UCommand {
+        self.stdin = Some(stdin.into());
+        self
+    }
+
+    pub fn set_stdout<T: Into<Stdio>>(&mut self, stdout: T) -> &mut UCommand {
+        self.stdout = Some(stdout.into());
+        self
+    }
+
+    pub fn set_stderr<T: Into<Stdio>>(&mut self, stderr: T) -> &mut UCommand {
+        self.stderr = Some(stderr.into());
+        self
     }
 
     /// Add a parameter to the invocation. Path arguments are treated relative
@@ -760,10 +781,10 @@ impl UCommand {
 
     /// provides stdinput to feed in to the command when spawned
     pub fn pipe_in<T: Into<Vec<u8>>>(&mut self, input: T) -> &mut UCommand {
-        if self.stdin.is_some() {
+        if self.bytes_into_stdin.is_some() {
             panic!("{}", MULTIPLE_STDIN_MEANINGLESS);
         }
-        self.stdin = Some(input.into());
+        self.bytes_into_stdin = Some(input.into());
         self
     }
 
@@ -777,7 +798,7 @@ impl UCommand {
     /// This is typically useful to test non-standard workflows
     /// like feeding something to a command that does not read it
     pub fn ignore_stdin_write_error(&mut self) -> &mut UCommand {
-        if self.stdin.is_none() {
+        if self.bytes_into_stdin.is_none() {
             panic!("{}", NO_STDIN_MEANINGLESS);
         }
         self.ignore_stdin_write_error = true;
@@ -806,13 +827,13 @@ impl UCommand {
         log_info("run", &self.comm_string);
         let mut child = self
             .raw
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stdin(self.stdin.take().unwrap_or_else(|| Stdio::piped()))
+            .stdout(self.stdout.take().unwrap_or_else(|| Stdio::piped()))
+            .stderr(self.stderr.take().unwrap_or_else(|| Stdio::piped()))
             .spawn()
             .unwrap();
 
-        if let Some(ref input) = self.stdin {
+        if let Some(ref input) = self.bytes_into_stdin {
             let write_result = child
                 .stdin
                 .take()


### PR DESCRIPTION
Currently, if the second call to splice fails, or if pipe creation fails, cat will not attempt to fall back to normal read/write. This was an oversight on my part. This PR fixes that.