### PR TITLE
sort: separate additional data from the Line struct

### DIFF
--- a/src/uu/sort/src/check.rs
+++ b/src/uu/sort/src/check.rs
@@ -8,7 +8,7 @@
 //! Check if a file is ordered
 
 use crate::{
-    chunks::{self, Chunk},
+    chunks::{self, Chunk, RecycledChunk},
     compare_by, open, GlobalSettings,
 };
 use itertools::Itertools;
@@ -34,7 +34,7 @@ pub fn check(path: &str, settings: &GlobalSettings) -> i32 {
         move || reader(file, recycled_receiver, loaded_sender, &settings)
     });
     for _ in 0..2 {
-        let _ = recycled_sender.send(Chunk::new(vec![0; 100 * 1024], |_| Vec::new()));
+        let _ = recycled_sender.send(RecycledChunk::new(100 * 1024));
     }
 
     let mut prev_chunk: Option<Chunk> = None;
@@ -44,21 +44,29 @@ pub fn check(path: &str, settings: &GlobalSettings) -> i32 {
         if let Some(prev_chunk) = prev_chunk.take() {
             // Check if the first element of the new chunk is greater than the last
             // element from the previous chunk
-            let prev_last = prev_chunk.borrow_lines().last().unwrap();
-            let new_first = chunk.borrow_lines().first().unwrap();
+            let prev_last = prev_chunk.lines().last().unwrap();
+            let new_first = chunk.lines().first().unwrap();
 
-            if compare_by(prev_last, new_first, settings) == Ordering::Greater {
+            if compare_by(
+                prev_last,
+                new_first,
+                settings,
+                prev_chunk.line_data(),
+                chunk.line_data(),
+            ) == Ordering::Greater
+            {
                 if !settings.check_silent {
                     println!("sort: {}:{}: disorder: {}", path, line_idx, new_first.line);
                 }
                 return 1;
             }
-            let _ = recycled_sender.send(prev_chunk);
+            let _ = recycled_sender.send(prev_chunk.recycle());
         }
 
-        for (a, b) in chunk.borrow_lines().iter().tuple_windows() {
+        for (a, b) in chunk.lines().iter().tuple_windows() {
             line_idx += 1;
-            if compare_by(a, b, settings) == Ordering::Greater {
+            if compare_by(a, b, settings, chunk.line_data(), chunk.line_data()) == Ordering::Greater
+            {
                 if !settings.check_silent {
                     println!("sort: {}:{}: disorder: {}", path, line_idx, b.line);
                 }
@@ -74,16 +82,15 @@ pub fn check(path: &str, settings: &GlobalSettings) -> i32 {
 /// The function running on the reader thread.
 fn reader(
     mut file: Box<dyn Read + Send>,
-    receiver: Receiver<Chunk>,
+    receiver: Receiver<RecycledChunk>,
     sender: SyncSender<Chunk>,
     settings: &GlobalSettings,
 ) {
     let mut carry_over = vec![];
-    for chunk in receiver.iter() {
-        let (recycled_lines, recycled_buffer) = chunk.recycle();
+    for recycled_chunk in receiver.iter() {
         let should_continue = chunks::read(
             &sender,
-            recycled_buffer,
+            recycled_chunk,
             None,
             &mut carry_over,
             &mut file,
@@ -93,7 +100,6 @@ fn reader(
             } else {
                 b'\n'
             },
-            recycled_lines,
             settings,
         );
         if !should_continue {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -23,11 +23,11 @@ mod ext_sort;
 mod merge;
 mod numeric_str_cmp;
 
+use chunks::LineData;
 use clap::{crate_version, App, Arg};
 use custom_str_cmp::custom_str_cmp;
 use ext_sort::ext_sort;
 use fnv::FnvHasher;
-use itertools::Itertools;
 use numeric_str_cmp::{numeric_str_cmp, NumInfo, NumInfoParseSettings};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -170,6 +170,17 @@ pub struct GlobalSettings {
     tmp_dir: PathBuf,
     compress_prog: Option<String>,
     merge_batch_size: usize,
+    precomputed: Precomputed,
+}
+
+/// Data needed for sorting. Should be computed once before starting to sort
+/// by calling `GlobalSettings::init_precomputed`.
+#[derive(Clone, Debug)]
+struct Precomputed {
+    needs_tokens: bool,
+    num_infos_per_line: usize,
+    floats_per_line: usize,
+    selections_per_line: usize,
 }
 
 impl GlobalSettings {
@@ -210,6 +221,28 @@ impl GlobalSettings {
             None => BufWriter::new(Box::new(stdout()) as Box<dyn Write>),
         }
     }
+
+    /// Precompute some data needed for sorting.
+    /// This function **must** be called before starting to sort, and `GlobalSettings` may not be altered
+    /// afterwards.
+    fn init_precomputed(&mut self) {
+        self.precomputed.needs_tokens = self.selectors.iter().any(|s| s.needs_tokens);
+        self.precomputed.selections_per_line = self
+            .selectors
+            .iter()
+            .filter(|s| !s.is_default_selection)
+            .count();
+        self.precomputed.num_infos_per_line = self
+            .selectors
+            .iter()
+            .filter(|s| matches!(s.settings.mode, SortMode::Numeric | SortMode::HumanNumeric))
+            .count();
+        self.precomputed.floats_per_line = self
+            .selectors
+            .iter()
+            .filter(|s| matches!(s.settings.mode, SortMode::GeneralNumeric))
+            .count();
+    }
 }
 
 impl Default for GlobalSettings {
@@ -237,9 +270,16 @@ impl Default for GlobalSettings {
             tmp_dir: PathBuf::new(),
             compress_prog: None,
             merge_batch_size: 32,
+            precomputed: Precomputed {
+                num_infos_per_line: 0,
+                floats_per_line: 0,
+                selections_per_line: 0,
+                needs_tokens: false,
+            },
         }
     }
 }
+
 #[derive(Clone, PartialEq, Debug)]
 struct KeySettings {
     mode: SortMode,
@@ -322,32 +362,10 @@ impl Default for KeySettings {
         Self::from(&GlobalSettings::default())
     }
 }
-
-#[derive(Clone, Debug)]
 enum NumCache {
     AsF64(GeneralF64ParseResult),
     WithInfo(NumInfo),
-}
-
-impl NumCache {
-    fn as_f64(&self) -> GeneralF64ParseResult {
-        match self {
-            NumCache::AsF64(n) => *n,
-            _ => unreachable!(),
-        }
-    }
-    fn as_num_info(&self) -> &NumInfo {
-        match self {
-            NumCache::WithInfo(n) => n,
-            _ => unreachable!(),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct Selection<'a> {
-    slice: &'a str,
-    num_cache: Option<Box<NumCache>>,
+    None,
 }
 
 type Field = Range<usize>;
@@ -355,31 +373,39 @@ type Field = Range<usize>;
 #[derive(Clone, Debug)]
 pub struct Line<'a> {
     line: &'a str,
-    selections: Box<[Selection<'a>]>,
+    index: usize,
 }
 
 impl<'a> Line<'a> {
-    fn create(string: &'a str, settings: &GlobalSettings) -> Self {
-        let fields = if settings
+    /// Creates a new `Line`.
+    ///
+    /// If additional data is needed for sorting it is added to `line_data`.
+    /// `token_buffer` allows to reuse the allocation for tokens.
+    fn create(
+        line: &'a str,
+        index: usize,
+        line_data: &mut LineData<'a>,
+        token_buffer: &mut Vec<Field>,
+        settings: &GlobalSettings,
+    ) -> Self {
+        token_buffer.clear();
+        if settings.precomputed.needs_tokens {
+            tokenize(line, settings.separator, token_buffer);
+        }
+        for (selection, num_cache) in settings
             .selectors
             .iter()
-            .any(|selector| selector.needs_tokens)
+            .filter(|selector| !selector.is_default_selection)
+            .map(|selector| selector.get_selection(line, token_buffer))
         {
-            // Only tokenize if we will need tokens.
-            Some(tokenize(string, settings.separator))
-        } else {
-            None
-        };
-
-        Line {
-            line: string,
-            selections: settings
-                .selectors
-                .iter()
-                .filter(|selector| !selector.is_default_selection)
-                .map(|selector| selector.get_selection(string, fields.as_deref()))
-                .collect(),
+            line_data.selections.push(selection);
+            match num_cache {
+                NumCache::AsF64(parsed_float) => line_data.parsed_floats.push(parsed_float),
+                NumCache::WithInfo(num_info) => line_data.num_infos.push(num_info),
+                NumCache::None => (),
+            }
         }
+        Self { line, index }
     }
 
     fn print(&self, writer: &mut impl Write, settings: &GlobalSettings) {
@@ -408,7 +434,8 @@ impl<'a> Line<'a> {
         let line = self.line.replace('\t', ">");
         writeln!(writer, "{}", line)?;
 
-        let fields = tokenize(self.line, settings.separator);
+        let mut fields = vec![];
+        tokenize(self.line, settings.separator, &mut fields);
         for selector in settings.selectors.iter() {
             let mut selection = selector.get_range(self.line, Some(&fields));
             match selector.settings.mode {
@@ -539,51 +566,51 @@ impl<'a> Line<'a> {
     }
 }
 
-/// Tokenize a line into fields.
-fn tokenize(line: &str, separator: Option<char>) -> Vec<Field> {
+/// Tokenize a line into fields. The result is stored into `token_buffer`.
+fn tokenize(line: &str, separator: Option<char>, token_buffer: &mut Vec<Field>) {
+    assert!(token_buffer.is_empty());
     if let Some(separator) = separator {
-        tokenize_with_separator(line, separator)
+        tokenize_with_separator(line, separator, token_buffer)
     } else {
-        tokenize_default(line)
+        tokenize_default(line, token_buffer)
     }
 }
 
 /// By default fields are separated by the first whitespace after non-whitespace.
 /// Whitespace is included in fields at the start.
-fn tokenize_default(line: &str) -> Vec<Field> {
-    let mut tokens = vec![0..0];
+/// The result is stored into `token_buffer`.
+fn tokenize_default(line: &str, token_buffer: &mut Vec<Field>) {
+    token_buffer.push(0..0);
     // pretend that there was whitespace in front of the line
     let mut previous_was_whitespace = true;
     for (idx, char) in line.char_indices() {
         if char.is_whitespace() {
             if !previous_was_whitespace {
-                tokens.last_mut().unwrap().end = idx;
-                tokens.push(idx..0);
+                token_buffer.last_mut().unwrap().end = idx;
+                token_buffer.push(idx..0);
             }
             previous_was_whitespace = true;
         } else {
             previous_was_whitespace = false;
         }
     }
-    tokens.last_mut().unwrap().end = line.len();
-    tokens
+    token_buffer.last_mut().unwrap().end = line.len();
 }
 
 /// Split between separators. These separators are not included in fields.
-fn tokenize_with_separator(line: &str, separator: char) -> Vec<Field> {
-    let mut tokens = vec![];
+/// The result is stored into `token_buffer`.
+fn tokenize_with_separator(line: &str, separator: char, token_buffer: &mut Vec<Field>) {
     let separator_indices =
         line.char_indices()
             .filter_map(|(i, c)| if c == separator { Some(i) } else { None });
     let mut start = 0;
     for sep_idx in separator_indices {
-        tokens.push(start..sep_idx);
+        token_buffer.push(start..sep_idx);
         start = sep_idx + 1;
     }
     if start < line.len() {
-        tokens.push(start..line.len());
+        token_buffer.push(start..line.len());
     }
-    tokens
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -764,8 +791,14 @@ impl FieldSelector {
     }
 
     /// Get the selection that corresponds to this selector for the line.
-    /// If needs_fields returned false, tokens may be None.
-    fn get_selection<'a>(&self, line: &'a str, tokens: Option<&[Field]>) -> Selection<'a> {
+    /// If needs_fields returned false, tokens may be empty.
+    fn get_selection<'a>(&self, line: &'a str, tokens: &[Field]) -> (&'a str, NumCache) {
+        // `get_range` expects `None` when we don't need tokens and would get confused by an empty vector.
+        let tokens = if self.needs_tokens {
+            Some(tokens)
+        } else {
+            None
+        };
         let mut range = &line[self.get_range(line, tokens)];
         let num_cache = if self.settings.mode == SortMode::Numeric
             || self.settings.mode == SortMode::HumanNumeric
@@ -780,24 +813,19 @@ impl FieldSelector {
             );
             // Shorten the range to what we need to pass to numeric_str_cmp later.
             range = &range[num_range];
-            Some(Box::new(NumCache::WithInfo(info)))
+            NumCache::WithInfo(info)
         } else if self.settings.mode == SortMode::GeneralNumeric {
             // Parse this number as f64, as this is the requirement for general numeric sorting.
-            Some(Box::new(NumCache::AsF64(general_f64_parse(
-                &range[get_leading_gen(range)],
-            ))))
+            NumCache::AsF64(general_f64_parse(&range[get_leading_gen(range)]))
         } else {
             // This is not a numeric sort, so we don't need a NumCache.
-            None
+            NumCache::None
         };
-        Selection {
-            slice: range,
-            num_cache,
-        }
+        (range, num_cache)
     }
 
     /// Look up the range in the line that corresponds to this selector.
-    /// If needs_fields returned false, tokens may be None.
+    /// If needs_fields returned false, tokens must be None.
     fn get_range<'a>(&self, line: &'a str, tokens: Option<&[Field]>) -> Range<usize> {
         enum Resolution {
             // The start index of the resolved character, inclusive
@@ -1297,18 +1325,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         );
     }
 
-    exec(&files, &settings)
-}
+    settings.init_precomputed();
 
-fn output_sorted_lines<'a>(iter: impl Iterator<Item = &'a Line<'a>>, settings: &GlobalSettings) {
-    if settings.unique {
-        print_sorted(
-            iter.dedup_by(|a, b| compare_by(a, b, settings) == Ordering::Equal),
-            settings,
-        );
-    } else {
-        print_sorted(iter, settings);
-    }
+    exec(&files, &settings)
 }
 
 fn exec(files: &[String], settings: &GlobalSettings) -> i32 {
@@ -1328,55 +1347,59 @@ fn exec(files: &[String], settings: &GlobalSettings) -> i32 {
     0
 }
 
-fn sort_by<'a>(unsorted: &mut Vec<Line<'a>>, settings: &GlobalSettings) {
+fn sort_by<'a>(unsorted: &mut Vec<Line<'a>>, settings: &GlobalSettings, line_data: &LineData<'a>) {
     if settings.stable || settings.unique {
-        unsorted.par_sort_by(|a, b| compare_by(a, b, settings))
+        unsorted.par_sort_by(|a, b| compare_by(a, b, settings, line_data, line_data))
     } else {
-        unsorted.par_sort_unstable_by(|a, b| compare_by(a, b, settings))
+        unsorted.par_sort_unstable_by(|a, b| compare_by(a, b, settings, line_data, line_data))
     }
 }
 
-fn compare_by<'a>(a: &Line<'a>, b: &Line<'a>, global_settings: &GlobalSettings) -> Ordering {
-    let mut idx = 0;
+fn compare_by<'a>(
+    a: &Line<'a>,
+    b: &Line<'a>,
+    global_settings: &GlobalSettings,
+    a_line_data: &LineData<'a>,
+    b_line_data: &LineData<'a>,
+) -> Ordering {
+    let mut selection_index = 0;
+    let mut num_info_index = 0;
+    let mut parsed_float_index = 0;
     for selector in &global_settings.selectors {
-        let mut _selections = None;
-        let (a_selection, b_selection) = if selector.is_default_selection {
+        let (a_str, b_str) = if selector.is_default_selection {
             // We can select the whole line.
-            // We have to store the selections outside of the if-block so that they live long enough.
-            _selections = Some((
-                Selection {
-                    slice: a.line,
-                    num_cache: None,
-                },
-                Selection {
-                    slice: b.line,
-                    num_cache: None,
-                },
-            ));
-            // Unwrap the selections again, and return references to them.
-            (
-                &_selections.as_ref().unwrap().0,
-                &_selections.as_ref().unwrap().1,
-            )
+            (a.line, b.line)
         } else {
-            let selections = (&a.selections[idx], &b.selections[idx]);
-            idx += 1;
+            let selections = (
+                a_line_data.selections
+                    [a.index * global_settings.precomputed.selections_per_line + selection_index],
+                b_line_data.selections
+                    [b.index * global_settings.precomputed.selections_per_line + selection_index],
+            );
+            selection_index += 1;
             selections
         };
-        let a_str = a_selection.slice;
-        let b_str = b_selection.slice;
+
         let settings = &selector.settings;
 
         let cmp: Ordering = match settings.mode {
             SortMode::Random => random_shuffle(a_str, b_str, &global_settings.salt),
-            SortMode::Numeric | SortMode::HumanNumeric => numeric_str_cmp(
-                (a_str, a_selection.num_cache.as_ref().unwrap().as_num_info()),
-                (b_str, b_selection.num_cache.as_ref().unwrap().as_num_info()),
-            ),
-            SortMode::GeneralNumeric => general_numeric_compare(
-                a_selection.num_cache.as_ref().unwrap().as_f64(),
-                b_selection.num_cache.as_ref().unwrap().as_f64(),
-            ),
+            SortMode::Numeric | SortMode::HumanNumeric => {
+                let a_num_info = &a_line_data.num_infos
+                    [a.index * global_settings.precomputed.num_infos_per_line + num_info_index];
+                let b_num_info = &b_line_data.num_infos
+                    [b.index * global_settings.precomputed.num_infos_per_line + num_info_index];
+                num_info_index += 1;
+                numeric_str_cmp((a_str, a_num_info), (b_str, b_num_info))
+            }
+            SortMode::GeneralNumeric => {
+                let a_float = &a_line_data.parsed_floats
+                    [a.index * global_settings.precomputed.floats_per_line + parsed_float_index];
+                let b_float = &b_line_data.parsed_floats
+                    [b.index * global_settings.precomputed.floats_per_line + parsed_float_index];
+                parsed_float_index += 1;
+                general_numeric_compare(a_float, b_float)
+            }
             SortMode::Month => month_compare(a_str, b_str),
             SortMode::Version => version_compare(a_str, b_str),
             SortMode::Default => custom_str_cmp(
@@ -1470,7 +1493,7 @@ fn get_leading_gen(input: &str) -> Range<usize> {
 }
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-enum GeneralF64ParseResult {
+pub enum GeneralF64ParseResult {
     Invalid,
     NaN,
     NegInfinity,
@@ -1497,8 +1520,8 @@ fn general_f64_parse(a: &str) -> GeneralF64ParseResult {
 /// Compares two floats, with errors and non-numerics assumed to be -inf.
 /// Stops coercing at the first non-numeric char.
 /// We explicitly need to convert to f64 in this case.
-fn general_numeric_compare(a: GeneralF64ParseResult, b: GeneralF64ParseResult) -> Ordering {
-    a.partial_cmp(&b).unwrap()
+fn general_numeric_compare(a: &GeneralF64ParseResult, b: &GeneralF64ParseResult) -> Ordering {
+    a.partial_cmp(b).unwrap()
 }
 
 fn get_rand_string() -> String {
@@ -1646,6 +1669,12 @@ mod tests {
 
     use super::*;
 
+    fn tokenize_helper(line: &str, separator: Option<char>) -> Vec<Field> {
+        let mut buffer = vec![];
+        tokenize(line, separator, &mut buffer);
+        buffer
+    }
+
     #[test]
     fn test_get_hash() {
         let a = "Ted".to_string();
@@ -1689,20 +1718,23 @@ mod tests {
     #[test]
     fn test_tokenize_fields() {
         let line = "foo bar b    x";
-        assert_eq!(tokenize(line, None), vec![0..3, 3..7, 7..9, 9..14,],);
+        assert_eq!(tokenize_helper(line, None), vec![0..3, 3..7, 7..9, 9..14,],);
     }
 
     #[test]
     fn test_tokenize_fields_leading_whitespace() {
         let line = "    foo bar b    x";
-        assert_eq!(tokenize(line, None), vec![0..7, 7..11, 11..13, 13..18,]);
+        assert_eq!(
+            tokenize_helper(line, None),
+            vec![0..7, 7..11, 11..13, 13..18,]
+        );
     }
 
     #[test]
     fn test_tokenize_fields_custom_separator() {
         let line = "aaa foo bar b    x";
         assert_eq!(
-            tokenize(line, Some('a')),
+            tokenize_helper(line, Some('a')),
             vec![0..0, 1..1, 2..2, 3..9, 10..18,]
         );
     }
@@ -1710,11 +1742,11 @@ mod tests {
     #[test]
     fn test_tokenize_fields_trailing_custom_separator() {
         let line = "a";
-        assert_eq!(tokenize(line, Some('a')), vec![0..0]);
+        assert_eq!(tokenize_helper(line, Some('a')), vec![0..0]);
         let line = "aa";
-        assert_eq!(tokenize(line, Some('a')), vec![0..0, 1..1]);
+        assert_eq!(tokenize_helper(line, Some('a')), vec![0..0, 1..1]);
         let line = "..a..a";
-        assert_eq!(tokenize(line, Some('a')), vec![0..2, 3..5]);
+        assert_eq!(tokenize_helper(line, Some('a')), vec![0..2, 3..5]);
     }
 
     #[test]
@@ -1722,13 +1754,7 @@ mod tests {
     fn test_line_size() {
         // We should make sure to not regress the size of the Line struct because
         // it is unconditional overhead for every line we sort.
-        assert_eq!(std::mem::size_of::<Line>(), 32);
-        // These are the fields of Line:
-        assert_eq!(std::mem::size_of::<&str>(), 16);
-        assert_eq!(std::mem::size_of::<Box<[Selection]>>(), 16);
-
-        // How big is a selection? Constant cost all lines pay when we need selections.
-        assert_eq!(std::mem::size_of::<Selection>(), 24);
+        assert_eq!(std::mem::size_of::<Line>(), 24);
     }
 
     #[test]


### PR DESCRIPTION
Data that was previously boxed inside the Line struct was moved to
separate vectors. Inside of each Line remains only an index that
allows to access that data.
This helps with keeping the Line struct small and therefore reduces
memory usage in most cases.
Additionally, this improves performance because one big allocation (the
vectors) are faster than many small ones (many boxes inside of each
Line). Those vectors can be reused as well, reducing the amount of
(de-)allocations.

<details>
<summary>
Some benchmarks showing improvements
</summary>

## Sorting a 1.2M wordlist
```plaintext
Benchmark #1: target/release/sort shuffled_wordlist.txt
  Time (mean ± σ):      14.1 ms ±   0.4 ms    [User: 66.6 ms, System: 5.1 ms]
  Range (min … max):    13.5 ms …  15.9 ms    170 runs
 
Benchmark #2: ./oldsort shuffled_wordlist.txt
  Time (mean ± σ):      14.5 ms ±   0.4 ms    [User: 62.3 ms, System: 4.8 ms]
  Range (min … max):    13.7 ms …  16.8 ms    183 runs
 
Benchmark #3: sort shuffled_wordlist.txt
  Time (mean ± σ):      26.4 ms ±   1.0 ms    [User: 24.2 ms, System: 2.2 ms]
  Range (min … max):    25.6 ms …  34.8 ms    106 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  'target/release/sort shuffled_wordlist.txt' ran
    1.03 ± 0.04 times faster than './oldsort shuffled_wordlist.txt'
    1.87 ± 0.09 times faster than 'sort shuffled_wordlist.txt'
```
## Sorting a 576K list of numbers (1 to 100000)
```plaintext

hyperfine "target/release/sort shuffled_numbers.txt -n" "./oldsort shuffled_numbers.txt -n" "sort shuffled_numbers.txt -n"
Benchmark #1: target/release/sort shuffled_numbers.txt -n
  Time (mean ± σ):      15.7 ms ±   0.4 ms    [User: 76.6 ms, System: 5.9 ms]
  Range (min … max):    14.9 ms …  16.9 ms    168 runs
 
Benchmark #2: ./oldsort shuffled_numbers.txt -n
  Time (mean ± σ):      25.0 ms ±   0.6 ms    [User: 79.1 ms, System: 6.8 ms]
  Range (min … max):    24.0 ms …  27.3 ms    110 runs
 
Benchmark #3: sort shuffled_numbers.txt -n
  Time (mean ± σ):      31.5 ms ±   0.6 ms    [User: 30.3 ms, System: 1.3 ms]
  Range (min … max):    30.7 ms …  34.9 ms    81 runs
 
Summary
  'target/release/sort shuffled_numbers.txt -n' ran
    1.60 ± 0.06 times faster than './oldsort shuffled_numbers.txt -n'
    2.01 ± 0.06 times faster than 'sort shuffled_numbers.txt -n'
```
This shows a performance improvement of about 60% in comparison to before this patch.
Please note that performance in comparison to GNU sort varies depending on the size of the file, as can be seen below:

## Sorting a 76M list of numbers (1 to 10000000)
```plaintext
hyperfine "target/release/sort shuffled_numbers.txt -n" "./oldsort shuffled_numbers.txt -n" "sort shuffled_numbers.txt -n"
Benchmark #1: target/release/sort shuffled_numbers.txt -n
  Time (mean ± σ):      3.213 s ±  0.065 s    [User: 30.983 s, System: 0.155 s]
  Range (min … max):    3.140 s …  3.343 s    10 runs
 
Benchmark #2: ./oldsort shuffled_numbers.txt -n
  Time (mean ± σ):      4.889 s ±  0.060 s    [User: 30.456 s, System: 0.228 s]
  Range (min … max):    4.840 s …  5.040 s    10 runs
 
Benchmark #3: sort shuffled_numbers.txt -n
  Time (mean ± σ):      2.354 s ±  0.043 s    [User: 8.934 s, System: 0.286 s]
  Range (min … max):    2.309 s …  2.454 s    10 runs
 
Summary
  'sort shuffled_numbers.txt -n' ran
    1.37 ± 0.04 times faster than 'target/release/sort shuffled_numbers.txt -n'
    2.08 ± 0.05 times faster than './oldsort shuffled_numbers.txt -n'
```
This patch makes if faster, but GNU sort still has a performance advantage.

## Sorting a 76M list of numbers (1 to 10000000) (human-numeric sort)
```plaintext
hyperfine "target/release/sort shuffled_numbers.txt -h" "./oldsort shuffled_numbers.txt -h" "sort shuffled_numbers.txt -h"
Benchmark #1: target/release/sort shuffled_numbers.txt -h
  Time (mean ± σ):      3.217 s ±  0.045 s    [User: 30.818 s, System: 0.159 s]
  Range (min … max):    3.129 s …  3.264 s    10 runs
 
Benchmark #2: ./oldsort shuffled_numbers.txt -h
  Time (mean ± σ):      4.913 s ±  0.069 s    [User: 30.492 s, System: 0.228 s]
  Range (min … max):    4.850 s …  5.053 s    10 runs
 
Benchmark #3: sort shuffled_numbers.txt -h
  Time (mean ± σ):      3.074 s ±  0.088 s    [User: 12.932 s, System: 0.288 s]
  Range (min … max):    3.000 s …  3.302 s    10 runs
 
Summary
  'sort shuffled_numbers.txt -h' ran
    1.05 ± 0.03 times faster than 'target/release/sort shuffled_numbers.txt -h'
    1.60 ± 0.05 times faster than './oldsort shuffled_numbers.txt -h'
```
As above, you can clearly see the improvement from this patch, but we don't fully reach GNU's performance. While we can't claim to be faster than GNU, we are clearly competitive. Who's faster depends on the individual workload and even the hardware used. Just for fun, below are the two benchmarks from above, but running from my hdd instead of my ssd. This time, we're faster:

##  [HDD] Sorting a 76M list of numbers (1 to 10000000)
```plaintext
hyperfine "target/release/sort -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp" "./oldsort shuffled_numbers.txt -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp" "sort shuffled_numbers.txt -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp"
Benchmark #1: target/release/sort -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp
  Time (mean ± σ):      3.238 s ±  0.050 s    [User: 31.116 s, System: 0.164 s]
  Range (min … max):    3.162 s …  3.312 s    10 runs
 
Benchmark #2: ./oldsort shuffled_numbers.txt -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp
  Time (mean ± σ):     12.621 s ±  0.253 s    [User: 68.410 s, System: 0.471 s]
  Range (min … max):   12.373 s … 13.034 s    10 runs
 
Benchmark #3: sort shuffled_numbers.txt -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp
  Time (mean ± σ):      5.279 s ±  0.058 s    [User: 21.177 s, System: 0.591 s]
  Range (min … max):    5.174 s …  5.354 s    10 runs
 
Summary
  'target/release/sort -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp' ran
    1.63 ± 0.03 times faster than 'sort shuffled_numbers.txt -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp'
    3.90 ± 0.10 times faster than './oldsort shuffled_numbers.txt -n /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp'
```

## [HDD] Sorting a 76M list of numbers (1 to 10000000) (human-numeric sort)
```plaintext
hyperfine "target/release/sort -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp" "./oldsort shuffled_numbers.txt -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp" "sort shuffled_numbers.txt -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp"
Benchmark #1: target/release/sort -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp
  Time (mean ± σ):      3.168 s ±  0.041 s    [User: 30.543 s, System: 0.156 s]
  Range (min … max):    3.121 s …  3.245 s    10 runs
 
Benchmark #2: ./oldsort shuffled_numbers.txt -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp
  Time (mean ± σ):     12.668 s ±  0.248 s    [User: 68.165 s, System: 0.492 s]
  Range (min … max):   12.448 s … 13.159 s    10 runs
 
Benchmark #3: sort shuffled_numbers.txt -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp
  Time (mean ± σ):      6.866 s ±  0.505 s    [User: 28.992 s, System: 0.617 s]
  Range (min … max):    6.540 s …  8.277 s    10 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (8.277 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
 
Summary
  'target/release/sort -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp' ran
    2.17 ± 0.16 times faster than 'sort shuffled_numbers.txt -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp'
    4.00 ± 0.09 times faster than './oldsort shuffled_numbers.txt -h /mnt/hdd1/tmp/shuffled_numbers.txt -T/mnt/hdd1/tmp'
```

## Sorting a 76M list of numbers (1 to 10000000) (general-numeric sort)
Finally, we're significantly faster even with bigger files when doing a general-numeric sort (now even more than before):
```plaintext
hyperfine "target/release/sort shuffled_numbers.txt -g" "./oldsort shuffled_numbers.txt -g" "sort shuffled_numbers.txt -g"
Benchmark #1: target/release/sort shuffled_numbers.txt -g
  Time (mean ± σ):      2.214 s ±  0.058 s    [User: 13.472 s, System: 0.127 s]
  Range (min … max):    2.164 s …  2.348 s    10 runs
 
Benchmark #2: ./oldsort shuffled_numbers.txt -g
  Time (mean ± σ):      4.167 s ±  0.040 s    [User: 16.939 s, System: 0.216 s]
  Range (min … max):    4.121 s …  4.249 s    10 runs
 
Benchmark #3: sort shuffled_numbers.txt -g
  Time (mean ± σ):      4.639 s ±  0.064 s    [User: 21.838 s, System: 0.279 s]
  Range (min … max):    4.548 s …  4.747 s    10 runs
 
Summary
  'target/release/sort shuffled_numbers.txt -g' ran
    1.88 ± 0.05 times faster than './oldsort shuffled_numbers.txt -g'
    2.10 ± 0.06 times faster than 'sort shuffled_numbers.txt -g'
```
</details>