### PR TITLE
Move common pipe and splice functions into uucore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "getopts",
  "lazy_static",
  "libc",
+ "nix 0.20.0",
  "once_cell",
  "termion",
  "thiserror",

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/cat.rs"
 clap = { version = "2.33", features = ["wrap_help"] }
 thiserror = "1.0"
 atty = "0.2"
-uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["fs"] }
+uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["fs", "pipes"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -29,8 +29,6 @@ use std::os::unix::io::AsRawFd;
 /// Linux splice support
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod splice;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use std::os::unix::io::RawFd;
 
 /// Unix domain socket support
 #[cfg(unix)]
@@ -137,10 +135,18 @@ struct OutputState {
     one_blank_kept: bool,
 }
 
+#[cfg(unix)]
+trait FdReadable: Read + AsRawFd {}
+#[cfg(not(unix))]
+trait FdReadable: Read {}
+
+#[cfg(unix)]
+impl<T> FdReadable for T where T: Read + AsRawFd {}
+#[cfg(not(unix))]
+impl<T> FdReadable for T where T: Read {}
+
 /// Represents an open file handle, stream, or other device
-struct InputHandle<R: Read> {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    file_descriptor: RawFd,
+struct InputHandle<R: FdReadable> {
     reader: R,
     is_interactive: bool,
 }
@@ -297,7 +303,7 @@ pub fn uu_app() -> App<'static, 'static> {
         )
 }
 
-fn cat_handle<R: Read>(
+fn cat_handle<R: FdReadable>(
     handle: &mut InputHandle<R>,
     options: &OutputOptions,
     state: &mut OutputState,
@@ -319,8 +325,6 @@ fn cat_path(
     if path == "-" {
         let stdin = io::stdin();
         let mut handle = InputHandle {
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            file_descriptor: stdin.as_raw_fd(),
             reader: stdin,
             is_interactive: atty::is(atty::Stream::Stdin),
         };
@@ -333,8 +337,6 @@ fn cat_path(
             let socket = UnixStream::connect(path)?;
             socket.shutdown(Shutdown::Write)?;
             let mut handle = InputHandle {
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                file_descriptor: socket.as_raw_fd(),
                 reader: socket,
                 is_interactive: false,
             };
@@ -347,8 +349,6 @@ fn cat_path(
                 return Err(CatError::OutputIsInput);
             }
             let mut handle = InputHandle {
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                file_descriptor: file.as_raw_fd(),
                 reader: file,
                 is_interactive: false,
             };
@@ -437,14 +437,14 @@ fn get_input_type(path: &str) -> CatResult<InputType> {
 
 /// Writes handle to stdout with no configuration. This allows a
 /// simple memory copy.
-fn write_fast<R: Read>(handle: &mut InputHandle<R>) -> CatResult<()> {
+fn write_fast<R: FdReadable>(handle: &mut InputHandle<R>) -> CatResult<()> {
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // If we're on Linux or Android, try to use the splice() system call
         // for faster writing. If it works, we're done.
-        if !splice::write_fast_using_splice(handle, stdout_lock.as_raw_fd())? {
+        if !splice::write_fast_using_splice(handle, &stdout_lock)? {
             return Ok(());
         }
     }
@@ -462,7 +462,7 @@ fn write_fast<R: Read>(handle: &mut InputHandle<R>) -> CatResult<()> {
 
 /// Outputs file contents to stdout in a line-by-line fashion,
 /// propagating any errors that might occur.
-fn write_lines<R: Read>(
+fn write_lines<R: FdReadable>(
     handle: &mut InputHandle<R>,
     options: &OutputOptions,
     state: &mut OutputState,

--- a/src/uu/cat/src/splice.rs
+++ b/src/uu/cat/src/splice.rs
@@ -5,6 +5,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 
 use uucore::pipes::{pipe, splice, splice_exact};
 
+const SPLICE_SIZE: usize = 1024 * 128;
 const BUF_SIZE: usize = 1024 * 16;
 
 /// This function is called from `write_fast()` on Linux and Android. The
@@ -22,7 +23,7 @@ pub(super) fn write_fast_using_splice<R: FdReadable>(
     let (pipe_rd, pipe_wr) = pipe()?;
 
     loop {
-        match splice(&handle.reader, &pipe_wr, BUF_SIZE) {
+        match splice(&handle.reader, &pipe_wr, SPLICE_SIZE) {
             Ok(n) => {
                 if n == 0 {
                     return Ok(false);

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/wc.rs"
 
 [dependencies]
 clap = { version = "2.33", features = ["wrap_help"] }
-uucore = { version=">=0.0.9", package="uucore", path="../../uucore" }
+uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["pipes"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 bytecount = "0.6.2"
 utf-8 = "0.7.6"

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/yes.rs"
 
 [dependencies]
 clap = { version = "2.33", features = ["wrap_help"] }
-uucore = { version=">=0.0.9", package="uucore", path="../../uucore" }
+uucore = { version=">=0.0.9", package="uucore", path="../../uucore", features=["pipes"] }
 uucore_procs = { version=">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -31,6 +31,7 @@ data-encoding-macro = { version="0.1.12", optional=true }
 z85 = { version="3.0.3", optional=true }
 libc = { version="0.2.15", optional=true }
 once_cell = "1.8.0"
+nix = { version="0.20", optional=true }
 
 [dev-dependencies]
 clap = "2.33.3"
@@ -57,3 +58,4 @@ signals = []
 utf8 = []
 utmpx = ["time", "libc", "dns-lookup"]
 wide = []
+pipes = ["nix"]

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -19,6 +19,8 @@ pub mod mode;
 pub mod entries;
 #[cfg(all(unix, feature = "perms"))]
 pub mod perms;
+#[cfg(all(unix, feature = "pipes"))]
+pub mod pipes;
 #[cfg(all(unix, feature = "process"))]
 pub mod process;
 

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -1,0 +1,54 @@
+/// Thin pipe-related wrappers around functions from the `nix` crate.
+use std::fs::File;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::unix::io::AsRawFd;
+use std::os::unix::io::FromRawFd;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use nix::{fcntl::SpliceFFlags, sys::uio::IoVec};
+
+pub use nix::{Error, Result};
+
+/// A wrapper around [`nix::unistd::Pipe`] that ensures the pipe is cleaned up.
+pub fn pipe() -> Result<(File, File)> {
+    let (read, write) = nix::unistd::pipe()?;
+    // SAFETY: The file descriptors do not have other owners.
+    unsafe { Ok((File::from_raw_fd(read), File::from_raw_fd(write))) }
+}
+
+/// Less noisy wrapper around [`nix::fcntl::splice`].
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn splice(source: &impl AsRawFd, target: &impl AsRawFd, len: usize) -> Result<usize> {
+    nix::fcntl::splice(
+        source.as_raw_fd(),
+        None,
+        target.as_raw_fd(),
+        None,
+        len,
+        SpliceFFlags::empty(),
+    )
+}
+
+/// Splice wrapper which fully finishes the write.
+///
+/// Panics if `source` runs out of data before `len` bytes have been moved.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn splice_exact(source: &impl AsRawFd, target: &impl AsRawFd, len: usize) -> Result<()> {
+    let mut left = len;
+    while left != 0 {
+        let written = splice(source, target, left)?;
+        assert_ne!(written, 0, "unexpected end of data");
+        left -= written;
+    }
+    Ok(())
+}
+
+/// Use vmsplice() to copy data from memory into a pipe.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn vmsplice(target: &impl AsRawFd, bytes: &[u8]) -> Result<usize> {
+    nix::fcntl::vmsplice(
+        target.as_raw_fd(),
+        &[IoVec::from_slice(bytes)],
+        SpliceFFlags::empty(),
+    )
+}

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -49,6 +49,8 @@ pub use crate::features::mode;
 pub use crate::features::entries;
 #[cfg(all(unix, feature = "perms"))]
 pub use crate::features::perms;
+#[cfg(all(unix, feature = "pipes"))]
+pub use crate::features::pipes;
 #[cfg(all(unix, feature = "process"))]
 pub use crate::features::process;
 #[cfg(all(unix, not(target_os = "fuchsia"), feature = "signals"))]


### PR DESCRIPTION
`wc`, `cat` and `yes` do similar things with splicing and pipes. This unifies them somewhat and makes it easier to extend to other tools in the future.