### PR TITLE
Fixed a warning on freebdsd

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -9,7 +9,7 @@ use std::os::unix::fs;
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink as symlink_file;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "freebsd")))]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_file;


### PR DESCRIPTION
warning: unused import: `std::os::unix::fs::PermissionsExt`