### PR TITLE
Add touch as a common core utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ feat_common_core = [
     "true",
     "truncate",
     "tsort",
+    "touch",
     "unexpand",
     "uniq",
     "wc",


### PR DESCRIPTION
Found out that touch wasn't compiled in what I assume in ordinary Ubuntu
Linux setup.

```
                          ./+o+-       hbina@komputa
                  yyyyy- -yyyyyy+      OS: Ubuntu 20.04 focal
               ://+//////-yyyyyyo      Kernel: x86_64 Linux 5.12.9-051209-generic
           .++ .:/++++++/-.+sss/`      Uptime: 1h 5m
         .:++o:  /++++++++/:--:/-      Packages: 2241
        o:+o+:++.`..```.-/oo+++++/     Shell: bash 5.0.17
       .:+o:+o/.          `+sssoo+/    Resolution: 1920x1080
  .++/+:+oo+o:`             /sssooo.   DE: GNOME 3.36.5
 /+++//+:`oo+o               /::--:.   WM: Mutter
 \+/+o+++`o++o               ++////.   WM Theme: Adwaita
  .++.o+++oo+:`             /dddhhh.   GTK Theme: Yaru [GTK2/3]
       .+.o+oo:.          `oddhhhh+    Icon Theme: ubuntu-mono-dark
        \+.++o+o``-````.:ohdhhhhh+     Font: Cantarell 11
         `:o+++ `ohhhhhhhhyo++os:      Disk: 142G / 475G (32%)
           .o:`.syhhhhhhh/.oo++o`      CPU: AMD Ryzen 7 4800U with Radeon Graphics @ 16x 1.8GHz
               /osyyyyyyo++ooo+++/     GPU: AMD/ATI
                   ````` +oo+++o\:     RAM: 9370MiB / 31584MiB
                          `oo++.

```

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>