### PR TITLE
gitignore: track cargo.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ target/
 .*.swp
 .*.swo
 .idea
-Cargo.lock
 lib*.a
 /docs/_build
 *.iml


### PR DESCRIPTION
Looks like the repo already included the cargo.lock file, so remove gitignore entry for it.

Also it would be good to include cargo.lock to ensure repeatable builds.