### PR TITLE
seq: correctly compute width due to decimal places

### DIFF
--- a/src/uu/seq/src/digits.rs
+++ b/src/uu/seq/src/digits.rs
@@ -1,0 +1,190 @@
+//! Counting number of digits needed to represent a number.
+//!
+//! The [`num_integral_digits`] and [`num_fractional_digits`] functions
+//! count the number of digits needed to represent a number in decimal
+//! notation (like "123.456").
+use std::convert::TryInto;
+use std::num::ParseIntError;
+
+use uucore::display::Quotable;
+
+/// The number of digits after the decimal point in a given number.
+///
+/// The input `s` is a string representing a number, either an integer
+/// or a floating point number in either decimal notation or scientific
+/// notation. This function returns the number of digits after the
+/// decimal point needed to print the number in decimal notation.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// assert_eq!(num_fractional_digits("123.45e-1").unwrap(), 3);
+/// ```
+pub fn num_fractional_digits(s: &str) -> Result<usize, ParseIntError> {
+    match (s.find('.'), s.find('e')) {
+        // For example, "123456".
+        (None, None) => Ok(0),
+
+        // For example, "123e456".
+        (None, Some(j)) => {
+            let exponent: i64 = s[j + 1..].parse()?;
+            if exponent < 0 {
+                Ok(-exponent as usize)
+            } else {
+                Ok(0)
+            }
+        }
+
+        // For example, "123.456".
+        (Some(i), None) => Ok(s.len() - (i + 1)),
+
+        // For example, "123.456e789".
+        (Some(i), Some(j)) if i < j => {
+            // Because of the match guard, this subtraction will not underflow.
+            let num_digits_between_decimal_point_and_e = (j - (i + 1)) as i64;
+            let exponent: i64 = s[j + 1..].parse()?;
+            if num_digits_between_decimal_point_and_e < exponent {
+                Ok(0)
+            } else {
+                Ok((num_digits_between_decimal_point_and_e - exponent)
+                    .try_into()
+                    .unwrap())
+            }
+        }
+        _ => crash!(
+            1,
+            "invalid floating point argument: {}\n Try '{} --help' for more information.",
+            s.quote(),
+            uucore::execution_phrase()
+        ),
+    }
+}
+
+/// The number of digits before the decimal point in a given number.
+///
+/// The input `s` is a string representing a number, either an integer
+/// or a floating point number in either decimal notation or scientific
+/// notation. This function returns the number of digits before the
+/// decimal point needed to print the number in decimal notation.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// assert_eq!(num_fractional_digits("123.45e-1").unwrap(), 2);
+/// ```
+pub fn num_integral_digits(s: &str) -> Result<usize, ParseIntError> {
+    match (s.find('.'), s.find('e')) {
+        // For example, "123456".
+        (None, None) => Ok(s.len()),
+
+        // For example, "123e456".
+        (None, Some(j)) => {
+            let exponent: i64 = s[j + 1..].parse()?;
+            let total = j as i64 + exponent;
+            if total < 1 {
+                Ok(1)
+            } else {
+                Ok(total.try_into().unwrap())
+            }
+        }
+
+        // For example, "123.456".
+        (Some(i), None) => Ok(i),
+
+        // For example, "123.456e789".
+        (Some(i), Some(j)) => {
+            let exponent: i64 = s[j + 1..].parse()?;
+            let minimum: usize = {
+                let integral_part: f64 = crash_if_err!(1, s[..j].parse());
+                if integral_part == -0.0 && integral_part.is_sign_negative() {
+                    2
+                } else {
+                    1
+                }
+            };
+
+            let total = i as i64 + exponent;
+            if total < minimum as i64 {
+                Ok(minimum)
+            } else {
+                Ok(total.try_into().unwrap())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod test_num_integral_digits {
+        use crate::num_integral_digits;
+
+        #[test]
+        fn test_integer() {
+            assert_eq!(num_integral_digits("123").unwrap(), 3);
+        }
+
+        #[test]
+        fn test_decimal() {
+            assert_eq!(num_integral_digits("123.45").unwrap(), 3);
+        }
+
+        #[test]
+        fn test_scientific_no_decimal_positive_exponent() {
+            assert_eq!(num_integral_digits("123e4").unwrap(), 3 + 4);
+        }
+
+        #[test]
+        fn test_scientific_with_decimal_positive_exponent() {
+            assert_eq!(num_integral_digits("123.45e6").unwrap(), 3 + 6);
+        }
+
+        #[test]
+        fn test_scientific_no_decimal_negative_exponent() {
+            assert_eq!(num_integral_digits("123e-4").unwrap(), 1);
+        }
+
+        #[test]
+        fn test_scientific_with_decimal_negative_exponent() {
+            assert_eq!(num_integral_digits("123.45e-6").unwrap(), 1);
+            assert_eq!(num_integral_digits("123.45e-1").unwrap(), 2);
+        }
+    }
+
+    mod test_num_fractional_digits {
+        use crate::num_fractional_digits;
+
+        #[test]
+        fn test_integer() {
+            assert_eq!(num_fractional_digits("123").unwrap(), 0);
+        }
+
+        #[test]
+        fn test_decimal() {
+            assert_eq!(num_fractional_digits("123.45").unwrap(), 2);
+        }
+
+        #[test]
+        fn test_scientific_no_decimal_positive_exponent() {
+            assert_eq!(num_fractional_digits("123e4").unwrap(), 0);
+        }
+
+        #[test]
+        fn test_scientific_with_decimal_positive_exponent() {
+            assert_eq!(num_fractional_digits("123.45e6").unwrap(), 0);
+            assert_eq!(num_fractional_digits("123.45e1").unwrap(), 1);
+        }
+
+        #[test]
+        fn test_scientific_no_decimal_negative_exponent() {
+            assert_eq!(num_fractional_digits("123e-4").unwrap(), 4);
+            assert_eq!(num_fractional_digits("123e-1").unwrap(), 1);
+        }
+
+        #[test]
+        fn test_scientific_with_decimal_negative_exponent() {
+            assert_eq!(num_fractional_digits("123.45e-6").unwrap(), 8);
+            assert_eq!(num_fractional_digits("123.45e-1").unwrap(), 3);
+        }
+    }
+}

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -67,38 +67,6 @@ impl Number {
             Number::F64(n) => n,
         }
     }
-
-    /// Number of characters needed to print the integral part of the number.
-    ///
-    /// The number of characters includes one character to represent the
-    /// minus sign ("-") if this number is negative.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use num_bigint::{BigInt, Sign};
-    ///
-    /// assert_eq!(
-    ///     Number::BigInt(BigInt::new(Sign::Plus, vec![123])).num_digits(),
-    ///     3
-    /// );
-    /// assert_eq!(
-    ///     Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
-    ///     4
-    /// );
-    /// assert_eq!(Number::F64(123.45).num_digits(), 3);
-    /// assert_eq!(Number::MinusZero.num_digits(), 2);
-    /// ```
-    fn num_digits(&self) -> usize {
-        match self {
-            Number::MinusZero => 2,
-            Number::BigInt(n) => n.to_string().len(),
-            Number::F64(n) => {
-                let s = n.to_string();
-                s.find('.').unwrap_or_else(|| s.len())
-            }
-        }
-    }
 }
 
 impl FromStr for Number {
@@ -403,24 +371,4 @@ fn print_seq_integers(
         write!(stdout, "{}", terminator)?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::Number;
-    use num_bigint::{BigInt, Sign};
-
-    #[test]
-    fn test_number_num_digits() {
-        assert_eq!(
-            Number::BigInt(BigInt::new(Sign::Plus, vec![123])).num_digits(),
-            3
-        );
-        assert_eq!(
-            Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
-            4
-        );
-        assert_eq!(Number::F64(123.45).num_digits(), 3);
-        assert_eq!(Number::MinusZero.num_digits(), 2);
-    }
 }

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -23,6 +23,56 @@ fn test_rejects_non_floats() {
     ));
 }
 
+#[test]
+fn test_invalid_float() {
+    new_ucmd!()
+        .args(&["1e2.3"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid floating point argument: '1e2.3'")
+        .stderr_contains("for more information.");
+    new_ucmd!()
+        .args(&["1e2.3", "2"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid floating point argument: '1e2.3'")
+        .stderr_contains("for more information.");
+    new_ucmd!()
+        .args(&["1", "1e2.3"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid floating point argument: '1e2.3'")
+        .stderr_contains("for more information.");
+    new_ucmd!()
+        .args(&["1e2.3", "2", "3"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid floating point argument: '1e2.3'")
+        .stderr_contains("for more information.");
+    new_ucmd!()
+        .args(&["1", "1e2.3", "3"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid floating point argument: '1e2.3'")
+        .stderr_contains("for more information.");
+    new_ucmd!()
+        .args(&["1", "2", "1e2.3"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid floating point argument: '1e2.3'")
+        .stderr_contains("for more information.");
+}
+
+#[test]
+fn test_width_invalid_float() {
+    new_ucmd!()
+        .args(&["-w", "1e2.3"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid floating point argument: '1e2.3'")
+        .stderr_contains("for more information.");
+}
+
 // ---- Tests for the big integer based path ----
 
 #[test]
@@ -175,6 +225,90 @@ fn test_width_negative_zero() {
         .args(&["-w", "-0", "1"])
         .succeeds()
         .stdout_is("-0\n01\n")
+        .no_stderr();
+}
+
+#[test]
+fn test_width_negative_zero_scientific_notation() {
+    new_ucmd!()
+        .args(&["-w", "-0e0", "1"])
+        .succeeds()
+        .stdout_is("-0\n01\n")
+        .no_stderr();
+
+    new_ucmd!()
+        .args(&["-w", "-0e+1", "1"])
+        .succeeds()
+        .stdout_is("-00\n001\n")
+        .no_stderr();
+
+    new_ucmd!()
+        .args(&["-w", "-0.000e0", "1"])
+        .succeeds()
+        .stdout_is("-0.000\n01.000\n")
+        .no_stderr();
+
+    new_ucmd!()
+        .args(&["-w", "-0.000e-2", "1"])
+        .succeeds()
+        .stdout_is("-0.00000\n01.00000\n")
+        .no_stderr();
+
+    new_ucmd!()
+        .args(&["-w", "-0.000e5", "1"])
+        .succeeds()
+        .stdout_is("-000000\n0000001\n")
+        .no_stderr();
+
+    new_ucmd!()
+        .args(&["-w", "-0.000e5", "1"])
+        .succeeds()
+        .stdout_is("-000000\n0000001\n")
+        .no_stderr();
+}
+
+#[test]
+fn test_width_decimal_scientific_notation_increment() {
+    new_ucmd!()
+        .args(&["-w", ".1", "1e-2", ".11"])
+        .succeeds()
+        .stdout_is("0.10\n0.11\n")
+        .no_stderr();
+
+    new_ucmd!()
+        .args(&["-w", ".0", "1.500e-1", ".2"])
+        .succeeds()
+        .stdout_is("0.0000\n0.1500\n")
+        .no_stderr();
+}
+
+/// Test that trailing zeros in the start argument contribute to precision.
+#[test]
+fn test_width_decimal_scientific_notation_trailing_zeros_start() {
+    new_ucmd!()
+        .args(&["-w", ".1000", "1e-2", ".11"])
+        .succeeds()
+        .stdout_is("0.1000\n0.1100\n")
+        .no_stderr();
+}
+
+/// Test that trailing zeros in the increment argument contribute to precision.
+#[test]
+fn test_width_decimal_scientific_notation_trailing_zeros_increment() {
+    new_ucmd!()
+        .args(&["-w", "1e-1", "0.0100", ".11"])
+        .succeeds()
+        .stdout_is("0.1000\n0.1100\n")
+        .no_stderr();
+}
+
+/// Test that trailing zeros in the end argument do not contribute to width.
+#[test]
+fn test_width_decimal_scientific_notation_trailing_zeros_end() {
+    new_ucmd!()
+        .args(&["-w", "1e-1", "1e-2", ".1100"])
+        .succeeds()
+        .stdout_is("0.10\n0.11\n")
         .no_stderr();
 }
 


### PR DESCRIPTION
This pull request fixes a bug in the behavior of `seq` with the `-w` option when printing floating point numbers with digits after the decimal point. Previously, the code assumed that the string provided on the command-line was a floating point number in decimal format, like 12.34. But the command-line argument might be a floating point number in scientific notation, like 1e-2. This commit changes the code to compute the number of required decimal places to display in fixed-width mode after converting the command-line argument to `f64`. For example:

    $ seq -w .1 1e-2 .11
    0.10
    0.11
