### PR TITLE
 realpath: add -L and -P command-line arguments

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1430,8 +1430,8 @@ pub fn localize_to_target(root: &Path, source: &Path, target: &Path) -> CopyResu
 
 pub fn paths_refer_to_same_file(p1: &Path, p2: &Path) -> io::Result<bool> {
     // We have to take symlinks and relative paths into account.
-    let pathbuf1 = canonicalize(p1, CanonicalizeMode::Normal)?;
-    let pathbuf2 = canonicalize(p2, CanonicalizeMode::Normal)?;
+    let pathbuf1 = canonicalize(p1, CanonicalizeMode::Normal, true)?;
+    let pathbuf2 = canonicalize(p2, CanonicalizeMode::Normal, true)?;
 
     Ok(pathbuf1 == pathbuf2)
 }

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -361,8 +361,8 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
 }
 
 fn relative_path<'a>(src: &Path, dst: &Path) -> Result<Cow<'a, Path>> {
-    let src_abs = canonicalize(src, CanonicalizeMode::Normal)?;
-    let mut dst_abs = canonicalize(dst.parent().unwrap(), CanonicalizeMode::Normal)?;
+    let src_abs = canonicalize(src, CanonicalizeMode::Normal, true)?;
+    let mut dst_abs = canonicalize(dst.parent().unwrap(), CanonicalizeMode::Normal, true)?;
     dst_abs.push(dst.components().last().unwrap());
     let suffix_pos = src_abs
         .components()

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -82,7 +82,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 }
             }
         } else {
-            match canonicalize(&p, can_mode) {
+            match canonicalize(&p, can_mode, true) {
                 Ok(path) => show(&path, no_newline, use_zero),
                 Err(err) => {
                     if verbose {

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -102,7 +102,7 @@ fn resolve_path(p: &Path, strip: bool, zero: bool) -> std::io::Result<()> {
     } else {
         CanonicalizeMode::Normal
     };
-    let abs = canonicalize(p, mode)?;
+    let abs = canonicalize(p, mode, true)?;
     let line_ending = if zero { '\0' } else { '\n' };
     print!("{}{}", abs.display(), line_ending);
     Ok(())

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -42,12 +42,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         Some(p) => Path::new(p).to_path_buf(),
         None => env::current_dir().unwrap(),
     };
-    let absto = canonicalize(to, CanonicalizeMode::Normal).unwrap();
-    let absfrom = canonicalize(from, CanonicalizeMode::Normal).unwrap();
+    let absto = canonicalize(to, CanonicalizeMode::Normal, true).unwrap();
+    let absfrom = canonicalize(from, CanonicalizeMode::Normal, true).unwrap();
 
     if matches.is_present(options::DIR) {
         let base = Path::new(&matches.value_of(options::DIR).unwrap()).to_path_buf();
-        let absbase = canonicalize(base, CanonicalizeMode::Normal).unwrap();
+        let absbase = canonicalize(base, CanonicalizeMode::Normal, true).unwrap();
         if !absto.as_path().starts_with(absbase.as_path())
             || !absfrom.as_path().starts_with(absbase.as_path())
         {

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -106,3 +106,88 @@ fn test_realpath_file_and_links_strip_zero() {
         .succeeds()
         .stdout_contains("bar\u{0}");
 }
+
+#[test]
+fn test_logical() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("dir1");
+    at.mkdir("dir1/dir2");
+    at.symlink_dir("dir1/dir2", "link_to_dir2");
+
+    let expected = format!("{}\n", at.as_string());
+    scene
+        .ucmd()
+        .args(&["-L", "link_to_dir2/.."])
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
+fn test_physical() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("dir1");
+    at.mkdir("dir1/dir2");
+    at.symlink_dir("dir1/dir2", "link_to_dir2");
+
+    let expected = format!("{}/dir1\n", at.as_string());
+    scene
+        .ucmd()
+        .args(&["-P", "link_to_dir2/.."])
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
+fn test_physical_default() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("dir1");
+    at.mkdir("dir1/dir2");
+    at.symlink_dir("dir1/dir2", "link_to_dir2");
+
+    let expected = format!("{}/dir1\n", at.as_string());
+    scene
+        .ucmd()
+        .arg("link_to_dir2/..")
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
+fn test_physical_overrides_logical() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("dir1");
+    at.mkdir("dir1/dir2");
+    at.symlink_dir("dir1/dir2", "link_to_dir2");
+
+    let expected = format!("{}/dir1\n", at.as_string());
+    scene
+        .ucmd()
+        .args(&["-L", "-P", "link_to_dir2/.."])
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
+fn test_logical_overrides_physical() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("dir1");
+    at.mkdir("dir1/dir2");
+    at.symlink_dir("dir1/dir2", "link_to_dir2");
+
+    let expected = format!("{}\n", at.as_string());
+    scene
+        .ucmd()
+        .args(&["-P", "-L", "link_to_dir2/.."])
+        .succeeds()
+        .stdout_is(expected);
+}


### PR DESCRIPTION
This is my second attempt at adding these, see pull request #2530. (In this one I have tried to minimize the changes to `uucore::fs` to only the changes required to get the new features to work.)

Partially resolves issue #2253.

This pull request adds the `-L` (logical) and `-P` (physical) command-line arguments to `realpath`. The `-L` option makes the program resolve ".." components before symbolic links. The `-P` option makes the program resolve symbolic links as they are encountered. This also changes the default behavior of `realpath` from the `-L` behavior to the `-P` behavior. This matches the behavior of GNU `realpath`. I don't fully understand all the things that `-L` is supposed to do, but this is a start, and seems to match the basic tests in the GNU coreutils test suite.