### PR TITLE
`ls`: C sort order and fix subdirectory listing

### DIFF
--- a/src/uu/ls/BENCHMARKING.md
+++ b/src/uu/ls/BENCHMARKING.md
@@ -36,6 +36,8 @@ args="$@"
 hyperfine "ls $args" "target/release/coreutils ls $args"
 ```
 
+**Note**: No localization is currently implemented. This means that the comparison above is not really fair. We can fix this by setting `LC_ALL=C`, so GNU `ls` can ignore localization.
+
 ## Checking system call count
 
 - Another thing to look at would be system calls count using strace (on linux) or equivalent on other operating systems.

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1284,7 +1284,13 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
 fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>) {
     let mut entries: Vec<_> = if config.files == Files::All {
         vec![
-            PathData::new(dir.p_buf.join("."), None, Some(".".into()), config, false),
+            PathData::new(
+                dir.p_buf.clone(),
+                Some(Ok(*dir.file_type().unwrap())),
+                Some(".".into()),
+                config,
+                false,
+            ),
             PathData::new(dir.p_buf.join(".."), None, Some("..".into()), config, false),
         ]
     } else {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1244,14 +1244,8 @@ fn sort_entries(entries: &mut Vec<PathData>, config: &Config) {
             entries.sort_by_key(|k| Reverse(k.md().as_ref().map(|md| md.len()).unwrap_or(0)))
         }
         // The default sort in GNU ls is case insensitive
-        Sort::Name => entries.sort_by_cached_key(|k| {
-            let has_dot: bool = k.file_name.starts_with('.');
-            let filename_nodot: &str = &k.file_name[if has_dot { 1 } else { 0 }..];
-            // We want hidden files to appear before regular files of the same
-            // name, so we need to negate the "has_dot" variable.
-            (filename_nodot.to_lowercase(), !has_dot)
-        }),
-        Sort::Version => entries.sort_by(|k, j| version_cmp::version_cmp(&k.p_buf, &j.p_buf)),
+        Sort::Name => entries.sort_by(|a, b| a.file_name.cmp(&b.file_name)),
+        Sort::Version => entries.sort_by(|a, b| version_cmp::version_cmp(&a.p_buf, &b.p_buf)),
         Sort::Extension => entries.sort_by(|a, b| {
             a.p_buf
                 .extension()

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -57,6 +57,7 @@ fn test_ls_a() {
     // Using the present working directory
     scene
         .ucmd()
+        .arg("-1")
         .succeeds()
         .stdout_does_not_contain(".test-1")
         .stdout_does_not_contain("..")
@@ -65,6 +66,7 @@ fn test_ls_a() {
     scene
         .ucmd()
         .arg("-a")
+        .arg("-1")
         .succeeds()
         .stdout_contains(&".test-1")
         .stdout_contains(&"..")
@@ -73,6 +75,7 @@ fn test_ls_a() {
     scene
         .ucmd()
         .arg("-A")
+        .arg("-1")
         .succeeds()
         .stdout_contains(".test-1")
         .stdout_does_not_contain("..")
@@ -81,6 +84,7 @@ fn test_ls_a() {
     // Using a subdirectory
     scene
         .ucmd()
+        .arg("-1")
         .arg("some-dir")
         .succeeds()
         .stdout_does_not_contain(".test-2")
@@ -90,6 +94,7 @@ fn test_ls_a() {
     scene
         .ucmd()
         .arg("-a")
+        .arg("-1")
         .arg("some-dir")
         .succeeds()
         .stdout_contains(&".test-2")
@@ -100,6 +105,7 @@ fn test_ls_a() {
     scene
         .ucmd()
         .arg("-A")
+        .arg("-1")
         .arg("some-dir")
         .succeeds()
         .stdout_contains(".test-2")

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -527,7 +527,6 @@ fn test_ls_sort_name() {
         .succeeds()
         .stdout_is(["test-1", "test-2", "test-3\n"].join(sep));
 
-    // Order of a named sort ignores leading dots.
     let scene_dot = TestScenario::new(util_name!());
     let at = &scene_dot.fixtures;
     at.touch(".a");
@@ -540,7 +539,7 @@ fn test_ls_sort_name() {
         .arg("--sort=name")
         .arg("-A")
         .succeeds()
-        .stdout_is([".a", "a", ".b", "b\n"].join(sep));
+        .stdout_is([".a", ".b", "a", "b\n"].join(sep));
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -43,23 +43,68 @@ fn test_ls_a() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     at.touch(".test-1");
+    at.mkdir("some-dir");
+    at.touch(
+        Path::new("some-dir")
+            .join(".test-2")
+            .as_os_str()
+            .to_str()
+            .unwrap(),
+    );
 
-    let result = scene.ucmd().succeeds();
-    let stdout = result.stdout_str();
-    assert!(!stdout.contains(".test-1"));
-    assert!(!stdout.contains(".."));
+    let re_pwd = Regex::new(r"^\.\n").unwrap();
+
+    // Using the present working directory
+    scene
+        .ucmd()
+        .succeeds()
+        .stdout_does_not_contain(".test-1")
+        .stdout_does_not_contain("..")
+        .stdout_does_not_match(&re_pwd);
 
     scene
         .ucmd()
         .arg("-a")
         .succeeds()
         .stdout_contains(&".test-1")
-        .stdout_contains(&"..");
+        .stdout_contains(&"..")
+        .stdout_matches(&re_pwd);
 
-    let result = scene.ucmd().arg("-A").succeeds();
-    result.stdout_contains(".test-1");
-    let stdout = result.stdout_str();
-    assert!(!stdout.contains(".."));
+    scene
+        .ucmd()
+        .arg("-A")
+        .succeeds()
+        .stdout_contains(".test-1")
+        .stdout_does_not_contain("..")
+        .stdout_does_not_match(&re_pwd);
+
+    // Using a subdirectory
+    scene
+        .ucmd()
+        .arg("some-dir")
+        .succeeds()
+        .stdout_does_not_contain(".test-2")
+        .stdout_does_not_contain("..")
+        .stdout_does_not_match(&re_pwd);
+
+    scene
+        .ucmd()
+        .arg("-a")
+        .arg("some-dir")
+        .succeeds()
+        .stdout_contains(&".test-2")
+        .stdout_contains(&"..")
+        .no_stderr()
+        .stdout_matches(&re_pwd);
+
+    scene
+        .ucmd()
+        .arg("-A")
+        .arg("some-dir")
+        .succeeds()
+        .stdout_contains(".test-2")
+        .stdout_does_not_contain("..")
+        .stdout_does_not_match(&re_pwd);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/2149

- The sort order is reverted to a simple string compare without any preprocessing (lowercasing & ignoring leading periods) to match the C locale. This makes the uutils `ls` faster than GNU on my machine, but this is misleading because GNU does localization by default. The `BENCHMARKING.md` therefore includes a note stating that comparisons should be done with `LC_ALL=C`.
- The name of the `.` folder is fixed and tests are added for this case.

**Before**
```
❯ target/release/coreutils ls -al test_folder/
drwxr-xr-x  3 terts terts 4096 May  1 09:16 test_folder
drwxr-xr-x 15 terts terts 4096 May  2 10:15 ..
-rw-r--r--  1 terts terts    0 Apr 30 21:23 Formula
-rw-r--r--  1 terts terts    0 May  1 09:16 formula
drwxr-xr-x  2 terts terts 4096 Apr 30 21:23 .git
-rw-r--r--  1 terts terts    0 Apr 30 21:23 Makefile
-rw-r--r--  1 terts terts    0 Apr 30 21:23 README.md
```

**After**
```
❯ target/release/coreutils ls -al test_folder/
drwxr-xr-x  3 terts terts 4096 May  1 09:16 .
drwxr-xr-x 15 terts terts 4096 May  2 10:15 ..
drwxr-xr-x  2 terts terts 4096 Apr 30 21:23 .git
-rw-r--r--  1 terts terts    0 Apr 30 21:23 Formula
-rw-r--r--  1 terts terts    0 Apr 30 21:23 Makefile
-rw-r--r--  1 terts terts    0 Apr 30 21:23 README.md
-rw-r--r--  1 terts terts    0 May  1 09:16 formula
```