### PR TITLE
Expand truncate tests

### DIFF
--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -6,26 +6,31 @@ static TFILE2: &'static str = "truncate_test_2";
 
 #[test]
 fn test_increase_file_size() {
+    let expected = 5 * 1024;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE1);
     ucmd.args(&["-s", "+5K", TFILE1]).succeeds();
 
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 5 * 1024);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_increase_file_size_kb() {
+    let expected = 5 * 1000;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE1);
     ucmd.args(&["-s", "+5KB", TFILE1]).succeeds();
 
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 5 * 1000);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_reference() {
+    let expected = 5 * 1000;
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     let mut file = at.make_file(TFILE2);
@@ -40,27 +45,32 @@ fn test_reference() {
         .run();
 
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 5 * 1000);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_decrease_file_size() {
+    let expected = 6;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size=-4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 6);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_space_in_size() {
+    let expected = 4;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size", " 4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 4);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
@@ -82,60 +92,72 @@ fn test_failed_incorrect_arg() {
 
 #[test]
 fn test_at_most_shrinks() {
+    let expected = 4;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size", "<4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 4);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_at_most_no_change() {
+    let expected = 10;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size", "<40", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 10);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_at_least_grows() {
+    let expected = 15;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size", ">15", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 15);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_at_least_no_change() {
+    let expected = 10;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size", ">4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 10);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_round_down() {
+    let expected = 8;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size", "/4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 8);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
 
 #[test]
 fn test_round_up() {
+    let expected = 12;
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
     ucmd.args(&["--size", "*4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
-    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 12);
+    let actual = file.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -79,3 +79,63 @@ fn test_failed_incorrect_arg() {
     let (_at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["-s", "+5A", TFILE1]).fails();
 }
+
+#[test]
+fn test_at_most_shrinks() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file = at.make_file(TFILE2);
+    file.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--size", "<4", TFILE2]).succeeds();
+    file.seek(SeekFrom::End(0)).unwrap();
+    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 4);
+}
+
+#[test]
+fn test_at_most_no_change() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file = at.make_file(TFILE2);
+    file.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--size", "<40", TFILE2]).succeeds();
+    file.seek(SeekFrom::End(0)).unwrap();
+    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 10);
+}
+
+#[test]
+fn test_at_least_grows() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file = at.make_file(TFILE2);
+    file.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--size", ">15", TFILE2]).succeeds();
+    file.seek(SeekFrom::End(0)).unwrap();
+    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 15);
+}
+
+#[test]
+fn test_at_least_no_change() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file = at.make_file(TFILE2);
+    file.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--size", ">4", TFILE2]).succeeds();
+    file.seek(SeekFrom::End(0)).unwrap();
+    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 10);
+}
+
+#[test]
+fn test_round_down() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file = at.make_file(TFILE2);
+    file.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--size", "/4", TFILE2]).succeeds();
+    file.seek(SeekFrom::End(0)).unwrap();
+    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 8);
+}
+
+#[test]
+fn test_round_up() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file = at.make_file(TFILE2);
+    file.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--size", "*4", TFILE2]).succeeds();
+    file.seek(SeekFrom::End(0)).unwrap();
+    assert!(file.seek(SeekFrom::Current(0)).unwrap() == 12);
+}


### PR DESCRIPTION
* Adds some more tests to improve coverage on truncate.
* Make assert error messages provide useful info for debuging test failures