### PR TITLE
uptime: use sysctl to get the boottime if other methods failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963488c73b34185a9028742c2be0219ed1d8558e59f85c3b466a4f54affba936"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "libc",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,6 +3107,7 @@ version = "0.0.7"
 dependencies = [
  "chrono",
  "clap",
+ "sysctl",
  "uucore",
  "uucore_procs",
 ]

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -20,6 +20,9 @@ clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["libc", "utmpx"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 
+[target.'cfg(unix)'.dependencies]
+sysctl = "0.4.2"
+
 [[bin]]
 name = "uptime"
 path = "src/main.rs"


### PR DESCRIPTION
`sysctl` seems to be the way to get the boottime on `freebsd`.

This PR should fix two errors from https://github.com/uutils/coreutils/pull/2581, but we'll have to wait for that PR to land to know for sure. I'm marking this as a draft in the meantime.