### PR TITLE
Unify error macros

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -122,7 +122,7 @@ pub fn base_app<'a>(name: &str, version: &'a str, about: &'a str) -> App<'static
 pub fn get_input<'a>(config: &Config, stdin_ref: &'a Stdin) -> Box<dyn Read + 'a> {
     match &config.to_read {
         Some(name) => {
-            let file_buf = safe_unwrap!(File::open(Path::new(name)));
+            let file_buf = crash_if_err!(1, File::open(Path::new(name)));
             Box::new(BufReader::new(file_buf)) // as Box<dyn Read>
         }
         None => {

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -725,14 +725,14 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .unwrap()
         .map(str::to_string)
         .collect();
-    let patterns = return_if_err!(1, patterns::get_patterns(&patterns[..]));
+    let patterns = crash_if_err!(1, patterns::get_patterns(&patterns[..]));
     let options = CsplitOptions::new(&matches);
     if file_name == "-" {
         let stdin = io::stdin();
         crash_if_err!(1, csplit(&options, patterns, stdin.lock()));
     } else {
-        let file = return_if_err!(1, File::open(file_name));
-        let file_metadata = return_if_err!(1, file.metadata());
+        let file = crash_if_err!(1, File::open(file_name));
+        let file_metadata = crash_if_err!(1, file.metadata());
         if !file_metadata.is_file() {
             crash!(1, "'{}' is not a regular file", file_name);
         }

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -329,12 +329,15 @@ fn expand(options: Options) {
                         // now dump out either spaces if we're expanding, or a literal tab if we're not
                         if init || !options.iflag {
                             if nts <= options.tspaces.len() {
-                                safe_unwrap!(output.write_all(options.tspaces[..nts].as_bytes()));
+                                crash_if_err!(
+                                    1,
+                                    output.write_all(options.tspaces[..nts].as_bytes())
+                                );
                             } else {
-                                safe_unwrap!(output.write_all(" ".repeat(nts).as_bytes()));
+                                crash_if_err!(1, output.write_all(" ".repeat(nts).as_bytes()));
                             };
                         } else {
-                            safe_unwrap!(output.write_all(&buf[byte..byte + nbytes]));
+                            crash_if_err!(1, output.write_all(&buf[byte..byte + nbytes]));
                         }
                     }
                     _ => {
@@ -352,14 +355,14 @@ fn expand(options: Options) {
                             init = false;
                         }
 
-                        safe_unwrap!(output.write_all(&buf[byte..byte + nbytes]));
+                        crash_if_err!(1, output.write_all(&buf[byte..byte + nbytes]));
                     }
                 }
 
                 byte += nbytes; // advance the pointer
             }
 
-            safe_unwrap!(output.flush());
+            crash_if_err!(1, output.flush());
             buf.truncate(0); // clear the buffer
         }
     }

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -119,7 +119,7 @@ fn fold(filenames: Vec<String>, bytes: bool, spaces: bool, width: usize) {
             stdin_buf = stdin();
             &mut stdin_buf as &mut dyn Read
         } else {
-            file_buf = safe_unwrap!(File::open(Path::new(filename)));
+            file_buf = crash_if_err!(1, File::open(Path::new(filename)));
             &mut file_buf as &mut dyn Read
         });
 

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -468,7 +468,7 @@ where
             stdin_buf = stdin();
             Box::new(stdin_buf) as Box<dyn Read>
         } else {
-            file_buf = safe_unwrap!(File::open(filename));
+            file_buf = crash_if_err!(1, File::open(filename));
             Box::new(file_buf) as Box<dyn Read>
         });
         if options.check {
@@ -485,19 +485,25 @@ where
             } else {
                 "+".to_string()
             };
-            let gnu_re = safe_unwrap!(Regex::new(&format!(
-                r"^(?P<digest>[a-fA-F0-9]{}) (?P<binary>[ \*])(?P<fileName>.*)",
-                modifier,
-            )));
-            let bsd_re = safe_unwrap!(Regex::new(&format!(
-                r"^{algorithm} \((?P<fileName>.*)\) = (?P<digest>[a-fA-F0-9]{digest_size})",
-                algorithm = options.algoname,
-                digest_size = modifier,
-            )));
+            let gnu_re = crash_if_err!(
+                1,
+                Regex::new(&format!(
+                    r"^(?P<digest>[a-fA-F0-9]{}) (?P<binary>[ \*])(?P<fileName>.*)",
+                    modifier,
+                ))
+            );
+            let bsd_re = crash_if_err!(
+                1,
+                Regex::new(&format!(
+                    r"^{algorithm} \((?P<fileName>.*)\) = (?P<digest>[a-fA-F0-9]{digest_size})",
+                    algorithm = options.algoname,
+                    digest_size = modifier,
+                ))
+            );
 
             let buffer = file;
             for (i, line) in buffer.lines().enumerate() {
-                let line = safe_unwrap!(line);
+                let line = crash_if_err!(1, line);
                 let (ck_filename, sum, binary_check) = match gnu_re.captures(&line) {
                     Some(caps) => (
                         caps.name("fileName").unwrap().as_str(),
@@ -527,14 +533,17 @@ where
                         }
                     },
                 };
-                let f = safe_unwrap!(File::open(ck_filename));
+                let f = crash_if_err!(1, File::open(ck_filename));
                 let mut ckf = BufReader::new(Box::new(f) as Box<dyn Read>);
-                let real_sum = safe_unwrap!(digest_reader(
-                    &mut *options.digest,
-                    &mut ckf,
-                    binary_check,
-                    options.output_bits
-                ))
+                let real_sum = crash_if_err!(
+                    1,
+                    digest_reader(
+                        &mut *options.digest,
+                        &mut ckf,
+                        binary_check,
+                        options.output_bits
+                    )
+                )
                 .to_ascii_lowercase();
                 if sum == real_sum {
                     if !options.quiet {
@@ -548,12 +557,15 @@ where
                 }
             }
         } else {
-            let sum = safe_unwrap!(digest_reader(
-                &mut *options.digest,
-                &mut file,
-                options.binary,
-                options.output_bits
-            ));
+            let sum = crash_if_err!(
+                1,
+                digest_reader(
+                    &mut *options.digest,
+                    &mut file,
+                    options.binary,
+                    options.output_bits
+                )
+            );
             if options.tag {
                 println!("{} ({}) = {}", options.algoname, filename.display(), sum);
             } else {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1362,8 +1362,8 @@ fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>)
         vec![]
     };
 
-    let mut temp: Vec<_> = safe_unwrap!(fs::read_dir(&dir.p_buf))
-        .map(|res| safe_unwrap!(res))
+    let mut temp: Vec<_> = crash_if_err!(1, fs::read_dir(&dir.p_buf))
+        .map(|res| crash_if_err!(1, res))
         .filter(|e| should_display(e, config))
         .map(|e| PathData::new(DirEntry::path(&e), Some(e.file_type()), None, config, false))
         .collect();

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -291,7 +291,7 @@ impl Pinky {
 
         let mut s = ut.host();
         if self.include_where && !s.is_empty() {
-            s = safe_unwrap!(ut.canon_host());
+            s = crash_if_err!(1, ut.canon_host());
             print!(" {}", s);
         }
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -105,7 +105,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         let dec = slice.find('.').unwrap_or(len);
         largest_dec = len - dec;
         padding = dec;
-        return_if_err!(1, slice.parse())
+        crash_if_err!(1, slice.parse())
     } else {
         Number::BigInt(BigInt::one())
     };
@@ -115,7 +115,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         let dec = slice.find('.').unwrap_or(len);
         largest_dec = cmp::max(largest_dec, len - dec);
         padding = cmp::max(padding, dec);
-        return_if_err!(1, slice.parse())
+        crash_if_err!(1, slice.parse())
     } else {
         Number::BigInt(BigInt::one())
     };
@@ -130,7 +130,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let last = {
         let slice = numbers[numbers.len() - 1];
         padding = cmp::max(padding, slice.find('.').unwrap_or_else(|| slice.len()));
-        return_if_err!(1, slice.parse())
+        crash_if_err!(1, slice.parse())
     };
     if largest_dec > 0 {
         largest_dec -= 1;

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -170,7 +170,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let command_params: Vec<&str> = command_values.collect();
 
     let mut tmp_dir = tempdir().unwrap();
-    let (preload_env, libstdbuf) = return_if_err!(1, get_preload_env(&mut tmp_dir));
+    let (preload_env, libstdbuf) = crash_if_err!(1, get_preload_env(&mut tmp_dir));
     command.env(preload_env, libstdbuf);
     set_command_env(&mut command, "_STDBUF_I", options.stdin);
     set_command_env(&mut command, "_STDBUF_O", options.stdout);

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -221,7 +221,7 @@ fn timeout(
                     cmd[0]
                 );
             }
-            return_if_err!(ERR_EXIT_STATUS, process.send_signal(signal));
+            crash_if_err!(ERR_EXIT_STATUS, process.send_signal(signal));
             if let Some(kill_after) = kill_after {
                 match process.wait_or_timeout(kill_after) {
                     Ok(Some(status)) => {
@@ -235,13 +235,13 @@ fn timeout(
                         if verbose {
                             show_error!("sending signal KILL to command '{}'", cmd[0]);
                         }
-                        return_if_err!(
+                        crash_if_err!(
                             ERR_EXIT_STATUS,
                             process.send_signal(
                                 uucore::signals::signal_by_name_or_value("KILL").unwrap()
                             )
                         );
-                        return_if_err!(ERR_EXIT_STATUS, process.wait());
+                        crash_if_err!(ERR_EXIT_STATUS, process.wait());
                         137
                     }
                     Err(_) => 124,
@@ -251,7 +251,7 @@ fn timeout(
             }
         }
         Err(_) => {
-            return_if_err!(ERR_EXIT_STATUS, process.send_signal(signal));
+            crash_if_err!(ERR_EXIT_STATUS, process.send_signal(signal));
             ERR_EXIT_STATUS
         }
     }

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -53,7 +53,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = format!("{} [OPTION]...", uucore::execution_phrase());
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
 
-    let uname = return_if_err!(1, PlatformInfo::new());
+    let uname = crash_if_err!(1, PlatformInfo::new());
     let mut output = String::new();
 
     let all = matches.is_present(options::ALL);

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -178,13 +178,13 @@ fn write_tabs(
                 break;
             }
 
-            safe_unwrap!(output.write_all(b"\t"));
+            crash_if_err!(1, output.write_all(b"\t"));
             scol += nts;
         }
     }
 
     while col > scol {
-        safe_unwrap!(output.write_all(b" "));
+        crash_if_err!(1, output.write_all(b" "));
         scol += 1;
     }
 }
@@ -272,7 +272,7 @@ fn unexpand(options: Options) {
                         init,
                         true,
                     );
-                    safe_unwrap!(output.write_all(&buf[byte..]));
+                    crash_if_err!(1, output.write_all(&buf[byte..]));
                     scol = col;
                     break;
                 }
@@ -292,7 +292,7 @@ fn unexpand(options: Options) {
                         };
 
                         if !tabs_buffered {
-                            safe_unwrap!(output.write_all(&buf[byte..byte + nbytes]));
+                            crash_if_err!(1, output.write_all(&buf[byte..byte + nbytes]));
                             scol = col; // now printed up to this column
                         }
                     }
@@ -317,7 +317,7 @@ fn unexpand(options: Options) {
                         } else {
                             0
                         };
-                        safe_unwrap!(output.write_all(&buf[byte..byte + nbytes]));
+                        crash_if_err!(1, output.write_all(&buf[byte..byte + nbytes]));
                         scol = col; // we've now printed up to this column
                     }
                 }
@@ -336,7 +336,7 @@ fn unexpand(options: Options) {
                 init,
                 true,
             );
-            safe_unwrap!(output.flush());
+            crash_if_err!(1, output.flush());
             buf.truncate(0); // clear out the buffer
         }
     }

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -492,7 +492,7 @@ impl Who {
         };
 
         let s = if self.do_lookup {
-            safe_unwrap!(ut.canon_host())
+            crash_if_err!(1, ut.canon_host())
         } else {
             ut.host()
         };

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -99,24 +99,6 @@ macro_rules! crash_if_err(
 
 //====
 
-/// Unwraps the Result. Instead of panicking, it shows the error and then
-/// returns from the function with the provided exit code.
-/// Assumes the current function returns an i32 value.
-#[macro_export]
-macro_rules! return_if_err(
-    ($exit_code:expr, $exp:expr) => (
-        match $exp {
-            Ok(m) => m,
-            Err(f) => {
-                $crate::show_error!("{}", f);
-                return $exit_code;
-            }
-        }
-    )
-);
-
-//====
-
 #[macro_export]
 macro_rules! safe_write(
     ($fd:expr, $($args:tt)+) => (
@@ -133,18 +115,6 @@ macro_rules! safe_writeln(
         match writeln!($fd, $($args)+) {
             Ok(_) => {}
             Err(f) => panic!("{}", f)
-        }
-    )
-);
-
-/// Unwraps the Result. Instead of panicking, it exists the program with exit
-/// code 1.
-#[macro_export]
-macro_rules! safe_unwrap(
-    ($exp:expr) => (
-        match $exp {
-            Ok(m) => m,
-            Err(f) => $crate::crash!(1, "{}", f.to_string())
         }
     )
 );


### PR DESCRIPTION
Related to #2585. This PR removes the `return_if_err` and `safe_unwrap` macros and replaces them with `crash_if_err` instead.