### PR TITLE
ln: don't return an empty path in `relative_path`

### DIFF
--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -382,12 +382,15 @@ fn relative_path<'a>(src: &Path, dst: &Path) -> Result<Cow<'a, Path>> {
 
     let src_iter = src_abs.components().skip(suffix_pos).map(|x| x.as_os_str());
 
-    let result: PathBuf = dst_abs
+    let mut result: PathBuf = dst_abs
         .components()
         .skip(suffix_pos + 1)
         .map(|_| OsStr::new(".."))
         .chain(src_iter)
         .collect();
+    if result.as_os_str().is_empty() {
+        result.push(".");
+    }
     Ok(result.into())
 }
 

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -580,3 +580,11 @@ fn test_relative_src_already_symlink() {
     ucmd.arg("-sr").arg("file2").arg("file3").succeeds();
     assert!(at.resolve_link("file3").ends_with("file1"));
 }
+
+#[test]
+fn test_relative_recursive() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir");
+    ucmd.args(&["-sr", "dir", "dir/recursive"]).succeeds();
+    assert_eq!(at.resolve_link("dir/recursive"), ".");
+}


### PR DESCRIPTION
Instead of returning an empty `Path` we should return a path to the current directory (`.`)