### PR TITLE
Fix need for ssh keys

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -5,12 +5,12 @@
 set -e
 if test ! -d ../gnu; then
     echo "Could not find ../gnu"
-    echo "git clone git@github.com:coreutils/coreutils.git gnu"
+    echo "git clone https://github.com:coreutils/coreutils.git gnu"
     exit 1
 fi
 if test ! -d ../gnulib; then
     echo "Could not find ../gnulib"
-    echo "git clone git@github.com:coreutils/gnulib.git gnulib"
+    echo "git clone https://github.com/coreutils/gnulib.git gnulib"
     exit 1
 fi
 


### PR DESCRIPTION
Github now mandates git ssh keys instead of username/password. I modified the download instructions to remove the need for ssh authentication.

```bash
git clone git@github.com:coreutils/coreutils.git gnu
Cloning into 'gnu'...
The authenticity of host 'github.com (140.82.112.4)' can't be established.
RSA key fingerprint is SHA256:XXXXX.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com,140.82.112.4' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
````