### PR TITLE
cut: fix `-d=` (#2424)

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -531,7 +531,16 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 let zero_terminated = matches.is_present(options::ZERO_TERMINATED);
 
                 match matches.value_of(options::DELIMITER) {
-                    Some(delim) => {
+                    Some(mut delim) => {
+                        // GNU's `cut` supports `-d=` to set the delimiter to `=`.
+                        // Clap parsing is limited in this situation, see:
+                        // https://github.com/uutils/coreutils/issues/2424#issuecomment-863825242
+                        // Since clap parsing handles `-d=` as delimiter explicitly set to "" and
+                        // an empty delimiter is not accepted by GNU's `cut` (and makes no sense),
+                        // we can use this as basis for a simple workaround:
+                        if delim.is_empty() {
+                            delim = "=";
+                        }
                         if delim.chars().count() > 1 {
                             Err(msg_opt_invalid_should_be!(
                                 "empty or 1 character long",

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -157,3 +157,12 @@ fn test_directory_and_no_such_file() {
         .run()
         .stderr_is("cut: some: No such file or directory\n");
 }
+
+#[test]
+fn test_equal_as_delimiter() {
+    new_ucmd!()
+        .args(&["-f", "2", "-d="])
+        .pipe_in("--libdir=./out/lib")
+        .succeeds()
+        .stdout_only("./out/lib\n");
+}


### PR DESCRIPTION
fix for #2424

GNU's `cut` supports `-d=` to set the delimiter to `=`.
Clap parsing is limited in this situation, [see](https://github.com/uutils/coreutils/issues/2424#issuecomment-863825242
).
Since clap parsing handles `-d=` as delimiter explicitly set to `""` we can use this as basis for a simple workaround. 

The downside is that `uu_cut` loses the ability to handle empty delimiters.
I don't know how often this is used, or if it is useful at all, but I consider this an acceptable tradeoff.
GNU's behaviour for an empty delimiter is to echo the input.



Other alternatives for a workaround to fix #2424 could be:

1. parse/regex `args` before calling `App::get_matches()`
2. set `Arg::with_name(options::DELIMITER).empty_values(false)` use `App::get_matches_safe()`, handle the error manually and set the delimiter to `=`