### PR TITLE
uucore: delete unused macros

### DIFF
--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -176,13 +176,6 @@ macro_rules! msg_invalid_input {
     };
 }
 
-#[macro_export]
-macro_rules! snippet_no_file_at_path {
-    ($path:expr) => {
-        format!("nonexistent path {}", $path)
-    };
-}
-
 // -- message templates : invalid input : flag
 
 #[macro_export]
@@ -226,55 +219,6 @@ macro_rules! msg_opt_invalid_should_be {
             $long_flag,
             $short_flag
         )
-    };
-}
-
-// -- message templates : invalid input : args
-
-#[macro_export]
-macro_rules! msg_arg_invalid_value {
-    ($expects:expr, $received:expr) => {
-        msg_invalid_input!(format!(
-            "expects its argument to be {}, but was provided {}",
-            $expects, $received
-        ))
-    };
-}
-
-#[macro_export]
-macro_rules! msg_args_invalid_value {
-    ($expects:expr, $received:expr) => {
-        msg_invalid_input!(format!(
-            "expects its arguments to be {}, but was provided {}",
-            $expects, $received
-        ))
-    };
-    ($msg:expr) => {
-        msg_invalid_input!($msg)
-    };
-}
-
-#[macro_export]
-macro_rules! msg_args_nonexistent_file {
-    ($received:expr) => {
-        msg_args_invalid_value!("paths to files", snippet_no_file_at_path!($received))
-    };
-}
-
-#[macro_export]
-macro_rules! msg_wrong_number_of_arguments {
-    () => {
-        msg_args_invalid_value!("wrong number of arguments")
-    };
-    ($min:expr, $max:expr) => {
-        msg_args_invalid_value!(format!("expects {}-{} arguments", $min, $max))
-    };
-    ($exact:expr) => {
-        if $exact == 1 {
-            msg_args_invalid_value!("expects 1 argument")
-        } else {
-            msg_args_invalid_value!(format!("expects {} arguments", $exact))
-        }
     };
 }
 


### PR DESCRIPTION
After moving all(literally) the argument parsing stuff to clap, there is need to keep these macros.