### PR TITLE
uucore: fix order of group IDs return from entries::get_groups()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,7 @@ sha1 = { version="0.6", features=["std"] }
 tempfile = "3.2.0"
 time = "0.1"
 unindent = "0.1"
-uucore = { version=">=0.0.8", package="uucore", path="src/uucore", features=["entries"] }
+uucore = { version=">=0.0.8", package="uucore", path="src/uucore", features=["entries", "process"] }
 walkdir = "2.2"
 atty = "0.2.14"
 

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -10,7 +10,7 @@
 
 #[macro_use]
 extern crate uucore;
-use uucore::entries::{get_groups, gid2grp, Locate, Passwd};
+use uucore::entries::{get_groups_gnu, gid2grp, Locate, Passwd};
 
 use clap::{crate_version, App, Arg};
 
@@ -35,7 +35,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         None => {
             println!(
                 "{}",
-                get_groups()
+                get_groups_gnu(None)
                     .unwrap()
                     .iter()
                     .map(|&g| gid2grp(g).unwrap())

--- a/src/uucore/src/lib/features/entries.rs
+++ b/src/uucore/src/lib/features/entries.rs
@@ -5,7 +5,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (vars) Passwd cstr fnam gecos ngroups
+// spell-checker:ignore (vars) Passwd cstr fnam gecos ngroups egid
 
 //! Get password/group file entry
 //!
@@ -72,6 +72,41 @@ pub fn get_groups() -> IOResult<Vec<gid_t>> {
     }
 }
 
+/// The list of group IDs returned from GNU's `groups` and GNU's `id --groups`
+/// starts with the effective group ID (egid).
+/// This is a wrapper for `get_groups()` to mimic this behavior.
+///
+/// If `arg_id` is `None` (default), `get_groups_gnu` moves the effective
+/// group id (egid) to the first entry in the returned Vector.
+/// If `arg_id` is `Some(x)`, `get_groups_gnu` moves the id with value `x`
+/// to the first entry in the returned Vector. This might be necessary
+/// for `id --groups --real` if `gid` and `egid` are not equal.
+///
+/// From: https://www.man7.org/linux/man-pages/man3/getgroups.3p.html
+/// As implied by the definition of supplementary groups, the
+/// effective group ID may appear in the array returned by
+/// getgroups() or it may be returned only by getegid().  Duplication
+/// may exist, but the application needs to call getegid() to be sure
+/// of getting all of the information. Various implementation
+/// variations and administrative sequences cause the set of groups
+/// appearing in the result of getgroups() to vary in order and as to
+/// whether the effective group ID is included, even when the set of
+/// groups is the same (in the mathematical sense of ``set''). (The
+/// history of a process and its parents could affect the details of
+/// the result.)
+pub fn get_groups_gnu(arg_id: Option<u32>) -> IOResult<Vec<gid_t>> {
+    let mut groups = get_groups()?;
+    let egid = arg_id.unwrap_or_else(crate::features::process::getegid);
+    if !groups.is_empty() && *groups.first().unwrap() == egid {
+        return Ok(groups);
+    } else if let Some(index) = groups.iter().position(|&x| x == egid) {
+        groups.remove(index);
+    }
+    groups.insert(0, egid);
+    Ok(groups)
+}
+
+#[derive(Copy, Clone)]
 pub struct Passwd {
     inner: passwd,
 }
@@ -267,4 +302,19 @@ pub fn usr2uid(name: &str) -> IOResult<uid_t> {
 #[inline]
 pub fn grp2gid(name: &str) -> IOResult<gid_t> {
     Group::locate(name).map(|p| p.gid())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_entries_get_groups_gnu() {
+        if let Ok(mut groups) = get_groups() {
+            if let Some(last) = groups.pop() {
+                groups.insert(0, last);
+                assert_eq!(get_groups_gnu(Some(last)).unwrap(), groups);
+            }
+        }
+    }
 }


### PR DESCRIPTION
As discussed here: #2361
the group IDs returned for GNU's 'group' and GNU's 'id --groups'
starts with the effective group ID.
This implements a wrapper for `entris::get_groups()` which mimics
GNU's behaviour.

* add tests for `id`
* add tests for `groups`
* fix `id --groups --real` to no longer ignore `--real`