### PR TITLE
gnu/test: add the iso en_us locale to help with some tests

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -71,6 +71,19 @@ jobs:
         ## Install dependencies
         sudo apt-get update
         sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq
+    - name: Add various locales
+      shell: bash
+      run: |
+        echo "Before:"
+        locale -a
+        ## Some tests fail with 'cannot change locale (en_US.ISO-8859-1): No such file or directory'
+        ## Some others need a French locale
+        sudo locale-gen
+        sudo locale-gen fr_FR
+        sudo locale-gen fr_FR.UTF-8
+        sudo update-locale
+        echo "After:"
+        locale -a
     - name: Build binaries
       shell: bash
       run: |


### PR DESCRIPTION
Closes #2754

We are regressing deliberately because they are actual issues.
* `expr` with multibytes: https://github.com/uutils/coreutils/issues/3132
* `sort -k` isn't working well with other locales: https://github.com/uutils/coreutils/issues/3123