### PR TITLE
ls: Improve error handling and other improvements

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2223,17 +2223,21 @@ fn display_file_name(
                 // Because we use an absolute path, we can assume this is guaranteed to exist.
                 // Otherwise, we use path.md(), which will guarantee we color to the same
                 // color of non-existent symlinks according to style_for_path_with_metadata.
-                let target_metadata = match target_data.md() {
-                    Some(md) => md,
-                    None => path.md().unwrap(),
-                };
+                if path.md().is_none() {
+                    name.push_str(&path.p_buf.read_link().unwrap().to_string_lossy());
+                } else {
+                    let target_metadata = match target_data.md() {
+                        Some(md) => md,
+                        None => path.md().unwrap(),
+                    };
 
-                name.push_str(&color_name(
-                    ls_colors,
-                    &target_data.p_buf,
-                    target.to_string_lossy().into_owned(),
-                    target_metadata,
-                ));
+                    name.push_str(&color_name(
+                        ls_colors,
+                        &target_data.p_buf,
+                        target.to_string_lossy().into_owned(),
+                        target_metadata,
+                    ));
+                }
             } else {
                 // If no coloring is required, we just use target as is.
                 name.push_str(&target.to_string_lossy());

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2274,6 +2274,7 @@ fn display_symlink_count(metadata: &Metadata) -> String {
     metadata.nlink().to_string()
 }
 
+#[allow(unused_variables)]
 fn display_inode(metadata: &Metadata) -> String {
     #[cfg(unix)]
     {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1343,7 +1343,6 @@ fn list(locs: Vec<&Path>, config: Config) -> UResult<()> {
                 std::io::Error::new(ErrorKind::NotFound, "NotFound"),
                 path_data.p_buf.into_os_string()
             ));
-            //show!(err.map_err_context(|| pd.p_buf.to_string_lossy().into_owned()));
             continue;
         };
 
@@ -1487,7 +1486,6 @@ fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>)
                         std::io::Error::new(ErrorKind::NotFound, "NotFound"),
                         unwrapped.file_name()
                     ));
-                    //show!(err.map_err_context(|| pd.p_buf.to_string_lossy().into_owned()));
                     continue;
                 }
                 Ok(dir_ft) => {
@@ -1499,7 +1497,6 @@ fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>)
                             std::io::Error::new(ErrorKind::NotFound, "NotFound"),
                             unwrapped.file_name()
                         ));
-                        //show!(err.map_err_context(|| pd.p_buf.to_string_lossy().into_owned()));
                     }
                     res
                 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1545,7 +1545,10 @@ fn get_metadata(p_buf: &Path, dereference: bool) -> std::io::Result<Metadata> {
     }
 }
 
-fn display_dir_entry_size(entry: &PathData, config: &Config) -> (usize, usize, usize, usize, usize) {
+fn display_dir_entry_size(
+    entry: &PathData,
+    config: &Config,
+) -> (usize, usize, usize, usize, usize) {
     // TODO: Cache/memorize the display_* results so we don't have to recalculate them.
     if let Some(md) = entry.md() {
         (
@@ -1781,10 +1784,11 @@ fn display_item_long(
         {
             if config.inode {
                 let _ = write!(
-                out,
-                "{} ",
-                pad_left(&get_inode(md), padding.longest_inode_len),
-            );}
+                    out,
+                    "{} ",
+                    pad_left(&get_inode(md), padding.longest_inode_len),
+                );
+            }
         }
 
         let _ = write!(
@@ -1849,11 +1853,8 @@ fn display_item_long(
         #[cfg(unix)]
         {
             if config.inode {
-                let _ = write!(
-                out,
-                "{} ",
-                pad_left("?", padding.longest_inode_len),
-            );}
+                let _ = write!(out, "{} ", pad_left("?", padding.longest_inode_len),);
+            }
         }
 
         let _ = write!(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1347,7 +1347,6 @@ fn list(locs: Vec<&Path>, config: Config) -> UResult<()> {
             continue;
         };
 
-        // don't do file_type() to save allocating metadata
         let show_dir_contents = match path_data.file_type() {
             Some(ft) => !config.directory && ft.is_dir(),
             None => {
@@ -1415,7 +1414,7 @@ fn is_hidden(file_path: &DirEntry) -> bool {
         let attr = metadata.file_attributes();
         (attr & 0x2) > 0
     }
-    #[cfg(unix)]
+    #[cfg(not(windows))]
     {
         file_path
             .file_name()
@@ -2306,7 +2305,7 @@ fn display_symlink_count(metadata: &Metadata) -> String {
 fn display_inode(metadata: &Metadata) -> String {
     #[cfg(unix)]
     {
-        metadata.ino().to_string()
+        get_inode(metadata)
     }
     #[cfg(not(unix))]
     {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2052,9 +2052,9 @@ fn display_size_or_rdev(metadata: &Metadata, config: &Config) -> String {
         let ft = metadata.file_type();
         if ft.is_char_device() || ft.is_block_device() {
             let dev: u64 = metadata.rdev();
-            let major = (dev >> 24) as u8;
-            let minor = (dev & 0xff) as u8;
-            return format!("{},{:>5}", major, minor,);
+            let major = (dev >> 8) as u8;
+            let minor = dev as u8;
+            return format!("{}, {}", major, minor,);
         }
     }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1597,14 +1597,27 @@ fn display_items(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout
             mut longest_size_len,
         ) = (1, 1, 1, 1, 1);
 
+        #[cfg(unix)]
         for item in items {
             let context_len = item.security_context.len();
             let (link_count_len, uname_len, group_len, size_len, inode_len) =
                 display_dir_entry_size(item, config);
-            #[cfg(unix)]
-            {
-                longest_inode_len = inode_len.max(longest_inode_len);
+            longest_inode_len = inode_len.max(longest_inode_len);
+            longest_link_count_len = link_count_len.max(longest_link_count_len);
+            longest_size_len = size_len.max(longest_size_len);
+            longest_uname_len = uname_len.max(longest_uname_len);
+            longest_group_len = group_len.max(longest_group_len);
+            if config.context {
+                longest_context_len = context_len.max(longest_context_len);
             }
+            longest_size_len = size_len.max(longest_size_len);
+        }
+
+        #[cfg(not(unix))]
+        for item in items {
+            let context_len = item.security_context.len();
+            let (link_count_len, uname_len, group_len, size_len, _inode_len) =
+                display_dir_entry_size(item, config);
             longest_link_count_len = link_count_len.max(longest_link_count_len);
             longest_size_len = size_len.max(longest_size_len);
             longest_uname_len = uname_len.max(longest_uname_len);

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2274,7 +2274,6 @@ fn display_symlink_count(metadata: &Metadata) -> String {
     metadata.nlink().to_string()
 }
 
-#[cfg(unix)]
 fn display_inode(metadata: &Metadata) -> String {
     #[cfg(unix)]
     {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1315,9 +1315,7 @@ impl PathData {
 
     fn md(&self) -> Option<&Metadata> {
         self.md
-            .get_or_init(|| {
-                get_metadata(&self.p_buf, self.must_dereference).ok()
-            })
+            .get_or_init(|| get_metadata(&self.p_buf, self.must_dereference).ok())
             .as_ref()
     }
 
@@ -1500,7 +1498,8 @@ fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>)
                     continue;
                 }
                 Ok(dir_ft) => {
-                    let res = PathData::new(unwrapped.path(), Some(Ok(dir_ft)), None, config, false);
+                    let res =
+                        PathData::new(unwrapped.path(), Some(Ok(dir_ft)), None, config, false);
                     if dir_ft.is_symlink() && res.md().is_none() {
                         let _ = out.flush();
                         show!(LsError::IOErrorContext(
@@ -1843,7 +1842,7 @@ fn display_item_long(
         {
             if config.inode {
                 if config.recursive {
-                    let _ = write!(out, "       {} ", "?".to_string());                    
+                    let _ = write!(out, "       {} ", "?".to_string());
                 } else {
                     let _ = write!(out, "{} ", "?".to_string());
                 }
@@ -2198,7 +2197,10 @@ fn display_file_name(
     //     name.push_str(&path.p_buf.read_link().unwrap().to_string_lossy());
     // }
 
-    if config.format == Format::Long && path.file_type().is_some() && path.file_type().unwrap().is_symlink() {
+    if config.format == Format::Long
+        && path.file_type().is_some()
+        && path.file_type().unwrap().is_symlink()
+    {
         if let Ok(target) = path.p_buf.read_link() {
             name.push_str(" -> ");
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1315,24 +1315,6 @@ fn test_ls_color() {
             "{}  test-color\nb  {}\n",
             a_with_colors, z_with_colors
         ));
-
-    // link resolution should not contain colors
-    // this is GNU behavior but is not the present behavior uutils
-    // keeping here as we may choose later to make an option
-    // at.mkdir("temp_dir");
-    // at.symlink_file("temp_dir/does_not_exist", "temp_dir/dangle");
-    // let dangle_colors = format!("\x1b[1;40;31m{}\x1b[0m", "dangle");
-    // scene
-    //     .ucmd()
-    //     .arg("--color")
-    //     .arg("-l")
-    //     .arg("temp_dir")
-    //     .succeeds()
-    //     .stdout_contains(format!(
-    //         "{} -> {}/temp_dir/does_not_exist",
-    //         dangle_colors,
-    //         at.subdir.to_string_lossy()
-    //     ));
 }
 
 #[cfg(unix)]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -101,6 +101,7 @@ fn test_ls_io_errors() {
         .arg("-la")
         .arg("some-dir3/*")
         .fails()
+        .stderr_contains("some-dir4")
         .stderr_contains("cannot open directory")
         .stderr_contains("Permission denied")
         .stdout_does_not_contain("some-dir4");

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -104,7 +104,7 @@ fn test_ls_io_errors() {
         .stderr_contains("some-dir4")
         .stderr_contains("cannot open directory")
         .stderr_contains("Permission denied")
-        .stdout_does_contain("some-dir4");
+        .stdout_contains("some-dir4");
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -64,6 +64,12 @@ fn test_ls_io_errors() {
     at.mkdir("some-dir1");
     at.mkdir("some-dir2");
     at.symlink_file("does_not_exist", "some-dir2/dangle");
+    at.mkdir("some-dir3");
+    at.mkdir("some-dir3/some-dir4");
+    at.mkdir("some-dir3/some-dir5");
+    at.mkdir("some-dir3/some-dir6");
+    at.mkdir("some-dir3/some-dir7");
+    at.mkdir("some-dir3/some-dir8");
 
     scene.ccmd("chmod").arg("000").arg("some-dir1").succeeds();
 
@@ -83,6 +89,32 @@ fn test_ls_io_errors() {
         .stderr_contains("cannot access")
         .stderr_contains("No such file or directory")
         .stdout_contains(if cfg!(windows) { "dangle" } else { "? dangle" });
+
+    scene
+        .ccmd("chmod")
+        .arg("000")
+        .arg("some-dir3/some-dir4")
+        .succeeds();
+
+    scene
+        .ucmd()
+        .arg("-la")
+        .arg("some-dir3/*")
+        .fails()
+        .stderr_contains("some-dir4")
+        .stderr_contains("cannot open directory")
+        .stderr_contains("Permission denied")
+        .stdout_does_not_contain("some-dir4");
+
+    scene
+        .ucmd()
+        .arg("-laR")
+        .arg("some-dir3")
+        .fails()
+        .stderr_contains("some-dir4")
+        .stderr_contains("cannot open directory")
+        .stderr_contains("Permission denied")
+        .stdout_does_not_contain("some-dir4");
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -104,7 +104,7 @@ fn test_ls_io_errors() {
         .stderr_contains("some-dir4")
         .stderr_contains("cannot open directory")
         .stderr_contains("Permission denied")
-        .stdout_does_not_contain("some-dir4");
+        .stdout_does_contain("some-dir4");
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -65,12 +65,8 @@ fn test_ls_io_errors() {
     at.mkdir("some-dir2");
     at.symlink_file("does_not_exist", "some-dir2/dangle");
 
-    scene.ccmd("chmod")
-            .arg("000")
-            .arg(format!("{}/", at.subdir.to_string_lossy()))
-            .arg("some-dir1")
-            .succeeds();
-    
+    scene.ccmd("chmod").arg("000").arg("some-dir1").succeeds();
+
     scene
         .ucmd()
         .arg("-1")
@@ -102,7 +98,7 @@ fn test_ls_walk_glob() {
             .to_str()
             .unwrap(),
     );
- 
+
     #[allow(clippy::trivial_regex)]
     let re_pwd = Regex::new(r"^\.\n").unwrap();
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -101,7 +101,6 @@ fn test_ls_io_errors() {
         .arg("-la")
         .arg("some-dir3/*")
         .fails()
-        .stderr_contains("some-dir4")
         .stderr_contains("cannot open directory")
         .stderr_contains("Permission denied")
         .stdout_does_not_contain("some-dir4");

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -51,17 +51,6 @@ fn test_ls_ordering() {
 
     scene
         .ucmd()
-        .arg("-i")
-        .succeeds()
-        .stdout_matches(&Regex::new(".*some-dir1.*some-dir3.*some-dir5\\n").unwrap())
-        .stdout_matches(&Regex::new(".*some-dir2.*some-dir4.*some-dir6").unwrap())
-        .stdout_does_not_match(
-            &Regex::new(".*some-dir1.*some-dir2.*some-dir3.*some-dir4.*some-dir5.*some-dir6")
-                .unwrap(),
-        );
-
-    scene
-        .ucmd()
         .arg("-Rl")
         .succeeds()
         .stdout_matches(&Regex::new("some-dir1:\\ntotal 0").unwrap());
@@ -1334,20 +1323,22 @@ fn test_ls_color() {
         ));
 
     // link resolution should not contain colors
-    at.mkdir("temp_dir");
-    at.symlink_file("temp_dir/does_not_exist", "temp_dir/dangle");
-    let dangle_colors = format!("\x1b[1;40;31m{}\x1b[0m", "dangle");
-    scene
-        .ucmd()
-        .arg("--color")
-        .arg("-l")
-        .arg("temp_dir")
-        .succeeds()
-        .stdout_contains(format!(
-            "{} -> {}/temp_dir/does_not_exist",
-            dangle_colors,
-            at.subdir.to_string_lossy()
-        ));
+    // this is GNU behavior but is not the present behavior uutils
+    // keeping here as we may choose later to make an option
+    // at.mkdir("temp_dir");
+    // at.symlink_file("temp_dir/does_not_exist", "temp_dir/dangle");
+    // let dangle_colors = format!("\x1b[1;40;31m{}\x1b[0m", "dangle");
+    // scene
+    //     .ucmd()
+    //     .arg("--color")
+    //     .arg("-l")
+    //     .arg("temp_dir")
+    //     .succeeds()
+    //     .stdout_contains(format!(
+    //         "{} -> {}/temp_dir/does_not_exist",
+    //         dangle_colors,
+    //         at.subdir.to_string_lossy()
+    //     ));
 }
 
 #[cfg(unix)]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -98,16 +98,6 @@ fn test_ls_io_errors() {
 
     scene
         .ucmd()
-        .arg("-la")
-        .arg("some-dir3/*")
-        .fails()
-        .stderr_contains("some-dir4")
-        .stderr_contains("cannot open directory")
-        .stderr_contains("Permission denied")
-        .stdout_does_not_contain("some-dir4");
-
-    scene
-        .ucmd()
         .arg("-laR")
         .arg("some-dir3")
         .fails()


### PR DESCRIPTION
Referenced as an issue as well: https://github.com/uutils/coreutils/issues/2785

- print error in the correct order by flushing the stdout buffer before printing an error
- print correct GNU error codes
- correct formatting for config.inode, and for dangling links
- correct padding for  Format::Long
- remove colors after the -> link symbol as this doesn't match GNU
- correct the major, minor #s for char devices, and correct padding
- improve speed for all metadata intensive ops by not allocating metadata unless in a Sort mode
- new tests, have struggled with how to deal with stderr, stdout ordering in a test though
- tried to implement UIoError, but am still having issues matching the formatting of GNU