### PR TITLE
dd: allow multiple instances of arguments

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1060,8 +1060,11 @@ Printing performance stats is also triggered by the INFO signal (where supported
         .arg(
             Arg::new(options::CONV)
                 .long(options::CONV)
-                .overrides_with(options::CONV)
                 .takes_value(true)
+                .multiple_occurrences(true)
+                .use_delimiter(true)
+                .require_delimiter(true)
+                .multiple_values(true)
                 .require_equals(true)
                 .value_name("CONV")
                 .help("(alternatively conv=CONV[,CONV]) specifies a comma-separated list of conversion options or (for legacy reasons) file flags. Conversion options and file flags may be intermixed.
@@ -1098,8 +1101,11 @@ Conversion Flags:
         .arg(
             Arg::new(options::IFLAG)
                 .long(options::IFLAG)
-                .overrides_with(options::IFLAG)
                 .takes_value(true)
+                .multiple_occurrences(true)
+                .use_delimiter(true)
+                .require_delimiter(true)
+                .multiple_values(true)
                 .require_equals(true)
                 .value_name("FLAG")
                 .help("(alternatively iflag=FLAG[,FLAG]) a comma separated list of input flags which specify how the input source is treated. FLAG may be any of the input-flags or general-flags specified below.
@@ -1125,8 +1131,11 @@ General-Flags
         .arg(
             Arg::new(options::OFLAG)
                 .long(options::OFLAG)
-                .overrides_with(options::OFLAG)
                 .takes_value(true)
+                .multiple_occurrences(true)
+                .use_delimiter(true)
+                .require_delimiter(true)
+                .multiple_values(true)
                 .require_equals(true)
                 .value_name("FLAG")
                 .help("(alternatively oflag=FLAG[,FLAG]) a comma separated list of output flags which specify how the output source is treated. FLAG may be any of the output-flags or general-flags specified below.

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -954,6 +954,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::INFILE)
                 .long(options::INFILE)
+                .overrides_with(options::INFILE)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("FILE")
@@ -962,6 +963,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::OUTFILE)
                 .long(options::OUTFILE)
+                .overrides_with(options::OUTFILE)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("FILE")
@@ -970,6 +972,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::IBS)
                 .long(options::IBS)
+                .overrides_with(options::IBS)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("N")
@@ -978,6 +981,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::OBS)
                 .long(options::OBS)
+                .overrides_with(options::OBS)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("N")
@@ -986,6 +990,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::BS)
                 .long(options::BS)
+                .overrides_with(options::BS)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("N")
@@ -994,6 +999,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::CBS)
                 .long(options::CBS)
+                .overrides_with(options::CBS)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("N")
@@ -1002,6 +1008,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::SKIP)
                 .long(options::SKIP)
+                .overrides_with(options::SKIP)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("N")
@@ -1010,6 +1017,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::SEEK)
                 .long(options::SEEK)
+                .overrides_with(options::SEEK)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("N")
@@ -1018,6 +1026,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::COUNT)
                 .long(options::COUNT)
+                .overrides_with(options::COUNT)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("N")
@@ -1026,6 +1035,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .arg(
             Arg::new(options::STATUS)
                 .long(options::STATUS)
+                .overrides_with(options::STATUS)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("LEVEL")
@@ -1050,6 +1060,7 @@ Printing performance stats is also triggered by the INFO signal (where supported
         .arg(
             Arg::new(options::CONV)
                 .long(options::CONV)
+                .overrides_with(options::CONV)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("CONV")
@@ -1087,6 +1098,7 @@ Conversion Flags:
         .arg(
             Arg::new(options::IFLAG)
                 .long(options::IFLAG)
+                .overrides_with(options::IFLAG)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("FLAG")
@@ -1113,6 +1125,7 @@ General-Flags
         .arg(
             Arg::new(options::OFLAG)
                 .long(options::OFLAG)
+                .overrides_with(options::OFLAG)
                 .takes_value(true)
                 .require_equals(true)
                 .value_name("FLAG")

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -414,16 +414,11 @@ fn parse_flag_list<T: std::str::FromStr<Err = ParseError>>(
     tag: &str,
     matches: &Matches,
 ) -> Result<Vec<T>, ParseError> {
-    let mut flags = Vec::new();
-
-    if let Some(comma_str) = matches.value_of(tag) {
-        for s in comma_str.split(',') {
-            let flag = s.parse()?;
-            flags.push(flag);
-        }
-    }
-
-    Ok(flags)
+    matches
+        .values_of(tag)
+        .unwrap_or_default()
+        .map(|f| f.parse())
+        .collect()
 }
 
 /// Parse Conversion Options (Input Variety)


### PR DESCRIPTION
Correct the behavior of `dd` when multiple arguments are provided.
Before this commit, if the multiple arguments was provided then
the validation error are returned.

For example

```
$ printf '' | ./target/debug/dd status=none status=noxfer
error: The argument '--status=<LEVEL>' was provided more than once, but cannot be used multiple times

USAGE:
    dd [OPTIONS]

For more information try --help
```

The unittest was added for this case.
The issue for this PR is https://github.com/uutils/coreutils/issues/3009