### PR TITLE
all: enable infer long arguments in clap

### DIFF
--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -8,7 +8,7 @@
 
 use platform_info::*;
 
-use clap::{crate_version, App};
+use clap::{crate_version, App, AppSettings};
 use uucore::error::{FromIo, UResult};
 
 static ABOUT: &str = "Display machine architecture";
@@ -28,4 +28,5 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
 }

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -18,7 +18,7 @@ use std::fs::File;
 use std::io::{BufReader, Stdin};
 use std::path::Path;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 
 pub static BASE_CMD_PARSE_ERROR: i32 = 1;
 
@@ -97,6 +97,7 @@ pub fn base_app(about: &str) -> App {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(about)
+        .setting(AppSettings::InferLongArgs)
         // Format arguments.
         .arg(
             Arg::new(options::DECODE)

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDO) fullname
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::path::{is_separator, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
@@ -97,6 +97,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::MULTIPLE)
                 .short('a')

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -36,9 +36,6 @@ const ENCODINGS: &[(&str, Format)] = &[
     ("base2lsbf", Format::Base2Lsbf),
     ("base2msbf", Format::Base2Msbf),
     ("z85", Format::Z85),
-    // common abbreviations. TODO: once we have clap 3.0 we can use `AppSettings::InferLongArgs` to get all abbreviations automatically
-    ("base2l", Format::Base2Lsbf),
-    ("base2m", Format::Base2Msbf),
 ];
 
 fn usage() -> String {

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -14,7 +14,7 @@
 extern crate unix_socket;
 
 // last synced with: cat (GNU coreutils) 8.13
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::{metadata, File};
 use std::io::{self, Read, Write};
 use thiserror::Error;
@@ -245,6 +245,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .override_usage(SYNTAX)
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)
                 .hide(true)

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -5,7 +5,7 @@
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::{display::Quotable, show_error, show_warning};
 
-use clap::{App, Arg};
+use clap::{App, AppSettings, Arg};
 use selinux::{OpaqueSecurityContext, SecurityContext};
 
 use std::borrow::Cow;
@@ -164,6 +164,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(VERSION)
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::dereference::DEREFERENCE)
                 .long(options::dereference::DEREFERENCE)

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -12,7 +12,7 @@ pub use uucore::entries;
 use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::perms::{chown_base, options, IfFrom};
 
-use clap::{App, Arg, ArgMatches};
+use clap::{App, AppSettings, Arg, ArgMatches};
 
 use std::fs;
 use std::os::unix::fs::MetadataExt;
@@ -68,6 +68,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(VERSION)
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::verbosity::CHANGES)
                 .short('c')

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDO) Chmoder cmode fmode fperm fref ugoa RFILE RFILE's
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
@@ -125,6 +125,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::CHANGES)
                 .long(options::CHANGES)

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -13,7 +13,7 @@ use uucore::perms::{chown_base, options, IfFrom};
 
 use uucore::error::{FromIo, UResult, USimpleError};
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
 use std::fs;
 use std::os::unix::fs::MetadataExt;
@@ -71,6 +71,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::verbosity::CHANGES)
                 .short('c')

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -10,7 +10,7 @@
 mod error;
 
 use crate::error::ChrootError;
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::ffi::CString;
 use std::io::Error;
 use std::path::Path;
@@ -96,6 +96,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(SYNTAX)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::NEWROOT)
                 .hide(true)

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -6,7 +6,7 @@
 // file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) fname
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{self, stdin, BufReader, Read};
 use std::path::Path;
@@ -146,6 +146,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(SUMMARY)
         .override_usage(SYNTAX)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)
                 .hide(true)

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -15,7 +15,7 @@ use uucore::error::FromIo;
 use uucore::error::UResult;
 use uucore::InvalidEncodingHandling;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
 static ABOUT: &str = "compare two sorted files line by line";
 static LONG_HELP: &str = "";
@@ -152,6 +152,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::COLUMN_1)
                 .short('1')

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -27,7 +27,7 @@ use winapi::um::fileapi::GetFileInformationByHandle;
 
 use std::borrow::Cow;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use filetime::FileTime;
 use quick_error::ResultExt;
 use std::collections::HashSet;
@@ -300,6 +300,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::TARGET_DIRECTORY)
              .short('t')
              .conflicts_with(options::NO_TARGET_DIRECTORY)

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -12,7 +12,7 @@ use std::{
     io::{BufRead, BufWriter, Write},
 };
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use regex::Regex;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
@@ -757,6 +757,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SUFFIX_FORMAT)
                 .short('b')

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -11,7 +11,7 @@
 extern crate uucore;
 
 use bstr::io::BufReadExt;
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use std::path::Path;
@@ -539,6 +539,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .override_usage(SYNTAX)
         .about(SUMMARY)
         .after_help(LONG_HELP)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES)
                 .short('b')

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -11,7 +11,7 @@
 use chrono::{DateTime, FixedOffset, Local, Offset, Utc};
 #[cfg(windows)]
 use chrono::{Datelike, Timelike};
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 #[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 use libc::{clock_settime, timespec, CLOCK_REALTIME};
 use std::fs::File;
@@ -261,6 +261,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_DATE)
                 .short('d')

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -36,7 +36,7 @@ use std::thread;
 use std::time;
 
 use byte_unit::Byte;
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use gcd::Gcd;
 #[cfg(target_os = "linux")]
 use signal_hook::consts::signal;
@@ -941,6 +941,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::INFILE)
                 .long(options::INFILE)

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -531,5 +531,4 @@ pub fn uu_app<'a>() -> App<'a> {
                 .help("limit listing to file systems not of type TYPE"),
         )
         .arg(Arg::new(OPT_PATHS).multiple_occurrences(true))
-        .override_help("Filesystem(s) to list")
 }

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -12,7 +12,7 @@ use uucore::error::UResult;
 use uucore::fsext::statfs_fn;
 use uucore::fsext::{read_fs_list, FsUsage, MountInfo};
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 
 use number_prefix::NumberPrefix;
 use std::cell::Cell;
@@ -425,6 +425,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_ALL)
                 .short('a')

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -13,7 +13,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
 
@@ -165,6 +165,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(LONG_HELP)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BOURNE_SHELL)
                 .long("sh")

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -5,7 +5,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::path::Path;
 use uucore::display::print_verbatim;
 use uucore::error::{UResult, UUsageError};
@@ -87,6 +87,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .about(ABOUT)
         .version(crate_version!())
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ZERO)
                 .long(options::ZERO)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -10,8 +10,7 @@ extern crate uucore;
 
 use chrono::prelude::DateTime;
 use chrono::Local;
-use clap::ArgMatches;
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::env;
@@ -630,6 +629,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(LONG_HELP)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ALL)
                 .short('a')
@@ -644,7 +644,6 @@ pub fn uu_app<'a>() -> App<'a> {
                     although  the apparent  size is usually smaller, it may be larger due to holes \
                     in ('sparse') files, internal  fragmentation,  indirect  blocks, and the like"
                 )
-                .alias("app") // The GNU test suite uses this alias
         )
         .arg(
             Arg::new(options::BLOCK_SIZE)
@@ -753,7 +752,6 @@ pub fn uu_app<'a>() -> App<'a> {
             Arg::new(options::THRESHOLD)
                 .short('t')
                 .long(options::THRESHOLD)
-                .alias("th")
                 .value_name("SIZE")
                 .number_of_values(1)
                 .allow_hyphen_values(true)

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -6,7 +6,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::io::{self, Write};
 use std::iter::Peekable;
 use std::str::Chars;
@@ -134,8 +134,9 @@ pub fn uu_app<'a>() -> App<'a> {
         // TrailingVarArg specifies the final positional argument is a VarArg
         // and it doesn't attempts the parse any further args.
         // Final argument must have multiple(true) or the usage string equivalent.
-        .setting(clap::AppSettings::TrailingVarArg)
-        .setting(clap::AppSettings::AllowHyphenValues)
+        .setting(AppSettings::TrailingVarArg)
+        .setting(AppSettings::AllowHyphenValues)
+        .setting(AppSettings::InferLongArgs)
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(AFTER_HELP)

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -127,6 +127,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .override_usage(USAGE)
         .after_help(AFTER_HELP)
         .setting(AppSettings::AllowExternalSubcommands)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new("ignore-environment")
             .short('i')
             .long("ignore-environment")

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -12,7 +12,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::str::from_utf8;
@@ -184,6 +184,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::INITIAL)
                 .long(options::INITIAL)

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -5,7 +5,7 @@
 //* For the full copyright and license information, please view the LICENSE
 //* file that was distributed with this source code.
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use uucore::error::{UResult, USimpleError};
 use uucore::InvalidEncodingHandling;
 
@@ -17,6 +17,7 @@ const HELP: &str = "help";
 
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(VERSION).long(VERSION))
         .arg(Arg::new(HELP).long(HELP))
 }

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -14,7 +14,7 @@ use std::fmt::Write as FmtWrite;
 use std::io::{self, stdin, stdout, BufRead, Write};
 
 mod factor;
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 pub use factor::*;
 use uucore::display::Quotable;
 use uucore::error::UResult;
@@ -81,5 +81,6 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::NUMBER).multiple_occurrences(true))
 }

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::cmp;
 use std::fs::File;
 use std::io::{stdin, stdout, Write};
@@ -226,6 +226,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_CROWN_MARGIN)
                 .short('c')

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDOs) ncount routput
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
@@ -69,6 +69,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .override_usage(SYNTAX)
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES)
                 .long(options::BYTES)

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -25,7 +25,7 @@ use uucore::{
     error::{UError, UResult},
 };
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 
 mod options {
     pub const USERS: &str = "USERNAME";
@@ -109,6 +109,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::USERS)
                 .multiple_occurrences(true)

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -20,7 +20,7 @@ mod digest;
 use self::digest::Digest;
 use self::digest::DigestWriter;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{App, AppSettings, Arg, ArgMatches};
 use hex::ToHex;
 use md5::Context as Md5;
 use regex::Regex;
@@ -343,6 +343,7 @@ pub fn uu_app_common<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about("Compute and check message digests.")
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new("binary")
                 .short('b')

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -5,7 +5,7 @@
 
 // spell-checker:ignore (vars) zlines BUFWRITER seekable
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::convert::{TryFrom, TryInto};
 use std::ffi::OsString;
 use std::io::{self, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
@@ -47,6 +47,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(USAGE)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES_NAME)
                 .short('c')

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDO) gethostid
 
-use clap::{crate_version, App};
+use clap::{crate_version, App, AppSettings};
 use libc::c_long;
 use uucore::error::UResult;
 
@@ -29,6 +29,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .override_usage(SYNTAX)
+        .setting(AppSettings::InferLongArgs)
 }
 
 fn hostid() {

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -11,7 +11,7 @@ use std::collections::hash_set::HashSet;
 use std::net::ToSocketAddrs;
 use std::str;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
 use uucore::error::{FromIo, UResult};
 
@@ -76,6 +76,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_DOMAIN)
                 .short('d')

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -39,7 +39,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::ffi::CStr;
 use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
@@ -351,6 +351,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::OPT_AUDIT)
                 .short('A')

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -12,7 +12,7 @@ mod mode;
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use file_diff::diff;
 use filetime::{set_file_times, FileTime};
 use uucore::backup_control::{self, BackupMode};
@@ -196,6 +196,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             backup_control::arguments::backup()
         )

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, Split, Stdin, Write};
@@ -600,6 +600,7 @@ standard output. The default join field is the first, delimited by blanks.
 
 When FILE1 or FILE2 (not both) is -, read standard input.",
         )
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new("a")
                 .short('a')

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use libc::{c_int, pid_t};
 use std::io::Error;
 use uucore::display::Quotable;
@@ -82,6 +82,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::LIST)
                 .short('l')

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -4,7 +4,7 @@
 //  *
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::hard_link;
 use std::path::Path;
 use uucore::display::Quotable;
@@ -40,6 +40,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILES)
                 .hide(true)

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use uucore::display::Quotable;
 use uucore::error::{UError, UResult};
 
@@ -183,6 +183,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(backup_control::arguments::backup())
         .arg(backup_control::arguments::backup_no_args())
         // TODO: opts.arg(

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -12,7 +12,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App};
+use clap::{crate_version, App, AppSettings};
 use std::ffi::CStr;
 use uucore::error::UResult;
 use uucore::InvalidEncodingHandling;
@@ -59,4 +59,5 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -15,7 +15,7 @@ extern crate lazy_static;
 
 mod quoting_style;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use glob::Pattern;
 use lscolors::LsColors;
 use number_prefix::NumberPrefix;
@@ -709,6 +709,7 @@ pub fn uu_app<'a>() -> App<'a> {
             the command line, expect that it will ignore files and directories \
             whose names start with '.'.",
         )
+        .setting(AppSettings::InferLongArgs)
         // Format arguments
         .arg(
             Arg::new(options::FORMAT)

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -10,8 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::OsValues;
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches, OsValues};
 use std::fs;
 use std::path::Path;
 use uucore::display::Quotable;
@@ -114,6 +113,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::MODE)
                 .short('m')
@@ -125,7 +125,6 @@ pub fn uu_app<'a>() -> App<'a> {
             Arg::new(options::PARENTS)
                 .short('p')
                 .long(options::PARENTS)
-                .alias("parent")
                 .help("make parent directories as needed"),
         )
         .arg(

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -8,7 +8,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use libc::mkfifo;
 use std::ffi::CString;
 use uucore::error::{UResult, USimpleError};
@@ -75,6 +75,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .override_usage(USAGE)
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::MODE)
                 .short('m')

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -9,7 +9,7 @@
 
 use std::ffi::CString;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use libc::{dev_t, mode_t};
 use libc::{S_IFBLK, S_IFCHR, S_IFIFO, S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOTH, S_IWUSR};
 
@@ -149,6 +149,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .override_usage(USAGE)
         .after_help(LONG_HELP)
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new("mode")
                 .short('m')

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -8,7 +8,7 @@
 
 // spell-checker:ignore (paths) GPGHome
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use uucore::display::{println_verbatim, Quotable};
 use uucore::error::{FromIo, UError, UResult};
 
@@ -139,6 +139,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_DIRECTORY)
                 .short('d')

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -17,7 +17,7 @@ use std::{
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 extern crate nix;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use crossterm::{
     event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
     execute, queue,
@@ -100,6 +100,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .about("A file perusal filter for CRT viewing.")
         .version(crate_version!())
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SILENT)
                 .short('d')

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -13,7 +13,7 @@ mod error;
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -123,6 +123,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
     .arg(
         backup_control::arguments::backup()
     )

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -110,6 +110,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .setting(AppSettings::TrailingVarArg)
+        .setting(AppSettings::InferLongArgs)
         .version(crate_version!())
         .arg(
             Arg::new(options::ADJUSTMENT)

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -8,7 +8,7 @@
 
 // spell-checker:ignore (ToDO) corasick memchr
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
 use std::iter::repeat;
@@ -145,6 +145,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .name(NAME)
         .version(crate_version!())
         .override_usage(USAGE)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)
                 .hide(true)

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -126,6 +126,7 @@ pub fn uu_app<'a>() -> App<'a> {
                 .multiple_occurrences(true),
         )
         .setting(AppSettings::TrailingVarArg)
+        .setting(AppSettings::InferLongArgs)
 }
 
 fn replace_fds() -> UResult<()> {

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDO) NPROCESSORS nprocs numstr threadstr sysconf
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::env;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
@@ -75,6 +75,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_ALL)
                 .long(OPT_ALL)

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -196,6 +196,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .about(ABOUT)
         .after_help(LONG_HELP)
         .setting(AppSettings::AllowNegativeNumbers)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::DELIMITER)
                 .short('d')

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -295,7 +295,8 @@ pub fn uu_app<'a>() -> App<'a> {
         .setting(
             AppSettings::TrailingVarArg |
             AppSettings::DontDelimitTrailingValues |
-            AppSettings::DeriveDisplayOrder
+            AppSettings::DeriveDisplayOrder |
+            AppSettings::InferLongArgs
         )
         .arg(
             Arg::new(options::ADDRESS_RADIX)

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDO) delim
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
 use std::iter::repeat;
@@ -52,6 +52,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SERIAL)
                 .long(options::SERIAL)

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -8,7 +8,7 @@
 //  * that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) lstat
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs;
 use std::io::{ErrorKind, Write};
 use uucore::display::Quotable;
@@ -92,6 +92,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::POSIX)
                 .short('p')

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -18,7 +18,7 @@ use std::io::BufReader;
 use std::fs::File;
 use std::os::unix::fs::MetadataExt;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::path::PathBuf;
 use uucore::InvalidEncodingHandling;
 
@@ -136,6 +136,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::LONG_FORMAT)
                 .short('l')

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -13,7 +13,7 @@ extern crate quick_error;
 
 use chrono::offset::Local;
 use chrono::DateTime;
-use clap::App;
+use clap::{App, AppSettings};
 use getopts::Matches;
 use getopts::{HasArg, Occur};
 use itertools::Itertools;
@@ -172,7 +172,7 @@ quick_error! {
 }
 
 pub fn uu_app<'a>() -> App<'a> {
-    App::new(uucore::util_name())
+    App::new(uucore::util_name()).setting(AppSettings::InferLongArgs)
 }
 
 #[uucore_procs::gen_uumain]

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -7,7 +7,7 @@
 
 /* last synced with: printenv (GNU coreutils) 8.13 */
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::env;
 use uucore::error::UResult;
 
@@ -65,6 +65,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_NULL)
                 .short('0')

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -2,7 +2,7 @@
 // spell-checker:ignore (change!) each's
 // spell-checker:ignore (ToDO) LONGHELP FORMATSTRING templating parameterizing formatstr
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use uucore::error::{UResult, UUsageError};
 use uucore::memo;
 use uucore::InvalidEncodingHandling;
@@ -297,4 +297,5 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .arg(Arg::new(VERSION).long(VERSION))
         .arg(Arg::new(HELP).long(HELP))
+        .setting(AppSettings::InferLongArgs)
 }

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDOs) corasick memchr Roff trunc oset iset
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use regex::Regex;
 use std::cmp;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -705,6 +705,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .name(NAME)
         .version(crate_version!())
         .override_usage(BRIEF)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)
                 .hide(true)

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -5,7 +5,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::env;
 use std::io;
 use std::path::PathBuf;
@@ -156,6 +156,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_LOGICAL)
                 .short('L')

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs;
 use std::io::{stdout, Write};
 use std::path::{Path, PathBuf};
@@ -102,6 +102,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_CANONICALIZE)
                 .short('f')

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::{
     io::{stdout, Write},
     path::{Path, PathBuf},
@@ -78,6 +78,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_QUIET)
                 .short('q')

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDO) subpath absto absfrom absbase
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::env;
 use std::path::{Path, PathBuf};
 use uucore::display::println_verbatim;
@@ -86,6 +86,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::DIR).short('d').takes_value(true).help(
             "If any of FROM and TO is not subpath of DIR, output absolute path instead of relative",
         ))

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use remove_dir_all::remove_dir_all;
 use std::collections::VecDeque;
 use std::fs;
@@ -149,7 +149,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_FORCE)
             .short('f')

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::{read_dir, remove_dir};
 use std::io;
 use std::path::Path;
@@ -179,6 +179,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_IGNORE_FAIL_NON_EMPTY)
                 .long(OPT_IGNORE_FAIL_NON_EMPTY)

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -2,7 +2,7 @@
 
 use uucore::error::{UResult, UUsageError};
 
-use clap::{App, Arg};
+use clap::{App, AppSettings, Arg};
 use selinux::{OpaqueSecurityContext, SecurityClass, SecurityContext};
 
 use std::borrow::Cow;
@@ -114,6 +114,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(VERSION)
         .about(ABOUT)
         .after_help(DESCRIPTION)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::COMPUTE)
                 .short('c')

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -147,6 +147,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .setting(AppSettings::TrailingVarArg)
         .setting(AppSettings::AllowHyphenValues)
+        .setting(AppSettings::InferLongArgs)
         .version(crate_version!())
         .about(ABOUT)
         .arg(

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -8,7 +8,7 @@
 
 // spell-checker:ignore (words) writeback wipesync
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use rand::prelude::SliceRandom;
 use rand::Rng;
 use std::cell::{Cell, RefCell};
@@ -326,6 +326,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(AFTER_HELP)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FORCE)
                 .long(options::FORCE)

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -7,7 +7,7 @@
 
 // spell-checker:ignore (ToDO) cmdline evec seps rvec fdata
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use rand::Rng;
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
@@ -124,6 +124,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .help_template(TEMPLATE)
         .override_usage(USAGE)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ECHO)
                 .short('e')

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use uucore::error::{UResult, USimpleError};
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 
 static ABOUT: &str = "Pause for NUMBER seconds.";
 static LONG_HELP: &str = "Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
@@ -50,6 +50,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::NUMBER)
                 .help("pause for NUMBER seconds")

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -25,7 +25,7 @@ mod numeric_str_cmp;
 mod tmp_dir;
 
 use chunks::LineData;
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use custom_str_cmp::custom_str_cmp;
 use ext_sort::ext_sort;
 use fnv::FnvHasher;
@@ -1281,6 +1281,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::modes::SORT)
                 .long(options::modes::SORT)

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -11,7 +11,7 @@ mod filenames;
 mod platform;
 
 use crate::filenames::FilenameFactory;
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::convert::TryFrom;
 use std::env;
 use std::fs::remove_file;
@@ -107,6 +107,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about("Create output files containing consecutive or interleaved sections of input")
+        .setting(AppSettings::InferLongArgs)
         // strategy (mutually exclusive)
         .arg(
             Arg::new(OPT_BYTES)

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -16,7 +16,7 @@ use uucore::fsext::{
 };
 use uucore::libc::mode_t;
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::borrow::Cow;
 use std::convert::AsRef;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
@@ -970,6 +970,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::DEREFERENCE)
                 .short('L')

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -197,6 +197,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .about(ABOUT)
         .after_help(LONG_HELP)
         .setting(AppSettings::TrailingVarArg)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::INPUT)
                 .long(options::INPUT)

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{stdin, Read};
 use std::path::Path;
@@ -146,6 +146,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .override_usage(USAGE)
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)
                 .multiple_occurrences(true)

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -9,7 +9,7 @@
 
 extern crate libc;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
@@ -198,6 +198,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE_SYSTEM)
                 .short('f')

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -8,7 +8,7 @@
 // spell-checker:ignore (ToDO) sbytes slen dlen memmem memmap Mmap mmap SIGBUS
 mod error;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use memchr::memmem;
 use memmap2::Mmap;
 use std::io::{stdin, stdout, BufWriter, Read, Write};
@@ -66,6 +66,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .override_usage(USAGE)
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BEFORE)
                 .short('b')

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -22,7 +22,7 @@ mod platform;
 use chunks::ReverseChunks;
 use lines::lines;
 
-use clap::{App, Arg};
+use clap::{App, AppSettings, Arg};
 use std::collections::VecDeque;
 use std::ffi::OsString;
 use std::fmt;
@@ -279,6 +279,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(USAGE)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES)
                 .short('c')

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -8,7 +8,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use retain_mut::RetainMut;
 use std::fs::OpenOptions;
 use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
@@ -64,6 +64,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help("If a FILE is -, it refers to a file named - .")
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::APPEND)
                 .long(options::APPEND)

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -167,6 +167,7 @@ pub fn uu_app<'a>() -> App<'a> {
                 .multiple_occurrences(true)
         )
         .setting(AppSettings::TrailingVarArg)
+        .setting(AppSettings::InferLongArgs)
 }
 
 /// Remove pre-existing SIGCHLD handlers that would make waiting for the child's exit code fail.

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -13,7 +13,7 @@ pub extern crate filetime;
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, App, Arg, ArgGroup};
+use clap::{crate_version, App, AppSettings, Arg, ArgGroup};
 use filetime::*;
 use std::fs::{self, File};
 use std::path::Path;
@@ -133,6 +133,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ACCESS)
                 .short('a')
@@ -176,7 +177,6 @@ pub fn uu_app<'a>() -> App<'a> {
             Arg::new(options::sources::REFERENCE)
                 .short('r')
                 .long(options::sources::REFERENCE)
-                .alias("ref") // clapv3
                 .help("use this file's times instead of the current time")
                 .value_name("FILE")
                 .allow_invalid_utf8(true),

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -11,7 +11,7 @@ mod convert;
 mod operation;
 mod unicode_table;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use nom::AsBytes;
 use operation::{translate_input, Sequence, SqueezeOperation, TranslateOperation};
 use std::io::{stdin, stdout, BufReader, BufWriter};
@@ -56,7 +56,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .get_matches_from(args);
 
     let delete_flag = matches.is_present(options::DELETE);
-    let complement_flag = matches.is_present(options::COMPLEMENT) || matches.is_present("C");
+    let complement_flag = matches.is_present(options::COMPLEMENT);
     let squeeze_flag = matches.is_present(options::SQUEEZE);
     let truncate_set1_flag = matches.is_present(options::TRUNCATE_SET1);
 
@@ -148,17 +148,14 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::COMPLEMENT)
-                // .visible_short_alias('C')  // TODO: requires clap "3.0.0-beta.2"
+                .visible_short_alias('C')
                 .short('c')
                 .long(options::COMPLEMENT)
                 .help("use the complement of SET1"),
-        )
-        .arg(
-            Arg::new("C") // work around for `Arg::visible_short_alias`
-                .short('C')
-                .help("same as -c"),
         )
         .arg(
             Arg::new(options::DELETE)

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -5,7 +5,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-use clap::App;
+use clap::{App, AppSettings};
 use uucore::error::UResult;
 
 #[uucore_procs::gen_uumain]
@@ -15,5 +15,5 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app<'a>() -> App<'a> {
-    App::new(uucore::util_name())
+    App::new(uucore::util_name()).setting(AppSettings::InferLongArgs)
 }

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -6,7 +6,7 @@
 //  * file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) RFILE refsize rfilename fsize tsize
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::convert::TryFrom;
 use std::fs::{metadata, OpenOptions};
 use std::io::ErrorKind;
@@ -117,6 +117,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::IO_BLOCKS)
             .short('o')

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -5,7 +5,7 @@
 //  *
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
@@ -98,6 +98,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .override_usage(USAGE)
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::FILE).default_value("-").hide(true))
 }
 

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -9,7 +9,7 @@
 
 // spell-checker:ignore (ToDO) ttyname filedesc
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::ffi::CStr;
 use std::io::Write;
 use uucore::error::{UResult, UUsageError};
@@ -75,6 +75,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SILENT)
                 .long(options::SILENT)

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -10,7 +10,7 @@
 
 // spell-checker:ignore (ToDO) nodename kernelname kernelrelease kernelversion sysname hwplatform mnrsv
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use platform_info::*;
 use uucore::error::{FromIo, UResult};
 
@@ -122,6 +122,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::ALL)
             .short('a')
             .long(options::ALL)

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -11,7 +11,7 @@
 
 #[macro_use]
 extern crate uucore;
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Stdout, Write};
 use std::str::from_utf8;
@@ -108,6 +108,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .override_usage(USAGE)
         .about(SUMMARY)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::FILE).hide(true).multiple_occurrences(true))
         .arg(
             Arg::new(options::ALL)

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -5,7 +5,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::fs::File;
 use std::io::{self, stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::Path;
@@ -303,6 +303,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ALL_REPEATED)
                 .short('D')

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -10,7 +10,7 @@
 use std::fs::remove_file;
 use std::path::Path;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
@@ -31,6 +31,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_PATH)
                 .required(true)

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -9,7 +9,7 @@
 // spell-checker:ignore (ToDO) getloadavg upsecs updays nusers loadavg boottime uphours upmins
 
 use chrono::{Local, TimeZone, Utc};
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 
 // import crate time from utmpx
 pub use uucore::libc;
@@ -66,6 +66,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SINCE)
                 .short('s')

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -10,7 +10,7 @@
 
 use std::path::Path;
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use uucore::error::UResult;
 use uucore::utmpx::{self, Utmpx};
 
@@ -68,5 +68,6 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(ARG_FILES).takes_value(true).max_values(1))
 }

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -17,7 +17,7 @@ use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
 use word_count::{TitledWordCount, WordCount};
 
-use clap::{crate_version, App, Arg, ArgMatches};
+use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
 use std::cmp::max;
 use std::fs::{self, File};
@@ -166,6 +166,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES)
                 .short('c')

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -12,7 +12,7 @@ use uucore::error::{FromIo, UResult};
 use uucore::libc::{ttyname, STDIN_FILENO, S_IWGRP};
 use uucore::utmpx::{self, time, Utmpx};
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::os::unix::fs::MetadataExt;
@@ -165,6 +165,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ALL)
                 .long(options::ALL)

--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate clap;
 
-use clap::App;
+use clap::{App, AppSettings};
 
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
@@ -31,4 +31,5 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .setting(AppSettings::InferLongArgs)
 }

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -13,7 +13,7 @@ use std::io::{self, Write};
 #[macro_use]
 extern crate clap;
 
-use clap::{App, Arg};
+use clap::{App, AppSettings, Arg};
 use uucore::error::{UResult, USimpleError};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -47,7 +47,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app<'a>() -> App<'a> {
-    app_from_crate!().arg(Arg::new("STRING").index(1).multiple_occurrences(true))
+    app_from_crate!()
+        .arg(Arg::new("STRING").index(1).multiple_occurrences(true))
+        .setting(AppSettings::InferLongArgs)
 }
 
 fn prepare_buffer<'a>(input: &'a str, buffer: &'a mut [u8; BUF_SIZE]) -> &'a [u8] {

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -34,7 +34,7 @@ fn test_base32_encode_file() {
 
 #[test]
 fn test_decode() {
-    for decode_param in &["-d", "--decode"] {
+    for decode_param in &["-d", "--decode", "--dec"] {
         let input = "JBSWY3DPFQQFO33SNRSCC===\n"; // spell-checker:disable-line
         new_ucmd!()
             .arg(decode_param)
@@ -56,7 +56,7 @@ fn test_garbage() {
 
 #[test]
 fn test_ignore_garbage() {
-    for ignore_garbage_param in &["-i", "--ignore-garbage"] {
+    for ignore_garbage_param in &["-i", "--ignore-garbage", "--ig"] {
         let input = "JBSWY\x013DPFQ\x02QFO33SNRSCC===\n"; // spell-checker:disable-line
         new_ucmd!()
             .arg("-d")
@@ -69,7 +69,7 @@ fn test_ignore_garbage() {
 
 #[test]
 fn test_wrap() {
-    for wrap_param in &["-w", "--wrap"] {
+    for wrap_param in &["-w", "--wrap", "--wr"] {
         let input = "The quick brown fox jumps over the lazy dog.";
         new_ucmd!()
             .arg(wrap_param)

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -26,7 +26,7 @@ fn test_base64_encode_file() {
 
 #[test]
 fn test_decode() {
-    for decode_param in &["-d", "--decode"] {
+    for decode_param in &["-d", "--decode", "--dec"] {
         let input = "aGVsbG8sIHdvcmxkIQ=="; // spell-checker:disable-line
         new_ucmd!()
             .arg(decode_param)
@@ -48,7 +48,7 @@ fn test_garbage() {
 
 #[test]
 fn test_ignore_garbage() {
-    for ignore_garbage_param in &["-i", "--ignore-garbage"] {
+    for ignore_garbage_param in &["-i", "--ignore-garbage", "--ig"] {
         let input = "aGVsbG8sIHdvcmxkIQ==\0"; // spell-checker:disable-line
         new_ucmd!()
             .arg("-d")
@@ -61,7 +61,7 @@ fn test_ignore_garbage() {
 
 #[test]
 fn test_wrap() {
-    for wrap_param in &["-w", "--wrap"] {
+    for wrap_param in &["-w", "--wrap", "--wr"] {
         let input = "The quick brown fox jumps over the lazy dog.";
         new_ucmd!()
             .arg(wrap_param)

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -61,7 +61,7 @@ fn test_do_not_remove_suffix() {
 
 #[test]
 fn test_multiple_param() {
-    for &multiple_param in &["-a", "--multiple"] {
+    for &multiple_param in &["-a", "--multiple", "--mul"] {
         let path = "/foo/bar/baz";
         new_ucmd!()
             .args(&[multiple_param, path, path])
@@ -72,7 +72,7 @@ fn test_multiple_param() {
 
 #[test]
 fn test_suffix_param() {
-    for &suffix_param in &["-s", "--suffix"] {
+    for &suffix_param in &["-s", "--suffix", "--suf"] {
         let path = "/foo/bar/baz.exe";
         new_ucmd!()
             .args(&[suffix_param, ".exe", path, path])
@@ -83,7 +83,7 @@ fn test_suffix_param() {
 
 #[test]
 fn test_zero_param() {
-    for &zero_param in &["-z", "--zero"] {
+    for &zero_param in &["-z", "--zero", "--ze"] {
         let path = "/foo/bar/baz";
         new_ucmd!()
             .args(&[zero_param, "-a", path, path])

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -264,7 +264,7 @@ fn test_numbered_lines_no_trailing_newline() {
 
 #[test]
 fn test_stdin_show_nonprinting() {
-    for same_param in &["-v", "--show-nonprinting"] {
+    for same_param in &["-v", "--show-nonprinting", "--show-non"] {
         new_ucmd!()
             .args(&[same_param])
             .pipe_in("\t\0\n")
@@ -275,7 +275,7 @@ fn test_stdin_show_nonprinting() {
 
 #[test]
 fn test_stdin_show_tabs() {
-    for same_param in &["-T", "--show-tabs"] {
+    for same_param in &["-T", "--show-tabs", "--show-ta"] {
         new_ucmd!()
             .args(&[same_param])
             .pipe_in("\t\0\n")
@@ -286,7 +286,7 @@ fn test_stdin_show_tabs() {
 
 #[test]
 fn test_stdin_show_ends() {
-    for &same_param in &["-E", "--show-ends"] {
+    for &same_param in &["-E", "--show-ends", "--show-e"] {
         new_ucmd!()
             .args(&[same_param, "-"])
             .pipe_in("\t\0\n\t")
@@ -317,7 +317,7 @@ fn test_show_ends_crlf() {
 
 #[test]
 fn test_stdin_show_all() {
-    for same_param in &["-A", "--show-all"] {
+    for same_param in &["-A", "--show-all", "--show-a"] {
         new_ucmd!()
             .args(&[same_param])
             .pipe_in("\t\0\n")
@@ -346,7 +346,7 @@ fn test_stdin_nonprinting_and_tabs() {
 
 #[test]
 fn test_stdin_squeeze_blank() {
-    for same_param in &["-s", "--squeeze-blank"] {
+    for same_param in &["-s", "--squeeze-blank", "--squeeze"] {
         new_ucmd!()
             .arg(same_param)
             .pipe_in("\n\na\n\n\n\n\nb\n\n\n")
@@ -358,7 +358,7 @@ fn test_stdin_squeeze_blank() {
 #[test]
 fn test_stdin_number_non_blank() {
     // spell-checker:disable-next-line
-    for same_param in &["-b", "--number-nonblank"] {
+    for same_param in &["-b", "--number-nonblank", "--number-non"] {
         new_ucmd!()
             .arg(same_param)
             .arg("-")

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -60,7 +60,7 @@ fn test_1() {
 #[test]
 fn test_fail_silently() {
     if get_effective_gid() != 0 {
-        for opt in &["-f", "--silent", "--quiet"] {
+        for opt in &["-f", "--silent", "--quiet", "--sil", "--qui"] {
             new_ucmd!()
                 .arg(opt)
                 .arg("bin")

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore (flags) reflink (fs) tmpfs (linux) rlimit Rlim NOFILE
+// spell-checker:ignore (flags) reflink (fs) tmpfs (linux) rlimit Rlim NOFILE clob
 
 use crate::common::util::*;
 #[cfg(not(windows))]
@@ -222,6 +222,17 @@ fn test_cp_arg_no_clobber() {
     ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg("--no-clobber")
+        .succeeds();
+
+    assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "How are you?\n");
+}
+
+#[test]
+fn test_cp_arg_no_clobber_inferred_arg() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .arg("--no-clob")
         .succeeds();
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "How are you?\n");

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -41,7 +41,7 @@ static COMPLEX_SEQUENCE: &TestedSequence = &TestedSequence {
 
 #[test]
 fn test_byte_sequence() {
-    for &param in &["-b", "--bytes"] {
+    for &param in &["-b", "--bytes", "--byt"] {
         for example_seq in EXAMPLE_SEQUENCES {
             new_ucmd!()
                 .args(&[param, example_seq.sequence, INPUT])
@@ -53,7 +53,7 @@ fn test_byte_sequence() {
 
 #[test]
 fn test_char_sequence() {
-    for &param in &["-c", "--characters"] {
+    for &param in &["-c", "--characters", "--char"] {
         for example_seq in EXAMPLE_SEQUENCES {
             //as of coreutils 8.25 a char range is effectively the same as a byte range; there is no distinct treatment of utf8 chars.
             new_ucmd!()
@@ -66,7 +66,7 @@ fn test_char_sequence() {
 
 #[test]
 fn test_field_sequence() {
-    for &param in &["-f", "--fields"] {
+    for &param in &["-f", "--fields", "--fie"] {
         for example_seq in EXAMPLE_SEQUENCES {
             new_ucmd!()
                 .args(&[param, example_seq.sequence, INPUT])
@@ -78,7 +78,7 @@ fn test_field_sequence() {
 
 #[test]
 fn test_specify_delimiter() {
-    for &param in &["-d", "--delimiter"] {
+    for &param in &["-d", "--delimiter", "--del"] {
         new_ucmd!()
             .args(&[param, ":", "-f", COMPLEX_SEQUENCE.sequence, INPUT])
             .succeeds()
@@ -100,15 +100,28 @@ fn test_output_delimiter() {
         ])
         .succeeds()
         .stdout_only_fixture("output_delimiter.expected");
+
+    new_ucmd!()
+        .args(&[
+            "-d:",
+            "--output-del=@",
+            "-f",
+            COMPLEX_SEQUENCE.sequence,
+            INPUT,
+        ])
+        .succeeds()
+        .stdout_only_fixture("output_delimiter.expected");
 }
 
 #[test]
 fn test_complement() {
-    new_ucmd!()
-        .args(&["-d_", "--complement", "-f", "2"])
-        .pipe_in("9_1\n8_2\n7_3")
-        .succeeds()
-        .stdout_only("9\n8\n7\n");
+    for param in &["--complement", "--com"] {
+        new_ucmd!()
+            .args(&["-d_", param, "-f", "2"])
+            .pipe_in("9_1\n8_2\n7_3")
+            .succeeds()
+            .stdout_only("9\n8\n7\n");
+    }
 }
 
 #[test]
@@ -122,7 +135,7 @@ fn test_zero_terminated() {
 
 #[test]
 fn test_only_delimited() {
-    for param in &["-s", "--only-delimited"] {
+    for param in &["-s", "--only-delimited", "--only-del"] {
         new_ucmd!()
             .args(&["-d_", param, "-f", "1"])
             .pipe_in("91\n82\n7_3")

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -7,12 +7,9 @@ use rust_users::*;
 
 #[test]
 fn test_date_email() {
-    new_ucmd!().arg("--rfc-email").succeeds();
-}
-
-#[test]
-fn test_date_email2() {
-    new_ucmd!().arg("-R").succeeds();
+    for param in &["--rfc-email", "--rfc-e", "-R"] {
+        new_ucmd!().arg(param).succeeds();
+    }
 }
 
 #[test]
@@ -26,37 +23,40 @@ fn test_date_rfc_3339() {
     let re = Regex::new(rfc_regexp).unwrap();
 
     // Check that the output matches the regexp
-    scene
-        .ucmd()
-        .arg("--rfc-3339=ns")
-        .succeeds()
-        .stdout_matches(&re);
+    for param in &["--rfc-3339", "--rfc-3"] {
+        scene
+            .ucmd()
+            .arg(format!("{}=ns", param))
+            .succeeds()
+            .stdout_matches(&re);
 
-    scene
-        .ucmd()
-        .arg("--rfc-3339=seconds")
-        .succeeds()
-        .stdout_matches(&re);
+        scene
+            .ucmd()
+            .arg(format!("{}=seconds", param))
+            .succeeds()
+            .stdout_matches(&re);
+    }
 }
 
 #[test]
 fn test_date_rfc_8601() {
-    new_ucmd!().arg("--iso-8601=ns").succeeds();
+    for param in &["--iso-8601", "--i"] {
+        new_ucmd!().arg(format!("{}=ns", param)).succeeds();
+    }
 }
 
 #[test]
 fn test_date_rfc_8601_second() {
-    new_ucmd!().arg("--iso-8601=second").succeeds();
+    for param in &["--iso-8601", "--i"] {
+        new_ucmd!().arg(format!("{}=second", param)).succeeds();
+    }
 }
 
 #[test]
 fn test_date_utc() {
-    new_ucmd!().arg("--utc").succeeds();
-}
-
-#[test]
-fn test_date_universal() {
-    new_ucmd!().arg("--universal").succeeds();
+    for param in &["--universal", "--utc", "--uni", "--u"] {
+        new_ucmd!().arg(param).succeeds();
+    }
 }
 
 #[test]

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -6,6 +6,11 @@ fn test_df_compatible_no_size_arg() {
 }
 
 #[test]
+fn test_df_shortened_long_argument() {
+    new_ucmd!().arg("--a").succeeds();
+}
+
+#[test]
 fn test_df_compatible() {
     new_ucmd!().arg("-ah").succeeds();
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -27,6 +27,28 @@ lazy_static! {
     static ref UMASK_MUTEX: Mutex<()> = Mutex::new(());
 }
 
+const LONG_ARGS: &[&str] = &[
+    "-l",
+    "--long",
+    "--l",
+    "--format=long",
+    "--for=long",
+    "--format=verbose",
+    "--for=verbose",
+];
+
+const ACROSS_ARGS: &[&str] = &[
+    "-x",
+    "--format=across",
+    "--format=horizontal",
+    "--for=across",
+    "--for=horizontal",
+];
+
+const COMMA_ARGS: &[&str] = &["-m", "--format=commas", "--for=commas"];
+
+const COLUMN_ARGS: &[&str] = &["-C", "--format=columns", "--for=columns"];
+
 #[test]
 fn test_ls_ls() {
     new_ucmd!().succeeds();
@@ -315,7 +337,13 @@ fn test_ls_width() {
     at.touch(&at.plus_as_string("test-width-3"));
     at.touch(&at.plus_as_string("test-width-4"));
 
-    for option in &["-w 100", "-w=100", "--width=100", "--width 100"] {
+    for option in &[
+        "-w 100",
+        "-w=100",
+        "--width=100",
+        "--width 100",
+        "--wid=100",
+    ] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -324,7 +352,7 @@ fn test_ls_width() {
             .stdout_only("test-width-1  test-width-2  test-width-3  test-width-4\n");
     }
 
-    for option in &["-w 50", "-w=50", "--width=50", "--width 50"] {
+    for option in &["-w 50", "-w=50", "--width=50", "--width 50", "--wid=50"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -333,7 +361,7 @@ fn test_ls_width() {
             .stdout_only("test-width-1  test-width-3\ntest-width-2  test-width-4\n");
     }
 
-    for option in &["-w 25", "-w=25", "--width=25", "--width 25"] {
+    for option in &["-w 25", "-w=25", "--width=25", "--width 25", "--wid=25"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -342,7 +370,7 @@ fn test_ls_width() {
             .stdout_only("test-width-1\ntest-width-2\ntest-width-3\ntest-width-4\n");
     }
 
-    for option in &["-w 0", "-w=0", "--width=0", "--width 0"] {
+    for option in &["-w 0", "-w=0", "--width=0", "--width 0", "--wid=0"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -358,7 +386,7 @@ fn test_ls_width() {
         .fails()
         .stderr_contains("invalid line width");
 
-    for option in &["-w 1a", "-w=1a", "--width=1a", "--width 1a"] {
+    for option in &["-w 1a", "-w=1a", "--width=1a", "--width 1a", "--wid 1a"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -382,12 +410,12 @@ fn test_ls_columns() {
 
     result.stdout_only("test-columns-1\ntest-columns-2\ntest-columns-3\ntest-columns-4\n");
 
-    for option in &["-C", "--format=columns"] {
+    for option in COLUMN_ARGS {
         let result = scene.ucmd().arg(option).succeeds();
         result.stdout_only("test-columns-1  test-columns-2  test-columns-3  test-columns-4\n");
     }
 
-    for option in &["-C", "--format=columns"] {
+    for option in COLUMN_ARGS {
         scene
             .ucmd()
             .arg("-w=40")
@@ -400,7 +428,7 @@ fn test_ls_columns() {
     // environment variable.
     #[cfg(not(windows))]
     {
-        for option in &["-C", "--format=columns"] {
+        for option in COLUMN_ARGS {
             scene
                 .ucmd()
                 .env("COLUMNS", "40")
@@ -438,14 +466,14 @@ fn test_ls_across() {
     at.touch(&at.plus_as_string("test-across-3"));
     at.touch(&at.plus_as_string("test-across-4"));
 
-    for option in &["-x", "--format=across"] {
+    for option in ACROSS_ARGS {
         let result = scene.ucmd().arg(option).succeeds();
         // Because the test terminal has width 0, this is the same output as
         // the columns option.
         result.stdout_only("test-across-1  test-across-2  test-across-3  test-across-4\n");
     }
 
-    for option in &["-x", "--format=across"] {
+    for option in ACROSS_ARGS {
         // Because the test terminal has width 0, this is the same output as
         // the columns option.
         scene
@@ -466,12 +494,12 @@ fn test_ls_commas() {
     at.touch(&at.plus_as_string("test-commas-3"));
     at.touch(&at.plus_as_string("test-commas-4"));
 
-    for option in &["-m", "--format=commas"] {
+    for option in COMMA_ARGS {
         let result = scene.ucmd().arg(option).succeeds();
         result.stdout_only("test-commas-1, test-commas-2, test-commas-3, test-commas-4\n");
     }
 
-    for option in &["-m", "--format=commas"] {
+    for option in COMMA_ARGS {
         scene
             .ucmd()
             .arg("-w=30")
@@ -479,7 +507,7 @@ fn test_ls_commas() {
             .succeeds()
             .stdout_only("test-commas-1, test-commas-2,\ntest-commas-3, test-commas-4\n");
     }
-    for option in &["-m", "--format=commas"] {
+    for option in COMMA_ARGS {
         scene
             .ucmd()
             .arg("-w=45")
@@ -507,7 +535,7 @@ fn test_ls_long() {
     let at = &scene.fixtures;
     at.touch(&at.plus_as_string("test-long"));
 
-    for arg in &["-l", "--long", "--format=long", "--format=verbose"] {
+    for arg in LONG_ARGS {
         let result = scene.ucmd().arg(arg).arg("test-long").succeeds();
         #[cfg(not(windows))]
         result.stdout_contains("-rw-rw-r--");
@@ -533,7 +561,7 @@ fn test_ls_long_format() {
     at.touch(&at.plus_as_string("test-long-dir/test-long-file"));
     at.mkdir(&at.plus_as_string("test-long-dir/test-long-dir"));
 
-    for arg in &["-l", "--long", "--format=long", "--format=verbose"] {
+    for arg in LONG_ARGS {
         // Assuming sane username do not have spaces within them.
         // A line of the output should be:
         // One of the characters -bcCdDlMnpPsStTx?
@@ -808,7 +836,7 @@ fn test_ls_long_total_size() {
         .collect()
     };
 
-    for arg in &["-l", "--long", "--format=long", "--format=verbose"] {
+    for arg in LONG_ARGS {
         let result = scene.ucmd().arg(arg).succeeds();
         result.stdout_contains(expected_prints["long_vanilla"]);
 
@@ -1383,20 +1411,14 @@ fn test_ls_color() {
     assert!(!result.stdout_str().contains(z_with_colors));
 
     // Color should be enabled
-    scene
-        .ucmd()
-        .arg("--color")
-        .succeeds()
-        .stdout_contains(a_with_colors)
-        .stdout_contains(z_with_colors);
-
-    // Color should be enabled
-    scene
-        .ucmd()
-        .arg("--color=always")
-        .succeeds()
-        .stdout_contains(a_with_colors)
-        .stdout_contains(z_with_colors);
+    for param in &["--color", "--col", "--color=always", "--col=always"] {
+        scene
+            .ucmd()
+            .arg(param)
+            .succeeds()
+            .stdout_contains(a_with_colors)
+            .stdout_contains(z_with_colors);
+    }
 
     // Color should be disabled
     let result = scene.ucmd().arg("--color=never").succeeds();
@@ -1492,24 +1514,21 @@ fn test_ls_indicator_style() {
     assert!(at.is_fifo("named-pipe.fifo"));
 
     // Classify, File-Type, and Slash all contain indicators for directories.
-    let options = vec!["classify", "file-type", "slash"];
-    for opt in options {
+    for opt in [
+        "--indicator-style=classify",
+        "--ind=classify",
+        "--indicator-style=file-type",
+        "--ind=file-type",
+        "--indicator-style=slash",
+        "--ind=slash",
+        "--classify",
+        "--class",
+        "--file-type",
+        "--file",
+        "-p",
+    ] {
         // Verify that classify and file-type both contain indicators for symlinks.
-        scene
-            .ucmd()
-            .arg(format!("--indicator-style={}", opt))
-            .succeeds()
-            .stdout_contains(&"/");
-    }
-
-    // Same test as above, but with the alternate flags.
-    let options = vec!["--classify", "--file-type", "-p"];
-    for opt in options {
-        scene
-            .ucmd()
-            .arg(opt.to_string())
-            .succeeds()
-            .stdout_contains(&"/");
+        scene.ucmd().arg(opt).succeeds().stdout_contains(&"/");
     }
 
     // Classify and File-Type all contain indicators for pipes and links.

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -11,7 +11,7 @@ use crate::common::util::*;
 #[test]
 fn test_count() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-q", "--count"] {
+    for opt in &["-q", "--count", "--c"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -21,7 +21,7 @@ fn test_count() {
 #[test]
 fn test_boot() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-b", "--boot"] {
+    for opt in &["-b", "--boot", "--b"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -31,7 +31,7 @@ fn test_boot() {
 #[test]
 fn test_heading() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-H", "--heading"] {
+    for opt in &["-H", "--heading", "--head"] {
         // allow whitespace variation
         // * minor whitespace differences occur between platform built-in outputs;
         //   specifically number of TABs between "TIME" and "COMMENT" may be variant
@@ -49,7 +49,7 @@ fn test_heading() {
 #[test]
 fn test_short() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-s", "--short"] {
+    for opt in &["-s", "--short", "--s"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -59,7 +59,7 @@ fn test_short() {
 #[test]
 fn test_login() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-l", "--login"] {
+    for opt in &["-l", "--login", "--log"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -79,7 +79,7 @@ fn test_m() {
 #[test]
 fn test_process() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-p", "--process"] {
+    for opt in &["-p", "--process", "--p"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -89,7 +89,7 @@ fn test_process() {
 #[test]
 fn test_runlevel() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-r", "--runlevel"] {
+    for opt in &["-r", "--runlevel", "--r"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
 
@@ -102,7 +102,7 @@ fn test_runlevel() {
 #[test]
 fn test_time() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-t", "--time"] {
+    for opt in &["-t", "--time", "--t"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -118,7 +118,15 @@ fn test_mesg() {
     // --writable
     //     same as -T
     let ts = TestScenario::new(util_name!());
-    for opt in &["-T", "-w", "--mesg", "--message", "--writable"] {
+    for opt in &[
+        "-T",
+        "-w",
+        "--mesg",
+        "--m",
+        "--message",
+        "--writable",
+        "--w",
+    ] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -146,7 +154,7 @@ fn test_too_many_args() {
 #[test]
 fn test_users() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-u", "--users"] {
+    for opt in &["-u", "--users", "--us"] {
         let actual = ts.ucmd().arg(opt).succeeds().stdout_move_str();
         let expect = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         println!("actual: {:?}", actual);
@@ -180,7 +188,7 @@ fn test_lookup() {
 #[test]
 fn test_dead() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-d", "--dead"] {
+    for opt in &["-d", "--dead", "--de"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -212,7 +220,7 @@ fn test_all() {
     }
 
     let ts = TestScenario::new(util_name!());
-    for opt in &["-a", "--all"] {
+    for opt in &["-a", "--all", "--a"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/2931

Enables `AppSettings::InferLongArgs` on almost all utils.