### PR TITLE
cp: fix regressed issue with `--backup` and `-b`

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -232,6 +232,7 @@ fn get_usage() -> String {
 static OPT_ARCHIVE: &str = "archive";
 static OPT_ATTRIBUTES_ONLY: &str = "attributes-only";
 static OPT_BACKUP: &str = "backup";
+static OPT_BACKUP_NO_ARG: &str = "b";
 static OPT_CLI_SYMBOLIC_LINKS: &str = "cli-symbolic-links";
 static OPT_CONTEXT: &str = "context";
 static OPT_COPY_CONTENTS: &str = "copy-contents";
@@ -357,7 +358,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
              .help("remove each existing destination file before attempting to open it \
                     (contrast with --force). On Windows, current only works for writeable files."))
         .arg(Arg::with_name(OPT_BACKUP)
-             .short("b")
              .long(OPT_BACKUP)
              .help("make a backup of each existing destination file")
              .takes_value(true)
@@ -365,6 +365,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
              .min_values(0)
              .possible_values(backup_control::BACKUP_CONTROL_VALUES)
              .value_name("CONTROL")
+        )
+        .arg(Arg::with_name(OPT_BACKUP_NO_ARG)
+             .short(OPT_BACKUP_NO_ARG)
+             .help("like --backup but does not accept an argument")
         )
         .arg(Arg::with_name(OPT_SUFFIX)
              .short("S")
@@ -592,7 +596,7 @@ impl Options {
             || matches.is_present(OPT_ARCHIVE);
 
         let backup_mode = backup_control::determine_backup_mode(
-            matches.is_present(OPT_BACKUP),
+            matches.is_present(OPT_BACKUP_NO_ARG) || matches.is_present(OPT_BACKUP),
             matches.value_of(OPT_BACKUP),
         );
         let backup_suffix = backup_control::determine_backup_suffix(matches.value_of(OPT_SUFFIX));

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -317,6 +317,22 @@ fn test_cp_arg_backup() {
 }
 
 #[test]
+fn test_cp_arg_backup_with_other_args() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .arg("-vbL")
+        .succeeds();
+
+    assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
+    assert_eq!(
+        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        "How are you?\n"
+    );
+}
+
+#[test]
 fn test_cp_arg_backup_arg_first() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
This PR also adds a test for the regressed issue.

See the note about `--backup` and `-b` in #2284 for more info.