### PR TITLE
shuf: use rand::distributions::Uniform instead of a handwritten distribution

### DIFF
--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -8,8 +8,8 @@
 // spell-checker:ignore (ToDO) cmdline evec seps rvec fdata
 
 use clap::{crate_version, App, AppSettings, Arg};
-use rand::Rng;
 use rand::distributions::Uniform;
+use rand::Rng;
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use uucore::display::Quotable;


### PR DESCRIPTION
shuf currently uses a handwritten, and needlessly inefficient, code to sample from a uniform distribution. This PR updates the code to use `rand::distributions::Uniform` instead.

There is probably no real world performance improvement, but this should make the code a bit clearer. The randomization usually isn't the bottleneck, but it's now about faster, e.g. `seq 10000 | time shuf -rn 200000000 > /dev/null` is ~2x faster.