### PR TITLE
wc: print counts for each file as soon as computed instead of collecting them all before printing

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -311,7 +311,6 @@ fn word_count_from_path(path: &str, settings: &Settings) -> WcResult<WordCount> 
 
 fn wc(files: Vec<String>, settings: &Settings) -> Result<(), u32> {
     let mut total_word_count = WordCount::default();
-    let mut results = vec![];
     let mut max_width: usize = 0;
     let mut error_count = 0;
 
@@ -325,10 +324,7 @@ fn wc(files: Vec<String>, settings: &Settings) -> Result<(), u32> {
         });
         max_width = max(max_width, word_count.bytes.to_string().len() + 1);
         total_word_count += word_count;
-        results.push(word_count.with_title(path));
-    }
-
-    for result in &results {
+        let result = word_count.with_title(path);
         if let Err(err) = print_stats(settings, &result, max_width) {
             show_warning!("failed to print result for {}: {}", result.title, err);
             error_count += 1;


### PR DESCRIPTION
This pull request changes the behavior of `wc` to print the counts for a file as soon as it is computed, instead of waiting to compute the counts for all files before writing any output to `stdout`. The new behavior matches the behavior of GNU `wc`.

The old behavior looked like this (the word "hello" is entered on `stdin`):

    $ ./target/debug/coreutils wc tests/fixtures/wc/emptyfile.txt -
    hello
     0 0 0 tests/fixtures/wc/emptyfile.txt
     1 1 6
     1 1 6 total

The new behavior looks like this:

    $ ./target/debug/coreutils wc tests/fixtures/wc/emptyfile.txt -
     0 0 0 tests/fixtures/wc/emptyfile.txt
    hello
     1 1 6
     1 1 6 total
