### PR TITLE
`tr` should error out when if user provides more than 2 sets

### DIFF
--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -259,10 +259,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let squeeze_flag = matches.is_present(options::SQUEEZE);
     let truncate_flag = matches.is_present(options::TRUNCATE);
 
-    let sets = match matches.values_of(options::SETS) {
-        Some(v) => v.map(|v| v.to_string()).collect(),
-        None => vec![],
-    };
+    let sets = matches
+        .values_of(options::SETS)
+        .map(|v| v.map(ToString::to_string).collect::<Vec<_>>())
+        .unwrap_or_default();
 
     if sets.is_empty() {
         show_error!(

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -364,6 +364,7 @@ pub fn uu_app() -> App<'static, 'static> {
             Arg::with_name(options::SETS)
                 .multiple(true)
                 .takes_value(true)
+                .min_values(1)
                 .max_values(2),
         )
 }

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -281,15 +281,6 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         return 1;
     }
 
-    if sets.len() > 2 {
-        show_error!(
-            "extra operand '{}'\nTry `{} --help` for more information.",
-            sets[2],
-            executable!()
-        );
-        return 1;
-    }
-
     let stdin = stdin();
     let mut locked_stdin = stdin.lock();
     let stdout = stdout();
@@ -369,5 +360,10 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short("t")
                 .help("first truncate SET1 to length of SET2"),
         )
-        .arg(Arg::with_name(options::SETS).multiple(true))
+        .arg(
+            Arg::with_name(options::SETS)
+                .multiple(true)
+                .takes_value(true)
+                .max_values(2),
+        )
 }

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -235,7 +235,7 @@ fn get_usage() -> String {
 }
 
 fn get_long_usage() -> String {
-    String::from(
+    format!(
         "Translate, squeeze, and/or delete characters from standard input,
 writing to standard output.",
     )
@@ -259,7 +259,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let squeeze_flag = matches.is_present(options::SQUEEZE);
     let truncate_flag = matches.is_present(options::TRUNCATE);
 
-    let sets: Vec<String> = match matches.values_of(options::SETS) {
+    let sets = match matches.values_of(options::SETS) {
         Some(v) => v.map(|v| v.to_string()).collect(),
         None => vec![],
     };
@@ -276,6 +276,15 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         show_error!(
             "missing operand after '{}'\nTry `{} --help` for more information.",
             sets[0],
+            executable!()
+        );
+        return 1;
+    }
+
+    if sets.len() > 2 {
+        show_error!(
+            "extra operand '{}'\nTry `{} --help` for more information.",
+            sets[2],
             executable!()
         );
         return 1;

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -275,3 +275,11 @@ fn test_interpret_backslash_at_eol_literally() {
         .succeeds()
         .stdout_is("\\");
 }
+
+#[test]
+fn test_more_than_2_sets() {
+    new_ucmd!()
+        .args(&["'abcdefgh'", "'a", "'b'"])
+        .pipe_in("hello world")
+        .fails();
+}


### PR DESCRIPTION
```shell
coreutils on  master [$?] is 📦 v0.0.6 via 🦀 v1.53.0 
❯ echo "test" | ./target/debug/coreutils tr 'f' 'f' 'f'
test

coreutils on  master [$?] is 📦 v0.0.6 via 🦀 v1.53.0 
❯ echo "hello" | tr 'f' 'f' 'f'
tr: extra operand ‘f’
Try 'tr --help' for more information.
```

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>