### PR TITLE
CI: Stabilise the version of GNU tests used in CI

### DIFF
--- a/.github/workflows/GNU.yml
+++ b/.github/workflows/GNU.yml
@@ -12,16 +12,18 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: 'uutils'
-    - name: Chechout GNU coreutils
+    - name: Checkout GNU coreutils
       uses: actions/checkout@v2
       with:
         repository: 'coreutils/coreutils'
         path: 'gnu'
-    - name: Chechout GNU corelib
+        ref: v8.32
+    - name: Checkout GNU corelib
       uses: actions/checkout@v2
       with:
         repository: 'coreutils/gnulib'
         path: 'gnulib'
+        ref: 8e99f24c0931a38880c6ee9b8287c7da80b0036b
         fetch-depth: 0 # gnu gets upset if gnulib is a shallow checkout
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The “GNU tests” task is routinely broken on `master`.
Broken CI is worse than no CI, as it teaches people to ignore errors.

This PR pins the versions of the GNU testsuite (and GNUlib) used,
to current stable versions, so this task stops breaking unexpectedly.
This is a proposed alternative to #2225.

Presumably, someone will update `GNU.yml` when a new stable version
of the GNU coreutils is released, but I'm not volunteering.
