### PR TITLE
seq: correct fixed-width spacing for inf sequences

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -235,6 +235,14 @@ fn write_value_float(
             width = if width > 0 { width - 1 } else { width },
             precision = precision,
         )
+    } else if *value == ExtendedBigDecimal::Infinity || *value == ExtendedBigDecimal::MinusInfinity
+    {
+        format!(
+            "{value:>width$.precision$}",
+            value = value,
+            width = width,
+            precision = precision,
+        )
     } else {
         format!(
             "{value:>0width$.precision$}",

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -531,6 +531,22 @@ fn test_inf() {
 }
 
 #[test]
+fn test_inf_width() {
+    run(
+        &["-w", "1.000", "inf", "inf"],
+        b"1.000\n  inf\n  inf\n  inf\n",
+    );
+}
+
+#[test]
+fn test_neg_inf_width() {
+    run(
+        &["-w", "1.000", "-inf", "-inf"],
+        b"1.000\n -inf\n -inf\n -inf\n",
+    );
+}
+
+#[test]
 fn test_ignore_leading_whitespace() {
     new_ucmd!()
         .arg("   1")


### PR DESCRIPTION
Pad infinity and negative infinity values with spaces when using the
`-w` option to `seq`. This corrects the behavior of `seq` to match that
of the GNU version:

    $ seq -w 1.000 inf inf | head -n 4
    1.000
      inf
      inf
      inf

Previously, it incorrectly padded with 0s instead of spaces.