### PR TITLE
touch: support @<timestamp> date format

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -268,6 +268,10 @@ fn parse_date(str: &str) -> FileTime {
             return local_tm_to_filetime(to_local(tm));
         }
     }
+    if let Ok(tm) = time::strptime(str, "@%s") {
+        // Don't convert to local time in this case - seconds since epoch are not time-zone dependent
+        return local_tm_to_filetime(tm);
+    }
     show_error!("Unable to parse date: {}\n", str);
     process::exit(1);
 }

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -376,6 +376,24 @@ fn test_touch_set_date2() {
 }
 
 #[test]
+fn test_touch_set_date3() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_date";
+
+    ucmd.args(&["-d", "@1623786360", file])
+        .succeeds()
+        .no_stderr();
+
+    assert!(at.file_exists(file));
+
+    let expected = FileTime::from_unix_time(1623786360, 0);
+    let (atime, mtime) = get_file_times(&at, file);
+    assert_eq!(atime, mtime);
+    assert_eq!(atime, expected);
+    assert_eq!(mtime, expected);
+}
+
+#[test]
 fn test_touch_set_date_wrong_format() {
     let (_at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_set_date_wrong_format";


### PR DESCRIPTION
parse `@<seconds since epoch>` as a valid date.

In the long term we should move the date parsing logic to `core`, because there's something similar in `date`. `date` however uses the `chrono` crate, while `touch` uses `time 0.1`, so unifying that would probably require more work.

GNU also supports all kinds of date inputs, `last year tomorrow yesterday yesterday 10 seconds ago now today this friday this day` is perfectly valid for example. (See also [GNU's documentation](https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html#Date-input-formats))