### PR TITLE
Create coverage report for GNU tests

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         ## Install dependencies
         sudo apt-get update
-        sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq
+        sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq valgrind
     - name: Add various locales
       shell: bash
       run: |

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -182,3 +182,79 @@ jobs:
         else
           echo "::warning ::Skipping test summary comparison; no prior reference summary is available."
         fi
+
+  gnu_coverage:
+    name: Run GNU tests with coverage
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    steps:
+    - name: Checkout code uutil
+      uses: actions/checkout@v2
+      with:
+        path: 'uutils'
+    - name: Checkout GNU coreutils
+      uses: actions/checkout@v2
+      with:
+        repository: 'coreutils/coreutils'
+        path: 'gnu'
+        ref: 'v9.0'
+        submodules: recursive
+    - name: Install `rust` toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        default: true
+        profile: minimal # minimal component installation (ie, no documentation)
+        components: rustfmt
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq valgrind libexpect-perl -y
+    - name: Add various locales
+      run: |
+        echo "Before:"
+        locale -a
+        ## Some tests fail with 'cannot change locale (en_US.ISO-8859-1): No such file or directory'
+        ## Some others need a French locale
+        sudo locale-gen
+        sudo locale-gen fr_FR
+        sudo locale-gen fr_FR.UTF-8
+        sudo update-locale
+        echo "After:"
+        locale -a
+    - name: Build binaries
+      env:
+        CARGO_INCREMENTAL: "0"
+        RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        RUSTDOCFLAGS: "-Cpanic=abort"
+      run: |
+        cd uutils
+        UU_MAKE_PROFILE=debug bash util/build-gnu.sh
+    - name: Run GNU tests
+      run: bash uutils/util/run-gnu-test.sh
+    - name: "`grcov` ~ install"
+      uses: actions-rs/install@v0.1
+      with:
+        crate: grcov
+        version: latest
+        use-tool-cache: false
+    - name: Generate coverage data (via `grcov`)
+      id: coverage
+      run: |
+        ## Generate coverage data
+        cd uutils
+        COVERAGE_REPORT_DIR="target/debug"
+        COVERAGE_REPORT_FILE="${COVERAGE_REPORT_DIR}/lcov.info"
+        mkdir -p "${COVERAGE_REPORT_DIR}"
+        # display coverage files
+        grcov . --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+        # generate coverage report
+        grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+        echo ::set-output name=report::${COVERAGE_REPORT_FILE}
+    - name: Upload coverage results (to Codecov.io)
+      uses: codecov/codecov-action@v2
+      with:
+        file: ${{ steps.coverage.outputs.report }}
+        flags: gnutests
+        name: gnutests
+        working-directory: uutils

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         ## Install dependencies
         sudo apt-get update
-        sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq valgrind
+        sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq valgrind libexpect-perl
     - name: Add various locales
       shell: bash
       run: |

--- a/DEVELOPER_INSTRUCTIONS.md
+++ b/DEVELOPER_INSTRUCTIONS.md
@@ -21,7 +21,7 @@ Running GNU tests
 At the end you should have uutils, gnu and gnulib checked out next to each other.
 
 - Run `cd uutils && ./util/build-gnu.sh && cd ..` to get everything ready (this may take a while)
-- Finally, you can run `tests with bash uutils/util/run-gnu-test.sh <test>`. Instead of `<test>` insert the test you want to run, e.g. `tests/misc/wc-proc`.
+- Finally, you can run tests with `bash uutils/util/run-gnu-test.sh <test>`. Instead of `<test>` insert the test you want to run, e.g. `tests/misc/wc-proc.sh`.
 
 
 Code Coverage Report Generation
@@ -33,7 +33,7 @@ Code coverage report can be generated using [grcov](https://github.com/mozilla/g
 
 ### Using Nightly Rust
 
-To generate [gcov-based](https://github.com/mozilla/grcov#example-how-to-generate-gcda-files-for-cc) coverage report
+To generate [gcov-based](https://github.com/mozilla/grcov#example-how-to-generate-gcda-files-for-a-rust-project) coverage report
 
 ```bash
 $ export CARGO_INCREMENTAL=0

--- a/util/run-gnu-test.sh
+++ b/util/run-gnu-test.sh
@@ -31,6 +31,8 @@ export RUST_BACKTRACE=1
 if test -n "$1"; then
     # if set, run only the test passed
     export RUN_TEST="TESTS=$1"
+elif test -n "$CI"; then
+    sudo make -j "$(nproc)" check-root SUBDIRS=. RUN_EXPENSIVE_TESTS=yes RUN_VERY_EXPENSIVE_TESTS=yes VERBOSE=no gl_public_submodule_commit="" srcdir="${path_GNU}" TEST_SUITE_LOG="tests/test-suite-root.log" || :
 fi
 
 # * timeout used to kill occasionally errant/"stuck" processes (note: 'release' testing takes ~1 hour; 'debug' testing takes ~2.5 hours)


### PR DESCRIPTION
- It seems codecov-action can only upload reports to the same project.
- The code runs slower with coverage report enabled, so I extend the timeout limit to four hours. 
- codecov-action@v1 is deprecated, I didn't update the action in CICD.yml in case it breaks something.
- The origin windows coverage report action failed on my forked repo sometimes, but I don't think it's caused by my changes.
- Install valgrind  and libexpect-perl for tests that require it.

Closes #2946.