### PR TITLE
basenc, base64 and base32 have an ABOUT that's formatted differently than the other utils

### DIFF
--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -12,14 +12,14 @@ use uucore::{encoding::Format, error::UResult};
 
 pub mod base_common;
 
-static ABOUT: &str = "
- With no FILE, or when FILE is -, read standard input.
+static ABOUT: &str = "\
+With no FILE, or when FILE is -, read standard input.
 
- The data are encoded as described for the base32 alphabet in RFC
- 4648. When decoding, the input may contain newlines in addition
- to the bytes of the formal base32 alphabet. Use --ignore-garbage
- to attempt to recover from any other non-alphabet bytes in the
- encoded stream.
+The data are encoded as described for the base32 alphabet in RFC
+4648. When decoding, the input may contain newlines in addition
+to the bytes of the formal base32 alphabet. Use --ignore-garbage
+to attempt to recover from any other non-alphabet bytes in the
+encoded stream.
 ";
 
 fn usage() -> String {

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -13,14 +13,14 @@ use uucore::{encoding::Format, error::UResult};
 
 use std::io::{stdin, Read};
 
-static ABOUT: &str = "
- With no FILE, or when FILE is -, read standard input.
+static ABOUT: &str = "\
+With no FILE, or when FILE is -, read standard input.
 
- The data are encoded as described for the base64 alphabet in RFC
- 3548. When decoding, the input may contain newlines in addition
- to the bytes of the formal base64 alphabet. Use --ignore-garbage
- to attempt to recover from any other non-alphabet bytes in the
- encoded stream.
+The data are encoded as described for the base64 alphabet in RFC
+3548. When decoding, the input may contain newlines in addition
+to the bytes of the formal base64 alphabet. Use --ignore-garbage
+to attempt to recover from any other non-alphabet bytes in the
+encoded stream.
 ";
 
 fn usage() -> String {

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -19,12 +19,12 @@ use uucore::{
 
 use std::io::{stdin, Read};
 
-static ABOUT: &str = "
- With no FILE, or when FILE is -, read standard input.
+static ABOUT: &str = "\
+With no FILE, or when FILE is -, read standard input.
 
- When decoding, the input may contain newlines in addition to the bytes of
- the formal alphabet. Use --ignore-garbage to attempt to recover
- from any other non-alphabet bytes in the encoded stream.
+When decoding, the input may contain newlines in addition to the bytes of
+the formal alphabet. Use --ignore-garbage to attempt to recover
+from any other non-alphabet bytes in the encoded stream.
 ";
 
 const ENCODINGS: &[(&str, Format)] = &[


### PR DESCRIPTION
closes #3022 