### PR TITLE
head: print headings when reading multiple files

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -405,7 +405,7 @@ fn uu_head(options: &HeadOptions) {
     for fname in &options.files {
         let res = match fname.as_str() {
             "-" => {
-                if options.verbose {
+                if (options.files.len() > 1 && !options.quiet) || options.verbose {
                     if !first {
                         println!();
                     }
@@ -459,6 +459,9 @@ fn uu_head(options: &HeadOptions) {
                     },
                 };
                 if (options.files.len() > 1 && !options.quiet) || options.verbose {
+                    if !first {
+                        println!();
+                    }
                     println!("==> {} <==", name)
                 }
                 head_file(&mut file, options)

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -196,3 +196,28 @@ fn test_obsolete_extras() {
         .succeeds()
         .stdout_is("==> standard input <==\n1\02\03\04\05\0");
 }
+
+#[test]
+fn test_multiple_files() {
+    new_ucmd!()
+        .args(&["emptyfile.txt", "emptyfile.txt"])
+        .succeeds()
+        .stdout_is("==> emptyfile.txt <==\n\n==> emptyfile.txt <==\n");
+}
+
+#[test]
+fn test_multiple_files_with_stdin() {
+    new_ucmd!()
+        .args(&["emptyfile.txt", "-", "emptyfile.txt"])
+        .pipe_in("hello\n")
+        .succeeds()
+        .stdout_is(
+            "==> emptyfile.txt <==
+
+==> standard input <==
+hello
+
+==> emptyfile.txt <==
+",
+        );
+}


### PR DESCRIPTION
This pull request fixes a bug in which `head` failed to print headings for `stdin` inputs when reading from multiple files, and fix another bug in which `head` failed to print a blank line between the contents of a file and the heading for the next file when reading multiple files. The output now matches that of GNU `head`.

A future pull request can refactor the common code for printing the heading above the contents of each file.