### PR TITLE
du: add `--one-file-system`

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -57,6 +57,7 @@ mod options {
     pub const SI: &str = "si";
     pub const TIME: &str = "time";
     pub const TIME_STYLE: &str = "time-style";
+    pub const ONE_FILE_SYSTEM: &str = "one-file-system";
     pub const FILE: &str = "FILE";
 }
 
@@ -81,6 +82,7 @@ struct Options {
     max_depth: Option<usize>,
     total: bool,
     separate_dirs: bool,
+    one_file_system: bool,
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
@@ -317,6 +319,15 @@ fn du(
                 Ok(entry) => match Stat::new(entry.path()) {
                     Ok(this_stat) => {
                         if this_stat.is_dir {
+                            if options.one_file_system {
+                                if let (Some(this_inode), Some(my_inode)) =
+                                    (this_stat.inode, my_stat.inode)
+                                {
+                                    if this_inode.dev_id != my_inode.dev_id {
+                                        continue;
+                                    }
+                                }
+                            }
                             futures.push(du(this_stat, options, depth + 1, inodes));
                         } else {
                             if let Some(inode) = this_stat.inode {
@@ -532,12 +543,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .long(options::SI)
                 .help("like -h, but use powers of 1000 not 1024")
         )
-        // .arg(
-        //     Arg::with_name("one-file-system")
-        //         .short("x")
-        //         .long("one-file-system")
-        //         .help("skip directories on different file systems")
-        // )
+        .arg(
+            Arg::with_name(options::ONE_FILE_SYSTEM)
+                .short("x")
+                .long(options::ONE_FILE_SYSTEM)
+                .help("skip directories on different file systems")
+        )
         // .arg(
         //     Arg::with_name("")
         //         .short("x")
@@ -602,6 +613,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         max_depth,
         total: matches.is_present(options::TOTAL),
         separate_dirs: matches.is_present(options::SEPARATE_DIRS),
+        one_file_system: matches.is_present(options::ONE_FILE_SYSTEM),
     };
 
     let files = match matches.value_of(options::FILE) {

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -312,3 +312,20 @@ fn _du_no_permission(s: &str) {
 fn _du_no_permission(s: &str) {
     assert_eq!(s, "4\tsubdir/links\n");
 }
+
+#[test]
+fn test_du_one_file_system() {
+    let scene = TestScenario::new(util_name!());
+
+    let result = scene.ucmd().arg("-x").arg(SUB_DIR).succeeds();
+
+    #[cfg(target_os = "linux")]
+    {
+        let result_reference = scene.cmd("du").arg("-x").arg(SUB_DIR).run();
+        if result_reference.succeeded() {
+            assert_eq!(result.stdout_str(), result_reference.stdout_str());
+            return;
+        }
+    }
+    _du_basics_subdir(result.stdout_str());
+}


### PR DESCRIPTION
From original GNU `du`:
```
  -x, --one-file-system    skip directories on different file systems
```

Two directories are considered in the same file system if they have the same device id.