### PR TITLE
ls: Use sort_by_cached_key

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1147,7 +1147,7 @@ fn sort_entries(entries: &mut Vec<PathData>, config: &Config) {
             entries.sort_by_key(|k| Reverse(k.md().as_ref().map(|md| md.len()).unwrap_or(0)))
         }
         // The default sort in GNU ls is case insensitive
-        Sort::Name => entries.sort_by_key(|k| k.file_name.to_lowercase()),
+        Sort::Name => entries.sort_by_cached_key(|k| k.file_name.to_lowercase()),
         Sort::Version => entries.sort_by(|k, j| version_cmp::version_cmp(&k.p_buf, &j.p_buf)),
         Sort::None => {}
     }


### PR DESCRIPTION
For sorting by name, the key computation was becoming a non-trivial operation. Use sort_by_cached_key so gave a performance boost.

(tree is a linux kernel source tree)
**Before:**
```
Summary
  'ls -R tree > /dev/null' ran
    3.82 ± 0.61 times faster than 'target/release/ls -R tree > /dev/null'

Summary
  'ls -al -R tree > /dev/null' ran
    1.34 ± 0.11 times faster than 'target/release/ls -al -R tree > /dev/null'
```

**After:**
```
Summary
  'ls -R tree > /dev/null' ran
    2.32 ± 0.30 times faster than 'target/release/ls -R tree > /dev/null'

Summary
  'ls -al -R tree > /dev/null' ran
    1.14 ± 0.09 times faster than 'target/release/ls -al -R tree > /dev/null'
```