### PR TITLE
Properly handle "-d --attributes-only" on symlinks

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1335,12 +1335,17 @@ fn copy_file(
             }
         }
         CopyMode::AttrOnly => {
-            OpenOptions::new()
-                .write(true)
-                .truncate(false)
-                .create(true)
-                .open(&dest)
-                .unwrap();
+            let is_symlink = fs::symlink_metadata(&source)?.file_type().is_symlink();
+            if is_symlink && !options.dereference {
+                copy_helper(&source, &dest, options, context, symlinked_files)?;
+            } else {
+                OpenOptions::new()
+                    .write(true)
+                    .truncate(false)
+                    .create(true)
+                    .open(&dest)
+                    .unwrap();
+            }
         }
     };
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1444,3 +1444,17 @@ fn test_cp_archive_on_nonexistent_file() {
             "cp: cannot stat 'nonexistent_file.txt': No such file or directory (os error 2)",
         );
 }
+
+#[test]
+#[cfg(unix)]
+fn test_copy_symlink_with_no_dereference_and_attributes_only() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("file");
+    at.symlink_file("file", "sym");
+    ucmd.arg("-d")
+        .arg("--attributes-only")
+        .arg("sym")
+        .arg("sym2")
+        .succeeds();
+    assert!(at.is_symlink("sym2"));
+}


### PR DESCRIPTION
I believe this PR fixes #2926. 

If `sym` is a symlink, GNU interprets `cp -d --attributes-only sym sym2` as a command to copy the symlink, effectively letting `-d` override `--attributes-only`. UUtils was doing the opposite and letting `--attributes-only` override `-d`. This was first observed with the `-a` flag, which sets `-d` and a few other flags.

I think there's a good opportunity to refactor this. This PR checks if the source is a symlink on line 1338, then calls `copy_helper()`, which immediately does the same check on line 1384! Also, this behavior was already handled in `copy_directory()` with the same approach on line 1025; there might be other edge cases which are handled for directories but not files, or vice versa. I imagine we can cut down on this redundancy, but I'm not familiar enough with the codebase to offer specific suggestions.