### PR TITLE
du: fix tests on linux (#2066)

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -500,7 +500,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     };
 
     let strs = if matches.free.is_empty() {
-        vec!["./".to_owned()]
+        vec!["./".to_owned()] // TODO: gnu `du` doesn't use trailing "/" here
     } else {
         matches.free.clone()
     };


### PR DESCRIPTION
This closes #2066

* Fixed failing tests on some linux hosts by dynamically taking reference values from the system `du`.
If system `du` is not available, or host is not linux, this falls back to the existing hard coded reference values.

* Refactored tests to not access the fields of CmdResult #1982