### PR TITLE
Fix touch parse date error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,28 +514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr 2.4.0",
-]
-
-[[package]]
 name = "ctor"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi 0.3.9",
- ]
+]
 
 [[package]]
 name = "num-bigint"

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -238,10 +238,14 @@ fn parse_date(str: &str) -> FileTime {
     // be any simple specification for what format this parameter allows and I'm
     // not about to implement GNU parse_datetime.
     // http://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=blob_plain;f=lib/parse-datetime.y
-    match time::strptime(str, "%c") {
-        Ok(tm) => local_tm_to_filetime(to_local(tm)),
-        Err(e) => panic!("Unable to parse date\n{}", e),
+    let formats = vec!["%c", "%F"];
+    for f in formats {
+        if let Ok(tm) = time::strptime(str, f) {
+            return local_tm_to_filetime(to_local(tm));
+        }
     }
+    show_error!("Unable to parse date: {}\n", str);
+    process::exit(1);
 }
 
 fn parse_timestamp(s: &str) -> FileTime {

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -355,6 +355,34 @@ fn test_touch_set_date() {
 }
 
 #[test]
+fn test_touch_set_date2() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_date";
+
+    ucmd.args(&["-d", "2000-01-23", file])
+        .succeeds()
+        .no_stderr();
+
+    assert!(at.file_exists(file));
+
+    let start_of_year = str_to_filetime("%Y%m%d%H%M", "200001230000");
+    let (atime, mtime) = get_file_times(&at, file);
+    assert_eq!(atime, mtime);
+    assert_eq!(atime, start_of_year);
+    assert_eq!(mtime, start_of_year);
+}
+
+#[test]
+fn test_touch_set_date_wrong_format() {
+    let (_at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_date_wrong_format";
+
+    ucmd.args(&["-d", "2005-43-21", file])
+        .fails()
+        .stderr_contains("Unable to parse date: 2005-43-21");
+}
+
+#[test]
 fn test_touch_mtime_dst_succeeds() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_set_mtime_dst_succeeds";


### PR DESCRIPTION
Now it can parse `touch -d 2000-01-23 file`

Related to #2311