### PR TITLE
cp: Fail when copying a directory to a file

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1025,7 +1025,10 @@ fn copy_directory(
         if is_symlink && !options.dereference {
             copy_link(&path, &local_to_target, symlinked_files)?;
         } else if path.is_dir() && !local_to_target.exists() {
-            or_continue!(fs::create_dir_all(local_to_target));
+            if target.is_file() {
+                return Err("cannot overwrite non-directory with directory".into());
+            }
+            fs::create_dir_all(local_to_target)?;
         } else if !path.is_dir() {
             if preserve_hard_links {
                 let mut found_hard_link = false;

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1444,3 +1444,12 @@ fn test_cp_archive_on_nonexistent_file() {
             "cp: cannot stat 'nonexistent_file.txt': No such file or directory (os error 2)",
         );
 }
+#[test]
+fn test_cp_dir_vs_file() {
+    new_ucmd!()
+        .arg("-R")
+        .arg(TEST_COPY_FROM_FOLDER)
+        .arg(TEST_EXISTING_FILE)
+        .fails()
+        .stderr_only("cp: cannot overwrite non-directory with directory");
+}


### PR DESCRIPTION
This addresses the GNU test `cp/dir_vs_file`. Previously, uutils would ignore failures caused by copying directories to files, and return an exit code of 0 even though the copy didn't suceed. GNU expects an exit code of 1. 