### PR TITLE
sort: avoid sigpipe errors 

### DIFF
--- a/src/uu/sort/src/ext_sort.rs
+++ b/src/uu/sort/src/ext_sort.rs
@@ -255,7 +255,7 @@ fn write<I: WriteableTmpFile>(
 
 fn write_lines<'a, T: Write>(lines: &[Line<'a>], writer: &mut T, separator: u8) {
     for s in lines {
-        crash_if_err!(1, writer.write_all(s.line.as_bytes()));
-        crash_if_err!(1, writer.write_all(&[separator]));
+        writer.write_all(s.line.as_bytes()).unwrap();
+        writer.write_all(&[separator]).unwrap();
     }
 }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -384,13 +384,13 @@ impl<'a> Line<'a> {
 
     fn print(&self, writer: &mut impl Write, settings: &GlobalSettings) {
         if settings.zero_terminated && !settings.debug {
-            crash_if_err!(1, writer.write_all(self.line.as_bytes()));
-            crash_if_err!(1, writer.write_all(b"\0"));
+            writer.write_all(self.line.as_bytes()).unwrap();
+            writer.write_all(b"\0").unwrap();
         } else if !settings.debug {
-            crash_if_err!(1, writer.write_all(self.line.as_bytes()));
-            crash_if_err!(1, writer.write_all(b"\n"));
+            writer.write_all(self.line.as_bytes()).unwrap();
+            writer.write_all(b"\n").unwrap();
         } else {
-            crash_if_err!(1, self.print_debug(settings, writer));
+            self.print_debug(settings, writer).unwrap();
         }
     }
 

--- a/src/uucore/src/lib/mods/panic.rs
+++ b/src/uucore/src/lib/mods/panic.rs
@@ -8,7 +8,7 @@ pub fn mute_sigpipe_panic() {
     let hook = panic::take_hook();
     panic::set_hook(Box::new(move |info| {
         if let Some(res) = info.payload().downcast_ref::<String>() {
-            if res.contains("Broken pipe") {
+            if res.contains("BrokenPipe") {
                 return;
             }
         }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -913,3 +913,16 @@ fn test_merge_batch_size() {
         .succeeds()
         .stdout_only_fixture("merge_ints_interleaved.expected");
 }
+
+#[test]
+fn test_sigpipe_panic() {
+    let mut cmd = new_ucmd!();
+    let mut child = cmd.args(&["ext_sort.txt"]).run_no_wait();
+    // Dropping the stdout should not lead to an error.
+    // The "Broken pipe" error should be silently ignored.
+    drop(child.stdout.take());
+    assert_eq!(
+        String::from_utf8(child.wait_with_output().unwrap().stderr),
+        Ok(String::new())
+    );
+}


### PR DESCRIPTION
By calling `unwrap` we get a panic instead of an abort, and since we
mute sigpipe panics for all utilites, no error message will be printed.