### PR TITLE
Allow comments in VS Code configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Configure GitHub to not mark comments in configuration files as errors
-*.json linguist-language=JSON-with-Comments
+.vscode/*.json linguist-language=JSON-with-Comments

--- a/.vscode/.gitattributes
+++ b/.vscode/.gitattributes
@@ -1,0 +1,2 @@
+# Configure GitHub to not mark comments in configuration files as errors
+*.json linguist-language=JSON-with-Comments

--- a/.vscode/.gitattributes
+++ b/.vscode/.gitattributes
@@ -1,2 +1,2 @@
 # Configure GitHub to not mark comments in configuration files as errors
-.vscode/*.json linguist-language=JSON-with-Comments
+*.json linguist-language=jsonc

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -1,7 +1,12 @@
 // `cspell` settings
 {
-  "version": "0.1", // Version of the setting file.  Always 0.1
-  "language": "en", // language - current active spelling language
+  // version of the setting file (always 0.1)
+  "version": "0.1",
+
+  // spelling language
+  "language": "en",
+
+  // custom dictionaries
   "dictionaries": ["acronyms+names", "jargon", "people", "shell", "workspace"],
   "dictionaryDefinitions": [
     { "name": "acronyms+names", "path": "./cspell.dictionaries/acronyms+names.wordlist.txt" },
@@ -10,10 +15,19 @@
     { "name": "shell", "path": "./cspell.dictionaries/shell.wordlist.txt" },
     { "name": "workspace", "path": "./cspell.dictionaries/workspace.wordlist.txt" }
   ],
-  // ignorePaths -  a list of globs to specify which files are to be ignored
-  "ignorePaths": ["Cargo.lock", "target/**", "tests/**/fixtures/**", "src/uu/dd/test-resources/**", "vendor/**"],
-  // ignoreWords - a list of words to be ignored (even if they are in the flagWords)
+
+  // files to ignore (globs supported)
+  "ignorePaths": [
+    "Cargo.lock",
+    "target/**",
+    "tests/**/fixtures/**",
+    "src/uu/dd/test-resources/**",
+    "vendor/**"
+  ],
+
+  // words to ignore (even if they are in the flagWords)
   "ignoreWords": [],
-  // words - list of words to be always considered correct
+
+  // words to always consider correct
   "words": []
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
 // see <http://go.microsoft.com/fwlink/?LinkId=827846> for the documentation about the extensions.json format
 {
   "recommendations": [
-    // Rust language support.
+    // Rust language support
     "matklad.rust-analyzer",
     // `cspell` spell-checker support
     "streetsidesoftware.code-spell-checker"


### PR DESCRIPTION
Since JSON formally cannot contain comments, GitHub highlights comments in JSON files as errors, but the configuration files for VS Code in this repository contain comments. In this PR, I try to configure GitHub to use a different syntax highlighter for the affected files.

See [documentation of Linguist overrides](https://github.com/github/linguist/blob/master/docs/overrides.md).

Unfortunately, it is not clear to me whether this works or not. I see the `cSpell.json` with properly formatted comments but the `extensions.json` with comments marked as errors. And that is independently of whether I look at a branch with this change in or out.