### PR TITLE
Fix fmt crashing on subtracting unsigned numbers

### DIFF
--- a/src/uu/fmt/src/linebreak.rs
+++ b/src/uu/fmt/src/linebreak.rs
@@ -296,7 +296,7 @@ fn find_kp_breakpoints<'a, T: Iterator<Item = &'a WordInfo<'a>>>(
                         (0, 0.0)
                     } else {
                         compute_demerits(
-                            (args.opts.goal - tlen) as isize,
+                            args.opts.goal as isize - tlen as isize,
                             stretch,
                             w.word_nchars as isize,
                             active.prev_rat,

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -33,18 +33,16 @@ fn test_fmt_w_too_big() {
         "fmt: error: invalid width: '2501': Numerical result out of range"
     );
 }
-/* #[test]
- Fails for now, see https://github.com/uutils/coreutils/issues/1501
+#[test]
 fn test_fmt_w() {
     let result = new_ucmd!()
         .arg("-w")
         .arg("10")
         .arg("one-word-per-line.txt")
         .run();
-        //.stdout_is_fixture("call_graph.expected");
-    assert_eq!(result.stdout_str().trim(), "this is a file with one word per line");
+    //.stdout_is_fixture("call_graph.expected");
+    assert_eq!(
+        result.stdout_str().trim(),
+        "this is\na file\nwith one\nword per\nline"
+    );
 }
-
-
-fmt is pretty broken in general, needs more works to have more tests
- */


### PR DESCRIPTION
Fixes #1501. The `tlen` variable will sometimes exceed the size of the `goal` option, causing the overflow as they are both unsigned ints. We can cast to signed before the subtraction without worrying about loss of range as the maximum width and therefore the maximum that `goal` and `tlen` is 2500.