### PR TITLE
fix some issues with locale (replace "LANGUAGE" with "LC_ALL")

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -39,7 +39,7 @@ impl Config {
             Some(mut values) => {
                 let name = values.next().unwrap();
                 if values.len() != 0 {
-                    return Err(format!("extra operand ‘{}’", name));
+                    return Err(format!("extra operand '{}'", name));
                 }
 
                 if name == "-" {
@@ -58,7 +58,7 @@ impl Config {
             .value_of(options::WRAP)
             .map(|num| {
                 num.parse::<usize>()
-                    .map_err(|e| format!("Invalid wrap size: ‘{}’: {}", num, e))
+                    .map_err(|e| format!("Invalid wrap size: '{}': {}", num, e))
             })
             .transpose()?;
 

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -281,7 +281,7 @@ fn parse_spec(spec: &str) -> Result<(Option<u32>, Option<u32>), String> {
     let uid = if usr_only || usr_grp {
         Some(
             Passwd::locate(args[0])
-                .map_err(|_| format!("invalid user: ‘{}’", spec))?
+                .map_err(|_| format!("invalid user: '{}'", spec))?
                 .uid(),
         )
     } else {
@@ -290,7 +290,7 @@ fn parse_spec(spec: &str) -> Result<(Option<u32>, Option<u32>), String> {
     let gid = if grp_only || usr_grp {
         Some(
             Group::locate(args[1])
-                .map_err(|_| format!("invalid group: ‘{}’", spec))?
+                .map_err(|_| format!("invalid group: '{}'", spec))?
                 .gid(),
         )
     } else {

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1254,7 +1254,7 @@ fn copy_link(source: &Path, dest: &Path) -> CopyResult<()> {
             Some(name) => dest.join(name).into(),
             None => crash!(
                 EXIT_ERR,
-                "cannot stat ‘{}’: No such file or directory",
+                "cannot stat '{}': No such file or directory",
                 source.display()
             ),
         }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -210,7 +210,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
         if !form.starts_with('+') {
-            eprintln!("date: invalid date ‘{}’", form);
+            eprintln!("date: invalid date '{}'", form);
             return 1;
         }
         let form = form[1..].to_string();
@@ -239,7 +239,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let set_to = match matches.value_of(OPT_SET).map(parse_date) {
         None => None,
         Some(Err((input, _err))) => {
-            eprintln!("date: invalid date ‘{}’", input);
+            eprintln!("date: invalid date '{}'", input);
             return 1;
         }
         Some(Ok(date)) => Some(date),
@@ -305,7 +305,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     println!("{}", formatted);
                 }
                 Err((input, _err)) => {
-                    println!("date: invalid date ‘{}’", input);
+                    println!("date: invalid date '{}'", input);
                 }
             }
         }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -123,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if matches.is_present(options::PRINT_DATABASE) {
         if !files.is_empty() {
             show_usage_error!(
-                "extra operand ‘{}’\nfile operands cannot be combined with \
+                "extra operand '{}'\nfile operands cannot be combined with \
                  --print-database (-p)",
                 files[0]
             );
@@ -155,7 +155,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         result = parse(INTERNAL_DB.lines(), out_format, "")
     } else {
         if files.len() > 1 {
-            show_usage_error!("extra operand ‘{}’", files[1]);
+            show_usage_error!("extra operand '{}'", files[1]);
             return 1;
         }
         match File::open(files[0]) {

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -274,7 +274,7 @@ fn du(
             Err(e) => {
                 safe_writeln!(
                     stderr(),
-                    "{}: cannot read directory ‘{}‘: {}",
+                    "{}: cannot read directory '{}': {}",
                     options.program_name,
                     my_stat.path.display(),
                     e
@@ -318,9 +318,7 @@ fn du(
                             let error_message = "Permission denied";
                             show_error_custom_description!(description, "{}", error_message)
                         }
-                        _ => {
-                            show_error!("cannot access '{}': {}", entry.path().display(), error)
-                        }
+                        _ => show_error!("cannot access '{}': {}", entry.path().display(), error),
                     },
                 },
                 Err(error) => show_error!("{}", error),
@@ -594,9 +592,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let files = match matches.value_of(options::FILE) {
         Some(_) => matches.values_of(options::FILE).unwrap().collect(),
-        None => {
-            vec!["."]
-        }
+        None => vec!["."],
     };
 
     let block_size = u64::try_from(read_block_size(matches.value_of(options::BLOCK_SIZE))).unwrap();
@@ -693,8 +689,8 @@ Try '{} --help' for more information.",
                                                 time
                                             } else {
                                                 show_error!(
-                                                    "Invalid argument ‘{}‘ for --time.
-‘birth‘ and ‘creation‘ arguments are not supported on this platform.",
+                                                    "Invalid argument '{}' for --time.
+'birth' and 'creation' arguments are not supported on this platform.",
                                                     s
                                                 );
                                                 return 1;

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -269,7 +269,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             match Passwd::locate(users[i].as_str()) {
                 Ok(p) => Some(p),
                 Err(_) => {
-                    show_error!("‘{}’: no such user", users[i]);
+                    show_error!("'{}': no such user", users[i]);
                     exit_code = 1;
                     if i + 1 >= users.len() {
                         break;

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -373,7 +373,7 @@ impl Config {
             .value_of(options::WIDTH)
             .map(|x| {
                 x.parse::<u16>().unwrap_or_else(|_e| {
-                    show_error!("invalid line width: ‘{}’", x);
+                    show_error!("invalid line width: '{}'", x);
                     exit(2);
                 })
             })
@@ -756,7 +756,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             Arg::with_name(options::time::CHANGE)
                 .short(options::time::CHANGE)
                 .help("If the long listing format (e.g., -l, -o) is being used, print the status \
-                change time (the ‘ctime’ in the inode) instead of the modification time. When \
+                change time (the 'ctime' in the inode) instead of the modification time. When \
                 explicitly sorting by time (--sort=time or -t) or when not using a long listing \
                 format, sort according to the status change time.")
                 .overrides_with_all(&[

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -210,7 +210,7 @@ fn valid_type(tpe: String) -> Result<(), String> {
             if vec!['b', 'c', 'u', 'p'].contains(&first_char) {
                 Ok(())
             } else {
-                Err(format!("invalid device type ‘{}’", tpe))
+                Err(format!("invalid device type '{}'", tpe))
             }
         })
 }

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -154,7 +154,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if matches.is_present(OPT_TMPDIR) && PathBuf::from(prefix).is_absolute() {
         show_error!(
-            "invalid template, ‘{}’; with --tmpdir, it may not be absolute",
+            "invalid template, '{}'; with --tmpdir, it may not be absolute",
             template
         );
         return 1;

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -230,7 +230,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
             // lacks permission to access metadata.
             if source.symlink_metadata().is_err() {
                 show_error!(
-                    "cannot stat ‘{}’: No such file or directory",
+                    "cannot stat '{}': No such file or directory",
                     source.display()
                 );
                 return 1;
@@ -240,7 +240,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
                 if b.no_target_dir {
                     if !source.is_dir() {
                         show_error!(
-                            "cannot overwrite directory ‘{}’ with non-directory",
+                            "cannot overwrite directory '{}' with non-directory",
                             target.display()
                         );
                         return 1;
@@ -249,7 +249,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
                     return match rename(source, target, &b) {
                         Err(e) => {
                             show_error!(
-                                "cannot move ‘{}’ to ‘{}’: {}",
+                                "cannot move '{}' to '{}': {}",
                                 source.display(),
                                 target.display(),
                                 e.to_string()
@@ -263,7 +263,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
                 return move_files_into_dir(&[source.clone()], target, &b);
             } else if target.exists() && source.is_dir() {
                 show_error!(
-                    "cannot overwrite non-directory ‘{}’ with directory ‘{}’",
+                    "cannot overwrite non-directory '{}' with directory '{}'",
                     target.display(),
                     source.display()
                 );
@@ -278,7 +278,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
         _ => {
             if b.no_target_dir {
                 show_error!(
-                    "mv: extra operand ‘{}’\n\
+                    "mv: extra operand '{}'\n\
                      Try '{} --help' for more information.",
                     files[2].display(),
                     executable!()
@@ -294,7 +294,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
 
 fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> i32 {
     if !target_dir.is_dir() {
-        show_error!("target ‘{}’ is not a directory", target_dir.display());
+        show_error!("target '{}' is not a directory", target_dir.display());
         return 1;
     }
 
@@ -304,7 +304,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> i3
             Some(name) => target_dir.join(name),
             None => {
                 show_error!(
-                    "cannot stat ‘{}’: No such file or directory",
+                    "cannot stat '{}': No such file or directory",
                     sourcepath.display()
                 );
 
@@ -315,7 +315,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> i3
 
         if let Err(e) = rename(sourcepath, &targetpath, b) {
             show_error!(
-                "cannot move ‘{}’ to ‘{}’: {}",
+                "cannot move '{}' to '{}': {}",
                 sourcepath.display(),
                 targetpath.display(),
                 e.to_string()
@@ -338,7 +338,7 @@ fn rename(from: &Path, to: &Path, b: &Behavior) -> io::Result<()> {
         match b.overwrite {
             OverwriteMode::NoClobber => return Ok(()),
             OverwriteMode::Interactive => {
-                println!("{}: overwrite ‘{}’? ", executable!(), to.display());
+                println!("{}: overwrite '{}'? ", executable!(), to.display());
                 if !read_yes() {
                     return Ok(());
                 }
@@ -371,9 +371,9 @@ fn rename(from: &Path, to: &Path, b: &Behavior) -> io::Result<()> {
     rename_with_fallback(from, to)?;
 
     if b.verbose {
-        print!("‘{}’ -> ‘{}’", from.display(), to.display());
+        print!("'{}' -> '{}'", from.display(), to.display());
         match backup_path {
-            Some(path) => println!(" (backup: ‘{}’)", path.display()),
+            Some(path) => println!(" (backup: '{}')", path.display()),
             None => println!(),
         }
     }

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -62,7 +62,7 @@ impl<'a> Iterator for WhitespaceSplitter<'a> {
 
 fn parse_suffix(s: &str) -> Result<(f64, Option<Suffix>)> {
     if s.is_empty() {
-        return Err("invalid number: ‘’".to_string());
+        return Err("invalid number: ''".to_string());
     }
 
     let with_i = s.ends_with('i');
@@ -80,7 +80,7 @@ fn parse_suffix(s: &str) -> Result<(f64, Option<Suffix>)> {
         Some('Z') => Ok(Some((RawSuffix::Z, with_i))),
         Some('Y') => Ok(Some((RawSuffix::Y, with_i))),
         Some('0'..='9') => Ok(None),
-        _ => Err(format!("invalid suffix in input: ‘{}’", s)),
+        _ => Err(format!("invalid suffix in input: '{}'", s)),
     }?;
 
     let suffix_len = match suffix {
@@ -91,7 +91,7 @@ fn parse_suffix(s: &str) -> Result<(f64, Option<Suffix>)> {
 
     let number = s[..s.len() - suffix_len]
         .parse::<f64>()
-        .map_err(|_| format!("invalid number: ‘{}’", s))?;
+        .map_err(|_| format!("invalid number: '{}'", s))?;
 
     Ok((number, suffix))
 }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -114,7 +114,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
                     0 => Err(value),
                     _ => Ok(n),
                 })
-                .map_err(|value| format!("invalid header value ‘{}’", value))
+                .map_err(|value| format!("invalid header value '{}'", value))
         }
     }?;
 

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -234,7 +234,7 @@ fn idle_string(when: i64) -> String {
 }
 
 fn time_string(ut: &Utmpx) -> String {
-    time::strftime("%Y-%m-%d %H:%M", &ut.login_time()).unwrap()
+    time::strftime("%b %e %H:%M", &ut.login_time()).unwrap() // LC_ALL=C
 }
 
 impl Pinky {

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -234,7 +234,7 @@ impl LineSplitter {
     fn new(settings: &Settings) -> LineSplitter {
         LineSplitter {
             lines_per_split: settings.strategy_param.parse().unwrap_or_else(|_| {
-                crash!(1, "invalid number of lines: ‘{}’", settings.strategy_param)
+                crash!(1, "invalid number of lines: '{}'", settings.strategy_param)
             }),
         }
     }

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -24,7 +24,7 @@ use std::{cmp, fs, iter};
 macro_rules! check_bound {
     ($str: ident, $bound:expr, $beg: expr, $end: expr) => {
         if $end >= $bound {
-            return Err(format!("‘{}’: invalid directive", &$str[$beg..$end]));
+            return Err(format!("'{}': invalid directive", &$str[$beg..$end]));
         }
     };
 }

--- a/src/uu/test/src/parser.rs
+++ b/src/uu/test/src/parser.rs
@@ -167,7 +167,7 @@ impl Parser {
                 self.expr();
                 match self.next_token() {
                     Symbol::Literal(s) if s == ")" => (),
-                    _ => panic!("expected ‘)’"),
+                    _ => panic!("expected ')'"),
                 }
             }
         }
@@ -314,7 +314,7 @@ impl Parser {
         self.expr();
 
         match self.tokens.next() {
-            Some(token) => Err(format!("extra argument ‘{}’", token.to_string_lossy())),
+            Some(token) => Err(format!("extra argument '{}'", token.to_string_lossy())),
             None => Ok(()),
         }
     }

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -88,7 +88,7 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
                     return Ok(true);
                 }
                 _ => {
-                    return Err(format!("missing argument after ‘{:?}’", op));
+                    return Err(format!("missing argument after '{:?}'", op));
                 }
             };
 
@@ -140,7 +140,7 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
 }
 
 fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> Result<bool, String> {
-    let format_err = |value| format!("invalid integer ‘{}’", value);
+    let format_err = |value| format!("invalid integer '{}'", value);
 
     let a = a.to_string_lossy();
     let a: i64 = a.parse().map_err(|_| format_err(a))?;
@@ -156,7 +156,7 @@ fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> Result<bool, String> {
         "-ge" => a >= b,
         "-lt" => a < b,
         "-le" => a <= b,
-        _ => return Err(format!("unknown operator ‘{}’", operator)),
+        _ => return Err(format!("unknown operator '{}'", operator)),
     })
 }
 
@@ -164,7 +164,7 @@ fn isatty(fd: &OsStr) -> Result<bool, String> {
     let fd = fd.to_string_lossy();
 
     fd.parse()
-        .map_err(|_| format!("invalid integer ‘{}’", fd))
+        .map_err(|_| format!("invalid integer '{}'", fd))
         .map(|i| {
             #[cfg(not(target_os = "redox"))]
             unsafe {

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -311,7 +311,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if !(delete_flag || squeeze_flag) && sets.len() < 2 {
         show_error!(
-            "missing operand after ‘{}’\nTry `{} --help` for more information.",
+            "missing operand after '{}'\nTry `{} --help` for more information.",
             sets[0],
             executable!()
         );

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -210,7 +210,7 @@ fn truncate_reference_and_size(
     let mode = match parse_mode_and_size(size_string) {
         Ok(m) => match m {
             TruncateMode::Absolute(_) => {
-                crash!(1, "you must specify a relative ‘--size’ with ‘--reference’")
+                crash!(1, "you must specify a relative '--size' with '--reference'")
             }
             _ => m,
         },

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -300,7 +300,7 @@ fn idle_string<'a>(when: i64, boottime: i64) -> Cow<'a, str> {
 }
 
 fn time_string(ut: &Utmpx) -> String {
-    time::strftime("%Y-%m-%d %H:%M", &ut.login_time()).unwrap()
+    time::strftime("%b %e %H:%M", &ut.login_time()).unwrap() // LC_ALL=C
 }
 
 #[inline]
@@ -523,8 +523,8 @@ impl Who {
             buf.push_str(&msg);
         }
         buf.push_str(&format!(" {:<12}", line));
-        // "%Y-%m-%d %H:%M"
-        let time_size = 4 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2;
+        // "%b %e %H:%M" (LC_ALL=C)
+        let time_size = 3 + 2 + 2 + 1 + 2;
         buf.push_str(&format!(" {:<1$}", time, time_size));
 
         if !self.short_output {

--- a/src/uucore/src/lib/parser/parse_size.rs
+++ b/src/uucore/src/lib/parser/parse_size.rs
@@ -18,7 +18,7 @@ use std::fmt;
 ///
 /// # Errors
 ///
-/// Will return `ParseSizeError` if it’s not possible to parse this
+/// Will return `ParseSizeError` if it's not possible to parse this
 /// string into a number, e.g. if the string does not begin with a
 /// numeral, or if the unit is not one of the supported units described
 /// in the preceding section.
@@ -109,19 +109,19 @@ impl fmt::Display for ParseSizeError {
 
 impl ParseSizeError {
     fn parse_failure(s: &str) -> ParseSizeError {
-        // stderr on linux (GNU coreutils 8.32)
+        // stderr on linux (GNU coreutils 8.32) (LC_ALL=C)
         // has to be handled in the respective uutils because strings differ, e.g.:
         //
         // `NUM`
-        // head:     invalid number of bytes: ‘1fb’
-        // tail:     invalid number of bytes: ‘1fb’
+        // head:     invalid number of bytes: '1fb'
+        // tail:     invalid number of bytes: '1fb'
         //
         // `SIZE`
-        // split:    invalid number of bytes: ‘1fb’
-        // truncate: Invalid number: ‘1fb’
+        // split:    invalid number of bytes: '1fb'
+        // truncate: Invalid number: '1fb'
         //
         // `MODE`
-        // stdbuf:   invalid mode ‘1fb’
+        // stdbuf:   invalid mode '1fb'
         //
         // `SIZE`
         // sort:     invalid suffix in --buffer-size argument '1fb'
@@ -140,27 +140,27 @@ impl ParseSizeError {
         //                   --width
         //                   --strings
         // etc.
-        ParseSizeError::ParseFailure(format!("‘{}’", s))
+        ParseSizeError::ParseFailure(format!("'{}'", s))
     }
 
     fn size_too_big(s: &str) -> ParseSizeError {
-        // stderr on linux (GNU coreutils 8.32)
+        // stderr on linux (GNU coreutils 8.32) (LC_ALL=C)
         // has to be handled in the respective uutils because strings differ, e.g.:
         //
-        // head:     invalid number of bytes: ‘1Y’: Value too large for defined data type
-        // tail:     invalid number of bytes: ‘1Y’: Value too large for defined data type
-        // split:    invalid number of bytes: ‘1Y’: Value too large for defined data type
-        // truncate:          Invalid number: ‘1Y’: Value too large for defined data type
-        // stdbuf:               invalid mode ‘1Y’: Value too large for defined data type
+        // head:     invalid number of bytes: '1Y': Value too large for defined data type
+        // tail:     invalid number of bytes: '1Y': Value too large for defined data type
+        // split:    invalid number of bytes: '1Y': Value too large for defined data type
+        // truncate:          Invalid number: '1Y': Value too large for defined data type
+        // stdbuf:               invalid mode '1Y': Value too large for defined data type
         // sort:     -S argument '1Y' too large
         // du:       -B argument '1Y' too large
         // od:       -N argument '1Y' too large
         // etc.
         //
         // stderr on macos (brew - GNU coreutils 8.32) also differs for the same version, e.g.:
-        // ghead:   invalid number of bytes: ‘1Y’: Value too large to be stored in data type
-        // gtail:   invalid number of bytes: ‘1Y’: Value too large to be stored in data type
-        ParseSizeError::SizeTooBig(format!("‘{}’: Value too large for defined data type", s))
+        // ghead:   invalid number of bytes: '1Y': Value too large to be stored in data type
+        // gtail:   invalid number of bytes: '1Y': Value too large to be stored in data type
+        ParseSizeError::SizeTooBig(format!("'{}': Value too large for defined data type", s))
     }
 }
 
@@ -227,7 +227,7 @@ mod tests {
         ));
 
         assert_eq!(
-            ParseSizeError::SizeTooBig("‘1Y’: Value too large for defined data type".to_string()),
+            ParseSizeError::SizeTooBig("'1Y': Value too large for defined data type".to_string()),
             parse_size("1Y").unwrap_err()
         );
     }
@@ -262,7 +262,7 @@ mod tests {
         for &test_string in &test_strings {
             assert_eq!(
                 parse_size(test_string).unwrap_err(),
-                ParseSizeError::ParseFailure(format!("‘{}’", test_string))
+                ParseSizeError::ParseFailure(format!("'{}'", test_string))
             );
         }
     }

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -103,7 +103,7 @@ fn test_wrap_bad_arg() {
             .arg(wrap_param)
             .arg("b")
             .fails()
-            .stderr_only("base32: Invalid wrap size: ‘b’: invalid digit found in string\n");
+            .stderr_only("base32: Invalid wrap size: 'b': invalid digit found in string\n");
     }
 }
 
@@ -114,7 +114,7 @@ fn test_base32_extra_operand() {
         .arg("a.txt")
         .arg("a.txt")
         .fails()
-        .stderr_only("base32: extra operand ‘a.txt’");
+        .stderr_only("base32: extra operand 'a.txt'");
 }
 
 #[test]

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -89,7 +89,7 @@ fn test_wrap_bad_arg() {
             .arg(wrap_param)
             .arg("b")
             .fails()
-            .stderr_only("base64: Invalid wrap size: ‘b’: invalid digit found in string\n");
+            .stderr_only("base64: Invalid wrap size: 'b': invalid digit found in string\n");
     }
 }
 
@@ -100,7 +100,7 @@ fn test_base64_extra_operand() {
         .arg("a.txt")
         .arg("a.txt")
         .fails()
-        .stderr_only("base64: extra operand ‘a.txt’");
+        .stderr_only("base64: extra operand 'a.txt'");
 }
 
 #[test]

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -172,14 +172,14 @@ fn test_chown_only_colon() {
     // expected:
     // $ chown -v :: file.txt 2>out_err ; echo $? ; cat out_err
     // 1
-    // chown: invalid group: ‘::’
+    // chown: invalid group: '::'
     scene
         .ucmd()
         .arg("::")
         .arg("--verbose")
         .arg(file1)
         .fails()
-        .stderr_contains(&"invalid group: ‘::’");
+        .stderr_contains(&"invalid group: '::'");
 }
 
 #[test]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -117,7 +117,7 @@ fn test_date_format_without_plus() {
     new_ucmd!()
         .arg("%s")
         .fails()
-        .stderr_contains("date: invalid date ‘%s’")
+        .stderr_contains("date: invalid date '%s'")
         .code_is(1);
 }
 

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -355,7 +355,7 @@ fn test_du_no_permission() {
 
     let result = scene.ucmd().arg(SUB_DIR_LINKS).run(); // TODO: replace with ".fails()" once `du` is fixed
     result.stderr_contains(
-        "du: cannot read directory ‘subdir/links‘: Permission denied (os error 13)",
+        "du: cannot read directory 'subdir/links': Permission denied (os error 13)",
     );
 
     #[cfg(target_os = "linux")]

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -255,21 +255,21 @@ fn test_head_invalid_num() {
     new_ucmd!()
         .args(&["-c", "1024R", "emptyfile.txt"])
         .fails()
-        .stderr_is("head: invalid number of bytes: ‘1024R’");
+        .stderr_is("head: invalid number of bytes: '1024R'");
     new_ucmd!()
         .args(&["-n", "1024R", "emptyfile.txt"])
         .fails()
-        .stderr_is("head: invalid number of lines: ‘1024R’");
+        .stderr_is("head: invalid number of lines: '1024R'");
     #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-c", "1Y", "emptyfile.txt"])
         .fails()
-        .stderr_is("head: invalid number of bytes: ‘1Y’: Value too large for defined data type");
+        .stderr_is("head: invalid number of bytes: '1Y': Value too large for defined data type");
     #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-n", "1Y", "emptyfile.txt"])
         .fails()
-        .stderr_is("head: invalid number of lines: ‘1Y’: Value too large for defined data type");
+        .stderr_is("head: invalid number of lines: '1Y': Value too large for defined data type");
     #[cfg(target_pointer_width = "32")]
     {
         let sizes = ["1000G", "10T"];
@@ -279,7 +279,7 @@ fn test_head_invalid_num() {
                 .fails()
                 .code_is(1)
                 .stderr_only(format!(
-                    "head: invalid number of bytes: ‘{}’: Value too large for defined data type",
+                    "head: invalid number of bytes: '{}': Value too large for defined data type",
                     size
                 ));
         }

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -432,7 +432,7 @@ fn check_coreutil_version(util_name: &str, version_expected: &str) -> String {
     let scene = TestScenario::new(util_name);
     let version_check = scene
         .cmd_keepenv(&util_name)
-        .env("LANGUAGE", "C")
+        .env("LC_ALL", "C")
         .arg("--version")
         .run();
     version_check
@@ -476,7 +476,7 @@ fn expected_result(args: &[&str]) -> Result<CmdResult, String> {
     let scene = TestScenario::new(util_name);
     let result = scene
         .cmd_keepenv(util_name)
-        .env("LANGUAGE", "C")
+        .env("LC_ALL", "C")
         .args(args)
         .run();
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -168,7 +168,7 @@ fn test_ls_width() {
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
             .fails()
-            .stderr_only("ls: invalid line width: ‘1a’");
+            .stderr_only("ls: invalid line width: '1a'");
     }
 }
 

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -614,7 +614,7 @@ fn test_mv_overwrite_nonempty_dir() {
     // Not same error as GNU; the error message is a rust builtin
     // TODO: test (and implement) correct error message (or at least decide whether to do so)
     // Current: "mv: couldn't rename path (Directory not empty; from=a; to=b)"
-    // GNU:     "mv: cannot move ‘a’ to ‘b’: Directory not empty"
+    // GNU:     "mv: cannot move 'a' to 'b': Directory not empty"
 
     // Verbose output for the move should not be shown on failure
     let result = ucmd.arg("-vT").arg(dir_a).arg(dir_b).fails();
@@ -638,7 +638,7 @@ fn test_mv_backup_dir() {
         .arg(dir_b)
         .succeeds()
         .stdout_only(format!(
-            "‘{}’ -> ‘{}’ (backup: ‘{}~’)\n",
+            "'{}' -> '{}' (backup: '{}~')\n",
             dir_a, dir_b, dir_b
         ));
 
@@ -672,7 +672,7 @@ fn test_mv_errors() {
 
     // $ at.touch file && at.mkdir dir
     // $ mv -T file dir
-    // err == mv: cannot overwrite directory ‘dir’ with non-directory
+    // err == mv: cannot overwrite directory 'dir' with non-directory
     scene
         .ucmd()
         .arg("-T")
@@ -680,13 +680,13 @@ fn test_mv_errors() {
         .arg(dir)
         .fails()
         .stderr_is(format!(
-            "mv: cannot overwrite directory ‘{}’ with non-directory\n",
+            "mv: cannot overwrite directory '{}' with non-directory\n",
             dir
         ));
 
     // $ at.mkdir dir && at.touch file
     // $ mv dir file
-    // err == mv: cannot overwrite non-directory ‘file’ with directory ‘dir’
+    // err == mv: cannot overwrite non-directory 'file' with directory 'dir'
     assert!(!scene
         .ucmd()
         .arg(dir)
@@ -713,7 +713,7 @@ fn test_mv_verbose() {
         .arg(file_a)
         .arg(file_b)
         .succeeds()
-        .stdout_only(format!("‘{}’ -> ‘{}’\n", file_a, file_b));
+        .stdout_only(format!("'{}' -> '{}'\n", file_a, file_b));
 
     at.touch(file_a);
     scene
@@ -723,7 +723,7 @@ fn test_mv_verbose() {
         .arg(file_b)
         .succeeds()
         .stdout_only(format!(
-            "‘{}’ -> ‘{}’ (backup: ‘{}~’)\n",
+            "'{}' -> '{}' (backup: '{}~')\n",
             file_a, file_b, file_b
         ));
 }
@@ -756,5 +756,5 @@ fn test_mv_permission_error() {
 // -r--r--r-- 1 user user 0 okt 25 11:21 b
 // $
 // $ mv -v a b
-// mv: try to overwrite ‘b’, overriding mode 0444 (r--r--r--)? y
-// ‘a’ -> ‘b’
+// mv: try to overwrite 'b', overriding mode 0444 (r--r--r--)? y
+// 'a' -> 'b'

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -35,7 +35,7 @@ fn test_from_iec_i_requires_suffix() {
     new_ucmd!()
         .args(&["--from=iec-i", "1024"])
         .fails()
-        .stderr_is("numfmt: missing 'i' suffix in input: ‘1024’ (e.g Ki/Mi/Gi)");
+        .stderr_is("numfmt: missing 'i' suffix in input: '1024' (e.g Ki/Mi/Gi)");
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn test_header_error_if_non_numeric() {
     new_ucmd!()
         .args(&["--header=two"])
         .run()
-        .stderr_is("numfmt: invalid header value ‘two’");
+        .stderr_is("numfmt: invalid header value 'two'");
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn test_header_error_if_0() {
     new_ucmd!()
         .args(&["--header=0"])
         .run()
-        .stderr_is("numfmt: invalid header value ‘0’");
+        .stderr_is("numfmt: invalid header value '0'");
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn test_header_error_if_negative() {
     new_ucmd!()
         .args(&["--header=-3"])
         .run()
-        .stderr_is("numfmt: invalid header value ‘-3’");
+        .stderr_is("numfmt: invalid header value '-3'");
 }
 
 #[test]
@@ -187,7 +187,7 @@ fn test_should_report_invalid_empty_number_on_empty_stdin() {
         .args(&["--from=auto"])
         .pipe_in("\n")
         .run()
-        .stderr_is("numfmt: invalid number: ‘’\n");
+        .stderr_is("numfmt: invalid number: ''\n");
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn test_should_report_invalid_empty_number_on_blank_stdin() {
         .args(&["--from=auto"])
         .pipe_in("  \t  \n")
         .run()
-        .stderr_is("numfmt: invalid number: ‘’\n");
+        .stderr_is("numfmt: invalid number: ''\n");
 }
 
 #[test]
@@ -205,14 +205,14 @@ fn test_should_report_invalid_suffix_on_stdin() {
         .args(&["--from=auto"])
         .pipe_in("1k")
         .run()
-        .stderr_is("numfmt: invalid suffix in input: ‘1k’\n");
+        .stderr_is("numfmt: invalid suffix in input: '1k'\n");
 
     // GNU numfmt reports this one as “invalid number”
     new_ucmd!()
         .args(&["--from=auto"])
         .pipe_in("NaN")
         .run()
-        .stderr_is("numfmt: invalid suffix in input: ‘NaN’\n");
+        .stderr_is("numfmt: invalid suffix in input: 'NaN'\n");
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn test_should_report_invalid_number_with_interior_junk() {
         .args(&["--from=auto"])
         .pipe_in("1x0K")
         .run()
-        .stderr_is("numfmt: invalid number: ‘1x0K’\n");
+        .stderr_is("numfmt: invalid number: '1x0K'\n");
 }
 
 #[test]
@@ -461,7 +461,7 @@ fn test_delimiter_overrides_whitespace_separator() {
         .args(&["-d,"])
         .pipe_in("1 234,56")
         .fails()
-        .stderr_is("numfmt: invalid number: ‘1 234’\n");
+        .stderr_is("numfmt: invalid number: '1 234'\n");
 }
 
 #[test]

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -106,7 +106,7 @@ fn expected_result(args: &[&str]) -> String {
     #[allow(clippy::needless_borrow)]
     TestScenario::new(&util_name)
         .cmd_keepenv(util_name)
-        .env("LANGUAGE", "C")
+        .env("LC_ALL", "C")
         .args(args)
         .succeeds()
         .stdout_move_str()

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -309,7 +309,7 @@ fn test_split_lines_number() {
         .args(&["--lines", "2fb", "file"])
         .fails()
         .code_is(1)
-        .stderr_only("split: invalid number of lines: ‘2fb’");
+        .stderr_only("split: invalid number of lines: '2fb'");
 }
 
 #[test]
@@ -318,13 +318,13 @@ fn test_split_invalid_bytes_size() {
         .args(&["-b", "1024R"])
         .fails()
         .code_is(1)
-        .stderr_only("split: invalid number of bytes: ‘1024R’");
+        .stderr_only("split: invalid number of bytes: '1024R'");
     #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-b", "1Y"])
         .fails()
         .code_is(1)
-        .stderr_only("split: invalid number of bytes: ‘1Y’: Value too large for defined data type");
+        .stderr_only("split: invalid number of bytes: '1Y': Value too large for defined data type");
     #[cfg(target_pointer_width = "32")]
     {
         let sizes = ["1000G", "10T"];
@@ -334,7 +334,7 @@ fn test_split_invalid_bytes_size() {
                 .fails()
                 .code_is(1)
                 .stderr_only(format!(
-                    "split: invalid number of bytes: ‘{}’: Value too large for defined data type",
+                    "split: invalid number of bytes: '{}': Value too large for defined data type",
                     size
                 ));
         }

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -317,7 +317,7 @@ fn expected_result(args: &[&str]) -> String {
     #[allow(clippy::needless_borrow)]
     TestScenario::new(&util_name)
         .cmd_keepenv(util_name)
-        .env("LANGUAGE", "C")
+        .env("LC_ALL", "C")
         .args(args)
         .succeeds()
         .stdout_move_str()

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -63,12 +63,12 @@ fn test_stdbuf_invalid_mode_fails() {
             .args(&[*option, "1024R", "head"])
             .fails()
             .code_is(125)
-            .stderr_only("stdbuf: invalid mode ‘1024R’");
+            .stderr_only("stdbuf: invalid mode '1024R'");
         #[cfg(not(target_pointer_width = "128"))]
         new_ucmd!()
             .args(&[*option, "1Y", "head"])
             .fails()
             .code_is(125)
-            .stderr_contains("stdbuf: invalid mode ‘1Y’: Value too large for defined data type");
+            .stderr_contains("stdbuf: invalid mode '1Y': Value too large for defined data type");
     }
 }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -364,21 +364,21 @@ fn test_tail_invalid_num() {
     new_ucmd!()
         .args(&["-c", "1024R", "emptyfile.txt"])
         .fails()
-        .stderr_is("tail: invalid number of bytes: ‘1024R’");
+        .stderr_is("tail: invalid number of bytes: '1024R'");
     new_ucmd!()
         .args(&["-n", "1024R", "emptyfile.txt"])
         .fails()
-        .stderr_is("tail: invalid number of lines: ‘1024R’");
+        .stderr_is("tail: invalid number of lines: '1024R'");
     #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-c", "1Y", "emptyfile.txt"])
         .fails()
-        .stderr_is("tail: invalid number of bytes: ‘1Y’: Value too large for defined data type");
+        .stderr_is("tail: invalid number of bytes: '1Y': Value too large for defined data type");
     #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-n", "1Y", "emptyfile.txt"])
         .fails()
-        .stderr_is("tail: invalid number of lines: ‘1Y’: Value too large for defined data type");
+        .stderr_is("tail: invalid number of lines: '1Y': Value too large for defined data type");
     #[cfg(target_pointer_width = "32")]
     {
         let sizes = ["1000G", "10T"];
@@ -388,7 +388,7 @@ fn test_tail_invalid_num() {
                 .fails()
                 .code_is(1)
                 .stderr_only(format!(
-                    "tail: invalid number of bytes: ‘{}’: Value too large for defined data type",
+                    "tail: invalid number of bytes: '{}': Value too large for defined data type",
                     size
                 ));
         }

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -165,7 +165,7 @@ fn test_dangling_string_comparison_is_error() {
         .args(&["missing_something", "="])
         .run()
         .status_code(2)
-        .stderr_is("test: missing argument after ‘=’");
+        .stderr_is("test: missing argument after '='");
 }
 
 #[test]
@@ -265,7 +265,7 @@ fn test_float_inequality_is_error() {
         .args(&["123.45", "-ge", "6"])
         .run()
         .status_code(2)
-        .stderr_is("test: invalid integer ‘123.45’");
+        .stderr_is("test: invalid integer '123.45'");
 }
 
 #[test]
@@ -283,7 +283,7 @@ fn test_invalid_utf8_integer_compare() {
 
     cmd.run()
         .status_code(2)
-        .stderr_is("test: invalid integer ‘fo�o’");
+        .stderr_is("test: invalid integer 'fo�o'");
 
     let mut cmd = new_ucmd!();
     cmd.raw.arg(arg);
@@ -291,7 +291,7 @@ fn test_invalid_utf8_integer_compare() {
 
     cmd.run()
         .status_code(2)
-        .stderr_is("test: invalid integer ‘fo�o’");
+        .stderr_is("test: invalid integer 'fo�o'");
 }
 
 #[test]
@@ -674,7 +674,7 @@ fn test_erroneous_parenthesized_expression() {
         .args(&["a", "!=", "(", "b", "-a", "b", ")", "!=", "c"])
         .run()
         .status_code(2)
-        .stderr_is("test: extra argument ‘b’");
+        .stderr_is("test: extra argument 'b'");
 }
 
 #[test]

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -249,7 +249,7 @@ fn test_size_and_reference() {
 
 #[test]
 fn test_error_filename_only() {
-    // truncate: you must specify either ‘--size’ or ‘--reference’
+    // truncate: you must specify either '--size' or '--reference'
     new_ucmd!().args(&["file"]).fails().stderr_contains(
         "error: The following required arguments were not provided:
     --reference <RFILE>
@@ -262,15 +262,15 @@ fn test_invalid_numbers() {
     new_ucmd!()
         .args(&["-s", "0X", "file"])
         .fails()
-        .stderr_contains("Invalid number: ‘0X’");
+        .stderr_contains("Invalid number: '0X'");
     new_ucmd!()
         .args(&["-s", "0XB", "file"])
         .fails()
-        .stderr_contains("Invalid number: ‘0XB’");
+        .stderr_contains("Invalid number: '0XB'");
     new_ucmd!()
         .args(&["-s", "0B", "file"])
         .fails()
-        .stderr_contains("Invalid number: ‘0B’");
+        .stderr_contains("Invalid number: '0B'");
 }
 
 #[test]
@@ -299,13 +299,13 @@ fn test_truncate_bytes_size() {
         .args(&["--size", "1024R", "file"])
         .fails()
         .code_is(1)
-        .stderr_only("truncate: Invalid number: ‘1024R’");
+        .stderr_only("truncate: Invalid number: '1024R'");
     #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["--size", "1Y", "file"])
         .fails()
         .code_is(1)
-        .stderr_only("truncate: Invalid number: ‘1Y’: Value too large for defined data type");
+        .stderr_only("truncate: Invalid number: '1Y': Value too large for defined data type");
     #[cfg(target_pointer_width = "32")]
     {
         let sizes = ["1000G", "10T"];
@@ -315,7 +315,7 @@ fn test_truncate_bytes_size() {
                 .fails()
                 .code_is(1)
                 .stderr_only(format!(
-                    "truncate: Invalid number: ‘{}’: Value too large for defined data type",
+                    "truncate: Invalid number: '{}': Value too large for defined data type",
                     size
                 ));
         }

--- a/tests/by-util/test_users.rs
+++ b/tests/by-util/test_users.rs
@@ -17,7 +17,7 @@ fn test_users_check_name() {
     #[allow(clippy::needless_borrow)]
     let expected = TestScenario::new(&util_name)
         .cmd_keepenv(util_name)
-        .env("LANGUAGE", "C")
+        .env("LC_ALL", "C")
         .succeeds()
         .stdout_move_str();
 

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -158,13 +158,12 @@ fn test_users() {
         let mut v_actual: Vec<&str> = actual.split_whitespace().collect();
         let mut v_expect: Vec<&str> = expect.split_whitespace().collect();
 
-        // TODO: `--users` differs from GNU's output on macOS
-        // Diff < left / right > :
-        // <"runner   console      2021-05-20 22:03 00:08         196\n"
-        // >"runner   console      2021-05-20 22:03  old          196\n"
+        // TODO: `--users` sometimes differs from GNU's output on macOS (race condition?)
+        // actual: "runner   console      Jun 23 06:37 00:34         196\n"
+        // expect: "runner   console      Jun 23 06:37  old          196\n"
         if cfg!(target_os = "macos") {
-            v_actual.remove(4);
-            v_expect.remove(4);
+            v_actual.remove(5);
+            v_expect.remove(5);
         }
 
         assert_eq!(v_actual, v_expect);
@@ -242,7 +241,7 @@ fn expected_result(args: &[&str]) -> String {
     #[allow(clippy::needless_borrow)]
     TestScenario::new(&util_name)
         .cmd_keepenv(util_name)
-        .env("LANGUAGE", "C")
+        .env("LC_ALL", "C")
         .args(args)
         .succeeds()
         .stdout_move_str()


### PR DESCRIPTION
My understanding is that, as long as uutils does not support locales, we try to stick to the C locale.

However, a conversation https://github.com/uutils/coreutils/pull/2361#issuecomment-860289046 with @tertsdiepraam made me aware that `LANGUAGE=C` is not enough and that `LC_ALL=C` is needed as the environment variable that overrides all the other localization settings.

e.g.
```bash
$ LANGUAGE=C id foobar
id: ‘foobar’: no such user

$ LC_ALL=C id foobar
id: 'foobar': no such user
```
This PR does:
* replace `LANGUAGE` with `LC_ALL` as environment variable in the tests
* fix the the date string of affected uutils
* replace `‘` and `’` with `'`
