### PR TITLE
ls: On Windows use metadata owned by DirEntry instead of retrieved one additionaly

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1412,8 +1412,7 @@ fn sort_entries(entries: &mut Vec<PathData>, config: &Config) {
 fn is_hidden(file_path: &DirEntry) -> bool {
     #[cfg(windows)]
     {
-        let path = file_path.path();
-        let metadata = fs::metadata(&path).unwrap_or_else(|_| fs::symlink_metadata(&path).unwrap());
+        let metadata = file_path.metadata().unwrap();
         let attr = metadata.file_attributes();
         (attr & 0x2) > 0
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1642,6 +1642,41 @@ fn test_ls_hidden_windows() {
     scene.ucmd().arg("-a").succeeds().stdout_contains(file);
 }
 
+#[cfg(windows)]
+#[test]
+fn test_ls_hidden_link_windows() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let file = "visibleWindowsFileNoDot";
+    at.touch(file);
+
+    let link = "hiddenWindowsLinkNoDot";
+    at.symlink_dir(file, link);
+    // hide the link
+    scene.cmd("attrib").arg("/l").arg("+h").arg(link).succeeds();
+
+    scene
+        .ucmd()
+        .succeeds()
+        .stdout_contains(file)
+        .stdout_does_not_contain(link);
+
+    scene
+        .ucmd()
+        .arg("-a")
+        .succeeds()
+        .stdout_contains(file)
+        .stdout_contains(link);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_ls_success_on_c_drv_root_windows() {
+    let scene = TestScenario::new(util_name!());
+    scene.ucmd().arg("C:\\").succeeds();
+}
+
 #[test]
 fn test_ls_version_sort() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
This PR will make `is_hidden` to use the `Metadata` that `DirEntry` has instead of retrieved with `std::fs::metadata` and `std::fs::symlink_metadata`.

With this change, the `Application Data` folder, that is symlink to hidden folder, will be hidden, that will same as `dir` behavior in cmd.

Also, `coreutils ls C:\` will not panic. (it is probably issue in `std::fs`, but I came up with this PR when I was reproducing it.)

The test from #1662 and #2441 should pass.