### PR TITLE
truncate: create non-existent file by default

### DIFF
--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -321,3 +321,28 @@ fn test_truncate_bytes_size() {
         }
     }
 }
+
+/// Test that truncating a non-existent file creates that file.
+#[test]
+fn test_new_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let filename = "new_file_that_does_not_exist_yet";
+    ucmd.args(&["-s", "8", filename])
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert!(at.file_exists(filename));
+    assert_eq!(at.read_bytes(filename), vec![b'\0'; 8]);
+}
+
+/// Test for not creating a non-existent file.
+#[test]
+fn test_new_file_no_create() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let filename = "new_file_that_does_not_exist_yet";
+    ucmd.args(&["-s", "8", "-c", filename])
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert!(!at.file_exists(filename));
+}


### PR DESCRIPTION
Fix the behavior of truncate when given a non-existent file so that it
correctly creates the file before truncating it (unless the
`--no-create` option is also given).

This should make one of the GNU tests pass (`tests/misc/truncate-no-create-missing.sh`).