### PR TITLE
sort: handle cases where the output file is also an input file

### DIFF
--- a/src/uu/sort/src/check.rs
+++ b/src/uu/sort/src/check.rs
@@ -42,7 +42,13 @@ pub fn check(path: &OsStr, settings: &GlobalSettings) -> i32 {
         move || reader(file, recycled_receiver, loaded_sender, &settings)
     });
     for _ in 0..2 {
-        let _ = recycled_sender.send(RecycledChunk::new(100 * 1024));
+        let _ = recycled_sender.send(RecycledChunk::new(if settings.buffer_size < 100 * 1024 {
+            // when the buffer size is smaller than 100KiB we choose it instead of the default.
+            // this improves testability.
+            settings.buffer_size
+        } else {
+            100 * 1024
+        }));
     }
 
     let mut prev_chunk: Option<Chunk> = None;

--- a/src/uu/sort/src/check.rs
+++ b/src/uu/sort/src/check.rs
@@ -14,6 +14,7 @@ use crate::{
 use itertools::Itertools;
 use std::{
     cmp::Ordering,
+    ffi::OsStr,
     io::Read,
     iter,
     sync::mpsc::{sync_channel, Receiver, SyncSender},
@@ -25,7 +26,7 @@ use std::{
 /// # Returns
 ///
 /// The code we should exit with.
-pub fn check(path: &str, settings: &GlobalSettings) -> i32 {
+pub fn check(path: &OsStr, settings: &GlobalSettings) -> i32 {
     let max_allowed_cmp = if settings.unique {
         // If `unique` is enabled, the previous line must compare _less_ to the next one.
         Ordering::Less
@@ -63,7 +64,12 @@ pub fn check(path: &str, settings: &GlobalSettings) -> i32 {
             ) > max_allowed_cmp
             {
                 if !settings.check_silent {
-                    eprintln!("sort: {}:{}: disorder: {}", path, line_idx, new_first.line);
+                    eprintln!(
+                        "sort: {}:{}: disorder: {}",
+                        path.to_string_lossy(),
+                        line_idx,
+                        new_first.line
+                    );
                 }
                 return 1;
             }
@@ -74,7 +80,12 @@ pub fn check(path: &str, settings: &GlobalSettings) -> i32 {
             line_idx += 1;
             if compare_by(a, b, settings, chunk.line_data(), chunk.line_data()) > max_allowed_cmp {
                 if !settings.check_silent {
-                    eprintln!("sort: {}:{}: disorder: {}", path, line_idx, b.line);
+                    eprintln!(
+                        "sort: {}:{}: disorder: {}",
+                        path.to_string_lossy(),
+                        line_idx,
+                        b.line
+                    );
                 }
                 return 1;
             }

--- a/src/uu/sort/src/ext_sort.rs
+++ b/src/uu/sort/src/ext_sort.rs
@@ -89,8 +89,6 @@ fn reader_writer<F: Iterator<Item = Box<dyn Read + Send>>, Tmp: WriteableTmpFile
         files,
         &settings.tmp_dir,
         separator,
-        // Heuristically chosen: Dividing by 10 seems to keep our memory usage roughly
-        // around settings.buffer_size as a whole.
         buffer_size,
         settings,
         receiver,

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -194,12 +194,14 @@ fn merge_without_limit<M: MergeInput + 'static, F: Iterator<Item = M>>(
     let mut mergeable_files = vec![];
 
     for (file_number, receiver) in loaded_receivers.into_iter().enumerate() {
-        mergeable_files.push(MergeableFile {
-            current_chunk: Rc::new(receiver.recv().unwrap()),
-            file_number,
-            line_idx: 0,
-            receiver,
-        })
+        if let Ok(chunk) = receiver.recv() {
+            mergeable_files.push(MergeableFile {
+                current_chunk: Rc::new(chunk),
+                file_number,
+                line_idx: 0,
+                receiver,
+            })
+        }
     }
 
     FileMerger {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -173,7 +173,7 @@ impl Output {
         BufWriter::new(match self.file {
             Some((_name, file)) => {
                 // truncate the file
-                file.set_len(0).unwrap();
+                let _ = file.set_len(0);
                 Box::new(file)
             }
             None => Box::new(stdout()),

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -33,8 +33,8 @@ use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use std::cmp::Ordering;
 use std::env;
-use std::ffi::OsStr;
-use std::fs::File;
+use std::ffi::{OsStr, OsString};
+use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::io::{stdin, stdout, BufRead, BufReader, Read, Write};
 use std::ops::Range;
@@ -146,24 +146,44 @@ impl SortMode {
 }
 
 pub struct Output {
-    file: Option<File>,
+    file: Option<(String, File)>,
 }
 
 impl Output {
     fn new(name: Option<&str>) -> Self {
         Self {
             file: name.map(|name| {
-                File::create(name).unwrap_or_else(|e| {
-                    crash!(2, "open failed: {}: {}", name, strip_errno(&e.to_string()))
-                })
+                // This is different from `File::create()` because we don't truncate the output yet.
+                // This allows using the output file as an input file.
+                (
+                    name.to_owned(),
+                    OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .open(name)
+                        .unwrap_or_else(|e| {
+                            crash!(2, "open failed: {}: {}", name, strip_errno(&e.to_string()))
+                        }),
+                )
             }),
         }
     }
 
     fn into_write(self) -> Box<dyn Write> {
         match self.file {
-            Some(file) => Box::new(file),
+            Some((_name, file)) => {
+                // truncate the file
+                file.set_len(0).unwrap();
+                Box::new(file)
+            }
             None => Box::new(stdout()),
+        }
+    }
+
+    fn as_output_name(&self) -> Option<&str> {
+        match &self.file {
+            Some((name, _file)) => Some(name),
+            None => None,
         }
     }
 }
@@ -956,29 +976,28 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     settings.debug = matches.is_present(options::DEBUG);
 
     // check whether user specified a zero terminated list of files for input, otherwise read files from args
-    let mut files: Vec<String> = if matches.is_present(options::FILES0_FROM) {
-        let files0_from: Vec<String> = matches
-            .values_of(options::FILES0_FROM)
-            .map(|v| v.map(ToString::to_string).collect())
+    let mut files: Vec<OsString> = if matches.is_present(options::FILES0_FROM) {
+        let files0_from: Vec<OsString> = matches
+            .values_of_os(options::FILES0_FROM)
+            .map(|v| v.map(ToOwned::to_owned).collect())
             .unwrap_or_default();
 
         let mut files = Vec::new();
         for path in &files0_from {
-            let reader = open(path.as_str());
+            let reader = open(&path);
             let buf_reader = BufReader::new(reader);
             for line in buf_reader.split(b'\0').flatten() {
-                files.push(
+                files.push(OsString::from(
                     std::str::from_utf8(&line)
-                        .expect("Could not parse string from zero terminated input.")
-                        .to_string(),
-                );
+                        .expect("Could not parse string from zero terminated input."),
+                ));
             }
         }
         files
     } else {
         matches
-            .values_of(options::FILES)
-            .map(|v| v.map(ToString::to_string).collect())
+            .values_of_os(options::FILES)
+            .map(|v| v.map(ToOwned::to_owned).collect())
             .unwrap_or_default()
     };
 
@@ -1066,9 +1085,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if files.is_empty() {
         /* if no file, default to stdin */
-        files.push("-".to_owned());
+        files.push("-".to_string().into());
     } else if settings.check && files.len() != 1 {
-        crash!(2, "extra operand `{}' not allowed with -c", files[1])
+        crash!(
+            2,
+            "extra operand `{}' not allowed with -c",
+            files[1].to_string_lossy()
+        )
     }
 
     if let Some(arg) = matches.args.get(options::SEPARATOR) {
@@ -1122,7 +1145,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     settings.init_precomputed();
 
-    exec(&files, &settings, output)
+    exec(&mut files, &settings, output)
 }
 
 pub fn uu_app() -> App<'static, 'static> {
@@ -1345,9 +1368,9 @@ pub fn uu_app() -> App<'static, 'static> {
         )
 }
 
-fn exec(files: &[String], settings: &GlobalSettings, output: Output) -> i32 {
+fn exec(files: &mut [OsString], settings: &GlobalSettings, output: Output) -> i32 {
     if settings.merge {
-        let mut file_merger = merge::merge(files.iter().map(open), settings);
+        let mut file_merger = merge::merge(files, settings, output.as_output_name());
         file_merger.write_all(settings, output);
     } else if settings.check {
         if files.len() > 1 {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -36,7 +36,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
-use std::io::{stdin, stdout, BufRead, BufReader, Read, Write};
+use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::ops::Range;
 use std::path::Path;
 use std::path::PathBuf;
@@ -169,15 +169,15 @@ impl Output {
         }
     }
 
-    fn into_write(self) -> Box<dyn Write> {
-        match self.file {
+    fn into_write(self) -> BufWriter<Box<dyn Write>> {
+        BufWriter::new(match self.file {
             Some((_name, file)) => {
                 // truncate the file
                 file.set_len(0).unwrap();
                 Box::new(file)
             }
             None => Box::new(stdout()),
-        }
+        })
     }
 
     fn as_output_name(&self) -> Option<&str> {

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1039,3 +1039,12 @@ fn test_output_device() {
         .pipe_in("input")
         .succeeds();
 }
+
+#[test]
+fn test_merge_empty_input() {
+    new_ucmd!()
+        .args(&["-m", "empty.txt"])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1020,3 +1020,13 @@ fn test_separator_null() {
         .succeeds()
         .stdout_only("a\0z\0z\nz\0b\0a\nz\0a\0b\n");
 }
+
+#[test]
+fn test_output_is_input() {
+    let input = "a\nb\nc\n";
+    let (at, mut cmd) = at_and_ucmd!();
+    at.touch("file");
+    at.append("file", input);
+    cmd.args(&["-m", "-o", "file", "file"]).succeeds();
+    assert_eq!(at.read("file"), input);
+}

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1030,3 +1030,12 @@ fn test_output_is_input() {
     cmd.args(&["-m", "-o", "file", "file"]).succeeds();
     assert_eq!(at.read("file"), input);
 }
+
+#[test]
+#[cfg(unix)]
+fn test_output_device() {
+    new_ucmd!()
+        .args(&["-o", "/dev/null"])
+        .pipe_in("input")
+        .succeeds();
+}

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -771,6 +771,7 @@ fn test_check() {
         new_ucmd!()
             .arg(diagnose_arg)
             .arg("check_fail.txt")
+            .arg("--buffer-size=10b")
             .fails()
             .stderr_only("sort: check_fail.txt:6: disorder: 5\n");
 
@@ -890,6 +891,29 @@ fn test_compress() {
         ])
         .succeeds()
         .stdout_only_fixture("ext_sort.expected");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_compress_merge() {
+    new_ucmd!()
+        .args(&[
+            "--compress-program",
+            "gzip",
+            "-S",
+            "10",
+            "--batch-size=2",
+            "-m",
+            "--unique",
+            "merge_ints_interleaved_1.txt",
+            "merge_ints_interleaved_2.txt",
+            "merge_ints_interleaved_3.txt",
+            "merge_ints_interleaved_3.txt",
+            "merge_ints_interleaved_2.txt",
+            "merge_ints_interleaved_1.txt",
+        ])
+        .succeeds()
+        .stdout_only_fixture("merge_ints_interleaved.expected");
 }
 
 #[test]
@@ -1027,7 +1051,8 @@ fn test_output_is_input() {
     let (at, mut cmd) = at_and_ucmd!();
     at.touch("file");
     at.append("file", input);
-    cmd.args(&["-m", "-o", "file", "file"]).succeeds();
+    cmd.args(&["-m", "-u", "-o", "file", "file", "file", "file"])
+        .succeeds();
     assert_eq!(at.read("file"), input);
 }
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1000,6 +1000,7 @@ fn test_verifies_out_file() {
         new_ucmd!()
             .args(&["-o", "nonexistent_dir/nonexistent_file"])
             .pipe_in(input)
+            .ignore_stdin_write_error()
             .fails()
             .status_code(2)
             .stderr_only(


### PR DESCRIPTION
In such cases we have to create a temporary copy of the input file to prevent
overwriting the input with the output. This only affects merge sort, because it
is the only mode where we start writing to the output before having read all inputs.

I also included fixes for other bugs I encountered.