### PR TITLE
maint: enable gnu test for arch

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -123,3 +123,6 @@ test -f "${BUILDDIR}/getlimits" || cp src/getlimits "${BUILDDIR}"
 # When decoding an invalid base32/64 string, gnu writes everything it was able to decode until
 # it hit the decode error, while we don't write anything if the input is invalid.
 sed -i "s/\(baddecode.*OUT=>\"\).*\"/\1\"/g" tests/misc/base64.pl
+
+# Remove the check whether a util was built. Otherwise tests against utils like "arch" are not run.
+sed -i "s|require_built_ |# require_built_ |g" init.cfg


### PR DESCRIPTION
Gnu checks before testing a utility whether that utility was actually built.
It thinks `arch` was not built, even though it was.

This patch does not convince gnu that `arch` was built (I wasn't able to figure that out),
but instead comments out the check in `init.cfg` when running `build-gnu.sh`.