### PR TITLE
dd: support seek and count=0 when writing to file

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -604,5 +604,21 @@ fn test_seek_bytes() {
         .stdout_is("\0\0\0\0\0\0\0\0abcdefghijklm\n");
 }
 
+/// Test for writing zero input blocks to a file plus seeking.
+#[test]
+fn test_seek_and_count_zero_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let filename = "outfile";
+    ucmd.args(&[
+        "bs=8",
+        "seek=8",
+        "oflag=seek_bytes",
+        "count=0",
+        &format!("of={}", filename),
+    ])
+    .succeeds();
+    assert_eq!(at.read_bytes(filename), b"\0\0\0\0\0\0\0\0");
+}
+
 // conv=[ascii,ebcdic,ibm], conv=[ucase,lcase], conv=[block,unblock], conv=sync
 // TODO: Move conv tests from unit test module


### PR DESCRIPTION
Correct the behavior of `dd` when seeking in the output file and
reading zero blocks of the input file. Previously, `dd` would seek
past the end of the file without padding the file with null bytes when
seeking beyond the end of the output file. This commit makes `dd` pad
the file with null bytes when seeking past the end of the output
file. This fix is specifically for writing to an output file, not
stdout.

So
```
$ dd bs=8 seek=8 oflag=seek_bytes count=0 of=outfile
```
now results in a new file, `outfile`, being created and containing 8 null bytes. Previously, `outfile` was empty.