### PR TITLE
echo: Allow echo with escapes to work with `\0`

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -88,10 +88,7 @@ fn print_escaped(input: &str, mut output: impl Write) -> io::Result<bool> {
                         start = 0;
                         next
                     }),
-                    '0' => parse_code(&mut iter, 8, 3, 3).unwrap_or_else(|| {
-                        start = 0;
-                        next
-                    }),
+                    '0' => parse_code(&mut iter, 8, 3, 3).unwrap_or('\0'),
                     _ => {
                         start = 0;
                         next

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -138,11 +138,19 @@ fn test_escape_short_octal() {
 }
 
 #[test]
-fn test_escape_no_octal() {
+fn test_escape_nul() {
     new_ucmd!()
         .args(&["-e", "foo\\0 bar"])
         .succeeds()
-        .stdout_only("foo\\0 bar\n");
+        .stdout_only("foo\0 bar\n");
+}
+
+#[test]
+fn test_escape_octal_invalid_digit() {
+    new_ucmd!()
+        .args(&["-e", "foo\\08 bar"])
+        .succeeds()
+        .stdout_only("foo\u{0}8 bar\n");
 }
 
 #[test]


### PR DESCRIPTION
Testing with `gecho` on macos outputs a nul character for a `\0` that isn't followed by a valid octal digit