### PR TITLE
hashsum: add tests for Windows text mode

### DIFF
--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -38,6 +38,30 @@ macro_rules! test_digest {
                 .no_stderr()
                 .stdout_is("input.txt: OK\n");
         }
+
+        #[cfg(windows)]
+        #[test]
+        fn test_text_mode() {
+            // TODO Replace this with hard-coded files that store the
+            // expected output of text mode on an input file that has
+            // "\r\n" line endings.
+            let result = new_ucmd!()
+                .args(&[DIGEST_ARG, BITS_ARG, "-b"])
+                .pipe_in("a\nb\nc\n")
+                .succeeds();
+            let expected = result.no_stderr().stdout();
+            // Replace the "*-\n" at the end of the output with " -\n".
+            // The asterisk indicates that the digest was computed in
+            // binary mode.
+            let n = expected.len();
+            let expected = [&expected[..n - 3], &[b' ', b'-', b'\n']].concat();
+            new_ucmd!()
+                .args(&[DIGEST_ARG, BITS_ARG, "-t"])
+                .pipe_in("a\r\nb\r\nc\r\n")
+                .succeeds()
+                .no_stderr()
+                .stdout_is(std::str::from_utf8(&expected).unwrap());
+        }
     }
     )*)
 }


### PR DESCRIPTION
I extracted this from pull request #2663, since it would be nice to know whether the feature is working and whether the test is correctly implemented before trying to debug the build issues in #2663. I don't have a Windows machine so I'm relying on GitHub Actions to tell me whether this is passing.