### PR TITLE
tail --sleep-interval takes a value

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -117,6 +117,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .arg(
             Arg::with_name(options::SLEEP_INT)
                 .short("s")
+                .takes_value(true)
                 .long(options::SLEEP_INT)
                 .help("Number or seconds to sleep between polling the file when running with -f"),
         )

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -343,3 +343,12 @@ fn test_negative_indexing() {
     assert_eq!(positive_lines_index.stdout(), negative_lines_index.stdout());
     assert_eq!(positive_bytes_index.stdout(), negative_bytes_index.stdout());
 }
+
+#[test]
+fn test_sleep_interval() {
+    new_ucmd!()
+        .arg("-s")
+        .arg("10")
+        .arg(FOOBAR_TXT)
+        .succeeds();
+}


### PR DESCRIPTION
Currently if you try to use the `--sleep-interval` option it will fail as the number is not taken as a value for the option. 
The test will ensure this issue doesn't regress, I wasn't sure about how to create a more detailed test to confirm the option is having the expected effect.