### PR TITLE
tac: support multi-character line separator with possible overlaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,6 +2937,7 @@ name = "uu_tac"
 version = "0.0.7"
 dependencies = [
  "clap",
+ "memchr 2.4.0",
  "uucore",
  "uucore_procs",
 ]

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "src/tac.rs"
 
 [dependencies]
+memchr = "2"
 clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.9", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore axxbxx bxxaxx
+// spell-checker:ignore axxbxx bxxaxx axxx axxxx xxaxx xxax xxxxa
 use crate::common::util::*;
 
 #[test]
@@ -123,6 +123,78 @@ fn test_multi_char_separator() {
         .pipe_in("axxbxx")
         .succeeds()
         .stdout_is("bxxaxx");
+}
+
+#[test]
+fn test_multi_char_separator_overlap() {
+    // The right-most pair of "x" characters in the input is treated as
+    // the only line separator. That is, "axxx" is interpreted as having
+    // one line comprising the string "ax" followed by the line
+    // separator "xx".
+    new_ucmd!()
+        .args(&["-s", "xx"])
+        .pipe_in("axxx")
+        .succeeds()
+        .stdout_is("axxx");
+
+    // Each non-overlapping pair of "x" characters in the input is
+    // treated as a line separator. That is, "axxxx" is interpreted as
+    // having two lines:
+    //
+    // * the second line is the empty string "" followed by the line
+    //   separator "xx",
+    // * the first line is the string "a" followed by the line separator
+    //   "xx".
+    //
+    // The lines are printed in reverse, resulting in "xx" followed by
+    // "axx".
+    new_ucmd!()
+        .args(&["-s", "xx"])
+        .pipe_in("axxxx")
+        .succeeds()
+        .stdout_is("xxaxx");
+}
+
+#[test]
+fn test_multi_char_separator_overlap_before() {
+    // With the "-b" option, the line separator is assumed to be at the
+    // beginning of the line. In this case, That is, "axxx" is
+    // interpreted as having two lines:
+    //
+    // * the second line is the empty string "" preceded by the line
+    //   separator "xx",
+    // * the first line is the string "ax" preceded by no line
+    //   separator, since there are no more characters preceding it.
+    //
+    // The lines are printed in reverse, resulting in "xx" followed by
+    // "ax".
+    new_ucmd!()
+        .args(&["-b", "-s", "xx"])
+        .pipe_in("axxx")
+        .succeeds()
+        .stdout_is("xxax");
+
+    // With the "-b" option, the line separator is assumed to be at the
+    // beginning of the line. Each non-overlapping pair of "x"
+    // characters in the input is treated as a line separator. That is,
+    // "axxxx" is interpreted as having three lines:
+    //
+    // * the third line is the empty string "" preceded by the line
+    //   separator "xx" (the last two "x" characters in the input
+    //   string),
+    // * the second line is the empty string "" preceded by the line
+    //   separator "xx" (the first two "x" characters in the input
+    //   string),
+    // * the first line is the string "a" preceded by no line separator,
+    //   since there are no more characters preceding it.
+    //
+    // The lines are printed in reverse, resulting in "xx" followed by
+    // "xx" followed by "a".
+    new_ucmd!()
+        .args(&["-b", "-s", "xx"])
+        .pipe_in("axxxx")
+        .succeeds()
+        .stdout_is("xxxxa");
 }
 
 #[test]


### PR DESCRIPTION
Fix a bug in `tac` where multi-character line separators would cause
incorrect behavior when there was overlap between candidate matches in
the input string. This commit adds a dependency on `memchr` in order to
use the `memchr::memmem::rfind_iter()` function to scan for
non-overlapping instances of the specified line separator characters,
scanning from right to left.

Fixes #2580.