### PR TITLE
expr: Fix a warning in the doc generation

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -7,7 +7,7 @@
 
 //!
 //! Here we employ shunting-yard algorithm for building AST from tokens according to operators' precedence and associative-ness.
-//! * https://en.wikipedia.org/wiki/Shunting-yard_algorithm
+//! * `<https://en.wikipedia.org/wiki/Shunting-yard_algorithm>`
 //!
 
 // spell-checker:ignore (ToDO) binop binops ints paren prec


### PR DESCRIPTION
```
warning: this URL is not a hyperlink
```