### PR TITLE
Fix Rust 1.58 clippy lints

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -83,7 +83,7 @@ pub fn main() {
                 mf.write_all(
                     format!(
                         "\tmap.insert(\"{k}\", ({krate}::uumain, {krate}::uu_app));\n",
-                        k = krate[override_prefix.len()..].to_string(),
+                        k = &krate[override_prefix.len()..],
                         krate = krate
                     )
                     .as_bytes(),
@@ -92,7 +92,7 @@ pub fn main() {
                 tf.write_all(
                     format!(
                         "#[path=\"{dir}/test_{k}.rs\"]\nmod test_{k};\n",
-                        k = krate[override_prefix.len()..].to_string(),
+                        k = &krate[override_prefix.len()..],
                         dir = util_tests_dir,
                     )
                     .as_bytes(),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1974,7 +1974,7 @@ fn display_item_long(
         let _ = write!(
             out,
             "{}{} {}",
-            "l?????????".to_string(),
+            "l?????????",
             if item.security_context.len() > 1 {
                 // GNU `ls` uses a "." character to indicate a file with a security context,
                 // but not other alternate access method.

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -63,9 +63,7 @@ fn test_tee_append() {
 fn test_tee_no_more_writeable_1() {
     // equals to 'tee /dev/full out2 <multi_read' call
     let (at, mut ucmd) = at_and_ucmd!();
-    let content = (1..=10)
-        .map(|x| format!("{}\n", x.to_string()))
-        .collect::<String>();
+    let content = (1..=10).map(|x| format!("{}\n", x)).collect::<String>();
     let file_out = "tee_file_out";
 
     ucmd.arg("/dev/full")
@@ -85,9 +83,7 @@ fn test_tee_no_more_writeable_2() {
     // but currently there is no way to redirect stdout to /dev/full
     // so this test is disabled
     let (_at, mut ucmd) = at_and_ucmd!();
-    let _content = (1..=10)
-        .map(|x| format!("{}\n", x.to_string()))
-        .collect::<String>();
+    let _content = (1..=10).map(|x| format!("{}\n", x)).collect::<String>();
     let file_out_a = "tee_file_out_a";
     let file_out_b = "tee_file_out_b";
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1230,14 +1230,7 @@ pub fn check_coreutil_version(
         .output()
     {
         Ok(s) => s,
-        Err(e) => {
-            return Err(format!(
-                "{}: '{}' {}",
-                UUTILS_WARNING,
-                util_name,
-                e.to_string()
-            ))
-        }
+        Err(e) => return Err(format!("{}: '{}' {}", UUTILS_WARNING, util_name, e)),
     };
     std::str::from_utf8(&version_check.stdout).unwrap()
         .split('\n')
@@ -1247,7 +1240,7 @@ pub fn check_coreutil_version(
             || Err(format!("{}: unexpected output format for reference coreutil: '{} --version'", UUTILS_WARNING, util_name)),
             |s| {
                 if s.contains(&format!("(GNU coreutils) {}", version_expected)) {
-                    Ok(format!("{}: {}", UUTILS_INFO, s.to_string()))
+                    Ok(format!("{}: {}", UUTILS_INFO, s))
                 } else if s.contains("(GNU coreutils)") {
                     let version_found = parse_coreutil_version(s);
                     let version_expected = version_expected.parse::<f32>().unwrap_or_default();


### PR DESCRIPTION
Since we decided on holding off on merging https://github.com/uutils/coreutils/pull/2869, I pulled the clippy lint fixes into this PR, so they can be merged.