### PR TITLE
sort: add some custom string comparisons

### DIFF
--- a/src/uu/sort/src/custom_str_cmp.rs
+++ b/src/uu/sort/src/custom_str_cmp.rs
@@ -1,0 +1,64 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * (c) Michael Debertol <michael.debertol..AT..gmail.com>
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+
+//! Custom string comparisons.
+//!
+//! The goal is to compare strings without transforming them first (i.e. not allocating new strings)
+
+use std::cmp::Ordering;
+
+fn filter_char(c: char, ignore_non_printing: bool, ignore_non_dictionary: bool) -> bool {
+    if ignore_non_dictionary && !(c.is_ascii_alphanumeric() || c.is_ascii_whitespace()) {
+        return false;
+    }
+    if ignore_non_printing && (c.is_ascii_control() || !c.is_ascii()) {
+        return false;
+    }
+    true
+}
+
+fn cmp_chars(a: char, b: char, ignore_case: bool) -> Ordering {
+    if ignore_case {
+        a.to_ascii_uppercase().cmp(&b.to_ascii_uppercase())
+    } else {
+        a.cmp(&b)
+    }
+}
+
+pub fn custom_str_cmp(
+    a: &str,
+    b: &str,
+    ignore_non_printing: bool,
+    ignore_non_dictionary: bool,
+    ignore_case: bool,
+) -> Ordering {
+    if !(ignore_case || ignore_non_dictionary || ignore_non_printing) {
+        // There are no custom settings. Fall back to the default strcmp, which is faster.
+        return a.cmp(&b);
+    }
+    let mut a_chars = a
+        .chars()
+        .filter(|&c| filter_char(c, ignore_non_printing, ignore_non_dictionary));
+    let mut b_chars = b
+        .chars()
+        .filter(|&c| filter_char(c, ignore_non_printing, ignore_non_dictionary));
+    loop {
+        let a_char = a_chars.next();
+        let b_char = b_chars.next();
+        match (a_char, b_char) {
+            (None, None) => return Ordering::Equal,
+            (Some(_), None) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(a_char), Some(b_char)) => {
+                let ordering = cmp_chars(a_char, b_char, ignore_case);
+                if ordering != Ordering::Equal {
+                    return ordering;
+                }
+            }
+        }
+    }
+}

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1254,8 +1254,8 @@ fn compare_by(a: &Line, b: &Line, global_settings: &GlobalSettings) -> Ordering 
                     (b_str, b_selection.num_cache.as_num_info()),
                 ),
                 SortMode::GeneralNumeric => general_numeric_compare(
-                    general_f64_parse(&a_str[get_leading_gen(a_str)]),
-                    general_f64_parse(&b_str[get_leading_gen(b_str)]),
+                    a_selection.num_cache.as_f64(),
+                    b_selection.num_cache.as_f64(),
                 ),
                 SortMode::Month => month_compare(a_str, b_str),
                 SortMode::Version => version_compare(a_str, b_str),

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1222,7 +1222,7 @@ fn ext_sort_by(unsorted: Vec<Line>, settings: GlobalSettings) -> Vec<Line> {
         settings.clone(),
     );
     let iter = external_sorter
-        .sort_by(unsorted.into_iter(), settings.clone())
+        .sort_by(unsorted.into_iter(), settings)
         .unwrap()
         .map(|x| x.unwrap())
         .collect::<Vec<Line>>();


### PR DESCRIPTION
This removes the need to allocate a new string for each line when used
with -f, -d or -i. Instead, a custom string comparison algorithm takes
care of these cases.

The resulting performance improvement is about 20% per flag (i.e. there
is a 60% improvement when combining all three flags)

As a side-effect, the size of the Line struct was reduced from 96 to 80
bytes, reducing the overhead for each line.