### PR TITLE
wc: remove leading space when printing multiple counts

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -372,51 +372,42 @@ fn print_stats(
     let mut is_first: bool = true;
 
     if settings.show_lines {
-        if is_first {
-            write!(stdout_lock, "{:1$}", result.count.lines, min_width)?;
-        } else {
-            write!(stdout_lock, " {:1$}", result.count.lines, min_width)?;
+        if !is_first {
+            write!(stdout_lock, " ")?;
         }
+        write!(stdout_lock, "{:1$}", result.count.lines, min_width)?;
         is_first = false;
     }
     if settings.show_words {
-        if is_first {
-            write!(stdout_lock, "{:1$}", result.count.words, min_width)?;
-        } else {
-            write!(stdout_lock, " {:1$}", result.count.words, min_width)?;
+        if !is_first {
+            write!(stdout_lock, " ")?;
         }
+        write!(stdout_lock, "{:1$}", result.count.words, min_width)?;
         is_first = false;
     }
     if settings.show_bytes {
-        if is_first {
-            write!(stdout_lock, "{:1$}", result.count.bytes, min_width)?;
-        } else {
-            write!(stdout_lock, " {:1$}", result.count.bytes, min_width)?;
+        if !is_first {
+            write!(stdout_lock, " ")?;
         }
+        write!(stdout_lock, "{:1$}", result.count.bytes, min_width)?;
         is_first = false;
     }
     if settings.show_chars {
-        if is_first {
-            write!(stdout_lock, "{:1$}", result.count.chars, min_width)?;
-        } else {
-            write!(stdout_lock, " {:1$}", result.count.chars, min_width)?;
+        if !is_first {
+            write!(stdout_lock, " ")?;
         }
+        write!(stdout_lock, "{:1$}", result.count.chars, min_width)?;
         is_first = false;
     }
     if settings.show_max_line_length {
-        if is_first {
-            write!(
-                stdout_lock,
-                "{:1$}",
-                result.count.max_line_length, min_width
-            )?;
-        } else {
-            write!(
-                stdout_lock,
-                " {:1$}",
-                result.count.max_line_length, min_width
-            )?;
+        if !is_first {
+            write!(stdout_lock, " ")?;
         }
+        write!(
+            stdout_lock,
+            "{:1$}",
+            result.count.max_line_length, min_width
+        )?;
     }
 
     if result.title == "-" {

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -323,7 +323,12 @@ fn wc(files: Vec<String>, settings: &Settings) -> Result<(), u32> {
             error_count += 1;
             WordCount::default()
         });
-        max_width = max(max_width, word_count.bytes.to_string().len() + 1);
+        // Compute the number of digits needed to display the number
+        // of bytes in the file. Even if the settings indicate that we
+        // won't *display* the number of bytes, we still use the
+        // number of digits in the byte count as the width when
+        // formatting each count as a string for output.
+        max_width = max(max_width, word_count.bytes.to_string().len());
         total_word_count += word_count;
         results.push(word_count.with_title(path));
     }
@@ -364,24 +369,54 @@ fn print_stats(
         min_width = 0;
     }
 
+    let mut is_first: bool = true;
+
     if settings.show_lines {
-        write!(stdout_lock, "{:1$}", result.count.lines, min_width)?;
+        if is_first {
+            write!(stdout_lock, "{:1$}", result.count.lines, min_width)?;
+        } else {
+            write!(stdout_lock, " {:1$}", result.count.lines, min_width)?;
+        }
+        is_first = false;
     }
     if settings.show_words {
-        write!(stdout_lock, "{:1$}", result.count.words, min_width)?;
+        if is_first {
+            write!(stdout_lock, "{:1$}", result.count.words, min_width)?;
+        } else {
+            write!(stdout_lock, " {:1$}", result.count.words, min_width)?;
+        }
+        is_first = false;
     }
     if settings.show_bytes {
-        write!(stdout_lock, "{:1$}", result.count.bytes, min_width)?;
+        if is_first {
+            write!(stdout_lock, "{:1$}", result.count.bytes, min_width)?;
+        } else {
+            write!(stdout_lock, " {:1$}", result.count.bytes, min_width)?;
+        }
+        is_first = false;
     }
     if settings.show_chars {
-        write!(stdout_lock, "{:1$}", result.count.chars, min_width)?;
+        if is_first {
+            write!(stdout_lock, "{:1$}", result.count.chars, min_width)?;
+        } else {
+            write!(stdout_lock, " {:1$}", result.count.chars, min_width)?;
+        }
+        is_first = false;
     }
     if settings.show_max_line_length {
-        write!(
-            stdout_lock,
-            "{:1$}",
-            result.count.max_line_length, min_width
-        )?;
+        if is_first {
+            write!(
+                stdout_lock,
+                "{:1$}",
+                result.count.max_line_length, min_width
+            )?;
+        } else {
+            write!(
+                stdout_lock,
+                " {:1$}",
+                result.count.max_line_length, min_width
+            )?;
+        }
     }
 
     if result.title == "-" {

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -33,7 +33,7 @@ fn test_stdin_default() {
     new_ucmd!()
         .pipe_in_fixture("lorem_ipsum.txt")
         .run()
-        .stdout_is("  13 109 772\n");
+        .stdout_is(" 13 109 772\n");
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn test_utf8() {
         .args(&["-lwmcL"])
         .pipe_in_fixture("UTF_8_test.txt")
         .run()
-        .stdout_is("   300  4969 22781 22213    79\n");
+        .stdout_is("  300  4969 22781 22213    79\n");
     // GNU returns "  300  2086 22219 22781    79"
     // TODO: we should fix that to match GNU's behavior
 }
@@ -71,7 +71,7 @@ fn test_stdin_all_counts() {
         .args(&["-c", "-m", "-l", "-L", "-w"])
         .pipe_in_fixture("alice_in_wonderland.txt")
         .run()
-        .stdout_is("   5  57 302 302  66\n");
+        .stdout_is("  5  57 302 302  66\n");
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn test_single_default() {
     new_ucmd!()
         .arg("moby_dick.txt")
         .run()
-        .stdout_is("   18  204 1115 moby_dick.txt\n");
+        .stdout_is("  18  204 1115 moby_dick.txt\n");
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn test_single_all_counts() {
     new_ucmd!()
         .args(&["-c", "-l", "-L", "-m", "-w", "alice_in_wonderland.txt"])
         .run()
-        .stdout_is("   5  57 302 302  66 alice_in_wonderland.txt\n");
+        .stdout_is("  5  57 302 302  66 alice_in_wonderland.txt\n");
 }
 
 #[test]
@@ -108,64 +108,54 @@ fn test_multiple_default() {
         ])
         .run()
         .stdout_is(
-            "   13  109  772 lorem_ipsum.txt\n   18  204 1115 moby_dick.txt\n    5   57  302 \
-             alice_in_wonderland.txt\n   36  370 2189 total\n",
+            "  13  109  772 lorem_ipsum.txt\n  18  204 1115 moby_dick.txt\n   5   57  302 \
+             alice_in_wonderland.txt\n  36  370 2189 total\n",
         );
 }
 
 /// Test for an empty file.
 #[test]
 fn test_file_empty() {
-    // TODO There is a leading space in the output that should be
-    // removed; see issue #2173.
     new_ucmd!()
         .args(&["-clmwL", "emptyfile.txt"])
         .run()
-        .stdout_is(" 0 0 0 0 0 emptyfile.txt\n");
+        .stdout_is("0 0 0 0 0 emptyfile.txt\n");
 }
 
 /// Test for an file containing a single non-whitespace character
 /// *without* a trailing newline.
 #[test]
 fn test_file_single_line_no_trailing_newline() {
-    // TODO There is a leading space in the output that should be
-    // removed; see issue #2173.
     new_ucmd!()
         .args(&["-clmwL", "notrailingnewline.txt"])
         .run()
-        .stdout_is(" 1 1 2 2 1 notrailingnewline.txt\n");
+        .stdout_is("1 1 2 2 1 notrailingnewline.txt\n");
 }
 
 /// Test for a file that has 100 empty lines (that is, the contents of
 /// the file are the newline character repeated one hundred times).
 #[test]
 fn test_file_many_empty_lines() {
-    // TODO There is a leading space in the output that should be
-    // removed; see issue #2173.
     new_ucmd!()
         .args(&["-clmwL", "manyemptylines.txt"])
         .run()
-        .stdout_is(" 100   0 100 100   0 manyemptylines.txt\n");
+        .stdout_is("100   0 100 100   0 manyemptylines.txt\n");
 }
 
 /// Test for a file that has one long line comprising only spaces.
 #[test]
 fn test_file_one_long_line_only_spaces() {
-    // TODO There is a leading space in the output that should be
-    // removed; see issue #2173.
     new_ucmd!()
         .args(&["-clmwL", "onelongemptyline.txt"])
         .run()
-        .stdout_is("     1     0 10001 10001 10000 onelongemptyline.txt\n");
+        .stdout_is("    1     0 10001 10001 10000 onelongemptyline.txt\n");
 }
 
 /// Test for a file that has one long line comprising a single "word".
 #[test]
 fn test_file_one_long_word() {
-    // TODO There is a leading space in the output that should be
-    // removed; see issue #2173.
     new_ucmd!()
         .args(&["-clmwL", "onelongword.txt"])
         .run()
-        .stdout_is("     1     1 10001 10001 10000 onelongword.txt\n");
+        .stdout_is("    1     1 10001 10001 10000 onelongword.txt\n");
 }


### PR DESCRIPTION
Remove the leading space from the output of `wc` when printing two or
more types of counts.

Fixes #2173.