### PR TITLE
truncate: fix character used to indicate round up

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -147,7 +147,7 @@ fn truncate(
                 '<' => TruncateMode::AtMost,
                 '>' => TruncateMode::AtLeast,
                 '/' => TruncateMode::RoundDown,
-                '*' => TruncateMode::RoundUp,
+                '%' => TruncateMode::RoundUp,
                 _ => TruncateMode::Absolute, /* assume that the size is just a number */
             };
 

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -206,7 +206,7 @@ fn test_round_up() {
     let (at, mut ucmd) = at_and_ucmd!();
     let mut file = at.make_file(TFILE2);
     file.write_all(b"1234567890").unwrap();
-    ucmd.args(&["--size", "*4", TFILE2]).succeeds();
+    ucmd.args(&["--size", "%4", TFILE2]).succeeds();
     file.seek(SeekFrom::End(0)).unwrap();
     let actual = file.seek(SeekFrom::Current(0)).unwrap();
     assert!(


### PR DESCRIPTION
This pull request fixes a bug in which the incorrect character was being used to indicate "round up to the nearest multiple" mode in `truncate`. The character was "*" but it should be "%". This commit corrects that. Here is the corresponding section of the GNU man page for `truncate` in GNU coreutils v8.28:
```
       SIZE may also be prefixed by one of the following modifying characters:
       '+' extend by, '-' reduce by, '<' at most, '>' at least, '/' round down
       to multiple of, '%' round up to multiple of.
```

(As far as I can this is just a typo that was never noticed. It seems that `truncate` was introduced in https://github.com/uutils/coreutils/commit/968483bdf6332b382dfc673e6e9545dabf68e765, where you can already see the discrepancy between the implementation, which has `'*'` and the help text, which has `'%'`.)