### PR TITLE
fix: update itertools 0.8.0 -> 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,15 +923,6 @@ checksum = "1c429fffa658f288669529fc26565f728489a2e39bc7b24a428aaaf51355182e"
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
@@ -2681,7 +2672,7 @@ dependencies = [
  "chrono",
  "clap 3.0.10",
  "getopts",
- "itertools 0.10.3",
+ "itertools",
  "quick-error 2.0.1",
  "regex",
  "uucore",
@@ -2702,7 +2693,7 @@ name = "uu_printf"
 version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
- "itertools 0.8.2",
+ "itertools",
  "uucore",
  "uucore_procs",
 ]
@@ -2845,7 +2836,7 @@ dependencies = [
  "compare",
  "ctrlc",
  "fnv",
- "itertools 0.10.3",
+ "itertools",
  "memchr 2.4.1",
  "ouroboros",
  "rand",
@@ -3145,7 +3136,7 @@ dependencies = [
  "data-encoding-macro",
  "dns-lookup",
  "dunce",
- "itertools 0.8.2",
+ "itertools",
  "lazy_static",
  "libc",
  "nix 0.23.1",

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -21,7 +21,7 @@ uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_p
 getopts = "0.2.21"
 chrono = "0.4.19"
 quick-error = "2.0.1"
-itertools = "0.10"
+itertools = "0.10.0"
 regex = "1.0"
 
 [[bin]]

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -2,8 +2,8 @@
 name = "uu_printf"
 version = "0.0.12"
 authors = [
-    "Nathan Ross",
-    "uutils developers",
+  "Nathan Ross",
+  "uutils developers",
 ]
 license = "MIT"
 description = "printf ~ (uutils) FORMAT and display ARGUMENTS"
@@ -18,10 +18,9 @@ edition = "2018"
 path = "src/printf.rs"
 
 [dependencies]
-clap = { version = "3.0", features = ["wrap_help", "cargo"] }
-itertools = "0.8.0"
-uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["memo"] }
-uucore_procs = { version=">=0.0.8", package="uucore_procs", path="../../uucore_procs" }
+clap = {version = "3.0", features = ["wrap_help", "cargo"]}
+itertools = "0.10.0"
+uucore = {version = ">=0.0.11", package = "uucore", path = "../../uucore", features = ["memo"]}
 
 [[bin]]
 name = "printf"

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -21,7 +21,7 @@ dns-lookup = { version="1.0.5", optional=true }
 dunce = "1.0.0"
 wild = "2.0"
 # * optional
-itertools = { version="0.8", optional=true }
+itertools = { version="0.10.0", optional=true }
 thiserror = { version="1.0", optional=true }
 time = { version="<= 0.1.43", optional=true }
 # * "problem" dependencies (pinned)


### PR DESCRIPTION
Targets https://github.com/uutils/coreutils/issues/2940

* since versions were mxing versions of x.y and x.y.z I changed all to x.y.z
* minor whitespace formatting