### PR TITLE
test: handle additional parentheses edge cases

### DIFF
--- a/src/uu/test/src/parser.rs
+++ b/src/uu/test/src/parser.rs
@@ -10,6 +10,21 @@
 use std::ffi::OsString;
 use std::iter::Peekable;
 
+/// Represents one of the binary comparison operators for strings, integers, or files
+#[derive(Debug, PartialEq)]
+pub enum Op {
+    StringOp(OsString),
+    IntOp(OsString),
+    FileOp(OsString),
+}
+
+/// Represents one of the unary test operators for strings or files
+#[derive(Debug, PartialEq)]
+pub enum UnaryOp {
+    StrlenOp(OsString),
+    FiletestOp(OsString),
+}
+
 /// Represents a parsed token from a test expression
 #[derive(Debug, PartialEq)]
 pub enum Symbol {
@@ -17,11 +32,8 @@ pub enum Symbol {
     Bang,
     BoolOp(OsString),
     Literal(OsString),
-    StringOp(OsString),
-    IntOp(OsString),
-    FileOp(OsString),
-    StrlenOp(OsString),
-    FiletestOp(OsString),
+    Op(Op),
+    UnaryOp(UnaryOp),
     None,
 }
 
@@ -35,12 +47,14 @@ impl Symbol {
                 "(" => Symbol::LParen,
                 "!" => Symbol::Bang,
                 "-a" | "-o" => Symbol::BoolOp(s),
-                "=" | "==" | "!=" => Symbol::StringOp(s),
-                "-eq" | "-ge" | "-gt" | "-le" | "-lt" | "-ne" => Symbol::IntOp(s),
-                "-ef" | "-nt" | "-ot" => Symbol::FileOp(s),
-                "-n" | "-z" => Symbol::StrlenOp(s),
+                "=" | "==" | "!=" => Symbol::Op(Op::StringOp(s)),
+                "-eq" | "-ge" | "-gt" | "-le" | "-lt" | "-ne" => Symbol::Op(Op::IntOp(s)),
+                "-ef" | "-nt" | "-ot" => Symbol::Op(Op::FileOp(s)),
+                "-n" | "-z" => Symbol::UnaryOp(UnaryOp::StrlenOp(s)),
                 "-b" | "-c" | "-d" | "-e" | "-f" | "-g" | "-G" | "-h" | "-k" | "-L" | "-O"
-                | "-p" | "-r" | "-s" | "-S" | "-t" | "-u" | "-w" | "-x" => Symbol::FiletestOp(s),
+                | "-p" | "-r" | "-s" | "-S" | "-t" | "-u" | "-w" | "-x" => {
+                    Symbol::UnaryOp(UnaryOp::FiletestOp(s))
+                }
                 _ => Symbol::Literal(s),
             },
             None => Symbol::None,
@@ -60,11 +74,11 @@ impl Symbol {
             Symbol::Bang => OsString::from("!"),
             Symbol::BoolOp(s)
             | Symbol::Literal(s)
-            | Symbol::StringOp(s)
-            | Symbol::IntOp(s)
-            | Symbol::FileOp(s)
-            | Symbol::StrlenOp(s)
-            | Symbol::FiletestOp(s) => s,
+            | Symbol::Op(Op::StringOp(s))
+            | Symbol::Op(Op::IntOp(s))
+            | Symbol::Op(Op::FileOp(s))
+            | Symbol::UnaryOp(UnaryOp::StrlenOp(s))
+            | Symbol::UnaryOp(UnaryOp::FiletestOp(s)) => s,
             Symbol::None => panic!(),
         })
     }
@@ -78,7 +92,6 @@ impl Symbol {
 ///
 ///   EXPR → TERM | EXPR BOOLOP EXPR
 ///   TERM → ( EXPR )
-///   TERM → ( )
 ///   TERM → ! EXPR
 ///   TERM → UOP str
 ///   UOP → STRLEN | FILETEST
@@ -113,6 +126,20 @@ impl Parser {
         Symbol::new(self.tokens.next())
     }
 
+    /// Consume the next token & verify that it matches the provided value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the next token does not match the provided value.
+    ///
+    /// TODO: remove panics and convert Parser to return error messages.
+    fn expect(&mut self, value: &str) {
+        match self.next_token() {
+            Symbol::Literal(s) if s == value => (),
+            _ => panic!("expected ‘{}’", value),
+        }
+    }
+
     /// Peek at the next token from the input stream, returning it as a Symbol.
     /// The stream is unchanged and will return the same Symbol on subsequent
     /// calls to `next()` or `peek()`.
@@ -144,8 +171,7 @@ impl Parser {
         match symbol {
             Symbol::LParen => self.lparen(),
             Symbol::Bang => self.bang(),
-            Symbol::StrlenOp(_) => self.uop(symbol),
-            Symbol::FiletestOp(_) => self.uop(symbol),
+            Symbol::UnaryOp(_) => self.uop(symbol),
             Symbol::None => self.stack.push(symbol),
             literal => self.literal(literal),
         }
@@ -154,21 +180,75 @@ impl Parser {
     /// Parse a (possibly) parenthesized expression.
     ///
     /// test has no reserved keywords, so "(" will be interpreted as a literal
-    /// if it is followed by nothing or a comparison operator OP.
+    /// in certain cases:
+    ///
+    /// * when found at the end of the token stream
+    /// * when followed by a binary operator that is not _itself_ interpreted
+    ///   as a literal
+    ///
     fn lparen(&mut self) {
-        match self.peek() {
-            // lparen is a literal when followed by nothing or comparison
-            Symbol::None | Symbol::StringOp(_) | Symbol::IntOp(_) | Symbol::FileOp(_) => {
+        // Look ahead up to 3 tokens to determine if the lparen is being used
+        // as a grouping operator or should be treated as a literal string
+        let peek3: Vec<Symbol> = self
+            .tokens
+            .clone()
+            .take(3)
+            .map(|token| Symbol::new(Some(token)))
+            .collect();
+
+        match peek3.as_slice() {
+            // case 1: lparen is a literal when followed by nothing
+            [] => self.literal(Symbol::LParen.into_literal()),
+
+            // case 2: error if end of stream is `( <any_token>`
+            [symbol] => {
+                eprintln!("test: missing argument after ‘{:?}’", symbol);
+                std::process::exit(2);
+            }
+
+            // case 3: `( uop <any_token> )` → parenthesized unary operation;
+            //         this case ensures we don’t get confused by `( -f ) )`
+            //         or `( -f ( )`, for example
+            [Symbol::UnaryOp(_), _, Symbol::Literal(s)] if s == ")" => {
+                let symbol = self.next_token();
+                self.uop(symbol);
+                self.expect(")");
+            }
+
+            // case 4: binary comparison of literal lparen, e.g. `( != )`
+            [Symbol::Op(_), Symbol::Literal(s)] | [Symbol::Op(_), Symbol::Literal(s), _]
+                if s == ")" =>
+            {
                 self.literal(Symbol::LParen.into_literal());
             }
-            // empty parenthetical
-            Symbol::Literal(s) if s == ")" => {}
+
+            // case 5: after handling the prior cases, any single token inside
+            //         parentheses is a literal, e.g. `( -f )`
+            [_, Symbol::Literal(s)] | [_, Symbol::Literal(s), _] if s == ")" => {
+                let symbol = self.next_token();
+                self.literal(symbol);
+                self.expect(")");
+            }
+
+            // case 6: two binary ops in a row, treat the first op as a literal
+            [Symbol::Op(_), Symbol::Op(_), _] => {
+                let symbol = self.next_token();
+                self.literal(symbol);
+                self.expect(")");
+            }
+
+            // case 7: if earlier cases didn’t match, `( op <any_token>…`
+            //         indicates binary comparison of literal lparen with
+            //         anything _except_ ")" (case 4)
+            [Symbol::Op(_), _] | [Symbol::Op(_), _, _] => {
+                self.literal(Symbol::LParen.into_literal());
+            }
+
+            // Otherwise, lparen indicates the start of a parenthesized
+            // expression
             _ => {
                 self.expr();
-                match self.next_token() {
-                    Symbol::Literal(s) if s == ")" => (),
-                    _ => panic!("expected ')'"),
-                }
+                self.expect(")");
             }
         }
     }
@@ -192,7 +272,7 @@ impl Parser {
     ///
     fn bang(&mut self) {
         match self.peek() {
-            Symbol::StringOp(_) | Symbol::IntOp(_) | Symbol::FileOp(_) | Symbol::BoolOp(_) => {
+            Symbol::Op(_) | Symbol::BoolOp(_) => {
                 // we need to peek ahead one more token to disambiguate the first
                 // three cases listed above
                 let peek2 = Symbol::new(self.tokens.clone().nth(1));
@@ -200,7 +280,7 @@ impl Parser {
                 match peek2 {
                     // case 1: `! <OP as literal>`
                     // case 3: `! = OP str`
-                    Symbol::StringOp(_) | Symbol::None => {
+                    Symbol::Op(_) | Symbol::None => {
                         // op is literal
                         let op = self.next_token().into_literal();
                         self.literal(op);
@@ -294,7 +374,7 @@ impl Parser {
 
         // EXPR → str OP str
         match self.peek() {
-            Symbol::StringOp(_) | Symbol::IntOp(_) | Symbol::FileOp(_) => {
+            Symbol::Op(_) => {
                 let op = self.next_token();
 
                 match self.next_token() {

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -11,7 +11,7 @@
 mod parser;
 
 use clap::{crate_version, App, AppSettings};
-use parser::{parse, Symbol};
+use parser::{parse, Op, Symbol, UnaryOp};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use uucore::executable;
@@ -160,19 +160,19 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
 
             Ok(!result)
         }
-        Some(Symbol::StringOp(op)) => {
+        Some(Symbol::Op(Op::StringOp(op))) => {
             let b = stack.pop();
             let a = stack.pop();
             Ok(if op == "!=" { a != b } else { a == b })
         }
-        Some(Symbol::IntOp(op)) => {
+        Some(Symbol::Op(Op::IntOp(op))) => {
             let b = pop_literal!();
             let a = pop_literal!();
 
             Ok(integers(&a, &b, &op)?)
         }
-        Some(Symbol::FileOp(_op)) => unimplemented!(),
-        Some(Symbol::StrlenOp(op)) => {
+        Some(Symbol::Op(Op::FileOp(_op))) => unimplemented!(),
+        Some(Symbol::UnaryOp(UnaryOp::StrlenOp(op))) => {
             let s = match stack.pop() {
                 Some(Symbol::Literal(s)) => s,
                 Some(Symbol::None) => OsString::from(""),
@@ -190,7 +190,7 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
                 !s.is_empty()
             })
         }
-        Some(Symbol::FiletestOp(op)) => {
+        Some(Symbol::UnaryOp(UnaryOp::FiletestOp(op))) => {
             let op = op.to_string_lossy();
 
             let f = pop_literal!();

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -11,10 +11,9 @@
 mod parser;
 
 use clap::{crate_version, App, AppSettings};
-use parser::{parse, Op, Symbol, UnaryOp};
+use parser::{parse, Operator, Symbol, UnaryOperator};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
-use uucore::executable;
 
 const USAGE: &str = "test EXPRESSION
 or:  test
@@ -87,7 +86,7 @@ the version described here.  Please refer to your shell's documentation
 for details about the options it supports.";
 
 pub fn uu_app() -> App<'static, 'static> {
-    App::new(executable!())
+    App::new(uucore::util_name())
         .setting(AppSettings::DisableHelpFlags)
         .setting(AppSettings::DisableVersion)
 }
@@ -160,19 +159,19 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
 
             Ok(!result)
         }
-        Some(Symbol::Op(Op::StringOp(op))) => {
+        Some(Symbol::Op(Operator::String(op))) => {
             let b = stack.pop();
             let a = stack.pop();
             Ok(if op == "!=" { a != b } else { a == b })
         }
-        Some(Symbol::Op(Op::IntOp(op))) => {
+        Some(Symbol::Op(Operator::Int(op))) => {
             let b = pop_literal!();
             let a = pop_literal!();
 
             Ok(integers(&a, &b, &op)?)
         }
-        Some(Symbol::Op(Op::FileOp(_op))) => unimplemented!(),
-        Some(Symbol::UnaryOp(UnaryOp::StrlenOp(op))) => {
+        Some(Symbol::Op(Operator::File(_op))) => unimplemented!(),
+        Some(Symbol::UnaryOp(UnaryOperator::StrlenOp(op))) => {
             let s = match stack.pop() {
                 Some(Symbol::Literal(s)) => s,
                 Some(Symbol::None) => OsString::from(""),
@@ -190,7 +189,7 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
                 !s.is_empty()
             })
         }
-        Some(Symbol::UnaryOp(UnaryOp::FiletestOp(op))) => {
+        Some(Symbol::UnaryOp(UnaryOperator::FiletestOp(op))) => {
             let op = op.to_string_lossy();
 
             let f = pop_literal!();


### PR DESCRIPTION
Handle additional edge cases arising from test(1)’s lack of reserved words.
For example, left parenthesis followed by an operator could indicate
either

* string comparison of a literal left parenthesis, e.g. `( = foo`
* parenthesized expression using an operator as a literal, e.g. `( = != foo )`