### PR TITLE
touch: change the error message to match the GNU error message #2346

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -166,7 +166,15 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             }
 
             if let Err(e) = File::create(path) {
-                show_warning!("cannot touch '{}': {}", path, e);
+                match e.kind() {
+                    std::io::ErrorKind::NotFound => {
+                        show_error!("cannot touch '{}': {}", path, "No such file or directory")
+                    }
+                    std::io::ErrorKind::PermissionDenied => {
+                        show_error!("cannot touch '{}': {}", path, "Permission denied")
+                    }
+                    _ => show_error!("cannot touch '{}': {}", path, e),
+                }
                 error_code = 1;
                 continue;
             };


### PR DESCRIPTION
I'm in the process of adding a test as well but I'm having problems running it. I've asked for help in the discord channel so as soon as I make it work, I'll also commit it.