### PR TITLE
tests: show pretty diffs for assertion failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "nix 0.20.0",
+ "pretty_assertions",
  "rand 0.7.3",
  "regex",
  "sha1",
@@ -527,6 +528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote 1.0.9",
+ "syn",
+]
+
+[[package]]
 name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +548,12 @@ name = "data-encoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -944,6 +961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "paste"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1037,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,6 +335,7 @@ filetime = "0.2"
 glob = "0.3.0"
 libc = "0.2"
 nix = "0.20.0"
+pretty_assertions = "0.7.2"
 rand = "0.7"
 regex = "1.0"
 sha1 = { version="0.6", features=["std"] }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -2,6 +2,7 @@
 
 #[cfg(not(windows))]
 use libc;
+use pretty_assertions::assert_eq;
 use std::env;
 #[cfg(not(windows))]
 use std::ffi::CString;
@@ -221,7 +222,7 @@ impl CmdResult {
     /// like stdout_is(...), but expects the contents of the file at the provided relative path
     pub fn stdout_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &CmdResult {
         let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
-        self.stdout_is_bytes(contents)
+        self.stdout_is(String::from_utf8(contents).unwrap())
     }
 
     /// asserts that the command resulted in stderr stream output that equals the
@@ -245,7 +246,7 @@ impl CmdResult {
     /// Like stdout_is_fixture, but for stderr
     pub fn stderr_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &CmdResult {
         let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
-        self.stderr_is_bytes(contents)
+        self.stderr_is(String::from_utf8(contents).unwrap())
     }
 
     /// asserts that
@@ -619,7 +620,7 @@ impl TestScenario {
             },
             util_name: String::from(util_name),
             fixtures: AtPath::new(tmpd.as_ref().path()),
-            tmpd: tmpd,
+            tmpd,
         };
         let mut fixture_path_builder = env::current_dir().unwrap();
         fixture_path_builder.push(TESTS_DIR);


### PR DESCRIPTION
- All assert_eq in tests/common/util.rs now print a pretty diff on test
failures.
- {stdout, stderr}_is_fixture now compare the expected output and the
fixture as Strings, which leads to more usable diffs.

If we had flipped the order of two lines in `sort`, the assertion failure would have printed something like this:
![Bildschirmfoto von 2021-04-24 16-35-35](https://user-images.githubusercontent.com/44171190/115962559-45951e80-a51c-11eb-9f6e-9d4c4f19c87c.png)
After this change it displays like this:
![Bildschirmfoto von 2021-04-24 16-29-56](https://user-images.githubusercontent.com/44171190/115962576-665d7400-a51c-11eb-9b28-9ac0fa96d7e8.png)

This makes it much easier to spot the difference.

Added dev dependency: pretty_assertions