### PR TITLE
sort: make -k only take one argument per flag

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1267,6 +1267,7 @@ pub fn uu_app() -> App<'static, 'static> {
                 .help("sort by a key")
                 .long_help(LONG_HELP_KEYS)
                 .multiple(true)
+                .number_of_values(1)
                 .takes_value(true),
         )
         .arg(

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -951,3 +951,11 @@ fn test_conflict_check_out() {
             );
     }
 }
+
+#[test]
+fn test_key_takes_one_arg() {
+    new_ucmd!()
+        .args(&["-k", "2.3", "keys_open_ended.txt"])
+        .succeeds()
+        .stdout_is_fixture("keys_open_ended.expected");
+}


### PR DESCRIPTION
This makes it so that `sort -k 1 file` treats `file` as the input file
and not the second key.