### PR TITLE
split: replace string checking with Strategy enum

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -155,7 +155,7 @@ pub fn uu_app() -> App<'static, 'static> {
                 .long(OPT_LINES)
                 .takes_value(true)
                 .default_value("1000")
-                .help("write to shell COMMAND file name is $FILE (Currently not implemented for Windows)"),
+                .help("put NUMBER lines/records per output file"),
         )
         // rest of the arguments
         .arg(


### PR DESCRIPTION
Previously, the code was checking strings to decide which chunking strategy to use. This pull request creates a `Strategy` enum and moves all the responsibility of parsing the `Strategy` to the same time as all the other `Settings` fields are parsed.
