### PR TITLE
env+printenv: use UResult + improve compatibility

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -1,6 +1,7 @@
 // This file is part of the uutils coreutils package.
 //
 // (c) Jordi Boggiano <j.boggiano@seld.be>
+// (c) Thomas Queiroz <thomasqueirozb@gmail.com>
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -131,7 +131,7 @@ pub fn uu_app() -> App<'static, 'static> {
             .long("ignore-environment")
             .help("start with an empty environment"))
         .arg(Arg::with_name("chdir")
-            .short("c")
+            .short("C") // GNU env compatibility
             .long("chdir")
             .takes_value(true)
             .number_of_values(1)

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -229,6 +229,14 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
         }
     }
 
+    // GNU env tests this behavior
+    if opts.program.is_empty() && running_directory.is_some() {
+        return Err(UUsageError::new(
+            125,
+            "must specify command with --chdir (-C)".to_string(),
+        ));
+    }
+
     // NOTE: we manually set and unset the env vars below rather than using Command::env() to more
     //       easily handle the case where no command is given
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -244,6 +244,13 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
 
     // unset specified env vars
     for name in &opts.unsets {
+        if name.is_empty() || name.contains(0 as char) || name.contains('=') {
+            return Err(USimpleError::new(
+                125,
+                format!("cannot unset {}: Invalid argument", name.quote()),
+            ));
+        }
+
         env::remove_var(name);
     }
 

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -9,6 +9,7 @@
 
 use clap::{crate_version, App, Arg};
 use std::env;
+use uucore::error::UResult;
 
 static ABOUT: &str = "Display the values of the specified environment VARIABLE(s), or (with no VARIABLE) display name and value pairs for them all.";
 
@@ -20,7 +21,8 @@ fn usage() -> String {
     format!("{0} [VARIABLE]... [OPTION]...", uucore::execution_phrase())
 }
 
-pub fn uumain(args: impl uucore::Args) -> i32 {
+#[uucore_procs::gen_uumain]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 
     let matches = uu_app().usage(&usage[..]).get_matches_from(args);
@@ -40,7 +42,7 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         for (env_var, value) in env::vars() {
             print!("{}={}{}", env_var, value, separator);
         }
-        return 0;
+        return Ok(());
     }
 
     for env_var in variables {
@@ -48,7 +50,8 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
             print!("{}{}", var, separator);
         }
     }
-    0
+
+    Ok(())
 }
 
 pub fn uu_app() -> App<'static, 'static> {

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -45,13 +45,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     }
 
+    let mut not_found = false;
     for env_var in variables {
         if let Ok(var) = env::var(env_var) {
             print!("{}{}", var, separator);
+        } else {
+            not_found = true;
         }
     }
 
-    Ok(())
+    if not_found {
+        Err(1.into())
+    } else {
+        Ok(())
+    }
 }
 
 pub fn uu_app() -> App<'static, 'static> {

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore (words) bamf chdir
+// spell-checker:ignore (words) bamf chdir rlimit prlimit
 
 #[cfg(not(windows))]
 use std::fs;
@@ -78,6 +78,20 @@ fn test_combined_file_set_unset() {
             .count(),
         1
     );
+}
+
+#[test]
+fn test_unset_invalid_variables() {
+    use uucore::display::Quotable;
+
+    // Cannot test input with \0 in it, since output will also contain \0. rlimit::prlimit fails
+    // with this error: Error { kind: InvalidInput, message: "nul byte found in provided data" }
+    for var in &["", "a=b"] {
+        new_ucmd!().arg("-u").arg(var).run().stderr_only(format!(
+            "env: cannot unset {}: Invalid argument",
+            var.quote()
+        ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
env now passes all GNU tests except for `tests/misc/env-S.pl` and `tests/misc/env-signal-handler.sh`

Also related to #2464