### PR TITLE
Fix CICD dependency display errors

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -7,6 +7,8 @@ name: CICD
 # spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot gmake grcov halium lcov libssl mkdir popd printf pushd rustc rustfmt rustup shopt xargs
 # spell-checker:ignore (misc) aarch alnum armhf bindir busytest coreutils gnueabihf issuecomment maint nullglob onexitbegin onexitend runtest tempfile testsuite uutils
 
+# ToDO: [2021-06; rivy] change from `cargo-tree` to `cargo tree` once MSRV is >= 1.45
+
 env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -198,7 +198,7 @@ jobs:
         echo "## dependency list"
         cargo fetch --locked --quiet
         ## * using the 'stable' toolchain is necessary to avoid "unexpected '--filter-platform'" errors
-        RUSTUP_TOOLCHAIN=stable cargo-tree tree --frozen --all --no-dev-dependencies --no-indent --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
+        RUSTUP_TOOLCHAIN=stable cargo-tree tree --locked --all --no-dev-dependencies --no-indent --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
     - name: Test
       uses: actions-rs/cargo@v1
       with:
@@ -418,7 +418,7 @@ jobs:
         # dependencies
         echo "## dependency list"
         cargo fetch --locked --quiet
-        cargo-tree tree --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --all --no-dev-dependencies --no-indent | grep -vE "$PWD" | sort --unique
+        cargo-tree tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --all --no-dev-dependencies --no-indent | grep -vE "$PWD" | sort --unique
     - name: Build
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -189,7 +189,7 @@ jobs:
         # tooling info display
         echo "## tooling"
         which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
-        rustup -V
+        rustup -V 2>/dev/null
         rustup show active-toolchain
         cargo -V
         rustc -V
@@ -410,7 +410,7 @@ jobs:
         # tooling info display
         echo "## tooling"
         which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
-        rustup -V
+        rustup -V 2>/dev/null
         rustup show active-toolchain
         cargo -V
         rustc -V

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -64,7 +64,7 @@ jobs:
         ## tooling info display
         echo "## tooling"
         which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
-        rustup -V
+        rustup -V 2>/dev/null
         rustup show active-toolchain
         cargo -V
         rustc -V

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -73,7 +73,7 @@ jobs:
         echo "## dependency list"
         cargo fetch --locked --quiet
         ## * using the 'stable' toolchain is necessary to avoid "unexpected '--filter-platform'" errors
-        RUSTUP_TOOLCHAIN=stable cargo-tree tree --frozen --all --no-dev-dependencies --no-indent --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
+        RUSTUP_TOOLCHAIN=stable cargo-tree tree --locked --all --no-dev-dependencies --no-indent --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
     - name: Commit any changes (to '${{ env.BRANCH_TARGET }}')
       uses: EndBug/add-and-commit@v7
       with:

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -2,6 +2,8 @@ name: FixPR
 
 # Trigger automated fixes for PRs being merged (with associated commits)
 
+# ToDO: [2021-06; rivy] change from `cargo-tree` to `cargo tree` once MSRV is >= 1.45
+
 env:
   BRANCH_TARGET: master
 

--- a/.vscode/cspell.dictionaries/people.wordlist.txt
+++ b/.vscode/cspell.dictionaries/people.wordlist.txt
@@ -58,6 +58,9 @@ Haitao Li
 Inokentiy Babushkin
     Inokentiy
     Babushkin
+Jan Scheer * jhscheer
+    Jan
+    Scheer
 Jeremiah Peschka
     Jeremiah
     Peschka


### PR DESCRIPTION
This makes the dependency display more lax about network access and should stop the errors seen in the CICD/MinRustV step.

Plus, some minor housekeeping.