### PR TITLE
Update filename quoting and printing

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -9,6 +9,8 @@ bytewise
 canonicalization
 canonicalize
 canonicalizing
+codepoint
+codepoints
 colorizable
 colorize
 coprime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "getopts",
  "lazy_static",
  "libc",
+ "once_cell",
  "termion",
  "thiserror",
  "time",

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -38,7 +38,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let name = uucore::util_name();
 
     let config_result: Result<base_common::Config, String> =
-        base_common::parse_base_cmd_args(args, &name, VERSION, ABOUT, &usage);
+        base_common::parse_base_cmd_args(args, name, VERSION, ABOUT, &usage);
     let config = config_result.unwrap_or_else(|s| crash!(BASE_CMD_PARSE_ERROR, "{}", s));
 
     // Create a reference to stdin so we can return a locked stdin from
@@ -52,12 +52,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         config.wrap_cols,
         config.ignore_garbage,
         config.decode,
-        &name,
+        name,
     );
 
     0
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    base_common::base_app(&uucore::util_name(), VERSION, ABOUT)
+    base_common::base_app(uucore::util_name(), VERSION, ABOUT)
 }

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -9,6 +9,7 @@
 
 use std::io::{stdout, Read, Write};
 
+use uucore::display::Quotable;
 use uucore::encoding::{wrap_print, Data, Format};
 use uucore::InvalidEncodingHandling;
 
@@ -40,8 +41,9 @@ impl Config {
                 let name = values.next().unwrap();
                 if let Some(extra_op) = values.next() {
                     return Err(format!(
-                        "extra operand '{}'\nTry '{} --help' for more information.",
-                        extra_op, app_name
+                        "extra operand {}\nTry '{} --help' for more information.",
+                        extra_op.quote(),
+                        app_name
                     ));
                 }
 
@@ -49,7 +51,7 @@ impl Config {
                     None
                 } else {
                     if !Path::exists(Path::new(name)) {
-                        return Err(format!("{}: No such file or directory", name));
+                        return Err(format!("{}: No such file or directory", name.maybe_quote()));
                     }
                     Some(name.to_owned())
                 }
@@ -61,7 +63,7 @@ impl Config {
             .value_of(options::WRAP)
             .map(|num| {
                 num.parse::<usize>()
-                    .map_err(|_| format!("invalid wrap size: '{}'", num))
+                    .map_err(|_| format!("invalid wrap size: {}", num.quote()))
             })
             .transpose()?;
 

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -38,7 +38,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let usage = usage();
     let name = uucore::util_name();
     let config_result: Result<base_common::Config, String> =
-        base_common::parse_base_cmd_args(args, &name, VERSION, ABOUT, &usage);
+        base_common::parse_base_cmd_args(args, name, VERSION, ABOUT, &usage);
     let config = config_result.unwrap_or_else(|s| crash!(BASE_CMD_PARSE_ERROR, "{}", s));
 
     // Create a reference to stdin so we can return a locked stdin from
@@ -52,7 +52,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         config.wrap_cols,
         config.ignore_garbage,
         config.decode,
-        &name,
+        name,
     );
 
     0

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -47,7 +47,7 @@ fn usage() -> String {
 }
 
 pub fn uu_app() -> App<'static, 'static> {
-    let mut app = base_common::base_app(&uucore::util_name(), crate_version!(), ABOUT);
+    let mut app = base_common::base_app(uucore::util_name(), crate_version!(), ABOUT);
     for encoding in ENCODINGS {
         app = app.arg(Arg::with_name(encoding.0).long(encoding.0));
     }
@@ -88,7 +88,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         config.wrap_cols,
         config.ignore_garbage,
         config.decode,
-        &name,
+        name,
     );
 
     0

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -20,6 +20,7 @@ use clap::{crate_version, App, Arg};
 use std::fs::{metadata, File};
 use std::io::{self, Read, Write};
 use thiserror::Error;
+use uucore::display::Quotable;
 use uucore::error::UResult;
 
 #[cfg(unix)]
@@ -386,7 +387,7 @@ fn cat_files(files: Vec<String>, options: &OutputOptions) -> UResult<()> {
 
     for path in &files {
         if let Err(err) = cat_path(path, options, &mut state, &out_info) {
-            error_messages.push(format!("{}: {}", path, err));
+            error_messages.push(format!("{}: {}", path.maybe_quote(), err));
         }
     }
     if state.skipped_carriage_return {

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
-use uucore::{show_error, show_usage_error, show_warning};
+use uucore::{display::Quotable, show_error, show_usage_error, show_warning};
 
 use clap::{App, Arg};
 use selinux::{OpaqueSecurityContext, SecurityContext};
@@ -111,13 +111,13 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 Ok(context) => context,
 
                 Err(_r) => {
-                    show_error!("Invalid security context '{}'.", context.to_string_lossy());
+                    show_error!("Invalid security context {}.", context.quote());
                     return libc::EXIT_FAILURE;
                 }
             };
 
             if SecurityContext::from_c_str(&c_context, false).check() == Some(false) {
-                show_error!("Invalid security context '{}'.", context.to_string_lossy());
+                show_error!("Invalid security context {}.", context.quote());
                 return libc::EXIT_FAILURE;
             }
 
@@ -564,7 +564,7 @@ fn process_file(
             println!(
                 "{}: Changing security context of: {}",
                 uucore::util_name(),
-                file_full_name.to_string_lossy()
+                file_full_name.quote()
             );
         }
 
@@ -699,9 +699,9 @@ fn root_dev_ino_warn(dir_name: &Path) {
         );
     } else {
         show_warning!(
-            "It is dangerous to operate recursively on '{}' (same as '/'). \
+            "It is dangerous to operate recursively on {} (same as '/'). \
              Use --{} to override this failsafe.",
-            dir_name.to_string_lossy(),
+            dir_name.quote(),
             options::preserve_root::NO_PRESERVE_ROOT,
         );
     }
@@ -726,8 +726,8 @@ fn emit_cycle_warning(file_name: &Path) {
         "Circular directory structure.\n\
 This almost certainly means that you have a corrupted file system.\n\
 NOTIFY YOUR SYSTEM MANAGER.\n\
-The following directory is part of the cycle '{}'.",
-        file_name.display()
+The following directory is part of the cycle {}.",
+        file_name.quote()
     )
 }
 

--- a/src/uu/chcon/src/errors.rs
+++ b/src/uu/chcon/src/errors.rs
@@ -2,6 +2,8 @@ use std::ffi::OsString;
 use std::fmt::Write;
 use std::io;
 
+use uucore::display::Quotable;
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]
@@ -30,7 +32,7 @@ pub(crate) enum Error {
         source: io::Error,
     },
 
-    #[error("{operation} failed on '{}'", .operand1.to_string_lossy())]
+    #[error("{operation} failed on {}", .operand1.quote())]
     Io1 {
         operation: &'static str,
         operand1: OsString,

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -9,6 +9,7 @@
 
 #[macro_use]
 extern crate uucore;
+use uucore::display::Quotable;
 pub use uucore::entries;
 use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::perms::{chown_base, options, IfFrom};
@@ -32,7 +33,7 @@ fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>,
     let dest_gid = if let Some(file) = matches.value_of(options::REFERENCE) {
         fs::metadata(&file)
             .map(|meta| Some(meta.gid()))
-            .map_err_context(|| format!("failed to get attributes of '{}'", file))?
+            .map_err_context(|| format!("failed to get attributes of {}", file.quote()))?
     } else {
         let group = matches.value_of(options::ARG_GROUP).unwrap_or_default();
         if group.is_empty() {
@@ -40,7 +41,12 @@ fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>,
         } else {
             match entries::grp2gid(group) {
                 Ok(g) => Some(g),
-                _ => return Err(USimpleError::new(1, format!("invalid group: '{}'", group))),
+                _ => {
+                    return Err(USimpleError::new(
+                        1,
+                        format!("invalid group: {}", group.quote()),
+                    ))
+                }
             }
         }
     };

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -9,6 +9,7 @@
 
 #[macro_use]
 extern crate uucore;
+use uucore::display::Quotable;
 pub use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::perms::{chown_base, options, IfFrom};
 
@@ -44,7 +45,7 @@ fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Optio
     let dest_gid: Option<u32>;
     if let Some(file) = matches.value_of(options::REFERENCE) {
         let meta = fs::metadata(&file)
-            .map_err_context(|| format!("failed to get attributes of '{}'", file))?;
+            .map_err_context(|| format!("failed to get attributes of {}", file.quote()))?;
         dest_gid = Some(meta.gid());
         dest_uid = Some(meta.uid());
     } else {
@@ -173,7 +174,7 @@ fn parse_spec(spec: &str) -> UResult<(Option<u32>, Option<u32>)> {
     let uid = if usr_only || usr_grp {
         Some(
             Passwd::locate(args[0])
-                .map_err(|_| USimpleError::new(1, format!("invalid user: '{}'", spec)))?
+                .map_err(|_| USimpleError::new(1, format!("invalid user: {}", spec.quote())))?
                 .uid(),
         )
     } else {
@@ -182,7 +183,7 @@ fn parse_spec(spec: &str) -> UResult<(Option<u32>, Option<u32>)> {
     let gid = if grp_only || usr_grp {
         Some(
             Group::locate(args[1])
-                .map_err(|_| USimpleError::new(1, format!("invalid group: '{}'", spec)))?
+                .map_err(|_| USimpleError::new(1, format!("invalid group: {}", spec.quote())))?
                 .gid(),
         )
     } else {

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -150,7 +150,7 @@ fn set_context(root: &Path, options: &clap::ArgMatches) {
         Some(u) => {
             let s: Vec<&str> = u.split(':').collect();
             if s.len() != 2 || s.iter().any(|&spec| spec.is_empty()) {
-                crash!(1, "invalid userspec: `{}`", u)
+                crash!(1, "invalid userspec: {}", u.quote())
             };
             s
         }

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -15,6 +15,7 @@ use std::ffi::CString;
 use std::io::Error;
 use std::path::Path;
 use std::process::Command;
+use uucore::display::Quotable;
 use uucore::libc::{self, chroot, setgid, setgroups, setuid};
 use uucore::{entries, InvalidEncodingHandling};
 
@@ -53,8 +54,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if !newroot.is_dir() {
         crash!(
             1,
-            "cannot change root directory to `{}`: no such directory",
-            newroot.display()
+            "cannot change root directory to {}: no such directory",
+            newroot.quote()
         );
     }
 
@@ -170,7 +171,6 @@ fn set_context(root: &Path, options: &clap::ArgMatches) {
 }
 
 fn enter_chroot(root: &Path) {
-    let root_str = root.display();
     std::env::set_current_dir(root).unwrap();
     let err = unsafe {
         chroot(CString::new(".").unwrap().as_bytes_with_nul().as_ptr() as *const libc::c_char)
@@ -179,7 +179,7 @@ fn enter_chroot(root: &Path) {
         crash!(
             1,
             "cannot chroot to {}: {}",
-            root_str,
+            root.quote(),
             Error::last_os_error()
         )
     };
@@ -189,7 +189,7 @@ fn set_main_group(group: &str) {
     if !group.is_empty() {
         let group_id = match entries::grp2gid(group) {
             Ok(g) => g,
-            _ => crash!(1, "no such group: {}", group),
+            _ => crash!(1, "no such group: {}", group.maybe_quote()),
         };
         let err = unsafe { setgid(group_id) };
         if err != 0 {
@@ -234,7 +234,12 @@ fn set_user(user: &str) {
         let user_id = entries::usr2uid(user).unwrap();
         let err = unsafe { setuid(user_id as libc::uid_t) };
         if err != 0 {
-            crash!(1, "cannot set user to {}: {}", user, Error::last_os_error())
+            crash!(
+                1,
+                "cannot set user to {}: {}",
+                user.maybe_quote(),
+                Error::last_os_error()
+            )
         }
     }
 }

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -14,6 +14,7 @@ use clap::{crate_version, App, Arg};
 use std::fs::File;
 use std::io::{self, stdin, BufReader, Read};
 use std::path::Path;
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 // NOTE: CRC_TABLE_LEN *must* be <= 256 as we cast 0..CRC_TABLE_LEN to u8
@@ -191,7 +192,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         match cksum("-") {
             Ok((crc, size)) => println!("{} {}", crc, size),
             Err(err) => {
-                show_error!("{}", err);
+                show_error!("-: {}", err);
                 return 2;
             }
         }
@@ -203,7 +204,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         match cksum(fname.as_ref()) {
             Ok((crc, size)) => println!("{} {} {}", crc, size, fname),
             Err(err) => {
-                show_error!("'{}' {}", fname, err);
+                show_error!("{}: {}", fname.maybe_quote(), err);
                 exit_code = 2;
             }
         }

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -10,6 +10,7 @@ use std::{
     fs::{remove_file, File},
     io::{BufRead, BufWriter, Write},
 };
+use uucore::display::Quotable;
 
 mod csplit_error;
 mod patterns;
@@ -734,7 +735,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         let file = crash_if_err!(1, File::open(file_name));
         let file_metadata = crash_if_err!(1, file.metadata());
         if !file_metadata.is_file() {
-            crash!(1, "'{}' is not a regular file", file_name);
+            crash!(1, "{} is not a regular file", file_name.quote());
         }
         crash_if_err!(1, csplit(&options, patterns, BufReader::new(file)));
     };

--- a/src/uu/csplit/src/csplit_error.rs
+++ b/src/uu/csplit/src/csplit_error.rs
@@ -1,26 +1,28 @@
 use std::io;
 use thiserror::Error;
 
+use uucore::display::Quotable;
+
 /// Errors thrown by the csplit command
 #[derive(Debug, Error)]
 pub enum CsplitError {
     #[error("IO error: {}", _0)]
     IoError(io::Error),
-    #[error("'{}': line number out of range", _0)]
+    #[error("{}: line number out of range", ._0.quote())]
     LineOutOfRange(String),
-    #[error("'{}': line number out of range on repetition {}", _0, _1)]
+    #[error("{}: line number out of range on repetition {}", ._0.quote(), _1)]
     LineOutOfRangeOnRepetition(String, usize),
-    #[error("'{}': match not found", _0)]
+    #[error("{}: match not found", ._0.quote())]
     MatchNotFound(String),
-    #[error("'{}': match not found on repetition {}", _0, _1)]
+    #[error("{}: match not found on repetition {}", ._0.quote(), _1)]
     MatchNotFoundOnRepetition(String, usize),
     #[error("line number must be greater than zero")]
     LineNumberIsZero,
     #[error("line number '{}' is smaller than preceding line number, {}", _0, _1)]
     LineNumberSmallerThanPrevious(usize, usize),
-    #[error("invalid pattern: {}", _0)]
+    #[error("{}: invalid pattern", ._0.quote())]
     InvalidPattern(String),
-    #[error("invalid number: '{}'", _0)]
+    #[error("invalid number: {}", ._0.quote())]
     InvalidNumber(String),
     #[error("incorrect conversion specification in suffix")]
     SuffixFormatIncorrect,

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -15,6 +15,7 @@ use clap::{crate_version, App, Arg};
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use std::path::Path;
+use uucore::display::Quotable;
 
 use self::searcher::Searcher;
 use uucore::ranges::Range;
@@ -351,19 +352,19 @@ fn cut_files(mut filenames: Vec<String>, mode: Mode) -> i32 {
             let path = Path::new(&filename[..]);
 
             if path.is_dir() {
-                show_error!("{}: Is a directory", filename);
+                show_error!("{}: Is a directory", filename.maybe_quote());
                 continue;
             }
 
             if path.metadata().is_err() {
-                show_error!("{}: No such file or directory", filename);
+                show_error!("{}: No such file or directory", filename.maybe_quote());
                 continue;
             }
 
             let file = match File::open(&path) {
                 Ok(f) => f,
                 Err(e) => {
-                    show_error!("opening '{}': {}", &filename[..], e);
+                    show_error!("opening {}: {}", filename.quote(), e);
                     continue;
                 }
             };

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -18,6 +18,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use uucore::display::Quotable;
+use uucore::show_error;
 #[cfg(windows)]
 use winapi::{
     shared::minwindef::WORD,
@@ -146,7 +147,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
         if !form.starts_with('+') {
-            eprintln!("date: invalid date {}", form.quote());
+            show_error!("invalid date {}", form.quote());
             return 1;
         }
         let form = form[1..].to_string();
@@ -175,7 +176,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let set_to = match matches.value_of(OPT_SET).map(parse_date) {
         None => None,
         Some(Err((input, _err))) => {
-            eprintln!("date: invalid date {}", input.quote());
+            show_error!("invalid date {}", input.quote());
             return 1;
         }
         Some(Ok(date)) => Some(date),
@@ -241,7 +242,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     println!("{}", formatted);
                 }
                 Err((input, _err)) => {
-                    println!("date: invalid date {}", input.quote());
+                    show_error!("invalid date {}", input.quote());
                 }
             }
         }
@@ -353,13 +354,13 @@ fn set_system_datetime(_date: DateTime<Utc>) -> i32 {
 
 #[cfg(target_os = "macos")]
 fn set_system_datetime(_date: DateTime<Utc>) -> i32 {
-    eprintln!("date: setting the date is not supported by macOS");
+    show_error!("setting the date is not supported by macOS");
     1
 }
 
 #[cfg(target_os = "redox")]
 fn set_system_datetime(_date: DateTime<Utc>) -> i32 {
-    eprintln!("date: setting the date is not supported by Redox");
+    show_error!("setting the date is not supported by Redox");
     1
 }
 
@@ -379,7 +380,7 @@ fn set_system_datetime(date: DateTime<Utc>) -> i32 {
 
     if result != 0 {
         let error = std::io::Error::last_os_error();
-        eprintln!("date: cannot set date: {}", error);
+        show_error!("cannot set date: {}", error);
         error.raw_os_error().unwrap()
     } else {
         0
@@ -409,7 +410,7 @@ fn set_system_datetime(date: DateTime<Utc>) -> i32 {
 
     if result == 0 {
         let error = std::io::Error::last_os_error();
-        eprintln!("date: cannot set date: {}", error);
+        show_error!("cannot set date: {}", error);
         error.raw_os_error().unwrap()
     } else {
         0

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -17,6 +17,7 @@ use libc::{clock_settime, timespec, CLOCK_REALTIME};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
+use uucore::display::Quotable;
 #[cfg(windows)]
 use winapi::{
     shared::minwindef::WORD,
@@ -145,7 +146,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
         if !form.starts_with('+') {
-            eprintln!("date: invalid date '{}'", form);
+            eprintln!("date: invalid date {}", form.quote());
             return 1;
         }
         let form = form[1..].to_string();
@@ -174,7 +175,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     let set_to = match matches.value_of(OPT_SET).map(parse_date) {
         None => None,
         Some(Err((input, _err))) => {
-            eprintln!("date: invalid date '{}'", input);
+            eprintln!("date: invalid date {}", input.quote());
             return 1;
         }
         Some(Ok(date)) => Some(date),
@@ -240,7 +241,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     println!("{}", formatted);
                 }
                 Err((input, _err)) => {
-                    println!("date: invalid date '{}'", input);
+                    println!("date: invalid date {}", input.quote());
                 }
             }
         }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -17,6 +17,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 use clap::{crate_version, App, Arg};
+use uucore::display::Quotable;
 
 mod options {
     pub const BOURNE_SHELL: &str = "bourne-shell";
@@ -94,9 +95,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if matches.is_present(options::PRINT_DATABASE) {
         if !files.is_empty() {
             show_usage_error!(
-                "extra operand '{}'\nfile operands cannot be combined with \
+                "extra operand {}\nfile operands cannot be combined with \
                  --print-database (-p)",
-                files[0]
+                files[0].quote()
             );
             return 1;
         }
@@ -126,7 +127,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         result = parse(INTERNAL_DB.lines(), out_format, "")
     } else {
         if files.len() > 1 {
-            show_usage_error!("extra operand '{}'", files[1]);
+            show_usage_error!("extra operand {}", files[1].quote());
             return 1;
         }
         match File::open(files[0]) {
@@ -135,7 +136,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 result = parse(fin.lines().filter_map(Result::ok), out_format, files[0])
             }
             Err(e) => {
-                show_error!("{}: {}", files[0], e);
+                show_error!("{}: {}", files[0].maybe_quote(), e);
                 return 1;
             }
         }
@@ -314,7 +315,8 @@ where
         if val.is_empty() {
             return Err(format!(
                 "{}:{}: invalid line;  missing second token",
-                fp, num
+                fp.maybe_quote(),
+                num
             ));
         }
         let lower = key.to_lowercase();
@@ -341,7 +343,12 @@ where
                 } else if let Some(s) = table.get(lower.as_str()) {
                     result.push_str(format!("{}={}:", s, val).as_str());
                 } else {
-                    return Err(format!("{}:{}: unrecognized keyword {}", fp, num, key));
+                    return Err(format!(
+                        "{}:{}: unrecognized keyword {}",
+                        fp.maybe_quote(),
+                        num,
+                        key
+                    ));
                 }
             }
         }

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -10,6 +10,7 @@ extern crate uucore;
 
 use clap::{crate_version, App, Arg};
 use std::path::Path;
+use uucore::display::print_verbatim;
 use uucore::error::{UResult, UUsageError};
 use uucore::InvalidEncodingHandling;
 
@@ -65,7 +66,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     if d.components().next() == None {
                         print!(".")
                     } else {
-                        print!("{}", d.to_string_lossy());
+                        print_verbatim(d).unwrap();
                     }
                 }
                 None => {

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -466,7 +466,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let options = Options {
         all: matches.is_present(options::ALL),
-        util_name: uucore::util_name(),
+        util_name: uucore::util_name().to_owned(),
         max_depth,
         total: matches.is_present(options::TOTAL),
         separate_dirs: matches.is_present(options::SEPARATE_DIRS),

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -22,6 +22,7 @@ use std::env;
 use std::io::{self, Write};
 use std::iter::Iterator;
 use std::process::Command;
+use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 
 const USAGE: &str = "env [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]";
@@ -93,7 +94,7 @@ fn load_config_file(opts: &mut Options) -> UResult<()> {
         };
 
         let conf = conf.map_err(|error| {
-            eprintln!("env: error: \"{}\": {}", file, error);
+            show_error!("{}: {}", file.maybe_quote(), error);
             1
         })?;
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -65,8 +65,14 @@ fn parse_name_value_opt<'a>(opts: &mut Options<'a>, opt: &'a str) -> Result<bool
 
 fn parse_program_opt<'a>(opts: &mut Options<'a>, opt: &'a str) -> Result<(), i32> {
     if opts.null {
-        eprintln!("{}: cannot specify --null (-0) with command", crate_name!());
-        eprintln!("Type \"{} --help\" for detailed information", crate_name!());
+        eprintln!(
+            "{}: cannot specify --null (-0) with command",
+            uucore::util_name()
+        );
+        eprintln!(
+            "Type \"{} --help\" for detailed information",
+            uucore::execution_phrase()
+        );
         Err(1)
     } else {
         opts.program.push(opt);

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -17,6 +17,7 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
+use uucore::display::Quotable;
 
 static ABOUT: &str = "Convert tabs in each FILE to spaces, writing to standard output.
  With no FILE, or when FILE is -, read standard input.";
@@ -216,7 +217,7 @@ fn open(path: String) -> BufReader<Box<dyn Read + 'static>> {
     } else {
         file_buf = match File::open(&path[..]) {
             Ok(a) => a,
-            Err(e) => crash!(1, "{}: {}\n", &path[..], e),
+            Err(e) => crash!(1, "{}: {}\n", path.maybe_quote(), e),
         };
         BufReader::new(Box::new(file_buf) as Box<dyn Read>)
     }

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -16,6 +16,7 @@ use std::io::{self, stdin, stdout, BufRead, Write};
 mod factor;
 use clap::{crate_version, App, Arg};
 pub use factor::*;
+use uucore::display::Quotable;
 
 mod miller_rabin;
 pub mod numeric;
@@ -52,7 +53,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     if let Some(values) = matches.values_of(options::NUMBER) {
         for number in values {
             if let Err(e) = print_factors_str(number, &mut w, &mut factors_buffer) {
-                show_warning!("{}: {}", number, e);
+                show_warning!("{}: {}", number.maybe_quote(), e);
             }
         }
     } else {
@@ -61,7 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         for line in stdin.lock().lines() {
             for number in line.unwrap().split_whitespace() {
                 if let Err(e) = print_factors_str(number, &mut w, &mut factors_buffer) {
-                    show_warning!("{}: {}", number, e);
+                    show_warning!("{}: {}", number.maybe_quote(), e);
                 }
             }
         }

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -15,6 +15,7 @@ use std::cmp;
 use std::fs::File;
 use std::io::{stdin, stdout, Write};
 use std::io::{BufReader, BufWriter, Read};
+use uucore::display::Quotable;
 
 use self::linebreak::break_lines;
 use self::parasplit::ParagraphStream;
@@ -187,7 +188,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             _ => match File::open(i) {
                 Ok(f) => BufReader::new(Box::new(f) as Box<dyn Read + 'static>),
                 Err(e) => {
-                    show_warning!("{}: {}", i, e);
+                    show_warning!("{}: {}", i.maybe_quote(), e);
                     continue;
                 }
             },

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -133,7 +133,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         fmt_opts.width = match s.parse::<usize>() {
             Ok(t) => t,
             Err(e) => {
-                crash!(1, "Invalid WIDTH specification: `{}': {}", s, e);
+                crash!(1, "Invalid WIDTH specification: {}: {}", s.quote(), e);
             }
         };
         if fmt_opts.width > MAX_WIDTH {
@@ -150,7 +150,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         fmt_opts.goal = match s.parse::<usize>() {
             Ok(t) => t,
             Err(e) => {
-                crash!(1, "Invalid GOAL specification: `{}': {}", s, e);
+                crash!(1, "Invalid GOAL specification: {}: {}", s.quote(), e);
             }
         };
         if !matches.is_present(OPT_WIDTH) {
@@ -164,7 +164,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         fmt_opts.tabwidth = match s.parse::<usize>() {
             Ok(t) => t,
             Err(e) => {
-                crash!(1, "Invalid TABWIDTH specification: `{}': {}", s, e);
+                crash!(1, "Invalid TABWIDTH specification: {}: {}", s.quote(), e);
             }
         };
     };

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -17,7 +17,10 @@
 
 #[macro_use]
 extern crate uucore;
-use uucore::entries::{get_groups_gnu, gid2grp, Locate, Passwd};
+use uucore::{
+    display::Quotable,
+    entries::{get_groups_gnu, gid2grp, Locate, Passwd},
+};
 
 use clap::{crate_version, App, Arg};
 
@@ -77,7 +80,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     .join(" ")
             );
         } else {
-            show_error!("'{}': no such user", user);
+            show_error!("{}: no such user", user.quote());
             exit_code = 1;
         }
     }

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -34,6 +34,7 @@ use std::io::{self, stdin, BufRead, BufReader, Read};
 use std::iter;
 use std::num::ParseIntError;
 use std::path::Path;
+use uucore::display::Quotable;
 
 const NAME: &str = "hashsum";
 
@@ -525,7 +526,7 @@ where
                             if options.warn {
                                 show_warning!(
                                     "{}: {}: improperly formatted {} checksum line",
-                                    filename.display(),
+                                    filename.maybe_quote(),
                                     i + 1,
                                     options.algoname
                                 );
@@ -546,6 +547,10 @@ where
                     )
                 )
                 .to_ascii_lowercase();
+                // FIXME: (How) should these be quoted?
+                // They seem like they would be processed programmatically, and
+                // our ordinary quoting might interfere, but newlines should be
+                // sanitized probably
                 if sum == real_sum {
                     if !options.quiet {
                         println!("{}: OK", ck_filename);

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -547,10 +547,15 @@ where
                     )
                 )
                 .to_ascii_lowercase();
-                // FIXME: (How) should these be quoted?
-                // They seem like they would be processed programmatically, and
-                // our ordinary quoting might interfere, but newlines should be
-                // sanitized probably
+                // FIXME: Filenames with newlines should be treated specially.
+                // GNU appears to replace newlines by \n and backslashes by
+                // \\ and prepend a backslash (to the hash or filename) if it did
+                // this escaping.
+                // Different sorts of output (checking vs outputting hashes) may
+                // handle this differently. Compare carefully to GNU.
+                // If you can, try to preserve invalid unicode using OsStr(ing)Ext
+                // and display it using uucore::display::print_verbatim(). This is
+                // easier (and more important) on Unix than on Windows.
                 if sum == real_sum {
                     if !options.quiet {
                         println!("{}: OK", ck_filename);

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -9,6 +9,7 @@ use clap::{crate_version, App, Arg};
 use std::convert::TryFrom;
 use std::ffi::OsString;
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
+use uucore::display::Quotable;
 use uucore::{crash, show_error_custom_description};
 
 const EXIT_FAILURE: i32 = 1;
@@ -127,10 +128,10 @@ fn arg_iterate<'a>(
             match parse::parse_obsolete(s) {
                 Some(Ok(iter)) => Ok(Box::new(vec![first].into_iter().chain(iter).chain(args))),
                 Some(Err(e)) => match e {
-                    parse::ParseError::Syntax => Err(format!("bad argument format: '{}'", s)),
+                    parse::ParseError::Syntax => Err(format!("bad argument format: {}", s.quote())),
                     parse::ParseError::Overflow => Err(format!(
-                        "invalid argument: '{}' Value too large for defined datatype",
-                        s
+                        "invalid argument: {} Value too large for defined datatype",
+                        s.quote()
                     )),
                 },
                 None => Ok(Box::new(vec![first, second].into_iter().chain(args))),
@@ -418,7 +419,7 @@ fn uu_head(options: &HeadOptions) -> Result<(), u32> {
                 let mut file = match std::fs::File::open(name) {
                     Ok(f) => f,
                     Err(err) => {
-                        let prefix = format!("cannot open '{}' for reading", name);
+                        let prefix = format!("cannot open {} for reading", name.quote());
                         match err.kind() {
                             ErrorKind::NotFound => {
                                 show_error_custom_description!(prefix, "No such file or directory");

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -41,6 +41,7 @@ extern crate uucore;
 
 use clap::{crate_version, App, Arg};
 use std::ffi::CStr;
+use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::error::UResult;
 use uucore::error::{set_exit_code, USimpleError};
@@ -230,7 +231,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             match Passwd::locate(users[i].as_str()) {
                 Ok(p) => Some(p),
                 Err(_) => {
-                    show_error!("'{}': no such user", users[i]);
+                    show_error!("{}: no such user", users[i].quote());
                     set_exit_code(1);
                     if i + 1 >= users.len() {
                         break;

--- a/src/uu/install/src/mode.rs
+++ b/src/uu/install/src/mode.rs
@@ -22,8 +22,9 @@ pub fn parse(mode_string: &str, considering_dir: bool, umask: u32) -> Result<u32
 #[cfg(any(unix, target_os = "redox"))]
 pub fn chmod(path: &Path, mode: u32) -> Result<(), ()> {
     use std::os::unix::fs::PermissionsExt;
+    use uucore::display::Quotable;
     fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|err| {
-        show_error!("{}: chmod failed with error {}", path.display(), err);
+        show_error!("{}: chmod failed with error {}", path.maybe_quote(), err);
     })
 }
 

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -13,6 +13,7 @@ extern crate uucore;
 use clap::{crate_version, App, Arg};
 use libc::{c_int, pid_t};
 use std::io::Error;
+use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::signals::ALL_SIGNALS;
 use uucore::InvalidEncodingHandling;
@@ -154,7 +155,7 @@ fn print_signal(signal_name_or_value: &str) -> UResult<()> {
     }
     Err(USimpleError::new(
         1,
-        format!("unknown signal name {}", signal_name_or_value),
+        format!("unknown signal name {}", signal_name_or_value.quote()),
     ))
 }
 
@@ -190,7 +191,7 @@ fn kill(signalname: &str, pids: &[String]) -> UResult<()> {
         None => {
             return Err(USimpleError::new(
                 1,
-                format!("unknown signal name {}", signalname),
+                format!("unknown signal name {}", signalname.quote()),
             ));
         }
     };
@@ -204,7 +205,7 @@ fn kill(signalname: &str, pids: &[String]) -> UResult<()> {
             Err(e) => {
                 return Err(USimpleError::new(
                     1,
-                    format!("failed to parse argument {}: {}", pid, e),
+                    format!("failed to parse argument {}: {}", pid.quote(), e),
                 ));
             }
         };

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -35,7 +35,7 @@ fn get_userlogin() -> Option<String> {
 
 static SUMMARY: &str = "Print user's login name";
 
-fn usage() -> String {
+fn usage() -> &'static str {
     uucore::execution_phrase()
 }
 
@@ -44,8 +44,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = usage();
-    let _ = uu_app().usage(&usage[..]).get_matches_from(args);
+    let _ = uu_app().usage(usage()).get_matches_from(args);
 
     match get_userlogin() {
         Some(userlogin) => println!("{}", userlogin),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -40,7 +40,10 @@ use std::{
     time::Duration,
 };
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
-use uucore::error::{set_exit_code, FromIo, UError, UResult};
+use uucore::{
+    display::Quotable,
+    error::{set_exit_code, FromIo, UError, UResult},
+};
 
 use unicode_width::UnicodeWidthStr;
 #[cfg(unix)]
@@ -150,8 +153,8 @@ impl Error for LsError {}
 impl Display for LsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LsError::InvalidLineWidth(s) => write!(f, "invalid line width: '{}'", s),
-            LsError::NoMetadata(p) => write!(f, "could not open file: '{}'", p.display()),
+            LsError::InvalidLineWidth(s) => write!(f, "invalid line width: {}", s.quote()),
+            LsError::NoMetadata(p) => write!(f, "could not open file: {}", p.quote()),
         }
     }
 }
@@ -410,18 +413,18 @@ impl Config {
             },
             None => match termsize::get() {
                 Some(size) => size.cols,
-                None => match std::env::var("COLUMNS") {
-                    Ok(columns) => match columns.parse() {
-                        Ok(columns) => columns,
-                        Err(_) => {
+                None => match std::env::var_os("COLUMNS") {
+                    Some(columns) => match columns.to_str().and_then(|s| s.parse().ok()) {
+                        Some(columns) => columns,
+                        None => {
                             show_error!(
-                                "ignoring invalid width in environment variable COLUMNS: '{}'",
-                                columns
+                                "ignoring invalid width in environment variable COLUMNS: {}",
+                                columns.quote()
                             );
                             DEFAULT_TERM_WIDTH
                         }
                     },
-                    Err(_) => DEFAULT_TERM_WIDTH,
+                    None => DEFAULT_TERM_WIDTH,
                 },
             },
         };
@@ -538,7 +541,7 @@ impl Config {
                 Ok(p) => {
                     ignore_patterns.add(p);
                 }
-                Err(_) => show_warning!("Invalid pattern for ignore: '{}'", pattern),
+                Err(_) => show_warning!("Invalid pattern for ignore: {}", pattern.quote()),
             }
         }
 
@@ -548,7 +551,7 @@ impl Config {
                     Ok(p) => {
                         ignore_patterns.add(p);
                     }
-                    Err(_) => show_warning!("Invalid pattern for hide: '{}'", pattern),
+                    Err(_) => show_warning!("Invalid pattern for hide: {}", pattern.quote()),
                 }
             }
         }
@@ -1255,7 +1258,7 @@ fn list(locs: Vec<&Path>, config: Config) -> UResult<()> {
 
         if path_data.md().is_none() {
             show!(std::io::ErrorKind::NotFound
-                .map_err_context(|| format!("cannot access '{}'", path_data.p_buf.display())));
+                .map_err_context(|| format!("cannot access {}", path_data.p_buf.quote())));
             // We found an error, no need to continue the execution
             continue;
         }

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -12,6 +12,7 @@ use clap::OsValues;
 use clap::{crate_version, App, Arg};
 use std::fs;
 use std::path::Path;
+use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 
 static ABOUT: &str = "Create the given DIRECTORY(ies) if they do not exist";
@@ -43,7 +44,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Not tested on Windows
     let mode: u16 = match matches.value_of(options::MODE) {
         Some(m) => u16::from_str_radix(m, 8)
-            .map_err(|_| USimpleError::new(1, format!("invalid mode '{}'", m)))?,
+            .map_err(|_| USimpleError::new(1, format!("invalid mode {}", m.quote())))?,
         None => 0o755_u16,
     };
 
@@ -100,13 +101,13 @@ fn mkdir(path: &Path, recursive: bool, mode: u16, verbose: bool) -> UResult<()> 
         fs::create_dir
     };
 
-    create_dir(path).map_err_context(|| format!("cannot create directory '{}'", path.display()))?;
+    create_dir(path).map_err_context(|| format!("cannot create directory {}", path.quote()))?;
 
     if verbose {
         println!(
-            "{}: created directory '{}'",
+            "{}: created directory {}",
             uucore::util_name(),
-            path.display()
+            path.quote()
         );
     }
 
@@ -121,7 +122,7 @@ fn chmod(path: &Path, mode: u16) -> UResult<()> {
     let mode = Permissions::from_mode(u32::from(mode));
 
     set_permissions(path, mode)
-        .map_err_context(|| format!("cannot set permissions '{}'", path.display()))
+        .map_err_context(|| format!("cannot set permissions {}", path.quote()))
 }
 
 #[cfg(windows)]

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -11,7 +11,7 @@ extern crate uucore;
 use clap::{crate_version, App, Arg};
 use libc::mkfifo;
 use std::ffi::CString;
-use uucore::InvalidEncodingHandling;
+use uucore::{display::Quotable, InvalidEncodingHandling};
 
 static NAME: &str = "mkfifo";
 static USAGE: &str = "mkfifo [OPTION]... NAME...";
@@ -61,7 +61,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             mkfifo(name.as_ptr(), mode as libc::mode_t)
         };
         if err == -1 {
-            show_error!("cannot create fifo '{}': File exists", f);
+            show_error!("cannot create fifo {}: File exists", f.quote());
             exit_code = 1;
         }
     }

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -16,6 +16,7 @@ use clap::{crate_version, App, Arg, ArgMatches};
 use libc::{dev_t, mode_t};
 use libc::{S_IFBLK, S_IFCHR, S_IFIFO, S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOTH, S_IWUSR};
 
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Create the special file NAME of the given TYPE.";
@@ -219,7 +220,7 @@ fn valid_type(tpe: String) -> Result<(), String> {
             if vec!['b', 'c', 'u', 'p'].contains(&first_char) {
                 Ok(())
             } else {
-                Err(format!("invalid device type '{}'", tpe))
+                Err(format!("invalid device type {}", tpe.quote()))
             }
         })
 }

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -12,6 +12,7 @@
 extern crate uucore;
 
 use clap::{crate_version, App, Arg};
+use uucore::display::{println_verbatim, Quotable};
 use uucore::error::{FromIo, UError, UResult};
 
 use std::env;
@@ -57,16 +58,20 @@ impl Display for MkTempError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use MkTempError::*;
         match self {
-            PersistError(p) => write!(f, "could not persist file '{}'", p.display()),
-            MustEndInX(s) => write!(f, "with --suffix, template '{}' must end in X", s),
-            TooFewXs(s) => write!(f, "too few X's in template '{}'", s),
+            PersistError(p) => write!(f, "could not persist file {}", p.quote()),
+            MustEndInX(s) => write!(f, "with --suffix, template {} must end in X", s.quote()),
+            TooFewXs(s) => write!(f, "too few X's in template {}", s.quote()),
             ContainsDirSeparator(s) => {
-                write!(f, "invalid suffix '{}', contains directory separator", s)
+                write!(
+                    f,
+                    "invalid suffix {}, contains directory separator",
+                    s.quote()
+                )
             }
             InvalidTemplate(s) => write!(
                 f,
-                "invalid template, '{}'; with --tmpdir, it may not be absolute",
-                s
+                "invalid template, {}; with --tmpdir, it may not be absolute",
+                s.quote()
             ),
         }
     }
@@ -244,8 +249,7 @@ pub fn dry_exec(mut tmpdir: PathBuf, prefix: &str, rand: usize, suffix: &str) ->
         }
     }
     tmpdir.push(buf);
-    println!("{}", tmpdir.display());
-    Ok(())
+    println_verbatim(tmpdir).map_err_context(|| "failed to print directory name".to_owned())
 }
 
 fn exec(dir: PathBuf, prefix: &str, rand: usize, suffix: &str, make_dir: bool) -> UResult<()> {
@@ -274,6 +278,5 @@ fn exec(dir: PathBuf, prefix: &str, rand: usize, suffix: &str, make_dir: bool) -
             .map_err(|e| MkTempError::PersistError(e.file.path().to_path_buf()))?
             .1
     };
-    println!("{}", path.display());
-    Ok(())
+    println_verbatim(path).map_err_context(|| "failed to print directory name".to_owned())
 }

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -30,6 +30,7 @@ use crossterm::{
 
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
+use uucore::display::Quotable;
 
 const BELL: &str = "\x07";
 
@@ -64,12 +65,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             let file = Path::new(file);
             if file.is_dir() {
                 terminal::disable_raw_mode().unwrap();
-                show_usage_error!("'{}' is a directory.", file.display());
+                show_usage_error!("{} is a directory.", file.quote());
                 return 1;
             }
             if !file.exists() {
                 terminal::disable_raw_mode().unwrap();
-                show_error!("cannot open {}: No such file or directory", file.display());
+                show_error!("cannot open {}: No such file or directory", file.quote());
                 return 1;
             }
             if length > 1 {

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -19,6 +19,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Error;
 use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Run COMMAND ignoring hangup signals.";
@@ -122,13 +123,16 @@ fn find_stdout() -> File {
         .open(Path::new(NOHUP_OUT))
     {
         Ok(t) => {
-            show_error!("ignoring input and appending output to '{}'", NOHUP_OUT);
+            show_error!(
+                "ignoring input and appending output to {}",
+                NOHUP_OUT.quote()
+            );
             t
         }
         Err(e1) => {
             let home = match env::var("HOME") {
                 Err(_) => {
-                    show_error!("failed to open '{}': {}", NOHUP_OUT, e1);
+                    show_error!("failed to open {}: {}", NOHUP_OUT.quote(), e1);
                     exit!(internal_failure_code)
                 }
                 Ok(h) => h,
@@ -143,12 +147,15 @@ fn find_stdout() -> File {
                 .open(&homeout)
             {
                 Ok(t) => {
-                    show_error!("ignoring input and appending output to '{}'", homeout_str);
+                    show_error!(
+                        "ignoring input and appending output to {}",
+                        homeout_str.quote()
+                    );
                     t
                 }
                 Err(e2) => {
-                    show_error!("failed to open '{}': {}", NOHUP_OUT, e1);
-                    show_error!("failed to open '{}': {}", homeout_str, e2);
+                    show_error!("failed to open {}: {}", NOHUP_OUT.quote(), e1);
+                    show_error!("failed to open {}: {}", homeout_str.quote(), e2);
                     exit!(internal_failure_code)
                 }
             }

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -1,3 +1,5 @@
+use uucore::display::Quotable;
+
 use crate::options::{NumfmtOptions, RoundMethod};
 use crate::units::{DisplayableSuffix, RawSuffix, Result, Suffix, Unit, IEC_BASES, SI_BASES};
 
@@ -78,7 +80,7 @@ fn parse_suffix(s: &str) -> Result<(f64, Option<Suffix>)> {
         Some('Z') => Some((RawSuffix::Z, with_i)),
         Some('Y') => Some((RawSuffix::Y, with_i)),
         Some('0'..='9') => None,
-        _ => return Err(format!("invalid suffix in input: '{}'", s)),
+        _ => return Err(format!("invalid suffix in input: {}", s.quote())),
     };
 
     let suffix_len = match suffix {
@@ -89,7 +91,7 @@ fn parse_suffix(s: &str) -> Result<(f64, Option<Suffix>)> {
 
     let number = s[..s.len() - suffix_len]
         .parse::<f64>()
-        .map_err(|_| format!("invalid number: '{}'", s))?;
+        .map_err(|_| format!("invalid number: {}", s.quote()))?;
 
     Ok((number, suffix))
 }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -15,6 +15,7 @@ use crate::options::*;
 use crate::units::{Result, Unit};
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::io::{BufRead, Write};
+use uucore::display::Quotable;
 use uucore::ranges::Range;
 
 pub mod format;
@@ -113,7 +114,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
                     0 => Err(value),
                     _ => Ok(n),
                 })
-                .map_err(|value| format!("invalid header value '{}'", value))
+                .map_err(|value| format!("invalid header value {}", value.quote()))
         }
     }?;
 

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -59,7 +59,7 @@ impl<'b> MultifileReader<'b> {
                             // print an error at the time that the file is needed,
                             // then move on the the next file.
                             // This matches the behavior of the original `od`
-                            eprintln!("{}: {}: {}", uucore::util_name(), fname.maybe_quote(), e);
+                            show_error!("{}: {}", fname.maybe_quote(), e);
                             self.any_err = true
                         }
                     }
@@ -92,7 +92,7 @@ impl<'b> io::Read for MultifileReader<'b> {
                             Ok(0) => break,
                             Ok(n) => n,
                             Err(e) => {
-                                eprintln!("{}: I/O: {}", uucore::util_name(), e);
+                                show_error!("I/O: {}", e);
                                 self.any_err = true;
                                 break;
                             }

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::io::BufReader;
 use std::vec::Vec;
 
+use uucore::display::Quotable;
+
 pub enum InputSource<'a> {
     FileName(&'a str),
     Stdin,
@@ -57,7 +59,7 @@ impl<'b> MultifileReader<'b> {
                             // print an error at the time that the file is needed,
                             // then move on the the next file.
                             // This matches the behavior of the original `od`
-                            eprintln!("{}: '{}': {}", uucore::util_name(), fname, e);
+                            eprintln!("{}: {}: {}", uucore::util_name(), fname.maybe_quote(), e);
                             self.any_err = true
                         }
                     }

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -43,6 +43,7 @@ use crate::partialreader::*;
 use crate::peekreader::*;
 use crate::prn_char::format_ascii_dump;
 use clap::{self, crate_version, AppSettings, Arg, ArgMatches};
+use uucore::display::Quotable;
 use uucore::parse_size::ParseSizeError;
 use uucore::InvalidEncodingHandling;
 
@@ -635,7 +636,7 @@ fn format_error_message(error: ParseSizeError, s: &str, option: &str) -> String 
     // GNU's od echos affected flag, -N or --read-bytes (-j or --skip-bytes, etc.), depending user's selection
     // GNU's od does distinguish between "invalid (suffix in) argument"
     match error {
-        ParseSizeError::ParseFailure(_) => format!("invalid --{} argument '{}'", option, s),
-        ParseSizeError::SizeTooBig(_) => format!("--{} argument '{}' too large", option, s),
+        ParseSizeError::ParseFailure(_) => format!("invalid --{} argument {}", option, s.quote()),
+        ParseSizeError::SizeTooBig(_) => format!("--{} argument {} too large", option, s.quote()),
     }
 }

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -1,5 +1,7 @@
 // spell-checker:ignore formatteriteminfo docopt fvox fvoxw vals acdx
 
+use uucore::display::Quotable;
+
 use crate::formatteriteminfo::FormatterItemInfo;
 use crate::prn_char::*;
 use crate::prn_float::*;
@@ -272,8 +274,9 @@ fn parse_type_string(params: &str) -> Result<Vec<ParsedFormatterItemInfo>, Strin
     while let Some(type_char) = ch {
         let type_char = format_type(type_char).ok_or_else(|| {
             format!(
-                "unexpected char '{}' in format specification '{}'",
-                type_char, params
+                "unexpected char '{}' in format specification {}",
+                type_char,
+                params.quote()
             )
         })?;
 
@@ -293,8 +296,9 @@ fn parse_type_string(params: &str) -> Result<Vec<ParsedFormatterItemInfo>, Strin
             if !decimal_size.is_empty() {
                 byte_size = decimal_size.parse().map_err(|_| {
                     format!(
-                        "invalid number '{}' in format specification '{}'",
-                        decimal_size, params
+                        "invalid number {} in format specification {}",
+                        decimal_size.quote(),
+                        params.quote()
                     )
                 })?;
             }
@@ -305,8 +309,9 @@ fn parse_type_string(params: &str) -> Result<Vec<ParsedFormatterItemInfo>, Strin
 
         let ft = od_format_type(type_char, byte_size).ok_or_else(|| {
             format!(
-                "invalid size '{}' in format specification '{}'",
-                byte_size, params
+                "invalid size '{}' in format specification {}",
+                byte_size,
+                params.quote()
             )
         })?;
         formats.push(ParsedFormatterItemInfo::new(ft, show_ascii_dump));

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -15,6 +15,7 @@ extern crate uucore;
 use clap::{crate_version, App, Arg};
 use std::fs;
 use std::io::{ErrorKind, Write};
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 // operating mode
@@ -153,10 +154,10 @@ fn check_basic(path: &[String]) -> bool {
         if component_len > POSIX_NAME_MAX {
             writeln!(
                 &mut std::io::stderr(),
-                "limit {} exceeded by length {} of file name component '{}'",
+                "limit {} exceeded by length {} of file name component {}",
                 POSIX_NAME_MAX,
                 component_len,
-                p
+                p.quote()
             );
             return false;
         }
@@ -175,8 +176,8 @@ fn check_extra(path: &[String]) -> bool {
         if p.starts_with('-') {
             writeln!(
                 &mut std::io::stderr(),
-                "leading hyphen in file name component '{}'",
-                p
+                "leading hyphen in file name component {}",
+                p.quote()
             );
             return false;
         }
@@ -197,10 +198,10 @@ fn check_default(path: &[String]) -> bool {
     if total_len > libc::PATH_MAX as usize {
         writeln!(
             &mut std::io::stderr(),
-            "limit {} exceeded by length {} of file name '{}'",
+            "limit {} exceeded by length {} of file name {}",
             libc::PATH_MAX,
             total_len,
-            joined_path
+            joined_path.quote()
         );
         return false;
     }
@@ -210,10 +211,10 @@ fn check_default(path: &[String]) -> bool {
         if component_len > libc::FILENAME_MAX as usize {
             writeln!(
                 &mut std::io::stderr(),
-                "limit {} exceeded by length {} of file name component '{}'",
+                "limit {} exceeded by length {} of file name component {}",
                 libc::FILENAME_MAX,
                 component_len,
-                p
+                p.quote()
             );
             return false;
         }
@@ -246,9 +247,9 @@ fn check_portable_chars(path_segment: &str) -> bool {
             let invalid = path_segment[i..].chars().next().unwrap();
             writeln!(
                 &mut std::io::stderr(),
-                "nonportable character '{}' in file name component '{}'",
+                "nonportable character '{}' in file name component {}",
                 invalid,
-                path_segment
+                path_segment.quote()
             );
             return false;
         }

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -24,6 +24,8 @@ use std::io::{stdin, stdout, BufRead, BufReader, Lines, Read, Stdout, Write};
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
 
+use uucore::display::Quotable;
+
 type IOError = std::io::Error;
 
 const NAME: &str = "pr";
@@ -517,7 +519,7 @@ fn parse_usize(matches: &Matches, opt: &str) -> Option<Result<usize, PrError>> {
         let i = value_to_parse.0;
         let option = value_to_parse.1;
         i.parse().map_err(|_e| {
-            PrError::EncounteredErrors(format!("invalid {} argument '{}'", option, i))
+            PrError::EncounteredErrors(format!("invalid {} argument {}", option, i.quote()))
         })
     };
     matches
@@ -619,7 +621,7 @@ fn build_options(
         let unparsed_num = i.get(1).unwrap().as_str().trim();
         let x: Vec<_> = unparsed_num.split(':').collect();
         x[0].to_string().parse::<usize>().map_err(|_e| {
-            PrError::EncounteredErrors(format!("invalid {} argument '{}'", "+", unparsed_num))
+            PrError::EncounteredErrors(format!("invalid {} argument {}", "+", unparsed_num.quote()))
         })
     }) {
         Some(res) => res?,
@@ -633,7 +635,11 @@ fn build_options(
         .map(|unparsed_num| {
             let x: Vec<_> = unparsed_num.split(':').collect();
             x[1].to_string().parse::<usize>().map_err(|_e| {
-                PrError::EncounteredErrors(format!("invalid {} argument '{}'", "+", unparsed_num))
+                PrError::EncounteredErrors(format!(
+                    "invalid {} argument {}",
+                    "+",
+                    unparsed_num.quote()
+                ))
             })
         }) {
         Some(res) => Some(res?),
@@ -643,7 +649,10 @@ fn build_options(
     let invalid_pages_map = |i: String| {
         let unparsed_value = matches.opt_str(options::PAGE_RANGE_OPTION).unwrap();
         i.parse::<usize>().map_err(|_e| {
-            PrError::EncounteredErrors(format!("invalid --pages argument '{}'", unparsed_value))
+            PrError::EncounteredErrors(format!(
+                "invalid --pages argument {}",
+                unparsed_value.quote()
+            ))
         })
     };
 
@@ -741,7 +750,7 @@ fn build_options(
     let start_column_option = match re_col.captures(&free_args).map(|i| {
         let unparsed_num = i.get(1).unwrap().as_str().trim();
         unparsed_num.parse::<usize>().map_err(|_e| {
-            PrError::EncounteredErrors(format!("invalid {} argument '{}'", "-", unparsed_num))
+            PrError::EncounteredErrors(format!("invalid {} argument {}", "-", unparsed_num.quote()))
         })
     }) {
         Some(res) => Some(res?),

--- a/src/uu/printf/src/cli.rs
+++ b/src/uu/printf/src/cli.rs
@@ -2,19 +2,10 @@
 
 // spell-checker:ignore (ToDO) bslice
 
-use std::env;
-use std::io::{stderr, stdout, Write};
+use std::io::{stdout, Write};
 
 pub const EXIT_OK: i32 = 0;
 pub const EXIT_ERR: i32 = 1;
-
-pub fn err_msg(msg: &str) {
-    let exe_path = match env::current_exe() {
-        Ok(p) => p.to_string_lossy().into_owned(),
-        _ => String::from(""),
-    };
-    writeln!(&mut stderr(), "{}: {}", exe_path, msg).unwrap();
-}
 
 // by default stdout only flushes
 // to console when a newline is passed.

--- a/src/uu/printf/src/memo.rs
+++ b/src/uu/printf/src/memo.rs
@@ -9,7 +9,7 @@ use itertools::put_back_n;
 use std::iter::Peekable;
 use std::slice::Iter;
 use uucore::display::Quotable;
-use uucore::show_error;
+use uucore::show_warning;
 
 use crate::tokenize::sub::Sub;
 use crate::tokenize::token::{Token, Tokenizer};
@@ -20,8 +20,8 @@ pub struct Memo {
 }
 
 fn warn_excess_args(first_arg: &str) {
-    show_error!(
-        "warning: ignoring excess arguments, starting with {}",
+    show_warning!(
+        "ignoring excess arguments, starting with {}",
         first_arg.quote()
     );
 }

--- a/src/uu/printf/src/memo.rs
+++ b/src/uu/printf/src/memo.rs
@@ -8,8 +8,9 @@
 use itertools::put_back_n;
 use std::iter::Peekable;
 use std::slice::Iter;
+use uucore::display::Quotable;
+use uucore::show_error;
 
-use crate::cli;
 use crate::tokenize::sub::Sub;
 use crate::tokenize::token::{Token, Tokenizer};
 use crate::tokenize::unescaped_text::UnescapedText;
@@ -19,10 +20,10 @@ pub struct Memo {
 }
 
 fn warn_excess_args(first_arg: &str) {
-    cli::err_msg(&format!(
-        "warning: ignoring excess arguments, starting with '{}'",
-        first_arg
-    ));
+    show_error!(
+        "warning: ignoring excess arguments, starting with {}",
+        first_arg.quote()
+    );
 }
 
 impl Memo {

--- a/src/uu/printf/src/tokenize/num_format/formatter.rs
+++ b/src/uu/printf/src/tokenize/num_format/formatter.rs
@@ -3,10 +3,9 @@
 
 use itertools::{put_back_n, PutBackN};
 use std::str::Chars;
+use uucore::{display::Quotable, show_error};
 
 use super::format_field::FormatField;
-
-use crate::cli;
 
 // contains the rough ingredients to final
 // output for a number, organized together
@@ -66,5 +65,5 @@ pub fn get_it_at(offset: usize, str_in: &str) -> PutBackN<Chars> {
 // TODO: put this somewhere better
 pub fn warn_incomplete_conv(pf_arg: &str) {
     // important: keep println here not print
-    cli::err_msg(&format!("{}: value not completely converted", pf_arg))
+    show_error!("{}: value not completely converted", pf_arg.maybe_quote());
 }

--- a/src/uu/printf/src/tokenize/num_format/num_format.rs
+++ b/src/uu/printf/src/tokenize/num_format/num_format.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::vec::Vec;
 
 use uucore::display::Quotable;
-use uucore::show_error;
+use uucore::{show_error, show_warning};
 
 use super::format_field::{FieldType, FormatField};
 use super::formatter::{Base, FormatPrimitive, Formatter, InitialPrefix};
@@ -30,8 +30,8 @@ fn warn_char_constant_ign(remaining_bytes: Vec<u8>) {
         Ok(_) => {}
         Err(e) => {
             if let env::VarError::NotPresent = e {
-                show_error!(
-                    "warning: {:?}: character(s) following character \
+                show_warning!(
+                    "{:?}: character(s) following character \
                      constant have been ignored",
                     &*remaining_bytes
                 );

--- a/src/uu/printf/src/tokenize/num_format/num_format.rs
+++ b/src/uu/printf/src/tokenize/num_format/num_format.rs
@@ -7,6 +7,9 @@
 use std::env;
 use std::vec::Vec;
 
+use uucore::display::Quotable;
+use uucore::show_error;
+
 use super::format_field::{FieldType, FormatField};
 use super::formatter::{Base, FormatPrimitive, Formatter, InitialPrefix};
 use super::formatters::cninetyninehexfloatf::CninetyNineHexFloatf;
@@ -15,11 +18,9 @@ use super::formatters::floatf::Floatf;
 use super::formatters::intf::Intf;
 use super::formatters::scif::Scif;
 
-use crate::cli;
-
 pub fn warn_expected_numeric(pf_arg: &str) {
     // important: keep println here not print
-    cli::err_msg(&format!("{}: expected a numeric value", pf_arg));
+    show_error!("{}: expected a numeric value", pf_arg.maybe_quote());
 }
 
 // when character constant arguments have excess characters
@@ -29,11 +30,11 @@ fn warn_char_constant_ign(remaining_bytes: Vec<u8>) {
         Ok(_) => {}
         Err(e) => {
             if let env::VarError::NotPresent = e {
-                cli::err_msg(&format!(
+                show_error!(
                     "warning: {:?}: character(s) following character \
                      constant have been ignored",
                     &*remaining_bytes
-                ));
+                );
             }
         }
     }

--- a/src/uu/printf/src/tokenize/sub.rs
+++ b/src/uu/printf/src/tokenize/sub.rs
@@ -10,6 +10,7 @@ use std::iter::Peekable;
 use std::process::exit;
 use std::slice::Iter;
 use std::str::Chars;
+use uucore::show_error;
 // use std::collections::HashSet;
 
 use super::num_format::format_field::{FieldType, FormatField};
@@ -19,7 +20,7 @@ use super::unescaped_text::UnescapedText;
 use crate::cli;
 
 fn err_conv(sofar: &str) {
-    cli::err_msg(&format!("%{}: invalid conversion specification", sofar));
+    show_error!("%{}: invalid conversion specification", sofar);
     exit(cli::EXIT_ERR);
 }
 

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -17,6 +17,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::default::Default;
 use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static NAME: &str = "ptx";
@@ -292,7 +293,11 @@ fn create_word_set(config: &Config, filter: &WordFilter, file_map: &FileMap) -> 
 
 fn get_reference(config: &Config, word_ref: &WordRef, line: &str, context_reg: &Regex) -> String {
     if config.auto_ref {
-        format!("{}:{}", word_ref.filename, word_ref.local_line_nr + 1)
+        format!(
+            "{}:{}",
+            word_ref.filename.maybe_quote(),
+            word_ref.local_line_nr + 1
+        )
     } else if config.input_ref {
         let (beg, end) = match context_reg.find(line) {
             Some(x) => (x.start(), x.end()),

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -14,6 +14,7 @@ use clap::{crate_version, App, Arg};
 use std::fs;
 use std::io::{stdout, Write};
 use std::path::{Path, PathBuf};
+use uucore::display::Quotable;
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
 
 const ABOUT: &str = "Print value of a symbolic link or canonical file name.";
@@ -71,10 +72,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     }
 
     if no_newline && files.len() > 1 && !silent {
-        eprintln!(
-            "{}: ignoring --no-newline with multiple arguments",
-            uucore::util_name()
-        );
+        show_error!("ignoring --no-newline with multiple arguments");
         no_newline = false;
     }
 
@@ -85,12 +83,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 Ok(path) => show(&path, no_newline, use_zero),
                 Err(err) => {
                     if verbose {
-                        eprintln!(
-                            "{}: {}: errno {}",
-                            uucore::util_name(),
-                            f,
-                            err.raw_os_error().unwrap()
-                        );
+                        show_error!("{}: errno {}", f.maybe_quote(), err.raw_os_error().unwrap());
                     }
                     return 1;
                 }
@@ -100,12 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 Ok(path) => show(&path, no_newline, use_zero),
                 Err(err) => {
                     if verbose {
-                        eprintln!(
-                            "{}: {}: errno {:?}",
-                            uucore::util_name(),
-                            f,
-                            err.raw_os_error().unwrap()
-                        );
+                        show_error!("{}: errno {}", f.maybe_quote(), err.raw_os_error().unwrap());
                     }
                     return 1;
                 }

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -11,8 +11,14 @@
 extern crate uucore;
 
 use clap::{crate_version, App, Arg};
-use std::path::{Path, PathBuf};
-use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
+use std::{
+    io::{stdout, Write},
+    path::{Path, PathBuf},
+};
+use uucore::{
+    display::{print_verbatim, Quotable},
+    fs::{canonicalize, MissingHandling, ResolveMode},
+};
 
 static ABOUT: &str = "print the resolved path";
 
@@ -58,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
     for path in &paths {
         if let Err(e) = resolve_path(path, strip, zero, logical, can_mode) {
             if !quiet {
-                show_error!("{}: {}", e, path.display());
+                show_error!("{}: {}", path.maybe_quote(), e);
             }
             retcode = 1
         };
@@ -154,8 +160,9 @@ fn resolve_path(
         ResolveMode::Physical
     };
     let abs = canonicalize(p, can_mode, resolve)?;
-    let line_ending = if zero { '\0' } else { '\n' };
+    let line_ending = if zero { b'\0' } else { b'\n' };
 
-    print!("{}{}", abs.display(), line_ending);
+    print_verbatim(&abs)?;
+    stdout().write_all(&[line_ending])?;
     Ok(())
 }

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -10,6 +10,7 @@
 use clap::{crate_version, App, Arg};
 use std::env;
 use std::path::{Path, PathBuf};
+use uucore::display::println_verbatim;
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
 use uucore::InvalidEncodingHandling;
 
@@ -48,7 +49,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         if !absto.as_path().starts_with(absbase.as_path())
             || !absfrom.as_path().starts_with(absbase.as_path())
         {
-            println!("{}", absto.display());
+            println_verbatim(absto).unwrap();
             return 0;
         }
     }
@@ -74,7 +75,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         .map(|x| result.push(x.as_os_str()))
         .last();
 
-    println!("{}", result.display());
+    println_verbatim(result).unwrap();
     0
 }
 

--- a/src/uu/runcon/src/errors.rs
+++ b/src/uu/runcon/src/errors.rs
@@ -3,6 +3,8 @@ use std::fmt::Write;
 use std::io;
 use std::str::Utf8Error;
 
+use uucore::display::Quotable;
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]
@@ -31,7 +33,7 @@ pub(crate) enum Error {
         source: io::Error,
     },
 
-    #[error("{operation} failed on '{}'", .operand1.to_string_lossy())]
+    #[error("{operation} failed on {}", .operand1.quote())]
     Io1 {
         operation: &'static str,
         operand1: OsString,

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -14,6 +14,7 @@ use num_traits::{Num, ToPrimitive};
 use std::cmp;
 use std::io::{stdout, Write};
 use std::str::FromStr;
+use uucore::display::Quotable;
 
 static ABOUT: &str = "Display numbers from FIRST to LAST, in steps of INCREMENT.";
 static OPT_SEPARATOR: &str = "separator";
@@ -115,14 +116,14 @@ impl FromStr for Number {
             }
             Err(_) => match s.parse::<f64>() {
                 Ok(value) if value.is_nan() => Err(format!(
-                    "invalid 'not-a-number' argument: '{}'\nTry '{} --help' for more information.",
-                    s,
+                    "invalid 'not-a-number' argument: {}\nTry '{} --help' for more information.",
+                    s.quote(),
                     uucore::execution_phrase(),
                 )),
                 Ok(value) => Ok(Number::F64(value)),
                 Err(_) => Err(format!(
-                    "invalid floating point argument: '{}'\nTry '{} --help' for more information.",
-                    s,
+                    "invalid floating point argument: {}\nTry '{} --help' for more information.",
+                    s.quote(),
                     uucore::execution_phrase(),
                 )),
             },

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -14,6 +14,7 @@ use clap::{crate_version, App, Arg};
 use rand::Rng;
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 enum Mode {
@@ -76,7 +77,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             Some(count) => match count.parse::<usize>() {
                 Ok(val) => val,
                 Err(_) => {
-                    show_error!("invalid line count: '{}'", count);
+                    show_error!("invalid line count: {}", count.quote());
                     return 1;
                 }
             },
@@ -185,13 +186,13 @@ fn read_input_file(filename: &str) -> Vec<u8> {
     } else {
         match File::open(filename) {
             Ok(f) => Box::new(f) as Box<dyn Read>,
-            Err(e) => crash!(1, "failed to open '{}': {}", filename, e),
+            Err(e) => crash!(1, "failed to open {}: {}", filename.quote(), e),
         }
     });
 
     let mut data = Vec::new();
     if let Err(e) = file.read_to_end(&mut data) {
-        crash!(1, "failed reading '{}': {}", filename, e)
+        crash!(1, "failed reading {}: {}", filename.quote(), e)
     };
 
     data
@@ -235,7 +236,7 @@ fn shuf_bytes(input: &mut Vec<&[u8]>, opts: Options) {
         None => Box::new(stdout()) as Box<dyn Write>,
         Some(s) => match File::create(&s[..]) {
             Ok(f) => Box::new(f) as Box<dyn Write>,
-            Err(e) => crash!(1, "failed to open '{}' for writing: {}", &s[..], e),
+            Err(e) => crash!(1, "failed to open {} for writing: {}", s.quote(), e),
         },
     });
 
@@ -243,7 +244,7 @@ fn shuf_bytes(input: &mut Vec<&[u8]>, opts: Options) {
         Some(r) => WrappedRng::RngFile(rand::rngs::adapter::ReadRng::new(
             match File::open(&r[..]) {
                 Ok(f) => f,
-                Err(e) => crash!(1, "failed to open random source '{}': {}", &r[..], e),
+                Err(e) => crash!(1, "failed to open random source {}: {}", r.quote(), e),
             },
         )),
         None => WrappedRng::RngDefault(rand::thread_rng()),
@@ -288,14 +289,14 @@ fn shuf_bytes(input: &mut Vec<&[u8]>, opts: Options) {
 fn parse_range(input_range: &str) -> Result<(usize, usize), String> {
     let split: Vec<&str> = input_range.split('-').collect();
     if split.len() != 2 {
-        Err(format!("invalid input range: '{}'", input_range))
+        Err(format!("invalid input range: {}", input_range.quote()))
     } else {
         let begin = split[0]
             .parse::<usize>()
-            .map_err(|_| format!("invalid input range: '{}'", split[0]))?;
+            .map_err(|_| format!("invalid input range: {}", split[0].quote()))?;
         let end = split[1]
             .parse::<usize>()
-            .map_err(|_| format!("invalid input range: '{}'", split[1]))?;
+            .map_err(|_| format!("invalid input range: {}", split[1].quote()))?;
         Ok((begin, end + 1))
     }
 }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -767,19 +767,19 @@ impl KeyPosition {
 
         let field = field_and_char
             .next()
-            .ok_or_else(|| format!("invalid key `{}`", key))?;
+            .ok_or_else(|| format!("invalid key {}", key.quote()))?;
         let char = field_and_char.next();
 
         let field = field
             .parse()
-            .map_err(|e| format!("failed to parse field index `{}`: {}", field, e))?;
+            .map_err(|e| format!("failed to parse field index {}: {}", field.quote(), e))?;
         if field == 0 {
             return Err("field index can not be 0".to_string());
         }
 
         let char = char.map_or(Ok(default_char_index), |char| {
             char.parse()
-                .map_err(|e| format!("failed to parse character index `{}`: {}", char, e))
+                .map_err(|e| format!("failed to parse character index {}: {}", char.quote(), e))
         })?;
 
         Ok(Self {
@@ -890,7 +890,7 @@ impl FieldSelector {
                     'R' => key_settings.set_sort_mode(SortMode::Random)?,
                     'r' => key_settings.reverse = true,
                     'V' => key_settings.set_sort_mode(SortMode::Version)?,
-                    c => return Err(format!("invalid option: `{}`", c)),
+                    c => return Err(format!("invalid option: '{}'", c)),
                 }
             }
             Ok(ignore_blanks)

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -19,6 +19,7 @@ use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 use std::{char, fs::remove_file};
+use uucore::display::Quotable;
 use uucore::parse_size::parse_size;
 
 static OPT_BYTES: &str = "bytes";
@@ -238,7 +239,11 @@ impl LineSplitter {
     fn new(settings: &Settings) -> LineSplitter {
         LineSplitter {
             lines_per_split: settings.strategy_param.parse().unwrap_or_else(|_| {
-                crash!(1, "invalid number of lines: '{}'", settings.strategy_param)
+                crash!(
+                    1,
+                    "invalid number of lines: {}",
+                    settings.strategy_param.quote()
+                )
             }),
         }
     }
@@ -373,8 +378,8 @@ fn split(settings: &Settings) -> i32 {
         let r = File::open(Path::new(&settings.input)).unwrap_or_else(|_| {
             crash!(
                 1,
-                "cannot open '{}' for reading: No such file or directory",
-                settings.input
+                "cannot open {} for reading: No such file or directory",
+                settings.input.quote()
             )
         });
         Box::new(r) as Box<dyn Read>
@@ -383,7 +388,7 @@ fn split(settings: &Settings) -> i32 {
     let mut splitter: Box<dyn Splitter> = match settings.strategy.as_str() {
         s if s == OPT_LINES => Box::new(LineSplitter::new(settings)),
         s if (s == OPT_BYTES || s == OPT_LINE_BYTES) => Box::new(ByteSplitter::new(settings)),
-        a => crash!(1, "strategy {} not supported", a),
+        a => crash!(1, "strategy {} not supported", a.quote()),
     };
 
     let mut fileno = 0;

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -7,6 +7,7 @@
 
 #[macro_use]
 extern crate uucore;
+use uucore::display::Quotable;
 use uucore::entries;
 use uucore::fs::display_permissions;
 use uucore::fsext::{
@@ -24,7 +25,7 @@ use std::{cmp, fs, iter};
 macro_rules! check_bound {
     ($str: ident, $bound:expr, $beg: expr, $end: expr) => {
         if $end >= $bound {
-            return Err(format!("'{}': invalid directive", &$str[$beg..$end]));
+            return Err(format!("{}: invalid directive", $str[$beg..$end].quote()));
         }
     };
 }
@@ -652,11 +653,7 @@ impl Stater {
                                                     return 1;
                                                 }
                                             };
-                                            arg = format!(
-                                                "`{}' -> `{}'",
-                                                file,
-                                                dst.to_string_lossy()
-                                            );
+                                            arg = format!("{} -> {}", file.quote(), dst.quote());
                                         } else {
                                             arg = file.to_string();
                                         }
@@ -750,7 +747,7 @@ impl Stater {
                     }
                 }
                 Err(e) => {
-                    show_error!("cannot stat '{}': {}", file, e);
+                    show_error!("cannot stat {}: {}", file.quote(), e);
                     return 1;
                 }
             }
@@ -843,7 +840,11 @@ impl Stater {
                     }
                 }
                 Err(e) => {
-                    show_error!("cannot read file system information for '{}': {}", file, e);
+                    show_error!(
+                        "cannot read file system information for {}: {}",
+                        file.quote(),
+                        e
+                    );
                     return 1;
                 }
             }

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -14,6 +14,7 @@ use clap::{crate_version, App, Arg};
 use std::fs::File;
 use std::io::{stdin, Read, Result};
 use std::path::Path;
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static NAME: &str = "sum";
@@ -118,7 +119,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         let reader = match open(file) {
             Ok(f) => f,
             Err(error) => {
-                show_error!("'{}' {}", file, error);
+                show_error!("{}: {}", file.maybe_quote(), error);
                 exit_code = 2;
                 continue;
             }

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -14,6 +14,7 @@ extern crate uucore;
 
 use clap::{crate_version, App, Arg};
 use std::path::Path;
+use uucore::display::Quotable;
 
 static EXIT_ERR: i32 = 1;
 
@@ -175,7 +176,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     for f in &files {
         if !Path::new(&f).exists() {
-            crash!(EXIT_ERR, "cannot stat '{}': No such file or directory", f);
+            crash!(
+                EXIT_ERR,
+                "cannot stat {}: No such file or directory",
+                f.quote()
+            );
         }
     }
 

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -14,6 +14,7 @@ use clap::{crate_version, App, Arg};
 use memchr::memmem;
 use std::io::{stdin, stdout, BufReader, Read, Write};
 use std::{fs::File, path::Path};
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static NAME: &str = "tac";
@@ -141,11 +142,11 @@ fn tac(filenames: Vec<String>, before: bool, _: bool, separator: &str) -> i32 {
             let path = Path::new(filename);
             if path.is_dir() || path.metadata().is_err() {
                 if path.is_dir() {
-                    show_error!("{}: read error: Invalid argument", filename);
+                    show_error!("{}: read error: Invalid argument", filename.maybe_quote());
                 } else {
                     show_error!(
-                        "failed to open '{}' for reading: No such file or directory",
-                        filename
+                        "failed to open {} for reading: No such file or directory",
+                        filename.quote()
                     );
                 }
                 exit_code = 1;
@@ -154,7 +155,7 @@ fn tac(filenames: Vec<String>, before: bool, _: bool, separator: &str) -> i32 {
             match File::open(path) {
                 Ok(f) => Box::new(f) as Box<dyn Read>,
                 Err(e) => {
-                    show_error!("failed to open '{}' for reading: {}", filename, e);
+                    show_error!("failed to open {} for reading: {}", filename.quote(), e);
                     exit_code = 1;
                     continue;
                 }
@@ -163,7 +164,7 @@ fn tac(filenames: Vec<String>, before: bool, _: bool, separator: &str) -> i32 {
 
         let mut data = Vec::new();
         if let Err(e) = file.read_to_end(&mut data) {
-            show_error!("failed to read '{}': {}", filename, e);
+            show_error!("failed to read {}: {}", filename.quote(), e);
             exit_code = 1;
             continue;
         };

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -12,7 +12,8 @@ use clap::{crate_version, App, Arg};
 use retain_mut::RetainMut;
 use std::fs::OpenOptions;
 use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+use uucore::display::Quotable;
 
 #[cfg(unix)]
 use uucore::libc;
@@ -167,7 +168,7 @@ impl Write for MultiWriter {
             let result = writer.write_all(buf);
             match result {
                 Err(f) => {
-                    show_error!("{}: {}", writer.name, f.to_string());
+                    show_error!("{}: {}", writer.name.maybe_quote(), f);
                     false
                 }
                 _ => true,
@@ -181,7 +182,7 @@ impl Write for MultiWriter {
             let result = writer.flush();
             match result {
                 Err(f) => {
-                    show_error!("{}: {}", writer.name, f.to_string());
+                    show_error!("{}: {}", writer.name.maybe_quote(), f);
                     false
                 }
                 _ => true,
@@ -214,7 +215,7 @@ impl Read for NamedReader {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self.inner.read(buf) {
             Err(f) => {
-                show_error!("{}: {}", Path::new("stdin").display(), f.to_string());
+                show_error!("stdin: {}", f);
                 Err(f)
             }
             okay => okay,

--- a/src/uu/test/src/parser.rs
+++ b/src/uu/test/src/parser.rs
@@ -11,6 +11,7 @@ use std::ffi::OsString;
 use std::iter::Peekable;
 
 use uucore::display::Quotable;
+use uucore::show_error;
 
 /// Represents one of the binary comparison operators for strings, integers, or files
 #[derive(Debug, PartialEq)]
@@ -207,7 +208,7 @@ impl Parser {
 
             // case 2: error if end of stream is `( <any_token>`
             [symbol] => {
-                eprintln!("test: missing argument after ‘{:?}’", symbol);
+                show_error!("missing argument after ‘{:?}’", symbol);
                 std::process::exit(2);
             }
 

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -13,7 +13,7 @@ mod parser;
 use clap::{crate_version, App, AppSettings};
 use parser::{parse, Operator, Symbol, UnaryOperator};
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use uucore::{display::Quotable, show_error};
 
 const USAGE: &str = "test EXPRESSION
 or:  test
@@ -93,10 +93,7 @@ pub fn uu_app() -> App<'static, 'static> {
 
 pub fn uumain(mut args: impl uucore::Args) -> i32 {
     let program = args.next().unwrap_or_else(|| OsString::from("test"));
-    let binary_name = Path::new(&program)
-        .file_name()
-        .unwrap_or_else(|| OsStr::new("test"))
-        .to_string_lossy();
+    let binary_name = uucore::util_name();
     let mut args: Vec<_> = args.collect();
 
     if binary_name.ends_with('[') {
@@ -116,8 +113,8 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
         }
         // If invoked via name '[', matching ']' must be in the last arg
         let last = args.pop();
-        if last != Some(OsString::from("]")) {
-            eprintln!("[: missing ']'");
+        if last.as_deref() != Some(OsStr::new("]")) {
+            show_error!("missing ']'");
             return 2;
         }
     }
@@ -133,7 +130,7 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
             }
         }
         Err(e) => {
-            eprintln!("test: {}", e);
+            show_error!("{}", e);
             2
         }
     }
@@ -190,11 +187,11 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
             })
         }
         Some(Symbol::UnaryOp(UnaryOperator::FiletestOp(op))) => {
-            let op = op.to_string_lossy();
+            let op = op.to_str().unwrap();
 
             let f = pop_literal!();
 
-            Ok(match op.as_ref() {
+            Ok(match op {
                 "-b" => path(&f, PathCondition::BlockSpecial),
                 "-c" => path(&f, PathCondition::CharacterSpecial),
                 "-d" => path(&f, PathCondition::Directory),
@@ -231,31 +228,33 @@ fn eval(stack: &mut Vec<Symbol>) -> Result<bool, String> {
 }
 
 fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> Result<bool, String> {
-    let format_err = |value| format!("invalid integer '{}'", value);
+    let format_err = |value: &OsStr| format!("invalid integer {}", value.quote());
 
-    let a = a.to_string_lossy();
-    let a: i64 = a.parse().map_err(|_| format_err(a))?;
+    let a: i64 = a
+        .to_str()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| format_err(a))?;
 
-    let b = b.to_string_lossy();
-    let b: i64 = b.parse().map_err(|_| format_err(b))?;
+    let b: i64 = b
+        .to_str()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| format_err(b))?;
 
-    let operator = op.to_string_lossy();
-    Ok(match operator.as_ref() {
-        "-eq" => a == b,
-        "-ne" => a != b,
-        "-gt" => a > b,
-        "-ge" => a >= b,
-        "-lt" => a < b,
-        "-le" => a <= b,
-        _ => return Err(format!("unknown operator '{}'", operator)),
+    Ok(match op.to_str() {
+        Some("-eq") => a == b,
+        Some("-ne") => a != b,
+        Some("-gt") => a > b,
+        Some("-ge") => a >= b,
+        Some("-lt") => a < b,
+        Some("-le") => a <= b,
+        _ => return Err(format!("unknown operator {}", op.quote())),
     })
 }
 
 fn isatty(fd: &OsStr) -> Result<bool, String> {
-    let fd = fd.to_string_lossy();
-
-    fd.parse()
-        .map_err(|_| format!("invalid integer '{}'", fd))
+    fd.to_str()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| format!("invalid integer {}", fd.quote()))
         .map(|i| {
             #[cfg(not(target_os = "redox"))]
             unsafe {

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -16,6 +16,7 @@ use clap::{crate_version, App, AppSettings, Arg};
 use std::io::ErrorKind;
 use std::process::{Command, Stdio};
 use std::time::Duration;
+use uucore::display::Quotable;
 use uucore::process::ChildExt;
 use uucore::signals::{signal_by_name_or_value, signal_name_by_value};
 use uucore::InvalidEncodingHandling;
@@ -61,7 +62,7 @@ impl Config {
                 let signal_result = signal_by_name_or_value(signal_);
                 match signal_result {
                     None => {
-                        unreachable!("invalid signal '{}'", signal_);
+                        unreachable!("invalid signal {}", signal_.quote());
                     }
                     Some(signal_value) => signal_value,
                 }
@@ -216,9 +217,9 @@ fn timeout(
         Ok(None) => {
             if verbose {
                 show_error!(
-                    "sending signal {} to command '{}'",
+                    "sending signal {} to command {}",
                     signal_name_by_value(signal).unwrap(),
-                    cmd[0]
+                    cmd[0].quote()
                 );
             }
             crash_if_err!(ERR_EXIT_STATUS, process.send_signal(signal));
@@ -233,7 +234,7 @@ fn timeout(
                     }
                     Ok(None) => {
                         if verbose {
-                            show_error!("sending signal KILL to command '{}'", cmd[0]);
+                            show_error!("sending signal KILL to command {}", cmd[0].quote());
                         }
                         crash_if_err!(
                             ERR_EXIT_STATUS,

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -17,6 +17,7 @@ use clap::{crate_version, App, Arg, ArgGroup};
 use filetime::*;
 use std::fs::{self, File};
 use std::path::Path;
+use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 
 static ABOUT: &str = "Update the access and modification times of each FILE to the current time.";
@@ -82,7 +83,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
 
             if let Err(e) = File::create(path) {
-                show!(e.map_err_context(|| format!("cannot touch '{}'", path.display())));
+                show!(e.map_err_context(|| format!("cannot touch {}", path.quote())));
                 continue;
             };
 
@@ -122,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         } else {
             filetime::set_file_times(path, atime, mtime)
         }
-        .map_err_context(|| format!("setting times of '{}'", path.display()))?;
+        .map_err_context(|| format!("setting times of {}", path.quote()))?;
     }
 
     Ok(())
@@ -209,7 +210,7 @@ fn stat(path: &Path, follow: bool) -> UResult<(FileTime, FileTime)> {
     } else {
         fs::metadata(path)
     }
-    .map_err_context(|| format!("failed to get attributes of '{}'", path.display()))?;
+    .map_err_context(|| format!("failed to get attributes of {}", path.quote()))?;
 
     Ok((
         FileTime::from_last_access_time(&metadata),
@@ -249,11 +250,16 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
         10 => ("%y%m%d%H%M", s.to_owned()),
         11 => ("%Y%m%d%H%M.%S", format!("{}{}", now.tm_year + 1900, s)),
         8 => ("%Y%m%d%H%M", format!("{}{}", now.tm_year + 1900, s)),
-        _ => return Err(USimpleError::new(1, format!("invalid date format '{}'", s))),
+        _ => {
+            return Err(USimpleError::new(
+                1,
+                format!("invalid date format {}", s.quote()),
+            ))
+        }
     };
 
     let tm = time::strptime(&ts, format)
-        .map_err(|_| USimpleError::new(1, format!("invalid date format '{}'", s)))?;
+        .map_err(|_| USimpleError::new(1, format!("invalid date format {}", s.quote())))?;
 
     let mut local = to_local(tm);
     local.tm_isdst = -1;
@@ -269,7 +275,10 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
     };
     let tm2 = time::at(ts);
     if tm.tm_hour != tm2.tm_hour {
-        return Err(USimpleError::new(1, format!("invalid date format '{}'", s)));
+        return Err(USimpleError::new(
+            1,
+            format!("invalid date format {}", s.quote()),
+        ));
     }
 
     Ok(ft)

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -21,7 +21,7 @@ use fnv::FnvHashMap;
 use std::io::{stdin, stdout, BufRead, BufWriter, Write};
 
 use crate::expand::ExpandSet;
-use uucore::InvalidEncodingHandling;
+use uucore::{display::Quotable, InvalidEncodingHandling};
 
 static ABOUT: &str = "translate or delete characters";
 
@@ -271,8 +271,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
 
     if !(delete_flag || squeeze_flag) && sets.len() < 2 {
         show_error!(
-            "missing operand after '{}'\nTry '{} --help' for more information.",
-            sets[0],
+            "missing operand after {}\nTry '{} --help' for more information.",
+            sets[0].quote(),
             uucore::execution_phrase()
         );
         return 1;

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -15,6 +15,7 @@ use std::convert::TryFrom;
 use std::fs::{metadata, OpenOptions};
 use std::io::ErrorKind;
 use std::path::Path;
+use uucore::display::Quotable;
 use uucore::parse_size::{parse_size, ParseSizeError};
 
 #[derive(Debug, Eq, PartialEq)]
@@ -120,8 +121,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                     let reference = matches.value_of(options::REFERENCE).map(String::from);
                     crash!(
                         1,
-                        "cannot stat '{}': No such file or directory",
-                        reference.unwrap_or_else(|| "".to_string())
+                        "cannot stat {}: No such file or directory",
+                        reference.as_deref().unwrap_or("").quote()
                     ); // TODO: fix '--no-create' see test_reference and test_truncate_bytes_size
                 }
                 _ => crash!(1, "{}", e.to_string()),

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static SUMMARY: &str = "Topological sort the strings in FILE.
@@ -45,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         file_buf = match File::open(Path::new(&input)) {
             Ok(a) => a,
             _ => {
-                show_error!("{}: No such file or directory", input);
+                show_error!("{}: No such file or directory", input.maybe_quote());
                 return 1;
             }
         };
@@ -68,7 +69,11 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
                 for ab in tokens.chunks(2) {
                     match ab.len() {
                         2 => g.add_edge(&ab[0], &ab[1]),
-                        _ => crash!(1, "{}: input contains an odd number of tokens", input),
+                        _ => crash!(
+                            1,
+                            "{}: input contains an odd number of tokens",
+                            input.maybe_quote()
+                        ),
                     }
                 }
             }

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -16,6 +16,7 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Stdout, Write};
 use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static NAME: &str = "unexpand";
@@ -141,9 +142,9 @@ fn open(path: String) -> BufReader<Box<dyn Read + 'static>> {
     if path == "-" {
         BufReader::new(Box::new(stdin()) as Box<dyn Read>)
     } else {
-        file_buf = match File::open(&path[..]) {
+        file_buf = match File::open(&path) {
             Ok(a) => a,
-            Err(e) => crash!(1, "{}: {}", &path[..], e),
+            Err(e) => crash!(1, "{}: {}", path.maybe_quote(), e),
         };
         BufReader::new(Box::new(file_buf) as Box<dyn Read>)
     }

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -14,6 +14,7 @@ use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Result, Write}
 use std::path::Path;
 use std::str::FromStr;
 use strum_macros::{AsRefStr, EnumString};
+use uucore::display::Quotable;
 
 static ABOUT: &str = "Report or omit repeated lines.";
 pub mod options {
@@ -217,7 +218,14 @@ fn get_line_string(io_line: Result<Vec<u8>>) -> String {
 fn opt_parsed<T: FromStr>(opt_name: &str, matches: &ArgMatches) -> Option<T> {
     matches.value_of(opt_name).map(|arg_str| {
         let opt_val: Option<T> = arg_str.parse().ok();
-        opt_val.unwrap_or_else(|| crash!(1, "Invalid argument for {}: {}", opt_name, arg_str))
+        opt_val.unwrap_or_else(|| {
+            crash!(
+                1,
+                "Invalid argument for {}: {}",
+                opt_name,
+                arg_str.maybe_quote()
+            )
+        })
     })
 }
 

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -17,6 +17,7 @@ use libc::{lstat, stat, unlink};
 use libc::{S_IFLNK, S_IFMT, S_IFREG};
 use std::ffi::CString;
 use std::io::{Error, ErrorKind};
+use uucore::display::Quotable;
 use uucore::InvalidEncodingHandling;
 
 static ABOUT: &str = "Unlink the file at [FILE].";
@@ -63,7 +64,12 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         let result = unsafe { lstat(c_string.as_ptr(), &mut buf as *mut stat) };
 
         if result < 0 {
-            crash!(1, "Cannot stat '{}': {}", paths[0], Error::last_os_error());
+            crash!(
+                1,
+                "Cannot stat {}: {}",
+                paths[0].quote(),
+                Error::last_os_error()
+            );
         }
 
         buf.st_mode & S_IFMT

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -30,6 +30,7 @@ data-encoding = { version="2.1", optional=true }
 data-encoding-macro = { version="0.1.12", optional=true }
 z85 = { version="3.0.3", optional=true }
 libc = { version="0.2.15", optional=true }
+once_cell = "1.8.0"
 
 [dev-dependencies]
 clap = "2.33.3"

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -5,6 +5,7 @@
 
 //! Common functions to manage permissions
 
+use crate::display::Quotable;
 use crate::error::strip_errno;
 use crate::error::UResult;
 use crate::error::USimpleError;
@@ -80,29 +81,29 @@ pub fn wrap_chown<P: AsRef<Path>>(
             VerbosityLevel::Silent => (),
             level => {
                 out = format!(
-                    "changing {} of '{}': {}",
+                    "changing {} of {}: {}",
                     if verbosity.groups_only {
                         "group"
                     } else {
                         "ownership"
                     },
-                    path.display(),
+                    path.quote(),
                     e
                 );
                 if level == VerbosityLevel::Verbose {
                     out = if verbosity.groups_only {
                         format!(
-                            "{}\nfailed to change group of '{}' from {} to {}",
+                            "{}\nfailed to change group of {} from {} to {}",
                             out,
-                            path.display(),
+                            path.quote(),
                             entries::gid2grp(meta.gid()).unwrap(),
                             entries::gid2grp(dest_gid).unwrap()
                         )
                     } else {
                         format!(
-                            "{}\nfailed to change ownership of '{}' from {}:{} to {}:{}",
+                            "{}\nfailed to change ownership of {} from {}:{} to {}:{}",
                             out,
-                            path.display(),
+                            path.quote(),
                             entries::uid2usr(meta.uid()).unwrap(),
                             entries::gid2grp(meta.gid()).unwrap(),
                             entries::uid2usr(dest_uid).unwrap(),
@@ -120,15 +121,15 @@ pub fn wrap_chown<P: AsRef<Path>>(
                 VerbosityLevel::Changes | VerbosityLevel::Verbose => {
                     out = if verbosity.groups_only {
                         format!(
-                            "changed group of '{}' from {} to {}",
-                            path.display(),
+                            "changed group of {} from {} to {}",
+                            path.quote(),
                             entries::gid2grp(meta.gid()).unwrap(),
                             entries::gid2grp(dest_gid).unwrap()
                         )
                     } else {
                         format!(
-                            "changed ownership of '{}' from {}:{} to {}:{}",
-                            path.display(),
+                            "changed ownership of {} from {}:{} to {}:{}",
+                            path.quote(),
                             entries::uid2usr(meta.uid()).unwrap(),
                             entries::gid2grp(meta.gid()).unwrap(),
                             entries::uid2usr(dest_uid).unwrap(),
@@ -141,14 +142,14 @@ pub fn wrap_chown<P: AsRef<Path>>(
         } else if verbosity.level == VerbosityLevel::Verbose {
             out = if verbosity.groups_only {
                 format!(
-                    "group of '{}' retained as {}",
-                    path.display(),
+                    "group of {} retained as {}",
+                    path.quote(),
                     entries::gid2grp(dest_gid).unwrap_or_default()
                 )
             } else {
                 format!(
-                    "ownership of '{}' retained as {}:{}",
-                    path.display(),
+                    "ownership of {} retained as {}:{}",
+                    path.quote(),
                     entries::uid2usr(dest_uid).unwrap(),
                     entries::gid2grp(dest_gid).unwrap()
                 )
@@ -358,9 +359,9 @@ impl ChownExecutor {
                 match self.verbosity.level {
                     VerbosityLevel::Silent => (),
                     _ => show_error!(
-                        "cannot {} '{}': {}",
+                        "cannot {} {}: {}",
                         if follow { "dereference" } else { "access" },
-                        path.display(),
+                        path.quote(),
                         strip_errno(&e)
                     ),
                 }

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -72,6 +72,8 @@ use std::sync::atomic::Ordering;
 
 use once_cell::sync::Lazy;
 
+use crate::display::Quotable;
+
 pub fn get_utility_is_second_arg() -> bool {
     crate::macros::UTILITY_IS_SECOND_ARG.load(Ordering::SeqCst)
 }
@@ -171,14 +173,15 @@ pub trait Args: Iterator<Item = OsString> + Sized {
                 Ok(string) => Ok(string),
                 Err(s_ret) => {
                     full_conversion = false;
-                    let lossy_conversion = s_ret.to_string_lossy();
                     eprintln!(
-                        "Input with broken encoding occurred! (s = '{}') ",
-                        &lossy_conversion
+                        "Input with broken encoding occurred! (s = {}) ",
+                        s_ret.quote()
                     );
                     match handling {
                         InvalidEncodingHandling::Ignore => Err(String::new()),
-                        InvalidEncodingHandling::ConvertLossy => Err(lossy_conversion.to_string()),
+                        InvalidEncodingHandling::ConvertLossy => {
+                            Err(s_ret.to_string_lossy().into_owned())
+                        }
                         InvalidEncodingHandling::Panic => {
                             panic!("Broken encoding found but caller cannot handle it")
                         }

--- a/src/uucore/src/lib/mods/backup_control.rs
+++ b/src/uucore/src/lib/mods/backup_control.rs
@@ -78,7 +78,10 @@
 
 // spell-checker:ignore backupopt
 
-use crate::error::{UError, UResult};
+use crate::{
+    display::Quotable,
+    error::{UError, UResult},
+};
 use clap::ArgMatches;
 use std::{
     env,
@@ -167,18 +170,22 @@ impl Display for BackupError {
         match self {
             BE::InvalidArgument(arg, origin) => write!(
                 f,
-                "invalid argument '{}' for '{}'\n{}",
-                arg, origin, VALID_ARGS_HELP
+                "invalid argument {} for '{}'\n{}",
+                arg.quote(),
+                origin,
+                VALID_ARGS_HELP
             ),
             BE::AmbiguousArgument(arg, origin) => write!(
                 f,
-                "ambiguous argument '{}' for '{}'\n{}",
-                arg, origin, VALID_ARGS_HELP
+                "ambiguous argument {} for '{}'\n{}",
+                arg.quote(),
+                origin,
+                VALID_ARGS_HELP
             ),
             BE::BackupImpossible() => write!(f, "cannot create backup"),
             // Placeholder for later
             // BE::BackupFailed(from, to, e) => Display::fmt(
-            //     &uio_error!(e, "failed to backup '{}' to '{}'", from.display(), to.display()),
+            //     &uio_error!(e, "failed to backup {} to {}", from.quote(), to.quote()),
             //     f
             // ),
         }

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -99,7 +99,10 @@ pub type UResult<T> = Result<T, Box<dyn UError>>;
 /// An example of a custom error from `ls`:
 ///
 /// ```
-/// use uucore::error::{UError, UResult};
+/// use uucore::{
+///     display::Quotable,
+///     error::{UError, UResult}
+/// };
 /// use std::{
 ///     error::Error,
 ///     fmt::{Display, Debug},
@@ -126,8 +129,8 @@ pub type UResult<T> = Result<T, Box<dyn UError>>;
 /// impl Display for LsError {
 ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 ///         match self {
-///             LsError::InvalidLineWidth(s) => write!(f, "invalid line width: '{}'", s),
-///             LsError::NoMetadata(p) => write!(f, "could not open file: '{}'", p.display()),
+///             LsError::InvalidLineWidth(s) => write!(f, "invalid line width: {}", s.quote()),
+///             LsError::NoMetadata(p) => write!(f, "could not open file: {}", p.quote()),
 ///         }
 ///     }
 /// }
@@ -158,7 +161,10 @@ pub trait UError: Error + Send {
     /// # Example
     ///
     /// ```
-    /// use uucore::error::{UError};
+    /// use uucore::{
+    ///     display::Quotable,
+    ///     error::UError
+    /// };
     /// use std::{
     ///     error::Error,
     ///     fmt::{Display, Debug},
@@ -189,8 +195,8 @@ pub trait UError: Error + Send {
     ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     ///         use MyError as ME;
     ///         match self {
-    ///             ME::Foo(s) => write!(f, "Unknown Foo: '{}'", s),
-    ///             ME::Bar(p) => write!(f, "Couldn't find Bar: '{}'", p.display()),
+    ///             ME::Foo(s) => write!(f, "Unknown Foo: {}", s.quote()),
+    ///             ME::Bar(p) => write!(f, "Couldn't find Bar: {}", p.quote()),
     ///             ME::Bing() => write!(f, "Exterminate!"),
     ///         }
     ///     }
@@ -209,7 +215,10 @@ pub trait UError: Error + Send {
     /// # Example
     ///
     /// ```
-    /// use uucore::error::{UError};
+    /// use uucore::{
+    ///     display::Quotable,
+    ///     error::UError
+    /// };
     /// use std::{
     ///     error::Error,
     ///     fmt::{Display, Debug},
@@ -240,8 +249,8 @@ pub trait UError: Error + Send {
     ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     ///         use MyError as ME;
     ///         match self {
-    ///             ME::Foo(s) => write!(f, "Unknown Foo: '{}'", s),
-    ///             ME::Bar(p) => write!(f, "Couldn't find Bar: '{}'", p.display()),
+    ///             ME::Foo(s) => write!(f, "Unknown Foo: {}", s.quote()),
+    ///             ME::Bar(p) => write!(f, "Couldn't find Bar: {}", p.quote()),
     ///             ME::Bing() => write!(f, "Exterminate!"),
     ///         }
     ///     }
@@ -342,7 +351,10 @@ impl UError for UUsageError {
 /// There are two ways to construct this type: with [`UIoError::new`] or by calling the
 /// [`FromIo::map_err_context`] method on a [`std::io::Result`] or [`std::io::Error`].
 /// ```
-/// use uucore::error::{FromIo, UResult, UIoError, UError};
+/// use uucore::{
+///     display::Quotable,
+///     error::{FromIo, UResult, UIoError, UError}
+/// };
 /// use std::fs::File;
 /// use std::path::Path;
 /// let path = Path::new("test.txt");
@@ -350,12 +362,12 @@ impl UError for UUsageError {
 /// // Manual construction
 /// let e: Box<dyn UError> = UIoError::new(
 ///     std::io::ErrorKind::NotFound,
-///     format!("cannot access '{}'", path.display())
+///     format!("cannot access {}", path.quote())
 /// );
 /// let res: UResult<()> = Err(e.into());
 ///
 /// // Converting from an `std::io::Error`.
-/// let res: UResult<File> = File::open(path).map_err_context(|| format!("cannot access '{}'", path.display()));
+/// let res: UResult<File> = File::open(path).map_err_context(|| format!("cannot access {}", path.quote()));
 /// ```
 #[derive(Debug)]
 pub struct UIoError {

--- a/src/uucore/src/lib/mods/ranges.rs
+++ b/src/uucore/src/lib/mods/ranges.rs
@@ -9,6 +9,8 @@
 
 use std::str::FromStr;
 
+use crate::display::Quotable;
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Range {
     pub low: usize,
@@ -86,7 +88,7 @@ impl Range {
 
         for item in list.split(',') {
             let range_item = FromStr::from_str(item)
-                .map_err(|e| format!("range '{}' was invalid: {}", item, e))?;
+                .map_err(|e| format!("range {} was invalid: {}", item.quote(), e))?;
             ranges.push(range_item);
         }
 

--- a/src/uucore/src/lib/parser/parse_time.rs
+++ b/src/uucore/src/lib/parser/parse_time.rs
@@ -9,6 +9,8 @@
 
 use std::time::Duration;
 
+use crate::display::Quotable;
+
 pub fn from_str(string: &str) -> Result<Duration, String> {
     let len = string.len();
     if len == 0 {
@@ -25,13 +27,13 @@ pub fn from_str(string: &str) -> Result<Duration, String> {
             if string == "inf" || string == "infinity" {
                 ("inf", 1)
             } else {
-                return Err(format!("invalid time interval '{}'", string));
+                return Err(format!("invalid time interval {}", string.quote()));
             }
         }
     };
     let num = numstr
         .parse::<f64>()
-        .map_err(|e| format!("invalid time interval '{}': {}", string, e))?;
+        .map_err(|e| format!("invalid time interval {}: {}", string.quote(), e))?;
 
     const NANOS_PER_SEC: u32 = 1_000_000_000;
     let whole_secs = num.trunc();

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -23,7 +23,7 @@ fn test_enter_chroot_fails() {
 
     assert!(result
         .stderr_str()
-        .starts_with("chroot: cannot chroot to jail: Operation not permitted (os error 1)"));
+        .starts_with("chroot: cannot chroot to 'jail': Operation not permitted (os error 1)"));
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn test_no_such_directory() {
 
     ucmd.arg("a")
         .fails()
-        .stderr_is("chroot: cannot change root directory to `a`: no such directory");
+        .stderr_is("chroot: cannot change root directory to 'a': no such directory");
 }
 
 #[test]

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -68,7 +68,7 @@ fn test_invalid_file() {
         .arg(folder_name)
         .fails()
         .no_stdout()
-        .stderr_contains("cksum: 'asdf' No such file or directory");
+        .stderr_contains("cksum: asdf: No such file or directory");
 
     // Then check when the file is of an invalid type
     at.mkdir(folder_name);
@@ -76,7 +76,7 @@ fn test_invalid_file() {
         .arg(folder_name)
         .fails()
         .no_stdout()
-        .stderr_contains("cksum: 'asdf' Is a directory");
+        .stderr_contains("cksum: asdf: Is a directory");
 }
 
 // Make sure crc is correct for files larger than 32 bytes

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -432,10 +432,7 @@ fn test_ls_long_symlink_color() {
     let mut result_lines = result
         .stdout_str()
         .lines()
-        .filter_map(|line| match line.starts_with("lrwx") {
-            true => Some(line),
-            false => None,
-        })
+        .filter(|line| line.starts_with("lrwx"))
         .enumerate();
 
     // For each enumerated line, we assert that the output of ls matches the expected output.
@@ -455,14 +452,12 @@ fn test_ls_long_symlink_color() {
 
         // We look up the Colors that are expected in `colors` using the ColorReferences
         // stored in `expected_output`.
-        let expected_name_color = match expected_output[i].0 {
-            Some(color_reference) => Some(colors[color_reference[0]][color_reference[1]].as_str()),
-            None => None,
-        };
-        let expected_target_color = match expected_output[i].2 {
-            Some(color_reference) => Some(colors[color_reference[0]][color_reference[1]].as_str()),
-            None => None,
-        };
+        let expected_name_color = expected_output[i]
+            .0
+            .map(|color_reference| colors[color_reference[0]][color_reference[1]].as_str());
+        let expected_target_color = expected_output[i]
+            .2
+            .map(|color_reference| colors[color_reference[0]][color_reference[1]].as_str());
 
         // This is the important part. The asserts inside assert_names_and_colors_are_equal
         // will panic if the colors or names do not match the expected colors or names.
@@ -470,11 +465,11 @@ fn test_ls_long_symlink_color() {
         // don't expect any color here, as in `expected_output[2], or don't know what specific
         // color to expect yet, as in expected_output[0:1].
         assert_names_and_colors_are_equal(
-            &matched_name_color,
+            matched_name_color,
             expected_name_color,
             &matched_name,
             expected_output[i].1,
-            &matched_target_color,
+            matched_target_color,
             expected_target_color,
             &matched_target,
             expected_output[i].3,
@@ -505,6 +500,7 @@ fn test_ls_long_symlink_color() {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn assert_names_and_colors_are_equal(
         name_color: &str,
         expected_name_color: Option<&str>,
@@ -530,7 +526,7 @@ fn test_ls_long_symlink_color() {
 
     fn capture_colored_string(input: &str) -> (Color, Name) {
         let colored_name = Regex::new(r"\x1b\[([0-9;]+)m(.+)\x1b\[0m").unwrap();
-        match colored_name.captures(&input) {
+        match colored_name.captures(input) {
             Some(captures) => (
                 captures.get(1).unwrap().as_str().to_string(),
                 captures.get(2).unwrap().as_str().to_string(),

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -531,7 +531,7 @@ fn test_keys_invalid_field() {
     new_ucmd!()
         .args(&["-k", "1."])
         .fails()
-        .stderr_only("sort: failed to parse key `1.`: failed to parse character index ``: cannot parse integer from empty string");
+        .stderr_only("sort: failed to parse key '1.': failed to parse character index ``: cannot parse integer from empty string");
 }
 
 #[test]
@@ -539,7 +539,7 @@ fn test_keys_invalid_field_option() {
     new_ucmd!()
         .args(&["-k", "1.1x"])
         .fails()
-        .stderr_only("sort: failed to parse key `1.1x`: invalid option: `x`");
+        .stderr_only("sort: failed to parse key '1.1x': invalid option: `x`");
 }
 
 #[test]
@@ -547,7 +547,7 @@ fn test_keys_invalid_field_zero() {
     new_ucmd!()
         .args(&["-k", "0.1"])
         .fails()
-        .stderr_only("sort: failed to parse key `0.1`: field index can not be 0");
+        .stderr_only("sort: failed to parse key '0.1': field index can not be 0");
 }
 
 #[test]
@@ -555,7 +555,7 @@ fn test_keys_invalid_char_zero() {
     new_ucmd!()
         .args(&["-k", "1.0"])
         .fails()
-        .stderr_only("sort: failed to parse key `1.0`: invalid character index 0 for the start position of a field");
+        .stderr_only("sort: failed to parse key '1.0': invalid character index 0 for the start position of a field");
 }
 
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -531,7 +531,7 @@ fn test_keys_invalid_field() {
     new_ucmd!()
         .args(&["-k", "1."])
         .fails()
-        .stderr_only("sort: failed to parse key '1.': failed to parse character index ``: cannot parse integer from empty string");
+        .stderr_only("sort: failed to parse key '1.': failed to parse character index '': cannot parse integer from empty string");
 }
 
 #[test]
@@ -539,7 +539,7 @@ fn test_keys_invalid_field_option() {
     new_ucmd!()
         .args(&["-k", "1.1x"])
         .fails()
-        .stderr_only("sort: failed to parse key '1.1x': invalid option: `x`");
+        .stderr_only("sort: failed to parse key '1.1x': invalid option: 'x'");
 }
 
 #[test]

--- a/tests/by-util/test_sum.rs
+++ b/tests/by-util/test_sum.rs
@@ -59,7 +59,7 @@ fn test_invalid_file() {
 
     at.mkdir("a");
 
-    ucmd.arg("a").fails().stderr_is("sum: 'a' Is a directory");
+    ucmd.arg("a").fails().stderr_is("sum: a: Is a directory");
 }
 
 #[test]
@@ -68,5 +68,5 @@ fn test_invalid_metadata() {
 
     ucmd.arg("b")
         .fails()
-        .stderr_is("sum: 'b' No such file or directory");
+        .stderr_is("sum: b: No such file or directory");
 }

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -320,7 +320,7 @@ fn test_invalid_utf8_integer_compare() {
 
     cmd.run()
         .status_code(2)
-        .stderr_is("test: invalid integer 'fo�o'");
+        .stderr_is("test: invalid integer $'fo\\x80o'");
 
     let mut cmd = new_ucmd!();
     cmd.raw.arg(arg);
@@ -328,7 +328,7 @@ fn test_invalid_utf8_integer_compare() {
 
     cmd.run()
         .status_code(2)
-        .stderr_is("test: invalid integer 'fo�o'");
+        .stderr_is("test: invalid integer $'fo\\x80o'");
 }
 
 #[test]


### PR DESCRIPTION
Followup to #2621. I did a search on the full repository for `'{}'`, `{}:`, `.display()` and `.to_string_lossy`.

This includes an optimization of the argument gathering machinery (4cc296a9dc96cfaef0e7ff1928f709a3275e35d1) and a few general improvements to invalid unicode handling.