### PR TITLE
od: fix reading from file while supplying a format argument

### DIFF
--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -435,6 +435,7 @@ pub fn uu_app() -> clap::App<'static, 'static> {
                 .long(options::FORMAT)
                 .help("select output format or formats")
                 .multiple(true)
+                .number_of_values(1)
                 .value_name("TYPE"),
         )
         .arg(

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -46,6 +46,17 @@ fn test_file() {
         .succeeds()
         .no_stderr()
         .stdout_is(unindent(ALPHA_OUT));
+
+    // Ensure that default format matches `-t o2`, and that `-t` does not absorb file argument
+    new_ucmd!()
+        .arg("--endian=little")
+        .arg("-t")
+        .arg("o2")
+        .arg(file.as_os_str())
+        .succeeds()
+        .no_stderr()
+        .stdout_is(unindent(ALPHA_OUT));
+
     let _ = remove_file(file);
 }
 


### PR DESCRIPTION
The following test case read stdin instead of file:
```
echo abcdefg > file
cargo run -- od --format x1 file
```

This is because the -t/--format argument was able to absorb multiple
arguments after it. This has now been fixed, and a test case is added
to ensure it will not happen again.