### PR TITLE
seq: compute width of numbers after parsing

### DIFF
--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -158,3 +158,21 @@ fn test_drop_negative_zero_end() {
         .stdout_is("1\n0\n")
         .no_stderr();
 }
+
+#[test]
+fn test_width_scientific_notation() {
+    new_ucmd!()
+        .args(&["-w", "999", "1e3"])
+        .succeeds()
+        .stdout_is("0999\n1000\n")
+        .no_stderr();
+}
+
+#[test]
+fn test_width_negative_zero() {
+    new_ucmd!()
+        .args(&["-w", "-0", "1"])
+        .succeeds()
+        .stdout_is("-0\n01\n")
+        .no_stderr();
+}


### PR DESCRIPTION
Fix a bug in `seq` where the number of characters needed to print the
number was computed incorrectly in some cases. This commit changes the
computation of the width to be after parsing the number instead of
before, in order to accommodate inputs like `1e3`, which requires four
digits when printing the number, not three.