### PR TITLE
ls: Fix problems dealing with dangling symlinks

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1198,7 +1198,7 @@ fn list(locs: Vec<String>, config: Config) -> i32 {
         let p = PathBuf::from(&loc);
         let path_data = PathData::new(p, None, None, &config, true);
 
-        if !path_data.md().is_some() {
+        if path_data.md().is_none() {
             show_error!("'{}': {}", &loc, "No such file or directory");
             /*
             We found an error, the return code of ls should not be 0

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1270,7 +1270,8 @@ fn sort_entries(entries: &mut Vec<PathData>, config: &Config) {
 
 #[cfg(windows)]
 fn is_hidden(file_path: &DirEntry) -> bool {
-    let metadata = fs::metadata(file_path.path()).unwrap();
+    let path = file_path.path();
+    let metadata = fs::metadata(&path).unwrap_or_else(|_| fs::symlink_metadata(&path).unwrap());
     let attr = metadata.file_attributes();
     (attr & 0x2) > 0
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1196,7 +1196,9 @@ fn list(locs: Vec<String>, config: Config) -> i32 {
 
     for loc in &locs {
         let p = PathBuf::from(&loc);
-        if !p.exists() {
+        let path_data = PathData::new(p, None, None, &config, true);
+
+        if !path_data.md().is_some() {
             show_error!("'{}': {}", &loc, "No such file or directory");
             /*
             We found an error, the return code of ls should not be 0
@@ -1205,8 +1207,6 @@ fn list(locs: Vec<String>, config: Config) -> i32 {
             has_failed = true;
             continue;
         }
-
-        let path_data = PathData::new(p, None, None, &config, true);
 
         let show_dir_contents = match path_data.file_type() {
             Some(ft) => !config.directory && ft.is_dir(),
@@ -1331,7 +1331,7 @@ fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>)
 
 fn get_metadata(entry: &Path, dereference: bool) -> std::io::Result<Metadata> {
     if dereference {
-        entry.metadata().or_else(|_| entry.symlink_metadata())
+        entry.metadata()
     } else {
         entry.symlink_metadata()
     }
@@ -1733,7 +1733,11 @@ fn display_file_name(path: &PathData, config: &Config) -> Option<Cell> {
     #[cfg(unix)]
     {
         if config.format != Format::Long && config.inode {
-            name = get_inode(path.md()?) + " " + &name;
+            name = path
+                .md()
+                .map_or_else(|| "?".to_string(), |md| get_inode(md))
+                + " "
+                + &name;
         }
     }
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2044,5 +2044,5 @@ fn test_ls_dangling_symlinks() {
         .arg("-Li")
         .arg("temp_dir")
         .succeeds() // this should fail, though at the moment, ls lacks a way to propagate errors encountered during display
-        .stdout_contains("? dangle");
+        .stdout_contains(if cfg!(windows) { "dangle" } else { "? dangle" });
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2021,3 +2021,28 @@ fn test_ls_path() {
         .run()
         .stdout_is(expected_stdout);
 }
+
+#[test]
+fn test_ls_dangling_symlinks() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("temp_dir");
+    at.symlink_file("does_not_exist", "temp_dir/dangle");
+
+    scene.ucmd().arg("-L").arg("temp_dir/dangle").fails();
+    scene.ucmd().arg("-H").arg("temp_dir/dangle").fails();
+
+    scene
+        .ucmd()
+        .arg("temp_dir/dangle")
+        .succeeds()
+        .stdout_contains("dangle");
+
+    scene
+        .ucmd()
+        .arg("-Li")
+        .arg("temp_dir")
+        .succeeds() // this should fail, though at the moment, ls lacks a way to propagate errors encountered during display
+        .stdout_contains("? dangle");
+}


### PR DESCRIPTION
- For dangling symlinks, errors should only be reported if
dereferencing options were passed and dereferencing was applicable to
the particular symlink
- With -i parameter, report '?' as the inode number for dangling
symlinks
- Add tests similar to dangle tests from GNU test suite

This is first step to fixing issues with dangle related tests from GNU test suite