### PR TITLE
`cat`/`cut`/`tty`/`nohup`: replace `is_std{in, out, err}_interactive` with atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,7 @@ dependencies = [
 name = "uu_cat"
 version = "0.0.6"
 dependencies = [
+ "atty",
  "clap",
  "nix 0.20.0",
  "thiserror",
@@ -1872,6 +1873,7 @@ dependencies = [
 name = "uu_cut"
 version = "0.0.6"
 dependencies = [
+ "atty",
  "bstr",
  "clap",
  "memchr 2.4.0",
@@ -2262,6 +2264,7 @@ dependencies = [
 name = "uu_nohup"
 version = "0.0.6"
 dependencies = [
+ "atty",
  "clap",
  "libc",
  "uucore",
@@ -2660,6 +2663,7 @@ dependencies = [
 name = "uu_tty"
 version = "0.0.6"
 dependencies = [
+ "atty",
  "clap",
  "libc",
  "uucore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,7 +351,7 @@ time = "0.1"
 unindent = "0.1"
 uucore = { version=">=0.0.8", package="uucore", path="src/uucore", features=["entries", "process"] }
 walkdir = "2.2"
-atty = "0.2.14"
+atty = "0.2"
 
 [target.'cfg(unix)'.dev-dependencies]
 rlimit = "0.4.0"

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/cat.rs"
 [dependencies]
 clap = "2.33"
 thiserror = "1.0"
+atty = "0.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -20,7 +20,6 @@ use clap::{crate_version, App, Arg};
 use std::fs::{metadata, File};
 use std::io::{self, Read, Write};
 use thiserror::Error;
-use uucore::fs::is_stdin_interactive;
 
 /// Linux splice support
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -306,7 +305,7 @@ fn cat_path(path: &str, options: &OutputOptions, state: &mut OutputState) -> Cat
             #[cfg(any(target_os = "linux", target_os = "android"))]
             file_descriptor: stdin.as_raw_fd(),
             reader: stdin,
-            is_interactive: is_stdin_interactive(),
+            is_interactive: atty::is(atty::Stream::Stdin),
         };
         return cat_handle(&mut handle, options, state);
     }

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -20,6 +20,7 @@ uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 memchr = "2"
 bstr = "0.2"
+atty = "0.2"
 
 [[bin]]
 name = "cut"

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -17,7 +17,6 @@ use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
 use self::searcher::Searcher;
-use uucore::fs::is_stdout_interactive;
 use uucore::ranges::Range;
 use uucore::InvalidEncodingHandling;
 
@@ -127,7 +126,7 @@ enum Mode {
 }
 
 fn stdout_writer() -> Box<dyn Write> {
-    if is_stdout_interactive() {
+    if atty::is(atty::Stream::Stdout) {
         Box::new(stdout())
     } else {
         Box::new(BufWriter::new(stdout())) as Box<dyn Write>

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -19,7 +19,7 @@ clap = "2.33"
 uucore = { version = ">=0.0.7", package = "uucore", path = "../../uucore" }
 uucore_procs = { version = ">=0.0.5", package = "uucore_procs", path = "../../uucore_procs" }
 crossterm = ">=0.19"
-atty = "0.2.14"
+atty = "0.2"
 unicode-width = "0.1.7"
 unicode-segmentation = "1.7.1"
 

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/nohup.rs"
 [dependencies]
 clap = "2.33"
 libc = "0.2.42"
+atty = "0.2.14"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/nohup.rs"
 [dependencies]
 clap = "2.33"
 libc = "0.2.42"
-atty = "0.2.14"
+atty = "0.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -19,7 +19,6 @@ use std::fs::{File, OpenOptions};
 use std::io::Error;
 use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
-use uucore::fs::{is_stderr_interactive, is_stdin_interactive, is_stdout_interactive};
 use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Run COMMAND ignoring hangup signals.";
@@ -84,7 +83,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 fn replace_fds() {
-    if is_stdin_interactive() {
+    if atty::is(atty::Stream::Stdin) {
         let new_stdin = match File::open(Path::new("/dev/null")) {
             Ok(t) => t,
             Err(e) => crash!(2, "Cannot replace STDIN: {}", e),
@@ -94,7 +93,7 @@ fn replace_fds() {
         }
     }
 
-    if is_stdout_interactive() {
+    if atty::is(atty::Stream::Stdout) {
         let new_stdout = find_stdout();
         let fd = new_stdout.as_raw_fd();
 
@@ -103,7 +102,7 @@ fn replace_fds() {
         }
     }
 
-    if is_stderr_interactive() && unsafe { dup2(1, 2) } != 2 {
+    if atty::is(atty::Stream::Stderr) && unsafe { dup2(1, 2) } != 2 {
         crash!(2, "Cannot replace STDERR: {}", Error::last_os_error())
     }
 }

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/tty.rs"
 [dependencies]
 clap = "2.33"
 libc = "0.2.42"
+atty = "0.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -14,7 +14,6 @@ extern crate uucore;
 
 use clap::{crate_version, App, Arg};
 use std::ffi::CStr;
-use uucore::fs::is_stdin_interactive;
 use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
@@ -67,7 +66,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         }
     }
 
-    if is_stdin_interactive() {
+    if atty::is(atty::Stream::Stdin) {
         libc::EXIT_SUCCESS
     } else {
         libc::EXIT_FAILURE

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -225,51 +225,6 @@ pub fn canonicalize<P: AsRef<Path>>(original: P, can_mode: CanonicalizeMode) -> 
     Ok(result)
 }
 
-#[cfg(unix)]
-pub fn is_stdin_interactive() -> bool {
-    unsafe { libc::isatty(libc::STDIN_FILENO) == 1 }
-}
-
-#[cfg(windows)]
-pub fn is_stdin_interactive() -> bool {
-    false
-}
-
-#[cfg(target_os = "redox")]
-pub fn is_stdin_interactive() -> bool {
-    termion::is_tty(&io::stdin())
-}
-
-#[cfg(unix)]
-pub fn is_stdout_interactive() -> bool {
-    unsafe { libc::isatty(libc::STDOUT_FILENO) == 1 }
-}
-
-#[cfg(windows)]
-pub fn is_stdout_interactive() -> bool {
-    false
-}
-
-#[cfg(target_os = "redox")]
-pub fn is_stdout_interactive() -> bool {
-    termion::is_tty(&io::stdout())
-}
-
-#[cfg(unix)]
-pub fn is_stderr_interactive() -> bool {
-    unsafe { libc::isatty(libc::STDERR_FILENO) == 1 }
-}
-
-#[cfg(windows)]
-pub fn is_stderr_interactive() -> bool {
-    false
-}
-
-#[cfg(target_os = "redox")]
-pub fn is_stderr_interactive() -> bool {
-    termion::is_tty(&io::stderr())
-}
-
 #[cfg(not(unix))]
 #[allow(unused_variables)]
 pub fn display_permissions(metadata: &fs::Metadata, display_file_type: bool) -> String {


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/1162