### PR TITLE
tests/pr: include one more possible minute

### DIFF
--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -22,6 +22,7 @@ fn file_last_modified_time(ucmd: &UCommand, path: &str) -> String {
 }
 
 fn all_minutes(from: DateTime<Local>, to: DateTime<Local>) -> Vec<String> {
+    let to = to + Duration::minutes(1);
     const FORMAT: &str = "%b %d %H:%M %Y";
     let mut vec = vec![];
     let mut current = from;


### PR DESCRIPTION
Previous attempt https://github.com/uutils/coreutils/pull/2405, but we have to include one more possible minute at the end to make it work.