### PR TITLE
Revert "rmdir: match GNU error output"

### DIFF
--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -20,8 +20,6 @@ static OPT_VERBOSE: &str = "verbose";
 
 static ARG_DIRS: &str = "dirs";
 
-static ENOTDIR: i32 = 20;
-
 fn get_usage() -> String {
     format!("{0} [OPTION]... DIRECTORY...", executable!())
 }
@@ -107,11 +105,6 @@ fn remove(dirs: Vec<String>, ignore: bool, parents: bool, verbose: bool) -> Resu
 fn remove_dir(path: &Path, ignore: bool, verbose: bool) -> Result<(), i32> {
     let mut read_dir = match fs::read_dir(path) {
         Ok(m) => m,
-        Err(e) if e.raw_os_error() == Some(ENOTDIR) => {
-        // To match the GNU output
-            show_error!("failed to remove '{}': Not a directory", path.display());
-            return Err(1);
-        }
         Err(e) => {
             show_error!("reading directory '{}': {}", path.display(), e);
             return Err(1);

--- a/tests/by-util/test_rmdir.rs
+++ b/tests/by-util/test_rmdir.rs
@@ -108,19 +108,3 @@ fn test_rmdir_ignore_nonempty_directory_with_parents() {
 
     assert!(at.dir_exists(dir));
 }
-
-#[test]
-fn test_rmdir_remove_symlink_match_gnu_error() {
-    let (at, mut ucmd) = at_and_ucmd!();
-
-    let file = "file";
-    let fl = "fl";
-    at.touch(file);
-    assert!(at.file_exists(file));
-    at.symlink_file(file, fl);
-    assert!(at.file_exists(fl));
-
-    ucmd.arg("fl/")
-        .fails()
-        .stderr_is("rmdir: failed to remove 'fl/': Not a directory");
-}


### PR DESCRIPTION
Reverts uutils/coreutils#2305

Fails on Windows with:
```
---- test_rmdir::test_rmdir_remove_symlink_match_gnu_error stdout ----
current_directory_resolved: 
touch: C:\Users\RUNNER~1\AppData\Local\Temp\.tmpboJOXp\file
symlink: C:\Users\RUNNER~1\AppData\Local\Temp\.tmpboJOXp\file,C:\Users\RUNNER~1\AppData\Local\Temp\.tmpboJOXp\fl
run: D:\a\coreutils\coreutils\target\i686-pc-windows-gnu\debug\coreutils.exe rmdir fl/
thread 'test_rmdir::test_rmdir_remove_symlink_match_gnu_error' panicked at 'assertion failed: `(left == right)`

Diff < left / right > :
<"rmdir: reading directory \'fl/\': The directory name is invalid. (os error 267)"
>"rmdir: failed to remove \'fl/\': Not a directory"

', tests\common\util.rs:229:9
```