### PR TITLE
`ls`: implement device symbol and id

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1621,20 +1621,23 @@ fn format_prefixed(prefixed: NumberPrefix<f64>) -> String {
 }
 
 fn display_file_size(metadata: &Metadata, config: &Config) -> String {
+    #[cfg(unix)]
+    {
+        let ft = metadata.file_type();
+        if ft.is_char_device() || ft.is_block_device() {
+            let dev: u64 = metadata.rdev();
+            let major = (dev >> 8) as u8;
+            let minor = dev as u8;
+            return format!("{}, {}", major, minor);
+        }
+    }
+
     // NOTE: The human-readable behaviour deviates from the GNU ls.
     // The GNU ls uses binary prefixes by default.
-    let ft = metadata.file_type();
-    if ft.is_char_device() || ft.is_block_device() {
-        let dev: u64 = metadata.rdev();
-        let major = (dev >> 8) as u8;
-        let minor = dev as u8;
-        return format!("{}, {}", major, minor);
-    } else {
-        match config.size_format {
-            SizeFormat::Binary => format_prefixed(NumberPrefix::binary(metadata.len() as f64)),
-            SizeFormat::Decimal => format_prefixed(NumberPrefix::decimal(metadata.len() as f64)),
-            SizeFormat::Bytes => metadata.len().to_string(),
-        }
+    match config.size_format {
+        SizeFormat::Binary => format_prefixed(NumberPrefix::binary(metadata.len() as f64)),
+        SizeFormat::Decimal => format_prefixed(NumberPrefix::decimal(metadata.len() as f64)),
+        SizeFormat::Bytes => metadata.len().to_string(),
     }
 }
 
@@ -1643,11 +1646,24 @@ fn display_file_type(file_type: FileType) -> char {
         'd'
     } else if file_type.is_symlink() {
         'l'
-    } else if file_type.is_block_device() {
-        'b'
-    } else if file_type.is_char_device() {
-        'c'
     } else {
+        #[cfg(unix)]
+        {
+            if file_type.is_block_device() {
+                'b'
+            } else if file_type.is_char_device() {
+                'c'
+            } else if file_type.is_fifo() {
+                'p'
+            } else if file_type.is_socket() {
+                's'
+            } else if file_type.is_file() {
+                '-'
+            } else {
+                '?'
+            }
+        }
+        #[cfg(not(unix))]
         '-'
     }
 }


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/2140

This is a quick fix to show the correct symbols for character device and block device, fifo and pipe special files and show the minor and major id numbers of devices. I'm not sure how to test this, so any ideas on that are welcome!

The id numbers are not spaced correctly yet, because that would require a bit of a rewrite of the `long` format. I would rather do that in another PR (which should also fix https://github.com/uutils/coreutils/issues/2139). This is what it looks like now:
```
crw-rw---- 1 root audio 116, 12 Apr 29 09:01 hwC0D0
crw-rw---- 1 root audio 116, 11 Apr 29 09:01 hwC0D2
crw-rw---- 1 root audio  116, 5 Apr 29 13:08 pcmC0D0c
crw-rw---- 1 root audio  116, 4 Apr 29 13:08 pcmC0D0p
```
and here is what it *should* eventually look like:
```
crw-rw----+ 1 root audio 116, 12 29 apr 09:01 hwC0D0
crw-rw----+ 1 root audio 116, 11 29 apr 09:01 hwC0D2
crw-rw----+ 1 root audio 116,  5 29 apr 13:08 pcmC0D0c
crw-rw----+ 1 root audio 116,  4 29 apr 13:08 pcmC0D0p
```
> Note: the `+` at the end is also not implemented yet.