### PR TITLE
sort: automatically fall back to extsort

### DIFF
--- a/src/uu/sort/BENCHMARKING.md
+++ b/src/uu/sort/BENCHMARKING.md
@@ -72,7 +72,8 @@ Run `cargo build --release` before benchmarking after you make a change!
 ## External sorting
 
 Try running commands with the `-S` option set to an amount of memory to be used, such as `1M`. Additionally, you could try sorting
-huge files (ideally multiple Gigabytes) with `-S`. Creating such a large file can be achieved by running `cat shuffled_wordlist.txt | sort -R >> shuffled_wordlist.txt`
+huge files (ideally multiple Gigabytes) with `-S` (or without `-S` to benchmark with our default value).
+Creating such a large file can be achieved by running `cat shuffled_wordlist.txt | sort -R >> shuffled_wordlist.txt`
 multiple times (this will add the contents of `shuffled_wordlist.txt` to itself).
 Example: Run `hyperfine './target/release/coreutils sort shuffled_wordlist.txt -S 1M' 'sort shuffled_wordlist.txt -S 1M'`
 

--- a/src/uu/sort/src/check.rs
+++ b/src/uu/sort/src/check.rs
@@ -87,6 +87,7 @@ fn reader(
         chunks::read(
             &mut sender,
             recycled_buffer,
+            None,
             &mut carry_over,
             &mut file,
             &mut iter::empty(),

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -108,6 +108,7 @@ fn reader(
         chunks::read(
             sender,
             recycled_buffer,
+            None,
             carry_over,
             file,
             &mut iter::empty(),

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -93,7 +93,10 @@ static THOUSANDS_SEP: char = ',';
 static NEGATIVE: char = '-';
 static POSITIVE: char = '+';
 
-static DEFAULT_BUF_SIZE: usize = std::usize::MAX;
+/// Choosing a higher buffer size does not result in performance improvements
+/// (at least not on my machine). TODO: In the future, we should also take the amount of
+/// available memory into consideration, instead of relying on this constant only.
+static DEFAULT_BUF_SIZE: usize = 1_000_000_000;
 
 #[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Copy)]
 enum SortMode {
@@ -127,7 +130,6 @@ pub struct GlobalSettings {
     zero_terminated: bool,
     buffer_size: usize,
     tmp_dir: PathBuf,
-    ext_sort: bool,
 }
 
 impl GlobalSettings {
@@ -189,7 +191,6 @@ impl Default for GlobalSettings {
             zero_terminated: false,
             buffer_size: DEFAULT_BUF_SIZE,
             tmp_dir: PathBuf::new(),
-            ext_sort: false,
         }
     }
 }
@@ -941,28 +942,15 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         env::set_var("RAYON_NUM_THREADS", &settings.threads);
     }
 
-    if matches.is_present(OPT_BUF_SIZE) {
-        settings.buffer_size = {
-            let input = matches
-                .value_of(OPT_BUF_SIZE)
-                .map(String::from)
-                .unwrap_or(format!("{}", DEFAULT_BUF_SIZE));
+    settings.buffer_size = matches
+        .value_of(OPT_BUF_SIZE)
+        .map(GlobalSettings::human_numeric_convert)
+        .unwrap_or(DEFAULT_BUF_SIZE);
 
-            GlobalSettings::human_numeric_convert(&input)
-        };
-        settings.ext_sort = true;
-    }
-
-    if matches.is_present(OPT_TMP_DIR) {
-        let result = matches
-            .value_of(OPT_TMP_DIR)
-            .map(String::from)
-            .unwrap_or(format!("{}", env::temp_dir().display()));
-        settings.tmp_dir = PathBuf::from(result);
-        settings.ext_sort = true;
-    } else {
-        settings.tmp_dir = env::temp_dir();
-    }
+    settings.tmp_dir = matches
+        .value_of(OPT_TMP_DIR)
+        .map(PathBuf::from)
+        .unwrap_or_else(env::temp_dir);
 
     settings.zero_terminated = matches.is_present(OPT_ZERO_TERMINATED);
     settings.merge = matches.is_present(OPT_MERGE);
@@ -1047,7 +1035,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     exec(&files, &settings)
 }
 
-fn output_sorted_lines<'a>(iter: impl Iterator<Item = Line<'a>>, settings: &GlobalSettings) {
+fn output_sorted_lines<'a>(iter: impl Iterator<Item = &'a Line<'a>>, settings: &GlobalSettings) {
     if settings.unique {
         print_sorted(
             iter.dedup_by(|a, b| compare_by(a, b, &settings) == Ordering::Equal),
@@ -1067,34 +1055,10 @@ fn exec(files: &[String], settings: &GlobalSettings) -> i32 {
             crash!(1, "only one file allowed with -c");
         }
         return check::check(files.first().unwrap(), settings);
-    } else if settings.ext_sort {
+    } else {
         let mut lines = files.iter().filter_map(open);
 
-        let mut sorted = ext_sort(&mut lines, &settings);
-        sorted.file_merger.write_all(settings);
-    } else {
-        let separator = if settings.zero_terminated { '\0' } else { '\n' };
-        let mut lines = vec![];
-        let mut full_string = String::new();
-
-        for mut file in files.iter().filter_map(open) {
-            crash_if_err!(1, file.read_to_string(&mut full_string));
-
-            if !full_string.ends_with(separator) {
-                full_string.push(separator);
-            }
-        }
-
-        if full_string.ends_with(separator) {
-            full_string.pop();
-        }
-
-        for line in full_string.split(if settings.zero_terminated { '\0' } else { '\n' }) {
-            lines.push(Line::create(line, &settings));
-        }
-
-        sort_by(&mut lines, &settings);
-        output_sorted_lines(lines.into_iter(), &settings);
+        ext_sort(&mut lines, &settings);
     }
     0
 }
@@ -1366,7 +1330,7 @@ fn version_compare(a: &str, b: &str) -> Ordering {
     }
 }
 
-fn print_sorted<'a, T: Iterator<Item = Line<'a>>>(iter: T, settings: &GlobalSettings) {
+fn print_sorted<'a, T: Iterator<Item = &'a Line<'a>>>(iter: T, settings: &GlobalSettings) {
     let mut writer = settings.out_writer();
     for line in iter {
         line.print(&mut writer, settings);

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -15,29 +15,18 @@ fn test_helper(file_name: &str, args: &str) {
         .stdout_is_fixture(format!("{}.expected.debug", file_name));
 }
 
-// FYI, the initialization size of our Line struct is 96 bytes.
-//
-// At very small buffer sizes, with that overhead we are certainly going
-// to overrun our buffer way, way, way too quickly because of these excess
-// bytes for the struct.
-//
-// For instance, seq 0..20000 > ...text = 108894 bytes
-// But overhead is 1920000 + 108894 = 2028894 bytes
-//
-// Or kjvbible-random.txt = 4332506 bytes, but minimum size of its
-// 99817 lines in memory * 96 bytes = 9582432 bytes
-//
-// Here, we test 108894 bytes with a 50K buffer
-//
 #[test]
-fn test_larger_than_specified_segment() {
-    new_ucmd!()
-        .arg("-n")
-        .arg("-S")
-        .arg("50K")
-        .arg("ext_sort.txt")
-        .succeeds()
-        .stdout_is_fixture("ext_sort.expected");
+fn test_buffer_sizes() {
+    let buffer_sizes = ["0", "50K", "1M", "1000G"];
+    for buffer_size in &buffer_sizes {
+        new_ucmd!()
+            .arg("-n")
+            .arg("-S")
+            .arg(buffer_size)
+            .arg("ext_sort.txt")
+            .succeeds()
+            .stdout_is_fixture("ext_sort.expected");
+    }
 }
 
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -17,7 +17,9 @@ fn test_helper(file_name: &str, args: &str) {
 
 #[test]
 fn test_buffer_sizes() {
-    let buffer_sizes = ["0", "50K", "1M", "1000G"];
+    let buffer_sizes = [
+        "0", "50K", "50k", "1M", "100M", "1000G", "10T", "500E", "1Y",
+    ];
     for buffer_size in &buffer_sizes {
         new_ucmd!()
             .arg("-n")
@@ -30,14 +32,18 @@ fn test_buffer_sizes() {
 }
 
 #[test]
-fn test_smaller_than_specified_segment() {
-    new_ucmd!()
-        .arg("-n")
-        .arg("-S")
-        .arg("100M")
-        .arg("ext_sort.txt")
-        .succeeds()
-        .stdout_is_fixture("ext_sort.expected");
+fn test_invalid_buffer_size() {
+    let buffer_sizes = ["asd", "100f"];
+    for invalid_buffer_size in &buffer_sizes {
+        new_ucmd!()
+            .arg("-S")
+            .arg(invalid_buffer_size)
+            .fails()
+            .stderr_only(format!(
+                "sort: error: failed to parse buffer size `{}`: invalid digit found in string",
+                invalid_buffer_size
+            ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
To make this work we make default sort a special case of external sort.

External sorting uses auxiliary files for intermediate chunks. However,
when we can keep our intermediate chunks in memory, we don't write them
to the file system at all. Only when we notice that we can't keep them
in memory they are written to the disk.

Additionally, we don't allocate buffers with the capacity of their
maximum size anymore. Instead, they start with a capacity of 8kb and are
grown only when needed.

This makes sorting smaller files about as fast as it was before
(I'm seeing a regression of ~3%), and allows us to seamlessly continue
with auxiliary files when needed.

Command for the benchmark mentioned above: `hyperfine "./coreutils-before-patch sort shuffled_wordlist.txt" "target/release/coreutils sort shuffled_wordlist.txt" "LC_ALL=C sort shuffled_wordlist.txt"`
```plaintext
Benchmark #1: ./coreutils-before-patch sort shuffled_wordlist.txt
  Time (mean ± σ):      14.5 ms ±   0.9 ms    [User: 62.1 ms, System: 5.2 ms]
  Range (min … max):    13.6 ms …  24.8 ms    161 runs
 
Benchmark #2: target/release/coreutils sort shuffled_wordlist.txt
  Time (mean ± σ):      15.0 ms ±   0.4 ms    [User: 62.6 ms, System: 6.0 ms]
  Range (min … max):    14.0 ms …  16.3 ms    176 runs
 
Benchmark #3: LC_ALL=C sort shuffled_wordlist.txt
  Time (mean ± σ):      27.0 ms ±   0.7 ms    [User: 24.4 ms, System: 2.2 ms]
  Range (min … max):    25.9 ms …  30.2 ms    101 runs
 
Summary
  './coreutils-before-patch sort shuffled_wordlist.txt' ran
    1.03 ± 0.07 times faster than 'target/release/coreutils sort shuffled_wordlist.txt'
    1.85 ± 0.13 times faster than 'LC_ALL=C sort shuffled_wordlist.txt'
```