### PR TITLE
Close file descriptors of pipes after use

### DIFF
--- a/src/uu/cat/src/splice.rs
+++ b/src/uu/cat/src/splice.rs
@@ -20,13 +20,7 @@ pub(super) fn write_fast_using_splice<R: Read>(
     handle: &mut InputHandle<R>,
     write_fd: RawFd,
 ) -> CatResult<bool> {
-    let (pipe_rd, pipe_wr) = match pipe() {
-        Ok(r) => r,
-        Err(_) => {
-            // It is very rare that creating a pipe fails, but it can happen.
-            return Ok(true);
-        }
-    };
+    let (pipe_rd, pipe_wr) = pipe()?;
 
     // Ensure the pipe is closed when the function returns.
     // SAFETY: The file descriptors do not have other owners.

--- a/src/uu/cat/src/splice.rs
+++ b/src/uu/cat/src/splice.rs
@@ -2,8 +2,9 @@ use super::{CatResult, InputHandle};
 
 use nix::fcntl::{splice, SpliceFFlags};
 use nix::unistd::{self, pipe};
+use std::fs::File;
 use std::io::Read;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{FromRawFd, RawFd};
 
 const BUF_SIZE: usize = 1024 * 16;
 
@@ -26,6 +27,10 @@ pub(super) fn write_fast_using_splice<R: Read>(
             return Ok(true);
         }
     };
+
+    // Ensure the pipe is closed when the function returns.
+    // SAFETY: The file descriptors do not have other owners.
+    let _handles = unsafe { (File::from_raw_fd(pipe_rd), File::from_raw_fd(pipe_wr)) };
 
     loop {
         match splice(

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -1,3 +1,5 @@
+// spell-checker:ignore NOFILE
+
 use crate::common::util::*;
 use std::fs::OpenOptions;
 #[cfg(unix)]

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -3,6 +3,9 @@ use std::fs::OpenOptions;
 #[cfg(unix)]
 use std::io::Read;
 
+#[cfg(target_os = "linux")]
+use rlimit::Resource;
+
 #[test]
 fn test_output_simple() {
     new_ucmd!()
@@ -85,6 +88,23 @@ fn test_fifo_symlink() {
     let output = proc.wait_with_output().unwrap();
     assert_eq!(&output.stdout, &data2);
     thread.join().unwrap();
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_closes_file_descriptors() {
+    // Each file creates a pipe, which has two file descriptors.
+    // If they are not closed then five is certainly too many.
+    new_ucmd!()
+        .args(&[
+            "alpha.txt",
+            "alpha.txt",
+            "alpha.txt",
+            "alpha.txt",
+            "alpha.txt",
+        ])
+        .with_limit(Resource::NOFILE, 9, 9)
+        .succeeds();
 }
 
 #[test]


### PR DESCRIPTION
[`nix::unistd::pipe`](https://docs.rs/nix/0.22.1/nix/unistd/fn.pipe.html) returns `RawFd`s which have to be closed at some point, otherwise they are leaked. Wrapping them in `File`s does the trick.

The leaked file descriptors can be observed by running `uucat /dev/null /dev/null /dev/null -` in one terminal (the `-` ensures it doesn't exit immediately) and then running `lsof -p $(pidof uucat)` in another.

It's possible to implement this without the `unsafe` keyword by writing a wrapper that calls [`nix::unistd::close`](https://docs.rs/nix/0.22.1/nix/unistd/fn.close.html) when it's dropped, but that function is technically also unsafe and probably will be marked as such in the future, so it's better to be upfront. See nix-rust/nix#1421.