### PR TITLE
Allow space in truncate --size

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -192,7 +192,8 @@ fn truncate(
 }
 
 fn parse_size(size: &str) -> (u64, TruncateMode) {
-    let mode = match size.chars().next().unwrap() {
+    let clean_size = size.replace(" ", "");
+    let mode = match clean_size.chars().next().unwrap() {
         '+' => TruncateMode::Extend,
         '-' => TruncateMode::Reduce,
         '<' => TruncateMode::AtMost,
@@ -203,9 +204,9 @@ fn parse_size(size: &str) -> (u64, TruncateMode) {
     };
     let bytes = {
         let mut slice = if mode == TruncateMode::Reference {
-            size
+            &clean_size
         } else {
-            &size[1..]
+            &clean_size[1..]
         };
         if slice.chars().last().unwrap().is_alphabetic() {
             slice = &slice[..slice.len() - 1];
@@ -220,11 +221,11 @@ fn parse_size(size: &str) -> (u64, TruncateMode) {
         Ok(num) => num,
         Err(e) => crash!(1, "'{}' is not a valid number: {}", size, e),
     };
-    if size.chars().last().unwrap().is_alphabetic() {
-        number *= match size.chars().last().unwrap().to_ascii_uppercase() {
-            'B' => match size
+    if clean_size.chars().last().unwrap().is_alphabetic() {
+        number *= match clean_size.chars().last().unwrap().to_ascii_uppercase() {
+            'B' => match clean_size
                 .chars()
-                .nth(size.len() - 2)
+                .nth(clean_size.len() - 2)
                 .unwrap()
                 .to_ascii_uppercase()
             {

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -54,6 +54,16 @@ fn test_decrease_file_size() {
 }
 
 #[test]
+fn test_space_in_size() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file = at.make_file(TFILE2);
+    file.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--size", " 4", TFILE2]).succeeds();
+    file.seek(SeekFrom::End(0)).unwrap();
+    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 4);
+}
+
+#[test]
 fn test_failed() {
     new_ucmd!().fails();
 }
@@ -69,3 +79,4 @@ fn test_failed_incorrect_arg() {
     let (_at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["-s", "+5A", TFILE1]).fails();
 }
+


### PR DESCRIPTION
The GNU `truncate` allows spaces in the size argument, so you can have calls like
```
truncate --size '< 10'
```
