### PR TITLE
uucore_procs: add full feature flag to syn

### DIFF
--- a/src/uucore_procs/Cargo.toml
+++ b/src/uucore_procs/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version="1.0" }
+syn = { version="1.0", features = ["full"] }
 
 [features]
 default = []


### PR DESCRIPTION
Fixes
```
cargo build
   Compiling uucore_procs v0.0.5 (/home/terts/Programming/coreutils/src/uucore_procs)
error[E0432]: unresolved import `syn::ItemFn`
 --> src/uucore_procs/src/lib.rs:7:36
  |
7 | use syn::{self, parse_macro_input, ItemFn};
  |                                    ^^^^^^ no `ItemFn` in the root

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `uucore_procs`

To learn more, run the command again with --verbose.
```
when building for example `ls` individually.