### PR TITLE
factor(doc): Fix benchmarking documentation and other sundries

### DIFF
--- a/src/uu/factor/BENCHMARKING.md
+++ b/src/uu/factor/BENCHMARKING.md
@@ -9,6 +9,7 @@ They are located outside the `uu_factor` crate, as they do not comply
 with the project's minimum supported Rust version, *i.e.* may require
 a newer version of `rustc`.
 
+
 ## Microbenchmarking deterministic functions
 
 We currently use [`criterion`] to benchmark deterministic functions,
@@ -19,9 +20,8 @@ the hardware, operating system version, etc., but they are noisy and affected
 by other tasks on the system (browser, compile jobs, etc.), which can cause
 `criterion` to report spurious performance improvements and regressions.
 
-This can be mitigated by getting as close to [idealized conditions][lemire]
+This can be mitigated by getting as close to [idealised conditions][lemire]
 as possible:
-
 - minimize the amount of computation and I/O running concurrently to the
   benchmark, *i.e.* close your browser and IM clients, don't compile at the
   same time, etc. ;
@@ -29,12 +29,14 @@ as possible:
 - [isolate a **physical** core], set it to `nohz_full`, and pin the benchmark
   to it, so it won't be preempted in the middle of a measurement ;
 - disable ASLR by running `setarch -R cargo bench`, so we can compare results
-  across multiple executions.
+  across multiple executions.  
+
 
 [`criterion`]: https://bheisler.github.io/criterion.rs/book/index.html
 [lemire]: https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/
 [isolate a **physical** core]: https://pyperf.readthedocs.io/en/latest/system.html#isolate-cpus-on-linux
 [frequency stays constant]: ... <!-- ToDO -->
+
 
 ### Guidance for designing microbenchmarks
 
@@ -43,28 +45,29 @@ into account; do not expect it to generalize to other projects.  It is based
 on Daniel Lemire's [*Microbenchmarking calls for idealized conditions*][lemire],
 which I recommend reading if you want to add benchmarks to `factor`.
 
-1. Select a small, self-contained, deterministic component
+1. Select a small, self-contained, deterministic component  
    `gcd` and `table::factor` are good example of such:
    - no I/O or access to external data structures ;
    - no call into other components ;
-   - behavior is deterministic: no RNG, no concurrency, ... ;
+   - behaviour is deterministic: no RNG, no concurrency, ... ;
    - the test's body is *fast* (~100ns for `gcd`, ~10µs for `factor::table`),
      so each sample takes a very short time, minimizing variability and
      maximizing the numbers of samples we can take in a given time.
 
-2. Benchmarks are immutable (once merged in `uutils`)
+2. Benchmarks are immutable (once merged in `uutils`)  
    Modifying a benchmark means previously-collected values cannot meaningfully
    be compared, silently giving nonsensical results.  If you must modify an
    existing benchmark, rename it.
 
-3. Test common cases
+3. Test common cases  
    We are interested in overall performance, rather than specific edge-cases;
-   use **reproducibly-randomized inputs**, sampling from either all possible
+   use **reproducibly-randomised inputs**, sampling from either all possible
    input values or some subset of interest.
 
-4. Use [`criterion`], `criterion::black_box`, ...
+4. Use [`criterion`], `criterion::black_box`, ...  
    `criterion` isn't perfect, but it is also much better than ad-hoc
    solutions in each benchmark.
+
 
 ## Wishlist
 
@@ -73,6 +76,7 @@ which I recommend reading if you want to add benchmarks to `factor`.
 `criterion` always uses the arithmetic average as estimator; in microbenchmarks,
 where the code under test is fully deterministic and the measurements are
 subject to additive, positive noise, [the minimum is more appropriate][lemire].
+
 
 ### CI & reproducible performance testing
 
@@ -91,16 +95,18 @@ performance improvements and regressions.
 [`cachegrind`]: https://www.valgrind.org/docs/manual/cg-manual.html
 [`iai`]: https://bheisler.github.io/criterion.rs/book/iai/iai.html
 
-### Comparing randomized implementations across multiple inputs
+
+### Comparing randomised implementations across multiple inputs
 
 `factor` is a challenging target for system benchmarks as it combines two
 characteristics:
 
-1. integer factoring algorithms are randomized, with large variance in
+1. integer factoring algorithms are randomised, with large variance in
    execution time ;
 
 2. various inputs also have large differences in factoring time, that
    corresponds to no natural, linear ordering of the inputs.
+
 
 If (1) was untrue (i.e. if execution time wasn't random), we could faithfully
 compare 2 implementations (2 successive versions, or `uutils` and GNU) using

--- a/src/uu/factor/BENCHMARKING.md
+++ b/src/uu/factor/BENCHMARKING.md
@@ -13,7 +13,7 @@ a newer version of `rustc`.
 We currently use [`criterion`] to benchmark deterministic functions,
 such as `gcd` and `table::factor`.
 
-However, µbenchmarks are by nature unstable: not only are they specific to
+However, microbenchmarks are by nature unstable: not only are they specific to
 the hardware, operating system version, etc., but they are noisy and affected
 by other tasks on the system (browser, compile jobs, etc.), which can cause
 `criterion` to report spurious performance improvements and regressions.
@@ -36,7 +36,7 @@ as possible:
 [frequency stays constant]: XXXTODO
 
 
-### Guidance for designing µbenchmarks
+### Guidance for designing microbenchmarks
 
 *Note:* this guidance is specific to `factor` and takes its application domain
 into account; do not expect it to generalise to other projects.  It is based
@@ -71,7 +71,7 @@ which I recommend reading if you want to add benchmarks to `factor`.
 
 ### Configurable statistical estimators
 
-`criterion` always uses the arithmetic average as estimator; in µbenchmarks,
+`criterion` always uses the arithmetic average as estimator; in microbenchmarks,
 where the code under test is fully deterministic and the measurements are
 subject to additive, positive noise, [the minimum is more appropriate][lemire].
 
@@ -84,7 +84,7 @@ to the constraints of the real-world, and aren't perfectly reproducible.
 Moreover, the mitigations for it (described above) aren't achievable in
 virtualized, multi-tenant environments such as CI.
 
-Instead, we could run the µbenchmarks in a simulated CPU with [`cachegrind`],
+Instead, we could run the microbenchmarks in a simulated CPU with [`cachegrind`],
 measure execution “time” in that model (in CI), and use it to detect and report
 performance improvements and regressions.
 

--- a/src/uu/factor/BENCHMARKING.md
+++ b/src/uu/factor/BENCHMARKING.md
@@ -1,7 +1,5 @@
 # Benchmarking `factor`
 
-<!-- spell-checker:ignore (names) Daniel Lemire * Lemire's ; (misc) nohz -->
-
 The benchmarks for `factor` are located under `tests/benches/factor`
 and can be invoked with `cargo bench` in that directory.
 
@@ -15,7 +13,7 @@ a newer version of `rustc`.
 We currently use [`criterion`] to benchmark deterministic functions,
 such as `gcd` and `table::factor`.
 
-However, microbenchmarks are by nature unstable: not only are they specific to
+However, µbenchmarks are by nature unstable: not only are they specific to
 the hardware, operating system version, etc., but they are noisy and affected
 by other tasks on the system (browser, compile jobs, etc.), which can cause
 `criterion` to report spurious performance improvements and regressions.
@@ -35,13 +33,13 @@ as possible:
 [`criterion`]: https://bheisler.github.io/criterion.rs/book/index.html
 [lemire]: https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/
 [isolate a **physical** core]: https://pyperf.readthedocs.io/en/latest/system.html#isolate-cpus-on-linux
-[frequency stays constant]: ... <!-- ToDO -->
+[frequency stays constant]: XXXTODO
 
 
-### Guidance for designing microbenchmarks
+### Guidance for designing µbenchmarks
 
 *Note:* this guidance is specific to `factor` and takes its application domain
-into account; do not expect it to generalize to other projects.  It is based
+into account; do not expect it to generalise to other projects.  It is based
 on Daniel Lemire's [*Microbenchmarking calls for idealized conditions*][lemire],
 which I recommend reading if you want to add benchmarks to `factor`.
 
@@ -73,7 +71,7 @@ which I recommend reading if you want to add benchmarks to `factor`.
 
 ### Configurable statistical estimators
 
-`criterion` always uses the arithmetic average as estimator; in microbenchmarks,
+`criterion` always uses the arithmetic average as estimator; in µbenchmarks,
 where the code under test is fully deterministic and the measurements are
 subject to additive, positive noise, [the minimum is more appropriate][lemire].
 
@@ -83,10 +81,10 @@ subject to additive, positive noise, [the minimum is more appropriate][lemire].
 Measuring performance on real hardware is important, as it relates directly
 to what users of `factor` experience; however, such measurements are subject
 to the constraints of the real-world, and aren't perfectly reproducible.
-Moreover, the mitigation for it (described above) isn't achievable in
+Moreover, the mitigations for it (described above) aren't achievable in
 virtualized, multi-tenant environments such as CI.
 
-Instead, we could run the microbenchmarks in a simulated CPU with [`cachegrind`],
+Instead, we could run the µbenchmarks in a simulated CPU with [`cachegrind`],
 measure execution “time” in that model (in CI), and use it to detect and report
 performance improvements and regressions.
 

--- a/src/uu/factor/build.rs
+++ b/src/uu/factor/build.rs
@@ -13,6 +13,8 @@
 //! 2 has no multiplicative inverse mode 2^64 because 2 | 2^64,
 //! and in any case divisibility by two is trivial by checking the LSB.
 
+// spell-checker:ignore (ToDO) invs newr newrp newtp outstr
+
 #![cfg_attr(test, allow(dead_code))]
 
 use std::env::{self, args};
@@ -58,13 +60,13 @@ fn main() {
     let mut x = primes.next().unwrap();
     for next in primes {
         // format the table
-        let output = format!("({}, {}, {}),", x, modular_inverse(x), std::u64::MAX / x);
-        if cols + output.len() > MAX_WIDTH {
-            write!(file, "\n    {}", output).unwrap();
-            cols = 4 + output.len();
+        let outstr = format!("({}, {}, {}),", x, modular_inverse(x), std::u64::MAX / x);
+        if cols + outstr.len() > MAX_WIDTH {
+            write!(file, "\n    {}", outstr).unwrap();
+            cols = 4 + outstr.len();
         } else {
-            write!(file, " {}", output).unwrap();
-            cols += 1 + output.len();
+            write!(file, " {}", outstr).unwrap();
+            cols += 1 + outstr.len();
         }
 
         x = next;
@@ -79,7 +81,7 @@ fn main() {
 }
 
 #[test]
-fn test_generator_is_prime() {
+fn test_generator_isprime() {
     assert_eq!(Sieve::odd_primes.take(10_000).all(is_prime));
 }
 
@@ -104,5 +106,5 @@ const PREAMBLE: &str = r##"/*
 // re-run src/factor/gen_tables.rs.
 
 #[allow(clippy::unreadable_literal)]
-pub const PRIME_INVERSIONS_U64: &[(u64, u64, u64)] = &[
+pub const P_INVS_U64: &[(u64, u64, u64)] = &[
    "##;

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -17,7 +17,6 @@ type Exponent = u8;
 #[derive(Clone, Debug)]
 struct Decomposition(SmallVec<[(u64, Exponent); NUM_FACTORS_INLINE]>);
 
-// spell-checker:ignore (names) Erdős–Kac * Erdős Kac
 // The number of factors to inline directly into a `Decomposition` object.
 // As a consequence of the Erdős–Kac theorem, the average number of prime factors
 // of integers < 10²⁵ ≃ 2⁸³ is 4, so we can use a slightly higher value.
@@ -251,7 +250,6 @@ impl Distribution<Factors> for Standard {
         let mut g = 1u64;
         let mut n = u64::MAX;
 
-        // spell-checker:ignore (names) Adam Kalai * Kalai's
         // Adam Kalai's algorithm for generating uniformly-distributed
         // integers and their factorization.
         //

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -21,7 +21,6 @@ impl Basis for Montgomery<u64> {
 }
 
 impl Basis for Montgomery<u32> {
-    // spell-checker:ignore (names) Steve Worley
     // Small set of bases for the Miller-Rabin prime test, valid for all 32b integers;
     //  discovered by Steve Worley on 2013-05-27, see miller-rabin.appspot.com
     #[allow(clippy::unreadable_literal)]
@@ -122,8 +121,8 @@ mod tests {
     }
 
     fn odd_primes() -> impl Iterator<Item = u64> {
-        use crate::table::{NEXT_PRIME, PRIME_INVERSIONS_U64};
-        PRIME_INVERSIONS_U64
+        use crate::table::{NEXT_PRIME, P_INVS_U64};
+        P_INVS_U64
             .iter()
             .map(|(p, _, _)| *p)
             .chain(iter::once(NEXT_PRIME))

--- a/src/uu/factor/src/numeric/gcd.rs
+++ b/src/uu/factor/src/numeric/gcd.rs
@@ -93,7 +93,7 @@ mod tests {
             gcd(a, gcd(b, c)) == gcd(gcd(a, b), c)
         }
 
-        fn scalar_multiplication(a: u64, b: u64, k: u64) -> bool {
+        fn scalar_mult(a: u64, b: u64, k: u64) -> bool {
             gcd(k * a, k * b) == k * gcd(a, b)
         }
 

--- a/src/uu/factor/src/numeric/modular_inverse.rs
+++ b/src/uu/factor/src/numeric/modular_inverse.rs
@@ -16,11 +16,11 @@ pub(crate) fn modular_inverse<T: Int>(a: T) -> T {
     debug_assert!(a % (one + one) == one, "{:?} is not odd", a);
 
     let mut t = zero;
-    let mut new_t = one;
+    let mut newt = one;
     let mut r = zero;
-    let mut new_r = a;
+    let mut newr = a;
 
-    while new_r != zero {
+    while newr != zero {
         let quot = if r == zero {
             // special case when we're just starting out
             // This works because we know that
@@ -28,15 +28,15 @@ pub(crate) fn modular_inverse<T: Int>(a: T) -> T {
             T::max_value()
         } else {
             r
-        } / new_r;
+        } / newr;
 
-        let new_tp = t.wrapping_sub(&quot.wrapping_mul(&new_t));
-        t = new_t;
-        new_t = new_tp;
+        let newtp = t.wrapping_sub(&quot.wrapping_mul(&newt));
+        t = newt;
+        newt = newtp;
 
-        let new_rp = r.wrapping_sub(&quot.wrapping_mul(&new_r));
-        r = new_r;
-        new_r = new_rp;
+        let newrp = r.wrapping_sub(&quot.wrapping_mul(&newr));
+        r = newr;
+        newr = newrp;
     }
 
     debug_assert_eq!(r, one);

--- a/src/uu/factor/src/numeric/montgomery.rs
+++ b/src/uu/factor/src/numeric/montgomery.rs
@@ -69,7 +69,7 @@ impl<T: DoubleInt> Montgomery<T> {
         let t_bits = T::zero().count_zeros() as usize;
 
         debug_assert!(x < (self.n.as_double_width()) << t_bits);
-        // TODO: optimize
+        // TODO: optimiiiiiiise
         let Montgomery { a, n } = self;
         let m = T::from_double_width(x).wrapping_mul(a);
         let nm = (n.as_double_width()) * (m.as_double_width());
@@ -138,7 +138,7 @@ impl<T: DoubleInt> Arithmetic for Montgomery<T> {
             r + self.n.wrapping_neg()
         };
 
-        // Normalize to [0; n[
+        // Normalise to [0; n[
         let r = if r < self.n { r } else { r - self.n };
 
         // Check that r (reduced back to the usual representation) equals
@@ -200,7 +200,7 @@ mod tests {
     }
     parametrized_check!(test_add);
 
-    fn test_multiplication<A: DoubleInt>() {
+    fn test_mult<A: DoubleInt>() {
         for n in 0..100 {
             let n = 2 * n + 1;
             let m = Montgomery::<A>::new(n);
@@ -213,7 +213,7 @@ mod tests {
             }
         }
     }
-    parametrized_check!(test_multiplication);
+    parametrized_check!(test_mult);
 
     fn test_roundtrip<A: DoubleInt>() {
         for n in 0..100 {

--- a/src/uu/factor/src/table.rs
+++ b/src/uu/factor/src/table.rs
@@ -13,7 +13,7 @@ use crate::Factors;
 include!(concat!(env!("OUT_DIR"), "/prime_table.rs"));
 
 pub fn factor(num: &mut u64, factors: &mut Factors) {
-    for &(prime, inv, ceil) in PRIME_INVERSIONS_U64 {
+    for &(prime, inv, ceil) in P_INVS_U64 {
         if *num == 1 {
             break;
         }
@@ -45,7 +45,7 @@ pub fn factor(num: &mut u64, factors: &mut Factors) {
 
 pub const CHUNK_SIZE: usize = 8;
 pub fn factor_chunk(n_s: &mut [u64; CHUNK_SIZE], f_s: &mut [Factors; CHUNK_SIZE]) {
-    for &(prime, inv, ceil) in PRIME_INVERSIONS_U64 {
+    for &(prime, inv, ceil) in P_INVS_U64 {
         if n_s[0] == 1 && n_s[1] == 1 && n_s[2] == 1 && n_s[3] == 1 {
             break;
         }


### PR DESCRIPTION
- Revert "docs/factor ~ fix markdownlint complaints"
- Revert "refactor/factor ~ polish spelling (comments, names, and exceptions)"

Since those commits included a bunch of other cosmetic changes, I'm really
not bothering to be more selective.
