### PR TITLE
hostid: added description in documentation

### DIFF
--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -12,6 +12,7 @@ use libc::c_long;
 use uucore::error::UResult;
 
 static SYNTAX: &str = "[options]";
+const SUMMARY: &str = "Print the numeric identifier (in hexadecimal) for the current host";
 
 // currently rust libc interface doesn't include gethostid
 extern "C" {
@@ -28,6 +29,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
+        .about(SUMMARY)
         .override_usage(SYNTAX)
         .setting(AppSettings::InferLongArgs)
 }


### PR DESCRIPTION
Addresses https://github.com/uutils/coreutils/issues/2990

Added the description for the **hostid** command. Please let me know if you need me to add anything else apart from the description.