### PR TITLE
tail&head: dont use is_numeric to check for digits

### DIFF
--- a/src/uu/head/src/parse.rs
+++ b/src/uu/head/src/parse.rs
@@ -20,7 +20,7 @@ pub fn parse_obsolete(src: &str) -> Option<Result<impl Iterator<Item = OsString>
         let mut has_num = false;
         let mut last_char = 0 as char;
         for (n, c) in &mut chars {
-            if c.is_numeric() {
+            if c.is_digit(10) {
                 has_num = true;
                 num_end = n;
             } else {

--- a/src/uu/tail/src/parse.rs
+++ b/src/uu/tail/src/parse.rs
@@ -19,7 +19,7 @@ pub fn parse_obsolete(src: &str) -> Option<Result<impl Iterator<Item = OsString>
         let mut has_num = false;
         let mut last_char = 0 as char;
         for (n, c) in &mut chars {
-            if c.is_numeric() {
+            if c.is_digit(10) {
                 has_num = true;
                 num_end = n;
             } else {

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -306,6 +306,10 @@ fn test_head_invalid_num() {
                 ));
         }
     }
+    new_ucmd!()
+        .args(&["-c", "-³"])
+        .fails()
+        .stderr_is("head: invalid number of bytes: '³'");
 }
 
 #[test]

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -36,6 +36,12 @@ fn test_group_num() {
     assert_eq!("", group_num(""));
 }
 
+#[test]
+#[should_panic]
+fn test_group_num_panic_if_invalid_numeric_characters() {
+    group_num("³³³³³");
+}
+
 #[cfg(test)]
 mod test_generate_tokens {
     use super::*;

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -491,6 +491,10 @@ fn test_tail_invalid_num() {
                 ));
         }
     }
+    new_ucmd!()
+        .args(&["-c", "-³"])
+        .fails()
+        .stderr_is("tail: invalid number of bytes: '³'");
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.43262@gmail.com>