### PR TITLE
tac: handle no line separators in file

### DIFF
--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -139,9 +139,16 @@ fn tac(filenames: Vec<String>, before: bool, _: bool, separator: &str) -> i32 {
                 i += 1;
             }
         }
+        // If the file contains no line separators, then simply write
+        // the contents of the file directly to stdout.
+        if offsets.is_empty() {
+            out.write_all(&data)
+                .unwrap_or_else(|e| crash!(1, "failed to write to stdout: {}", e));
+            return exit_code;
+        }
 
         // if there isn't a separator at the end of the file, fake it
-        if offsets.is_empty() || *offsets.last().unwrap() < data.len() - slen {
+        if *offsets.last().unwrap() < data.len() - slen {
             offsets.push(data.len());
         }
 

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -68,3 +68,8 @@ fn test_invalid_input() {
         .fails()
         .stderr_contains("dir: read error: Invalid argument");
 }
+
+#[test]
+fn test_no_line_separators() {
+    new_ucmd!().pipe_in("a").succeeds().stdout_is("a");
+}


### PR DESCRIPTION
Change the behavior of `tac` when there are no line separators in the
input. Previously, it was appending an extra line separator; this commit
prevents that from happening. The input is now writted directly to
stdout.