### PR TITLE
Updated sha libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,11 +129,10 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.2.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
- "byte-tools",
  "generic-array",
 ]
 
@@ -147,12 +146,6 @@ dependencies = [
  "memchr 2.4.1",
  "regex-automata",
 ]
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "byte-unit"
@@ -524,6 +517,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,10 +663,12 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
-version = "0.6.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecae1c064e29fcabb6c2e9939e53dc7da72ed90234ae36ebfe03a478742efbd1"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
+ "block-buffer",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -731,12 +744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fastrand"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,12 +803,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.8.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2297fb0e3ea512e380da24b52dca3924028f59df5e3a17a18f81d8349ca7ebe"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
- "nodrop",
  "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -931,6 +938,12 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -1095,12 +1108,6 @@ dependencies = [
  "libc",
  "memoffset",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -1730,27 +1737,23 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.6.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
- "block-buffer",
- "byte-tools",
+ "cfg-if 1.0.0",
+ "cpufeatures",
  "digest",
- "fake-simd",
- "generic-array",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
+checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
 dependencies = [
- "block-buffer",
- "byte-tools",
  "digest",
- "generic-array",
+ "keccak",
 ]
 
 [[package]]

--- a/src/uu/hashsum/Cargo.toml
+++ b/src/uu/hashsum/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "src/hashsum.rs"
 
 [dependencies]
-digest = "0.6.1"
+digest = "0.10.1"
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 hex = "0.2.0"
 libc = "0.2.42"
@@ -24,8 +24,8 @@ md5 = "0.3.5"
 regex = "1.0.1"
 regex-syntax = "0.6.7"
 sha1 = "0.6.0"
-sha2 = "0.6.0"
-sha3 = "0.6.0"
+sha2 = "0.10.1"
+sha3 = "0.10.0"
 blake2b_simd = "0.5.11"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
 

--- a/src/uu/hashsum/src/digest.rs
+++ b/src/uu/hashsum/src/digest.rs
@@ -18,8 +18,6 @@ use hex::ToHex;
 #[cfg(windows)]
 use memchr::memmem;
 
-use crate::digest::digest::{ExtendableOutput, Input, XofReader};
-
 pub trait Digest {
     fn new() -> Self
     where
@@ -114,11 +112,11 @@ macro_rules! impl_digest_sha {
             }
 
             fn input(&mut self, input: &[u8]) {
-                digest::Digest::input(self, input);
+                digest::Digest::update(self, input);
             }
 
             fn result(&mut self, out: &mut [u8]) {
-                out.copy_from_slice(digest::Digest::result(*self).as_slice());
+                digest::Digest::finalize_into_reset(self, out.into());
             }
 
             fn reset(&mut self) {
@@ -141,11 +139,11 @@ macro_rules! impl_digest_shake {
             }
 
             fn input(&mut self, input: &[u8]) {
-                self.process(input);
+                digest::Update::update(self, input);
             }
 
             fn result(&mut self, out: &mut [u8]) {
-                self.xof_result().read(out);
+                digest::ExtendableOutputReset::finalize_xof_reset_into(self, out);
             }
 
             fn reset(&mut self) {


### PR DESCRIPTION
This gives a speedup of ~5x for some algorithms:

Old version:
```bash
$ time target/release/coreutils sha256sum ~/Downloads/ideaIC-2021.3.tar.gz 
de44097f00f4f9c48cf5abc2fab58c6436a4345f00f83ae7a75734af177e3077  /home/master/Downloads/ideaIC-2021.3.tar.gz

real	0m2,669s
user	0m2,576s
sys	0m0,092s
```

New version:
```bash
$ time target/release/coreutils sha256sum ~/Downloads/ideaIC-2021.3.tar.gz
de44097f00f4f9c48cf5abc2fab58c6436a4345f00f83ae7a75734af177e3077  /home/master/Downloads/ideaIC-2021.3.tar.gz

real	0m0,420s
user	0m0,348s
sys	0m0,072s
```
