### PR TITLE
truncate: re-organize truncate() into one function for each mode of operation

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -189,12 +189,7 @@ fn truncate(
     };
     for filename in &filenames {
         let path = Path::new(filename);
-        match OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(!no_create)
-            .open(path)
-        {
+        match OpenOptions::new().write(true).create(!no_create).open(path) {
             Ok(file) => {
                 let fsize = match reference {
                     Some(_) => refsize,

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -262,3 +262,11 @@ fn test_reference_file_not_found() {
         .fails()
         .stderr_contains("cannot stat 'a': No such file or directory");
 }
+
+#[test]
+fn test_reference_with_size_file_not_found() {
+    new_ucmd!()
+        .args(&["-r", "a", "-s", "+1", "b"])
+        .fails()
+        .stderr_contains("cannot stat 'a': No such file or directory");
+}


### PR DESCRIPTION
This pull request reorganizes the code in `truncate.rs` into three distinct functions representing the three modes of operation of the `truncate` program. The three modes are

- `truncate -r RFILE FILE`, which sets the length of `FILE` to match the length of `RFILE`,
- `truncate -r RFILE -s NUM FILE`, which sets the length of `FILE` relative to the given `RFILE`,
- `truncate -s NUM FILE`, which sets the length of `FILE` either absolutely or relative to its current length.

This organization of the code makes it more concise and easier to follow.