### PR TITLE
Implement Total size feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
 name = "uu_basename"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "uucore",
  "uucore_procs",
 ]
@@ -2653,6 +2654,7 @@ dependencies = [
 name = "uu_who"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "uucore",
  "uucore_procs",
 ]

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1356,8 +1356,10 @@ fn display_items(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout
         }
 
         #[cfg(unix)]
-        if total_size > 0 {
-            let _ = writeln!(out, "total {}", display_file_size(total_size, config));
+        {
+            if total_size > 0 {
+                let _ = writeln!(out, "total {}", display_file_size(total_size, config));
+            }
         }
 
         for item in items {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -308,6 +308,31 @@ fn test_ls_long() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn test_ls_long_total_size() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch(&at.plus_as_string("test-long"));
+    at.append("test-long", "1");
+    at.touch(&at.plus_as_string("test-long2"));
+    at.append("test-long2", "2");
+
+    for arg in &["-l", "--long", "--format=long", "--format=verbose"] {
+        let result = scene.ucmd().arg(arg).succeeds();
+        result.stdout_contains("total 8");
+
+        for arg2 in &["-h", "--human-readable", "--si"] {
+            let result = scene.ucmd().arg(arg).arg(arg2).succeeds();
+            result.stdout_contains(if *arg2 == "--si" {
+                "total 8.2k"
+            } else {
+                "total 8.0K"
+            });
+        }
+    }
+}
+
 #[test]
 fn test_ls_long_formats() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
Total size for directories in long format is implemented with this PR for unix. For non-unix environments, there is no exact equivalent for what GNU displays so I've left it unimplemented at the moment instead of printing some other value.

Partially fixes #1872 