### PR TITLE
WIP: `cut`: refactoring

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -27,88 +27,23 @@ use uucore::InvalidEncodingHandling;
 mod searcher;
 
 static NAME: &str = "cut";
-static SYNTAX: &str =
-    "[-d] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+";
-static SUMMARY: &str =
-    "Prints specified byte or field columns from each line of stdin or the input files";
-static LONG_HELP: &str = "
- Each call must specify a mode (what to use for columns),
- a sequence (which columns to print), and provide a data source
+static ABOUT: &str =
+    "Print selected parts of lines from each FILE to standard output.
 
- Specifying a mode
+With no FILE, or when FILE is -, read standard input.
 
-    Use --bytes (-b) or --characters (-c) to specify byte mode
+Mandatory arguments to long options are mandatory for short options too.";
+static AFTER_HELP: &str =
+"Use one, and only one of -b, -c or -f.  Each LIST is made up of one
+range, or many ranges separated by commas.  Selected input is written
+in the same order that it is read, and is written exactly once.
+Each range is one of:
 
-    Use --fields (-f) to specify field mode, where each line is broken into
-    fields identified by a delimiter character. For example for a typical CSV
-    you could use this in combination with setting comma as the delimiter
+  N     N'th byte, character or field, counted from 1
+  N-    from N'th byte, character or field, to end of line
+  N-M   from N'th to M'th (included) byte, character or field
+  -M    from first to M'th (included) byte, character or field
 
- Specifying a sequence
-
-    A sequence is a group of 1 or more numbers or inclusive ranges separated
-    by a commas.
-
-    cut -f 2,5-7 some_file.txt
-    will display the 2nd, 5th, 6th, and 7th field for each source line
-
-    Ranges can extend to the end of the row by excluding the the second number
-
-    cut -f 3- some_file.txt
-    will display the 3rd field and all fields after for each source line
-
-    The first number of a range can be excluded, and this is effectively the
-    same as using 1 as the first number: it causes the range to begin at the
-    first column. Ranges can also display a single column
-
-    cut -f 1,3-5 some_file.txt
-    will display the 1st, 3rd, 4th, and 5th field for each source line
-
-    The --complement option, when used, inverts the effect of the sequence
-
-    cut --complement -f 4-6 some_file.txt
-    will display the every field but the 4th, 5th, and 6th
-
- Specifying a data source
-
-    If no sourcefile arguments are specified, stdin is used as the source of
-    lines to print
-
-    If sourcefile arguments are specified, stdin is ignored and all files are
-    read in consecutively if a sourcefile is not successfully read, a warning
-    will print to stderr, and the eventual status code will be 1, but cut
-    will continue to read through proceeding sourcefiles
-
-    To print columns from both STDIN and a file argument, use - (dash) as a
-    sourcefile argument to represent stdin.
-
- Field Mode options
-
-    The fields in each line are identified by a delimiter (separator)
-
-    Set the delimiter
-        Set the delimiter which separates fields in the file using the
-        --delimiter (-d) option. Setting the delimiter is optional.
-        If not set, a default delimiter of Tab will be used.
-
-    Optionally Filter based on delimiter
-        If the --only-delimited (-s) flag is provided, only lines which
-        contain the delimiter will be printed
-
-    Replace the delimiter
-        If the --output-delimiter option is provided, the argument used for
-        it will replace the delimiter character in each line printed. This is
-        useful for transforming tabular data - e.g. to convert a CSV to a
-        TSV (tab-separated file)
-
- Line endings
-
-    When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
-    'line ending' character (both for the purposes of reading lines and
-    separating printed lines) instead of \\n (newline). This is useful for
-    tabular data where some of the cells may contain newlines
-
-    echo 'ab\\0cd' | cut -z -c 1
-    will result in 'a\\0c\\0'
 ";
 
 struct Options {
@@ -435,7 +370,8 @@ mod options {
     pub const ONLY_DELIMITED: &str = "only-delimited";
     pub const OUTPUT_DELIMITER: &str = "output-delimiter";
     pub const COMPLEMENT: &str = "complement";
-    pub const FILE: &str = "file";
+    pub const FILE: &str = "FILE";
+    pub const N: &str = "n";
 }
 
 #[uucore_procs::gen_uumain]
@@ -589,82 +525,83 @@ pub fn uu_app() -> App<'static, 'static> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .usage(SYNTAX)
-        .about(SUMMARY)
-        .after_help(LONG_HELP)
+        .about(ABOUT)
+        .after_help(AFTER_HELP)
         .arg(
             Arg::with_name(options::BYTES)
                 .short("b")
                 .long(options::BYTES)
                 .takes_value(true)
-                .help("filter byte columns from the input source")
+                .help("select only these bytes")
                 .allow_hyphen_values(true)
-                .value_name("LIST")
-                .display_order(1),
+                .value_name("LIST"),
         )
         .arg(
             Arg::with_name(options::CHARACTERS)
                 .short("c")
                 .long(options::CHARACTERS)
-                .help("alias for character mode")
+                .help("select only these characters")
                 .takes_value(true)
                 .allow_hyphen_values(true)
-                .value_name("LIST")
-                .display_order(2),
+                .value_name("LIST"),
         )
         .arg(
             Arg::with_name(options::DELIMITER)
                 .short("d")
                 .long(options::DELIMITER)
-                .help("specify the delimiter character that separates fields in the input source. Defaults to Tab.")
+                .help("use DELIM instead of TAB for field delimiter")
                 .takes_value(true)
-                .value_name("DELIM")
-                .display_order(3),
+                .value_name("DELIM"),
         )
         .arg(
             Arg::with_name(options::FIELDS)
                 .short("f")
                 .long(options::FIELDS)
-                .help("filter field columns from the input source")
+                .help("select only these fields;  also print any line
+  that contains no delimiter character, unless
+  the -s option is specified")
                 .takes_value(true)
                 .allow_hyphen_values(true)
-                .value_name("LIST")
-                .display_order(4),
+                .value_name("LIST"),
+        )
+        .arg(
+            Arg::with_name(options::N)
+                .short(options::N)
+                .help("with -b: don't split multibyte characters")
+                .takes_value(false),
         )
         .arg(
             Arg::with_name(options::COMPLEMENT)
                 .long(options::COMPLEMENT)
-                .help("invert the filter - instead of displaying only the filtered columns, display all but those columns")
-                .takes_value(false)
-                .display_order(5),
+                .help("complement the set of selected bytes, characters
+  or fields")
+                .takes_value(false),
         )
         .arg(
             Arg::with_name(options::ONLY_DELIMITED)
-            .short("s")
+                .short("s")
                 .long(options::ONLY_DELIMITED)
-                .help("in field mode, only print lines which contain the delimiter")
-                .takes_value(false)
-                .display_order(6),
-        )
-        .arg(
-            Arg::with_name(options::ZERO_TERMINATED)
-            .short("z")
-                .long(options::ZERO_TERMINATED)
-                .help("instead of filtering columns based on line, filter columns based on \\0 (NULL character)")
-                .takes_value(false)
-                .display_order(8),
+                .help("do not print lines not containing delimiters")
+                .takes_value(false),
         )
         .arg(
             Arg::with_name(options::OUTPUT_DELIMITER)
             .long(options::OUTPUT_DELIMITER)
-                .help("in field mode, replace the delimiter in output lines with this option's argument")
+                .help("use STRING as the output delimiter
+  the default is to use the input delimiter")
                 .takes_value(true)
-                .value_name("NEW_DELIM")
-                .display_order(7),
+                .value_name("STRING"),
+        )
+        .arg(
+            Arg::with_name(options::ZERO_TERMINATED)
+                .short("z")
+                .long(options::ZERO_TERMINATED)
+                .help("line delimiter is NUL, not newline")
+                .takes_value(false),
         )
         .arg(
             Arg::with_name(options::FILE)
-            .hidden(true)
+                .hidden(false)
                 .multiple(true)
         )
 }

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -24,7 +24,10 @@ use uucore::error::{UError, UResult, USimpleError};
 use uucore::ranges::Range;
 use uucore::InvalidEncodingHandling;
 
-mod searcher;
+
+/* ****************************************************************************
+ * Help text and option definitions
+ * ****************************************************************************/
 
 static NAME: &str = "cut";
 static ABOUT: &str =
@@ -46,23 +49,26 @@ Each range is one of:
 
 ";
 
-struct Options {
-    out_delim: Option<String>,
-    zero_terminated: bool,
+mod options {
+    // Flags
+    pub const COMPLEMENT: &str = "complement";
+    pub const DONT_SPLIT_MULTIBYTES: &str = "n";
+    pub const ONLY_DELIMITED: &str = "only-delimited";
+    pub const ZERO_TERMINATED: &str = "zero-terminated";
+    // Options
+    pub const BYTES: &str = "bytes";
+    pub const CHARACTERS: &str = "characters";
+    pub const DELIMITER: &str = "delimiter";
+    pub const FIELDS: &str = "fields";
+    pub const OUTPUT_DELIMITER: &str = "output-delimiter";
+    // File input
+    pub const FILE: &str = "FILE";
 }
 
-struct FieldOptions {
-    delimiter: String, // one char long, String because of UTF8 representation
-    out_delimiter: Option<String>,
-    only_delimited: bool,
-    zero_terminated: bool,
-}
 
-enum Mode {
-    Bytes(Vec<Range>, Options),
-    Characters(Vec<Range>, Options),
-    Fields(Vec<Range>, FieldOptions),
-}
+/* ****************************************************************************
+ * Error handling and custom error
+ * ****************************************************************************/
 
 #[derive(Debug)]
 enum CutError {
@@ -105,6 +111,34 @@ impl Display for CutError {
         }
     }
 }
+
+
+/* ****************************************************************************
+ * Custom data types and structures
+ * ****************************************************************************/
+
+struct Options {
+    out_delim: Option<String>,
+    zero_terminated: bool,
+}
+
+struct FieldOptions {
+    delimiter: String, // one char long, String because of UTF8 representation
+    out_delimiter: Option<String>,
+    only_delimited: bool,
+    zero_terminated: bool,
+}
+
+enum Mode {
+    Bytes(Vec<Range>, Options),
+    Characters(Vec<Range>, Options),
+    Fields(Vec<Range>, FieldOptions),
+}
+
+
+/* ****************************************************************************
+ * Helper functions
+ * ****************************************************************************/
 
 fn stdout_writer() -> Box<dyn Write> {
     if atty::is(atty::Stream::Stdout) {
@@ -361,18 +395,9 @@ fn cut_files(mut filenames: Vec<String>, mode: Mode) -> UResult<()> {
     Ok(())
 }
 
-mod options {
-    pub const BYTES: &str = "bytes";
-    pub const CHARACTERS: &str = "characters";
-    pub const DELIMITER: &str = "delimiter";
-    pub const FIELDS: &str = "fields";
-    pub const ZERO_TERMINATED: &str = "zero-terminated";
-    pub const ONLY_DELIMITED: &str = "only-delimited";
-    pub const OUTPUT_DELIMITER: &str = "output-delimiter";
-    pub const COMPLEMENT: &str = "complement";
-    pub const FILE: &str = "FILE";
-    pub const N: &str = "n";
-}
+/* ****************************************************************************
+ * Main routine
+ * ****************************************************************************/
 
 #[uucore_procs::gen_uumain]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -565,8 +590,8 @@ pub fn uu_app() -> App<'static, 'static> {
                 .value_name("LIST"),
         )
         .arg(
-            Arg::with_name(options::N)
-                .short(options::N)
+            Arg::with_name(options::DONT_SPLIT_MULTIBYTES)
+                .short(options::DONT_SPLIT_MULTIBYTES)
                 .help("with -b: don't split multibyte characters")
                 .takes_value(false),
         )

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -11,18 +11,20 @@
  *
  * - Implement actual cutting: At files, bytes and chars
  * - Implement file handling
+ * - FIX: In cut_bytes iterator also joins empty matches --> wrong!
  */
 
 #[macro_use]
 extern crate uucore;
 
+// use bstr::io::BufReadExt;
 use clap::{crate_version, App, Arg, ArgMatches};
 use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::fs::File;
-use std::io::{stdout, BufReader, BufWriter, Read, Write};
-use std::path::Path;
-use uucore::display::Quotable;
+use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+// use uucore::display::Quotable;
 
 use uucore::error::{UError, UIoError, UResult};
 use uucore::ranges::Range;

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -575,7 +575,8 @@ pub fn uu_app() -> App<'static, 'static> {
   the default is to use the input delimiter",
                 )
                 .takes_value(true)
-                .value_name("STRING"),
+                .value_name("STRING")
+                .default_value("")
         )
         .arg(
             Arg::with_name(options::ZERO_TERMINATED)
@@ -584,5 +585,10 @@ pub fn uu_app() -> App<'static, 'static> {
                 .help("line delimiter is NUL, not newline")
                 .takes_value(false),
         )
-        .arg(Arg::with_name(options::FILE).hidden(false).multiple(true))
+        .arg(
+            Arg::with_name(options::FILE)
+                .hidden(false)
+                .multiple(true)
+                .default_value("-")
+        )
 }

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -459,13 +459,18 @@ fn get_behavior(matches: &ArgMatches) -> UResult<Behavior> {
         _ => return Err(CutError::OnlyOneListAllowed().into()),
     };
 
-    let output_delimiter = Some(" ".to_owned());
+//    let output_delimiter = Some(" ".to_owned());
+    let output_delimiter = matches.value_of(options::OUTPUT_DELIMITER).map(String::from);
 
-    let files: Vec<String> = matches
+    let mut files: Vec<String> = matches
         .values_of(options::FILE)
         .unwrap_or_default()
         .map(str::to_owned)
         .collect();
+
+    // Drop duplicate files
+    files.sort_unstable();
+    files.dedup();
 
     Ok(Behavior {
         // Flags
@@ -499,7 +504,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     //     Mode::Characters(_) => cut_characters(&behavior),
     //     Mode::Fields(_) => cut_fields(&behavior),
     // }
-    return Ok(());
+    // match behavior.mode {
+    //     Mode::Bytes(_) => cut_bytes(stdin(), &behavior)?,
+    //     _ => return Ok(()),
+    // }
+    cut_files(&behavior)
 }
 
 pub fn uu_app() -> App<'static, 'static> {

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -24,7 +24,7 @@ use std::io::{stdout, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 use uucore::display::Quotable;
 
-use uucore::error::{UError, UResult};
+use uucore::error::{UError, UIoError, UResult};
 use uucore::ranges::Range;
 use uucore::InvalidEncodingHandling;
 
@@ -77,8 +77,10 @@ enum CutError {
     InvalidFieldList(String),
     InvalidByteCharList(String),
     InputDelimOnlyOnFields(),
+    IsDirectory(PathBuf),
     SuppressingOnlyOnFields(),
     DelimSingleChar(),
+    NotImplemented(String),
 }
 
 impl UError for CutError {
@@ -111,11 +113,17 @@ impl Display for CutError {
                 f,
                 "an input delimiter may be specified only when operating on fields"
             ),
+            CE::IsDirectory(dir) => {
+                write!(f, "{}: Is a directory", dir.display())
+            },
             CE::SuppressingOnlyOnFields() => write!(
                 f,
                 "suppressing non-delimited lines makes sense\n        only when operating on fields"
             ),
             CE::DelimSingleChar() => write!(f, "the delimiter must be a single character"),
+            CE::NotImplemented(thing) => write!(
+                f, "'{}' isn't implemented yet.", thing
+            )
         }
     }
 }

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -119,97 +119,14 @@ macro_rules! safe_writeln(
     )
 );
 
-//-- message templates
-
-//-- message templates : (join utility sub-macros)
-
+/// Unwraps the Result. Instead of panicking, it exists the program with exit
+/// code 1.
 #[macro_export]
-macro_rules! snippet_list_join_oxford_comma {
-    ($conjunction:expr, $valOne:expr, $valTwo:expr) => (
-        format!("{}, {} {}", $valOne, $conjunction, $valTwo)
-    );
-    ($conjunction:expr, $valOne:expr, $valTwo:expr $(, $remaining_values:expr)*) => (
-        format!("{}, {}", $valOne, $crate::snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
-    );
-}
-
-#[macro_export]
-macro_rules! snippet_list_join {
-    ($conjunction:expr, $valOne:expr, $valTwo:expr) => (
-        format!("{} {} {}", $valOne, $conjunction, $valTwo)
-    );
-    ($conjunction:expr, $valOne:expr, $valTwo:expr $(, $remaining_values:expr)*) => (
-        format!("{}, {}", $valOne, $crate::snippet_list_join_oxford_comma!($conjunction, $valTwo $(, $remaining_values)*))
-    );
-}
-
-//-- message templates : invalid input
-
-#[macro_export]
-macro_rules! msg_invalid_input {
-    ($reason: expr) => {
-        format!("invalid input: {}", $reason)
-    };
-}
-
-// -- message templates : invalid input : flag
-
-#[macro_export]
-macro_rules! msg_invalid_opt_use {
-    ($about:expr, $flag:expr) => {
-        $crate::msg_invalid_input!(format!("The '{}' option {}", $flag, $about))
-    };
-    ($about:expr, $long_flag:expr, $short_flag:expr) => {
-        $crate::msg_invalid_input!(format!(
-            "The '{}' ('{}') option {}",
-            $long_flag, $short_flag, $about
-        ))
-    };
-}
-
-#[macro_export]
-macro_rules! msg_opt_only_usable_if {
-    ($clause:expr, $flag:expr) => {
-        $crate::msg_invalid_opt_use!(format!("only usable if {}", $clause), $flag)
-    };
-    ($clause:expr, $long_flag:expr, $short_flag:expr) => {
-        $crate::msg_invalid_opt_use!(
-            format!("only usable if {}", $clause),
-            $long_flag,
-            $short_flag
-        )
-    };
-}
-
-#[macro_export]
-macro_rules! msg_opt_invalid_should_be {
-    ($expects:expr, $received:expr, $flag:expr) => {
-        $crate::msg_invalid_opt_use!(
-            format!("expects {}, but was provided {}", $expects, $received),
-            $flag
-        )
-    };
-    ($expects:expr, $received:expr, $long_flag:expr, $short_flag:expr) => {
-        $crate::msg_invalid_opt_use!(
-            format!("expects {}, but was provided {}", $expects, $received),
-            $long_flag,
-            $short_flag
-        )
-    };
-}
-
-// -- message templates : invalid input : input combinations
-
-#[macro_export]
-macro_rules! msg_expects_one_of {
-    ($valOne:expr $(, $remaining_values:expr)*) => (
-        $crate::msg_invalid_input!(format!("expects one of {}", $crate::snippet_list_join!("or", $valOne $(, $remaining_values)*)))
-    );
-}
-
-#[macro_export]
-macro_rules! msg_expects_no_more_than_one_of {
-    ($valOne:expr $(, $remaining_values:expr)*) => (
-        $crate::msg_invalid_input!(format!("expects no more than one of {}", $crate::snippet_list_join!("or", $valOne $(, $remaining_values)*))) ;
-    );
-}
+macro_rules! safe_unwrap(
+    ($exp:expr) => (
+        match $exp {
+            Ok(m) => m,
+            Err(f) => $crate::crash!(1, "{}", f.to_string())
+        }
+    )
+);


### PR DESCRIPTION
~~Refactor `cut` (partially) to remove obscure macros from the code and use `UError` & friends instead. Allows us to remove the macros from the actual `macros` module as well, since cut was the last util using them. Also adapts the error messages to match what GNUs `cut` (version 8.32) outputs.~~

~~To be honest, I don't trust my changes myself because I find the code in this `cut` incredibly hard to read. It feels (to me at least) as if someone wanted to push Rusts pattern matching capabilities to the very limit. Some places you will find closures > 50 lines, which makes understanding the code very tricky... If requested, I may try my hand at some bigger refactoring of the codebase. This will be necessary anyways, as I found that the application currently throws different errors from GNUs `cut` in some places, because it checks the meaning of the arguments in some different order.~~

Perform a complete refactoring of the `cut` utility. Remove code duplications, reduce code complexity and drop macros that are used exclusively by cut. When finished, add some tests and try to achieve good code coverage. Make the `cut` utlility use `UError` for error handling instead of error strings and integer return codes only.

It's a work in progress, I'm posting it here in case anybody wants to join in or discuss about the current state.