### PR TITLE
dd: correct behavior when status=noxfer

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -398,8 +398,13 @@ where
         }
 
         match i.print_level {
-            Some(StatusLevel::Noxfer) | Some(StatusLevel::None) => {}
-            _ => print_transfer_stats(&ProgUpdate {
+            Some(StatusLevel::None) => {}
+            Some(StatusLevel::Noxfer) => print_io_lines(&ProgUpdate {
+                read_stat: rstat,
+                write_stat: wstat,
+                duration: start.elapsed(),
+            }),
+            Some(StatusLevel::Progress) | None => print_transfer_stats(&ProgUpdate {
                 read_stat: rstat,
                 write_stat: wstat,
                 duration: start.elapsed(),

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -183,7 +183,7 @@ fn test_final_stats_noxfer() {
     new_ucmd!()
         .args(&["status=noxfer"])
         .succeeds()
-        .stderr_only("");
+        .stderr_only("0+0 records in\n0+0 records out\n");
 }
 
 #[test]


### PR DESCRIPTION
Correct the behavior of `dd` with the `status=noxfer` option. Before
this commit, the status output was entirely suppressed (as happens
with `status=none`). This was incorrect behavior. After this commit,
the input/output counts are printed to stderr as expected.

For example,

    $ printf "" | dd status=noxfer
    0+0 records in
    0+0 records out

This commit also updates a unit test that was enforcing the wrong
behavior.