### PR TITLE
Only recommend rust-analyzer

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
+// spell-checker:ignore (misc) matklad
+// see <http://go.microsoft.com/fwlink/?LinkId=827846> for the documentation about the extensions.json format
 {
-  // spell-checker:ignore (misc) matklad
-  // see <http://go.microsoft.com/fwlink/?LinkId=827846> for the documentation about the extensions.json format
   "recommendations": [
     // Rust language support.
     "matklad.rust-analyzer",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,6 @@
   // see <http://go.microsoft.com/fwlink/?LinkId=827846> for the documentation about the extensions.json format
   "recommendations": [
     // Rust language support.
-    "rust-lang.rust",
-    // Provides support for rust-analyzer: novel LSP server for the Rust programming language.
     "matklad.rust-analyzer",
     // `cspell` spell-checker support
     "streetsidesoftware.code-spell-checker"


### PR DESCRIPTION
As discussed in uutils/coreutils#3017, only `rust-analyzer` should be recommended. Fixes uutils/coreutils#3017.