### PR TITLE
sort: fix `--key` argument handling

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1044,7 +1044,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .long(OPT_KEY)
                 .help("sort by a key")
                 .long_help(LONG_HELP_KEYS)
-                .multiple(true)
+                .use_delimiter(true)
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
When using `sort` with the `--key` option, all subsequent arguments
are considered its values, leading to failures such as:

  $ sort -t ":" -k 3 /etc/passwd
  sort: failed to parse key `/etc/passwd`: invalid option: `e`

This is a side-effect of having `multiple(true)` for this option,
as `multiple` supports separating values with either a comma or
whitespace. Therefore, as long as no other flag or option is
provided, all arguments following `-k` are treated like values
for this option.

Switching to `use_delimiter(true)` instead ensures only
comma-separated values are taken into account, and the following
arguments are properly interpreted.