### PR TITLE
chgrp/chown: move common code to `uucore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,6 @@ name = "uu_chgrp"
 version = "0.0.7"
 dependencies = [
  "clap",
- "uu_chown",
  "uucore",
  "uucore_procs",
 ]
@@ -2147,10 +2146,8 @@ name = "uu_chown"
 version = "0.0.7"
 dependencies = [
  "clap",
- "glob",
  "uucore",
  "uucore_procs",
- "walkdir",
 ]
 
 [[package]]
@@ -3165,6 +3162,7 @@ dependencies = [
  "termion",
  "thiserror",
  "time",
+ "walkdir",
  "wild",
  "winapi 0.3.9",
  "z85",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,9 +2126,9 @@ name = "uu_chgrp"
 version = "0.0.7"
 dependencies = [
  "clap",
+ "uu_chown",
  "uucore",
  "uucore_procs",
- "walkdir",
 ]
 
 [[package]]

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/chgrp.rs"
 clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
-uu_chown = { version=">=0.0.6", package="uu_chown", path="../chown"}
 
 [[bin]]
 name = "chgrp"

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/chgrp.rs"
 clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
-walkdir = "2.2"
+uu_chown = { version=">=0.0.6", package="uu_chown", path="../chown"}
 
 [[bin]]
 name = "chgrp"

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -9,10 +9,11 @@
 
 #[macro_use]
 extern crate uucore;
-use uu_chown::{Chowner, IfFrom};
 pub use uucore::entries;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::perms::{Verbosity, VerbosityLevel};
+use uucore::perms::{
+    ChownExecutor, IfFrom, Verbosity, VerbosityLevel, FTS_COMFOLLOW, FTS_LOGICAL, FTS_PHYSICAL,
+};
 
 use clap::{App, Arg};
 
@@ -50,11 +51,7 @@ pub mod options {
     pub static ARG_FILES: &str = "FILE";
 }
 
-const FTS_COMFOLLOW: u8 = 1;
-const FTS_PHYSICAL: u8 = 1 << 1;
-const FTS_LOGICAL: u8 = 1 << 2;
-
-fn usage() -> String {
+fn get_usage() -> String {
     format!(
         "{0} [OPTION]... GROUP FILE...\n    {0} [OPTION]... --reference=RFILE FILE...",
         uucore::execution_phrase()
@@ -67,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = usage();
+    let usage = get_usage();
 
     let mut app = uu_app().usage(&usage[..]);
 
@@ -172,7 +169,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    let executor = Chowner {
+    let executor = ChownExecutor {
         bit_flag,
         dest_gid,
         verbosity: Verbosity {

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -5,25 +5,20 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) COMFOLLOW Chgrper RFILE RFILE's derefer dgid nonblank nonprint nonprinting
+// spell-checker:ignore (ToDO) COMFOLLOW Chowner RFILE RFILE's derefer dgid nonblank nonprint nonprinting
 
 #[macro_use]
 extern crate uucore;
+use uu_chown::{Chowner, IfFrom};
 pub use uucore::entries;
-use uucore::fs::resolve_relative_path;
-use uucore::libc::gid_t;
-use uucore::perms::{wrap_chgrp, Verbosity};
+use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::perms::{Verbosity, VerbosityLevel};
 
 use clap::{App, Arg};
 
-extern crate walkdir;
-use walkdir::WalkDir;
-
 use std::fs;
-use std::fs::Metadata;
 use std::os::unix::fs::MetadataExt;
 
-use std::path::Path;
 use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Change the group of each FILE to GROUP.";
@@ -66,7 +61,8 @@ fn usage() -> String {
     )
 }
 
-pub fn uumain(args: impl uucore::Args) -> i32 {
+#[uucore_procs::gen_uumain]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
@@ -140,8 +136,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if recursive {
         if bit_flag == FTS_PHYSICAL {
             if derefer == 1 {
-                show_error!("-R --dereference requires -H or -L");
-                return 1;
+                return Err(USimpleError::new(1, "-R --dereference requires -H or -L"));
             }
             derefer = 0;
         }
@@ -149,26 +144,22 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         bit_flag = FTS_PHYSICAL;
     }
 
-    let verbosity = if matches.is_present(options::verbosity::CHANGES) {
-        Verbosity::Changes
+    let verbosity_level = if matches.is_present(options::verbosity::CHANGES) {
+        VerbosityLevel::Changes
     } else if matches.is_present(options::verbosity::SILENT)
         || matches.is_present(options::verbosity::QUIET)
     {
-        Verbosity::Silent
+        VerbosityLevel::Silent
     } else if matches.is_present(options::verbosity::VERBOSE) {
-        Verbosity::Verbose
+        VerbosityLevel::Verbose
     } else {
-        Verbosity::Normal
+        VerbosityLevel::Normal
     };
 
     let dest_gid = if let Some(file) = matches.value_of(options::REFERENCE) {
-        match fs::metadata(&file) {
-            Ok(meta) => Some(meta.gid()),
-            Err(e) => {
-                show_error!("failed to get attributes of '{}': {}", file, e);
-                return 1;
-            }
-        }
+        fs::metadata(&file)
+            .map(|meta| Some(meta.gid()))
+            .map_err_context(|| format!("failed to get attributes of '{}'", file))?
     } else {
         let group = matches.value_of(options::ARG_GROUP).unwrap_or_default();
         if group.is_empty() {
@@ -176,22 +167,24 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         } else {
             match entries::grp2gid(group) {
                 Ok(g) => Some(g),
-                _ => {
-                    show_error!("invalid group: {}", group);
-                    return 1;
-                }
+                _ => return Err(USimpleError::new(1, format!("invalid group: '{}'", group))),
             }
         }
     };
 
-    let executor = Chgrper {
+    let executor = Chowner {
         bit_flag,
         dest_gid,
-        verbosity,
+        verbosity: Verbosity {
+            groups_only: true,
+            level: verbosity_level,
+        },
         recursive,
         dereference: derefer != 0,
         preserve_root,
         files,
+        filter: IfFrom::All,
+        dest_uid: None,
     };
     executor.exec()
 }
@@ -274,173 +267,4 @@ pub fn uu_app() -> App<'static, 'static> {
                 .short(options::traverse::EVERY)
                 .help("traverse every symbolic link to a directory encountered"),
         )
-}
-
-struct Chgrper {
-    dest_gid: Option<gid_t>,
-    bit_flag: u8,
-    verbosity: Verbosity,
-    files: Vec<String>,
-    recursive: bool,
-    preserve_root: bool,
-    dereference: bool,
-}
-
-macro_rules! unwrap {
-    ($m:expr, $e:ident, $err:block) => {
-        match $m {
-            Ok(meta) => meta,
-            Err($e) => $err,
-        }
-    };
-}
-
-impl Chgrper {
-    fn exec(&self) -> i32 {
-        let mut ret = 0;
-        for f in &self.files {
-            ret |= self.traverse(f);
-        }
-        ret
-    }
-
-    #[cfg(windows)]
-    fn is_bind_root<P: AsRef<Path>>(&self, root: P) -> bool {
-        // TODO: is there an equivalent on Windows?
-        false
-    }
-
-    #[cfg(unix)]
-    fn is_bind_root<P: AsRef<Path>>(&self, path: P) -> bool {
-        if let (Ok(given), Ok(root)) = (fs::metadata(path), fs::metadata("/")) {
-            given.dev() == root.dev() && given.ino() == root.ino()
-        } else {
-            // FIXME: not totally sure if it's okay to just ignore an error here
-            false
-        }
-    }
-
-    fn traverse<P: AsRef<Path>>(&self, root: P) -> i32 {
-        let follow_arg = self.dereference || self.bit_flag != FTS_PHYSICAL;
-        let path = root.as_ref();
-        let meta = match self.obtain_meta(path, follow_arg) {
-            Some(m) => m,
-            _ => return 1,
-        };
-
-        // Prohibit only if:
-        // (--preserve-root and -R present) &&
-        // (
-        //     (argument is not symlink && resolved to be '/') ||
-        //     (argument is symlink && should follow argument && resolved to be '/')
-        // )
-        if self.recursive && self.preserve_root {
-            let may_exist = if follow_arg {
-                path.canonicalize().ok()
-            } else {
-                let real = resolve_relative_path(path);
-                if real.is_dir() {
-                    Some(real.canonicalize().expect("failed to get real path"))
-                } else {
-                    Some(real.into_owned())
-                }
-            };
-
-            if let Some(p) = may_exist {
-                if p.parent().is_none() || self.is_bind_root(p) {
-                    show_error!("it is dangerous to operate recursively on '/'");
-                    show_error!("use --no-preserve-root to override this failsafe");
-                    return 1;
-                }
-            }
-        }
-
-        let ret = match wrap_chgrp(
-            path,
-            &meta,
-            self.dest_gid,
-            follow_arg,
-            self.verbosity.clone(),
-        ) {
-            Ok(n) => {
-                if !n.is_empty() {
-                    show_error!("{}", n);
-                }
-                0
-            }
-            Err(e) => {
-                if self.verbosity != Verbosity::Silent {
-                    show_error!("{}", e);
-                }
-                1
-            }
-        };
-
-        if !self.recursive {
-            ret
-        } else {
-            ret | self.dive_into(&root)
-        }
-    }
-
-    fn dive_into<P: AsRef<Path>>(&self, root: P) -> i32 {
-        let mut ret = 0;
-        let root = root.as_ref();
-        let follow = self.dereference || self.bit_flag & FTS_LOGICAL != 0;
-        for entry in WalkDir::new(root).follow_links(follow).min_depth(1) {
-            let entry = unwrap!(entry, e, {
-                ret = 1;
-                show_error!("{}", e);
-                continue;
-            });
-            let path = entry.path();
-            let meta = match self.obtain_meta(path, follow) {
-                Some(m) => m,
-                _ => {
-                    ret = 1;
-                    continue;
-                }
-            };
-
-            ret = match wrap_chgrp(path, &meta, self.dest_gid, follow, self.verbosity.clone()) {
-                Ok(n) => {
-                    if !n.is_empty() {
-                        show_error!("{}", n);
-                    }
-                    0
-                }
-                Err(e) => {
-                    if self.verbosity != Verbosity::Silent {
-                        show_error!("{}", e);
-                    }
-                    1
-                }
-            }
-        }
-
-        ret
-    }
-
-    fn obtain_meta<P: AsRef<Path>>(&self, path: P, follow: bool) -> Option<Metadata> {
-        use self::Verbosity::*;
-        let path = path.as_ref();
-        let meta = if follow {
-            unwrap!(path.metadata(), e, {
-                match self.verbosity {
-                    Silent => (),
-                    _ => show_error!("cannot access '{}': {}", path.display(), e),
-                }
-                return None;
-            })
-        } else {
-            unwrap!(path.symlink_metadata(), e, {
-                match self.verbosity {
-                    Silent => (),
-                    _ => show_error!("cannot dereference '{}': {}", path.display(), e),
-                }
-                return None;
-            })
-        };
-        Some(meta)
-    }
 }

--- a/src/uu/chown/Cargo.toml
+++ b/src/uu/chown/Cargo.toml
@@ -16,10 +16,8 @@ path = "src/chown.rs"
 
 [dependencies]
 clap = { version = "2.33", features = ["wrap_help"] }
-glob = "0.3.0"
 uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
-walkdir = "2.2"
 
 [[bin]]
 name = "chown"

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -18,7 +18,7 @@ use filetime::{set_file_times, FileTime};
 use uucore::backup_control::{self, BackupMode};
 use uucore::entries::{grp2gid, usr2uid};
 use uucore::error::{FromIo, UError, UIoError, UResult, USimpleError};
-use uucore::perms::{wrap_chgrp, wrap_chown, Verbosity};
+use uucore::perms::{wrap_chown, Verbosity, VerbosityLevel};
 
 use libc::{getegid, geteuid};
 use std::error::Error;
@@ -641,7 +641,10 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> UResult<()> {
             Some(owner_id),
             Some(gid),
             false,
-            Verbosity::Normal,
+            Verbosity {
+                groups_only: false,
+                level: VerbosityLevel::Normal,
+            },
         ) {
             Ok(n) => {
                 if !n.is_empty() {
@@ -662,7 +665,17 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> UResult<()> {
             Ok(g) => g,
             _ => return Err(InstallError::NoSuchGroup(b.group.clone()).into()),
         };
-        match wrap_chgrp(to, &meta, Some(group_id), false, Verbosity::Normal) {
+        match wrap_chown(
+            to,
+            &meta,
+            Some(group_id),
+            None,
+            false,
+            Verbosity {
+                groups_only: true,
+                level: VerbosityLevel::Normal,
+            },
+        ) {
             Ok(n) => {
                 if !n.is_empty() {
                     show_error!("{}", n);

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -26,6 +26,7 @@ lazy_static = { version="1.3", optional=true }
 nix = { version="<= 0.19", optional=true }
 platform-info = { version="<= 0.1", optional=true }
 time = { version="<= 0.1.43", optional=true }
+walkdir = { version="2.3.2", optional=true }
 # * "problem" dependencies (pinned)
 data-encoding = { version="2.1", optional=true }
 data-encoding-macro = { version="0.1.12", optional=true }
@@ -50,7 +51,7 @@ entries = ["libc"]
 fs = ["libc"]
 fsext = ["libc", "time"]
 mode = ["libc"]
-perms = ["libc"]
+perms = ["libc", "walkdir"]
 process = ["libc"]
 ringbuffer = []
 signals = []

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -3,8 +3,12 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+use crate::error::UResult;
 pub use crate::features::entries;
+use crate::fs::resolve_relative_path;
+use crate::show_error;
 use libc::{self, gid_t, lchown, uid_t};
+use walkdir::WalkDir;
 
 use std::io::Error as IOError;
 use std::io::Result as IOResult;
@@ -145,4 +149,197 @@ pub fn wrap_chown<P: AsRef<Path>>(
         }
     }
     Ok(out)
+}
+
+pub enum IfFrom {
+    All,
+    User(u32),
+    Group(u32),
+    UserGroup(u32, u32),
+}
+
+pub struct ChownExecutor {
+    pub dest_uid: Option<u32>,
+    pub dest_gid: Option<u32>,
+    pub bit_flag: u8,
+    pub verbosity: Verbosity,
+    pub filter: IfFrom,
+    pub files: Vec<String>,
+    pub recursive: bool,
+    pub preserve_root: bool,
+    pub dereference: bool,
+}
+
+macro_rules! unwrap {
+    ($m:expr, $e:ident, $err:block) => {
+        match $m {
+            Ok(meta) => meta,
+            Err($e) => $err,
+        }
+    };
+}
+
+pub const FTS_COMFOLLOW: u8 = 1;
+pub const FTS_PHYSICAL: u8 = 1 << 1;
+pub const FTS_LOGICAL: u8 = 1 << 2;
+
+impl ChownExecutor {
+    pub fn exec(&self) -> UResult<()> {
+        let mut ret = 0;
+        for f in &self.files {
+            ret |= self.traverse(f);
+        }
+        if ret != 0 {
+            return Err(ret.into());
+        }
+        Ok(())
+    }
+
+    fn traverse<P: AsRef<Path>>(&self, root: P) -> i32 {
+        let follow_arg = self.dereference || self.bit_flag != FTS_PHYSICAL;
+        let path = root.as_ref();
+        let meta = match self.obtain_meta(path, follow_arg) {
+            Some(m) => m,
+            _ => return 1,
+        };
+
+        // Prohibit only if:
+        // (--preserve-root and -R present) &&
+        // (
+        //     (argument is not symlink && resolved to be '/') ||
+        //     (argument is symlink && should follow argument && resolved to be '/')
+        // )
+        if self.recursive && self.preserve_root {
+            let may_exist = if follow_arg {
+                path.canonicalize().ok()
+            } else {
+                let real = resolve_relative_path(path);
+                if real.is_dir() {
+                    Some(real.canonicalize().expect("failed to get real path"))
+                } else {
+                    Some(real.into_owned())
+                }
+            };
+
+            if let Some(p) = may_exist {
+                if p.parent().is_none() {
+                    show_error!("it is dangerous to operate recursively on '/'");
+                    show_error!("use --no-preserve-root to override this failsafe");
+                    return 1;
+                }
+            }
+        }
+
+        let ret = if self.matched(meta.uid(), meta.gid()) {
+            match wrap_chown(
+                path,
+                &meta,
+                self.dest_uid,
+                self.dest_gid,
+                follow_arg,
+                self.verbosity.clone(),
+            ) {
+                Ok(n) => {
+                    if !n.is_empty() {
+                        show_error!("{}", n);
+                    }
+                    0
+                }
+                Err(e) => {
+                    if self.verbosity.level != VerbosityLevel::Silent {
+                        show_error!("{}", e);
+                    }
+                    1
+                }
+            }
+        } else {
+            0
+        };
+
+        if !self.recursive {
+            ret
+        } else {
+            ret | self.dive_into(&root)
+        }
+    }
+
+    fn dive_into<P: AsRef<Path>>(&self, root: P) -> i32 {
+        let mut ret = 0;
+        let root = root.as_ref();
+        let follow = self.dereference || self.bit_flag & FTS_LOGICAL != 0;
+        for entry in WalkDir::new(root).follow_links(follow).min_depth(1) {
+            let entry = unwrap!(entry, e, {
+                ret = 1;
+                show_error!("{}", e);
+                continue;
+            });
+            let path = entry.path();
+            let meta = match self.obtain_meta(path, follow) {
+                Some(m) => m,
+                _ => {
+                    ret = 1;
+                    continue;
+                }
+            };
+
+            if !self.matched(meta.uid(), meta.gid()) {
+                continue;
+            }
+
+            ret = match wrap_chown(
+                path,
+                &meta,
+                self.dest_uid,
+                self.dest_gid,
+                follow,
+                self.verbosity.clone(),
+            ) {
+                Ok(n) => {
+                    if !n.is_empty() {
+                        show_error!("{}", n);
+                    }
+                    0
+                }
+                Err(e) => {
+                    if self.verbosity.level != VerbosityLevel::Silent {
+                        show_error!("{}", e);
+                    }
+                    1
+                }
+            }
+        }
+        ret
+    }
+
+    fn obtain_meta<P: AsRef<Path>>(&self, path: P, follow: bool) -> Option<Metadata> {
+        let path = path.as_ref();
+        let meta = if follow {
+            unwrap!(path.metadata(), e, {
+                match self.verbosity.level {
+                    VerbosityLevel::Silent => (),
+                    _ => show_error!("cannot access '{}': {}", path.display(), e),
+                }
+                return None;
+            })
+        } else {
+            unwrap!(path.symlink_metadata(), e, {
+                match self.verbosity.level {
+                    VerbosityLevel::Silent => (),
+                    _ => show_error!("cannot dereference '{}': {}", path.display(), e),
+                }
+                return None;
+            })
+        };
+        Some(meta)
+    }
+
+    #[inline]
+    fn matched(&self, uid: uid_t, gid: gid_t) -> bool {
+        match self.filter {
+            IfFrom::All => true,
+            IfFrom::User(u) => u == uid,
+            IfFrom::Group(g) => g == gid,
+            IfFrom::UserGroup(u, g) => u == uid && g == gid,
+        }
+    }
 }

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -43,7 +43,7 @@ fn test_invalid_group() {
         .arg("__nosuchgroup__")
         .arg("/")
         .fails()
-        .stderr_is("chgrp: invalid group: __nosuchgroup__");
+        .stderr_is("chgrp: invalid group: '__nosuchgroup__'");
 }
 
 #[test]


### PR DESCRIPTION
chgrp does mostly the same as chown.
By making chown a bit more configurable we can reuse its code for chgrp.
Closes #2565.
Depends on #2471 for correct error messages.