### PR TITLE
ls: provide `-s` & `-k` option

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1587,13 +1587,14 @@ fn display_item_long(
 
     #[cfg(unix)]
     {
-        // for long format, display the block_size as-well
-        let block_size = config.block_size.map_or_else(get_env_block_size, |v| v);
-        let _ = write!(
-            out,
-            "{} ",
-            pad_left((md.blocks() * 512 / block_size).to_string(), _max_blk_width)
-        );
+        if config.block_size.is_some() {
+            let block_size = config.block_size.map_or_else(get_env_block_size, |v| v);
+            let _ = write!(
+                out,
+                "{} ",
+                pad_left((md.blocks() * 512 / block_size).to_string(), _max_blk_width)
+            );
+        }
     }
 
     let _ = write!(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -236,6 +236,7 @@ struct Config {
     quoting_style: QuotingStyle,
     indicator_style: IndicatorStyle,
     time_style: TimeStyle,
+    #[cfg(unix)]
     block_size: Option<u64>,
 }
 
@@ -558,17 +559,22 @@ impl Config {
             Dereference::DirArgs
         };
 
-        let block_size = if options.is_present(options::size::BLOCK_SIZE) {
-            let block_size = if options.is_present(options::size::KB_BLOCK_SIZE) {
-                1024
-            } else {
-                env::var("BLOCKSIZE").map_or(512, |blk_sz| blk_sz.parse::<u64>().map_or(512, |v| v))
-            };
+        let block_size;
+        #[cfg(unix)]
+        {
+            block_size = if options.is_present(options::size::BLOCK_SIZE) {
+                let block_size = if options.is_present(options::size::KB_BLOCK_SIZE) {
+                    1024
+                } else {
+                    env::var("BLOCKSIZE")
+                        .map_or(512, |blk_sz| blk_sz.parse::<u64>().map_or(512, |v| v))
+                };
 
-            Some(block_size)
-        } else {
-            None
-        };
+                Some(block_size)
+            } else {
+                None
+            };
+        }
 
         Ok(Config {
             format,
@@ -589,6 +595,7 @@ impl Config {
             quoting_style,
             indicator_style,
             time_style,
+            #[cfg(unix)]
             block_size,
         })
     }


### PR DESCRIPTION
**work in progress** 

This is a preliminary set of changes for issue tracked here: https://github.com/uutils/coreutils/issues/2257 

Currently this is based of `ls` utility on `OS X`. it was pointed out in the discussion on the issue page, that we need to align with GNU. I am working on those changes and will keep updating the PR.

That said, I wanted to get some early feedback regarding coding conventions & style used in the project and anything else, that would help me do the rest of the changes in according to the feedback provided.


Current status and sample outputs are captured in the comment : https://github.com/uutils/coreutils/issues/2257#issuecomment-890402288 

**Pending tasks**
- make the changes compatible to GNU.
- Add/update test cases to cover the new options (`-s` & `-k`).
- Current code has `#[cfg(unix)]` tagged in the code. It was mentioned in the discussion, that we can use the CI tests to test on `Windows` platforms as-well. I will get to this once the first task is close to completion.