### PR TITLE
freebsd/circus: workaround the timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,10 @@
+env:
+  # Temporary workaround for error `error: sysinfo not supported on
+  # this platform` seen on FreeBSD platforms, affecting Rustup
+  #
+  # References: https://github.com/rust-lang/rustup/issues/2774
+  RUSTUP_IO_THREADS: 1
+
 task:
   name: stable x86_64-unknown-freebsd-12
   freebsd_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ env:
 task:
   name: stable x86_64-unknown-freebsd-12
   freebsd_instance:
-    image: freebsd-12-1-release-amd64
+    image: freebsd-12-2-release-amd64
   setup_script:
     - pkg install -y curl gmake
     - curl https://sh.rustup.rs -sSf --output rustup.sh


### PR DESCRIPTION
It is failing currently on:
```
info: installing component 'cargo'
error: error: 'sysinfo not supported on this platform'
```
with 1.52.1