### PR TITLE
Revert "silent buggy clippy warning"

### DIFF
--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -6,9 +6,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -10,9 +10,6 @@
 
 // spell-checker:ignore (ToDO) nonprint nonblank nonprinting
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[cfg(unix)]
 extern crate unix_socket;
 #[macro_use]

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -55,7 +55,6 @@ use walkdir::WalkDir;
 use std::os::unix::fs::PermissionsExt;
 
 #[cfg(target_os = "linux")]
-#[allow(clippy::missing_safety_doc)]
 ioctl!(write ficlone with 0x94, 9; std::os::raw::c_int);
 
 quick_error! {

--- a/src/uu/csplit/src/csplit_error.rs
+++ b/src/uu/csplit/src/csplit_error.rs
@@ -1,6 +1,3 @@
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 use std::io;
 use thiserror::Error;
 

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -5,9 +5,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -6,9 +6,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) gethostid
 
-// Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) MAKEWORD addrs hashset
 
-// Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) signalname pids
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) cpio svgz webm somegroup nlink rmvb xspf
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 #[cfg(unix)]

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -8,9 +8,6 @@
 
 // spell-checker:ignore (paths) GPGHome
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -8,9 +8,6 @@
 
 // spell-checker:ignore (ToDO) filetime strptime utcoff strs datetime MMDDhhmm
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 pub extern crate filetime;
 
 #[macro_use]

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 #[macro_use]
 extern crate uucore;
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -4,8 +4,6 @@
 //  *
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
 
 #[macro_use]
 extern crate uucore;

--- a/src/uucore/src/lib/features/encoding.rs
+++ b/src/uucore/src/lib/features/encoding.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (strings) ABCDEFGHIJKLMNOPQRSTUVWXYZ
 
-// clippy bug https://github.com/rust-lang/rust-clippy/issues/7422
-#![allow(clippy::nonstandard_macro_braces)]
-
 extern crate data_encoding;
 
 use self::data_encoding::{DecodeError, BASE32, BASE64};


### PR DESCRIPTION
Reverts uutils/coreutils#2475 as https://github.com/rust-lang/rust-clippy/issues/7422 is fixed.