### PR TITLE
hashsum: don't copy input buffer on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,6 +2392,7 @@ dependencies = [
  "hex",
  "libc",
  "md5",
+ "memchr 2.4.0",
  "regex",
  "regex-syntax",
  "sha1",

--- a/src/uu/hashsum/Cargo.toml
+++ b/src/uu/hashsum/Cargo.toml
@@ -19,6 +19,7 @@ digest = "0.6.2"
 clap = { version = "2.33", features = ["wrap_help"] }
 hex = "0.2.0"
 libc = "0.2.42"
+memchr = "2"
 md5 = "0.3.5"
 regex = "1.0.1"
 regex-syntax = "0.6.7"


### PR DESCRIPTION
Remove a copy operation of the input buffer being read for digest when
reading in text mode on Windows. Previously, the code was copying the
buffer to a completely new `Vec`, replacing "\r\n" with "\n". Instead,
the code now scans for the indices at which each "\r\n" occurs in the
input buffer and inputs into the digest only the characters before the
"\r" and after it.

This issue was referenced in https://github.com/uutils/coreutils/issues/2295#issuecomment-850627402 :

> If we try to parse in windows text mode (whatever that is - there are no tests for it and I have no idea why we want to modify the input file before hashing), there is a second vector used. That allocation is not used in other cases, we should make sure it's only allocated when actually used.
