### PR TITLE
CICD ~ refactor + add PR auto-fixes

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -17,6 +17,40 @@ env:
 on: [push, pull_request]
 
 jobs:
+  code_deps:
+    name: Style/dependencies
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { os: ubuntu-latest , features: feat_os_unix }
+    steps:
+    - uses: actions/checkout@v2
+    - name: Initialize workflow variables
+      id: vars
+      shell: bash
+      run: |
+        ## VARs setup
+        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        # target-specific options
+        # * CARGO_FEATURES_OPTION
+        CARGO_FEATURES_OPTION='' ;
+        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+        outputs CARGO_FEATURES_OPTION
+    - name: Install `rust` toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        profile: minimal # minimal component installation (ie, no documentation)
+    - name: "`cargo update` testing"
+      shell: bash
+      run: |
+        ## `cargo update` testing
+        # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
+        cargo fetch --locked --quiet || { echo "::error file=Cargo.lock::'Cargo.lock' file requires update (use \`cargo +${{ env.RUST_MIN_SRV }} update\`)" ; exit 1 ; }
+
   code_format:
     name: Style/format
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -48,36 +48,19 @@ jobs:
     - name: "`fmt` testing"
       shell: bash
       run: |
-        # `fmt` testing
+        ## `fmt` testing
         # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-        S=$(cargo fmt -- --check) && printf "%s\n" "$S" || { printf "%s\n" "$S" | sed -E -n -e "s/^Diff[[:space:]]+in[[:space:]]+${PWD//\//\\/}\/(.*)[[:space:]]+at[[:space:]]+[^0-9]+([0-9]+).*$/::warning file=\1,line=\2::WARNING: \`cargo fmt\`: style violation/p" ; }
+        S=$(cargo fmt -- --check) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s\n" "$S" | sed -E -n -e "s/^Diff[[:space:]]+in[[:space:]]+${PWD//\//\\/}\/(.*)[[:space:]]+at[[:space:]]+[^0-9]+([0-9]+).*$/::error file=\1,line=\2::ERROR: \`cargo fmt\`: style violation (file:'\1', line:\2; use \`cargo fmt \"\1\"\`)/p" ; exit 1 ; }
     - name: "`fmt` testing of tests"
+      if: success() || failure() # run regardless of prior step success/failure
       shell: bash
       run: |
-        # `fmt` testing of tests
+        ## `fmt` testing of tests
         # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-        S=$(find tests -name "*.rs" -print0 | xargs -0 cargo fmt -- --check) && printf "%s\n" "$S" || { printf "%s\n" "$S" | sed -E -n "s/^Diff[[:space:]]+in[[:space:]]+${PWD//\//\\/}\/(.*)[[:space:]]+at[[:space:]]+[^0-9]+([0-9]+).*$/::warning file=\1,line=\2::WARNING: \`cargo fmt\`: style violation/p" ; }
+        S=$(find tests -name "*.rs" -print0 | xargs -0 cargo fmt -- --check) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s\n" "$S" | sed -E -n "s/^Diff[[:space:]]+in[[:space:]]+${PWD//\//\\/}\/(.*)[[:space:]]+at[[:space:]]+[^0-9]+([0-9]+).*$/::error file=\1,line=\2::ERROR: \`cargo fmt\`: style violation (file:'\1', line:\2; use \`cargo fmt \"\1\"\`)/p" ; exit 1 ; }
 
-  code_spellcheck:
-    name: Style/spelling
-    runs-on: ${{ matrix.job.os }}
-    strategy:
-      matrix:
-        job:
-          - { os: ubuntu-latest }
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install/setup prerequisites
-      shell: bash
-      run: |
-        sudo apt-get -y update ; sudo apt-get -y install npm ; sudo npm install cspell -g;
-    - name: Run `cspell`
-      shell: bash
-      run: |
-        cspell --config .vscode/cSpell.json --no-summary --no-progress "**/*" | sed "s/\(.*\):\(.*\):\(.*\) - \(.*\)/::warning file=\1,line=\2,col=\3::cspell: \4/" || true
-
-  code_warnings:
-    name: Style/warnings
+  code_lint:
+    name: Style/lint
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false
@@ -106,13 +89,32 @@ jobs:
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
         components: clippy
-    - name: "`clippy` testing"
-      if: success() || failure() # run regardless of prior step success/failure
+    - name: "`clippy` lint testing"
       shell: bash
       run: |
-        # `clippy` testing
+        ## `clippy` lint testing
         # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-        S=$(cargo +nightly clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::warning file=\2,line=\3,col=\4::WARNING: \`cargo clippy\`: \1/p;" -e '}' ; }
+        S=$(cargo +nightly clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+${PWD//\//\\/}\/(.*):([0-9]+):([0-9]+).*$/::error file=\2,line=\3,col=\4::ERROR: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; exit 1 ; }
+
+  code_spellcheck:
+    name: Style/spelling
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      matrix:
+        job:
+          - { os: ubuntu-latest }
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install/setup prerequisites
+      shell: bash
+      run: |
+        ## Install/setup prerequisites
+        sudo apt-get -y update ; sudo apt-get -y install npm ; sudo npm install cspell -g ;
+    - name: Run `cspell`
+      shell: bash
+      run: |
+        ## Run `cspell`
+        cspell --config .vscode/cSpell.json --no-summary --no-progress "**/*" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::error file=\1,line=\2,col=\3::ERROR: \4 (file:'\1', line:\2)/p"
 
   min_version:
     name: MinRustV # Minimum supported rust version
@@ -137,20 +139,20 @@ jobs:
         use-tool-cache: true
       env:
         RUSTUP_TOOLCHAIN: stable
-    - name: Confirm compatible 'Cargo.lock'
+    - name: Confirm MinSRV compatible 'Cargo.lock'
       shell: bash
       run: |
-        # Confirm compatible 'Cargo.lock'
+        ## Confirm MinSRV compatible 'Cargo.lock'
         # * 'Cargo.lock' is required to be in a format that `cargo` of MinSRV can interpret (eg, v1-format for MinSRV < v1.38)
-        cargo fetch --locked --quiet || { echo "::error file=Cargo.lock::Incompatible 'Cargo.lock' format; try \`cargo +${{ env.RUST_MIN_SRV }} update\`" ; exit 1 ; }
+        cargo fetch --locked --quiet || { echo "::error file=Cargo.lock::Incompatible (or out-of-date) 'Cargo.lock' file; update using \`cargo +${{ env.RUST_MIN_SRV }} update\`" ; exit 1 ; }
     - name: Info
       shell: bash
       run: |
-        # Info
-        ## environment
+        ## Info
+        # environment
         echo "## environment"
         echo "CI='${CI}'"
-        ## tooling info display
+        # tooling info display
         echo "## tooling"
         which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
         rustup -V
@@ -158,12 +160,11 @@ jobs:
         cargo -V
         rustc -V
         cargo-tree tree -V
-        ## dependencies
+        # dependencies
         echo "## dependency list"
         cargo fetch --locked --quiet
         ## * using the 'stable' toolchain is necessary to avoid "unexpected '--filter-platform'" errors
         RUSTUP_TOOLCHAIN=stable cargo-tree tree --frozen --all --no-dev-dependencies --no-indent --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
-
     - name: Test
       uses: actions-rs/cargo@v1
       with:
@@ -172,8 +173,8 @@ jobs:
       env:
         RUSTFLAGS: '-Awarnings'
 
-  busybox_test:
-    name: Busybox test suite
+  build_makefile:
+    name: Build/Makefile
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false
@@ -188,42 +189,19 @@ jobs:
         toolchain: stable
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
-    - name: "prepare busytest"
+    - name: Install/setup prerequisites
       shell: bash
       run: |
-        make prepare-busytest
-    - name: "run busybox testsuite"
+        ## Install/setup prerequisites
+        sudo apt-get -y update ; sudo apt-get -y install python3-sphinx ;
+    - name: "`make build`"
       shell: bash
       run: |
-        bindir=$(pwd)/target/debug
-        cd tmp/busybox-*/testsuite
-        ## S=$(bindir=$bindir ./runtest) && printf "%s\n" "$S" || { printf "%s\n" "$S" | grep "FAIL:" | sed -e "s/FAIL: /::warning ::Test failure:/g" ; }
-        output=$(bindir=$bindir ./runtest 2>&1 || true)
-        printf "%s\n" "${output}"
-        n_fails=$(echo "$output" | grep "^FAIL:\s" | wc --lines)
-        if [ $n_fails -gt 0 ] ; then echo "::warning ::${n_fails}+ test failures" ; fi
-
-  makefile_build:
-    name: Test the build target of the Makefile
-    runs-on: ${{ matrix.job.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        job:
-          - { os: ubuntu-latest }
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-    - name: "Run make build"
-      shell: bash
-      run: |
-        sudo apt-get -y update ; sudo apt-get -y install python3-sphinx;
         make build
+    - name: "`make test`"
+      shell: bash
+      run: |
+        make test
 
   build:
     name: Build
@@ -251,7 +229,7 @@ jobs:
     - name: Install/setup prerequisites
       shell: bash
       run: |
-        ## install/setup prerequisites
+        ## Install/setup prerequisites
         case '${{ matrix.job.target }}' in
           arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
           aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
@@ -350,7 +328,7 @@ jobs:
     - name: Create all needed build/work directories
       shell: bash
       run: |
-        ## create build/work space
+        ## Create build/work space
         mkdir -p '${{ steps.vars.outputs.STAGING }}'
         mkdir -p '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}'
         mkdir -p '${{ steps.vars.outputs.STAGING }}/dpkg'
@@ -387,15 +365,15 @@ jobs:
     - name: Info
       shell: bash
       run: |
-        # Info
-        ## commit info
+        ## Info
+        # commit info
         echo "## commit"
         echo GITHUB_REF=${GITHUB_REF}
         echo GITHUB_SHA=${GITHUB_SHA}
-        ## environment
+        # environment
         echo "## environment"
         echo "CI='${CI}'"
-        ## tooling info display
+        # tooling info display
         echo "## tooling"
         which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
         rustup -V
@@ -403,7 +381,7 @@ jobs:
         cargo -V
         rustc -V
         cargo-tree tree -V
-        ## dependencies
+        # dependencies
         echo "## dependency list"
         cargo fetch --locked --quiet
         cargo-tree tree --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --all --no-dev-dependencies --no-indent | grep -vE "$PWD" | sort --unique
@@ -433,7 +411,7 @@ jobs:
     - name: Package
       shell: bash
       run: |
-        ## package artifact(s)
+        ## Package artifact(s)
         # binary
         cp 'target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/'
         # `strip` binary (if needed)
@@ -474,6 +452,37 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  test_busybox:
+    name: Tests/BusyBox test suite
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { os: ubuntu-latest }
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install `rust` toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        profile: minimal # minimal component installation (ie, no documentation)
+    - name: Install/setup prerequisites
+      shell: bash
+      run: |
+        make prepare-busytest
+    - name: "Run BusyBox test suite"
+      shell: bash
+      run: |
+        ## Run BusyBox test suite
+        bindir=$(pwd)/target/debug
+        cd tmp/busybox-*/testsuite
+        output=$(bindir=$bindir ./runtest 2>&1 || true)
+        printf "%s\n" "${output}"
+        n_fails=$(echo "$output" | grep "^FAIL:\s" | wc --lines)
+        if [ $n_fails -gt 0 ] ; then echo "::warning ::${n_fails}+ test failures" ; fi
+
   coverage:
     name: Code Coverage
     runs-on: ${{ matrix.job.os }}
@@ -490,7 +499,7 @@ jobs:
     - name: Install/setup prerequisites
       shell: bash
       run: |
-        ## install/setup prerequisites
+        ## Install/setup prerequisites
         case '${{ matrix.job.os }}' in
           macos-latest) brew install coreutils ;; # needed for testing
         esac
@@ -584,7 +593,7 @@ jobs:
       id: coverage
       shell: bash
       run: |
-        # generate coverage data
+        ## Generate coverage data
         COVERAGE_REPORT_DIR="target/debug"
         COVERAGE_REPORT_FILE="${COVERAGE_REPORT_DIR}/lcov.info"
         # GRCOV_IGNORE_OPTION='--ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*"' ## `grcov` ignores these params when passed as an environment variable (why?)

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -26,7 +26,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -66,7 +66,7 @@ jobs:
         job:
           - { os: ubuntu-latest }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -87,7 +87,7 @@ jobs:
           - { os: macos-latest   , features: feat_os_macos }
           - { os: windows-latest , features: feat_os_windows }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -122,7 +122,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
       uses: actions-rs/toolchain@v1
       with:
@@ -181,7 +181,7 @@ jobs:
         job:
           - { os: ubuntu-latest }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -212,7 +212,7 @@ jobs:
         job:
           - { os: ubuntu-latest }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -249,7 +249,7 @@ jobs:
           - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }  ## note: requires rust >= 1.43.0 to link correctly
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -488,7 +488,7 @@ jobs:
           - { os: macos-latest   , features: macos }
           - { os: windows-latest , features: windows }
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install/setup prerequisites
       shell: bash
       run: |

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -235,8 +235,6 @@ jobs:
           # { os, target, cargo-options, features, use-cross, toolchain }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_os_unix           , use-cross: use-cross }
-          - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    , features: feat_os_unix           , use-cross: use-cross }
           # - { os: ubuntu-18.04   , target: i586-unknown-linux-gnu      , features: feat_os_unix           , use-cross: use-cross } ## note: older windows platform; not required, dev-FYI only
           # - { os: ubuntu-18.04   , target: i586-unknown-linux-gnu      , features: feat_os_unix           , use-cross: use-cross } ## note: older windows platform; not required, dev-FYI only
           - { os: ubuntu-18.04   , target: i686-unknown-linux-gnu      , features: feat_os_unix           , use-cross: use-cross }

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash
       run: |
         ## VARs setup
-        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
         # target-specific options
         # * CARGO_FEATURES_OPTION
         CARGO_FEATURES_OPTION='' ;
@@ -66,7 +66,7 @@ jobs:
       shell: bash
       run: |
         ## VARs setup
-        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
         # target-specific options
         # * CARGO_FEATURES_OPTION
         CARGO_FEATURES_OPTION='' ;
@@ -110,7 +110,7 @@ jobs:
       shell: bash
       run: |
         ## VARs setup
-        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
         # target-specific options
         # * CARGO_FEATURES_OPTION
         CARGO_FEATURES_OPTION='' ;
@@ -276,7 +276,7 @@ jobs:
       shell: bash
       run: |
         ## VARs setup
-        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
         # toolchain
         TOOLCHAIN="stable" ## default to "stable" toolchain
         # * specify alternate/non-default TOOLCHAIN for *-pc-windows-gnu targets; gnu targets on Windows are broken for the standard *-pc-windows-msvc toolchain (refs: GH:rust-lang/rust#47048, GH:rust-lang/rust#53454, GH:rust-lang/cargo#6754)
@@ -382,7 +382,7 @@ jobs:
       shell: bash
       run: |
         ## Dependent VARs setup
-        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        outputs() { step_id="dep_vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
         # * determine sub-crate utility list
         UTILITY_LIST="$(./util/show-utils.sh ${CARGO_FEATURES_OPTION})"
         echo UTILITY_LIST=${UTILITY_LIST}
@@ -544,7 +544,7 @@ jobs:
       shell: bash
       run: |
         ## VARs setup
-        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
         # toolchain
         TOOLCHAIN="nightly-${{ env.RUST_COV_SRV }}" ## default to "nightly" toolchain (required for certain required unstable compiler flags) ## !maint: refactor when stable channel has needed support
         # * specify gnu-type TOOLCHAIN for windows; `grcov` requires gnu-style code coverage data files
@@ -579,7 +579,7 @@ jobs:
       shell: bash
       run: |
         ## Dependent VARs setup
-        outputs() { for var in "$@" ; do echo steps.vars.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        outputs() { step_id="dep_vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
         # * determine sub-crate utility list
         UTILITY_LIST="$(./util/show-utils.sh ${CARGO_FEATURES_OPTION})"
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo "-puu_${u}"; done;)"

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -1,0 +1,133 @@
+name: FixPR
+
+# Trigger automated fixes for PRs being merged (with associated commits)
+
+env:
+  BRANCH_TARGET: master
+
+on:
+  # * only trigger on pull request closed to specific branches
+  # ref: https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/9
+  pull_request:
+    branches:
+      - master # == env.BRANCH_TARGET ## unfortunately, env context variables are only available in jobs/steps (see <https://github.community/t/how-to-use-env-context/16975/2>)
+    types: [ closed ]
+
+jobs:
+  code_deps:
+    # Refresh dependencies (ie, 'Cargo.lock') and show updated dependency tree
+    if: github.event.pull_request.merged == true ## only for PR merges
+    name: Update/dependencies
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      matrix:
+        job:
+          - { os: ubuntu-latest , features: feat_os_unix }
+    steps:
+    - uses: actions/checkout@v2
+    - name: Initialize job variables
+      id: vars
+      shell: bash
+      run: |
+        ## VARs setup
+        outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        # surface MSRV from CICD workflow
+        RUST_MIN_SRV=$(grep -P "^\s+RUST_MIN_SRV:" .github/workflows/CICD.yml | grep -Po "(?<=\x22)\d+[.]\d+(?:[.]\d+)?(?=\x22)" )
+        outputs RUST_MIN_SRV
+    - name: Install `rust` toolchain (v${{ steps.vars.outputs.RUST_MIN_SRV }})
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ steps.vars.outputs.RUST_MIN_SRV }}
+        default: true
+        profile: minimal # minimal component installation (ie, no documentation)
+    - name: Install `cargo-tree` # for dependency information
+      uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-tree
+        version: latest
+        use-tool-cache: true
+      env:
+        RUSTUP_TOOLCHAIN: stable
+    - name: Ensure updated 'Cargo.lock'
+      shell: bash
+      run: |
+        # Ensure updated 'Cargo.lock'
+        # * 'Cargo.lock' is required to be in a format that `cargo` of MinSRV can interpret (eg, v1-format for MinSRV < v1.38)
+        cargo fetch --locked --quiet || cargo +${{ steps.vars.outputs.RUST_MIN_SRV }} update
+    - name: Info
+      shell: bash
+      run: |
+        # Info
+        ## environment
+        echo "## environment"
+        echo "CI='${CI}'"
+        ## tooling info display
+        echo "## tooling"
+        which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
+        rustup -V
+        rustup show active-toolchain
+        cargo -V
+        rustc -V
+        cargo-tree tree -V
+        ## dependencies
+        echo "## dependency list"
+        cargo fetch --locked --quiet
+        ## * using the 'stable' toolchain is necessary to avoid "unexpected '--filter-platform'" errors
+        RUSTUP_TOOLCHAIN=stable cargo-tree tree --frozen --all --no-dev-dependencies --no-indent --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
+    - name: Commit any changes (to '${{ env.BRANCH_TARGET }}')
+      uses: EndBug/add-and-commit@v7
+      with:
+        branch: ${{ env.BRANCH_TARGET }}
+        default_author: github_actions
+        message: "maint ~ refresh 'Cargo.lock'"
+        add: Cargo.lock
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  code_format:
+    # Recheck/refresh code formatting
+    if: github.event.pull_request.merged == true ## only for PR merges
+    name: Update/format
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { os: ubuntu-latest , features: feat_os_unix }
+    steps:
+    - uses: actions/checkout@v2
+    - name: Initialize job variables
+      id: vars
+      shell: bash
+      run: |
+        ## VARs setup
+        outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+        # target-specific options
+        # * CARGO_FEATURES_OPTION
+        CARGO_FEATURES_OPTION='' ;
+        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+        outputs CARGO_FEATURES_OPTION
+    - name: Install `rust` toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        profile: minimal # minimal component installation (ie, no documentation)
+        components: rustfmt
+    - name: "`cargo fmt`"
+      shell: bash
+      run: |
+        cargo fmt
+    - name: "`cargo fmt` tests"
+      shell: bash
+      run: |
+        # `cargo fmt` of tests
+        find tests -name "*.rs" -print0 | xargs -0 cargo fmt --
+    - name: Commit any changes (to '${{ env.BRANCH_TARGET }}')
+      uses: EndBug/add-and-commit@v7
+      with:
+        branch: ${{ env.BRANCH_TARGET }}
+        default_author: github_actions
+        message: "maint ~ rustfmt (`cargo fmt`)"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/GNU.yml
+++ b/.github/workflows/GNU.yml
@@ -1,5 +1,7 @@
 name: GNU
 
+# spell-checker:ignore (names) gnulib ; (utils) autopoint gperf pyinotify texinfo ; (vars) XPASS
+
 on: [push, pull_request]
 
 jobs:
@@ -7,7 +9,6 @@ jobs:
     name: Run GNU tests
     runs-on: ubuntu-latest
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
     - name: Checkout code uutil
       uses: actions/checkout@v2
       with:
@@ -18,7 +19,7 @@ jobs:
         repository: 'coreutils/coreutils'
         path: 'gnu'
         ref: v8.32
-    - name: Checkout GNU corelib
+    - name: Checkout GNU coreutils library (gnulib)
       uses: actions/checkout@v2
       with:
         repository: 'coreutils/gnulib'
@@ -32,23 +33,26 @@ jobs:
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
         components: rustfmt
-    - name: Install deps
+    - name: Install dependencies
       shell: bash
       run: |
+        ## Install dependencies
         sudo apt-get update
         sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify python3-sphinx jq
     - name: Build binaries
       shell: bash
       run: |
-       cd uutils
-       bash util/build-gnu.sh
+        ## Build binaries
+        cd uutils
+        bash util/build-gnu.sh
     - name: Run GNU tests
       shell: bash
       run: |
         bash uutils/util/run-gnu-test.sh
-    - name: Extract tests info
+    - name: Extract testing info
       shell: bash
       run: |
+        ## Extract testing info
         LOG_FILE=gnu/tests/test-suite.log
         if test -f "$LOG_FILE"
         then
@@ -58,7 +62,9 @@ jobs:
             FAIL=$(sed -n "s/.*# FAIL: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
             XPASS=$(sed -n "s/.*# XPASS: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
             ERROR=$(sed -n "s/.*# ERROR: \(.*\)/\1/p" "$LOG_FILE"|tr -d '\r'|head -n1)
-            echo "::warning ::GNU testsuite = TOTAL: $TOTAL / PASS: $PASS / FAIL: $FAIL / ERROR: $ERROR"
+            output="GNU tests summary = TOTAL: $TOTAL / PASS: $PASS / FAIL: $FAIL / ERROR: $ERROR"
+            echo "${output}"
+            if [[ "$FAIL" -gt 0 || "$ERROR" -gt 0 ]]; then echo "::warning ::${output}" ; fi
             jq -n \
                   --arg date "$(date --rfc-email)" \
                   --arg sha "$GITHUB_SHA" \
@@ -72,12 +78,10 @@ jobs:
           else
             echo "::error ::Failed to get summary of test results"
           fi
-
     - uses: actions/upload-artifact@v2
       with:
         name: test-report
         path: gnu/tests/**/*.log
-
     - uses: actions/upload-artifact@v2
       with:
         name: gnu-result

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -1,4 +1,4 @@
-name: GNU
+name: GnuTests
 
 # spell-checker:ignore (names) gnulib ; (utils) autopoint gperf pyinotify texinfo ; (vars) XPASS
 

--- a/.vscode/cspell.dictionaries/acronyms+names.wordlist.txt
+++ b/.vscode/cspell.dictionaries/acronyms+names.wordlist.txt
@@ -12,6 +12,7 @@ FIFOs
 FQDN # fully qualified domain name
 GID # group ID
 GIDs
+GNU
 GNUEABI
 GNUEABIhf
 JFS
@@ -45,6 +46,7 @@ Deno
 EditorConfig
 FreeBSD
 Gmail
+GNU
 Irix
 MS-DOS
 MSDOS

--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -78,6 +78,7 @@ symlinks
 syscall
 syscalls
 tokenize
+toolchain
 truthy
 unbuffered
 unescape

--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -48,17 +48,19 @@ xattr
 # * rust/rustc
 RUSTDOCFLAGS
 RUSTFLAGS
+clippy
+rustc
+rustfmt
+rustup
+#
 bitor # BitOr trait function
 bitxor # BitXor trait function
-clippy
 concat
 fract
 powi
 println
 repr
 rfind
-rustc
-rustfmt
 struct
 structs
 substr

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -186,7 +186,7 @@ mod tests {
     fn make_os_vec(os_str: &OsStr) -> Vec<OsString> {
         vec![
             OsString::from("test"),
-            OsString::from("สวัสดี"),
+            OsString::from("สวัสดี"), // spell-checker:disable-line
             os_str.to_os_string(),
         ]
     }

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -162,7 +162,7 @@ fn test_directory_and_no_such_file() {
 fn test_equal_as_delimiter() {
     new_ucmd!()
         .args(&["-f", "2", "-d="])
-        .pipe_in("--libdir=./out/lib")
+        .pipe_in("--dir=./out/lib")
         .succeeds()
         .stdout_only("./out/lib\n");
 }

--- a/util/GHA-delete-GNU-workflow-logs.sh
+++ b/util/GHA-delete-GNU-workflow-logs.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# spell-checker:ignore (utils) gitsome jq ; (gh) repos
+
+ME="${0}"
+ME_dir="$(dirname -- "${ME}")"
+ME_parent_dir="$(dirname -- "${ME_dir}")"
+ME_parent_dir_abs="$(realpath -mP -- "${ME_parent_dir}")"
+
+# ref: <https://stackoverflow.com/questions/57927115/anyone-know-a-way-to-delete-a-workflow-from-github-actions>
+
+# note: requires `gh` and `jq`
+
+## tools available?
+
+# * `gh` available?
+unset GH
+gh --version 1>/dev/null 2>&1
+if [ $? -eq 0 ]; then export GH="gh"; fi
+
+# * `jq` available?
+unset JQ
+jq --version 1>/dev/null 2>&1
+if [ $? -eq 0 ]; then export JQ="jq"; fi
+
+if [ -z "${GH}" ] || [ -z "${JQ}" ]; then
+    if [ -z "${GH}" ]; then
+        echo 'ERR!: missing `gh` (see install instructions at <https://github.com/cli/cli>)' 1>&2
+    fi
+    if [ -z "${JQ}" ]; then
+        echo 'ERR!: missing `jq` (install with `sudo apt install jq`)' 1>&2
+    fi
+    exit 1
+fi
+
+dry_run=true
+
+USER_NAME=uutils
+REPO_NAME=coreutils
+WORK_NAME=GNU
+
+# * `--paginate` retrieves all pages
+# gh api --paginate "repos/${USER_NAME}/${REPO_NAME}/actions/runs" | jq -r ".workflow_runs[] | select(.name == \"${WORK_NAME}\") | (.id)" | xargs -n1 sh -c "for arg do { echo gh api repos/${USER_NAME}/${REPO_NAME}/actions/runs/\${arg} -X DELETE ; if [ -z "$dry_run" ]; then gh api repos/${USER_NAME}/${REPO_NAME}/actions/runs/\${arg} -X DELETE ; fi ; } ; done ;" _
+gh api "repos/${USER_NAME}/${REPO_NAME}/actions/runs" | jq -r ".workflow_runs[] | select(.name == \"${WORK_NAME}\") | (.id)" | xargs -n1 sh -c "for arg do { echo gh api repos/${USER_NAME}/${REPO_NAME}/actions/runs/\${arg} -X DELETE ; if [ -z "$dry_run" ]; then gh api repos/${USER_NAME}/${REPO_NAME}/actions/runs/\${arg} -X DELETE ; fi ; } ; done ;" _


### PR DESCRIPTION
This is a continuation of #2368.

Style warnings have been converted to errors (with instructions for repair in the error messages; see <https://github.com/rivy-t/rs.coreutils/actions/runs/953446073>). This should push contributors to fix issues earlier and rely less on maintainers to ask for changes.

BusyBox and GNU tests still produce soft warnings when any test fails (with test summaries of failed tests; see <https://github.com/rivy-t/rs.coreutils/actions/runs/953373363> for a fully successful run with only a BusyBox test failure summary).

We should ask for "no-error/no-red PRs" from contributors.

A new 'FixPR' workflow runs on any PR merge to 'master' which auto-fixes 'Cargo.lock' and code formatting, when necessary.

Suggestions for changes?