### PR TITLE
[: install test as [ as well

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-# spell-checker:ignore (misc) testsuite runtest (targets) busytest distclean manpages pkgs ; (vars/env) BINDIR BUILDDIR CARGOFLAGS DESTDIR DOCSDIR INSTALLDIR INSTALLEES MANDIR MULTICALL
+# spell-checker:ignore (misc) testsuite runtest findstring (targets) busytest distclean manpages pkgs ; (vars/env) BINDIR BUILDDIR CARGOFLAGS DESTDIR DOCSDIR INSTALLDIR INSTALLEES MANDIR MULTICALL
 
 # Config options
 PROFILE         ?= debug
@@ -307,10 +307,12 @@ ifeq (${MULTICALL}, y)
 	$(INSTALL) $(BUILDDIR)/coreutils $(INSTALLDIR_BIN)/$(PROG_PREFIX)coreutils
 	cd $(INSTALLDIR_BIN) && $(foreach prog, $(filter-out coreutils, $(INSTALLEES)), \
 		ln -fs $(PROG_PREFIX)coreutils $(PROG_PREFIX)$(prog) &&) :
+	$(if $(findstring test,$(INSTALLEES)), ln -fs $(PROG_PREFIX)coreutils $(PROG_PREFIX)[)
 	cat $(DOCSDIR)/_build/man/coreutils.1 | gzip > $(INSTALLDIR_MAN)/$(PROG_PREFIX)coreutils.1.gz
 else
 	$(foreach prog, $(INSTALLEES), \
 		$(INSTALL) $(BUILDDIR)/$(prog) $(INSTALLDIR_BIN)/$(PROG_PREFIX)$(prog);)
+	$(if $(findstring test,$(INSTALLEES)), $(INSTALL) $(BUILDDIR)/test $(INSTALLDIR_BIN)/$(PROG_PREFIX)[)
 endif
 	$(foreach man, $(filter $(INSTALLEES), $(basename $(notdir $(wildcard $(DOCSDIR)/_build/man/*)))), \
 		cat $(DOCSDIR)/_build/man/$(man).1 | gzip > $(INSTALLDIR_MAN)/$(PROG_PREFIX)$(man).1.gz &&) :
@@ -326,6 +328,7 @@ ifeq (${MULTICALL}, y)
 endif
 	rm -f $(addprefix $(INSTALLDIR_MAN)/,$(PROG_PREFIX)coreutils.1.gz)
 	rm -f $(addprefix $(INSTALLDIR_BIN)/$(PROG_PREFIX),$(PROGS))
+	rm -f $(INSTALLDIR_BIN)/$(PROG_PREFIX)[
 	rm -f $(addprefix $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_$(PROG_PREFIX),$(PROGS))
 	rm -f $(addprefix $(DESTDIR)$(PREFIX)/share/bash-completion/completions/$(PROG_PREFIX),$(PROGS))
 	rm -f $(addprefix $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/$(PROG_PREFIX),$(addsuffix .fish,$(PROGS)))

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -31,7 +31,7 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     let mut args: Vec<_> = args.collect();
 
     // If invoked via name '[', matching ']' must be in the last arg
-    if binary_name == "[" {
+    if binary_name.ends_with('[') {
         let last = args.pop();
         if last != Some(OsString::from("]")) {
             eprintln!("[: missing ']'");

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -718,3 +718,21 @@ fn test_bracket_syntax_missing_right_bracket() {
         .status_code(2)
         .stderr_is("[: missing ']'");
 }
+
+#[test]
+fn test_bracket_syntax_help() {
+    let scenario = TestScenario::new("[");
+    let mut ucmd = scenario.ucmd();
+
+    ucmd.arg("--help").succeeds().stdout_contains("USAGE:");
+}
+
+#[test]
+fn test_bracket_syntax_version() {
+    let scenario = TestScenario::new("[");
+    let mut ucmd = scenario.ucmd();
+
+    ucmd.arg("--version")
+        .succeeds()
+        .stdout_matches(&r"\[ \d+\.\d+\.\d+".parse().unwrap());
+}


### PR DESCRIPTION
Closes #2420.

This installs `test` as `[` as well. When `test` is called with a binary name that ends with `[`, it changes its behavior a bit.
I would rather add `[` as its own utility instead of changing the behavior of `test` based on its binary name,
but I ran into problems trying to do that because `[` is not a valid crate/feature name. Working around it in build.rs and in GNUmakefile adds complexity and feels easy to get wrong... In any case we can't convince cargo to create a binary called `[`, which we can't work around if `uutils` is installed via `cargo install`.

There are plans for cargo to [support creating arbitrarily named binaries](https://github.com/rust-lang/cargo/issues/1706), which would mean we'd only have to work around the restriction for the feature name.

Maybe we can solve this problem in some other way?