### PR TITLE
tty: Make test_stdout_fail() less flaky

### DIFF
--- a/src/uu/printf/src/tokenize/num_format/formatter.rs
+++ b/src/uu/printf/src/tokenize/num_format/formatter.rs
@@ -11,22 +11,12 @@ use super::format_field::FormatField;
 // output for a number, organized together
 // to allow for easy generalization of output manipulation
 // (e.g. max number of digits after decimal)
+#[derive(Default)]
 pub struct FormatPrimitive {
     pub prefix: Option<String>,
     pub pre_decimal: Option<String>,
     pub post_decimal: Option<String>,
     pub suffix: Option<String>,
-}
-
-impl Default for FormatPrimitive {
-    fn default() -> FormatPrimitive {
-        FormatPrimitive {
-            prefix: None,
-            pre_decimal: None,
-            post_decimal: None,
-            suffix: None,
-        }
-    }
 }
 
 #[derive(Clone, PartialEq)]

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -800,7 +800,7 @@ impl Default for KeyPosition {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 struct FieldSelector {
     from: KeyPosition,
     to: Option<KeyPosition>,
@@ -810,18 +810,6 @@ struct FieldSelector {
     // Selections are therefore not needed when this selector matches the whole line
     // or the sort mode is general-numeric.
     needs_selection: bool,
-}
-
-impl Default for FieldSelector {
-    fn default() -> Self {
-        Self {
-            from: Default::default(),
-            to: None,
-            settings: Default::default(),
-            needs_tokens: false,
-            needs_selection: false,
-        }
-    }
 }
 
 impl FieldSelector {


### PR DESCRIPTION
This one fails pretty commonly locally, though not in the CI for some reason.

(Includes ~~#2649~~ #2652, merge that one first)