### PR TITLE
CONTRIBUTING: Add Apache License note (#2086)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,10 @@ Contributions are very welcome, and should target Rust's master branch until the
 standard libraries are stabilized. You may *claim* an item on the to-do list by
 following these steps:
 
-1. Open an issue named "Implement [the utility of your choice]", e.g. "Implement ls"
+1. Open an issue named "Implement [the utility of your choice]", e.g. "Implement
+   ls".
 1. State that you are working on this utility.
-1. Develop the utility
+1. Develop the utility.
 1. Add integration tests.
 1. Add the reference to your utility into Cargo.toml and Makefile.
 1. Remove utility from the to-do list in the README.
@@ -17,12 +18,20 @@ search the issues to make sure no one else is working on it.
 
 ## Best practices
 
-1. Follow what GNU is doing in terms of options and behavior. It is recommended to look at the GNU Coreutils manual ([on the web](https://www.gnu.org/software/coreutils/manual/html_node/index.html), or locally using `info <utility>`). It is more in depth than the man pages and provides a good description of available features and their implementation details.
-1. If possible, look at the GNU test suite execution in the CI and make the test work if failing.
+1. Follow what GNU is doing in terms of options and behavior. It is recommended
+   to look at the GNU Coreutils manual ([on the
+   web](https://www.gnu.org/software/coreutils/manual/html_node/index.html), or
+   locally using `info <utility>`). It is more in depth than the man pages and
+   provides a good description of available features and their implementation
+   details.
+1. If possible, look at the GNU test suite execution in the CI and make the test
+   work if failing.
 1. Use clap for argument management.
-1. Make sure that the code coverage is covering all of the cases, including errors.     
+1. Make sure that the code coverage is covering all of the cases, including
+   errors.
 1. The code must be clippy-warning-free and rustfmt-compliant.
-1. Don't hesitate to move common functions into uucore if they can be reused by other binaries.
+1. Don't hesitate to move common functions into uucore if they can be reused by
+   other binaries.
 1. Unsafe code should be documented with Safety comments.
 1. uutils is original code. It cannot contain code from existing GNU or Unix-like
    utilities, nor should it link to or reference GNU libraries.
@@ -99,7 +108,8 @@ project, a tool like `cargo-license` can be used to show their license details.
 The following types of license are acceptable:
 
 * MIT License
-* Dual- or tri-license with an MIT License option ("Apache-2.0 or MIT" is a popular combination)
+* Dual- or tri-license with an MIT License option ("Apache-2.0 or MIT" is a
+  popular combination)
 * "MIT equivalent" license (2-clause BSD, 3-clause BSD, ISC)
 * License less restrictive than the MIT License (CC0 1.0 Universal)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,13 @@ The following types of license are acceptable:
 * "MIT equivalent" license (2-clause BSD, 3-clause BSD, ISC)
 * License less restrictive than the MIT License (CC0 1.0 Universal)
 
+Some licenses are similar to the above, but are not preferable because they
+contain additional conditions not present in the MIT License. The following are
+accepted in referenced dependencies, on a case-by-case basis, when there is no
+MIT-licensed alternative:
+
+* Apache License version 2.0
+
 Licenses we will not use:
 
 * An ambiguous license, or no license

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,12 +112,6 @@ The following types of license are acceptable:
   popular combination)
 * "MIT equivalent" license (2-clause BSD, 3-clause BSD, ISC)
 * License less restrictive than the MIT License (CC0 1.0 Universal)
-
-Some licenses are similar to the above, but are not preferable because they
-contain additional conditions not present in the MIT License. The following are
-accepted in referenced dependencies, on a case-by-case basis, when there is no
-MIT-licensed alternative:
-
 * Apache License version 2.0
 
 Licenses we will not use:


### PR DESCRIPTION
Add a note the licensing section, stating that references using the
Apache License are acceptable on a case-by-case basis when there is no
MIT-licensed alternative.

  * Follow-up to #1994 / https://github.com/uutils/coreutils/pull/2493

  * Intended to resolve issue #2086