### PR TITLE
truncate: change cli error return code

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -6,7 +6,6 @@
 //  * file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) RFILE refsize rfilename fsize tsize
-use clap;
 use clap::{crate_version, App, AppSettings, Arg};
 use std::convert::TryFrom;
 use std::fs::{metadata, OpenOptions};

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -6,6 +6,7 @@
 //  * file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) RFILE refsize rfilename fsize tsize
+use clap;
 use clap::{crate_version, App, AppSettings, Arg};
 use std::convert::TryFrom;
 use std::fs::{metadata, OpenOptions};
@@ -115,7 +116,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app()
         .override_usage(&usage[..])
         .after_help(&long_usage[..])
-        .get_matches_from(args);
+        .try_get_matches_from(args)
+        .unwrap_or_else(|e| {
+            e.print();
+            match e.kind {
+                clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => {
+                    std::process::exit(0)
+                }
+                _ => std::process::exit(1),
+            }
+        });
 
     let files: Vec<String> = matches
         .values_of(options::ARG_FILES)

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -118,7 +118,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .after_help(&long_usage[..])
         .try_get_matches_from(args)
         .unwrap_or_else(|e| {
-            e.print();
+            e.print().expect("Error writing clap::Error");
             match e.kind {
                 clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => {
                     std::process::exit(0)

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -116,15 +116,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .override_usage(&usage[..])
         .after_help(&long_usage[..])
         .try_get_matches_from(args)
-        .unwrap_or_else(|e| {
+        .map_err(|e| {
             e.print().expect("Error writing clap::Error");
             match e.kind {
-                clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => {
-                    std::process::exit(0)
-                }
-                _ => std::process::exit(1),
+                clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => 0,
+                _ => 1,
             }
-        });
+        })?;
 
     let files: Vec<String> = matches
         .values_of(options::ARG_FILES)

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -250,11 +250,24 @@ fn test_size_and_reference() {
 #[test]
 fn test_error_filename_only() {
     // truncate: you must specify either '--size' or '--reference'
-    new_ucmd!().args(&["file"]).fails().stderr_contains(
-        "error: The following required arguments were not provided:
+    new_ucmd!()
+        .args(&["file"])
+        .fails()
+        .code_is(1)
+        .stderr_contains(
+            "error: The following required arguments were not provided:
     --reference <RFILE>
     --size <SIZE>",
-    );
+        );
+}
+
+#[test]
+fn test_invalid_option() {
+    // truncate: cli parsing error returns 1
+    new_ucmd!()
+        .args(&["--this-arg-does-not-exist"])
+        .fails()
+        .code_is(1);
 }
 
 #[test]


### PR DESCRIPTION
Exit with status code 1 for argument parsing errors in `truncate`. When `clap` encounters an error during argument parsing, it exits with status code 2. This causes some GNU tests to fail since they expect status code 1.

Closes #2951