### PR TITLE
Add block size display to ls (`ls -l`)

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1392,12 +1392,12 @@ fn get_display_size(md: &Metadata) -> u64 {
         if md.is_dir() {
             return 0;
         }
-        return md.len() as u64;
+        md.len() as u64
     }
 
     #[cfg(unix)]
     {
-        return md.blocks() as u64;
+        md.blocks() as u64
     }
 }
 
@@ -1418,7 +1418,7 @@ fn get_max_sizes(items: &[PathData], config: &Config) -> (usize, usize, usize, u
         }
     }
 
-    return (max_links, max_width, max_blocks, total_size);
+    (max_links, max_width, max_blocks, total_size)
 }
 
 fn pad_left(string: impl Display, count: usize) -> String {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2059,12 +2059,14 @@ fn test_ls_block_size_display_short() {
     at.append("file-2", &"x".repeat(100000));
 
     let result = scene.ucmd().arg("-s").succeeds();
-    #[cfg(not(windows))]
+    // Block sizes vary by OS. Only values for the following OS'es are checked
+    #[cfg(target_os = "macos")]
     result.stdout_only("  0 dir-test\n  8 file-1\n200 file-2\n");
-    #[cfg(windows)]
+    #[cfg(any(target_os = "linux", target_os="freebsd"))]
+    result.stdout_only("  8 dir-test\n  8 file-1\n200 file-2\n");
+    #[cfg(target_os = "windows")]
     result.stdout_only("     0 dir-test\n  1000 file-1\n100000 file-2\n");
 }
-
 
 #[test]
 fn test_ls_block_size_display_long() {
@@ -2078,12 +2080,21 @@ fn test_ls_block_size_display_long() {
     at.append("file-2", &"x".repeat(100000));
 
     let result = scene.ucmd().arg("-ls").succeeds();
-    #[cfg(not(windows))] {
+    // Block sizes vary by OS. Only values for the following OS'es are checked
+    #[cfg(target_os = "macos")]
+    {
         result.stdout_contains("\n  0 ");
         result.stdout_contains("\n  8 "); // for file-1
         result.stdout_contains("\n200 "); // for file-
     }
-    #[cfg(windows)] {
+    #[cfg(any(target_os = "linux", target_os="freebsd"))]
+    {
+        result.stdout_contains("\n  8 "); // for directory
+        result.stdout_contains("\n  8 "); // for file-1
+        result.stdout_contains("\n200 "); // for file-2
+    }
+    #[cfg(target_os = "windows")]
+    {
         result.stdout_contains("\n     0 ");
         result.stdout_contains("\n  1000 "); // for file-1
         result.stdout_contains("\n100000 "); // for file-2

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2063,7 +2063,7 @@ fn test_ls_block_size_display_short() {
     // Block sizes vary by OS. Only values for the following OS'es are checked
     #[cfg(target_os = "macos")]
     result.stdout_only("  0 dir-test\n  8 file-1\n200 file-2\n");
-    #[cfg(any(target_os = "linux", target_os="freebsd"))]
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     result.stdout_only("  8 dir-test\n  8 file-1\n200 file-2\n");
     #[cfg(target_os = "windows")]
     result.stdout_only("     0 dir-test\n  1000 file-1\n100000 file-2\n");
@@ -2088,7 +2088,7 @@ fn test_ls_block_size_display_long() {
         result.stdout_contains("\n  8 "); // for file-1
         result.stdout_contains("\n200 "); // for file-
     }
-    #[cfg(any(target_os = "linux", target_os="freebsd"))]
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     {
         result.stdout_contains("\n  8 "); // for directory
         result.stdout_contains("\n  8 "); // for file-1

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2058,7 +2058,8 @@ fn test_ls_block_size_display_short() {
     at.touch("file-2");
     at.append("file-2", &"x".repeat(100000));
 
-    let result = scene.ucmd().arg("-s").succeeds();
+    let result = scene.ucmd().arg("-s").arg("-w=0").succeeds();
+
     // Block sizes vary by OS. Only values for the following OS'es are checked
     #[cfg(target_os = "macos")]
     result.stdout_only("  0 dir-test\n  8 file-1\n200 file-2\n");


### PR DESCRIPTION
This adds block size display to `ls` on Unix systems, and displays size on Windows to keep it consistent with the existing behaviour. This works on both long and grid-displays. This still does not implement the `-k` flag for #2257 but we can add it going forward.

I've tested this on macOS, Windows and FreeBSD.

```
$ cargo run ls -ls

total 152
 16 -rw-r--r--  1 anirudh staff  5221 Jul  8 21:31 CODE_OF_CONDUCT.md
  8 -rw-r--r--  1 anirudh staff  2513 Jul  8 21:31 CONTRIBUTING.md
120 -rw-r--r--  1 anirudh staff 58234 Jul  8 21:31 Cargo.lock
 32 -rw-r--r--  1 anirudh staff 15208 Jul  8 21:31 Cargo.toml
  8 -rw-r--r--  1 anirudh staff  2296 Jul  8 21:31 DEVELOPER_INSTRUCTIONS.md
 16 -rw-r--r--  1 anirudh staff  7108 Jul  8 22:45 GNUmakefile
  8 -rw-r--r--  1 anirudh staff  1053 Jul  8 21:31 LICENSE
  8 -rw-r--r--  1 anirudh staff    55 Jul  8 21:31 Makefile
 24 -rw-r--r--  1 anirudh staff 10342 Jul  8 21:31 Makefile.toml
 40 -rw-r--r--  1 anirudh staff 18288 Jul  8 21:31 README.md
 16 -rw-r--r--  1 anirudh staff  7283 Jul  8 21:31 build.rs
  8 -rw-r--r--  1 anirudh staff    16 Jul  8 21:31 clippy.toml
  0 drwxr-xr-x 11 anirudh staff   352 Jul  8 21:31 docs
  0 drwxr-xr-x  4 anirudh staff   128 Jul  8 21:31 examples
  0 drwxr-xr-x  6 anirudh staff   192 Jul  8 21:31 src
  0 drwxr-xr-x  6 anirudh staff   192 Jul  8 21:32 target
  0 drwxr-xr-x  7 anirudh staff   224 Jul  8 21:31 tests
  0 drwxr-xr-x 15 anirudh staff   480 Jul  8 21:31 util
```

```
$ cargo run ls -s
 16 CODE_OF_CONDUCT.md    8 CONTRIBUTING.md  120 Cargo.lock   32 Cargo.toml    8 DEVELOPER_INSTRUCTIONS.md   16 GNUmakefile    8 LICENSE    8 Makefile   24 Makefile.toml   40 README.md   16 build.rs    8 clippy.toml    0 docs    0 examples    0 src    0 target    0 tests    0 util
```

I'm aware there's already a PR #2435 but that has since been closed, so I thought I'd open this instead.