### PR TITLE
update GNU coreutils version in GnuTests workflow

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         repository: 'coreutils/coreutils'
         path: 'gnu'
-        ref: v8.32
+        ref: v9.0
     - name: Checkout GNU coreutils library (gnulib)
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Updates it to the next and latest release. This is necessary to pull the [fixed invalid-j test](https://github.com/coreutils/coreutils/commit/1d5dbb82030a2ca7aef606d36a9d04863240c7a8) that will, once all the outstanding join PRs get merged, allow join to pass all its GNU tests (#2634). Seems to make some other tests fail, so those might require more investigation, but presumably aren't because of bugs introduced in the GNU repo.