### PR TITLE
test: implement parenthesized expressions, additional tests

### DIFF
--- a/src/uu/test/src/parser.rs
+++ b/src/uu/test/src/parser.rs
@@ -1,0 +1,292 @@
+// This file is part of the uutils coreutils package.
+//
+// (c) Daniel Rocco <drocco@gmail.com>
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use std::ffi::OsString;
+use std::iter::Peekable;
+
+/// Represents a parsed token from a test expression
+#[derive(Debug, PartialEq)]
+pub enum Symbol {
+    LParen,
+    Bang,
+    BoolOp(OsString),
+    Literal(OsString),
+    StringOp(OsString),
+    IntOp(OsString),
+    FileOp(OsString),
+    StrlenOp(OsString),
+    FiletestOp(OsString),
+    None,
+}
+
+impl Symbol {
+    /// Create a new Symbol from an OsString.
+    ///
+    /// Returns Symbol::None in place of None
+    fn new(token: Option<OsString>) -> Symbol {
+        match token {
+            Some(s) => match s.to_string_lossy().as_ref() {
+                "(" => Symbol::LParen,
+                "!" => Symbol::Bang,
+                "-a" | "-o" => Symbol::BoolOp(s),
+                "=" | "!=" => Symbol::StringOp(s),
+                "-eq" | "-ge" | "-gt" | "-le" | "-lt" | "-ne" => Symbol::IntOp(s),
+                "-ef" | "-nt" | "-ot" => Symbol::FileOp(s),
+                "-n" | "-z" => Symbol::StrlenOp(s),
+                "-b" | "-c" | "-d" | "-e" | "-f" | "-g" | "-G" | "-h" | "-k" | "-L" | "-O"
+                | "-p" | "-r" | "-s" | "-S" | "-t" | "-u" | "-w" | "-x" => Symbol::FiletestOp(s),
+                _ => Symbol::Literal(s),
+            },
+            None => Symbol::None,
+        }
+    }
+
+    /// Convert this Symbol into a Symbol::Literal, useful for cases where
+    /// test treats an operator as a string operand (test has no reserved
+    /// words).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` is Symbol::None
+    fn into_literal(self) -> Symbol {
+        Symbol::Literal(match self {
+            Symbol::LParen => OsString::from("("),
+            Symbol::Bang => OsString::from("!"),
+            Symbol::BoolOp(s)
+            | Symbol::Literal(s)
+            | Symbol::StringOp(s)
+            | Symbol::IntOp(s)
+            | Symbol::FileOp(s)
+            | Symbol::StrlenOp(s)
+            | Symbol::FiletestOp(s) => s,
+            Symbol::None => panic!(),
+        })
+    }
+}
+
+/// Recursive descent parser for test, which converts a list of OsStrings
+/// (typically command line arguments) into a stack of Symbols in postfix
+/// order.
+///
+/// Grammar:
+///
+///   EXPR → TERM | EXPR BOOLOP EXPR
+///   TERM → ( EXPR )
+///   TERM → ( )
+///   TERM → ! EXPR
+///   TERM → UOP str
+///   UOP → STRLEN | FILETEST
+///   TERM → str OP str
+///   TERM → str | 𝜖
+///   OP → STRINGOP | INTOP | FILEOP
+///   STRINGOP → = | !=
+///   INTOP → -eq | -ge | -gt | -le | -lt | -ne
+///   FILEOP → -ef | -nt | -ot
+///   STRLEN → -n | -z
+///   FILETEST → -b | -c | -d | -e | -f | -g | -G | -h | -k | -L | -O | -p |
+///               -r | -s | -S | -t | -u | -w | -x
+///   BOOLOP → -a | -o
+///
+#[derive(Debug)]
+struct Parser {
+    tokens: Peekable<std::vec::IntoIter<OsString>>,
+    pub stack: Vec<Symbol>,
+}
+
+impl Parser {
+    /// Construct a new Parser from a `Vec<OsString>` of tokens.
+    fn new(tokens: Vec<OsString>) -> Parser {
+        Parser {
+            tokens: tokens.into_iter().peekable(),
+            stack: vec![],
+        }
+    }
+
+    /// Fetch the next token from the input stream as a Symbol.
+    fn next_token(&mut self) -> Symbol {
+        Symbol::new(self.tokens.next())
+    }
+
+    /// Peek at the next token from the input stream, returning it as a Symbol.
+    /// The stream is unchanged and will return the same Symbol on subsequent
+    /// calls to `next()` or `peek()`.
+    fn peek(&mut self) -> Symbol {
+        Symbol::new(self.tokens.peek().map(|s| s.to_os_string()))
+    }
+
+    /// Test if the next token in the stream is a BOOLOP (-a or -o), without
+    /// removing the token from the stream.
+    fn peek_is_boolop(&mut self) -> bool {
+        if let Symbol::BoolOp(_) = self.peek() {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Parse an expression.
+    ///
+    ///   EXPR → TERM | EXPR BOOLOP EXPR
+    fn expr(&mut self) {
+        if !self.peek_is_boolop() {
+            self.term();
+        }
+        self.maybe_boolop();
+    }
+
+    /// Parse a term token and possible subsequent symbols: "(", "!", UOP,
+    /// literal, or None.
+    fn term(&mut self) {
+        let symbol = self.next_token();
+
+        match symbol {
+            Symbol::LParen => self.lparen(),
+            Symbol::Bang => self.bang(),
+            Symbol::StrlenOp(_) => self.uop(symbol),
+            Symbol::FiletestOp(_) => self.uop(symbol),
+            Symbol::None => self.stack.push(symbol),
+            literal => self.literal(literal),
+        }
+    }
+
+    /// Parse a (possibly) parenthesized expression.
+    ///
+    /// test has no reserved keywords, so "(" will be interpreted as a literal
+    /// if it is followed by nothing or a comparison operator OP.
+    fn lparen(&mut self) {
+        match self.peek() {
+            // lparen is a literal when followed by nothing or comparison
+            Symbol::None | Symbol::StringOp(_) | Symbol::IntOp(_) | Symbol::FileOp(_) => {
+                self.literal(Symbol::Literal(OsString::from("(")));
+            }
+            // empty parenthetical
+            Symbol::Literal(s) if s == ")" => {}
+            _ => {
+                self.expr();
+                match self.next_token() {
+                    Symbol::Literal(s) if s == ")" => (),
+                    _ => panic!("expected ‘)’"),
+                }
+            }
+        }
+    }
+
+    /// Parse a (possibly) negated expression.
+    ///
+    /// Example cases:
+    ///
+    /// * `! =`: negate the result of the implicit string length test of `=`
+    /// * `! = foo`: compare the literal strings `!` and `foo`
+    /// * `! <expr>`: negate the result of the expression
+    ///
+    fn bang(&mut self) {
+        if let Symbol::StringOp(_) | Symbol::IntOp(_) | Symbol::FileOp(_) = self.peek() {
+            // we need to peek ahead one more token to disambiguate the first
+            // two cases listed above: case 1 — `! <OP as literal>` — and
+            // case 2: `<! as literal> OP str`.
+            let peek2 = self.tokens.clone().nth(1);
+
+            if peek2.is_none() {
+                // op is literal
+                let op = self.next_token().into_literal();
+                self.stack.push(op);
+                self.stack.push(Symbol::Bang);
+            } else {
+                // bang is literal; parsing continues with op
+                self.literal(Symbol::Literal(OsString::from("!")));
+            }
+        } else {
+            self.expr();
+            self.stack.push(Symbol::Bang);
+        }
+    }
+
+    /// Peek at the next token and parse it as a BOOLOP or string literal,
+    /// as appropriate.
+    fn maybe_boolop(&mut self) {
+        if self.peek_is_boolop() {
+            let token = self.tokens.next().unwrap(); // safe because we peeked
+
+            // BoolOp by itself interpreted as Literal
+            if let Symbol::None = self.peek() {
+                self.literal(Symbol::Literal(token))
+            } else {
+                self.boolop(Symbol::BoolOp(token))
+            }
+        }
+    }
+
+    /// Parse a Boolean expression.
+    ///
+    /// Logical and (-a) has higher precedence than or (-o), so in an
+    /// expression like `foo -o '' -a ''`, the and subexpression is evaluated
+    /// first.
+    fn boolop(&mut self, op: Symbol) {
+        if op == Symbol::BoolOp(OsString::from("-a")) {
+            self.term();
+            self.stack.push(op);
+            self.maybe_boolop();
+        } else {
+            self.expr();
+            self.stack.push(op);
+        }
+    }
+
+    /// Parse a (possible) unary argument test (string length or file
+    /// attribute check).
+    ///
+    /// If a UOP is followed by nothing it is interpreted as a literal string.
+    fn uop(&mut self, op: Symbol) {
+        match self.next_token() {
+            Symbol::None => self.stack.push(op.into_literal()),
+            symbol => {
+                self.stack.push(symbol.into_literal());
+                self.stack.push(op);
+            }
+        }
+    }
+
+    /// Parse a string literal, optionally followed by a comparison operator
+    /// and a second string literal.
+    fn literal(&mut self, token: Symbol) {
+        self.stack.push(token.into_literal());
+
+        // EXPR → str OP str
+        match self.peek() {
+            Symbol::StringOp(_) | Symbol::IntOp(_) | Symbol::FileOp(_) => {
+                let op = self.next_token();
+
+                match self.next_token() {
+                    Symbol::None => panic!("missing argument after {:?}", op),
+                    token => self.stack.push(token.into_literal()),
+                }
+
+                self.stack.push(op);
+            }
+            _ => {}
+        }
+    }
+
+    /// Parser entry point: parse the token stream `self.tokens`, storing the
+    /// resulting `Symbol` stack in `self.stack`.
+    fn parse(&mut self) -> Result<(), String> {
+        self.expr();
+
+        match self.tokens.next() {
+            Some(token) => Err(format!("extra argument ‘{}’", token.to_string_lossy())),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Parse the token stream `args`, returning a `Symbol` stack representing the
+/// operations to perform in postfix order.
+pub fn parse(args: Vec<OsString>) -> Result<Vec<Symbol>, String> {
+    let mut p = Parser::new(args);
+    p.parse()?;
+    Ok(p.stack)
+}

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -2,12 +2,443 @@
 // This file is part of the uutils coreutils package.
 //
 // (c) mahkoh (ju.orth [at] gmail [dot] com)
+// (c) Daniel Rocco <drocco@gmail.com>
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
 
 use crate::common::util::*;
+
+#[test]
+fn test_empty_test_equivalent_to_false() {
+    new_ucmd!().run().status_code(1);
+}
+
+#[test]
+fn test_empty_string_is_false() {
+    new_ucmd!().arg("").run().status_code(1);
+}
+
+#[test]
+fn test_solo_not() {
+    new_ucmd!().arg("!").succeeds();
+}
+
+#[test]
+fn test_solo_and_or_or_is_a_literal() {
+    // /bin/test '' -a '' => 1; so test(1) must interpret `-a` by itself as
+    // a literal string
+    new_ucmd!().arg("-a").succeeds();
+    new_ucmd!().arg("-o").succeeds();
+}
+
+#[test]
+fn test_double_not_is_false() {
+    new_ucmd!().args(&["!", "!"]).run().status_code(1);
+}
+
+#[test]
+#[ignore = "fixme: parse/evaluation error (code 2); GNU returns 1"]
+fn test_and_not_is_false() {
+    new_ucmd!().args(&["-a", "!"]).run().status_code(1);
+}
+
+#[test]
+fn test_not_and_is_false() {
+    // `-a` is a literal here & has nonzero length
+    new_ucmd!().args(&["!", "-a"]).run().status_code(1);
+}
+
+#[test]
+#[ignore = "fixme: parse/evaluation error (code 2); GNU returns 0"]
+fn test_not_and_not_succeeds() {
+    new_ucmd!().args(&["!", "-a", "!"]).succeeds();
+}
+
+#[test]
+fn test_simple_or() {
+    new_ucmd!().args(&["foo", "-o", ""]).succeeds();
+}
+
+#[test]
+#[ignore = "fixme: parse/evaluation error (code 0); GNU returns 1"]
+fn test_negated_or() {
+    new_ucmd!()
+        .args(&["!", "foo", "-o", "bar"])
+        .run()
+        .status_code(1);
+    new_ucmd!().args(&["foo", "-o", "!", "bar"]).succeeds();
+    new_ucmd!()
+        .args(&["!", "foo", "-o", "!", "bar"])
+        .run()
+        .status_code(1);
+}
+
+#[test]
+fn test_strlen_of_nothing() {
+    // odd but matches GNU, which must interpret -n as a literal here
+    new_ucmd!().arg("-n").succeeds();
+}
+
+#[test]
+fn test_strlen_of_empty() {
+    new_ucmd!().args(&["-n", ""]).run().status_code(1);
+
+    // STRING equivalent to -n STRING
+    new_ucmd!().arg("").run().status_code(1);
+}
+
+#[test]
+fn test_nothing_is_empty() {
+    // -z is a literal here and has nonzero length
+    new_ucmd!().arg("-z").succeeds();
+}
+
+#[test]
+fn test_zero_len_of_empty() {
+    new_ucmd!().args(&["-z", ""]).succeeds();
+}
+
+#[test]
+fn test_solo_paren_is_literal() {
+    let scenario = TestScenario::new(util_name!());
+    let tests = [["("], [")"]];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).succeeds();
+    }
+}
+
+#[test]
+#[ignore = "GNU considers this an error"]
+fn test_solo_empty_parenthetical_is_error() {
+    new_ucmd!()
+        .args(&["(", ")"])
+        .run()
+        .status_code(2)
+        .stderr_is("test: missing argument after ‘)’");
+}
+
+#[test]
+fn test_zero_len_equals_zero_len() {
+    new_ucmd!().args(&["", "=", ""]).succeeds();
+}
+
+#[test]
+fn test_zero_len_not_equals_zero_len_is_false() {
+    new_ucmd!().args(&["", "!=", ""]).run().status_code(1);
+}
+
+#[test]
+fn test_string_comparison() {
+    let scenario = TestScenario::new(util_name!());
+    let tests = [
+        ["foo", "!=", "bar"],
+        ["contained\nnewline", "=", "contained\nnewline"],
+        ["(", "=", "("],
+        ["(", "!=", ")"],
+        ["!", "=", "!"],
+    ];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).succeeds();
+    }
+}
+
+#[test]
+#[ignore = "fixme: error reporting"]
+fn test_dangling_string_comparison_is_error() {
+    new_ucmd!()
+        .args(&["missing_something", "="])
+        .run()
+        .status_code(2)
+        .stderr_is("test: missing argument after ‘=’");
+}
+
+#[test]
+fn test_stringop_is_literal_after_bang() {
+    let scenario = TestScenario::new(util_name!());
+    let tests = [
+        ["!", "="],
+        ["!", "!="],
+        ["!", "-eq"],
+        ["!", "-ne"],
+        ["!", "-lt"],
+        ["!", "-le"],
+        ["!", "-gt"],
+        ["!", "-ge"],
+        ["!", "-ef"],
+        ["!", "-nt"],
+        ["!", "-ot"],
+    ];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).run().status_code(1);
+    }
+}
+
+#[test]
+fn test_a_bunch_of_not() {
+    new_ucmd!()
+        .args(&["!", "", "!=", "", "-a", "!", "", "!=", ""])
+        .succeeds();
+}
+
+#[test]
+fn test_pseudofloat_equal() {
+    new_ucmd!().args(&["123.45", "=", "123.45"]).succeeds();
+}
+
+#[test]
+fn test_pseudofloat_not_equal() {
+    new_ucmd!().args(&["123.45", "!=", "123.450"]).succeeds();
+}
+
+#[test]
+fn test_negative_arg_is_a_string() {
+    new_ucmd!().arg("-12345").succeeds();
+    new_ucmd!().arg("--qwert").succeeds();
+}
+
+#[test]
+fn test_some_int_compares() {
+    let scenario = TestScenario::new(util_name!());
+
+    let tests = [
+        ["0", "-eq", "0"],
+        ["0", "-ne", "1"],
+        ["421", "-lt", "3720"],
+        ["0", "-le", "0"],
+        ["11", "-gt", "10"],
+        ["1024", "-ge", "512"],
+        ["9223372036854775806", "-le", "9223372036854775807"],
+    ];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).succeeds();
+    }
+}
+
+#[test]
+#[ignore = "fixme: evaluation error (code 1); GNU returns 0"]
+fn test_values_greater_than_i64_allowed() {
+    new_ucmd!()
+        .args(&["9223372036854775808", "-gt", "0"])
+        .succeeds();
+}
+
+#[test]
+fn test_negative_int_compare() {
+    let scenario = TestScenario::new(util_name!());
+
+    let tests = [
+        ["-1", "-eq", "-1"],
+        ["-1", "-ne", "-2"],
+        ["-3720", "-lt", "-421"],
+        ["-10", "-le", "-10"],
+        ["-21", "-gt", "-22"],
+        ["-128", "-ge", "-256"],
+        ["-9223372036854775808", "-le", "-9223372036854775807"],
+    ];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).succeeds();
+    }
+}
+
+#[test]
+#[ignore = "fixme: error reporting"]
+fn test_float_inequality_is_error() {
+    new_ucmd!()
+        .args(&["123.45", "-ge", "6"])
+        .run()
+        .status_code(2)
+        .stderr_is("test: invalid integer ‘123.45’");
+}
+
+#[test]
+#[ignore = "fixme: parse/evaluation error (code 2); GNU returns 1"]
+fn test_file_is_itself() {
+    new_ucmd!()
+        .args(&["regular_file", "-ef", "regular_file"])
+        .succeeds();
+}
+
+#[test]
+#[ignore = "fixme: parse/evaluation error (code 2); GNU returns 1"]
+fn test_file_is_newer_than_and_older_than_itself() {
+    // odd but matches GNU
+    new_ucmd!()
+        .args(&["regular_file", "-nt", "regular_file"])
+        .run()
+        .status_code(1);
+    new_ucmd!()
+        .args(&["regular_file", "-ot", "regular_file"])
+        .run()
+        .status_code(1);
+}
+
+#[test]
+#[ignore = "todo: implement these"]
+fn test_newer_file() {
+    let scenario = TestScenario::new(util_name!());
+
+    scenario.cmd("touch").arg("newer_file").succeeds();
+    scenario
+        .cmd("touch")
+        .args(&["-m", "-d", "last Thursday", "regular_file"])
+        .succeeds();
+
+    scenario
+        .ucmd()
+        .args(&["newer_file", "-nt", "regular_file"])
+        .succeeds();
+    scenario
+        .ucmd()
+        .args(&["regular_file", "-ot", "newer_file"])
+        .succeeds();
+}
+
+#[test]
+fn test_file_exists() {
+    new_ucmd!().args(&["-e", "regular_file"]).succeeds();
+}
+
+#[test]
+fn test_nonexistent_file_does_not_exist() {
+    new_ucmd!()
+        .args(&["-e", "nonexistent_file"])
+        .run()
+        .status_code(1);
+}
+
+#[test]
+fn test_nonexistent_file_is_not_regular() {
+    new_ucmd!()
+        .args(&["-f", "nonexistent_file"])
+        .run()
+        .status_code(1);
+}
+
+#[test]
+fn test_file_exists_and_is_regular() {
+    new_ucmd!().args(&["-f", "regular_file"]).succeeds();
+}
+
+#[test]
+#[cfg(not(windows))] // FIXME: implement on Windows
+fn test_file_is_readable() {
+    new_ucmd!().args(&["-r", "regular_file"]).succeeds();
+}
+
+#[test]
+#[cfg(not(windows))] // FIXME: implement on Windows
+fn test_file_is_not_readable() {
+    let scenario = TestScenario::new(util_name!());
+    let mut ucmd = scenario.ucmd();
+    let mut chmod = scenario.cmd("chmod");
+
+    scenario.fixtures.touch("crypto_file");
+    chmod.args(&["u-r", "crypto_file"]).succeeds();
+
+    ucmd.args(&["!", "-r", "crypto_file"]).succeeds();
+}
+
+#[test]
+#[cfg(not(windows))] // FIXME: implement on Windows
+fn test_file_is_writable() {
+    new_ucmd!().args(&["-w", "regular_file"]).succeeds();
+}
+
+#[test]
+#[cfg(not(windows))] // FIXME: implement on Windows
+fn test_file_is_not_writable() {
+    let scenario = TestScenario::new(util_name!());
+    let mut ucmd = scenario.ucmd();
+    let mut chmod = scenario.cmd("chmod");
+
+    scenario.fixtures.touch("immutable_file");
+    chmod.args(&["u-w", "immutable_file"]).succeeds();
+
+    ucmd.args(&["!", "-w", "immutable_file"]).succeeds();
+}
+
+#[test]
+fn test_file_is_not_executable() {
+    new_ucmd!().args(&["!", "-x", "regular_file"]).succeeds();
+}
+
+#[test]
+#[cfg(not(windows))] // FIXME: implement on Windows
+fn test_file_is_executable() {
+    let scenario = TestScenario::new(util_name!());
+    let mut chmod = scenario.cmd("chmod");
+
+    chmod.args(&["u+x", "regular_file"]).succeeds();
+
+    scenario.ucmd().args(&["-x", "regular_file"]).succeeds();
+}
+
+#[test]
+fn test_is_not_empty() {
+    new_ucmd!().args(&["-s", "non_empty_file"]).succeeds();
+}
+
+#[test]
+fn test_nonexistent_file_size_test_is_false() {
+    new_ucmd!()
+        .args(&["-s", "nonexistent_file"])
+        .run()
+        .status_code(1);
+}
+
+#[test]
+fn test_not_is_not_empty() {
+    new_ucmd!().args(&["!", "-s", "regular_file"]).succeeds();
+}
+
+#[test]
+#[cfg(not(windows))]
+fn test_symlink_is_symlink() {
+    let scenario = TestScenario::new(util_name!());
+    let mut ln = scenario.cmd("ln");
+
+    // creating symlinks requires admin on Windows
+    ln.args(&["-s", "regular_file", "symlink"]).succeeds();
+
+    // FIXME: implement on Windows
+    scenario.ucmd().args(&["-h", "symlink"]).succeeds();
+    scenario.ucmd().args(&["-L", "symlink"]).succeeds();
+}
+
+#[test]
+fn test_file_is_not_symlink() {
+    let scenario = TestScenario::new(util_name!());
+
+    scenario
+        .ucmd()
+        .args(&["!", "-h", "regular_file"])
+        .succeeds();
+    scenario
+        .ucmd()
+        .args(&["!", "-L", "regular_file"])
+        .succeeds();
+}
+
+#[test]
+fn test_nonexistent_file_is_not_symlink() {
+    let scenario = TestScenario::new(util_name!());
+
+    scenario
+        .ucmd()
+        .args(&["!", "-h", "nonexistent_file"])
+        .succeeds();
+    scenario
+        .ucmd()
+        .args(&["!", "-L", "nonexistent_file"])
+        .succeeds();
+}
 
 #[test]
 fn test_op_prec_and_or_1() {
@@ -23,5 +454,14 @@ fn test_op_prec_and_or_2() {
 
 #[test]
 fn test_or_as_filename() {
-    new_ucmd!().args(&["x", "-a", "-z", "-o"]).fails();
+    new_ucmd!()
+        .args(&["x", "-a", "-z", "-o"])
+        .run()
+        .status_code(1);
+}
+
+#[test]
+#[ignore = "GNU considers this an error"]
+fn test_strlen_and_nothing() {
+    new_ucmd!().args(&["-n", "a", "-a"]).run().status_code(2);
 }

--- a/tests/fixtures/test/non_empty_file
+++ b/tests/fixtures/test/non_empty_file
@@ -1,0 +1,1 @@
+Not empty!


### PR DESCRIPTION
* Replace the parser with a recursive descent implementation that handles parentheses and produces a stack of operations in postfix order. Parsing now operates directly on OsStrings passed by the uucore framework.

* Replace the dispatch mechanism with a stack machine operating on the symbol stack produced by the parser.

* Add many tests, including tests for parenthesized expressions.
