### PR TITLE
all utils: enable wrap_help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ test = [ "uu_test" ]
 [workspace]
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 lazy_static = { version="1.3" }
 textwrap = { version="=0.11.0", features=["term_size"] } # !maint: [2020-05-10; rivy] unstable crate using undocumented features; pinned currently, will review
 uucore = { version=">=0.0.8", package="uucore", path="src/uucore" }

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/arch.rs"
 
 [dependencies]
 platform-info = "0.1"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/base32.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features = ["encoding"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/base64/Cargo.toml
+++ b/src/uu/base64/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/base64.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features = ["encoding"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 uu_base32 = { version=">=0.0.6", package="uu_base32", path="../base32"}

--- a/src/uu/basename/Cargo.toml
+++ b/src/uu/basename/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/basename.rs"
 
 [dependencies]
-clap = "2.33.2"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/cat.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 thiserror = "1.0"
 atty = "0.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/chgrp.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 walkdir = "2.2"

--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/chmod.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs", "mode"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/chown/Cargo.toml
+++ b/src/uu/chown/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/chown.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 glob = "0.3.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/cksum.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/comm/Cargo.toml
+++ b/src/uu/comm/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/comm.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 path = "src/cp.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 filetime = "0.2"
 libc = "0.2.85"
 quick-error = "1.2.3"

--- a/src/uu/csplit/Cargo.toml
+++ b/src/uu/csplit/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/csplit.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 thiserror = "1.0"
 regex = "1.0.0"
 glob = "0.2.11"

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/cut.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 memchr = "2"

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/date.rs"
 
 [dependencies]
 chrono = "0.4.4"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/df.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 number_prefix = "0.4"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["libc", "fsext"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/dircolors/Cargo.toml
+++ b/src/uu/dircolors/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/dircolors.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 glob = "0.3.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/dirname/Cargo.toml
+++ b/src/uu/dirname/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/dirname.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/du.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 chrono = "0.4"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/echo.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/env.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 rust-ini = "0.13.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }

--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/expand.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 unicode-width = "0.1.5"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/expr.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 num-bigint = "0.4.0"
 num-traits = "0.2.14"

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -21,7 +21,7 @@ rand = { version = "0.7", features = ["small_rng"] }
 smallvec = { version = "0.6.14, < 1.0" }
 uucore = { version = ">=0.0.8", package = "uucore", path = "../../uucore" }
 uucore_procs = { version = ">=0.0.5", package = "uucore_procs", path = "../../uucore_procs" }
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 
 [dev-dependencies]
 paste = "0.1.18"

--- a/src/uu/false/Cargo.toml
+++ b/src/uu/false/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/false.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/fmt/Cargo.toml
+++ b/src/uu/fmt/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/fmt.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 unicode-width = "0.1.5"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }

--- a/src/uu/fold/Cargo.toml
+++ b/src/uu/fold/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/fold.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/groups/Cargo.toml
+++ b/src/uu/groups/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/groups.rs"
 [dependencies]
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "process"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 
 [[bin]]
 name = "groups"

--- a/src/uu/hashsum/Cargo.toml
+++ b/src/uu/hashsum/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/hashsum.rs"
 
 [dependencies]
 digest = "0.6.2"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 hex = "0.2.0"
 libc = "0.2.42"
 md5 = "0.3.5"

--- a/src/uu/head/Cargo.toml
+++ b/src/uu/head/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/head.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["ringbuffer"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/hostid/Cargo.toml
+++ b/src/uu/hostid/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/hostid.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/hostname.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 hostname = { version = "0.3", features = ["set"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["wide"] }

--- a/src/uu/id/Cargo.toml
+++ b/src/uu/id/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/id.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "process"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 path = "src/install.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 filetime = "0.2"
 file_diff = "1.0.0"
 libc = ">= 0.2"

--- a/src/uu/join/Cargo.toml
+++ b/src/uu/join/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/join.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/kill/Cargo.toml
+++ b/src/uu/kill/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/kill.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["signals"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/link/Cargo.toml
+++ b/src/uu/link/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/link.rs"
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 
 [[bin]]
 name = "link"

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/ln.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/logname/Cargo.toml
+++ b/src/uu/logname/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/logname.rs"
 
 [dependencies]
 libc = "0.2.42"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/ls.rs"
 [dependencies]
 locale = "0.2.2"
 chrono = "0.4.19"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 unicode-width = "0.1.8"
 number_prefix = "0.4"
 term_grid = "0.1.5"

--- a/src/uu/mkdir/Cargo.toml
+++ b/src/uu/mkdir/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/mkdir.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs", "mode"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/mkfifo/Cargo.toml
+++ b/src/uu/mkfifo/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/mkfifo.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/mknod/Cargo.toml
+++ b/src/uu/mknod/Cargo.toml
@@ -16,7 +16,7 @@ name = "uu_mknod"
 path = "src/mknod.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "^0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["mode"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/mktemp.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 rand = "0.5"
 tempfile = "3.1"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/more.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version = ">=0.0.7", package = "uucore", path = "../../uucore" }
 uucore_procs = { version = ">=0.0.5", package = "uucore_procs", path = "../../uucore_procs" }
 crossterm = ">=0.19"

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/mv.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 fs_extra = "1.1.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/nice.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 nix = { version="<=0.13" }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }

--- a/src/uu/nl/Cargo.toml
+++ b/src/uu/nl/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/nl.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 aho-corasick = "0.7.3"
 libc = "0.2.42"
 memchr = "2.2.0"

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/nohup.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 atty = "0.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }

--- a/src/uu/nproc/Cargo.toml
+++ b/src/uu/nproc/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/nproc.rs"
 [dependencies]
 libc = "0.2.42"
 num_cpus = "1.10"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/numfmt/Cargo.toml
+++ b/src/uu/numfmt/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/numfmt.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/od.rs"
 
 [dependencies]
 byteorder = "1.3.2"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 half = "1.6"
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }

--- a/src/uu/paste/Cargo.toml
+++ b/src/uu/paste/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/paste.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/pathchk/Cargo.toml
+++ b/src/uu/pathchk/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/pathchk.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/pinky/Cargo.toml
+++ b/src/uu/pinky/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/pinky.rs"
 [dependencies]
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["utmpx", "entries"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 
 [[bin]]
 name = "pinky"

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/pr.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.7", package="uucore", path="../../uucore", features=["utmpx", "entries"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 getopts = "0.2.21"

--- a/src/uu/printenv/Cargo.toml
+++ b/src/uu/printenv/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/printenv.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 path = "src/printf.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 itertools = "0.8.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/ptx/Cargo.toml
+++ b/src/uu/ptx/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/ptx.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 aho-corasick = "0.7.3"
 libc = "0.2.42"
 memchr = "2.2.0"

--- a/src/uu/pwd/Cargo.toml
+++ b/src/uu/pwd/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/pwd.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/readlink/Cargo.toml
+++ b/src/uu/readlink/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/readlink.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/realpath/Cargo.toml
+++ b/src/uu/realpath/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/realpath.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/relpath/Cargo.toml
+++ b/src/uu/relpath/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/relpath.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/rm.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 walkdir = "2.2"
 remove_dir_all = "0.5.1"
 winapi = { version="0.3", features=[] }

--- a/src/uu/rmdir/Cargo.toml
+++ b/src/uu/rmdir/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/rmdir.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/seq.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 num-bigint = "0.4.0"
 num-traits = "0.2.14"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }

--- a/src/uu/shred/Cargo.toml
+++ b/src/uu/shred/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/shred.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 filetime = "0.2.1"
 libc = "0.2.42"
 rand = "0.5"

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/shuf.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 rand = "0.5"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/sleep.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/sort.rs"
 
 [dependencies]
 binary-heap-plus = "0.4.1"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 compare = "0.1.0"
 fnv = "1.0.7"
 itertools = "0.10.0"

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/split.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/stat.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "libc", "fs", "fsext"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/stdbuf/Cargo.toml
+++ b/src/uu/stdbuf/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/stdbuf.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 tempfile = "3.1"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/sum.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/sync.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["wide"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/tac.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/tail.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["ringbuffer"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/tee.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 retain_mut = "0.1.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["libc"] }

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/test.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/timeout.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 nix = "0.20.0"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["process", "signals"] }

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/touch.rs"
 
 [dependencies]
 filetime = "0.2.1"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 time = "0.1.40"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["libc"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/tr/Cargo.toml
+++ b/src/uu/tr/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/tr.rs"
 [dependencies]
 bit-set = "0.5.0"
 fnv = "1.0.5"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/true/Cargo.toml
+++ b/src/uu/true/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/true.rs"
 
 [dependencies]
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/truncate/Cargo.toml
+++ b/src/uu/truncate/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/truncate.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/tty.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 atty = "0.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["fs"] }

--- a/src/uu/uname/Cargo.toml
+++ b/src/uu/uname/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/uname.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 platform-info = "0.1"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/unexpand/Cargo.toml
+++ b/src/uu/unexpand/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/unexpand.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 unicode-width = "0.1.5"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/uniq.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 strum = "0.20"
 strum_macros = "0.20"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }

--- a/src/uu/unlink/Cargo.toml
+++ b/src/uu/unlink/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/unlink.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/uptime.rs"
 
 [dependencies]
 chrono = "0.4"
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["libc", "utmpx"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/users/Cargo.toml
+++ b/src/uu/users/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/users.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["utmpx"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/wc.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 thiserror = "1.0"

--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/who.rs"
 [dependencies]
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["utmpx"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
-clap = "2.33.3"
+clap = { version = "2.33", features = ["wrap_help"] }
 
 [[bin]]
 name = "who"

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/whoami.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["entries", "wide"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/yes.rs"
 
 [dependencies]
-clap = "2.33"
+clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore", features=["zero-copy"] }
 uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 


### PR DESCRIPTION
This makes clap wrap the help text according to the terminal width,
which improves readability for terminal widths < 120 chars,
because clap defaults to a width of 120 chars without this feature.