### PR TITLE
ls: Fix display of inodes and add allocation size feature

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1819,7 +1819,7 @@ fn display_total(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout
     }
     let display_total = match config.size_format {
         SizeFormat::Bytes => display_size(size_to_blocks(total_size, config), config),
-        _ => display_size(total_size, config),
+        SizeFormat::Binary | SizeFormat::Decimal => display_size(total_size, config),
     };
     let _ = writeln!(out, "total {}", display_total);
 }
@@ -1848,10 +1848,12 @@ fn display_more_info(
                 SizeFormat::Bytes => {
                     display_size(size_to_blocks(get_block_size(md), config), config)
                 }
-                _ => match display_size_or_rdev(md, config) {
-                    SizeOrDeviceId::Device(_, _) => "0".to_string(),
-                    SizeOrDeviceId::Size(size) => size,
-                },
+                SizeFormat::Binary | SizeFormat::Decimal => {
+                    match display_size_or_rdev(md, config) {
+                        SizeOrDeviceId::Device(_, _) => "0".to_string(),
+                        SizeOrDeviceId::Size(size) => size,
+                    }
+                }
             }
         } else {
             "?".to_owned()
@@ -1891,10 +1893,12 @@ fn display_items(items: &[PathData], config: &Config, out: &mut BufWriter<Stdout
                     SizeFormat::Bytes => {
                         display_size(size_to_blocks(get_block_size(md), config), config).len()
                     }
-                    _ => match display_size_or_rdev(md, config) {
-                        SizeOrDeviceId::Device(_, _) => 1usize,
-                        SizeOrDeviceId::Size(size) => size.len(),
-                    },
+                    SizeFormat::Binary | SizeFormat::Decimal => {
+                        match display_size_or_rdev(md, config) {
+                            SizeOrDeviceId::Device(_, _) => 1usize,
+                            SizeOrDeviceId::Size(size) => size.len(),
+                        }
+                    }
                 };
                 longest_block_size_len = block_size_len.max(longest_block_size_len);
             } else {


### PR DESCRIPTION
Only reason the GNU test block size (block-size.sh) appears to be failing is because of issues related to `dd` not parsing 'conv' correctly (!).

- Add block size display ("-s", "--size") feature
- Add custom block size option ("--block-size")
- Add kibibytes ("-k", "--kibibytes") feature
- Correct ordering of preferences for block size options
- Add env var parsing for BLOCK_SIZE, LS_BLOCK_SIZE, POSIXLY_CORRECT
- Fix how both block size and inode are displayed. Instead of printing through either display_long_item or display_file_name have been moved into a display_more_info function, which could be useful to other "ls" features that print the same whether in Format::Long or not.
- Tests included to check proper alignment and block size values, and ordering of option preferences
- Seems like a lot but these are all related options.