### PR TITLE
sort: remove duplication from usage string

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -916,9 +916,7 @@ impl FieldSelector {
 
 fn get_usage() -> String {
     format!(
-        "{0}
-Usage:
- {0} [OPTION]... [FILE]...
+        "{0} [OPTION]... [FILE]...
 Write the sorted concatenation of all FILE(s) to standard output.
 Mandatory arguments for long options are mandatory for short options too.
 With no FILE, or when FILE is -, read standard input.",


### PR DESCRIPTION
The custom usage string does not have to include the "sort\nUsage:" part,
because this part is already printed by clap.

It prevents the following duplication:

USAGE:
    sort
Usage:
 sort [OPTION]... [FILE]..

Now, only the following is printed:

USAGE:
    sort [OPTION]... [FILE]...