### PR TITLE
sort: delete temporary files when sort is terminated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
+dependencies = [
+ "nix 0.20.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,19 +1030,20 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeff60e3e37407a80ead3e9458145b456e978c4068cddbfea6afb48572962ca"
+checksum = "84236d64f1718c387232287cf036eb6632a5ecff226f4ff9dccb8c2b79ba0bde"
 dependencies = [
+ "aliasable",
  "ouroboros_macro",
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
+checksum = "f463857a6eb96c0136b1d56e56c718350cef30412ec065b48294799a088bca68"
 dependencies = [
  "Inflector",
  "proc-macro-error",
@@ -2480,6 +2497,7 @@ dependencies = [
  "binary-heap-plus",
  "clap",
  "compare",
+ "ctrlc",
  "fnv",
  "itertools 0.10.1",
  "memchr 2.4.0",

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -18,10 +18,11 @@ path = "src/sort.rs"
 binary-heap-plus = "0.4.1"
 clap = { version = "2.33", features = ["wrap_help"] }
 compare = "0.1.0"
+ctrlc = { version = "3.0", features = ["termination"] }
 fnv = "1.0.7"
 itertools = "0.10.0"
 memchr = "2.4.0"
-ouroboros = "0.9.3"
+ouroboros = "0.10.1"
 rand = "0.7"
 rayon = "1.5"
 tempfile = "3"

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -1,0 +1,80 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use tempfile::TempDir;
+use uucore::error::{UResult, USimpleError};
+
+use crate::SortError;
+
+/// A wrapper around TempDir that may only exist once in a process.
+///
+/// `TmpDirWrapper` handles the allocation of new temporary files in this temporary directory and
+/// deleting the whole directory when `SIGINT` is received. Creating a second `TmpDirWrapper` will
+/// fail because `ctrlc::set_handler()` fails when there's already a handler.
+/// The directory is only created once the first file is requested.
+pub struct TmpDirWrapper {
+    temp_dir: Option<TempDir>,
+    parent_path: PathBuf,
+    size: usize,
+    lock: Arc<Mutex<()>>,
+}
+
+impl TmpDirWrapper {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            parent_path: path,
+            size: 0,
+            temp_dir: None,
+            lock: Default::default(),
+        }
+    }
+
+    fn init_tmp_dir(&mut self) -> UResult<()> {
+        assert!(self.temp_dir.is_none());
+        assert_eq!(self.size, 0);
+        self.temp_dir = Some(
+            tempfile::Builder::new()
+                .prefix("uutils_sort")
+                .tempdir_in(&self.parent_path)
+                .map_err(|_| SortError::TmpDirCreationFailed)?,
+        );
+
+        let path = self.temp_dir.as_ref().unwrap().path().to_owned();
+        let lock = self.lock.clone();
+        ctrlc::set_handler(move || {
+            // Take the lock so that `next_file_path` returns no new file path.
+            let _lock = lock.lock().unwrap();
+            if let Err(e) = remove_tmp_dir(&path) {
+                show_error!("failed to delete temporary directory: {}", e);
+            }
+            std::process::exit(2)
+        })
+        .map_err(|e| USimpleError::new(2, format!("failed to set up signal handler: {}", e)))
+    }
+
+    pub fn next_file_path(&mut self) -> UResult<PathBuf> {
+        if self.temp_dir.is_none() {
+            self.init_tmp_dir()?;
+        }
+
+        let _lock = self.lock.lock().unwrap();
+        let file_name = self.size.to_string();
+        self.size += 1;
+        Ok(self.temp_dir.as_ref().unwrap().path().join(file_name))
+    }
+}
+
+/// Remove the directory at `path` by deleting its child files and then itself.
+/// Errors while deleting child files are ignored.
+fn remove_tmp_dir(path: &Path) -> std::io::Result<()> {
+    if let Ok(read_dir) = std::fs::read_dir(&path) {
+        for file in read_dir.flatten() {
+            // if we fail to delete the file here it was probably deleted by another thread
+            // in the meantime, but that's ok.
+            let _ = std::fs::remove_file(file.path());
+        }
+    }
+    std::fs::remove_dir(path)
+}


### PR DESCRIPTION
When hitting Ctrl+C sort now deletes any temporary files. To make this easier I
created a new struct `TmpDirWrapper` that handles the creation of new temporary
files and the registration of the signal handler.

I did not add tests because I don't think the way we currently run tests allows to send signals to a running test, but I'll try to look at this again.

Closes #2294.