### PR TITLE
uucore: refactor show_error! macro

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -347,7 +347,7 @@ fn cat_files(files: Vec<String>, options: &OutputOptions) -> Result<(), u32> {
 
     for path in &files {
         if let Err(err) = cat_path(path, &options, &mut state) {
-            show_info!("{}: {}", path, err);
+            show_error!("{}: {}", path, err);
             error_count += 1;
         }
     }

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -97,7 +97,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if recursive {
         if bit_flag == FTS_PHYSICAL {
             if derefer == 1 {
-                show_info!("-R --dereference requires -H or -L");
+                show_error!("-R --dereference requires -H or -L");
                 return 1;
             }
             derefer = 0;
@@ -132,7 +132,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 dest_gid = meta.gid();
             }
             Err(e) => {
-                show_info!("failed to get attributes of '{}': {}", file, e);
+                show_error!("failed to get attributes of '{}': {}", file, e);
                 return 1;
             }
         }
@@ -143,7 +143,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 dest_gid = g;
             }
             _ => {
-                show_info!("invalid group: {}", matches.free[0].as_str());
+                show_error!("invalid group: {}", matches.free[0].as_str());
                 return 1;
             }
         }
@@ -235,8 +235,8 @@ impl Chgrper {
 
             if let Some(p) = may_exist {
                 if p.parent().is_none() || self.is_bind_root(p) {
-                    show_info!("it is dangerous to operate recursively on '/'");
-                    show_info!("use --no-preserve-root to override this failsafe");
+                    show_error!("it is dangerous to operate recursively on '/'");
+                    show_error!("use --no-preserve-root to override this failsafe");
                     return 1;
                 }
             }
@@ -250,12 +250,12 @@ impl Chgrper {
             self.verbosity.clone(),
         ) {
             Ok(n) => {
-                show_info!("{}", n);
+                show_error!("{}", n);
                 0
             }
             Err(e) => {
                 if self.verbosity != Verbosity::Silent {
-                    show_info!("{}", e);
+                    show_error!("{}", e);
                 }
                 1
             }
@@ -275,7 +275,7 @@ impl Chgrper {
         for entry in WalkDir::new(root).follow_links(follow).min_depth(1) {
             let entry = unwrap!(entry, e, {
                 ret = 1;
-                show_info!("{}", e);
+                show_error!("{}", e);
                 continue;
             });
             let path = entry.path();
@@ -290,13 +290,13 @@ impl Chgrper {
             ret = match wrap_chgrp(path, &meta, self.dest_gid, follow, self.verbosity.clone()) {
                 Ok(n) => {
                     if !n.is_empty() {
-                        show_info!("{}", n);
+                        show_error!("{}", n);
                     }
                     0
                 }
                 Err(e) => {
                     if self.verbosity != Verbosity::Silent {
-                        show_info!("{}", e);
+                        show_error!("{}", e);
                     }
                     1
                 }
@@ -313,7 +313,7 @@ impl Chgrper {
             unwrap!(path.metadata(), e, {
                 match self.verbosity {
                     Silent => (),
-                    _ => show_info!("cannot access '{}': {}", path.display(), e),
+                    _ => show_error!("cannot access '{}': {}", path.display(), e),
                 }
                 return None;
             })
@@ -321,7 +321,7 @@ impl Chgrper {
             unwrap!(path.symlink_metadata(), e, {
                 match self.verbosity {
                     Silent => (),
-                    _ => show_info!("cannot dereference '{}': {}", path.display(), e),
+                    _ => show_error!("cannot dereference '{}': {}", path.display(), e),
                 }
                 return None;
             })

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -316,7 +316,7 @@ impl Chmoder {
                 show_error!("{}", err);
             }
             if self.verbose {
-                show_info!(
+                show_error!(
                     "failed to change mode of file '{}' from {:o} ({}) to {:o} ({})",
                     file.display(),
                     fperm,
@@ -328,7 +328,7 @@ impl Chmoder {
             Err(1)
         } else {
             if self.verbose || self.changes {
-                show_info!(
+                show_error!(
                     "mode of '{}' changed from {:o} ({}) to {:o} ({})",
                     file.display(),
                     fperm,

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -199,7 +199,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if recursive {
         if bit_flag == FTS_PHYSICAL {
             if derefer == 1 {
-                show_info!("-R --dereference requires -H or -L");
+                show_error!("-R --dereference requires -H or -L");
                 return 1;
             }
             derefer = 0;
@@ -227,7 +227,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             Ok((Some(uid), Some(gid))) => IfFrom::UserGroup(uid, gid),
             Ok((None, None)) => IfFrom::All,
             Err(e) => {
-                show_info!("{}", e);
+                show_error!("{}", e);
                 return 1;
             }
         }
@@ -244,7 +244,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 dest_uid = Some(meta.uid());
             }
             Err(e) => {
-                show_info!("failed to get attributes of '{}': {}", file, e);
+                show_error!("failed to get attributes of '{}': {}", file, e);
                 return 1;
             }
         }
@@ -255,7 +255,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 dest_gid = g;
             }
             Err(e) => {
-                show_info!("{}", e);
+                show_error!("{}", e);
                 return 1;
             }
         }
@@ -377,8 +377,8 @@ impl Chowner {
 
             if let Some(p) = may_exist {
                 if p.parent().is_none() {
-                    show_info!("it is dangerous to operate recursively on '/'");
-                    show_info!("use --no-preserve-root to override this failsafe");
+                    show_error!("it is dangerous to operate recursively on '/'");
+                    show_error!("use --no-preserve-root to override this failsafe");
                     return 1;
                 }
             }
@@ -395,13 +395,13 @@ impl Chowner {
             ) {
                 Ok(n) => {
                     if !n.is_empty() {
-                        show_info!("{}", n);
+                        show_error!("{}", n);
                     }
                     0
                 }
                 Err(e) => {
                     if self.verbosity != Verbosity::Silent {
-                        show_info!("{}", e);
+                        show_error!("{}", e);
                     }
                     1
                 }
@@ -424,7 +424,7 @@ impl Chowner {
         for entry in WalkDir::new(root).follow_links(follow).min_depth(1) {
             let entry = unwrap!(entry, e, {
                 ret = 1;
-                show_info!("{}", e);
+                show_error!("{}", e);
                 continue;
             });
             let path = entry.path();
@@ -450,13 +450,13 @@ impl Chowner {
             ) {
                 Ok(n) => {
                     if !n.is_empty() {
-                        show_info!("{}", n);
+                        show_error!("{}", n);
                     }
                     0
                 }
                 Err(e) => {
                     if self.verbosity != Verbosity::Silent {
-                        show_info!("{}", e);
+                        show_error!("{}", e);
                     }
                     1
                 }
@@ -472,7 +472,7 @@ impl Chowner {
             unwrap!(path.metadata(), e, {
                 match self.verbosity {
                     Silent => (),
-                    _ => show_info!("cannot access '{}': {}", path.display(), e),
+                    _ => show_error!("cannot access '{}': {}", path.display(), e),
                 }
                 return None;
             })
@@ -480,7 +480,7 @@ impl Chowner {
             unwrap!(path.symlink_metadata(), e, {
                 match self.verbosity {
                     Silent => (),
-                    _ => show_info!("cannot dereference '{}': {}", path.display(), e),
+                    _ => show_error!("cannot dereference '{}': {}", path.display(), e),
                 }
                 return None;
             })

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -105,7 +105,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if out_format == OutputFmt::Unknown {
         match guess_syntax() {
             OutputFmt::Unknown => {
-                show_info!("no SHELL environment variable, and no shell type option given");
+                show_error!("no SHELL environment variable, and no shell type option given");
                 return 1;
             }
             fmt => out_format = fmt,
@@ -130,7 +130,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 )
             }
             Err(e) => {
-                show_info!("{}: {}", matches.free[0], e);
+                show_error!("{}: {}", matches.free[0], e);
                 return 1;
             }
         }
@@ -141,7 +141,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             0
         }
         Err(s) => {
-            show_info!("{}", s);
+            show_error!("{}", s);
             1
         }
     }

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -370,13 +370,13 @@ fn directory(paths: Vec<String>, b: Behavior) -> i32 {
                 // created ancestor directories will have the default mode. Hence it is safe to use
                 // fs::create_dir_all and then only modify the target's dir mode.
                 if let Err(e) = fs::create_dir_all(path) {
-                    show_info!("{}: {}", path.display(), e);
+                    show_error!("{}: {}", path.display(), e);
                     all_successful = false;
                     continue;
                 }
 
                 if b.verbose {
-                    show_info!("creating directory '{}'", path.display());
+                    show_error!("creating directory '{}'", path.display());
                 }
             }
 
@@ -461,7 +461,7 @@ fn copy_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> i3
     let mut all_successful = true;
     for sourcepath in files.iter() {
         if !sourcepath.exists() {
-            show_info!(
+            show_error!(
                 "cannot stat '{}': No such file or directory",
                 sourcepath.display()
             );
@@ -471,7 +471,7 @@ fn copy_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> i3
         }
 
         if sourcepath.is_dir() {
-            show_info!("omitting directory '{}'", sourcepath.display());
+            show_error!("omitting directory '{}'", sourcepath.display());
             all_successful = false;
             continue;
         }
@@ -588,10 +588,10 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> Result<(), ()> {
         ) {
             Ok(n) => {
                 if !n.is_empty() {
-                    show_info!("{}", n);
+                    show_error!("{}", n);
                 }
             }
-            Err(e) => show_info!("{}", e),
+            Err(e) => show_error!("{}", e),
         }
     }
 
@@ -608,10 +608,10 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> Result<(), ()> {
         match wrap_chgrp(to, &meta, group_id, false, Verbosity::Normal) {
             Ok(n) => {
                 if !n.is_empty() {
-                    show_info!("{}", n);
+                    show_error!("{}", n);
                 }
             }
-            Err(e) => show_info!("{}", e),
+            Err(e) => show_error!("{}", e),
         }
     }
 
@@ -626,12 +626,12 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> Result<(), ()> {
 
         match set_file_times(to, accessed_time, modified_time) {
             Ok(_) => {}
-            Err(e) => show_info!("{}", e),
+            Err(e) => show_error!("{}", e),
         }
     }
 
     if b.verbose {
-        show_info!("'{}' -> '{}'", from.display(), to.display());
+        show_error!("'{}' -> '{}'", from.display(), to.display());
     }
 
     Ok(())

--- a/src/uu/install/src/mode.rs
+++ b/src/uu/install/src/mode.rs
@@ -23,7 +23,7 @@ pub fn parse(mode_string: &str, considering_dir: bool) -> Result<u32, String> {
 pub fn chmod(path: &Path, mode: u32) -> Result<(), ()> {
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|err| {
-        show_info!("{}: chmod failed with error {}", path.display(), err);
+        show_error!("{}: chmod failed with error {}", path.display(), err);
     })
 }
 

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -101,7 +101,7 @@ fn exec(dirs: Vec<String>, recursive: bool, mode: u16, verbose: bool) -> i32 {
         if !recursive {
             if let Some(parent) = path.parent() {
                 if parent != empty && !parent.exists() {
-                    show_info!(
+                    show_error!(
                         "cannot create directory '{}': No such file or directory",
                         path.display()
                     );
@@ -125,7 +125,7 @@ fn mkdir(path: &Path, recursive: bool, mode: u16, verbose: bool) -> i32 {
         fs::create_dir
     };
     if let Err(e) = create_dir(path) {
-        show_info!("{}: {}", path.display(), e.to_string());
+        show_error!("{}: {}", path.display(), e.to_string());
         return 1;
     }
 

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -136,7 +136,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let mode = match get_mode(&matches) {
         Ok(mode) => mode,
         Err(err) => {
-            show_info!("{}", err);
+            show_error!("{}", err);
             return 1;
         }
     };

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -157,7 +157,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     if matches.is_present(OPT_TMPDIR) && PathBuf::from(prefix).is_absolute() {
-        show_info!(
+        show_error!(
             "invalid template, ‘{}’; with --tmpdir, it may not be absolute",
             template
         );
@@ -229,7 +229,7 @@ fn exec(
             }
             Err(e) => {
                 if !quiet {
-                    show_info!("{}: {}", e, tmpdir.display());
+                    show_error!("{}: {}", e, tmpdir.display());
                 }
                 return 1;
             }
@@ -244,7 +244,7 @@ fn exec(
         Ok(f) => f,
         Err(e) => {
             if !quiet {
-                show_info!("failed to create tempfile: {}", e);
+                show_error!("failed to create tempfile: {}", e);
             }
             return 1;
         }

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -122,13 +122,13 @@ fn find_stdout() -> File {
         .open(Path::new(NOHUP_OUT))
     {
         Ok(t) => {
-            show_info!("ignoring input and appending output to '{}'", NOHUP_OUT);
+            show_error!("ignoring input and appending output to '{}'", NOHUP_OUT);
             t
         }
         Err(e1) => {
             let home = match env::var("HOME") {
                 Err(_) => {
-                    show_info!("failed to open '{}': {}", NOHUP_OUT, e1);
+                    show_error!("failed to open '{}': {}", NOHUP_OUT, e1);
                     exit!(internal_failure_code)
                 }
                 Ok(h) => h,
@@ -143,12 +143,12 @@ fn find_stdout() -> File {
                 .open(&homeout)
             {
                 Ok(t) => {
-                    show_info!("ignoring input and appending output to '{}'", homeout_str);
+                    show_error!("ignoring input and appending output to '{}'", homeout_str);
                     t
                 }
                 Err(e2) => {
-                    show_info!("failed to open '{}': {}", NOHUP_OUT, e1);
-                    show_info!("failed to open '{}': {}", homeout_str, e2);
+                    show_error!("failed to open '{}': {}", NOHUP_OUT, e1);
+                    show_error!("failed to open '{}': {}", homeout_str, e2);
                     exit!(internal_failure_code)
                 }
             }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -216,7 +216,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     match result {
         Err(e) => {
             std::io::stdout().flush().expect("error flushing stdout");
-            show_info!("{}", e);
+            show_error!("{}", e);
             1
         }
         _ => 0,

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -749,7 +749,7 @@ impl Stater {
                     }
                 }
                 Err(e) => {
-                    show_info!("cannot stat '{}': {}", file, e);
+                    show_error!("cannot stat '{}': {}", file, e);
                     return 1;
                 }
             }
@@ -842,7 +842,7 @@ impl Stater {
                     }
                 }
                 Err(e) => {
-                    show_info!("cannot read file system information for '{}': {}", file, e);
+                    show_error!("cannot read file system information for '{}': {}", file, e);
                     return 1;
                 }
             }
@@ -1001,7 +1001,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     match Stater::new(matches) {
         Ok(stater) => stater.exec(),
         Err(e) => {
-            show_info!("{}", e);
+            show_error!("{}", e);
             1
         }
     }

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -166,7 +166,7 @@ impl Write for MultiWriter {
             let result = writer.write_all(buf);
             match result {
                 Err(f) => {
-                    show_info!("{}: {}", writer.name, f.to_string());
+                    show_error!("{}: {}", writer.name, f.to_string());
                     false
                 }
                 _ => true,
@@ -180,7 +180,7 @@ impl Write for MultiWriter {
             let result = writer.flush();
             match result {
                 Err(f) => {
-                    show_info!("{}: {}", writer.name, f.to_string());
+                    show_error!("{}: {}", writer.name, f.to_string());
                     false
                 }
                 _ => true,
@@ -213,7 +213,7 @@ impl Read for NamedReader {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self.inner.read(buf) {
             Err(f) => {
-                show_info!("{}: {}", Path::new("stdin").display(), f.to_string());
+                show_error!("{}: {}", Path::new("stdin").display(), f.to_string());
                 Err(f)
             }
             okay => okay,

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -47,15 +47,6 @@ macro_rules! show_warning(
     })
 );
 
-/// Show an info message to stderr in a silimar style to GNU coreutils.
-#[macro_export]
-macro_rules! show_info(
-    ($($args:tt)+) => ({
-        eprint!("{}: ", executable!());
-        eprintln!($($args)+);
-    })
-);
-
 /// Show a bad inocation help message in a similar style to GNU coreutils.
 #[macro_export]
 macro_rules! show_usage_error(

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -25,7 +25,7 @@ macro_rules! executable(
 #[macro_export]
 macro_rules! show_error(
     ($($args:tt)+) => ({
-        eprint!("{}: error: ", executable!());
+        eprint!("{}: ", executable!());
         eprintln!($($args)+);
     })
 );

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -98,7 +98,7 @@ fn test_wrap_bad_arg() {
             .arg(wrap_param)
             .arg("b")
             .fails()
-            .stderr_only("base32: error: Invalid wrap size: ‘b’: invalid digit found in string\n");
+            .stderr_only("base32: Invalid wrap size: ‘b’: invalid digit found in string\n");
     }
 }
 
@@ -109,7 +109,7 @@ fn test_base32_extra_operand() {
         .arg("a.txt")
         .arg("a.txt")
         .fails()
-        .stderr_only("base32: error: extra operand ‘a.txt’");
+        .stderr_only("base32: extra operand ‘a.txt’");
 }
 
 #[test]
@@ -117,5 +117,5 @@ fn test_base32_file_not_found() {
     new_ucmd!()
         .arg("a.txt")
         .fails()
-        .stderr_only("base32: error: a.txt: No such file or directory");
+        .stderr_only("base32: a.txt: No such file or directory");
 }

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -88,7 +88,7 @@ fn test_wrap_bad_arg() {
             .arg(wrap_param)
             .arg("b")
             .fails()
-            .stderr_only("base64: error: Invalid wrap size: ‘b’: invalid digit found in string\n");
+            .stderr_only("base64: Invalid wrap size: ‘b’: invalid digit found in string\n");
     }
 }
 
@@ -99,7 +99,7 @@ fn test_base64_extra_operand() {
         .arg("a.txt")
         .arg("a.txt")
         .fails()
-        .stderr_only("base64: error: extra operand ‘a.txt’");
+        .stderr_only("base64: extra operand ‘a.txt’");
 }
 
 #[test]
@@ -107,5 +107,5 @@ fn test_base64_file_not_found() {
     new_ucmd!()
         .arg("a.txt")
         .fails()
-        .stderr_only("base64: error: a.txt: No such file or directory");
+        .stderr_only("base64: a.txt: No such file or directory");
 }

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -109,7 +109,7 @@ fn test_no_args() {
 fn test_no_args_output() {
     new_ucmd!()
         .fails()
-        .stderr_is("basename: error: missing operand\nTry 'basename --help' for more information.");
+        .stderr_is("basename: missing operand\nTry 'basename --help' for more information.");
 }
 
 #[test]
@@ -119,9 +119,10 @@ fn test_too_many_args() {
 
 #[test]
 fn test_too_many_args_output() {
-    new_ucmd!().args(&["a", "b", "c"]).fails().stderr_is(
-        "basename: error: extra operand 'c'\nTry 'basename --help' for more information.",
-    );
+    new_ucmd!()
+        .args(&["a", "b", "c"])
+        .fails()
+        .stderr_is("basename: extra operand 'c'\nTry 'basename --help' for more information.");
 }
 
 #[cfg(any(unix, target_os = "redox"))]

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -338,7 +338,7 @@ fn test_chmod_preserve_root() {
         .arg("755")
         .arg("/")
         .fails()
-        .stderr_contains(&"chmod: error: it is dangerous to operate recursively on '/'");
+        .stderr_contains(&"chmod: it is dangerous to operate recursively on '/'");
 }
 
 #[test]

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -21,7 +21,7 @@ fn test_enter_chroot_fails() {
 
     assert!(result
         .stderr_str()
-        .starts_with("chroot: error: cannot chroot to jail: Operation not permitted (os error 1)"));
+        .starts_with("chroot: cannot chroot to jail: Operation not permitted (os error 1)"));
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn test_no_such_directory() {
 
     ucmd.arg("a")
         .fails()
-        .stderr_is("chroot: error: cannot change root directory to `a`: no such directory");
+        .stderr_is("chroot: cannot change root directory to `a`: no such directory");
 }
 
 #[test]
@@ -43,9 +43,7 @@ fn test_invalid_user_spec() {
 
     let result = ucmd.arg("a").arg("--userspec=ARABA:").fails();
 
-    assert!(result
-        .stderr_str()
-        .starts_with("chroot: error: invalid userspec"));
+    assert!(result.stderr_str().starts_with("chroot: invalid userspec"));
 }
 
 #[test]

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -66,7 +66,7 @@ fn test_invalid_file() {
         .arg(folder_name)
         .fails()
         .no_stdout()
-        .stderr_contains("cksum: error: 'asdf' No such file or directory");
+        .stderr_contains("cksum: 'asdf' No such file or directory");
 
     // Then check when the file is of an invalid type
     at.mkdir(folder_name);
@@ -74,7 +74,7 @@ fn test_invalid_file() {
         .arg(folder_name)
         .fails()
         .no_stdout()
-        .stderr_contains("cksum: error: 'asdf' Is a directory");
+        .stderr_contains("cksum: 'asdf' Is a directory");
 }
 
 // Make sure crc is correct for files larger than 32 bytes

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -208,7 +208,7 @@ fn test_up_to_match_repeat_over() {
     ucmd.args(&["numbers50.txt", "/9$/", "{50}"])
         .fails()
         .stdout_is("16\n29\n30\n30\n30\n6\n")
-        .stderr_is("csplit: error: '/9$/': match not found on repetition 5");
+        .stderr_is("csplit: '/9$/': match not found on repetition 5");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -219,7 +219,7 @@ fn test_up_to_match_repeat_over() {
     ucmd.args(&["numbers50.txt", "/9$/", "{50}", "-k"])
         .fails()
         .stdout_is("16\n29\n30\n30\n30\n6\n")
-        .stderr_is("csplit: error: '/9$/': match not found on repetition 5");
+        .stderr_is("csplit: '/9$/': match not found on repetition 5");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -365,7 +365,7 @@ fn test_option_keep() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["-k", "numbers50.txt", "/20/", "/nope/"])
         .fails()
-        .stderr_is("csplit: error: '/nope/': match not found")
+        .stderr_is("csplit: '/nope/': match not found")
         .stdout_is("48\n93\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -541,7 +541,7 @@ fn test_up_to_match_context_overflow() {
     ucmd.args(&["numbers50.txt", "/45/+10"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/45/+10': line number out of range");
+        .stderr_is("csplit: '/45/+10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -552,7 +552,7 @@ fn test_up_to_match_context_overflow() {
     ucmd.args(&["numbers50.txt", "/45/+10", "-k"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/45/+10': line number out of range");
+        .stderr_is("csplit: '/45/+10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -567,7 +567,7 @@ fn test_skip_to_match_context_underflow() {
     ucmd.args(&["numbers50.txt", "%5%-10"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '%5%-10': line number out of range");
+        .stderr_is("csplit: '%5%-10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -578,7 +578,7 @@ fn test_skip_to_match_context_underflow() {
     ucmd.args(&["numbers50.txt", "%5%-10", "-k"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '%5%-10': line number out of range");
+        .stderr_is("csplit: '%5%-10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -592,7 +592,7 @@ fn test_skip_to_match_context_overflow() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%45%+10"])
         .fails()
-        .stderr_only("csplit: error: '%45%+10': line number out of range");
+        .stderr_only("csplit: '%45%+10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -602,7 +602,7 @@ fn test_skip_to_match_context_overflow() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%45%+10", "-k"])
         .fails()
-        .stderr_only("csplit: error: '%45%+10': line number out of range");
+        .stderr_only("csplit: '%45%+10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -616,7 +616,7 @@ fn test_up_to_no_match1() {
     ucmd.args(&["numbers50.txt", "/4/", "/nope/"])
         .fails()
         .stdout_is("6\n135\n")
-        .stderr_is("csplit: error: '/nope/': match not found");
+        .stderr_is("csplit: '/nope/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -627,7 +627,7 @@ fn test_up_to_no_match1() {
     ucmd.args(&["numbers50.txt", "/4/", "/nope/", "-k"])
         .fails()
         .stdout_is("6\n135\n")
-        .stderr_is("csplit: error: '/nope/': match not found");
+        .stderr_is("csplit: '/nope/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -643,7 +643,7 @@ fn test_up_to_no_match2() {
     ucmd.args(&["numbers50.txt", "/4/", "/nope/", "{50}"])
         .fails()
         .stdout_is("6\n135\n")
-        .stderr_is("csplit: error: '/nope/': match not found");
+        .stderr_is("csplit: '/nope/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -654,7 +654,7 @@ fn test_up_to_no_match2() {
     ucmd.args(&["numbers50.txt", "/4/", "/nope/", "{50}", "-k"])
         .fails()
         .stdout_is("6\n135\n")
-        .stderr_is("csplit: error: '/nope/': match not found");
+        .stderr_is("csplit: '/nope/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -670,7 +670,7 @@ fn test_up_to_no_match3() {
     ucmd.args(&["numbers50.txt", "/0$/", "{50}"])
         .fails()
         .stdout_is("18\n30\n30\n30\n30\n3\n")
-        .stderr_is("csplit: error: '/0$/': match not found on repetition 5");
+        .stderr_is("csplit: '/0$/': match not found on repetition 5");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -681,7 +681,7 @@ fn test_up_to_no_match3() {
     ucmd.args(&["numbers50.txt", "/0$/", "{50}", "-k"])
         .fails()
         .stdout_is("18\n30\n30\n30\n30\n3\n")
-        .stderr_is("csplit: error: '/0$/': match not found on repetition 5");
+        .stderr_is("csplit: '/0$/': match not found on repetition 5");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -701,7 +701,7 @@ fn test_up_to_no_match4() {
     ucmd.args(&["numbers50.txt", "/nope/", "/4/"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/nope/': match not found");
+        .stderr_is("csplit: '/nope/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -712,7 +712,7 @@ fn test_up_to_no_match4() {
     ucmd.args(&["numbers50.txt", "/nope/", "/4/", "-k"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/nope/': match not found");
+        .stderr_is("csplit: '/nope/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -741,7 +741,7 @@ fn test_up_to_no_match6() {
     ucmd.args(&["numbers50.txt", "/nope/-5"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/nope/-5': match not found");
+        .stderr_is("csplit: '/nope/-5': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -752,7 +752,7 @@ fn test_up_to_no_match6() {
     ucmd.args(&["numbers50.txt", "/nope/-5", "-k"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/nope/-5': match not found");
+        .stderr_is("csplit: '/nope/-5': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -767,7 +767,7 @@ fn test_up_to_no_match7() {
     ucmd.args(&["numbers50.txt", "/nope/+5"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/nope/+5': match not found");
+        .stderr_is("csplit: '/nope/+5': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -778,7 +778,7 @@ fn test_up_to_no_match7() {
     ucmd.args(&["numbers50.txt", "/nope/+5", "-k"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/nope/+5': match not found");
+        .stderr_is("csplit: '/nope/+5': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -792,7 +792,7 @@ fn test_skip_to_no_match1() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%nope%"])
         .fails()
-        .stderr_only("csplit: error: '%nope%': match not found");
+        .stderr_only("csplit: '%nope%': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -805,7 +805,7 @@ fn test_skip_to_no_match2() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%nope%", "{50}"])
         .fails()
-        .stderr_only("csplit: error: '%nope%': match not found");
+        .stderr_only("csplit: '%nope%': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -818,7 +818,7 @@ fn test_skip_to_no_match3() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%0$%", "{50}"])
         .fails()
-        .stderr_only("csplit: error: '%0$%': match not found on repetition 5");
+        .stderr_only("csplit: '%0$%': match not found on repetition 5");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -831,7 +831,7 @@ fn test_skip_to_no_match4() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%nope%", "/4/"])
         .fails()
-        .stderr_only("csplit: error: '%nope%': match not found");
+        .stderr_only("csplit: '%nope%': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -858,7 +858,7 @@ fn test_skip_to_no_match6() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%nope%-5"])
         .fails()
-        .stderr_only("csplit: error: '%nope%-5': match not found");
+        .stderr_only("csplit: '%nope%-5': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -871,7 +871,7 @@ fn test_skip_to_no_match7() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%nope%+5"])
         .fails()
-        .stderr_only("csplit: error: '%nope%+5': match not found");
+        .stderr_only("csplit: '%nope%+5': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -884,7 +884,7 @@ fn test_no_match() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%nope%"])
         .fails()
-        .stderr_only("csplit: error: '%nope%': match not found");
+        .stderr_only("csplit: '%nope%': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -895,7 +895,7 @@ fn test_no_match() {
     ucmd.args(&["numbers50.txt", "/nope/"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '/nope/': match not found");
+        .stderr_is("csplit: '/nope/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -992,7 +992,7 @@ fn test_too_small_linenum_repeat() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "/20/", "10", "{*}"])
         .fails()
-        .stderr_is("csplit: error: '10': line number out of range on repetition 5")
+        .stderr_is("csplit: '10': line number out of range on repetition 5")
         .stdout_is("48\n0\n0\n30\n30\n30\n3\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1003,7 +1003,7 @@ fn test_too_small_linenum_repeat() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "/20/", "10", "{*}", "-k"])
         .fails()
-        .stderr_is("csplit: error: '10': line number out of range on repetition 5")
+        .stderr_is("csplit: '10': line number out of range on repetition 5")
         .stdout_is("48\n0\n0\n30\n30\n30\n3\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1025,7 +1025,7 @@ fn test_linenum_out_of_range1() {
     ucmd.args(&["numbers50.txt", "100"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '100': line number out of range");
+        .stderr_is("csplit: '100': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1036,7 +1036,7 @@ fn test_linenum_out_of_range1() {
     ucmd.args(&["numbers50.txt", "100", "-k"])
         .fails()
         .stdout_is("141\n")
-        .stderr_is("csplit: error: '100': line number out of range");
+        .stderr_is("csplit: '100': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1051,7 +1051,7 @@ fn test_linenum_out_of_range2() {
     ucmd.args(&["numbers50.txt", "10", "100"])
         .fails()
         .stdout_is("18\n123\n")
-        .stderr_is("csplit: error: '100': line number out of range");
+        .stderr_is("csplit: '100': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1062,7 +1062,7 @@ fn test_linenum_out_of_range2() {
     ucmd.args(&["numbers50.txt", "10", "100", "-k"])
         .fails()
         .stdout_is("18\n123\n")
-        .stderr_is("csplit: error: '100': line number out of range");
+        .stderr_is("csplit: '100': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1078,7 +1078,7 @@ fn test_linenum_out_of_range3() {
     ucmd.args(&["numbers50.txt", "40", "{2}"])
         .fails()
         .stdout_is("108\n33\n")
-        .stderr_is("csplit: error: '40': line number out of range on repetition 1");
+        .stderr_is("csplit: '40': line number out of range on repetition 1");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1089,7 +1089,7 @@ fn test_linenum_out_of_range3() {
     ucmd.args(&["numbers50.txt", "40", "{2}", "-k"])
         .fails()
         .stdout_is("108\n33\n")
-        .stderr_is("csplit: error: '40': line number out of range on repetition 1");
+        .stderr_is("csplit: '40': line number out of range on repetition 1");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1105,7 +1105,7 @@ fn test_linenum_out_of_range4() {
     ucmd.args(&["numbers50.txt", "40", "{*}"])
         .fails()
         .stdout_is("108\n33\n")
-        .stderr_is("csplit: error: '40': line number out of range on repetition 1");
+        .stderr_is("csplit: '40': line number out of range on repetition 1");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1116,7 +1116,7 @@ fn test_linenum_out_of_range4() {
     ucmd.args(&["numbers50.txt", "40", "{*}", "-k"])
         .fails()
         .stdout_is("108\n33\n")
-        .stderr_is("csplit: error: '40': line number out of range on repetition 1");
+        .stderr_is("csplit: '40': line number out of range on repetition 1");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1132,7 +1132,7 @@ fn test_skip_to_match_negative_offset_before_a_match() {
     ucmd.args(&["numbers50.txt", "/20/-10", "/15/"])
         .fails()
         .stdout_is("18\n123\n")
-        .stderr_is("csplit: error: '/15/': match not found");
+        .stderr_is("csplit: '/15/': match not found");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("there should be splits created")
@@ -1177,7 +1177,7 @@ fn test_corner_case2() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "/10/-5", "/10/"])
         .fails()
-        .stderr_is("csplit: error: '/10/': match not found")
+        .stderr_is("csplit: '/10/': match not found")
         .stdout_is("8\n133\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1191,7 +1191,7 @@ fn test_corner_case3() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "/15/-3", "14", "/15/"])
         .fails()
-        .stderr_is("csplit: error: '/15/': match not found")
+        .stderr_is("csplit: '/15/': match not found")
         .stdout_is("24\n6\n111\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1223,7 +1223,7 @@ fn test_up_to_match_context_underflow() {
     ucmd.args(&["numbers50.txt", "/5/-10"])
         .fails()
         .stdout_is("0\n141\n")
-        .stderr_is("csplit: error: '/5/-10': line number out of range");
+        .stderr_is("csplit: '/5/-10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -1234,7 +1234,7 @@ fn test_up_to_match_context_underflow() {
     ucmd.args(&["numbers50.txt", "/5/-10", "-k"])
         .fails()
         .stdout_is("0\n141\n")
-        .stderr_is("csplit: error: '/5/-10': line number out of range");
+        .stderr_is("csplit: '/5/-10': line number out of range");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -1251,7 +1251,7 @@ fn test_linenum_range_with_up_to_match1() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "10", "/12/-5"])
         .fails()
-        .stderr_is("csplit: error: '/12/-5': line number out of range")
+        .stderr_is("csplit: '/12/-5': line number out of range")
         .stdout_is("18\n0\n123\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1262,7 +1262,7 @@ fn test_linenum_range_with_up_to_match1() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "10", "/12/-5", "-k"])
         .fails()
-        .stderr_is("csplit: error: '/12/-5': line number out of range")
+        .stderr_is("csplit: '/12/-5': line number out of range")
         .stdout_is("18\n0\n123\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1281,7 +1281,7 @@ fn test_linenum_range_with_up_to_match2() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "10", "/12/-15"])
         .fails()
-        .stderr_is("csplit: error: '/12/-15': line number out of range")
+        .stderr_is("csplit: '/12/-15': line number out of range")
         .stdout_is("18\n0\n123\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1292,7 +1292,7 @@ fn test_linenum_range_with_up_to_match2() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "10", "/12/-15", "-k"])
         .fails()
-        .stderr_is("csplit: error: '/12/-15': line number out of range")
+        .stderr_is("csplit: '/12/-15': line number out of range")
         .stdout_is("18\n0\n123\n");
 
     let count = glob(&at.plus_as_string("xx*"))
@@ -1310,7 +1310,7 @@ fn test_linenum_range_with_up_to_match3() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "10", "/10/", "-k"])
         .fails()
-        .stderr_is("csplit: error: '/10/': match not found")
+        .stderr_is("csplit: '/10/': match not found")
         .stdout_is("18\n123\n");
 
     let count = glob(&at.plus_as_string("xx*"))

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -149,11 +149,11 @@ fn test_directory_and_no_such_file() {
     ucmd.arg("-b1")
         .arg("some")
         .run()
-        .stderr_is("cut: error: some: Is a directory\n");
+        .stderr_is("cut: some: Is a directory\n");
 
     new_ucmd!()
         .arg("-b1")
         .arg("some")
         .run()
-        .stderr_is("cut: error: some: No such file or directory\n");
+        .stderr_is("cut: some: No such file or directory\n");
 }

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -76,7 +76,7 @@ fn test_du_basics_bad_name() {
     new_ucmd!()
         .arg("bad_name")
         .succeeds() // TODO: replace with ".fails()" once `du` is fixed
-        .stderr_only("du: error: bad_name: No such file or directory\n");
+        .stderr_only("du: bad_name: No such file or directory\n");
 }
 
 #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -17,11 +17,11 @@ fn test_complex_arithmetic() {
         .args(&["9223372036854775807", "+", "9223372036854775807"])
         .run();
     run.stdout_is("");
-    run.stderr_is("expr: error: +: Numerical result out of range");
+    run.stderr_is("expr: +: Numerical result out of range");
 
     let run = new_ucmd!().args(&["9", "/", "0"]).run();
     run.stdout_is("");
-    run.stderr_is("expr: error: division by zero");
+    run.stderr_is("expr: division by zero");
 }
 
 #[test]

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -30,7 +30,7 @@ fn test_fmt_w_too_big() {
     //.stdout_is_fixture("call_graph.expected");
     assert_eq!(
         result.stderr_str().trim(),
-        "fmt: error: invalid width: '2501': Numerical result out of range"
+        "fmt: invalid width: '2501': Numerical result out of range"
     );
 }
 #[test]

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -7,7 +7,7 @@ use crate::common::util::*;
 // From the Logs: "Build (ubuntu-18.04, x86_64-unknown-linux-gnu, feat_os_unix, use-cross)"
 // stderr: "whoami: cannot find name for user ID 1001"
 // Maybe: "adduser --uid 1001 username" can put things right?
-// stderr = id: error: Could not find uid 1001: No such id: 1001
+// stderr = id: Could not find uid 1001: No such id: 1001
 fn skipping_test_is_okay(result: &CmdResult, needle: &str) -> bool {
     if !result.succeeded() {
         println!("result.stdout = {}", result.stdout_str());

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -328,7 +328,7 @@ fn test_install_target_new_file_with_owner() {
         .arg(format!("{}/{}", dir, file))
         .run();
 
-    if is_ci() && result.stderr_str().contains("error: no such user:") {
+    if is_ci() && result.stderr_str().contains("no such user:") {
         // In the CI, some server are failing to return the user id.
         // As seems to be a configuration issue, ignoring it
         return;

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -301,7 +301,7 @@ fn test_install_target_new_file_with_group() {
         .arg(format!("{}/{}", dir, file))
         .run();
 
-    if is_ci() && result.stderr_str().contains("error: no such group:") {
+    if is_ci() && result.stderr_str().contains("no such group:") {
         // In the CI, some server are failing to return the group.
         // As seems to be a configuration issue, ignoring it
         return;

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -148,7 +148,7 @@ fn multitab_character() {
         .arg("-t")
         .arg("э")
         .fails()
-        .stderr_is("join: error: multi-character tab э");
+        .stderr_is("join: multi-character tab э");
 }
 
 #[test]
@@ -211,7 +211,7 @@ fn empty_format() {
         .arg("-o")
         .arg("")
         .fails()
-        .stderr_is("join: error: invalid file number in field spec: ''");
+        .stderr_is("join: invalid file number in field spec: ''");
 }
 
 #[test]

--- a/tests/by-util/test_link.rs
+++ b/tests/by-util/test_link.rs
@@ -23,7 +23,7 @@ fn test_link_no_circular() {
 
     ucmd.args(&[link, link])
         .fails()
-        .stderr_is("link: error: No such file or directory (os error 2)\n");
+        .stderr_is("link: No such file or directory (os error 2)\n");
     assert!(!at.file_exists(link));
 }
 
@@ -35,7 +35,7 @@ fn test_link_nonexistent_file() {
 
     ucmd.args(&[file, link])
         .fails()
-        .stderr_is("link: error: No such file or directory (os error 2)\n");
+        .stderr_is("link: No such file or directory (os error 2)\n");
     assert!(!at.file_exists(file));
     assert!(!at.file_exists(link));
 }

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -409,7 +409,7 @@ fn test_symlink_missing_destination() {
     at.touch(file);
 
     ucmd.args(&["-s", "-T", file]).fails().stderr_is(format!(
-        "ln: error: missing destination file operand after '{}'",
+        "ln: missing destination file operand after '{}'",
         file
     ));
 }

--- a/tests/by-util/test_logname.rs
+++ b/tests/by-util/test_logname.rs
@@ -9,7 +9,7 @@ fn test_normal() {
     for (key, value) in env::vars() {
         println!("{}: {}", key, value);
     }
-    if (is_ci() || uucore::os::is_wsl_1()) && result.stderr_str().contains("error: no login name") {
+    if (is_ci() || uucore::os::is_wsl_1()) && result.stderr_str().contains("no login name") {
         // ToDO: investigate WSL failure
         // In the CI, some server are failing to return logname.
         // As seems to be a configuration issue, ignoring it

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -167,7 +167,7 @@ fn test_ls_width() {
             .ucmd()
             .args(&option.split(" ").collect::<Vec<_>>())
             .fails()
-            .stderr_only("ls: error: invalid line width: ‘1a’");
+            .stderr_only("ls: invalid line width: ‘1a’");
     }
 }
 
@@ -875,7 +875,7 @@ fn test_ls_files_dirs() {
         .ucmd()
         .arg("doesntexist")
         .fails()
-        .stderr_contains(&"error: 'doesntexist': No such file or directory");
+        .stderr_contains(&"'doesntexist': No such file or directory");
 
     // One exists, the other doesn't
     scene
@@ -883,7 +883,7 @@ fn test_ls_files_dirs() {
         .arg("a")
         .arg("doesntexist")
         .fails()
-        .stderr_contains(&"error: 'doesntexist': No such file or directory")
+        .stderr_contains(&"'doesntexist': No such file or directory")
         .stdout_contains(&"a:");
 }
 

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -2,9 +2,7 @@ use crate::common::util::*;
 
 #[test]
 fn test_create_fifo_missing_operand() {
-    new_ucmd!()
-        .fails()
-        .stderr_is("mkfifo: error: missing operand");
+    new_ucmd!().fails().stderr_is("mkfifo: missing operand");
 }
 
 #[test]
@@ -43,5 +41,5 @@ fn test_create_one_fifo_already_exists() {
         .arg("abcdef")
         .arg("abcdef")
         .fails()
-        .stderr_is("mkfifo: error: cannot create fifo 'abcdef': File exists");
+        .stderr_is("mkfifo: cannot create fifo 'abcdef': File exists");
 }

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -120,7 +120,7 @@ fn test_mktemp_mktemp_t() {
         .arg(TEST_TEMPLATE8)
         .fails()
         .no_stdout()
-        .stderr_contains("error: suffix cannot contain any path separators");
+        .stderr_contains("suffix cannot contain any path separators");
 }
 
 #[test]

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -472,7 +472,7 @@ fn test_mv_overwrite_nonempty_dir() {
     at.touch(dummy);
     // Not same error as GNU; the error message is a rust builtin
     // TODO: test (and implement) correct error message (or at least decide whether to do so)
-    // Current: "mv: error: couldn't rename path (Directory not empty; from=a; to=b)"
+    // Current: "mv: couldn't rename path (Directory not empty; from=a; to=b)"
     // GNU:     "mv: cannot move ‘a’ to ‘b’: Directory not empty"
 
     // Verbose output for the move should not be shown on failure
@@ -539,7 +539,7 @@ fn test_mv_errors() {
         .arg(dir)
         .fails()
         .stderr_is(format!(
-            "mv: error: cannot overwrite directory ‘{}’ with non-directory\n",
+            "mv: cannot overwrite directory ‘{}’ with non-directory\n",
             dir
         ));
 

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -25,7 +25,7 @@ fn test_adjustment_with_no_command_should_error() {
     new_ucmd!()
     .args(&["-n", "19"])
     .run()
-    .stderr_is("nice: error: A command must be given with an adjustment.\nTry \"nice --help\" for more information.\n");
+    .stderr_is("nice: A command must be given with an adjustment.\nTry \"nice --help\" for more information.\n");
 }
 
 #[test]

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -258,7 +258,7 @@ fn test_rm_no_operand() {
     let mut ucmd = new_ucmd!();
 
     ucmd.fails()
-        .stderr_is("rm: error: missing an argument\nrm: error: for help, try 'rm --help'\n");
+        .stderr_is("rm: missing an argument\nrm: for help, try 'rm --help'\n");
 }
 
 #[test]

--- a/tests/by-util/test_rmdir.rs
+++ b/tests/by-util/test_rmdir.rs
@@ -39,7 +39,7 @@ fn test_rmdir_nonempty_directory_no_parents() {
     assert!(at.file_exists(file));
 
     ucmd.arg(dir).fails().stderr_is(
-        "rmdir: error: failed to remove 'test_rmdir_nonempty_no_parents': Directory not \
+        "rmdir: failed to remove 'test_rmdir_nonempty_no_parents': Directory not \
          empty\n",
     );
 
@@ -59,9 +59,9 @@ fn test_rmdir_nonempty_directory_with_parents() {
     assert!(at.file_exists(file));
 
     ucmd.arg("-p").arg(dir).fails().stderr_is(
-        "rmdir: error: failed to remove 'test_rmdir_nonempty/with/parents': Directory not \
-         empty\nrmdir: error: failed to remove 'test_rmdir_nonempty/with': Directory not \
-         empty\nrmdir: error: failed to remove 'test_rmdir_nonempty': Directory not \
+        "rmdir: failed to remove 'test_rmdir_nonempty/with/parents': Directory not \
+         empty\nrmdir: failed to remove 'test_rmdir_nonempty/with': Directory not \
+         empty\nrmdir: failed to remove 'test_rmdir_nonempty': Directory not \
          empty\n",
     );
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -42,7 +42,7 @@ fn test_invalid_buffer_size() {
             .arg(invalid_buffer_size)
             .fails()
             .stderr_only(format!(
-                "sort: error: failed to parse buffer size `{}`: invalid digit found in string",
+                "sort: failed to parse buffer size `{}`: invalid digit found in string",
                 invalid_buffer_size
             ));
     }
@@ -471,7 +471,7 @@ fn test_keys_invalid_field() {
     new_ucmd!()
         .args(&["-k", "1."])
         .fails()
-        .stderr_only("sort: error: failed to parse character index for key `1.`: cannot parse integer from empty string");
+        .stderr_only("sort: failed to parse character index for key `1.`: cannot parse integer from empty string");
 }
 
 #[test]
@@ -479,7 +479,7 @@ fn test_keys_invalid_field_option() {
     new_ucmd!()
         .args(&["-k", "1.1x"])
         .fails()
-        .stderr_only("sort: error: invalid option for key: `x`");
+        .stderr_only("sort: invalid option for key: `x`");
 }
 
 #[test]
@@ -487,14 +487,15 @@ fn test_keys_invalid_field_zero() {
     new_ucmd!()
         .args(&["-k", "0.1"])
         .fails()
-        .stderr_only("sort: error: field index was 0");
+        .stderr_only("sort: field index was 0");
 }
 
 #[test]
 fn test_keys_invalid_char_zero() {
-    new_ucmd!().args(&["-k", "1.0"]).fails().stderr_only(
-        "sort: error: invalid character index 0 in `1.0` for the start position of a field",
-    );
+    new_ucmd!()
+        .args(&["-k", "1.0"])
+        .fails()
+        .stderr_only("sort: invalid character index 0 in `1.0` for the start position of a field");
 }
 
 #[test]

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -26,7 +26,7 @@ fn test_stdbuf_line_buffered_stdout() {
 #[test]
 fn test_stdbuf_no_buffer_option_fails() {
     new_ucmd!().args(&["head"]).fails().stderr_is(
-        "The following required arguments were not provided:\n    \
+        "error: The following required arguments were not provided:\n    \
          --error <MODE>\n    \
          --input <MODE>\n    \
          --output <MODE>\n\n\

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -26,7 +26,7 @@ fn test_stdbuf_line_buffered_stdout() {
 #[test]
 fn test_stdbuf_no_buffer_option_fails() {
     new_ucmd!().args(&["head"]).fails().stderr_is(
-        "error: The following required arguments were not provided:\n    \
+        "The following required arguments were not provided:\n    \
          --error <MODE>\n    \
          --input <MODE>\n    \
          --output <MODE>\n\n\
@@ -49,10 +49,9 @@ fn test_stdbuf_trailing_var_arg() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn test_stdbuf_line_buffering_stdin_fails() {
-    new_ucmd!()
-        .args(&["-i", "L", "head"])
-        .fails()
-        .stderr_is("stdbuf: error: line buffering stdin is meaningless\nTry 'stdbuf --help' for more information.");
+    new_ucmd!().args(&["-i", "L", "head"]).fails().stderr_is(
+        "stdbuf: line buffering stdin is meaningless\nTry 'stdbuf --help' for more information.",
+    );
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -61,5 +60,5 @@ fn test_stdbuf_invalid_mode_fails() {
     new_ucmd!()
         .args(&["-i", "1024R", "head"])
         .fails()
-        .stderr_is("stdbuf: error: invalid mode 1024R\nTry 'stdbuf --help' for more information.");
+        .stderr_is("stdbuf: invalid mode 1024R\nTry 'stdbuf --help' for more information.");
 }

--- a/tests/by-util/test_sum.rs
+++ b/tests/by-util/test_sum.rs
@@ -59,9 +59,7 @@ fn test_invalid_file() {
 
     at.mkdir("a");
 
-    ucmd.arg("a")
-        .fails()
-        .stderr_is("sum: error: 'a' Is a directory");
+    ucmd.arg("a").fails().stderr_is("sum: 'a' Is a directory");
 }
 
 #[test]
@@ -70,5 +68,5 @@ fn test_invalid_metadata() {
 
     ucmd.arg("b")
         .fails()
-        .stderr_is("sum: error: 'b' No such file or directory");
+        .stderr_is("sum: 'b' No such file or directory");
 }

--- a/tests/by-util/test_sync.rs
+++ b/tests/by-util/test_sync.rs
@@ -37,5 +37,5 @@ fn test_sync_no_existing_files() {
         .arg("--data")
         .arg("do-no-exist")
         .fails()
-        .stderr_contains("error: cannot stat");
+        .stderr_contains("cannot stat");
 }

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -145,7 +145,7 @@ fn test_invalid_utf8() {
         .arg("not-utf8-sequence.txt")
         .run()
         .failure()
-        .stderr_only("uniq: error: invalid utf-8 sequence of 1 bytes from index 0");
+        .stderr_only("uniq: invalid utf-8 sequence of 1 bytes from index 0");
 }
 
 #[test]

--- a/tests/by-util/test_unlink.rs
+++ b/tests/by-util/test_unlink.rs
@@ -22,7 +22,7 @@ fn test_unlink_multiple_files() {
     at.touch(file_b);
 
     ucmd.arg(file_a).arg(file_b).fails().stderr_is(
-        "unlink: error: extra operand: 'test_unlink_multiple_file_b'\nTry 'unlink --help' \
+        "unlink: extra operand: 'test_unlink_multiple_file_b'\nTry 'unlink --help' \
          for more information.\n",
     );
 }
@@ -35,7 +35,7 @@ fn test_unlink_directory() {
     at.mkdir(dir);
 
     ucmd.arg(dir).fails().stderr_is(
-        "unlink: error: cannot unlink 'test_unlink_empty_directory': Not a regular file \
+        "unlink: cannot unlink 'test_unlink_empty_directory': Not a regular file \
          or symlink\n",
     );
 }
@@ -45,7 +45,7 @@ fn test_unlink_nonexistent() {
     let file = "test_unlink_nonexistent";
 
     new_ucmd!().arg(file).fails().stderr_is(
-        "unlink: error: Cannot stat 'test_unlink_nonexistent': No such file or directory \
+        "unlink: Cannot stat 'test_unlink_nonexistent': No such file or directory \
          (os error 2)\n",
     );
 }

--- a/tests/by-util/test_whoami.rs
+++ b/tests/by-util/test_whoami.rs
@@ -5,7 +5,7 @@ use crate::common::util::*;
 // considered okay. If we are not inside the CI this calls assert!(result.success).
 //
 // From the Logs: "Build (ubuntu-18.04, x86_64-unknown-linux-gnu, feat_os_unix, use-cross)"
-// stderr: "whoami: error: failed to get username"
+// stderr: "whoami: failed to get username"
 // Maybe: "adduser --uid 1001 username" can put things right?
 fn skipping_test_is_okay(result: &CmdResult, needle: &str) -> bool {
     if !result.succeeded() {


### PR DESCRIPTION
Follow up PR for the https://github.com/uutils/coreutils/pull/2273#issuecomment-848310698. 

* Deleted `show_info!` macro.
* Deleted `error:` prefix from the `show_error!`macro.
* Changed `show_info!` macro with `show_error!` across all utilities. 
* Updated tests. 