### PR TITLE
`ls`: file name handling performance improvements

### DIFF
--- a/src/uu/ls/BENCHMARKING.md
+++ b/src/uu/ls/BENCHMARKING.md
@@ -26,7 +26,15 @@ Example: `hyperfine --warmup 2 "target/release/coreutils ls -al -R tree > /dev/n
 `hyperfine --warmup 2 "target/release/coreutils ls -al -R tree > /dev/null" "ls -al -R tree > /dev/null"`
 (This assumes GNU ls is installed as `ls`)
 
-This can also be used to compare with version of ls built before your changes to ensure your change does not regress this
+This can also be used to compare with version of ls built before your changes to ensure your change does not regress this.
+
+Here is a `bash` script for doing this comparison:
+```bash
+#!/bin/bash
+cargo build --no-default-features --features ls --release
+args="$@"
+hyperfine "ls $args" "target/release/coreutils ls $args"
+```
 
 ## Checking system call count
 
@@ -43,7 +51,6 @@ cargo flamegraph --cmd coreutils -- ls [additional parameters]
 However, if the `-R` option is given, the output becomes pretty much useless due to recursion. We can fix this by merging all the direct recursive calls with `uniq`, below is a `bash` script that does this.
 ```bash
 #!/bin/bash
-
 cargo build --release --no-default-features --features ls
 perf record target/release/coreutils ls "$@"
 perf script | uniq | inferno-collapse-perf | inferno-flamegraph > flamegraph.svg 

--- a/src/uu/ls/BENCHMARKING.md
+++ b/src/uu/ls/BENCHMARKING.md
@@ -32,3 +32,19 @@ This can also be used to compare with version of ls built before your changes to
 
 - Another thing to look at would be system calls count using strace (on linux) or equivalent on other operating systems.
 - Example: `strace -c target/release/coreutils ls -al -R tree`
+
+## Cargo Flamegraph
+
+With Cargo Flamegraph you can easily make a flamegraph of `ls`:
+```bash
+cargo flamegraph --cmd coreutils -- ls [additional parameters]
+```
+
+However, if the `-R` option is given, the output becomes pretty much useless due to recursion. We can fix this by merging all the direct recursive calls with `uniq`, below is a `bash` script that does this.
+```bash
+#!/bin/bash
+
+cargo build --release --no-default-features --features ls
+perf record target/release/coreutils ls "$@"
+perf script | uniq | inferno-collapse-perf | inferno-flamegraph > flamegraph.svg 
+```

--- a/src/uu/ls/src/quoting_style.rs
+++ b/src/uu/ls/src/quoting_style.rs
@@ -171,7 +171,7 @@ impl Iterator for EscapedChar {
     }
 }
 
-fn shell_without_escape(name: String, quotes: Quotes, show_control_chars: bool) -> (String, bool) {
+fn shell_without_escape(name: &str, quotes: Quotes, show_control_chars: bool) -> (String, bool) {
     let mut must_quote = false;
     let mut escaped_str = String::with_capacity(name.len());
 
@@ -201,7 +201,7 @@ fn shell_without_escape(name: String, quotes: Quotes, show_control_chars: bool) 
     (escaped_str, must_quote)
 }
 
-fn shell_with_escape(name: String, quotes: Quotes) -> (String, bool) {
+fn shell_with_escape(name: &str, quotes: Quotes) -> (String, bool) {
     // We need to keep track of whether we are in a dollar expression
     // because e.g. \b\n is escaped as $'\b\n' and not like $'b'$'n'
     let mut in_dollar = false;
@@ -249,7 +249,7 @@ fn shell_with_escape(name: String, quotes: Quotes) -> (String, bool) {
     (escaped_str, must_quote)
 }
 
-pub(super) fn escape_name(name: String, style: &QuotingStyle) -> String {
+pub(super) fn escape_name(name: &str, style: &QuotingStyle) -> String {
     match style {
         QuotingStyle::Literal { show_control } => {
             if !show_control {
@@ -257,7 +257,7 @@ pub(super) fn escape_name(name: String, style: &QuotingStyle) -> String {
                     .flat_map(|c| EscapedChar::new_literal(c).hide_control())
                     .collect()
             } else {
-                name
+                name.into()
             }
         }
         QuotingStyle::C { quotes } => {
@@ -354,7 +354,7 @@ mod tests {
     fn check_names(name: &str, map: Vec<(&str, &str)>) {
         assert_eq!(
             map.iter()
-                .map(|(_, style)| escape_name(name.to_string(), &get_style(style)))
+                .map(|(_, style)| escape_name(name, &get_style(style)))
                 .collect::<Vec<String>>(),
             map.iter()
                 .map(|(correct, _)| correct.to_string())


### PR DESCRIPTION
I did some more performance improvements based on flamegraph data. I documented the method for this in `BENCHMARKING.md`. The changes I made are mostly reducing some allocations and reducing the times that `OsStrs` are converted to `Strings`.

**Before**
```
Benchmark #1: ls ../firefox-source/ -R
  Time (mean ± σ):     741.3 ms ±  26.7 ms    [User: 521.4 ms, System: 216.2 ms]
  Range (min … max):   708.8 ms … 766.3 ms    10 runs
 
Benchmark #2: target/release/coreutils ls ../firefox-source/ -R
  Time (mean ± σ):      1.049 s ±  0.031 s    [User: 831.8 ms, System: 212.2 ms]
  Range (min … max):    1.005 s …  1.090 s    10 runs
 
Summary
  'ls ../firefox-source/ -R' ran
    1.41 ± 0.07 times faster than 'target/release/coreutils ls ../firefox-source/ -R'
```

**After**
```
Benchmark #1: ls ../firefox-source/ -R
  Time (mean ± σ):     542.1 ms ±   3.4 ms    [User: 375.2 ms, System: 164.6 ms]
  Range (min … max):   537.9 ms … 547.2 ms    10 runs
 
Benchmark #2: target/release/coreutils ls ../firefox-source/ -R
  Time (mean ± σ):     649.3 ms ±   9.3 ms    [User: 479.6 ms, System: 167.4 ms]
  Range (min … max):   638.3 ms … 664.2 ms    10 runs
 
Summary
  'ls ../firefox-source/ -R' ran
    1.20 ± 0.02 times faster than 'target/release/coreutils ls ../firefox-source/ -R'
```