### PR TITLE
Improvements to `more`.

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -297,10 +297,7 @@ impl<'a> Pager<'a> {
     }
 
     fn page_down(&mut self) {
-        self.upper_mark = self
-            .upper_mark
-            .saturating_add(self.content_rows.into())
-            .min(self.line_count.saturating_sub(self.content_rows.into()));
+        self.upper_mark = self.upper_mark.saturating_add(self.content_rows.into());
     }
 
     fn page_up(&mut self) {

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -251,6 +251,10 @@ fn more(buff: &str, mut stdout: &mut Stdout, next_file: Option<&str>, silent: bo
                 }) => {
                     pager.page_up();
                 }
+                Event::Resize(col, row) => {
+                    pager.page_resize(col, row);
+                }
+                // FIXME: Need to fix, there are more than just unknown keys.
                 _ => {
                     wrong_key = true;
                 }
@@ -300,6 +304,11 @@ impl<'a> Pager<'a> {
 
     fn page_up(&mut self) {
         self.upper_mark = self.upper_mark.saturating_sub(self.content_rows.into());
+    }
+
+    // TODO: Deal with column size changes.
+    fn page_resize(&mut self, _: u16, row: u16) {
+        self.content_rows = row.saturating_sub(1);
     }
 
     fn draw(&self, stdout: &mut std::io::Stdout, wrong_key: bool) {

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -293,7 +293,7 @@ impl<'a> Pager<'a> {
     fn should_close(&mut self) -> bool {
         self.upper_mark
             .saturating_add(self.content_rows.into())
-            .eq(&self.line_count)
+            .ge(&self.line_count)
     }
 
     fn page_down(&mut self) {


### PR DESCRIPTION
1. Fixed display when terminal resizing.
2. Now displays the unknown command entered. This also actually fixes the match. It previously matched on _everything_ even terminal resizing.
3. Some minor improvement where we initialize vector with _at least_ the minimum required size (which is the common case).
4. Fixed the choice of integer type here. Casting `u16` to `usize` is always safe. But the other way round is not. Prefer `u16` whenever possible to express the limit of terminals. AFAIK, we are always casting up in this commit.
5. Prefer using `saturating_` functions instead just `+` operator to avoid underflow and overflow.
6. When scrolling down, the scrolling should first stop at the end of the file. Scroll down again to exit the file or visit the next file.

Thanks!

Pinging @tertsdiepraam 