### PR TITLE
tty: fix tests and exit codes

### DIFF
--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -44,7 +44,15 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 .help("print nothing, only return an exit status")
                 .required(false),
         )
-        .get_matches_from(args);
+        .get_matches_from_safe(args);
+
+    let matches = match matches {
+        Ok(m) => m,
+        Err(e) => {
+            eprint!("{}", e);
+            return 2;
+        }
+    };
 
     let silent = matches.is_present(options::SILENT);
 

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -14,6 +14,7 @@ extern crate uucore;
 
 use clap::{crate_version, App, Arg};
 use std::ffi::CStr;
+use std::io::Write;
 use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
@@ -66,11 +67,18 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         }
     };
 
+    let mut stdout = std::io::stdout();
+
     if !silent {
-        if !tty.chars().all(|c| c.is_whitespace()) {
-            println!("{}", tty);
+        let write_result = if !tty.chars().all(|c| c.is_whitespace()) {
+            writeln!(stdout, "{}", tty)
         } else {
-            println!("not a tty");
+            writeln!(stdout, "not a tty")
+        };
+        if write_result.is_err() || stdout.flush().is_err() {
+            // Don't return to prevent a panic later when another flush is attempted
+            // because the `uucore_procs::main` macro inserts a flush after execution for every utility.
+            std::process::exit(3);
         }
     }
 

--- a/tests/by-util/test_tty.rs
+++ b/tests/by-util/test_tty.rs
@@ -63,3 +63,12 @@ fn test_close_stdin_silent_alias() {
 fn test_wrong_argument() {
     new_ucmd!().args(&["a"]).fails().code_is(2);
 }
+
+#[test]
+#[cfg(not(windows))]
+fn test_stdout_fail() {
+    let mut child = new_ucmd!().run_no_wait();
+    drop(child.stdout.take());
+    let status = child.wait().unwrap();
+    assert_eq!(status.code(), Some(3));
+}

--- a/tests/by-util/test_tty.rs
+++ b/tests/by-util/test_tty.rs
@@ -1,11 +1,14 @@
+use std::fs::File;
+
 use crate::common::util::*;
 
 #[test]
 #[cfg(not(windows))]
 fn test_dev_null() {
     new_ucmd!()
-        .pipe_in("</dev/null")
+        .set_stdin(File::open("/dev/null").unwrap())
         .fails()
+        .code_is(1)
         .stdout_is("not a tty\n");
 }
 
@@ -14,44 +17,49 @@ fn test_dev_null() {
 fn test_dev_null_silent() {
     new_ucmd!()
         .args(&["-s"])
-        .pipe_in("</dev/null")
+        .set_stdin(File::open("/dev/null").unwrap())
         .fails()
+        .code_is(1)
         .stdout_is("");
 }
 
 #[test]
 fn test_close_stdin() {
-    new_ucmd!().pipe_in("<&-").fails().stdout_is("not a tty\n");
+    let mut child = new_ucmd!().run_no_wait();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(std::str::from_utf8(&output.stdout), Ok("not a tty\n"));
 }
 
 #[test]
 fn test_close_stdin_silent() {
-    new_ucmd!()
-        .args(&["-s"])
-        .pipe_in("<&-")
-        .fails()
-        .stdout_is("");
+    let mut child = new_ucmd!().arg("-s").run_no_wait();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
 }
 
 #[test]
 fn test_close_stdin_silent_long() {
-    new_ucmd!()
-        .args(&["--silent"])
-        .pipe_in("<&-")
-        .fails()
-        .stdout_is("");
+    let mut child = new_ucmd!().arg("--silent").run_no_wait();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
 }
 
 #[test]
 fn test_close_stdin_silent_alias() {
-    new_ucmd!()
-        .args(&["--quiet"])
-        .pipe_in("<&-")
-        .fails()
-        .stdout_is("");
+    let mut child = new_ucmd!().arg("--quiet").run_no_wait();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
 }
 
 #[test]
 fn test_wrong_argument() {
-    new_ucmd!().args(&["a"]).fails();
+    new_ucmd!().args(&["a"]).fails().code_is(2);
 }


### PR DESCRIPTION
There probably was a misunderstanding of what `pipe_in("</dev/null")` does. It pipes in the raw string `"</dev/null"`, not the `/dev/null` _file_. Piping in the string could cause a "Broken pipe" error because `tty` never reads anything from stdin.

I also fixed the exit codes for wrong arguments and write errors.