### PR TITLE
Closing #1916 - Concluding the test refactor

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -875,7 +875,7 @@ impl UCommand {
             code: prog.status.code(),
             success: prog.status.success(),
             stdout: prog.stdout,
-            stderr: prog.stderr
+            stderr: prog.stderr,
         }
     }
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -62,54 +62,54 @@ pub struct CmdResult {
     /// see [`success`]
     success: bool,
     /// captured standard output after running the Command
-    stdout: String,
+    stdout: Vec<u8>,
     /// captured standard error after running the Command
-    stderr: String,
+    stderr: Vec<u8>,
 }
 
 impl CmdResult {
     /// Returns a reference to the program's standard output as a slice of bytes
     pub fn stdout(&self) -> &[u8] {
-        &self.stdout.as_bytes()
+        &self.stdout
     }
 
     /// Returns the program's standard output as a string slice
     pub fn stdout_str(&self) -> &str {
-        &self.stdout
+        std::str::from_utf8(&self.stdout).unwrap()
     }
 
     /// Returns the program's standard output as a string
     /// consumes self
     pub fn stdout_move_str(self) -> String {
-        self.stdout
+        String::from_utf8(self.stdout).unwrap()
     }
 
     /// Returns the program's standard output as a vec of bytes
     /// consumes self
     pub fn stdout_move_bytes(self) -> Vec<u8> {
-        Vec::from(self.stdout)
+        self.stdout
     }
 
     /// Returns a reference to the program's standard error as a slice of bytes
     pub fn stderr(&self) -> &[u8] {
-        &self.stderr.as_bytes()
+        &self.stderr
     }
 
     /// Returns the program's standard error as a string slice
     pub fn stderr_str(&self) -> &str {
-        &self.stderr
+        std::str::from_utf8(&self.stderr).unwrap()
     }
 
     /// Returns the program's standard error as a string
     /// consumes self
     pub fn stderr_move_str(self) -> String {
-        self.stderr
+        String::from_utf8(self.stderr).unwrap()
     }
 
     /// Returns the program's standard error as a vec of bytes
     /// consumes self
     pub fn stderr_move_bytes(self) -> Vec<u8> {
-        Vec::from(self.stderr)
+        self.stderr
     }
 
     /// Returns the program's exit code
@@ -202,21 +202,21 @@ impl CmdResult {
     /// passed in value, trailing whitespace are kept to force strict comparison (#1235)
     /// stdout_only is a better choice unless stderr may or will be non-empty
     pub fn stdout_is<T: AsRef<str>>(&self, msg: T) -> &CmdResult {
-        assert_eq!(self.stdout, String::from(msg.as_ref()));
+        assert_eq!(self.stdout_str(), String::from(msg.as_ref()));
         self
     }
 
     /// Like `stdout_is` but newlines are normalized to `\n`.
     pub fn normalized_newlines_stdout_is<T: AsRef<str>>(&self, msg: T) -> &CmdResult {
         let msg = msg.as_ref().replace("\r\n", "\n");
-        assert_eq!(self.stdout.replace("\r\n", "\n"), msg);
+        assert_eq!(self.stdout_str().replace("\r\n", "\n"), msg);
         self
     }
 
     /// asserts that the command resulted in stdout stream output,
     /// whose bytes equal those of the passed in slice
     pub fn stdout_is_bytes<T: AsRef<[u8]>>(&self, msg: T) -> &CmdResult {
-        assert_eq!(self.stdout.as_bytes(), msg.as_ref());
+        assert_eq!(self.stdout, msg.as_ref());
         self
     }
 
@@ -231,7 +231,7 @@ impl CmdResult {
     /// stderr_only is a better choice unless stdout may or will be non-empty
     pub fn stderr_is<T: AsRef<str>>(&self, msg: T) -> &CmdResult {
         assert_eq!(
-            self.stderr.trim_end(),
+            self.stderr_str().trim_end(),
             String::from(msg.as_ref()).trim_end()
         );
         self
@@ -240,7 +240,7 @@ impl CmdResult {
     /// asserts that the command resulted in stderr stream output,
     /// whose bytes equal those of the passed in slice
     pub fn stderr_is_bytes<T: AsRef<[u8]>>(&self, msg: T) -> &CmdResult {
-        assert_eq!(self.stderr.as_bytes(), msg.as_ref());
+        assert_eq!(self.stderr, msg.as_ref());
         self
     }
 
@@ -874,8 +874,8 @@ impl UCommand {
             tmpd: self.tmpd.clone(),
             code: prog.status.code(),
             success: prog.status.success(),
-            stdout: from_utf8(&prog.stdout).unwrap().to_string(),
-            stderr: from_utf8(&prog.stderr).unwrap().to_string(),
+            stdout: prog.stdout,
+            stderr: prog.stderr
         }
     }
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -16,7 +16,6 @@ use std::os::windows::fs::{symlink_dir, symlink_file};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::rc::Rc;
-use std::str::from_utf8;
 use std::thread::sleep;
 use std::time::Duration;
 use tempfile::TempDir;


### PR DESCRIPTION
This is (hopefully) the last PR in the 'enable-arbitrary-binary-stdout' refactor saga.
It just changes `CmdResult`s inner representation to `Vec<u8>`, and then adjusts where necessary.

Possible future consideration:

Caching the `&str` and `String` representations after they're used at least once, could help performance. (Not in this PR)