### PR TITLE
chown: support '.' as 'user.group' separator (like ':')

### DIFF
--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -178,12 +178,12 @@ pub fn uu_app() -> App<'static, 'static> {
 /// * `sep` - Should be ':' or '.'
 fn parse_spec(spec: &str, sep: char) -> UResult<(Option<u32>, Option<u32>)> {
     assert!(['.', ':'].contains(&sep));
-    let args = spec.split_terminator(sep).collect::<Vec<_>>();
-    let usr_only = args.len() == 1 && !args[0].is_empty();
-    let grp_only = args.len() == 2 && args[0].is_empty();
-    let usr_grp = args.len() == 2 && !args[0].is_empty() && !args[1].is_empty();
-    let uid = if usr_only || usr_grp {
-        Some(match Passwd::locate(args[0]) {
+    let mut args = spec.splitn(2, sep);
+    let user = args.next().unwrap_or("");
+    let group = args.next().unwrap_or("");
+
+    let uid = if !user.is_empty() {
+        Some(match Passwd::locate(user) {
             Ok(u) => u.uid(), // We have been able to get the uid
             Err(_) =>
             // we have NOT been able to find the uid
@@ -202,9 +202,9 @@ fn parse_spec(spec: &str, sep: char) -> UResult<(Option<u32>, Option<u32>)> {
     } else {
         None
     };
-    let gid = if grp_only || usr_grp {
+    let gid = if !group.is_empty() {
         Some(
-            Group::locate(args[1])
+            Group::locate(group)
                 .map_err(|_| USimpleError::new(1, format!("invalid group: '{}'", spec)))?
                 .gid(),
         )

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -196,7 +196,10 @@ fn parse_spec(spec: &str, sep: char) -> UResult<(Option<u32>, Option<u32>)> {
                     // So, try to parse it this way
                     return parse_spec(spec, '.');
                 } else {
-                    return Err(USimpleError::new(1, format!("invalid user: {}", spec.quote())))?
+                    return Err(USimpleError::new(
+                        1,
+                        format!("invalid user: {}", spec.quote()),
+                    ))?;
                 }
             }
         })

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -5,7 +5,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) COMFOLLOW Passwd RFILE RFILE's derefer dgid duid
+// spell-checker:ignore (ToDO) COMFOLLOW Passwd RFILE RFILE's derefer dgid duid groupname
 
 #[macro_use]
 extern crate uucore;
@@ -30,7 +30,7 @@ fn get_usage() -> String {
 
 fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>, IfFrom)> {
     let filter = if let Some(spec) = matches.value_of(options::FROM) {
-        match parse_spec(spec)? {
+        match parse_spec(spec, ':')? {
             (Some(uid), None) => IfFrom::User(uid),
             (None, Some(gid)) => IfFrom::Group(gid),
             (Some(uid), Some(gid)) => IfFrom::UserGroup(uid, gid),
@@ -48,7 +48,7 @@ fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Optio
         dest_gid = Some(meta.gid());
         dest_uid = Some(meta.uid());
     } else {
-        let (u, g) = parse_spec(matches.value_of(options::ARG_OWNER).unwrap())?;
+        let (u, g) = parse_spec(matches.value_of(options::ARG_OWNER).unwrap(), ':')?;
         dest_uid = u;
         dest_gid = g;
     }
@@ -165,17 +165,40 @@ pub fn uu_app() -> App<'static, 'static> {
         )
 }
 
-fn parse_spec(spec: &str) -> UResult<(Option<u32>, Option<u32>)> {
-    let args = spec.split_terminator(':').collect::<Vec<_>>();
+/// Parse the username and groupname
+///
+/// In theory, it should be username:groupname
+/// but ...
+/// it can user.name:groupname
+/// or username.groupname
+///
+/// # Arguments
+///
+/// * `spec` - The input from the user
+/// * `sep` - Should be ':' or '.'
+fn parse_spec(spec: &str, sep: char) -> UResult<(Option<u32>, Option<u32>)> {
+    assert!(['.', ':'].contains(&sep));
+    let args = spec.split_terminator(sep).collect::<Vec<_>>();
     let usr_only = args.len() == 1 && !args[0].is_empty();
     let grp_only = args.len() == 2 && args[0].is_empty();
     let usr_grp = args.len() == 2 && !args[0].is_empty() && !args[1].is_empty();
     let uid = if usr_only || usr_grp {
-        Some(
-            Passwd::locate(args[0])
-                .map_err(|_| USimpleError::new(1, format!("invalid user: '{}'", spec)))?
-                .uid(),
-        )
+        Some(match Passwd::locate(args[0]) {
+            Ok(u) => u.uid(), // We have been able to get the uid
+            Err(_) =>
+            // we have NOT been able to find the uid
+            // but we could be in the case where we have user.group
+            {
+                if spec.contains('.') && !spec.contains(':') && sep == ':' {
+                    // but the input contains a '.' but not a ':'
+                    // we might have something like username.groupname
+                    // So, try to parse it this way
+                    return parse_spec(spec, '.');
+                } else {
+                    return Err(USimpleError::new(1, format!("invalid user: '{}'", spec)));
+                }
+            }
+        })
     } else {
         None
     };
@@ -197,7 +220,10 @@ mod test {
 
     #[test]
     fn test_parse_spec() {
-        assert!(matches!(parse_spec(":"), Ok((None, None))));
-        assert!(format!("{}", parse_spec("::").err().unwrap()).starts_with("invalid group: "));
+        assert!(matches!(parse_spec(":", ':'), Ok((None, None))));
+        assert!(matches!(parse_spec(".", ':'), Ok((None, None))));
+        assert!(matches!(parse_spec(".", '.'), Ok((None, None))));
+        assert!(format!("{}", parse_spec("::", ':').err().unwrap()).starts_with("invalid group: "));
+        assert!(format!("{}", parse_spec("..", ':').err().unwrap()).starts_with("invalid group: "));
     }
 }

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -248,6 +248,22 @@ fn test_chown_owner_group() {
     }
     result.stderr_contains(&"retained as");
 
+    scene
+        .ucmd()
+        .arg("root:root:root")
+        .arg("--verbose")
+        .arg(file1)
+        .fails()
+        .stderr_contains(&"invalid group");
+
+    scene
+        .ucmd()
+        .arg("root.root.root")
+        .arg("--verbose")
+        .arg(file1)
+        .fails()
+        .stderr_contains(&"invalid group");
+
     // TODO: on macos group name is not recognized correctly: "chown: invalid group: 'root:root'
     #[cfg(any(windows, all(unix, not(target_os = "macos"))))]
     scene


### PR DESCRIPTION
Should fix:
gnu/tests/chown/separator.sh