### PR TITLE
uu+tests: use strip_prefix and strip_suffix

### DIFF
--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -131,21 +131,15 @@ fn basename(fullname: &str, suffix: &str) -> String {
     // Convert to path buffer and get last path component
     let pb = PathBuf::from(path);
     match pb.components().last() {
-        Some(c) => strip_suffix(c.as_os_str().to_str().unwrap(), suffix),
+        Some(c) => {
+            let name = c.as_os_str().to_str().unwrap();
+            if name == suffix {
+                name.to_string()
+            } else {
+                name.strip_suffix(suffix).unwrap_or(name).to_string()
+            }
+        }
+
         None => "".to_owned(),
     }
-}
-
-// can be replaced with strip_suffix once MSRV is 1.45
-#[allow(clippy::manual_strip)]
-fn strip_suffix(name: &str, suffix: &str) -> String {
-    if name == suffix {
-        return name.to_owned();
-    }
-
-    if name.ends_with(suffix) {
-        return name[..name.len() - suffix.len()].to_owned();
-    }
-
-    name.to_owned()
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2103,11 +2103,9 @@ fn get_security_context(config: &Config, p_buf: &Path, must_dereference: bool) -
                 }
                 Ok(None) => substitute_string,
                 Ok(Some(context)) => {
-                    let mut context = context.as_bytes();
-                    if context.ends_with(&[0]) {
-                        // TODO: replace with `strip_prefix()` when MSRV >= 1.51
-                        context = &context[..context.len() - 1]
-                    };
+                    let context = context.as_bytes();
+
+                    let context = context.strip_suffix(&[0]).unwrap_or(context);
                     String::from_utf8(context.to_vec()).unwrap_or_else(|e| {
                         show_warning!(
                             "getting security context of: {}: {}",

--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -193,16 +193,13 @@ pub fn read<T: Read>(
 
 /// Split `read` into `Line`s, and add them to `lines`.
 fn parse_lines<'a>(
-    mut read: &'a str,
+    read: &'a str,
     lines: &mut Vec<Line<'a>>,
     line_data: &mut LineData<'a>,
     separator: u8,
     settings: &GlobalSettings,
 ) {
-    // Strip a trailing separator. TODO: Once our MinRustV is 1.45 or above, use strip_suffix() instead.
-    if read.ends_with(separator as char) {
-        read = &read[..read.len() - 1];
-    }
+    let read = read.strip_suffix(separator as char).unwrap_or(read);
 
     assert!(lines.is_empty());
     assert!(line_data.selections.is_empty());

--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -163,12 +163,11 @@ pub fn strip_minus_from_mode(args: &mut Vec<String>) -> bool {
         if arg == "--" {
             break;
         }
-        if arg.starts_with('-') {
+        if let Some(arg_stripped) = arg.strip_prefix('-') {
             if let Some(second) = arg.chars().nth(1) {
                 match second {
                     'r' | 'w' | 'x' | 'X' | 's' | 't' | 'u' | 'g' | 'o' | '0'..='7' => {
-                        // TODO: use strip_prefix() once minimum rust version reaches 1.45.0
-                        *arg = arg[1..arg.len()].to_string();
+                        *arg = arg_stripped.to_string();
                         return true;
                     }
                     _ => {}

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -728,20 +728,12 @@ impl AtPath {
         // Source:
         // http://stackoverflow.com/questions/31439011/getfinalpathnamebyhandle-without-prepended
         let prefix = "\\\\?\\";
-        // FixME: replace ...
-        #[allow(clippy::manual_strip)]
-        if s.starts_with(prefix) {
-            String::from(&s[prefix.len()..])
+
+        if let Some(stripped) = s.strip_prefix(prefix) {
+            String::from(stripped)
         } else {
             s
         }
-        // ... with ...
-        // if let Some(stripped) = s.strip_prefix(prefix) {
-        //     String::from(stripped)
-        // } else {
-        //     s
-        // }
-        // ... when using MSRV with stabilized `strip_prefix()`
     }
 }
 


### PR DESCRIPTION
This closes #2719

I opened this as a draft because of this:
https://github.com/uutils/coreutils/blob/d72a135b42b3c6eec2de587dd80a97f681cedd2f/src/uucore/src/lib/features/mode.rs#L167-L173

I don't really see the benefit of using strip_prefix here since the prefix is already known to be there. IMO it would just add more complexity.

Once someone responds to this I will either remove the comment or implement it using strip_prefix