### PR TITLE
maint: adapt code to new MinRustV

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -124,12 +124,7 @@ where
     // split the file based on patterns
     for pattern in patterns.into_iter() {
         let pattern_as_str = pattern.to_string();
-        #[allow(clippy::match_like_matches_macro)]
-        let is_skip = if let patterns::Pattern::SkipToMatch(_, _, _) = pattern {
-            true
-        } else {
-            false
-        };
+        let is_skip = matches!(pattern, patterns::Pattern::SkipToMatch(_, _, _));
         match pattern {
             patterns::Pattern::UpToLine(n, ex) => {
                 let mut up_to_line = n;

--- a/src/uu/expr/src/tokens.rs
+++ b/src/uu/expr/src/tokens.rs
@@ -63,12 +63,7 @@ impl Token {
         }
     }
     fn is_a_close_paren(&self) -> bool {
-        #[allow(clippy::match_like_matches_macro)]
-        // `matches!(...)` macro not stabilized until rust v1.42
-        match *self {
-            Token::ParClose => true,
-            _ => false,
-        }
+        matches!(*self, Token::ParClose)
     }
 }
 

--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -264,12 +264,9 @@ impl<'a> ParagraphStream<'a> {
                     return false;
                 }
 
-                #[allow(clippy::match_like_matches_macro)]
-                // `matches!(...)` macro not stabilized until rust v1.42
-                l_slice[..colon_posn].chars().all(|x| match x as usize {
-                    y if !(33..=126).contains(&y) => false,
-                    _ => true,
-                })
+                l_slice[..colon_posn]
+                    .chars()
+                    .all(|x| !matches!(x as usize, y if !(33..=126).contains(&y)))
             }
         }
     }
@@ -541,12 +538,7 @@ impl<'a> WordSplit<'a> {
     }
 
     fn is_punctuation(c: char) -> bool {
-        #[allow(clippy::match_like_matches_macro)]
-        // `matches!(...)` macro not stabilized until rust v1.42
-        match c {
-            '!' | '.' | '?' => true,
-            _ => false,
-        }
+        matches!(c, '!' | '.' | '?')
     }
 }
 

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -51,14 +51,23 @@ struct Options {
 }
 
 fn is_custom_binary(program: &str) -> bool {
-    #[allow(clippy::match_like_matches_macro)]
-    // `matches!(...)` macro not stabilized until rust v1.42
-    match program {
-        "md5sum" | "sha1sum" | "sha224sum" | "sha256sum" | "sha384sum" | "sha512sum"
-        | "sha3sum" | "sha3-224sum" | "sha3-256sum" | "sha3-384sum" | "sha3-512sum"
-        | "shake128sum" | "shake256sum" | "b2sum" => true,
-        _ => false,
-    }
+    matches!(
+        program,
+        "md5sum"
+            | "sha1sum"
+            | "sha224sum"
+            | "sha256sum"
+            | "sha384sum"
+            | "sha512sum"
+            | "sha3sum"
+            | "sha3-224sum"
+            | "sha3-256sum"
+            | "sha3-384sum"
+            | "sha3-512sum"
+            | "shake128sum"
+            | "shake256sum"
+            | "b2sum"
+    )
 }
 
 #[allow(clippy::cognitive_complexity)]

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -210,21 +210,14 @@ pub fn dry_exec(mut tmpdir: PathBuf, prefix: &str, rand: usize, suffix: &str) ->
     0
 }
 
-fn exec(
-    dir: PathBuf,
-    prefix: &str,
-    rand: usize,
-    suffix: &str,
-    make_dir: bool,
-    quiet: bool,
-) -> i32 {
+fn exec(dir: PathBuf, prefix: &str, rand: usize, suffix: &str, make_dir: bool, quiet: bool) -> i32 {
     let res = if make_dir {
         let tmpdir = Builder::new()
             .prefix(prefix)
             .rand_bytes(rand)
             .suffix(suffix)
             .tempdir_in(&dir);
-        
+
         // `into_path` consumes the TempDir without removing it
         tmpdir.map(|d| d.into_path().to_string_lossy().to_string())
     } else {
@@ -233,7 +226,7 @@ fn exec(
             .rand_bytes(rand)
             .suffix(suffix)
             .tempfile_in(&dir);
-        
+
         match tmpfile {
             Ok(f) => {
                 // `keep` ensures that the file is not deleted
@@ -245,7 +238,7 @@ fn exec(
                     }
                 }
             }
-            Err(x) => Err(x)
+            Err(x) => Err(x),
         }
     };
 

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -85,12 +85,7 @@ fn od_format_type(type_char: FormatType, byte_size: u8) -> Option<FormatterItemI
 }
 
 fn od_argument_with_option(ch: char) -> bool {
-    #[allow(clippy::match_like_matches_macro)]
-    // `matches!(...)` macro not stabilized until rust v1.42
-    match ch {
-        'A' | 'j' | 'N' | 'S' | 'w' => true,
-        _ => false,
-    }
+    matches!(ch, 'A' | 'j' | 'N' | 'S' | 'w')
 }
 
 /// Parses format flags from command line

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -386,13 +386,8 @@ fn prompt(msg: &str) -> bool {
     let stdin = stdin();
     let mut stdin = stdin.lock();
 
-    #[allow(clippy::match_like_matches_macro)]
-    // `matches!(...)` macro not stabilized until rust v1.42
     match stdin.read_until(b'\n', &mut buf) {
-        Ok(x) if x > 0 => match buf[0] {
-            b'y' | b'Y' => true,
-            _ => false,
-        },
+        Ok(x) if x > 0 => matches!(buf[0], b'y' | b'Y'),
         _ => false,
     }
 }

--- a/src/uu/sort/src/ext_sort.rs
+++ b/src/uu/sort/src/ext_sort.rs
@@ -34,7 +34,12 @@ const MIN_BUFFER_SIZE: usize = 8_000;
 
 /// Sort files by using auxiliary files for storing intermediate chunks (if needed), and output the result.
 pub fn ext_sort(files: &mut impl Iterator<Item = Box<dyn Read + Send>>, settings: &GlobalSettings) {
-    let tmp_dir = crash_if_err!(1, tempfile::Builder::new().prefix("uutils_sort").tempdir_in(&settings.tmp_dir));
+    let tmp_dir = crash_if_err!(
+        1,
+        tempfile::Builder::new()
+            .prefix("uutils_sort")
+            .tempdir_in(&settings.tmp_dir)
+    );
     let (sorted_sender, sorted_receiver) = std::sync::mpsc::sync_channel(1);
     let (recycled_sender, recycled_receiver) = std::sync::mpsc::sync_channel(1);
     thread::spawn({

--- a/src/uu/sort/src/numeric_str_cmp.rs
+++ b/src/uu/sort/src/numeric_str_cmp.rs
@@ -68,10 +68,10 @@ impl NumInfo {
             }
             first_char = false;
 
-            if parse_settings
-                .thousands_separator
-                .map_or(false, |c| c == char)
-            {
+            if matches!(
+                parse_settings.thousands_separator,
+                Some(c) if c == char,
+            ) {
                 continue;
             }
 

--- a/src/uu/sort/src/numeric_str_cmp.rs
+++ b/src/uu/sort/src/numeric_str_cmp.rs
@@ -70,7 +70,7 @@ impl NumInfo {
 
             if matches!(
                 parse_settings.thousands_separator,
-                Some(c) if c == char,
+                Some(c) if c == char
             ) {
                 continue;
             }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -583,11 +583,10 @@ impl FieldSelector {
             is_default_selection: from.field == 1
                 && from.char == 1
                 && to.is_none()
-                // TODO: Once our MinRustV is 1.42 or higher, change this to the matches! macro
-                && match settings.mode {
-                    SortMode::Numeric | SortMode::GeneralNumeric | SortMode::HumanNumeric => false,
-                    _ => true,
-                },
+                && !matches!(
+                    settings.mode,
+                    SortMode::Numeric | SortMode::GeneralNumeric | SortMode::HumanNumeric,
+                ),
             needs_tokens: from.field != 1 || from.char == 0 || to.is_some(),
             from,
             to,
@@ -650,7 +649,7 @@ impl FieldSelector {
             tokens: Option<&[Field]>,
             position: &KeyPosition,
         ) -> Resolution {
-            if tokens.map_or(false, |fields| fields.len() < position.field) {
+            if matches!(tokens, Some(tokens) if tokens.len() < position.field) {
                 Resolution::TooHigh
             } else if position.char == 0 {
                 let end = tokens.unwrap()[position.field - 1].end;

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -585,7 +585,7 @@ impl FieldSelector {
                 && to.is_none()
                 && !matches!(
                     settings.mode,
-                    SortMode::Numeric | SortMode::GeneralNumeric | SortMode::HumanNumeric,
+                    SortMode::Numeric | SortMode::GeneralNumeric | SortMode::HumanNumeric
                 ),
             needs_tokens: from.field != 1 || from.char == 0 || to.is_some(),
             from,

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -25,8 +25,7 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str =
     "Run COMMAND, with modified buffering operations for its standard streams.\n\n\
      Mandatory arguments to long options are mandatory for short options too.";
-static LONG_HELP: &str =
-    "If MODE is 'L' the corresponding stream will be line buffered.\n\
+static LONG_HELP: &str = "If MODE is 'L' the corresponding stream will be line buffered.\n\
      This option is invalid with standard input.\n\n\
      If MODE is '0' the corresponding stream will be unbuffered.\n\n\
      Otherwise MODE is a number which may be followed by one of the following:\n\n\

--- a/src/uu/test/src/parser.rs
+++ b/src/uu/test/src/parser.rs
@@ -121,13 +121,7 @@ impl Parser {
     /// Test if the next token in the stream is a BOOLOP (-a or -o), without
     /// removing the token from the stream.
     fn peek_is_boolop(&mut self) -> bool {
-        // TODO: change to `matches!(self.peek(), Symbol::BoolOp(_))` once MSRV is 1.42
-        // #[allow(clippy::match_like_matches_macro)] // needs MSRV 1.43
-        if let Symbol::BoolOp(_) = self.peek() {
-            true
-        } else {
-            false
-        }
+        matches!(self.peek(), Symbol::BoolOp(_))
     }
 
     /// Parse an expression.

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)] // work-around for GH:rust-lang/rust#62127; maint: can be removed when MinSRV >= v1.38.0
-#![allow(unused_macros)] // work-around for GH:rust-lang/rust#62127; maint: can be removed when MinSRV >= v1.38.0
-
 // Copyright (C) ~ Roy Ivy III <rivy.dev@gmail.com>; MIT license
 
 extern crate proc_macro;
@@ -44,7 +41,6 @@ impl syn::parse::Parse for Tokens {
 }
 
 #[proc_macro]
-#[cfg(not(test))] // work-around for GH:rust-lang/rust#62127; maint: can be removed when MinSRV >= v1.38.0
 pub fn main(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let Tokens { expr } = syn::parse_macro_input!(stream as Tokens);
     proc_dbg!(&expr);


### PR DESCRIPTION
We can now use the `matches!` macro, which means we don't have to `#[allow(clippy::match_like_matches_macro)]` anymore.
There were also a few attributes that could be removed since rust 1.38.

I also formatted all recent changes.