### PR TITLE
`ls`: fix grid alignment with `--color`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "term_grid",
  "termsize",
  "time",
+ "unicode-width",
  "uucore",
  "uucore_procs",
 ]

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/ls.rs"
 
 [dependencies]
 clap = "2.33"
+unicode-width = "0.1.8"
 number_prefix = "0.4"
 term_grid = "0.1.5"
 termsize = "0.1.6"

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -40,6 +40,7 @@ use std::{
 };
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 use time::{strftime, Timespec};
+use unicode_width::UnicodeWidthStr;
 #[cfg(unix)]
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 
@@ -1617,7 +1618,7 @@ fn display_file_name(path: &PathData, strip: Option<&Path>, config: &Config) -> 
 
     // We need to keep track of the width ourselfs instead of letting term_grid
     // infer it because the color codes mess up term_grid's width calculation.
-    let mut width = name.len();
+    let mut width = name.width();
 
     if let Some(ls_colors) = &config.color {
         name = color_name(&ls_colors, &path.p_buf, name, path.md()?);

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1615,6 +1615,10 @@ fn display_file_name(path: &PathData, strip: Option<&Path>, config: &Config) -> 
         }
     }
 
+    // We need to keep track of the width ourselfs instead of letting term_grid
+    // infer it because the color codes mess up term_grid's width calculation.
+    let mut width = name.len();
+
     if let Some(ls_colors) = &config.color {
         name = color_name(&ls_colors, &path.p_buf, name, path.md()?);
     }
@@ -1643,6 +1647,7 @@ fn display_file_name(path: &PathData, strip: Option<&Path>, config: &Config) -> 
 
         if let Some(c) = char_opt {
             name.push(c);
+            width += 1;
         }
     }
 
@@ -1653,7 +1658,10 @@ fn display_file_name(path: &PathData, strip: Option<&Path>, config: &Config) -> 
         }
     }
 
-    Some(name.into())
+    Some(Cell {
+        contents: name,
+        width,
+    })
 }
 
 fn color_name(ls_colors: &LsColors, path: &Path, name: String, md: &Metadata) -> String {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1616,7 +1616,7 @@ fn display_file_name(path: &PathData, strip: Option<&Path>, config: &Config) -> 
         }
     }
 
-    // We need to keep track of the width ourselfs instead of letting term_grid
+    // We need to keep track of the width ourselves instead of letting term_grid
     // infer it because the color codes mess up term_grid's width calculation.
     let mut width = name.width();
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -775,6 +775,18 @@ fn test_ls_color() {
         .arg("z")
         .succeeds()
         .stdout_only("");
+
+    // The colors must not mess up the grid layout
+    at.touch("b");
+    scene
+        .ucmd()
+        .arg("--color")
+        .arg("-w=15")
+        .succeeds()
+        .stdout_only(format!(
+            "{}  test-color\nb  {}\n",
+            a_with_colors, z_with_colors
+        ));
 }
 
 #[cfg(unix)]
@@ -1723,7 +1735,7 @@ fn test_ls_sort_extension() {
     let expected = vec![
         ".",
         "..",
-        ".hidden",    
+        ".hidden",
         "anotherFile",
         "file1",
         "file2",
@@ -1741,8 +1753,14 @@ fn test_ls_sort_extension() {
     ];
 
     let result = scene.ucmd().arg("-1aX").run();
-    assert_eq!(result.stdout_str().split('\n').collect::<Vec<_>>(), expected,);
+    assert_eq!(
+        result.stdout_str().split('\n').collect::<Vec<_>>(),
+        expected,
+    );
 
     let result = scene.ucmd().arg("-1a").arg("--sort=extension").run();
-    assert_eq!(result.stdout_str().split('\n').collect::<Vec<_>>(), expected,);
+    assert_eq!(
+        result.stdout_str().split('\n').collect::<Vec<_>>(),
+        expected,
+    );
 }


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/2132

**Before** (in the terminal this is colored, of course)
```
❯ target/release/coreutils ls --color
benches  CODE_OF_CONDUCT.md         examples          LICENSE           'one\ntwo'     README.md             tests
build.rs          CONTRIBUTING.md            flamegraph.svg    Makefile          'one\two'      src          util
Cargo.lock        DEVELOPER_INSTRUCTIONS.md  flamegraph_ls.sh  Makefile.toml     perf.data      target       
Cargo.toml        docs              GNUmakefile                'one'$'\n''&two'  perf.data.old  test_folder
```

**After**
```
❯ target/release/coreutils ls --color
benches     Cargo.toml          DEVELOPER_INSTRUCTIONS.md  flamegraph.svg    LICENSE        'one'$'\n''&two'  perf.data      src          tests
build.rs    CODE_OF_CONDUCT.md  docs                       flamegraph_ls.sh  Makefile       'one\ntwo'        perf.data.old  target       util
Cargo.lock  CONTRIBUTING.md     examples                   GNUmakefile       Makefile.toml  'one\two'         README.md      test_folder
```