### PR TITLE
refactor tests (#1982)

### DIFF
--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -91,10 +91,15 @@ fn tac(filenames: Vec<String>, before: bool, _: bool, separator: &str) -> i32 {
         } else {
             let path = Path::new(filename);
             if path.is_dir() || path.metadata().is_err() {
-                show_error!(
-                    "failed to open '{}' for reading: No such file or directory",
-                    filename
-                );
+                if path.is_dir() {
+                    show_error!("dir: read error: Invalid argument");
+                } else {
+                    show_error!(
+                        "failed to open '{}' for reading: No such file or directory",
+                        filename
+                    );
+                }
+                exit_code = 1;
                 continue;
             }
             match File::open(path) {

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -47,7 +47,7 @@ fn run_single_test(test: &TestCase, at: AtPath, mut ucmd: UCommand) {
         ucmd.arg(arg);
     }
     let r = ucmd.run();
-    if !r.success {
+    if !r.succeeded() {
         println!("{}", r.stderr_str());
         panic!("{:?}: failed", ucmd.raw);
     }

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -4,14 +4,11 @@ use crate::common::util::*;
 fn test_missing_operand() {
     let result = new_ucmd!().run();
 
-    assert_eq!(
-        true,
-        result
-            .stderr
-            .starts_with("error: The following required arguments were not provided")
-    );
+    assert!(result
+        .stderr_str()
+        .starts_with("error: The following required arguments were not provided"));
 
-    assert_eq!(true, result.stderr.contains("<newroot>"));
+    assert!(result.stderr_str().contains("<newroot>"));
 }
 
 #[test]
@@ -20,14 +17,11 @@ fn test_enter_chroot_fails() {
 
     at.mkdir("jail");
 
-    let result = ucmd.arg("jail").run();
+    let result = ucmd.arg("jail").fails();
 
-    assert_eq!(
-        true,
-        result.stderr.starts_with(
-            "chroot: error: cannot chroot to jail: Operation not permitted (os error 1)"
-        )
-    )
+    assert!(result
+        .stderr_str()
+        .starts_with("chroot: error: cannot chroot to jail: Operation not permitted (os error 1)"));
 }
 
 #[test]
@@ -47,19 +41,18 @@ fn test_invalid_user_spec() {
 
     at.mkdir("a");
 
-    let result = ucmd.arg("a").arg("--userspec=ARABA:").run();
+    let result = ucmd.arg("a").arg("--userspec=ARABA:").fails();
 
-    assert_eq!(
-        true,
-        result.stderr.starts_with("chroot: error: invalid userspec")
-    );
+    assert!(result
+        .stderr_str()
+        .starts_with("chroot: error: invalid userspec"));
 }
 
 #[test]
 fn test_preference_of_userspec() {
     let scene = TestScenario::new(util_name!());
     let result = scene.cmd("whoami").run();
-    if is_ci() && result.stderr.contains("No such user/group") {
+    if is_ci() && result.stderr_str().contains("No such user/group") {
         // In the CI, some server are failing to return whoami.
         // As seems to be a configuration issue, ignoring it
         return;
@@ -73,7 +66,7 @@ fn test_preference_of_userspec() {
     println!("result.stdout = {}", result.stdout_str());
     println!("result.stderr = {}", result.stderr_str());
 
-    if is_ci() && result.stderr.contains("cannot find name for user ID") {
+    if is_ci() && result.stderr_str().contains("cannot find name for user ID") {
         // In the CI, some server are failing to return id.
         // As seems to be a configuration issue, ignoring it
         return;

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -42,13 +42,9 @@ static TEST_MOUNT_OTHER_FILESYSTEM_FILE: &str = "mount/DO_NOT_copy_me.txt";
 fn test_cp_cp() {
     let (at, mut ucmd) = at_and_ucmd!();
     // Invoke our binary to make the copy.
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
-
-    // Check that the exit code represents a successful copy.
-    assert!(result.success);
+        .succeeds();
 
     // Check the content of the destination file that was copied.
     assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
@@ -57,12 +53,9 @@ fn test_cp_cp() {
 #[test]
 fn test_cp_existing_target() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_EXISTING_FILE)
-        .run();
-
-    assert!(result.success);
+        .succeeds();
 
     // Check the content of the destination file
     assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
@@ -74,52 +67,41 @@ fn test_cp_existing_target() {
 #[test]
 fn test_cp_duplicate_files() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
-
-    assert!(result.success);
-    assert!(result.stderr.contains("specified more than once"));
+        .succeeds()
+        .stderr_contains("specified more than once");
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 }
 
 #[test]
 fn test_cp_multiple_files_target_is_file() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
+    new_ucmd!()
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_EXISTING_FILE)
-        .run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("not a directory"));
+        .fails()
+        .stderr_contains("not a directory");
 }
 
 #[test]
 fn test_cp_directory_not_recursive() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
+    new_ucmd!()
         .arg(TEST_COPY_TO_FOLDER)
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("omitting directory"));
+        .fails()
+        .stderr_contains("omitting directory");
 }
 
 #[test]
 fn test_cp_multiple_files() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
     assert_eq!(at.read(TEST_HOW_ARE_YOU_DEST), "How are you?\n");
 }
@@ -129,14 +111,11 @@ fn test_cp_multiple_files() {
 #[cfg(not(macos))]
 fn test_cp_recurse() {
     let (at, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd
-        .arg("-r")
+    ucmd.arg("-r")
         .arg(TEST_COPY_FROM_FOLDER)
         .arg(TEST_COPY_TO_FOLDER_NEW)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     // Check the content of the destination file that was copied.
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_NEW_FILE), "Hello, World!\n");
 }
@@ -144,14 +123,10 @@ fn test_cp_recurse() {
 #[test]
 fn test_cp_with_dirs_t() {
     let (at, mut ucmd) = at_and_ucmd!();
-
-    //using -t option
-    let result_to_dir_t = ucmd
-        .arg("-t")
+    ucmd.arg("-t")
         .arg(TEST_COPY_TO_FOLDER)
         .arg(TEST_HELLO_WORLD_SOURCE)
-        .run();
-    assert!(result_to_dir_t.success);
+        .succeeds();
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 }
 
@@ -162,63 +137,52 @@ fn test_cp_with_dirs() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
-    //using -t option
-    let result_to_dir = scene
+    scene
         .ucmd()
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
-    assert!(result_to_dir.success);
+        .succeeds();
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 
-    let result_from_dir = scene
+    scene
         .ucmd()
         .arg(TEST_COPY_FROM_FOLDER_FILE)
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
-    assert!(result_from_dir.success);
+        .succeeds();
     assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
 }
 
 #[test]
 fn test_cp_arg_target_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("-t")
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 }
 
 #[test]
 fn test_cp_arg_no_target_directory() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
+    new_ucmd!()
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg("-v")
         .arg("-T")
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("cannot overwrite directory"));
+        .fails()
+        .stderr_contains("cannot overwrite directory");
 }
 
 #[test]
 fn test_cp_arg_interactive() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
+    new_ucmd!()
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg("-i")
         .pipe_in("N\n")
-        .run();
-
-    assert!(result.success);
-    assert!(result.stderr.contains("Not overwriting"));
+        .succeeds()
+        .stderr_contains("Not overwriting");
 }
 
 #[test]
@@ -227,39 +191,33 @@ fn test_cp_arg_link() {
     use std::os::linux::fs::MetadataExt;
 
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--link")
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.metadata(TEST_HELLO_WORLD_SOURCE).st_nlink(), 2);
 }
 
 #[test]
 fn test_cp_arg_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--symbolic-link")
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert!(at.is_symlink(TEST_HELLO_WORLD_DEST));
 }
 
 #[test]
 fn test_cp_arg_no_clobber() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--no-clobber")
         .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "How are you?\n");
 }
 
@@ -267,34 +225,31 @@ fn test_cp_arg_no_clobber() {
 fn test_cp_arg_no_clobber_twice() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
+
     at.touch("source.txt");
-    let result = scene
+    scene
         .ucmd()
         .arg("--no-clobber")
         .arg("source.txt")
         .arg("dest.txt")
-        .run();
+        .succeeds()
+        .no_stderr();
 
-    println!("stderr = {:?}", result.stderr_str());
-    println!("stdout = {:?}", result.stdout_str());
-    assert!(result.success);
-    assert!(result.stderr.is_empty());
     assert_eq!(at.read("source.txt"), "");
 
     at.append("source.txt", "some-content");
-    let result = scene
+    scene
         .ucmd()
         .arg("--no-clobber")
         .arg("source.txt")
         .arg("dest.txt")
-        .run();
+        .succeeds()
+        .stdout_does_not_contain("Not overwriting");
 
-    assert!(result.success);
     assert_eq!(at.read("source.txt"), "some-content");
     // Should be empty as the "no-clobber" should keep
     // the previous version
     assert_eq!(at.read("dest.txt"), "");
-    assert!(!result.stderr.contains("Not overwriting"));
 }
 
 #[test]
@@ -311,16 +266,11 @@ fn test_cp_arg_force() {
     permissions.set_readonly(true);
     set_permissions(at.plus(TEST_HELLO_WORLD_DEST), permissions).unwrap();
 
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--force")
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
+        .succeeds();
 
-    println!("{:?}", result.stderr_str());
-    println!("{:?}", result.stdout_str());
-
-    assert!(result.success);
     assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
 }
 
@@ -342,13 +292,11 @@ fn test_cp_arg_remove_destination() {
     permissions.set_readonly(true);
     set_permissions(at.plus(TEST_HELLO_WORLD_DEST), permissions).unwrap();
 
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--remove-destination")
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
 }
 
@@ -356,13 +304,11 @@ fn test_cp_arg_remove_destination() {
 fn test_cp_arg_backup() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--backup")
         .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
         at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
@@ -374,14 +320,12 @@ fn test_cp_arg_backup() {
 fn test_cp_arg_suffix() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--suffix")
         .arg(".bak")
         .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
         at.read(&*format!("{}.bak", TEST_HOW_ARE_YOU_SOURCE)),
@@ -391,9 +335,8 @@ fn test_cp_arg_suffix() {
 
 #[test]
 fn test_cp_deref_conflicting_options() {
-    let (_at, mut ucmd) = at_and_ucmd!();
-
-    ucmd.arg("-LP")
+    new_ucmd!()
+        .arg("-LP")
         .arg(TEST_COPY_TO_FOLDER)
         .arg(TEST_HELLO_WORLD_SOURCE)
         .fails();
@@ -401,8 +344,7 @@ fn test_cp_deref_conflicting_options() {
 
 #[test]
 fn test_cp_deref() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
+    let (at, mut ucmd) = at_and_ucmd!();
 
     #[cfg(not(windows))]
     let _r = fs::symlink(
@@ -415,16 +357,12 @@ fn test_cp_deref() {
         at.subdir.join(TEST_HELLO_WORLD_SOURCE_SYMLINK),
     );
     //using -L option
-    let result = scene
-        .ucmd()
-        .arg("-L")
+    ucmd.arg("-L")
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HELLO_WORLD_SOURCE_SYMLINK)
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
+        .succeeds();
 
-    // Check that the exit code represents a successful copy.
-    assert!(result.success);
     let path_to_new_symlink = at
         .subdir
         .join(TEST_COPY_TO_FOLDER)
@@ -444,8 +382,7 @@ fn test_cp_deref() {
 }
 #[test]
 fn test_cp_no_deref() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
+    let (at, mut ucmd) = at_and_ucmd!();
 
     #[cfg(not(windows))]
     let _r = fs::symlink(
@@ -458,16 +395,12 @@ fn test_cp_no_deref() {
         at.subdir.join(TEST_HELLO_WORLD_SOURCE_SYMLINK),
     );
     //using -P option
-    let result = scene
-        .ucmd()
-        .arg("-P")
+    ucmd.arg("-P")
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HELLO_WORLD_SOURCE_SYMLINK)
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
+        .succeeds();
 
-    // Check that the exit code represents a successful copy.
-    assert!(result.success);
     let path_to_new_symlink = at
         .subdir
         .join(TEST_COPY_TO_FOLDER)
@@ -490,14 +423,10 @@ fn test_cp_strip_trailing_slashes() {
     let (at, mut ucmd) = at_and_ucmd!();
 
     //using --strip-trailing-slashes option
-    let result = ucmd
-        .arg("--strip-trailing-slashes")
+    ucmd.arg("--strip-trailing-slashes")
         .arg(format!("{}/", TEST_HELLO_WORLD_SOURCE))
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
-
-    // Check that the exit code represents a successful copy.
-    assert!(result.success);
+        .succeeds();
 
     // Check the content of the destination file that was copied.
     assert_eq!(at.read(TEST_HELLO_WORLD_DEST), "Hello, World!\n");
@@ -507,14 +436,11 @@ fn test_cp_strip_trailing_slashes() {
 fn test_cp_parents() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    let result = ucmd
-        .arg("--parents")
+    ucmd.arg("--parents")
         .arg(TEST_COPY_FROM_FOLDER_FILE)
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
-    // Check the content of the destination file that was copied.
     assert_eq!(
         at.read(&format!(
             "{}/{}",
@@ -528,14 +454,12 @@ fn test_cp_parents() {
 fn test_cp_parents_multiple_files() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    let result = ucmd
-        .arg("--parents")
+    ucmd.arg("--parents")
         .arg(TEST_COPY_FROM_FOLDER_FILE)
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(
         at.read(&format!(
             "{}/{}",
@@ -554,20 +478,12 @@ fn test_cp_parents_multiple_files() {
 
 #[test]
 fn test_cp_parents_dest_not_directory() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    let result = ucmd
+    new_ucmd!()
         .arg("--parents")
         .arg(TEST_COPY_FROM_FOLDER_FILE)
         .arg(TEST_HELLO_WORLD_DEST)
-        .run();
-    println!("{:?}", result);
-
-    // Check that we did not succeed in copying.
-    assert!(!result.success);
-    assert!(result
-        .stderr
-        .contains("with --parents, the destination must be a directory"));
+        .fails()
+        .stderr_contains("with --parents, the destination must be a directory");
 }
 
 #[test]
@@ -594,18 +510,14 @@ fn test_cp_deref_folder_to_folder() {
     assert!(env::set_current_dir(&cwd).is_ok());
 
     //using -P -R option
-    let result = scene
+    scene
         .ucmd()
         .arg("-L")
         .arg("-R")
         .arg("-v")
         .arg(TEST_COPY_FROM_FOLDER)
         .arg(TEST_COPY_TO_FOLDER_NEW)
-        .run();
-    println!("cp output {}", result.stdout_str());
-
-    // Check that the exit code represents a successful copy.
-    assert!(result.success);
+        .succeeds();
 
     #[cfg(not(windows))]
     {
@@ -698,18 +610,14 @@ fn test_cp_no_deref_folder_to_folder() {
     assert!(env::set_current_dir(&cwd).is_ok());
 
     //using -P -R option
-    let result = scene
+    scene
         .ucmd()
         .arg("-P")
         .arg("-R")
         .arg("-v")
         .arg(TEST_COPY_FROM_FOLDER)
         .arg(TEST_COPY_TO_FOLDER_NEW)
-        .run();
-    println!("cp output {}", result.stdout_str());
-
-    // Check that the exit code represents a successful copy.
-    assert!(result.success);
+        .succeeds();
 
     #[cfg(not(windows))]
     {
@@ -791,13 +699,11 @@ fn test_cp_archive() {
         previous,
     )
     .unwrap();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--archive")
         .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
 
     let metadata = std_fs::metadata(at.subdir.join(TEST_HELLO_WORLD_SOURCE)).unwrap();
@@ -807,11 +713,10 @@ fn test_cp_archive() {
     let creation2 = metadata2.modified().unwrap();
 
     let scene2 = TestScenario::new("ls");
-    let result = scene2.cmd("ls").arg("-al").arg(at.subdir).run();
+    let result = scene2.cmd("ls").arg("-al").arg(at.subdir).succeeds();
 
     println!("ls dest {}", result.stdout_str());
     assert_eq!(creation, creation2);
-    assert!(result.success);
 }
 
 #[test]
@@ -850,11 +755,10 @@ fn test_cp_archive_recursive() {
     // Back to the initial cwd (breaks the other tests)
     assert!(env::set_current_dir(&cwd).is_ok());
 
-    let resultg = ucmd
-        .arg("--archive")
+    ucmd.arg("--archive")
         .arg(TEST_COPY_TO_FOLDER)
         .arg(TEST_COPY_TO_FOLDER_NEW)
-        .run();
+        .fails(); // fails for now
 
     let scene2 = TestScenario::new("ls");
     let result = scene2
@@ -865,7 +769,6 @@ fn test_cp_archive_recursive() {
 
     println!("ls dest {}", result.stdout_str());
 
-    let scene2 = TestScenario::new("ls");
     let result = scene2
         .cmd("ls")
         .arg("-al")
@@ -910,9 +813,6 @@ fn test_cp_archive_recursive() {
             .join("2.link")
             .to_string_lossy()
     ));
-
-    // fails for now
-    assert!(resultg.success);
 }
 
 #[test]
@@ -928,13 +828,11 @@ fn test_cp_preserve_timestamps() {
         previous,
     )
     .unwrap();
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--preserve=timestamps")
         .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
 
     let metadata = std_fs::metadata(at.subdir.join(TEST_HELLO_WORLD_SOURCE)).unwrap();
@@ -948,7 +846,6 @@ fn test_cp_preserve_timestamps() {
 
     println!("ls dest {}", result.stdout_str());
     assert_eq!(creation, creation2);
-    assert!(result.success);
 }
 
 #[test]
@@ -966,13 +863,11 @@ fn test_cp_dont_preserve_timestamps() {
     .unwrap();
     sleep(Duration::from_secs(3));
 
-    let result = ucmd
-        .arg(TEST_HELLO_WORLD_SOURCE)
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("--no-preserve=timestamps")
         .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .run();
+        .succeeds();
 
-    assert!(result.success);
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
 
     let metadata = std_fs::metadata(at.subdir.join(TEST_HELLO_WORLD_SOURCE)).unwrap();
@@ -992,7 +887,6 @@ fn test_cp_dont_preserve_timestamps() {
     // Some margins with time check
     assert!(res.as_secs() > 3595);
     assert!(res.as_secs() < 3605);
-    assert!(result.success);
 }
 
 #[test]
@@ -1017,7 +911,7 @@ fn test_cp_one_file_system() {
     let scene = TestScenario::new(util_name!());
 
     // Test must be run as root (or with `sudo -E`)
-    if scene.cmd("whoami").run().stdout != "root\n" {
+    if scene.cmd("whoami").run().stdout_str() != "root\n" {
         return;
     }
 
@@ -1042,17 +936,16 @@ fn test_cp_one_file_system() {
     at_src.touch(TEST_MOUNT_OTHER_FILESYSTEM_FILE);
 
     // Begin testing -x flag
-    let result = scene
+    scene
         .ucmd()
         .arg("-rx")
         .arg(TEST_MOUNT_COPY_FROM_FOLDER)
         .arg(TEST_COPY_TO_FOLDER_NEW)
-        .run();
+        .succeeds();
 
     // Ditch the mount before the asserts
     scene.cmd("umount").arg(mountpoint_path).succeeds();
 
-    assert!(result.success);
     assert!(!at_dst.file_exists(TEST_MOUNT_OTHER_FILESYSTEM_FILE));
     // Check if the other files were copied from the source folder hirerarchy
     for entry in WalkDir::new(at_src.as_string()) {

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -7,174 +7,147 @@ use rust_users::*;
 
 #[test]
 fn test_date_email() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--rfc-email").run();
-    assert!(result.success);
+    new_ucmd!().arg("--rfc-email").succeeds();
 }
 
 #[test]
 fn test_date_email2() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("-R").run();
-    assert!(result.success);
+    new_ucmd!().arg("-R").succeeds();
 }
 
 #[test]
 fn test_date_rfc_3339() {
     let scene = TestScenario::new(util_name!());
 
-    let mut result = scene.ucmd().arg("--rfc-3339=ns").succeeds();
+    let rfc_regexp = concat!(
+        r#"(\d+)-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01])\s([01]\d|2[0-3]):"#,
+        r#"([0-5]\d):([0-5]\d|60)(\.\d+)?(([Zz])|([\+|\-]([01]\d|2[0-3])))"#
+    );
+    let re = Regex::new(rfc_regexp).unwrap();
 
     // Check that the output matches the regexp
-    let rfc_regexp = r"(\d+)-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01])\s([01]\d|2[0-3]):([0-5]\d):([0-5]\d|60)(\.\d+)?(([Zz])|([\+|\-]([01]\d|2[0-3])))";
-    let re = Regex::new(rfc_regexp).unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene
+        .ucmd()
+        .arg("--rfc-3339=ns")
+        .succeeds()
+        .stdout_matches(&re);
 
-    result = scene.ucmd().arg("--rfc-3339=seconds").succeeds();
-
-    // Check that the output matches the regexp
-    let re = Regex::new(rfc_regexp).unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene
+        .ucmd()
+        .arg("--rfc-3339=seconds")
+        .succeeds()
+        .stdout_matches(&re);
 }
 
 #[test]
 fn test_date_rfc_8601() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--iso-8601=ns").run();
-    assert!(result.success);
+    new_ucmd!().arg("--iso-8601=ns").succeeds();
 }
 
 #[test]
 fn test_date_rfc_8601_second() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--iso-8601=second").run();
-    assert!(result.success);
+    new_ucmd!().arg("--iso-8601=second").succeeds();
 }
 
 #[test]
 fn test_date_utc() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--utc").run();
-    assert!(result.success);
+    new_ucmd!().arg("--utc").succeeds();
 }
 
 #[test]
 fn test_date_universal() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--universal").run();
-    assert!(result.success);
+    new_ucmd!().arg("--universal").succeeds();
 }
 
 #[test]
 fn test_date_format_y() {
     let scene = TestScenario::new(util_name!());
 
-    let mut result = scene.ucmd().arg("+%Y").succeeds();
-
-    assert!(result.success);
     let mut re = Regex::new(r"^\d{4}$").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene.ucmd().arg("+%Y").succeeds().stdout_matches(&re);
 
-    result = scene.ucmd().arg("+%y").succeeds();
-
-    assert!(result.success);
     re = Regex::new(r"^\d{2}$").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene.ucmd().arg("+%y").succeeds().stdout_matches(&re);
 }
 
 #[test]
 fn test_date_format_m() {
     let scene = TestScenario::new(util_name!());
 
-    let mut result = scene.ucmd().arg("+%b").succeeds();
-
-    assert!(result.success);
     let mut re = Regex::new(r"\S+").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene.ucmd().arg("+%b").succeeds().stdout_matches(&re);
 
-    result = scene.ucmd().arg("+%m").succeeds();
-
-    assert!(result.success);
     re = Regex::new(r"^\d{2}$").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene.ucmd().arg("+%m").succeeds().stdout_matches(&re);
 }
 
 #[test]
 fn test_date_format_day() {
     let scene = TestScenario::new(util_name!());
 
-    let mut result = scene.ucmd().arg("+%a").succeeds();
-
-    assert!(result.success);
     let mut re = Regex::new(r"\S+").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
-
-    result = scene.ucmd().arg("+%A").succeeds();
-
-    assert!(result.success);
+    scene.ucmd().arg("+%a").succeeds().stdout_matches(&re);
 
     re = Regex::new(r"\S+").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene.ucmd().arg("+%A").succeeds().stdout_matches(&re);
 
-    result = scene.ucmd().arg("+%u").succeeds();
-
-    assert!(result.success);
     re = Regex::new(r"^\d{1}$").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    scene.ucmd().arg("+%u").succeeds().stdout_matches(&re);
 }
 
 #[test]
 fn test_date_format_full_day() {
-    let scene = TestScenario::new(util_name!());
-
-    let result = scene.ucmd().arg("+'%a %Y-%m-%d'").succeeds();
-
-    assert!(result.success);
     let re = Regex::new(r"\S+ \d{4}-\d{2}-\d{2}").unwrap();
-    assert!(re.is_match(&result.stdout_str().trim()));
+    new_ucmd!()
+        .arg("+'%a %Y-%m-%d'")
+        .succeeds()
+        .stdout_matches(&re);
 }
 
 #[test]
 #[cfg(all(unix, not(target_os = "macos")))]
 fn test_date_set_valid() {
     if get_effective_uid() == 0 {
-        let (_, mut ucmd) = at_and_ucmd!();
-        let result = ucmd
+        new_ucmd!()
             .arg("--set")
             .arg("2020-03-12 13:30:00+08:00")
-            .succeeds();
-        result.no_stdout().no_stderr();
+            .succeeds()
+            .no_stdout()
+            .no_stderr();
     }
 }
 
 #[test]
 #[cfg(any(windows, all(unix, not(target_os = "macos"))))]
 fn test_date_set_invalid() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--set").arg("123abcd").fails();
-    let result = result.no_stdout();
-    assert!(result.stderr.starts_with("date: invalid date "));
+    let result = new_ucmd!().arg("--set").arg("123abcd").fails();
+    result.no_stdout();
+    assert!(result.stderr_str().starts_with("date: invalid date "));
 }
 
 #[test]
 #[cfg(all(unix, not(target_os = "macos")))]
 fn test_date_set_permissions_error() {
     if !(get_effective_uid() == 0 || is_wsl()) {
-        let (_, mut ucmd) = at_and_ucmd!();
-        let result = ucmd.arg("--set").arg("2020-03-11 21:45:00+08:00").fails();
-        let result = result.no_stdout();
-        assert!(result.stderr.starts_with("date: cannot set date: "));
+        let result = new_ucmd!()
+            .arg("--set")
+            .arg("2020-03-11 21:45:00+08:00")
+            .fails();
+        result.no_stdout();
+        assert!(result.stderr_str().starts_with("date: cannot set date: "));
     }
 }
 
 #[test]
 #[cfg(target_os = "macos")]
 fn test_date_set_mac_unavailable() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("--set").arg("2020-03-11 21:45:00+08:00").fails();
-    let result = result.no_stdout();
+    let result = new_ucmd!()
+        .arg("--set")
+        .arg("2020-03-11 21:45:00+08:00")
+        .fails();
+    result.no_stdout();
     assert!(result
-        .stderr
+        .stderr_str()
         .starts_with("date: setting the date is not supported by macOS"));
 }
 
@@ -183,13 +156,12 @@ fn test_date_set_mac_unavailable() {
 /// TODO: expected to fail currently; change to succeeds() when required.
 fn test_date_set_valid_2() {
     if get_effective_uid() == 0 {
-        let (_, mut ucmd) = at_and_ucmd!();
-        let result = ucmd
+        let result = new_ucmd!()
             .arg("--set")
             .arg("Sat 20 Mar 2021 14:53:01 AWST")
             .fails();
-        let result = result.no_stdout();
-        assert!(result.stderr.starts_with("date: invalid date "));
+        result.no_stdout();
+        assert!(result.stderr_str().starts_with("date: invalid date "));
     }
 }
 
@@ -198,13 +170,12 @@ fn test_date_set_valid_2() {
 /// TODO: expected to fail currently; change to succeeds() when required.
 fn test_date_set_valid_3() {
     if get_effective_uid() == 0 {
-        let (_, mut ucmd) = at_and_ucmd!();
-        let result = ucmd
+        let result = new_ucmd!()
             .arg("--set")
             .arg("Sat 20 Mar 2021 14:53:01") // Local timezone
             .fails();
-        let result = result.no_stdout();
-        assert!(result.stderr.starts_with("date: invalid date "));
+        result.no_stdout();
+        assert!(result.stderr_str().starts_with("date: invalid date "));
     }
 }
 
@@ -213,12 +184,11 @@ fn test_date_set_valid_3() {
 /// TODO: expected to fail currently; change to succeeds() when required.
 fn test_date_set_valid_4() {
     if get_effective_uid() == 0 {
-        let (_, mut ucmd) = at_and_ucmd!();
-        let result = ucmd
+        let result = new_ucmd!()
             .arg("--set")
             .arg("2020-03-11 21:45:00") // Local timezone
             .fails();
-        let result = result.no_stdout();
-        assert!(result.stderr.starts_with("date: invalid date "));
+        result.no_stdout();
+        assert!(result.stderr_str().starts_with("date: invalid date "));
     }
 }

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -2,30 +2,22 @@ use crate::common::util::*;
 
 #[test]
 fn test_df_compatible_no_size_arg() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("-a").run();
-    assert!(result.success);
+    new_ucmd!().arg("-a").succeeds();
 }
 
 #[test]
 fn test_df_compatible() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("-ah").run();
-    assert!(result.success);
+    new_ucmd!().arg("-ah").succeeds();
 }
 
 #[test]
 fn test_df_compatible_type() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("-aT").run();
-    assert!(result.success);
+    new_ucmd!().arg("-aT").succeeds();
 }
 
 #[test]
 fn test_df_compatible_si() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("-aH").run();
-    assert!(result.success);
+    new_ucmd!().arg("-aH").succeeds();
 }
 
 // ToDO: more tests...

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -140,8 +140,11 @@ fn test_unset_variable() {
 
 #[test]
 fn test_fail_null_with_program() {
-    let out = new_ucmd!().arg("--null").arg("cd").fails().stderr;
-    assert!(out.contains("cannot specify --null (-0) with command"));
+    new_ucmd!()
+        .arg("--null")
+        .arg("cd")
+        .fails()
+        .stderr_contains("cannot specify --null (-0) with command");
 }
 
 #[cfg(not(windows))]

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -29,7 +29,7 @@ fn test_fmt_w_too_big() {
         .run();
     //.stdout_is_fixture("call_graph.expected");
     assert_eq!(
-        result.stderr.trim(),
+        result.stderr_str().trim(),
         "fmt: error: invalid width: '2501': Numerical result out of range"
     );
 }

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -10,7 +10,7 @@ fn test_groups() {
         // As seems to be a configuration issue, ignoring it
         return;
     }
-    assert!(result.success);
+    result.success();
     assert!(!result.stdout_str().trim().is_empty());
 }
 
@@ -30,16 +30,12 @@ fn test_groups_arg() {
 
     println!("result.stdout = {}", result.stdout_str());
     println!("result.stderr = {}", result.stderr_str());
-    assert!(result.success);
+    result.success();
     assert!(!result.stdout_str().is_empty());
     let username = result.stdout_str().trim();
 
     // call groups with the user name to check that we
     // are getting something
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg(username).run();
-    println!("result.stdout = {}", result.stdout_str());
-    println!("result.stderr = {}", result.stderr_str());
-    assert!(result.success);
+    new_ucmd!().arg(username).succeeds();
     assert!(!result.stdout_str().is_empty());
 }

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -156,14 +156,10 @@ fn test_negative_zero_bytes() {
 }
 #[test]
 fn test_no_such_file_or_directory() {
-    let result = new_ucmd!().arg("no_such_file.toml").run();
-
-    assert_eq!(
-        true,
-        result
-            .stderr
-            .contains("cannot open 'no_such_file.toml' for reading: No such file or directory")
-    )
+    new_ucmd!()
+        .arg("no_such_file.toml")
+        .fails()
+        .stderr_contains("cannot open 'no_such_file.toml' for reading: No such file or directory");
 }
 
 // there was a bug not caught by previous tests

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -11,12 +11,10 @@ use std::thread::sleep;
 fn test_install_help() {
     let (_, mut ucmd) = at_and_ucmd!();
 
-    assert!(ucmd
-        .arg("--help")
+    ucmd.arg("--help")
         .succeeds()
         .no_stderr()
-        .stdout
-        .contains("FLAGS:"));
+        .stdout_contains("FLAGS:");
 }
 
 #[test]
@@ -59,13 +57,11 @@ fn test_install_failing_not_dir() {
     at.touch(file1);
     at.touch(file2);
     at.touch(file3);
-    assert!(ucmd
-        .arg(file1)
+    ucmd.arg(file1)
         .arg(file2)
         .arg(file3)
         .fails()
-        .stderr
-        .contains("not a directory"));
+        .stderr_contains("not a directory");
 }
 
 #[test]
@@ -77,13 +73,11 @@ fn test_install_unimplemented_arg() {
 
     at.touch(file);
     at.mkdir(dir);
-    assert!(ucmd
-        .arg(context_arg)
+    ucmd.arg(context_arg)
         .arg(file)
         .arg(dir)
         .fails()
-        .stderr
-        .contains("Unimplemented"));
+        .stderr_contains("Unimplemented");
 
     assert!(!at.file_exists(&format!("{}/{}", dir, file)));
 }
@@ -231,13 +225,11 @@ fn test_install_mode_failing() {
 
     at.touch(file);
     at.mkdir(dir);
-    assert!(ucmd
-        .arg(file)
+    ucmd.arg(file)
         .arg(dir)
         .arg(mode_arg)
         .fails()
-        .stderr
-        .contains("Invalid mode string: invalid digit found in string"));
+        .stderr_contains("Invalid mode string: invalid digit found in string");
 
     let dest_file = &format!("{}/{}", dir, file);
     assert!(at.file_exists(file));
@@ -336,7 +328,7 @@ fn test_install_target_new_file_with_owner() {
         .arg(format!("{}/{}", dir, file))
         .run();
 
-    if is_ci() && result.stderr.contains("error: no such user:") {
+    if is_ci() && result.stderr_str().contains("error: no such user:") {
         // In the CI, some server are failing to return the user id.
         // As seems to be a configuration issue, ignoring it
         return;
@@ -619,35 +611,27 @@ fn test_install_and_strip_with_program() {
 #[test]
 #[cfg(not(windows))]
 fn test_install_and_strip_with_invalid_program() {
-    let scene = TestScenario::new(util_name!());
-
-    let stderr = scene
-        .ucmd()
+    new_ucmd!()
         .arg("-s")
         .arg("--strip-program")
         .arg("/bin/date")
         .arg(strip_source_file())
         .arg(STRIP_TARGET_FILE)
         .fails()
-        .stderr;
-    assert!(stderr.contains("strip program failed"));
+        .stderr_contains("strip program failed");
 }
 
 #[test]
 #[cfg(not(windows))]
 fn test_install_and_strip_with_non_existent_program() {
-    let scene = TestScenario::new(util_name!());
-
-    let stderr = scene
-        .ucmd()
+    new_ucmd!()
         .arg("-s")
         .arg("--strip-program")
         .arg("/usr/bin/non_existent_program")
         .arg(strip_source_file())
         .arg(STRIP_TARGET_FILE)
         .fails()
-        .stderr;
-    assert!(stderr.contains("No such file or directory"));
+        .stderr_contains("No such file or directory");
 }
 
 #[test]

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -299,13 +299,11 @@ fn test_symlink_overwrite_dir_fail() {
     at.touch(path_a);
     at.mkdir(path_b);
 
-    assert!(
-        ucmd.args(&["-s", "-T", path_a, path_b])
-            .fails()
-            .stderr
-            .len()
-            > 0
-    );
+    assert!(!ucmd
+        .args(&["-s", "-T", path_a, path_b])
+        .fails()
+        .stderr_str()
+        .is_empty());
 }
 
 #[test]
@@ -358,7 +356,11 @@ fn test_symlink_target_only() {
 
     at.mkdir(dir);
 
-    assert!(ucmd.args(&["-s", "-t", dir]).fails().stderr.len() > 0);
+    assert!(!ucmd
+        .args(&["-s", "-t", dir])
+        .fails()
+        .stderr_str()
+        .is_empty());
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -103,6 +103,14 @@ fn test_ls_width() {
             .succeeds()
             .stdout_only("test-width-1\ntest-width-2\ntest-width-3\ntest-width-4\n");
     }
+
+    for option in &["-w 1a", "-w=1a", "--width=1a", "--width 1a"] {
+        scene
+            .ucmd()
+            .args(&option.split(" ").collect::<Vec<_>>())
+            .fails()
+            .stderr_only("ls: error: invalid line width: ‘1a’");
+    }
 }
 
 #[test]

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -19,8 +19,7 @@ fn test_create_one_fifo_with_invalid_mode() {
         .arg("-m")
         .arg("invalid")
         .fails()
-        .stderr
-        .contains("invalid mode");
+        .stderr_contains("invalid mode");
 }
 
 #[test]

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -2,18 +2,15 @@ use crate::common::util::*;
 
 #[test]
 fn test_more_no_arg() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.run();
-    assert!(!result.success);
+    // stderr = more: Reading from stdin isn't supported yet.
+    new_ucmd!().fails();
 }
 
 #[test]
 fn test_more_dir_arg() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    ucmd.arg(".");
-    let result = ucmd.run();
-    assert!(!result.success);
+    let result = new_ucmd!().arg(".").run();
+    result.failure();
     const EXPECTED_ERROR_MESSAGE: &str =
         "more: '.' is a directory.\nTry 'more --help' for more information.";
-    assert_eq!(result.stderr.trim(), EXPECTED_ERROR_MESSAGE);
+    assert_eq!(result.stderr_str().trim(), EXPECTED_ERROR_MESSAGE);
 }

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -476,16 +476,9 @@ fn test_mv_overwrite_nonempty_dir() {
     // GNU:     "mv: cannot move ‘a’ to ‘b’: Directory not empty"
 
     // Verbose output for the move should not be shown on failure
-    assert!(
-        ucmd.arg("-vT")
-            .arg(dir_a)
-            .arg(dir_b)
-            .fails()
-            .no_stdout()
-            .stderr
-            .len()
-            > 0
-    );
+    let result = ucmd.arg("-vT").arg(dir_a).arg(dir_b).fails();
+    result.no_stdout();
+    assert!(!result.stderr_str().is_empty());
 
     assert!(at.dir_exists(dir_a));
     assert!(at.dir_exists(dir_b));
@@ -526,15 +519,15 @@ fn test_mv_errors() {
 
     // $ mv -T -t a b
     // mv: cannot combine --target-directory (-t) and --no-target-directory (-T)
-    let result = scene
+    scene
         .ucmd()
         .arg("-T")
         .arg("-t")
         .arg(dir)
         .arg(file_a)
         .arg(file_b)
-        .fails();
-    assert!(result.stderr.contains("cannot be used with"));
+        .fails()
+        .stderr_contains("cannot be used with");
 
     // $ at.touch file && at.mkdir dir
     // $ mv -T file dir
@@ -553,7 +546,13 @@ fn test_mv_errors() {
     // $ at.mkdir dir && at.touch file
     // $ mv dir file
     // err == mv: cannot overwrite non-directory ‘file’ with directory ‘dir’
-    assert!(scene.ucmd().arg(dir).arg(file_a).fails().stderr.len() > 0);
+    assert!(!scene
+        .ucmd()
+        .arg(dir)
+        .arg(file_a)
+        .fails()
+        .stderr_str()
+        .is_empty());
 }
 
 #[test]

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -16,7 +16,7 @@ fn test_negative_adjustment() {
 
     let res = new_ucmd!().args(&["-n", "-1", "true"]).run();
     assert!(res
-        .stderr
+        .stderr_str()
         .starts_with("nice: warning: setpriority: Permission denied"));
 }
 

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -337,5 +337,5 @@ fn expected_result(args: &[&str]) -> String {
         .env("LANGUAGE", "C")
         .args(args)
         .run()
-        .stdout
+        .stdout_move_str()
 }

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -52,18 +52,19 @@ fn test_single_non_newline_separator_before() {
 
 #[test]
 fn test_invalid_input() {
-    let (_, mut ucmd) = at_and_ucmd!();
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
 
-    ucmd.arg("b")
-        .run()
-        .stderr
-        .contains("tac: error: failed to open 'b' for reading");
-
-    let (at, mut ucmd) = at_and_ucmd!();
+    scene
+        .ucmd()
+        .arg("b")
+        .fails()
+        .stderr_contains("failed to open 'b' for reading: No such file or directory");
 
     at.mkdir("a");
-    ucmd.arg("a")
-        .run()
-        .stderr
-        .contains("tac: error: failed to read 'a'");
+    scene
+        .ucmd()
+        .arg("a")
+        .fails()
+        .stderr_contains("dir: read error: Invalid argument");
 }

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -120,19 +120,15 @@ fn test_truncate_with_set1_shorter_than_set2() {
 #[test]
 fn missing_args_fails() {
     let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("missing operand"));
+    ucmd.fails().stderr_contains("missing operand");
 }
 
 #[test]
 fn missing_required_second_arg_fails() {
     let (_, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.args(&["foo"]).run();
-
-    assert!(!result.success);
-    assert!(result.stderr.contains("missing operand after"));
+    ucmd.args(&["foo"])
+        .fails()
+        .stderr_contains("missing operand after");
 }
 
 #[test]

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -18,33 +18,35 @@ fn test_sort_self_loop() {
 
 #[test]
 fn test_no_such_file() {
-    let result = new_ucmd!().arg("invalid_file_txt").run();
-
-    assert_eq!(true, result.stderr.contains("No such file or directory"));
+    new_ucmd!()
+        .arg("invalid_file_txt")
+        .fails()
+        .stderr_contains("No such file or directory");
 }
 
 #[test]
 fn test_version_flag() {
-    let version_short = new_ucmd!().arg("-V").run();
-    let version_long = new_ucmd!().arg("--version").run();
+    let version_short = new_ucmd!().arg("-V").succeeds();
+    let version_long = new_ucmd!().arg("--version").succeeds();
 
-    assert_eq!(version_short.stdout(), version_long.stdout());
+    assert_eq!(version_short.stdout_str(), version_long.stdout_str());
 }
 
 #[test]
 fn test_help_flag() {
-    let help_short = new_ucmd!().arg("-h").run();
-    let help_long = new_ucmd!().arg("--help").run();
+    let help_short = new_ucmd!().arg("-h").succeeds();
+    let help_long = new_ucmd!().arg("--help").succeeds();
 
-    assert_eq!(help_short.stdout(), help_long.stdout());
+    assert_eq!(help_short.stdout_str(), help_long.stdout_str());
 }
 
 #[test]
 fn test_multiple_arguments() {
-    let result = new_ucmd!()
+    new_ucmd!()
         .arg("call_graph.txt")
-        .arg("invalid_file.txt")
-        .run();
-
-    assert_eq!(true, result.stderr.contains("error: Found argument 'invalid_file.txt' which wasn't expected, or isn't valid in this context"))
+        .arg("invalid_file")
+        .fails()
+        .stderr_contains(
+            "Found argument 'invalid_file' which wasn't expected, or isn't valid in this context",
+        );
 }

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -23,7 +23,7 @@ fn test_heading() {
     for opt in vec!["-H"] {
         // allow whitespace variation
         // * minor whitespace differences occur between platform built-in outputs; specifically number of TABs between "TIME" and "COMMENT" may be variant
-        let actual = new_ucmd!().arg(opt).run().stdout;
+        let actual = new_ucmd!().arg(opt).run().stdout_move_str();
         let expect = expected_result(opt);
         println!("actual: {:?}", actual);
         println!("expect: {:?}", expect);
@@ -80,5 +80,5 @@ fn expected_result(arg: &str) -> String {
         .env("LANGUAGE", "C")
         .args(&[arg])
         .run()
-        .stdout
+        .stdout_move_str()
 }


### PR DESCRIPTION
This closes #1982

* refactor last remaining tests to not access the fields of `CmdResult`
* set the remaining fields of `CmdResult` to private
* use of new test utils from #2011 where applicable, e.g. `stdout_matches` etc.

Some minor things
* replace some `at_and_ucmd` with `new_ucmd` if "at" is not needed
* fix a return value in `tac`
