### PR TITLE
cp: improve symlink handling

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -941,7 +941,10 @@ fn copy_directory(root: &Path, target: &TargetSlice, options: &Options) -> CopyR
         return copy_file(root, target, options);
     }
 
-    let root_path = env::current_dir().unwrap().join(root);
+    let current_dir =
+        env::current_dir().unwrap_or_else(|e| crash!(1, "failed to get current directory {}", e));
+
+    let root_path = current_dir.join(root);
 
     let root_parent = if target.exists() {
         root_path.parent()
@@ -968,10 +971,7 @@ fn copy_directory(root: &Path, target: &TargetSlice, options: &Options) -> CopyR
     {
         let p = or_continue!(path);
         let is_symlink = fs::symlink_metadata(p.path())?.file_type().is_symlink();
-        let path = match env::current_dir() {
-            Ok(cwd) => cwd.join(&p.path()),
-            Err(e) => crash!(1, "failed to get current directory {}", e),
-        };
+        let path = current_dir.join(&p.path());
 
         let local_to_root_parent = match root_parent {
             Some(parent) => {

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1397,9 +1397,9 @@ pub fn paths_refer_to_same_file(p1: &Path, p2: &Path) -> io::Result<bool> {
 fn test_cp_localize_to_target() {
     assert!(
         localize_to_target(
-            &Path::new("a/source/"),
-            &Path::new("a/source/c.txt"),
-            &Path::new("target/")
+            Path::new("a/source/"),
+            Path::new("a/source/c.txt"),
+            Path::new("target/")
         )
         .unwrap()
             == Path::new("target/c.txt")

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1299,3 +1299,29 @@ fn test_closes_file_descriptors() {
         .with_limit(Resource::NOFILE, 9, 9)
         .succeeds();
 }
+
+#[test]
+fn test_copy_dir_symlink() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir");
+    at.symlink_dir("dir", "dir-link");
+    ucmd.args(&["-r", "dir-link", "copy"]).succeeds();
+    assert_eq!(at.resolve_link("copy"), "dir");
+}
+
+#[test]
+fn test_copy_dir_with_symlinks() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir");
+    at.make_file("dir/file");
+
+    TestScenario::new("ln")
+        .ucmd()
+        .arg("-sr")
+        .arg(at.subdir.join("dir/file"))
+        .arg(at.subdir.join("dir/file-link"))
+        .succeeds();
+
+    ucmd.args(&["-r", "dir", "copy"]).succeeds();
+    assert_eq!(at.resolve_link("copy/file-link"), "file");
+}


### PR DESCRIPTION
Closes #2423.

When we try to copy a symlink, don't dereference it (unless dereference is enabled). When recursively copying, dereference is disabled by default.