### PR TITLE
ci: update default branch to "main" in workflows

### DIFF
--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -5,14 +5,14 @@ name: FixPR
 # ToDO: [2021-06; rivy] change from `cargo-tree` to `cargo tree` once MSRV is >= 1.45
 
 env:
-  BRANCH_TARGET: master
+  BRANCH_TARGET: main
 
 on:
   # * only trigger on pull request closed to specific branches
   # ref: https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/9
   pull_request:
     branches:
-      - master # == env.BRANCH_TARGET ## unfortunately, env context variables are only available in jobs/steps (see <https://github.community/t/how-to-use-env-context/16975/2>)
+      - main # == env.BRANCH_TARGET ## unfortunately, env context variables are only available in jobs/steps (see <https://github.community/t/how-to-use-env-context/16975/2>)
     types: [ closed ]
 
 jobs:

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -96,7 +96,7 @@ jobs:
         workflow: GnuTests.yml
         name: gnu-result
         repo: uutils/coreutils
-        branch: master
+        branch: main
         path: dl
     - name: Download the log
       uses: dawidd6/action-download-artifact@v2
@@ -104,9 +104,9 @@ jobs:
         workflow: GnuTests.yml
         name: test-report
         repo: uutils/coreutils
-        branch: master
+        branch: main
         path: dl
-    - name: Compare failing tests against master
+    - name: Compare failing tests against main
       shell: bash
       run: |
             OLD_FAILING=$(sed -n "s/^FAIL: \([[:print:]]\+\).*/\1/p" dl/test-suite.log | sort)
@@ -121,11 +121,11 @@ jobs:
             do
               if ! grep -Fxq $LINE<<<"$OLD_FAILING"
               then
-                echo "::error ::GNU test failed: $LINE. $LINE is passing on 'master'. Maybe you have to rebase?"
+                echo "::error ::GNU test failed: $LINE. $LINE is passing on 'main'. Maybe you have to rebase?"
               fi
             done
-    - name: Compare against master results
+    - name: Compare against main results
       shell: bash
       run: |
-        mv dl/gnu-result.json master-gnu-result.json
+        mv dl/gnu-result.json main-gnu-result.json
         python uutils/util/compare_gnu_result.py

--- a/util/compare_gnu_result.py
+++ b/util/compare_gnu_result.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
 
 """
-Compare the current results to the last results gathered from the master branch to highlight
+Compare the current results to the last results gathered from the main branch to highlight
 if a PR is making the results better/worse
 """
 
@@ -10,7 +10,7 @@ import sys
 from os import environ
 
 NEW = json.load(open("gnu-result.json"))
-OLD = json.load(open("master-gnu-result.json"))
+OLD = json.load(open("main-gnu-result.json"))
 
 # Extract the specific results from the dicts
 last = OLD[list(OLD.keys())[0]]
@@ -24,7 +24,7 @@ skip_d = int(current["skip"]) - int(last["skip"])
 
 # Get an annotation to highlight changes
 print(
-    f"::warning ::Changes from master: PASS {pass_d:+d} / FAIL {fail_d:+d} / ERROR {error_d:+d} / SKIP {skip_d:+d} "
+    f"::warning ::Changes from main: PASS {pass_d:+d} / FAIL {fail_d:+d} / ERROR {error_d:+d} / SKIP {skip_d:+d} "
 )
 
 # If results are worse fail the job to draw attention


### PR DESCRIPTION
This is just a shot in the dark...does this have anything to do with the strange GNU test comparison results recently? I notice that the default branch name has changed to "main" somewhat recently.