### PR TITLE
wc: fix counting files from pseudo-filesystem

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -37,6 +37,8 @@ exponentiate
 eval
 falsey
 fileio
+filesystem
+filesystems
 flamegraph
 fullblock
 getfacl

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -1,3 +1,6 @@
+#[cfg(all(unix, not(target_os = "macos")))]
+use pretty_assertions::assert_ne;
+
 use crate::common::util::*;
 
 // spell-checker:ignore (flags) lwmcL clmwL ; (path) bogusfile emptyfile manyemptylines moby notrailingnewline onelongemptyline onelongword weirdchars
@@ -234,4 +237,11 @@ fn test_read_from_nonexistent_file() {
         .fails()
         .stderr_contains(MSG)
         .stdout_is("");
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn test_files_from_pseudo_filesystem() {
+    let result = new_ucmd!().arg("-c").arg("/proc/version").succeeds();
+    assert_ne!(result.stdout_str(), "0 /proc/version\n");
 }


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/2933

For these files from pseudo-filesystems, the size was reported as 0, even though it wasn't. So with this PR we just do a normal count if the size is 0. This is a negligible performance hit, because files that are actually empty are, well, empty, so reading them won't take long.