### PR TITLE
Add -e and -m to realpath

### DIFF
--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -1,5 +1,9 @@
 use crate::common::util::*;
 
+use std::path::Path;
+
+static GIBBERISH: &str = "supercalifragilisticexpialidocious";
+
 #[test]
 fn test_realpath_current_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -158,4 +162,43 @@ fn test_realpath_loop() {
     ucmd.arg("1")
         .succeeds()
         .stdout_only(at.plus_as_string("2\n"));
+}
+
+#[test]
+fn test_realpath_default_allows_final_non_existent() {
+    let p = Path::new("").join(GIBBERISH);
+    let (at, mut ucmd) = at_and_ucmd!();
+    let expect = path_concat!(at.root_dir_resolved(), p.to_str().unwrap()) + "\n";
+    ucmd.arg(p.as_os_str()).succeeds().stdout_only(expect);
+}
+
+#[test]
+fn test_realpath_default_forbids_non_final_non_existent() {
+    let p = Path::new("").join(GIBBERISH).join(GIBBERISH);
+    new_ucmd!().arg(p.to_str().unwrap()).fails();
+}
+
+#[test]
+fn test_realpath_existing() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.arg("-e")
+        .arg(".")
+        .succeeds()
+        .stdout_only(at.plus_as_string(&format!("{}\n", at.root_dir_resolved())));
+}
+
+#[test]
+fn test_realpath_existing_error() {
+    new_ucmd!().arg("-e").arg(GIBBERISH).fails();
+}
+
+#[test]
+fn test_realpath_missing() {
+    let p = Path::new("").join(GIBBERISH).join(GIBBERISH);
+    let (at, mut ucmd) = at_and_ucmd!();
+    let expect = path_concat!(at.root_dir_resolved(), p.to_str().unwrap()) + "\n";
+    ucmd.arg("-m")
+        .arg(p.as_os_str())
+        .succeeds()
+        .stdout_only(expect);
 }


### PR DESCRIPTION
Adds the `-e` and `-m` options to real path.
Renames the variants of `uucore::fs::MissingHandling` to more clearly indicate their effects. This does move away from the naming scheme used for the long options exposed for tools, which can't be changed for compatibility, but is more descriptive for the developers working on the code.