### PR TITLE
all: change macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,6 @@ dependencies = [
  "clap 3.0.10",
  "platform-info",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2047,7 +2046,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2056,7 +2054,6 @@ version = "0.0.12"
 dependencies = [
  "uu_base32",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2065,7 +2062,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2075,7 +2071,6 @@ dependencies = [
  "clap 3.0.10",
  "uu_base32",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2088,7 +2083,6 @@ dependencies = [
  "thiserror",
  "unix_socket",
  "uucore",
- "uucore_procs",
  "winapi-util",
 ]
 
@@ -2102,7 +2096,6 @@ dependencies = [
  "selinux",
  "thiserror",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2111,7 +2104,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2121,7 +2113,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
  "walkdir",
 ]
 
@@ -2131,7 +2122,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2140,7 +2130,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2150,7 +2139,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2160,7 +2148,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2175,7 +2162,6 @@ dependencies = [
  "quick-error 1.2.3",
  "selinux",
  "uucore",
- "uucore_procs",
  "walkdir",
  "winapi 0.3.9",
  "xattr",
@@ -2189,7 +2175,6 @@ dependencies = [
  "regex",
  "thiserror",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2201,7 +2186,6 @@ dependencies = [
  "clap 3.0.10",
  "memchr 2.4.1",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2212,7 +2196,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
  "winapi 0.3.9",
 ]
 
@@ -2227,7 +2210,6 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2237,7 +2219,6 @@ dependencies = [
  "clap 3.0.10",
  "number_prefix",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2247,7 +2228,6 @@ dependencies = [
  "clap 3.0.10",
  "glob",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2257,7 +2237,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2267,7 +2246,6 @@ dependencies = [
  "chrono",
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
  "winapi 0.3.9",
 ]
 
@@ -2277,7 +2255,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2288,7 +2265,6 @@ dependencies = [
  "libc",
  "rust-ini",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2298,7 +2274,6 @@ dependencies = [
  "clap 3.0.10",
  "unicode-width",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2311,7 +2286,6 @@ dependencies = [
  "num-traits",
  "onig",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2326,7 +2300,6 @@ dependencies = [
  "rand",
  "smallvec",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2335,7 +2308,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2346,7 +2318,6 @@ dependencies = [
  "libc",
  "unicode-width",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2355,7 +2326,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2364,7 +2334,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2384,7 +2353,6 @@ dependencies = [
  "sha2",
  "sha3",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2394,7 +2362,6 @@ dependencies = [
  "clap 3.0.10",
  "memchr 2.4.1",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2404,7 +2371,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2415,7 +2381,6 @@ dependencies = [
  "hostname",
  "libc",
  "uucore",
- "uucore_procs",
  "winapi 0.3.9",
 ]
 
@@ -2426,7 +2391,6 @@ dependencies = [
  "clap 3.0.10",
  "selinux",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2439,7 +2403,6 @@ dependencies = [
  "libc",
  "time",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2448,7 +2411,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2458,7 +2420,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2468,7 +2429,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2478,7 +2438,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2488,7 +2447,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2508,7 +2466,6 @@ dependencies = [
  "termsize",
  "unicode-width",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2518,7 +2475,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2528,7 +2484,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2538,7 +2493,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2549,7 +2503,6 @@ dependencies = [
  "rand",
  "tempfile",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2565,7 +2518,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2575,7 +2527,6 @@ dependencies = [
  "clap 3.0.10",
  "fs_extra",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2586,7 +2537,6 @@ dependencies = [
  "libc",
  "nix 0.23.1",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2600,7 +2550,6 @@ dependencies = [
  "regex",
  "regex-syntax",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2611,7 +2560,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2622,7 +2570,6 @@ dependencies = [
  "libc",
  "num_cpus",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2631,7 +2578,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2643,7 +2589,6 @@ dependencies = [
  "half",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2652,7 +2597,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2662,7 +2606,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2671,7 +2614,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2685,7 +2627,6 @@ dependencies = [
  "quick-error 2.0.1",
  "regex",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2694,7 +2635,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2704,7 +2644,6 @@ dependencies = [
  "clap 3.0.10",
  "itertools 0.8.2",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2718,7 +2657,6 @@ dependencies = [
  "regex",
  "regex-syntax",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2727,7 +2665,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2737,7 +2674,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2746,7 +2682,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2755,7 +2690,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2765,7 +2699,6 @@ dependencies = [
  "clap 3.0.10",
  "remove_dir_all",
  "uucore",
- "uucore_procs",
  "walkdir",
  "winapi 0.3.9",
 ]
@@ -2777,7 +2710,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2790,7 +2722,6 @@ dependencies = [
  "selinux",
  "thiserror",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2802,7 +2733,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2813,7 +2743,6 @@ dependencies = [
  "libc",
  "rand",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2824,7 +2753,6 @@ dependencies = [
  "rand",
  "rand_core",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2833,7 +2761,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2853,7 +2780,6 @@ dependencies = [
  "tempfile",
  "unicode-width",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2862,7 +2788,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2871,7 +2796,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2882,7 +2806,6 @@ dependencies = [
  "tempfile",
  "uu_stdbuf_libstdbuf",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2893,7 +2816,6 @@ dependencies = [
  "cpp_build",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2902,7 +2824,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2912,7 +2833,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
  "winapi 0.3.9",
 ]
 
@@ -2925,7 +2845,6 @@ dependencies = [
  "memmap2",
  "regex",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2937,7 +2856,6 @@ dependencies = [
  "nix 0.23.1",
  "redox_syscall",
  "uucore",
- "uucore_procs",
  "winapi 0.3.9",
 ]
 
@@ -2949,7 +2867,6 @@ dependencies = [
  "libc",
  "retain_mut",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2960,7 +2877,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2971,7 +2887,6 @@ dependencies = [
  "libc",
  "nix 0.23.1",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2982,7 +2897,6 @@ dependencies = [
  "filetime",
  "time",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -2992,7 +2906,6 @@ dependencies = [
  "clap 3.0.10",
  "nom",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3001,7 +2914,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3010,7 +2922,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3019,7 +2930,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3030,7 +2940,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3040,7 +2949,6 @@ dependencies = [
  "clap 3.0.10",
  "platform-info",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3050,7 +2958,6 @@ dependencies = [
  "clap 3.0.10",
  "unicode-width",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3061,7 +2968,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3070,7 +2976,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3080,7 +2985,6 @@ dependencies = [
  "chrono",
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3089,7 +2993,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3103,7 +3006,6 @@ dependencies = [
  "unicode-width",
  "utf-8",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3112,7 +3014,6 @@ version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3122,7 +3023,6 @@ dependencies = [
  "clap 3.0.10",
  "libc",
  "uucore",
- "uucore_procs",
  "winapi 0.3.9",
 ]
 
@@ -3133,7 +3033,6 @@ dependencies = [
  "clap 3.0.10",
  "nix 0.23.1",
  "uucore",
- "uucore_procs",
 ]
 
 [[package]]
@@ -3154,6 +3053,7 @@ dependencies = [
  "termion",
  "thiserror",
  "time",
+ "uucore_procs",
  "walkdir",
  "wild",
  "winapi 0.3.9",
@@ -3167,7 +3067,6 @@ version = "0.0.12"
 dependencies = [
  "proc-macro2",
  "quote 1.0.14",
- "syn",
 ]
 
 [[package]]

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/arch.rs"
 platform-info = "0.2"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "arch"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -14,7 +14,7 @@ use uucore::error::{FromIo, UResult};
 static ABOUT: &str = "Display machine architecture";
 static SUMMARY: &str = "Determine architecture name for current machine.";
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     uu_app().get_matches_from(args);
 

--- a/src/uu/arch/src/main.rs
+++ b/src/uu/arch/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_arch);
+uucore::bin!(uu_arch);

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/base32.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features = ["encoding"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "base32"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -26,7 +26,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let format = Format::Base32;
     let usage = usage();

--- a/src/uu/base32/src/main.rs
+++ b/src/uu/base32/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_base32);
+uucore::bin!(uu_base32);

--- a/src/uu/base64/Cargo.toml
+++ b/src/uu/base64/Cargo.toml
@@ -16,12 +16,8 @@ path = "src/base64.rs"
 
 [dependencies]
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features = ["encoding"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 uu_base32 = { version=">=0.0.8", package="uu_base32", path="../base32"}
 
 [[bin]]
 name = "base64"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -27,7 +27,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let format = Format::Base64;
     let usage = usage();

--- a/src/uu/base64/src/main.rs
+++ b/src/uu/base64/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_base64);
+uucore::bin!(uu_base64);

--- a/src/uu/basename/Cargo.toml
+++ b/src/uu/basename/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/basename.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "basename"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -31,7 +31,7 @@ pub mod options {
     pub static ZERO: &str = "zero";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/basename/src/main.rs
+++ b/src/uu/basename/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_basename);
+uucore::bin!(uu_basename);

--- a/src/uu/basenc/Cargo.toml
+++ b/src/uu/basenc/Cargo.toml
@@ -17,12 +17,8 @@ path = "src/basenc.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features = ["encoding"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 uu_base32 = { version=">=0.0.8", package="uu_base32", path="../base32"}
 
 [[bin]]
 name = "basenc"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -65,7 +65,7 @@ fn parse_cmd_args(args: impl uucore::Args) -> UResult<(Config, Format)> {
     Ok((config, format))
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let (config, format) = parse_cmd_args(args)?;
     // Create a reference to stdin so we can return a locked stdin from

--- a/src/uu/basenc/src/main.rs
+++ b/src/uu/basenc/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_basenc);
+uucore::bin!(uu_basenc);

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 thiserror = "1.0"
 atty = "0.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs", "pipes"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(unix)'.dependencies]
 unix_socket = "0.5.0"
@@ -31,6 +30,3 @@ winapi-util = "0.1.5"
 [[bin]]
 name = "cat"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -182,7 +182,7 @@ mod options {
     pub static SHOW_NONPRINTING: &str = "show-nonprinting";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/cat/src/main.rs
+++ b/src/uu/cat/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_cat);
+uucore::bin!(uu_cat);

--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/chcon.rs"
 [dependencies]
 clap         = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore       = { version = ">=0.0.9", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
-uucore_procs = { version = ">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 selinux      = { version = "0.2"   }
 fts-sys      = { version = "0.2"   }
 thiserror    = { version = "1.0"   }
@@ -25,6 +24,3 @@ libc         = { version = "0.2"   }
 [[bin]]
 name = "chcon"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -61,7 +61,7 @@ fn get_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = get_usage();
 

--- a/src/uu/chcon/src/main.rs
+++ b/src/uu/chcon/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_chcon);
+uucore::bin!(uu_chcon);

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/chgrp.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "chgrp"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -51,7 +51,7 @@ fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>,
     Ok((dest_gid, None, IfFrom::All))
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = get_usage();
 

--- a/src/uu/chgrp/src/main.rs
+++ b/src/uu/chgrp/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_chgrp);
+uucore::bin!(uu_chgrp);

--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -18,12 +18,8 @@ path = "src/chmod.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs", "mode"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 walkdir = "2.2"
 
 [[bin]]
 name = "chmod"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -48,7 +48,7 @@ fn get_long_usage() -> String {
     String::from("Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.")
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/chmod/src/main.rs
+++ b/src/uu/chmod/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_chmod);
+uucore::bin!(uu_chmod);

--- a/src/uu/chown/Cargo.toml
+++ b/src/uu/chown/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/chown.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "chown"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -54,7 +54,7 @@ fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Optio
     Ok((dest_gid, dest_uid, filter))
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = get_usage();
 

--- a/src/uu/chown/src/main.rs
+++ b/src/uu/chown/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_chown);
+uucore::bin!(uu_chown);

--- a/src/uu/chroot/Cargo.toml
+++ b/src/uu/chroot/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/chroot.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "chroot"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -31,7 +31,7 @@ mod options {
     pub const COMMAND: &str = "command";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/chroot/src/main.rs
+++ b/src/uu/chroot/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_chroot);
+uucore::bin!(uu_chroot);

--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/cksum.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "cksum"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -112,7 +112,7 @@ mod options {
     pub static FILE: &str = "file";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/cksum/src/main.rs
+++ b/src/uu/cksum/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_cksum);
+uucore::bin!(uu_cksum);

--- a/src/uu/comm/Cargo.toml
+++ b/src/uu/comm/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/comm.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "comm"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -130,7 +130,7 @@ fn open_file(name: &str) -> io::Result<LineReader> {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let args = args

--- a/src/uu/comm/src/main.rs
+++ b/src/uu/comm/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_comm);
+uucore::bin!(uu_comm);

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -25,7 +25,6 @@ libc = "0.2.85"
 quick-error = "1.2.3"
 selinux = { version="0.2", optional=true }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "fs", "perms", "mode"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 walkdir = "2.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -45,6 +44,3 @@ path = "src/main.rs"
 [features]
 feat_selinux = ["selinux"]
 feat_acl = ["exacl"]
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -454,7 +454,7 @@ pub fn uu_app<'a>() -> App<'a> {
              .multiple_occurrences(true))
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app()

--- a/src/uu/cp/src/main.rs
+++ b/src/uu/cp/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_cp);
+uucore::bin!(uu_cp);

--- a/src/uu/csplit/Cargo.toml
+++ b/src/uu/csplit/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 thiserror = "1.0"
 regex = "1.0.0"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "csplit"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -717,7 +717,7 @@ mod tests {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let args = args

--- a/src/uu/csplit/src/main.rs
+++ b/src/uu/csplit/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_csplit);
+uucore::bin!(uu_csplit);

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/cut.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 memchr = "2"
 bstr = "0.2"
 atty = "0.2"
@@ -25,6 +24,3 @@ atty = "0.2"
 [[bin]]
 name = "cut"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -395,7 +395,7 @@ mod options {
     pub const FILE: &str = "file";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/cut/src/main.rs
+++ b/src/uu/cut/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_cut);
+uucore::bin!(uu_cut);

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/date.rs"
 chrono = "^0.4.11"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -29,6 +28,3 @@ winapi = { version = "0.3", features = ["minwinbase", "sysinfoapi", "minwindef"]
 [[bin]]
 name = "date"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -140,7 +140,7 @@ impl<'a> From<&'a str> for Rfc3339Format {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let syntax = format!(
         "{0} [OPTION]... [+FORMAT]...

--- a/src/uu/date/src/main.rs
+++ b/src/uu/date/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_date);
+uucore::bin!(uu_date);

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -20,7 +20,6 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 gcd = "2.0"
 libc = "0.2"
 uucore = { version=">=0.0.8", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.5", package="uucore_procs", path="../../uucore_procs" }
 
 [dev-dependencies]
 tempfile = "^3"
@@ -31,6 +30,3 @@ signal-hook = "0.3.9"
 [[bin]]
 name = "dd"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -907,7 +907,7 @@ fn append_dashes_if_not_present(mut acc: Vec<String>, mut s: String) -> Vec<Stri
     acc
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let dashed_args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/dd/src/main.rs
+++ b/src/uu/dd/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_dd); // spell-checker:ignore procs uucore
+uucore::bin!(uu_dd); // spell-checker:ignore procs uucore

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/df.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 number_prefix = "0.4"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["libc", "fsext"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "df"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -277,7 +277,7 @@ impl UError for DfError {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/df/src/main.rs
+++ b/src/uu/df/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_df);
+uucore::bin!(uu_df);

--- a/src/uu/dircolors/Cargo.toml
+++ b/src/uu/dircolors/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/dircolors.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 glob = "0.3.0"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "dircolors"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -65,7 +65,7 @@ fn usage() -> String {
     format!("{0} {1}", uucore::execution_phrase(), SYNTAX)
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/dircolors/src/main.rs
+++ b/src/uu/dircolors/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_dircolors);
+uucore::bin!(uu_dircolors);

--- a/src/uu/dirname/Cargo.toml
+++ b/src/uu/dirname/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/dirname.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "dirname"

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -29,7 +29,7 @@ fn get_long_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/dirname/src/main.rs
+++ b/src/uu/dirname/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_dirname);
+uucore::bin!(uu_dirname);

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/du.rs"
 chrono = "^0.4.11"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version="0.3", features=[] }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -452,7 +452,7 @@ impl UError for DuError {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args

--- a/src/uu/du/src/main.rs
+++ b/src/uu/du/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_du);
+uucore::bin!(uu_du);

--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/echo.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "echo"

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -111,7 +111,7 @@ fn print_escaped(input: &str, mut output: impl Write) -> io::Result<bool> {
     Ok(should_stop)
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/echo/src/main.rs
+++ b/src/uu/echo/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_echo);
+uucore::bin!(uu_echo);

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 rust-ini = "0.17.0"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "env"

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -319,7 +319,7 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
     Ok(())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     run_env(args)
 }

--- a/src/uu/env/src/main.rs
+++ b/src/uu/env/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_env);
+uucore::bin!(uu_env);

--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/expand.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 unicode-width = "0.1.5"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "expand"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -171,7 +171,7 @@ impl Options {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/expand/src/main.rs
+++ b/src/uu/expand/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_expand);
+uucore::bin!(uu_expand);

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -21,11 +21,7 @@ num-bigint = "0.4.0"
 num-traits = "0.2.14"
 onig = "~4.3.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "expr"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -22,7 +22,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(Arg::new(HELP).long(HELP))
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/expr/src/main.rs
+++ b/src/uu/expr/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_expr);
+uucore::bin!(uu_expr);

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -21,12 +21,10 @@ num-traits = "0.2.13" # Needs at least version 0.2.13 for "OverflowingAdd"
 rand = { version = "0.8", features = ["small_rng"] }
 smallvec = "1.7"  # TODO(nicoo): Use `union` feature, requires Rust 1.49 or later.
 uucore = { version = ">=0.0.8", package = "uucore", path = "../../uucore" }
-uucore_procs = { version=">=0.0.8", package = "uucore_procs", path = "../../uucore_procs" }
 
 [dev-dependencies]
 paste = "0.1.18"
 quickcheck = "1.0.3"
-
 
 [[bin]]
 name = "factor"
@@ -34,6 +32,3 @@ path = "src/main.rs"
 
 [lib]
 path = "src/cli.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -44,7 +44,7 @@ fn print_factors_str(
     })
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
     let stdout = stdout();

--- a/src/uu/factor/src/main.rs
+++ b/src/uu/factor/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_factor);
+uucore::bin!(uu_factor);

--- a/src/uu/false/Cargo.toml
+++ b/src/uu/false/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/false.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "false"

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -8,7 +8,7 @@
 use clap::App;
 use uucore::error::UResult;
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     uu_app().get_matches_from(args);
     Err(1.into())

--- a/src/uu/false/src/main.rs
+++ b/src/uu/false/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_false);
+uucore::bin!(uu_false);

--- a/src/uu/fmt/Cargo.toml
+++ b/src/uu/fmt/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 unicode-width = "0.1.5"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "fmt"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -66,7 +66,7 @@ pub struct FmtOptions {
     tabwidth: usize,
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();

--- a/src/uu/fmt/src/main.rs
+++ b/src/uu/fmt/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_fmt);
+uucore::bin!(uu_fmt);

--- a/src/uu/fold/Cargo.toml
+++ b/src/uu/fold/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/fold.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "fold"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -29,7 +29,7 @@ mod options {
     pub const FILE: &str = "file";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/fold/src/main.rs
+++ b/src/uu/fold/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_fold);
+uucore::bin!(uu_fold);

--- a/src/uu/groups/Cargo.toml
+++ b/src/uu/groups/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/groups.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "process"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "groups"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -69,7 +69,7 @@ fn infallible_gid2grp(gid: &u32) -> String {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/groups/src/main.rs
+++ b/src/uu/groups/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_groups);
+uucore::bin!(uu_groups);

--- a/src/uu/hashsum/Cargo.toml
+++ b/src/uu/hashsum/Cargo.toml
@@ -28,11 +28,7 @@ sha2 = "0.6.0"
 sha3 = "0.6.0"
 blake2b_simd = "0.5.11"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "hashsum"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -274,7 +274,7 @@ fn is_valid_bit_num(arg: &str) -> Result<(), String> {
     parse_bit_num(arg).map(|_| ()).map_err(|e| format!("{}", e))
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     // if there is no program name for some reason, default to "hashsum"
     let program = args.next().unwrap_or_else(|| OsString::from(NAME));

--- a/src/uu/hashsum/src/main.rs
+++ b/src/uu/hashsum/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_hashsum);
+uucore::bin!(uu_hashsum);

--- a/src/uu/head/Cargo.toml
+++ b/src/uu/head/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/head.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 memchr = "2"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["ringbuffer"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "head"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -485,7 +485,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
     Ok(())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = match HeadOptions::get_from(args) {
         Ok(o) => o,

--- a/src/uu/head/src/main.rs
+++ b/src/uu/head/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_head);
+uucore::bin!(uu_head);

--- a/src/uu/hostid/Cargo.toml
+++ b/src/uu/hostid/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/hostid.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "hostid"

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -18,7 +18,7 @@ extern "C" {
     pub fn gethostid() -> c_long;
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     uu_app().get_matches_from(args);
     hostid();

--- a/src/uu/hostid/src/main.rs
+++ b/src/uu/hostid/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_hostid);
+uucore::bin!(uu_hostid);

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 hostname = { version = "0.3", features = ["set"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["wide"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 winapi = { version="0.3", features=["sysinfoapi", "winsock2"] }
 
 [[bin]]

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -58,7 +58,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... [HOSTNAME]", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/hostname/src/main.rs
+++ b/src/uu/hostname/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_hostname);
+uucore::bin!(uu_hostname);

--- a/src/uu/id/Cargo.toml
+++ b/src/uu/id/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/id.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "process"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 selinux = { version="0.2", optional = true }
 
 [[bin]]

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -126,7 +126,7 @@ struct State {
     user_specified: bool,
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let after_help = get_description();

--- a/src/uu/id/src/main.rs
+++ b/src/uu/id/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_id);
+uucore::bin!(uu_id);

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -23,7 +23,6 @@ filetime = "0.2"
 file_diff = "1.0.0"
 libc = ">= 0.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs", "mode", "perms", "entries"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [dev-dependencies]
 time = "0.1.40"

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -171,7 +171,7 @@ fn usage() -> String {
 ///
 /// Returns a program return code.
 ///
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/install/src/main.rs
+++ b/src/uu/install/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_install);
+uucore::bin!(uu_install);

--- a/src/uu/join/Cargo.toml
+++ b/src/uu/join/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/join.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "join"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -503,7 +503,7 @@ impl<'a> State<'a> {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/join/src/main.rs
+++ b/src/uu/join/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_join);
+uucore::bin!(uu_join);

--- a/src/uu/kill/Cargo.toml
+++ b/src/uu/kill/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/kill.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["signals"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "kill"

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -35,7 +35,7 @@ pub enum Mode {
     List,
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/kill/src/main.rs
+++ b/src/uu/kill/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_kill);
+uucore::bin!(uu_kill);

--- a/src/uu/link/Cargo.toml
+++ b/src/uu/link/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/link.rs"
 libc = "0.2.42"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "link"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -20,7 +20,7 @@ fn usage() -> String {
     format!("{0} FILE1 FILE2", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/link/src/main.rs
+++ b/src/uu/link/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_link);
+uucore::bin!(uu_link);

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/ln.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "ln"

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -129,7 +129,7 @@ mod options {
 
 static ARG_FILES: &str = "files";
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let long_usage = long_usage();

--- a/src/uu/ln/src/main.rs
+++ b/src/uu/ln/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_ln);
+uucore::bin!(uu_ln);

--- a/src/uu/logname/Cargo.toml
+++ b/src/uu/logname/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/logname.rs"
 libc = "0.2.42"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "logname"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -39,7 +39,7 @@ fn usage() -> &'static str {
     uucore::execution_phrase()
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/logname/src/main.rs
+++ b/src/uu/logname/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_logname);
+uucore::bin!(uu_logname);

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -24,7 +24,6 @@ termsize = "0.1.6"
 glob = "0.3.0"
 lscolors = { version = "0.7.1", features = ["ansi_term"] }
 uucore = { version = ">=0.0.8", package = "uucore", path = "../../uucore", features = ["entries", "fs"] }
-uucore_procs = { version=">=0.0.8", package = "uucore_procs", path = "../../uucore_procs" }
 once_cell = "1.7.2"
 atty = "0.2"
 selinux = { version="0.2", optional = true }
@@ -38,6 +37,3 @@ path = "src/main.rs"
 
 [features]
 feat_selinux = ["selinux"]
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -683,7 +683,7 @@ impl Config {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/ls/src/main.rs
+++ b/src/uu/ls/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_ls);
+uucore::bin!(uu_ls);

--- a/src/uu/mkdir/Cargo.toml
+++ b/src/uu/mkdir/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/mkdir.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs", "mode"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "mkdir"

--- a/src/uu/mkdir/src/main.rs
+++ b/src/uu/mkdir/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_mkdir);
+uucore::bin!(uu_mkdir);

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -78,7 +78,7 @@ fn strip_minus_from_mode(args: &mut Vec<String>) -> bool {
     mode::strip_minus_from_mode(args)
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/mkfifo/Cargo.toml
+++ b/src/uu/mkfifo/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/mkfifo.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "mkfifo"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/mkfifo/src/main.rs
+++ b/src/uu/mkfifo/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_mkfifo);
+uucore::bin!(uu_mkfifo);

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -25,7 +25,7 @@ mod options {
     pub static FIFO: &str = "fifo";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/mknod/Cargo.toml
+++ b/src/uu/mknod/Cargo.toml
@@ -19,11 +19,7 @@ path = "src/mknod.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "^0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["mode"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "mknod"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/mknod/src/main.rs
+++ b/src/uu/mknod/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_mknod);
+uucore::bin!(uu_mknod);

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -79,7 +79,7 @@ fn _mknod(file_name: &str, mode: mode_t, dev: dev_t) -> i32 {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 rand = "0.8"
 tempfile = "3.1"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "mktemp"

--- a/src/uu/mktemp/src/main.rs
+++ b/src/uu/mktemp/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_mktemp);
+uucore::bin!(uu_mktemp);

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -74,7 +74,7 @@ impl Display for MkTempError {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/more.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version = ">=0.0.7", package = "uucore", path = "../../uucore" }
-uucore_procs = { version=">=0.0.8", package = "uucore_procs", path = "../../uucore_procs" }
 crossterm = ">=0.19"
 atty = "0.2"
 unicode-width = "0.1.7"
@@ -33,6 +32,3 @@ nix = "0.23.1"
 [[bin]]
 name = "more"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/more/src/main.rs
+++ b/src/uu/more/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_more);
+uucore::bin!(uu_more);

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -49,7 +49,7 @@ pub mod options {
 
 const MULTI_FILE_TOP_PROMPT: &str = "::::::::::::::\n{}\n::::::::::::::\n";
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/mv.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 fs_extra = "1.1.0"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "mv"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/mv/src/main.rs
+++ b/src/uu/mv/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_mv);
+uucore::bin!(uu_mv);

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -72,7 +72,7 @@ fn usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 nix = "0.23.1"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "nice"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/nice/src/main.rs
+++ b/src/uu/nice/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_nice);
+uucore::bin!(uu_nice);

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -36,7 +36,7 @@ process).",
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/nl/Cargo.toml
+++ b/src/uu/nl/Cargo.toml
@@ -22,11 +22,7 @@ memchr = "2.2.0"
 regex = "1.0.1"
 regex-syntax = "0.6.7"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "nl"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/nl/src/main.rs
+++ b/src/uu/nl/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_nl);
+uucore::bin!(uu_nl);

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -81,7 +81,7 @@ pub mod options {
     pub const NUMBER_WIDTH: &str = "number-width";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 atty = "0.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "nohup"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/nohup/src/main.rs
+++ b/src/uu/nohup/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_nohup);
+uucore::bin!(uu_nohup);

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -81,7 +81,7 @@ impl Display for NohupError {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let args = args

--- a/src/uu/nproc/Cargo.toml
+++ b/src/uu/nproc/Cargo.toml
@@ -19,11 +19,7 @@ libc = "0.2.42"
 num_cpus = "1.10"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "nproc"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/nproc/src/main.rs
+++ b/src/uu/nproc/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_nproc);
+uucore::bin!(uu_nproc);

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -30,7 +30,7 @@ fn usage() -> String {
     format!("{0} [OPTIONS]...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/numfmt/Cargo.toml
+++ b/src/uu/numfmt/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/numfmt.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "numfmt"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/numfmt/src/main.rs
+++ b/src/uu/numfmt/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_numfmt);
+uucore::bin!(uu_numfmt);

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -164,7 +164,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
     })
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -20,11 +20,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 half = "1.6"
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "od"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/od/src/main.rs
+++ b/src/uu/od/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_od);
+uucore::bin!(uu_od);

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -248,7 +248,7 @@ impl OdOptions {
 
 /// parses and validates command line parameters, prepares data structures,
 /// opens the input and calls `odfunc` to process the input.
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/paste/Cargo.toml
+++ b/src/uu/paste/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/paste.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "paste"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/paste/src/main.rs
+++ b/src/uu/paste/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_paste);
+uucore::bin!(uu_paste);

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -34,7 +34,7 @@ fn read_line<R: Read>(
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/pathchk/Cargo.toml
+++ b/src/uu/pathchk/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/pathchk.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "pathchk"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/pathchk/src/main.rs
+++ b/src/uu/pathchk/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_pathchk);
+uucore::bin!(uu_pathchk);

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -40,7 +40,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... NAME...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let args = args

--- a/src/uu/pinky/Cargo.toml
+++ b/src/uu/pinky/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/pinky.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["utmpx", "entries"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "pinky"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/pinky/src/main.rs
+++ b/src/uu/pinky/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_pinky);
+uucore::bin!(uu_pinky);

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -51,7 +51,7 @@ fn get_long_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/pr.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.7", package="uucore", path="../../uucore", features=["entries"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 getopts = "0.2.21"
 chrono = "0.4.19"
 quick-error = "2.0.1"
@@ -27,6 +26,3 @@ regex = "1.0"
 [[bin]]
 name = "pr"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/pr/src/main.rs
+++ b/src/uu/pr/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_pr); // spell-checker:ignore procs uucore
+uucore::bin!(uu_pr); // spell-checker:ignore procs uucore

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -175,7 +175,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name()).setting(AppSettings::InferLongArgs)
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(uucore::InvalidEncodingHandling::Ignore)

--- a/src/uu/printenv/Cargo.toml
+++ b/src/uu/printenv/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/printenv.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "printenv"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/printenv/src/main.rs
+++ b/src/uu/printenv/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_printenv);
+uucore::bin!(uu_printenv);

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -21,7 +21,7 @@ fn usage() -> String {
     format!("{0} [VARIABLE]... [OPTION]...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -21,11 +21,7 @@ path = "src/printf.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 itertools = "0.8.0"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["memo"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "printf"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/printf/src/main.rs
+++ b/src/uu/printf/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_printf);
+uucore::bin!(uu_printf);

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -271,7 +271,7 @@ COPYRIGHT :
 
 ";
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/ptx/Cargo.toml
+++ b/src/uu/ptx/Cargo.toml
@@ -22,11 +22,7 @@ memchr = "2.2.0"
 regex = "1.0.1"
 regex-syntax = "0.6.7"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "ptx"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/ptx/src/main.rs
+++ b/src/uu/ptx/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_ptx);
+uucore::bin!(uu_ptx);

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -674,7 +674,7 @@ mod options {
     pub static WIDTH: &str = "width";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/pwd/Cargo.toml
+++ b/src/uu/pwd/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/pwd.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "pwd"

--- a/src/uu/pwd/src/main.rs
+++ b/src/uu/pwd/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_pwd);
+uucore::bin!(uu_pwd);

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -124,7 +124,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/readlink/Cargo.toml
+++ b/src/uu/readlink/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/readlink.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "readlink"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/readlink/src/main.rs
+++ b/src/uu/readlink/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_readlink);
+uucore::bin!(uu_readlink);

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -34,7 +34,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/realpath/Cargo.toml
+++ b/src/uu/realpath/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/realpath.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "realpath"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/realpath/src/main.rs
+++ b/src/uu/realpath/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_realpath);
+uucore::bin!(uu_realpath);

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -37,7 +37,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/relpath/Cargo.toml
+++ b/src/uu/relpath/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/relpath.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "relpath"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/relpath/src/main.rs
+++ b/src/uu/relpath/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_relpath);
+uucore::bin!(uu_relpath);

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -28,7 +28,7 @@ fn usage() -> String {
     format!("{} [-d DIR] TO [FROM]", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 walkdir = "2.2"
 remove_dir_all = "0.5.1"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version="0.3", features=[] }
@@ -27,6 +26,3 @@ winapi = { version="0.3", features=[] }
 [[bin]]
 name = "rm"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/rm/src/main.rs
+++ b/src/uu/rm/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_rm);
+uucore::bin!(uu_rm);

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -76,7 +76,7 @@ fn get_long_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let long_usage = get_long_usage();

--- a/src/uu/rmdir/Cargo.toml
+++ b/src/uu/rmdir/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/rmdir.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 libc = "0.2.42"
 
 [[bin]]

--- a/src/uu/rmdir/src/main.rs
+++ b/src/uu/rmdir/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_rmdir);
+uucore::bin!(uu_rmdir);

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -29,7 +29,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... DIRECTORY...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/runcon.rs"
 [dependencies]
 clap         = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore       = { version = ">=0.0.9", package="uucore", path="../../uucore", features=["entries", "fs", "perms"] }
-uucore_procs = { version = ">=0.0.6", package="uucore_procs", path="../../uucore_procs" }
 selinux      = { version = "0.2"   }
 fts-sys      = { version = "0.2"   }
 thiserror    = { version = "1.0"   }

--- a/src/uu/runcon/src/main.rs
+++ b/src/uu/runcon/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_runcon);
+uucore::bin!(uu_runcon);

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -44,7 +44,7 @@ fn get_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = get_usage();
 

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -21,11 +21,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 num-bigint = "0.4.0"
 num-traits = "0.2.14"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["memo"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "seq"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/seq/src/main.rs
+++ b/src/uu/seq/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_seq);
+uucore::bin!(uu_seq);

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -58,7 +58,7 @@ type RangeInt = (ExtendedBigInt, ExtendedBigInt, ExtendedBigInt);
 /// The elements are (first, increment, last).
 type RangeFloat = (ExtendedBigDecimal, ExtendedBigDecimal, ExtendedBigDecimal);
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/shred/Cargo.toml
+++ b/src/uu/shred/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 rand = "0.8"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "shred"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/shred/src/main.rs
+++ b/src/uu/shred/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_shred);
+uucore::bin!(uu_shred);

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -267,7 +267,7 @@ pub mod options {
     pub const ZERO: &str = "zero";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 rand = "0.8"
 rand_core = "0.6"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "shuf"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/shuf/src/main.rs
+++ b/src/uu/shuf/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_shuf);
+uucore::bin!(uu_shuf);

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -52,7 +52,7 @@ mod options {
     pub static FILE: &str = "file";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/sleep.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "sleep"

--- a/src/uu/sleep/src/main.rs
+++ b/src/uu/sleep/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_sleep);
+uucore::bin!(uu_sleep);

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -31,7 +31,7 @@ fn usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -28,7 +28,6 @@ rayon = "1.5"
 tempfile = "3"
 unicode-width = "0.1.8"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "sort"

--- a/src/uu/sort/src/main.rs
+++ b/src/uu/sort/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_sort);
+uucore::bin!(uu_sort);

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1056,7 +1056,7 @@ fn make_sort_mode_arg<'a>(mode: &'a str, short: char, help: &'a str) -> Arg<'a> 
     arg
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/split.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "split"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/split/src/main.rs
+++ b/src/uu/split/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_split);
+uucore::bin!(uu_split);

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -53,7 +53,7 @@ size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let long_usage = get_long_usage();

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/stat.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "libc", "fs", "fsext"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "stat"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/stat/src/main.rs
+++ b/src/uu/stat/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_stat);
+uucore::bin!(uu_stat);

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -947,7 +947,7 @@ for details about the options it supports.
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let long_usage = get_long_usage();

--- a/src/uu/stdbuf/Cargo.toml
+++ b/src/uu/stdbuf/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/stdbuf.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 tempfile = "3.1"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [build-dependencies]
 libstdbuf = { version="0.0.12", package="uu_stdbuf_libstdbuf", path="src/libstdbuf" }

--- a/src/uu/stdbuf/src/libstdbuf/Cargo.toml
+++ b/src/uu/stdbuf/src/libstdbuf/Cargo.toml
@@ -20,7 +20,6 @@ crate-type = ["cdylib", "rlib"] # XXX: note: the rlib is just to prevent Cargo f
 cpp = "0.5"
 libc = "0.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../../../uucore_procs" }
 
 [build-dependencies]
 cpp_build = "0.4"

--- a/src/uu/stdbuf/src/main.rs
+++ b/src/uu/stdbuf/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_stdbuf);
+uucore::bin!(uu_stdbuf);

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -149,7 +149,7 @@ fn get_preload_env(tmp_dir: &mut TempDir) -> io::Result<(String, PathBuf)> {
     Ok((preload.to_owned(), inject_path))
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/sum.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "sum"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/sum/src/main.rs
+++ b/src/uu/sum/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_sum);
+uucore::bin!(uu_sum);

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -96,7 +96,7 @@ mod options {
     pub static SYSTEM_V_COMPATIBLE: &str = "sysv";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/sync.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["wide"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "std", "winbase", "winerror"] }
 
 [[bin]]

--- a/src/uu/sync/src/main.rs
+++ b/src/uu/sync/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_sync);
+uucore::bin!(uu_sync);

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -161,7 +161,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -22,11 +22,7 @@ memmap2 = "0.5"
 regex = "1"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "tac"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/tac/src/main.rs
+++ b/src/uu/tac/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_tac);
+uucore::bin!(uu_tac);

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -35,7 +35,7 @@ mod options {
     pub static FILE: &str = "file";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/tail.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["ringbuffer"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version="0.3", features=["fileapi", "handleapi", "processthreadsapi", "synchapi", "winbase"] }
@@ -32,6 +31,3 @@ nix = "0.23.1"
 [[bin]]
 name = "tail"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/tail/src/main.rs
+++ b/src/uu/tail/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_tail);
+uucore::bin!(uu_tail);

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -158,7 +158,7 @@ impl Settings {
 }
 
 #[allow(clippy::cognitive_complexity)]
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = match Settings::get_from(args) {
         Ok(o) => o,

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 retain_mut = "=0.1.2" # ToDO: [2021-01-01; rivy; maint/MinSRV] ~ v0.1.5 uses const generics which aren't stabilized until rust v1.51.0
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["libc"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "tee"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/tee/src/main.rs
+++ b/src/uu/tee/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_tee);
+uucore::bin!(uu_tee);

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -38,7 +38,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/test.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.2"
@@ -26,6 +25,3 @@ redox_syscall = "0.2"
 [[bin]]
 name = "test"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/test/src/main.rs
+++ b/src/uu/test/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_test);
+uucore::bin!(uu_test);

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -92,7 +92,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .setting(AppSettings::DisableVersionFlag)
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     let program = args.next().unwrap_or_else(|| OsString::from("test"));
     let binary_name = uucore::util_name();

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -19,12 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 nix = "0.23.1"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["process", "signals"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
-
 
 [[bin]]
 name = "timeout"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/timeout/src/main.rs
+++ b/src/uu/timeout/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_timeout);
+uucore::bin!(uu_timeout);

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -100,7 +100,7 @@ impl Config {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -19,7 +19,6 @@ filetime = "0.2.1"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 time = "0.1.40"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["libc"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "touch"

--- a/src/uu/touch/src/main.rs
+++ b/src/uu/touch/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_touch);
+uucore::bin!(uu_touch);

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -52,7 +52,7 @@ fn usage() -> String {
     format!("{0} [OPTION]... [USER]", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/tr/Cargo.toml
+++ b/src/uu/tr/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/tr.rs"
 nom = "7.1.0"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "tr"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/tr/src/main.rs
+++ b/src/uu/tr/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_tr);
+uucore::bin!(uu_tr);

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -41,7 +41,7 @@ fn get_long_usage() -> String {
         .to_string()
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/true/Cargo.toml
+++ b/src/uu/true/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/true.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "true"

--- a/src/uu/true/src/main.rs
+++ b/src/uu/true/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_true);
+uucore::bin!(uu_true);

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -8,7 +8,7 @@
 use clap::{App, AppSettings};
 use uucore::error::UResult;
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     uu_app().get_matches_from(args);
     Ok(())

--- a/src/uu/truncate/Cargo.toml
+++ b/src/uu/truncate/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/truncate.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "truncate"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/truncate/src/main.rs
+++ b/src/uu/truncate/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_truncate);
+uucore::bin!(uu_truncate);

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -107,7 +107,7 @@ fn get_long_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let long_usage = get_long_usage();

--- a/src/uu/tsort/Cargo.toml
+++ b/src/uu/tsort/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/tsort.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "tsort"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/tsort/src/main.rs
+++ b/src/uu/tsort/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_tsort);
+uucore::bin!(uu_tsort);

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -23,7 +23,7 @@ mod options {
     pub const FILE: &str = "file";
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.42"
 atty = "0.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["fs"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "tty"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/tty/src/main.rs
+++ b/src/uu/tty/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_tty);
+uucore::bin!(uu_tty);

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -25,7 +25,7 @@ fn usage() -> String {
     format!("{0} [OPTION]...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let args = args

--- a/src/uu/uname/Cargo.toml
+++ b/src/uu/uname/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/uname.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 platform-info = "0.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "uname"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/uname/src/main.rs
+++ b/src/uu/uname/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_uname);
+uucore::bin!(uu_uname);

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -47,7 +47,7 @@ const HOST_OS: &str = "Fuchsia";
 #[cfg(target_os = "redox")]
 const HOST_OS: &str = "Redox";
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = format!("{} [OPTION]...", uucore::execution_phrase());
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/unexpand/Cargo.toml
+++ b/src/uu/unexpand/Cargo.toml
@@ -18,11 +18,7 @@ path = "src/unexpand.rs"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 unicode-width = "0.1.5"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "unexpand"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/unexpand/src/main.rs
+++ b/src/uu/unexpand/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_unexpand);
+uucore::bin!(uu_unexpand);

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -91,7 +91,7 @@ impl Options {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -19,11 +19,7 @@ clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 strum = "0.21"
 strum_macros = "0.21"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "uniq"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/uniq/src/main.rs
+++ b/src/uu/uniq/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_uniq);
+uucore::bin!(uu_uniq);

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -255,7 +255,7 @@ fn get_long_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let long_usage = get_long_usage();

--- a/src/uu/unlink/Cargo.toml
+++ b/src/uu/unlink/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/unlink.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "unlink"

--- a/src/uu/unlink/src/main.rs
+++ b/src/uu/unlink/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_unlink);
+uucore::bin!(uu_unlink);

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -18,7 +18,7 @@ use uucore::error::{FromIo, UResult};
 static ABOUT: &str = "Unlink the file at FILE.";
 static OPT_PATH: &str = "FILE";
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/uptime.rs"
 chrono = "^0.4.11"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["libc", "utmpx"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "uptime"

--- a/src/uu/uptime/src/main.rs
+++ b/src/uu/uptime/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_uptime);
+uucore::bin!(uu_uptime);

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -36,7 +36,7 @@ fn usage() -> String {
     format!("{0} [OPTION]...", uucore::execution_phrase())
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);

--- a/src/uu/users/Cargo.toml
+++ b/src/uu/users/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/users.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["utmpx"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "users"

--- a/src/uu/users/src/main.rs
+++ b/src/uu/users/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_users);
+uucore::bin!(uu_users);

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -30,7 +30,7 @@ If FILE is not specified, use {}.  /var/log/wtmp as FILE is common.",
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
     let after_help = get_long_usage();

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/wc.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["pipes"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 bytecount = "0.6.2"
 utf-8 = "0.7.6"
 unicode-width = "0.1.8"
@@ -29,6 +28,3 @@ libc = "0.2"
 [[bin]]
 name = "wc"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/wc/src/main.rs
+++ b/src/uu/wc/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_wc);
+uucore::bin!(uu_wc);

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -133,7 +133,7 @@ impl Input {
     }
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let usage = usage();
 

--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -17,11 +17,7 @@ path = "src/who.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["utmpx"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [[bin]]
 name = "who"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/who/src/main.rs
+++ b/src/uu/who/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_who);
+uucore::bin!(uu_who);

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -59,7 +59,7 @@ fn get_long_usage() -> String {
     )
 }
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/whoami.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["lmcons"] }

--- a/src/uu/whoami/src/main.rs
+++ b/src/uu/whoami/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_whoami);
+uucore::bin!(uu_whoami);

--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -19,7 +19,7 @@ mod platform;
 
 static ABOUT: &str = "Print the current username.";
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     uu_app().get_matches_from(args);
     let username = platform::get_username().map_err_context(|| "failed to get username".into())?;

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/yes.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["pipes"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 nix = "0.23.1"

--- a/src/uu/yes/src/main.rs
+++ b/src/uu/yes/src/main.rs
@@ -1,1 +1,1 @@
-uucore_procs::main!(uu_yes);
+uucore::bin!(uu_yes);

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -23,7 +23,7 @@ mod splice;
 // systems, but honestly this is good enough
 const BUF_SIZE: usize = 16 * 1024;
 
-#[uucore_procs::gen_uumain]
+#[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 path="src/lib/lib.rs"
 
 [dependencies]
+uucore_procs = { version=">=0.0.12", path="../uucore_procs" }
 clap = "3.0"
 dns-lookup = { version="1.0.5", optional=true }
 dunce = "1.0.0"

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -16,6 +16,8 @@ mod macros; // crate macros (macro_rules-type; exported to `crate::...`)
 mod mods; // core cross-platform modules
 mod parser; // string parsing modules
 
+pub use uucore_procs::*;
+
 // * cross-platform modules
 pub use crate::mods::backup_control;
 pub use crate::mods::display;
@@ -76,6 +78,19 @@ use std::sync::atomic::Ordering;
 use once_cell::sync::Lazy;
 
 use crate::display::Quotable;
+
+#[macro_export]
+macro_rules! bin {
+    ($util:ident) => {
+        pub fn main() {
+            use std::io::Write;
+            uucore::panic::mute_sigpipe_panic(); // suppress extraneous error output for SIGPIPE failures/panics
+            let code = $util::uumain(uucore::args_os()); // execute utility code
+            std::io::stdout().flush().expect("could not flush stdout"); // (defensively) flush stdout for utility prior to exit; see <https://github.com/rust-lang/rust/issues/23818>
+            std::process::exit(code);
+        }
+    };
+}
 
 pub fn get_utility_is_second_arg() -> bool {
     crate::macros::UTILITY_IS_SECOND_ARG.load(Ordering::SeqCst)

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -139,7 +139,7 @@ pub type UResult<T> = Result<T, Box<dyn UError>>;
 /// The main routine would look like this:
 ///
 /// ```ignore
-/// #[uucore_procs::gen_uumain]
+/// #[uucore::main]
 /// pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 ///     // Perform computations here ...
 ///     return Err(LsError::InvalidLineWidth(String::from("test")).into())

--- a/src/uucore_procs/Cargo.toml
+++ b/src/uucore_procs/Cargo.toml
@@ -18,9 +18,3 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version="1.0", features = ["full"] }
-
-[features]
-default = []
-# * non-default features
-debug = ["syn/extra-traits"] ## add Debug traits to syn structures (for `println!("{:?}", ...)`)

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -2,100 +2,20 @@
 
 extern crate proc_macro;
 use proc_macro::TokenStream;
-use proc_macro2::{Ident, Span};
 use quote::quote;
-use syn::{self, parse_macro_input, ItemFn};
 
 //## rust proc-macro background info
 //* ref: <https://dev.to/naufraghi/procedural-macro-in-rust-101-k3f> @@ <http://archive.is/Vbr5e>
 //* ref: [path construction from LitStr](https://oschwald.github.io/maxminddb-rust/syn/struct.LitStr.html) @@ <http://archive.is/8YDua>
 
-//## proc_dbg macro
-//* used to help debug the compile-time proc_macro code
-
-#[cfg(feature = "debug")]
-macro_rules! proc_dbg {
-    ($x:expr) => {
-        dbg!($x)
-    };
-}
-#[cfg(not(feature = "debug"))]
-macro_rules! proc_dbg {
-    ($x:expr) => {};
-}
-
-//## main!()
-
-// main!( EXPR )
-// generates a `main()` function for utilities within the uutils group
-// EXPR == syn::Expr::Lit::String | syn::Expr::Path::Ident ~ EXPR contains the lexical path to the utility `uumain()` function
-//* NOTE: EXPR is ultimately expected to be a multi-segment lexical path (eg, `crate::func`); so, if a single segment path is provided, a trailing "::uumain" is automatically added
-//* for more generic use (and future use of "eager" macros), EXPR may be in either STRING or IDENT form
-
-struct Tokens {
-    expr: syn::Expr,
-}
-
-impl syn::parse::Parse for Tokens {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        Ok(Tokens {
-            expr: input.parse()?,
-        })
-    }
-}
-
-#[proc_macro]
-pub fn main(stream: TokenStream) -> TokenStream {
-    let Tokens { expr } = syn::parse_macro_input!(stream as Tokens);
-    proc_dbg!(&expr);
-
-    const ARG_PANIC_TEXT: &str =
-        "expected ident lexical path (or a literal string version) to 'uumain()' as argument";
-
-    // match EXPR as a string literal or an ident path, o/w panic!()
-    let mut expr = match expr {
-        syn::Expr::Lit(expr_lit) => match expr_lit.lit {
-            syn::Lit::Str(ref lit_str) => lit_str.parse::<syn::ExprPath>().unwrap(),
-            _ => panic!("{}", ARG_PANIC_TEXT),
-        },
-        syn::Expr::Path(expr_path) => expr_path,
-        _ => panic!("{}", ARG_PANIC_TEXT),
-    };
-    proc_dbg!(&expr);
-
-    // for a single segment ExprPath argument, add trailing '::uumain' segment
-    if expr.path.segments.len() < 2 {
-        expr = syn::parse_quote!( #expr::uumain );
-    };
-    proc_dbg!(&expr);
-
-    let f = quote::quote! { #expr(uucore::args_os()) };
-    proc_dbg!(&f);
-
-    // generate a uutils utility `main()` function, tailored for the calling utility
-    let result = quote::quote! {
-        fn main() {
-            use std::io::Write;
-            uucore::panic::mute_sigpipe_panic(); // suppress extraneous error output for SIGPIPE failures/panics
-            let code = #f; // execute utility code
-            std::io::stdout().flush().expect("could not flush stdout"); // (defensively) flush stdout for utility prior to exit; see <https://github.com/rust-lang/rust/issues/23818>
-            std::process::exit(code);
-        }
-    };
-    TokenStream::from(result)
-}
-
 #[proc_macro_attribute]
-pub fn gen_uumain(_args: TokenStream, stream: TokenStream) -> TokenStream {
-    let mut ast = parse_macro_input!(stream as ItemFn);
-
-    // Change the name of the function to "uumain_result" to prevent name-conflicts
-    ast.sig.ident = Ident::new("uumain_result", Span::call_site());
+pub fn main(_args: TokenStream, stream: TokenStream) -> TokenStream {
+    let stream = proc_macro2::TokenStream::from(stream);
 
     let new = quote!(
         pub fn uumain(args: impl uucore::Args) -> i32 {
-            #ast
-            let result = uumain_result(args);
+            #stream
+            let result = uumain(args);
             match result {
                 Ok(()) => uucore::error::get_exit_code(),
                 Err(e) => {

--- a/tests/benches/factor/Cargo.toml
+++ b/tests/benches/factor/Cargo.toml
@@ -16,7 +16,6 @@ criterion = "0.3"
 rand = "0.8"
 rand_chacha = "0.2.2"
 
-
 [[bench]]
 name = "gcd"
 harness = false


### PR DESCRIPTION
I tried to clean up the macros a bit:
- Change the `main!` proc macro to a `bin!` macro_rules macro. It is now in `uucore` since it's no longer a proc macro. This could be a bit faster, but mostly it's much simpler and smaller. It's called `bin` now, because I wanted to rename `gen_uumain` to `main` and it is the entry point for the `bin` target in `Cargo.toml`.
- Re-export uucore_procs from uucore, so that we can reference the proc macros as `uucore::[proc_macro_name]`
- Make utils to not import uucore_procs directly but access proc macros via `uucore`.
- Remove the `syn` dependency and don't parse proc_macro input (hopefully for faster compile times)

All this combined means that `main.rs` now looks like this:
```rust
// before: uucore_procs::main!(uu_arch);
uucore::bin!(uu_arch);
```

And the main function in e.g. `arch.rs` is:
```rust
// before: #[uucore_procs::gen_uumain]
#[uucore::main]
pub fn uumain(args: impl uucore::Args) -> UResult<()> {
    // snip
}
```

Because there are so many changes, I'll put comments on the important files to review.