### PR TITLE
cp: only allow directory for -t

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -315,6 +315,12 @@ pub fn uu_app<'a>() -> App<'a> {
              .long(options::TARGET_DIRECTORY)
              .value_name(options::TARGET_DIRECTORY)
              .takes_value(true)
+             .validator(|s| {
+                 if Path::new(s).is_dir() {
+                     return Ok(());
+                 }
+                 Err("must specify a directory")
+             })
              .help("copy all SOURCE arguments into target-directory"))
         .arg(Arg::new(options::NO_TARGET_DIRECTORY)
              .short('T')

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -319,7 +319,7 @@ pub fn uu_app<'a>() -> App<'a> {
                  if Path::new(s).is_dir() {
                      return Ok(());
                  }
-                 Err("must specify a directory")
+                 Err(format!("'{}' is not a directory", s))
              })
              .help("copy all SOURCE arguments into target-directory"))
         .arg(Arg::new(options::NO_TARGET_DIRECTORY)

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -475,7 +475,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             LONG_HELP,
             backup_control::BACKUP_CONTROL_LONG_HELP
         ))
-        .get_matches_from(args);
+        .try_get_matches_from(args)?;
 
     let options = Options::from_matches(&matches)?;
 

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -50,6 +50,7 @@
 
 // spell-checker:ignore uioerror
 
+use clap;
 use std::{
     error::Error,
     fmt::{Display, Formatter},
@@ -613,5 +614,15 @@ impl UError for ExitCode {
 impl From<i32> for Box<dyn UError> {
     fn from(i: i32) -> Self {
         ExitCode::new(i)
+    }
+}
+
+/// Implementations for clap::Error
+impl UError for clap::Error {
+    fn code(&self) -> i32 {
+        match self.kind {
+            clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => 0,
+            _ => 1,
+        }
     }
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -184,6 +184,16 @@ fn test_cp_arg_no_target_directory() {
 }
 
 #[test]
+fn test_cp_target_directory_is_file() {
+    new_ucmd!()
+        .arg("-t")
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .fails()
+        .stderr_contains("must specify a directory");
+}
+
+#[test]
 fn test_cp_arg_interactive() {
     new_ucmd!()
         .arg(TEST_HELLO_WORLD_SOURCE)

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -190,7 +190,7 @@ fn test_cp_target_directory_is_file() {
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg(TEST_HELLO_WORLD_SOURCE)
         .fails()
-        .stderr_contains("must specify a directory");
+        .stderr_contains(format!("'{}' is not a directory", TEST_HOW_ARE_YOU_SOURCE));
 }
 
 #[test]


### PR DESCRIPTION
Add a validator to the `--target-directory` option that only allows directories as the argument value.

Closes #2986