### PR TITLE
dev random blocks on linux

### DIFF
--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -347,10 +347,18 @@ fn test_squeeze_blank_before_numbering() {
 #[cfg(unix)]
 fn test_dev_random() {
     let mut buf = [0; 2048];
-    let mut proc = new_ucmd!().args(&["/dev/random"]).run_no_wait();
+    #[cfg(target_os = "linux")]
+    fn rand_gen() -> &'static str { "/dev/urandom"}
+
+    #[cfg(not(target_os = "linux"))]
+    fn rand_gen() -> &'static str { "/dev/random"}
+
+    let mut proc = new_ucmd!().args(&[rand_gen()]).run_no_wait();
     let mut proc_stdout = proc.stdout.take().unwrap();
+    println!("I got to 1");
     proc_stdout.read_exact(&mut buf).unwrap();
 
+    println!("I got to 3");
     let num_zeroes = buf.iter().fold(0, |mut acc, &n| {
         if n == 0 {
             acc += 1;

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -355,10 +355,8 @@ fn test_dev_random() {
 
     let mut proc = new_ucmd!().args(&[rand_gen()]).run_no_wait();
     let mut proc_stdout = proc.stdout.take().unwrap();
-    println!("I got to 1");
     proc_stdout.read_exact(&mut buf).unwrap();
 
-    println!("I got to 3");
     let num_zeroes = buf.iter().fold(0, |mut acc, &n| {
         if n == 0 {
             acc += 1;

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -348,12 +348,12 @@ fn test_squeeze_blank_before_numbering() {
 fn test_dev_random() {
     let mut buf = [0; 2048];
     #[cfg(target_os = "linux")]
-    fn rand_gen() -> &'static str { "/dev/urandom"}
+    const DEV_RANDOM: &str = "/dev/urandom";
 
     #[cfg(not(target_os = "linux"))]
-    fn rand_gen() -> &'static str { "/dev/random"}
+    const DEV_RANDOM: &str = "/dev/random";
 
-    let mut proc = new_ucmd!().args(&[rand_gen()]).run_no_wait();
+    let mut proc = new_ucmd!().args(&[DEV_RANDOM]).run_no_wait();
     let mut proc_stdout = proc.stdout.take().unwrap();
     proc_stdout.read_exact(&mut buf).unwrap();
 


### PR DESCRIPTION
/dev/random blocks on Linux, you have to use /dev/urandom. This fixes https://github.com/uutils/coreutils/issues/2214.