### PR TITLE
Fixing `more` terminal resizing

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -234,7 +234,7 @@ impl LineStateMachine {
     }
 
     pub fn retreat_mark(&mut self) {
-        self.upper_mark = self.upper_mark.saturating_sub(self.usable_rows).min(0);
+        self.upper_mark = self.upper_mark.saturating_sub(self.usable_rows).max(0);
         self.lower_mark = self.upper_mark.saturating_add(self.usable_rows);
     }
 

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -49,7 +49,7 @@ pub mod options {
     pub const FILES: &str = "files";
 }
 
-const MULTI_FILE_TOP_PROMPT: &str = "::::::::::::::\n{}\n::::::::::::::\n";
+const MULTI_FILE_TOP_PROMPT: &str = "\n\r::::::::::::::\n\r{}\n\r::::::::::::::\n\r";
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let matches = App::new(executable!())


### PR DESCRIPTION
See the demo [here](https://youtu.be/icyXPw_Obuk).

Unfortunately, it does pose a substantial rewrite and does not match `more` behavior exactly.
But in my opinion, this is a lot simpler and better to use.
The goal is to consolidate all the logic into the struct `LineStateMachine`.