### PR TITLE
`tr`: fix flaky test

### DIFF
--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -286,11 +286,6 @@ fn test_interpret_backslash_at_eol_literally() {
 }
 
 #[test]
-// FixME: panicked at 'failed to write to stdin of child: Broken pipe (os error 32)
-#[cfg(not(target_os = "freebsd"))]
 fn test_more_than_2_sets() {
-    new_ucmd!()
-        .args(&["'abcdef'", "'a'", "'b'"])
-        .pipe_in("hello world")
-        .fails();
+    new_ucmd!().args(&["'abcdef'", "'a'", "'b'"]).fails();
 }


### PR DESCRIPTION
The test `test_tr::test_more_than_2_sets` sometimes fails randomly. For example here: https://github.com/uutils/coreutils/runs/4845185000?check_suite_focus=true

Here's my guess to why this was happening: the command exits immediately because the arguments are wrong. Therefore, there might sometimes be no time to pipe the input into the command, which results in the broken pipe error. The fix is simple: remove the pipe. I also re-enabled this test for FreeBSD.  