### PR TITLE
make executable!() return the real executable name

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -625,7 +625,7 @@ jobs:
       uses: actions-rs/install@v0.1
       with:
         crate: grcov
-        version: 0.8.0
+        version: latest
         use-tool-cache: false
     - name: Generate coverage data (via `grcov`)
       id: coverage

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -625,7 +625,7 @@ jobs:
       uses: actions-rs/install@v0.1
       with:
         crate: grcov
-        version: latest
+        version: 0.8.0
         use-tool-cache: false
     - name: Generate coverage data (via `grcov`)
       id: coverage

--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -70,6 +70,7 @@ fn main() {
         Some(OsString::from(*util))
     } else {
         // unmatched binary name => regard as multi-binary container and advance argument list
+        uucore::set_utility_is_second_arg();
         args.next()
     };
 

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -27,7 +27,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(SUMMARY)

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -27,7 +27,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(SUMMARY)

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -28,13 +28,13 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 static BASE_CMD_PARSE_ERROR: i32 = 1;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let format = Format::Base32;
-    let usage = get_usage();
+    let usage = usage();
     let name = executable!();
 
     let config_result: Result<base_common::Config, String> =

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -38,7 +38,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let name = util_name!();
 
     let config_result: Result<base_common::Config, String> =
-        base_common::parse_base_cmd_args(args, name, VERSION, ABOUT, &usage);
+        base_common::parse_base_cmd_args(args, &name, VERSION, ABOUT, &usage);
     let config = config_result.unwrap_or_else(|s| crash!(BASE_CMD_PARSE_ERROR, "{}", s));
 
     // Create a reference to stdin so we can return a locked stdin from
@@ -52,12 +52,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         config.wrap_cols,
         config.ignore_garbage,
         config.decode,
-        name,
+        &name,
     );
 
     0
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    base_common::base_app(util_name!(), VERSION, ABOUT)
+    base_common::base_app(&util_name!(), VERSION, ABOUT)
 }

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -29,13 +29,13 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static BASE_CMD_PARSE_ERROR: i32 = 1;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", executable!())
+    format!("{0} [OPTION]... [FILE]", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let format = Format::Base32;
     let usage = usage();
-    let name = executable!();
+    let name = util_name!();
 
     let config_result: Result<base_common::Config, String> =
         base_common::parse_base_cmd_args(args, name, VERSION, ABOUT, &usage);
@@ -59,5 +59,5 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    base_common::base_app(executable!(), VERSION, ABOUT)
+    base_common::base_app(util_name!(), VERSION, ABOUT)
 }

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -29,13 +29,13 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static BASE_CMD_PARSE_ERROR: i32 = 1;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let format = Format::Base32;
     let usage = usage();
-    let name = util_name!();
+    let name = uucore::util_name();
 
     let config_result: Result<base_common::Config, String> =
         base_common::parse_base_cmd_args(args, &name, VERSION, ABOUT, &usage);
@@ -59,5 +59,5 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    base_common::base_app(&util_name!(), VERSION, ABOUT)
+    base_common::base_app(&uucore::util_name(), VERSION, ABOUT)
 }

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -29,13 +29,13 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 static BASE_CMD_PARSE_ERROR: i32 = 1;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let format = Format::Base64;
-    let usage = get_usage();
+    let usage = usage();
     let name = executable!();
     let config_result: Result<base_common::Config, String> =
         base_common::parse_base_cmd_args(args, name, VERSION, ABOUT, &usage);

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -38,7 +38,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = usage();
     let name = util_name!();
     let config_result: Result<base_common::Config, String> =
-        base_common::parse_base_cmd_args(args, name, VERSION, ABOUT, &usage);
+        base_common::parse_base_cmd_args(args, &name, VERSION, ABOUT, &usage);
     let config = config_result.unwrap_or_else(|s| crash!(BASE_CMD_PARSE_ERROR, "{}", s));
 
     // Create a reference to stdin so we can return a locked stdin from
@@ -52,7 +52,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         config.wrap_cols,
         config.ignore_garbage,
         config.decode,
-        name,
+        &name,
     );
 
     0

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -30,13 +30,13 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static BASE_CMD_PARSE_ERROR: i32 = 1;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let format = Format::Base64;
     let usage = usage();
-    let name = util_name!();
+    let name = uucore::util_name();
     let config_result: Result<base_common::Config, String> =
         base_common::parse_base_cmd_args(args, &name, VERSION, ABOUT, &usage);
     let config = config_result.unwrap_or_else(|s| crash!(BASE_CMD_PARSE_ERROR, "{}", s));

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -30,13 +30,13 @@ static VERSION: &str = env!("CARGO_PKG_VERSION");
 static BASE_CMD_PARSE_ERROR: i32 = 1;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", executable!())
+    format!("{0} [OPTION]... [FILE]", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let format = Format::Base64;
     let usage = usage();
-    let name = executable!();
+    let name = util_name!();
     let config_result: Result<base_common::Config, String> =
         base_common::parse_base_cmd_args(args, name, VERSION, ABOUT, &usage);
     let config = config_result.unwrap_or_else(|s| crash!(BASE_CMD_PARSE_ERROR, "{}", s));

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -46,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if !matches.is_present(options::NAME) {
         crash!(
             1,
-            "{1}\nTry '{0} --help' for more information.",
+            "{1}\nTry `{0} --help` for more information.",
             executable!(),
             "missing operand"
         );
@@ -60,7 +60,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if !multiple_paths && matches.occurrences_of(options::NAME) > 2 {
         crash!(
             1,
-            "extra operand '{1}'\nTry '{0} --help' for more information.",
+            "extra operand '{1}'\nTry `{0} --help` for more information.",
             executable!(),
             matches.values_of(options::NAME).unwrap().nth(2).unwrap()
         );

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -17,7 +17,7 @@ use uucore::InvalidEncodingHandling;
 static SUMMARY: &str = "Print NAME with any leading directory components removed
 If specified, also remove a trailing SUFFIX";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} NAME [SUFFIX]
     {0} OPTION... NAME...",
@@ -36,7 +36,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
-    let usage = get_usage();
+    let usage = usage();
     //
     // Argument parsing
     //

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -93,7 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(SUMMARY)
         .arg(

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -21,7 +21,7 @@ fn usage() -> String {
     format!(
         "{0} NAME [SUFFIX]
     {0} OPTION... NAME...",
-        executable!()
+        execution_phrase!()
     )
 }
 
@@ -47,7 +47,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "{1}\nTry `{0} --help` for more information.",
-            executable!(),
+            execution_phrase!(),
             "missing operand"
         );
     }
@@ -61,7 +61,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "extra operand '{1}'\nTry `{0} --help` for more information.",
-            executable!(),
+            execution_phrase!(),
             matches.values_of(options::NAME).unwrap().nth(2).unwrap()
         );
     }

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -21,7 +21,7 @@ fn usage() -> String {
     format!(
         "{0} NAME [SUFFIX]
     {0} OPTION... NAME...",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -47,7 +47,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "{1}\nTry '{0} --help' for more information.",
-            execution_phrase!(),
+            uucore::execution_phrase(),
             "missing operand"
         );
     }
@@ -61,7 +61,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "extra operand '{1}'\nTry '{0} --help' for more information.",
-            execution_phrase!(),
+            uucore::execution_phrase(),
             matches.values_of(options::NAME).unwrap().nth(2).unwrap()
         );
     }
@@ -93,7 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
         .arg(

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -46,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if !matches.is_present(options::NAME) {
         crash!(
             1,
-            "{1}\nTry `{0} --help` for more information.",
+            "{1}\nTry '{0} --help' for more information.",
             execution_phrase!(),
             "missing operand"
         );
@@ -60,7 +60,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if !multiple_paths && matches.occurrences_of(options::NAME) > 2 {
         crash!(
             1,
-            "extra operand '{1}'\nTry `{0} --help` for more information.",
+            "extra operand '{1}'\nTry '{0} --help' for more information.",
             execution_phrase!(),
             matches.values_of(options::NAME).unwrap().nth(2).unwrap()
         );

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -42,12 +42,12 @@ const ENCODINGS: &[(&str, Format)] = &[
     ("base2m", Format::Base2Msbf),
 ];
 
-fn get_usage() -> String {
-    format!("{0} [OPTION]... [FILE]", executable!())
+fn usage() -> String {
+    format!("{0} [OPTION]... [FILE]", execution_phrase!())
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    let mut app = base_common::base_app(executable!(), crate_version!(), ABOUT);
+    let mut app = base_common::base_app(&util_name!(), crate_version!(), ABOUT);
     for encoding in ENCODINGS {
         app = app.arg(Arg::with_name(encoding.0).long(encoding.0));
     }
@@ -55,7 +55,7 @@ pub fn uu_app() -> App<'static, 'static> {
 }
 
 fn parse_cmd_args(args: impl uucore::Args) -> (Config, Format) {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(
         args.collect_str(InvalidEncodingHandling::ConvertLossy)
             .accept_any(),
@@ -75,7 +75,7 @@ fn parse_cmd_args(args: impl uucore::Args) -> (Config, Format) {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let name = executable!();
+    let name = util_name!();
     let (config, format) = parse_cmd_args(args);
     // Create a reference to stdin so we can return a locked stdin from
     // parse_base_cmd_args
@@ -88,7 +88,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         config.wrap_cols,
         config.ignore_garbage,
         config.decode,
-        name,
+        &name,
     );
 
     0

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -43,11 +43,11 @@ const ENCODINGS: &[(&str, Format)] = &[
 ];
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    let mut app = base_common::base_app(&util_name!(), crate_version!(), ABOUT);
+    let mut app = base_common::base_app(&uucore::util_name(), crate_version!(), ABOUT);
     for encoding in ENCODINGS {
         app = app.arg(Arg::with_name(encoding.0).long(encoding.0));
     }
@@ -75,7 +75,7 @@ fn parse_cmd_args(args: impl uucore::Args) -> (Config, Format) {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let name = util_name!();
+    let name = uucore::util_name();
     let (config, format) = parse_cmd_args(args);
     // Create a reference to stdin so we can return a locked stdin from
     // parse_base_cmd_args

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -396,7 +396,7 @@ fn cat_files(files: Vec<String>, options: &OutputOptions) -> UResult<()> {
         Ok(())
     } else {
         // each next line is expected to display "cat: …"
-        let line_joiner = format!("\n{}: ", executable!());
+        let line_joiner = format!("\n{}: ", util_name!());
 
         Err(uucore::error::USimpleError::new(
             error_messages.len() as i32,

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -234,7 +234,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)
@@ -396,7 +396,7 @@ fn cat_files(files: Vec<String>, options: &OutputOptions) -> UResult<()> {
         Ok(())
     } else {
         // each next line is expected to display "cat: …"
-        let line_joiner = format!("\n{}: ", util_name!());
+        let line_joiner = format!("\n{}: ", uucore::util_name());
 
         Err(uucore::error::USimpleError::new(
             error_messages.len() as i32,

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -234,7 +234,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
-use uucore::{execution_phrase, show_error, show_usage_error, show_warning, util_name};
+use uucore::{show_error, show_usage_error, show_warning};
 
 use clap::{App, Arg};
 use selinux::{OpaqueSecurityContext, SecurityContext};
@@ -56,7 +56,7 @@ fn get_usage() -> String {
         "{0} [OPTION]... CONTEXT FILE... \n    \
          {0} [OPTION]... [-u USER] [-r ROLE] [-l RANGE] [-t TYPE] FILE... \n    \
          {0} [OPTION]... --reference=RFILE FILE...",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -152,7 +152,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(VERSION)
         .about(ABOUT)
         .arg(
@@ -563,7 +563,7 @@ fn process_file(
         if options.verbose {
             println!(
                 "{}: Changing security context of: {}",
-                util_name!(),
+                uucore::util_name(),
                 file_full_name.to_string_lossy()
             );
         }

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
-use uucore::{executable, show_error, show_usage_error, show_warning};
+use uucore::{execution_phrase, show_error, show_usage_error, show_warning, util_name};
 
 use clap::{App, Arg};
 use selinux::{OpaqueSecurityContext, SecurityContext};
@@ -56,7 +56,7 @@ fn get_usage() -> String {
         "{0} [OPTION]... CONTEXT FILE... \n    \
          {0} [OPTION]... [-u USER] [-r ROLE] [-l RANGE] [-t TYPE] FILE... \n    \
          {0} [OPTION]... --reference=RFILE FILE...",
-        executable!()
+        execution_phrase!()
     )
 }
 
@@ -152,7 +152,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(VERSION)
         .about(ABOUT)
         .arg(
@@ -563,7 +563,7 @@ fn process_file(
         if options.verbose {
             println!(
                 "{}: Changing security context of: {}",
-                executable!(),
+                util_name!(),
                 file_full_name.to_string_lossy()
             );
         }

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -59,7 +59,7 @@ const FTS_COMFOLLOW: u8 = 1;
 const FTS_PHYSICAL: u8 = 1 << 1;
 const FTS_LOGICAL: u8 = 1 << 2;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... GROUP FILE...\n    {0} [OPTION]... --reference=RFILE FILE...",
         executable!()
@@ -71,7 +71,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let mut app = uu_app().usage(&usage[..]);
 

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -62,7 +62,7 @@ const FTS_LOGICAL: u8 = 1 << 2;
 fn usage() -> String {
     format!(
         "{0} [OPTION]... GROUP FILE...\n    {0} [OPTION]... --reference=RFILE FILE...",
-        executable!()
+        execution_phrase!()
     )
 }
 

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -62,7 +62,7 @@ const FTS_LOGICAL: u8 = 1 << 2;
 fn usage() -> String {
     format!(
         "{0} [OPTION]... GROUP FILE...\n    {0} [OPTION]... --reference=RFILE FILE...",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -197,7 +197,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(VERSION)
         .about(ABOUT)
         .arg(

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -197,7 +197,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(VERSION)
         .about(ABOUT)
         .arg(

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -116,7 +116,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -36,7 +36,7 @@ mod options {
     pub const FILE: &str = "FILE";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... MODE[,MODE]... FILE...
 or: {0} [OPTION]... OCTAL-MODE FILE...
@@ -58,7 +58,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").
     let mode_had_minus_prefix = strip_minus_from_mode(&mut args);
 
-    let usage = get_usage();
+    let usage = usage();
     let after_help = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -41,7 +41,7 @@ fn usage() -> String {
         "{0} [OPTION]... MODE[,MODE]... FILE...
 or: {0} [OPTION]... OCTAL-MODE FILE...
 or: {0} [OPTION]... --reference=RFILE FILE...",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -116,7 +116,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -41,7 +41,7 @@ fn usage() -> String {
         "{0} [OPTION]... MODE[,MODE]... FILE...
 or: {0} [OPTION]... OCTAL-MODE FILE...
 or: {0} [OPTION]... --reference=RFILE FILE...",
-        executable!()
+        execution_phrase!()
     )
 }
 

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -64,7 +64,7 @@ const FTS_LOGICAL: u8 = 1 << 2;
 fn usage() -> String {
     format!(
         "{0} [OPTION]... [OWNER][:[GROUP]] FILE...\n{0} [OPTION]... --reference=RFILE FILE...",
-        executable!()
+        execution_phrase!()
     )
 }
 

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -165,7 +165,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -61,7 +61,7 @@ const FTS_COMFOLLOW: u8 = 1;
 const FTS_PHYSICAL: u8 = 1 << 1;
 const FTS_LOGICAL: u8 = 1 << 2;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... [OWNER][:[GROUP]] FILE...\n{0} [OPTION]... --reference=RFILE FILE...",
         executable!()
@@ -74,7 +74,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -64,7 +64,7 @@ const FTS_LOGICAL: u8 = 1 << 2;
 fn usage() -> String {
     format!(
         "{0} [OPTION]... [OWNER][:[GROUP]] FILE...\n{0} [OPTION]... --reference=RFILE FILE...",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -165,7 +165,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -46,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         Some(v) => Path::new(v),
         None => crash!(
             1,
-            "Missing operand: NEWROOT\nTry '{} --help' for more information.",
+            "Missing operand: NEWROOT\nTry `{} --help` for more information.",
             NAME
         ),
     };

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -92,7 +92,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .usage(SYNTAX)

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -16,7 +16,7 @@ use std::io::Error;
 use std::path::Path;
 use std::process::Command;
 use uucore::libc::{self, chroot, setgid, setgroups, setuid};
-use uucore::{entries, execution_phrase, InvalidEncodingHandling};
+use uucore::{entries, InvalidEncodingHandling};
 
 static ABOUT: &str = "Run COMMAND with root directory set to NEWROOT.";
 static SYNTAX: &str = "[OPTION]... NEWROOT [COMMAND [ARG]...]";
@@ -46,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         None => crash!(
             1,
             "Missing operand: NEWROOT\nTry '{} --help' for more information.",
-            execution_phrase!()
+            uucore::execution_phrase()
         ),
     };
 
@@ -91,7 +91,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .usage(SYNTAX)

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -16,9 +16,8 @@ use std::io::Error;
 use std::path::Path;
 use std::process::Command;
 use uucore::libc::{self, chroot, setgid, setgroups, setuid};
-use uucore::{entries, InvalidEncodingHandling};
+use uucore::{entries, execution_phrase, InvalidEncodingHandling};
 
-static NAME: &str = "chroot";
 static ABOUT: &str = "Run COMMAND with root directory set to NEWROOT.";
 static SYNTAX: &str = "[OPTION]... NEWROOT [COMMAND [ARG]...]";
 
@@ -47,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         None => crash!(
             1,
             "Missing operand: NEWROOT\nTry `{} --help` for more information.",
-            NAME
+            execution_phrase!()
         ),
     };
 

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -45,7 +45,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         Some(v) => Path::new(v),
         None => crash!(
             1,
-            "Missing operand: NEWROOT\nTry `{} --help` for more information.",
+            "Missing operand: NEWROOT\nTry '{} --help' for more information.",
             execution_phrase!()
         ),
     };

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -213,7 +213,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .about(SUMMARY)

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -213,7 +213,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .about(SUMMARY)

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -31,7 +31,7 @@ mod options {
     pub const FILE_2: &str = "FILE2";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{} [OPTION]... FILE1 FILE2", executable!())
 }
 
@@ -132,7 +132,7 @@ fn open_file(name: &str) -> io::Result<LineReader> {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -148,7 +148,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) delim mkdelim
 
-#[macro_use]
-extern crate uucore;
-
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, stdin, BufRead, BufReader, Stdin};
@@ -32,7 +29,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{} [OPTION]... FILE1 FILE2", execution_phrase!())
+    format!("{} [OPTION]... FILE1 FILE2", uucore::execution_phrase())
 }
 
 fn mkdelim(col: usize, opts: &ArgMatches) -> String {
@@ -148,7 +145,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -32,7 +32,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{} [OPTION]... FILE1 FILE2", executable!())
+    format!("{} [OPTION]... FILE1 FILE2", execution_phrase!())
 }
 
 fn mkdelim(col: usize, opts: &ArgMatches) -> String {

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -218,7 +218,7 @@ static LONG_HELP: &str = "";
 static EXIT_OK: i32 = 0;
 static EXIT_ERR: i32 = 1;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... [-T] SOURCE DEST
     {0} [OPTION]... SOURCE... DIRECTORY
@@ -465,7 +465,7 @@ pub fn uu_app() -> App<'static, 'static> {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app()
         .after_help(&*format!(
             "{}\n{}",

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -99,7 +99,7 @@ quick_error! {
         NotImplemented(opt: String) { display("Option '{}' not yet implemented.", opt) }
 
         /// Invalid arguments to backup
-        Backup(description: String) { display("{}\nTry `{} --help` for more information.", description, executable!()) }
+        Backup(description: String) { display("{}\nTry `{} --help` for more information.", description, execution_phrase!()) }
     }
 }
 
@@ -223,7 +223,7 @@ fn usage() -> String {
         "{0} [OPTION]... [-T] SOURCE DEST
     {0} [OPTION]... SOURCE... DIRECTORY
     {0} [OPTION]... -t DIRECTORY SOURCE...",
-        executable!()
+        execution_phrase!()
     )
 }
 
@@ -1060,7 +1060,7 @@ impl OverwriteMode {
         match *self {
             OverwriteMode::NoClobber => Err(Error::NotAllFilesCopied),
             OverwriteMode::Interactive(_) => {
-                if prompt_yes!("{}: overwrite {}? ", executable!(), path.display()) {
+                if prompt_yes!("{}: overwrite {}? ", util_name!(), path.display()) {
                     Ok(())
                 } else {
                     Err(Error::Skipped(format!(

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -99,7 +99,7 @@ quick_error! {
         NotImplemented(opt: String) { display("Option '{}' not yet implemented.", opt) }
 
         /// Invalid arguments to backup
-        Backup(description: String) { display("{}\nTry 'cp --help' for more information.", description) }
+        Backup(description: String) { display("{}\nTry `{} --help` for more information.", description, executable!()) }
     }
 }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -99,7 +99,7 @@ quick_error! {
         NotImplemented(opt: String) { display("Option '{}' not yet implemented.", opt) }
 
         /// Invalid arguments to backup
-        Backup(description: String) { display("{}\nTry `{} --help` for more information.", description, execution_phrase!()) }
+        Backup(description: String) { display("{}\nTry '{} --help' for more information.", description, execution_phrase!()) }
     }
 }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -293,7 +293,7 @@ static DEFAULT_ATTRIBUTES: &[Attribute] = &[
 ];
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(options::TARGET_DIRECTORY)

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -99,7 +99,7 @@ quick_error! {
         NotImplemented(opt: String) { display("Option '{}' not yet implemented.", opt) }
 
         /// Invalid arguments to backup
-        Backup(description: String) { display("{}\nTry '{} --help' for more information.", description, execution_phrase!()) }
+        Backup(description: String) { display("{}\nTry '{} --help' for more information.", description, uucore::execution_phrase()) }
     }
 }
 
@@ -223,7 +223,7 @@ fn usage() -> String {
         "{0} [OPTION]... [-T] SOURCE DEST
     {0} [OPTION]... SOURCE... DIRECTORY
     {0} [OPTION]... -t DIRECTORY SOURCE...",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -293,7 +293,7 @@ static DEFAULT_ATTRIBUTES: &[Attribute] = &[
 ];
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(options::TARGET_DIRECTORY)
@@ -1060,7 +1060,7 @@ impl OverwriteMode {
         match *self {
             OverwriteMode::NoClobber => Err(Error::NotAllFilesCopied),
             OverwriteMode::Interactive(_) => {
-                if prompt_yes!("{}: overwrite {}? ", util_name!(), path.display()) {
+                if prompt_yes!("{}: overwrite {}? ", uucore::util_name(), path.display()) {
                     Ok(())
                 } else {
                     Err(Error::Skipped(format!(

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -34,7 +34,7 @@ mod options {
     pub const PATTERN: &str = "pattern";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... FILE PATTERN...", executable!())
 }
 
@@ -706,7 +706,7 @@ mod tests {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -739,7 +739,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(SUMMARY)
         .arg(

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -35,7 +35,10 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE PATTERN...", execution_phrase!())
+    format!(
+        "{0} [OPTION]... FILE PATTERN...",
+        uucore::execution_phrase()
+    )
 }
 
 /// Command line options for csplit.
@@ -739,7 +742,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
         .arg(

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -35,7 +35,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE PATTERN...", executable!())
+    format!("{0} [OPTION]... FILE PATTERN...", execution_phrase!())
 }
 
 /// Command line options for csplit.

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -548,7 +548,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -548,7 +548,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -253,7 +253,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -8,9 +8,6 @@
 
 // spell-checker:ignore (chrono) Datelike Timelike ; (format) DATEFILE MMDDhhmm ; (vars) datetime datetimes
 
-#[macro_use]
-extern crate uucore;
-
 use chrono::{DateTime, FixedOffset, Local, Offset, Utc};
 #[cfg(windows)]
 use chrono::{Datelike, Timelike};
@@ -253,7 +250,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -7,8 +7,6 @@
 
 // spell-checker:ignore fname, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, behaviour, bmax, bremain, btotal, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, outfile, parseargs, rlen, rmax, rposition, rremain, rsofar, rstat, sigusr, sigval, wlen, wstat
 
-#[macro_use]
-extern crate uucore;
 use uucore::InvalidEncodingHandling;
 
 #[cfg(test)]
@@ -1046,7 +1044,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> clap::App<'static, 'static> {
-    clap::App::new(util_name!())
+    clap::App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1046,7 +1046,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> clap::App<'static, 'static> {
-    clap::App::new(executable!())
+    clap::App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -79,7 +79,7 @@ struct Filesystem {
     usage: FsUsage,
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", executable!())
 }
 
@@ -284,7 +284,7 @@ impl UError for DfError {
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let paths: Vec<String> = matches

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -80,7 +80,7 @@ struct Filesystem {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", executable!())
+    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 impl FsSelector {
@@ -295,7 +295,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     #[cfg(windows)]
     {
         if matches.is_present(OPT_INODES) {
-            println!("{}: doesn't support -i option", executable!());
+            println!("{}: doesn't support -i option", util_name!());
             return Ok(());
         }
     }

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -80,7 +80,7 @@ struct Filesystem {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 impl FsSelector {
@@ -295,7 +295,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     #[cfg(windows)]
     {
         if matches.is_present(OPT_INODES) {
-            println!("{}: doesn't support -i option", util_name!());
+            println!("{}: doesn't support -i option", uucore::util_name());
             return Ok(());
         }
     }
@@ -427,7 +427,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -427,7 +427,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -153,7 +153,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(LONG_HELP)

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -62,7 +62,7 @@ pub fn guess_syntax() -> OutputFmt {
     }
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} {1}", executable!(), SYNTAX)
 }
 
@@ -71,7 +71,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(&args);
 

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -63,7 +63,7 @@ pub fn guess_syntax() -> OutputFmt {
 }
 
 fn usage() -> String {
-    format!("{0} {1}", executable!(), SYNTAX)
+    format!("{0} {1}", execution_phrase!(), SYNTAX)
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -63,7 +63,7 @@ pub fn guess_syntax() -> OutputFmt {
 }
 
 fn usage() -> String {
-    format!("{0} {1}", execution_phrase!(), SYNTAX)
+    format!("{0} {1}", uucore::execution_phrase(), SYNTAX)
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -153,7 +153,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(LONG_HELP)

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -21,7 +21,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION] NAME...", execution_phrase!())
+    format!("{0} [OPTION] NAME...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -86,7 +86,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .about(ABOUT)
         .version(crate_version!())
         .arg(

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -21,7 +21,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION] NAME...", executable!())
+    format!("{0} [OPTION] NAME...", execution_phrase!())
 }
 
 fn get_long_usage() -> String {

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -86,7 +86,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .about(ABOUT)
         .version(crate_version!())
         .arg(

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -20,7 +20,7 @@ mod options {
     pub const DIR: &str = "dir";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION] NAME...", executable!())
 }
 
@@ -37,7 +37,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
     let after_help = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -392,7 +392,7 @@ fn convert_size_other(size: u64, _multiplier: u64, block_size: u64) -> String {
     format!("{}", ((size as f64) / (block_size as f64)).ceil())
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... [FILE]...
     {0} [OPTION]... --files0-from=F",
@@ -456,7 +456,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -70,7 +70,6 @@ mod options {
     pub const FILE: &str = "FILE";
 }
 
-const NAME: &str = "du";
 const SUMMARY: &str = "estimate file space usage";
 const LONG_HELP: &str = "
 Display values are in units of the first available SIZE from --block-size,
@@ -87,7 +86,7 @@ const UNITS: [(char, u32); 6] = [('E', 6), ('P', 5), ('T', 4), ('G', 3), ('M', 2
 
 struct Options {
     all: bool,
-    program_name: String,
+    util_name: String,
     max_depth: Option<usize>,
     total: bool,
     separate_dirs: bool,
@@ -295,7 +294,7 @@ fn du(
                 safe_writeln!(
                     stderr(),
                     "{}: cannot read directory '{}': {}",
-                    options.program_name,
+                    options.util_name,
                     my_stat.path.display(),
                     e
                 );
@@ -423,8 +422,9 @@ Valid arguments are:
 - 'full-iso'
 - 'long-iso'
 - 'iso'
-Try '{} --help' for more information.",
-                s, NAME
+Try `{} --help` for more information.",
+                s,
+                executable!()
             ),
             DuError::InvalidTimeArg(s) => write!(
                 f,
@@ -466,7 +466,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let options = Options {
         all: matches.is_present(options::ALL),
-        program_name: NAME.to_owned(),
+        util_name: util_name!().to_string(),
         max_depth,
         total: matches.is_present(options::TOTAL),
         separate_dirs: matches.is_present(options::SEPARATE_DIRS),

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -422,7 +422,7 @@ Valid arguments are:
 - 'full-iso'
 - 'long-iso'
 - 'iso'
-Try `{} --help` for more information.",
+Try '{} --help' for more information.",
                 s,
                 execution_phrase!()
             ),

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -396,7 +396,7 @@ fn usage() -> String {
     format!(
         "{0} [OPTION]... [FILE]...
     {0} [OPTION]... --files0-from=F",
-        executable!()
+        execution_phrase!()
     )
 }
 
@@ -424,7 +424,7 @@ Valid arguments are:
 - 'iso'
 Try `{} --help` for more information.",
                 s,
-                executable!()
+                execution_phrase!()
             ),
             DuError::InvalidTimeArg(s) => write!(
                 f,

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -396,7 +396,7 @@ fn usage() -> String {
     format!(
         "{0} [OPTION]... [FILE]...
     {0} [OPTION]... --files0-from=F",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -424,7 +424,7 @@ Valid arguments are:
 - 'iso'
 Try '{} --help' for more information.",
                 s,
-                execution_phrase!()
+                uucore::execution_phrase()
             ),
             DuError::InvalidTimeArg(s) => write!(
                 f,
@@ -466,7 +466,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let options = Options {
         all: matches.is_present(options::ALL),
-        util_name: util_name!(),
+        util_name: uucore::util_name(),
         max_depth,
         total: matches.is_present(options::TOTAL),
         separate_dirs: matches.is_present(options::SEPARATE_DIRS),
@@ -625,7 +625,7 @@ fn parse_depth(max_depth_str: Option<&str>, summarize: bool) -> UResult<Option<u
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(LONG_HELP)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -466,7 +466,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let options = Options {
         all: matches.is_present(options::ALL),
-        util_name: util_name!().to_string(),
+        util_name: util_name!(),
         max_depth,
         total: matches.is_present(options::TOTAL),
         separate_dirs: matches.is_present(options::SEPARATE_DIRS),

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -625,7 +625,7 @@ fn parse_depth(max_depth_str: Option<&str>, summarize: bool) -> UResult<Option<u
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(LONG_HELP)

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -132,7 +132,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         // TrailingVarArg specifies the final positional argument is a VarArg
         // and it doesn't attempts the parse any further args.

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -132,7 +132,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         // TrailingVarArg specifies the final positional argument is a VarArg
         // and it doesn't attempts the parse any further args.

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -33,7 +33,7 @@ static LONG_HELP: &str = "";
 static DEFAULT_TABSTOP: usize = 8;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", executable!())
+    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 /// The mode to use when replacing tabs beyond the last one specified in

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -32,7 +32,7 @@ static LONG_HELP: &str = "";
 
 static DEFAULT_TABSTOP: usize = 8;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", executable!())
 }
 
@@ -170,7 +170,7 @@ impl Options {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     expand(Options::new(&matches));

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -178,7 +178,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -33,7 +33,7 @@ static LONG_HELP: &str = "";
 static DEFAULT_TABSTOP: usize = 8;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 /// The mode to use when replacing tabs beyond the last one specified in
@@ -178,7 +178,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -18,7 +18,7 @@ const VERSION: &str = "version";
 const HELP: &str = "help";
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .arg(Arg::with_name(VERSION).long(VERSION))
         .arg(Arg::with_name(HELP).long(HELP))
 }

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -18,7 +18,7 @@ const VERSION: &str = "version";
 const HELP: &str = "help";
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .arg(Arg::with_name(VERSION).long(VERSION))
         .arg(Arg::with_name(HELP).long(HELP))
 }
@@ -140,5 +140,5 @@ Environment variables:
 }
 
 fn print_version() {
-    println!("{} {}", util_name!(), crate_version!());
+    println!("{} {}", uucore::util_name(), crate_version!());
 }

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -140,5 +140,5 @@ Environment variables:
 }
 
 fn print_version() {
-    println!("{} {}", executable!(), crate_version!());
+    println!("{} {}", util_name!(), crate_version!());
 }

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -75,7 +75,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(SUMMARY)
         .arg(Arg::with_name(options::NUMBER).multiple(true))

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -75,7 +75,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
         .arg(Arg::with_name(options::NUMBER).multiple(true))

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -10,7 +10,6 @@ extern crate uucore;
 
 use clap::App;
 use uucore::error::UResult;
-use uucore::util_name;
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -19,5 +18,5 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
 }

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -9,7 +9,8 @@
 extern crate uucore;
 
 use clap::App;
-use uucore::{error::UResult, executable};
+use uucore::error::UResult;
+use uucore::util_name;
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -18,5 +19,5 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
 }

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -50,7 +50,7 @@ static OPT_TAB_WIDTH: &str = "tab-width";
 
 static ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{} [OPTION]... [FILE]...", executable!())
 }
 
@@ -75,7 +75,7 @@ pub struct FmtOptions {
 
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -211,7 +211,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -51,7 +51,7 @@ static OPT_TAB_WIDTH: &str = "tab-width";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{} [OPTION]... [FILE]...", executable!())
+    format!("{} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 pub type FileOrStdReader = BufReader<Box<dyn Read + 'static>>;

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -51,7 +51,7 @@ static OPT_TAB_WIDTH: &str = "tab-width";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 pub type FileOrStdReader = BufReader<Box<dyn Read + 'static>>;
@@ -211,7 +211,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -64,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -64,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(SYNTAX)

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -85,7 +85,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -28,12 +28,12 @@ static ABOUT: &str = "Print group memberships for each USERNAME or, \
                       if no USERNAME is specified, for\nthe current process \
                       (which may differ if the groups data‐base has changed).";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [USERNAME]...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -29,7 +29,7 @@ static ABOUT: &str = "Print group memberships for each USERNAME or, \
                       (which may differ if the groups data‐base has changed).";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USERNAME]...", executable!())
+    format!("{0} [OPTION]... [USERNAME]...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -29,7 +29,7 @@ static ABOUT: &str = "Print group memberships for each USERNAME or, \
                       (which may differ if the groups data‐base has changed).";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USERNAME]...", execution_phrase!())
+    format!("{0} [OPTION]... [USERNAME]...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -85,7 +85,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -342,7 +342,7 @@ pub fn uu_app_common() -> App<'static, 'static> {
     const TEXT_HELP: &str = "read in text mode";
     #[cfg(not(windows))]
     const TEXT_HELP: &str = "read in text mode (default)";
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about("Compute and check message digests.")
         .arg(

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -342,7 +342,7 @@ pub fn uu_app_common() -> App<'static, 'static> {
     const TEXT_HELP: &str = "read in text mode";
     #[cfg(not(windows))]
     const TEXT_HELP: &str = "read in text mode (default)";
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about("Compute and check message digests.")
         .arg(

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -9,7 +9,7 @@ use clap::{crate_version, App, Arg};
 use std::convert::TryFrom;
 use std::ffi::OsString;
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
-use uucore::{crash, executable, show_error, show_error_custom_description};
+use uucore::{crash, show_error_custom_description, util_name};
 
 const EXIT_FAILURE: i32 = 1;
 const EXIT_SUCCESS: i32 = 0;
@@ -41,7 +41,7 @@ use lines::zlines;
 use take::take_all_but;
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .usage(USAGE)

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -9,7 +9,7 @@ use clap::{crate_version, App, Arg};
 use std::convert::TryFrom;
 use std::ffi::OsString;
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
-use uucore::{crash, show_error_custom_description, util_name};
+use uucore::{crash, show_error_custom_description};
 
 const EXIT_FAILURE: i32 = 1;
 const EXIT_SUCCESS: i32 = 0;
@@ -41,7 +41,7 @@ use lines::zlines;
 use take::take_all_but;
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .usage(USAGE)

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -29,7 +29,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .usage(SYNTAX)
 }

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -29,7 +29,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .usage(SYNTAX)
 }

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -54,7 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [HOSTNAME]", executable!())
+    format!("{0} [OPTION]... [HOSTNAME]", execution_phrase!())
 }
 
 fn execute(args: impl uucore::Args) -> UResult<()> {

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -54,7 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [HOSTNAME]", execution_phrase!())
+    format!("{0} [OPTION]... [HOSTNAME]", uucore::execution_phrase())
 }
 
 fn execute(args: impl uucore::Args) -> UResult<()> {
@@ -74,7 +74,7 @@ fn execute(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -73,7 +73,7 @@ fn execute(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -53,11 +53,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     result
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [HOSTNAME]", executable!())
 }
+
 fn execute(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     match matches.value_of(OPT_HOST) {

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -76,7 +76,7 @@ mod options {
     pub const ARG_USERS: &str = "USER";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [USER]...", executable!())
 }
 
@@ -127,7 +127,7 @@ struct State {
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
     let after_help = get_description();
 
     let matches = uu_app()

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -347,7 +347,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -77,7 +77,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]...", executable!())
+    format!("{0} [OPTION]... [USER]...", execution_phrase!())
 }
 
 fn get_description() -> String {

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -77,7 +77,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]...", execution_phrase!())
+    format!("{0} [OPTION]... [USER]...", uucore::execution_phrase())
 }
 
 fn get_description() -> String {
@@ -347,7 +347,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -89,7 +89,7 @@ impl Display for InstallError {
             IE::DirNeedsArg() => write!(
                 f,
                 "{} with -d requires at least one argument.",
-                executable!()
+                util_name!()
             ),
             IE::CreateDirFailed(dir, e) => {
                 Display::fmt(&uio_error!(e, "failed to create {}", dir.display()), f)
@@ -173,7 +173,7 @@ static OPT_CONTEXT: &str = "context";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", executable!())
+    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 /// Main install utility function, called from main.rs.

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -202,7 +202,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -86,11 +86,13 @@ impl Display for InstallError {
         use InstallError as IE;
         match self {
             IE::Unimplemented(opt) => write!(f, "Unimplemented feature: {}", opt),
-            IE::DirNeedsArg() => write!(
-                f,
-                "{} with -d requires at least one argument.",
-                util_name!()
-            ),
+            IE::DirNeedsArg() => {
+                write!(
+                    f,
+                    "{} with -d requires at least one argument.",
+                    uucore::util_name()
+                )
+            }
             IE::CreateDirFailed(dir, e) => {
                 Display::fmt(&uio_error!(e, "failed to create {}", dir.display()), f)
             }
@@ -173,7 +175,7 @@ static OPT_CONTEXT: &str = "context";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 /// Main install utility function, called from main.rs.
@@ -202,7 +204,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -172,7 +172,7 @@ static OPT_CONTEXT: &str = "context";
 
 static ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", executable!())
 }
 
@@ -182,7 +182,7 @@ fn get_usage() -> String {
 ///
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -41,7 +41,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .accept_any();
     let (args, obs_signal) = handle_obsolete(args);
 
-    let usage = format!("{} [OPTIONS]... PID...", execution_phrase!());
+    let usage = format!("{} [OPTIONS]... PID...", uucore::execution_phrase());
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mode = if matches.is_present(options::TABLE) || matches.is_present(options::TABLE_OLD) {
@@ -76,7 +76,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -41,7 +41,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .accept_any();
     let (args, obs_signal) = handle_obsolete(args);
 
-    let usage = format!("{} [OPTIONS]... PID...", executable!());
+    let usage = format!("{} [OPTIONS]... PID...", execution_phrase!());
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mode = if matches.is_present(options::TABLE) || matches.is_present(options::TABLE_OLD) {

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -76,7 +76,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -19,7 +19,7 @@ pub mod options {
     pub static FILES: &str = "FILES";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} FILE1 FILE2", executable!())
 }
 
@@ -31,7 +31,7 @@ pub fn normalize_error_message(e: Error) -> String {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let files: Vec<_> = matches

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -20,7 +20,7 @@ pub mod options {
 }
 
 fn usage() -> String {
-    format!("{0} FILE1 FILE2", executable!())
+    format!("{0} FILE1 FILE2", execution_phrase!())
 }
 
 pub fn normalize_error_message(e: Error) -> String {

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -20,7 +20,7 @@ pub mod options {
 }
 
 fn usage() -> String {
-    format!("{0} FILE1 FILE2", execution_phrase!())
+    format!("{0} FILE1 FILE2", uucore::execution_phrase())
 }
 
 pub fn normalize_error_message(e: Error) -> String {
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -68,7 +68,7 @@ impl Display for LnError {
             }
             Self::ExtraOperand(s) => write!(
                 f,
-                "extra operand '{}'\nTry `{} --help` for more information.",
+                "extra operand '{}'\nTry '{} --help' for more information.",
                 s,
                 execution_phrase!()
             ),

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -92,7 +92,7 @@ impl UError for LnError {
     }
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... [-T] TARGET LINK_NAME   (1st form)
        {0} [OPTION]... TARGET                  (2nd form)
@@ -102,7 +102,7 @@ fn get_usage() -> String {
     )
 }
 
-fn get_long_usage() -> String {
+fn long_usage() -> String {
     String::from(
         " In the 1st form, create a link to TARGET with the name LINK_NAME.
         In the 2nd form, create a link to TARGET in the current directory.
@@ -136,8 +136,8 @@ static ARG_FILES: &str = "files";
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
-    let long_usage = get_long_usage();
+    let usage = usage();
+    let long_usage = long_usage();
 
     let matches = uu_app()
         .usage(&usage[..])

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -70,7 +70,7 @@ impl Display for LnError {
                 f,
                 "extra operand '{}'\nTry `{} --help` for more information.",
                 s,
-                executable!()
+                execution_phrase!()
             ),
             Self::InvalidBackupMode(s) => write!(f, "{}", s),
         }
@@ -98,7 +98,7 @@ fn usage() -> String {
        {0} [OPTION]... TARGET                  (2nd form)
        {0} [OPTION]... TARGET... DIRECTORY     (3rd form)
        {0} [OPTION]... -t DIRECTORY TARGET...  (4th form)",
-        executable!()
+        execution_phrase!()
     )
 }
 
@@ -431,7 +431,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> Result<()> {
         match settings.overwrite {
             OverwriteMode::NoClobber => {}
             OverwriteMode::Interactive => {
-                print!("{}: overwrite '{}'? ", executable!(), dst.display());
+                print!("{}: overwrite '{}'? ", util_name!(), dst.display());
                 if !read_yes() {
                     return Ok(());
                 }

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -68,7 +68,7 @@ impl Display for LnError {
             }
             Self::ExtraOperand(s) => write!(
                 f,
-                "extra operand '{}'\nTry '{} --help' for more information.",
+                "extra operand '{}'\nTry `{} --help` for more information.",
                 s,
                 executable!()
             ),

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -70,7 +70,7 @@ impl Display for LnError {
                 f,
                 "extra operand '{}'\nTry '{} --help' for more information.",
                 s,
-                execution_phrase!()
+                uucore::execution_phrase()
             ),
             Self::InvalidBackupMode(s) => write!(f, "{}", s),
         }
@@ -98,7 +98,7 @@ fn usage() -> String {
        {0} [OPTION]... TARGET                  (2nd form)
        {0} [OPTION]... TARGET... DIRECTORY     (3rd form)
        {0} [OPTION]... -t DIRECTORY TARGET...  (4th form)",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -196,7 +196,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(
@@ -431,7 +431,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> Result<()> {
         match settings.overwrite {
             OverwriteMode::NoClobber => {}
             OverwriteMode::Interactive => {
-                print!("{}: overwrite '{}'? ", util_name!(), dst.display());
+                print!("{}: overwrite '{}'? ", uucore::util_name(), dst.display());
                 if !read_yes() {
                     return Ok(());
                 }

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -196,7 +196,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -35,7 +35,7 @@ fn get_userlogin() -> Option<String> {
 
 static SUMMARY: &str = "Print user's login name";
 
-fn get_usage() -> String {
+fn usage() -> String {
     String::from(executable!())
 }
 
@@ -44,7 +44,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
     let _ = uu_app().usage(&usage[..]).get_matches_from(args);
 
     match get_userlogin() {

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -56,7 +56,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(SUMMARY)
 }

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -36,7 +36,7 @@ fn get_userlogin() -> Option<String> {
 static SUMMARY: &str = "Print user's login name";
 
 fn usage() -> String {
-    execution_phrase!()
+    uucore::execution_phrase()
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -56,7 +56,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
 }

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -36,7 +36,7 @@ fn get_userlogin() -> Option<String> {
 static SUMMARY: &str = "Print user's login name";
 
 fn usage() -> String {
-    execution_phrase!().to_string()
+    execution_phrase!()
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -36,7 +36,7 @@ fn get_userlogin() -> Option<String> {
 static SUMMARY: &str = "Print user's login name";
 
 fn usage() -> String {
-    String::from(executable!())
+    execution_phrase!().to_string()
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -46,7 +46,7 @@ use unicode_width::UnicodeWidthStr;
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 use uucore::{fs::display_permissions, version_cmp::version_cmp};
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", executable!())
 }
 
@@ -603,7 +603,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let app = uu_app().usage(&usage[..]);
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -618,7 +618,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(
             "By default, ls will list the files and contents of any directories on \

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -47,7 +47,7 @@ use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 use uucore::{fs::display_permissions, version_cmp::version_cmp};
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 pub mod options {
@@ -618,7 +618,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(
             "By default, ls will list the files and contents of any directories on \

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -47,7 +47,7 @@ use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 use uucore::{fs::display_permissions, version_cmp::version_cmp};
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", executable!())
+    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 pub mod options {

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -22,13 +22,13 @@ mod options {
     pub const DIRS: &str = "dirs";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [USER]", executable!())
 }
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
 
     // Linux-specific options, not implemented
     // opts.optflag("Z", "context", "set SELinux security context" +

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -23,7 +23,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]", execution_phrase!())
+    format!("{0} [OPTION]... [USER]", uucore::execution_phrase())
 }
 
 #[uucore_procs::gen_uumain]
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(
@@ -103,7 +103,11 @@ fn mkdir(path: &Path, recursive: bool, mode: u16, verbose: bool) -> UResult<()> 
     create_dir(path).map_err_context(|| format!("cannot create directory '{}'", path.display()))?;
 
     if verbose {
-        println!("{}: created directory '{}'", util_name!(), path.display());
+        println!(
+            "{}: created directory '{}'",
+            uucore::util_name(),
+            path.display()
+        );
     }
 
     chmod(path, mode)

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -23,7 +23,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]", executable!())
+    format!("{0} [OPTION]... [USER]", execution_phrase!())
 }
 
 #[uucore_procs::gen_uumain]
@@ -103,7 +103,7 @@ fn mkdir(path: &Path, recursive: bool, mode: u16, verbose: bool) -> UResult<()> 
     create_dir(path).map_err_context(|| format!("cannot create directory '{}'", path.display()))?;
 
     if verbose {
-        println!("{}: created directory '{}'", executable!(), path.display());
+        println!("{}: created directory '{}'", util_name!(), path.display());
     }
 
     chmod(path, mode)

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -70,7 +70,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -70,7 +70,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -145,7 +145,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .usage(USAGE)
         .after_help(LONG_HELP)

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -113,7 +113,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if ch == 'p' {
         if matches.is_present("major") || matches.is_present("minor") {
             eprintln!("Fifos do not have major and minor device numbers.");
-            eprintln!("Try '{} --help' for more information.", NAME);
+            eprintln!("Try `{} --help` for more information.", NAME);
             1
         } else {
             _mknod(file_name, S_IFIFO | mode, 0)
@@ -122,7 +122,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         match (matches.value_of("major"), matches.value_of("minor")) {
             (None, None) | (_, None) | (None, _) => {
                 eprintln!("Special files require major and minor device numbers.");
-                eprintln!("Try '{} --help' for more information.", NAME);
+                eprintln!("Try `{} --help` for more information.", NAME);
                 1
             }
             (Some(major), Some(minor)) => {

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -71,8 +71,8 @@ fn _mknod(file_name: &str, mode: mode_t, dev: dev_t) -> i32 {
         }
 
         if errno == -1 {
-            let c_str =
-                CString::new(execution_phrase!().as_bytes()).expect("Failed to convert to CString");
+            let c_str = CString::new(uucore::execution_phrase().as_bytes())
+                .expect("Failed to convert to CString");
             // shows the error from the mknod syscall
             libc::perror(c_str.as_ptr());
         }
@@ -113,7 +113,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if ch == 'p' {
         if matches.is_present("major") || matches.is_present("minor") {
             eprintln!("Fifos do not have major and minor device numbers.");
-            eprintln!("Try '{} --help' for more information.", execution_phrase!());
+            eprintln!(
+                "Try '{} --help' for more information.",
+                uucore::execution_phrase()
+            );
             1
         } else {
             _mknod(file_name, S_IFIFO | mode, 0)
@@ -122,7 +125,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         match (matches.value_of("major"), matches.value_of("minor")) {
             (None, None) | (_, None) | (None, _) => {
                 eprintln!("Special files require major and minor device numbers.");
-                eprintln!("Try '{} --help' for more information.", execution_phrase!());
+                eprintln!(
+                    "Try '{} --help' for more information.",
+                    uucore::execution_phrase()
+                );
                 1
             }
             (Some(major), Some(minor)) => {
@@ -145,7 +151,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .usage(USAGE)
         .after_help(LONG_HELP)

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -18,7 +18,6 @@ use libc::{S_IFBLK, S_IFCHR, S_IFIFO, S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOT
 
 use uucore::InvalidEncodingHandling;
 
-static NAME: &str = "mknod";
 static ABOUT: &str = "Create the special file NAME of the given TYPE.";
 static USAGE: &str = "mknod [OPTION]... NAME TYPE [MAJOR MINOR]";
 static LONG_HELP: &str = "Mandatory arguments to long options are mandatory for short options too.
@@ -72,7 +71,8 @@ fn _mknod(file_name: &str, mode: mode_t, dev: dev_t) -> i32 {
         }
 
         if errno == -1 {
-            let c_str = CString::new(NAME).expect("Failed to convert to CString");
+            let c_str =
+                CString::new(execution_phrase!().as_bytes()).expect("Failed to convert to CString");
             // shows the error from the mknod syscall
             libc::perror(c_str.as_ptr());
         }
@@ -113,7 +113,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if ch == 'p' {
         if matches.is_present("major") || matches.is_present("minor") {
             eprintln!("Fifos do not have major and minor device numbers.");
-            eprintln!("Try `{} --help` for more information.", NAME);
+            eprintln!("Try `{} --help` for more information.", execution_phrase!());
             1
         } else {
             _mknod(file_name, S_IFIFO | mode, 0)
@@ -122,7 +122,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         match (matches.value_of("major"), matches.value_of("minor")) {
             (None, None) | (_, None) | (None, _) => {
                 eprintln!("Special files require major and minor device numbers.");
-                eprintln!("Try `{} --help` for more information.", NAME);
+                eprintln!("Try `{} --help` for more information.", execution_phrase!());
                 1
             }
             (Some(major), Some(minor)) => {

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -113,7 +113,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if ch == 'p' {
         if matches.is_present("major") || matches.is_present("minor") {
             eprintln!("Fifos do not have major and minor device numbers.");
-            eprintln!("Try `{} --help` for more information.", execution_phrase!());
+            eprintln!("Try '{} --help' for more information.", execution_phrase!());
             1
         } else {
             _mknod(file_name, S_IFIFO | mode, 0)
@@ -122,7 +122,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         match (matches.value_of("major"), matches.value_of("minor")) {
             (None, None) | (_, None) | (None, _) => {
                 eprintln!("Special files require major and minor device numbers.");
-                eprintln!("Try `{} --help` for more information.", execution_phrase!());
+                eprintln!("Try '{} --help' for more information.", execution_phrase!());
                 1
             }
             (Some(major), Some(minor)) => {

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -36,7 +36,7 @@ static OPT_T: &str = "t";
 
 static ARG_TEMPLATE: &str = "template";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [TEMPLATE]", executable!())
 }
 
@@ -74,7 +74,7 @@ impl Display for MkTempError {
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -134,7 +134,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -37,7 +37,7 @@ static OPT_T: &str = "t";
 static ARG_TEMPLATE: &str = "template";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [TEMPLATE]", executable!())
+    format!("{0} [OPTION]... [TEMPLATE]", execution_phrase!())
 }
 
 #[derive(Debug)]

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -37,7 +37,7 @@ static OPT_T: &str = "t";
 static ARG_TEMPLATE: &str = "template";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [TEMPLATE]", execution_phrase!())
+    format!("{0} [OPTION]... [TEMPLATE]", uucore::execution_phrase())
 }
 
 #[derive(Debug)]
@@ -134,7 +134,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -93,7 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .about("A file perusal filter for CRT viewing.")
         .version(crate_version!())
         .arg(

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -93,7 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .about("A file perusal filter for CRT viewing.")
         .version(crate_version!())
         .arg(

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -58,7 +58,7 @@ static OPT_VERBOSE: &str = "verbose";
 
 static ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... [-T] SOURCE DEST
 {0} [OPTION]... SOURCE... DIRECTORY
@@ -68,7 +68,7 @@ fn get_usage() -> String {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app()
         .after_help(&*format!(

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -63,7 +63,7 @@ fn usage() -> String {
         "{0} [OPTION]... [-T] SOURCE DEST
 {0} [OPTION]... SOURCE... DIRECTORY
 {0} [OPTION]... -t DIRECTORY SOURCE...",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -133,7 +133,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
     .arg(
@@ -296,7 +296,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
                     "mv: extra operand '{}'\n\
                      Try '{} --help' for more information.",
                     files[2].display(),
-                    execution_phrase!()
+                    uucore::execution_phrase()
                 );
                 return 1;
             }
@@ -353,7 +353,7 @@ fn rename(from: &Path, to: &Path, b: &Behavior) -> io::Result<()> {
         match b.overwrite {
             OverwriteMode::NoClobber => return Ok(()),
             OverwriteMode::Interactive => {
-                println!("{}: overwrite '{}'? ", util_name!(), to.display());
+                println!("{}: overwrite '{}'? ", uucore::util_name(), to.display());
                 if !read_yes() {
                     return Ok(());
                 }

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -133,7 +133,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
     .arg(

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -294,7 +294,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
             if b.no_target_dir {
                 show_error!(
                     "mv: extra operand '{}'\n\
-                     Try `{} --help` for more information.",
+                     Try '{} --help' for more information.",
                     files[2].display(),
                     execution_phrase!()
                 );

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -294,7 +294,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
             if b.no_target_dir {
                 show_error!(
                     "mv: extra operand '{}'\n\
-                     Try '{} --help' for more information.",
+                     Try `{} --help` for more information.",
                     files[2].display(),
                     executable!()
                 );

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -63,7 +63,7 @@ fn usage() -> String {
         "{0} [OPTION]... [-T] SOURCE DEST
 {0} [OPTION]... SOURCE... DIRECTORY
 {0} [OPTION]... -t DIRECTORY SOURCE...",
-        executable!()
+        execution_phrase!()
     )
 }
 
@@ -296,7 +296,7 @@ fn exec(files: &[PathBuf], b: Behavior) -> i32 {
                     "mv: extra operand '{}'\n\
                      Try `{} --help` for more information.",
                     files[2].display(),
-                    executable!()
+                    execution_phrase!()
                 );
                 return 1;
             }
@@ -353,7 +353,7 @@ fn rename(from: &Path, to: &Path, b: &Behavior) -> io::Result<()> {
         match b.overwrite {
             OverwriteMode::NoClobber => return Ok(()),
             OverwriteMode::Interactive => {
-                println!("{}: overwrite '{}'? ", executable!(), to.display());
+                println!("{}: overwrite '{}'? ", util_name!(), to.display());
                 if !read_yes() {
                     return Ok(());
                 }

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -31,7 +31,7 @@ Run COMMAND with an adjusted niceness, which affects process scheduling.
 With no COMMAND, print the current niceness.  Niceness values range from at
 least -20 (most favorable to the process) to 19 (least favorable to the
 process).",
-        executable!()
+        execution_phrase!()
     )
 }
 
@@ -54,7 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             if !matches.is_present(options::COMMAND) {
                 show_error!(
                     "A command must be given with an adjustment.\nTry `{} --help` for more information.",
-                    executable!()
+                    execution_phrase!()
                 );
                 return 125;
             }

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -53,7 +53,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         Some(nstr) => {
             if !matches.is_present(options::COMMAND) {
                 show_error!(
-                    "A command must be given with an adjustment.\nTry `{} --help` for more information.",
+                    "A command must be given with an adjustment.\nTry '{} --help' for more information.",
                     execution_phrase!()
                 );
                 return 125;

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -101,7 +101,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .setting(AppSettings::TrailingVarArg)
         .version(crate_version!())
         .arg(

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -22,7 +22,7 @@ pub mod options {
     pub static COMMAND: &str = "COMMAND";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "
   {0} [OPTIONS] [COMMAND [ARGS]]
@@ -36,7 +36,7 @@ process).",
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -31,7 +31,7 @@ Run COMMAND with an adjusted niceness, which affects process scheduling.
 With no COMMAND, print the current niceness.  Niceness values range from at
 least -20 (most favorable to the process) to 19 (least favorable to the
 process).",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -54,7 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             if !matches.is_present(options::COMMAND) {
                 show_error!(
                     "A command must be given with an adjustment.\nTry '{} --help' for more information.",
-                    execution_phrase!()
+                    uucore::execution_phrase()
                 );
                 return 125;
             }
@@ -101,7 +101,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .setting(AppSettings::TrailingVarArg)
         .version(crate_version!())
         .arg(

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -53,7 +53,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         Some(nstr) => {
             if !matches.is_present(options::COMMAND) {
                 show_error!(
-                    "A command must be given with an adjustment.\nTry \"{} --help\" for more information.",
+                    "A command must be given with an adjustment.\nTry `{} --help` for more information.",
                     executable!()
                 );
                 return 125;

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -143,7 +143,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -143,7 +143,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -40,7 +40,7 @@ mod options {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
@@ -156,7 +156,7 @@ fn find_stdout() -> File {
     }
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} COMMAND [ARG]...\n    {0} FLAG", executable!())
 }
 

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -71,7 +71,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -157,7 +157,7 @@ fn find_stdout() -> File {
 }
 
 fn usage() -> String {
-    format!("{0} COMMAND [ARG]...\n    {0} FLAG", executable!())
+    format!("{0} COMMAND [ARG]...\n    {0} FLAG", execution_phrase!())
 }
 
 #[cfg(target_vendor = "apple")]

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -71,7 +71,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
@@ -157,7 +157,10 @@ fn find_stdout() -> File {
 }
 
 fn usage() -> String {
-    format!("{0} COMMAND [ARG]...\n    {0} FLAG", execution_phrase!())
+    format!(
+        "{0} COMMAND [ARG]...\n    {0} FLAG",
+        uucore::execution_phrase()
+    )
 }
 
 #[cfg(target_vendor = "apple")]

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -27,12 +27,12 @@ static OPT_IGNORE: &str = "ignore";
 
 static ABOUT: &str = "Print the number of cores available to the current process.";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTIONS]...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mut ignore = match matches.value_of(OPT_IGNORE) {

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -70,7 +70,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -28,7 +28,7 @@ static OPT_IGNORE: &str = "ignore";
 static ABOUT: &str = "Print the number of cores available to the current process.";
 
 fn usage() -> String {
-    format!("{0} [OPTIONS]...", executable!())
+    format!("{0} [OPTIONS]...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -28,7 +28,7 @@ static OPT_IGNORE: &str = "ignore";
 static ABOUT: &str = "Print the number of cores available to the current process.";
 
 fn usage() -> String {
-    format!("{0} [OPTIONS]...", execution_phrase!())
+    format!("{0} [OPTIONS]...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -70,7 +70,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -175,7 +175,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -50,7 +50,7 @@ FIELDS supports cut(1) style field ranges:
 Multiple fields/ranges can be separated with commas
 ";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [NUMBER]...", executable!())
 }
 
@@ -154,7 +154,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -51,7 +51,7 @@ Multiple fields/ranges can be separated with commas
 ";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [NUMBER]...", execution_phrase!())
+    format!("{0} [OPTION]... [NUMBER]...", uucore::execution_phrase())
 }
 
 fn handle_args<'a>(args: impl Iterator<Item = &'a str>, options: NumfmtOptions) -> Result<()> {
@@ -175,7 +175,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -51,7 +51,7 @@ Multiple fields/ranges can be separated with commas
 ";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [NUMBER]...", executable!())
+    format!("{0} [OPTION]... [NUMBER]...", execution_phrase!())
 }
 
 fn handle_args<'a>(args: impl Iterator<Item = &'a str>, options: NumfmtOptions) -> Result<()> {

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -57,7 +57,7 @@ impl<'b> MultifileReader<'b> {
                             // print an error at the time that the file is needed,
                             // then move on the the next file.
                             // This matches the behavior of the original `od`
-                            eprintln!("{}: '{}': {}", util_name!(), fname, e);
+                            eprintln!("{}: '{}': {}", uucore::util_name(), fname, e);
                             self.any_err = true
                         }
                     }
@@ -90,7 +90,7 @@ impl<'b> io::Read for MultifileReader<'b> {
                             Ok(0) => break,
                             Ok(n) => n,
                             Err(e) => {
-                                eprintln!("{}: I/O: {}", util_name!(), e);
+                                eprintln!("{}: I/O: {}", uucore::util_name(), e);
                                 self.any_err = true;
                                 break;
                             }

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -57,12 +57,7 @@ impl<'b> MultifileReader<'b> {
                             // print an error at the time that the file is needed,
                             // then move on the the next file.
                             // This matches the behavior of the original `od`
-                            eprintln!(
-                                "{}: '{}': {}",
-                                executable!().split("::").next().unwrap(), // remove module
-                                fname,
-                                e
-                            );
+                            eprintln!("{}: '{}': {}", util_name!(), fname, e);
                             self.any_err = true
                         }
                     }
@@ -95,11 +90,7 @@ impl<'b> io::Read for MultifileReader<'b> {
                             Ok(0) => break,
                             Ok(n) => n,
                             Err(e) => {
-                                eprintln!(
-                                    "{}: I/O: {}",
-                                    executable!().split("::").next().unwrap(), // remove module
-                                    e
-                                );
+                                eprintln!("{}: I/O: {}", util_name!(), e);
                                 self.any_err = true;
                                 break;
                             }

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -252,7 +252,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> clap::App<'static, 'static> {
-    clap::App::new(executable!())
+    clap::App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .usage(USAGE)

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -252,7 +252,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> clap::App<'static, 'static> {
-    clap::App::new(util_name!())
+    clap::App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .usage(USAGE)

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -52,7 +52,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -52,7 +52,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -39,12 +39,12 @@ mod options {
 const POSIX_PATH_MAX: usize = 256;
 const POSIX_NAME_MAX: usize = 14;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... NAME...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -96,7 +96,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -25,7 +25,6 @@ enum Mode {
     Both,    // a combination of `Basic` and `Extra`
 }
 
-static NAME: &str = "pathchk";
 static ABOUT: &str = "Check whether file names are valid or portable";
 
 mod options {
@@ -40,7 +39,7 @@ const POSIX_PATH_MAX: usize = 256;
 const POSIX_NAME_MAX: usize = 14;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... NAME...", executable!())
+    format!("{0} [OPTION]... NAME...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -71,7 +70,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let mut res = if paths.is_none() {
         show_error!(
             "missing operand\nTry `{} --help` for more information",
-            NAME
+            execution_phrase!()
         );
         false
     } else {

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -69,7 +69,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     // take necessary actions
     let paths = matches.values_of(options::PATH);
     let mut res = if paths.is_none() {
-        show_error!("missing operand\nTry {} --help for more information", NAME);
+        show_error!(
+            "missing operand\nTry `{} --help` for more information",
+            NAME
+        );
         false
     } else {
         true

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -39,7 +39,7 @@ const POSIX_PATH_MAX: usize = 256;
 const POSIX_NAME_MAX: usize = 14;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... NAME...", execution_phrase!())
+    format!("{0} [OPTION]... NAME...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -70,7 +70,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let mut res = if paths.is_none() {
         show_error!(
             "missing operand\nTry '{} --help' for more information",
-            execution_phrase!()
+            uucore::execution_phrase()
         );
         false
     } else {
@@ -98,7 +98,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -69,7 +69,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let paths = matches.values_of(options::PATH);
     let mut res = if paths.is_none() {
         show_error!(
-            "missing operand\nTry `{} --help` for more information",
+            "missing operand\nTry '{} --help' for more information",
             execution_phrase!()
         );
         false

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -130,7 +130,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -40,7 +40,7 @@ mod options {
     pub const USER: &str = "user";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [USER]...", executable!())
 }
 
@@ -57,7 +57,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
     let after_help = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -41,7 +41,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]...", executable!())
+    format!("{0} [OPTION]... [USER]...", execution_phrase!())
 }
 
 fn get_long_usage() -> String {

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -41,7 +41,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]...", execution_phrase!())
+    format!("{0} [OPTION]... [USER]...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -130,7 +130,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -23,7 +23,6 @@ use std::fs::{metadata, File};
 use std::io::{stdin, stdout, BufRead, BufReader, Lines, Read, Stdout, Write};
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
-use uucore::util_name;
 
 type IOError = std::io::Error;
 
@@ -170,7 +169,7 @@ quick_error! {
 
 pub fn uu_app() -> clap::App<'static, 'static> {
     // TODO: migrate to clap to get more shell completions
-    clap::App::new(util_name!())
+    clap::App::new(uucore::util_name())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -23,7 +23,7 @@ use std::fs::{metadata, File};
 use std::io::{stdin, stdout, BufRead, BufReader, Lines, Read, Stdout, Write};
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
-use uucore::executable;
+use uucore::util_name;
 
 type IOError = std::io::Error;
 
@@ -170,7 +170,7 @@ quick_error! {
 
 pub fn uu_app() -> clap::App<'static, 'static> {
     // TODO: migrate to clap to get more shell completions
-    clap::App::new(executable!())
+    clap::App::new(util_name!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -19,12 +19,12 @@ static OPT_NULL: &str = "null";
 
 static ARG_VARIABLES: &str = "variables";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [VARIABLE]... [OPTION]...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -55,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -20,7 +20,7 @@ static OPT_NULL: &str = "null";
 static ARG_VARIABLES: &str = "variables";
 
 fn usage() -> String {
-    format!("{0} [VARIABLE]... [OPTION]...", executable!())
+    format!("{0} [VARIABLE]... [OPTION]...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -7,9 +7,6 @@
 
 /* last synced with: printenv (GNU coreutils) 8.13 */
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, App, Arg};
 use std::env;
 
@@ -20,7 +17,7 @@ static OPT_NULL: &str = "null";
 static ARG_VARIABLES: &str = "variables";
 
 fn usage() -> String {
-    format!("{0} [VARIABLE]... [OPTION]...", execution_phrase!())
+    format!("{0} [VARIABLE]... [OPTION]...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -55,7 +52,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -303,7 +303,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .arg(Arg::with_name(VERSION).long(VERSION))
         .arg(Arg::with_name(HELP).long(HELP))
 }

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -284,7 +284,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let location = &args[0];
     if args.len() <= 1 {
         println!(
-            "{0}: missing operand\nTry '{0} --help' for more information.",
+            "{0}: missing operand\nTry `{0} --help` for more information.",
             location
         );
         return 1;

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -281,11 +281,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let location = &args[0];
     if args.len() <= 1 {
         println!(
-            "{0}: missing operand\nTry `{0} --help` for more information.",
-            location
+            "{0}: missing operand\nTry `{1} --help` for more information.",
+            util_name!(),
+            execution_phrase!()
         );
         return 1;
     }
@@ -294,7 +294,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if formatstr == "--help" {
         print!("{} {}", LONGHELP_LEAD, LONGHELP_BODY);
     } else if formatstr == "--version" {
-        println!("{} {}", executable!(), crate_version!());
+        println!("{} {}", util_name!(), crate_version!());
     } else {
         let printf_args = &args[2..];
         memo::Memo::run_all(formatstr, printf_args);

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -283,7 +283,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if args.len() <= 1 {
         println!(
-            "{0}: missing operand\nTry `{1} --help` for more information.",
+            "{0}: missing operand\nTry '{1} --help' for more information.",
             util_name!(),
             execution_phrase!()
         );

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -2,9 +2,6 @@
 // spell-checker:ignore (change!) each's
 // spell-checker:ignore (ToDO) LONGHELP FORMATSTRING templating parameterizing formatstr
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, App, Arg};
 use uucore::InvalidEncodingHandling;
 
@@ -284,8 +281,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if args.len() <= 1 {
         println!(
             "{0}: missing operand\nTry '{1} --help' for more information.",
-            util_name!(),
-            execution_phrase!()
+            uucore::util_name(),
+            uucore::execution_phrase()
         );
         return 1;
     }
@@ -294,7 +291,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if formatstr == "--help" {
         print!("{} {}", LONGHELP_LEAD, LONGHELP_BODY);
     } else if formatstr == "--version" {
-        println!("{} {}", util_name!(), crate_version!());
+        println!("{} {}", uucore::util_name(), crate_version!());
     } else {
         let printf_args = &args[2..];
         memo::Memo::run_all(formatstr, printf_args);
@@ -303,7 +300,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .arg(Arg::with_name(VERSION).long(VERSION))
         .arg(Arg::with_name(HELP).long(HELP))
 }

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -659,7 +659,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(BRIEF)

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -659,7 +659,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(BRIEF)

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -35,7 +35,7 @@ pub fn absolute_path(path: &Path) -> io::Result<PathBuf> {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", execution_phrase!())
+    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
 #[uucore_procs::gen_uumain]
@@ -66,7 +66,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -35,7 +35,7 @@ pub fn absolute_path(path: &Path) -> io::Result<PathBuf> {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", executable!())
+    format!("{0} [OPTION]... FILE...", execution_phrase!())
 }
 
 #[uucore_procs::gen_uumain]

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -66,7 +66,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -34,13 +34,13 @@ pub fn absolute_path(path: &Path) -> io::Result<PathBuf> {
     Ok(path_buf)
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... FILE...", executable!())
 }
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -98,7 +98,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -29,12 +29,12 @@ const OPT_ZERO: &str = "zero";
 
 const ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let mut no_newline = matches.is_present(OPT_NO_NEWLINE);

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -58,7 +58,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if files.is_empty() {
         crash!(
             1,
-            "missing operand\nTry `{} --help` for more information",
+            "missing operand\nTry '{} --help' for more information",
             execution_phrase!()
         );
     }

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -16,7 +16,6 @@ use std::io::{stdout, Write};
 use std::path::{Path, PathBuf};
 use uucore::fs::{canonicalize, CanonicalizeMode};
 
-const NAME: &str = "readlink";
 const ABOUT: &str = "Print value of a symbolic link or canonical file name.";
 const OPT_CANONICALIZE: &str = "canonicalize";
 const OPT_CANONICALIZE_MISSING: &str = "canonicalize-missing";
@@ -30,7 +29,7 @@ const OPT_ZERO: &str = "zero";
 const ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", executable!())
+    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -60,12 +59,15 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "missing operand\nTry `{} --help` for more information",
-            NAME
+            execution_phrase!()
         );
     }
 
     if no_newline && files.len() > 1 && !silent {
-        eprintln!("{}: ignoring --no-newline with multiple arguments", NAME);
+        eprintln!(
+            "{}: ignoring --no-newline with multiple arguments",
+            util_name!()
+        );
         no_newline = false;
     }
 
@@ -76,7 +78,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 Ok(path) => show(&path, no_newline, use_zero),
                 Err(err) => {
                     if verbose {
-                        eprintln!("{}: {}: errno {}", NAME, f, err.raw_os_error().unwrap());
+                        eprintln!(
+                            "{}: {}: errno {}",
+                            util_name!(),
+                            f,
+                            err.raw_os_error().unwrap()
+                        );
                     }
                     return 1;
                 }
@@ -86,7 +93,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 Ok(path) => show(&path, no_newline, use_zero),
                 Err(err) => {
                     if verbose {
-                        eprintln!("{}: {}: errno {:?}", NAME, f, err.raw_os_error().unwrap());
+                        eprintln!(
+                            "{}: {}: errno {:?}",
+                            util_name!(),
+                            f,
+                            err.raw_os_error().unwrap()
+                        );
                     }
                     return 1;
                 }

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -59,7 +59,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if files.is_empty() {
         crash!(
             1,
-            "missing operand\nTry {} --help for more information",
+            "missing operand\nTry `{} --help` for more information",
             NAME
         );
     }

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -29,7 +29,7 @@ const OPT_ZERO: &str = "zero";
 const ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -59,14 +59,14 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "missing operand\nTry '{} --help' for more information",
-            execution_phrase!()
+            uucore::execution_phrase()
         );
     }
 
     if no_newline && files.len() > 1 && !silent {
         eprintln!(
             "{}: ignoring --no-newline with multiple arguments",
-            util_name!()
+            uucore::util_name()
         );
         no_newline = false;
     }
@@ -80,7 +80,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     if verbose {
                         eprintln!(
                             "{}: {}: errno {}",
-                            util_name!(),
+                            uucore::util_name(),
                             f,
                             err.raw_os_error().unwrap()
                         );
@@ -95,7 +95,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     if verbose {
                         eprintln!(
                             "{}: {}: errno {:?}",
-                            util_name!(),
+                            uucore::util_name(),
                             f,
                             err.raw_os_error().unwrap()
                         );
@@ -110,7 +110,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -55,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -22,12 +22,12 @@ static OPT_ZERO: &str = "zero";
 
 static ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... FILE...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -23,7 +23,7 @@ static OPT_ZERO: &str = "zero";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", execution_phrase!())
+    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -55,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -23,7 +23,7 @@ static OPT_ZERO: &str = "zero";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", executable!())
+    format!("{0} [OPTION]... FILE...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -25,7 +25,7 @@ mod options {
     pub const FROM: &str = "FROM";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{} [-d DIR] TO [FROM]", executable!())
 }
 
@@ -33,7 +33,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -82,7 +82,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -26,7 +26,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{} [-d DIR] TO [FROM]", executable!())
+    format!("{} [-d DIR] TO [FROM]", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) subpath absto absfrom absbase
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, App, Arg};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -26,7 +23,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{} [-d DIR] TO [FROM]", execution_phrase!())
+    format!("{} [-d DIR] TO [FROM]", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -82,7 +79,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -140,7 +140,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
 

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -52,7 +52,7 @@ static OPT_VERBOSE: &str = "verbose";
 
 static ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... FILE...", executable!())
 }
 
@@ -74,7 +74,7 @@ fn get_long_usage() -> String {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let long_usage = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -53,7 +53,7 @@ static OPT_VERBOSE: &str = "verbose";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", executable!())
+    format!("{0} [OPTION]... FILE...", execution_phrase!())
 }
 
 fn get_long_usage() -> String {
@@ -93,7 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         // Still check by hand and not use clap
         // Because "rm -f" is a thing
         show_error!("missing an argument");
-        show_error!("for help, try '{0} --help'", executable!());
+        show_error!("for help, try '{0} --help'", execution_phrase!());
         return 1;
     } else {
         let options = Options {

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -53,7 +53,7 @@ static OPT_VERBOSE: &str = "verbose";
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", execution_phrase!())
+    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -93,7 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         // Still check by hand and not use clap
         // Because "rm -f" is a thing
         show_error!("missing an argument");
-        show_error!("for help, try '{0} --help'", execution_phrase!());
+        show_error!("for help, try '{0} --help'", uucore::execution_phrase());
         return 1;
     } else {
         let options = Options {
@@ -140,7 +140,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
 

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -53,7 +53,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -26,12 +26,12 @@ static ENOTDIR: i32 = 20;
 #[cfg(windows)]
 static ENOTDIR: i32 = 267;
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... DIRECTORY...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -27,7 +27,7 @@ static ENOTDIR: i32 = 20;
 static ENOTDIR: i32 = 267;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... DIRECTORY...", execution_phrase!())
+    format!("{0} [OPTION]... DIRECTORY...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -53,7 +53,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -27,7 +27,7 @@ static ENOTDIR: i32 = 20;
 static ENOTDIR: i32 = 267;
 
 fn usage() -> String {
-    format!("{0} [OPTION]... DIRECTORY...", executable!())
+    format!("{0} [OPTION]... DIRECTORY...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -22,7 +22,7 @@ static OPT_WIDTHS: &str = "widths";
 
 static ARG_NUMBERS: &str = "numbers";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... LAST
     {0} [OPTION]... FIRST LAST
@@ -86,7 +86,7 @@ impl FromStr for Number {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let numbers = matches.values_of(ARG_NUMBERS).unwrap().collect::<Vec<_>>();

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -163,7 +163,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .setting(AppSettings::AllowLeadingHyphen)
         .version(crate_version!())
         .about(ABOUT)

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -70,13 +70,13 @@ impl FromStr for Number {
             Ok(n) => Ok(Number::BigInt(n)),
             Err(_) => match s.parse::<f64>() {
                 Ok(value) if value.is_nan() => Err(format!(
-                    "invalid 'not-a-number' argument: '{}'\nTry '{} --help' for more information.",
+                    "invalid 'not-a-number' argument: '{}'\nTry `{} --help` for more information.",
                     s,
                     executable!(),
                 )),
                 Ok(value) => Ok(Number::F64(value)),
                 Err(_) => Err(format!(
-                    "invalid floating point argument: '{}'\nTry '{} --help' for more information.",
+                    "invalid floating point argument: '{}'\nTry `{} --help` for more information.",
                     s,
                     executable!(),
                 )),
@@ -121,7 +121,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     };
     if increment.is_zero() {
         show_error!(
-            "invalid Zero increment value: '{}'\nTry '{} --help' for more information.",
+            "invalid Zero increment value: '{}'\nTry `{} --help` for more information.",
             numbers[1],
             executable!()
         );

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -27,7 +27,7 @@ fn usage() -> String {
         "{0} [OPTION]... LAST
     {0} [OPTION]... FIRST LAST
     {0} [OPTION]... FIRST INCREMENT LAST",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 #[derive(Clone)]
@@ -72,13 +72,13 @@ impl FromStr for Number {
                 Ok(value) if value.is_nan() => Err(format!(
                     "invalid 'not-a-number' argument: '{}'\nTry '{} --help' for more information.",
                     s,
-                    execution_phrase!(),
+                    uucore::execution_phrase(),
                 )),
                 Ok(value) => Ok(Number::F64(value)),
                 Err(_) => Err(format!(
                     "invalid floating point argument: '{}'\nTry '{} --help' for more information.",
                     s,
-                    execution_phrase!(),
+                    uucore::execution_phrase(),
                 )),
             },
         }
@@ -123,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         show_error!(
             "invalid Zero increment value: '{}'\nTry '{} --help' for more information.",
             numbers[1],
-            execution_phrase!()
+            uucore::execution_phrase()
         );
         return 1;
     }
@@ -163,7 +163,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .setting(AppSettings::AllowLeadingHyphen)
         .version(crate_version!())
         .about(ABOUT)

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -27,7 +27,7 @@ fn usage() -> String {
         "{0} [OPTION]... LAST
     {0} [OPTION]... FIRST LAST
     {0} [OPTION]... FIRST INCREMENT LAST",
-        executable!()
+        execution_phrase!()
     )
 }
 #[derive(Clone)]
@@ -72,13 +72,13 @@ impl FromStr for Number {
                 Ok(value) if value.is_nan() => Err(format!(
                     "invalid 'not-a-number' argument: '{}'\nTry `{} --help` for more information.",
                     s,
-                    executable!(),
+                    execution_phrase!(),
                 )),
                 Ok(value) => Ok(Number::F64(value)),
                 Err(_) => Err(format!(
                     "invalid floating point argument: '{}'\nTry `{} --help` for more information.",
                     s,
-                    executable!(),
+                    execution_phrase!(),
                 )),
             },
         }
@@ -123,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         show_error!(
             "invalid Zero increment value: '{}'\nTry `{} --help` for more information.",
             numbers[1],
-            executable!()
+            execution_phrase!()
         );
         return 1;
     }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -70,13 +70,13 @@ impl FromStr for Number {
             Ok(n) => Ok(Number::BigInt(n)),
             Err(_) => match s.parse::<f64>() {
                 Ok(value) if value.is_nan() => Err(format!(
-                    "invalid 'not-a-number' argument: '{}'\nTry `{} --help` for more information.",
+                    "invalid 'not-a-number' argument: '{}'\nTry '{} --help' for more information.",
                     s,
                     execution_phrase!(),
                 )),
                 Ok(value) => Ok(Number::F64(value)),
                 Err(_) => Err(format!(
-                    "invalid floating point argument: '{}'\nTry `{} --help` for more information.",
+                    "invalid floating point argument: '{}'\nTry '{} --help' for more information.",
                     s,
                     execution_phrase!(),
                 )),
@@ -121,7 +121,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     };
     if increment.is_zero() {
         show_error!(
-            "invalid Zero increment value: '{}'\nTry `{} --help` for more information.",
+            "invalid Zero increment value: '{}'\nTry '{} --help' for more information.",
             numbers[1],
             execution_phrase!()
         );

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -330,7 +330,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(AFTER_HELP)

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -213,7 +213,7 @@ static ABOUT: &str = "Overwrite the specified FILE(s) repeatedly, in order to ma
 for even very expensive hardware probing to recover the data.
 ";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{} [OPTION]... FILE...", executable!())
 }
 
@@ -270,7 +270,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let app = uu_app().usage(&usage[..]);
 

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -214,7 +214,7 @@ for even very expensive hardware probing to recover the data.
 ";
 
 fn usage() -> String {
-    format!("{} [OPTION]... FILE...", execution_phrase!())
+    format!("{} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
 static AFTER_HELP: &str =
@@ -330,7 +330,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(AFTER_HELP)

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -214,7 +214,7 @@ for even very expensive hardware probing to recover the data.
 ";
 
 fn usage() -> String {
-    format!("{} [OPTION]... FILE...", executable!())
+    format!("{} [OPTION]... FILE...", execution_phrase!())
 }
 
 static AFTER_HELP: &str =

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -115,7 +115,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .template(TEMPLATE)

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -115,7 +115,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .template(TEMPLATE)

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -49,7 +49,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -26,7 +26,7 @@ mod options {
     pub const NUMBER: &str = "NUMBER";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} {1}[SUFFIX]... \n    {0} OPTION",
         executable!(),
@@ -36,7 +36,7 @@ fn get_usage() -> String {
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -29,7 +29,7 @@ mod options {
 fn usage() -> String {
     format!(
         "{0} {1}[SUFFIX]... \n    {0} OPTION",
-        executable!(),
+        execution_phrase!(),
         options::NUMBER
     )
 }

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -29,7 +29,7 @@ mod options {
 fn usage() -> String {
     format!(
         "{0} {1}[SUFFIX]... \n    {0} OPTION",
-        execution_phrase!(),
+        uucore::execution_phrase(),
         options::NUMBER
     )
 }
@@ -49,7 +49,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1287,7 +1287,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1055,7 +1055,7 @@ impl FieldSelector {
     }
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... [FILE]...
 Write the sorted concatenation of all FILE(s) to standard output.
@@ -1081,7 +1081,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
-    let usage = get_usage();
+    let usage = usage();
     let mut settings: GlobalSettings = Default::default();
 
     let matches = match uu_app().usage(&usage[..]).get_matches_from_safe(args) {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1060,7 +1060,7 @@ fn usage() -> String {
 Write the sorted concatenation of all FILE(s) to standard output.
 Mandatory arguments for long options are mandatory for short options too.
 With no FILE, or when FILE is -, read standard input.",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -1286,7 +1286,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -52,7 +52,6 @@ use uucore::InvalidEncodingHandling;
 
 use crate::tmp_dir::TmpDirWrapper;
 
-const NAME: &str = "sort";
 const ABOUT: &str = "Display sorted concatenation of all FILE(s).";
 
 const LONG_HELP_KEYS: &str = "The key format is FIELD[.CHAR][OPTIONS][,FIELD[.CHAR]][OPTIONS].
@@ -1061,7 +1060,7 @@ fn usage() -> String {
 Write the sorted concatenation of all FILE(s) to standard output.
 Mandatory arguments for long options are mandatory for short options too.
 With no FILE, or when FILE is -, read standard input.",
-        NAME
+        execution_phrase!()
     )
 }
 

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -36,7 +36,7 @@ static OPT_VERBOSE: &str = "verbose";
 static ARG_INPUT: &str = "input";
 static ARG_PREFIX: &str = "prefix";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [INPUT [PREFIX]]", NAME)
 }
 fn get_long_usage() -> String {
@@ -47,12 +47,12 @@ fn get_long_usage() -> String {
 Output fixed-size pieces of INPUT to PREFIXaa, PREFIX ab, ...; default
 size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is
 -, read standard input.",
-        get_usage()
+        usage()
     )
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let long_usage = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -127,7 +127,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about("Create output files containing consecutive or interleaved sections of input")
         // strategy (mutually exclusive)

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -35,7 +35,10 @@ static ARG_INPUT: &str = "input";
 static ARG_PREFIX: &str = "prefix";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [INPUT [PREFIX]]", execution_phrase!())
+    format!(
+        "{0} [OPTION]... [INPUT [PREFIX]]",
+        uucore::execution_phrase()
+    )
 }
 fn get_long_usage() -> String {
     format!(
@@ -125,7 +128,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about("Create output files containing consecutive or interleaved sections of input")
         // strategy (mutually exclusive)

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -21,8 +21,6 @@ use std::path::Path;
 use std::{char, fs::remove_file};
 use uucore::parse_size::parse_size;
 
-static NAME: &str = "split";
-
 static OPT_BYTES: &str = "bytes";
 static OPT_LINE_BYTES: &str = "line-bytes";
 static OPT_LINES: &str = "lines";
@@ -37,7 +35,7 @@ static ARG_INPUT: &str = "input";
 static ARG_PREFIX: &str = "prefix";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [INPUT [PREFIX]]", NAME)
+    format!("{0} [OPTION]... [INPUT [PREFIX]]", execution_phrase!())
 }
 fn get_long_usage() -> String {
     format!(

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -963,7 +963,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -883,7 +883,7 @@ impl Stater {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", executable!())
+    format!("{0} [OPTION]... FILE...", execution_phrase!())
 }
 
 fn get_long_usage() -> String {

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -882,7 +882,7 @@ impl Stater {
     }
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... FILE...", executable!())
 }
 
@@ -945,7 +945,7 @@ for details about the options it supports.
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let long_usage = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -883,7 +883,7 @@ impl Stater {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", execution_phrase!())
+    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -963,7 +963,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -47,7 +47,7 @@ mod options {
     pub const COMMAND: &str = "command";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} OPTION... COMMAND", executable!())
 }
 
@@ -152,7 +152,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -185,7 +185,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -48,7 +48,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} OPTION... COMMAND", executable!())
+    format!("{0} OPTION... COMMAND", execution_phrase!())
 }
 
 const STDBUF_INJECT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/libstdbuf.so"));
@@ -161,7 +161,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             125,
             "{}\nTry `{} --help` for more information.",
             e.0,
-            executable!()
+            execution_phrase!()
         )
     });
 

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -156,8 +156,14 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
-    let options = ProgramOptions::try_from(&matches)
-        .unwrap_or_else(|e| crash!(125, "{}\nTry 'stdbuf --help' for more information.", e.0));
+    let options = ProgramOptions::try_from(&matches).unwrap_or_else(|e| {
+        crash!(
+            125,
+            "{}\nTry `{} --help` for more information.",
+            e.0,
+            executable!()
+        )
+    });
 
     let mut command_values = matches.values_of::<&str>(options::COMMAND).unwrap();
     let mut command = Command::new(command_values.next().unwrap());

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -48,7 +48,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} OPTION... COMMAND", execution_phrase!())
+    format!("{0} OPTION... COMMAND", uucore::execution_phrase())
 }
 
 const STDBUF_INJECT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/libstdbuf.so"));
@@ -161,7 +161,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             125,
             "{}\nTry '{} --help' for more information.",
             e.0,
-            execution_phrase!()
+            uucore::execution_phrase()
         )
     });
 
@@ -191,7 +191,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -159,7 +159,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let options = ProgramOptions::try_from(&matches).unwrap_or_else(|e| {
         crash!(
             125,
-            "{}\nTry `{} --help` for more information.",
+            "{}\nTry '{} --help' for more information.",
             e.0,
             execution_phrase!()
         )

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -140,7 +140,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -140,7 +140,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -193,7 +193,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -159,12 +159,12 @@ mod platform {
     }
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... FILE...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -160,7 +160,7 @@ mod platform {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", executable!())
+    format!("{0} [OPTION]... FILE...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -160,7 +160,7 @@ mod platform {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", execution_phrase!())
+    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -193,7 +193,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -213,7 +213,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about("output the last part of files")
         // TODO: add usage

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -213,7 +213,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about("output the last part of files")
         // TODO: add usage

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -32,12 +32,12 @@ struct Options {
     files: Vec<String>,
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -57,7 +57,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .after_help("If a FILE is -, it refers to a file named - .")

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -33,7 +33,7 @@ struct Options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", executable!())
+    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -33,7 +33,7 @@ struct Options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -57,7 +57,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .after_help("If a FILE is -, it refers to a file named - .")

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -14,7 +14,6 @@ use clap::{crate_version, App, AppSettings};
 use parser::{parse, Symbol};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
-use uucore::util_name;
 
 const USAGE: &str = "test EXPRESSION
 or:  test
@@ -87,7 +86,7 @@ the version described here.  Please refer to your shell's documentation
 for details about the options it supports.";
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .setting(AppSettings::DisableHelpFlags)
         .setting(AppSettings::DisableVersion)
 }

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -14,7 +14,7 @@ use clap::{crate_version, App, AppSettings};
 use parser::{parse, Symbol};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
-use uucore::executable;
+use uucore::util_name;
 
 const USAGE: &str = "test EXPRESSION
 or:  test
@@ -87,7 +87,7 @@ the version described here.  Please refer to your shell's documentation
 for details about the options it supports.";
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .setting(AppSettings::DisableHelpFlags)
         .setting(AppSettings::DisableVersion)
 }

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -22,7 +22,7 @@ use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Start COMMAND, and kill it if still running after DURATION.";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION] DURATION COMMAND...", executable!())
 }
 
@@ -100,7 +100,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let app = uu_app().usage(&usage[..]);
 

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -23,7 +23,10 @@ use uucore::InvalidEncodingHandling;
 static ABOUT: &str = "Start COMMAND, and kill it if still running after DURATION.";
 
 fn usage() -> String {
-    format!("{0} [OPTION] DURATION COMMAND...", execution_phrase!())
+    format!(
+        "{0} [OPTION] DURATION COMMAND...",
+        uucore::execution_phrase()
+    )
 }
 
 const ERR_EXIT_STATUS: i32 = 125;

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -23,7 +23,7 @@ use uucore::InvalidEncodingHandling;
 static ABOUT: &str = "Start COMMAND, and kill it if still running after DURATION.";
 
 fn usage() -> String {
-    format!("{0} [OPTION] DURATION COMMAND...", executable!())
+    format!("{0} [OPTION] DURATION COMMAND...", execution_phrase!())
 }
 
 const ERR_EXIT_STATUS: i32 = 125;

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -129,7 +129,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -47,13 +47,13 @@ fn local_tm_to_filetime(tm: time::Tm) -> FileTime {
     FileTime::from_unix_time(ts.sec as i64, ts.nsec as u32)
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [USER]", executable!())
 }
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -48,7 +48,7 @@ fn local_tm_to_filetime(tm: time::Tm) -> FileTime {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]", executable!())
+    format!("{0} [OPTION]... [USER]", execution_phrase!())
 }
 
 #[uucore_procs::gen_uumain]

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -48,7 +48,7 @@ fn local_tm_to_filetime(tm: time::Tm) -> FileTime {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [USER]", execution_phrase!())
+    format!("{0} [OPTION]... [USER]", uucore::execution_phrase())
 }
 
 #[uucore_procs::gen_uumain]
@@ -129,7 +129,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -263,7 +263,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if sets.is_empty() {
         show_error!(
-            "missing operand\nTry `{} --help` for more information.",
+            "missing operand\nTry '{} --help' for more information.",
             execution_phrase!()
         );
         return 1;
@@ -271,7 +271,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if !(delete_flag || squeeze_flag) && sets.len() < 2 {
         show_error!(
-            "missing operand after '{}'\nTry `{} --help` for more information.",
+            "missing operand after '{}'\nTry '{} --help' for more information.",
             sets[0],
             execution_phrase!()
         );

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -229,7 +229,7 @@ fn translate_input<T: SymbolTranslator>(
 }
 
 fn usage() -> String {
-    format!("{} [OPTION]... SET1 [SET2]", executable!())
+    format!("{} [OPTION]... SET1 [SET2]", execution_phrase!())
 }
 
 fn get_long_usage() -> String {
@@ -264,7 +264,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if sets.is_empty() {
         show_error!(
             "missing operand\nTry `{} --help` for more information.",
-            executable!()
+            execution_phrase!()
         );
         return 1;
     }
@@ -273,7 +273,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         show_error!(
             "missing operand after '{}'\nTry `{} --help` for more information.",
             sets[0],
-            executable!()
+            execution_phrase!()
         );
         return 1;
     }

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -312,7 +312,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -228,7 +228,7 @@ fn translate_input<T: SymbolTranslator>(
     }
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{} [OPTION]... SET1 [SET2]", executable!())
 }
 
@@ -243,7 +243,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
     let after_help = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -229,7 +229,7 @@ fn translate_input<T: SymbolTranslator>(
 }
 
 fn usage() -> String {
-    format!("{} [OPTION]... SET1 [SET2]", execution_phrase!())
+    format!("{} [OPTION]... SET1 [SET2]", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -264,7 +264,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if sets.is_empty() {
         show_error!(
             "missing operand\nTry '{} --help' for more information.",
-            execution_phrase!()
+            uucore::execution_phrase()
         );
         return 1;
     }
@@ -273,7 +273,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         show_error!(
             "missing operand after '{}'\nTry '{} --help' for more information.",
             sets[0],
-            execution_phrase!()
+            uucore::execution_phrase()
         );
         return 1;
     }
@@ -312,7 +312,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -10,7 +10,6 @@ extern crate uucore;
 
 use clap::App;
 use uucore::error::UResult;
-use uucore::util_name;
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -19,5 +18,5 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
 }

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -10,7 +10,7 @@ extern crate uucore;
 
 use clap::App;
 use uucore::error::UResult;
-use uucore::executable;
+use uucore::util_name;
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -19,5 +19,5 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
 }

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -63,7 +63,7 @@ pub mod options {
     pub static ARG_FILES: &str = "files";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", executable!())
 }
 
@@ -90,7 +90,7 @@ fn get_long_usage() -> String {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let long_usage = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -133,7 +133,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -64,7 +64,7 @@ pub mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
+    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -133,7 +133,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -64,7 +64,7 @@ pub mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", executable!())
+    format!("{0} [OPTION]... [FILE]...", execution_phrase!())
 }
 
 fn get_long_usage() -> String {

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -90,7 +90,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .usage(USAGE)
         .about(SUMMARY)

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -90,7 +90,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .usage(USAGE)
         .about(SUMMARY)

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -78,7 +78,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -23,12 +23,12 @@ mod options {
     pub const SILENT: &str = "silent";
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) ttyname filedesc
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, App, Arg};
 use std::ffi::CStr;
 use std::io::Write;
@@ -24,7 +21,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]...", execution_phrase!())
+    format!("{0} [OPTION]...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -78,7 +75,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -24,7 +24,7 @@ mod options {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]...", executable!())
+    format!("{0} [OPTION]...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -50,7 +50,7 @@ const HOST_OS: &str = "Fuchsia";
 const HOST_OS: &str = "Redox";
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = format!("{} [OPTION]...", execution_phrase!());
+    let usage = format!("{} [OPTION]...", uucore::execution_phrase());
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let uname = return_if_err!(1, PlatformInfo::new());
@@ -119,7 +119,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(options::ALL)

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -119,7 +119,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(options::ALL)

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -50,7 +50,7 @@ const HOST_OS: &str = "Fuchsia";
 const HOST_OS: &str = "Redox";
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = format!("{} [OPTION]...", executable!());
+    let usage = format!("{} [OPTION]...", execution_phrase!());
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let uname = return_if_err!(1, PlatformInfo::new());

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -102,7 +102,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -102,7 +102,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
         .usage(USAGE)

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -221,7 +221,7 @@ fn opt_parsed<T: FromStr>(opt_name: &str, matches: &ArgMatches) -> Option<T> {
     })
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [INPUT [OUTPUT]]...", executable!())
 }
 
@@ -235,7 +235,7 @@ fn get_long_usage() -> String {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let long_usage = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -281,7 +281,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -222,7 +222,7 @@ fn opt_parsed<T: FromStr>(opt_name: &str, matches: &ArgMatches) -> Option<T> {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [INPUT [OUTPUT]]...", executable!())
+    format!("{0} [OPTION]... [INPUT [OUTPUT]]...", execution_phrase!())
 }
 
 fn get_long_usage() -> String {

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -222,7 +222,10 @@ fn opt_parsed<T: FromStr>(opt_name: &str, matches: &ArgMatches) -> Option<T> {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [INPUT [OUTPUT]]...", execution_phrase!())
+    format!(
+        "{0} [OPTION]... [INPUT [OUTPUT]]...",
+        uucore::execution_phrase()
+    )
 }
 
 fn get_long_usage() -> String {
@@ -281,7 +284,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -22,7 +22,7 @@ use uucore::InvalidEncodingHandling;
 static ABOUT: &str = "Unlink the file at [FILE].";
 static OPT_PATH: &str = "FILE";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{} [OPTION]... FILE", executable!())
 }
 
@@ -31,7 +31,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -95,7 +95,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(OPT_PATH).hidden(true).multiple(true))

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -43,13 +43,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if paths.is_empty() {
         crash!(
             1,
-            "missing operand\nTry '{0} --help' for more information.",
+            "missing operand\nTry `{0} --help` for more information.",
             executable!()
         );
     } else if paths.len() > 1 {
         crash!(
             1,
-            "extra operand: '{1}'\nTry '{0} --help' for more information.",
+            "extra operand: '{1}'\nTry `{0} --help` for more information.",
             executable!(),
             paths[1]
         );

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -23,7 +23,7 @@ static ABOUT: &str = "Unlink the file at [FILE].";
 static OPT_PATH: &str = "FILE";
 
 fn usage() -> String {
-    format!("{} [OPTION]... FILE", executable!())
+    format!("{} [OPTION]... FILE", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -44,13 +44,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "missing operand\nTry `{0} --help` for more information.",
-            executable!()
+            execution_phrase!()
         );
     } else if paths.len() > 1 {
         crash!(
             1,
             "extra operand: '{1}'\nTry `{0} --help` for more information.",
-            executable!(),
+            execution_phrase!(),
             paths[1]
         );
     }

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -23,7 +23,7 @@ static ABOUT: &str = "Unlink the file at [FILE].";
 static OPT_PATH: &str = "FILE";
 
 fn usage() -> String {
-    format!("{} [OPTION]... FILE", execution_phrase!())
+    format!("{} [OPTION]... FILE", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -44,13 +44,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         crash!(
             1,
             "missing operand\nTry '{0} --help' for more information.",
-            execution_phrase!()
+            uucore::execution_phrase()
         );
     } else if paths.len() > 1 {
         crash!(
             1,
             "extra operand: '{1}'\nTry '{0} --help' for more information.",
-            execution_phrase!(),
+            uucore::execution_phrase(),
             paths[1]
         );
     }
@@ -95,7 +95,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(OPT_PATH).hidden(true).multiple(true))

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -43,13 +43,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if paths.is_empty() {
         crash!(
             1,
-            "missing operand\nTry `{0} --help` for more information.",
+            "missing operand\nTry '{0} --help' for more information.",
             execution_phrase!()
         );
     } else if paths.len() > 1 {
         crash!(
             1,
-            "extra operand: '{1}'\nTry `{0} --help` for more information.",
+            "extra operand: '{1}'\nTry '{0} --help' for more information.",
             execution_phrase!(),
             paths[1]
         );

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -64,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -32,12 +32,12 @@ extern "C" {
     fn GetTickCount() -> uucore::libc::uint32_t;
 }
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]...", executable!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
     let (boot_time, user_count) = process_utmpx();

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -33,7 +33,7 @@ extern "C" {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]...", executable!())
+    format!("{0} [OPTION]...", execution_phrase!())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -33,7 +33,7 @@ extern "C" {
 }
 
 fn usage() -> String {
-    format!("{0} [OPTION]...", execution_phrase!())
+    format!("{0} [OPTION]...", uucore::execution_phrase())
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -64,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -18,7 +18,7 @@ static ABOUT: &str = "Print the user names of users currently logged in to the c
 
 static ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [FILE]", executable!())
 }
 
@@ -31,7 +31,7 @@ If FILE is not specified, use {}.  /var/log/wtmp as FILE is common.",
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
     let after_help = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -65,7 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(ARG_FILES).takes_value(true).max_values(1))

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -8,9 +8,6 @@
 
 // spell-checker:ignore (paths) wtmp
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, App, Arg};
 use uucore::utmpx::{self, Utmpx};
 
@@ -19,7 +16,7 @@ static ABOUT: &str = "Print the user names of users currently logged in to the c
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [FILE]", execution_phrase!())
+    format!("{0} [FILE]", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -65,7 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(Arg::with_name(ARG_FILES).takes_value(true).max_values(1))

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -19,7 +19,7 @@ static ABOUT: &str = "Print the user names of users currently logged in to the c
 static ARG_FILES: &str = "files";
 
 fn usage() -> String {
-    format!("{0} [FILE]", executable!())
+    format!("{0} [FILE]", execution_phrase!())
 }
 
 fn get_long_usage() -> String {

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -95,7 +95,7 @@ pub mod options {
 
 static ARG_FILES: &str = "files";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!(
         "{0} [OPTION]... [FILE]...
  With no FILE, or when FILE is -, read standard input.",
@@ -132,7 +132,7 @@ impl Input {
 }
 
 pub fn uumain(args: impl uucore::Args) -> i32 {
-    let usage = get_usage();
+    let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -164,7 +164,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -350,13 +350,8 @@ fn digit_width(input: &Input) -> WcResult<Option<usize>> {
 fn max_width(inputs: &[Input]) -> usize {
     let mut result = 1;
     for input in inputs {
-        match digit_width(input) {
-            Ok(maybe_n) => {
-                if let Some(n) = maybe_n {
-                    result = result.max(n);
-                }
-            }
-            Err(_) => continue,
+        if let Ok(Some(n)) = digit_width(input) {
+            result = result.max(n);
         }
     }
     result

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -99,7 +99,7 @@ fn usage() -> String {
     format!(
         "{0} [OPTION]... [FILE]...
  With no FILE, or when FILE is -, read standard input.",
-        execution_phrase!()
+        uucore::execution_phrase()
     )
 }
 
@@ -164,7 +164,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -99,7 +99,7 @@ fn usage() -> String {
     format!(
         "{0} [OPTION]... [FILE]...
  With no FILE, or when FILE is -, read standard input.",
-        executable!()
+        execution_phrase!()
     )
 }
 

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -44,7 +44,7 @@ static RUNLEVEL_HELP: &str = "print current runlevel";
 #[cfg(not(target_os = "linux"))]
 static RUNLEVEL_HELP: &str = "print current runlevel (This is meaningless on non Linux)";
 
-fn get_usage() -> String {
+fn usage() -> String {
     format!("{0} [OPTION]... [ FILE | ARG1 ARG2 ]", executable!())
 }
 
@@ -61,7 +61,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = get_usage();
+    let usage = usage();
     let after_help = get_long_usage();
 
     let matches = uu_app()

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -160,7 +160,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(util_name!())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -45,7 +45,7 @@ static RUNLEVEL_HELP: &str = "print current runlevel";
 static RUNLEVEL_HELP: &str = "print current runlevel (This is meaningless on non Linux)";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [ FILE | ARG1 ARG2 ]", executable!())
+    format!("{0} [OPTION]... [ FILE | ARG1 ARG2 ]", execution_phrase!())
 }
 
 fn get_long_usage() -> String {

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -45,7 +45,10 @@ static RUNLEVEL_HELP: &str = "print current runlevel";
 static RUNLEVEL_HELP: &str = "print current runlevel (This is meaningless on non Linux)";
 
 fn usage() -> String {
-    format!("{0} [OPTION]... [ FILE | ARG1 ARG2 ]", execution_phrase!())
+    format!(
+        "{0} [OPTION]... [ FILE | ARG1 ARG2 ]",
+        uucore::execution_phrase()
+    )
 }
 
 fn get_long_usage() -> String {
@@ -160,7 +163,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(util_name!())
+    App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -77,6 +77,15 @@ pub use crate::features::wide;
 //## core functions
 
 use std::ffi::OsString;
+use std::sync::atomic::Ordering;
+
+pub fn get_utility_is_second_arg() -> bool {
+    crate::macros::UTILITY_IS_SECOND_ARG.load(Ordering::SeqCst)
+}
+
+pub fn set_utility_is_second_arg() {
+    crate::macros::UTILITY_IS_SECOND_ARG.store(true, Ordering::SeqCst)
+}
 
 pub enum InvalidEncodingHandling {
     Ignore,

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -87,6 +87,38 @@ pub fn set_utility_is_second_arg() {
     crate::macros::UTILITY_IS_SECOND_ARG.store(true, Ordering::SeqCst)
 }
 
+/// Get the executable path (as `OsString`).
+fn executable_os() -> OsString {
+    args_os().next().unwrap()
+}
+
+/// Get the executable path (as `String`).
+fn executable() -> String {
+    executable_os().to_string_lossy().into_owned()
+}
+
+/// Derive the utility name.
+pub fn util_name() -> String {
+    if get_utility_is_second_arg() {
+        args_os().nth(1).unwrap().to_string_lossy().into_owned()
+    } else {
+        executable()
+    }
+}
+
+/// Derive the complete execution phrase for "usage".
+pub fn execution_phrase() -> String {
+    if get_utility_is_second_arg() {
+        args_os()
+            .take(2)
+            .map(|os_str| os_str.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ")
+    } else {
+        executable()
+    }
+}
+
 pub enum InvalidEncodingHandling {
     Ignore,
     ConvertLossy,

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -17,11 +17,11 @@ macro_rules! executable_os(
 #[macro_export]
 macro_rules! executable(
     () => ({
-        let exe = match executable_os!().to_str() {
+        let exe = match $crate::executable_os!().to_str() {
             // * UTF-8
             Some(s) => s.to_string(),
             // * "lossless" debug format if `executable_os!()` is not well-formed UTF-8
-            None => format!("{:?}", executable_os!())
+            None => format!("{:?}", $crate::executable_os!())
         };
         &exe.to_owned()
     })
@@ -31,7 +31,7 @@ macro_rules! executable(
 #[macro_export]
 macro_rules! executable_name(
     () => ({
-        &std::path::Path::new(executable_os!()).file_stem().unwrap().to_string_lossy()
+        &std::path::Path::new($crate::executable_os!()).file_stem().unwrap().to_string_lossy()
     })
 );
 
@@ -55,7 +55,7 @@ macro_rules! show(
     ($err:expr) => ({
         let e = $err;
         uucore::error::set_exit_code(e.code());
-        eprintln!("{}: {}", executable_name!(), e);
+        eprintln!("{}: {}", $crate::executable_name!(), e);
     })
 );
 
@@ -72,7 +72,7 @@ macro_rules! show_if_err(
 #[macro_export]
 macro_rules! show_error(
     ($($args:tt)+) => ({
-        eprint!("{}: ", executable_name!());
+        eprint!("{}: ", $crate::executable_name!());
         eprintln!($($args)+);
     })
 );
@@ -81,7 +81,7 @@ macro_rules! show_error(
 #[macro_export]
 macro_rules! show_error_custom_description (
     ($err:expr,$($args:tt)+) => ({
-        eprint!("{}: {}: ", executable_name!(), $err);
+        eprint!("{}: {}: ", $crate::executable_name!(), $err);
         eprintln!($($args)+);
     })
 );
@@ -89,7 +89,7 @@ macro_rules! show_error_custom_description (
 #[macro_export]
 macro_rules! show_warning(
     ($($args:tt)+) => ({
-        eprint!("{}: warning: ", executable_name!());
+        eprint!("{}: warning: ", $crate::executable_name!());
         eprintln!($($args)+);
     })
 );
@@ -98,9 +98,9 @@ macro_rules! show_warning(
 #[macro_export]
 macro_rules! show_usage_error(
     ($($args:tt)+) => ({
-        eprint!("{}: ", executable_name!());
+        eprint!("{}: ", $crate::executable_name!());
         eprintln!($($args)+);
-        eprintln!("Try `{:?} --help` for more information.", executable!());
+        eprintln!("Try `{:?} --help` for more information.", $crate::executable!());
     })
 );
 
@@ -118,8 +118,8 @@ macro_rules! exit(
 #[macro_export]
 macro_rules! crash(
     ($exit_code:expr, $($args:tt)+) => ({
-        show_error!($($args)+);
-        exit!($exit_code)
+        $crate::show_error!($($args)+);
+        $crate::exit!($exit_code)
     })
 );
 
@@ -130,7 +130,7 @@ macro_rules! crash_if_err(
     ($exit_code:expr, $exp:expr) => (
         match $exp {
             Ok(m) => m,
-            Err(f) => crash!($exit_code, "{}", f),
+            Err(f) => $crate::crash!($exit_code, "{}", f),
         }
     )
 );
@@ -146,7 +146,7 @@ macro_rules! return_if_err(
         match $exp {
             Ok(m) => m,
             Err(f) => {
-                show_error!("{}", f);
+                $crate::show_error!("{}", f);
                 return $exit_code;
             }
         }
@@ -182,7 +182,7 @@ macro_rules! safe_unwrap(
     ($exp:expr) => (
         match $exp {
             Ok(m) => m,
-            Err(f) => crash!(1, "{}", f.to_string())
+            Err(f) => $crate::crash!(1, "{}", f.to_string())
         }
     )
 );
@@ -197,7 +197,7 @@ macro_rules! snippet_list_join_oxford_comma {
         format!("{}, {} {}", $valOne, $conjunction, $valTwo)
     );
     ($conjunction:expr, $valOne:expr, $valTwo:expr $(, $remaining_values:expr)*) => (
-        format!("{}, {}", $valOne, snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
+        format!("{}, {}", $valOne, $crate::snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
     );
 }
 
@@ -207,7 +207,7 @@ macro_rules! snippet_list_join {
         format!("{} {} {}", $valOne, $conjunction, $valTwo)
     );
     ($conjunction:expr, $valOne:expr, $valTwo:expr $(, $remaining_values:expr)*) => (
-        format!("{}, {}", $valOne, snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
+        format!("{}, {}", $valOne, $crate::snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
     );
 }
 
@@ -225,10 +225,10 @@ macro_rules! msg_invalid_input {
 #[macro_export]
 macro_rules! msg_invalid_opt_use {
     ($about:expr, $flag:expr) => {
-        msg_invalid_input!(format!("The '{}' option {}", $flag, $about))
+        $crate::msg_invalid_input!(format!("The '{}' option {}", $flag, $about))
     };
     ($about:expr, $long_flag:expr, $short_flag:expr) => {
-        msg_invalid_input!(format!(
+        $crate::msg_invalid_input!(format!(
             "The '{}' ('{}') option {}",
             $long_flag, $short_flag, $about
         ))
@@ -238,10 +238,10 @@ macro_rules! msg_invalid_opt_use {
 #[macro_export]
 macro_rules! msg_opt_only_usable_if {
     ($clause:expr, $flag:expr) => {
-        msg_invalid_opt_use!(format!("only usable if {}", $clause), $flag)
+        $crate::msg_invalid_opt_use!(format!("only usable if {}", $clause), $flag)
     };
     ($clause:expr, $long_flag:expr, $short_flag:expr) => {
-        msg_invalid_opt_use!(
+        $crate::msg_invalid_opt_use!(
             format!("only usable if {}", $clause),
             $long_flag,
             $short_flag
@@ -252,13 +252,13 @@ macro_rules! msg_opt_only_usable_if {
 #[macro_export]
 macro_rules! msg_opt_invalid_should_be {
     ($expects:expr, $received:expr, $flag:expr) => {
-        msg_invalid_opt_use!(
+        $crate::msg_invalid_opt_use!(
             format!("expects {}, but was provided {}", $expects, $received),
             $flag
         )
     };
     ($expects:expr, $received:expr, $long_flag:expr, $short_flag:expr) => {
-        msg_invalid_opt_use!(
+        $crate::msg_invalid_opt_use!(
             format!("expects {}, but was provided {}", $expects, $received),
             $long_flag,
             $short_flag
@@ -271,13 +271,13 @@ macro_rules! msg_opt_invalid_should_be {
 #[macro_export]
 macro_rules! msg_expects_one_of {
     ($valOne:expr $(, $remaining_values:expr)*) => (
-        msg_invalid_input!(format!("expects one of {}", snippet_list_join!("or", $valOne $(, $remaining_values)*)))
+        $crate::msg_invalid_input!(format!("expects one of {}", $crate::snippet_list_join!("or", $valOne $(, $remaining_values)*)))
     );
 }
 
 #[macro_export]
 macro_rules! msg_expects_no_more_than_one_of {
     ($valOne:expr $(, $remaining_values:expr)*) => (
-        msg_invalid_input!(format!("expects no more than one of {}", snippet_list_join!("or", $valOne $(, $remaining_values)*))) ;
+        $crate::msg_invalid_input!(format!("expects no more than one of {}", $crate::snippet_list_join!("or", $valOne $(, $remaining_values)*))) ;
     );
 }

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -189,25 +189,25 @@ macro_rules! safe_unwrap(
 
 //-- message templates
 
-//-- message templates : general
+//-- message templates : (join utility sub-macros)
 
 #[macro_export]
-macro_rules! snippet_list_join_oxford {
+macro_rules! snippet_list_join_oxford_comma {
     ($conjunction:expr, $valOne:expr, $valTwo:expr) => (
         format!("{}, {} {}", $valOne, $conjunction, $valTwo)
     );
     ($conjunction:expr, $valOne:expr, $valTwo:expr $(, $remaining_values:expr)*) => (
-        format!("{}, {}", $valOne, snippet_list_join_inner!($conjunction, $valTwo $(, $remaining_values)*))
+        format!("{}, {}", $valOne, snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
     );
 }
 
 #[macro_export]
-macro_rules! snippet_list_join_or {
-    ($valOne:expr, $valTwo:expr) => (
-        format!("{} or {}", $valOne, $valTwo)
+macro_rules! snippet_list_join {
+    ($conjunction:expr, $valOne:expr, $valTwo:expr) => (
+        format!("{} {} {}", $valOne, $conjunction, $valTwo)
     );
-    ($valOne:expr, $valTwo:expr $(, $remaining_values:expr)*) => (
-        format!("{}, {}", $valOne, snippet_list_join_oxford!("or", $valTwo $(, $remaining_values)*))
+    ($conjunction:expr, $valOne:expr, $valTwo:expr $(, $remaining_values:expr)*) => (
+        format!("{}, {}", $valOne, snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
     );
 }
 
@@ -271,13 +271,13 @@ macro_rules! msg_opt_invalid_should_be {
 #[macro_export]
 macro_rules! msg_expects_one_of {
     ($valOne:expr $(, $remaining_values:expr)*) => (
-        msg_invalid_input!(format!("expects one of {}", snippet_list_join_or!($valOne $(, $remaining_values)*)))
+        msg_invalid_input!(format!("expects one of {}", snippet_list_join!("or", $valOne $(, $remaining_values)*)))
     );
 }
 
 #[macro_export]
 macro_rules! msg_expects_no_more_than_one_of {
     ($valOne:expr $(, $remaining_values:expr)*) => (
-        msg_invalid_input!(format!("expects no more than one of {}", snippet_list_join_or!($valOne $(, $remaining_values)*))) ;
+        msg_invalid_input!(format!("expects no more than one of {}", snippet_list_join!("or", $valOne $(, $remaining_values)*))) ;
     );
 }

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -119,7 +119,7 @@ macro_rules! exit(
 macro_rules! crash(
     ($exit_code:expr, $($args:tt)+) => ({
         show_error!($($args)+);
-        ::std::process::exit($exit_code)
+        exit!($exit_code)
     })
 );
 

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -20,6 +20,7 @@ macro_rules! executable_os(
 
 /// Get the executable path (as `String`).
 #[macro_export]
+#[deprecated = "Use util_name!() or execution_phrase!() instead"]
 macro_rules! executable(
     () => ({
         $crate::executable_os!().to_string_lossy().to_string()
@@ -33,7 +34,10 @@ macro_rules! util_name(
         if $crate::get_utility_is_second_arg() {
             $crate::args_os().nth(1).unwrap().to_string_lossy().to_string()
         } else {
-            $crate::executable!()
+            #[allow(deprecated)]
+            {
+                $crate::executable!()
+            }
         }
     })
 );
@@ -51,7 +55,10 @@ macro_rules! execution_phrase(
             .collect::<Vec<_>>()
             .join(" ")
         } else {
-            $crate::executable!()
+            #[allow(deprecated)]
+            {
+                $crate::executable!()
+            }
         }
     })
 );

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -125,7 +125,7 @@ macro_rules! show_usage_error(
     ($($args:tt)+) => ({
         eprint!("{}: ", $crate::util_name!());
         eprintln!($($args)+);
-        eprintln!("Try `{:?} --help` for more information.", $crate::executable!());
+        eprintln!("Try `{} --help` for more information.", $crate::execution_phrase!());
     })
 );
 

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -9,7 +9,7 @@
 #[macro_export]
 macro_rules! executable_os(
     () => ({
-        &std::env::args_os().next().unwrap()
+        &uucore::args_os().next().unwrap()
     })
 );
 

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -10,67 +10,14 @@ use std::sync::atomic::AtomicBool;
 /// Whether we were called as a multicall binary ("coreutils <utility>")
 pub static UTILITY_IS_SECOND_ARG: AtomicBool = AtomicBool::new(false);
 
-/// Get the executable path (as `OsString`).
-#[macro_export]
-macro_rules! executable_os(
-    () => ({
-        $crate::args_os().next().unwrap()
-    })
-);
-
-/// Get the executable path (as `String`).
-#[macro_export]
-#[deprecated = "Use util_name!() or execution_phrase!() instead"]
-macro_rules! executable(
-    () => ({
-        $crate::executable_os!().to_string_lossy().to_string()
-    })
-);
-
-/// Derive the utility name.
-#[macro_export]
-macro_rules! util_name(
-    () => ({
-        if $crate::get_utility_is_second_arg() {
-            $crate::args_os().nth(1).unwrap().to_string_lossy().to_string()
-        } else {
-            #[allow(deprecated)]
-            {
-                $crate::executable!()
-            }
-        }
-    })
-);
-
-//====
-
-/// Derive the complete execution phrase for "usage".
-#[macro_export]
-macro_rules! execution_phrase(
-    () => ({
-        if $crate::get_utility_is_second_arg() {
-            $crate::args_os()
-            .take(2)
-            .map(|os_str| os_str.to_string_lossy().to_string())
-            .collect::<Vec<_>>()
-            .join(" ")
-        } else {
-            #[allow(deprecated)]
-            {
-                $crate::executable!()
-            }
-        }
-    })
-);
-
 //====
 
 #[macro_export]
 macro_rules! show(
     ($err:expr) => ({
         let e = $err;
-        uucore::error::set_exit_code(e.code());
-        eprintln!("{}: {}", $crate::util_name!(), e);
+        $crate::error::set_exit_code(e.code());
+        eprintln!("{}: {}", $crate::util_name(), e);
     })
 );
 
@@ -87,7 +34,7 @@ macro_rules! show_if_err(
 #[macro_export]
 macro_rules! show_error(
     ($($args:tt)+) => ({
-        eprint!("{}: ", $crate::util_name!());
+        eprint!("{}: ", $crate::util_name());
         eprintln!($($args)+);
     })
 );
@@ -96,7 +43,7 @@ macro_rules! show_error(
 #[macro_export]
 macro_rules! show_error_custom_description (
     ($err:expr,$($args:tt)+) => ({
-        eprint!("{}: {}: ", $crate::util_name!(), $err);
+        eprint!("{}: {}: ", $crate::util_name(), $err);
         eprintln!($($args)+);
     })
 );
@@ -104,7 +51,7 @@ macro_rules! show_error_custom_description (
 #[macro_export]
 macro_rules! show_warning(
     ($($args:tt)+) => ({
-        eprint!("{}: warning: ", $crate::util_name!());
+        eprint!("{}: warning: ", $crate::util_name());
         eprintln!($($args)+);
     })
 );
@@ -113,9 +60,9 @@ macro_rules! show_warning(
 #[macro_export]
 macro_rules! show_usage_error(
     ($($args:tt)+) => ({
-        eprint!("{}: ", $crate::util_name!());
+        eprint!("{}: ", $crate::util_name());
         eprintln!($($args)+);
-        eprintln!("Try '{} --help' for more information.", $crate::execution_phrase!());
+        eprintln!("Try '{} --help' for more information.", $crate::execution_phrase());
     })
 );
 

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -20,7 +20,7 @@ macro_rules! executable(
         let exe = match $crate::executable_os!().to_str() {
             // * UTF-8
             Some(s) => s.to_string(),
-            // * "lossless" debug format if `executable_os!()` is not well-formed UTF-8
+            // * "lossless" debug format (if/when `executable_os!()` is not well-formed UTF-8)
             None => format!("{:?}", $crate::executable_os!())
         };
         &exe.to_owned()
@@ -31,7 +31,14 @@ macro_rules! executable(
 #[macro_export]
 macro_rules! executable_name(
     () => ({
-        &std::path::Path::new($crate::executable_os!()).file_stem().unwrap().to_string_lossy()
+        let stem = &std::path::Path::new($crate::executable_os!()).file_stem().unwrap().to_owned();
+        let exe = match stem.to_str() {
+            // * UTF-8
+            Some(s) => s.to_string(),
+            // * "lossless" debug format (if/when `executable_os!()` is not well-formed UTF-8)
+            None => format!("{:?}", stem)
+        };
+        &exe.to_owned()
     })
 );
 
@@ -40,11 +47,12 @@ macro_rules! executable_name(
 macro_rules! util_name(
     () => ({
         let crate_name = env!("CARGO_PKG_NAME");
-        if crate_name.starts_with("uu_") {
+        let name = if crate_name.starts_with("uu_") {
             &crate_name[3..]
         } else {
-            &crate_name
-        }
+            crate_name
+        };
+        &name.to_owned()
     })
 );
 

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -58,6 +58,23 @@ macro_rules! util_name(
 
 //====
 
+/// Derive the complete execution phrase for "usage".
+#[macro_export]
+macro_rules! execution_phrase(
+    () => ({
+        let exe = if (executable_name!() == util_name!()) {
+        executable!().to_string()
+    } else {
+        format!("{} {}", executable!(), util_name!())
+            .as_str()
+            .to_owned()
+    };
+    &exe.to_owned()
+    })
+);
+
+//====
+
 #[macro_export]
 macro_rules! show(
     ($err:expr) => ({

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -115,7 +115,7 @@ macro_rules! show_usage_error(
     ($($args:tt)+) => ({
         eprint!("{}: ", $crate::util_name!());
         eprintln!($($args)+);
-        eprintln!("Try `{} --help` for more information.", $crate::execution_phrase!());
+        eprintln!("Try '{} --help' for more information.", $crate::execution_phrase!());
     })
 );
 

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -55,7 +55,7 @@ macro_rules! show(
     ($err:expr) => ({
         let e = $err;
         uucore::error::set_exit_code(e.code());
-        eprintln!("{}: {}", $crate::executable_name!(), e);
+        eprintln!("{}: {}", $crate::util_name!(), e);
     })
 );
 
@@ -72,7 +72,7 @@ macro_rules! show_if_err(
 #[macro_export]
 macro_rules! show_error(
     ($($args:tt)+) => ({
-        eprint!("{}: ", $crate::executable_name!());
+        eprint!("{}: ", $crate::util_name!());
         eprintln!($($args)+);
     })
 );
@@ -81,7 +81,7 @@ macro_rules! show_error(
 #[macro_export]
 macro_rules! show_error_custom_description (
     ($err:expr,$($args:tt)+) => ({
-        eprint!("{}: {}: ", $crate::executable_name!(), $err);
+        eprint!("{}: {}: ", $crate::util_name!(), $err);
         eprintln!($($args)+);
     })
 );
@@ -89,7 +89,7 @@ macro_rules! show_error_custom_description (
 #[macro_export]
 macro_rules! show_warning(
     ($($args:tt)+) => ({
-        eprint!("{}: warning: ", $crate::executable_name!());
+        eprint!("{}: warning: ", $crate::util_name!());
         eprintln!($($args)+);
     })
 );
@@ -98,7 +98,7 @@ macro_rules! show_warning(
 #[macro_export]
 macro_rules! show_usage_error(
     ($($args:tt)+) => ({
-        eprint!("{}: ", $crate::executable_name!());
+        eprint!("{}: ", $crate::util_name!());
         eprintln!($($args)+);
         eprintln!("Try `{:?} --help` for more information.", $crate::executable!());
     })

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -5,19 +5,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-/// Get the utility name.
-#[macro_export]
-macro_rules! util_name(
-    () => ({
-        let crate_name =  env!("CARGO_PKG_NAME");
-        if crate_name.starts_with("uu_") {
-            &crate_name[3..]
-        } else {
-            &crate_name
-        }
-    })
-);
-
 /// Get the executable path (as `OsString`).
 #[macro_export]
 macro_rules! executable_os(
@@ -47,6 +34,21 @@ macro_rules! executable_name(
         &std::path::Path::new(executable_os!()).file_stem().unwrap().to_string_lossy()
     })
 );
+
+/// Derive the utility name.
+#[macro_export]
+macro_rules! util_name(
+    () => ({
+        let crate_name = env!("CARGO_PKG_NAME");
+        if crate_name.starts_with("uu_") {
+            &crate_name[3..]
+        } else {
+            &crate_name
+        }
+    })
+);
+
+//====
 
 #[macro_export]
 macro_rules! show(
@@ -102,19 +104,21 @@ macro_rules! show_usage_error(
     })
 );
 
-/// Display the provided error message, then `exit()` with the provided exit code
-#[macro_export]
-macro_rules! crash(
-    ($exit_code:expr, $($args:tt)+) => ({
-        show_error!($($args)+);
-        ::std::process::exit($exit_code)
-    })
-);
+//====
 
 /// Calls `exit()` with the provided exit code.
 #[macro_export]
 macro_rules! exit(
     ($exit_code:expr) => ({
+        ::std::process::exit($exit_code)
+    })
+);
+
+/// Display the provided error message, then `exit()` with the provided exit code
+#[macro_export]
+macro_rules! crash(
+    ($exit_code:expr, $($args:tt)+) => ({
+        show_error!($($args)+);
         ::std::process::exit($exit_code)
     })
 );
@@ -131,6 +135,8 @@ macro_rules! crash_if_err(
     )
 );
 
+//====
+
 /// Unwraps the Result. Instead of panicking, it shows the error and then
 /// returns from the function with the provided exit code.
 /// Assumes the current function returns an i32 value.
@@ -146,6 +152,8 @@ macro_rules! return_if_err(
         }
     )
 );
+
+//====
 
 #[macro_export]
 macro_rules! safe_write(

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -5,19 +5,24 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-/// Deduce the name of the binary from the current source code filename.
-///
-/// e.g.: `src/uu/cp/src/cp.rs` -> `cp`
+/// Get the utility name.
+#[macro_export]
+macro_rules! util_name(
+    () => ({
+        let crate_name =  env!("CARGO_PKG_NAME");
+        if crate_name.starts_with("uu_") {
+            &crate_name[3..]
+        } else {
+            &crate_name
+        }
+    })
+);
+
+/// Get the executable name.
 #[macro_export]
 macro_rules! executable(
     () => ({
-        let module = module_path!();
-        let module = module.split("::").next().unwrap_or(module);
-        if &module[0..3] == "uu_" {
-            &module[3..]
-        } else {
-            module
-        }
+        &std::env::args().next().unwrap()
     })
 );
 

--- a/src/uucore/src/lib/mods/coreopts.rs
+++ b/src/uucore/src/lib/mods/coreopts.rs
@@ -120,7 +120,7 @@ impl<'a> CoreOptions<'a> {
 macro_rules! app {
     ($syntax: expr, $summary: expr, $long_help: expr) => {
         uucore::coreopts::CoreOptions::new(uucore::coreopts::HelpText {
-            name: executable!(),
+            name: util_name!(),
             version: env!("CARGO_PKG_VERSION"),
             syntax: $syntax,
             summary: $summary,
@@ -130,7 +130,7 @@ macro_rules! app {
     };
     ($syntax: expr, $summary: expr, $long_help: expr, $display_usage: expr) => {
         uucore::coreopts::CoreOptions::new(uucore::coreopts::HelpText {
-            name: executable!(),
+            name: util_name!(),
             version: env!("CARGO_PKG_VERSION"),
             syntax: $syntax,
             summary: $summary,

--- a/src/uucore/src/lib/mods/coreopts.rs
+++ b/src/uucore/src/lib/mods/coreopts.rs
@@ -120,7 +120,7 @@ impl<'a> CoreOptions<'a> {
 macro_rules! app {
     ($syntax: expr, $summary: expr, $long_help: expr) => {
         uucore::coreopts::CoreOptions::new(uucore::coreopts::HelpText {
-            name: util_name!(),
+            name: uucore::util_name(),
             version: env!("CARGO_PKG_VERSION"),
             syntax: $syntax,
             summary: $summary,
@@ -130,7 +130,7 @@ macro_rules! app {
     };
     ($syntax: expr, $summary: expr, $long_help: expr, $display_usage: expr) => {
         uucore::coreopts::CoreOptions::new(uucore::coreopts::HelpText {
-            name: util_name!(),
+            name: uucore::util_name(),
             version: env!("CARGO_PKG_VERSION"),
             syntax: $syntax,
             summary: $summary,

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -203,8 +203,8 @@ pub trait UError: Error + Send {
     /// Print usage help to a custom error.
     ///
     /// Return true or false to control whether a short usage help is printed
-    /// below the error message. The usage help is in the format: "Try '{name}
-    /// --help' for more information." and printed only if `true` is returned.
+    /// below the error message. The usage help is in the format: "Try `{name}
+    /// --help` for more information." and printed only if `true` is returned.
     ///
     /// # Example
     ///
@@ -519,7 +519,7 @@ macro_rules! uio_error(
 /// let res: UResult<()> = Err(1.into());
 /// ```
 /// This type is especially useful for a trivial conversion from utils returning [`i32`] to
-/// returning [`UResult`].  
+/// returning [`UResult`].
 #[derive(Debug)]
 pub struct ExitCode(pub i32);
 

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -104,7 +104,7 @@ pub fn gen_uumain(_args: TokenStream, stream: TokenStream) -> TokenStream {
                         show_error!("{}", s);
                     }
                     if e.usage() {
-                        eprintln!("Try '{} --help' for more information.", executable!());
+                        eprintln!("Try `{} --help` for more information.", executable!());
                     }
                     e.code()
                 }

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -104,7 +104,7 @@ pub fn gen_uumain(_args: TokenStream, stream: TokenStream) -> TokenStream {
                         show_error!("{}", s);
                     }
                     if e.usage() {
-                        eprintln!("Try `{} --help` for more information.", execution_phrase!());
+                        eprintln!("Try '{} --help' for more information.", execution_phrase!());
                     }
                     e.code()
                 }

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -104,7 +104,7 @@ pub fn gen_uumain(_args: TokenStream, stream: TokenStream) -> TokenStream {
                         show_error!("{}", s);
                     }
                     if e.usage() {
-                        eprintln!("Try '{} --help' for more information.", execution_phrase!());
+                        eprintln!("Try '{} --help' for more information.", uucore::execution_phrase());
                     }
                     e.code()
                 }

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -104,7 +104,7 @@ pub fn gen_uumain(_args: TokenStream, stream: TokenStream) -> TokenStream {
                         show_error!("{}", s);
                     }
                     if e.usage() {
-                        eprintln!("Try `{} --help` for more information.", executable!());
+                        eprintln!("Try `{} --help` for more information.", execution_phrase!());
                     }
                     e.code()
                 }

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -85,11 +85,15 @@ fn test_wrap() {
 #[test]
 fn test_wrap_no_arg() {
     for wrap_param in &["-w", "--wrap"] {
-        let expected_stderr = "error: The argument '--wrap <wrap>\' requires a value but none was \
-                               supplied\n\nUSAGE:\n    base32 [OPTION]... [FILE]\n\nFor more \
-                               information try --help"
-            .to_string();
-        new_ucmd!()
+        let ts = TestScenario::new(util_name!());
+        let expected_stderr = &format!(
+            "error: The argument '--wrap <wrap>\' requires a value but none was \
+                               supplied\n\nUSAGE:\n    {1} {0} [OPTION]... [FILE]\n\nFor more \
+                               information try --help",
+            ts.util_name,
+            ts.bin_path.to_string_lossy()
+        );
+        ts.ucmd()
             .arg(wrap_param)
             .fails()
             .stderr_only(expected_stderr);

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -114,9 +114,12 @@ fn test_no_args() {
 
 #[test]
 fn test_no_args_output() {
-    new_ucmd!()
-        .fails()
-        .stderr_is("basename: missing operand\nTry 'basename --help' for more information.");
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd().fails().stderr_is(&format!(
+        "{0}: missing operand\nTry `{1} {0} --help` for more information.",
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 #[test]
@@ -126,10 +129,12 @@ fn test_too_many_args() {
 
 #[test]
 fn test_too_many_args_output() {
-    new_ucmd!()
-        .args(&["a", "b", "c"])
-        .fails()
-        .stderr_is("basename: extra operand 'c'\nTry 'basename --help' for more information.");
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd().args(&["a", "b", "c"]).fails().stderr_is(format!(
+        "{0}: extra operand 'c'\nTry `{1} {0} --help` for more information.",
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 #[cfg(any(unix, target_os = "redox"))]

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -116,7 +116,7 @@ fn test_no_args() {
 fn test_no_args_output() {
     let ts = TestScenario::new(util_name!());
     ts.ucmd().fails().stderr_is(&format!(
-        "{0}: missing operand\nTry `{1} {0} --help` for more information.",
+        "{0}: missing operand\nTry '{1} {0} --help' for more information.",
         ts.util_name,
         ts.bin_path.to_string_lossy()
     ));
@@ -131,7 +131,7 @@ fn test_too_many_args() {
 fn test_too_many_args_output() {
     let ts = TestScenario::new(util_name!());
     ts.ucmd().args(&["a", "b", "c"]).fails().stderr_is(format!(
-        "{0}: extra operand 'c'\nTry `{1} {0} --help` for more information.",
+        "{0}: extra operand 'c'\nTry '{1} {0} --help' for more information.",
         ts.util_name,
         ts.bin_path.to_string_lossy()
     ));

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -568,7 +568,7 @@ fn test_cp_backup_no_clobber_conflicting_options() {
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .fails().stderr_is(&format!(
-            "{0}: options --backup and --no-clobber are mutually exclusive\nTry `{1} {0} --help` for more information.",
+            "{0}: options --backup and --no-clobber are mutually exclusive\nTry '{1} {0} --help' for more information.",
             ts.util_name,
             ts.bin_path.to_string_lossy()
         ));

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -561,14 +561,17 @@ fn test_cp_backup_off() {
 
 #[test]
 fn test_cp_backup_no_clobber_conflicting_options() {
-    let (_, mut ucmd) = at_and_ucmd!();
-
-    ucmd.arg("--backup")
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd()
+        .arg("--backup")
         .arg("--no-clobber")
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .fails()
-        .stderr_is("cp: options --backup and --no-clobber are mutually exclusive\nTry 'cp --help' for more information.");
+        .fails().stderr_is(&format!(
+            "{0}: options --backup and --no-clobber are mutually exclusive\nTry `{1} {0} --help` for more information.",
+            ts.util_name,
+            ts.bin_path.to_string_lossy()
+        ));
 }
 
 #[test]

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -15,11 +15,15 @@ fn test_more_dir_arg() {
     // Maybe we could capture the error, i.e. "Device not found" in that case
     // but I am leaving this for later
     if atty::is(atty::Stream::Stdout) {
-        let result = new_ucmd!().arg(".").run();
+        let ts = TestScenario::new(util_name!());
+        let result = ts.ucmd().arg(".").run();
         result.failure();
-        const EXPECTED_ERROR_MESSAGE: &str =
-            "more: '.' is a directory.\nTry 'more --help' for more information.";
-        assert_eq!(result.stderr_str().trim(), EXPECTED_ERROR_MESSAGE);
+        let expected_error_message = &format!(
+            "{0}: '.' is a directory.\nTry `{1} {0} --help` for more information.",
+            ts.util_name,
+            ts.bin_path.to_string_lossy()
+        );
+        assert_eq!(result.stderr_str().trim(), expected_error_message);
     } else {
     }
 }

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -19,7 +19,7 @@ fn test_more_dir_arg() {
         let result = ts.ucmd().arg(".").run();
         result.failure();
         let expected_error_message = &format!(
-            "{0}: '.' is a directory.\nTry `{1} {0} --help` for more information.",
+            "{0}: '.' is a directory.\nTry '{1} {0} --help' for more information.",
             ts.util_name,
             ts.bin_path.to_string_lossy()
         );

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -529,7 +529,7 @@ fn test_mv_backup_no_clobber_conflicting_options() {
         .arg("file1")
         .arg("file2")
         .fails()
-        .stderr_is(&format!("{0}: options --backup and --no-clobber are mutually exclusive\nTry `{1} {0} --help` for more information.",
+        .stderr_is(&format!("{0}: options --backup and --no-clobber are mutually exclusive\nTry '{1} {0} --help' for more information.",
             ts.util_name,
             ts.bin_path.to_string_lossy()
         ));

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -522,14 +522,17 @@ fn test_mv_backup_off() {
 
 #[test]
 fn test_mv_backup_no_clobber_conflicting_options() {
-    let (_, mut ucmd) = at_and_ucmd!();
+    let ts = TestScenario::new(util_name!());
 
-    ucmd.arg("--backup")
+    ts.ucmd().arg("--backup")
         .arg("--no-clobber")
         .arg("file1")
         .arg("file2")
         .fails()
-        .stderr_is("mv: options --backup and --no-clobber are mutually exclusive\nTry 'mv --help' for more information.");
+        .stderr_is(&format!("{0}: options --backup and --no-clobber are mutually exclusive\nTry `{1} {0} --help` for more information.",
+            ts.util_name,
+            ts.bin_path.to_string_lossy()
+        ));
 }
 
 #[test]

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -22,10 +22,15 @@ fn test_negative_adjustment() {
 
 #[test]
 fn test_adjustment_with_no_command_should_error() {
-    new_ucmd!()
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
     .args(&["-n", "19"])
     .run()
-    .stderr_is("nice: A command must be given with an adjustment.\nTry \"nice --help\" for more information.\n");
+    .stderr_is(&format!("{0}: A command must be given with an adjustment.\nTry `{1} {0} --help` for more information.\n",
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 #[test]

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -27,7 +27,7 @@ fn test_adjustment_with_no_command_should_error() {
     ts.ucmd()
     .args(&["-n", "19"])
     .run()
-    .stderr_is(&format!("{0}: A command must be given with an adjustment.\nTry `{1} {0} --help` for more information.\n",
+    .stderr_is(&format!("{0}: A command must be given with an adjustment.\nTry '{1} {0} --help' for more information.\n",
         ts.util_name,
         ts.bin_path.to_string_lossy()
     ));

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -255,10 +255,12 @@ fn test_rm_force_no_operand() {
 
 #[test]
 fn test_rm_no_operand() {
-    let mut ucmd = new_ucmd!();
-
-    ucmd.fails()
-        .stderr_is("rm: missing an argument\nrm: for help, try 'rm --help'\n");
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd().fails().stderr_is(&format!(
+        "{0}: missing an argument\n{0}: for help, try '{1} {0} --help'\n",
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 #[test]

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -5,7 +5,7 @@ fn test_rejects_nan() {
     let ts = TestScenario::new(util_name!());
 
     ts.ucmd().args(&["NaN"]).fails().stderr_only(format!(
-        "{0}: invalid 'not-a-number' argument: 'NaN'\nTry `{1} {0} --help` for more information.",
+        "{0}: invalid 'not-a-number' argument: 'NaN'\nTry '{1} {0} --help' for more information.",
         ts.util_name,
         ts.bin_path.to_string_lossy()
     ));
@@ -16,7 +16,7 @@ fn test_rejects_non_floats() {
     let ts = TestScenario::new(util_name!());
 
     ts.ucmd().args(&["foo"]).fails().stderr_only(&format!(
-        "{0}: invalid floating point argument: 'foo'\nTry `{1} {0} --help` for more information.",
+        "{0}: invalid floating point argument: 'foo'\nTry '{1} {0} --help' for more information.",
         ts.util_name,
         ts.bin_path.to_string_lossy()
     ));

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -2,16 +2,24 @@ use crate::common::util::*;
 
 #[test]
 fn test_rejects_nan() {
-    new_ucmd!().args(&["NaN"]).fails().stderr_only(
-        "seq: invalid 'not-a-number' argument: 'NaN'\nTry 'seq --help' for more information.",
-    );
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd().args(&["NaN"]).fails().stderr_only(format!(
+        "{0}: invalid 'not-a-number' argument: 'NaN'\nTry `{1} {0} --help` for more information.",
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 #[test]
 fn test_rejects_non_floats() {
-    new_ucmd!().args(&["foo"]).fails().stderr_only(
-        "seq: invalid floating point argument: 'foo'\nTry 'seq --help' for more information.",
-    );
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd().args(&["foo"]).fails().stderr_only(&format!(
+        "{0}: invalid floating point argument: 'foo'\nTry `{1} {0} --help` for more information.",
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 // ---- Tests for the big integer based path ----

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -59,7 +59,7 @@ fn test_stdbuf_line_buffering_stdin_fails() {
         .args(&["-i", "L", "head"])
         .fails()
         .stderr_is(&format!(
-            "{0}: line buffering stdin is meaningless\nTry `{1} {0} --help` for more information.",
+            "{0}: line buffering stdin is meaningless\nTry '{1} {0} --help' for more information.",
             ts.util_name,
             ts.bin_path.to_string_lossy()
         ));

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -25,15 +25,19 @@ fn test_stdbuf_line_buffered_stdout() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn test_stdbuf_no_buffer_option_fails() {
-    new_ucmd!().args(&["head"]).fails().stderr_is(
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd().args(&["head"]).fails().stderr_is(&format!(
         "error: The following required arguments were not provided:\n    \
          --error <MODE>\n    \
          --input <MODE>\n    \
          --output <MODE>\n\n\
          USAGE:\n    \
-         stdbuf OPTION... COMMAND\n\n\
+         {1} {0} OPTION... COMMAND\n\n\
          For more information try --help",
-    );
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -49,9 +53,16 @@ fn test_stdbuf_trailing_var_arg() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn test_stdbuf_line_buffering_stdin_fails() {
-    new_ucmd!().args(&["-i", "L", "head"]).fails().stderr_is(
-        "stdbuf: line buffering stdin is meaningless\nTry 'stdbuf --help' for more information.",
-    );
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-i", "L", "head"])
+        .fails()
+        .stderr_is(&format!(
+            "{0}: line buffering stdin is meaningless\nTry `{1} {0} --help` for more information.",
+            ts.util_name,
+            ts.bin_path.to_string_lossy()
+        ));
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/tests/by-util/test_unlink.rs
+++ b/tests/by-util/test_unlink.rs
@@ -14,17 +14,20 @@ fn test_unlink_file() {
 
 #[test]
 fn test_unlink_multiple_files() {
-    let (at, mut ucmd) = at_and_ucmd!();
+    let ts = TestScenario::new(util_name!());
+
+    let (at, mut ucmd) = (ts.fixtures.clone(), ts.ucmd());
     let file_a = "test_unlink_multiple_file_a";
     let file_b = "test_unlink_multiple_file_b";
 
     at.touch(file_a);
     at.touch(file_b);
 
-    ucmd.arg(file_a).arg(file_b).fails().stderr_is(
-        "unlink: extra operand: 'test_unlink_multiple_file_b'\nTry 'unlink --help' \
-         for more information.\n",
-    );
+    ucmd.arg(file_a).arg(file_b).fails().stderr_is(&format!(
+        "{0}: extra operand: 'test_unlink_multiple_file_b'\nTry `{1} {0} --help` for more information.",
+        ts.util_name,
+        ts.bin_path.to_string_lossy()
+    ));
 }
 
 #[test]

--- a/tests/by-util/test_unlink.rs
+++ b/tests/by-util/test_unlink.rs
@@ -24,7 +24,7 @@ fn test_unlink_multiple_files() {
     at.touch(file_b);
 
     ucmd.arg(file_a).arg(file_b).fails().stderr_is(&format!(
-        "{0}: extra operand: 'test_unlink_multiple_file_b'\nTry `{1} {0} --help` for more information.",
+        "{0}: extra operand: 'test_unlink_multiple_file_b'\nTry '{1} {0} --help' for more information.",
         ts.util_name,
         ts.bin_path.to_string_lossy()
     ));

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -713,7 +713,7 @@ impl AtPath {
 ///
 /// Fixtures can be found under `tests/fixtures/$util_name/`
 pub struct TestScenario {
-    bin_path: PathBuf,
+    pub bin_path: PathBuf,
     pub util_name: String,
     pub fixtures: AtPath,
     tmpd: Rc<TempDir>,

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -2,6 +2,11 @@ mod common;
 
 use common::util::TestScenario;
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink as symlink_file;
+#[cfg(windows)]
+use std::os::windows::fs::symlink_file;
+
 #[test]
 #[cfg(feature = "ls")]
 fn execution_phrase_double() {
@@ -24,7 +29,7 @@ fn execution_phrase_single() {
     use std::process::Command;
 
     let scenario = TestScenario::new("ls");
-    std::fs::copy(scenario.bin_path, scenario.fixtures.plus("uu-ls")).unwrap();
+    symlink_file(scenario.bin_path, scenario.fixtures.plus("uu-ls")).unwrap();
     let output = Command::new(scenario.fixtures.plus("uu-ls"))
         .arg("--some-invalid-arg")
         .output()
@@ -65,7 +70,7 @@ fn util_name_single() {
     };
 
     let scenario = TestScenario::new("sort");
-    std::fs::copy(scenario.bin_path, scenario.fixtures.plus("uu-sort")).unwrap();
+    symlink_file(scenario.bin_path, scenario.fixtures.plus("uu-sort")).unwrap();
     let mut child = Command::new(scenario.fixtures.plus("uu-sort"))
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -1,0 +1,81 @@
+mod common;
+
+use common::util::TestScenario;
+
+#[test]
+#[cfg(feature = "ls")]
+fn execution_phrase_double() {
+    use std::process::Command;
+
+    let scenario = TestScenario::new("ls");
+    let output = Command::new(&scenario.bin_path)
+        .arg("ls")
+        .arg("--some-invalid-arg")
+        .output()
+        .unwrap();
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains(&format!("USAGE:\n    {} ls", scenario.bin_path.display(),)));
+}
+
+#[test]
+#[cfg(feature = "ls")]
+fn execution_phrase_single() {
+    use std::process::Command;
+
+    let scenario = TestScenario::new("ls");
+    std::fs::copy(scenario.bin_path, scenario.fixtures.plus("uu-ls")).unwrap();
+    let output = Command::new(scenario.fixtures.plus("uu-ls"))
+        .arg("--some-invalid-arg")
+        .output()
+        .unwrap();
+    assert!(String::from_utf8(output.stderr).unwrap().contains(&format!(
+        "USAGE:\n    {}",
+        scenario.fixtures.plus("uu-ls").display()
+    )));
+}
+
+#[test]
+#[cfg(feature = "sort")]
+fn util_name_double() {
+    use std::{
+        io::Write,
+        process::{Command, Stdio},
+    };
+
+    let scenario = TestScenario::new("sort");
+    let mut child = Command::new(&scenario.bin_path)
+        .arg("sort")
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    // input invalid utf8 to cause an error
+    child.stdin.take().unwrap().write_all(&[255]).unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(String::from_utf8(output.stderr).unwrap().contains("sort: "));
+}
+
+#[test]
+#[cfg(feature = "sort")]
+fn util_name_single() {
+    use std::{
+        io::Write,
+        process::{Command, Stdio},
+    };
+
+    let scenario = TestScenario::new("sort");
+    std::fs::copy(scenario.bin_path, scenario.fixtures.plus("uu-sort")).unwrap();
+    let mut child = Command::new(scenario.fixtures.plus("uu-sort"))
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    // input invalid utf8 to cause an error
+    child.stdin.take().unwrap().write_all(&[255]).unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(String::from_utf8(output.stderr).unwrap().contains(&format!(
+        "{}: ",
+        scenario.fixtures.plus("uu-sort").display()
+    )));
+}


### PR DESCRIPTION
Closes #2470.
For errors and the usage string we should use the real name of the executable, so that when the executable is renamed to a custom name the custom name is printed.
The app *name*  however has to be the name of the utility regardless of how it was called.