### PR TITLE
seq: trim leading whitespace from inputs

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -99,6 +99,7 @@ impl Number {
 impl FromStr for Number {
     type Err = String;
     fn from_str(mut s: &str) -> Result<Self, Self::Err> {
+        s = s.trim_start();
         if s.starts_with('+') {
             s = &s[1..];
         }

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -200,3 +200,27 @@ fn test_neg_inf() {
 fn test_inf() {
     run(&["inf"], b"1\n2\n3\n");
 }
+
+#[test]
+fn test_ignore_leading_whitespace() {
+    new_ucmd!()
+        .arg("   1")
+        .succeeds()
+        .stdout_is("1\n")
+        .no_stderr();
+}
+
+#[test]
+fn test_trailing_whitespace_error() {
+    // In some locales, the GNU error message has curly quotes (‘)
+    // instead of straight quotes ('). We just test the straight single
+    // quotes.
+    new_ucmd!()
+        .arg("1 ")
+        .fails()
+        .no_stdout()
+        .stderr_contains("seq: invalid floating point argument: '1 '")
+        // FIXME The second line of the error message is "Try 'seq
+        // --help' for more information."
+        .stderr_contains("for more information.");
+}


### PR DESCRIPTION
Before this change:
```
$ ./target/debug/coreutils seq " 1"
seq: invalid floating point argument: ' 1'
Try './target/debug/coreutils seq --help' for more information.
$ ./target/debug/coreutils seq "1 "
seq: invalid floating point argument: '1 '
Try './target/debug/coreutils seq --help' for more information.
```
After this change:
```
$ ./target/debug/coreutils seq " 1"
1
$ ./target/debug/coreutils seq "1 "
seq: invalid floating point argument: '1 '
Try './target/debug/coreutils seq --help' for more information.
```
GNU `seq`:
```
$ seq " 1"
1
$ seq "1 "
seq: invalid floating point argument: ‘1 ’
Try 'seq --help' for more information.
```