### PR TITLE
ls: Various small display formatting fixes

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1468,11 +1468,7 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
     true
 }
 
-fn enter_directory(
-    dir: &PathData,
-    config: &Config,
-    out: &mut BufWriter<Stdout>,
-) {
+fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>) {
     // Create vec of entries with initial dot files
     let mut entries: Vec<PathData> = if config.files == Files::All {
         vec![
@@ -1596,7 +1592,7 @@ fn display_dir_entry_size(
             display_symlink_count(md).len(),
             display_uname(md, config).len(),
             display_group(md, config).len(),
-            match display_size_or_rdev(md, config) { 
+            match display_size_or_rdev(md, config) {
                 SizeOrDeviceId::Device(x, y) => x.len() + y.len() + 3,
                 SizeOrDeviceId::Size(z) => z.len(),
             },
@@ -1920,7 +1916,7 @@ fn display_item_long(
                     display_date(md, config),
                     dfn,
                 );
-            },
+            }
             SizeOrDeviceId::Device(major, minor) => {
                 let _ = writeln!(
                     out,
@@ -1930,7 +1926,7 @@ fn display_item_long(
                     display_date(md, config),
                     dfn,
                 );
-            },
+            }
         };
     } else {
         // this 'else' is expressly for the case of a dangling symlink

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -115,12 +115,9 @@ fn test_ls_only_dirs_formatting() {
     at.mkdir("some-dir2");
     at.mkdir("some-dir3");
 
-    scene
-        .ucmd()
-        .arg("-1")
-        .arg("-R")        
-        .succeeds()
-        .stdout_only(".:\nsome-dir1\nsome-dir2\nsome-dir3\n\n./some-dir1:\n\n./some-dir2:\n\n./some-dir3:\n");       
+    scene.ucmd().arg("-1").arg("-R").succeeds().stdout_only(
+        ".:\nsome-dir1\nsome-dir2\nsome-dir3\n\n./some-dir1:\n\n./some-dir2:\n\n./some-dir3:\n",
+    );
 }
 
 //#[cfg(all(feature = "mknod"))]
@@ -130,14 +127,14 @@ fn test_ls_devices() {
     let at = &scene.fixtures;
     at.mkdir("some-dir1");
 
-    // We need superuser privileges to create own devices? 
+    // We need superuser privileges to create own devices?
     // Can we do this in the CI?
     //
     //scene.ccmd("mknod").arg("some-dev1").arg("c").arg("1").arg("3").succeeds();
-    
+
     // scene
     //     .ucmd()
-    //     .arg("-al")        
+    //     .arg("-al")
     //     .succeeds()
     //     .stdout_contains("1,")
     //     .stdout_contains("3");
@@ -147,17 +144,17 @@ fn test_ls_devices() {
         scene
             .ucmd()
             .arg("-al")
-            .arg("/dev/null")        
+            .arg("/dev/null")
             .succeeds()
             .stdout_contains("3, 2");
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         scene
             .ucmd()
             .arg("-al")
-            .arg("/dev/null")        
+            .arg("/dev/null")
             .succeeds()
             .stdout_contains("1, 3");
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -108,6 +108,62 @@ fn test_ls_io_errors() {
 }
 
 #[test]
+fn test_ls_only_dirs_formatting() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("some-dir1");
+    at.mkdir("some-dir2");
+    at.mkdir("some-dir3");
+
+    scene
+        .ucmd()
+        .arg("-1")
+        .arg("-R")        
+        .succeeds()
+        .stdout_only(".:\nsome-dir1\nsome-dir2\nsome-dir3\n\n./some-dir1:\n\n./some-dir2:\n\n./some-dir3:\n");       
+}
+
+//#[cfg(all(feature = "mknod"))]
+#[test]
+fn test_ls_devices() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("some-dir1");
+
+    // We need superuser privileges to create own devices? 
+    // Can we do this in the CI?
+    //
+    //scene.ccmd("mknod").arg("some-dev1").arg("c").arg("1").arg("3").succeeds();
+    
+    // scene
+    //     .ucmd()
+    //     .arg("-al")        
+    //     .succeeds()
+    //     .stdout_contains("1,")
+    //     .stdout_contains("3");
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        scene
+            .ucmd()
+            .arg("-al")
+            .arg("/dev/null")        
+            .succeeds()
+            .stdout_contains("3, 2");
+    }
+    
+    #[cfg(target_os = "linux")]
+    {
+        scene
+            .ucmd()
+            .arg("-al")
+            .arg("/dev/null")        
+            .succeeds()
+            .stdout_contains("1, 3");
+    }
+}
+
+#[test]
 fn test_ls_walk_glob() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
- Fix: No initial newline when no files in base directory, with test
- Fix: Long item display for dangling links and certain restricted files should include extra ‘?’ for symlink count
- Fix: Correctly display device IDs on MacOS and Linux, with approximately correct padding, with test
- Return proper error code for ERRNO 1 for FS restricted files, like SIP files/dirs on MacOS, any suggestions on how to create a file which will pop an error for a test?
- Any suggestion on how to merge stdout and stderr in order to test error ordering?  Don't want to give up any gains because this is untested.