### PR TITLE
`uucore`: allow backup suffix with hyphen value

### DIFF
--- a/src/uucore/src/lib/mods/backup_control.rs
+++ b/src/uucore/src/lib/mods/backup_control.rs
@@ -231,6 +231,7 @@ pub mod arguments {
             .help("override the usual backup suffix")
             .takes_value(true)
             .value_name("SUFFIX")
+            .allow_hyphen_values(true)
     }
 }
 
@@ -617,5 +618,14 @@ mod tests {
 
         assert_eq!(result, BackupMode::SimpleBackup);
         env::remove_var(ENV_VERSION_CONTROL);
+    }
+
+    #[test]
+    fn test_suffix_takes_hyphen_value() {
+        let _dummy = TEST_MUTEX.lock().unwrap();
+        let matches = make_app().get_matches_from(vec!["app", "-b", "--suffix", "-v"]);
+
+        let result = determine_backup_suffix(&matches);
+        assert_eq!(result, "-v");
     }
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -386,6 +386,24 @@ fn test_cp_arg_suffix() {
 }
 
 #[test]
+fn test_cp_arg_suffix_hyphen_value() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg("-b")
+        .arg("--suffix")
+        .arg("-v")
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .succeeds();
+
+    assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
+    assert_eq!(
+        at.read(&*format!("{}-v", TEST_HOW_ARE_YOU_SOURCE)),
+        "How are you?\n"
+    );
+}
+
+#[test]
 fn test_cp_custom_backup_suffix_via_env() {
     let (at, mut ucmd) = at_and_ucmd!();
     let suffix = "super-suffix-of-the-century";

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -816,6 +816,31 @@ fn test_install_backup_short_custom_suffix() {
 }
 
 #[test]
+fn test_install_backup_short_custom_suffix_hyphen_value() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let file_a = "test_install_backup_custom_suffix_file_a";
+    let file_b = "test_install_backup_custom_suffix_file_b";
+    let suffix = "-v";
+
+    at.touch(file_a);
+    at.touch(file_b);
+    scene
+        .ucmd()
+        .arg("-b")
+        .arg(format!("--suffix={}", suffix))
+        .arg(file_a)
+        .arg(file_b)
+        .succeeds()
+        .no_stderr();
+
+    assert!(at.file_exists(file_a));
+    assert!(at.file_exists(file_b));
+    assert!(at.file_exists(&format!("{}{}", file_b, suffix)));
+}
+
+#[test]
 fn test_install_backup_custom_suffix_via_env() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -181,6 +181,33 @@ fn test_symlink_custom_backup_suffix() {
 }
 
 #[test]
+fn test_symlink_custom_backup_suffix_hyphen_value() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_symlink_custom_backup_suffix";
+    let link = "test_symlink_custom_backup_suffix_link";
+    let suffix = "-v";
+
+    at.touch(file);
+    at.symlink_file(file, link);
+    assert!(at.file_exists(file));
+    assert!(at.is_symlink(link));
+    assert_eq!(at.resolve_link(link), file);
+
+    let arg = &format!("--suffix={}", suffix);
+    ucmd.args(&["-b", arg, "-s", file, link])
+        .succeeds()
+        .no_stderr();
+    assert!(at.file_exists(file));
+
+    assert!(at.is_symlink(link));
+    assert_eq!(at.resolve_link(link), file);
+
+    let backup = &format!("{}{}", link, suffix);
+    assert!(at.is_symlink(backup));
+    assert_eq!(at.resolve_link(backup), file);
+}
+
+#[test]
 fn test_symlink_backup_numbering() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_symlink_backup_numbering";

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -341,6 +341,27 @@ fn test_mv_custom_backup_suffix() {
 }
 
 #[test]
+fn test_mv_custom_backup_suffix_hyphen_value() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file_a = "test_mv_custom_backup_suffix_file_a";
+    let file_b = "test_mv_custom_backup_suffix_file_b";
+    let suffix = "-v";
+
+    at.touch(file_a);
+    at.touch(file_b);
+    ucmd.arg("-b")
+        .arg(format!("--suffix={}", suffix))
+        .arg(file_a)
+        .arg(file_b)
+        .succeeds()
+        .no_stderr();
+
+    assert!(!at.file_exists(file_a));
+    assert!(at.file_exists(file_b));
+    assert!(at.file_exists(&format!("{}{}", file_b, suffix)));
+}
+
+#[test]
 fn test_mv_custom_backup_suffix_via_env() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_custom_backup_suffix_file_a";


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/2985

The issue was also present for `ln`, `install` and `mv`, which use the same option.