### PR TITLE
tail: support zero-terminated lines in streams

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -483,9 +483,12 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
     // contains count lines/chars. When reaching the end of file, output the
     // data in the ringbuf.
     match settings.mode {
-        FilterMode::Lines(count, _) => {
-            for line in unbounded_tail_collect(lines(reader), count, settings.beginning) {
-                print!("{}", line);
+        FilterMode::Lines(count, sep) => {
+            let mut stdout = stdout();
+            for line in unbounded_tail_collect(lines(reader, sep), count, settings.beginning) {
+                stdout
+                    .write_all(&line)
+                    .map_err_context(|| String::from("IO error"))?;
             }
         }
         FilterMode::Bytes(count) => {

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -489,3 +489,17 @@ fn test_no_such_file() {
 fn test_no_trailing_newline() {
     new_ucmd!().pipe_in("x").succeeds().stdout_only("x");
 }
+
+#[test]
+fn test_lines_zero_terminated() {
+    new_ucmd!()
+        .args(&["-z", "-n", "2"])
+        .pipe_in("a\0b\0c\0d\0e\0")
+        .succeeds()
+        .stdout_only("d\0e\0");
+    new_ucmd!()
+        .args(&["-z", "-n", "+2"])
+        .pipe_in("a\0b\0c\0d\0e\0")
+        .succeeds()
+        .stdout_only("b\0c\0d\0e\0");
+}


### PR DESCRIPTION
Support `-z` option when the input is not a seekable file. Previously,
the option was accepted by the argument parser, but it was being
ignored by the application logic.