### PR TITLE
Fix a clippy warning

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -187,7 +187,7 @@ fn test_du_d_flag() {
                 // TODO: gnu `du` doesn't use trailing "/" here
                 // result.stdout_str(), result_reference.stdout_str()
                 result.stdout_str().trim_end_matches("/\n"),
-                result_reference.stdout_str().trim_end_matches("\n")
+                result_reference.stdout_str().trim_end_matches('\n')
             );
             return;
         }


### PR DESCRIPTION
WARNING: `cargo clippy`: single-character string constant used as pattern