### PR TITLE
sort: prevent race when deleting files

### DIFF
--- a/src/uu/sort/src/ext_sort.rs
+++ b/src/uu/sort/src/ext_sort.rs
@@ -12,6 +12,7 @@
 //! The buffers for the individual chunks are recycled. There are two buffers.
 
 use std::cmp::Ordering;
+use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::{
@@ -238,7 +239,7 @@ fn read_write_loop<I: WriteableTmpFile>(
 
         let tmp_file = write::<I>(
             &mut chunk,
-            tmp_dir.next_file_path()?,
+            tmp_dir.next_file()?,
             settings.compress_prog.as_deref(),
             separator,
         )?;
@@ -268,7 +269,7 @@ fn read_write_loop<I: WriteableTmpFile>(
 /// `compress_prog` is used to optionally compress file contents.
 fn write<I: WriteableTmpFile>(
     chunk: &mut Chunk,
-    file: PathBuf,
+    file: (File, PathBuf),
     compress_prog: Option<&str>,
     separator: u8,
 ) -> UResult<I::Closed> {


### PR DESCRIPTION
Move the creation of temporary files into next_file so that it happens
while the lock is taken.

Previously, only the computation of the new file path happened while
the lock was taken, while the creation happened later.

I saw this test failing _sometimes_ in Ci, but I was only able to reproduce _a_ race by inserting `sleep`s in the right places, so I'm not _entirely_ sure this is why CI was failing. Maybe there's another problem too.