### PR TITLE
Ignore the clippy::collapsible_match in wc

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -347,6 +347,7 @@ fn digit_width(input: &Input) -> WcResult<Option<usize>> {
 /// let inputs = vec![Input::Stdin(StdinKind::Explicit)];
 /// assert_eq!(7, max_width(&inputs));
 /// ```
+#[allow(clippy::collapsible_match)]
 fn max_width(inputs: &[Input]) -> usize {
     let mut result = 1;
     for input in inputs {


### PR DESCRIPTION
Not sure it is an actual issue