### PR TITLE
Preserve error message for "other" I/O errors

### DIFF
--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -399,7 +399,6 @@ impl Display for UIoError {
             TimedOut => "Timed out",
             WriteZero => "Write zero",
             Interrupted => "Interrupted",
-            Other => "Other",
             UnexpectedEof => "Unexpected end of file",
             _ => {
                 // TODO: using `strip_errno()` causes the error message


### PR DESCRIPTION
These errors still have a unique message even if the `ErrorKind` enum doesn't classify them.

Solves part of #2639. The message is now "Is a directory" instead of "No such file or directory", but that actually seems to be incorrect behavior rather than a bad error message.