### PR TITLE
truncate: simplify parse_size() function and correct error message

### DIFF
--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -235,3 +235,13 @@ fn test_size_and_reference() {
         actual
     );
 }
+
+#[test]
+fn test_invalid_numbers() {
+    // TODO For compatibility with GNU, `truncate -s 0X` should cause
+    // the same error as `truncate -s 0X file`, but currently it returns
+    // a different error.
+    new_ucmd!().args(&["-s", "0X", "file"]).fails().stderr_contains("Invalid number: ‘0X’");
+    new_ucmd!().args(&["-s", "0XB", "file"]).fails().stderr_contains("Invalid number: ‘0XB’");
+    new_ucmd!().args(&["-s", "0B", "file"]).fails().stderr_contains("Invalid number: ‘0B’");
+}


### PR DESCRIPTION
This pull request changes the interface provided by the `parse_size()` function to reduce its responsibilities to just a single task: parsing a number of bytes from a string of the form '123KB', etc. Previously, the function was also responsible for deciding which mode truncate would operate in. Furthermore, this commit simplifies the code for parsing the number and unit to be less verbose and use less mutable state. Finally, this commit adds some unit tests for the `parse_size()` function itself, as well as a test for invalid size arguments for the command-line itself.

(There may be other coreutils programs that require parsing a size from a string with units, they could use this function.)