### PR TITLE
`ls`: add support for showing SELinux context (--context/-Z)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,6 +2632,7 @@ dependencies = [
  "lscolors",
  "number_prefix",
  "once_cell",
+ "selinux",
  "term_grid",
  "termsize",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ feat_os_unix_musl = [
 # NOTE:
 # The selinux(-sys) crate requires `libselinux` headers and shared library to be accessible in the C toolchain at compile time.
 # Running a uutils compiled with `feat_selinux` requires an SELinux enabled Kernel at run time.
-feat_selinux = ["cp/selinux", "id/selinux", "selinux", "feat_require_selinux"]
+feat_selinux = ["cp/selinux", "id/selinux", "ls/selinux", "selinux", "feat_require_selinux"]
 # "feat_acl" == set of utilities providing support for acl (access control lists) if enabled with `--features feat_acl`.
 # NOTE:
 # On linux, the posix-acl/acl-sys crate requires `libacl` headers and shared library to be accessible in the C toolchain at compile time.

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -28,6 +28,7 @@ uucore = { version = ">=0.0.8", package = "uucore", path = "../../uucore", featu
 uucore_procs = { version=">=0.0.6", package = "uucore_procs", path = "../../uucore_procs" }
 once_cell = "1.7.2"
 atty = "0.2"
+selinux = { version="0.2.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 lazy_static = "1.4.0"
@@ -35,3 +36,6 @@ lazy_static = "1.4.0"
 [[bin]]
 name = "ls"
 path = "src/main.rs"
+
+[features]
+feat_selinux = ["selinux"]

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1259,7 +1259,11 @@ impl PathData {
             None => OnceCell::new(),
         };
 
-        let security_context = get_security_context(config, &p_buf, must_dereference);
+        let security_context = if config.context {
+            get_security_context(config, &p_buf, must_dereference)
+        } else {
+            String::new()
+        };
 
         Self {
             md: OnceCell::new(),
@@ -2089,44 +2093,41 @@ fn display_symlink_count(metadata: &Metadata) -> String {
 
 // This returns the SELinux security context as UTF8 `String`.
 // In the long term this should be changed to `OsStr`, see discussions at #2621/#2656
-fn get_security_context(config: &Config, p_buf: &PathBuf, must_dereference: bool) -> String {
+#[allow(unused_variables)]
+fn get_security_context(config: &Config, p_buf: &Path, must_dereference: bool) -> String {
     let substitute_string = "?".to_string();
-    if config.context {
-        if config.selinux_supported {
-            #[cfg(feature = "selinux")]
-            {
-                match selinux::SecurityContext::of_path(p_buf, must_dereference, false) {
-                    Err(_r) => {
-                        // TODO: show the actual reason why it failed
-                        show_warning!("failed to get security context of: {}", p_buf.quote());
-                        substitute_string
-                    }
-                    Ok(None) => substitute_string,
-                    Ok(Some(context)) => {
-                        let mut context = context.as_bytes();
-                        if context.ends_with(&[0]) {
-                            // TODO: replace with `strip_prefix()` when MSRV >= 1.51
-                            context = &context[..context.len() - 1]
-                        };
-                        String::from_utf8(context.to_vec()).unwrap_or_else(|e| {
-                            show_warning!(
-                                "getting security context of: {}: {}",
-                                p_buf.quote(),
-                                e.to_string()
-                            );
-                            String::from_utf8_lossy(context).into_owned()
-                        })
-                    }
+    if config.selinux_supported {
+        #[cfg(feature = "selinux")]
+        {
+            match selinux::SecurityContext::of_path(p_buf, must_dereference, false) {
+                Err(_r) => {
+                    // TODO: show the actual reason why it failed
+                    show_warning!("failed to get security context of: {}", p_buf.quote());
+                    substitute_string
+                }
+                Ok(None) => substitute_string,
+                Ok(Some(context)) => {
+                    let mut context = context.as_bytes();
+                    if context.ends_with(&[0]) {
+                        // TODO: replace with `strip_prefix()` when MSRV >= 1.51
+                        context = &context[..context.len() - 1]
+                    };
+                    String::from_utf8(context.to_vec()).unwrap_or_else(|e| {
+                        show_warning!(
+                            "getting security context of: {}: {}",
+                            p_buf.quote(),
+                            e.to_string()
+                        );
+                        String::from_utf8_lossy(context).into_owned()
+                    })
                 }
             }
-            #[cfg(not(feature = "selinux"))]
-            {
-                substitute_string
-            }
-        } else {
+        }
+        #[cfg(not(feature = "selinux"))]
+        {
             substitute_string
         }
     } else {
-        String::new()
+        substitute_string
     }
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -639,10 +639,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(|v| v.map(Path::new).collect())
         .unwrap_or_else(|| vec![Path::new(".")]);
 
-    if config.context && !config.selinux_supported {
-        show_warning!("--context (-Z) works only on an SELinux-enabled kernel",);
-    }
-
     list(locs, config)
 }
 
@@ -1260,7 +1256,7 @@ impl PathData {
             None => OnceCell::new(),
         };
 
-        let security_context: String = if config.context {
+        let security_context = if config.context {
             if config.selinux_supported {
                 #[cfg(feature = "selinux")]
                 {
@@ -1692,9 +1688,9 @@ fn display_item_long(
         out,
         "{}{} {}",
         display_permissions(md, true),
-        if item.security_context != "?" {
-            // GNU `ls` uses a "." character to indicate a file with a security context, but not
-            // other alternate access method.
+        if item.security_context.len() > 1 {
+            // GNU `ls` uses a "." character to indicate a file with a security context,
+            // but not other alternate access method.
             "."
         } else {
             ""

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2282,7 +2282,23 @@ fn test_ls_dangling_symlinks() {
 
 #[test]
 #[cfg(feature = "feat_selinux")]
-fn test_ls_context() {
+fn test_ls_context1() {
+    use selinux::{self, KernelSupport};
+    if selinux::kernel_support() == KernelSupport::Unsupported {
+        println!("test skipped: Kernel has no support for SElinux context",);
+        return;
+    }
+
+    let file = "test_ls_context_file";
+    let expected = format!("unconfined_u:object_r:user_tmp_t:s0 {}\n", file);
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch(file);
+    ucmd.args(&["-Z", file]).succeeds().stdout_is(expected);
+}
+
+#[test]
+#[cfg(feature = "feat_selinux")]
+fn test_ls_context2() {
     use selinux::{self, KernelSupport};
     if selinux::kernel_support() == KernelSupport::Unsupported {
         println!("test skipped: Kernel has no support for SElinux context",);


### PR DESCRIPTION
This adds SELinux security context (--context/-Z) support to `uu_ls`.

Since the SELinux specific parts are  gated behind `--featues feat_selinux`, the tests don't run in the CICD and I appreciate a volunteer to run:
`cargo test test_ls_context --features feat_selinux`
on an SELinux enabled Linux distribution with libselinux headers installed (e.g. on fedora dnf install libselinux-devel).

(With this the "gnu/tests/id/no-context.sh" test now passes because it depends on `uu_ls -Z` being implemented.)