### PR TITLE
tr/dirname: fix clap short_alias

### DIFF
--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -12,19 +12,23 @@ use clap::{App, Arg};
 use std::path::Path;
 use uucore::InvalidEncodingHandling;
 
-static NAME: &str = "dirname";
-static SYNTAX: &str = "[OPTION] NAME...";
-static SUMMARY: &str = "strip last component from file name";
+static ABOUT: &str = "strip last component from file name";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
-static LONG_HELP: &str = "
- Output each NAME with its last non-slash component and trailing slashes
- removed; if NAME contains no /'s, output '.' (meaning the current
- directory).
-";
 
 mod options {
     pub const ZERO: &str = "zero";
     pub const DIR: &str = "dir";
+}
+
+fn get_usage() -> String {
+    format!("{0} [OPTION] NAME...", executable!())
+}
+
+fn get_long_usage() -> String {
+    String::from(
+        "Output each NAME with its last non-slash component and trailing slashes
+        removed; if NAME contains no /'s, output '.' (meaning the current directory).",
+    )
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -32,17 +36,18 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
+    let usage = get_usage();
+    let after_help = get_long_usage();
+
     let matches = App::new(executable!())
-        .name(NAME)
-        .usage(SYNTAX)
-        .about(SUMMARY)
-        .after_help(LONG_HELP)
+        .about(ABOUT)
+        .usage(&usage[..])
+        .after_help(&after_help[..])
         .version(VERSION)
         .arg(
             Arg::with_name(options::ZERO)
-                .short(options::ZERO)
+                .long(options::ZERO)
                 .short("z")
-                .takes_value(false)
                 .help("separate output with NUL rather than newline"),
         )
         .arg(Arg::with_name(options::DIR).hidden(true).multiple(true))

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -23,11 +23,9 @@ use std::io::{stdin, stdout, BufRead, BufWriter, Write};
 use crate::expand::ExpandSet;
 use uucore::InvalidEncodingHandling;
 
-static NAME: &str = "tr";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = "translate or delete characters";
-static LONG_HELP: &str = "Translate,  squeeze, and/or delete characters from standard input,
-writing to standard output.";
+
 const BUFFER_LEN: usize = 1024;
 
 mod options {
@@ -186,23 +184,37 @@ fn get_usage() -> String {
     format!("{} [OPTION]... SET1 [SET2]", executable!())
 }
 
+fn get_long_usage() -> String {
+    String::from(
+        "Translate, squeeze, and/or delete characters from standard input,
+writing to standard output.",
+    )
+}
+
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
+
+    let usage = get_usage();
+    let after_help = get_long_usage();
 
     let matches = App::new(executable!())
         .version(VERSION)
         .about(ABOUT)
         .usage(&usage[..])
-        .after_help(LONG_HELP)
+        .after_help(&after_help[..])
         .arg(
             Arg::with_name(options::COMPLEMENT)
-                .short("C")
+                // .visible_short_alias('C')  // TODO: requires clap "3.0.0-beta.2"
                 .short("c")
                 .long(options::COMPLEMENT)
                 .help("use the complement of SET1"),
+        )
+        .arg(
+            Arg::with_name("C") // work around for `Arg::visible_short_alias`
+                .short("C")
+                .help("same as -c"),
         )
         .arg(
             Arg::with_name(options::DELETE)
@@ -216,8 +228,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .short("s")
                 .help(
                     "replace each sequence  of  a  repeated  character  that  is
-            listed  in the last specified SET, with a single occurrence
-            of that character",
+  listed  in the last specified SET, with a single occurrence
+  of that character",
                 ),
         )
         .arg(
@@ -230,7 +242,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .get_matches_from(args);
 
     let delete_flag = matches.is_present(options::DELETE);
-    let complement_flag = matches.is_present(options::COMPLEMENT);
+    let complement_flag = matches.is_present(options::COMPLEMENT) || matches.is_present("C");
     let squeeze_flag = matches.is_present(options::SQUEEZE);
     let truncate_flag = matches.is_present(options::TRUNCATE);
 
@@ -242,7 +254,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if sets.is_empty() {
         show_error!(
             "missing operand\nTry `{} --help` for more information.",
-            NAME
+            executable!()
         );
         return 1;
     }
@@ -251,7 +263,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         show_error!(
             "missing operand after ‘{}’\nTry `{} --help` for more information.",
             sets[0],
-            NAME
+            executable!()
         );
         return 1;
     }

--- a/tests/by-util/test_dirname.rs
+++ b/tests/by-util/test_dirname.rs
@@ -17,6 +17,21 @@ fn test_path_without_trailing_slashes() {
 }
 
 #[test]
+fn test_path_without_trailing_slashes_and_zero() {
+    new_ucmd!()
+        .arg("-z")
+        .arg("/root/alpha/beta/gamma/delta/epsilon/omega")
+        .succeeds()
+        .stdout_is("/root/alpha/beta/gamma/delta/epsilon\u{0}");
+
+    new_ucmd!()
+        .arg("--zero")
+        .arg("/root/alpha/beta/gamma/delta/epsilon/omega")
+        .succeeds()
+        .stdout_is("/root/alpha/beta/gamma/delta/epsilon\u{0}");
+}
+
+#[test]
 fn test_root() {
     new_ucmd!().arg("/").run().stdout_is("/\n");
 }

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -46,6 +46,20 @@ fn test_delete_complement() {
 }
 
 #[test]
+fn test_delete_complement_2() {
+    new_ucmd!()
+        .args(&["-d", "-C", "0-9"])
+        .pipe_in("Phone: 01234 567890")
+        .succeeds()
+        .stdout_is("01234567890");
+    new_ucmd!()
+        .args(&["-d", "--complement", "0-9"])
+        .pipe_in("Phone: 01234 567890")
+        .succeeds()
+        .stdout_is("01234567890");
+}
+
+#[test]
 fn test_squeeze() {
     new_ucmd!()
         .args(&["-s", "a-z"])


### PR DESCRIPTION
I noticed there were two (tr and dirname) getopts to clap ports which called `short()` within `App::arg` more than once. However, this does not create an alias for the short flag because the last call to `short()` takes precedence over previous calls.
Since `Arg::visible_short_alias()` is only available in clap >3.0, aliases for short flags can only be created with a work around, i.e. an additional call to `App::arg()`.

* implements `-C` as an alias for `-c` for `tr` and adds tests
* fix `--zero` flag for `dirname` and adds tests

* refactor `dirname` and `tr` to be more consistent with other clap ports, e.g. use of `get_usage()` and `get_long_usage()`