### PR TITLE
`ls`: fix flaky test `test_ls_io_errors`

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1,28 +1,27 @@
 // spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile
 
-#[cfg(unix)]
-extern crate unix_socket;
-use crate::common::util::*;
-
-extern crate regex;
-use self::regex::Regex;
-
-#[cfg(all(unix, feature = "chmod"))]
-use nix::unistd::{close, dup2};
-use std::collections::HashMap;
-#[cfg(all(unix, feature = "chmod"))]
-use std::os::unix::io::AsRawFd;
-use std::path::Path;
-use std::thread::sleep;
-use std::time::Duration;
 #[cfg(not(windows))]
 extern crate libc;
+extern crate regex;
+#[cfg(not(windows))]
+extern crate tempfile;
+#[cfg(unix)]
+extern crate unix_socket;
+
+use self::regex::Regex;
+use crate::common::util::*;
+#[cfg(all(unix, feature = "chmod"))]
+use nix::unistd::{close, dup};
+use std::collections::HashMap;
+#[cfg(all(unix, feature = "chmod"))]
+use std::os::unix::io::IntoRawFd;
+use std::path::Path;
 #[cfg(not(windows))]
 use std::path::PathBuf;
 #[cfg(not(windows))]
 use std::sync::Mutex;
-#[cfg(not(windows))]
-extern crate tempfile;
+use std::thread::sleep;
+use std::time::Duration;
 
 #[cfg(not(windows))]
 lazy_static! {
@@ -142,7 +141,7 @@ fn test_ls_devices() {
     }
 }
 
-#[cfg(all(feature = "chmod"))]
+#[cfg(feature = "chmod")]
 #[test]
 fn test_ls_io_errors() {
     let scene = TestScenario::new(util_name!());
@@ -202,56 +201,52 @@ fn test_ls_io_errors() {
     #[cfg(unix)]
     {
         at.touch("some-dir4/bad-fd.txt");
-        let fd1 = at.open("some-dir4/bad-fd.txt").as_raw_fd();
-        let fd2 = 25000;
-        let rv1 = dup2(fd1, fd2);
-        let rv2 = close(fd1);
+        let fd1 = at.open("some-dir4/bad-fd.txt").into_raw_fd();
+        let fd2 = dup(dbg!(fd1)).unwrap();
+        close(fd1).unwrap();
 
-        // dup and close work on the mac, but doesn't work in some linux containers
-        // so check to see that return values are non-error before proceeding
-        if rv1.is_ok() && rv2.is_ok() {
-            // on the mac and in certain Linux containers bad fds are typed as dirs,
-            // however sometimes bad fds are typed as links and directory entry on links won't fail
-            if PathBuf::from(format!("/dev/fd/{fd}", fd = fd2)).is_dir() {
-                scene
-                    .ucmd()
-                    .arg("-alR")
-                    .arg(format!("/dev/fd/{fd}", fd = fd2))
-                    .fails()
-                    .stderr_contains(format!(
-                        "cannot open directory '/dev/fd/{fd}': Bad file descriptor",
-                        fd = fd2
-                    ))
-                    .stdout_does_not_contain(format!("{fd}:\n", fd = fd2));
-
-                scene
-                    .ucmd()
-                    .arg("-RiL")
-                    .arg(format!("/dev/fd/{fd}", fd = fd2))
-                    .fails()
-                    .stderr_contains(format!("cannot open directory '/dev/fd/{fd}': Bad file descriptor", fd = fd2))
-                    // don't double print bad fd errors
-                    .stderr_does_not_contain(format!("ls: cannot open directory '/dev/fd/{fd}': Bad file descriptor\nls: cannot open directory '/dev/fd/{fd}': Bad file descriptor", fd = fd2));
-            } else {
-                scene
-                    .ucmd()
-                    .arg("-alR")
-                    .arg(format!("/dev/fd/{fd}", fd = fd2))
-                    .succeeds();
-
-                scene
-                    .ucmd()
-                    .arg("-RiL")
-                    .arg(format!("/dev/fd/{fd}", fd = fd2))
-                    .succeeds();
-            }
+        // on the mac and in certain Linux containers bad fds are typed as dirs,
+        // however sometimes bad fds are typed as links and directory entry on links won't fail
+        if PathBuf::from(format!("/dev/fd/{fd}", fd = fd2)).is_dir() {
+            scene
+                .ucmd()
+                .arg("-alR")
+                .arg(format!("/dev/fd/{fd}", fd = fd2))
+                .fails()
+                .stderr_contains(format!(
+                    "cannot open directory '/dev/fd/{fd}': Bad file descriptor",
+                    fd = fd2
+                ))
+                .stdout_does_not_contain(format!("{fd}:\n", fd = fd2));
 
             scene
                 .ucmd()
-                .arg("-alL")
+                .arg("-RiL")
+                .arg(format!("/dev/fd/{fd}", fd = fd2))
+                .fails()
+                .stderr_contains(format!("cannot open directory '/dev/fd/{fd}': Bad file descriptor", fd = fd2))
+                // don't double print bad fd errors
+                .stderr_does_not_contain(format!("ls: cannot open directory '/dev/fd/{fd}': Bad file descriptor\nls: cannot open directory '/dev/fd/{fd}': Bad file descriptor", fd = fd2));
+        } else {
+            scene
+                .ucmd()
+                .arg("-alR")
+                .arg(format!("/dev/fd/{fd}", fd = fd2))
+                .succeeds();
+
+            scene
+                .ucmd()
+                .arg("-RiL")
                 .arg(format!("/dev/fd/{fd}", fd = fd2))
                 .succeeds();
         }
+
+        scene
+            .ucmd()
+            .arg("-alL")
+            .arg(format!("/dev/fd/{fd}", fd = fd2))
+            .succeeds();
+
         let _ = close(fd2);
     }
 }


### PR DESCRIPTION
Hopefully fixes: https://github.com/uutils/coreutils/issues/3002

The test wasn't being triggered on my Linux machine, so I changed some things until it did, so hopefully it now works for both unix and mac. We'll have to see if it also fixes the flakiness.