### PR TITLE
sort: allow null bytes for -t

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1065,7 +1065,10 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if let Some(arg) = matches.args.get(options::SEPARATOR) {
         let separator = arg.vals[0].to_string_lossy();
-        let separator = separator;
+        let mut separator = separator.as_ref();
+        if separator == "\\0" {
+            separator = "\0";
+        }
         if separator.len() != 1 {
             crash!(1, "separator must be exactly one character long");
         }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -959,3 +959,12 @@ fn test_key_takes_one_arg() {
         .succeeds()
         .stdout_is_fixture("keys_open_ended.expected");
 }
+
+#[test]
+fn test_separator_null() {
+    new_ucmd!()
+        .args(&["-k1,1", "-k3,3", "-t", "\\0"])
+        .pipe_in("z\0a\0b\nz\0b\0a\na\0z\0z\n")
+        .succeeds()
+        .stdout_only("a\0z\0z\nz\0b\0a\nz\0a\0b\n");
+}


### PR DESCRIPTION
You can't actually pass a null byte as an argument to a program, instead we interpret `\0` as a null byte.

This is also for compatibility with gnu (gnu sort has this feature since version 5.0.91)