### PR TITLE
silent buggy clippy warning

### DIFF
--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -6,6 +6,9 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -10,6 +10,9 @@
 
 // spell-checker:ignore (ToDO) nonprint nonblank nonprinting
 
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 #[cfg(unix)]
 extern crate unix_socket;
 #[macro_use]

--- a/src/uu/csplit/src/csplit_error.rs
+++ b/src/uu/csplit/src/csplit_error.rs
@@ -1,3 +1,6 @@
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 use std::io;
 use thiserror::Error;
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -7,6 +7,9 @@
 
 // spell-checker:ignore (ToDO) cpio svgz webm somegroup nlink rmvb xspf
 
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 #[macro_use]
 extern crate uucore;
 #[cfg(unix)]

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -5,6 +5,9 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -8,6 +8,9 @@
 
 // spell-checker:ignore (paths) GPGHome
 
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -8,6 +8,9 @@
 
 // spell-checker:ignore (ToDO) filetime strptime utcoff strs datetime MMDDhhmm
 
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 pub extern crate filetime;
 
 #[macro_use]

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -4,6 +4,8 @@
 //  *
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
 
 #[macro_use]
 extern crate uucore;

--- a/src/uucore/src/lib/features/encoding.rs
+++ b/src/uucore/src/lib/features/encoding.rs
@@ -7,6 +7,9 @@
 
 // spell-checker:ignore (strings) ABCDEFGHIJKLMNOPQRSTUVWXYZ
 
+// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
+
 extern crate data_encoding;
 
 use self::data_encoding::{DecodeError, BASE32, BASE64};


### PR DESCRIPTION
Fails with:
```
error: use of irregular braces for `write!` macro
  --> src/uucore/src/lib/features/encoding.rs:19:17
   |
19 | #[derive(Debug, Error)]
   |                 ^^^^^
   |
   = note: `-D clippy::nonstandard-macro-braces` implied by `-D warnings`
help: consider writing `Error`
  --> src/uucore/src/lib/features/encoding.rs:19:17
   |
19 | #[derive(Debug, Error)]
   |                 ^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#nonstandard_macro_braces
   = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)
```