### PR TITLE
seq: compute correct width for -0e0

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -286,18 +286,25 @@ fn print_seq(
     let mut stdout = stdout.lock();
     let (first, increment, last) = range;
     let mut i = 0isize;
+    let is_first_minus_zero = first == -0.0 && first.is_sign_negative();
     let mut value = first + i as f64 * increment;
     let mut is_first_iteration = true;
     while !done_printing(&value, &increment, &last) {
         if !is_first_iteration {
             write!(stdout, "{}", separator)?;
         }
+        let mut width = padding;
+        if is_first_iteration && is_first_minus_zero {
+            write!(stdout, "-")?;
+            width -= 1;
+        }
         is_first_iteration = false;
+
         let istr = format!("{:.*}", largest_dec, value);
         let ilen = istr.len();
         let before_dec = istr.find('.').unwrap_or(ilen);
-        if pad && before_dec < padding {
-            for _ in 0..(padding - before_dec) {
+        if pad && before_dec < width {
+            for _ in 0..(width - before_dec) {
                 write!(stdout, "0")?;
             }
         }

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -178,6 +178,15 @@ fn test_width_negative_zero() {
         .no_stderr();
 }
 
+#[test]
+fn test_width_negative_zero_scientific_notation() {
+    new_ucmd!()
+        .args(&["-w", "-0e0", "1"])
+        .succeeds()
+        .stdout_is("-0\n01\n")
+        .no_stderr();
+}
+
 // TODO This is duplicated from `test_yes.rs`; refactor them.
 /// Run `seq`, capture some of the output, close the pipe, and verify it.
 fn run(args: &[&str], expected: &[u8]) {


### PR DESCRIPTION
This adds code similar to the code in `print_seq_integers()` that correctly supports negative zero as a starting number when the negative zero is given in the input in scientific notation.

Before this change:
```
$ ./target/debug/coreutils seq -w -0e0 1
00
01
```
After this change:
```
$ ./target/debug/coreutils seq -w -0e0 1
-0
01
```
That matches GNU seq:
```
$ seq -w -0e0 1
-0
01
```