### PR TITLE
Refactored tests for more utilities

### DIFF
--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -62,14 +62,16 @@ fn test_invalid_file() {
     let folder_name = "asdf";
 
     // First check when file doesn't exist
-    ts.ucmd().arg(folder_name)
+    ts.ucmd()
+        .arg(folder_name)
         .fails()
         .no_stdout()
         .stderr_contains("cksum: error: 'asdf' No such file or directory");
-    
+
     // Then check when the file is of an invalid type
     at.mkdir(folder_name);
-    ts.ucmd().arg(folder_name)
+    ts.ucmd()
+        .arg(folder_name)
         .fails()
         .no_stdout()
         .stderr_contains("cksum: error: 'asdf' Is a directory");

--- a/tests/by-util/test_hostid.rs
+++ b/tests/by-util/test_hostid.rs
@@ -4,10 +4,6 @@ use self::regex::Regex;
 
 #[test]
 fn test_normal() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.run();
-
-    assert!(result.success);
     let re = Regex::new(r"^[0-9a-f]{8}").unwrap();
-    assert!(re.is_match(&result.stdout_str()));
+    new_ucmd!().succeeds().stdout_matches(&re);
 }

--- a/tests/by-util/test_hostname.rs
+++ b/tests/by-util/test_hostname.rs
@@ -14,9 +14,7 @@ fn test_hostname() {
 #[cfg(not(target_vendor = "apple"))]
 #[test]
 fn test_hostname_ip() {
-    let result = new_ucmd!().arg("-i").run();
-    println!("{:#?}", result);
-    assert!(result.success);
+    let result = new_ucmd!().arg("-i").succeeds();
     assert!(!result.stdout_str().trim().is_empty());
 }
 

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -388,8 +388,7 @@ fn test_mktemp_tmpdir_one_arg() {
         .arg("--tmpdir")
         .arg("apt-key-gpghome.XXXXXXXXXX")
         .succeeds();
-    result.no_stderr()
-          .stdout_contains("apt-key-gpghome.");
+    result.no_stderr().stdout_contains("apt-key-gpghome.");
     assert!(PathBuf::from(result.stdout_str().trim()).is_file());
 }
 

--- a/tests/by-util/test_nproc.rs
+++ b/tests/by-util/test_nproc.rs
@@ -2,54 +2,46 @@ use crate::common::util::*;
 
 #[test]
 fn test_nproc() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.run();
-    assert!(result.success);
-    let nproc: u8 = result.stdout.trim().parse().unwrap();
+    let nproc: u8 = new_ucmd!().succeeds().stdout_str().trim().parse().unwrap();
     assert!(nproc > 0);
 }
 
 #[test]
 fn test_nproc_all_omp() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--all").run();
-    assert!(result.success);
-    let nproc: u8 = result.stdout.trim().parse().unwrap();
+    let result = new_ucmd!().arg("--all").succeeds();
+
+    let nproc: u8 = result.stdout_str().trim().parse().unwrap();
     assert!(nproc > 0);
 
     let result = TestScenario::new(util_name!())
         .ucmd_keepenv()
         .env("OMP_NUM_THREADS", "1")
-        .run();
-    assert!(result.success);
-    let nproc_omp: u8 = result.stdout.trim().parse().unwrap();
+        .succeeds();
+
+    let nproc_omp: u8 = result.stdout_str().trim().parse().unwrap();
     assert!(nproc - 1 == nproc_omp);
 
     let result = TestScenario::new(util_name!())
         .ucmd_keepenv()
         .env("OMP_NUM_THREADS", "1") // Has no effect
         .arg("--all")
-        .run();
-    assert!(result.success);
-    let nproc_omp: u8 = result.stdout.trim().parse().unwrap();
+        .succeeds();
+    let nproc_omp: u8 = result.stdout_str().trim().parse().unwrap();
     assert!(nproc == nproc_omp);
 }
 
 #[test]
 fn test_nproc_ignore() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.run();
-    assert!(result.success);
-    let nproc: u8 = result.stdout.trim().parse().unwrap();
+    let result = new_ucmd!().succeeds();
+    let nproc: u8 = result.stdout_str().trim().parse().unwrap();
     if nproc > 1 {
         // Ignore all CPU but one
         let result = TestScenario::new(util_name!())
             .ucmd_keepenv()
             .arg("--ignore")
             .arg((nproc - 1).to_string())
-            .run();
-        assert!(result.success);
-        let nproc: u8 = result.stdout.trim().parse().unwrap();
+            .succeeds();
+        let nproc: u8 = result.stdout_str().trim().parse().unwrap();
         assert!(nproc == 1);
     }
 }

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -75,5 +75,5 @@ fn expected_result(args: &[&str]) -> String {
         .env("LANGUAGE", "C")
         .args(args)
         .run()
-        .stdout
+        .stdout_move_str()
 }

--- a/tests/by-util/test_printenv.rs
+++ b/tests/by-util/test_printenv.rs
@@ -7,10 +7,11 @@ fn test_get_all() {
     env::set_var(key, "VALUE");
     assert_eq!(env::var(key), Ok("VALUE".to_string()));
 
-    let result = TestScenario::new(util_name!()).ucmd_keepenv().run();
-    assert!(result.success);
-    assert!(result.stdout.contains("HOME="));
-    assert!(result.stdout.contains("KEY=VALUE"));
+    TestScenario::new(util_name!())
+        .ucmd_keepenv()
+        .succeeds()
+        .stdout_contains("HOME=")
+        .stdout_contains("KEY=VALUE");
 }
 
 #[test]
@@ -22,9 +23,8 @@ fn test_get_var() {
     let result = TestScenario::new(util_name!())
         .ucmd_keepenv()
         .arg("KEY")
-        .run();
+        .succeeds();
 
-    assert!(result.success);
-    assert!(!result.stdout.is_empty());
-    assert!(result.stdout.trim() == "VALUE");
+    assert!(!result.stdout_str().is_empty());
+    assert!(result.stdout_str().trim() == "VALUE");
 }

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -5,7 +5,7 @@ static GIBBERISH: &'static str = "supercalifragilisticexpialidocious";
 #[test]
 fn test_canonicalize() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let actual = ucmd.arg("-f").arg(".").run().stdout;
+    let actual = ucmd.arg("-f").arg(".").run().stdout_move_str();
     let expect = at.root_dir_resolved() + "\n";
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
@@ -15,7 +15,7 @@ fn test_canonicalize() {
 #[test]
 fn test_canonicalize_existing() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let actual = ucmd.arg("-e").arg(".").run().stdout;
+    let actual = ucmd.arg("-e").arg(".").run().stdout_move_str();
     let expect = at.root_dir_resolved() + "\n";
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
@@ -25,7 +25,7 @@ fn test_canonicalize_existing() {
 #[test]
 fn test_canonicalize_missing() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let actual = ucmd.arg("-m").arg(GIBBERISH).run().stdout;
+    let actual = ucmd.arg("-m").arg(GIBBERISH).run().stdout_move_str();
     let expect = path_concat!(at.root_dir_resolved(), GIBBERISH) + "\n";
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
@@ -37,7 +37,7 @@ fn test_long_redirection_to_current_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     // Create a 256-character path to current directory
     let dir = path_concat!(".", ..128);
-    let actual = ucmd.arg("-n").arg("-m").arg(dir).run().stdout;
+    let actual = ucmd.arg("-n").arg("-m").arg(dir).run().stdout_move_str();
     let expect = at.root_dir_resolved();
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
@@ -48,7 +48,12 @@ fn test_long_redirection_to_current_dir() {
 fn test_long_redirection_to_root() {
     // Create a 255-character path to root
     let dir = path_concat!("..", ..85);
-    let actual = new_ucmd!().arg("-n").arg("-m").arg(dir).run().stdout;
+    let actual = new_ucmd!()
+        .arg("-n")
+        .arg("-m")
+        .arg(dir)
+        .run()
+        .stdout_move_str();
     let expect = get_root_path();
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -65,7 +65,7 @@ fn test_random_shuffle_len() {
     // check whether output is the same length as the input
     const FILE: &'static str = "default_unsorted_ints.expected";
     let (at, _ucmd) = at_and_ucmd!();
-    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout;
+    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
     let expected = at.read(FILE);
 
     assert_ne!(result, expected);
@@ -77,9 +77,9 @@ fn test_random_shuffle_contains_all_lines() {
     // check whether lines of input are all in output
     const FILE: &'static str = "default_unsorted_ints.expected";
     let (at, _ucmd) = at_and_ucmd!();
-    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout;
+    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
     let expected = at.read(FILE);
-    let result_sorted = new_ucmd!().pipe_in(result.clone()).run().stdout;
+    let result_sorted = new_ucmd!().pipe_in(result.clone()).run().stdout_move_str();
 
     assert_ne!(result, expected);
     assert_eq!(result_sorted, expected);
@@ -92,9 +92,9 @@ fn test_random_shuffle_two_runs_not_the_same() {
     // as the starting order, or if both random sorts end up having the same order.
     const FILE: &'static str = "default_unsorted_ints.expected";
     let (at, _ucmd) = at_and_ucmd!();
-    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout;
+    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
     let expected = at.read(FILE);
-    let unexpected = new_ucmd!().arg("-R").arg(FILE).run().stdout;
+    let unexpected = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
 
     assert_ne!(result, expected);
     assert_ne!(result, unexpected);
@@ -107,9 +107,9 @@ fn test_random_shuffle_contains_two_runs_not_the_same() {
     // as the starting order, or if both random sorts end up having the same order.
     const FILE: &'static str = "default_unsorted_ints.expected";
     let (at, _ucmd) = at_and_ucmd!();
-    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout;
+    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
     let expected = at.read(FILE);
-    let unexpected = new_ucmd!().arg("-R").arg(FILE).run().stdout;
+    let unexpected = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
 
     assert_ne!(result, expected);
     assert_ne!(result, unexpected);

--- a/tests/by-util/test_sync.rs
+++ b/tests/by-util/test_sync.rs
@@ -5,8 +5,7 @@ use tempfile::tempdir;
 
 #[test]
 fn test_sync_default() {
-    let result = new_ucmd!().run();
-    assert!(result.success);
+    new_ucmd!().succeeds();
 }
 
 #[test]
@@ -18,8 +17,10 @@ fn test_sync_incorrect_arg() {
 fn test_sync_fs() {
     let temporary_directory = tempdir().unwrap();
     let temporary_path = fs::canonicalize(temporary_directory.path()).unwrap();
-    let result = new_ucmd!().arg("--file-system").arg(&temporary_path).run();
-    assert!(result.success);
+    new_ucmd!()
+        .arg("--file-system")
+        .arg(&temporary_path)
+        .succeeds();
 }
 
 #[test]
@@ -27,12 +28,14 @@ fn test_sync_data() {
     // Todo add a second arg
     let temporary_directory = tempdir().unwrap();
     let temporary_path = fs::canonicalize(temporary_directory.path()).unwrap();
-    let result = new_ucmd!().arg("--data").arg(&temporary_path).run();
-    assert!(result.success);
+    new_ucmd!().arg("--data").arg(&temporary_path).succeeds();
 }
 
 #[test]
 fn test_sync_no_existing_files() {
-    let result = new_ucmd!().arg("--data").arg("do-no-exist").fails();
-    assert!(result.stderr.contains("error: cannot stat"));
+    new_ucmd!()
+        .arg("--data")
+        .arg("do-no-exist")
+        .fails()
+        .stderr_contains("error: cannot stat");
 }

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -28,7 +28,7 @@ fn test_version_flag() {
     let version_short = new_ucmd!().arg("-V").run();
     let version_long = new_ucmd!().arg("--version").run();
 
-    assert_eq!(version_short.stdout, version_long.stdout);
+    assert_eq!(version_short.stdout(), version_long.stdout());
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn test_help_flag() {
     let help_short = new_ucmd!().arg("-h").run();
     let help_long = new_ucmd!().arg("--help").run();
 
-    assert_eq!(help_short.stdout, help_long.stdout);
+    assert_eq!(help_short.stdout(), help_long.stdout());
 }
 
 #[test]

--- a/tests/by-util/test_uname.rs
+++ b/tests/by-util/test_uname.rs
@@ -2,60 +2,41 @@ use crate::common::util::*;
 
 #[test]
 fn test_uname_compatible() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd.arg("-a").run();
-    assert!(result.success);
+    new_ucmd!().arg("-a").succeeds();
 }
 
 #[test]
 fn test_uname_name() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd.arg("-n").run();
-    assert!(result.success);
+    new_ucmd!().arg("-n").succeeds();
 }
 
 #[test]
 fn test_uname_processor() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd.arg("-p").run();
-    assert!(result.success);
-    assert_eq!(result.stdout.trim_end(), "unknown");
+    let result = new_ucmd!().arg("-p").succeeds();
+    assert_eq!(result.stdout_str().trim_end(), "unknown");
 }
 
 #[test]
 fn test_uname_hwplatform() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd.arg("-i").run();
-    assert!(result.success);
-    assert_eq!(result.stdout.trim_end(), "unknown");
+    let result = new_ucmd!().arg("-i").succeeds();
+    assert_eq!(result.stdout_str().trim_end(), "unknown");
 }
 
 #[test]
 fn test_uname_machine() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd.arg("-m").run();
-    assert!(result.success);
+    new_ucmd!().arg("-m").succeeds();
 }
 
 #[test]
 fn test_uname_kernel_version() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd.arg("-v").run();
-    assert!(result.success);
+    new_ucmd!().arg("-v").succeeds();
 }
 
 #[test]
 fn test_uname_kernel() {
     let (_, mut ucmd) = at_and_ucmd!();
 
-    let result = ucmd.arg("-o").run();
-    assert!(result.success);
+    let result = ucmd.arg("-o").succeeds();
     #[cfg(target_os = "linux")]
-    assert!(result.stdout.to_lowercase().contains("linux"));
+    assert!(result.stdout_str().to_lowercase().contains("linux"));
 }

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -4,33 +4,23 @@ use crate::common::util::*;
 
 #[test]
 fn test_uptime() {
-    let result = TestScenario::new(util_name!()).ucmd_keepenv().run();
+    TestScenario::new(util_name!())
+        .ucmd_keepenv()
+        .succeeds()
+        .stdout_contains("load average:")
+        .stdout_contains(" up ");
 
-    println!("stdout = {}", result.stdout);
-    println!("stderr = {}", result.stderr);
-
-    assert!(result.success);
-    assert!(result.stdout.contains("load average:"));
-    assert!(result.stdout.contains(" up "));
     // Don't check for users as it doesn't show in some CI
 }
 
 #[test]
 fn test_uptime_since() {
-    let scene = TestScenario::new(util_name!());
-
-    let result = scene.ucmd().arg("--since").succeeds();
-
-    println!("stdout = {}", result.stdout);
-    println!("stderr = {}", result.stderr);
-
-    assert!(result.success);
     let re = Regex::new(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}").unwrap();
-    assert!(re.is_match(&result.stdout.trim()));
+
+    new_ucmd!().arg("--since").succeeds().stdout_matches(&re);
 }
 
 #[test]
 fn test_failed() {
-    let (_at, mut ucmd) = at_and_ucmd!();
-    ucmd.arg("willfail").fails();
+    new_ucmd!().arg("willfail").fails();
 }

--- a/tests/by-util/test_users.rs
+++ b/tests/by-util/test_users.rs
@@ -3,14 +3,11 @@ use std::env;
 
 #[test]
 fn test_users_noarg() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.run();
-    assert!(result.success);
+    new_ucmd!().succeeds();
 }
 #[test]
 fn test_users_check_name() {
-    let result = TestScenario::new(util_name!()).ucmd_keepenv().run();
-    assert!(result.success);
+    let result = TestScenario::new(util_name!()).ucmd_keepenv().succeeds();
 
     // Expectation: USER is often set
     let key = "USER";
@@ -21,9 +18,9 @@ fn test_users_check_name() {
         // Check if "users" contains the name of the user
         {
             println!("username found {}", &username);
-            println!("result.stdout {}", &result.stdout);
-            if !&result.stdout.is_empty() {
-                assert!(result.stdout.contains(&username))
+            // println!("result.stdout {}", &result.stdout);
+            if !result.stdout_str().is_empty() {
+                result.stdout_contains(&username);
             }
         }
     }


### PR DESCRIPTION
After this, we have 83 more occurrences of usage of `.success`,  18 of `.stdout`, and 64 of `.stderr` (measured by removing `pub` from the fields).

This is excluding @jhscheer 's open PR which removes yet more.

Also ran cargo fmt and made sure to install it onto my local hooks.
Not sure why but it looks like cargo-fmt selectively formats or doesn't format certain files with different invocations.
Maybe due to feature flags.