### PR TITLE
uucore: refactor - reduce duplicate code related to `fs::display_perm…

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
 use uucore::fs::display_permissions_unix;
+use uucore::libc::mode_t;
 #[cfg(not(windows))]
 use uucore::mode;
 use uucore::InvalidEncodingHandling;
@@ -306,7 +307,7 @@ impl Chmoder {
                     "mode of '{}' retained as {:04o} ({})",
                     file.display(),
                     fperm,
-                    display_permissions_unix(fperm),
+                    display_permissions_unix(fperm as mode_t, false),
                 );
             }
             Ok(())
@@ -319,9 +320,9 @@ impl Chmoder {
                     "failed to change mode of file '{}' from {:o} ({}) to {:o} ({})",
                     file.display(),
                     fperm,
-                    display_permissions_unix(fperm),
+                    display_permissions_unix(fperm as mode_t, false),
                     mode,
-                    display_permissions_unix(mode)
+                    display_permissions_unix(mode as mode_t, false)
                 );
             }
             Err(1)
@@ -331,9 +332,9 @@ impl Chmoder {
                     "mode of '{}' changed from {:o} ({}) to {:o} ({})",
                     file.display(),
                     fperm,
-                    display_permissions_unix(fperm),
+                    display_permissions_unix(fperm as mode_t, false),
                     mode,
-                    display_permissions_unix(mode)
+                    display_permissions_unix(mode as mode_t, false)
                 );
             }
             Ok(())

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1480,9 +1480,8 @@ fn display_item_long(
 
     let _ = write!(
         out,
-        "{}{} {}",
-        display_file_type(md.file_type()),
-        display_permissions(&md),
+        "{} {}",
+        display_permissions(&md, true),
         pad_left(display_symlink_count(&md), max_links),
     );
 
@@ -1665,16 +1664,6 @@ fn display_size(len: u64, config: &Config) -> String {
         SizeFormat::Binary => format_prefixed(NumberPrefix::binary(len as f64)),
         SizeFormat::Decimal => format_prefixed(NumberPrefix::decimal(len as f64)),
         SizeFormat::Bytes => len.to_string(),
-    }
-}
-
-fn display_file_type(file_type: FileType) -> char {
-    if file_type.is_dir() {
-        'd'
-    } else if file_type.is_symlink() {
-        'l'
-    } else {
-        '-'
     }
 }
 

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/stat.rs"
 [dependencies]
 clap = "2.33"
 time = "0.1.40"
-uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "libc"] }
+uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "libc", "fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]

--- a/src/uu/stat/src/fsext.rs
+++ b/src/uu/stat/src/fsext.rs
@@ -41,13 +41,6 @@ impl BirthTime for Metadata {
     }
 }
 
-#[macro_export]
-macro_rules! has {
-    ($mode:expr, $perm:expr) => {
-        $mode & $perm != 0
-    };
-}
-
 pub fn pretty_time(sec: i64, nsec: i64) -> String {
     // sec == seconds since UNIX_EPOCH
     // nsec == nanoseconds since (UNIX_EPOCH + sec)
@@ -79,65 +72,6 @@ pub fn pretty_filetype<'a>(mode: mode_t, size: u64) -> &'a str {
         // See coreutils/gnulib/lib/file-type.c
         _ => "weird file",
     }
-}
-
-pub fn pretty_access(mode: mode_t) -> String {
-    let mut result = String::with_capacity(10);
-    result.push(match mode & S_IFMT {
-        S_IFDIR => 'd',
-        S_IFCHR => 'c',
-        S_IFBLK => 'b',
-        S_IFREG => '-',
-        S_IFIFO => 'p',
-        S_IFLNK => 'l',
-        S_IFSOCK => 's',
-        // TODO: Other file types
-        _ => '?',
-    });
-
-    result.push(if has!(mode, S_IRUSR) { 'r' } else { '-' });
-    result.push(if has!(mode, S_IWUSR) { 'w' } else { '-' });
-    result.push(if has!(mode, S_ISUID as mode_t) {
-        if has!(mode, S_IXUSR) {
-            's'
-        } else {
-            'S'
-        }
-    } else if has!(mode, S_IXUSR) {
-        'x'
-    } else {
-        '-'
-    });
-
-    result.push(if has!(mode, S_IRGRP) { 'r' } else { '-' });
-    result.push(if has!(mode, S_IWGRP) { 'w' } else { '-' });
-    result.push(if has!(mode, S_ISGID as mode_t) {
-        if has!(mode, S_IXGRP) {
-            's'
-        } else {
-            'S'
-        }
-    } else if has!(mode, S_IXGRP) {
-        'x'
-    } else {
-        '-'
-    });
-
-    result.push(if has!(mode, S_IROTH) { 'r' } else { '-' });
-    result.push(if has!(mode, S_IWOTH) { 'w' } else { '-' });
-    result.push(if has!(mode, S_ISVTX as mode_t) {
-        if has!(mode, S_IXOTH) {
-            't'
-        } else {
-            'T'
-        }
-    } else if has!(mode, S_IXOTH) {
-        'x'
-    } else {
-        '-'
-    });
-
-    result
 }
 
 use std::borrow::Cow;

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -7,13 +7,13 @@
 
 // spell-checker:ignore (ToDO) mtab fsext showfs otype fmtstr prec ftype blocksize nlink rdev fnodes fsid namelen blksize inodes fstype iosize statfs gnulib NBLOCKSIZE
 
-#[macro_use]
 mod fsext;
 pub use crate::fsext::*;
 
 #[macro_use]
 extern crate uucore;
 use uucore::entries;
+use uucore::fs::display_permissions;
 
 use clap::{App, Arg, ArgMatches};
 use std::borrow::Cow;
@@ -575,7 +575,7 @@ impl Stater {
                                     }
                                     // access rights in human readable form
                                     'A' => {
-                                        arg = pretty_access(meta.mode() as mode_t);
+                                        arg = display_permissions(&meta, true);
                                         otype = OutputType::Str;
                                     }
                                     // number of blocks allocated (see %B)

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -10,42 +10,6 @@ mod test_fsext {
     use super::*;
 
     #[test]
-    fn test_access() {
-        assert_eq!("drwxr-xr-x", pretty_access(S_IFDIR | 0o755));
-        assert_eq!("-rw-r--r--", pretty_access(S_IFREG | 0o644));
-        assert_eq!("srw-r-----", pretty_access(S_IFSOCK | 0o640));
-        assert_eq!("lrw-r-xr-x", pretty_access(S_IFLNK | 0o655));
-        assert_eq!("?rw-r-xr-x", pretty_access(0o655));
-
-        assert_eq!(
-            "brwSr-xr-x",
-            pretty_access(S_IFBLK | S_ISUID as mode_t | 0o655)
-        );
-        assert_eq!(
-            "brwsr-xr-x",
-            pretty_access(S_IFBLK | S_ISUID as mode_t | 0o755)
-        );
-
-        assert_eq!(
-            "prw---sr--",
-            pretty_access(S_IFIFO | S_ISGID as mode_t | 0o614)
-        );
-        assert_eq!(
-            "prw---Sr--",
-            pretty_access(S_IFIFO | S_ISGID as mode_t | 0o604)
-        );
-
-        assert_eq!(
-            "c---r-xr-t",
-            pretty_access(S_IFCHR | S_ISVTX as mode_t | 0o055)
-        );
-        assert_eq!(
-            "c---r-xr-T",
-            pretty_access(S_IFCHR | S_ISVTX as mode_t | 0o054)
-        );
-    }
-
-    #[test]
     fn test_file_type() {
         assert_eq!("block special file", pretty_filetype(S_IFBLK, 0));
         assert_eq!("character special file", pretty_filetype(S_IFCHR, 0));


### PR DESCRIPTION
…issions`

This is a refactor to reduce duplicate code, it affects chmod/ls/stat.
* merge `stat/src/fsext::pretty_access` into `uucore/src/lib/feature/fs::display_permissions_unix`
* move tests for `fs::display_permissions` from `test_stat::test_access` to `uucore/src/lib/features/fs::test_display_permissions`
* adjust `uu_chmod`, `uu_ls` and `uu_stat` to use `uucore::fs::display_permissions`