### PR TITLE
join: print unsorted line in error message

### DIFF
--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -235,6 +235,7 @@ impl Spec {
 
 struct Line {
     fields: Vec<Vec<u8>>,
+    string: Vec<u8>,
 }
 
 impl Line {
@@ -247,10 +248,10 @@ impl Line {
                 .map(Vec::from)
                 .collect(),
             Sep::Char(sep) => string.split(|c| *c == sep).map(Vec::from).collect(),
-            Sep::Line => vec![string],
+            Sep::Line => vec![string.clone()],
         };
 
-        Line { fields }
+        Line { fields, string }
     }
 
     /// Get field at index.
@@ -444,9 +445,11 @@ impl<'a> State<'a> {
 
         if diff == Ordering::Greater {
             eprintln!(
-                "{}:{}: is not sorted",
+                "{}: {}:{}: is not sorted: {}",
+                uucore::execution_phrase(),
                 self.file_name.maybe_quote(),
-                self.line_num
+                self.line_num,
+                String::from_utf8_lossy(&line.string)
             );
 
             // This is fatal if the check is enabled.

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -283,11 +283,16 @@ fn missing_format_fields() {
 
 #[test]
 fn wrong_line_order() {
+    let ts = TestScenario::new(util_name!());
     new_ucmd!()
         .arg("fields_2.txt")
         .arg("fields_4.txt")
         .fails()
-        .stderr_is("fields_4.txt:5: is not sorted");
+        .stderr_is(&format!(
+            "{} {}: fields_4.txt:5: is not sorted: 11 g 5 gh",
+            ts.bin_path.to_string_lossy(),
+            ts.util_name
+        ));
 }
 
 #[test]


### PR DESCRIPTION
This expands the error message that is printed if either input file has
an unsorted line. Both the program name (join) and the offending line
are printed out with the message to match the behaviour of the GNU
utility.

Note: while copying the input string with `clone` may look bad, this makes the `Sep::Line` arm have the same performance as the rest of the match arms (which clone the input line in their calls to `Vec::from`).