### PR TITLE
seq: correct error message for zero increment

### DIFF
--- a/src/uu/seq/src/error.rs
+++ b/src/uu/seq/src/error.rs
@@ -40,11 +40,11 @@ impl SeqError {
     fn argtype(&self) -> &str {
         match self {
             SeqError::ParseError(_, e) => match e {
-                ParseNumberError::Float => "floating point",
-                ParseNumberError::Nan => "'not-a-number'",
-                ParseNumberError::Hex => "hexadecimal",
+                ParseNumberError::Float => "floating point argument",
+                ParseNumberError::Nan => "'not-a-number' argument",
+                ParseNumberError::Hex => "hexadecimal argument",
             },
-            SeqError::ZeroIncrement(_) => "Zero increment",
+            SeqError::ZeroIncrement(_) => "Zero increment value",
         }
     }
 }
@@ -61,7 +61,7 @@ impl Display for SeqError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "invalid {} argument: {}\nTry '{} --help' for more information.",
+            "invalid {}: {}\nTry '{} --help' for more information.",
             self.argtype(),
             self.arg().quote(),
             uucore::execution_phrase(),

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -701,3 +701,13 @@ fn test_format_option() {
         .succeeds()
         .stdout_only("0.00\n0.10\n0.20\n0.30\n0.40\n0.50\n");
 }
+
+#[test]
+fn test_invalid_zero_increment_value() {
+    new_ucmd!()
+        .args(&["0", "0", "1"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid Zero increment value: '0'")
+        .stderr_contains("for more information.");
+}


### PR DESCRIPTION
Change a word in the error message displayed when an increment value
of 0 is provided to `seq`. This commit changes the message from "Zero
increment argument" to "Zero increment value" to match the GNU `seq`
error message.

This fixes the GNU tests `inc-zero-1` through `inc-zero-4` in the `tests/misc/seq.pl` file. After this change, the only remaining test failures in that file have to do with format strings provided to `-f`.