### PR TITLE
Workaround the Windows CI install issue.

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -363,6 +363,10 @@ jobs:
         mkdir -p '${{ steps.vars.outputs.STAGING }}/dpkg'
     - name: rust toolchain ~ install
       uses: actions-rs/toolchain@v1
+      env:
+        # Override auto-detection of RAM for Rustc install.
+        # https://github.com/rust-lang/rustup/issues/2229#issuecomment-585855925
+        RUSTUP_UNPACK_RAM: "21474836480"
       with:
         toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
         target: ${{ matrix.job.target }}


### PR DESCRIPTION
Fails trom time to time with:
```
info: installing component 'rustc'
memory allocation of 16777216 bytes failed
Error: The process 'C:\Rust\.cargo\bin\rustup.exe' failed with exit code 3221226505
```

on  Build (windows-latest, i686-pc-windows-gnu, feat_os_windows)