### PR TITLE
dircolors: replace getopts with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
 name = "uu_dircolors"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "glob 0.3.0",
  "uucore",
  "uucore_procs",

--- a/src/uu/dircolors/Cargo.toml
+++ b/src/uu/dircolors/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/dircolors.rs"
 
 [dependencies]
+clap = "2.33"
 glob = "0.3.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -19,9 +19,7 @@ use std::io::{BufRead, BufReader};
 use clap::{crate_version, App, Arg};
 
 mod options {
-    pub const SH: &str = "sh";
     pub const BOURNE_SHELL: &str = "bourne-shell";
-    pub const CSH: &str = "csh";
     pub const C_SHELL: &str = "c-shell";
     pub const PRINT_DATABASE: &str = "print-database";
     pub const FILE: &str = "FILE";
@@ -75,52 +73,33 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    /* Clap has .visible_alias, but it generates help like this
-     *     -b, --sh                output Bourne shell code to set LS_COLORS [aliases: bourne-shell]
-     * whereas we want help like this
-     *     -b, --sh                output Bourne shell code to set LS_COLORS
-     *         --bourne-shell      output Bourne shell code to set LS_COLORS
-     * (or preferably like the original, but that doesn't seem possible with clap:)
-     *     -b, --sh, --bourne-shell    output Bourne shell code to set LS_COLORS
-     * therefore, command aliases are defined manually as multiple commands
-     */
     let matches = App::new(executable!())
         .version(crate_version!())
         .about(SUMMARY)
         .usage(&usage[..])
         .after_help(LONG_HELP)
         .arg(
-            Arg::with_name(options::SH)
+            Arg::with_name(options::BOURNE_SHELL)
                 .long("sh")
                 .short("b")
+                .visible_alias("bourne-shell")
                 .help("output Bourne shell code to set LS_COLORS")
                 .display_order(1),
         )
         .arg(
-            Arg::with_name(options::BOURNE_SHELL)
-                .long("bourne-shell")
-                .help("output Bourne shell code to set LS_COLORS")
-                .display_order(2),
-        )
-        .arg(
-            Arg::with_name(options::CSH)
+            Arg::with_name(options::C_SHELL)
                 .long("csh")
                 .short("c")
+                .visible_alias("c-shell")
                 .help("output C shell code to set LS_COLORS")
-                .display_order(3),
-        )
-        .arg(
-            Arg::with_name(options::C_SHELL)
-                .long("c-shell")
-                .help("output C shell code to set LS_COLORS")
-                .display_order(4),
+                .display_order(2),
         )
         .arg(
             Arg::with_name(options::PRINT_DATABASE)
                 .long("print-database")
                 .short("p")
                 .help("print the byte counts")
-                .display_order(5),
+                .display_order(3),
         )
         .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
         .get_matches_from(&args);
@@ -131,10 +110,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     // clap provides .conflicts_with / .conflicts_with_all, but we want to
     // manually handle conflicts so we can match the output of GNU coreutils
-    if (matches.is_present(options::CSH)
-        || matches.is_present(options::C_SHELL)
-        || matches.is_present(options::SH)
-        || matches.is_present(options::BOURNE_SHELL))
+    if (matches.is_present(options::C_SHELL) || matches.is_present(options::BOURNE_SHELL))
         && matches.is_present(options::PRINT_DATABASE)
     {
         show_usage_error!(
@@ -158,9 +134,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     let mut out_format = OutputFmt::Unknown;
-    if matches.is_present(options::CSH) || matches.is_present(options::C_SHELL) {
+    if matches.is_present(options::C_SHELL) {
         out_format = OutputFmt::CShell;
-    } else if matches.is_present(options::SH) || matches.is_present(options::BOURNE_SHELL) {
+    } else if matches.is_present(options::BOURNE_SHELL) {
         out_format = OutputFmt::Shell;
     }
 

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -16,7 +16,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
-use clap::{App, Arg, crate_version};
+use clap::{crate_version, App, Arg};
 
 mod options {
     pub const SH: &str = "sh";
@@ -65,11 +65,7 @@ pub fn guess_syntax() -> OutputFmt {
 }
 
 fn get_usage() -> String {
-    format!(
-        "{0} {1}",
-        executable!(),
-        SYNTAX
-    )
+    format!("{0} {1}", executable!(), SYNTAX)
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -93,50 +89,52 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .about(SUMMARY)
         .usage(&usage[..])
         .after_help(LONG_HELP)
-        .arg(Arg::with_name(options::SH)
-            .long("sh")
-            .short("b")
-            .help("output Bourne shell code to set LS_COLORS")
-            .display_order(1)
+        .arg(
+            Arg::with_name(options::SH)
+                .long("sh")
+                .short("b")
+                .help("output Bourne shell code to set LS_COLORS")
+                .display_order(1),
         )
-        .arg(Arg::with_name(options::BOURNE_SHELL)
-            .long("bourne-shell")
-            .help("output Bourne shell code to set LS_COLORS")
-            .display_order(2)
+        .arg(
+            Arg::with_name(options::BOURNE_SHELL)
+                .long("bourne-shell")
+                .help("output Bourne shell code to set LS_COLORS")
+                .display_order(2),
         )
-        .arg(Arg::with_name(options::CSH)
-            .long("csh")
-            .short("c")
-            .help("output C shell code to set LS_COLORS")
-            .display_order(3)
+        .arg(
+            Arg::with_name(options::CSH)
+                .long("csh")
+                .short("c")
+                .help("output C shell code to set LS_COLORS")
+                .display_order(3),
         )
-        .arg(Arg::with_name(options::C_SHELL)
-            .long("c-shell")
-            .help("output C shell code to set LS_COLORS")
-            .display_order(4)
+        .arg(
+            Arg::with_name(options::C_SHELL)
+                .long("c-shell")
+                .help("output C shell code to set LS_COLORS")
+                .display_order(4),
         )
-        .arg(Arg::with_name(options::PRINT_DATABASE)
-            .long("print-database")
-            .short("p")
-            .help("print the byte counts")
-            .display_order(5)
+        .arg(
+            Arg::with_name(options::PRINT_DATABASE)
+                .long("print-database")
+                .short("p")
+                .help("print the byte counts")
+                .display_order(5),
         )
-        .arg(Arg::with_name(options::FILE)
-                .hidden(true)
-                .multiple(true)
-        )
+        .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
         .get_matches_from(&args);
 
-    let files =  matches.values_of(options::FILE)
+    let files = matches
+        .values_of(options::FILE)
         .map_or(vec![], |file_values| file_values.collect());
 
     // clap provides .conflicts_with / .conflicts_with_all, but we want to
     // manually handle conflicts so we can match the output of GNU coreutils
     if (matches.is_present(options::CSH)
-            || matches.is_present(options::C_SHELL)
-            || matches.is_present(options::SH)
-            || matches.is_present(options::BOURNE_SHELL)
-        )
+        || matches.is_present(options::C_SHELL)
+        || matches.is_present(options::SH)
+        || matches.is_present(options::BOURNE_SHELL))
         && matches.is_present(options::PRINT_DATABASE)
     {
         show_usage_error!(
@@ -187,11 +185,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         match File::open(files[0]) {
             Ok(f) => {
                 let fin = BufReader::new(f);
-                result = parse(
-                    fin.lines().filter_map(Result::ok),
-                    out_format,
-                    files[0],
-                )
+                result = parse(fin.lines().filter_map(Result::ok), out_format, files[0])
             }
             Err(e) => {
                 show_error!("{}: {}", files[0], e);


### PR DESCRIPTION
Closes #2119.

This ports dircolors from `getopts` to `clap`.

A couple of things I was uncertain about:
- Should I add myself to the copyright header or not?
- I left in a few verbose comments justifying doing some things in a non-clap-standard way - are those OK?
- Most of the commands in here get the version using a snippet like `static VERSION: &str = env!("CARGO_PKG_VERSION");`, but clap provides the `crate_version!()` macro for this.  Is it OK to use the macro, or should I do it manually?
  - `echo`, `env`, `hashsum`, and `tail` are using `crate_version!()`.  Would it be good to standardize on one or the other?

The dircolors tests are all still passing, at least on Debian.

The only difference I have observed is that clap auto-generates `-h` and `-V` short options for help and version, and there is no way (in clap 2.x) to disable them, although that should be possible in 3.x, currently in beta.

