### PR TITLE
cp: correctly copy mode, ownership, acl and context

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -35,6 +35,7 @@ falsey
 fileio
 flamegraph
 fullblock
+getfacl
 gibi
 gibibytes
 glob
@@ -49,6 +50,7 @@ iflag
 iflags
 kibi
 kibibytes
+libacl
 lcase
 lossily
 mebi
@@ -91,6 +93,7 @@ seedable
 semver
 semiprime
 semiprimes
+setfacl
 shortcode
 shortcodes
 siginfo

--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -16,6 +16,7 @@ chrono
 conv
 corasick
 crossterm
+exacl
 filetime
 formatteriteminfo
 fsext

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +730,21 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "exacl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769bbd173781e84865b957cf83449f0d2869f4c9d2f191cbbffffb3d9751ba2b"
+dependencies = [
+ "bitflags",
+ "log",
+ "nix 0.21.0",
+ "num_enum",
+ "scopeguard",
+ "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -964,9 +990,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libloading"
@@ -1116,6 +1142,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1219,28 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn",
 ]
 
 [[package]]
@@ -1347,6 +1408,16 @@ dependencies = [
  "ctor",
  "diff",
  "output_vt100",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -1707,6 +1778,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,10 +2296,12 @@ name = "uu_cp"
 version = "0.0.7"
 dependencies = [
  "clap",
+ "exacl",
  "filetime",
  "ioctl-sys",
  "libc",
  "quick-error 1.2.3",
+ "selinux",
  "uucore",
  "uucore_procs",
  "walkdir",
@@ -3191,6 +3293,12 @@ dependencies = [
  "quote 1.0.9",
  "syn",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,12 @@ feat_os_unix_musl = [
 # NOTE:
 # The selinux(-sys) crate requires `libselinux` headers and shared library to be accessible in the C toolchain at compile time.
 # Running a uutils compiled with `feat_selinux` requires an SELinux enabled Kernel at run time.
-feat_selinux = ["id/selinux", "selinux", "feat_require_selinux"]
+feat_selinux = ["cp/selinux", "id/selinux", "selinux", "feat_require_selinux"]
+# "feat_acl" == set of utilities providing support for acl (access control lists) if enabled with `--features feat_acl`.
+# NOTE:
+# On linux, the posix-acl/acl-sys crate requires `libacl` headers and shared library to be accessible in the C toolchain at compile time.
+# On FreeBSD and macOS this is not required.
+feat_acl = ["cp/feat_acl"]
 ## feature sets with requirements (restricting cross-platform availability)
 #
 # ** NOTE: these `feat_require_...` sets should be minimized as much as possible to encourage cross-platform availability of utilities

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -24,7 +24,7 @@ filetime = "0.2"
 libc = "0.2.85"
 quick-error = "1.2.3"
 selinux = { version="0.2.3", optional=true }
-uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["fs", "perms"] }
+uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["fs", "perms", "mode"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 walkdir = "2.2"
 

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -23,7 +23,8 @@ clap = { version = "2.33", features = ["wrap_help"] }
 filetime = "0.2"
 libc = "0.2.85"
 quick-error = "1.2.3"
-uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["fs"] }
+selinux = { version="0.2.3", optional=true }
+uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["fs", "perms"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 walkdir = "2.2"
 
@@ -35,7 +36,12 @@ winapi = { version="0.3", features=["fileapi"] }
 
 [target.'cfg(unix)'.dependencies]
 xattr="0.2.1"
+exacl= { version = "0.6.0", optional=true }
 
 [[bin]]
 name = "cp"
 path = "src/main.rs"
+
+[features]
+feat_selinux = ["selinux"]
+feat_acl = ["exacl"]

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -29,7 +29,7 @@ walkdir = { version="2.3.2", optional=true }
 data-encoding = { version="2.1", optional=true }
 data-encoding-macro = { version="0.1.12", optional=true }
 z85 = { version="3.0.3", optional=true }
-libc = { version="0.2.15, <= 0.2.85", optional=true } ## libc: initial utmp support added in v0.2.15; but v0.2.68 breaks the build for MinSRV v1.31.0
+libc = { version="0.2.15", optional=true }
 
 [dev-dependencies]
 clap = "2.33.3"

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -8,6 +8,8 @@ use std::fs::set_permissions;
 use std::os::unix::fs;
 
 #[cfg(unix)]
+use std::os::unix::fs::symlink as symlink_file;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_file;
@@ -1352,4 +1354,17 @@ fn test_preserve_mode() {
         at.plus("dest").metadata().unwrap().mode() & 0o7777,
         PERMS_ALL
     );
+}
+
+#[test]
+fn test_canonicalize_symlink() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir");
+    at.touch("dir/file");
+    symlink_file("../dir/file", at.plus("dir/file-ln")).unwrap();
+    ucmd.arg("dir/file-ln")
+        .arg(".")
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -7,7 +7,7 @@ use std::fs::set_permissions;
 #[cfg(not(windows))]
 use std::os::unix::fs;
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_file;
@@ -1304,4 +1304,52 @@ fn test_copy_symlink_force() {
     ucmd.args(&["file-link", "copy", "-f", "--no-dereference"])
         .succeeds();
     assert_eq!(at.resolve_link("copy"), "file");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_no_preserve_mode() {
+    use std::os::unix::prelude::MetadataExt;
+
+    use uucore::mode::get_umask;
+
+    const PERMS_ALL: u32 = 0o7777;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("file");
+    set_permissions(at.plus("file"), PermissionsExt::from_mode(PERMS_ALL)).unwrap();
+    ucmd.arg("file")
+        .arg("dest")
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+    let umask = get_umask();
+    // remove sticky bit, setuid and setgid bit; apply umask
+    let expected_perms = PERMS_ALL & !0o7000 & !umask;
+    assert_eq!(
+        at.plus("dest").metadata().unwrap().mode() & 0o7777,
+        expected_perms
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_preserve_mode() {
+    use std::os::unix::prelude::MetadataExt;
+
+    const PERMS_ALL: u32 = 0o7777;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("file");
+    set_permissions(at.plus("file"), PermissionsExt::from_mode(PERMS_ALL)).unwrap();
+    ucmd.arg("file")
+        .arg("dest")
+        .arg("-p")
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+    assert_eq!(
+        at.plus("dest").metadata().unwrap().mode() & 0o7777,
+        PERMS_ALL
+    );
 }


### PR DESCRIPTION
Fix a mix-up between ownership and mode. The latter (mode / file permissions)
can also be set on windows (which however only affects the read-only flag),
while there doesn't seem to be a straight-forward way to change file ownership
on windows.

Copy the acl as well when copying the mode. This is a non-default feature and can be
enabled with `--features feat_acl`, because it doesn't seem to work on CI.
It is only available for unix so far.

Copy the SELinux context if possible.