### PR TITLE
Disable the GNU tests in CI

### DIFF
--- a/.github/workflows/GNU.yml
+++ b/.github/workflows/GNU.yml
@@ -1,6 +1,7 @@
 name: GNU
 
-on: [push, pull_request]
+# on: [push, pull_request]
+on: []
 
 jobs:
   gnu:


### PR DESCRIPTION
Those are routinely broken on `master` and should not be run as part of CI until they are fixed.

Broken CI is worse than no CI, as it teaches people to ignore errors.