### PR TITLE
`whoami`: remove `advapi32-sys` dependency and use `winapi`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,16 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
-name = "advapi32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,7 +2741,6 @@ dependencies = [
 name = "uu_whoami"
 version = "0.0.6"
 dependencies = [
- "advapi32-sys",
  "clap",
  "uucore",
  "uucore_procs",

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -20,7 +20,6 @@ uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-advapi32-sys = "0.2.0"
 winapi = { version = "0.3", features = ["lmcons"] }
 
 [[bin]]

--- a/src/uu/whoami/src/platform/windows.rs
+++ b/src/uu/whoami/src/platform/windows.rs
@@ -11,7 +11,7 @@ extern crate winapi;
 
 use self::winapi::shared::lmcons;
 use self::winapi::shared::minwindef;
-use self::winapi::um::winnt;
+use self::winapi::um::{winbase, winnt};
 use std::io::{Error, Result};
 use std::mem;
 use uucore::wide::FromWide;
@@ -20,7 +20,7 @@ pub unsafe fn get_username() -> Result<String> {
     #[allow(deprecated)]
     let mut buffer: [winnt::WCHAR; lmcons::UNLEN as usize + 1] = mem::uninitialized();
     let mut len = buffer.len() as minwindef::DWORD;
-    if advapi32::GetUserNameW(buffer.as_mut_ptr(), &mut len) == 0 {
+    if winbase::GetUserNameW(buffer.as_mut_ptr(), &mut len) == 0 {
         return Err(Error::last_os_error());
     }
     let username = String::from_wide(&buffer[..len as usize - 1]);


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/1564