### PR TITLE
wc: print counts for each file as soon as computed

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -373,7 +373,6 @@ fn wc(inputs: Vec<Input>, settings: &Settings) -> Result<(), u32> {
     let max_width = max_width(&inputs);
 
     let mut total_word_count = WordCount::default();
-    let mut results = vec![];
 
     let num_inputs = inputs.len();
 
@@ -384,10 +383,7 @@ fn wc(inputs: Vec<Input>, settings: &Settings) -> Result<(), u32> {
             WordCount::default()
         });
         total_word_count += word_count;
-        results.push(word_count.with_title(input.to_title()));
-    }
-
-    for result in &results {
+        let result = word_count.with_title(input.to_title());
         if let Err(err) = print_stats(settings, &result, max_width) {
             show_warning!(
                 "failed to print result for {}: {}",


### PR DESCRIPTION
This pull request changes the behavior of `wc` to print the counts for a file as soon as it is computed, instead of waiting to compute the counts for all files before writing any output to `stdout`. The new behavior matches the behavior of GNU `wc`.

The old behavior looked like this (the word "hello" is entered on `stdin`):

    $ wc emptyfile.txt -
    hello
          0       0       0 emptyfile.txt
          1       1       6 -
          1       1       6 total


The new behavior looks like this:

    $ wc emptyfile.txt -
          0       0       0 emptyfile.txt
    hello
          1       1       6 -
          1       1       6 total
