### PR TITLE
basename: handle paths comprising only slashes

### DIFF
--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -119,8 +119,14 @@ pub fn uu_app() -> App<'static, 'static> {
 }
 
 fn basename(fullname: &str, suffix: &str) -> String {
-    // Remove all platform-specific path separators from the end
+    // Remove all platform-specific path separators from the end.
     let path = fullname.trim_end_matches(is_separator);
+
+    // If the path contained *only* suffix characters (for example, if
+    // `fullname` were "///" and `suffix` were "/"), then `path` would
+    // be left with the empty string. In that case, we set `path` to be
+    // the original `fullname` to avoid returning the empty path.
+    let path = if path.is_empty() { fullname } else { path };
 
     // Convert to path buffer and get last path component
     let pb = PathBuf::from(path);

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -147,3 +147,30 @@ fn invalid_utf8_args_unix() {
     let os_str = OsStr::from_bytes(&source[..]);
     test_invalid_utf8_args(os_str);
 }
+
+#[test]
+fn test_root() {
+    new_ucmd!().arg("/").succeeds().stdout_is("/\n");
+}
+
+#[test]
+fn test_double_slash() {
+    // TODO The GNU tests seem to suggest that some systems treat "//"
+    // as the same directory as "/" directory but not all systems. We
+    // should extend this test to account for that possibility.
+    let expected = if cfg!(windows) { "\\" } else { "/\n" };
+    new_ucmd!().arg("//").succeeds().stdout_is(expected);
+    new_ucmd!()
+        .args(&["//", "/"])
+        .succeeds()
+        .stdout_is(expected);
+    new_ucmd!()
+        .args(&["//", "//"])
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
+fn test_triple_slash() {
+    new_ucmd!().arg("///").succeeds().stdout_is("/\n");
+}

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -150,7 +150,8 @@ fn invalid_utf8_args_unix() {
 
 #[test]
 fn test_root() {
-    new_ucmd!().arg("/").succeeds().stdout_is("/\n");
+    let expected = if cfg!(windows) { "\\\n" } else { "/\n" };
+    new_ucmd!().arg("/").succeeds().stdout_is(expected);
 }
 
 #[test]
@@ -158,7 +159,7 @@ fn test_double_slash() {
     // TODO The GNU tests seem to suggest that some systems treat "//"
     // as the same directory as "/" directory but not all systems. We
     // should extend this test to account for that possibility.
-    let expected = if cfg!(windows) { "\\" } else { "/\n" };
+    let expected = if cfg!(windows) { "\\\n" } else { "/\n" };
     new_ucmd!().arg("//").succeeds().stdout_is(expected);
     new_ucmd!()
         .args(&["//", "/"])
@@ -172,5 +173,6 @@ fn test_double_slash() {
 
 #[test]
 fn test_triple_slash() {
-    new_ucmd!().arg("///").succeeds().stdout_is("/\n");
+    let expected = if cfg!(windows) { "\\\n" } else { "/\n" };
+    new_ucmd!().arg("///").succeeds().stdout_is(expected);
 }


### PR DESCRIPTION
Fix an issue where `basename` would print the empty path when provided
an input comprising only slashes (for example, "/" or "//" or
"///"). Now it correctly prints the path "/".