### PR TITLE
`stdbuf`: fix `cargo publish` problem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ sort     = { optional=true, version="0.0.9", package="uu_sort", path="src/uu/sor
 split    = { optional=true, version="0.0.9", package="uu_split", path="src/uu/split" }
 stat     = { optional=true, version="0.0.9", package="uu_stat", path="src/uu/stat" }
 # Very ugly, uncomment when the issue #2876 is fixed
-stdbuf   = { optional=true, version="0.0.8", package="uu_stdbuf", path="src/uu/stdbuf" }
+stdbuf   = { optional=true, version="0.0.9", package="uu_stdbuf", path="src/uu/stdbuf" }
 sum      = { optional=true, version="0.0.9", package="uu_sum", path="src/uu/sum" }
 sync     = { optional=true, version="0.0.9", package="uu_sync", path="src/uu/sync" }
 tac      = { optional=true, version="0.0.9", package="uu_tac", path="src/uu/tac" }


### PR DESCRIPTION
It turns out that `cargo publish` doesn't just create a file called `liblibstdbuf.so`, but instead something like `liblibstdbuf-1285737e7e670288.so`. With this PR, we loop through the directory until we find a file which starts with `liblibstdbuf` and ends with `.so` (or another dylib extension). This fixed https://github.com/uutils/coreutils/issues/2876 for me locally.