### PR TITLE
seq: use augmenting addition to update value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "binary-heap-plus"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +2937,7 @@ dependencies = [
 name = "uu_seq"
 version = "0.0.7"
 dependencies = [
+ "bigdecimal",
  "clap",
  "num-bigint",
  "num-traits",

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -1,3 +1,4 @@
+# spell-checker:ignore bigdecimal
 [package]
 name = "uu_seq"
 version = "0.0.7"
@@ -18,6 +19,7 @@ path = "src/seq.rs"
 clap = { version = "2.33", features = ["wrap_help"] }
 num-bigint = "0.4.0"
 num-traits = "0.2.14"
+bigdecimal = "0.3"
 uucore = { version=">=0.0.9", package="uucore", path="../../uucore" }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 

--- a/src/uu/seq/src/number.rs
+++ b/src/uu/seq/src/number.rs
@@ -1,3 +1,4 @@
+// spell-checker:ignore bigdecimal
 //! A type to represent the possible start, increment, and end values for seq.
 //!
 //! The [`Number`] enumeration represents the possible values for the
@@ -6,8 +7,10 @@
 //! parsed from a string by calling [`parse`].
 use std::str::FromStr;
 
+use bigdecimal::BigDecimal;
+use bigdecimal::ParseBigDecimalError;
 use num_bigint::BigInt;
-use num_traits::ToPrimitive;
+use num_bigint::ParseBigIntError;
 use num_traits::Zero;
 
 use uucore::display::Quotable;
@@ -15,32 +18,51 @@ use uucore::display::Quotable;
 /// An integral or floating point number.
 pub enum Number {
     /// Negative zero, as if it were an integer.
-    MinusZero,
+    MinusZeroInt,
 
     /// An arbitrary precision integer.
     BigInt(BigInt),
 
-    /// A 64-bit float.
-    F64(f64),
+    /// Floating point negative zero.
+    MinusZeroFloat,
+
+    /// An arbitrary precision float.
+    BigDecimal(BigDecimal),
 }
 
 impl Number {
     /// Decide whether this number is zero (either positive or negative).
     pub fn is_zero(&self) -> bool {
         match self {
-            Number::MinusZero => true,
+            Number::MinusZeroInt => true,
+            Number::MinusZeroFloat => true,
             Number::BigInt(n) => n.is_zero(),
-            Number::F64(n) => n.is_zero(),
+            Number::BigDecimal(n) => n.is_zero(),
         }
     }
 
-    /// Convert this number into a `f64`.
-    pub fn into_f64(self) -> f64 {
+    /// Convert this number into a `BigDecimal`.
+    ///
+    /// [`BigDecimal`] does not distinguish between negative zero and
+    /// positive zero. Calling code is responsible for remembering
+    /// whether this `Number` was negative zero or positive zero.
+    ///
+    /// # Examples
+    ///
+    /// Positive and negative zeros become the same [`BigDecimal`]:
+    ///
+    /// ```rust,ignore
+    /// use bigdecimal::BigDecimal
+    ///
+    /// assert_eq!(Number::MinusZeroInt.into_big_decimal(), BigDecimal::zero());
+    /// assert_eq!(Number::MinusZeroFloat.into_big_decimal(), BigDecimal::zero());
+    /// ```
+    pub fn into_big_decimal(self) -> BigDecimal {
         match self {
-            Number::MinusZero => -0.,
-            // BigInt::to_f64() can not return None.
-            Number::BigInt(n) => n.to_f64().unwrap(),
-            Number::F64(n) => n,
+            Number::MinusZeroInt => -BigDecimal::zero(),
+            Number::MinusZeroFloat => -BigDecimal::zero(),
+            Number::BigInt(n) => BigDecimal::from(n),
+            Number::BigDecimal(n) => n,
         }
     }
 
@@ -62,53 +84,90 @@ impl Number {
     ///     Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
     ///     4
     /// );
-    /// assert_eq!(Number::F64(123.45).num_digits(), 3);
-    /// assert_eq!(Number::MinusZero.num_digits(), 2);
+    /// assert_eq!(Number::BigDecimal("123.45".parse()).num_digits(), 3);
+    /// assert_eq!(Number::MinusZeroInt.num_digits(), 2);
     /// ```
     pub fn num_digits(&self) -> usize {
         match self {
-            Number::MinusZero => 2,
+            Number::MinusZeroInt => 2,
+            Number::MinusZeroFloat => 2,
             Number::BigInt(n) => n.to_string().len(),
-            Number::F64(n) => {
-                let s = n.to_string();
+            Number::BigDecimal(n) => {
+                let s = format!("{}", n);
                 s.find('.').unwrap_or_else(|| s.len())
             }
         }
     }
 }
 
+/// Parse a [`BigInt`] or a "negative zero" from a string.
+///
+/// Even though "negative zero" is usually only a concept for floating
+/// point numbers, the `seq` tool allows negative zero at the start of a
+/// sequence.
+fn parse_bigint_or_minus_zero(s: &str) -> Result<Number, ParseBigIntError> {
+    // If `s` is '-0', then `parse()` returns `BigInt::zero()`, but we
+    // need to return `Number::MinusZeroInt` instead.
+    s.parse::<BigInt>().map(|n| {
+        if n == BigInt::zero() && s.starts_with('-') {
+            Number::MinusZeroInt
+        } else {
+            Number::BigInt(n)
+        }
+    })
+}
+
+/// Parse a [`BigDecimal`] or a negative zero from a string.
+fn parse_bigdecimal_or_minus_zero(s: &str) -> Result<Number, ParseBigDecimalError> {
+    // If `s` is '-0.0', then `parse()` returns `BigDecimal::zero()`,
+    // but we need to return `Number::MinusZeroFloat` instead.
+    s.parse::<BigDecimal>().map(|x| {
+        if x == BigDecimal::zero() && s.starts_with('-') {
+            Number::MinusZeroFloat
+        } else {
+            Number::BigDecimal(x)
+        }
+    })
+}
+
+/// The error message when an argument is a NaN.
+fn nan_error_message(arg: &str) -> String {
+    format!(
+        "invalid 'not-a-number' argument: {}\nTry '{} --help' for more information.",
+        arg.quote(),
+        uucore::execution_phrase(),
+    )
+}
+
+/// The error message when an argument is not a valid floating point number.
+fn float_error_message(arg: &str) -> String {
+    format!(
+        "invalid floating point argument: {}\nTry '{} --help' for more information.",
+        arg.quote(),
+        uucore::execution_phrase(),
+    )
+}
+
 impl FromStr for Number {
     type Err = String;
+
     fn from_str(mut s: &str) -> Result<Self, Self::Err> {
         if s.starts_with('+') {
             s = &s[1..];
         }
 
-        match s.parse::<BigInt>() {
-            Ok(n) => {
-                // If `s` is '-0', then `parse()` returns
-                // `BigInt::zero()`, but we need to return
-                // `Number::MinusZero` instead.
-                if n == BigInt::zero() && s.starts_with('-') {
-                    Ok(Number::MinusZero)
-                } else {
-                    Ok(Number::BigInt(n))
-                }
-            }
-            Err(_) => match s.parse::<f64>() {
-                Ok(value) if value.is_nan() => Err(format!(
-                    "invalid 'not-a-number' argument: {}\nTry '{} --help' for more information.",
-                    s.quote(),
-                    uucore::execution_phrase(),
-                )),
-                Ok(value) => Ok(Number::F64(value)),
-                Err(_) => Err(format!(
-                    "invalid floating point argument: {}\nTry '{} --help' for more information.",
-                    s.quote(),
-                    uucore::execution_phrase(),
-                )),
-            },
-        }
+        // TODO Add support for positive and negative infinity; the
+        // `bigdecimal` crate does not support them:
+        // https://github.com/akubera/bigdecimal-rs/issues/67
+        parse_bigint_or_minus_zero(s).or_else(|_| {
+            parse_bigdecimal_or_minus_zero(s).map_err(|_| match s.parse::<f64>() {
+                Ok(x) if x.is_nan() => nan_error_message(s),
+                // The `Ok(_)` pattern should never match, because
+                // any floating point number should be parsed by the
+                // `parse::<BigDecimal>()` call above.
+                Ok(_) | Err(_) => float_error_message(s),
+            })
+        })
     }
 }
 
@@ -127,7 +186,14 @@ mod tests {
             Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
             4
         );
-        assert_eq!(Number::F64(123.45).num_digits(), 3);
-        assert_eq!(Number::MinusZero.num_digits(), 2);
+        assert_eq!(
+            Number::BigDecimal("123.45".parse().unwrap()).num_digits(),
+            3
+        );
+        assert_eq!(Number::BigDecimal("1000".parse().unwrap()).num_digits(), 4);
+        assert_eq!(Number::MinusZeroInt.num_digits(), 2);
+        assert_eq!("1e3".parse::<Number>().unwrap().num_digits(), 4);
+        assert_eq!("1000".parse::<Number>().unwrap().num_digits(), 4);
+        assert_eq!("1000.1".parse::<Number>().unwrap().num_digits(), 4);
     }
 }

--- a/src/uu/seq/src/number.rs
+++ b/src/uu/seq/src/number.rs
@@ -1,0 +1,133 @@
+//! A type to represent the possible start, increment, and end values for seq.
+//!
+//! The [`Number`] enumeration represents the possible values for the
+//! start, increment, and end values for `seq`. These may be integers,
+//! floating point numbers, negative zero, etc. A [`Number`] can be
+//! parsed from a string by calling [`parse`].
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+use num_traits::ToPrimitive;
+use num_traits::Zero;
+
+use uucore::display::Quotable;
+
+/// An integral or floating point number.
+pub enum Number {
+    /// Negative zero, as if it were an integer.
+    MinusZero,
+
+    /// An arbitrary precision integer.
+    BigInt(BigInt),
+
+    /// A 64-bit float.
+    F64(f64),
+}
+
+impl Number {
+    /// Decide whether this number is zero (either positive or negative).
+    pub fn is_zero(&self) -> bool {
+        match self {
+            Number::MinusZero => true,
+            Number::BigInt(n) => n.is_zero(),
+            Number::F64(n) => n.is_zero(),
+        }
+    }
+
+    /// Convert this number into a `f64`.
+    pub fn into_f64(self) -> f64 {
+        match self {
+            Number::MinusZero => -0.,
+            // BigInt::to_f64() can not return None.
+            Number::BigInt(n) => n.to_f64().unwrap(),
+            Number::F64(n) => n,
+        }
+    }
+
+    /// Number of characters needed to print the integral part of the number.
+    ///
+    /// The number of characters includes one character to represent the
+    /// minus sign ("-") if this number is negative.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use num_bigint::{BigInt, Sign};
+    ///
+    /// assert_eq!(
+    ///     Number::BigInt(BigInt::new(Sign::Plus, vec![123])).num_digits(),
+    ///     3
+    /// );
+    /// assert_eq!(
+    ///     Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
+    ///     4
+    /// );
+    /// assert_eq!(Number::F64(123.45).num_digits(), 3);
+    /// assert_eq!(Number::MinusZero.num_digits(), 2);
+    /// ```
+    pub fn num_digits(&self) -> usize {
+        match self {
+            Number::MinusZero => 2,
+            Number::BigInt(n) => n.to_string().len(),
+            Number::F64(n) => {
+                let s = n.to_string();
+                s.find('.').unwrap_or_else(|| s.len())
+            }
+        }
+    }
+}
+
+impl FromStr for Number {
+    type Err = String;
+    fn from_str(mut s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('+') {
+            s = &s[1..];
+        }
+
+        match s.parse::<BigInt>() {
+            Ok(n) => {
+                // If `s` is '-0', then `parse()` returns
+                // `BigInt::zero()`, but we need to return
+                // `Number::MinusZero` instead.
+                if n == BigInt::zero() && s.starts_with('-') {
+                    Ok(Number::MinusZero)
+                } else {
+                    Ok(Number::BigInt(n))
+                }
+            }
+            Err(_) => match s.parse::<f64>() {
+                Ok(value) if value.is_nan() => Err(format!(
+                    "invalid 'not-a-number' argument: {}\nTry '{} --help' for more information.",
+                    s.quote(),
+                    uucore::execution_phrase(),
+                )),
+                Ok(value) => Ok(Number::F64(value)),
+                Err(_) => Err(format!(
+                    "invalid floating point argument: {}\nTry '{} --help' for more information.",
+                    s.quote(),
+                    uucore::execution_phrase(),
+                )),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Number;
+    use num_bigint::{BigInt, Sign};
+
+    #[test]
+    fn test_number_num_digits() {
+        assert_eq!(
+            Number::BigInt(BigInt::new(Sign::Plus, vec![123])).num_digits(),
+            3
+        );
+        assert_eq!(
+            Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
+            4
+        );
+        assert_eq!(Number::F64(123.45).num_digits(), 3);
+        assert_eq!(Number::MinusZero.num_digits(), 2);
+    }
+}

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -121,7 +121,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 false,
             )
         }
-        (Number::MinusZeroFloat, last, increment) => print_seq(
+        (Number::MinusZeroFloat | Number::MinusZeroInt, last, increment) => print_seq(
             (
                 BigDecimal::zero(),
                 increment.into_big_decimal(),
@@ -233,7 +233,7 @@ fn print_seq(
     while !done_printing(&value, &increment, &last) {
         let mut width = padding;
         if is_first_iteration && is_first_minus_zero {
-            print!("-");
+            write!(stdout, "-")?;
             width -= 1;
         }
         is_first_iteration = false;
@@ -246,7 +246,7 @@ fn print_seq(
             }
         }
         write!(stdout, "{}", istr)?;
-        value += increment.clone();
+        value += &increment;
         if !done_printing(&value, &increment, &last) {
             write!(stdout, "{}", separator)?;
         }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -8,13 +8,14 @@ extern crate uucore;
 
 use clap::{crate_version, App, AppSettings, Arg};
 use num_bigint::BigInt;
+use num_traits::Num;
 use num_traits::One;
 use num_traits::Zero;
-use num_traits::{Num, ToPrimitive};
 use std::cmp;
 use std::io::{stdout, ErrorKind, Write};
-use std::str::FromStr;
-use uucore::display::Quotable;
+
+mod number;
+use crate::number::Number;
 
 static ABOUT: &str = "Display numbers from FIRST to LAST, in steps of INCREMENT.";
 static OPT_SEPARATOR: &str = "separator";
@@ -36,99 +37,6 @@ struct SeqOptions {
     separator: String,
     terminator: String,
     widths: bool,
-}
-
-enum Number {
-    /// Negative zero, as if it were an integer.
-    MinusZero,
-    BigInt(BigInt),
-    F64(f64),
-}
-
-impl Number {
-    fn is_zero(&self) -> bool {
-        match self {
-            Number::MinusZero => true,
-            Number::BigInt(n) => n.is_zero(),
-            Number::F64(n) => n.is_zero(),
-        }
-    }
-
-    fn into_f64(self) -> f64 {
-        match self {
-            Number::MinusZero => -0.,
-            // BigInt::to_f64() can not return None.
-            Number::BigInt(n) => n.to_f64().unwrap(),
-            Number::F64(n) => n,
-        }
-    }
-
-    /// Number of characters needed to print the integral part of the number.
-    ///
-    /// The number of characters includes one character to represent the
-    /// minus sign ("-") if this number is negative.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use num_bigint::{BigInt, Sign};
-    ///
-    /// assert_eq!(
-    ///     Number::BigInt(BigInt::new(Sign::Plus, vec![123])).num_digits(),
-    ///     3
-    /// );
-    /// assert_eq!(
-    ///     Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
-    ///     4
-    /// );
-    /// assert_eq!(Number::F64(123.45).num_digits(), 3);
-    /// assert_eq!(Number::MinusZero.num_digits(), 2);
-    /// ```
-    fn num_digits(&self) -> usize {
-        match self {
-            Number::MinusZero => 2,
-            Number::BigInt(n) => n.to_string().len(),
-            Number::F64(n) => {
-                let s = n.to_string();
-                s.find('.').unwrap_or_else(|| s.len())
-            }
-        }
-    }
-}
-
-impl FromStr for Number {
-    type Err = String;
-    fn from_str(mut s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with('+') {
-            s = &s[1..];
-        }
-
-        match s.parse::<BigInt>() {
-            Ok(n) => {
-                // If `s` is '-0', then `parse()` returns
-                // `BigInt::zero()`, but we need to return
-                // `Number::MinusZero` instead.
-                if n == BigInt::zero() && s.starts_with('-') {
-                    Ok(Number::MinusZero)
-                } else {
-                    Ok(Number::BigInt(n))
-                }
-            }
-            Err(_) => match s.parse::<f64>() {
-                Ok(value) if value.is_nan() => Err(format!(
-                    "invalid 'not-a-number' argument: {}\nTry '{} --help' for more information.",
-                    s.quote(),
-                    uucore::execution_phrase(),
-                )),
-                Ok(value) => Ok(Number::F64(value)),
-                Err(_) => Err(format!(
-                    "invalid floating point argument: {}\nTry '{} --help' for more information.",
-                    s.quote(),
-                    uucore::execution_phrase(),
-                )),
-            },
-        }
-    }
 }
 
 /// A range of integers.
@@ -358,24 +266,4 @@ fn print_seq_integers(
         write!(stdout, "{}", terminator)?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::Number;
-    use num_bigint::{BigInt, Sign};
-
-    #[test]
-    fn test_number_num_digits() {
-        assert_eq!(
-            Number::BigInt(BigInt::new(Sign::Plus, vec![123])).num_digits(),
-            3
-        );
-        assert_eq!(
-            Number::BigInt(BigInt::new(Sign::Minus, vec![123])).num_digits(),
-            4
-        );
-        assert_eq!(Number::F64(123.45).num_digits(), 3);
-        assert_eq!(Number::MinusZero.num_digits(), 2);
-    }
 }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -12,7 +12,7 @@ use num_traits::One;
 use num_traits::Zero;
 use num_traits::{Num, ToPrimitive};
 use std::cmp;
-use std::io::{stdout, Write};
+use std::io::{stdout, ErrorKind, Write};
 use std::str::FromStr;
 use uucore::display::Quotable;
 
@@ -192,7 +192,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .num_digits()
         .max(increment.num_digits())
         .max(last.num_digits());
-    match (first, last, increment) {
+    let result = match (first, last, increment) {
         (Number::MinusZero, Number::BigInt(last), Number::BigInt(increment)) => print_seq_integers(
             (BigInt::zero(), increment, last),
             options.separator,
@@ -219,8 +219,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             options.widths,
             padding,
         ),
+    };
+    match result {
+        Ok(_) => 0,
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => 0,
+        Err(_) => 1,
     }
-    0
 }
 
 pub fn uu_app() -> App<'static, 'static> {
@@ -276,7 +280,9 @@ fn print_seq(
     terminator: String,
     pad: bool,
     padding: usize,
-) {
+) -> std::io::Result<()> {
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
     let (first, increment, last) = range;
     let mut i = 0isize;
     let mut value = first + i as f64 * increment;
@@ -286,20 +292,21 @@ fn print_seq(
         let before_dec = istr.find('.').unwrap_or(ilen);
         if pad && before_dec < padding {
             for _ in 0..(padding - before_dec) {
-                print!("0");
+                write!(stdout, "0")?;
             }
         }
-        print!("{}", istr);
+        write!(stdout, "{}", istr)?;
         i += 1;
         value = first + i as f64 * increment;
         if !done_printing(&value, &increment, &last) {
-            print!("{}", separator);
+            write!(stdout, "{}", separator)?;
         }
     }
     if (first >= last && increment < 0f64) || (first <= last && increment > 0f64) {
-        print!("{}", terminator);
+        write!(stdout, "{}", terminator)?;
     }
-    crash_if_err!(1, stdout().flush());
+    stdout.flush()?;
+    Ok(())
 }
 
 /// Print an integer sequence.
@@ -323,31 +330,34 @@ fn print_seq_integers(
     pad: bool,
     padding: usize,
     is_first_minus_zero: bool,
-) {
+) -> std::io::Result<()> {
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
     let (first, increment, last) = range;
     let mut value = first;
     let mut is_first_iteration = true;
     while !done_printing(&value, &increment, &last) {
         if !is_first_iteration {
-            print!("{}", separator);
+            write!(stdout, "{}", separator)?;
         }
         let mut width = padding;
         if is_first_iteration && is_first_minus_zero {
-            print!("-");
+            write!(stdout, "-")?;
             width -= 1;
         }
         is_first_iteration = false;
         if pad {
-            print!("{number:>0width$}", number = value, width = width);
+            write!(stdout, "{number:>0width$}", number = value, width = width)?;
         } else {
-            print!("{}", value);
+            write!(stdout, "{}", value)?;
         }
         value += &increment;
     }
 
     if !is_first_iteration {
-        print!("{}", terminator);
+        write!(stdout, "{}", terminator)?;
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -200,3 +200,45 @@ fn test_neg_inf() {
 fn test_inf() {
     run(&["inf"], b"1\n2\n3\n");
 }
+
+#[test]
+fn test_negative_zero_scientific_notation() {
+    new_ucmd!()
+        .args(&["-0e0", "1"])
+        .succeeds()
+        .stdout_is("-0\n1\n")
+        .no_stderr();
+}
+
+#[test]
+fn test_float_precision_increment() {
+    new_ucmd!()
+        .args(&["999", "0.1", "1000.1"])
+        .succeeds()
+        .stdout_is(
+            "999.0
+999.1
+999.2
+999.3
+999.4
+999.5
+999.6
+999.7
+999.8
+999.9
+1000.0
+1000.1
+",
+        )
+        .no_stderr();
+}
+
+/// Test for floating point precision issues.
+#[test]
+fn test_negative_increment_decimal() {
+    new_ucmd!()
+        .args(&["0.1", "-0.1", "-0.2"])
+        .succeeds()
+        .stdout_is("0.1\n0.0\n-0.1\n-0.2\n")
+        .no_stderr();
+}

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -1,4 +1,5 @@
 use crate::common::util::*;
+use std::io::Read;
 
 #[test]
 fn test_rejects_nan() {
@@ -175,4 +176,27 @@ fn test_width_negative_zero() {
         .succeeds()
         .stdout_is("-0\n01\n")
         .no_stderr();
+}
+
+// TODO This is duplicated from `test_yes.rs`; refactor them.
+/// Run `seq`, capture some of the output, close the pipe, and verify it.
+fn run(args: &[&str], expected: &[u8]) {
+    let mut cmd = new_ucmd!();
+    let mut child = cmd.args(args).run_no_wait();
+    let mut stdout = child.stdout.take().unwrap();
+    let mut buf = vec![0; expected.len()];
+    stdout.read_exact(&mut buf).unwrap();
+    drop(stdout);
+    assert!(child.wait().unwrap().success());
+    assert_eq!(buf.as_slice(), expected);
+}
+
+#[test]
+fn test_neg_inf() {
+    run(&["--", "-inf", "0"], b"-inf\n-inf\n-inf\n");
+}
+
+#[test]
+fn test_inf() {
+    run(&["inf"], b"1\n2\n3\n");
 }

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -152,6 +152,15 @@ fn test_preserve_negative_zero_start() {
 }
 
 #[test]
+fn test_negative_zero_int_start_float_increment() {
+    new_ucmd!()
+        .args(&["-0", "0.1", "0.1"])
+        .succeeds()
+        .stdout_is("-0.0\n0.1\n")
+        .no_stderr();
+}
+
+#[test]
 fn test_drop_negative_zero_end() {
     new_ucmd!()
         .args(&["1", "-1", "-0"])


### PR DESCRIPTION
This pull request fixes a floating-point precision issue with the update in the main loop of `seq`. Before this commit, the behavior was

    $ seq 0.1 -0.1 -0.2
    0.1
    0.0
    -0.1

which was incorrect: -0.2 should be printed as well. This was happening
because the update in the main loop was essentially

    value = start + (i * increment);

which caused `value` to become `-0.20000000000000004`. That exceeds the lower bound of -0.2, so that number was not printed. By changing the update to

    value += increment;

we eliminate this issue.