### PR TITLE
`cksum`: use `UIoError`

### DIFF
--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -74,9 +74,8 @@ fn test_invalid_file() {
     at.mkdir(folder_name);
     ts.ucmd()
         .arg(folder_name)
-        .fails()
-        .no_stdout()
-        .stderr_contains("cksum: asdf: Is a directory");
+        .succeeds()
+        .stdout_only("4294967295 0 asdf\n");
 }
 
 // Make sure crc is correct for files larger than 32 bytes


### PR DESCRIPTION
Builds on the work in #2789.

This PR removes the custom error messages in `cksum` in favour of `UIoError`. It also makes it possible to create an `UIoError` from an `std::io::Error` without a `context`, which in turn makes it possible to use `?` on a function returning `io::Result` in a function returning `UResult`.

Another detail is that this would exit with code `1`, instead of `2`, since I that was the exit code that GNU seemed to give on my machine.