### PR TITLE
Moved factor to use clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
 name = "uu_factor"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "coz",
  "num-traits",
  "paste",

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -21,6 +21,7 @@ rand = { version = "0.7", features = ["small_rng"] }
 smallvec = { version = "0.6.14, < 1.0" }
 uucore = { version = ">=0.0.8", package = "uucore", path = "../../uucore" }
 uucore_procs = { version = ">=0.0.5", package = "uucore_procs", path = "../../uucore_procs" }
+clap = "2.33"
 
 [dev-dependencies]
 paste = "0.1.18"

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -40,6 +40,18 @@ fn test_first_100000_integers() {
 }
 
 #[test]
+fn test_cli_args() {
+    // Make sure that factor works with CLI arguments as well.
+    new_ucmd!().args(&["3"]).succeeds().stdout_contains("3: 3");
+
+    new_ucmd!()
+        .args(&["3", "6"])
+        .succeeds()
+        .stdout_contains("3: 3")
+        .stdout_contains("6: 2 3");
+}
+
+#[test]
 fn test_random() {
     use conv::prelude::*;
 


### PR DESCRIPTION
Issue: https://github.com/uutils/coreutils/issues/2121

Help looks like:
```
factor 0.0.6
Print the prime factors of the given NUMBER(s).
If none are specified, read from standard input.

USAGE:
    factor [NUMBER]...

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <NUMBER>...
```