### PR TITLE
realpath: Error when resolved symlink is absolute and ENOENT

### DIFF
--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -202,3 +202,24 @@ fn test_realpath_missing() {
         .succeeds()
         .stdout_only(expect);
 }
+
+#[test]
+fn test_realpath_when_symlink_is_absolute_and_enoent() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("dir2");
+    at.touch("dir2/bar");
+
+    at.mkdir("dir1");
+    at.symlink_file("dir2/bar", "dir1/foo1");
+    at.symlink_file("/dir2/bar", "dir1/foo2");
+    at.relative_symlink_file("dir2/baz", at.plus("dir1/foo3").to_str().unwrap());
+
+    ucmd.arg("dir1/foo1")
+        .arg("dir1/foo2")
+        .arg("dir1/foo3")
+        .run()
+        .stdout_contains("/dir2/bar\n")
+        .stdout_contains("/dir2/baz\n")
+        .stderr_is("realpath: dir1/foo2: No such file or directory");
+}

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -679,6 +679,11 @@ impl AtPath {
         symlink_file(&self.plus(original), &self.plus(link)).unwrap();
     }
 
+    pub fn relative_symlink_file(&self, original: &str, link: &str) {
+        log_info("symlink", &format!("{},{}", original, link));
+        symlink_file(original, link).unwrap();
+    }
+
     pub fn symlink_dir(&self, original: &str, link: &str) {
         log_info(
             "symlink",


### PR DESCRIPTION
This PR changes `realpath` to match the behavior in GNU where,

```shell
hbina@akarin ~/Documents> mkdir dir1
hbina@akarin ~/Documents> mkdir dir2
hbina@akarin ~/Documents> touch dir2/bar
hbina@akarin ~/Documents> ln -s ../dir2/bar dir1/foo1
hbina@akarin ~/Documents> ln -s /dir2/bar dir1/foo2
hbina@akarin ~/Documents> ln -s ../dir2/baz dir1/foo3
hbina@akarin ~/Documents> realpath ./dir1/foo1 ./dir1/foo2 ./dir1/foo3
/home/hbina/Documents/dir2/bar
realpath: ./dir1/foo2: No such file or directory
/home/hbina/Documents/dir2/baz
```

Currently, our `realpath` will happily print the second one out,

```shell
hbina@akarin ~/Documents> ~/git/uutils/target/debug/coreutils realpath ./dir1/foo1 ./dir1/foo2 ./dir1/foo3
/home/hbina/Documents/dir2/bar
/dir2/bar
/home/hbina/Documents/dir2/baz
```

Closes https://github.com/uutils/coreutils/issues/3036

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>