### PR TITLE
uucore::entries: Fix safety issues

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -182,6 +182,7 @@ getgrgid
 getgrnam
 getgrouplist
 getgroups
+getpwent
 getpwnam
 getpwuid
 getuid

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -183,7 +183,7 @@ fn parse_spec(spec: &str, sep: char) -> UResult<(Option<u32>, Option<u32>)> {
 
     let uid = if !user.is_empty() {
         Some(match Passwd::locate(user) {
-            Ok(u) => u.uid(), // We have been able to get the uid
+            Ok(u) => u.uid, // We have been able to get the uid
             Err(_) =>
             // we have NOT been able to find the uid
             // but we could be in the case where we have user.group
@@ -208,7 +208,7 @@ fn parse_spec(spec: &str, sep: char) -> UResult<(Option<u32>, Option<u32>)> {
         Some(
             Group::locate(group)
                 .map_err(|_| USimpleError::new(1, format!("invalid group: {}", spec.quote())))?
-                .gid(),
+                .gid,
         )
     } else {
         None

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -245,7 +245,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         // GNU's `id` does not support the flags: -p/-P/-A.
         if matches.is_present(options::OPT_PASSWORD) {
             // BSD's `id` ignores all but the first specified user
-            pline(possible_pw.map(|v| v.uid()));
+            pline(possible_pw.as_ref().map(|v| v.uid));
             return Ok(());
         };
         if matches.is_present(options::OPT_HUMAN_READABLE) {
@@ -259,7 +259,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             return Ok(());
         }
 
-        let (uid, gid) = possible_pw.map(|p| (p.uid(), p.gid())).unwrap_or((
+        let (uid, gid) = possible_pw.as_ref().map(|p| (p.uid, p.gid)).unwrap_or((
             if state.rflag { getuid() } else { geteuid() },
             if state.rflag { getgid() } else { getegid() },
         ));
@@ -302,7 +302,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
         let groups = entries::get_groups_gnu(Some(gid)).unwrap();
         let groups = if state.user_specified {
-            possible_pw.map(|p| p.belongs_to()).unwrap()
+            possible_pw.as_ref().map(|p| p.belongs_to()).unwrap()
         } else {
             groups.clone()
         };
@@ -453,7 +453,7 @@ pub fn uu_app() -> App<'static, 'static> {
 
 fn pretty(possible_pw: Option<Passwd>) {
     if let Some(p) = possible_pw {
-        print!("uid\t{}\ngroups\t", p.name());
+        print!("uid\t{}\ngroups\t", p.name);
         println!(
             "{}",
             p.belongs_to()
@@ -466,10 +466,10 @@ fn pretty(possible_pw: Option<Passwd>) {
         let login = cstr2cow!(getlogin() as *const _);
         let rid = getuid();
         if let Ok(p) = Passwd::locate(rid) {
-            if login == p.name() {
+            if login == p.name {
                 println!("login\t{}", login);
             }
-            println!("uid\t{}", p.name());
+            println!("uid\t{}", p.name);
         } else {
             println!("uid\t{}", rid);
         }
@@ -477,7 +477,7 @@ fn pretty(possible_pw: Option<Passwd>) {
         let eid = getegid();
         if eid == rid {
             if let Ok(p) = Passwd::locate(eid) {
-                println!("euid\t{}", p.name());
+                println!("euid\t{}", p.name);
             } else {
                 println!("euid\t{}", eid);
             }
@@ -486,7 +486,7 @@ fn pretty(possible_pw: Option<Passwd>) {
         let rid = getgid();
         if rid != eid {
             if let Ok(g) = Group::locate(rid) {
-                println!("euid\t{}", g.name());
+                println!("euid\t{}", g.name);
             } else {
                 println!("euid\t{}", rid);
             }
@@ -511,16 +511,16 @@ fn pline(possible_uid: Option<uid_t>) {
 
     println!(
         "{}:{}:{}:{}:{}:{}:{}:{}:{}:{}",
-        pw.name(),
-        pw.user_passwd(),
-        pw.uid(),
-        pw.gid(),
-        pw.user_access_class(),
-        pw.passwd_change_time(),
-        pw.expiration(),
-        pw.user_info(),
-        pw.user_dir(),
-        pw.user_shell()
+        pw.name,
+        pw.user_passwd,
+        pw.uid,
+        pw.gid,
+        pw.user_access_class,
+        pw.passwd_change_time,
+        pw.expiration,
+        pw.user_info,
+        pw.user_dir,
+        pw.user_shell
     );
 }
 
@@ -531,13 +531,7 @@ fn pline(possible_uid: Option<uid_t>) {
 
     println!(
         "{}:{}:{}:{}:{}:{}:{}",
-        pw.name(),
-        pw.user_passwd(),
-        pw.uid(),
-        pw.gid(),
-        pw.user_info(),
-        pw.user_dir(),
-        pw.user_shell()
+        pw.name, pw.user_passwd, pw.uid, pw.gid, pw.user_info, pw.user_dir, pw.user_shell
     );
 }
 

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -267,11 +267,11 @@ impl Pinky {
 
         if self.include_fullname {
             if let Ok(pw) = Passwd::locate(ut.user().as_ref()) {
-                let mut gecos = pw.user_info().into_owned();
+                let mut gecos = pw.user_info;
                 if let Some(n) = gecos.find(',') {
                     gecos.truncate(n + 1);
                 }
-                print!(" {:<19.19}", gecos.replace("&", &pw.name().capitalize()));
+                print!(" {:<19.19}", gecos.replace("&", &pw.name.capitalize()));
             } else {
                 print!(" {:19}", "        ???");
             }
@@ -333,13 +333,13 @@ impl Pinky {
         for u in &self.names {
             print!("Login name: {:<28}In real life: ", u);
             if let Ok(pw) = Passwd::locate(u.as_str()) {
-                println!(" {}", pw.user_info().replace("&", &pw.name().capitalize()));
+                println!(" {}", pw.user_info.replace("&", &pw.name.capitalize()));
                 if self.include_home_and_shell {
-                    print!("Directory: {:<29}", pw.user_dir());
-                    println!("Shell:  {}", pw.user_shell());
+                    print!("Directory: {:<29}", pw.user_dir);
+                    println!("Shell:  {}", pw.user_shell);
                 }
                 if self.include_project {
-                    let mut p = PathBuf::from(pw.user_dir().as_ref());
+                    let mut p = PathBuf::from(&pw.user_dir);
                     p.push(".project");
                     if let Ok(f) = File::open(p) {
                         print!("Project: ");
@@ -347,7 +347,7 @@ impl Pinky {
                     }
                 }
                 if self.include_plan {
-                    let mut p = PathBuf::from(pw.user_dir().as_ref());
+                    let mut p = PathBuf::from(&pw.user_dir);
                     p.push(".plan");
                     if let Ok(f) = File::open(p) {
                         println!("Plan:");

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -24,14 +24,11 @@ fn test_capitalize() {
 fn test_long_format() {
     let login = "root";
     let pw: Passwd = Passwd::locate(login).unwrap();
-    let real_name = pw.user_info().replace("&", &pw.name().capitalize());
+    let real_name = pw.user_info.replace("&", &pw.name.capitalize());
     let ts = TestScenario::new(util_name!());
     ts.ucmd().arg("-l").arg(login).succeeds().stdout_is(format!(
         "Login name: {:<28}In real life:  {}\nDirectory: {:<29}Shell:  {}\n\n",
-        login,
-        real_name,
-        pw.user_dir(),
-        pw.user_shell()
+        login, real_name, pw.user_dir, pw.user_shell
     ));
 
     ts.ucmd()


### PR DESCRIPTION
- Protect `getpwnam()` and friends with a lock. This makes the wrappers safe, they were occasionally causing segfaults before (in tests).
- Do not use unsafe `Vec` operations unnecessarily.