### PR TITLE
`groups`: fix test for Arch-based systems

### DIFF
--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -46,7 +46,7 @@ fn expected_result(args: &[&str]) -> String {
     #[cfg(not(target_os = "linux"))]
     let util_name = "gid";
 
-    TestScenario::new(&util_name)
+    TestScenario::new(util_name)
         .cmd_keepenv(util_name)
         .env("LANGUAGE", "C")
         .args(args)

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -1,7 +1,7 @@
 use crate::common::util::*;
 
 #[test]
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 fn test_groups() {
     if !is_ci() {
         new_ucmd!().succeeds().stdout_is(expected_result(&[]));
@@ -13,7 +13,7 @@ fn test_groups() {
 }
 
 #[test]
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[ignore = "fixme: 'groups USERNAME' needs more debugging"]
 fn test_groups_username() {
     let scene = TestScenario::new(util_name!());
@@ -37,9 +37,14 @@ fn test_groups_username() {
         .stdout_is(expected_result(&[&username]));
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 fn expected_result(args: &[&str]) -> String {
+    // We want to use GNU id. On most linux systems, this is "id", but on
+    // bsd-like systems (e.g. FreeBSD, MacOS), it is commonly "gid".
+    #[cfg(any(target_os = "linux"))]
     let util_name = "id";
+    #[cfg(not(target_os = "linux"))]
+    let util_name = "gid";
 
     TestScenario::new(&util_name)
         .cmd_keepenv(util_name)

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -13,7 +13,7 @@ fn test_groups() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux"))]
+#[cfg(any(target_vendor = "apple", target_os = "linux"))]
 #[ignore = "fixme: 'groups USERNAME' needs more debugging"]
 fn test_groups_username() {
     let scene = TestScenario::new(util_name!());
@@ -39,15 +39,13 @@ fn test_groups_username() {
 
 #[cfg(any(target_vendor = "apple", target_os = "linux"))]
 fn expected_result(args: &[&str]) -> String {
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(target_vendor = "apple")]
-    let util_name = format!("g{}", util_name!());
+    let util_name = "id";
 
     TestScenario::new(&util_name)
         .cmd_keepenv(util_name)
         .env("LANGUAGE", "C")
         .args(args)
+        .args(&["-Gn"])
         .succeeds()
         .stdout_move_str()
 }


### PR DESCRIPTION
On Arch-based systems (at least mine, which is Manjaro), the `groups` command comes from shadow utils instead of GNU coreutils. We can check against `id -Gn` instead, which should be identical according to the docs.

cc @jhscheer 