### PR TITLE
Don't panic when calling cp -a with a nonexistent file

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -768,8 +768,8 @@ fn preserve_hardlinks(
                     let mut stat = mem::zeroed();
                     if libc::lstat(src_path.as_ptr(), &mut stat) < 0 {
                         return Err(format!(
-                            "cannot stat {:?}: {}",
-                            src_path,
+                            "cannot stat {}: {}",
+                            source.quote(),
                             std::io::Error::last_os_error()
                         )
                         .into());
@@ -849,7 +849,7 @@ fn copy(sources: &[Source], target: &TargetSlice, options: &Options) -> CopyResu
             let mut found_hard_link = false;
             if preserve_hard_links {
                 let dest = construct_dest_path(source, target, &target_type, options)?;
-                preserve_hardlinks(&mut hard_links, source, dest, &mut found_hard_link).unwrap();
+                preserve_hardlinks(&mut hard_links, source, dest, &mut found_hard_link)?;
             }
             if !found_hard_link {
                 if let Err(error) =
@@ -1031,7 +1031,7 @@ fn copy_directory(
                 let mut found_hard_link = false;
                 let source = path.to_path_buf();
                 let dest = local_to_target.as_path().to_path_buf();
-                preserve_hardlinks(&mut hard_links, &source, dest, &mut found_hard_link).unwrap();
+                preserve_hardlinks(&mut hard_links, &source, dest, &mut found_hard_link)?;
                 if !found_hard_link {
                     match copy_file(
                         path.as_path(),

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -26,6 +26,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 static TEST_EXISTING_FILE: &str = "existing_file.txt";
+static TEST_NONEXISTENT_FILE: &str = "nonexistent_file.txt";
 static TEST_HELLO_WORLD_SOURCE: &str = "hello_world.txt";
 static TEST_HELLO_WORLD_SOURCE_SYMLINK: &str = "hello_world.txt.link";
 static TEST_HELLO_WORLD_DEST: &str = "copy_of_hello_world.txt";
@@ -1428,4 +1429,15 @@ fn test_copy_through_dangling_symlink() {
         .arg("target")
         .fails()
         .stderr_only("cp: not writing through dangling symlink 'target'");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_archive_on_nonexistent_file() {
+    new_ucmd!()
+        .arg("-a")
+        .arg(TEST_NONEXISTENT_FILE)
+        .arg(TEST_EXISTING_FILE)
+        .fails()
+        .stderr_only("cp: cannot stat 'nonexistent_file.txt': No such file or directory (os error 2)");
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -26,7 +26,6 @@ use std::thread::sleep;
 use std::time::Duration;
 
 static TEST_EXISTING_FILE: &str = "existing_file.txt";
-static TEST_NONEXISTENT_FILE: &str = "nonexistent_file.txt";
 static TEST_HELLO_WORLD_SOURCE: &str = "hello_world.txt";
 static TEST_HELLO_WORLD_SOURCE_SYMLINK: &str = "hello_world.txt.link";
 static TEST_HELLO_WORLD_DEST: &str = "copy_of_hello_world.txt";
@@ -44,6 +43,8 @@ static TEST_MOUNT_COPY_FROM_FOLDER: &str = "dir_with_mount";
 static TEST_MOUNT_MOUNTPOINT: &str = "mount";
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 static TEST_MOUNT_OTHER_FILESYSTEM_FILE: &str = "mount/DO_NOT_copy_me.txt";
+#[cfg(unix)]
+static TEST_NONEXISTENT_FILE: &str = "nonexistent_file.txt";
 
 #[test]
 fn test_cp_cp() {
@@ -1439,5 +1440,7 @@ fn test_cp_archive_on_nonexistent_file() {
         .arg(TEST_NONEXISTENT_FILE)
         .arg(TEST_EXISTING_FILE)
         .fails()
-        .stderr_only("cp: cannot stat 'nonexistent_file.txt': No such file or directory (os error 2)");
+        .stderr_only(
+            "cp: cannot stat 'nonexistent_file.txt': No such file or directory (os error 2)",
+        );
 }


### PR DESCRIPTION
Fixes #2959 by propagating errors from `preserve_hardlinks()` instead of unwrapping them. On Unix platforms, `preserve_hardlinks()` returns an Error if the file specified by `source` does not exist. This was previously causing `cp -a abc xyz` to panic on Unix if there was no file called `abc`. This problem did not occur on Windows.

This PR also slightly changes the formatting of the original error to match GNU's output.