### PR TITLE
`ls`: add birth time for windows and attempt to fix tests

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1559,6 +1559,7 @@ fn get_system_time(md: &Metadata, config: &Config) -> Option<SystemTime> {
     match config.time {
         Time::Modification => md.modified().ok(),
         Time::Access => md.accessed().ok(),
+        Time::Birth => md.created().ok(),
         _ => None,
     }
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -559,8 +559,6 @@ fn test_ls_long_ctime() {
 }
 
 #[test]
-#[cfg(not(windows))]
-// This test is currently failing on windows
 fn test_ls_order_birthtime() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -570,15 +568,11 @@ fn test_ls_order_birthtime() {
         After creating the first file try to sync it.
         This ensures the file gets created immediately instead of being saved
         inside the OS's IO operation buffer.
-        Without this, both files might accidentally be created at the same time,
-        even though we placed a timeout between creating the two.
-
-        https://github.com/uutils/coreutils/pull/1986/#issuecomment-828490651
+        Without this, both files might accidentally be created at the same time.
     */
     at.make_file("test-birthtime-1").sync_all().unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(1));
-    at.make_file("test-birthtime-2");
-    at.touch("test-birthtime-1");
+    at.make_file("test-birthtime-2").sync_all().unwrap();
+    at.open("test-birthtime-1");
 
     let result = scene.ucmd().arg("--time=birth").arg("-t").run();
 


### PR DESCRIPTION
This is an attempt to make the tests for `ls -t --time=birth` a little bit more stable and also enable the test for Windows. ~Keeping this as a draft for now to see whether it works out.~

Tests are green, the failures are unrelated, so this seems to fix it. `AtPath::touch` seemed to be the issue for windows because it uses `File::create`, which sets the creation time on Windows. I'm not sure whether this fixes the stability of the other tests, but the best we can do is wait and see.