### PR TITLE
ls: Fix minor output mismatch

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1223,7 +1223,7 @@ fn list(locs: Vec<String>, config: Config) -> i32 {
 
     sort_entries(&mut dirs, &config);
     for dir in dirs {
-        if locs.len() > 1 {
+        if locs.len() > 1 || config.recursive {
             let _ = writeln!(out, "\n{}:", dir.p_buf.display());
         }
         enter_directory(&dir, &config, &mut out);

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -899,6 +899,12 @@ fn test_ls_recursive() {
 
     scene.ucmd().arg("a").succeeds();
     scene.ucmd().arg("a/a").succeeds();
+    scene
+        .ucmd()
+        .arg("z")
+        .arg("-R")
+        .succeeds()
+        .stdout_contains(&"z:");
     let result = scene
         .ucmd()
         .arg("--color=never")


### PR DESCRIPTION
When a single directory is passed to ls in recursive mode, uutils ls
won't print the directory name

GNU ls:
z:


uutils ls:


This commit fixes this minor inconsistency and adds corresponding test.