### PR TITLE
paste: Fixes and cleanup

### DIFF
--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -10,7 +10,6 @@
 use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
-use std::iter::repeat;
 use std::path::Path;
 use uucore::error::{FromIo, UResult};
 
@@ -110,10 +109,11 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
                 }
                 delim_count += 1;
             }
-            println!("{}", &output[..output.len() - 1]);
+            output.pop();
+            println!("{}", output);
         }
     } else {
-        let mut eof: Vec<bool> = repeat(false).take(files.len()).collect();
+        let mut eof = vec![false; files.len()];
         loop {
             let mut output = String::new();
             let mut eof_count = 0;
@@ -137,7 +137,9 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
             if files.len() == eof_count {
                 break;
             }
-            println!("{}", &output[..output.len() - 1]);
+            // Remove final delimiter
+            output.pop();
+            println!("{}", output);
             delim_count = 0;
         }
     }

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -94,9 +94,10 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
     let mut stdout = stdout.lock();
 
     let mut line = String::new();
+    let mut output = String::new();
     if serial {
         for file in &mut files {
-            let mut output = String::new();
+            output.clear();
             loop {
                 line.clear();
                 match read_line(file.as_mut(), &mut line) {
@@ -115,7 +116,7 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
     } else {
         let mut eof = vec![false; files.len()];
         loop {
-            let mut output = String::new();
+            output.clear();
             let mut eof_count = 0;
             for (i, file) in files.iter_mut().enumerate() {
                 if eof[i] {

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -88,10 +88,7 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
         files.push(file);
     }
 
-    let delimiters: Vec<String> = unescape(delimiters)
-        .chars()
-        .map(|x| x.to_string())
-        .collect();
+    let delimiters: Vec<char> = unescape(delimiters).chars().collect();
     let mut delim_count = 0;
 
     if serial {
@@ -103,7 +100,7 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
                     Ok(0) => break,
                     Ok(_) => {
                         output.push_str(line.trim_end());
-                        output.push_str(&delimiters[delim_count % delimiters.len()]);
+                        output.push(delimiters[delim_count % delimiters.len()]);
                     }
                     Err(e) => return Err(e.map_err_context(String::new)),
                 }
@@ -131,7 +128,7 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
                         Err(e) => return Err(e.map_err_context(String::new)),
                     }
                 }
-                output.push_str(&delimiters[delim_count % delimiters.len()]);
+                output.push(delimiters[delim_count % delimiters.len()]);
                 delim_count += 1;
             }
             if files.len() == eof_count {

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -93,17 +93,17 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
     let stdout = stdout();
     let mut stdout = stdout.lock();
 
-    let mut line = String::new();
     let mut output = String::new();
     if serial {
         for file in &mut files {
             output.clear();
             loop {
-                line.clear();
-                match read_line(file.as_mut(), &mut line) {
+                match read_line(file.as_mut(), &mut output) {
                     Ok(0) => break,
                     Ok(_) => {
-                        output.push_str(line.trim_end());
+                        if output.ends_with('\n') {
+                            output.pop();
+                        }
                         output.push(delimiters[delim_count % delimiters.len()]);
                     }
                     Err(e) => return Err(e.map_err_context(String::new)),
@@ -122,13 +122,16 @@ fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> 
                 if eof[i] {
                     eof_count += 1;
                 } else {
-                    line.clear();
-                    match read_line(file.as_mut(), &mut line) {
+                    match read_line(file.as_mut(), &mut output) {
                         Ok(0) => {
                             eof[i] = true;
                             eof_count += 1;
                         }
-                        Ok(_) => output.push_str(line.trim_end()),
+                        Ok(_) => {
+                            if output.ends_with('\n') {
+                                output.pop();
+                            }
+                        }
                         Err(e) => return Err(e.map_err_context(String::new)),
                     }
                 }

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -9,7 +9,7 @@
 
 use clap::{crate_version, App, AppSettings, Arg};
 use std::fs::File;
-use std::io::{stdin, BufRead, BufReader, Read, stdout, Write};
+use std::io::{stdin, stdout, BufRead, BufReader, Read, Write};
 use std::path::Path;
 use uucore::error::{FromIo, UResult};
 
@@ -76,7 +76,7 @@ pub fn uu_app<'a>() -> App<'a> {
 }
 
 fn paste(filenames: Vec<String>, serial: bool, delimiters: &str) -> UResult<()> {
-    let mut files = vec![];
+    let mut files = Vec::with_capacity(filenames.len());
     for name in filenames {
         let file = if name == "-" {
             None

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -72,6 +72,12 @@ static EXAMPLE_DATA: &[TestData] = &[
         ins: &["1\na\n", "2\nb\n"],
         out: "1💣a\n2💣b\n",
     },
+    TestData {
+        name: "trailing whitespace",
+        args: &["-d", "|"],
+        ins: &["1 \na \n", "2\t\nb\t\n"],
+        out: "1 |2\t\na |b\t\n",
+    },
 ];
 
 #[test]

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -60,6 +60,18 @@ static EXAMPLE_DATA: &[TestData] = &[
         ins: &["1\na\n", "2\nb\n"],
         out: "1 2\na b\n",
     },
+    TestData {
+        name: "multibyte-delim",
+        args: &["-d", "💣"],
+        ins: &["1\na\n", "2\nb\n"],
+        out: "1💣2\na💣b\n",
+    },
+    TestData {
+        name: "multibyte-delim-serial",
+        args: &["-d", "💣", "-s"],
+        ins: &["1\na\n", "2\nb\n"],
+        out: "1💣a\n2💣b\n",
+    },
 ];
 
 #[test]


### PR DESCRIPTION
* Fix panic when a unicode delimiter is used
* Do not trim extra whitespace after lines

Plus some cleanup to e.g. reuse allocations, write directly to a locked stdout, etc. See commits for more info.