### PR TITLE
ls: Cache sort keys for default sort order

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1147,7 +1147,7 @@ fn sort_entries(entries: &mut Vec<PathData>, config: &Config) {
             entries.sort_by_key(|k| Reverse(k.md().as_ref().map(|md| md.len()).unwrap_or(0)))
         }
         // The default sort in GNU ls is case insensitive
-        Sort::Name => entries.sort_by_key(|k| k.file_name.to_lowercase()),
+        Sort::Name => entries.sort_by_cached_key(|k| k.file_name.to_lowercase()),
         Sort::Version => entries.sort_by(|k, j| version_cmp::version_cmp(&k.p_buf, &j.p_buf)),
         Sort::None => {}
     }


### PR DESCRIPTION
Easy performance gain by caching sort keys for the default sort order (by name) to avoid repeated string allocations and conversion to lowercase.

Following benchmark was done on the rust repo directory.

## benchmark

### before

```
$ hyperfine 'ls -al -R' "~/code/coreutils/target/release/ls -a1 -R ~/code/rust/"
Benchmark #1: ls -al -R
  Time (mean ± σ):     143.4 ms ±   6.8 ms    [User: 71.4 ms, System: 71.6 ms]
  Range (min … max):   135.2 ms … 163.7 ms    19 runs
 
Benchmark #2: ~/code/coreutils/target/release/ls -a1 -R ~/code/rust/
  Time (mean ± σ):      1.791 s ±  0.016 s    [User: 1.584 s, System: 0.202 s]
  Range (min … max):    1.772 s …  1.830 s    10 runs
 
Summary
  'ls -al -R' ran
   12.49 ± 0.61 times faster than '~/code/coreutils/target/release/ls -a1 -R ~/code/rust/'
```

### after

```
$ hyperfine 'ls -al -R' "~/code/coreutils/target/release/ls -a1 -R ~/code/rust/"
Benchmark #1: ls -al -R
  Time (mean ± σ):     139.9 ms ±   2.7 ms    [User: 64.4 ms, System: 75.1 ms]
  Range (min … max):   135.4 ms … 143.8 ms    21 runs
 
Benchmark #2: ~/code/coreutils/target/release/ls -a1 -R ~/code/rust/
  Time (mean ± σ):     828.4 ms ±   7.5 ms    [User: 612.2 ms, System: 212.6 ms]
  Range (min … max):   819.5 ms … 838.7 ms    10 runs
 
Summary
  'ls -al -R' ran
    5.92 ± 0.13 times faster than '~/code/coreutils/target/release/ls -a1 -R ~/code/rust/'
```