### PR TITLE
truncate: fix error message for file not found

### DIFF
--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -245,3 +245,11 @@ fn test_invalid_numbers() {
     new_ucmd!().args(&["-s", "0XB", "file"]).fails().stderr_contains("Invalid number: ‘0XB’");
     new_ucmd!().args(&["-s", "0B", "file"]).fails().stderr_contains("Invalid number: ‘0B’");
 }
+
+#[test]
+fn test_reference_file_not_found() {
+    new_ucmd!()
+        .args(&["-r", "a", "b"])
+        .fails()
+        .stderr_contains("cannot stat 'a': No such file or directory");
+}


### PR DESCRIPTION
This pull request changes the error message for when the reference file (the `-r` argument) is not found to match GNU coreutils. This commit also eliminates a redundant call to `File::open`; the file need not be opened because the size in bytes can be read from the result of `std::fs::metadata()`. (The error message suggests that implementation as well: it states `"cannot stat '{}'"`.)