### PR TITLE
backup_control: Streamline CLI arguments, use UError

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 path="src/lib/lib.rs"
 
 [dependencies]
+clap = "2.33.3"
 dns-lookup = { version="1.0.5", optional=true }
 dunce = "1.0.0"
 getopts = "<= 0.2.21"

--- a/src/uucore/src/lib/mods/backup_control.rs
+++ b/src/uucore/src/lib/mods/backup_control.rs
@@ -102,10 +102,10 @@ the VERSION_CONTROL environment variable.  Here are the values:
   simple, never   always make simple backups";
 
 static VALID_ARGS_HELP: &str = "Valid arguments are:
-  - ‘none’, ‘off’
-  - ‘simple’, ‘never’
-  - ‘existing’, ‘nil’
-  - ‘numbered’, ‘t’";
+  - 'none', 'off'
+  - 'simple', 'never'
+  - 'existing', 'nil'
+  - 'numbered', 't'";
 
 /// Available backup modes.
 ///
@@ -167,12 +167,12 @@ impl Display for BackupError {
         match self {
             BE::InvalidArgument(arg, origin) => write!(
                 f,
-                "invalid argument ‘{}’ for ‘{}’\n{}",
+                "invalid argument '{}' for '{}'\n{}",
                 arg, origin, VALID_ARGS_HELP
             ),
             BE::AmbiguousArgument(arg, origin) => write!(
                 f,
-                "ambiguous argument ‘{}’ for ‘{}’\n{}",
+                "ambiguous argument '{}' for '{}'\n{}",
                 arg, origin, VALID_ARGS_HELP
             ),
             BE::BackupImpossible() => write!(f, "cannot create backup"),
@@ -329,7 +329,7 @@ pub fn determine_backup_mode(matches: &ArgMatches) -> UResult<BackupMode> {
         // Use method to determine the type of backups to make. When this option
         // is used but method is not specified, then the value of the
         // VERSION_CONTROL environment variable is used. And if VERSION_CONTROL
-        // is not set, the default backup type is ‘existing’.
+        // is not set, the default backup type is 'existing'.
         if let Some(method) = matches.value_of(arguments::OPT_BACKUP) {
             // Second argument is for the error string that is returned.
             match_method(method, "backup type")
@@ -516,7 +516,7 @@ mod tests {
 
         assert!(result.is_err());
         let text = format!("{}", result.unwrap_err());
-        assert!(text.contains("invalid argument ‘foobar’ for ‘backup type’"));
+        assert!(text.contains("invalid argument 'foobar' for 'backup type'"));
     }
 
     // --backup errors on ambiguous argument
@@ -529,7 +529,7 @@ mod tests {
 
         assert!(result.is_err());
         let text = format!("{}", result.unwrap_err());
-        assert!(text.contains("ambiguous argument ‘n’ for ‘backup type’"));
+        assert!(text.contains("ambiguous argument 'n' for 'backup type'"));
     }
 
     // --backup accepts shortened arguments (si for simple)
@@ -580,7 +580,7 @@ mod tests {
 
         assert!(result.is_err());
         let text = format!("{}", result.unwrap_err());
-        assert!(text.contains("invalid argument ‘foobar’ for ‘$VERSION_CONTROL’"));
+        assert!(text.contains("invalid argument 'foobar' for '$VERSION_CONTROL'"));
         env::remove_var(ENV_VERSION_CONTROL);
     }
 
@@ -595,7 +595,7 @@ mod tests {
 
         assert!(result.is_err());
         let text = format!("{}", result.unwrap_err());
-        assert!(text.contains("ambiguous argument ‘n’ for ‘$VERSION_CONTROL’"));
+        assert!(text.contains("ambiguous argument 'n' for '$VERSION_CONTROL'"));
         env::remove_var(ENV_VERSION_CONTROL);
     }
 

--- a/src/uucore/src/lib/mods/backup_control.rs
+++ b/src/uucore/src/lib/mods/backup_control.rs
@@ -25,6 +25,39 @@ pub enum BackupMode {
     ExistingBackup,
 }
 
+pub mod arguments {
+    extern crate clap;
+
+    pub static OPT_BACKUP: &str = "backupopt_backup";
+    pub static OPT_BACKUP_NO_ARG: &str = "backupopt_b";
+    pub static OPT_SUFFIX: &str = "backupopt_suffix";
+
+    pub fn backup() -> clap::Arg<'static, 'static> {
+        clap::Arg::with_name(OPT_BACKUP)
+            .long("backup")
+            .help("make a backup of each existing destination file")
+            .takes_value(true)
+            .require_equals(true)
+            .min_values(0)
+            .value_name("CONTROL")
+    }
+
+    pub fn backup_no_args() -> clap::Arg<'static, 'static> {
+        clap::Arg::with_name(OPT_BACKUP_NO_ARG)
+            .short("b")
+            .help("like --backup but does not accept an argument")
+    }
+
+    pub fn suffix() -> clap::Arg<'static, 'static> {
+        clap::Arg::with_name(OPT_SUFFIX)
+            .short("S")
+            .long("suffix")
+            .help("override the usual backup suffix")
+            .takes_value(true)
+            .value_name("SUFFIX")
+    }
+}
+
 pub fn determine_backup_suffix(supplied_suffix: Option<&str>) -> String {
     if let Some(suffix) = supplied_suffix {
         String::from(suffix)


### PR DESCRIPTION
Hello again,

this is my follow-up from #2467 (@miDeb). This PR adds:

- an `arguments` module that contains ready-to-use `clap::Arg`s for the backup-related CLI options
- A `UCustomError`-based `BackupError` enum
- A more intuitive signature to `determine_backup_mode/suffix`, which now both take a `clap::ArgMatches` and parse the options from there themselves (using what's defined in the `arguments` module)
- Updated tests (Which imo are much nicer to read)
- A **lot** of new docs so hopefully people understand what I tried to accomplish

Waiting for your feedback!