### PR TITLE
To fix more with short input, Revert "more: do not accidentically hide last line"

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -355,7 +355,7 @@ fn calc_range(mut upper_mark: u16, rows: u16, line_count: u16) -> (u16, u16) {
     let mut lower_mark = upper_mark.saturating_add(rows);
 
     if lower_mark >= line_count {
-        upper_mark = line_count.saturating_sub(rows).saturating_add(1);
+        upper_mark = line_count.saturating_sub(rows);
         lower_mark = line_count;
     } else {
         lower_mark = lower_mark.saturating_sub(1)


### PR DESCRIPTION
This reverts commit 420e9322eac301906ea87bb03a3a9304ebb5f846.

by bisecting, I found this patch introduced a new bug that

```sh
$ echo a | cargo run -- more
```
prints nothing.
