### PR TITLE
test_ls: Do not rely on the system time of metadata'access time

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1327,17 +1327,14 @@ fn test_ls_order_time() {
     // So the order should be 2 3 4 1
     for arg in &["-u", "--time=atime", "--time=access", "--time=use"] {
         let result = scene.ucmd().arg("-t").arg(arg).succeeds();
-        let file3_access = at.open("test-3").metadata().unwrap().accessed().unwrap();
-        let file4_access = at.open("test-4").metadata().unwrap().accessed().unwrap();
+        at.open("test-3").metadata().unwrap().accessed().unwrap();
+        at.open("test-4").metadata().unwrap().accessed().unwrap();
 
         // It seems to be dependent on the platform whether the access time is actually set
-        if file3_access > file4_access {
-            result.stdout_only("test-3\ntest-4\ntest-2\ntest-1\n");
-        } else {
-            // Access time does not seem to be set on Windows and some other
-            // systems so the order is 4 3 2 1
-            result.stdout_only("test-4\ntest-3\ntest-2\ntest-1\n");
-        }
+        #[cfg(unix)]
+        result.stdout_only("test-3\ntest-4\ntest-2\ntest-1\n");
+        #[cfg(windows)]
+        result.stdout_only("test-4\ntest-3\ntest-2\ntest-1\n");
     }
 
     // test-2 had the last ctime change when the permissions were set


### PR DESCRIPTION
```shell
---- test_ls::test_ls_order_time stdout ----
current_directory_resolved:
touch: C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-1
write(append): C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-1
touch: C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-2
write(append): C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-2
touch: C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-3
write(append): C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-3
touch: C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-4
write(append): C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-4
open: C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-3
run: C:\Users\Hanif\git\coreutils\target\debug\coreutils.exe ls -al
run: C:\Users\Hanif\git\coreutils\target\debug\coreutils.exe ls -t
run: C:\Users\Hanif\git\coreutils\target\debug\coreutils.exe ls --sort=time
run: C:\Users\Hanif\git\coreutils\target\debug\coreutils.exe ls -tr
run: C:\Users\Hanif\git\coreutils\target\debug\coreutils.exe ls --sort=time -r
run: C:\Users\Hanif\git\coreutils\target\debug\coreutils.exe ls -t -u
open: C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-3
open: C:\Users\Hanif\AppData\Local\Temp\.tmp2wgS4L\test-4
thread 'test_ls::test_ls_order_time' panicked at 'assertion failed: `(left == right)`

Diff < left / right > :
<"test-4\ntest-3\ntest-2\ntest-1\n"
>"test-3\ntest-4\ntest-2\ntest-1\n"

', tests\common\util.rs:233:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_ls::test_ls_order_time

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1496 filtered out; finished in 0.60s

error: test failed, to rerun pass '--test tests'
```

`file3_access` here is larger than `file4_access` but somehow it failed? https://github.com/uutils/coreutils/blob/main/tests/by-util/test_ls.rs#L1330-L1331

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.43262@gmail.com>