### PR TITLE
stat: fix test to ignore selinux related output

### DIFF
--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -198,9 +198,16 @@ fn test_terse_normal_format() {
     let expect = expected_result(&args);
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
-    let v_actual: Vec<&str> = actual.split(' ').collect();
-    let v_expect: Vec<&str> = expect.split(' ').collect();
+    let v_actual: Vec<&str> = actual.trim().split(' ').collect();
+    let mut v_expect: Vec<&str> = expect.trim().split(' ').collect();
     assert!(!v_expect.is_empty());
+
+    // uu_stat does not support selinux
+    if v_actual.len() == v_expect.len() - 1 && v_expect[v_expect.len() - 1].contains(":") {
+        // assume last element contains: `SELinux security context string`
+        v_expect.pop();
+    }
+
     // * allow for inequality if `stat` (aka, expect) returns "0" (unknown value)
     assert!(
         expect == "0"


### PR DESCRIPTION
On Fedora Linux `test_terse_normal_format` fails because uu_stat doesn't print `SELinux security context string` if invoked with `-t`.
```
run: stat -t /                                                                                                                                     
actual: "/ 4096 8 416d 0 0 fd01 2 18 0 0 1619888495 1605377538 1605377538 1576062995 4096\n"                                                       
expect: "/ 4096 8 416d 0 0 fd01 2 18 0 0 1619888495 1605377538 1605377538 1576062995 4096 system_u:object_r:root_t:s0\n"
```
