### PR TITLE
test: du: Skip nondynamic comparison on linux for test_du_bytes

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -579,7 +579,8 @@ fn test_du_bytes() {
     #[cfg(all(
         not(target_vendor = "apple"),
         not(target_os = "windows"),
-        not(target_os = "freebsd")
+        not(target_os = "freebsd"),
+        not(target_os = "linux")
     ))]
     result.stdout_contains("21529\t./subdir\n");
 }


### PR DESCRIPTION
The `test_du_bytes` testcase for the `du --bytes` command is written to perform
a dynamic comparison on linux hosts, i.e. it compares the output of the command
to that of the hosts `du` from the GNU coreutils.

Previously the test was written such that it would *first* perform the dynamic
comparison, and *after that* continue to a static comparison which may fail for
specific hosts that have a filesystem different from what the test expects.

This patch excludes linux hosts from the static comparison to ensure the test
performs only the dynamic comparison.