### PR TITLE
date: fix format literal for nanoseconds

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -215,8 +215,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             eprintln!("date: invalid date ‘{}’", form);
             return 1;
         }
-        // GNU `date` uses `%N` for nano seconds, however crate::chrono uses `%f`
-        let form = form[1..].replace("%N", "%f");
+        let form = form[1..].to_string();
         Format::Custom(form)
     } else if let Some(fmt) = matches
         .values_of(OPT_ISO_8601)
@@ -302,7 +301,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         for date in dates {
             match date {
                 Ok(date) => {
-                    let formatted = date.format(format_string);
+                    // GNU `date` uses `%N` for nano seconds, however crate::chrono uses `%f`
+                    let format_string = &format_string.replace("%N", "%f");
+                    let formatted = date.format(format_string).to_string().replace("%f", "%N");
                     println!("{}", formatted);
                 }
                 Err((input, _err)) => {

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -122,6 +122,12 @@ fn test_date_format_without_plus() {
 }
 
 #[test]
+fn test_date_format_literal() {
+    new_ucmd!().arg("+%%s").succeeds().stdout_is("%s\n");
+    new_ucmd!().arg("+%%N").succeeds().stdout_is("%N\n");
+}
+
+#[test]
 #[cfg(all(unix, not(target_os = "macos")))]
 fn test_date_set_valid() {
     if get_effective_uid() == 0 {


### PR DESCRIPTION
This is a fix for #2205 that also considers format literals as pointed out by @jfinkels https://github.com/uutils/coreutils/pull/2205#discussion_r630583042