### PR TITLE
Fix typo in `utils/build-gnu.sh`

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -5,7 +5,7 @@
 set -e
 if test ! -d ../gnu; then
     echo "Could not find ../gnu"
-    echo "git clone https://github.com:coreutils/coreutils.git gnu"
+    echo "git clone https://github.com/coreutils/coreutils.git gnu"
     exit 1
 fi
 if test ! -d ../gnulib; then


### PR DESCRIPTION
The URL of the GNU coreutils repo contained a typo.