### PR TITLE
wc: correct some error messages for invalid inputs

### DIFF
--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -168,3 +168,26 @@ fn test_file_one_long_word() {
         .run()
         .stdout_is("    1     1 10001 10001 10000 onelongword.txt\n");
 }
+
+/// Test that getting counts from a directory is an error.
+#[test]
+fn test_read_from_directory_error() {
+    // TODO To match GNU `wc`, the `stdout` should be:
+    //
+    //     "      0       0       0 .\n"
+    //
+    new_ucmd!()
+        .args(&["."])
+        .fails()
+        .stderr_contains(".: Is a directory\n")
+        .stdout_is("0 0 0 .\n");
+}
+
+/// Test that getting counts from nonexistent file is an error.
+#[test]
+fn test_read_from_nonexistent_file() {
+    new_ucmd!()
+        .args(&["bogusfile"])
+        .fails()
+        .stderr_contains("bogusfile: No such file or directory\n");
+}


### PR DESCRIPTION
This pull request changes the error messages that get printed to `stderr` for compatibility with GNU `wc` when an input is a directory and when an input does not exist. The messages are now
```
$ ./target/debug/coreutils wc /tmp
wc: /tmp: Is a directory
0 0 0 /tmp
$ ./target/debug/coreutils wc blah
wc: blah: No such file or directory
0 0 0 blah
```

Fixes #2211.