### PR TITLE
Fix idempotence of `utils/build-gnu.sh`

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -40,7 +40,7 @@ done
 ./bootstrap --gnulib-srcdir="$GNULIB_SRCDIR"
 ./configure --quiet --disable-gcc-warnings
 #Add timeout to to protect against hangs
-sed -i 's|"\$@|/usr/bin/timeout 600 "\$@|' build-aux/test-driver
+sed -i 's|^"\$@|/usr/bin/timeout 600 "\$@|' build-aux/test-driver
 # Change the PATH in the Makefile to test the uutils coreutils instead of the GNU coreutils
 sed -i "s/^[[:blank:]]*PATH=.*/  PATH='${BUILDDIR//\//\\/}\$(PATH_SEPARATOR)'\"\$\$PATH\" \\\/" Makefile
 sed -i 's| tr | /usr/bin/tr |' tests/init.sh
@@ -95,11 +95,11 @@ sed -i 's|paste |/usr/bin/paste |' tests/misc/od-endian.sh
 sed -i 's|seq |/usr/bin/seq |' tests/misc/sort-discrim.sh
 
 # Add specific timeout to tests that currently hang to limit time spent waiting
-sed -i 's|seq \$|/usr/bin/timeout 0.1 seq \$|' tests/misc/seq-precision.sh tests/misc/seq-long-double.sh
+sed -i 's|\(^\s*\)seq \$|\1/usr/bin/timeout 0.1 seq \$|' tests/misc/seq-precision.sh tests/misc/seq-long-double.sh
 
 
 # Remove dup of /usr/bin/ when executed several times
-grep -rl '/usr/bin//usr/bin/' tests/* | xargs --no-run-if-empty sed -i 's|/usr/bin//usr/bin/|/usr/bin/|g'
+grep -rlE '/usr/bin/\s?/usr/bin' init.cfg tests/* | xargs --no-run-if-empty sed -Ei 's|/usr/bin/\s?/usr/bin/|/usr/bin/|g'
 
 
 #### Adjust tests to make them work with Rust/coreutils


### PR DESCRIPTION
Fixes #2733

This is a minimal patch to restore idempotence of `utils/build-gnu.sh`.

* Fix regular expressions to only match when run the first time.
* Enhance the regular expression which removes duplicated "/usr/bin/" to allow a space between them (+ also considers `init.cfg`).



