### PR TITLE
ls: Use case-insensitive comparison for filenames

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1483,7 +1483,11 @@ fn sort_entries(entries: &mut [PathData], config: &Config, out: &mut BufWriter<S
         }),
         Sort::Size => entries.sort_by_key(|k| Reverse(k.md(out).map(|md| md.len()).unwrap_or(0))),
         // The default sort in GNU ls is case insensitive
-        Sort::Name => entries.sort_by(|a, b| a.display_name.cmp(&b.display_name)),
+        Sort::Name => entries.sort_by(|a, b| {
+            a.display_name
+                .to_ascii_lowercase()
+                .cmp(&b.display_name.to_ascii_lowercase())
+        }),
         Sort::Version => entries
             .sort_by(|a, b| version_cmp(&a.p_buf.to_string_lossy(), &b.p_buf.to_string_lossy())),
         Sort::Extension => entries.sort_by(|a, b| {


### PR DESCRIPTION
```shell
hbina@akarin:~/git/uutils$ git checkout main 
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
hbina@akarin:~/git/uutils$ diff <(ls --color=never) <(cargo run --quiet -- ls)
1,3d0
< build.rs
< Cargo.lock
< Cargo.toml
5a3,4
> Cargo.lock
> Cargo.toml
7,8d5
< docs
< examples
13a11,13
> build.rs
> docs
> examples
hbina@akarin:~/git/uutils$ git checkout hbina-ls-sort-using-lowercase 
Switched to branch 'hbina-ls-sort-using-lowercase'
hbina@akarin:~/git/uutils$ diff <(ls --color=never) <(cargo run --quiet -- ls)
```

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>