### PR TITLE
rm: allow -r flag to be specified multiple times

### DIFF
--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -186,6 +186,7 @@ pub fn uu_app() -> App<'static, 'static> {
         )
         .arg(
             Arg::with_name(OPT_RECURSIVE).short("r")
+            .multiple(true)
             .long(OPT_RECURSIVE)
             .help("remove directories and their contents recursively")
         )

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -170,6 +170,29 @@ fn test_rm_recursive() {
 }
 
 #[test]
+fn test_rm_recursive_multiple() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir = "test_rm_recursive_directory";
+    let file_a = "test_rm_recursive_directory/test_rm_recursive_file_a";
+    let file_b = "test_rm_recursive_directory/test_rm_recursive_file_b";
+
+    at.mkdir(dir);
+    at.touch(file_a);
+    at.touch(file_b);
+
+    ucmd.arg("-r")
+        .arg("-r")
+        .arg("-r")
+        .arg(dir)
+        .succeeds()
+        .no_stderr();
+
+    assert!(!at.dir_exists(dir));
+    assert!(!at.file_exists(file_a));
+    assert!(!at.file_exists(file_b));
+}
+
+#[test]
 fn test_rm_directory_without_flag() {
     let (at, mut ucmd) = at_and_ucmd!();
     let dir = "test_rm_directory_without_flag_dir";


### PR DESCRIPTION
GNU rm allows the `-r` flag to be specified multiple times, but
uutils/coreutils would previously exit with an error.

I encountered this while attempting to run `make clean` on the
Postgres source tree (github.com/postgres/postgres).

Updates #1663.