### PR TITLE
tac: correct error message when reading from directory

### DIFF
--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -97,7 +97,7 @@ fn tac(filenames: Vec<String>, before: bool, _: bool, separator: &str) -> i32 {
             let path = Path::new(filename);
             if path.is_dir() || path.metadata().is_err() {
                 if path.is_dir() {
-                    show_error!("dir: read error: Invalid argument");
+                    show_error!("{}: read error: Invalid argument", filename);
                 } else {
                     show_error!(
                         "failed to open '{}' for reading: No such file or directory",

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -66,5 +66,5 @@ fn test_invalid_input() {
         .ucmd()
         .arg("a")
         .fails()
-        .stderr_contains("dir: read error: Invalid argument");
+        .stderr_contains("a: read error: Invalid argument");
 }


### PR DESCRIPTION
Correct the error message produced by `tac` when trying to read from a
directory. Previously if the path 'a' referred to a directory, then
running `tac a` would produce the error message

    dir: read error: Invalid argument

after this commit it produces

    a: read error: Invalid argument

which matches GNU `tac`.