### PR TITLE
head: display errors for each input file instead of terminating at the first error

### DIFF
--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -162,6 +162,18 @@ fn test_no_such_file_or_directory() {
         .stderr_contains("cannot open 'no_such_file.toml' for reading: No such file or directory");
 }
 
+/// Test that each non-existent files gets its own error message printed.
+#[test]
+fn test_multiple_nonexistent_files() {
+    new_ucmd!()
+        .args(&["bogusfile1", "bogusfile2"])
+        .fails()
+        .stdout_does_not_contain("==> bogusfile1 <==")
+        .stderr_contains("cannot open 'bogusfile1' for reading: No such file or directory")
+        .stdout_does_not_contain("==> bogusfile2 <==")
+        .stderr_contains("cannot open 'bogusfile2' for reading: No such file or directory");
+}
+
 // there was a bug not caught by previous tests
 // where for negative n > 3, the total amount of lines
 // was correct, but it would eat from the second line

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -315,7 +315,12 @@ impl CmdResult {
     }
 
     pub fn stdout_does_not_contain<T: AsRef<str>>(&self, cmp: T) -> &CmdResult {
-        assert!(!self.stdout_str().contains(cmp.as_ref()));
+        assert!(
+            !self.stdout_str().contains(cmp.as_ref()),
+            "'{}' contains '{}' but should not",
+            self.stdout_str(),
+            cmp.as_ref(),
+        );
         self
     }
 


### PR DESCRIPTION
This pull request changes the behavior of `head` to display an error for each problematic file, instead of displaying an error message for the first problematic file and terminating immediately at that point. This change now matches the behavior of GNU `head`.

Before this commit, the first error caused the program to terminate immediately:

    $ head a b c
    head: error: head: cannot open 'a' for reading: No such file or directory

After this commit:

    $ head a b c
    head: cannot open 'a' for reading: No such file or directory
    head: cannot open 'b' for reading: No such file or directory
    head: cannot open 'c' for reading: No such file or directory