### PR TITLE
test_sort: Preserve the environment variable when executing tests

### DIFF
--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1066,12 +1066,15 @@ fn test_separator_null() {
 #[test]
 fn test_output_is_input() {
     let input = "a\nb\nc\n";
-    let (at, mut cmd) = at_and_ucmd!();
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
     at.touch("file");
     at.append("file", input);
-    cmd.args(&["-m", "-u", "-o", "file2", "file", "file", "file"])
+    scene
+        .ucmd_keepenv()
+        .args(&["-m", "-u", "-o", "file", "file", "file", "file"])
         .succeeds();
-    assert_eq!(at.read("file2"), input);
+    assert_eq!(at.read("file"), input);
 }
 
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1069,9 +1069,9 @@ fn test_output_is_input() {
     let (at, mut cmd) = at_and_ucmd!();
     at.touch("file");
     at.append("file", input);
-    cmd.args(&["-m", "-u", "-o", "file", "file", "file", "file"])
+    cmd.args(&["-m", "-u", "-o", "file2", "file", "file", "file"])
         .succeeds();
-    assert_eq!(at.read("file"), input);
+    assert_eq!(at.read("file2"), input);
 }
 
 #[test]


### PR DESCRIPTION
Currently failing on my Windows machine

```shell
PS C:\Users\Hanif\git\coreutils> cargo t --quiet -- test_sort::test_output_is_input

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 21 filtered out; finished in 0.00s


running 1 test
F
failures:

---- test_sort::test_output_is_input stdout ----
current_directory_resolved:
touch: C:\Users\Hanif\AppData\Local\Temp\.tmpmpU3Qq\file
write(append): C:\Users\Hanif\AppData\Local\Temp\.tmpmpU3Qq\file
run: C:\Users\Hanif\git\coreutils\target\debug\coreutils.exe sort -m -u -o file file file file
thread 'test_sort::test_output_is_input' panicked at 'Command was expected to succeed.
stdout =
 stderr = sort: could not create temporary directory
', tests\common\util.rs:174:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_sort::test_output_is_input

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1496 filtered out; finished in 0.24s

error: test failed, to rerun pass '--test tests'
```

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.43262@gmail.com>