### PR TITLE
Add support for --hyperlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +298,7 @@ dependencies = [
  "conv",
  "filetime",
  "glob",
+ "hostname",
  "lazy_static",
  "libc",
  "nix 0.23.1",
@@ -2487,10 +2494,12 @@ dependencies = [
 name = "uu_ls"
 version = "0.0.12"
 dependencies = [
+ "ascii",
  "atty",
  "chrono",
  "clap 3.0.10",
  "glob",
+ "hostname",
  "lazy_static",
  "lscolors",
  "number_prefix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,6 +368,7 @@ chrono = "^0.4.11"
 conv = "0.3"
 filetime = "0.2"
 glob = "0.3.0"
+hostname_lib = {package = "hostname", version = "0.3"}
 libc = "0.2"
 pretty_assertions = "1"
 rand = "0.8"

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -27,6 +27,8 @@ uucore = { version = ">=0.0.8", package = "uucore", path = "../../uucore", featu
 once_cell = "1.7.2"
 atty = "0.2"
 selinux = { version="0.2", optional = true }
+ascii = "1.0.0"
+hostname = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 lazy_static = "1.4.0"

--- a/src/uu/ls/src/url_escaper.rs
+++ b/src/uu/ls/src/url_escaper.rs
@@ -1,0 +1,133 @@
+use std::{
+    borrow::Cow,
+    convert::{TryFrom, TryInto},
+    ffi::OsStr,
+};
+
+use ascii::{AsciiChar, AsciiStr, AsciiString};
+/// this is logically enum ByteOrResult {Char(AsciiChar), Escape([AsciiChar; 2])}
+/// but we don't use that definition because rustc uses 3 bytes instead of 2 for it (even if we use a pair instead of the array)
+#[derive(Copy, Clone)]
+#[repr(C)]
+struct AsciiOrEscape(Option<AsciiChar>, AsciiChar);
+
+impl AsciiOrEscape {
+    pub fn ascii(ch: AsciiChar) -> Self {
+        Self(None, ch)
+    }
+
+    pub fn escape(c0: AsciiChar, c1: AsciiChar) -> Self {
+        Self(Some(c0), c1)
+    }
+
+    #[inline]
+    pub fn classify(self) -> Result<AsciiChar, [AsciiChar; 2]> {
+        if let Some(c0) = self.0 {
+            Err([c0, self.1])
+        } else {
+            Ok(self.1)
+        }
+    }
+
+    pub fn is_byte(self) -> bool {
+        self.0.is_none()
+    }
+}
+
+pub struct UrlEscaper {
+    table: Box<[AsciiOrEscape; 256]>,
+}
+
+impl UrlEscaper {
+    pub fn new() -> Self {
+        let mut table = Vec::with_capacity(256);
+        static HEX_BYTES: &[u8; 16] = b"0123456789abcdef";
+        let hex_bytes = AsciiStr::from_ascii(HEX_BYTES).unwrap();
+        for &c0 in hex_bytes {
+            for &c1 in hex_bytes {
+                table.push(AsciiOrEscape::escape(c0, c1));
+            }
+        }
+        assert_eq!(table.len(), 256);
+        for r in [b'0'..=b'9', b'A'..=b'Z', b'a'..=b'z'] {
+            for b in r {
+                table[b as usize] = AsciiOrEscape::ascii(AsciiChar::from_ascii(b).unwrap());
+            }
+        }
+        for b in [b'_', b'-', b'.', b'~'] {
+            table[b as usize] = AsciiOrEscape::ascii(AsciiChar::from_ascii(b).unwrap());
+        }
+        Self {
+            table: table.into_boxed_slice().try_into().map_err(|_| ()).unwrap(),
+        }
+    }
+
+    pub fn into_path_escaper(mut self) -> Self {
+        let slash = AsciiOrEscape::ascii(AsciiChar::from_ascii(b'/').unwrap());
+        self.table[b'/' as usize] = slash;
+        if std::path::MAIN_SEPARATOR != '/' {
+            if let Some(main_separator) = self.table.get_mut(std::path::MAIN_SEPARATOR as usize) {
+                *main_separator = slash;
+            }
+        }
+        self
+    }
+
+    pub fn escape<'a>(&self, s: &'a [u8]) -> Cow<'a, AsciiStr> {
+        let table = &*self.table;
+
+        let mut not_escapes = 0usize;
+        let mut not_identities = false;
+        for b in s.iter().copied() {
+            if std::path::MAIN_SEPARATOR != '/' && (std::path::MAIN_SEPARATOR as usize) < 256 {
+                not_identities |= b == (std::path::MAIN_SEPARATOR as u8);
+            }
+            // cannot overflow because it will be at most s.len() since we are summing 0 or 1 values
+            not_escapes = not_escapes.wrapping_add(table[b as usize].is_byte() as usize);
+        }
+
+        if not_escapes == s.len() && !not_identities {
+            // this won't fail because the string only has ASCII characters (otherwise it would need escapes)
+            Cow::Borrowed(AsciiStr::from_ascii(s).unwrap())
+        } else {
+            static ERROR: &str = "escaped string length too large to fit in memory";
+            // Vec only supports capacity up to isize::MAX, so we must use isize to do all checks
+            let len = isize::try_from(s.len()).expect(ERROR);
+            // can't wrap because not_escapes <= s.len
+            let escapes = len.wrapping_sub(not_escapes as isize);
+            // check for overflow
+            let size = len
+                .checked_add(escapes)
+                .expect(ERROR)
+                .checked_add(escapes)
+                .expect(ERROR);
+
+            let mut res = AsciiString::with_capacity(size as usize);
+
+            for b in s.iter().copied() {
+                match table[b as usize].classify() {
+                    Ok(ch) => {
+                        res.push(ch);
+                    }
+                    Err(escape) => {
+                        res += (&[AsciiChar::Percent, escape[0], escape[1]] as &[AsciiChar]).into();
+                    }
+                }
+            }
+            assert_eq!(res.len(), size as usize);
+
+            Cow::Owned(res)
+        }
+    }
+
+    #[cfg(unix)]
+    pub fn escape_os<'a>(&self, s: &'a OsStr) -> Option<Cow<'a, AsciiStr>> {
+        use std::os::unix::prelude::OsStrExt;
+        Some(self.escape(s.as_bytes()))
+    }
+
+    #[cfg(not(unix))]
+    pub fn escape_os<'a>(&self, s: &'a OsStr) -> Option<Cow<'a, AsciiStr>> {
+        s.to_str().map(|x| self.escape(x.as_bytes()))
+    }
+}


### PR DESCRIPTION
Should work like GNU ls, except for always including quotes in hyperlinks while GNU ls sometimes doesn't.

The code is as optimized as possible, with the constraints of using already existing functions and code structure and not using SIMD instructions for URL escaping (which would have increased complexity a lot).

There is a preparatory commit which changes all uses of Config to &mut so that we can store there lazily computed data that are needed for all hyperlinks.
