### PR TITLE
wc: emit '-' in ouput when set on command-line

### DIFF
--- a/src/uu/wc/src/wordcount.rs
+++ b/src/uu/wc/src/wordcount.rs
@@ -103,7 +103,7 @@ impl WordCount {
         (word_count, char_count)
     }
 
-    pub fn with_title(self, title: &str) -> TitledWordCount {
+    pub fn with_title(self, title: Option<&str>) -> TitledWordCount {
         TitledWordCount { title, count: self }
     }
 
@@ -120,12 +120,12 @@ impl WordCount {
     }
 }
 
-/// This struct supplements the actual word count with a title that is displayed
-/// to the user at the end of the program.
+/// This struct supplements the actual word count with an optional title that is
+/// displayed to the user at the end of the program.
 /// The reason we don't simply include title in the `WordCount` struct is that
 /// it would result in unneccesary copying of `String`.
 #[derive(Debug, Default, Clone)]
 pub struct TitledWordCount<'a> {
-    pub title: &'a str,
+    pub title: Option<&'a str>,
     pub count: WordCount,
 }

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -37,6 +37,15 @@ fn test_stdin_default() {
 }
 
 #[test]
+fn test_stdin_explicit() {
+    new_ucmd!()
+        .pipe_in_fixture("lorem_ipsum.txt")
+        .arg("-")
+        .run()
+        .stdout_is(" 13 109 772 -\n");
+}
+
+#[test]
 fn test_utf8() {
     new_ucmd!()
         .args(&["-lwmcL"])


### PR DESCRIPTION
When stdin is explicitly specified on the command-line with '-', emit it
in the output stats to match GNU wc output.

Fixes #2188.