### PR TITLE
truncate: better error msg when dir does not exist

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -218,7 +218,8 @@ fn truncate_reference_and_size(
     let fsize = metadata.len() as usize;
     let tsize = mode.to_size(fsize);
     for filename in &filenames {
-        file_truncate(filename, create, tsize).map_err_context(String::new)?;
+        file_truncate(filename, create, tsize)
+            .map_err_context(|| format!("cannot open {} for writing", filename.quote()))?;
     }
     Ok(())
 }
@@ -251,7 +252,8 @@ fn truncate_reference_file_only(
     })?;
     let tsize = metadata.len() as usize;
     for filename in &filenames {
-        file_truncate(filename, create, tsize).map_err_context(String::new)?;
+        file_truncate(filename, create, tsize)
+            .map_err_context(|| format!("cannot open {} for writing", filename.quote()))?;
     }
     Ok(())
 }
@@ -286,7 +288,11 @@ fn truncate_size_only(size_string: &str, filenames: Vec<String>, create: bool) -
         match file_truncate(filename, create, tsize) {
             Ok(_) => continue,
             Err(e) if e.kind() == ErrorKind::NotFound && !create => continue,
-            Err(e) => return Err(e.map_err_context(String::new)),
+            Err(e) => {
+                return Err(
+                    e.map_err_context(|| format!("cannot open {} for writing", filename.quote()))
+                )
+            }
         }
     }
     Ok(())

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -377,3 +377,12 @@ fn test_division_by_zero_reference_and_size() {
         .no_stdout()
         .stderr_contains("division by zero");
 }
+
+#[test]
+fn test_no_such_dir() {
+    new_ucmd!()
+        .args(&["-s", "0", "a/b"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("cannot open 'a/b' for writing: No such file or directory");
+}


### PR DESCRIPTION
Improve the error message that gets printed when a directory does not
exist. After this commit, the error message is

    truncate: cannot open '{file}' for writing: No such file or directory

where `{file}` is the name of a file in a directory that does not
exist.