### PR TITLE
Allow truncate to take --size and --reference

### DIFF
--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -161,3 +161,16 @@ fn test_round_up() {
     let actual = file.seek(SeekFrom::Current(0)).unwrap();
     assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
 }
+
+#[test]
+fn test_size_and_reference() {
+    let expected = 15;
+    let (at, mut ucmd) = at_and_ucmd!();
+    let mut file1 = at.make_file(TFILE1);
+    let mut file2 = at.make_file(TFILE2);
+    file1.write_all(b"1234567890").unwrap();
+    ucmd.args(&["--reference", TFILE1, "--size", "+5", TFILE2]).succeeds();
+    file2.seek(SeekFrom::End(0)).unwrap();
+    let actual = file2.seek(SeekFrom::Current(0)).unwrap();
+    assert!(expected == actual, "expected '{}' got '{}'", expected, actual);
+}


### PR DESCRIPTION
The GNU truncate allows you to use `--reference` when giving an increase or decrease by size.