### PR TITLE
ls: Fix newline when only dirs in base directory

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1366,8 +1366,16 @@ fn list(locs: Vec<&Path>, config: Config) -> UResult<()> {
 
     display_items(&files, &config, &mut out);
 
-    for dir in &dirs {
-        enter_directory(dir, &config, initial_locs_len, &mut out);
+    for (pos, dir) in dirs.iter().enumerate() {
+        // Print dir heading - name... 'total' comes after error display
+        if initial_locs_len > 1 || config.recursive {
+            if pos.eq(&0usize) && files.is_empty() {
+                let _ = writeln!(out, "{}:", dir.p_buf.display());
+            } else {
+                let _ = writeln!(out, "\n{}:", dir.p_buf.display());
+            }
+        }
+        enter_directory(dir, &config, &mut out);
     }
 
     Ok(())
@@ -1437,12 +1445,7 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
     true
 }
 
-fn enter_directory(
-    dir: &PathData,
-    config: &Config,
-    initial_locs_len: usize,
-    out: &mut BufWriter<Stdout>,
-) {
+fn enter_directory(dir: &PathData, config: &Config, out: &mut BufWriter<Stdout>) {
     // Create vec of entries with initial dot files
     let mut entries: Vec<PathData> = if config.files == Files::All {
         vec![
@@ -1508,10 +1511,6 @@ fn enter_directory(
     sort_entries(&mut vec_path_data, config);
     entries.append(&mut vec_path_data);
 
-    // Print dir heading - name...
-    if initial_locs_len > 1 || config.recursive {
-        let _ = writeln!(out, "\n{}:", dir.p_buf.display());
-    }
     // ...and total
     if config.format == Format::Long {
         display_total(&entries, config, out);
@@ -1525,7 +1524,8 @@ fn enter_directory(
             .skip(if config.files == Files::All { 2 } else { 0 })
             .filter(|p| p.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
         {
-            enter_directory(e, config, 0, out);
+            let _ = writeln!(out, "\n{}:", e.p_buf.display());
+            enter_directory(e, config, out);
         }
     }
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -115,9 +115,18 @@ fn test_ls_only_dirs_formatting() {
     at.mkdir("some-dir2");
     at.mkdir("some-dir3");
 
-    scene.ucmd().arg("-1").arg("-R").succeeds().stdout_only(
-        ".:\nsome-dir1\nsome-dir2\nsome-dir3\n\n./some-dir1:\n\n./some-dir2:\n\n./some-dir3:\n",
-    );
+    #[cfg(unix)]
+    {
+        scene.ucmd().arg("-1").arg("-R").succeeds().stdout_only(
+            ".:\nsome-dir1\nsome-dir2\nsome-dir3\n\n./some-dir1:\n\n./some-dir2:\n\n./some-dir3:\n",
+        );
+    }
+    #[cfg(windows)]
+    {
+        scene.ucmd().arg("-1").arg("-R").succeeds().stdout_only(
+            ".:\nsome-dir1\nsome-dir2\nsome-dir3\n\n.\\some-dir1:\n\n.\\some-dir2:\n\n.\\some-dir3:\n",
+        );
+    }
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -108,6 +108,19 @@ fn test_ls_io_errors() {
 }
 
 #[test]
+fn test_ls_only_dirs_formatting() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("some-dir1");
+    at.mkdir("some-dir2");
+    at.mkdir("some-dir3");
+
+    scene.ucmd().arg("-1").arg("-R").succeeds().stdout_only(
+        ".:\nsome-dir1\nsome-dir2\nsome-dir3\n\n./some-dir1:\n\n./some-dir2:\n\n./some-dir3:\n",
+    );
+}
+
+#[test]
 fn test_ls_walk_glob() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
Fix: Don't print an initial newline when no files in base directory, with test