### PR TITLE
factor: Add annotations for coz, the causal profiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "coz"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef55b3fe2f5477d59e12bc792e8b3c95a25bd099eadcfae006ecea136de76e2"
+dependencies = [
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "cpp"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,7 +618,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.6",
+ "redox_syscall 0.2.7",
  "winapi 0.3.9",
 ]
 
@@ -1249,9 +1259,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
+checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
 dependencies = [
  "bitflags",
 ]
@@ -1262,7 +1272,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
- "redox_syscall 0.2.6",
+ "redox_syscall 0.2.7",
 ]
 
 [[package]]
@@ -1533,7 +1543,7 @@ checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
  "numtoa",
- "redox_syscall 0.2.6",
+ "redox_syscall 0.2.7",
  "redox_termios",
 ]
 
@@ -1898,6 +1908,7 @@ dependencies = [
 name = "uu_factor"
 version = "0.0.6"
 dependencies = [
+ "coz",
  "criterion",
  "num-traits",
  "paste",

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 [build-dependencies]
 num-traits = "0.2.13" # used in src/numerics.rs, which is included by build.rs
 
-
 [dependencies]
+coz = { version = "0.1.3", optional = true }
 num-traits = "0.2.13" # Needs at least version 0.2.13 for "OverflowingAdd"
 rand = { version="0.7", features=["small_rng"] }
 smallvec = { version="0.6.14, < 1.0" }

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -125,6 +125,8 @@ fn _factor<A: Arithmetic + miller_rabin::Basis>(num: u64, f: Factors) -> Factors
     let n = A::new(num);
     let divisor = match miller_rabin::test::<A>(n) {
         Prime => {
+            #[cfg(feature="coz")]
+            coz::progress!("factor found");
             let mut r = f;
             r.push(num);
             return r;
@@ -139,6 +141,8 @@ fn _factor<A: Arithmetic + miller_rabin::Basis>(num: u64, f: Factors) -> Factors
 }
 
 pub fn factor(mut n: u64) -> Factors {
+    #[cfg(feature="coz")]
+    coz::begin!("factorization");
     let mut factors = Factors::one();
 
     if n < 2 {
@@ -152,16 +156,23 @@ pub fn factor(mut n: u64) -> Factors {
     }
 
     if n == 1 {
+        #[cfg(feature="coz")]
+        coz::end!("factorization");
         return factors;
     }
 
     let (factors, n) = table::factor(n, factors);
 
-    if n < (1 << 32) {
+    let r = if n < (1 << 32) {
         _factor::<Montgomery<u32>>(n, factors)
     } else {
         _factor::<Montgomery<u64>>(n, factors)
-    }
+    };
+
+    #[cfg(feature="coz")]
+    coz::end!("factorization");
+
+    return r;
 }
 
 #[cfg(test)]

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -33,6 +33,8 @@ pub(crate) fn factor(mut num: u64, mut factors: Factors) -> (Factors, u64) {
             if x <= ceil {
                 num = x;
                 k += 1;
+                #[cfg(feature="coz")]
+                coz::progress!("factor found");
             } else {
                 if k > 0 {
                     factors.add(prime, k);


### PR DESCRIPTION
`coz` is a profiling utility that's helpful in figuring out which parts of the
code would yield the greatest performance improvement when optimized (as opposed
to which take the longest).

The dependency on it is [optional], and when the corresponding feature is not
enabled there is no functional or performance change.

[optional]: https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies
