### PR TITLE
tests/common: refactor to reduce duplicate code

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -573,8 +573,7 @@ fn test_du_bytes() {
     #[cfg(all(
         not(target_vendor = "apple"),
         not(target_os = "windows"),
-        not(target_os = "freebsd"),
-        not(target_os = "linux")
+        not(target_os = "freebsd")
     ))]
     result.stdout_contains("21529\t./subdir\n");
 }

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -3,6 +3,8 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
+//spell-checker: ignore coreutil
+
 use crate::common::util::*;
 
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -1,55 +1,12 @@
 use crate::common::util::*;
 
-// spell-checker:ignore (ToDO) coreutil
-
-// These tests run the GNU coreutils `(g)groups` binary in `$PATH` in order to gather reference values.
-// If the `(g)groups` in `$PATH` doesn't include a coreutils version string,
-// or the version is too low, the test is skipped.
-
-// The reference version is 8.32. Here 8.30 was chosen because right now there's no
-// ubuntu image for github action available with a higher version than 8.30.
-const VERSION_MIN: &str = "8.30"; // minimum Version for the reference `groups` in $PATH
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31
-const UUTILS_WARNING: &str = "uutils-tests-warning";
-const UUTILS_INFO: &str = "uutils-tests-info";
-
-macro_rules! unwrap_or_return {
-    ( $e:expr ) => {
-        match $e {
-            Ok(x) => x,
-            Err(e) => {
-                println!("{}: test skipped: {}", UUTILS_INFO, e);
-                return;
-            }
-        }
-    };
-}
-
-fn whoami() -> String {
-    // Apparently some CI environments have configuration issues, e.g. with 'whoami' and 'id'.
-    //
-    // From the Logs: "Build (ubuntu-18.04, x86_64-unknown-linux-gnu, feat_os_unix, use-cross)"
-    //    whoami: cannot find name for user ID 1001
-    // id --name: cannot find name for user ID 1001
-    // id --name: cannot find name for group ID 116
-    //
-    // However, when running "id" from within "/bin/bash" it looks fine:
-    // id: "uid=1001(runner) gid=118(docker) groups=118(docker),4(adm),101(systemd-journal)"
-    // whoami: "runner"
-
-    // Use environment variable to get current user instead of
-    // invoking `whoami` and fall back to user "nobody" on error.
-    std::env::var("USER").unwrap_or_else(|e| {
-        println!("{}: {}, using \"nobody\" instead", UUTILS_WARNING, e);
-        "nobody".to_string()
-    })
-}
 
 #[test]
 #[cfg(unix)]
 fn test_groups() {
     let result = new_ucmd!().run();
-    let exp_result = unwrap_or_return!(expected_result(&[]));
+    let exp_result = unwrap_or_return!(expected_result(util_name!(), &[]));
 
     result
         .stdout_is(exp_result.stdout_str())
@@ -63,7 +20,7 @@ fn test_groups_username() {
     let test_users = [&whoami()[..]];
 
     let result = new_ucmd!().args(&test_users).run();
-    let exp_result = unwrap_or_return!(expected_result(&test_users));
+    let exp_result = unwrap_or_return!(expected_result(util_name!(), &test_users));
 
     result
         .stdout_is(exp_result.stdout_str())
@@ -74,103 +31,17 @@ fn test_groups_username() {
 #[test]
 #[cfg(unix)]
 fn test_groups_username_multiple() {
-    // TODO: [2021-06; jhscheer] refactor this as `let util_name = host_name_for(util_name!())` when that function is added to 'tests/common'
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(all(unix, not(target_os = "linux")))]
-    let util_name = &format!("g{}", util_name!());
-    let version_check_string = check_coreutil_version(util_name, VERSION_MIN_MULTIPLE_USERS);
-    if version_check_string.starts_with(UUTILS_WARNING) {
-        println!("{}\ntest skipped", version_check_string);
-        return;
-    }
+    unwrap_or_return!(check_coreutil_version(
+        util_name!(),
+        VERSION_MIN_MULTIPLE_USERS
+    ));
     let test_users = ["root", "man", "postfix", "sshd", &whoami()];
 
     let result = new_ucmd!().args(&test_users).run();
-    let exp_result = unwrap_or_return!(expected_result(&test_users));
+    let exp_result = unwrap_or_return!(expected_result(util_name!(), &test_users));
 
     result
         .stdout_is(exp_result.stdout_str())
         .stderr_is(exp_result.stderr_str())
         .code_is(exp_result.code());
-}
-
-fn check_coreutil_version(util_name: &str, version_expected: &str) -> String {
-    // example:
-    // $ id --version | head -n 1
-    // id (GNU coreutils) 8.32.162-4eda
-    let scene = TestScenario::new(util_name);
-    let version_check = scene
-        .cmd_keepenv(&util_name)
-        .env("LC_ALL", "C")
-        .arg("--version")
-        .run();
-    version_check
-        .stdout_str()
-        .split('\n')
-        .collect::<Vec<_>>()
-        .get(0)
-        .map_or_else(
-            || format!("{}: unexpected output format for reference coreutil: '{} --version'", UUTILS_WARNING, util_name),
-            |s| {
-                if s.contains(&format!("(GNU coreutils) {}", version_expected)) {
-                    s.to_string()
-                } else if s.contains("(GNU coreutils)") {
-                    let version_found = s.split_whitespace().last().unwrap()[..4].parse::<f32>().unwrap_or_default();
-                    let version_expected = version_expected.parse::<f32>().unwrap_or_default();
-                    if version_found > version_expected {
-                    format!("{}: version for the reference coreutil '{}' is higher than expected; expected: {}, found: {}", UUTILS_INFO, util_name, version_expected, version_found)
-                    } else {
-                    format!("{}: version for the reference coreutil '{}' does not match; expected: {}, found: {}", UUTILS_WARNING, util_name, version_expected, version_found) }
-                } else {
-                    format!("{}: no coreutils version string found for reference coreutils '{} --version'", UUTILS_WARNING, util_name)
-                }
-            },
-        )
-}
-
-#[allow(clippy::needless_borrow)]
-#[cfg(unix)]
-fn expected_result(args: &[&str]) -> Result<CmdResult, String> {
-    // TODO: [2021-06; jhscheer] refactor this as `let util_name = host_name_for(util_name!())` when that function is added to 'tests/common'
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(all(unix, not(target_os = "linux")))]
-    let util_name = &format!("g{}", util_name!());
-
-    let version_check_string = check_coreutil_version(util_name, VERSION_MIN);
-    if version_check_string.starts_with(UUTILS_WARNING) {
-        return Err(version_check_string);
-    }
-    println!("{}", version_check_string);
-
-    let scene = TestScenario::new(util_name);
-    let result = scene
-        .cmd_keepenv(util_name)
-        .env("LC_ALL", "C")
-        .args(args)
-        .run();
-
-    let (stdout, stderr): (String, String) = if cfg!(target_os = "linux") {
-        (
-            result.stdout_str().to_string(),
-            result.stderr_str().to_string(),
-        )
-    } else {
-        // strip 'g' prefix from results:
-        let from = util_name.to_string() + ":";
-        let to = &from[1..];
-        (
-            result.stdout_str().replace(&from, to),
-            result.stderr_str().replace(&from, to),
-        )
-    };
-
-    Ok(CmdResult::new(
-        Some(result.tmpd()),
-        Some(result.code()),
-        result.succeeded(),
-        stdout.as_bytes(),
-        stderr.as_bytes(),
-    ))
 }

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -10,8 +10,9 @@ const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced 
 #[test]
 #[cfg(unix)]
 fn test_groups() {
-    let result = new_ucmd!().run();
-    let exp_result = unwrap_or_return!(expected_result(util_name!(), &[]));
+    let ts = TestScenario::new(util_name!());
+    let result = ts.ucmd().run();
+    let exp_result = unwrap_or_return!(expected_result(&ts, &[]));
 
     result
         .stdout_is(exp_result.stdout_str())
@@ -24,8 +25,9 @@ fn test_groups() {
 fn test_groups_username() {
     let test_users = [&whoami()[..]];
 
-    let result = new_ucmd!().args(&test_users).run();
-    let exp_result = unwrap_or_return!(expected_result(util_name!(), &test_users));
+    let ts = TestScenario::new(util_name!());
+    let result = ts.ucmd().args(&test_users).run();
+    let exp_result = unwrap_or_return!(expected_result(&ts, &test_users));
 
     result
         .stdout_is(exp_result.stdout_str())
@@ -42,8 +44,9 @@ fn test_groups_username_multiple() {
     ));
     let test_users = ["root", "man", "postfix", "sshd", &whoami()];
 
-    let result = new_ucmd!().args(&test_users).run();
-    let exp_result = unwrap_or_return!(expected_result(util_name!(), &test_users));
+    let ts = TestScenario::new(util_name!());
+    let result = ts.ucmd().args(&test_users).run();
+    let exp_result = unwrap_or_return!(expected_result(&ts, &test_users));
 
     result
         .stdout_is(exp_result.stdout_str())

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -1,3 +1,8 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+
 use crate::common::util::*;
 
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -2,54 +2,13 @@ use crate::common::util::*;
 
 // spell-checker:ignore (ToDO) coreutil
 
-// These tests run the GNU coreutils `(g)id` binary in `$PATH` in order to gather reference values.
-// If the `(g)id` in `$PATH` doesn't include a coreutils version string,
-// or the version is too low, the test is skipped.
-
-// The reference version is 8.32. Here 8.30 was chosen because right now there's no
-// ubuntu image for github action available with a higher version than 8.30.
-const VERSION_MIN: &str = "8.30"; // minimum Version for the reference `id` in $PATH
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31
-const UUTILS_WARNING: &str = "uutils-tests-warning";
-const UUTILS_INFO: &str = "uutils-tests-info";
-
-macro_rules! unwrap_or_return {
-    ( $e:expr ) => {
-        match $e {
-            Ok(x) => x,
-            Err(e) => {
-                println!("{}: test skipped: {}", UUTILS_INFO, e);
-                return;
-            }
-        }
-    };
-}
-
-fn whoami() -> String {
-    // Apparently some CI environments have configuration issues, e.g. with 'whoami' and 'id'.
-    //
-    // From the Logs: "Build (ubuntu-18.04, x86_64-unknown-linux-gnu, feat_os_unix, use-cross)"
-    //    whoami: cannot find name for user ID 1001
-    // id --name: cannot find name for user ID 1001
-    // id --name: cannot find name for group ID 116
-    //
-    // However, when running "id" from within "/bin/bash" it looks fine:
-    // id: "uid=1001(runner) gid=118(docker) groups=118(docker),4(adm),101(systemd-journal)"
-    // whoami: "runner"
-
-    // Use environment variable to get current user instead of
-    // invoking `whoami` and fall back to user "nobody" on error.
-    std::env::var("USER").unwrap_or_else(|e| {
-        println!("{}: {}, using \"nobody\" instead", UUTILS_WARNING, e);
-        "nobody".to_string()
-    })
-}
 
 #[test]
 #[cfg(unix)]
 fn test_id_no_specified_user() {
     let result = new_ucmd!().run();
-    let exp_result = unwrap_or_return!(expected_result(&[]));
+    let exp_result = unwrap_or_return!(expected_result(util_name!(), &[]));
     let mut _exp_stdout = exp_result.stdout_str().to_string();
 
     #[cfg(target_os = "linux")]
@@ -72,7 +31,7 @@ fn test_id_single_user() {
     let test_users = [&whoami()[..]];
 
     let scene = TestScenario::new(util_name!());
-    let mut exp_result = unwrap_or_return!(expected_result(&test_users));
+    let mut exp_result = unwrap_or_return!(expected_result(util_name!(), &test_users));
     scene
         .ucmd()
         .args(&test_users)
@@ -85,7 +44,7 @@ fn test_id_single_user() {
     for &opt in &["--user", "--group", "--groups"] {
         let mut args = vec![opt];
         args.extend_from_slice(&test_users);
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -94,7 +53,7 @@ fn test_id_single_user() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.push("--zero");
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -103,7 +62,7 @@ fn test_id_single_user() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.push("--name");
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -112,7 +71,7 @@ fn test_id_single_user() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.pop();
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -128,7 +87,7 @@ fn test_id_single_user() {
 fn test_id_single_user_non_existing() {
     let args = &["hopefully_non_existing_username"];
     let result = new_ucmd!().args(args).run();
-    let exp_result = unwrap_or_return!(expected_result(args));
+    let exp_result = unwrap_or_return!(expected_result(util_name!(), args));
 
     // It is unknown why on macOS (and possibly others?) `id` adds "Invalid argument".
     // coreutils 8.32: $ LC_ALL=C id foobar
@@ -147,7 +106,7 @@ fn test_id_name() {
     for &opt in &["--user", "--group", "--groups"] {
         let args = [opt, "--name"];
         let result = scene.ucmd().args(&args).run();
-        let exp_result = unwrap_or_return!(expected_result(&args));
+        let exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         result
             .stdout_is(exp_result.stdout_str())
             .stderr_is(exp_result.stderr_str())
@@ -166,7 +125,7 @@ fn test_id_real() {
     for &opt in &["--user", "--group", "--groups"] {
         let args = [opt, "--real"];
         let result = scene.ucmd().args(&args).run();
-        let exp_result = unwrap_or_return!(expected_result(&args));
+        let exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         result
             .stdout_is(exp_result.stdout_str())
             .stderr_is(exp_result.stderr_str())
@@ -206,21 +165,16 @@ fn test_id_password_style() {
 #[test]
 #[cfg(unix)]
 fn test_id_multiple_users() {
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(all(unix, not(target_os = "linux")))]
-    let util_name = &format!("g{}", util_name!());
-    let version_check_string = check_coreutil_version(util_name, VERSION_MIN_MULTIPLE_USERS);
-    if version_check_string.starts_with(UUTILS_WARNING) {
-        println!("{}\ntest skipped", version_check_string);
-        return;
-    }
+    unwrap_or_return!(check_coreutil_version(
+        util_name!(),
+        VERSION_MIN_MULTIPLE_USERS
+    ));
 
     // Same typical users that GNU test suite is using.
     let test_users = ["root", "man", "postfix", "sshd", &whoami()];
 
     let scene = TestScenario::new(util_name!());
-    let mut exp_result = unwrap_or_return!(expected_result(&test_users));
+    let mut exp_result = unwrap_or_return!(expected_result(util_name!(), &test_users));
     scene
         .ucmd()
         .args(&test_users)
@@ -233,7 +187,7 @@ fn test_id_multiple_users() {
     for &opt in &["--user", "--group", "--groups"] {
         let mut args = vec![opt];
         args.extend_from_slice(&test_users);
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -242,7 +196,7 @@ fn test_id_multiple_users() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.push("--zero");
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -251,7 +205,7 @@ fn test_id_multiple_users() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.push("--name");
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -260,7 +214,7 @@ fn test_id_multiple_users() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.pop();
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -274,15 +228,10 @@ fn test_id_multiple_users() {
 #[test]
 #[cfg(unix)]
 fn test_id_multiple_users_non_existing() {
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(all(unix, not(target_os = "linux")))]
-    let util_name = &format!("g{}", util_name!());
-    let version_check_string = check_coreutil_version(util_name, VERSION_MIN_MULTIPLE_USERS);
-    if version_check_string.starts_with(UUTILS_WARNING) {
-        println!("{}\ntest skipped", version_check_string);
-        return;
-    }
+    unwrap_or_return!(check_coreutil_version(
+        util_name!(),
+        VERSION_MIN_MULTIPLE_USERS
+    ));
 
     let test_users = [
         "root",
@@ -298,7 +247,7 @@ fn test_id_multiple_users_non_existing() {
     ];
 
     let scene = TestScenario::new(util_name!());
-    let mut exp_result = unwrap_or_return!(expected_result(&test_users));
+    let mut exp_result = unwrap_or_return!(expected_result(util_name!(), &test_users));
     scene
         .ucmd()
         .args(&test_users)
@@ -311,7 +260,7 @@ fn test_id_multiple_users_non_existing() {
     for &opt in &["--user", "--group", "--groups"] {
         let mut args = vec![opt];
         args.extend_from_slice(&test_users);
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -320,7 +269,7 @@ fn test_id_multiple_users_non_existing() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.push("--zero");
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -329,7 +278,7 @@ fn test_id_multiple_users_non_existing() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.push("--name");
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -338,7 +287,7 @@ fn test_id_multiple_users_non_existing() {
             .stderr_is(exp_result.stderr_str().replace(": Invalid argument", ""))
             .code_is(exp_result.code());
         args.pop();
-        exp_result = unwrap_or_return!(expected_result(&args));
+        exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
         scene
             .ucmd()
             .args(&args)
@@ -360,12 +309,12 @@ fn test_id_default_format() {
             .ucmd()
             .args(&args)
             .fails()
-            .stderr_only(unwrap_or_return!(expected_result(&args)).stderr_str());
+            .stderr_only(unwrap_or_return!(expected_result(util_name!(), &args)).stderr_str());
         for &opt2 in &["--user", "--group", "--groups"] {
             // u/g/G n/r
             let args = [opt2, opt1];
             let result = scene.ucmd().args(&args).run();
-            let exp_result = unwrap_or_return!(expected_result(&args));
+            let exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
             result
                 .stdout_is(exp_result.stdout_str())
                 .stderr_is(exp_result.stderr_str())
@@ -379,7 +328,7 @@ fn test_id_default_format() {
             .ucmd()
             .args(&args)
             .succeeds()
-            .stdout_only(unwrap_or_return!(expected_result(&args)).stdout_str());
+            .stdout_only(unwrap_or_return!(expected_result(util_name!(), &args)).stdout_str());
     }
 }
 
@@ -393,7 +342,7 @@ fn test_id_zero() {
             .ucmd()
             .args(&[z_flag])
             .fails()
-            .stderr_only(unwrap_or_return!(expected_result(&[z_flag])).stderr_str());
+            .stderr_only(unwrap_or_return!(expected_result(util_name!(), &[z_flag])).stderr_str());
         for &opt1 in &["--name", "--real"] {
             // id: cannot print only names or real IDs in default format
             let args = [opt1, z_flag];
@@ -401,12 +350,12 @@ fn test_id_zero() {
                 .ucmd()
                 .args(&args)
                 .fails()
-                .stderr_only(unwrap_or_return!(expected_result(&args)).stderr_str());
+                .stderr_only(unwrap_or_return!(expected_result(util_name!(), &args)).stderr_str());
             for &opt2 in &["--user", "--group", "--groups"] {
                 // u/g/G n/r z
                 let args = [opt2, z_flag, opt1];
                 let result = scene.ucmd().args(&args).run();
-                let exp_result = unwrap_or_return!(expected_result(&args));
+                let exp_result = unwrap_or_return!(expected_result(util_name!(), &args));
                 result
                     .stdout_is(exp_result.stdout_str())
                     .stderr_is(exp_result.stderr_str())
@@ -420,86 +369,7 @@ fn test_id_zero() {
                 .ucmd()
                 .args(&args)
                 .succeeds()
-                .stdout_only(unwrap_or_return!(expected_result(&args)).stdout_str());
+                .stdout_only(unwrap_or_return!(expected_result(util_name!(), &args)).stdout_str());
         }
     }
-}
-
-fn check_coreutil_version(util_name: &str, version_expected: &str) -> String {
-    // example:
-    // $ id --version | head -n 1
-    // id (GNU coreutils) 8.32.162-4eda
-    let scene = TestScenario::new(util_name);
-    let version_check = scene
-        .cmd_keepenv(&util_name)
-        .env("LC_ALL", "C")
-        .arg("--version")
-        .run();
-    version_check
-        .stdout_str()
-        .split('\n')
-        .collect::<Vec<_>>()
-        .get(0)
-        .map_or_else(
-            || format!("{}: unexpected output format for reference coreutil: '{} --version'", UUTILS_WARNING, util_name),
-            |s| {
-                if s.contains(&format!("(GNU coreutils) {}", version_expected)) {
-                    s.to_string()
-                } else if s.contains("(GNU coreutils)") {
-                    let version_found = s.split_whitespace().last().unwrap()[..4].parse::<f32>().unwrap_or_default();
-                    let version_expected = version_expected.parse::<f32>().unwrap_or_default();
-                    if version_found > version_expected {
-                    format!("{}: version for the reference coreutil '{}' is higher than expected; expected: {}, found: {}", UUTILS_INFO, util_name, version_expected, version_found)
-                    } else {
-                    format!("{}: version for the reference coreutil '{}' does not match; expected: {}, found: {}", UUTILS_WARNING, util_name, version_expected, version_found) }
-                } else {
-                    format!("{}: no coreutils version string found for reference coreutils '{} --version'", UUTILS_WARNING, util_name)
-                }
-            },
-        )
-}
-
-#[allow(clippy::needless_borrow)]
-#[cfg(unix)]
-fn expected_result(args: &[&str]) -> Result<CmdResult, String> {
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(all(unix, not(target_os = "linux")))]
-    let util_name = &format!("g{}", util_name!());
-
-    let version_check_string = check_coreutil_version(util_name, VERSION_MIN);
-    if version_check_string.starts_with(UUTILS_WARNING) {
-        return Err(version_check_string);
-    }
-    println!("{}", version_check_string);
-
-    let scene = TestScenario::new(util_name);
-    let result = scene
-        .cmd_keepenv(util_name)
-        .env("LC_ALL", "C")
-        .args(args)
-        .run();
-
-    let (stdout, stderr): (String, String) = if cfg!(target_os = "linux") {
-        (
-            result.stdout_str().to_string(),
-            result.stderr_str().to_string(),
-        )
-    } else {
-        // strip 'g' prefix from results:
-        let from = util_name.to_string() + ":";
-        let to = &from[1..];
-        (
-            result.stdout_str().replace(&from, to),
-            result.stderr_str().replace(&from, to),
-        )
-    };
-
-    Ok(CmdResult::new(
-        Some(result.tmpd()),
-        Some(result.code()),
-        result.succeeded(),
-        stdout.as_bytes(),
-        stderr.as_bytes(),
-    ))
 }

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -1,6 +1,11 @@
-use crate::common::util::*;
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) coreutil
+
+use crate::common::util::*;
 
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31
 

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -42,15 +42,17 @@ fn test_long_format() {
         ));
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_long_format_multiple_users() {
     let args = ["-l", "root", "root", "root"];
+    let expect = unwrap_or_return!(expected_result(util_name!(), &args));
 
     new_ucmd!()
         .args(&args)
         .succeeds()
-        .stdout_is(expected_result(&args));
+        .stdout_is(expect.stdout_str())
+        .stderr_is(expect.stderr_str());
 }
 
 #[test]
@@ -59,55 +61,38 @@ fn test_long_format_wo_user() {
     new_ucmd!().arg("-l").fails().code_is(1);
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_short_format_i() {
     // allow whitespace variation
     // * minor whitespace differences occur between platform built-in outputs; specifically, the number of trailing TABs may be variant
     let args = ["-i"];
     let actual = new_ucmd!().args(&args).succeeds().stdout_move_str();
-    let expect = expected_result(&args);
+    let expect = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
     let v_actual: Vec<&str> = actual.split_whitespace().collect();
     let v_expect: Vec<&str> = expect.split_whitespace().collect();
     assert_eq!(v_actual, v_expect);
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_short_format_q() {
     // allow whitespace variation
     // * minor whitespace differences occur between platform built-in outputs; specifically, the number of trailing TABs may be variant
     let args = ["-q"];
     let actual = new_ucmd!().args(&args).succeeds().stdout_move_str();
-    let expect = expected_result(&args);
+    let expect = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
     let v_actual: Vec<&str> = actual.split_whitespace().collect();
     let v_expect: Vec<&str> = expect.split_whitespace().collect();
     assert_eq!(v_actual, v_expect);
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_no_flag() {
     let actual = new_ucmd!().succeeds().stdout_move_str();
-    let expect = expected_result(&[]);
+    let expect = unwrap_or_return!(expected_result(util_name!(), &[])).stdout_move_str();
     let v_actual: Vec<&str> = actual.split_whitespace().collect();
     let v_expect: Vec<&str> = expect.split_whitespace().collect();
     assert_eq!(v_actual, v_expect);
-}
-
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
-fn expected_result(args: &[&str]) -> String {
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(target_vendor = "apple")]
-    let util_name = format!("g{}", util_name!());
-
-    // note: clippy::needless_borrow *false positive*
-    #[allow(clippy::needless_borrow)]
-    TestScenario::new(&util_name)
-        .cmd_keepenv(util_name)
-        .env("LC_ALL", "C")
-        .args(args)
-        .succeeds()
-        .stdout_move_str()
 }

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -25,19 +25,16 @@ fn test_long_format() {
     let login = "root";
     let pw: Passwd = Passwd::locate(login).unwrap();
     let real_name = pw.user_info().replace("&", &pw.name().capitalize());
-    new_ucmd!()
-        .arg("-l")
-        .arg(login)
-        .succeeds()
-        .stdout_is(format!(
-            "Login name: {:<28}In real life:  {}\nDirectory: {:<29}Shell:  {}\n\n",
-            login,
-            real_name,
-            pw.user_dir(),
-            pw.user_shell()
-        ));
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd().arg("-l").arg(login).succeeds().stdout_is(format!(
+        "Login name: {:<28}In real life:  {}\nDirectory: {:<29}Shell:  {}\n\n",
+        login,
+        real_name,
+        pw.user_dir(),
+        pw.user_shell()
+    ));
 
-    new_ucmd!()
+    ts.ucmd()
         .arg("-lb")
         .arg(login)
         .succeeds()
@@ -51,9 +48,10 @@ fn test_long_format() {
 #[test]
 fn test_long_format_multiple_users() {
     let args = ["-l", "root", "root", "root"];
-    let expect = unwrap_or_return!(expected_result(util_name!(), &args));
+    let ts = TestScenario::new(util_name!());
+    let expect = unwrap_or_return!(expected_result(&ts, &args));
 
-    new_ucmd!()
+    ts.ucmd()
         .args(&args)
         .succeeds()
         .stdout_is(expect.stdout_str())
@@ -72,8 +70,9 @@ fn test_short_format_i() {
     // allow whitespace variation
     // * minor whitespace differences occur between platform built-in outputs; specifically, the number of trailing TABs may be variant
     let args = ["-i"];
-    let actual = new_ucmd!().args(&args).succeeds().stdout_move_str();
-    let expect = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
+    let ts = TestScenario::new(util_name!());
+    let actual = ts.ucmd().args(&args).succeeds().stdout_move_str();
+    let expect = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
     let v_actual: Vec<&str> = actual.split_whitespace().collect();
     let v_expect: Vec<&str> = expect.split_whitespace().collect();
     assert_eq!(v_actual, v_expect);
@@ -85,8 +84,9 @@ fn test_short_format_q() {
     // allow whitespace variation
     // * minor whitespace differences occur between platform built-in outputs; specifically, the number of trailing TABs may be variant
     let args = ["-q"];
-    let actual = new_ucmd!().args(&args).succeeds().stdout_move_str();
-    let expect = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
+    let ts = TestScenario::new(util_name!());
+    let actual = ts.ucmd().args(&args).succeeds().stdout_move_str();
+    let expect = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
     let v_actual: Vec<&str> = actual.split_whitespace().collect();
     let v_expect: Vec<&str> = expect.split_whitespace().collect();
     assert_eq!(v_actual, v_expect);
@@ -95,8 +95,9 @@ fn test_short_format_q() {
 #[cfg(unix)]
 #[test]
 fn test_no_flag() {
-    let actual = new_ucmd!().succeeds().stdout_move_str();
-    let expect = unwrap_or_return!(expected_result(util_name!(), &[])).stdout_move_str();
+    let ts = TestScenario::new(util_name!());
+    let actual = ts.ucmd().succeeds().stdout_move_str();
+    let expect = unwrap_or_return!(expected_result(&ts, &[])).stdout_move_str();
     let v_actual: Vec<&str> = actual.split_whitespace().collect();
     let v_expect: Vec<&str> = expect.split_whitespace().collect();
     assert_eq!(v_actual, v_expect);

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -1,3 +1,8 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+
 extern crate uucore;
 
 use crate::common::util::*;

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -114,16 +114,18 @@ const FS_FORMAT_STR: &str = "%b %c %i %l %n %s %S %t %T"; // avoid "%a %d %f" wh
 #[cfg(target_os = "linux")]
 fn test_terse_fs_format() {
     let args = ["-f", "-t", "/proc"];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-    new_ucmd!().args(&args).run().stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).run().stdout_is(expected_stdout);
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_fs_format() {
     let args = ["-f", "-c", FS_FORMAT_STR, "/dev/shm"];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-    new_ucmd!().args(&args).run().stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).run().stdout_is(expected_stdout);
 }
 
 #[cfg(unix)]
@@ -132,8 +134,9 @@ fn test_terse_normal_format() {
     // note: contains birth/creation date which increases test fragility
     // * results may vary due to built-in `stat` limitations as well as linux kernel and rust version capability variations
     let args = ["-t", "/"];
-    let actual = new_ucmd!().args(&args).succeeds().stdout_move_str();
-    let expect = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
+    let ts = TestScenario::new(util_name!());
+    let actual = ts.ucmd().args(&args).succeeds().stdout_move_str();
+    let expect = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
     let v_actual: Vec<&str> = actual.trim().split(' ').collect();
@@ -161,8 +164,9 @@ fn test_terse_normal_format() {
 #[test]
 fn test_format_created_time() {
     let args = ["-c", "%w", "/bin"];
-    let actual = new_ucmd!().args(&args).succeeds().stdout_move_str();
-    let expect = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
+    let ts = TestScenario::new(util_name!());
+    let actual = ts.ucmd().args(&args).succeeds().stdout_move_str();
+    let expect = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
     // note: using a regex instead of `split_whitespace()` in order to detect whitespace differences
@@ -185,8 +189,9 @@ fn test_format_created_time() {
 #[test]
 fn test_format_created_seconds() {
     let args = ["-c", "%W", "/bin"];
-    let actual = new_ucmd!().args(&args).succeeds().stdout_move_str();
-    let expect = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
+    let ts = TestScenario::new(util_name!());
+    let actual = ts.ucmd().args(&args).succeeds().stdout_move_str();
+    let expect = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
     println!("actual: {:?}", actual);
     println!("expect: {:?}", expect);
     // note: using a regex instead of `split_whitespace()` in order to detect whitespace differences
@@ -209,18 +214,16 @@ fn test_format_created_seconds() {
 #[test]
 fn test_normal_format() {
     let args = ["-c", NORMAL_FORMAT_STR, "/bin"];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-    new_ucmd!()
-        .args(&args)
-        .succeeds()
-        .stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }
 
 #[cfg(unix)]
 #[test]
 fn test_symlinks() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
 
     let mut tested: bool = false;
     // arbitrarily chosen symlinks with hope that the CI environment provides at least one of them
@@ -234,22 +237,12 @@ fn test_symlinks() {
         if at.file_exists(file) && at.is_symlink(file) {
             tested = true;
             let args = ["-c", NORMAL_FORMAT_STR, file];
-            let expected_stdout =
-                unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-            scene
-                .ucmd()
-                .args(&args)
-                .succeeds()
-                .stdout_is(expected_stdout);
+            let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+            ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
             // -L, --dereference    follow links
             let args = ["-L", "-c", NORMAL_FORMAT_STR, file];
-            let expected_stdout =
-                unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-            scene
-                .ucmd()
-                .args(&args)
-                .succeeds()
-                .stdout_is(expected_stdout);
+            let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+            ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
         }
     }
     if !tested {
@@ -275,11 +268,9 @@ fn test_char() {
         #[cfg(any(target_vendor = "apple"))]
         "/dev/ptmx",
     ];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-    new_ucmd!()
-        .args(&args)
-        .succeeds()
-        .stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }
 
 #[cfg(unix)]
@@ -294,11 +285,9 @@ fn test_multi_files() {
         "/etc/fstab",
         "/var",
     ];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-    new_ucmd!()
-        .args(&args)
-        .succeeds()
-        .stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }
 
 #[cfg(unix)]
@@ -308,9 +297,7 @@ fn test_printf() {
         "--printf=123%-# 15q\\r\\\"\\\\\\a\\b\\e\\f\\v%+020.23m\\x12\\167\\132\\112\\n",
         "/",
     ];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-    new_ucmd!()
-        .args(&args)
-        .succeeds()
-        .stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -1,3 +1,8 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+
 extern crate regex;
 
 use crate::common::util::*;

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -1,30 +1,33 @@
-use crate::common::util::*;
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
 
 // spell-checker:ignore (flags) runlevel mesg
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+use crate::common::util::*;
+
+#[cfg(unix)]
 #[test]
 fn test_count() {
     for opt in &["-q", "--count"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_boot() {
     for opt in &["-b", "--boot"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_heading() {
     for opt in &["-H", "--heading"] {
@@ -32,7 +35,7 @@ fn test_heading() {
         // * minor whitespace differences occur between platform built-in outputs;
         //   specifically number of TABs between "TIME" and "COMMENT" may be variant
         let actual = new_ucmd!().arg(opt).succeeds().stdout_move_str();
-        let expect = expected_result(&[opt]);
+        let expect = unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
         println!("actual: {:?}", actual);
         println!("expect: {:?}", expect);
         let v_actual: Vec<&str> = actual.split_whitespace().collect();
@@ -41,76 +44,70 @@ fn test_heading() {
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_short() {
     for opt in &["-s", "--short"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_login() {
     for opt in &["-l", "--login"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_m() {
     for opt in &["-m"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_process() {
     for opt in &["-p", "--process"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn test_runlevel() {
     for opt in &["-r", "--runlevel"] {
-        #[cfg(any(target_vendor = "apple", target_os = "linux"))]
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
 
         #[cfg(not(target_os = "linux"))]
         new_ucmd!().arg(opt).succeeds().stdout_is("");
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_time() {
     for opt in &["-t", "--time"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_mesg() {
     // -T, -w, --mesg
@@ -120,21 +117,22 @@ fn test_mesg() {
     // --writable
     //     same as -T
     for opt in &["-T", "-w", "--mesg", "--message", "--writable"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn test_arg1_arg2() {
     let args = ["am", "i"];
+    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
 
     new_ucmd!()
         .args(&args)
         .succeeds()
-        .stdout_is(expected_result(&args));
+        .stdout_is(expected_stdout);
 }
 
 #[test]
@@ -146,12 +144,12 @@ fn test_too_many_args() {
     new_ucmd!().args(&args).fails().stderr_contains(EXPECTED);
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_users() {
     for opt in &["-u", "--users"] {
         let actual = new_ucmd!().arg(opt).succeeds().stdout_move_str();
-        let expect = expected_result(&[opt]);
+        let expect = unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
         println!("actual: {:?}", actual);
         println!("expect: {:?}", expect);
 
@@ -170,28 +168,26 @@ fn test_users() {
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_lookup() {
     let opt = "--lookup";
-    new_ucmd!()
-        .arg(opt)
-        .succeeds()
-        .stdout_is(expected_result(&[opt]));
+    let expected_stdout =
+        unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+    new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_dead() {
     for opt in &["-d", "--dead"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_all_separately() {
     if cfg!(target_os = "macos") {
@@ -201,20 +197,23 @@ fn test_all_separately() {
 
     // -a, --all         same as -b -d --login -p -r -t -T -u
     let args = ["-b", "-d", "--login", "-p", "-r", "-t", "-T", "-u"];
+    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
     let scene = TestScenario::new(util_name!());
     scene
         .ucmd()
         .args(&args)
         .succeeds()
-        .stdout_is(expected_result(&args));
+        .stdout_is(expected_stdout);
+    let expected_stdout =
+        unwrap_or_return!(expected_result(util_name!(), &["--all"])).stdout_move_str();
     scene
         .ucmd()
         .arg("--all")
         .succeeds()
-        .stdout_is(expected_result(&args));
+        .stdout_is(expected_stdout);
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+#[cfg(unix)]
 #[test]
 fn test_all() {
     if cfg!(target_os = "macos") {
@@ -223,26 +222,8 @@ fn test_all() {
     }
 
     for opt in &["-a", "--all"] {
-        new_ucmd!()
-            .arg(opt)
-            .succeeds()
-            .stdout_is(expected_result(&[opt]));
+        let expected_stdout =
+            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
     }
-}
-
-#[cfg(any(target_vendor = "apple", target_os = "linux"))]
-fn expected_result(args: &[&str]) -> String {
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(target_vendor = "apple")]
-    let util_name = format!("g{}", util_name!());
-
-    // note: clippy::needless_borrow *false positive*
-    #[allow(clippy::needless_borrow)]
-    TestScenario::new(&util_name)
-        .cmd_keepenv(util_name)
-        .env("LC_ALL", "C")
-        .args(args)
-        .succeeds()
-        .stdout_move_str()
 }

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -10,32 +10,33 @@ use crate::common::util::*;
 #[cfg(unix)]
 #[test]
 fn test_count() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-q", "--count"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
 #[cfg(unix)]
 #[test]
 fn test_boot() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-b", "--boot"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
 #[cfg(unix)]
 #[test]
 fn test_heading() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-H", "--heading"] {
         // allow whitespace variation
         // * minor whitespace differences occur between platform built-in outputs;
         //   specifically number of TABs between "TIME" and "COMMENT" may be variant
-        let actual = new_ucmd!().arg(opt).succeeds().stdout_move_str();
-        let expect = unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        let actual = ts.ucmd().arg(opt).succeeds().stdout_move_str();
+        let expect = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         println!("actual: {:?}", actual);
         println!("expect: {:?}", expect);
         let v_actual: Vec<&str> = actual.split_whitespace().collect();
@@ -47,63 +48,63 @@ fn test_heading() {
 #[cfg(unix)]
 #[test]
 fn test_short() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-s", "--short"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
 #[cfg(unix)]
 #[test]
 fn test_login() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-l", "--login"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
 #[cfg(unix)]
 #[test]
 fn test_m() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-m"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
 #[cfg(unix)]
 #[test]
 fn test_process() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-p", "--process"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
 #[cfg(unix)]
 #[test]
 fn test_runlevel() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-r", "--runlevel"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
 
         #[cfg(not(target_os = "linux"))]
-        new_ucmd!().arg(opt).succeeds().stdout_is("");
+        ts.ucmd().arg(opt).succeeds().stdout_is("");
     }
 }
 
 #[cfg(unix)]
 #[test]
 fn test_time() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-t", "--time"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
@@ -116,10 +117,10 @@ fn test_mesg() {
     //     same as -T
     // --writable
     //     same as -T
+    let ts = TestScenario::new(util_name!());
     for opt in &["-T", "-w", "--mesg", "--message", "--writable"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
@@ -127,12 +128,9 @@ fn test_mesg() {
 #[test]
 fn test_arg1_arg2() {
     let args = ["am", "i"];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-
-    new_ucmd!()
-        .args(&args)
-        .succeeds()
-        .stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }
 
 #[test]
@@ -147,9 +145,10 @@ fn test_too_many_args() {
 #[cfg(unix)]
 #[test]
 fn test_users() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-u", "--users"] {
-        let actual = new_ucmd!().arg(opt).succeeds().stdout_move_str();
-        let expect = unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
+        let actual = ts.ucmd().arg(opt).succeeds().stdout_move_str();
+        let expect = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         println!("actual: {:?}", actual);
         println!("expect: {:?}", expect);
 
@@ -172,18 +171,18 @@ fn test_users() {
 #[test]
 fn test_lookup() {
     let opt = "--lookup";
-    let expected_stdout =
-        unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-    new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+    ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
 }
 
 #[cfg(unix)]
 #[test]
 fn test_dead() {
+    let ts = TestScenario::new(util_name!());
     for opt in &["-d", "--dead"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }
 
@@ -197,20 +196,11 @@ fn test_all_separately() {
 
     // -a, --all         same as -b -d --login -p -r -t -T -u
     let args = ["-b", "-d", "--login", "-p", "-r", "-t", "-T", "-u"];
-    let expected_stdout = unwrap_or_return!(expected_result(util_name!(), &args)).stdout_move_str();
-    let scene = TestScenario::new(util_name!());
-    scene
-        .ucmd()
-        .args(&args)
-        .succeeds()
-        .stdout_is(expected_stdout);
-    let expected_stdout =
-        unwrap_or_return!(expected_result(util_name!(), &["--all"])).stdout_move_str();
-    scene
-        .ucmd()
-        .arg("--all")
-        .succeeds()
-        .stdout_is(expected_stdout);
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
+    let expected_stdout = unwrap_or_return!(expected_result(&ts, &["--all"])).stdout_move_str();
+    ts.ucmd().arg("--all").succeeds().stdout_is(expected_stdout);
 }
 
 #[cfg(unix)]
@@ -221,9 +211,9 @@ fn test_all() {
         return;
     }
 
+    let ts = TestScenario::new(util_name!());
     for opt in &["-a", "--all"] {
-        let expected_stdout =
-            unwrap_or_return!(expected_result(util_name!(), &[opt])).stdout_move_str();
-        new_ucmd!().arg(opt).succeeds().stdout_is(expected_stdout);
+        let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
+        ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
 }

--- a/tests/by-util/test_whoami.rs
+++ b/tests/by-util/test_whoami.rs
@@ -3,6 +3,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
+#[cfg(unix)]
 use crate::common::util::*;
 
 #[test]
@@ -39,7 +40,9 @@ fn test_normal_compare_env() {
     if whoami == "nobody" {
         println!("test skipped:");
         return;
-    } else {
+    } else if !is_ci() {
         new_ucmd!().succeeds().stdout_is(format!("{}\n", whoami));
+    } else {
+        println!("test skipped:");
     }
 }

--- a/tests/by-util/test_whoami.rs
+++ b/tests/by-util/test_whoami.rs
@@ -1,63 +1,45 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+
 use crate::common::util::*;
 
-// Apparently some CI environments have configuration issues, e.g. with 'whoami' and 'id'.
-// If we are running inside the CI and "needle" is in "stderr" skipping this test is
-// considered okay. If we are not inside the CI this calls assert!(result.success).
-//
-// From the Logs: "Build (ubuntu-18.04, x86_64-unknown-linux-gnu, feat_os_unix, use-cross)"
-// stderr: "whoami: failed to get username"
-// Maybe: "adduser --uid 1001 username" can put things right?
-fn skipping_test_is_okay(result: &CmdResult, needle: &str) -> bool {
-    if !result.succeeded() {
-        println!("result.stdout = {}", result.stdout_str());
-        println!("result.stderr = {}", result.stderr_str());
-        if is_ci() && result.stderr_str().contains(needle) {
-            println!("test skipped:");
-            return true;
-        } else {
-            result.success();
-        }
-    }
-    false
-}
-
 #[test]
+#[cfg(unix)]
 fn test_normal() {
-    let (_, mut ucmd) = at_and_ucmd!();
+    let ts = TestScenario::new(util_name!());
+    let result = ts.ucmd().run();
+    let exp_result = unwrap_or_return!(expected_result(&ts, &[]));
 
-    let result = ucmd.run();
-
-    // use std::env;
-    // println!("env::var(CI).is_ok() = {}", env::var("CI").is_ok());
-    // for (key, value) in env::vars() {
-    //     println!("{}: {}", key, value);
-    // }
-
-    if skipping_test_is_okay(&result, "failed to get username") {
-        return;
-    }
-
-    result.no_stderr();
-    assert!(!result.stdout_str().trim().is_empty());
+    result
+        .stdout_is(exp_result.stdout_str())
+        .stderr_is(exp_result.stderr_str())
+        .code_is(exp_result.code());
 }
 
 #[test]
-#[cfg(not(windows))]
+#[cfg(unix)]
 fn test_normal_compare_id() {
-    let scene = TestScenario::new(util_name!());
-
-    let result_ucmd = scene.ucmd().run();
-    if skipping_test_is_okay(&result_ucmd, "failed to get username") {
-        return;
+    let ts = TestScenario::new("id");
+    let id_un = unwrap_or_return!(expected_result(&ts, &["-un"]));
+    if id_un.succeeded() {
+        new_ucmd!().succeeds().stdout_is(id_un.stdout_str());
+    } else if is_ci() && id_un.stderr_str().contains("cannot find name for user ID") {
+        println!("test skipped:");
+    } else {
+        id_un.success();
     }
+}
 
-    let result_cmd = scene.cmd("id").arg("-un").run();
-    if skipping_test_is_okay(&result_cmd, "cannot find name for user ID") {
+#[test]
+#[cfg(unix)]
+fn test_normal_compare_env() {
+    let whoami = whoami();
+    if whoami == "nobody" {
+        println!("test skipped:");
         return;
+    } else {
+        new_ucmd!().succeeds().stdout_is(format!("{}\n", whoami));
     }
-
-    assert_eq!(
-        result_ucmd.stdout_str().trim(),
-        result_cmd.stdout_str().trim()
-    );
 }

--- a/tests/common/macros.rs
+++ b/tests/common/macros.rs
@@ -66,3 +66,19 @@ macro_rules! at_and_ucmd {
         (ts.fixtures.clone(), ts.ucmd())
     }};
 }
+
+/// If `common::util::expected_result` returns an error, i.e. the `util` in `$PATH` doesn't
+/// include a coreutils version string or the version is too low,
+/// this macro can be used to automatically skip the test and print the reason.
+#[macro_export]
+macro_rules! unwrap_or_return {
+    ( $e:expr ) => {
+        match $e {
+            Ok(x) => x,
+            Err(e) => {
+                println!("test skipped: {}", e);
+                return;
+            }
+        }
+    };
+}

--- a/tests/common/macros.rs
+++ b/tests/common/macros.rs
@@ -1,3 +1,8 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+
 /// Platform-independent helper for constructing a PathBuf from individual elements
 #[macro_export]
 macro_rules! path_concat {

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1,3 +1,8 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+
 //spell-checker: ignore (linux) rlimit prlimit Rlim coreutil
 
 #![allow(dead_code)]


### PR DESCRIPTION
* move fn expected_result to common/util.rs
* move fn check_coreutil_version to common/util.rs
* move fn whoami to common/util.rs
* move macro unwrap_or_return to common/macros.rs
* add documentation
* add tests