### PR TITLE
Switched 'arch' to use clap instead of getopts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
 name = "uu_arch"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "platform-info",
  "uucore",
  "uucore_procs",
@@ -2406,6 +2407,7 @@ name = "uu_stat"
 version = "0.0.6"
 dependencies = [
  "clap",
+ "libc",
  "time",
  "uucore",
  "uucore_procs",

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/arch.rs"
 
 [dependencies]
 platform-info = "0.1"
+clap = "2.33"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -10,17 +10,20 @@
 extern crate uucore;
 
 use platform_info::*;
-use uucore::InvalidEncodingHandling;
 
-static SYNTAX: &str = "Display machine architecture";
+use clap::App;
+
+static VERSION: &str = env!("CARGO_PKG_VERSION");
+static ABOUT: &str = "Display machine architecture";
 static SUMMARY: &str = "Determine architecture name for current machine.";
-static LONG_HELP: &str = "";
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    app!(SYNTAX, SUMMARY, LONG_HELP).parse(
-        args.collect_str(InvalidEncodingHandling::ConvertLossy)
-            .accept_any(),
-    );
+    App::new(executable!())
+        .version(VERSION)
+        .about(ABOUT)
+        .after_help(SUMMARY)
+        .get_matches_from(args);
+
     let uts = return_if_err!(1, PlatformInfo::new());
     println!("{}", uts.machine().trim());
     0


### PR DESCRIPTION
Help looks a bit different.
Before:
```

 arch 0.0.6

 arch Display machine architecture

 Determine architecture name for current machine.

 Options:
    --help              print usage information
    --version           print name and version number


 Reference


```

After:
```
arch 0.0.6
Display machine architecture

USAGE:
    arch

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

Determine architecture name for current machine.
```