### PR TITLE
Fix mv bug: Resolve symlinks, dot and dot-dot dirs, and fail when the source and target are the same file

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -199,13 +199,14 @@ fn determine_overwrite_mode(matches: &ArgMatches) -> OverwriteMode {
 }
 
 fn exec(files: &[String], b: Behavior) -> i32 {
-
     let paths: Vec<PathBuf> = {
         let paths = files.iter().map(Path::new);
-        
+
         // Strip slashes from path, if strip opt present
         if b.strip_slashes {
-            paths.map(|p| p.components().as_path().to_owned()).collect::<Vec<PathBuf>>()
+            paths
+                .map(|p| p.components().as_path().to_owned())
+                .collect::<Vec<PathBuf>>()
         } else {
             paths.map(|p| p.to_owned()).collect::<Vec<PathBuf>>()
         }
@@ -231,7 +232,9 @@ fn exec(files: &[String], b: Behavior) -> i32 {
             // GNU semantics are: if the source and target are the same, no move occurs and we print an error
             if source.eq(target) {
                 show_error!(
-                    "'{}' and '{}' are the same file", source.display(), target.display()
+                    "'{}' and '{}' are the same file",
+                    source.display(),
+                    target.display()
                 );
                 return 1;
             }
@@ -356,15 +359,13 @@ fn rename(from: &Path, to: &Path, b: &Behavior) -> io::Result<()> {
         }
     }
 
-
-    
     // "to" may no longer exist if it was backed up
     if to.exists() && to.is_dir() {
         // normalize behavior between *nix and windows
         if from.is_dir() {
             if is_empty_dir(to) {
                 fs::remove_dir(to)?
-        } else {
+            } else {
                 return Err(io::Error::new(io::ErrorKind::Other, "Directory not empty"));
             }
         }

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -219,7 +219,7 @@ fn exec(files: &[String], b: Behavior) -> i32 {
         2 => {
             let source = &paths[0];
             let target = &paths[1];
-            // Here we use the `symlink_metadata()` method instead of `exists()`,
+            // Here we use the `metadata()` method instead of `exists()`,
             // since it handles dangling symlinks correctly. The method gives an
             // `Ok()` results unless the source does not exist, or the user
             // lacks permission to access metadata.

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -233,6 +233,20 @@ fn test_mv_force_replace_file() {
 }
 
 #[test]
+fn test_mv_same_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file_a = "test_mv_same_file_a";
+
+    at.touch(file_a);
+    ucmd.arg(file_a)
+        .arg(file_a)
+        .fails()
+        .stderr_is(format!(
+            "mv: '{}' and '{}' are the same file\n", file_a, file_a
+        ));
+}
+
+#[test]
 fn test_mv_simple_backup() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_simple_backup_file_a";

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -238,12 +238,10 @@ fn test_mv_same_file() {
     let file_a = "test_mv_same_file_a";
 
     at.touch(file_a);
-    ucmd.arg(file_a)
-        .arg(file_a)
-        .fails()
-        .stderr_is(format!(
-            "mv: '{}' and '{}' are the same file\n", file_a, file_a
-        ));
+    ucmd.arg(file_a).arg(file_a).fails().stderr_is(format!(
+        "mv: '{}' and '{}' are the same file\n",
+        file_a, file_a
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Attempted fix of the mv bug described at: https://github.com/uutils/coreutils/issues/2760

Initially made the problem more complicated than it actually was, so there is some minor moving around of code blocks.  Have included a test as well.