### PR TITLE
dd: block/unblock on ebcdic/ascii conversions

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -444,6 +444,20 @@ pub fn parse_conv_flag_input(matches: &Matches) -> Result<IConvFlags, ParseError
                     return Err(ParseError::MultipleFmtTable);
                 } else {
                     fmt = Some(flag);
+                    // From the GNU documentation:
+                    //
+                    // > ‘ascii’
+                    // >
+                    // > Convert EBCDIC to ASCII, using the conversion
+                    // > table specified by POSIX. This provides a 1:1
+                    // > translation for all 256 bytes. This implies
+                    // > ‘conv=unblock’; input is converted to ASCII
+                    // > before trailing spaces are deleted.
+                    //
+                    // -- https://www.gnu.org/software/coreutils/manual/html_node/dd-invocation.html
+                    if cbs.is_some() {
+                        iconvflags.unblock = cbs;
+                    }
                 }
             }
             ConvFlag::FmtAtoE => {
@@ -451,6 +465,19 @@ pub fn parse_conv_flag_input(matches: &Matches) -> Result<IConvFlags, ParseError
                     return Err(ParseError::MultipleFmtTable);
                 } else {
                     fmt = Some(flag);
+                    // From the GNU documentation:
+                    //
+                    // > ‘ebcdic’
+                    // >
+                    // > Convert ASCII to EBCDIC. This is the inverse
+                    // > of the ‘ascii’ conversion. This implies
+                    // > ‘conv=block’; trailing spaces are added before
+                    // > being converted to EBCDIC.
+                    //
+                    // -- https://www.gnu.org/software/coreutils/manual/html_node/dd-invocation.html
+                    if cbs.is_some() {
+                        iconvflags.block = cbs;
+                    }
                 }
             }
             ConvFlag::FmtAtoI => {

--- a/src/uu/dd/src/parseargs/unit_tests.rs
+++ b/src/uu/dd/src/parseargs/unit_tests.rs
@@ -157,6 +157,7 @@ fn test_all_top_level_args_no_leading_dashes() {
     assert_eq!(
         IConvFlags {
             ctable: Some(&EBCDIC_TO_ASCII_LCASE_TO_UCASE),
+            unblock: Some(1), // because ascii implies unblock
             ..IConvFlags::default()
         },
         parse_conv_flag_input(&matches).unwrap()
@@ -241,6 +242,7 @@ fn test_all_top_level_args_with_leading_dashes() {
     assert_eq!(
         IConvFlags {
             ctable: Some(&EBCDIC_TO_ASCII_LCASE_TO_UCASE),
+            unblock: Some(1), // because ascii implies unblock
             ..IConvFlags::default()
         },
         parse_conv_flag_input(&matches).unwrap()


### PR DESCRIPTION
Update `dd` so that the conversion `conv=ascii` implies `conv=unblock`
and, symmetrically, the conversion `conv=ebcdic` implies `conv=block`.