### PR TITLE
suggestion: uumain return types into Result<(), i32>

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -160,7 +160,7 @@ fn create_app() -> App<'static, 'static> {
             .help("remove variable from the environment"))
 }
 
-fn run_env(args: impl uucore::Args) -> Result<(), i32> {
+pub fn uumain(args: impl uucore::Args) -> Result<(), i32> {
     let app = create_app();
     let matches = app.get_matches_from(args);
 
@@ -270,11 +270,4 @@ fn run_env(args: impl uucore::Args) -> Result<(), i32> {
     }
 
     Ok(())
-}
-
-pub fn uumain(args: impl uucore::Args) -> i32 {
-    match run_env(args) {
-        Ok(()) => 0,
-        Err(code) => code,
-    }
 }

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -65,7 +65,7 @@ pub fn main(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     };
     proc_dbg!(&expr);
 
-    let f = quote::quote! { #expr(uucore::args_os()) };
+    let f = quote::quote! { #expr(uucore::args_os()).map(|()| 0).unwrap_or_else(|code| code) };
     proc_dbg!(&f);
 
     // generate a uutils utility `main()` function, tailored for the calling utility


### PR DESCRIPTION
`env` is delegating its implementation to `run_env` with return type `Result`.
it gives better interface for early returning with error codes.

I suggest to choose this interface as the default inteface of uumain instead of current one.

let me know if you guys are interested in it. Then I will finish the work.