### PR TITLE
Run clippy on the full workspace

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -130,7 +130,7 @@ jobs:
       run: |
         ## `clippy` lint testing
         # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-        S=$(cargo +nightly clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+${PWD//\//\\/}\/(.*):([0-9]+):([0-9]+).*$/::error file=\2,line=\3,col=\4::ERROR: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; exit 1 ; }
+        S=$(cargo +nightly clippy --workspace --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+${PWD//\//\\/}\/(.*):([0-9]+):([0-9]+).*$/::error file=\2,line=\3,col=\4::ERROR: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; exit 1 ; }
 
   code_spellcheck:
     name: Style/spelling

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit.
-        entry: cargo +nightly clippy --all-targets --all-features --
+        entry: cargo +nightly clippy --workspace --all-targets --all-features --
         pass_filenames: false
         types: [file, rust]
         language: system

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -568,7 +568,7 @@ mod tests {
                 assert_eq!(input_splitter.add_line_to_buffer(0, line), None);
                 assert_eq!(input_splitter.buffer_len(), 1);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -577,7 +577,7 @@ mod tests {
                 assert_eq!(input_splitter.add_line_to_buffer(1, line), None);
                 assert_eq!(input_splitter.buffer_len(), 2);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -589,7 +589,7 @@ mod tests {
                 );
                 assert_eq!(input_splitter.buffer_len(), 2);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         input_splitter.rewind_buffer();
@@ -599,7 +599,7 @@ mod tests {
                 assert_eq!(line, String::from("bbb"));
                 assert_eq!(input_splitter.buffer_len(), 1);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -607,7 +607,7 @@ mod tests {
                 assert_eq!(line, String::from("ccc"));
                 assert_eq!(input_splitter.buffer_len(), 0);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -615,7 +615,7 @@ mod tests {
                 assert_eq!(line, String::from("ddd"));
                 assert_eq!(input_splitter.buffer_len(), 0);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         assert!(input_splitter.next().is_none());
@@ -640,7 +640,7 @@ mod tests {
                 assert_eq!(input_splitter.add_line_to_buffer(0, line), None);
                 assert_eq!(input_splitter.buffer_len(), 1);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -649,7 +649,7 @@ mod tests {
                 assert_eq!(input_splitter.add_line_to_buffer(1, line), None);
                 assert_eq!(input_splitter.buffer_len(), 2);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -658,7 +658,7 @@ mod tests {
                 assert_eq!(input_splitter.add_line_to_buffer(2, line), None);
                 assert_eq!(input_splitter.buffer_len(), 3);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         input_splitter.rewind_buffer();
@@ -669,7 +669,7 @@ mod tests {
                 assert_eq!(input_splitter.add_line_to_buffer(0, line), None);
                 assert_eq!(input_splitter.buffer_len(), 3);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -677,7 +677,7 @@ mod tests {
                 assert_eq!(line, String::from("aaa"));
                 assert_eq!(input_splitter.buffer_len(), 2);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -685,7 +685,7 @@ mod tests {
                 assert_eq!(line, String::from("bbb"));
                 assert_eq!(input_splitter.buffer_len(), 1);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -693,7 +693,7 @@ mod tests {
                 assert_eq!(line, String::from("ccc"));
                 assert_eq!(input_splitter.buffer_len(), 0);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         match input_splitter.next() {
@@ -701,7 +701,7 @@ mod tests {
                 assert_eq!(line, String::from("ddd"));
                 assert_eq!(input_splitter.buffer_len(), 0);
             }
-            item @ _ => panic!("wrong item: {:?}", item),
+            item => panic!("wrong item: {:?}", item),
         };
 
         assert!(input_splitter.next().is_none());

--- a/src/uu/dd/src/parseargs/unit_tests.rs
+++ b/src/uu/dd/src/parseargs/unit_tests.rs
@@ -10,7 +10,7 @@ fn unimplemented_flags_should_error_non_linux() {
     let mut succeeded = Vec::new();
 
     // The following flags are only implemented in linux
-    for flag in vec![
+    for &flag in &[
         "direct",
         "directory",
         "dsync",
@@ -27,13 +27,11 @@ fn unimplemented_flags_should_error_non_linux() {
         ];
         let matches = uu_app().get_matches_from_safe(args).unwrap();
 
-        match parse_iflags(&matches) {
-            Ok(_) => succeeded.push(format!("iflag={}", flag)),
-            Err(_) => { /* expected behaviour :-) */ }
+        if parse_iflags(&matches).is_ok() {
+            succeeded.push(format!("iflag={}", flag));
         }
-        match parse_oflags(&matches) {
-            Ok(_) => succeeded.push(format!("oflag={}", flag)),
-            Err(_) => { /* expected behaviour :-) */ }
+        if parse_oflags(&matches).is_ok() {
+            succeeded.push(format!("oflag={}", flag));
         }
     }
 

--- a/src/uu/dd/src/parseargs/unit_tests.rs
+++ b/src/uu/dd/src/parseargs/unit_tests.rs
@@ -50,7 +50,7 @@ fn unimplemented_flags_should_error() {
     let mut succeeded = Vec::new();
 
     // The following flags are not implemented
-    for flag in vec!["cio", "nocache", "nolinks", "text", "binary"] {
+    for &flag in &["cio", "nocache", "nolinks", "text", "binary"] {
         let args = vec![
             String::from("dd"),
             format!("--iflag={}", flag),
@@ -58,13 +58,11 @@ fn unimplemented_flags_should_error() {
         ];
         let matches = uu_app().get_matches_from_safe(args).unwrap();
 
-        match parse_iflags(&matches) {
-            Ok(_) => succeeded.push(format!("iflag={}", flag)),
-            Err(_) => { /* expected behaviour :-) */ }
+        if parse_iflags(&matches).is_ok() {
+            succeeded.push(format!("iflag={}", flag))
         }
-        match parse_oflags(&matches) {
-            Ok(_) => succeeded.push(format!("oflag={}", flag)),
-            Err(_) => { /* expected behaviour :-) */ }
+        if parse_oflags(&matches).is_ok() {
+            succeeded.push(format!("oflag={}", flag))
         }
     }
 
@@ -356,7 +354,7 @@ fn parse_icf_token_ibm() {
 
     assert_eq!(exp.len(), act.len());
     for cf in &exp {
-        assert!(exp.contains(&cf));
+        assert!(exp.contains(cf));
     }
 }
 
@@ -373,7 +371,7 @@ fn parse_icf_tokens_elu() {
 
     assert_eq!(exp.len(), act.len());
     for cf in &exp {
-        assert!(exp.contains(&cf));
+        assert!(exp.contains(cf));
     }
 }
 
@@ -405,7 +403,7 @@ fn parse_icf_tokens_remaining() {
 
     assert_eq!(exp.len(), act.len());
     for cf in &exp {
-        assert!(exp.contains(&cf));
+        assert!(exp.contains(cf));
     }
 }
 
@@ -429,7 +427,7 @@ fn parse_iflag_tokens() {
 
     assert_eq!(exp.len(), act.len());
     for cf in &exp {
-        assert!(exp.contains(&cf));
+        assert!(exp.contains(cf));
     }
 }
 
@@ -453,7 +451,7 @@ fn parse_oflag_tokens() {
 
     assert_eq!(exp.len(), act.len());
     for cf in &exp {
-        assert!(exp.contains(&cf));
+        assert!(exp.contains(cf));
     }
 }
 
@@ -481,7 +479,7 @@ fn parse_iflag_tokens_linux() {
 
     assert_eq!(exp.len(), act.len());
     for cf in &exp {
-        assert!(exp.contains(&cf));
+        assert!(exp.contains(cf));
     }
 }
 
@@ -509,7 +507,7 @@ fn parse_oflag_tokens_linux() {
 
     assert_eq!(exp.len(), act.len());
     for cf in &exp {
-        assert!(exp.contains(&cf));
+        assert!(exp.contains(cf));
     }
 }
 

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -86,7 +86,7 @@ mod tests {
             let mut n_c: [u64; CHUNK_SIZE] = rng.gen();
             let mut f_c: [Factors; CHUNK_SIZE] = rng.gen();
 
-            let mut n_i = n_c.clone();
+            let mut n_i = n_c;
             let mut f_i = f_c.clone();
             for (n, f) in n_i.iter_mut().zip(f_i.iter_mut()) {
                 factor(n, f);

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -483,7 +483,7 @@ mod tests {
     fn options(args: &str) -> Result<HeadOptions, String> {
         let combined = "head ".to_owned() + args;
         let args = combined.split_whitespace();
-        HeadOptions::get_from(args.map(|s| OsString::from(s)))
+        HeadOptions::get_from(args.map(OsString::from))
     }
     #[test]
     fn test_args_modes() {
@@ -522,6 +522,7 @@ mod tests {
         assert!(options("-c IsThisJustFantasy").is_err());
     }
     #[test]
+    #[allow(clippy::bool_comparison)]
     fn test_options_correct_defaults() {
         let opts = HeadOptions::new();
         let opts2: HeadOptions = Default::default();
@@ -552,7 +553,7 @@ mod tests {
         assert!(parse_mode("1T", Modes::Bytes).is_err());
     }
     fn arg_outputs(src: &str) -> Result<String, String> {
-        let split = src.split_whitespace().map(|x| OsString::from(x));
+        let split = src.split_whitespace().map(OsString::from);
         match arg_iterate(split) {
             Ok(args) => {
                 let vec = args

--- a/src/uu/od/src/inputdecoder.rs
+++ b/src/uu/od/src/inputdecoder.rs
@@ -161,6 +161,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn smoke_test() {
         let data = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xff, 0xff];
         let mut input = PeekReader::new(Cursor::new(&data));

--- a/src/uu/od/src/mockstream.rs
+++ b/src/uu/od/src/mockstream.rs
@@ -56,15 +56,15 @@ impl FailingMockStream {
     /// `kind` and `message` can be specified to define the exact error.
     pub fn new(kind: ErrorKind, message: &'static str, repeat_count: i32) -> FailingMockStream {
         FailingMockStream {
-            kind: kind,
-            message: message,
-            repeat_count: repeat_count,
+            kind,
+            message,
+            repeat_count,
         }
     }
 
     fn error(&mut self) -> Result<usize> {
         if self.repeat_count == 0 {
-            return Ok(0);
+            Ok(0)
         } else {
             if self.repeat_count > 0 {
                 self.repeat_count -= 1;

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -122,9 +122,10 @@ mod tests {
 
     #[test]
     fn test_multi_file_reader_one_read() {
-        let mut inputs = Vec::new();
-        inputs.push(InputSource::Stream(Box::new(Cursor::new(&b"abcd"[..]))));
-        inputs.push(InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))));
+        let inputs = vec![
+            InputSource::Stream(Box::new(Cursor::new(&b"abcd"[..]))),
+            InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))),
+        ];
         let mut v = [0; 10];
 
         let mut sut = MultifileReader::new(inputs);
@@ -136,9 +137,10 @@ mod tests {
 
     #[test]
     fn test_multi_file_reader_two_reads() {
-        let mut inputs = Vec::new();
-        inputs.push(InputSource::Stream(Box::new(Cursor::new(&b"abcd"[..]))));
-        inputs.push(InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))));
+        let inputs = vec![
+            InputSource::Stream(Box::new(Cursor::new(&b"abcd"[..]))),
+            InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))),
+        ];
         let mut v = [0; 5];
 
         let mut sut = MultifileReader::new(inputs);
@@ -154,9 +156,10 @@ mod tests {
         let c = Cursor::new(&b"1234"[..])
             .chain(FailingMockStream::new(ErrorKind::Other, "Failing", 1))
             .chain(Cursor::new(&b"5678"[..]));
-        let mut inputs = Vec::new();
-        inputs.push(InputSource::Stream(Box::new(c)));
-        inputs.push(InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))));
+        let inputs = vec![
+            InputSource::Stream(Box::new(c)),
+            InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))),
+        ];
         let mut v = [0; 5];
 
         let mut sut = MultifileReader::new(inputs);
@@ -171,24 +174,25 @@ mod tests {
 
     #[test]
     fn test_multi_file_reader_read_error_at_start() {
-        let mut inputs = Vec::new();
-        inputs.push(InputSource::Stream(Box::new(FailingMockStream::new(
-            ErrorKind::Other,
-            "Failing",
-            1,
-        ))));
-        inputs.push(InputSource::Stream(Box::new(Cursor::new(&b"abcd"[..]))));
-        inputs.push(InputSource::Stream(Box::new(FailingMockStream::new(
-            ErrorKind::Other,
-            "Failing",
-            1,
-        ))));
-        inputs.push(InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))));
-        inputs.push(InputSource::Stream(Box::new(FailingMockStream::new(
-            ErrorKind::Other,
-            "Failing",
-            1,
-        ))));
+        let inputs = vec![
+            InputSource::Stream(Box::new(FailingMockStream::new(
+                ErrorKind::Other,
+                "Failing",
+                1,
+            ))),
+            InputSource::Stream(Box::new(Cursor::new(&b"abcd"[..]))),
+            InputSource::Stream(Box::new(FailingMockStream::new(
+                ErrorKind::Other,
+                "Failing",
+                1,
+            ))),
+            InputSource::Stream(Box::new(Cursor::new(&b"ABCD"[..]))),
+            InputSource::Stream(Box::new(FailingMockStream::new(
+                ErrorKind::Other,
+                "Failing",
+                1,
+            ))),
+        ];
         let mut v = [0; 5];
 
         let mut sut = MultifileReader::new(inputs);

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -316,9 +316,7 @@ fn parse_type_string(params: &str) -> Result<Vec<ParsedFormatterItemInfo>, Strin
 }
 
 #[cfg(test)]
-pub fn parse_format_flags_str(
-    args_str: &Vec<&'static str>,
-) -> Result<Vec<FormatterItemInfo>, String> {
+pub fn parse_format_flags_str(args_str: &[&'static str]) -> Result<Vec<FormatterItemInfo>, String> {
     let args: Vec<String> = args_str.iter().map(|s| s.to_string()).collect();
     parse_format_flags(&args).map(|v| {
         // tests using this function assume add_ascii_dump is not set
@@ -332,7 +330,7 @@ pub fn parse_format_flags_str(
 #[test]
 fn test_no_options() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od"]).unwrap(),
+        parse_format_flags_str(&["od"]).unwrap(),
         vec![FORMAT_ITEM_OCT16]
     );
 }
@@ -340,7 +338,7 @@ fn test_no_options() {
 #[test]
 fn test_one_option() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-F"]).unwrap(),
+        parse_format_flags_str(&["od", "-F"]).unwrap(),
         vec![FORMAT_ITEM_F64]
     );
 }
@@ -348,7 +346,7 @@ fn test_one_option() {
 #[test]
 fn test_two_separate_options() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-F", "-x"]).unwrap(),
+        parse_format_flags_str(&["od", "-F", "-x"]).unwrap(),
         vec![FORMAT_ITEM_F64, FORMAT_ITEM_HEX16]
     );
 }
@@ -356,7 +354,7 @@ fn test_two_separate_options() {
 #[test]
 fn test_two_combined_options() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-Fx"]).unwrap(),
+        parse_format_flags_str(&["od", "-Fx"]).unwrap(),
         vec![FORMAT_ITEM_F64, FORMAT_ITEM_HEX16]
     );
 }
@@ -364,7 +362,7 @@ fn test_two_combined_options() {
 #[test]
 fn test_ignore_non_format_parameters() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-d", "-Ax"]).unwrap(),
+        parse_format_flags_str(&["od", "-d", "-Ax"]).unwrap(),
         vec![FORMAT_ITEM_DEC16U]
     );
 }
@@ -372,7 +370,7 @@ fn test_ignore_non_format_parameters() {
 #[test]
 fn test_ignore_separate_parameters() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-I", "-A", "x"]).unwrap(),
+        parse_format_flags_str(&["od", "-I", "-A", "x"]).unwrap(),
         vec![FORMAT_ITEM_DEC64S]
     );
 }
@@ -380,36 +378,36 @@ fn test_ignore_separate_parameters() {
 #[test]
 fn test_ignore_trailing_vals() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-D", "--", "-x"]).unwrap(),
+        parse_format_flags_str(&["od", "-D", "--", "-x"]).unwrap(),
         vec![FORMAT_ITEM_DEC32U]
     );
 }
 
 #[test]
 fn test_invalid_long_format() {
-    parse_format_flags_str(&vec!["od", "--format=X"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=xX"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=aC"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=fI"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=xD"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=X"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=xX"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=aC"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=fI"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=xD"]).unwrap_err();
 
-    parse_format_flags_str(&vec!["od", "--format=xC1"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=x1C"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=xz1"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=xzC"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=xzz"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=xCC"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=xC1"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=x1C"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=xz1"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=xzC"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=xzz"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=xCC"]).unwrap_err();
 
-    parse_format_flags_str(&vec!["od", "--format=c1"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=x256"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=d5"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format=f1"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=c1"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=x256"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=d5"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format=f1"]).unwrap_err();
 }
 
 #[test]
 fn test_long_format_a() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format=a"]).unwrap(),
+        parse_format_flags_str(&["od", "--format=a"]).unwrap(),
         vec![FORMAT_ITEM_A]
     );
 }
@@ -417,7 +415,7 @@ fn test_long_format_a() {
 #[test]
 fn test_long_format_cz() {
     assert_eq!(
-        parse_format_flags(&vec!["od".to_string(), "--format=cz".to_string()]).unwrap(),
+        parse_format_flags(&["od".to_string(), "--format=cz".to_string()]).unwrap(),
         vec![ParsedFormatterItemInfo::new(FORMAT_ITEM_C, true)]
     );
 }
@@ -425,7 +423,7 @@ fn test_long_format_cz() {
 #[test]
 fn test_long_format_d() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format=d8"]).unwrap(),
+        parse_format_flags_str(&["od", "--format=d8"]).unwrap(),
         vec![FORMAT_ITEM_DEC64S]
     );
 }
@@ -433,7 +431,7 @@ fn test_long_format_d() {
 #[test]
 fn test_long_format_d_default() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format=d"]).unwrap(),
+        parse_format_flags_str(&["od", "--format=d"]).unwrap(),
         vec![FORMAT_ITEM_DEC32S]
     );
 }
@@ -441,7 +439,7 @@ fn test_long_format_d_default() {
 #[test]
 fn test_long_format_o_default() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format=o"]).unwrap(),
+        parse_format_flags_str(&["od", "--format=o"]).unwrap(),
         vec![FORMAT_ITEM_OCT32]
     );
 }
@@ -449,7 +447,7 @@ fn test_long_format_o_default() {
 #[test]
 fn test_long_format_u_default() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format=u"]).unwrap(),
+        parse_format_flags_str(&["od", "--format=u"]).unwrap(),
         vec![FORMAT_ITEM_DEC32U]
     );
 }
@@ -457,7 +455,7 @@ fn test_long_format_u_default() {
 #[test]
 fn test_long_format_x_default() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format=x"]).unwrap(),
+        parse_format_flags_str(&["od", "--format=x"]).unwrap(),
         vec![FORMAT_ITEM_HEX32]
     );
 }
@@ -465,7 +463,7 @@ fn test_long_format_x_default() {
 #[test]
 fn test_long_format_f_default() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format=f"]).unwrap(),
+        parse_format_flags_str(&["od", "--format=f"]).unwrap(),
         vec![FORMAT_ITEM_F32]
     );
 }
@@ -473,7 +471,7 @@ fn test_long_format_f_default() {
 #[test]
 fn test_long_format_next_arg() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "--format", "f8"]).unwrap(),
+        parse_format_flags_str(&["od", "--format", "f8"]).unwrap(),
         vec![FORMAT_ITEM_F64]
     );
 }
@@ -481,7 +479,7 @@ fn test_long_format_next_arg() {
 #[test]
 fn test_short_format_next_arg() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-t", "x8"]).unwrap(),
+        parse_format_flags_str(&["od", "-t", "x8"]).unwrap(),
         vec![FORMAT_ITEM_HEX64]
     );
 }
@@ -489,23 +487,23 @@ fn test_short_format_next_arg() {
 #[test]
 fn test_short_format_combined_arg() {
     assert_eq!(
-        parse_format_flags_str(&vec!["od", "-tu8"]).unwrap(),
+        parse_format_flags_str(&["od", "-tu8"]).unwrap(),
         vec![FORMAT_ITEM_DEC64U]
     );
 }
 
 #[test]
 fn test_format_next_arg_invalid() {
-    parse_format_flags_str(&vec!["od", "--format", "-v"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "--format"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "-t", "-v"]).unwrap_err();
-    parse_format_flags_str(&vec!["od", "-t"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format", "-v"]).unwrap_err();
+    parse_format_flags_str(&["od", "--format"]).unwrap_err();
+    parse_format_flags_str(&["od", "-t", "-v"]).unwrap_err();
+    parse_format_flags_str(&["od", "-t"]).unwrap_err();
 }
 
 #[test]
 fn test_mixed_formats() {
     assert_eq!(
-        parse_format_flags(&vec![
+        parse_format_flags(&[
             "od".to_string(),
             "--skip-bytes=2".to_string(),
             "-vItu1z".to_string(),

--- a/src/uu/od/src/prn_float.rs
+++ b/src/uu/od/src/prn_float.rs
@@ -91,6 +91,7 @@ fn format_float(f: f64, width: usize, precision: usize) -> String {
 }
 
 #[test]
+#[allow(clippy::excessive_precision)]
 fn test_format_flo32() {
     assert_eq!(format_flo32(1.0), "     1.0000000");
     assert_eq!(format_flo32(9.9999990), "     9.9999990");

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -104,7 +104,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     settings.strategy = String::from(OPT_LINES);
     settings.strategy_param = matches.value_of(OPT_LINES).unwrap().to_owned();
     // take any (other) defined strategy
-    for strategy in vec![OPT_LINE_BYTES, OPT_BYTES].into_iter() {
+    for &strategy in &[OPT_LINE_BYTES, OPT_BYTES] {
         if matches.occurrences_of(strategy) > 0 {
             settings.strategy = String::from(strategy);
             settings.strategy_param = matches.value_of(strategy).unwrap().to_owned();

--- a/src/uucore/src/lib/features/ringbuffer.rs
+++ b/src/uucore/src/lib/features/ringbuffer.rs
@@ -106,7 +106,6 @@ mod tests {
 
     use crate::ringbuffer::RingBuffer;
     use std::collections::VecDeque;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_size_limit_zero() {
@@ -128,7 +127,7 @@ mod tests {
     fn test_from_iter() {
         let iter = [0, 1, 2].iter();
         let actual = RingBuffer::from_iter(iter, 2).data;
-        let expected = VecDeque::from_iter([1, 2].iter());
+        let expected: VecDeque<&i32> = [1, 2].iter().collect();
         assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
These lints were cluttering up the "problems" tab in my VS Code. `--workspace` fixes the disparity.

I'm not sure why only tests were affected.