### PR TITLE
docs ~ fix addition of 'jhscheer' to spell-checker exceptions word list

### DIFF
--- a/.vscode/cspell.dictionaries/people.wordlist.txt
+++ b/.vscode/cspell.dictionaries/people.wordlist.txt
@@ -61,6 +61,7 @@ Inokentiy Babushkin
 Jan Scheer * jhscheer
     Jan
     Scheer
+    jhscheer
 Jeremiah Peschka
     Jeremiah
     Peschka


### PR DESCRIPTION
Unfortunately, `cspell` and the internal speller for VSCode have slightly different semantics for the exception word lists.

This should actually fix the spelling error; local `cspell` says all is well.

