### PR TITLE
seq: implement -f FORMAT option

### DIFF
--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -20,7 +20,7 @@ bigdecimal = "0.3"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 num-bigint = "0.4.0"
 num-traits = "0.2.14"
-uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
+uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["memo"] }
 uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -693,3 +693,11 @@ fn test_parse_error_hex() {
         .fails()
         .usage_error("invalid hexadecimal argument: '0xlmnop'");
 }
+
+#[test]
+fn test_format_option() {
+    new_ucmd!()
+        .args(&["-f", "%.2f", "0.0", "0.1", "0.5"])
+        .succeeds()
+        .stdout_only("0.00\n0.10\n0.20\n0.30\n0.40\n0.50\n");
+}


### PR DESCRIPTION
Add support for the `-f FORMAT` option to `seq`. This option instructs
the program to render each value in the generated sequence using a
given `printf`-style floating point format. For example,

    $ seq -f %.2f 0.0 0.1 0.5
    0.00
    0.10
    0.20
    0.30
    0.40
    0.50

Fixes issue #2616.

This will cause GNU tests `fmt-1` through `fmt-5` in `tests/misc/seq.pl`.