### PR TITLE
tests/util: add a convenience wrapper to run a ucmd with root permissions

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1363,6 +1363,7 @@ pub fn expected_result(ts: &TestScenario, args: &[&str]) -> std::result::Result<
 }
 
 /// This is a convenience wrapper to run a ucmd with root permissions.
+/// It can be used to test programs when being root is needed
 /// This runs 'sudo -E --non-interactive target/debug/coreutils util_name args`
 /// This is primarily designed to run in an environment where whoami is in $path
 /// and where non-interactive sudo is possible.

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1767,6 +1767,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    #[cfg(feature = "whoami")]
     fn test_run_ucmd_as_root() {
         // We need non-interactive `sudo.
         // CICD environment should allow non-interactive `sudo`.


### PR DESCRIPTION
As far as I can tell the CICD tests do not run as root, however some functionality can only be tested with root permissions.
While tinkering with #2689 it became apparent to me that there's a need for a a convenience wrapper to run a ucmd with root permissions.
Please let me know if there's a better way to do this.