### PR TITLE
tail: refactor code into ReverseChunks iterator

### DIFF
--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -1,0 +1,83 @@
+//! Iterating over a file by chunks, starting at the end of the file.
+//!
+//! Use [`ReverseChunks::new`] to create a new iterator over chunks of
+//! bytes from the file.
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+
+/// When reading files in reverse in `bounded_tail`, this is the size of each
+/// block read at a time.
+pub const BLOCK_SIZE: u64 = 1 << 16;
+
+/// An iterator over a file in non-overlapping chunks from the end of the file.
+///
+/// Each chunk is a [`Vec`]<[`u8`]> of size [`BLOCK_SIZE`] (except
+/// possibly the last chunk, which might be smaller). Each call to
+/// [`next`] will seek backwards through the given file.
+pub struct ReverseChunks<'a> {
+    /// The file to iterate over, by blocks, from the end to the beginning.
+    file: &'a File,
+
+    /// The total number of bytes in the file.
+    size: u64,
+
+    /// The total number of blocks to read.
+    max_blocks_to_read: usize,
+
+    /// The index of the next block to read.
+    block_idx: usize,
+}
+
+impl<'a> ReverseChunks<'a> {
+    pub fn new(file: &'a mut File) -> ReverseChunks<'a> {
+        let size = file.seek(SeekFrom::End(0)).unwrap();
+        let max_blocks_to_read = (size as f64 / BLOCK_SIZE as f64).ceil() as usize;
+        let block_idx = 0;
+        ReverseChunks {
+            file,
+            size,
+            max_blocks_to_read,
+            block_idx,
+        }
+    }
+}
+
+impl<'a> Iterator for ReverseChunks<'a> {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If there are no more chunks to read, terminate the iterator.
+        if self.block_idx >= self.max_blocks_to_read {
+            return None;
+        }
+
+        // The chunk size is `BLOCK_SIZE` for all but the last chunk
+        // (that is, the chunk closest to the beginning of the file),
+        // which contains the remainder of the bytes.
+        let block_size = if self.block_idx == self.max_blocks_to_read - 1 {
+            self.size % BLOCK_SIZE
+        } else {
+            BLOCK_SIZE
+        };
+
+        // Seek backwards by the next chunk, read the full chunk into
+        // `buf`, and then seek back to the start of the chunk again.
+        let mut buf = vec![0; BLOCK_SIZE as usize];
+        let pos = self
+            .file
+            .seek(SeekFrom::Current(-(block_size as i64)))
+            .unwrap();
+        self.file
+            .read_exact(&mut buf[0..(block_size as usize)])
+            .unwrap();
+        let pos2 = self
+            .file
+            .seek(SeekFrom::Current(-(block_size as i64)))
+            .unwrap();
+        assert_eq!(pos, pos2);
+
+        self.block_idx += 1;
+
+        Some(buf[0..(block_size as usize)].to_vec())
+    }
+}


### PR DESCRIPTION
This pull request refactors code from the `backwards_thru_file()` function into a new `ReverseChunks` iterator, and use that iterator to simplify the implementation of the `backwards_thru_file()` function. The `ReverseChunks` iterator yields `Vec<u8>` objects, each of which references bytes of a given file.

This has the benefit of providing and using an abstraction similar to one in the standard library, https://doc.rust-lang.org/std/slice/struct.RChunks.html. However, it creates a new `Vec<u8>` for each chunk, whereas the previous code was re-using the same `Vec<u8>` to read each chunk into. Perhaps someone more familar with Rust could propose an improvement to this part of the code.