### PR TITLE
cp: add support for --reflink=never

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -210,7 +210,6 @@ pub struct Options {
     overwrite: OverwriteMode,
     parents: bool,
     strip_trailing_slashes: bool,
-    reflink: bool,
     reflink_mode: ReflinkMode,
     preserve_attributes: Vec<Attribute>,
     recursive: bool,
@@ -633,12 +632,12 @@ impl Options {
             update: matches.is_present(OPT_UPDATE),
             verbose: matches.is_present(OPT_VERBOSE),
             strip_trailing_slashes: matches.is_present(OPT_STRIP_TRAILING_SLASHES),
-            reflink: matches.is_present(OPT_REFLINK),
             reflink_mode: {
                 if let Some(reflink) = matches.value_of(OPT_REFLINK) {
                     match reflink {
                         "always" => ReflinkMode::Always,
                         "auto" => ReflinkMode::Auto,
+                        "never" => ReflinkMode::Never,
                         value => {
                             return Err(Error::InvalidArgument(format!(
                                 "invalid argument '{}' for \'reflink\'",
@@ -1196,7 +1195,7 @@ fn copy_file(source: &Path, dest: &Path, options: &Options) -> CopyResult<()> {
 ///Copy the file from `source` to `dest` either using the normal `fs::copy` or the
 ///`FICLONE` ioctl if --reflink is specified and the filesystem supports it.
 fn copy_helper(source: &Path, dest: &Path, options: &Options) -> CopyResult<()> {
-    if options.reflink {
+    if options.reflink_mode != ReflinkMode::Never {
         #[cfg(not(target_os = "linux"))]
         return Err("--reflink is only supported on linux".to_string().into());
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1095,13 +1095,10 @@ fn test_cp_reflink_always() {
 #[cfg(target_os = "linux")]
 fn test_cp_reflink_auto() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg("--reflink=auto")
+    ucmd.arg("--reflink=auto")
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_EXISTING_FILE)
-        .run();
-
-    assert!(result.success);
+        .succeeds();
 
     // Check the content of the destination file
     assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
@@ -1111,13 +1108,10 @@ fn test_cp_reflink_auto() {
 #[cfg(target_os = "linux")]
 fn test_cp_reflink_never() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg("--reflink=never")
+    ucmd.arg("--reflink=never")
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_EXISTING_FILE)
-        .run();
-
-    assert!(result.success);
+        .succeeds();
 
     // Check the content of the destination file
     assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
@@ -1131,8 +1125,6 @@ fn test_cp_reflink_bad() {
         .arg("--reflink=bad")
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_EXISTING_FILE)
-        .run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("invalid argument"));
+        .fails()
+        .stderr_contains("invalid argument");
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1072,3 +1072,67 @@ fn test_cp_one_file_system() {
         }
     }
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_cp_reflink_always() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let result = ucmd
+        .arg("--reflink=always")
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_EXISTING_FILE)
+        .run();
+
+    if result.success {
+        // Check the content of the destination file
+        assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
+    } else {
+        // Older Linux versions do not support cloning.
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_cp_reflink_auto() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let result = ucmd
+        .arg("--reflink=auto")
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_EXISTING_FILE)
+        .run();
+
+    assert!(result.success);
+
+    // Check the content of the destination file
+    assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_cp_reflink_never() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let result = ucmd
+        .arg("--reflink=never")
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_EXISTING_FILE)
+        .run();
+
+    assert!(result.success);
+
+    // Check the content of the destination file
+    assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_cp_reflink_bad() {
+    let (_, mut ucmd) = at_and_ucmd!();
+    let result = ucmd
+        .arg("--reflink=bad")
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_EXISTING_FILE)
+        .run();
+
+    assert!(!result.success);
+    assert!(result.stderr.contains("invalid argument"));
+}


### PR DESCRIPTION
- Passing `never` to `--reflink` does not raise an error anymore.
- Remove `Options::reflink` flag as it was redundant with
  `reflink_mode`.
- Add basic tests for this option.  Does not check that a copy-on-write
  rather than a regular copy was made.