### PR TITLE
whoami/id: refactor tests for #1982

### DIFF
--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -1,11 +1,32 @@
 use crate::common::util::*;
 
+// Apparently some CI environments have configuration issues, e.g. with 'whoami' and 'id'.
+// If we are running inside the CI and "needle" is in "stderr" skipping this test is
+// considered okay. If we are not inside the CI this calls assert!(result.success).
+//
+// From the Logs: "Build (ubuntu-18.04, x86_64-unknown-linux-gnu, feat_os_unix, use-cross)"
+// stderr: "whoami: cannot find name for user ID 1001"
+// Maybe: "adduser --uid 1001 username" can put things right?
+// stderr = id: error: Could not find uid 1001: No such id: 1001
+fn skipping_test_is_okay(result: &CmdResult, needle: &str) -> bool {
+    if !result.succeeded() {
+        println!("result.stdout = {}", result.stdout_str());
+        println!("result.stderr = {}", result.stderr_str());
+        if is_ci() && result.stderr_str().contains(needle) {
+            println!("test skipped:");
+            return true;
+        } else {
+            result.success();
+        }
+    }
+    false
+}
+
 fn return_whoami_username() -> String {
     let scene = TestScenario::new("whoami");
     let result = scene.cmd("whoami").run();
-    if is_ci() && result.stderr.contains("cannot find name for user ID") {
-        // In the CI, some server are failing to return whoami.
-        // As seems to be a configuration issue, ignoring it
+    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
+        println!("test skipped:");
         return String::from("");
     }
 
@@ -14,40 +35,41 @@ fn return_whoami_username() -> String {
 
 #[test]
 fn test_id() {
-    let result = new_ucmd!().arg("-u").run();
-    if result.stderr.contains("cannot find name for user ID") {
-        // In the CI, some server are failing to return whoami.
-        // As seems to be a configuration issue, ignoring it
+    let scene = TestScenario::new(util_name!());
+
+    let result = scene.ucmd().arg("-u").succeeds();
+    let uid = result.stdout_str().trim();
+
+    let result = scene.ucmd().run();
+    if skipping_test_is_okay(&result, "Could not find uid") {
         return;
     }
 
-    let uid = result.success().stdout_str().trim();
-    let result = new_ucmd!().run();
-    if is_ci() && result.stderr.contains("cannot find name for user ID") {
-        // In the CI, some server are failing to return whoami.
-        // As seems to be a configuration issue, ignoring it
-        return;
-    }
-
-    if !result.stderr_str().contains("Could not find uid") {
-        // Verify that the id found by --user/-u exists in the list
-        result.success().stdout_contains(&uid);
-    }
+    // Verify that the id found by --user/-u exists in the list
+    result.stdout_contains(uid);
 }
 
 #[test]
 fn test_id_from_name() {
     let username = return_whoami_username();
-    if username == "" {
-        // Sometimes, the CI is failing here
+    if username.is_empty() {
         return;
     }
 
-    let result = new_ucmd!().arg(&username).succeeds();
+    let scene = TestScenario::new(util_name!());
+    let result = scene.ucmd().arg(&username).run();
+    if skipping_test_is_okay(&result, "Could not find uid") {
+        return;
+    }
+
     let uid = result.stdout_str().trim();
 
-    new_ucmd!()
-        .succeeds()
+    let result = scene.ucmd().run();
+    if skipping_test_is_okay(&result, "Could not find uid") {
+        return;
+    }
+
+    result
         // Verify that the id found by --user/-u exists in the list
         .stdout_contains(uid)
         // Verify that the username found by whoami exists in the list
@@ -56,48 +78,42 @@ fn test_id_from_name() {
 
 #[test]
 fn test_id_name_from_id() {
-    let result = new_ucmd!().arg("-u").succeeds();
-    let uid = result.stdout_str().trim();
+    let result = new_ucmd!().arg("-nu").run();
 
-    let result = new_ucmd!().arg("-nu").arg(uid).run();
-    if is_ci() && result.stderr.contains("No such user/group") {
-        // In the CI, some server are failing to return whoami.
-        // As seems to be a configuration issue, ignoring it
+    let username_id = result.stdout_str().trim();
+
+    let username_whoami = return_whoami_username();
+    if username_whoami.is_empty() {
         return;
     }
-
-    let username_id = result.success().stdout_str().trim();
-
-    let scene = TestScenario::new("whoami");
-    let result = scene.cmd("whoami").succeeds();
-
-    let username_whoami = result.stdout_str().trim();
 
     assert_eq!(username_id, username_whoami);
 }
 
 #[test]
 fn test_id_group() {
-    let mut result = new_ucmd!().arg("-g").succeeds();
+    let scene = TestScenario::new(util_name!());
+
+    let mut result = scene.ucmd().arg("-g").succeeds();
     let s1 = result.stdout_str().trim();
     assert!(s1.parse::<f64>().is_ok());
 
-    result = new_ucmd!().arg("--group").succeeds();
+    result = scene.ucmd().arg("--group").succeeds();
     let s1 = result.stdout_str().trim();
     assert!(s1.parse::<f64>().is_ok());
 }
 
 #[test]
 fn test_id_groups() {
-    let result = new_ucmd!().arg("-G").succeeds();
-    assert!(result.success);
+    let scene = TestScenario::new(util_name!());
+
+    let result = scene.ucmd().arg("-G").succeeds();
     let groups = result.stdout_str().trim().split_whitespace();
     for s in groups {
         assert!(s.parse::<f64>().is_ok());
     }
 
-    let result = new_ucmd!().arg("--groups").succeeds();
-    assert!(result.success);
+    let result = scene.ucmd().arg("--groups").succeeds();
     let groups = result.stdout_str().trim().split_whitespace();
     for s in groups {
         assert!(s.parse::<f64>().is_ok());
@@ -106,11 +122,13 @@ fn test_id_groups() {
 
 #[test]
 fn test_id_user() {
-    let mut result = new_ucmd!().arg("-u").succeeds();
+    let scene = TestScenario::new(util_name!());
+
+    let result = scene.ucmd().arg("-u").succeeds();
     let s1 = result.stdout_str().trim();
     assert!(s1.parse::<f64>().is_ok());
 
-    result = new_ucmd!().arg("--user").succeeds();
+    let result = scene.ucmd().arg("--user").succeeds();
     let s1 = result.stdout_str().trim();
     assert!(s1.parse::<f64>().is_ok());
 }
@@ -118,28 +136,34 @@ fn test_id_user() {
 #[test]
 fn test_id_pretty_print() {
     let username = return_whoami_username();
-    if username == "" {
-        // Sometimes, the CI is failing here
+    if username.is_empty() {
         return;
     }
 
-    let result = new_ucmd!().arg("-p").run();
-    if result.stdout_str().trim() == "" {
-        // Sometimes, the CI is failing here with
-        // old rust versions on Linux
+    let scene = TestScenario::new(util_name!());
+    let result = scene.ucmd().arg("-p").run();
+    if result.stdout_str().trim().is_empty() {
+        // this fails only on: "MinRustV (ubuntu-latest, feat_os_unix)"
+        // `rustc 1.40.0 (73528e339 2019-12-16)`
+        // run: /home/runner/work/coreutils/coreutils/target/debug/coreutils id -p
+        // thread 'test_id::test_id_pretty_print' panicked at 'Command was expected to succeed.
+        // stdout =
+        // stderr = ', tests/common/util.rs:157:13
+        println!("test skipped:");
         return;
     }
+
     result.success().stdout_contains(username);
 }
 
 #[test]
 fn test_id_password_style() {
     let username = return_whoami_username();
-    if username == "" {
-        // Sometimes, the CI is failing here
+    if username.is_empty() {
         return;
     }
 
     let result = new_ucmd!().arg("-P").succeeds();
+
     assert!(result.stdout_str().starts_with(&username));
 }

--- a/tests/by-util/test_whoami.rs
+++ b/tests/by-util/test_whoami.rs
@@ -1,50 +1,63 @@
 use crate::common::util::*;
-use std::env;
+
+// Apparently some CI environments have configuration issues, e.g. with 'whoami' and 'id'.
+// If we are running inside the CI and "needle" is in "stderr" skipping this test is
+// considered okay. If we are not inside the CI this calls assert!(result.success).
+//
+// From the Logs: "Build (ubuntu-18.04, x86_64-unknown-linux-gnu, feat_os_unix, use-cross)"
+// stderr: "whoami: error: failed to get username"
+// Maybe: "adduser --uid 1001 username" can put things right?
+fn skipping_test_is_okay(result: &CmdResult, needle: &str) -> bool {
+    if !result.succeeded() {
+        println!("result.stdout = {}", result.stdout_str());
+        println!("result.stderr = {}", result.stderr_str());
+        if is_ci() && result.stderr_str().contains(needle) {
+            println!("test skipped:");
+            return true;
+        } else {
+            result.success();
+        }
+    }
+    false
+}
 
 #[test]
 fn test_normal() {
     let (_, mut ucmd) = at_and_ucmd!();
 
     let result = ucmd.run();
-    println!("result.stdout = {}", result.stdout);
-    println!("result.stderr = {}", result.stderr);
-    println!("env::var(CI).is_ok() = {}", env::var("CI").is_ok());
 
-    for (key, value) in env::vars() {
-        println!("{}: {}", key, value);
-    }
-    if is_ci() && result.stderr.contains("failed to get username") {
-        // In the CI, some server are failing to return whoami.
-        // As seems to be a configuration issue, ignoring it
+    // use std::env;
+    // println!("env::var(CI).is_ok() = {}", env::var("CI").is_ok());
+    // for (key, value) in env::vars() {
+    //     println!("{}: {}", key, value);
+    // }
+
+    if skipping_test_is_okay(&result, "failed to get username") {
         return;
     }
 
-    assert!(result.success);
-    assert!(!result.stdout.trim().is_empty());
+    result.no_stderr();
+    assert!(!result.stdout_str().trim().is_empty());
 }
 
 #[test]
 #[cfg(not(windows))]
 fn test_normal_compare_id() {
-    let (_, mut ucmd) = at_and_ucmd!();
+    let scene = TestScenario::new(util_name!());
 
-    let result = ucmd.run();
-
-    println!("result.stdout = {}", result.stdout);
-    println!("result.stderr = {}", result.stderr);
-    if is_ci() && result.stderr.contains("failed to get username") {
-        // In the CI, some server are failing to return whoami.
-        // As seems to be a configuration issue, ignoring it
+    let result_ucmd = scene.ucmd().run();
+    if skipping_test_is_okay(&result_ucmd, "failed to get username") {
         return;
     }
-    assert!(result.success);
-    let ts = TestScenario::new("id");
-    let id = ts.cmd("id").arg("-un").run();
 
-    if is_ci() && id.stderr.contains("cannot find name for user ID") {
-        // In the CI, some server are failing to return whoami.
-        // As seems to be a configuration issue, ignoring it
+    let result_cmd = scene.cmd("id").arg("-un").run();
+    if skipping_test_is_okay(&result_cmd, "cannot find name for user ID") {
         return;
     }
-    assert_eq!(result.stdout.trim(), id.stdout.trim());
+
+    assert_eq!(
+        result_ucmd.stdout_str().trim(),
+        result_cmd.stdout_str().trim()
+    );
 }


### PR DESCRIPTION
part of the ongoing effort in #1982
The tests are still the same but don't access the fields of CmdResult

* there were a lot of calls to `is_ci()` which I put in an extra function `skipping_test_is_okay()`
* cleaned up and updated exception handling for the `whoami`, `id` calls
* removed unnecessary calls to `println`
* removed unnecessary `String` conversions