### PR TITLE
Decrease the value RUSTUP_UNPACK_RAM to  200000000

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -366,7 +366,7 @@ jobs:
       env:
         # Override auto-detection of RAM for Rustc install.
         # https://github.com/rust-lang/rustup/issues/2229#issuecomment-585855925
-        RUSTUP_UNPACK_RAM: "21474836480"
+        RUSTUP_UNPACK_RAM: "200000000"
       with:
         toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
         target: ${{ matrix.job.target }}


### PR DESCRIPTION
as it failed here:
https://github.com/uutils/coreutils/pull/2269/checks?check_run_id=2650288868