### PR TITLE
make: use "cargo clean" instead of removing the target/$profile folder

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -313,7 +313,7 @@ busytest: $(BUILDDIR)/busybox $(addprefix test_busybox_,$(filter-out $(SKIP_UTIL
 endif
 
 clean:
-	$(RM) $(BUILDDIR)
+	cargo clean
 	cd $(DOCSDIR) && $(MAKE) clean
 
 distclean: clean


### PR DESCRIPTION
There is an issue with the `make clean` command that it only removes the artifacts generated with the profile that it's been passed, i.e. by default only removes `target/debug`. This leads to confusion if someone uses `make install` (which implies building with release) and then tries to clean the directory. So I changed it to use `cargo clean`, which is probably closer to the expected behaviour.

This issue came up here: https://github.com/uutils/coreutils/issues/2920#issuecomment-1022478326