### PR TITLE
tac: add support for --regex option to tac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,7 @@ version = "0.0.7"
 dependencies = [
  "clap",
  "memchr 2.4.0",
+ "regex",
  "uucore",
  "uucore_procs",
 ]

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/tac.rs"
 
 [dependencies]
 memchr = "2"
+regex = "1"
 clap = { version = "2.33", features = ["wrap_help"] }
 uucore = { version=">=0.0.9", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }


### PR DESCRIPTION
Add support for `tac --regex`, where the line separator is interpreted
as a regular expression.