### PR TITLE
seq: add is_first_iteration to avoid comparisons

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -287,7 +287,12 @@ fn print_seq(
     let (first, increment, last) = range;
     let mut i = 0isize;
     let mut value = first + i as f64 * increment;
+    let mut is_first_iteration = true;
     while !done_printing(&value, &increment, &last) {
+        if !is_first_iteration {
+            write!(stdout, "{}", separator)?;
+        }
+        is_first_iteration = false;
         let istr = format!("{:.*}", largest_dec, value);
         let ilen = istr.len();
         let before_dec = istr.find('.').unwrap_or(ilen);
@@ -299,11 +304,8 @@ fn print_seq(
         write!(stdout, "{}", istr)?;
         i += 1;
         value = first + i as f64 * increment;
-        if !done_printing(&value, &increment, &last) {
-            write!(stdout, "{}", separator)?;
-        }
     }
-    if (first >= last && increment < 0f64) || (first <= last && increment > 0f64) {
+    if !is_first_iteration {
         write!(stdout, "{}", terminator)?;
     }
     stdout.flush()?;


### PR DESCRIPTION
Add the `is_first_iteration` Boolean variable to the `print_seq()`
function in order to avoid unnecessary comparisons. Specifically, before
this change, the `done_printing()` function was called twice on each
iteration of the main loop. After this change, it is only called once
per iteration.

Furthermore, this change makes the `print_seq()` function similar in
structure to the `print_seq_integers()` function.

This change was suggested in https://github.com/uutils/coreutils/pull/2615/files#r706598679