### PR TITLE
uutils: implement shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ version = "0.0.6"
 dependencies = [
  "atty",
  "chrono",
+ "clap",
  "conv",
  "filetime",
  "glob 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
 name = "uu_expr"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "libc",
  "num-bigint",
  "num-traits",
@@ -1986,6 +1987,7 @@ dependencies = [
 name = "uu_false"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "uucore",
  "uucore_procs",
 ]
@@ -2051,6 +2053,7 @@ dependencies = [
 name = "uu_hostid"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "libc",
  "uucore",
  "uucore_procs",
@@ -2327,6 +2330,7 @@ name = "uu_pr"
 version = "0.0.6"
 dependencies = [
  "chrono",
+ "clap",
  "getopts",
  "itertools 0.10.0",
  "quick-error 2.0.1",
@@ -2349,6 +2353,7 @@ dependencies = [
 name = "uu_printf"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "itertools 0.8.2",
  "uucore",
  "uucore_procs",
@@ -2585,6 +2590,7 @@ dependencies = [
 name = "uu_test"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "libc",
  "redox_syscall 0.1.57",
  "uucore",
@@ -2628,6 +2634,7 @@ dependencies = [
 name = "uu_true"
 version = "0.0.6"
 dependencies = [
+ "clap",
  "uucore",
  "uucore_procs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ test = [ "uu_test" ]
 [workspace]
 
 [dependencies]
+clap = "2.33.3"
 lazy_static = { version="1.3" }
 textwrap = { version="=0.11.0", features=["term_size"] } # !maint: [2020-05-10; rivy] unstable crate using undocumented features; pinned currently, will review
 uucore = { version=">=0.0.8", package="uucore", path="src/uucore" }

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -326,6 +326,9 @@ ifeq (${MULTICALL}, y)
 endif
 	rm -f $(addprefix $(INSTALLDIR_MAN)/,$(PROG_PREFIX)coreutils.1.gz)
 	rm -f $(addprefix $(INSTALLDIR_BIN)/$(PROG_PREFIX),$(PROGS))
+	rm -f $(addprefix $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_$(PROG_PREFIX),$(PROGS))
+	rm -f $(addprefix $(DESTDIR)$(PREFIX)/share/bash-completion/completions/$(PROG_PREFIX),$(PROGS))
+	rm -f $(addprefix $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/$(PROG_PREFIX),$(addsuffix .fish,$(PROGS)))
 	rm -f $(addprefix $(INSTALLDIR_MAN)/$(PROG_PREFIX),$(addsuffix .1.gz,$(PROGS)))
 
 .PHONY: all build build-coreutils build-pkgs build-docs test distclean clean busytest install uninstall

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -314,6 +314,11 @@ else
 endif
 	$(foreach man, $(filter $(INSTALLEES), $(basename $(notdir $(wildcard $(DOCSDIR)/_build/man/*)))), \
 		cat $(DOCSDIR)/_build/man/$(man).1 | gzip > $(INSTALLDIR_MAN)/$(PROG_PREFIX)$(man).1.gz &&) :
+	$(foreach prog, $(INSTALLEES), \
+		$(BUILDDIR)/coreutils completion $(prog) zsh > $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_$(PROG_PREFIX)$(prog); \
+		$(BUILDDIR)/coreutils completion $(prog) bash > $(DESTDIR)$(PREFIX)/share/bash-completion/completions/$(PROG_PREFIX)$(prog); \
+		$(BUILDDIR)/coreutils completion $(prog) fish > $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/$(PROG_PREFIX)$(prog).fish; \
+	)
 
 uninstall:
 ifeq (${MULTICALL}, y)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ $ cargo install --path .
 
 This command will install uutils into Cargo's *bin* folder (*e.g.* `$HOME/.cargo/bin`).
 
+This does not install files necessary for shell completion. For shell completion to work,
+use `GNU Make` or see `Manually install shell completions`.
+
 ### GNU Make
 
 To install all available utilities:
@@ -179,6 +182,10 @@ Set install parent directory (default value is /usr/local):
 $ make PREFIX=/my/path install
 ```
 
+Installing with `make` installs shell completions for all installed utilities
+for `bash`, `fish` and `zsh`. Completions for `elvish` and `powershell` can also
+be generated; See `Manually install shell completions`.
+
 ### NixOS
 
 The [standard package set](https://nixos.org/nixpkgs/manual/) of [NixOS](https://nixos.org/)
@@ -186,6 +193,23 @@ provides this package out of the box since 18.03:
 
 ```shell
 $ nix-env -iA nixos.uutils-coreutils
+```
+
+### Manually install shell completions
+
+The `coreutils` binary can generate completions for the `bash`, `elvish`, `fish`, `powershell`
+and `zsh` shells. It prints the result to stdout.
+
+The syntax is:
+```bash
+cargo run completion <utility> <shell>
+```
+
+So, to install completions for `ls` on `bash` to `/usr/local/share/bash-completion/completions/ls`,
+run:
+
+```bash
+cargo run completion ls bash > /usr/local/share/bash-completion/completions/ls
 ```
 
 ## Un-installation Instructions

--- a/build.rs
+++ b/build.rs
@@ -43,7 +43,7 @@ pub fn main() {
     let mut tf = File::create(Path::new(&out_dir).join("test_modules.rs")).unwrap();
 
     mf.write_all(
-        "type UtilityMap<T> = HashMap<&'static str, fn(T) -> i32>;\n\
+        "type UtilityMap<T> = HashMap<&'static str, (fn(T) -> i32, fn() -> App<'static, 'static>)>;\n\
          \n\
          fn util_map<T: uucore::Args>() -> UtilityMap<T> {\n\
          \tlet mut map = UtilityMap::new();\n\
@@ -60,8 +60,8 @@ pub fn main() {
                 mf.write_all(
                     format!(
                         "\
-                         \tmap.insert(\"test\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"[\", {krate}::uumain);\n\
+                         \tmap.insert(\"test\", ({krate}::uumain, {krate}::uu_app));\n\
+                         \t\tmap.insert(\"[\", ({krate}::uumain, {krate}::uu_app));\n\
                          ",
                         krate = krate
                     )
@@ -80,7 +80,7 @@ pub fn main() {
             k if k.starts_with(override_prefix) => {
                 mf.write_all(
                     format!(
-                        "\tmap.insert(\"{k}\", {krate}::uumain);\n",
+                        "\tmap.insert(\"{k}\", ({krate}::uumain, {krate}::uu_app));\n",
                         k = krate[override_prefix.len()..].to_string(),
                         krate = krate
                     )
@@ -100,7 +100,7 @@ pub fn main() {
             "false" | "true" => {
                 mf.write_all(
                     format!(
-                        "\tmap.insert(\"{krate}\", r#{krate}::uumain);\n",
+                        "\tmap.insert(\"{krate}\", (r#{krate}::uumain, r#{krate}::uu_app));\n",
                         krate = krate
                     )
                     .as_bytes(),
@@ -120,20 +120,20 @@ pub fn main() {
                 mf.write_all(
                     format!(
                         "\
-                         \tmap.insert(\"{krate}\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"md5sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha1sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha224sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha256sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha384sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha512sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha3sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha3-224sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha3-256sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha3-384sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"sha3-512sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"shake128sum\", {krate}::uumain);\n\
-                         \t\tmap.insert(\"shake256sum\", {krate}::uumain);\n\
+                         \tmap.insert(\"{krate}\", ({krate}::uumain, {krate}::uu_app_custom));\n\
+                         \t\tmap.insert(\"md5sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha1sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha224sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha256sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha384sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha512sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha3sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha3-224sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha3-256sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha3-384sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"sha3-512sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"shake128sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
+                         \t\tmap.insert(\"shake256sum\", ({krate}::uumain, {krate}::uu_app_common));\n\
                          ",
                         krate = krate
                     )
@@ -153,7 +153,7 @@ pub fn main() {
             _ => {
                 mf.write_all(
                     format!(
-                        "\tmap.insert(\"{krate}\", {krate}::uumain);\n",
+                        "\tmap.insert(\"{krate}\", ({krate}::uumain, {krate}::uu_app));\n",
                         krate = krate
                     )
                     .as_bytes(),

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -17,13 +17,16 @@ static ABOUT: &str = "Display machine architecture";
 static SUMMARY: &str = "Determine architecture name for current machine.";
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .after_help(SUMMARY)
-        .get_matches_from(args);
+    uu_app().get_matches_from(args);
 
     let uts = return_if_err!(1, PlatformInfo::new());
     println!("{}", uts.machine().trim());
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .after_help(SUMMARY)
 }

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -10,6 +10,7 @@ extern crate uucore;
 
 use std::io::{stdin, Read};
 
+use clap::App;
 use uucore::encoding::Format;
 
 pub mod base_common;
@@ -55,4 +56,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     );
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    base_common::base_app(executable!(), VERSION, ABOUT)
 }

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -78,10 +78,17 @@ pub fn parse_base_cmd_args(
     about: &str,
     usage: &str,
 ) -> Result<Config, String> {
-    let app = App::new(name)
+    let app = base_app(name, version, about).usage(usage);
+    let arg_list = args
+        .collect_str(InvalidEncodingHandling::ConvertLossy)
+        .accept_any();
+    Config::from(app.get_matches_from(arg_list))
+}
+
+pub fn base_app<'a>(name: &str, version: &'a str, about: &'a str) -> App<'static, 'a> {
+    App::new(name)
         .version(version)
         .about(about)
-        .usage(usage)
         // Format arguments.
         .arg(
             Arg::with_name(options::DECODE)
@@ -106,11 +113,7 @@ pub fn parse_base_cmd_args(
         )
         // "multiple" arguments are used to check whether there is more than one
         // file passed in.
-        .arg(Arg::with_name(options::FILE).index(1).multiple(true));
-    let arg_list = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
-    Config::from(app.get_matches_from(arg_list))
+        .arg(Arg::with_name(options::FILE).index(1).multiple(true))
 }
 
 pub fn get_input<'a>(config: &Config, stdin_ref: &'a Stdin) -> Box<dyn Read + 'a> {

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -10,6 +10,7 @@
 extern crate uucore;
 
 use uu_base32::base_common;
+pub use uu_base32::uu_app;
 
 use uucore::encoding::Format;
 

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -40,31 +40,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     //
     // Argument parsing
     //
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(SUMMARY)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::MULTIPLE)
-                .short("a")
-                .long(options::MULTIPLE)
-                .help("support multiple arguments and treat each as a NAME"),
-        )
-        .arg(Arg::with_name(options::NAME).multiple(true).hidden(true))
-        .arg(
-            Arg::with_name(options::SUFFIX)
-                .short("s")
-                .long(options::SUFFIX)
-                .value_name("SUFFIX")
-                .help("remove a trailing SUFFIX; implies -a"),
-        )
-        .arg(
-            Arg::with_name(options::ZERO)
-                .short("z")
-                .long(options::ZERO)
-                .help("end each output line with NUL, not newline"),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     // too few arguments
     if !matches.is_present(options::NAME) {
@@ -114,6 +90,32 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(SUMMARY)
+        .arg(
+            Arg::with_name(options::MULTIPLE)
+                .short("a")
+                .long(options::MULTIPLE)
+                .help("support multiple arguments and treat each as a NAME"),
+        )
+        .arg(Arg::with_name(options::NAME).multiple(true).hidden(true))
+        .arg(
+            Arg::with_name(options::SUFFIX)
+                .short("s")
+                .long(options::SUFFIX)
+                .value_name("SUFFIX")
+                .help("remove a trailing SUFFIX; implies -a"),
+        )
+        .arg(
+            Arg::with_name(options::ZERO)
+                .short("z")
+                .long(options::ZERO)
+                .help("end each output line with NUL, not newline"),
+        )
 }
 
 fn basename(fullname: &str, suffix: &str) -> String {

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -169,7 +169,65 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().get_matches_from(args);
+
+    let number_mode = if matches.is_present(options::NUMBER_NONBLANK) {
+        NumberingMode::NonEmpty
+    } else if matches.is_present(options::NUMBER) {
+        NumberingMode::All
+    } else {
+        NumberingMode::None
+    };
+
+    let show_nonprint = vec![
+        options::SHOW_ALL.to_owned(),
+        options::SHOW_NONPRINTING_ENDS.to_owned(),
+        options::SHOW_NONPRINTING_TABS.to_owned(),
+        options::SHOW_NONPRINTING.to_owned(),
+    ]
+    .iter()
+    .any(|v| matches.is_present(v));
+
+    let show_ends = vec![
+        options::SHOW_ENDS.to_owned(),
+        options::SHOW_ALL.to_owned(),
+        options::SHOW_NONPRINTING_ENDS.to_owned(),
+    ]
+    .iter()
+    .any(|v| matches.is_present(v));
+
+    let show_tabs = vec![
+        options::SHOW_ALL.to_owned(),
+        options::SHOW_TABS.to_owned(),
+        options::SHOW_NONPRINTING_TABS.to_owned(),
+    ]
+    .iter()
+    .any(|v| matches.is_present(v));
+
+    let squeeze_blank = matches.is_present(options::SQUEEZE_BLANK);
+    let files: Vec<String> = match matches.values_of(options::FILE) {
+        Some(v) => v.clone().map(|v| v.to_owned()).collect(),
+        None => vec!["-".to_owned()],
+    };
+
+    let options = OutputOptions {
+        show_ends,
+        number: number_mode,
+        show_nonprint,
+        show_tabs,
+        squeeze_blank,
+    };
+    let success = cat_files(files, &options).is_ok();
+
+    if success {
+        0
+    } else {
+        1
+    }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)
@@ -229,61 +287,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .long(options::SHOW_NONPRINTING)
                 .help("use ^ and M- notation, except for LF (\\n) and TAB (\\t)"),
         )
-        .get_matches_from(args);
-
-    let number_mode = if matches.is_present(options::NUMBER_NONBLANK) {
-        NumberingMode::NonEmpty
-    } else if matches.is_present(options::NUMBER) {
-        NumberingMode::All
-    } else {
-        NumberingMode::None
-    };
-
-    let show_nonprint = vec![
-        options::SHOW_ALL.to_owned(),
-        options::SHOW_NONPRINTING_ENDS.to_owned(),
-        options::SHOW_NONPRINTING_TABS.to_owned(),
-        options::SHOW_NONPRINTING.to_owned(),
-    ]
-    .iter()
-    .any(|v| matches.is_present(v));
-
-    let show_ends = vec![
-        options::SHOW_ENDS.to_owned(),
-        options::SHOW_ALL.to_owned(),
-        options::SHOW_NONPRINTING_ENDS.to_owned(),
-    ]
-    .iter()
-    .any(|v| matches.is_present(v));
-
-    let show_tabs = vec![
-        options::SHOW_ALL.to_owned(),
-        options::SHOW_TABS.to_owned(),
-        options::SHOW_NONPRINTING_TABS.to_owned(),
-    ]
-    .iter()
-    .any(|v| matches.is_present(v));
-
-    let squeeze_blank = matches.is_present(options::SQUEEZE_BLANK);
-    let files: Vec<String> = match matches.values_of(options::FILE) {
-        Some(v) => v.clone().map(|v| v.to_owned()).collect(),
-        None => vec!["-".to_owned()],
-    };
-
-    let options = OutputOptions {
-        show_ends,
-        number: number_mode,
-        show_nonprint,
-        show_tabs,
-        squeeze_blank,
-    };
-    let success = cat_files(files, &options).is_ok();
-
-    if success {
-        0
-    } else {
-        1
-    }
 }
 
 fn cat_handle<R: Read>(

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -73,84 +73,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let mut app = App::new(executable!())
-        .version(VERSION)
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::verbosity::CHANGES)
-                .short("c")
-                .long(options::verbosity::CHANGES)
-                .help("like verbose but report only when a change is made"),
-        )
-        .arg(
-            Arg::with_name(options::verbosity::SILENT)
-                .short("f")
-                .long(options::verbosity::SILENT),
-        )
-        .arg(
-            Arg::with_name(options::verbosity::QUIET)
-                .long(options::verbosity::QUIET)
-                .help("suppress most error messages"),
-        )
-        .arg(
-            Arg::with_name(options::verbosity::VERBOSE)
-                .short("v")
-                .long(options::verbosity::VERBOSE)
-                .help("output a diagnostic for every file processed"),
-        )
-        .arg(
-            Arg::with_name(options::dereference::DEREFERENCE)
-                .long(options::dereference::DEREFERENCE),
-        )
-        .arg(
-           Arg::with_name(options::dereference::NO_DEREFERENCE)
-               .short("h")
-               .long(options::dereference::NO_DEREFERENCE)
-               .help(
-                   "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)",
-               ),
-        )
-        .arg(
-            Arg::with_name(options::preserve_root::PRESERVE)
-                .long(options::preserve_root::PRESERVE)
-                .help("fail to operate recursively on '/'"),
-        )
-        .arg(
-            Arg::with_name(options::preserve_root::NO_PRESERVE)
-                .long(options::preserve_root::NO_PRESERVE)
-                .help("do not treat '/' specially (the default)"),
-        )
-        .arg(
-            Arg::with_name(options::REFERENCE)
-                .long(options::REFERENCE)
-                .value_name("RFILE")
-                .help("use RFILE's group rather than specifying GROUP values")
-                .takes_value(true)
-                .multiple(false),
-        )
-        .arg(
-            Arg::with_name(options::RECURSIVE)
-                .short("R")
-                .long(options::RECURSIVE)
-                .help("operate on files and directories recursively"),
-        )
-        .arg(
-            Arg::with_name(options::traverse::TRAVERSE)
-                .short(options::traverse::TRAVERSE)
-                .help("if a command line argument is a symbolic link to a directory, traverse it"),
-        )
-        .arg(
-            Arg::with_name(options::traverse::NO_TRAVERSE)
-                .short(options::traverse::NO_TRAVERSE)
-                .help("do not traverse any symbolic links (default)")
-                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::EVERY]),
-        )
-        .arg(
-            Arg::with_name(options::traverse::EVERY)
-                .short(options::traverse::EVERY)
-                .help("traverse every symbolic link to a directory encountered"),
-        );
+    let mut app = uu_app().usage(&usage[..]);
 
     // we change the positional args based on whether
     // --reference was used.
@@ -272,6 +195,86 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         files,
     };
     executor.exec()
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(VERSION)
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::verbosity::CHANGES)
+                .short("c")
+                .long(options::verbosity::CHANGES)
+                .help("like verbose but report only when a change is made"),
+        )
+        .arg(
+            Arg::with_name(options::verbosity::SILENT)
+                .short("f")
+                .long(options::verbosity::SILENT),
+        )
+        .arg(
+            Arg::with_name(options::verbosity::QUIET)
+                .long(options::verbosity::QUIET)
+                .help("suppress most error messages"),
+        )
+        .arg(
+            Arg::with_name(options::verbosity::VERBOSE)
+                .short("v")
+                .long(options::verbosity::VERBOSE)
+                .help("output a diagnostic for every file processed"),
+        )
+        .arg(
+            Arg::with_name(options::dereference::DEREFERENCE)
+                .long(options::dereference::DEREFERENCE),
+        )
+        .arg(
+           Arg::with_name(options::dereference::NO_DEREFERENCE)
+               .short("h")
+               .long(options::dereference::NO_DEREFERENCE)
+               .help(
+                   "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)",
+               ),
+        )
+        .arg(
+            Arg::with_name(options::preserve_root::PRESERVE)
+                .long(options::preserve_root::PRESERVE)
+                .help("fail to operate recursively on '/'"),
+        )
+        .arg(
+            Arg::with_name(options::preserve_root::NO_PRESERVE)
+                .long(options::preserve_root::NO_PRESERVE)
+                .help("do not treat '/' specially (the default)"),
+        )
+        .arg(
+            Arg::with_name(options::REFERENCE)
+                .long(options::REFERENCE)
+                .value_name("RFILE")
+                .help("use RFILE's group rather than specifying GROUP values")
+                .takes_value(true)
+                .multiple(false),
+        )
+        .arg(
+            Arg::with_name(options::RECURSIVE)
+                .short("R")
+                .long(options::RECURSIVE)
+                .help("operate on files and directories recursively"),
+        )
+        .arg(
+            Arg::with_name(options::traverse::TRAVERSE)
+                .short(options::traverse::TRAVERSE)
+                .help("if a command line argument is a symbolic link to a directory, traverse it"),
+        )
+        .arg(
+            Arg::with_name(options::traverse::NO_TRAVERSE)
+                .short(options::traverse::NO_TRAVERSE)
+                .help("do not traverse any symbolic links (default)")
+                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::EVERY]),
+        )
+        .arg(
+            Arg::with_name(options::traverse::EVERY)
+                .short(options::traverse::EVERY)
+                .help("traverse every symbolic link to a directory encountered"),
+        )
 }
 
 struct Chgrper {

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -73,101 +73,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::verbosity::CHANGES)
-                .short("c")
-                .long(options::verbosity::CHANGES)
-                .help("like verbose but report only when a change is made"),
-        )
-        .arg(Arg::with_name(options::dereference::DEREFERENCE).long(options::dereference::DEREFERENCE).help(
-            "affect the referent of each symbolic link (this is the default), rather than the symbolic link itself",
-        ))
-        .arg(
-            Arg::with_name(options::dereference::NO_DEREFERENCE)
-                .short("h")
-                .long(options::dereference::NO_DEREFERENCE)
-                .help(
-                    "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::FROM)
-                .long(options::FROM)
-                .help(
-                    "change the owner and/or group of each file only if its current owner and/or group match those specified here. Either may be omitted, in which case a match is not required for the omitted attribute",
-                )
-                .value_name("CURRENT_OWNER:CURRENT_GROUP"),
-        )
-        .arg(
-            Arg::with_name(options::preserve_root::PRESERVE)
-                .long(options::preserve_root::PRESERVE)
-                .help("fail to operate recursively on '/'"),
-        )
-        .arg(
-            Arg::with_name(options::preserve_root::NO_PRESERVE)
-                .long(options::preserve_root::NO_PRESERVE)
-                .help("do not treat '/' specially (the default)"),
-        )
-        .arg(
-            Arg::with_name(options::verbosity::QUIET)
-                .long(options::verbosity::QUIET)
-                .help("suppress most error messages"),
-        )
-        .arg(
-            Arg::with_name(options::RECURSIVE)
-                .short("R")
-                .long(options::RECURSIVE)
-                .help("operate on files and directories recursively"),
-        )
-        .arg(
-            Arg::with_name(options::REFERENCE)
-                .long(options::REFERENCE)
-                .help("use RFILE's owner and group rather than specifying OWNER:GROUP values")
-                .value_name("RFILE")
-                .min_values(1),
-        )
-        .arg(Arg::with_name(options::verbosity::SILENT).short("f").long(options::verbosity::SILENT))
-        .arg(
-            Arg::with_name(options::traverse::TRAVERSE)
-                .short(options::traverse::TRAVERSE)
-                .help("if a command line argument is a symbolic link to a directory, traverse it")
-                .overrides_with_all(&[options::traverse::EVERY, options::traverse::NO_TRAVERSE]),
-        )
-        .arg(
-            Arg::with_name(options::traverse::EVERY)
-                .short(options::traverse::EVERY)
-                .help("traverse every symbolic link to a directory encountered")
-                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::NO_TRAVERSE]),
-        )
-        .arg(
-            Arg::with_name(options::traverse::NO_TRAVERSE)
-                .short(options::traverse::NO_TRAVERSE)
-                .help("do not traverse any symbolic links (default)")
-                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::EVERY]),
-        )
-        .arg(
-            Arg::with_name(options::verbosity::VERBOSE)
-                .long(options::verbosity::VERBOSE)
-                .help("output a diagnostic for every file processed"),
-        )
-        .arg(
-            Arg::with_name(ARG_OWNER)
-                .multiple(false)
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name(ARG_FILES)
-                .multiple(true)
-                .takes_value(true)
-                .required(true)
-                .min_values(1),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     /* First arg is the owner/group */
     let owner = matches.value_of(ARG_OWNER).unwrap();
@@ -271,6 +177,102 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         files,
     };
     executor.exec()
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::verbosity::CHANGES)
+                .short("c")
+                .long(options::verbosity::CHANGES)
+                .help("like verbose but report only when a change is made"),
+        )
+        .arg(Arg::with_name(options::dereference::DEREFERENCE).long(options::dereference::DEREFERENCE).help(
+            "affect the referent of each symbolic link (this is the default), rather than the symbolic link itself",
+        ))
+        .arg(
+            Arg::with_name(options::dereference::NO_DEREFERENCE)
+                .short("h")
+                .long(options::dereference::NO_DEREFERENCE)
+                .help(
+                    "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::FROM)
+                .long(options::FROM)
+                .help(
+                    "change the owner and/or group of each file only if its current owner and/or group match those specified here. Either may be omitted, in which case a match is not required for the omitted attribute",
+                )
+                .value_name("CURRENT_OWNER:CURRENT_GROUP"),
+        )
+        .arg(
+            Arg::with_name(options::preserve_root::PRESERVE)
+                .long(options::preserve_root::PRESERVE)
+                .help("fail to operate recursively on '/'"),
+        )
+        .arg(
+            Arg::with_name(options::preserve_root::NO_PRESERVE)
+                .long(options::preserve_root::NO_PRESERVE)
+                .help("do not treat '/' specially (the default)"),
+        )
+        .arg(
+            Arg::with_name(options::verbosity::QUIET)
+                .long(options::verbosity::QUIET)
+                .help("suppress most error messages"),
+        )
+        .arg(
+            Arg::with_name(options::RECURSIVE)
+                .short("R")
+                .long(options::RECURSIVE)
+                .help("operate on files and directories recursively"),
+        )
+        .arg(
+            Arg::with_name(options::REFERENCE)
+                .long(options::REFERENCE)
+                .help("use RFILE's owner and group rather than specifying OWNER:GROUP values")
+                .value_name("RFILE")
+                .min_values(1),
+        )
+        .arg(Arg::with_name(options::verbosity::SILENT).short("f").long(options::verbosity::SILENT))
+        .arg(
+            Arg::with_name(options::traverse::TRAVERSE)
+                .short(options::traverse::TRAVERSE)
+                .help("if a command line argument is a symbolic link to a directory, traverse it")
+                .overrides_with_all(&[options::traverse::EVERY, options::traverse::NO_TRAVERSE]),
+        )
+        .arg(
+            Arg::with_name(options::traverse::EVERY)
+                .short(options::traverse::EVERY)
+                .help("traverse every symbolic link to a directory encountered")
+                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::NO_TRAVERSE]),
+        )
+        .arg(
+            Arg::with_name(options::traverse::NO_TRAVERSE)
+                .short(options::traverse::NO_TRAVERSE)
+                .help("do not traverse any symbolic links (default)")
+                .overrides_with_all(&[options::traverse::TRAVERSE, options::traverse::EVERY]),
+        )
+        .arg(
+            Arg::with_name(options::verbosity::VERBOSE)
+                .long(options::verbosity::VERBOSE)
+                .help("output a diagnostic for every file processed"),
+        )
+        .arg(
+            Arg::with_name(ARG_OWNER)
+                .multiple(false)
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name(ARG_FILES)
+                .multiple(true)
+                .takes_value(true)
+                .required(true)
+                .min_values(1),
+        )
 }
 
 fn parse_spec(spec: &str) -> Result<(Option<u32>, Option<u32>), String> {

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -36,54 +36,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(SYNTAX)
-        .arg(
-            Arg::with_name(options::NEWROOT)
-                .hidden(true)
-                .required(true)
-                .index(1),
-        )
-        .arg(
-            Arg::with_name(options::USER)
-                .short("u")
-                .long(options::USER)
-                .help("User (ID or name) to switch before running the program")
-                .value_name("USER"),
-        )
-        .arg(
-            Arg::with_name(options::GROUP)
-                .short("g")
-                .long(options::GROUP)
-                .help("Group (ID or name) to switch to")
-                .value_name("GROUP"),
-        )
-        .arg(
-            Arg::with_name(options::GROUPS)
-                .short("G")
-                .long(options::GROUPS)
-                .help("Comma-separated list of groups to switch to")
-                .value_name("GROUP1,GROUP2..."),
-        )
-        .arg(
-            Arg::with_name(options::USERSPEC)
-                .long(options::USERSPEC)
-                .help(
-                    "Colon-separated user and group to switch to. \
-                     Same as -u USER -g GROUP. \
-                     Userspec has higher preference than -u and/or -g",
-                )
-                .value_name("USER:GROUP"),
-        )
-        .arg(
-            Arg::with_name(options::COMMAND)
-                .hidden(true)
-                .multiple(true)
-                .index(2),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let default_shell: &'static str = "/bin/sh";
     let default_option: &'static str = "-i";
@@ -136,6 +89,56 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     } else {
         pstatus.code().unwrap_or(-1)
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .usage(SYNTAX)
+        .arg(
+            Arg::with_name(options::NEWROOT)
+                .hidden(true)
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name(options::USER)
+                .short("u")
+                .long(options::USER)
+                .help("User (ID or name) to switch before running the program")
+                .value_name("USER"),
+        )
+        .arg(
+            Arg::with_name(options::GROUP)
+                .short("g")
+                .long(options::GROUP)
+                .help("Group (ID or name) to switch to")
+                .value_name("GROUP"),
+        )
+        .arg(
+            Arg::with_name(options::GROUPS)
+                .short("G")
+                .long(options::GROUPS)
+                .help("Comma-separated list of groups to switch to")
+                .value_name("GROUP1,GROUP2..."),
+        )
+        .arg(
+            Arg::with_name(options::USERSPEC)
+                .long(options::USERSPEC)
+                .help(
+                    "Colon-separated user and group to switch to. \
+                     Same as -u USER -g GROUP. \
+                     Userspec has higher preference than -u and/or -g",
+                )
+                .value_name("USER:GROUP"),
+        )
+        .arg(
+            Arg::with_name(options::COMMAND)
+                .hidden(true)
+                .multiple(true)
+                .index(2),
+        )
 }
 
 fn set_context(root: &Path, options: &clap::ArgMatches) {

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -180,13 +180,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .name(NAME)
-        .version(crate_version!())
-        .about(SUMMARY)
-        .usage(SYNTAX)
-        .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let files: Vec<String> = match matches.values_of(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
@@ -216,4 +210,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     exit_code
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .name(NAME)
+        .version(crate_version!())
+        .about(SUMMARY)
+        .usage(SYNTAX)
+        .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
 }

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -137,10 +137,20 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
+
+    let mut f1 = open_file(matches.value_of(options::FILE_1).unwrap()).unwrap();
+    let mut f2 = open_file(matches.value_of(options::FILE_2).unwrap()).unwrap();
+
+    comm(&mut f1, &mut f2, &matches);
+
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
-        .usage(&usage[..])
         .after_help(LONG_HELP)
         .arg(
             Arg::with_name(options::COLUMN_1)
@@ -167,12 +177,4 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         )
         .arg(Arg::with_name(options::FILE_1).required(true))
         .arg(Arg::with_name(options::FILE_2).required(true))
-        .get_matches_from(args);
-
-    let mut f1 = open_file(matches.value_of(options::FILE_1).unwrap()).unwrap();
-    let mut f2 = open_file(matches.value_of(options::FILE_2).unwrap()).unwrap();
-
-    comm(&mut f1, &mut f2, &matches);
-
-    0
 }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -375,7 +375,7 @@ pub fn uu_app() -> App<'static, 'static> {
         .arg(Arg::with_name(options::UPDATE)
              .short("u")
              .long(options::UPDATE)
-             .help("copy only when the SOURCE file is newer than the destination file\
+             .help("copy only when the SOURCE file is newer than the destination file \
                     or when the destination file is missing"))
         .arg(Arg::with_name(options::REFLINK)
              .long(options::REFLINK)
@@ -398,7 +398,7 @@ pub fn uu_app() -> App<'static, 'static> {
              .conflicts_with_all(&[options::PRESERVE_DEFAULT_ATTRIBUTES, options::NO_PRESERVE])
              // -d sets this option
              // --archive sets this option
-             .help("Preserve the specified attributes (default: mode(unix only),ownership,timestamps),\
+             .help("Preserve the specified attributes (default: mode (unix only), ownership, timestamps), \
                     if possible additional attributes: context, links, xattr, all"))
         .arg(Arg::with_name(options::PRESERVE_DEFAULT_ATTRIBUTES)
              .short("-p")

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -290,13 +290,10 @@ static DEFAULT_ATTRIBUTES: &[Attribute] = &[
     Attribute::Timestamps,
 ];
 
-pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
-    let matches = App::new(executable!())
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
-        .after_help(&*format!("{}\n{}", LONG_HELP, backup_control::BACKUP_CONTROL_LONG_HELP))
-        .usage(&usage[..])
         .arg(Arg::with_name(options::TARGET_DIRECTORY)
              .short("t")
              .conflicts_with(options::NO_TARGET_DIRECTORY)
@@ -464,6 +461,17 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
         .arg(Arg::with_name(options::PATHS)
              .multiple(true))
+}
+
+pub fn uumain(args: impl uucore::Args) -> i32 {
+    let usage = get_usage();
+    let matches = uu_app()
+        .after_help(&*format!(
+            "{}\n{}",
+            LONG_HELP,
+            backup_control::BACKUP_CONTROL_LONG_HELP
+        ))
+        .usage(&usage[..])
         .get_matches_from(args);
 
     let options = crash_if_err!(EXIT_ERR, Options::from_matches(&matches));

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -711,10 +711,37 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
+
+    // get the file to split
+    let file_name = matches.value_of(options::FILE).unwrap();
+
+    // get the patterns to split on
+    let patterns: Vec<String> = matches
+        .values_of(options::PATTERN)
+        .unwrap()
+        .map(str::to_string)
+        .collect();
+    let patterns = return_if_err!(1, patterns::get_patterns(&patterns[..]));
+    let options = CsplitOptions::new(&matches);
+    if file_name == "-" {
+        let stdin = io::stdin();
+        crash_if_err!(1, csplit(&options, patterns, stdin.lock()));
+    } else {
+        let file = return_if_err!(1, File::open(file_name));
+        let file_metadata = return_if_err!(1, file.metadata());
+        if !file_metadata.is_file() {
+            crash!(1, "'{}' is not a regular file", file_name);
+        }
+        crash_if_err!(1, csplit(&options, patterns, BufReader::new(file)));
+    };
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(SUMMARY)
-        .usage(&usage[..])
         .arg(
             Arg::with_name(options::SUFFIX_FORMAT)
                 .short("b")
@@ -768,29 +795,4 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .required(true),
         )
         .after_help(LONG_HELP)
-        .get_matches_from(args);
-
-    // get the file to split
-    let file_name = matches.value_of(options::FILE).unwrap();
-
-    // get the patterns to split on
-    let patterns: Vec<String> = matches
-        .values_of(options::PATTERN)
-        .unwrap()
-        .map(str::to_string)
-        .collect();
-    let patterns = return_if_err!(1, patterns::get_patterns(&patterns[..]));
-    let options = CsplitOptions::new(&matches);
-    if file_name == "-" {
-        let stdin = io::stdin();
-        crash_if_err!(1, csplit(&options, patterns, stdin.lock()));
-    } else {
-        let file = return_if_err!(1, File::open(file_name));
-        let file_metadata = return_if_err!(1, file.metadata());
-        if !file_metadata.is_file() {
-            crash!(1, "'{}' is not a regular file", file_name);
-        }
-        crash_if_err!(1, csplit(&options, patterns, BufReader::new(file)));
-    };
-    0
 }

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -396,88 +396,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .name(NAME)
-        .version(crate_version!())
-        .usage(SYNTAX)
-        .about(SUMMARY)
-        .after_help(LONG_HELP)
-        .arg(
-            Arg::with_name(options::BYTES)
-                .short("b")
-                .long(options::BYTES)
-                .takes_value(true)
-                .help("filter byte columns from the input source")
-                .allow_hyphen_values(true)
-                .value_name("LIST")
-                .display_order(1),
-        )
-        .arg(
-            Arg::with_name(options::CHARACTERS)
-                .short("c")
-                .long(options::CHARACTERS)
-                .help("alias for character mode")
-                .takes_value(true)
-                .allow_hyphen_values(true)
-                .value_name("LIST")
-                .display_order(2),
-        )
-        .arg(
-            Arg::with_name(options::DELIMITER)
-                .short("d")
-                .long(options::DELIMITER)
-                .help("specify the delimiter character that separates fields in the input source. Defaults to Tab.")
-                .takes_value(true)
-                .value_name("DELIM")
-                .display_order(3),
-        )
-        .arg(
-            Arg::with_name(options::FIELDS)
-                .short("f")
-                .long(options::FIELDS)
-                .help("filter field columns from the input source")
-                .takes_value(true)
-                .allow_hyphen_values(true)
-                .value_name("LIST")
-                .display_order(4),
-        )
-        .arg(
-            Arg::with_name(options::COMPLEMENT)
-                .long(options::COMPLEMENT)
-                .help("invert the filter - instead of displaying only the filtered columns, display all but those columns")
-                .takes_value(false)
-                .display_order(5),
-        )
-        .arg(
-            Arg::with_name(options::ONLY_DELIMITED)
-            .short("s")
-                .long(options::ONLY_DELIMITED)
-                .help("in field mode, only print lines which contain the delimiter")
-                .takes_value(false)
-                .display_order(6),
-        )
-        .arg(
-            Arg::with_name(options::ZERO_TERMINATED)
-            .short("z")
-                .long(options::ZERO_TERMINATED)
-                .help("instead of filtering columns based on line, filter columns based on \\0 (NULL character)")
-                .takes_value(false)
-                .display_order(8),
-        )
-        .arg(
-            Arg::with_name(options::OUTPUT_DELIMITER)
-            .long(options::OUTPUT_DELIMITER)
-                .help("in field mode, replace the delimiter in output lines with this option's argument")
-                .takes_value(true)
-                .value_name("NEW_DELIM")
-                .display_order(7),
-        )
-        .arg(
-            Arg::with_name(options::FILE)
-            .hidden(true)
-                .multiple(true)
-        )
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let complement = matches.is_present(options::COMPLEMENT);
 
@@ -626,4 +545,88 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             1
         }
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .name(NAME)
+        .version(crate_version!())
+        .usage(SYNTAX)
+        .about(SUMMARY)
+        .after_help(LONG_HELP)
+        .arg(
+            Arg::with_name(options::BYTES)
+                .short("b")
+                .long(options::BYTES)
+                .takes_value(true)
+                .help("filter byte columns from the input source")
+                .allow_hyphen_values(true)
+                .value_name("LIST")
+                .display_order(1),
+        )
+        .arg(
+            Arg::with_name(options::CHARACTERS)
+                .short("c")
+                .long(options::CHARACTERS)
+                .help("alias for character mode")
+                .takes_value(true)
+                .allow_hyphen_values(true)
+                .value_name("LIST")
+                .display_order(2),
+        )
+        .arg(
+            Arg::with_name(options::DELIMITER)
+                .short("d")
+                .long(options::DELIMITER)
+                .help("specify the delimiter character that separates fields in the input source. Defaults to Tab.")
+                .takes_value(true)
+                .value_name("DELIM")
+                .display_order(3),
+        )
+        .arg(
+            Arg::with_name(options::FIELDS)
+                .short("f")
+                .long(options::FIELDS)
+                .help("filter field columns from the input source")
+                .takes_value(true)
+                .allow_hyphen_values(true)
+                .value_name("LIST")
+                .display_order(4),
+        )
+        .arg(
+            Arg::with_name(options::COMPLEMENT)
+                .long(options::COMPLEMENT)
+                .help("invert the filter - instead of displaying only the filtered columns, display all but those columns")
+                .takes_value(false)
+                .display_order(5),
+        )
+        .arg(
+            Arg::with_name(options::ONLY_DELIMITED)
+            .short("s")
+                .long(options::ONLY_DELIMITED)
+                .help("in field mode, only print lines which contain the delimiter")
+                .takes_value(false)
+                .display_order(6),
+        )
+        .arg(
+            Arg::with_name(options::ZERO_TERMINATED)
+            .short("z")
+                .long(options::ZERO_TERMINATED)
+                .help("instead of filtering columns based on line, filter columns based on \\0 (NULL character)")
+                .takes_value(false)
+                .display_order(8),
+        )
+        .arg(
+            Arg::with_name(options::OUTPUT_DELIMITER)
+            .long(options::OUTPUT_DELIMITER)
+                .help("in field mode, replace the delimiter in output lines with this option's argument")
+                .takes_value(true)
+                .value_name("NEW_DELIM")
+                .display_order(7),
+        )
+        .arg(
+            Arg::with_name(options::FILE)
+            .hidden(true)
+                .multiple(true)
+        )
 }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -142,71 +142,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
  {0} [OPTION]... [MMDDhhmm[[CC]YY][.ss]]",
         NAME
     );
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&syntax[..])
-        .arg(
-            Arg::with_name(OPT_DATE)
-                .short("d")
-                .long(OPT_DATE)
-                .takes_value(true)
-                .help("display time described by STRING, not 'now'"),
-        )
-        .arg(
-            Arg::with_name(OPT_FILE)
-                .short("f")
-                .long(OPT_FILE)
-                .takes_value(true)
-                .help("like --date; once for each line of DATEFILE"),
-        )
-        .arg(
-            Arg::with_name(OPT_ISO_8601)
-                .short("I")
-                .long(OPT_ISO_8601)
-                .takes_value(true)
-                .help(ISO_8601_HELP_STRING),
-        )
-        .arg(
-            Arg::with_name(OPT_RFC_EMAIL)
-                .short("R")
-                .long(OPT_RFC_EMAIL)
-                .help(RFC_5322_HELP_STRING),
-        )
-        .arg(
-            Arg::with_name(OPT_RFC_3339)
-                .long(OPT_RFC_3339)
-                .takes_value(true)
-                .help(RFC_3339_HELP_STRING),
-        )
-        .arg(
-            Arg::with_name(OPT_DEBUG)
-                .long(OPT_DEBUG)
-                .help("annotate the parsed date, and warn about questionable usage to stderr"),
-        )
-        .arg(
-            Arg::with_name(OPT_REFERENCE)
-                .short("r")
-                .long(OPT_REFERENCE)
-                .takes_value(true)
-                .help("display the last modification time of FILE"),
-        )
-        .arg(
-            Arg::with_name(OPT_SET)
-                .short("s")
-                .long(OPT_SET)
-                .takes_value(true)
-                .help(OPT_SET_HELP_STRING),
-        )
-        .arg(
-            Arg::with_name(OPT_UNIVERSAL)
-                .short("u")
-                .long(OPT_UNIVERSAL)
-                .alias(OPT_UNIVERSAL_2)
-                .help("print or set Coordinated Universal Time (UTC)"),
-        )
-        .arg(Arg::with_name(OPT_FORMAT).multiple(false))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&syntax[..]).get_matches_from(args);
 
     let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
         if !form.starts_with('+') {
@@ -312,6 +248,72 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_DATE)
+                .short("d")
+                .long(OPT_DATE)
+                .takes_value(true)
+                .help("display time described by STRING, not 'now'"),
+        )
+        .arg(
+            Arg::with_name(OPT_FILE)
+                .short("f")
+                .long(OPT_FILE)
+                .takes_value(true)
+                .help("like --date; once for each line of DATEFILE"),
+        )
+        .arg(
+            Arg::with_name(OPT_ISO_8601)
+                .short("I")
+                .long(OPT_ISO_8601)
+                .takes_value(true)
+                .help(ISO_8601_HELP_STRING),
+        )
+        .arg(
+            Arg::with_name(OPT_RFC_EMAIL)
+                .short("R")
+                .long(OPT_RFC_EMAIL)
+                .help(RFC_5322_HELP_STRING),
+        )
+        .arg(
+            Arg::with_name(OPT_RFC_3339)
+                .long(OPT_RFC_3339)
+                .takes_value(true)
+                .help(RFC_3339_HELP_STRING),
+        )
+        .arg(
+            Arg::with_name(OPT_DEBUG)
+                .long(OPT_DEBUG)
+                .help("annotate the parsed date, and warn about questionable usage to stderr"),
+        )
+        .arg(
+            Arg::with_name(OPT_REFERENCE)
+                .short("r")
+                .long(OPT_REFERENCE)
+                .takes_value(true)
+                .help("display the last modification time of FILE"),
+        )
+        .arg(
+            Arg::with_name(OPT_SET)
+                .short("s")
+                .long(OPT_SET)
+                .takes_value(true)
+                .help(OPT_SET_HELP_STRING),
+        )
+        .arg(
+            Arg::with_name(OPT_UNIVERSAL)
+                .short("u")
+                .long(OPT_UNIVERSAL)
+                .alias(OPT_UNIVERSAL_2)
+                .help("print or set Coordinated Universal Time (UTC)"),
+        )
+        .arg(Arg::with_name(OPT_FORMAT).multiple(false))
 }
 
 /// Return the appropriate format string for the given settings.

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -258,120 +258,7 @@ fn use_size(free_size: u64, total_size: u64) -> String {
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_ALL)
-                .short("a")
-                .long("all")
-                .help("include dummy file systems"),
-        )
-        .arg(
-            Arg::with_name(OPT_BLOCKSIZE)
-                .short("B")
-                .long("block-size")
-                .takes_value(true)
-                .help(
-                    "scale sizes by SIZE before printing them; e.g.\
-                     '-BM' prints sizes in units of 1,048,576 bytes",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_DIRECT)
-                .long("direct")
-                .help("show statistics for a file instead of mount point"),
-        )
-        .arg(
-            Arg::with_name(OPT_TOTAL)
-                .long("total")
-                .help("produce a grand total"),
-        )
-        .arg(
-            Arg::with_name(OPT_HUMAN_READABLE)
-                .short("h")
-                .long("human-readable")
-                .conflicts_with(OPT_HUMAN_READABLE_2)
-                .help("print sizes in human readable format (e.g., 1K 234M 2G)"),
-        )
-        .arg(
-            Arg::with_name(OPT_HUMAN_READABLE_2)
-                .short("H")
-                .long("si")
-                .conflicts_with(OPT_HUMAN_READABLE)
-                .help("likewise, but use powers of 1000 not 1024"),
-        )
-        .arg(
-            Arg::with_name(OPT_INODES)
-                .short("i")
-                .long("inodes")
-                .help("list inode information instead of block usage"),
-        )
-        .arg(
-            Arg::with_name(OPT_KILO)
-                .short("k")
-                .help("like --block-size=1K"),
-        )
-        .arg(
-            Arg::with_name(OPT_LOCAL)
-                .short("l")
-                .long("local")
-                .help("limit listing to local file systems"),
-        )
-        .arg(
-            Arg::with_name(OPT_NO_SYNC)
-                .long("no-sync")
-                .conflicts_with(OPT_SYNC)
-                .help("do not invoke sync before getting usage info (default)"),
-        )
-        .arg(
-            Arg::with_name(OPT_OUTPUT)
-                .long("output")
-                .takes_value(true)
-                .use_delimiter(true)
-                .help(
-                    "use the output format defined by FIELD_LIST,\
-                     or print all fields if FIELD_LIST is omitted.",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_PORTABILITY)
-                .short("P")
-                .long("portability")
-                .help("use the POSIX output format"),
-        )
-        .arg(
-            Arg::with_name(OPT_SYNC)
-                .long("sync")
-                .conflicts_with(OPT_NO_SYNC)
-                .help("invoke sync before getting usage info"),
-        )
-        .arg(
-            Arg::with_name(OPT_TYPE)
-                .short("t")
-                .long("type")
-                .takes_value(true)
-                .use_delimiter(true)
-                .help("limit listing to file systems of type TYPE"),
-        )
-        .arg(
-            Arg::with_name(OPT_PRINT_TYPE)
-                .short("T")
-                .long("print-type")
-                .help("print file system type"),
-        )
-        .arg(
-            Arg::with_name(OPT_EXCLUDE_TYPE)
-                .short("x")
-                .long("exclude-type")
-                .takes_value(true)
-                .use_delimiter(true)
-                .help("limit listing to file systems not of type TYPE"),
-        )
-        .arg(Arg::with_name(OPT_PATHS).multiple(true))
-        .help("Filesystem(s) to list")
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let paths: Vec<String> = matches
         .values_of(OPT_PATHS)
@@ -510,4 +397,119 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     EXIT_OK
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_ALL)
+                .short("a")
+                .long("all")
+                .help("include dummy file systems"),
+        )
+        .arg(
+            Arg::with_name(OPT_BLOCKSIZE)
+                .short("B")
+                .long("block-size")
+                .takes_value(true)
+                .help(
+                    "scale sizes by SIZE before printing them; e.g.\
+                     '-BM' prints sizes in units of 1,048,576 bytes",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_DIRECT)
+                .long("direct")
+                .help("show statistics for a file instead of mount point"),
+        )
+        .arg(
+            Arg::with_name(OPT_TOTAL)
+                .long("total")
+                .help("produce a grand total"),
+        )
+        .arg(
+            Arg::with_name(OPT_HUMAN_READABLE)
+                .short("h")
+                .long("human-readable")
+                .conflicts_with(OPT_HUMAN_READABLE_2)
+                .help("print sizes in human readable format (e.g., 1K 234M 2G)"),
+        )
+        .arg(
+            Arg::with_name(OPT_HUMAN_READABLE_2)
+                .short("H")
+                .long("si")
+                .conflicts_with(OPT_HUMAN_READABLE)
+                .help("likewise, but use powers of 1000 not 1024"),
+        )
+        .arg(
+            Arg::with_name(OPT_INODES)
+                .short("i")
+                .long("inodes")
+                .help("list inode information instead of block usage"),
+        )
+        .arg(
+            Arg::with_name(OPT_KILO)
+                .short("k")
+                .help("like --block-size=1K"),
+        )
+        .arg(
+            Arg::with_name(OPT_LOCAL)
+                .short("l")
+                .long("local")
+                .help("limit listing to local file systems"),
+        )
+        .arg(
+            Arg::with_name(OPT_NO_SYNC)
+                .long("no-sync")
+                .conflicts_with(OPT_SYNC)
+                .help("do not invoke sync before getting usage info (default)"),
+        )
+        .arg(
+            Arg::with_name(OPT_OUTPUT)
+                .long("output")
+                .takes_value(true)
+                .use_delimiter(true)
+                .help(
+                    "use the output format defined by FIELD_LIST,\
+                     or print all fields if FIELD_LIST is omitted.",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_PORTABILITY)
+                .short("P")
+                .long("portability")
+                .help("use the POSIX output format"),
+        )
+        .arg(
+            Arg::with_name(OPT_SYNC)
+                .long("sync")
+                .conflicts_with(OPT_NO_SYNC)
+                .help("invoke sync before getting usage info"),
+        )
+        .arg(
+            Arg::with_name(OPT_TYPE)
+                .short("t")
+                .long("type")
+                .takes_value(true)
+                .use_delimiter(true)
+                .help("limit listing to file systems of type TYPE"),
+        )
+        .arg(
+            Arg::with_name(OPT_PRINT_TYPE)
+                .short("T")
+                .long("print-type")
+                .help("print file system type"),
+        )
+        .arg(
+            Arg::with_name(OPT_EXCLUDE_TYPE)
+                .short("x")
+                .long("exclude-type")
+                .takes_value(true)
+                .use_delimiter(true)
+                .help("limit listing to file systems not of type TYPE"),
+        )
+        .arg(Arg::with_name(OPT_PATHS).multiple(true))
+        .help("Filesystem(s) to list")
 }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -73,36 +73,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(SUMMARY)
-        .usage(&usage[..])
-        .after_help(LONG_HELP)
-        .arg(
-            Arg::with_name(options::BOURNE_SHELL)
-                .long("sh")
-                .short("b")
-                .visible_alias("bourne-shell")
-                .help("output Bourne shell code to set LS_COLORS")
-                .display_order(1),
-        )
-        .arg(
-            Arg::with_name(options::C_SHELL)
-                .long("csh")
-                .short("c")
-                .visible_alias("c-shell")
-                .help("output C shell code to set LS_COLORS")
-                .display_order(2),
-        )
-        .arg(
-            Arg::with_name(options::PRINT_DATABASE)
-                .long("print-database")
-                .short("p")
-                .help("print the byte counts")
-                .display_order(3),
-        )
-        .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
-        .get_matches_from(&args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(&args);
 
     let files = matches
         .values_of(options::FILE)
@@ -179,6 +150,37 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             1
         }
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(SUMMARY)
+        .after_help(LONG_HELP)
+        .arg(
+            Arg::with_name(options::BOURNE_SHELL)
+                .long("sh")
+                .short("b")
+                .visible_alias("bourne-shell")
+                .help("output Bourne shell code to set LS_COLORS")
+                .display_order(1),
+        )
+        .arg(
+            Arg::with_name(options::C_SHELL)
+                .long("csh")
+                .short("c")
+                .visible_alias("c-shell")
+                .help("output C shell code to set LS_COLORS")
+                .display_order(2),
+        )
+        .arg(
+            Arg::with_name(options::PRINT_DATABASE)
+                .long("print-database")
+                .short("p")
+                .help("print the byte counts")
+                .display_order(3),
+        )
+        .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
 }
 
 pub trait StrUtils {

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -38,18 +38,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let after_help = get_long_usage();
 
-    let matches = App::new(executable!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&after_help[..])
-        .version(crate_version!())
-        .arg(
-            Arg::with_name(options::ZERO)
-                .long(options::ZERO)
-                .short("z")
-                .help("separate output with NUL rather than newline"),
-        )
-        .arg(Arg::with_name(options::DIR).hidden(true).multiple(true))
         .get_matches_from(args);
 
     let separator = if matches.is_present(options::ZERO) {
@@ -91,4 +82,17 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .about(ABOUT)
+        .version(crate_version!())
+        .arg(
+            Arg::with_name(options::ZERO)
+                .long(options::ZERO)
+                .short("z")
+                .help("separate output with NUL rather than newline"),
+        )
+        .arg(Arg::with_name(options::DIR).hidden(true).multiple(true))
 }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -387,182 +387,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(SUMMARY)
-        .usage(&usage[..])
-        .after_help(LONG_HELP)
-        .arg(
-            Arg::with_name(options::ALL)
-                .short("a")
-                .long(options::ALL)
-                .help("write counts for all files, not just directories"),
-        )
-        .arg(
-            Arg::with_name(options::APPARENT_SIZE)
-                .long(options::APPARENT_SIZE)
-                .help(
-                    "print apparent sizes,  rather  than  disk  usage \
-                    although  the apparent  size is usually smaller, it may be larger due to holes \
-                    in ('sparse') files, internal  fragmentation,  indirect  blocks, and the like"
-                )
-                .alias("app") // The GNU test suite uses this alias
-        )
-        .arg(
-            Arg::with_name(options::BLOCK_SIZE)
-                .short("B")
-                .long(options::BLOCK_SIZE)
-                .value_name("SIZE")
-                .help(
-                    "scale sizes  by  SIZE before printing them. \
-                    E.g., '-BM' prints sizes in units of 1,048,576 bytes.  See SIZE format below."
-                )
-        )
-        .arg(
-            Arg::with_name(options::BYTES)
-                .short("b")
-                .long("bytes")
-                .help("equivalent to '--apparent-size --block-size=1'")
-        )
-        .arg(
-            Arg::with_name(options::TOTAL)
-                .long("total")
-                .short("c")
-                .help("produce a grand total")
-        )
-        .arg(
-            Arg::with_name(options::MAX_DEPTH)
-                .short("d")
-                .long("max-depth")
-                .value_name("N")
-                .help(
-                    "print the total for a directory (or file, with --all) \
-                    only if it is N or fewer levels below the command \
-                    line argument;  --max-depth=0 is the same as --summarize"
-                )
-        )
-        .arg(
-            Arg::with_name(options::HUMAN_READABLE)
-                .long("human-readable")
-                .short("h")
-                .help("print sizes in human readable format (e.g., 1K 234M 2G)")
-        )
-        .arg(
-            Arg::with_name("inodes")
-                .long("inodes")
-                .help(
-                    "list inode usage information instead of block usage like --block-size=1K"
-                )
-        )
-        .arg(
-            Arg::with_name(options::BLOCK_SIZE_1K)
-                .short("k")
-                .help("like --block-size=1K")
-        )
-        .arg(
-            Arg::with_name(options::COUNT_LINKS)
-                .short("l")
-                .long("count-links")
-                .help("count sizes many times if hard linked")
-        )
-        .arg(
-            Arg::with_name(options::DEREFERENCE)
-                .short("L")
-                .long(options::DEREFERENCE)
-                .help("dereference all symbolic links")
-        )
-        // .arg(
-        //     Arg::with_name("no-dereference")
-        //         .short("P")
-        //         .long("no-dereference")
-        //         .help("don't follow any symbolic links (this is the default)")
-        // )
-        .arg(
-            Arg::with_name(options::BLOCK_SIZE_1M)
-                .short("m")
-                .help("like --block-size=1M")
-        )
-        .arg(
-            Arg::with_name(options::NULL)
-                .short("0")
-                .long("null")
-                .help("end each output line with 0 byte rather than newline")
-        )
-        .arg(
-            Arg::with_name(options::SEPARATE_DIRS)
-                .short("S")
-                .long("separate-dirs")
-                .help("do not include size of subdirectories")
-        )
-        .arg(
-            Arg::with_name(options::SUMMARIZE)
-                .short("s")
-                .long("summarize")
-                .help("display only a total for each argument")
-        )
-        .arg(
-            Arg::with_name(options::SI)
-                .long(options::SI)
-                .help("like -h, but use powers of 1000 not 1024")
-        )
-        .arg(
-            Arg::with_name(options::ONE_FILE_SYSTEM)
-                .short("x")
-                .long(options::ONE_FILE_SYSTEM)
-                .help("skip directories on different file systems")
-        )
-        .arg(
-            Arg::with_name(options::THRESHOLD)
-                .short("t")
-                .long(options::THRESHOLD)
-                .alias("th")
-                .value_name("SIZE")
-                .number_of_values(1)
-                .allow_hyphen_values(true)
-                .help("exclude entries smaller than SIZE if positive, \
-                          or entries greater than SIZE if negative")
-        )
-        // .arg(
-        //     Arg::with_name("")
-        //         .short("x")
-        //         .long("exclude-from")
-        //         .value_name("FILE")
-        //         .help("exclude files that match any pattern in FILE")
-        // )
-        // .arg(
-        //     Arg::with_name("exclude")
-        //         .long("exclude")
-        //         .value_name("PATTERN")
-        //         .help("exclude files that match PATTERN")
-        // )
-        .arg(
-            Arg::with_name(options::TIME)
-                .long(options::TIME)
-                .value_name("WORD")
-                .require_equals(true)
-                .min_values(0)
-                .possible_values(&["atime", "access", "use", "ctime", "status", "birth", "creation"])
-                .help(
-                    "show time of the last modification of any file in the \
-                    directory, or any of its subdirectories.  If WORD is given, show time as WORD instead \
-                    of modification time: atime, access, use, ctime, status, birth or creation"
-                )
-        )
-        .arg(
-            Arg::with_name(options::TIME_STYLE)
-                .long(options::TIME_STYLE)
-                .value_name("STYLE")
-                .help(
-                    "show times using style STYLE: \
-                    full-iso, long-iso, iso, +FORMAT FORMAT is interpreted like 'date'"
-                )
-        )
-        .arg(
-            Arg::with_name(options::FILE)
-                .hidden(true)
-                .multiple(true)
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let summarize = matches.is_present(options::SUMMARIZE);
 
@@ -741,6 +566,183 @@ Try '{} --help' for more information.",
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(SUMMARY)
+        .after_help(LONG_HELP)
+        .arg(
+            Arg::with_name(options::ALL)
+                .short("a")
+                .long(options::ALL)
+                .help("write counts for all files, not just directories"),
+        )
+        .arg(
+            Arg::with_name(options::APPARENT_SIZE)
+                .long(options::APPARENT_SIZE)
+                .help(
+                    "print apparent sizes,  rather  than  disk  usage \
+                    although  the apparent  size is usually smaller, it may be larger due to holes \
+                    in ('sparse') files, internal  fragmentation,  indirect  blocks, and the like"
+                )
+                .alias("app") // The GNU test suite uses this alias
+        )
+        .arg(
+            Arg::with_name(options::BLOCK_SIZE)
+                .short("B")
+                .long(options::BLOCK_SIZE)
+                .value_name("SIZE")
+                .help(
+                    "scale sizes  by  SIZE before printing them. \
+                    E.g., '-BM' prints sizes in units of 1,048,576 bytes.  See SIZE format below."
+                )
+        )
+        .arg(
+            Arg::with_name(options::BYTES)
+                .short("b")
+                .long("bytes")
+                .help("equivalent to '--apparent-size --block-size=1'")
+        )
+        .arg(
+            Arg::with_name(options::TOTAL)
+                .long("total")
+                .short("c")
+                .help("produce a grand total")
+        )
+        .arg(
+            Arg::with_name(options::MAX_DEPTH)
+                .short("d")
+                .long("max-depth")
+                .value_name("N")
+                .help(
+                    "print the total for a directory (or file, with --all) \
+                    only if it is N or fewer levels below the command \
+                    line argument;  --max-depth=0 is the same as --summarize"
+                )
+        )
+        .arg(
+            Arg::with_name(options::HUMAN_READABLE)
+                .long("human-readable")
+                .short("h")
+                .help("print sizes in human readable format (e.g., 1K 234M 2G)")
+        )
+        .arg(
+            Arg::with_name("inodes")
+                .long("inodes")
+                .help(
+                    "list inode usage information instead of block usage like --block-size=1K"
+                )
+        )
+        .arg(
+            Arg::with_name(options::BLOCK_SIZE_1K)
+                .short("k")
+                .help("like --block-size=1K")
+        )
+        .arg(
+            Arg::with_name(options::COUNT_LINKS)
+                .short("l")
+                .long("count-links")
+                .help("count sizes many times if hard linked")
+        )
+        .arg(
+            Arg::with_name(options::DEREFERENCE)
+                .short("L")
+                .long(options::DEREFERENCE)
+                .help("dereference all symbolic links")
+        )
+        // .arg(
+        //     Arg::with_name("no-dereference")
+        //         .short("P")
+        //         .long("no-dereference")
+        //         .help("don't follow any symbolic links (this is the default)")
+        // )
+        .arg(
+            Arg::with_name(options::BLOCK_SIZE_1M)
+                .short("m")
+                .help("like --block-size=1M")
+        )
+        .arg(
+            Arg::with_name(options::NULL)
+                .short("0")
+                .long("null")
+                .help("end each output line with 0 byte rather than newline")
+        )
+        .arg(
+            Arg::with_name(options::SEPARATE_DIRS)
+                .short("S")
+                .long("separate-dirs")
+                .help("do not include size of subdirectories")
+        )
+        .arg(
+            Arg::with_name(options::SUMMARIZE)
+                .short("s")
+                .long("summarize")
+                .help("display only a total for each argument")
+        )
+        .arg(
+            Arg::with_name(options::SI)
+                .long(options::SI)
+                .help("like -h, but use powers of 1000 not 1024")
+        )
+        .arg(
+            Arg::with_name(options::ONE_FILE_SYSTEM)
+                .short("x")
+                .long(options::ONE_FILE_SYSTEM)
+                .help("skip directories on different file systems")
+        )
+        .arg(
+            Arg::with_name(options::THRESHOLD)
+                .short("t")
+                .long(options::THRESHOLD)
+                .alias("th")
+                .value_name("SIZE")
+                .number_of_values(1)
+                .allow_hyphen_values(true)
+                .help("exclude entries smaller than SIZE if positive, \
+                          or entries greater than SIZE if negative")
+        )
+        // .arg(
+        //     Arg::with_name("")
+        //         .short("x")
+        //         .long("exclude-from")
+        //         .value_name("FILE")
+        //         .help("exclude files that match any pattern in FILE")
+        // )
+        // .arg(
+        //     Arg::with_name("exclude")
+        //         .long("exclude")
+        //         .value_name("PATTERN")
+        //         .help("exclude files that match PATTERN")
+        // )
+        .arg(
+            Arg::with_name(options::TIME)
+                .long(options::TIME)
+                .value_name("WORD")
+                .require_equals(true)
+                .min_values(0)
+                .possible_values(&["atime", "access", "use", "ctime", "status", "birth", "creation"])
+                .help(
+                    "show time of the last modification of any file in the \
+                    directory, or any of its subdirectories.  If WORD is given, show time as WORD instead \
+                    of modification time: atime, access, use, ctime, status, birth or creation"
+                )
+        )
+        .arg(
+            Arg::with_name(options::TIME_STYLE)
+                .long(options::TIME_STYLE)
+                .value_name("STYLE")
+                .help(
+                    "show times using style STYLE: \
+                    full-iso, long-iso, iso, +FORMAT FORMAT is interpreted like 'date'"
+                )
+        )
+        .arg(
+            Arg::with_name(options::FILE)
+                .hidden(true)
+                .multiple(true)
+        )
 }
 
 #[derive(Clone, Copy)]

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -114,7 +114,7 @@ fn build_command<'a, 'b>(args: &'a mut Vec<&'b str>) -> (Cow<'b, str>, &'a [&'b 
     (progname, &args[..])
 }
 
-fn create_app() -> App<'static, 'static> {
+pub fn uu_app() -> App<'static, 'static> {
     App::new(crate_name!())
         .version(crate_version!())
         .author(crate_authors!())
@@ -158,7 +158,7 @@ fn create_app() -> App<'static, 'static> {
 }
 
 fn run_env(args: impl uucore::Args) -> Result<(), i32> {
-    let app = create_app();
+    let app = uu_app();
     let matches = app.get_matches_from(args);
 
     let ignore_env = matches.is_present("ignore-environment");

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -108,10 +108,16 @@ impl Options {
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
+
+    expand(Options::new(&matches));
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
-        .usage(&usage[..])
         .after_help(LONG_HELP)
         .arg(
             Arg::with_name(options::INITIAL)
@@ -138,10 +144,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .hidden(true)
                 .takes_value(true)
         )
-        .get_matches_from(args);
-
-    expand(Options::new(&matches));
-    0
 }
 
 fn open(path: String) -> BufReader<Box<dyn Read + 'static>> {

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/expr.rs"
 
 [dependencies]
+clap = "2.33.3"
 libc = "0.2.42"
 num-bigint = "0.4.0"
 num-traits = "0.2.14"

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -8,13 +8,20 @@
 #[macro_use]
 extern crate uucore;
 
+use clap::{crate_version, App, Arg};
 use uucore::InvalidEncodingHandling;
 
 mod syntax_tree;
 mod tokens;
 
-static NAME: &str = "expr";
-static VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = "version";
+const HELP: &str = "help";
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .arg(Arg::with_name(VERSION).long(VERSION))
+        .arg(Arg::with_name(HELP).long(HELP))
+}
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let args = args
@@ -133,5 +140,5 @@ Environment variables:
 }
 
 fn print_version() {
-    println!("{} {}", NAME, VERSION);
+    println!("{} {}", executable!(), crate_version!());
 }

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -36,11 +36,7 @@ fn print_factors_str(num_str: &str, w: &mut impl io::Write) -> Result<(), Box<dy
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(SUMMARY)
-        .arg(Arg::with_name(options::NUMBER).multiple(true))
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
     let stdout = stdout();
     let mut w = io::BufWriter::new(stdout.lock());
 
@@ -67,4 +63,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(SUMMARY)
+        .arg(Arg::with_name(options::NUMBER).multiple(true))
 }

--- a/src/uu/false/Cargo.toml
+++ b/src/uu/false/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/false.rs"
 
 [dependencies]
+clap = "2.33.3"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -5,6 +5,15 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
+use clap::{App, AppSettings};
+use uucore::executable;
+
 pub fn uumain(_: impl uucore::Args) -> i32 {
     1
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .setting(AppSettings::DisableHelpFlags)
+        .setting(AppSettings::DisableVersion)
 }

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -5,15 +5,14 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-use clap::{App, AppSettings};
+use clap::App;
 use uucore::executable;
 
-pub fn uumain(_: impl uucore::Args) -> i32 {
+pub fn uumain(args: impl uucore::Args) -> i32 {
+    uu_app().get_matches_from(args);
     1
 }
 
 pub fn uu_app() -> App<'static, 'static> {
     App::new(executable!())
-        .setting(AppSettings::DisableHelpFlags)
-        .setting(AppSettings::DisableVersion)
 }

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -219,10 +219,10 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("c")
                 .long(OPT_CROWN_MARGIN)
                 .help(
-                    "First and second line of paragraph
-        may have different indentations, in which
-        case the first line's indentation is preserved,
-        and each subsequent line's indentation matches the second line.",
+                    "First and second line of paragraph \
+                    may have different indentations, in which \
+                    case the first line's indentation is preserved, \
+                    and each subsequent line's indentation matches the second line.",
                 ),
         )
         .arg(
@@ -230,7 +230,7 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("t")
                 .long("tagged-paragraph")
                 .help(
-                    "Like -c, except that the first and second line of a paragraph *must*
+                    "Like -c, except that the first and second line of a paragraph *must* \
                     have different indentation or they are treated as separate paragraphs.",
                 ),
         )
@@ -239,7 +239,7 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("m")
                 .long("preserve-headers")
                 .help(
-                    "Attempt to detect and preserve mail headers in the input.
+                    "Attempt to detect and preserve mail headers in the input. \
                     Be careful when combining this flag with -p.",
                 ),
         )
@@ -254,10 +254,10 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("u")
                 .long("uniform-spacing")
                 .help(
-                    "Insert exactly one
-                    space between words, and two between sentences.
-                    Sentence breaks in the input are detected as [?!.]
-                    followed by two spaces or a newline; other punctuation
+                    "Insert exactly one \
+                    space between words, and two between sentences. \
+                    Sentence breaks in the input are detected as [?!.] \
+                    followed by two spaces or a newline; other punctuation \
                     is not interpreted as a sentence break.",
                 ),
         )
@@ -266,9 +266,9 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("p")
                 .long("prefix")
                 .help(
-                    "Reformat only lines
-                    beginning with PREFIX, reattaching PREFIX to reformatted lines.
-                    Unless -x is specified, leading whitespace will be ignored
+                    "Reformat only lines \
+                    beginning with PREFIX, reattaching PREFIX to reformatted lines. \
+                    Unless -x is specified, leading whitespace will be ignored \
                     when matching PREFIX.",
                 )
                 .value_name("PREFIX"),
@@ -278,8 +278,8 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("P")
                 .long("skip-prefix")
                 .help(
-                    "Do not reformat lines
-                    beginning with PSKIP. Unless -X is specified, leading whitespace
+                    "Do not reformat lines \
+                    beginning with PSKIP. Unless -X is specified, leading whitespace \
                     will be ignored when matching PSKIP",
                 )
                 .value_name("PSKIP"),
@@ -289,7 +289,7 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("x")
                 .long("exact-prefix")
                 .help(
-                    "PREFIX must match at the
+                    "PREFIX must match at the \
                     beginning of the line with no preceding whitespace.",
                 ),
         )
@@ -298,7 +298,7 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("X")
                 .long("exact-skip-prefix")
                 .help(
-                    "PSKIP must match at the
+                    "PSKIP must match at the \
                     beginning of the line with no preceding whitespace.",
                 ),
         )
@@ -317,7 +317,7 @@ pub fn uu_app() -> App<'static, 'static> {
                 .value_name("GOAL"),
         )
         .arg(Arg::with_name(OPT_QUICK).short("q").long("quick").help(
-            "Break lines more quickly at the
+            "Break lines more quickly at the \
             expense of a potentially more ragged appearance.",
         ))
         .arg(
@@ -325,8 +325,8 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("T")
                 .long("tab-width")
                 .help(
-                    "Treat tabs as TABWIDTH spaces for
-                    determining line length, default 8. Note that this is used only for
+                    "Treat tabs as TABWIDTH spaces for \
+                    determining line length, default 8. Note that this is used only for \
                     calculating line lengths; tabs are preserved in the output.",
                 )
                 .value_name("TABWIDTH"),

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -77,129 +77,7 @@ pub struct FmtOptions {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_CROWN_MARGIN)
-                .short("c")
-                .long(OPT_CROWN_MARGIN)
-                .help(
-                    "First and second line of paragraph
-        may have different indentations, in which
-        case the first line's indentation is preserved,
-        and each subsequent line's indentation matches the second line.",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_TAGGED_PARAGRAPH)
-                .short("t")
-                .long("tagged-paragraph")
-                .help(
-                    "Like -c, except that the first and second line of a paragraph *must*
-                    have different indentation or they are treated as separate paragraphs.",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_PRESERVE_HEADERS)
-                .short("m")
-                .long("preserve-headers")
-                .help(
-                    "Attempt to detect and preserve mail headers in the input.
-                    Be careful when combining this flag with -p.",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_SPLIT_ONLY)
-                .short("s")
-                .long("split-only")
-                .help("Split lines only, do not reflow."),
-        )
-        .arg(
-            Arg::with_name(OPT_UNIFORM_SPACING)
-                .short("u")
-                .long("uniform-spacing")
-                .help(
-                    "Insert exactly one
-                    space between words, and two between sentences.
-                    Sentence breaks in the input are detected as [?!.]
-                    followed by two spaces or a newline; other punctuation
-                    is not interpreted as a sentence break.",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_PREFIX)
-                .short("p")
-                .long("prefix")
-                .help(
-                    "Reformat only lines
-                    beginning with PREFIX, reattaching PREFIX to reformatted lines.
-                    Unless -x is specified, leading whitespace will be ignored
-                    when matching PREFIX.",
-                )
-                .value_name("PREFIX"),
-        )
-        .arg(
-            Arg::with_name(OPT_SKIP_PREFIX)
-                .short("P")
-                .long("skip-prefix")
-                .help(
-                    "Do not reformat lines
-                    beginning with PSKIP. Unless -X is specified, leading whitespace
-                    will be ignored when matching PSKIP",
-                )
-                .value_name("PSKIP"),
-        )
-        .arg(
-            Arg::with_name(OPT_EXACT_PREFIX)
-                .short("x")
-                .long("exact-prefix")
-                .help(
-                    "PREFIX must match at the
-                    beginning of the line with no preceding whitespace.",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_EXACT_SKIP_PREFIX)
-                .short("X")
-                .long("exact-skip-prefix")
-                .help(
-                    "PSKIP must match at the
-                    beginning of the line with no preceding whitespace.",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_WIDTH)
-                .short("w")
-                .long("width")
-                .help("Fill output lines up to a maximum of WIDTH columns, default 79.")
-                .value_name("WIDTH"),
-        )
-        .arg(
-            Arg::with_name(OPT_GOAL)
-                .short("g")
-                .long("goal")
-                .help("Goal width, default ~0.94*WIDTH. Must be less than WIDTH.")
-                .value_name("GOAL"),
-        )
-        .arg(Arg::with_name(OPT_QUICK).short("q").long("quick").help(
-            "Break lines more quickly at the
-            expense of a potentially more ragged appearance.",
-        ))
-        .arg(
-            Arg::with_name(OPT_TAB_WIDTH)
-                .short("T")
-                .long("tab-width")
-                .help(
-                    "Treat tabs as TABWIDTH spaces for
-                    determining line length, default 8. Note that this is used only for
-                    calculating line lengths; tabs are preserved in the output.",
-                )
-                .value_name("TABWIDTH"),
-        )
-        .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mut files: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -330,4 +208,128 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_CROWN_MARGIN)
+                .short("c")
+                .long(OPT_CROWN_MARGIN)
+                .help(
+                    "First and second line of paragraph
+        may have different indentations, in which
+        case the first line's indentation is preserved,
+        and each subsequent line's indentation matches the second line.",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_TAGGED_PARAGRAPH)
+                .short("t")
+                .long("tagged-paragraph")
+                .help(
+                    "Like -c, except that the first and second line of a paragraph *must*
+                    have different indentation or they are treated as separate paragraphs.",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_PRESERVE_HEADERS)
+                .short("m")
+                .long("preserve-headers")
+                .help(
+                    "Attempt to detect and preserve mail headers in the input.
+                    Be careful when combining this flag with -p.",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_SPLIT_ONLY)
+                .short("s")
+                .long("split-only")
+                .help("Split lines only, do not reflow."),
+        )
+        .arg(
+            Arg::with_name(OPT_UNIFORM_SPACING)
+                .short("u")
+                .long("uniform-spacing")
+                .help(
+                    "Insert exactly one
+                    space between words, and two between sentences.
+                    Sentence breaks in the input are detected as [?!.]
+                    followed by two spaces or a newline; other punctuation
+                    is not interpreted as a sentence break.",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_PREFIX)
+                .short("p")
+                .long("prefix")
+                .help(
+                    "Reformat only lines
+                    beginning with PREFIX, reattaching PREFIX to reformatted lines.
+                    Unless -x is specified, leading whitespace will be ignored
+                    when matching PREFIX.",
+                )
+                .value_name("PREFIX"),
+        )
+        .arg(
+            Arg::with_name(OPT_SKIP_PREFIX)
+                .short("P")
+                .long("skip-prefix")
+                .help(
+                    "Do not reformat lines
+                    beginning with PSKIP. Unless -X is specified, leading whitespace
+                    will be ignored when matching PSKIP",
+                )
+                .value_name("PSKIP"),
+        )
+        .arg(
+            Arg::with_name(OPT_EXACT_PREFIX)
+                .short("x")
+                .long("exact-prefix")
+                .help(
+                    "PREFIX must match at the
+                    beginning of the line with no preceding whitespace.",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_EXACT_SKIP_PREFIX)
+                .short("X")
+                .long("exact-skip-prefix")
+                .help(
+                    "PSKIP must match at the
+                    beginning of the line with no preceding whitespace.",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_WIDTH)
+                .short("w")
+                .long("width")
+                .help("Fill output lines up to a maximum of WIDTH columns, default 79.")
+                .value_name("WIDTH"),
+        )
+        .arg(
+            Arg::with_name(OPT_GOAL)
+                .short("g")
+                .long("goal")
+                .help("Goal width, default ~0.94*WIDTH. Must be less than WIDTH.")
+                .value_name("GOAL"),
+        )
+        .arg(Arg::with_name(OPT_QUICK).short("q").long("quick").help(
+            "Break lines more quickly at the
+            expense of a potentially more ragged appearance.",
+        ))
+        .arg(
+            Arg::with_name(OPT_TAB_WIDTH)
+                .short("T")
+                .long("tab-width")
+                .help(
+                    "Treat tabs as TABWIDTH spaces for
+                    determining line length, default 8. Note that this is used only for
+                    calculating line lengths; tabs are preserved in the output.",
+                )
+                .value_name("TABWIDTH"),
+        )
+        .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
 }

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -36,7 +36,35 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .accept_any();
 
     let (args, obs_width) = handle_obsolete(&args[..]);
-    let matches = App::new(executable!())
+    let matches = uu_app().get_matches_from(args);
+
+    let bytes = matches.is_present(options::BYTES);
+    let spaces = matches.is_present(options::SPACES);
+    let poss_width = match matches.value_of(options::WIDTH) {
+        Some(v) => Some(v.to_owned()),
+        None => obs_width,
+    };
+
+    let width = match poss_width {
+        Some(inp_width) => match inp_width.parse::<usize>() {
+            Ok(width) => width,
+            Err(e) => crash!(1, "illegal width value (\"{}\"): {}", inp_width, e),
+        },
+        None => 80,
+    };
+
+    let files = match matches.values_of(options::FILE) {
+        Some(v) => v.map(|v| v.to_owned()).collect(),
+        None => vec!["-".to_owned()],
+    };
+
+    fold(files, bytes, spaces, width);
+
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)
@@ -68,31 +96,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .takes_value(true),
         )
         .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
-        .get_matches_from(args);
-
-    let bytes = matches.is_present(options::BYTES);
-    let spaces = matches.is_present(options::SPACES);
-    let poss_width = match matches.value_of(options::WIDTH) {
-        Some(v) => Some(v.to_owned()),
-        None => obs_width,
-    };
-
-    let width = match poss_width {
-        Some(inp_width) => match inp_width.parse::<usize>() {
-            Ok(width) => width,
-            Err(e) => crash!(1, "illegal width value (\"{}\"): {}", inp_width, e),
-        },
-        None => 80,
-    };
-
-    let files = match matches.values_of(options::FILE) {
-        Some(v) => v.map(|v| v.to_owned()).collect(),
-        None => vec!["-".to_owned()],
-    };
-
-    fold(files, bytes, spaces, width);
-
-    0
 }
 
 fn handle_obsolete(args: &[String]) -> (Vec<String>, Option<String>) {

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -35,17 +35,7 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::USERS)
-                .multiple(true)
-                .takes_value(true)
-                .value_name(options::USERS),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let users: Vec<String> = matches
         .values_of(options::USERS)
@@ -92,4 +82,16 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         }
     }
     exit_code
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::USERS)
+                .multiple(true)
+                .takes_value(true)
+                .value_name(options::USERS),
+        )
 }

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -285,119 +285,7 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     // Default binary in Windows, text mode otherwise
     let binary_flag_default = cfg!(windows);
 
-    let binary_help = format!(
-        "read in binary mode{}",
-        if binary_flag_default {
-            " (default)"
-        } else {
-            ""
-        }
-    );
-
-    let text_help = format!(
-        "read in text mode{}",
-        if binary_flag_default {
-            ""
-        } else {
-            " (default)"
-        }
-    );
-
-    let mut app = App::new(executable!())
-        .version(crate_version!())
-        .about("Compute and check message digests.")
-        .arg(
-            Arg::with_name("binary")
-                .short("b")
-                .long("binary")
-                .help(&binary_help),
-        )
-        .arg(
-            Arg::with_name("check")
-                .short("c")
-                .long("check")
-                .help("read hashsums from the FILEs and check them"),
-        )
-        .arg(
-            Arg::with_name("tag")
-                .long("tag")
-                .help("create a BSD-style checksum"),
-        )
-        .arg(
-            Arg::with_name("text")
-                .short("t")
-                .long("text")
-                .help(&text_help)
-                .conflicts_with("binary"),
-        )
-        .arg(
-            Arg::with_name("quiet")
-                .short("q")
-                .long("quiet")
-                .help("don't print OK for each successfully verified file"),
-        )
-        .arg(
-            Arg::with_name("status")
-                .short("s")
-                .long("status")
-                .help("don't output anything, status code shows success"),
-        )
-        .arg(
-            Arg::with_name("strict")
-                .long("strict")
-                .help("exit non-zero for improperly formatted checksum lines"),
-        )
-        .arg(
-            Arg::with_name("warn")
-                .short("w")
-                .long("warn")
-                .help("warn about improperly formatted checksum lines"),
-        )
-        // Needed for variable-length output sums (e.g. SHAKE)
-        .arg(
-            Arg::with_name("bits")
-                .long("bits")
-                .help("set the size of the output (only for SHAKE)")
-                .takes_value(true)
-                .value_name("BITS")
-                // XXX: should we actually use validators?  they're not particularly efficient
-                .validator(is_valid_bit_num),
-        )
-        .arg(
-            Arg::with_name("FILE")
-                .index(1)
-                .multiple(true)
-                .value_name("FILE"),
-        );
-
-    if !is_custom_binary(&binary_name) {
-        let algorithms = &[
-            ("md5", "work with MD5"),
-            ("sha1", "work with SHA1"),
-            ("sha224", "work with SHA224"),
-            ("sha256", "work with SHA256"),
-            ("sha384", "work with SHA384"),
-            ("sha512", "work with SHA512"),
-            ("sha3", "work with SHA3"),
-            ("sha3-224", "work with SHA3-224"),
-            ("sha3-256", "work with SHA3-256"),
-            ("sha3-384", "work with SHA3-384"),
-            ("sha3-512", "work with SHA3-512"),
-            (
-                "shake128",
-                "work with SHAKE128 using BITS for the output size",
-            ),
-            (
-                "shake256",
-                "work with SHAKE256 using BITS for the output size",
-            ),
-            ("b2sum", "work with BLAKE2"),
-        ];
-
-        for (name, desc) in algorithms {
-            app = app.arg(Arg::with_name(name).long(name).help(desc));
-        }
-    }
+    let app = uu_app(&binary_name);
 
     // FIXME: this should use get_matches_from_safe() and crash!(), but at the moment that just
     //        causes "error: " to be printed twice (once from crash!() and once from clap).  With
@@ -442,6 +330,124 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     match res {
         Ok(()) => 0,
         Err(e) => e,
+    }
+}
+
+pub fn uu_app_common() -> App<'static, 'static> {
+    #[cfg(windows)]
+    const BINARY_HELP: &str = "read in binary mode (default)";
+    #[cfg(not(windows))]
+    const BINARY_HELP: &str = "read in binary mode";
+    #[cfg(windows)]
+    const TEXT_HELP: &str = "read in text mode";
+    #[cfg(not(windows))]
+    const TEXT_HELP: &str = "read in text mode (default)";
+    App::new(executable!())
+        .version(crate_version!())
+        .about("Compute and check message digests.")
+        .arg(
+            Arg::with_name("binary")
+                .short("b")
+                .long("binary")
+                .help(BINARY_HELP),
+        )
+        .arg(
+            Arg::with_name("check")
+                .short("c")
+                .long("check")
+                .help("read hashsums from the FILEs and check them"),
+        )
+        .arg(
+            Arg::with_name("tag")
+                .long("tag")
+                .help("create a BSD-style checksum"),
+        )
+        .arg(
+            Arg::with_name("text")
+                .short("t")
+                .long("text")
+                .help(TEXT_HELP)
+                .conflicts_with("binary"),
+        )
+        .arg(
+            Arg::with_name("quiet")
+                .short("q")
+                .long("quiet")
+                .help("don't print OK for each successfully verified file"),
+        )
+        .arg(
+            Arg::with_name("status")
+                .short("s")
+                .long("status")
+                .help("don't output anything, status code shows success"),
+        )
+        .arg(
+            Arg::with_name("strict")
+                .long("strict")
+                .help("exit non-zero for improperly formatted checksum lines"),
+        )
+        .arg(
+            Arg::with_name("warn")
+                .short("w")
+                .long("warn")
+                .help("warn about improperly formatted checksum lines"),
+        )
+        // Needed for variable-length output sums (e.g. SHAKE)
+        .arg(
+            Arg::with_name("bits")
+                .long("bits")
+                .help("set the size of the output (only for SHAKE)")
+                .takes_value(true)
+                .value_name("BITS")
+                // XXX: should we actually use validators?  they're not particularly efficient
+                .validator(is_valid_bit_num),
+        )
+        .arg(
+            Arg::with_name("FILE")
+                .index(1)
+                .multiple(true)
+                .value_name("FILE"),
+        )
+}
+
+pub fn uu_app_custom() -> App<'static, 'static> {
+    let mut app = uu_app_common();
+    let algorithms = &[
+        ("md5", "work with MD5"),
+        ("sha1", "work with SHA1"),
+        ("sha224", "work with SHA224"),
+        ("sha256", "work with SHA256"),
+        ("sha384", "work with SHA384"),
+        ("sha512", "work with SHA512"),
+        ("sha3", "work with SHA3"),
+        ("sha3-224", "work with SHA3-224"),
+        ("sha3-256", "work with SHA3-256"),
+        ("sha3-384", "work with SHA3-384"),
+        ("sha3-512", "work with SHA3-512"),
+        (
+            "shake128",
+            "work with SHAKE128 using BITS for the output size",
+        ),
+        (
+            "shake256",
+            "work with SHAKE256 using BITS for the output size",
+        ),
+        ("b2sum", "work with BLAKE2"),
+    ];
+
+    for (name, desc) in algorithms {
+        app = app.arg(Arg::with_name(name).long(name).help(desc));
+    }
+    app
+}
+
+// hashsum is handled differently in build.rs, therefore this is not the same
+// as in other utilities.
+fn uu_app(binary_name: &str) -> App<'static, 'static> {
+    if !is_custom_binary(binary_name) {
+        uu_app_custom()
+    } else {
+        uu_app_common()
     }
 }
 

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -40,7 +40,7 @@ mod take;
 use lines::zlines;
 use take::take_all_but;
 
-fn app<'a>() -> App<'a, 'a> {
+pub fn uu_app() -> App<'static, 'static> {
     App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
@@ -167,7 +167,7 @@ impl HeadOptions {
 
     ///Construct options from matches
     pub fn get_from(args: impl uucore::Args) -> Result<Self, String> {
-        let matches = app().get_matches_from(arg_iterate(args)?);
+        let matches = uu_app().get_matches_from(arg_iterate(args)?);
 
         let mut options = HeadOptions::new();
 

--- a/src/uu/hostid/Cargo.toml
+++ b/src/uu/hostid/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/hostid.rs"
 
 [dependencies]
+clap = "2.33.3"
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -10,12 +10,10 @@
 #[macro_use]
 extern crate uucore;
 
+use clap::{crate_version, App};
 use libc::c_long;
-use uucore::InvalidEncodingHandling;
 
 static SYNTAX: &str = "[options]";
-static SUMMARY: &str = "";
-static LONG_HELP: &str = "";
 
 // currently rust libc interface doesn't include gethostid
 extern "C" {
@@ -23,12 +21,15 @@ extern "C" {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    app!(SYNTAX, SUMMARY, LONG_HELP).parse(
-        args.collect_str(InvalidEncodingHandling::ConvertLossy)
-            .accept_any(),
-    );
+    uu_app().get_matches_from(args);
     hostid();
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .usage(SYNTAX)
 }
 
 fn hostid() {

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -52,10 +52,25 @@ fn get_usage() -> String {
 }
 fn execute(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
+
+    match matches.value_of(OPT_HOST) {
+        None => display_hostname(&matches),
+        Some(host) => {
+            if let Err(err) = hostname::set(host) {
+                show_error!("{}", err);
+                1
+            } else {
+                0
+            }
+        }
+    }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
-        .usage(&usage[..])
         .arg(
             Arg::with_name(OPT_DOMAIN)
                 .short("d")
@@ -80,19 +95,6 @@ fn execute(args: impl uucore::Args) -> i32 {
              possible",
         ))
         .arg(Arg::with_name(OPT_HOST))
-        .get_matches_from(args);
-
-    match matches.value_of(OPT_HOST) {
-        None => display_hostname(&matches),
-        Some(host) => {
-            if let Err(err) = hostname::set(host) {
-                show_error!("{}", err);
-                1
-            } else {
-                0
-            }
-        }
-    }
 }
 
 fn display_hostname(matches: &ArgMatches) -> i32 {

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -115,106 +115,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let after_help = get_description();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&after_help[..])
-        .arg(
-            Arg::with_name(options::OPT_AUDIT)
-                .short("A")
-                .conflicts_with_all(&[
-                    options::OPT_GROUP,
-                    options::OPT_EFFECTIVE_USER,
-                    options::OPT_HUMAN_READABLE,
-                    options::OPT_PASSWORD,
-                    options::OPT_GROUPS,
-                    options::OPT_ZERO,
-                ])
-                .help(
-                    "Display the process audit user ID and other process audit properties,\n\
-                      which requires privilege (not available on Linux).",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::OPT_EFFECTIVE_USER)
-                .short("u")
-                .long(options::OPT_EFFECTIVE_USER)
-                .conflicts_with(options::OPT_GROUP)
-                .help("Display only the effective user ID as a number."),
-        )
-        .arg(
-            Arg::with_name(options::OPT_GROUP)
-                .short("g")
-                .long(options::OPT_GROUP)
-                .help("Display only the effective group ID as a number"),
-        )
-        .arg(
-            Arg::with_name(options::OPT_GROUPS)
-                .short("G")
-                .long(options::OPT_GROUPS)
-                .conflicts_with_all(&[
-                    options::OPT_GROUP,
-                    options::OPT_EFFECTIVE_USER,
-                    options::OPT_HUMAN_READABLE,
-                    options::OPT_PASSWORD,
-                    options::OPT_AUDIT,
-                ])
-                .help(
-                    "Display only the different group IDs as white-space separated numbers, \
-                      in no particular order.",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::OPT_HUMAN_READABLE)
-                .short("p")
-                .help("Make the output human-readable. Each display is on a separate line."),
-        )
-        .arg(
-            Arg::with_name(options::OPT_NAME)
-                .short("n")
-                .long(options::OPT_NAME)
-                .help(
-                    "Display the name of the user or group ID for the -G, -g and -u options \
-                      instead of the number.\nIf any of the ID numbers cannot be mapped into \
-                      names, the number will be displayed as usual.",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::OPT_PASSWORD)
-                .short("P")
-                .help("Display the id as a password file entry."),
-        )
-        .arg(
-            Arg::with_name(options::OPT_REAL_ID)
-                .short("r")
-                .long(options::OPT_REAL_ID)
-                .help(
-                    "Display the real ID for the -G, -g and -u options instead of \
-                      the effective ID.",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::OPT_ZERO)
-                .short("z")
-                .long(options::OPT_ZERO)
-                .help(
-                    "delimit entries with NUL characters, not whitespace;\n\
-                      not permitted in default format",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::OPT_CONTEXT)
-                .short("Z")
-                .long(options::OPT_CONTEXT)
-                .help("NotImplemented: print only the security context of the process"),
-        )
-        .arg(
-            Arg::with_name(options::ARG_USERS)
-                .multiple(true)
-                .takes_value(true)
-                .value_name(options::ARG_USERS),
-        )
         .get_matches_from(args);
 
     let users: Vec<String> = matches
@@ -383,6 +286,107 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     exit_code
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::OPT_AUDIT)
+                .short("A")
+                .conflicts_with_all(&[
+                    options::OPT_GROUP,
+                    options::OPT_EFFECTIVE_USER,
+                    options::OPT_HUMAN_READABLE,
+                    options::OPT_PASSWORD,
+                    options::OPT_GROUPS,
+                    options::OPT_ZERO,
+                ])
+                .help(
+                    "Display the process audit user ID and other process audit properties,\n\
+                      which requires privilege (not available on Linux).",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::OPT_EFFECTIVE_USER)
+                .short("u")
+                .long(options::OPT_EFFECTIVE_USER)
+                .conflicts_with(options::OPT_GROUP)
+                .help("Display only the effective user ID as a number."),
+        )
+        .arg(
+            Arg::with_name(options::OPT_GROUP)
+                .short("g")
+                .long(options::OPT_GROUP)
+                .help("Display only the effective group ID as a number"),
+        )
+        .arg(
+            Arg::with_name(options::OPT_GROUPS)
+                .short("G")
+                .long(options::OPT_GROUPS)
+                .conflicts_with_all(&[
+                    options::OPT_GROUP,
+                    options::OPT_EFFECTIVE_USER,
+                    options::OPT_HUMAN_READABLE,
+                    options::OPT_PASSWORD,
+                    options::OPT_AUDIT,
+                ])
+                .help(
+                    "Display only the different group IDs as white-space separated numbers, \
+                      in no particular order.",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::OPT_HUMAN_READABLE)
+                .short("p")
+                .help("Make the output human-readable. Each display is on a separate line."),
+        )
+        .arg(
+            Arg::with_name(options::OPT_NAME)
+                .short("n")
+                .long(options::OPT_NAME)
+                .help(
+                    "Display the name of the user or group ID for the -G, -g and -u options \
+                      instead of the number.\nIf any of the ID numbers cannot be mapped into \
+                      names, the number will be displayed as usual.",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::OPT_PASSWORD)
+                .short("P")
+                .help("Display the id as a password file entry."),
+        )
+        .arg(
+            Arg::with_name(options::OPT_REAL_ID)
+                .short("r")
+                .long(options::OPT_REAL_ID)
+                .help(
+                    "Display the real ID for the -G, -g and -u options instead of \
+                      the effective ID.",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::OPT_ZERO)
+                .short("z")
+                .long(options::OPT_ZERO)
+                .help(
+                    "delimit entries with NUL characters, not whitespace;\n\
+                      not permitted in default format",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::OPT_CONTEXT)
+                .short("Z")
+                .long(options::OPT_CONTEXT)
+                .help("NotImplemented: print only the security context of the process"),
+        )
+        .arg(
+            Arg::with_name(options::ARG_USERS)
+                .multiple(true)
+                .takes_value(true)
+                .value_name(options::ARG_USERS),
+        )
 }
 
 fn pretty(possible_pw: Option<Passwd>) {

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -442,7 +442,72 @@ impl<'a> State<'a> {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let matches = App::new(NAME)
+    let matches = uu_app().get_matches_from(args);
+
+    let keys = parse_field_number_option(matches.value_of("j"));
+    let key1 = parse_field_number_option(matches.value_of("1"));
+    let key2 = parse_field_number_option(matches.value_of("2"));
+
+    let mut settings: Settings = Default::default();
+
+    if let Some(value) = matches.value_of("v") {
+        settings.print_unpaired = parse_file_number(value);
+        settings.print_joined = false;
+    } else if let Some(value) = matches.value_of("a") {
+        settings.print_unpaired = parse_file_number(value);
+    }
+
+    settings.ignore_case = matches.is_present("i");
+    settings.key1 = get_field_number(keys, key1);
+    settings.key2 = get_field_number(keys, key2);
+
+    if let Some(value) = matches.value_of("t") {
+        settings.separator = match value.len() {
+            0 => Sep::Line,
+            1 => Sep::Char(value.chars().next().unwrap()),
+            _ => crash!(1, "multi-character tab {}", value),
+        };
+    }
+
+    if let Some(format) = matches.value_of("o") {
+        if format == "auto" {
+            settings.autoformat = true;
+        } else {
+            settings.format = format
+                .split(|c| c == ' ' || c == ',' || c == '\t')
+                .map(Spec::parse)
+                .collect();
+        }
+    }
+
+    if let Some(empty) = matches.value_of("e") {
+        settings.empty = empty.to_string();
+    }
+
+    if matches.is_present("nocheck-order") {
+        settings.check_order = CheckOrder::Disabled;
+    }
+
+    if matches.is_present("check-order") {
+        settings.check_order = CheckOrder::Enabled;
+    }
+
+    if matches.is_present("header") {
+        settings.headers = true;
+    }
+
+    let file1 = matches.value_of("file1").unwrap();
+    let file2 = matches.value_of("file2").unwrap();
+
+    if file1 == "-" && file2 == "-" {
+        crash!(1, "both files cannot be standard input");
+    }
+
+    exec(file1, file2, &settings)
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(NAME)
         .version(crate_version!())
         .about(
             "For each pair of input lines with identical join fields, write a line to
@@ -542,68 +607,6 @@ FILENUM is 1 or 2, corresponding to FILE1 or FILE2",
                 .value_name("FILE2")
                 .hidden(true),
         )
-        .get_matches_from(args);
-
-    let keys = parse_field_number_option(matches.value_of("j"));
-    let key1 = parse_field_number_option(matches.value_of("1"));
-    let key2 = parse_field_number_option(matches.value_of("2"));
-
-    let mut settings: Settings = Default::default();
-
-    if let Some(value) = matches.value_of("v") {
-        settings.print_unpaired = parse_file_number(value);
-        settings.print_joined = false;
-    } else if let Some(value) = matches.value_of("a") {
-        settings.print_unpaired = parse_file_number(value);
-    }
-
-    settings.ignore_case = matches.is_present("i");
-    settings.key1 = get_field_number(keys, key1);
-    settings.key2 = get_field_number(keys, key2);
-
-    if let Some(value) = matches.value_of("t") {
-        settings.separator = match value.len() {
-            0 => Sep::Line,
-            1 => Sep::Char(value.chars().next().unwrap()),
-            _ => crash!(1, "multi-character tab {}", value),
-        };
-    }
-
-    if let Some(format) = matches.value_of("o") {
-        if format == "auto" {
-            settings.autoformat = true;
-        } else {
-            settings.format = format
-                .split(|c| c == ' ' || c == ',' || c == '\t')
-                .map(Spec::parse)
-                .collect();
-        }
-    }
-
-    if let Some(empty) = matches.value_of("e") {
-        settings.empty = empty.to_string();
-    }
-
-    if matches.is_present("nocheck-order") {
-        settings.check_order = CheckOrder::Disabled;
-    }
-
-    if matches.is_present("check-order") {
-        settings.check_order = CheckOrder::Enabled;
-    }
-
-    if matches.is_present("header") {
-        settings.headers = true;
-    }
-
-    let file1 = matches.value_of("file1").unwrap();
-    let file2 = matches.value_of("file2").unwrap();
-
-    if file1 == "-" && file2 == "-" {
-        crash!(1, "both files cannot be standard input");
-    }
-
-    exec(file1, file2, &settings)
 }
 
 fn exec(file1: &str, file2: &str, settings: &Settings) -> i32 {

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -43,38 +43,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let (args, obs_signal) = handle_obsolete(args);
 
     let usage = format!("{} [OPTIONS]... PID...", executable!());
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::LIST)
-                .short("l")
-                .long(options::LIST)
-                .help("Lists signals")
-                .conflicts_with(options::TABLE)
-                .conflicts_with(options::TABLE_OLD),
-        )
-        .arg(
-            Arg::with_name(options::TABLE)
-                .short("t")
-                .long(options::TABLE)
-                .help("Lists table of signals"),
-        )
-        .arg(Arg::with_name(options::TABLE_OLD).short("L").hidden(true))
-        .arg(
-            Arg::with_name(options::SIGNAL)
-                .short("s")
-                .long(options::SIGNAL)
-                .help("Sends given signal")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name(options::PIDS_OR_SIGNALS)
-                .hidden(true)
-                .multiple(true),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mode = if matches.is_present(options::TABLE) || matches.is_present(options::TABLE_OLD) {
         Mode::Table
@@ -104,6 +73,39 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     EXIT_OK
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::LIST)
+                .short("l")
+                .long(options::LIST)
+                .help("Lists signals")
+                .conflicts_with(options::TABLE)
+                .conflicts_with(options::TABLE_OLD),
+        )
+        .arg(
+            Arg::with_name(options::TABLE)
+                .short("t")
+                .long(options::TABLE)
+                .help("Lists table of signals"),
+        )
+        .arg(Arg::with_name(options::TABLE_OLD).short("L").hidden(true))
+        .arg(
+            Arg::with_name(options::SIGNAL)
+                .short("s")
+                .long(options::SIGNAL)
+                .help("Sends given signal")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(options::PIDS_OR_SIGNALS)
+                .hidden(true)
+                .multiple(true),
+        )
 }
 
 fn handle_obsolete(mut args: Vec<String>) -> (Vec<String>, Option<String>) {

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -32,19 +32,7 @@ pub fn normalize_error_message(e: Error) -> String {
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::FILES)
-                .hidden(true)
-                .required(true)
-                .min_values(2)
-                .max_values(2)
-                .takes_value(true),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let files: Vec<_> = matches
         .values_of_os(options::FILES)
@@ -60,4 +48,18 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             1
         }
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::FILES)
+                .hidden(true)
+                .required(true)
+                .min_values(2)
+                .max_values(2)
+                .takes_value(true),
+        )
 }

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -45,11 +45,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .accept_any();
 
     let usage = get_usage();
-    let _ = App::new(executable!())
-        .version(crate_version!())
-        .about(SUMMARY)
-        .usage(&usage[..])
-        .get_matches_from(args);
+    let _ = uu_app().usage(&usage[..]).get_matches_from(args);
 
     match get_userlogin() {
         Some(userlogin) => println!("{}", userlogin),
@@ -57,4 +53,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(SUMMARY)
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -558,10 +558,22 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let app = App::new(executable!())
+    let app = uu_app().usage(&usage[..]);
+
+    let matches = app.get_matches_from(args);
+
+    let locs = matches
+        .values_of(options::PATHS)
+        .map(|v| v.map(ToString::to_string).collect())
+        .unwrap_or_else(|| vec![String::from(".")]);
+
+    list(locs, Config::from(matches))
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
-        .usage(&usage[..])
 
         // Format arguments
         .arg(
@@ -1095,16 +1107,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     // Positional arguments
         .arg(Arg::with_name(options::PATHS).multiple(true).takes_value(true))
 
-        .after_help(AFTER_HELP);
-
-    let matches = app.get_matches_from(args);
-
-    let locs = matches
-        .values_of(options::PATHS)
-        .map(|v| v.map(ToString::to_string).collect())
-        .unwrap_or_else(|| vec![String::from(".")]);
-
-    list(locs, Config::from(matches))
+        .after_help(AFTER_HELP)
 }
 
 /// Represents a Path along with it's associated data

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -86,8 +86,16 @@ pub fn uu_app() -> App<'static, 'static> {
         .arg(
             Arg::with_name(options::SE_LINUX_SECURITY_CONTEXT)
                 .short(options::SE_LINUX_SECURITY_CONTEXT)
-                .help("set the SELinux security context to default type")
+                .help("set the SELinux security context to default type"),
         )
-        .arg(Arg::with_name(options::CONTEXT).long(options::CONTEXT).value_name("CTX").help("like -Z, or if CTX is specified then set the SELinux\nor SMACK security context to CTX"))
+        .arg(
+            Arg::with_name(options::CONTEXT)
+                .long(options::CONTEXT)
+                .value_name("CTX")
+                .help(
+                    "like -Z, or if CTX is specified then set the SELinux \
+                    or SMACK security context to CTX",
+                ),
+        )
         .arg(Arg::with_name(options::FIFO).hidden(true).multiple(true))
 }

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -29,27 +29,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .name(NAME)
-        .version(crate_version!())
-        .usage(USAGE)
-        .about(SUMMARY)
-        .arg(
-            Arg::with_name(options::MODE)
-                .short("m")
-                .long(options::MODE)
-                .help("file permissions for the fifo")
-                .default_value("0666")
-                .value_name("0666"),
-        )
-        .arg(
-            Arg::with_name(options::SE_LINUX_SECURITY_CONTEXT)
-                .short(options::SE_LINUX_SECURITY_CONTEXT)
-                .help("set the SELinux security context to default type")
-        )
-        .arg(Arg::with_name(options::CONTEXT).long(options::CONTEXT).value_name("CTX").help("like -Z, or if CTX is specified then set the SELinux\nor SMACK security context to CTX"))
-        .arg(Arg::with_name(options::FIFO).hidden(true).multiple(true))
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     if matches.is_present(options::CONTEXT) {
         crash!(1, "--context is not implemented");
@@ -87,4 +67,27 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     exit_code
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .name(NAME)
+        .version(crate_version!())
+        .usage(USAGE)
+        .about(SUMMARY)
+        .arg(
+            Arg::with_name(options::MODE)
+                .short("m")
+                .long(options::MODE)
+                .help("file permissions for the fifo")
+                .default_value("0666")
+                .value_name("0666"),
+        )
+        .arg(
+            Arg::with_name(options::SE_LINUX_SECURITY_CONTEXT)
+                .short(options::SE_LINUX_SECURITY_CONTEXT)
+                .help("set the SELinux security context to default type")
+        )
+        .arg(Arg::with_name(options::CONTEXT).long(options::CONTEXT).value_name("CTX").help("like -Z, or if CTX is specified then set the SELinux\nor SMACK security context to CTX"))
+        .arg(Arg::with_name(options::FIFO).hidden(true).multiple(true))
 }

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -89,48 +89,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     // opts.optflag("Z", "", "set the SELinux security context to default type");
     // opts.optopt("", "context", "like -Z, or if CTX is specified then set the SELinux or SMACK security context to CTX");
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .usage(USAGE)
-        .after_help(LONG_HELP)
-        .about(ABOUT)
-        .arg(
-            Arg::with_name("mode")
-                .short("m")
-                .long("mode")
-                .value_name("MODE")
-                .help("set file permission bits to MODE, not a=rw - umask"),
-        )
-        .arg(
-            Arg::with_name("name")
-                .value_name("NAME")
-                .help("name of the new file")
-                .required(true)
-                .index(1),
-        )
-        .arg(
-            Arg::with_name("type")
-                .value_name("TYPE")
-                .help("type of the new file (b, c, u or p)")
-                .required(true)
-                .validator(valid_type)
-                .index(2),
-        )
-        .arg(
-            Arg::with_name("major")
-                .value_name("MAJOR")
-                .help("major file type")
-                .validator(valid_u64)
-                .index(3),
-        )
-        .arg(
-            Arg::with_name("minor")
-                .value_name("MINOR")
-                .help("minor file type")
-                .validator(valid_u64)
-                .index(4),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let mode = match get_mode(&matches) {
         Ok(mode) => mode,
@@ -183,6 +142,50 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             }
         }
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .usage(USAGE)
+        .after_help(LONG_HELP)
+        .about(ABOUT)
+        .arg(
+            Arg::with_name("mode")
+                .short("m")
+                .long("mode")
+                .value_name("MODE")
+                .help("set file permission bits to MODE, not a=rw - umask"),
+        )
+        .arg(
+            Arg::with_name("name")
+                .value_name("NAME")
+                .help("name of the new file")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("type")
+                .value_name("TYPE")
+                .help("type of the new file (b, c, u or p)")
+                .required(true)
+                .validator(valid_type)
+                .index(2),
+        )
+        .arg(
+            Arg::with_name("major")
+                .value_name("MAJOR")
+                .help("major file type")
+                .validator(valid_u64)
+                .index(3),
+        )
+        .arg(
+            Arg::with_name("minor")
+                .value_name("MINOR")
+                .help("minor file type")
+                .validator(valid_u64)
+                .index(4),
+        )
 }
 
 fn get_mode(matches: &ArgMatches) -> Result<mode_t, String> {

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -40,61 +40,7 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_DIRECTORY)
-                .short("d")
-                .long(OPT_DIRECTORY)
-                .help("Make a directory instead of a file"),
-        )
-        .arg(
-            Arg::with_name(OPT_DRY_RUN)
-                .short("u")
-                .long(OPT_DRY_RUN)
-                .help("do not create anything; merely print a name (unsafe)"),
-        )
-        .arg(
-            Arg::with_name(OPT_QUIET)
-                .short("q")
-                .long("quiet")
-                .help("Fail silently if an error occurs."),
-        )
-        .arg(
-            Arg::with_name(OPT_SUFFIX)
-                .long(OPT_SUFFIX)
-                .help(
-                    "append SUFFIX to TEMPLATE; SUFFIX must not contain a path separator. \
-                     This option is implied if TEMPLATE does not end with X.",
-                )
-                .value_name("SUFFIX"),
-        )
-        .arg(
-            Arg::with_name(OPT_TMPDIR)
-                .short("p")
-                .long(OPT_TMPDIR)
-                .help(
-                    "interpret TEMPLATE relative to DIR; if DIR is not specified, use \
-                     $TMPDIR ($TMP on windows) if set, else /tmp. With this option, TEMPLATE must not \
-                     be an absolute name; unlike with -t, TEMPLATE may contain \
-                     slashes, but mktemp creates only the final component",
-                )
-                .value_name("DIR"),
-        )
-        .arg(Arg::with_name(OPT_T).short(OPT_T).help(
-            "Generate a template (using the supplied prefix and TMPDIR (TMP on windows) if set) \
-             to create a filename template [deprecated]",
-        ))
-        .arg(
-            Arg::with_name(ARG_TEMPLATE)
-                .multiple(false)
-                .takes_value(true)
-                .max_values(1)
-                .default_value(DEFAULT_TEMPLATE),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let template = matches.value_of(ARG_TEMPLATE).unwrap();
     let tmpdir = matches.value_of(OPT_TMPDIR).unwrap_or_default();
@@ -169,6 +115,62 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     } else {
         exec(tmpdir, prefix, rand, suffix, make_dir, suppress_file_err)
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_DIRECTORY)
+                .short("d")
+                .long(OPT_DIRECTORY)
+                .help("Make a directory instead of a file"),
+        )
+        .arg(
+            Arg::with_name(OPT_DRY_RUN)
+                .short("u")
+                .long(OPT_DRY_RUN)
+                .help("do not create anything; merely print a name (unsafe)"),
+        )
+        .arg(
+            Arg::with_name(OPT_QUIET)
+                .short("q")
+                .long("quiet")
+                .help("Fail silently if an error occurs."),
+        )
+        .arg(
+            Arg::with_name(OPT_SUFFIX)
+                .long(OPT_SUFFIX)
+                .help(
+                    "append SUFFIX to TEMPLATE; SUFFIX must not contain a path separator. \
+                     This option is implied if TEMPLATE does not end with X.",
+                )
+                .value_name("SUFFIX"),
+        )
+        .arg(
+            Arg::with_name(OPT_TMPDIR)
+                .short("p")
+                .long(OPT_TMPDIR)
+                .help(
+                    "interpret TEMPLATE relative to DIR; if DIR is not specified, use \
+                     $TMPDIR ($TMP on windows) if set, else /tmp. With this option, TEMPLATE must not \
+                     be an absolute name; unlike with -t, TEMPLATE may contain \
+                     slashes, but mktemp creates only the final component",
+                )
+                .value_name("DIR"),
+        )
+        .arg(Arg::with_name(OPT_T).short(OPT_T).help(
+            "Generate a template (using the supplied prefix and TMPDIR (TMP on windows) if set) \
+             to create a filename template [deprecated]",
+        ))
+        .arg(
+            Arg::with_name(ARG_TEMPLATE)
+                .multiple(false)
+                .takes_value(true)
+                .max_values(1)
+                .default_value(DEFAULT_TEMPLATE),
+        )
 }
 
 fn parse_template(temp: &str) -> Option<(&str, usize, &str)> {

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -46,20 +46,7 @@ process).",
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .setting(AppSettings::TrailingVarArg)
-        .version(crate_version!())
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::ADJUSTMENT)
-                .short("n")
-                .long(options::ADJUSTMENT)
-                .help("add N to the niceness (default is 10)")
-                .takes_value(true)
-                .allow_hyphen_values(true),
-        )
-        .arg(Arg::with_name(options::COMMAND).multiple(true))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mut niceness = unsafe {
         nix::errno::Errno::clear();
@@ -119,4 +106,19 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     } else {
         126
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .setting(AppSettings::TrailingVarArg)
+        .version(crate_version!())
+        .arg(
+            Arg::with_name(options::ADJUSTMENT)
+                .short("n")
+                .long(options::ADJUSTMENT)
+                .help("add N to the niceness (default is 10)")
+                .takes_value(true)
+                .allow_hyphen_values(true),
+        )
+        .arg(Arg::with_name(options::COMMAND).multiple(true))
 }

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -88,7 +88,62 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().get_matches_from(args);
+
+    // A mutable settings object, initialized with the defaults.
+    let mut settings = Settings {
+        header_numbering: NumberingStyle::NumberForNone,
+        body_numbering: NumberingStyle::NumberForAll,
+        footer_numbering: NumberingStyle::NumberForNone,
+        section_delimiter: ['\\', ':'],
+        starting_line_number: 1,
+        line_increment: 1,
+        join_blank_lines: 1,
+        number_width: 6,
+        number_format: NumberFormat::Right,
+        renumber: true,
+        number_separator: String::from("\t"),
+    };
+
+    // Update the settings from the command line options, and terminate the
+    // program if some options could not successfully be parsed.
+    let parse_errors = helper::parse_options(&mut settings, &matches);
+    if !parse_errors.is_empty() {
+        show_error!("Invalid arguments supplied.");
+        for message in &parse_errors {
+            println!("{}", message);
+        }
+        return 1;
+    }
+
+    let mut read_stdin = false;
+    let files: Vec<String> = match matches.values_of(options::FILE) {
+        Some(v) => v.clone().map(|v| v.to_owned()).collect(),
+        None => vec!["-".to_owned()],
+    };
+
+    for file in &files {
+        if file == "-" {
+            // If both file names and '-' are specified, we choose to treat first all
+            // regular files, and then read from stdin last.
+            read_stdin = true;
+            continue;
+        }
+        let path = Path::new(file);
+        let reader = File::open(path).unwrap();
+        let mut buffer = BufReader::new(reader);
+        nl(&mut buffer, &settings);
+    }
+
+    if read_stdin {
+        let mut buffer = BufReader::new(stdin());
+        nl(&mut buffer, &settings);
+    }
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)
@@ -169,58 +224,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .help("use NUMBER columns for line numbers")
                 .value_name("NUMBER"),
         )
-        .get_matches_from(args);
-
-    // A mutable settings object, initialized with the defaults.
-    let mut settings = Settings {
-        header_numbering: NumberingStyle::NumberForNone,
-        body_numbering: NumberingStyle::NumberForAll,
-        footer_numbering: NumberingStyle::NumberForNone,
-        section_delimiter: ['\\', ':'],
-        starting_line_number: 1,
-        line_increment: 1,
-        join_blank_lines: 1,
-        number_width: 6,
-        number_format: NumberFormat::Right,
-        renumber: true,
-        number_separator: String::from("\t"),
-    };
-
-    // Update the settings from the command line options, and terminate the
-    // program if some options could not successfully be parsed.
-    let parse_errors = helper::parse_options(&mut settings, &matches);
-    if !parse_errors.is_empty() {
-        show_error!("Invalid arguments supplied.");
-        for message in &parse_errors {
-            println!("{}", message);
-        }
-        return 1;
-    }
-
-    let mut read_stdin = false;
-    let files: Vec<String> = match matches.values_of(options::FILE) {
-        Some(v) => v.clone().map(|v| v.to_owned()).collect(),
-        None => vec!["-".to_owned()],
-    };
-
-    for file in &files {
-        if file == "-" {
-            // If both file names and '-' are specified, we choose to treat first all
-            // regular files, and then read from stdin last.
-            read_stdin = true;
-            continue;
-        }
-        let path = Path::new(file);
-        let reader = File::open(path).unwrap();
-        let mut buffer = BufReader::new(reader);
-        nl(&mut buffer, &settings);
-    }
-
-    if read_stdin {
-        let mut buffer = BufReader::new(stdin());
-        nl(&mut buffer, &settings);
-    }
-    0
 }
 
 // nl implements the main functionality for an individual buffer.

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -45,19 +45,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .after_help(LONG_HELP)
-        .arg(
-            Arg::with_name(options::CMD)
-                .hidden(true)
-                .required(true)
-                .multiple(true),
-        )
-        .setting(AppSettings::TrailingVarArg)
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     replace_fds();
 
@@ -80,6 +68,20 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         libc::ENOENT => EXIT_ENOENT,
         _ => EXIT_CANNOT_INVOKE,
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .after_help(LONG_HELP)
+        .arg(
+            Arg::with_name(options::CMD)
+                .hidden(true)
+                .required(true)
+                .multiple(true),
+        )
+        .setting(AppSettings::TrailingVarArg)
 }
 
 fn replace_fds() {

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -33,24 +33,7 @@ fn get_usage() -> String {
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_ALL)
-                .short("")
-                .long(OPT_ALL)
-                .help("print the number of cores available to the system"),
-        )
-        .arg(
-            Arg::with_name(OPT_IGNORE)
-                .short("")
-                .long(OPT_IGNORE)
-                .takes_value(true)
-                .help("ignore up to N cores"),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mut ignore = match matches.value_of(OPT_IGNORE) {
         Some(numstr) => match numstr.parse() {
@@ -84,6 +67,25 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
     println!("{}", cores);
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_ALL)
+                .short("")
+                .long(OPT_ALL)
+                .help("print the number of cores available to the system"),
+        )
+        .arg(
+            Arg::with_name(OPT_IGNORE)
+                .short("")
+                .long(OPT_IGNORE)
+                .takes_value(true)
+                .help("ignore up to N cores"),
+        )
 }
 
 #[cfg(any(

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -214,7 +214,45 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let clap_opts = clap::App::new(executable!())
+    let clap_opts = uu_app();
+
+    let clap_matches = clap_opts
+        .clone() // Clone to reuse clap_opts to print help
+        .get_matches_from(args.clone());
+
+    let od_options = match OdOptions::new(clap_matches, args) {
+        Err(s) => {
+            crash!(1, "{}", s);
+        }
+        Ok(o) => o,
+    };
+
+    let mut input_offset =
+        InputOffset::new(od_options.radix, od_options.skip_bytes, od_options.label);
+
+    let mut input = open_input_peek_reader(
+        &od_options.input_strings,
+        od_options.skip_bytes,
+        od_options.read_bytes,
+    );
+    let mut input_decoder = InputDecoder::new(
+        &mut input,
+        od_options.line_bytes,
+        PEEK_BUFFER_SIZE,
+        od_options.byte_order,
+    );
+
+    let output_info = OutputInfo::new(
+        od_options.line_bytes,
+        &od_options.formats[..],
+        od_options.output_duplicates,
+    );
+
+    odfunc(&mut input_offset, &mut input_decoder, &output_info)
+}
+
+pub fn uu_app() -> clap::App<'static, 'static> {
+    clap::App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
         .usage(USAGE)
@@ -434,41 +472,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             AppSettings::DontDelimitTrailingValues,
             AppSettings::DisableVersion,
             AppSettings::DeriveDisplayOrder,
-        ]);
-
-    let clap_matches = clap_opts
-        .clone() // Clone to reuse clap_opts to print help
-        .get_matches_from(args.clone());
-
-    let od_options = match OdOptions::new(clap_matches, args) {
-        Err(s) => {
-            crash!(1, "{}", s);
-        }
-        Ok(o) => o,
-    };
-
-    let mut input_offset =
-        InputOffset::new(od_options.radix, od_options.skip_bytes, od_options.label);
-
-    let mut input = open_input_peek_reader(
-        &od_options.input_strings,
-        od_options.skip_bytes,
-        od_options.read_bytes,
-    );
-    let mut input_decoder = InputDecoder::new(
-        &mut input,
-        od_options.line_bytes,
-        PEEK_BUFFER_SIZE,
-        od_options.byte_order,
-    );
-
-    let output_info = OutputInfo::new(
-        od_options.line_bytes,
-        &od_options.formats[..],
-        od_options.output_duplicates,
-    );
-
-    odfunc(&mut input_offset, &mut input_decoder, &output_info)
+        ])
 }
 
 /// Loops through the input line by line, calling print_bytes to take care of the output.

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -37,7 +37,22 @@ fn read_line<R: Read>(
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let matches = App::new(executable!())
+    let matches = uu_app().get_matches_from(args);
+
+    let serial = matches.is_present(options::SERIAL);
+    let delimiters = matches.value_of(options::DELIMITER).unwrap().to_owned();
+    let files = matches
+        .values_of(options::FILE)
+        .unwrap()
+        .map(|s| s.to_owned())
+        .collect();
+    paste(files, serial, delimiters);
+
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(
@@ -61,18 +76,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .multiple(true)
                 .default_value("-"),
         )
-        .get_matches_from(args);
-
-    let serial = matches.is_present(options::SERIAL);
-    let delimiters = matches.value_of(options::DELIMITER).unwrap().to_owned();
-    let files = matches
-        .values_of(options::FILE)
-        .unwrap()
-        .map(|s| s.to_owned())
-        .collect();
-    paste(files, serial, delimiters);
-
-    0
 }
 
 fn paste(filenames: Vec<String>, serial: bool, delimiters: String) {

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -49,27 +49,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::POSIX)
-                .short("p")
-                .help("check for most POSIX systems"),
-        )
-        .arg(
-            Arg::with_name(options::POSIX_SPECIAL)
-                .short("P")
-                .help(r#"check for empty names and leading "-""#),
-        )
-        .arg(
-            Arg::with_name(options::PORTABILITY)
-                .long(options::PORTABILITY)
-                .help("check for all POSIX systems (equivalent to -p -P)"),
-        )
-        .arg(Arg::with_name(options::PATH).hidden(true).multiple(true))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     // set working mode
     let is_posix = matches.values_of(options::POSIX).is_some();
@@ -113,6 +93,28 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     } else {
         1
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::POSIX)
+                .short("p")
+                .help("check for most POSIX systems"),
+        )
+        .arg(
+            Arg::with_name(options::POSIX_SPECIAL)
+                .short("P")
+                .help(r#"check for empty names and leading "-""#),
+        )
+        .arg(
+            Arg::with_name(options::PORTABILITY)
+                .long(options::PORTABILITY)
+                .help("check for all POSIX systems (equivalent to -p -P)"),
+        )
+        .arg(Arg::with_name(options::PATH).hidden(true).multiple(true))
 }
 
 // check a path, given as a slice of it's components and an operating mode

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -60,62 +60,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let after_help = get_long_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&after_help[..])
-        .arg(
-            Arg::with_name(options::LONG_FORMAT)
-                .short("l")
-                .requires(options::USER)
-                .help("produce long format output for the specified USERs"),
-        )
-        .arg(
-            Arg::with_name(options::OMIT_HOME_DIR)
-                .short("b")
-                .help("omit the user's home directory and shell in long format"),
-        )
-        .arg(
-            Arg::with_name(options::OMIT_PROJECT_FILE)
-                .short("h")
-                .help("omit the user's project file in long format"),
-        )
-        .arg(
-            Arg::with_name(options::OMIT_PLAN_FILE)
-                .short("p")
-                .help("omit the user's plan file in long format"),
-        )
-        .arg(
-            Arg::with_name(options::SHORT_FORMAT)
-                .short("s")
-                .help("do short format output, this is the default"),
-        )
-        .arg(
-            Arg::with_name(options::OMIT_HEADINGS)
-                .short("f")
-                .help("omit the line of column headings in short format"),
-        )
-        .arg(
-            Arg::with_name(options::OMIT_NAME)
-                .short("w")
-                .help("omit the user's full name in short format"),
-        )
-        .arg(
-            Arg::with_name(options::OMIT_NAME_HOST)
-                .short("i")
-                .help("omit the user's full name and remote host in short format"),
-        )
-        .arg(
-            Arg::with_name(options::OMIT_NAME_HOST_TIME)
-                .short("q")
-                .help("omit the user's full name, remote host and idle time in short format"),
-        )
-        .arg(
-            Arg::with_name(options::USER)
-                .takes_value(true)
-                .multiple(true),
-        )
         .get_matches_from(args);
 
     let users: Vec<String> = matches
@@ -180,6 +127,63 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     } else {
         pk.long_pinky()
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::LONG_FORMAT)
+                .short("l")
+                .requires(options::USER)
+                .help("produce long format output for the specified USERs"),
+        )
+        .arg(
+            Arg::with_name(options::OMIT_HOME_DIR)
+                .short("b")
+                .help("omit the user's home directory and shell in long format"),
+        )
+        .arg(
+            Arg::with_name(options::OMIT_PROJECT_FILE)
+                .short("h")
+                .help("omit the user's project file in long format"),
+        )
+        .arg(
+            Arg::with_name(options::OMIT_PLAN_FILE)
+                .short("p")
+                .help("omit the user's plan file in long format"),
+        )
+        .arg(
+            Arg::with_name(options::SHORT_FORMAT)
+                .short("s")
+                .help("do short format output, this is the default"),
+        )
+        .arg(
+            Arg::with_name(options::OMIT_HEADINGS)
+                .short("f")
+                .help("omit the line of column headings in short format"),
+        )
+        .arg(
+            Arg::with_name(options::OMIT_NAME)
+                .short("w")
+                .help("omit the user's full name in short format"),
+        )
+        .arg(
+            Arg::with_name(options::OMIT_NAME_HOST)
+                .short("i")
+                .help("omit the user's full name and remote host in short format"),
+        )
+        .arg(
+            Arg::with_name(options::OMIT_NAME_HOST_TIME)
+                .short("q")
+                .help("omit the user's full name, remote host and idle time in short format"),
+        )
+        .arg(
+            Arg::with_name(options::USER)
+                .takes_value(true)
+                .multiple(true),
+        )
 }
 
 struct Pinky {

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/pr.rs"
 
 [dependencies]
+clap = "2.33.3"
 uucore = { version=">=0.0.7", package="uucore", path="../../uucore", features=["utmpx", "entries"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 getopts = "0.2.21"

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -23,6 +23,7 @@ use std::fs::{metadata, File};
 use std::io::{stdin, stdout, BufRead, BufReader, Lines, Read, Stdout, Write};
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
+use uucore::executable;
 
 type IOError = std::io::Error;
 
@@ -165,6 +166,11 @@ quick_error! {
             display("pr: cannot open {}, No such file or directory", path)
         }
     }
+}
+
+pub fn uu_app() -> clap::App<'static, 'static> {
+    // TODO: migrate to clap to get more shell completions
+    clap::App::new(executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -26,23 +26,7 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_NULL)
-                .short("0")
-                .long(OPT_NULL)
-                .help("end each output line with 0 byte rather than newline"),
-        )
-        .arg(
-            Arg::with_name(ARG_VARIABLES)
-                .multiple(true)
-                .takes_value(true)
-                .min_values(1),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let variables: Vec<String> = matches
         .values_of(ARG_VARIABLES)
@@ -68,4 +52,22 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         }
     }
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_NULL)
+                .short("0")
+                .long(OPT_NULL)
+                .help("end each output line with 0 byte rather than newline"),
+        )
+        .arg(
+            Arg::with_name(ARG_VARIABLES)
+                .multiple(true)
+                .takes_value(true)
+                .min_values(1),
+        )
 }

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 path = "src/printf.rs"
 
 [dependencies]
+clap = "2.33.3"
 itertools = "0.8.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -2,14 +2,18 @@
 // spell-checker:ignore (change!) each's
 // spell-checker:ignore (ToDO) LONGHELP FORMATSTRING templating parameterizing formatstr
 
+#[macro_use]
+extern crate uucore;
+
+use clap::{crate_version, App, Arg};
 use uucore::InvalidEncodingHandling;
 
 mod cli;
 mod memo;
 mod tokenize;
 
-static NAME: &str = "printf";
-static VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = "version";
+const HELP: &str = "help";
 static LONGHELP_LEAD: &str = "printf
 
  USAGE: printf FORMATSTRING [ARGUMENT]...
@@ -290,10 +294,16 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if formatstr == "--help" {
         print!("{} {}", LONGHELP_LEAD, LONGHELP_BODY);
     } else if formatstr == "--version" {
-        println!("{} {}", NAME, VERSION);
+        println!("{} {}", executable!(), crate_version!());
     } else {
         let printf_args = &args[2..];
         memo::Memo::run_all(formatstr, printf_args);
     }
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .arg(Arg::with_name(VERSION).long(VERSION))
+        .arg(Arg::with_name(HELP).long(HELP))
 }

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -39,23 +39,7 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_LOGICAL)
-                .short("L")
-                .long(OPT_LOGICAL)
-                .help("use PWD from environment, even if it contains symlinks"),
-        )
-        .arg(
-            Arg::with_name(OPT_PHYSICAL)
-                .short("P")
-                .long(OPT_PHYSICAL)
-                .help("avoid all symlinks"),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     match env::current_dir() {
         Ok(logical_path) => {
@@ -72,4 +56,22 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     };
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_LOGICAL)
+                .short("L")
+                .long(OPT_LOGICAL)
+                .help("use PWD from environment, even if it contains symlinks"),
+        )
+        .arg(
+            Arg::with_name(OPT_PHYSICAL)
+                .short("P")
+                .long(OPT_PHYSICAL)
+                .help("avoid all symlinks"),
+        )
 }

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -35,69 +35,7 @@ fn get_usage() -> String {
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_CANONICALIZE)
-                .short("f")
-                .long(OPT_CANONICALIZE)
-                .help(
-                    "canonicalize by following every symlink in every component of the \
-                     given name recursively; all but the last component must exist",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_CANONICALIZE_EXISTING)
-                .short("e")
-                .long("canonicalize-existing")
-                .help(
-                    "canonicalize by following every symlink in every component of the \
-                     given name recursively, all components must exist",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_CANONICALIZE_MISSING)
-                .short("m")
-                .long(OPT_CANONICALIZE_MISSING)
-                .help(
-                    "canonicalize by following every symlink in every component of the \
-                     given name recursively, without requirements on components existence",
-                ),
-        )
-        .arg(
-            Arg::with_name(OPT_NO_NEWLINE)
-                .short("n")
-                .long(OPT_NO_NEWLINE)
-                .help("do not output the trailing delimiter"),
-        )
-        .arg(
-            Arg::with_name(OPT_QUIET)
-                .short("q")
-                .long(OPT_QUIET)
-                .help("suppress most error messages"),
-        )
-        .arg(
-            Arg::with_name(OPT_SILENT)
-                .short("s")
-                .long(OPT_SILENT)
-                .help("suppress most error messages"),
-        )
-        .arg(
-            Arg::with_name(OPT_VERBOSE)
-                .short("v")
-                .long(OPT_VERBOSE)
-                .help("report error message"),
-        )
-        .arg(
-            Arg::with_name(OPT_ZERO)
-                .short("z")
-                .long(OPT_ZERO)
-                .help("separate output with NUL rather than newline"),
-        )
-        .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mut no_newline = matches.is_present(OPT_NO_NEWLINE);
     let use_zero = matches.is_present(OPT_ZERO);
@@ -157,6 +95,70 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_CANONICALIZE)
+                .short("f")
+                .long(OPT_CANONICALIZE)
+                .help(
+                    "canonicalize by following every symlink in every component of the \
+                     given name recursively; all but the last component must exist",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_CANONICALIZE_EXISTING)
+                .short("e")
+                .long("canonicalize-existing")
+                .help(
+                    "canonicalize by following every symlink in every component of the \
+                     given name recursively, all components must exist",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_CANONICALIZE_MISSING)
+                .short("m")
+                .long(OPT_CANONICALIZE_MISSING)
+                .help(
+                    "canonicalize by following every symlink in every component of the \
+                     given name recursively, without requirements on components existence",
+                ),
+        )
+        .arg(
+            Arg::with_name(OPT_NO_NEWLINE)
+                .short("n")
+                .long(OPT_NO_NEWLINE)
+                .help("do not output the trailing delimiter"),
+        )
+        .arg(
+            Arg::with_name(OPT_QUIET)
+                .short("q")
+                .long(OPT_QUIET)
+                .help("suppress most error messages"),
+        )
+        .arg(
+            Arg::with_name(OPT_SILENT)
+                .short("s")
+                .long(OPT_SILENT)
+                .help("suppress most error messages"),
+        )
+        .arg(
+            Arg::with_name(OPT_VERBOSE)
+                .short("v")
+                .long(OPT_VERBOSE)
+                .help("report error message"),
+        )
+        .arg(
+            Arg::with_name(OPT_ZERO)
+                .short("z")
+                .long(OPT_ZERO)
+                .help("separate output with NUL rather than newline"),
+        )
+        .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
 }
 
 fn show(path: &Path, no_newline: bool, use_zero: bool) {

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -35,26 +35,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .accept_any();
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::DIR)
-                .short("d")
-                .takes_value(true)
-                .help("If any of FROM and TO is not subpath of DIR, output absolute path instead of relative"),
-        )
-        .arg(
-            Arg::with_name(options::TO)
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name(options::FROM)
-                .takes_value(true),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let to = Path::new(matches.value_of(options::TO).unwrap()).to_path_buf(); // required
     let from = match matches.value_of(options::FROM) {
@@ -98,4 +79,25 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     println!("{}", result.display());
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::DIR)
+                .short("d")
+                .takes_value(true)
+                .help("If any of FROM and TO is not subpath of DIR, output absolute path instead of relative"),
+        )
+        .arg(
+            Arg::with_name(options::TO)
+                .required(true)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(options::FROM)
+                .takes_value(true),
+        )
 }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -87,42 +87,7 @@ impl FromStr for Number {
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
-        .setting(AppSettings::AllowLeadingHyphen)
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(OPT_SEPARATOR)
-                .short("s")
-                .long("separator")
-                .help("Separator character (defaults to \\n)")
-                .takes_value(true)
-                .number_of_values(1),
-        )
-        .arg(
-            Arg::with_name(OPT_TERMINATOR)
-                .short("t")
-                .long("terminator")
-                .help("Terminator character (defaults to \\n)")
-                .takes_value(true)
-                .number_of_values(1),
-        )
-        .arg(
-            Arg::with_name(OPT_WIDTHS)
-                .short("w")
-                .long("widths")
-                .help("Equalize widths of all numbers by padding with zeros"),
-        )
-        .arg(
-            Arg::with_name(ARG_NUMBERS)
-                .multiple(true)
-                .takes_value(true)
-                .allow_hyphen_values(true)
-                .max_values(3)
-                .required(true),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let numbers = matches.values_of(ARG_NUMBERS).unwrap().collect::<Vec<_>>();
 
@@ -195,6 +160,43 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         ),
     }
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .setting(AppSettings::AllowLeadingHyphen)
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(OPT_SEPARATOR)
+                .short("s")
+                .long("separator")
+                .help("Separator character (defaults to \\n)")
+                .takes_value(true)
+                .number_of_values(1),
+        )
+        .arg(
+            Arg::with_name(OPT_TERMINATOR)
+                .short("t")
+                .long("terminator")
+                .help("Terminator character (defaults to \\n)")
+                .takes_value(true)
+                .number_of_values(1),
+        )
+        .arg(
+            Arg::with_name(OPT_WIDTHS)
+                .short("w")
+                .long("widths")
+                .help("Equalize widths of all numbers by padding with zeros"),
+        )
+        .arg(
+            Arg::with_name(ARG_NUMBERS)
+                .multiple(true)
+                .takes_value(true)
+                .allow_hyphen_values(true)
+                .max_values(3)
+                .required(true),
+        )
 }
 
 fn done_printing<T: Num + PartialOrd>(next: &T, increment: &T, last: &T) -> bool {

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -272,62 +272,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let app = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .after_help(AFTER_HELP)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::FORCE)
-                .long(options::FORCE)
-                .short("f")
-                .help("change permissions to allow writing if necessary"),
-        )
-        .arg(
-            Arg::with_name(options::ITERATIONS)
-                .long(options::ITERATIONS)
-                .short("n")
-                .help("overwrite N times instead of the default (3)")
-                .value_name("NUMBER")
-                .default_value("3"),
-        )
-        .arg(
-            Arg::with_name(options::SIZE)
-                .long(options::SIZE)
-                .short("s")
-                .takes_value(true)
-                .value_name("N")
-                .help("shred this many bytes (suffixes like K, M, G accepted)"),
-        )
-        .arg(
-            Arg::with_name(options::REMOVE)
-                .short("u")
-                .long(options::REMOVE)
-                .help("truncate and remove file after overwriting;  See below"),
-        )
-        .arg(
-            Arg::with_name(options::VERBOSE)
-                .long(options::VERBOSE)
-                .short("v")
-                .help("show progress"),
-        )
-        .arg(
-            Arg::with_name(options::EXACT)
-                .long(options::EXACT)
-                .short("x")
-                .help(
-                    "do not round file sizes up to the next full block;\n\
-                     this is the default for non-regular files",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::ZERO)
-                .long(options::ZERO)
-                .short("z")
-                .help("add a final overwrite with zeros to hide shredding"),
-        )
-        // Positional arguments
-        .arg(Arg::with_name(options::FILE).hidden(true).multiple(true));
+    let app = uu_app().usage(&usage[..]);
 
     let matches = app.get_matches_from(args);
 
@@ -382,6 +327,64 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .after_help(AFTER_HELP)
+        .arg(
+            Arg::with_name(options::FORCE)
+                .long(options::FORCE)
+                .short("f")
+                .help("change permissions to allow writing if necessary"),
+        )
+        .arg(
+            Arg::with_name(options::ITERATIONS)
+                .long(options::ITERATIONS)
+                .short("n")
+                .help("overwrite N times instead of the default (3)")
+                .value_name("NUMBER")
+                .default_value("3"),
+        )
+        .arg(
+            Arg::with_name(options::SIZE)
+                .long(options::SIZE)
+                .short("s")
+                .takes_value(true)
+                .value_name("N")
+                .help("shred this many bytes (suffixes like K, M, G accepted)"),
+        )
+        .arg(
+            Arg::with_name(options::REMOVE)
+                .short("u")
+                .long(options::REMOVE)
+                .help("truncate and remove file after overwriting;  See below"),
+        )
+        .arg(
+            Arg::with_name(options::VERBOSE)
+                .long(options::VERBOSE)
+                .short("v")
+                .help("show progress"),
+        )
+        .arg(
+            Arg::with_name(options::EXACT)
+                .long(options::EXACT)
+                .short("x")
+                .help(
+                    "do not round file sizes up to the next full block;\n\
+                     this is the default for non-regular files",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::ZERO)
+                .long(options::ZERO)
+                .short("z")
+                .help("add a final overwrite with zeros to hide shredding"),
+        )
+        // Positional arguments
+        .arg(Arg::with_name(options::FILE).hidden(true).multiple(true))
 }
 
 // TODO: Add support for all postfixes here up to and including EiB

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -56,7 +56,66 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().get_matches_from(args);
+
+    let mode = if let Some(args) = matches.values_of(options::ECHO) {
+        Mode::Echo(args.map(String::from).collect())
+    } else if let Some(range) = matches.value_of(options::INPUT_RANGE) {
+        match parse_range(range) {
+            Ok(m) => Mode::InputRange(m),
+            Err(msg) => {
+                crash!(1, "{}", msg);
+            }
+        }
+    } else {
+        Mode::Default(matches.value_of(options::FILE).unwrap_or("-").to_string())
+    };
+
+    let options = Options {
+        head_count: match matches.value_of(options::HEAD_COUNT) {
+            Some(count) => match count.parse::<usize>() {
+                Ok(val) => val,
+                Err(_) => {
+                    show_error!("invalid line count: '{}'", count);
+                    return 1;
+                }
+            },
+            None => std::usize::MAX,
+        },
+        output: matches.value_of(options::OUTPUT).map(String::from),
+        random_source: matches.value_of(options::RANDOM_SOURCE).map(String::from),
+        repeat: matches.is_present(options::REPEAT),
+        sep: if matches.is_present(options::ZERO_TERMINATED) {
+            0x00_u8
+        } else {
+            0x0a_u8
+        },
+    };
+
+    match mode {
+        Mode::Echo(args) => {
+            let mut evec = args.iter().map(String::as_bytes).collect::<Vec<_>>();
+            find_seps(&mut evec, options.sep);
+            shuf_bytes(&mut evec, options);
+        }
+        Mode::InputRange((b, e)) => {
+            let rvec = (b..e).map(|x| format!("{}", x)).collect::<Vec<String>>();
+            let mut rvec = rvec.iter().map(String::as_bytes).collect::<Vec<&[u8]>>();
+            shuf_bytes(&mut rvec, options);
+        }
+        Mode::Default(filename) => {
+            let fdata = read_input_file(&filename);
+            let mut fdata = vec![&fdata[..]];
+            find_seps(&mut fdata, options.sep);
+            shuf_bytes(&mut fdata, options);
+        }
+    }
+
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .name(NAME)
         .version(crate_version!())
         .template(TEMPLATE)
@@ -118,62 +177,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .help("line delimiter is NUL, not newline"),
         )
         .arg(Arg::with_name(options::FILE).takes_value(true))
-        .get_matches_from(args);
-
-    let mode = if let Some(args) = matches.values_of(options::ECHO) {
-        Mode::Echo(args.map(String::from).collect())
-    } else if let Some(range) = matches.value_of(options::INPUT_RANGE) {
-        match parse_range(range) {
-            Ok(m) => Mode::InputRange(m),
-            Err(msg) => {
-                crash!(1, "{}", msg);
-            }
-        }
-    } else {
-        Mode::Default(matches.value_of(options::FILE).unwrap_or("-").to_string())
-    };
-
-    let options = Options {
-        head_count: match matches.value_of(options::HEAD_COUNT) {
-            Some(count) => match count.parse::<usize>() {
-                Ok(val) => val,
-                Err(_) => {
-                    show_error!("invalid line count: '{}'", count);
-                    return 1;
-                }
-            },
-            None => std::usize::MAX,
-        },
-        output: matches.value_of(options::OUTPUT).map(String::from),
-        random_source: matches.value_of(options::RANDOM_SOURCE).map(String::from),
-        repeat: matches.is_present(options::REPEAT),
-        sep: if matches.is_present(options::ZERO_TERMINATED) {
-            0x00_u8
-        } else {
-            0x0a_u8
-        },
-    };
-
-    match mode {
-        Mode::Echo(args) => {
-            let mut evec = args.iter().map(String::as_bytes).collect::<Vec<_>>();
-            find_seps(&mut evec, options.sep);
-            shuf_bytes(&mut evec, options);
-        }
-        Mode::InputRange((b, e)) => {
-            let rvec = (b..e).map(|x| format!("{}", x)).collect::<Vec<String>>();
-            let mut rvec = rvec.iter().map(String::as_bytes).collect::<Vec<&[u8]>>();
-            shuf_bytes(&mut rvec, options);
-        }
-        Mode::Default(filename) => {
-            let fdata = read_input_file(&filename);
-            let mut fdata = vec![&fdata[..]];
-            find_seps(&mut fdata, options.sep);
-            shuf_bytes(&mut fdata, options);
-        }
-    }
-
-    0
 }
 
 fn read_input_file(filename: &str) -> Vec<u8> {

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -35,10 +35,20 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
+
+    if let Some(values) = matches.values_of(options::NUMBER) {
+        let numbers = values.collect();
+        sleep(numbers);
+    }
+
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
-        .usage(&usage[..])
         .after_help(LONG_HELP)
         .arg(
             Arg::with_name(options::NUMBER)
@@ -49,14 +59,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .multiple(true)
                 .required(true),
         )
-        .get_matches_from(args);
-
-    if let Some(values) = matches.values_of(options::NUMBER) {
-        let numbers = values.collect();
-        sleep(numbers);
-    }
-
-    0
 }
 
 fn sleep(args: Vec<&str>) {

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -30,7 +30,7 @@ static OPT_ADDITIONAL_SUFFIX: &str = "additional-suffix";
 static OPT_FILTER: &str = "filter";
 static OPT_NUMERIC_SUFFIXES: &str = "numeric-suffixes";
 static OPT_SUFFIX_LENGTH: &str = "suffix-length";
-static OPT_DEFAULT_SUFFIX_LENGTH: usize = 2;
+static OPT_DEFAULT_SUFFIX_LENGTH: &str = "2";
 static OPT_VERBOSE: &str = "verbose";
 
 static ARG_INPUT: &str = "input";
@@ -54,85 +54,10 @@ size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let long_usage = get_long_usage();
-    let default_suffix_length_str = OPT_DEFAULT_SUFFIX_LENGTH.to_string();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about("Create output files containing consecutive or interleaved sections of input")
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&long_usage[..])
-        // strategy (mutually exclusive)
-        .arg(
-            Arg::with_name(OPT_BYTES)
-                .short("b")
-                .long(OPT_BYTES)
-                .takes_value(true)
-                .default_value("2")
-                .help("use suffixes of length N (default 2)"),
-        )
-        .arg(
-            Arg::with_name(OPT_LINE_BYTES)
-                .short("C")
-                .long(OPT_LINE_BYTES)
-                .takes_value(true)
-                .default_value("2")
-                .help("put at most SIZE bytes of lines per output file"),
-        )
-        .arg(
-            Arg::with_name(OPT_LINES)
-                .short("l")
-                .long(OPT_LINES)
-                .takes_value(true)
-                .default_value("1000")
-                .help("write to shell COMMAND file name is $FILE (Currently not implemented for Windows)"),
-        )
-        // rest of the arguments
-        .arg(
-            Arg::with_name(OPT_ADDITIONAL_SUFFIX)
-                .long(OPT_ADDITIONAL_SUFFIX)
-                .takes_value(true)
-                .default_value("")
-                .help("additional suffix to append to output file names"),
-        )
-        .arg(
-            Arg::with_name(OPT_FILTER)
-                .long(OPT_FILTER)
-                .takes_value(true)
-                .help("write to shell COMMAND file name is $FILE (Currently not implemented for Windows)"),
-        )
-        .arg(
-            Arg::with_name(OPT_NUMERIC_SUFFIXES)
-                .short("d")
-                .long(OPT_NUMERIC_SUFFIXES)
-                .takes_value(true)
-                .default_value("0")
-                .help("use numeric suffixes instead of alphabetic"),
-        )
-        .arg(
-            Arg::with_name(OPT_SUFFIX_LENGTH)
-                .short("a")
-                .long(OPT_SUFFIX_LENGTH)
-                .takes_value(true)
-                .default_value(default_suffix_length_str.as_str())
-                .help("use suffixes of length N (default 2)"),
-        )
-        .arg(
-            Arg::with_name(OPT_VERBOSE)
-                .long(OPT_VERBOSE)
-                .help("print a diagnostic just before each output file is opened"),
-        )
-        .arg(
-            Arg::with_name(ARG_INPUT)
-            .takes_value(true)
-            .default_value("-")
-            .index(1)
-        )
-        .arg(
-            Arg::with_name(ARG_PREFIX)
-            .takes_value(true)
-            .default_value("x")
-            .index(2)
-        )
         .get_matches_from(args);
 
     let mut settings = Settings {
@@ -199,6 +124,84 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     split(&settings)
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about("Create output files containing consecutive or interleaved sections of input")
+        // strategy (mutually exclusive)
+        .arg(
+            Arg::with_name(OPT_BYTES)
+                .short("b")
+                .long(OPT_BYTES)
+                .takes_value(true)
+                .default_value("2")
+                .help("use suffixes of length N (default 2)"),
+        )
+        .arg(
+            Arg::with_name(OPT_LINE_BYTES)
+                .short("C")
+                .long(OPT_LINE_BYTES)
+                .takes_value(true)
+                .default_value("2")
+                .help("put at most SIZE bytes of lines per output file"),
+        )
+        .arg(
+            Arg::with_name(OPT_LINES)
+                .short("l")
+                .long(OPT_LINES)
+                .takes_value(true)
+                .default_value("1000")
+                .help("write to shell COMMAND file name is $FILE (Currently not implemented for Windows)"),
+        )
+        // rest of the arguments
+        .arg(
+            Arg::with_name(OPT_ADDITIONAL_SUFFIX)
+                .long(OPT_ADDITIONAL_SUFFIX)
+                .takes_value(true)
+                .default_value("")
+                .help("additional suffix to append to output file names"),
+        )
+        .arg(
+            Arg::with_name(OPT_FILTER)
+                .long(OPT_FILTER)
+                .takes_value(true)
+                .help("write to shell COMMAND file name is $FILE (Currently not implemented for Windows)"),
+        )
+        .arg(
+            Arg::with_name(OPT_NUMERIC_SUFFIXES)
+                .short("d")
+                .long(OPT_NUMERIC_SUFFIXES)
+                .takes_value(true)
+                .default_value("0")
+                .help("use numeric suffixes instead of alphabetic"),
+        )
+        .arg(
+            Arg::with_name(OPT_SUFFIX_LENGTH)
+                .short("a")
+                .long(OPT_SUFFIX_LENGTH)
+                .takes_value(true)
+                .default_value(OPT_DEFAULT_SUFFIX_LENGTH)
+                .help("use suffixes of length N (default 2)"),
+        )
+        .arg(
+            Arg::with_name(OPT_VERBOSE)
+                .long(OPT_VERBOSE)
+                .help("print a diagnostic just before each output file is opened"),
+        )
+        .arg(
+            Arg::with_name(ARG_INPUT)
+            .takes_value(true)
+            .default_value("-")
+            .index(1)
+        )
+        .arg(
+            Arg::with_name(ARG_PREFIX)
+            .takes_value(true)
+            .default_value("x")
+            .index(2)
+        )
 }
 
 #[allow(dead_code)]

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -947,11 +947,24 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let long_usage = get_long_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&long_usage[..])
+        .get_matches_from(args);
+
+    match Stater::new(matches) {
+        Ok(stater) => stater.exec(),
+        Err(e) => {
+            show_error!("{}", e);
+            1
+        }
+    }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
         .arg(
             Arg::with_name(options::DEREFERENCE)
                 .short("L")
@@ -996,13 +1009,4 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .takes_value(true)
                 .min_values(1),
         )
-        .get_matches_from(args);
-
-    match Stater::new(matches) {
-        Ok(stater) => stater.exec(),
-        Err(e) => {
-            show_error!("{}", e);
-            1
-        }
-    }
 }

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -98,24 +98,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .name(NAME)
-        .version(crate_version!())
-        .usage(USAGE)
-        .about(SUMMARY)
-        .arg(Arg::with_name(options::FILE).multiple(true).hidden(true))
-        .arg(
-            Arg::with_name(options::BSD_COMPATIBLE)
-                .short(options::BSD_COMPATIBLE)
-                .help("use the BSD sum algorithm, use 1K blocks (default)"),
-        )
-        .arg(
-            Arg::with_name(options::SYSTEM_V_COMPATIBLE)
-                .short("s")
-                .long(options::SYSTEM_V_COMPATIBLE)
-                .help("use System V sum algorithm, use 512 bytes blocks"),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let files: Vec<String> = match matches.values_of(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
@@ -154,4 +137,24 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     exit_code
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .name(NAME)
+        .version(crate_version!())
+        .usage(USAGE)
+        .about(SUMMARY)
+        .arg(Arg::with_name(options::FILE).multiple(true).hidden(true))
+        .arg(
+            Arg::with_name(options::BSD_COMPATIBLE)
+                .short(options::BSD_COMPATIBLE)
+                .help("use the BSD sum algorithm, use 1K blocks (default)"),
+        )
+        .arg(
+            Arg::with_name(options::SYSTEM_V_COMPATIBLE)
+                .short("s")
+                .long(options::SYSTEM_V_COMPATIBLE)
+                .help("use System V sum algorithm, use 512 bytes blocks"),
+        )
 }

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -166,26 +166,7 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::FILE_SYSTEM)
-                .short("f")
-                .long(options::FILE_SYSTEM)
-                .conflicts_with(options::DATA)
-                .help("sync the file systems that contain the files (Linux and Windows only)"),
-        )
-        .arg(
-            Arg::with_name(options::DATA)
-                .short("d")
-                .long(options::DATA)
-                .conflicts_with(options::FILE_SYSTEM)
-                .help("sync only file data, no unneeded metadata (Linux only)"),
-        )
-        .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -209,6 +190,27 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         sync();
     }
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::FILE_SYSTEM)
+                .short("f")
+                .long(options::FILE_SYSTEM)
+                .conflicts_with(options::DATA)
+                .help("sync the file systems that contain the files (Linux and Windows only)"),
+        )
+        .arg(
+            Arg::with_name(options::DATA)
+                .short("d")
+                .long(options::DATA)
+                .conflicts_with(options::FILE_SYSTEM)
+                .help("sync only file data, no unneeded metadata (Linux only)"),
+        )
+        .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
 }
 
 fn sync() -> isize {

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -72,74 +72,7 @@ impl Default for Settings {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let mut settings: Settings = Default::default();
 
-    let app = App::new(executable!())
-        .version(crate_version!())
-        .about("output the last part of files")
-        // TODO: add usage
-        .arg(
-            Arg::with_name(options::BYTES)
-                .short("c")
-                .long(options::BYTES)
-                .takes_value(true)
-                .allow_hyphen_values(true)
-                .overrides_with_all(&[options::BYTES, options::LINES])
-                .help("Number of bytes to print"),
-        )
-        .arg(
-            Arg::with_name(options::FOLLOW)
-                .short("f")
-                .long(options::FOLLOW)
-                .help("Print the file as it grows"),
-        )
-        .arg(
-            Arg::with_name(options::LINES)
-                .short("n")
-                .long(options::LINES)
-                .takes_value(true)
-                .allow_hyphen_values(true)
-                .overrides_with_all(&[options::BYTES, options::LINES])
-                .help("Number of lines to print"),
-        )
-        .arg(
-            Arg::with_name(options::PID)
-                .long(options::PID)
-                .takes_value(true)
-                .help("with -f, terminate after process ID, PID dies"),
-        )
-        .arg(
-            Arg::with_name(options::verbosity::QUIET)
-                .short("q")
-                .long(options::verbosity::QUIET)
-                .visible_alias("silent")
-                .overrides_with_all(&[options::verbosity::QUIET, options::verbosity::VERBOSE])
-                .help("never output headers giving file names"),
-        )
-        .arg(
-            Arg::with_name(options::SLEEP_INT)
-                .short("s")
-                .takes_value(true)
-                .long(options::SLEEP_INT)
-                .help("Number or seconds to sleep between polling the file when running with -f"),
-        )
-        .arg(
-            Arg::with_name(options::verbosity::VERBOSE)
-                .short("v")
-                .long(options::verbosity::VERBOSE)
-                .overrides_with_all(&[options::verbosity::QUIET, options::verbosity::VERBOSE])
-                .help("always output headers giving file names"),
-        )
-        .arg(
-            Arg::with_name(options::ZERO_TERM)
-                .short("z")
-                .long(options::ZERO_TERM)
-                .help("Line delimiter is NUL, not newline"),
-        )
-        .arg(
-            Arg::with_name(options::ARG_FILES)
-                .multiple(true)
-                .takes_value(true)
-                .min_values(1),
-        );
+    let app = uu_app();
 
     let matches = app.get_matches_from(args);
 
@@ -242,6 +175,77 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about("output the last part of files")
+        // TODO: add usage
+        .arg(
+            Arg::with_name(options::BYTES)
+                .short("c")
+                .long(options::BYTES)
+                .takes_value(true)
+                .allow_hyphen_values(true)
+                .overrides_with_all(&[options::BYTES, options::LINES])
+                .help("Number of bytes to print"),
+        )
+        .arg(
+            Arg::with_name(options::FOLLOW)
+                .short("f")
+                .long(options::FOLLOW)
+                .help("Print the file as it grows"),
+        )
+        .arg(
+            Arg::with_name(options::LINES)
+                .short("n")
+                .long(options::LINES)
+                .takes_value(true)
+                .allow_hyphen_values(true)
+                .overrides_with_all(&[options::BYTES, options::LINES])
+                .help("Number of lines to print"),
+        )
+        .arg(
+            Arg::with_name(options::PID)
+                .long(options::PID)
+                .takes_value(true)
+                .help("with -f, terminate after process ID, PID dies"),
+        )
+        .arg(
+            Arg::with_name(options::verbosity::QUIET)
+                .short("q")
+                .long(options::verbosity::QUIET)
+                .visible_alias("silent")
+                .overrides_with_all(&[options::verbosity::QUIET, options::verbosity::VERBOSE])
+                .help("never output headers giving file names"),
+        )
+        .arg(
+            Arg::with_name(options::SLEEP_INT)
+                .short("s")
+                .takes_value(true)
+                .long(options::SLEEP_INT)
+                .help("Number or seconds to sleep between polling the file when running with -f"),
+        )
+        .arg(
+            Arg::with_name(options::verbosity::VERBOSE)
+                .short("v")
+                .long(options::verbosity::VERBOSE)
+                .overrides_with_all(&[options::verbosity::QUIET, options::verbosity::VERBOSE])
+                .help("always output headers giving file names"),
+        )
+        .arg(
+            Arg::with_name(options::ZERO_TERM)
+                .short("z")
+                .long(options::ZERO_TERM)
+                .help("Line delimiter is NUL, not newline"),
+        )
+        .arg(
+            Arg::with_name(options::ARG_FILES)
+                .multiple(true)
+                .takes_value(true)
+                .min_values(1),
+        )
 }
 
 fn follow<T: Read>(readers: &mut [BufReader<T>], filenames: &[String], settings: &Settings) {

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -39,25 +39,7 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .after_help("If a FILE is -, it refers to a file named - .")
-        .arg(
-            Arg::with_name(options::APPEND)
-                .long(options::APPEND)
-                .short("a")
-                .help("append to the given FILEs, do not overwrite"),
-        )
-        .arg(
-            Arg::with_name(options::IGNORE_INTERRUPTS)
-                .long(options::IGNORE_INTERRUPTS)
-                .short("i")
-                .help("ignore interrupt signals (ignored on non-Unix platforms)"),
-        )
-        .arg(Arg::with_name(options::FILE).multiple(true))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let options = Options {
         append: matches.is_present(options::APPEND),
@@ -72,6 +54,26 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         Ok(_) => 0,
         Err(_) => 1,
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .after_help("If a FILE is -, it refers to a file named - .")
+        .arg(
+            Arg::with_name(options::APPEND)
+                .long(options::APPEND)
+                .short("a")
+                .help("append to the given FILEs, do not overwrite"),
+        )
+        .arg(
+            Arg::with_name(options::IGNORE_INTERRUPTS)
+                .long(options::IGNORE_INTERRUPTS)
+                .short("i")
+                .help("ignore interrupt signals (ignored on non-Unix platforms)"),
+        )
+        .arg(Arg::with_name(options::FILE).multiple(true))
 }
 
 #[cfg(unix)]

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/test.rs"
 
 [dependencies]
+clap = "2.33.3"
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -10,9 +10,17 @@
 
 mod parser;
 
+use clap::{App, AppSettings};
 use parser::{parse, Symbol};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
+use uucore::executable;
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .setting(AppSettings::DisableHelpFlags)
+        .setting(AppSettings::DisableVersion)
+}
 
 pub fn uumain(mut args: impl uucore::Args) -> i32 {
     let program = args.next().unwrap_or_else(|| OsString::from("test"));

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -102,9 +102,25 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let app = App::new("timeout")
+    let app = uu_app().usage(&usage[..]);
+
+    let matches = app.get_matches_from(args);
+
+    let config = Config::from(matches);
+    timeout(
+        &config.command,
+        config.duration,
+        config.signal,
+        config.kill_after,
+        config.foreground,
+        config.preserve_status,
+        config.verbose,
+    )
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new("timeout")
         .version(crate_version!())
-        .usage(&usage[..])
         .about(ABOUT)
         .arg(
             Arg::with_name(options::FOREGROUND)
@@ -144,20 +160,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .required(true)
                 .multiple(true)
         )
-        .setting(AppSettings::TrailingVarArg);
-
-    let matches = app.get_matches_from(args);
-
-    let config = Config::from(matches);
-    timeout(
-        &config.command,
-        config.duration,
-        config.signal,
-        config.kill_after,
-        config.foreground,
-        config.preserve_status,
-        config.verbose,
-    )
+        .setting(AppSettings::TrailingVarArg)
 }
 
 /// Remove pre-existing SIGCHLD handlers that would make waiting for the child's exit code fail.

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -55,80 +55,7 @@ fn get_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::ACCESS)
-                .short("a")
-                .help("change only the access time"),
-        )
-        .arg(
-            Arg::with_name(options::sources::CURRENT)
-                .short("t")
-                .help("use [[CC]YY]MMDDhhmm[.ss] instead of the current time")
-                .value_name("STAMP")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name(options::sources::DATE)
-                .short("d")
-                .long(options::sources::DATE)
-                .help("parse argument and use it instead of current time")
-                .value_name("STRING"),
-        )
-        .arg(
-            Arg::with_name(options::MODIFICATION)
-                .short("m")
-                .help("change only the modification time"),
-        )
-        .arg(
-            Arg::with_name(options::NO_CREATE)
-                .short("c")
-                .long(options::NO_CREATE)
-                .help("do not create any files"),
-        )
-        .arg(
-            Arg::with_name(options::NO_DEREF)
-                .short("h")
-                .long(options::NO_DEREF)
-                .help(
-                    "affect each symbolic link instead of any referenced file \
-                     (only for systems that can change the timestamps of a symlink)",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::sources::REFERENCE)
-                .short("r")
-                .long(options::sources::REFERENCE)
-                .help("use this file's times instead of the current time")
-                .value_name("FILE"),
-        )
-        .arg(
-            Arg::with_name(options::TIME)
-                .long(options::TIME)
-                .help(
-                    "change only the specified time: \"access\", \"atime\", or \
-                     \"use\" are equivalent to -a; \"modify\" or \"mtime\" are \
-                     equivalent to -m",
-                )
-                .value_name("WORD")
-                .possible_values(&["access", "atime", "use"])
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name(ARG_FILES)
-                .multiple(true)
-                .takes_value(true)
-                .min_values(1),
-        )
-        .group(ArgGroup::with_name(options::SOURCES).args(&[
-            options::sources::CURRENT,
-            options::sources::DATE,
-            options::sources::REFERENCE,
-        ]))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -234,6 +161,81 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         }
     }
     error_code
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::ACCESS)
+                .short("a")
+                .help("change only the access time"),
+        )
+        .arg(
+            Arg::with_name(options::sources::CURRENT)
+                .short("t")
+                .help("use [[CC]YY]MMDDhhmm[.ss] instead of the current time")
+                .value_name("STAMP")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(options::sources::DATE)
+                .short("d")
+                .long(options::sources::DATE)
+                .help("parse argument and use it instead of current time")
+                .value_name("STRING"),
+        )
+        .arg(
+            Arg::with_name(options::MODIFICATION)
+                .short("m")
+                .help("change only the modification time"),
+        )
+        .arg(
+            Arg::with_name(options::NO_CREATE)
+                .short("c")
+                .long(options::NO_CREATE)
+                .help("do not create any files"),
+        )
+        .arg(
+            Arg::with_name(options::NO_DEREF)
+                .short("h")
+                .long(options::NO_DEREF)
+                .help(
+                    "affect each symbolic link instead of any referenced file \
+                     (only for systems that can change the timestamps of a symlink)",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::sources::REFERENCE)
+                .short("r")
+                .long(options::sources::REFERENCE)
+                .help("use this file's times instead of the current time")
+                .value_name("FILE"),
+        )
+        .arg(
+            Arg::with_name(options::TIME)
+                .long(options::TIME)
+                .help(
+                    "change only the specified time: \"access\", \"atime\", or \
+                     \"use\" are equivalent to -a; \"modify\" or \"mtime\" are \
+                     equivalent to -m",
+                )
+                .value_name("WORD")
+                .possible_values(&["access", "atime", "use"])
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(ARG_FILES)
+                .multiple(true)
+                .takes_value(true)
+                .min_values(1),
+        )
+        .group(ArgGroup::with_name(options::SOURCES).args(&[
+            options::sources::CURRENT,
+            options::sources::DATE,
+            options::sources::REFERENCE,
+        ]))
 }
 
 fn stat(path: &str, follow: bool) -> (FileTime, FileTime) {

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -249,46 +249,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let after_help = get_long_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&after_help[..])
-        .arg(
-            Arg::with_name(options::COMPLEMENT)
-                // .visible_short_alias('C')  // TODO: requires clap "3.0.0-beta.2"
-                .short("c")
-                .long(options::COMPLEMENT)
-                .help("use the complement of SET1"),
-        )
-        .arg(
-            Arg::with_name("C") // work around for `Arg::visible_short_alias`
-                .short("C")
-                .help("same as -c"),
-        )
-        .arg(
-            Arg::with_name(options::DELETE)
-                .short("d")
-                .long(options::DELETE)
-                .help("delete characters in SET1, do not translate"),
-        )
-        .arg(
-            Arg::with_name(options::SQUEEZE)
-                .long(options::SQUEEZE)
-                .short("s")
-                .help(
-                    "replace each sequence  of  a  repeated  character  that  is
-  listed  in the last specified SET, with a single occurrence
-  of that character",
-                ),
-        )
-        .arg(
-            Arg::with_name(options::TRUNCATE)
-                .long(options::TRUNCATE)
-                .short("t")
-                .help("first truncate SET1 to length of SET2"),
-        )
-        .arg(Arg::with_name(options::SETS).multiple(true))
         .get_matches_from(args);
 
     let delete_flag = matches.is_present(options::DELETE);
@@ -357,4 +320,45 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::COMPLEMENT)
+                // .visible_short_alias('C')  // TODO: requires clap "3.0.0-beta.2"
+                .short("c")
+                .long(options::COMPLEMENT)
+                .help("use the complement of SET1"),
+        )
+        .arg(
+            Arg::with_name("C") // work around for `Arg::visible_short_alias`
+                .short("C")
+                .help("same as -c"),
+        )
+        .arg(
+            Arg::with_name(options::DELETE)
+                .short("d")
+                .long(options::DELETE)
+                .help("delete characters in SET1, do not translate"),
+        )
+        .arg(
+            Arg::with_name(options::SQUEEZE)
+                .long(options::SQUEEZE)
+                .short("s")
+                .help(
+                    "replace each sequence  of  a  repeated  character  that  is
+  listed  in the last specified SET, with a single occurrence
+  of that character",
+                ),
+        )
+        .arg(
+            Arg::with_name(options::TRUNCATE)
+                .long(options::TRUNCATE)
+                .short("t")
+                .help("first truncate SET1 to length of SET2"),
+        )
+        .arg(Arg::with_name(options::SETS).multiple(true))
 }

--- a/src/uu/true/Cargo.toml
+++ b/src/uu/true/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/true.rs"
 
 [dependencies]
+clap = "2.33.3"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -5,6 +5,15 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
+use clap::{App, AppSettings};
+use uucore::executable;
+
 pub fn uumain(_: impl uucore::Args) -> i32 {
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .setting(AppSettings::DisableHelpFlags)
+        .setting(AppSettings::DisableVersion)
 }

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -5,15 +5,14 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-use clap::{App, AppSettings};
+use clap::App;
 use uucore::executable;
 
-pub fn uumain(_: impl uucore::Args) -> i32 {
+pub fn uumain(args: impl uucore::Args) -> i32 {
+    uu_app().get_matches_from(args);
     0
 }
 
 pub fn uu_app() -> App<'static, 'static> {
     App::new(executable!())
-        .setting(AppSettings::DisableHelpFlags)
-        .setting(AppSettings::DisableVersion)
 }

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -93,45 +93,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let long_usage = get_long_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&long_usage[..])
-        .arg(
-            Arg::with_name(options::IO_BLOCKS)
-            .short("o")
-            .long(options::IO_BLOCKS)
-            .help("treat SIZE as the number of I/O blocks of the file rather than bytes (NOT IMPLEMENTED)")
-        )
-        .arg(
-            Arg::with_name(options::NO_CREATE)
-            .short("c")
-            .long(options::NO_CREATE)
-            .help("do not create files that do not exist")
-        )
-        .arg(
-            Arg::with_name(options::REFERENCE)
-            .short("r")
-            .long(options::REFERENCE)
-            .required_unless(options::SIZE)
-            .help("base the size of each file on the size of RFILE")
-            .value_name("RFILE")
-        )
-        .arg(
-            Arg::with_name(options::SIZE)
-            .short("s")
-            .long(options::SIZE)
-            .required_unless(options::REFERENCE)
-            .help("set or adjust the size of each file according to SIZE, which is in bytes unless --io-blocks is specified")
-            .value_name("SIZE")
-        )
-        .arg(Arg::with_name(options::ARG_FILES)
-             .value_name("FILE")
-             .multiple(true)
-             .takes_value(true)
-             .required(true)
-             .min_values(1))
         .get_matches_from(args);
 
     let files: Vec<String> = matches
@@ -166,6 +130,46 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::IO_BLOCKS)
+            .short("o")
+            .long(options::IO_BLOCKS)
+            .help("treat SIZE as the number of I/O blocks of the file rather than bytes (NOT IMPLEMENTED)")
+        )
+        .arg(
+            Arg::with_name(options::NO_CREATE)
+            .short("c")
+            .long(options::NO_CREATE)
+            .help("do not create files that do not exist")
+        )
+        .arg(
+            Arg::with_name(options::REFERENCE)
+            .short("r")
+            .long(options::REFERENCE)
+            .required_unless(options::SIZE)
+            .help("base the size of each file on the size of RFILE")
+            .value_name("RFILE")
+        )
+        .arg(
+            Arg::with_name(options::SIZE)
+            .short("s")
+            .long(options::SIZE)
+            .required_unless(options::REFERENCE)
+            .help("set or adjust the size of each file according to SIZE, which is in bytes unless --io-blocks is specified")
+            .value_name("SIZE")
+        )
+        .arg(Arg::with_name(options::ARG_FILES)
+             .value_name("FILE")
+             .multiple(true)
+             .takes_value(true)
+             .required(true)
+             .min_values(1))
 }
 
 /// Truncate the named file to the specified size.

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -30,16 +30,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .usage(USAGE)
-        .about(SUMMARY)
-        .arg(
-            Arg::with_name(options::FILE)
-                .default_value("-")
-                .hidden(true),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let input = matches
         .value_of(options::FILE)
@@ -96,6 +87,18 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .usage(USAGE)
+        .about(SUMMARY)
+        .arg(
+            Arg::with_name(options::FILE)
+                .default_value("-")
+                .hidden(true),
+        )
 }
 
 // We use String as a representation of node here

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -33,19 +33,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::SILENT)
-                .long(options::SILENT)
-                .visible_alias("quiet")
-                .short("s")
-                .help("print nothing, only return an exit status")
-                .required(false),
-        )
-        .get_matches_from_safe(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from_safe(args);
 
     let matches = match matches {
         Ok(m) => m,
@@ -87,4 +75,18 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     } else {
         libc::EXIT_FAILURE
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::SILENT)
+                .long(options::SILENT)
+                .visible_alias("quiet")
+                .short("s")
+                .help("print nothing, only return an exit status")
+                .required(false),
+        )
 }

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -47,49 +47,7 @@ const HOST_OS: &str = "Redox";
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = format!("{} [OPTION]...", executable!());
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(Arg::with_name(options::ALL)
-            .short("a")
-            .long(options::ALL)
-            .help("Behave as though all of the options -mnrsv were specified."))
-        .arg(Arg::with_name(options::KERNELNAME)
-            .short("s")
-            .long(options::KERNELNAME)
-            .alias("sysname") // Obsolescent option in GNU uname
-            .help("print the kernel name."))
-        .arg(Arg::with_name(options::NODENAME)
-            .short("n")
-            .long(options::NODENAME)
-            .help("print the nodename (the nodename may be a name that the system is known by to a communications network)."))
-        .arg(Arg::with_name(options::KERNELRELEASE)
-            .short("r")
-            .long(options::KERNELRELEASE)
-            .alias("release") // Obsolescent option in GNU uname
-            .help("print the operating system release."))
-        .arg(Arg::with_name(options::KERNELVERSION)
-            .short("v")
-            .long(options::KERNELVERSION)
-            .help("print the operating system version."))
-        .arg(Arg::with_name(options::HWPLATFORM)
-            .short("i")
-            .long(options::HWPLATFORM)
-            .help("print the hardware platform (non-portable)"))
-        .arg(Arg::with_name(options::MACHINE)
-            .short("m")
-            .long(options::MACHINE)
-            .help("print the machine hardware name."))
-        .arg(Arg::with_name(options::PROCESSOR)
-            .short("p")
-            .long(options::PROCESSOR)
-            .help("print the processor type (non-portable)"))
-        .arg(Arg::with_name(options::OS)
-            .short("o")
-            .long(options::OS)
-            .help("print the operating system name."))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let uname = return_if_err!(1, PlatformInfo::new());
     let mut output = String::new();
@@ -154,4 +112,48 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     println!("{}", output.trim_end());
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(Arg::with_name(options::ALL)
+            .short("a")
+            .long(options::ALL)
+            .help("Behave as though all of the options -mnrsv were specified."))
+        .arg(Arg::with_name(options::KERNELNAME)
+            .short("s")
+            .long(options::KERNELNAME)
+            .alias("sysname") // Obsolescent option in GNU uname
+            .help("print the kernel name."))
+        .arg(Arg::with_name(options::NODENAME)
+            .short("n")
+            .long(options::NODENAME)
+            .help("print the nodename (the nodename may be a name that the system is known by to a communications network)."))
+        .arg(Arg::with_name(options::KERNELRELEASE)
+            .short("r")
+            .long(options::KERNELRELEASE)
+            .alias("release") // Obsolescent option in GNU uname
+            .help("print the operating system release."))
+        .arg(Arg::with_name(options::KERNELVERSION)
+            .short("v")
+            .long(options::KERNELVERSION)
+            .help("print the operating system version."))
+        .arg(Arg::with_name(options::HWPLATFORM)
+            .short("i")
+            .long(options::HWPLATFORM)
+            .help("print the hardware platform (non-portable)"))
+        .arg(Arg::with_name(options::MACHINE)
+            .short("m")
+            .long(options::MACHINE)
+            .help("print the machine hardware name."))
+        .arg(Arg::with_name(options::PROCESSOR)
+            .short("p")
+            .long(options::PROCESSOR)
+            .help("print the processor type (non-portable)"))
+        .arg(Arg::with_name(options::OS)
+            .short("o")
+            .long(options::OS)
+            .help("print the operating system name."))
 }

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -94,7 +94,15 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().get_matches_from(args);
+
+    unexpand(Options::new(matches));
+
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)
@@ -126,11 +134,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .long(options::NO_UTF8)
                 .takes_value(false)
                 .help("interpret input file as 8-bit ASCII rather than UTF-8"))
-        .get_matches_from(args);
-
-    unexpand(Options::new(matches));
-
-    0
 }
 
 fn open(path: String) -> BufReader<Box<dyn Read + 'static>> {

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -33,12 +33,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let usage = get_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(Arg::with_name(OPT_PATH).hidden(true).multiple(true))
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let paths: Vec<String> = matches
         .values_of(OPT_PATH)
@@ -97,4 +92,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(Arg::with_name(OPT_PATH).hidden(true).multiple(true))
 }

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -38,17 +38,7 @@ fn get_usage() -> String {
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
-        .usage(&usage[..])
-        .arg(
-            Arg::with_name(options::SINCE)
-                .short("s")
-                .long(options::SINCE)
-                .help("system up since"),
-        )
-        .get_matches_from(args);
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let (boot_time, user_count) = process_utmpx();
     let uptime = get_uptime(boot_time);
@@ -71,6 +61,18 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
         0
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(
+            Arg::with_name(options::SINCE)
+                .short("s")
+                .long(options::SINCE)
+                .help("system up since"),
+        )
 }
 
 #[cfg(unix)]

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -34,12 +34,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let after_help = get_long_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&after_help[..])
-        .arg(Arg::with_name(ARG_FILES).takes_value(true).max_values(1))
         .get_matches_from(args);
 
     let files: Vec<String> = matches
@@ -65,4 +62,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
+        .arg(Arg::with_name(ARG_FILES).takes_value(true).max_values(1))
 }

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -134,10 +134,39 @@ impl Input {
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
 
-    let matches = App::new(executable!())
+    let matches = uu_app().usage(&usage[..]).get_matches_from(args);
+
+    let mut inputs: Vec<Input> = matches
+        .values_of(ARG_FILES)
+        .map(|v| {
+            v.map(|i| {
+                if i == "-" {
+                    Input::Stdin(StdinKind::Explicit)
+                } else {
+                    Input::Path(ToString::to_string(i))
+                }
+            })
+            .collect()
+        })
+        .unwrap_or_default();
+
+    if inputs.is_empty() {
+        inputs.push(Input::Stdin(StdinKind::Implicit));
+    }
+
+    let settings = Settings::new(&matches);
+
+    if wc(inputs, &settings).is_ok() {
+        0
+    } else {
+        1
+    }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
         .version(crate_version!())
         .about(ABOUT)
-        .usage(&usage[..])
         .arg(
             Arg::with_name(options::BYTES)
                 .short("c")
@@ -169,33 +198,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .help("print the word counts"),
         )
         .arg(Arg::with_name(ARG_FILES).multiple(true).takes_value(true))
-        .get_matches_from(args);
-
-    let mut inputs: Vec<Input> = matches
-        .values_of(ARG_FILES)
-        .map(|v| {
-            v.map(|i| {
-                if i == "-" {
-                    Input::Stdin(StdinKind::Explicit)
-                } else {
-                    Input::Path(ToString::to_string(i))
-                }
-            })
-            .collect()
-        })
-        .unwrap_or_default();
-
-    if inputs.is_empty() {
-        inputs.push(Input::Stdin(StdinKind::Implicit));
-    }
-
-    let settings = Settings::new(&matches);
-
-    if wc(inputs, &settings).is_ok() {
-        0
-    } else {
-        1
-    }
 }
 
 fn word_count_from_reader<T: WordCountable>(

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -64,11 +64,105 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = get_usage();
     let after_help = get_long_usage();
 
-    let matches = App::new(executable!())
-        .version(crate_version!())
-        .about(ABOUT)
+    let matches = uu_app()
         .usage(&usage[..])
         .after_help(&after_help[..])
+        .get_matches_from(args);
+
+    let files: Vec<String> = matches
+        .values_of(options::FILE)
+        .map(|v| v.map(ToString::to_string).collect())
+        .unwrap_or_default();
+
+    // If true, attempt to canonicalize hostnames via a DNS lookup.
+    let do_lookup = matches.is_present(options::LOOKUP);
+
+    // If true, display only a list of usernames and count of
+    // the users logged on.
+    // Ignored for 'who am i'.
+    let short_list = matches.is_present(options::COUNT);
+
+    let all = matches.is_present(options::ALL);
+
+    // If true, display a line at the top describing each field.
+    let include_heading = matches.is_present(options::HEADING);
+
+    // If true, display a '+' for each user if mesg y, a '-' if mesg n,
+    // or a '?' if their tty cannot be statted.
+    let include_mesg = all || matches.is_present(options::MESG) || matches.is_present("w");
+
+    // If true, display the last boot time.
+    let need_boottime = all || matches.is_present(options::BOOT);
+
+    // If true, display dead processes.
+    let need_deadprocs = all || matches.is_present(options::DEAD);
+
+    // If true, display processes waiting for user login.
+    let need_login = all || matches.is_present(options::LOGIN);
+
+    // If true, display processes started by init.
+    let need_initspawn = all || matches.is_present(options::PROCESS);
+
+    // If true, display the last clock change.
+    let need_clockchange = all || matches.is_present(options::TIME);
+
+    // If true, display the current runlevel.
+    let need_runlevel = all || matches.is_present(options::RUNLEVEL);
+
+    let use_defaults = !(all
+        || need_boottime
+        || need_deadprocs
+        || need_login
+        || need_initspawn
+        || need_runlevel
+        || need_clockchange
+        || matches.is_present(options::USERS));
+
+    // If true, display user processes.
+    let need_users = all || matches.is_present(options::USERS) || use_defaults;
+
+    // If true, display the hours:minutes since each user has touched
+    // the keyboard, or "." if within the last minute, or "old" if
+    // not within the last day.
+    let include_idle = need_deadprocs || need_login || need_runlevel || need_users;
+
+    // If true, display process termination & exit status.
+    let include_exit = need_deadprocs;
+
+    // If true, display only name, line, and time fields.
+    let short_output = !include_exit && use_defaults;
+
+    // If true, display info only for the controlling tty.
+    let my_line_only = matches.is_present(options::ONLY_HOSTNAME_USER) || files.len() == 2;
+
+    let mut who = Who {
+        do_lookup,
+        short_list,
+        short_output,
+        include_idle,
+        include_heading,
+        include_mesg,
+        include_exit,
+        need_boottime,
+        need_deadprocs,
+        need_login,
+        need_initspawn,
+        need_clockchange,
+        need_runlevel,
+        need_users,
+        my_line_only,
+        args: files,
+    };
+
+    who.exec();
+
+    0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    App::new(executable!())
+        .version(crate_version!())
+        .about(ABOUT)
         .arg(
             Arg::with_name(options::ALL)
                 .long(options::ALL)
@@ -164,96 +258,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .min_values(1)
                 .max_values(2),
         )
-        .get_matches_from(args);
-
-    let files: Vec<String> = matches
-        .values_of(options::FILE)
-        .map(|v| v.map(ToString::to_string).collect())
-        .unwrap_or_default();
-
-    // If true, attempt to canonicalize hostnames via a DNS lookup.
-    let do_lookup = matches.is_present(options::LOOKUP);
-
-    // If true, display only a list of usernames and count of
-    // the users logged on.
-    // Ignored for 'who am i'.
-    let short_list = matches.is_present(options::COUNT);
-
-    let all = matches.is_present(options::ALL);
-
-    // If true, display a line at the top describing each field.
-    let include_heading = matches.is_present(options::HEADING);
-
-    // If true, display a '+' for each user if mesg y, a '-' if mesg n,
-    // or a '?' if their tty cannot be statted.
-    let include_mesg = all || matches.is_present(options::MESG) || matches.is_present("w");
-
-    // If true, display the last boot time.
-    let need_boottime = all || matches.is_present(options::BOOT);
-
-    // If true, display dead processes.
-    let need_deadprocs = all || matches.is_present(options::DEAD);
-
-    // If true, display processes waiting for user login.
-    let need_login = all || matches.is_present(options::LOGIN);
-
-    // If true, display processes started by init.
-    let need_initspawn = all || matches.is_present(options::PROCESS);
-
-    // If true, display the last clock change.
-    let need_clockchange = all || matches.is_present(options::TIME);
-
-    // If true, display the current runlevel.
-    let need_runlevel = all || matches.is_present(options::RUNLEVEL);
-
-    let use_defaults = !(all
-        || need_boottime
-        || need_deadprocs
-        || need_login
-        || need_initspawn
-        || need_runlevel
-        || need_clockchange
-        || matches.is_present(options::USERS));
-
-    // If true, display user processes.
-    let need_users = all || matches.is_present(options::USERS) || use_defaults;
-
-    // If true, display the hours:minutes since each user has touched
-    // the keyboard, or "." if within the last minute, or "old" if
-    // not within the last day.
-    let include_idle = need_deadprocs || need_login || need_runlevel || need_users;
-
-    // If true, display process termination & exit status.
-    let include_exit = need_deadprocs;
-
-    // If true, display only name, line, and time fields.
-    let short_output = !include_exit && use_defaults;
-
-    // If true, display info only for the controlling tty.
-    let my_line_only = matches.is_present(options::ONLY_HOSTNAME_USER) || files.len() == 2;
-
-    let mut who = Who {
-        do_lookup,
-        short_list,
-        short_output,
-        include_idle,
-        include_heading,
-        include_mesg,
-        include_exit,
-        need_boottime,
-        need_deadprocs,
-        need_login,
-        need_initspawn,
-        need_clockchange,
-        need_runlevel,
-        need_users,
-        my_line_only,
-        args: files,
-    };
-
-    who.exec();
-
-    0
 }
 
 struct Who {

--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -1,3 +1,5 @@
+use clap::App;
+
 //  * This file is part of the uutils coreutils package.
 //  *
 //  * (c) Jordi Boggiano <j.boggiano@seld.be>
@@ -15,7 +17,7 @@ extern crate uucore;
 mod platform;
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let app = app_from_crate!();
+    let app = uu_app();
 
     if let Err(err) = app.get_matches_from_safe(args) {
         if err.kind == clap::ErrorKind::HelpDisplayed
@@ -32,6 +34,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
         0
     }
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    app_from_crate!()
 }
 
 pub fn exec() {

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -12,7 +12,7 @@ extern crate clap;
 #[macro_use]
 extern crate uucore;
 
-use clap::Arg;
+use clap::{App, Arg};
 use std::borrow::Cow;
 use std::io::{self, Write};
 use uucore::zero_copy::ZeroCopyWriter;
@@ -22,7 +22,7 @@ use uucore::zero_copy::ZeroCopyWriter;
 const BUF_SIZE: usize = 16 * 1024;
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let app = app_from_crate!().arg(Arg::with_name("STRING").index(1).multiple(true));
+    let app = uu_app();
 
     let matches = match app.get_matches_from_safe(args) {
         Ok(m) => m,
@@ -54,6 +54,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     exec(bytes);
 
     0
+}
+
+pub fn uu_app() -> App<'static, 'static> {
+    app_from_crate!().arg(Arg::with_name("STRING").index(1).multiple(true))
 }
 
 #[cfg(not(feature = "latency"))]


### PR DESCRIPTION
This adds a hidden `completion` subcommand to coreutils. When invoked with
`coreutils completion <utility> <shell>` a completion file will be printed
to stdout. When running `make install` those files will be created for all
utilities and copied to the appropriate locations.
`make install` will install completions for zsh, fish and bash; however,
clap also supports generating completions for powershell and elvish.

With this patch all utilities are required to have a publich uu_app function
that returns a clap::App in addition to the uumain function.