### PR TITLE
`ls`: reduce write syscalls & cleanup

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -22,25 +22,22 @@ use lscolors::LsColors;
 use number_prefix::NumberPrefix;
 use once_cell::unsync::OnceCell;
 use quoting_style::{escape_name, QuotingStyle};
-#[cfg(unix)]
-use std::collections::HashMap;
-#[cfg(any(unix, target_os = "redox"))]
-use std::os::unix::fs::{FileTypeExt, MetadataExt};
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
-#[cfg(unix)]
-use std::time::Duration;
-use std::{cmp::Reverse, process::exit};
 use std::{
+    cmp::Reverse,
     fs::{self, DirEntry, FileType, Metadata},
-    io::{stdout, BufWriter, Write},
+    io::{stdout, BufWriter, Stdout, Write},
     path::{Path, PathBuf},
-};
-use std::{
-    io::Stdout,
+    process::exit,
     time::{SystemTime, UNIX_EPOCH},
 };
-
+#[cfg(unix)]
+use std::{
+    collections::HashMap,
+    os::unix::fs::{FileTypeExt, MetadataExt},
+    time::Duration,
+};
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 use time::{strftime, Timespec};
 #[cfg(unix)]


### PR DESCRIPTION
Instead of writing directly to `stdout`, with `print!` and `println!`, we can write to a `BufWriter` to reduce `write` syscalls. Doing so leads to the following improvements:

* GNU is now 4.06 times faster instead of 4.31.
* Our time spent on syscalls is now on par with GNU instead of 60% longer.
* Number of `write` calls goes from 344064 to 1090 when running `ls -R` on the Firefox source code.

The full benchmarks are in the `details` tag below. Because `print!` doesn't return a `Result` and `write!` does, I simply discarded the return values of `write!`.

Because this was a simple change I figured I could sneak in a few other changes to clean up the code some more. I hope that's okay. These changes are:

* Merging some imports
* Use `Entry` API with the cache `HashMap`s.
* Remove some redundant code from the `indicator_style` argument parsing.
* Make `display_file_type` return a `char` instead of `String`.

<details>
<summary>Full Benchmarks</summary>
<h2>Before</h2>
<pre><code>❯ hyperfine --warmup 2 'ls -R' '../coreutils/target/release/coreutils ls -R'
Benchmark #1: ls -R
  Time (mean ± σ):     537.6 ms ±   6.9 ms    [User: 379.8 ms, System: 156.0 ms]
  Range (min … max):   527.6 ms … 553.5 ms    10 runs
 
Benchmark #2: ../coreutils/target/release/coreutils ls -R
  Time (mean ± σ):      2.315 s ±  0.026 s    [User: 2.089 s, System: 0.224 s]
  Range (min … max):    2.287 s …  2.372 s    10 runs
 
Summary
  'ls -R' ran
    4.31 ± 0.07 times faster than '../coreutils/target/release/coreutils ls -R'
</code></pre>

<pre><code>❯ strace -c ../coreutils/target/release/coreutils ls -R > /dev/null 
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 72,26    6,736737          19    344064           write
 11,74    1,094781          29     37436           getdents64
  5,48    0,510923          27     18697           openat
  5,31    0,494837          26     18697           close
  5,14    0,479311          25     18697           newfstatat
</code></pre>

<h2>After</h2>
<pre><code>❯ hyperfine --warmup 2 'ls -R' '../coreutils/target/release/coreutils ls -R'
Benchmark #1: ls -R
  Time (mean ± σ):     533.0 ms ±   3.2 ms    [User: 381.2 ms, System: 150.0 ms]
  Range (min … max):   528.2 ms … 540.5 ms    10 runs
 
Benchmark #2: ../coreutils/target/release/coreutils ls -R
  Time (mean ± σ):      2.165 s ±  0.015 s    [User: 1.997 s, System: 0.165 s]
  Range (min … max):    2.144 s …  2.195 s    10 runs
 
Summary
  'ls -R' ran
    4.06 ± 0.04 times faster than '../coreutils/target/release/coreutils ls -R'
</code></pre>

<pre><code>❯ strace -c ../coreutils/target/release/coreutils ls -R > /dev/null
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 41,39    0,510284          13     37436           getdents64
 19,68    0,242657          12     18697           openat
 19,38    0,238876          12     18697           close
 18,60    0,229333          12     18697           newfstatat
  0,51    0,006314           5      1090           write
</code></pre>
</details>