### PR TITLE
seq: improve compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,6 +2402,8 @@ name = "uu_seq"
 version = "0.0.6"
 dependencies = [
  "clap",
+ "num-bigint",
+ "num-traits",
  "uucore",
  "uucore_procs",
 ]

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -16,6 +16,8 @@ path = "src/seq.rs"
 
 [dependencies]
 clap = "2.33"
+num-bigint = "0.4.0"
+num-traits = "0.2.14"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -119,7 +119,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .multiple(true)
                 .takes_value(true)
                 .allow_hyphen_values(true)
-                .max_values(3),
+                .max_values(3)
+                .required(true),
         )
         .get_matches_from(args);
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -7,8 +7,13 @@
 extern crate uucore;
 
 use clap::{App, AppSettings, Arg};
+use num_bigint::BigInt;
+use num_traits::One;
+use num_traits::Zero;
+use num_traits::{Num, ToPrimitive};
 use std::cmp;
 use std::io::{stdout, Write};
+use std::str::FromStr;
 
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = "Display numbers from FIRST to LAST, in steps of INCREMENT.";
@@ -33,16 +38,46 @@ struct SeqOptions {
     widths: bool,
 }
 
-fn parse_float(mut s: &str) -> Result<f64, String> {
-    if s.starts_with('+') {
-        s = &s[1..];
+enum Number {
+    BigInt(BigInt),
+    F64(f64),
+}
+
+impl Number {
+    fn is_zero(&self) -> bool {
+        match self {
+            Number::BigInt(n) => n.is_zero(),
+            Number::F64(n) => n.is_zero(),
+        }
     }
-    match s.parse() {
-        Ok(n) => Ok(n),
-        Err(e) => Err(format!(
-            "seq: invalid floating point argument `{}`: {}",
-            s, e
-        )),
+
+    fn into_f64(self) -> f64 {
+        match self {
+            // BigInt::to_f64() can not return None.
+            Number::BigInt(n) => n.to_f64().unwrap(),
+            Number::F64(n) => n,
+        }
+    }
+}
+
+impl FromStr for Number {
+    type Err = String;
+    /// Tries to parse this string as a BigInt, or if that fails as an f64.
+    fn from_str(mut s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('+') {
+            s = &s[1..];
+        }
+
+        match s.parse::<BigInt>() {
+            Ok(n) => Ok(Number::BigInt(n)),
+            Err(_) => match s.parse::<f64>() {
+                Ok(n) => Ok(Number::F64(n)),
+                Err(e) => Err(format!(
+                    "seq: invalid floating point argument `{}`: {}",
+                    s, e
+                )),
+            },
+        }
     }
 }
 
@@ -107,7 +142,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         let dec = slice.find('.').unwrap_or(len);
         largest_dec = len - dec;
         padding = dec;
-        match parse_float(slice) {
+        match slice.parse() {
             Ok(n) => n,
             Err(s) => {
                 show_error!("{}", s);
@@ -115,7 +150,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             }
         }
     } else {
-        1.0
+        Number::BigInt(BigInt::one())
     };
     let increment = if numbers.len() > 2 {
         let slice = numbers[1];
@@ -123,7 +158,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         let dec = slice.find('.').unwrap_or(len);
         largest_dec = cmp::max(largest_dec, len - dec);
         padding = cmp::max(padding, dec);
-        match parse_float(slice) {
+        match slice.parse() {
             Ok(n) => n,
             Err(s) => {
                 show_error!("{}", s);
@@ -131,16 +166,16 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             }
         }
     } else {
-        1.0
+        Number::BigInt(BigInt::one())
     };
-    if increment == 0.0 {
+    if increment.is_zero() {
         show_error!("increment value: '{}'", numbers[1]);
         return 1;
     }
     let last = {
         let slice = numbers[numbers.len() - 1];
         padding = cmp::max(padding, slice.find('.').unwrap_or_else(|| slice.len()));
-        match parse_float(slice) {
+        match slice.parse::<Number>() {
             Ok(n) => n,
             Err(s) => {
                 show_error!("{}", s);
@@ -156,28 +191,42 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         Some(term) => escape_sequences(&term[..]),
         None => separator.clone(),
     };
-    print_seq(
-        first,
-        increment,
-        last,
-        largest_dec,
-        separator,
-        terminator,
-        options.widths,
-        padding,
-    );
 
+    match (first, last, increment) {
+        (Number::BigInt(first), Number::BigInt(last), Number::BigInt(increment)) => {
+            print_seq_integers(
+                first,
+                increment,
+                last,
+                separator,
+                terminator,
+                options.widths,
+                padding,
+            )
+        }
+        (first, last, increment) => print_seq(
+            first.into_f64(),
+            increment.into_f64(),
+            last.into_f64(),
+            largest_dec,
+            separator,
+            terminator,
+            options.widths,
+            padding,
+        ),
+    }
     0
 }
 
-fn done_printing(next: f64, increment: f64, last: f64) -> bool {
-    if increment >= 0f64 {
+fn done_printing<T: Num + PartialOrd>(next: &T, increment: &T, last: &T) -> bool {
+    if increment >= &T::zero() {
         next > last
     } else {
         next < last
     }
 }
 
+/// Floating point based code path
 #[allow(clippy::too_many_arguments)]
 fn print_seq(
     first: f64,
@@ -191,7 +240,7 @@ fn print_seq(
 ) {
     let mut i = 0isize;
     let mut value = first + i as f64 * increment;
-    while !done_printing(value, increment, last) {
+    while !done_printing(&value, &increment, &last) {
         let istr = format!("{:.*}", largest_dec, value);
         let ilen = istr.len();
         let before_dec = istr.find('.').unwrap_or(ilen);
@@ -203,7 +252,7 @@ fn print_seq(
         print!("{}", istr);
         i += 1;
         value = first + i as f64 * increment;
-        if !done_printing(value, increment, last) {
+        if !done_printing(&value, &increment, &last) {
             print!("{}", separator);
         }
     }
@@ -211,4 +260,34 @@ fn print_seq(
         print!("{}", terminator);
     }
     crash_if_err!(1, stdout().flush());
+}
+
+/// BigInt based code path
+fn print_seq_integers(
+    first: BigInt,
+    increment: BigInt,
+    last: BigInt,
+    separator: String,
+    terminator: String,
+    pad: bool,
+    padding: usize,
+) {
+    let mut value = first;
+    let mut is_first_iteration = true;
+    while !done_printing(&value, &increment, &last) {
+        if !is_first_iteration {
+            print!("{}", separator);
+        }
+        is_first_iteration = false;
+        if pad {
+            print!("{number:>0width$}", number = value, width = padding);
+        } else {
+            print!("{}", value);
+        }
+        value += &increment;
+    }
+
+    if !is_first_iteration {
+        print!("{}", terminator);
+    }
 }

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -1,5 +1,7 @@
 use crate::common::util::*;
 
+// ---- Tests for the big integer based path ----
+
 #[test]
 fn test_count_up() {
     new_ucmd!()
@@ -44,4 +46,63 @@ fn test_seq_wrong_arg() {
 #[test]
 fn test_zero_step() {
     new_ucmd!().args(&["10", "0", "32"]).fails();
+}
+
+#[test]
+fn test_big_numbers() {
+    new_ucmd!()
+        .args(&[
+            "1000000000000000000000000000",
+            "1000000000000000000000000001",
+        ])
+        .succeeds()
+        .stdout_only("1000000000000000000000000000\n1000000000000000000000000001\n");
+}
+
+// ---- Tests for the floating point based path ----
+
+#[test]
+fn test_count_up_floats() {
+    new_ucmd!()
+        .args(&["10.0"])
+        .run()
+        .stdout_is("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n");
+}
+
+#[test]
+fn test_count_down_floats() {
+    new_ucmd!()
+        .args(&["--", "5", "-1.0", "1"])
+        .run()
+        .stdout_is("5.0\n4.0\n3.0\n2.0\n1.0\n");
+    new_ucmd!()
+        .args(&["5", "-1", "1.0"])
+        .run()
+        .stdout_is("5\n4\n3\n2\n1\n");
+}
+
+#[test]
+fn test_separator_and_terminator_floats() {
+    new_ucmd!()
+        .args(&["-s", ",", "-t", "!", "2.0", "6"])
+        .run()
+        .stdout_is("2.0,3.0,4.0,5.0,6.0!");
+}
+
+#[test]
+fn test_equalize_widths_floats() {
+    new_ucmd!()
+        .args(&["-w", "5", "10.0"])
+        .run()
+        .stdout_is("05\n06\n07\n08\n09\n10\n");
+}
+
+#[test]
+fn test_seq_wrong_arg_floats() {
+    new_ucmd!().args(&["-w", "5", "10.0", "33", "32"]).fails();
+}
+
+#[test]
+fn test_zero_step_floats() {
+    new_ucmd!().args(&["10.0", "0", "32"]).fails();
 }

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -28,6 +28,18 @@ fn test_separator_and_terminator() {
         .args(&["-s", ",", "-t", "!", "2", "6"])
         .run()
         .stdout_is("2,3,4,5,6!");
+    new_ucmd!()
+        .args(&["-s", ",", "2", "6"])
+        .run()
+        .stdout_is("2,3,4,5,6\n");
+    new_ucmd!()
+        .args(&["-s", "\n", "2", "6"])
+        .run()
+        .stdout_is("2\n3\n4\n5\n6\n");
+    new_ucmd!()
+        .args(&["-s", "\\n", "2", "6"])
+        .run()
+        .stdout_is("2\\n3\\n4\\n5\\n6\n");
 }
 
 #[test]


### PR DESCRIPTION
- Implements a BigInt based code path for integer sequences when all arguments are integers.
- Change the default value for the -t flag to GNU's implicit default.
- Remove support for escape sequences: Do not interpret "\n" / "\t" as a newline/tab. Only actual tab/newline characters should be treated as tab/newline.
- Small bug fix: Already make clap show an error if no arguments are supplied instead of panicking on an unwrap.