### PR TITLE
`more`: rewrite drawing logic

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -295,10 +295,7 @@ impl<'a> Pager<'a> {
     }
 
     fn page_down(&mut self) {
-        self.upper_mark = self
-            .line_count
-            .saturating_sub(self.content_rows)
-            .min(self.upper_mark + self.content_rows);
+        self.upper_mark += self.content_rows;
     }
 
     fn page_up(&mut self) {


### PR DESCRIPTION
Should do the same as https://github.com/uutils/coreutils/pull/2380 and I restructured the code to have a `Pager` struct. I used some of the changes from #2380, but as I was already writing this, merging that first would not make sense.

Fixes/changes:
- do not accidentally skip the first line (or hide the first line)
- going to the end, back up and down again no longer skips past the last page
- state is stored in the `Pager` struct, cleaning up the main loop
- drawing the prompt and flushing are separated
- use `usize` everywhere instead of `u16`

cc @miDeb 