### PR TITLE
sort: optimize the line struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,12 +1446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,7 +1906,7 @@ dependencies = [
  "quickcheck",
  "rand 0.7.3",
  "rand_chacha",
- "smallvec 0.6.14",
+ "smallvec",
  "uucore",
  "uucore_procs",
 ]
@@ -2392,7 +2386,6 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "semver",
- "smallvec 1.6.1",
  "tempdir",
  "unicode-width",
  "uucore",

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -21,7 +21,6 @@ clap = "2.33"
 fnv = "1.0.7"
 itertools = "0.10.0"
 semver = "0.9.0"
-smallvec = "1.6.1"
 unicode-width = "0.1.8"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/sort/src/external_sort/mod.rs
+++ b/src/uu/sort/src/external_sort/mod.rs
@@ -113,7 +113,7 @@ pub fn ext_sort(
 
         chunk.push(seq);
 
-        if total_read >= settings.buffer_size {
+        if total_read + chunk.len() * std::mem::size_of::<Line>() >= settings.buffer_size {
             super::sort_by(&mut chunk, &settings);
             write_chunk(
                 settings,
@@ -135,6 +135,9 @@ pub fn ext_sort(
         );
         iter.chunks += 1;
     }
+
+    // We manually drop here to not go over our memory limit when we allocate below.
+    drop(chunk);
 
     // initialize buffers for each chunk
     //


### PR DESCRIPTION
(Based on #2156 for convenience, the actual change is in the latest commit)
Related to #2134.
I still need to kick this around a bit, these are IMHO the low hanging fruits when it comes to memory usage reduction.