### PR TITLE
Proper columns for `ls -l`

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1539,6 +1539,42 @@ fn display_grid(
     }
 }
 
+/// This writes to the BufWriter out a single string of the output of `ls -l`.
+///
+/// It writes the following keys, in order:
+/// * `inode` ([`get_inode`], config-optional)
+/// * `permissions` ([`display_permissions`])
+/// * `symlink_count` ([`display_symlink_count`])
+/// * `owner` ([`display_uname`], config-optional)
+/// * `group` ([`display_group`], config-optional)
+/// * `author` ([`display_uname`], config-optional)
+/// * `size / rdev` ([`display_size_or_rdev`])
+/// * `system_time` ([`get_system_time`])
+/// * `file_name` ([`display_file_name`])
+///
+/// This function needs to display information in columns:
+/// * permissions and system_time are already guaranteed to be pre-formatted in fixed length.
+/// * file_name is the last column and is left-aligned.
+/// * Everything else needs to be padded using [`pad_left`].
+///
+/// That's why we have the parameters:
+/// ```txt
+///    max_links: usize,
+///    longest_uname_len: usize,
+///    longest_group_len: usize,
+///    max_size: usize,
+/// ```
+/// that decide the maximum possible character count of each field.
+///
+/// [`get_inode`]: ls::get_inode
+/// [`display_permissions`]: ls::display_permissions
+/// [`display_symlink_count`]: ls::display_symlink_count
+/// [`display_uname`]: ls::display_uname
+/// [`display_group`]: ls::display_group
+/// [`display_size_or_rdev`]: ls::display_size_or_rdev
+/// [`get_system_time`]: ls::get_system_time
+/// [`display_file_name`]: ls::display_file_name
+/// [`pad_left`]: ls::pad_left
 fn display_item_long(
     item: &PathData,
     longest_link_count_len: usize,

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1238,7 +1238,7 @@ impl PathData {
 
     fn md(&self) -> Option<&Metadata> {
         self.md
-            .get_or_init(|| get_metadata(&self.p_buf, self.must_dereference).ok())
+            .get_or_init(|| get_metadata(&self.p_buf.as_path(), self.must_dereference).ok())
             .as_ref()
     }
 
@@ -1799,7 +1799,7 @@ fn classify_file(path: &PathData) -> Option<char> {
 }
 
 fn display_file_name(path: &PathData, config: &Config) -> Option<Cell> {
-    let mut name = escape_name(&path.display_name, &config.quoting_style);
+    let mut name = escape_name(&path.display_name.as_str(), &config.quoting_style);
 
     #[cfg(unix)]
     {
@@ -1817,7 +1817,7 @@ fn display_file_name(path: &PathData, config: &Config) -> Option<Cell> {
     let mut width = name.width();
 
     if let Some(ls_colors) = &config.color {
-        name = color_name(ls_colors, &path.p_buf, name, path.md()?);
+        name = color_name(ls_colors, &path.p_buf.as_path(), name, path.md()?);
     }
 
     if config.indicator_style != IndicatorStyle::None {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1414,7 +1414,7 @@ fn pad_left(string: String, count: usize) -> String {
 
 fn pad_right(string: String, count: usize) -> String { format!("{:<width$}", string, width = count) }
 
-fn display_items(items: &Vec<PathData>, config: &Config, out: &mut BufWriter<Stdout>) {
+fn display_items(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout>) {
     if config.format == Format::Long {
         let (mut longest_link_count_len, mut longest_uname_len, mut longest_group_len, mut longest_size_len) = (1, 1, 1, 1);
         let mut total_size = 0;

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1395,6 +1395,7 @@ fn get_metadata(entry: &Path, dereference: bool) -> std::io::Result<Metadata> {
 }
 
 fn display_dir_entry_size(entry: &PathData, config: &Config) -> (usize, usize, usize, usize) {
+    // TODO: Cache/memoize the display_* results so we don't have to recalculate them.
     if let Some(md) = entry.md() {
         (
             display_symlink_count(md).len(),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1409,6 +1409,8 @@ fn pad_left(string: String, count: usize) -> String {
     format!("{:>width$}", string, width = count)
 }
 
+fn pad_right(string: String, count: usize) -> String { format!("{:<width$}", string, width = count) }
+
 fn display_items(items: &Vec<PathData>, config: &Config, out: &mut BufWriter<Stdout>) {
     if config.format == Format::Long {
         let (mut max_links, mut max_width) = (1, 1);

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1409,7 +1409,7 @@ fn pad_left(string: String, count: usize) -> String {
     format!("{:>width$}", string, width = count)
 }
 
-fn display_items(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout>) {
+fn display_items(items: &Vec<PathData>, config: &Config, out: &mut BufWriter<Stdout>) {
     if config.format == Format::Long {
         let (mut max_links, mut max_width) = (1, 1);
         let mut total_size = 0;

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1238,7 +1238,7 @@ impl PathData {
 
     fn md(&self) -> Option<&Metadata> {
         self.md
-            .get_or_init(|| get_metadata(&self.p_buf.as_path(), self.must_dereference).ok())
+            .get_or_init(|| get_metadata(&self.p_buf, self.must_dereference).ok())
             .as_ref()
     }
 
@@ -1845,7 +1845,7 @@ fn classify_file(path: &PathData) -> Option<char> {
 }
 
 fn display_file_name(path: &PathData, config: &Config) -> Option<Cell> {
-    let mut name = escape_name(&path.display_name.as_str(), &config.quoting_style);
+    let mut name = escape_name(&path.display_name, &config.quoting_style);
 
     #[cfg(unix)]
     {
@@ -1863,7 +1863,7 @@ fn display_file_name(path: &PathData, config: &Config) -> Option<Cell> {
     let mut width = name.width();
 
     if let Some(ls_colors) = &config.color {
-        name = color_name(ls_colors, &path.p_buf.as_path(), name, path.md()?);
+        name = color_name(ls_colors, &path.p_buf, name, path.md()?);
     }
 
     if config.indicator_style != IndicatorStyle::None {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1412,15 +1412,23 @@ fn pad_left(string: String, count: usize) -> String {
     format!("{:>width$}", string, width = count)
 }
 
-fn pad_right(string: String, count: usize) -> String { format!("{:<width$}", string, width = count) }
+fn pad_right(string: String, count: usize) -> String {
+    format!("{:<width$}", string, width = count)
+}
 
 fn display_items(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout>) {
     if config.format == Format::Long {
-        let (mut longest_link_count_len, mut longest_uname_len, mut longest_group_len, mut longest_size_len) = (1, 1, 1, 1);
+        let (
+            mut longest_link_count_len,
+            mut longest_uname_len,
+            mut longest_group_len,
+            mut longest_size_len,
+        ) = (1, 1, 1, 1);
         let mut total_size = 0;
 
         for item in items {
-            let (link_count_len, uname_len, group_len, size_len) = display_dir_entry_size(item, config);
+            let (link_count_len, uname_len, group_len, size_len) =
+                display_dir_entry_size(item, config);
             longest_link_count_len = link_count_len.max(longest_link_count_len);
             longest_size_len = size_len.max(longest_size_len);
             longest_uname_len = uname_len.max(longest_uname_len);
@@ -1434,7 +1442,15 @@ fn display_items(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout
         }
 
         for item in items {
-            display_item_long(item, longest_link_count_len, longest_uname_len, longest_group_len,longest_size_len, config, out);
+            display_item_long(
+                item,
+                longest_link_count_len,
+                longest_uname_len,
+                longest_group_len,
+                longest_size_len,
+                config,
+                out,
+            );
         }
     } else {
         let names = items.iter().filter_map(|i| display_file_name(i, config));
@@ -1607,17 +1623,29 @@ fn display_item_long(
     );
 
     if config.long.owner {
-        let _ = write!(out, " {}", pad_right(display_uname(md, config), longest_uname_len));
+        let _ = write!(
+            out,
+            " {}",
+            pad_right(display_uname(md, config), longest_uname_len)
+        );
     }
 
     if config.long.group {
-        let _ = write!(out, " {}", pad_right(display_group(md, config), longest_group_len));
+        let _ = write!(
+            out,
+            " {}",
+            pad_right(display_group(md, config), longest_group_len)
+        );
     }
 
     // Author is only different from owner on GNU/Hurd, so we reuse
     // the owner, since GNU/Hurd is not currently supported by Rust.
     if config.long.author {
-        let _ = write!(out, " {}", pad_right(display_uname(md, config), longest_uname_len));
+        let _ = write!(
+            out,
+            " {}",
+            pad_right(display_uname(md, config), longest_uname_len)
+        );
     }
 
     let _ = writeln!(

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -353,15 +353,14 @@ fn test_ls_long_format() {
     at.touch(&at.plus_as_string("test-long-dir/test-long-file"));
     at.mkdir(&at.plus_as_string("test-long-dir/test-long-dir"));
 
-
     for arg in &["-l", "--long", "--format=long", "--format=verbose"] {
         let result = scene.ucmd().arg(arg).arg("test-long-dir").succeeds();
-        // Assuming sane unames and groups do not have spaces within them.
+        // Assuming sane username do not have spaces within them.
         // A line of the output should be:
         // One of the characters -bcCdDlMnpPsStTx?
         // rwx, with - for missing permissions, thrice.
         // A number, preceded by column whitespace, and followed by a single space.
-        // A uname/group, currently [^ ], followed by column whitespace, twice (or thrice for Hurd).
+        // A username, currently [^ ], followed by column whitespace, twice (or thrice for Hurd).
         // A number, followed by a single space.
         // A month, followed by a single space.
         // A day, preceded by column whitespace, and followed by a single space.


### PR DESCRIPTION
Implemented column-formating to mimic the behavior of GNU coreutils's ls 

Previously, columns from users with names / uids of different lengths would not render in a column when invoking `ls -l` causing a very disorganized and hard to read output:
```
total 8455364
drwxr-xr-x  25 root root       4096 Apr 29 14:06 .
drwxr-xr-x  25 root root       4096 Apr 29 14:06 ..
lrwxrwxrwx   1 root root          7 Sep 21  2019 bin -> usr/bin
drwxr-xr-x   4 root root       4096 Aug 21 06:47 boot
drwxr-xr-x   2 root root       4096 Sep 21  2019 cdrom
drwxr-xr-x  22 root root       5000 Aug 27 05:16 dev
drwxr-xr-x 165 root root      12288 Aug 28 12:11 etc
drwxr-xr-x   3 root root       4096 Sep 21  2019 home
d-wxrwx--t   3 root aa          0 Aug 30 02:32 hugepages
lrwxrwxrwx   1 root root         32 Oct 20  2019 initrd.img -> boot/initrd.img-5.0.0-32-generic
lrwxrwxrwx   1 root root         32 Oct 20  2019 initrd.img.old -> boot/initrd.img-5.0.0-31-generic
lrwxrwxrwx   1 root root          7 Sep 21  2019 lib -> usr/lib
lrwxrwxrwx   1 root root          9 Sep 21  2019 lib32 -> usr/lib32
lrwxrwxrwx   1 root root          9 Sep 21  2019 lib64 -> usr/lib64
lrwxrwxrwx   1 root root         10 Sep 21  2019 libx32 -> usr/libx32
drwx------   2 root root      16384 Sep 21  2019 lost+found
drwxr-xr-x   3 root root       4096 Sep 21  2019 media
drwx------   1 aa aa       4096 Aug  8 16:27 aa
drwxr-xr-x   2 root root       4096 Jul 16 16:56 mnt
drwxr-xr-x   8 root root       4096 Aug 13 03:48 opt
dr-xr-xr-x 393 root root          0 Aug 27 05:16 proc
drwx------  12 root root       4096 Aug 23 14:21 root
-rw-r--r--   1 root root 3221225472 Feb  4  2021 rootfs.img
drwxr-xr-x  41 root root       1360 Aug 30 06:45 run
lrwxrwxrwx   1 root root          8 Sep 21  2019 sbin -> usr/sbin
drwxr-xr-x  15 root root       4096 Aug  6 23:32 snap
drwxr-xr-x   2 root root       4096 Apr 16  2019 srv
-rw-------   1 root root 8589934592 Sep 23  2019 swapfile
dr-xr-xr-x  13 root root          0 Aug 27 05:16 sys
drwxrwxrwt  26 root root      16384 Aug 30 12:40 tmp
drwxr-xr-x  17 root root       4096 Nov  8  2019 usr
drwxr-xr-x  15 root root       4096 Jul 16 16:54 var
lrwxrwxrwx   1 root root         29 Oct 20  2019 vmlinuz -> boot/vmlinuz-5.0.0-32-generic
lrwxrwxrwx   1 root root         29 Oct 20  2019 vmlinuz.old -> boot/vmlinuz-5.0.0-31-generic
```

As you can see, elements owned by aa and by root render out-of-column with each other due to owner, group, and author columns (if they exist) not having padding.

Implemented columns to owners, groups, and authors in `display_item_long` and changed `display_items` to provide the expected behavior.

Modified `display_dir_entry_size` and added a `pad_right` function to allow the expected behavior to exist.

Finally, I took the liberty to document `display_item_long` to make it easier for people to understand why it acts the way it does in the future. I plan to document more functions as I change more things within ls to make it more consistent with its expected behavior (which may be similar to or differ from GNU ls). If that's unwelcome, feel free to cherrypick and leave out the last commit. :3