### PR TITLE
date: fix format for nanoseconds

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -207,11 +207,16 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .alias(OPT_UNIVERSAL_2)
                 .help("print or set Coordinated Universal Time (UTC)"),
         )
-        .arg(Arg::with_name(OPT_FORMAT).multiple(true))
+        .arg(Arg::with_name(OPT_FORMAT).multiple(false))
         .get_matches_from(args);
 
     let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
-        let form = form[1..].into();
+        if !form.starts_with('+') {
+            eprintln!("date: invalid date ‘{}’", form);
+            return 1;
+        }
+        // GNU `date` uses `%N` for nano seconds, however crate::chrono uses `%f`
+        let form = form[1..].replace("%N", "%f");
         Format::Custom(form)
     } else if let Some(fmt) = matches
         .values_of(OPT_ISO_8601)
@@ -237,7 +242,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let set_to = match matches.value_of(OPT_SET).map(parse_date) {
         None => None,
         Some(Err((input, _err))) => {
-            eprintln!("date: invalid date '{}'", input);
+            eprintln!("date: invalid date ‘{}’", input);
             return 1;
         }
         Some(Ok(date)) => Some(date),
@@ -301,7 +306,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     println!("{}", formatted);
                 }
                 Err((input, _err)) => {
-                    println!("date: invalid date '{}'", input);
+                    println!("date: invalid date ‘{}’", input);
                 }
             }
         }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -105,6 +105,23 @@ fn test_date_format_full_day() {
 }
 
 #[test]
+fn test_date_nano_seconds() {
+    // %N     nanoseconds (000000000..999999999)
+    let re = Regex::new(r"^\d{1,9}$").unwrap();
+    new_ucmd!().arg("+%N").succeeds().stdout_matches(&re);
+}
+
+#[test]
+fn test_date_format_without_plus() {
+    // [+FORMAT]
+    new_ucmd!()
+        .arg("%s")
+        .fails()
+        .stderr_contains("date: invalid date ‘%s’")
+        .code_is(1);
+}
+
+#[test]
 #[cfg(all(unix, not(target_os = "macos")))]
 fn test_date_set_valid() {
     if get_effective_uid() == 0 {


### PR DESCRIPTION
This closes #2204.

The panic described in the issue originates in `crate::chrono`.
The reason is that chrono and date differ in their format sequences for nano seconds, i.e. chrono uses `%f` instead of `%N`.

* replace `%N` with `%f` before further processing input format

Other changes
* check if `FORMAT` starts with `+`
* adjust error message to reflect GNU date's behavior
* add tests for the changes