### PR TITLE
truncate: add a division by zero error

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -202,6 +202,9 @@ fn truncate_reference_and_size(
         }
         Ok(m) => m,
     };
+    if let TruncateMode::RoundDown(0) | TruncateMode::RoundUp(0) = mode {
+        return Err(USimpleError::new(1, "division by zero"));
+    }
     let metadata = metadata(rfilename).map_err(|e| match e.kind() {
         ErrorKind::NotFound => USimpleError::new(
             1,
@@ -271,6 +274,9 @@ fn truncate_reference_file_only(
 fn truncate_size_only(size_string: &str, filenames: Vec<String>, create: bool) -> UResult<()> {
     let mode = parse_mode_and_size(size_string)
         .map_err(|e| USimpleError::new(1, format!("Invalid number: {}", e)))?;
+    if let TruncateMode::RoundDown(0) | TruncateMode::RoundUp(0) = mode {
+        return Err(USimpleError::new(1, "division by zero"));
+    }
     for filename in &filenames {
         let fsize = match metadata(filename) {
             Ok(m) => m.len(),

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -346,3 +346,34 @@ fn test_new_file_no_create() {
         .no_stderr();
     assert!(!at.file_exists(filename));
 }
+
+#[test]
+fn test_division_by_zero_size_only() {
+    new_ucmd!()
+        .args(&["-s", "/0", "file"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("division by zero");
+    new_ucmd!()
+        .args(&["-s", "%0", "file"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("division by zero");
+}
+
+#[test]
+fn test_division_by_zero_reference_and_size() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.make_file(FILE1);
+    ucmd.args(&["-r", FILE1, "-s", "/0", "file"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("division by zero");
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.make_file(FILE1);
+    ucmd.args(&["-r", FILE1, "-s", "%0", "file"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("division by zero");
+}


### PR DESCRIPTION
This pull request adds an error for division by zero. Previously, running `truncate -s /0 file` or `-s %0` would panic due to division by zero. After this change, it writes an error message "division by zero" to stderr and terminates with an error code.

The first commit in this pull request is a refactor to allow us to return the division by zero `USimpleError` in the right place. It was not possible before due to the containing function returning `std::io::Result` instead `UResult`.

This should cause the GNU test `tests/misc/truncate-relative/sh` to pass.