### PR TITLE
seq: Eliminated special handling of -0.0

### DIFF
--- a/src/uu/seq/src/extendedbigdecimal.rs
+++ b/src/uu/seq/src/extendedbigdecimal.rs
@@ -130,14 +130,7 @@ impl Display for ExtendedBigDecimal {
             }
             ExtendedBigDecimal::Infinity => f32::INFINITY.fmt(f),
             ExtendedBigDecimal::MinusInfinity => f32::NEG_INFINITY.fmt(f),
-            ExtendedBigDecimal::MinusZero => {
-                // FIXME In Rust version 1.53.0 and later, the display
-                // of floats was updated to allow displaying negative
-                // zero. See
-                // https://github.com/rust-lang/rust/pull/78618. Currently,
-                // this just formats "0.0".
-                (0.0f32).fmt(f)
-            }
+            ExtendedBigDecimal::MinusZero => (-0.0f32).fmt(f),
             ExtendedBigDecimal::Nan => "nan".fmt(f),
         }
     }
@@ -280,11 +273,6 @@ mod tests {
         assert_eq!(format!("{}", ExtendedBigDecimal::Infinity), "inf");
         assert_eq!(format!("{}", ExtendedBigDecimal::MinusInfinity), "-inf");
         assert_eq!(format!("{}", ExtendedBigDecimal::Nan), "nan");
-        // FIXME In Rust version 1.53.0 and later, the display of floats
-        // was updated to allow displaying negative zero. Until then, we
-        // just display `MinusZero` as "0.0".
-        //
-        //     assert_eq!(format!("{}", ExtendedBigDecimal::MinusZero), "-0.0");
-        //
+        assert_eq!(format!("{}", ExtendedBigDecimal::MinusZero), "-0");
     }
 }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -198,41 +198,29 @@ fn done_printing<T: Zero + PartialOrd>(next: &T, increment: &T, last: &T) -> boo
 }
 
 /// Write a big decimal formatted according to the given parameters.
-///
-/// This method is an adapter to support displaying negative zero on
-/// Rust versions earlier than 1.53.0. After that version, we should be
-/// able to display negative zero using the default formatting provided
-/// by `-0.0f32`, for example.
 fn write_value_float(
     writer: &mut impl Write,
     value: &ExtendedBigDecimal,
     width: usize,
     precision: usize,
-    is_first_iteration: bool,
+    _is_first_iteration: bool,
 ) -> std::io::Result<()> {
-    let value_as_str = if *value == ExtendedBigDecimal::MinusZero && is_first_iteration {
-        format!(
-            "-{value:>0width$.precision$}",
-            value = value,
-            width = if width > 0 { width - 1 } else { width },
-            precision = precision,
-        )
-    } else if *value == ExtendedBigDecimal::Infinity || *value == ExtendedBigDecimal::MinusInfinity
-    {
-        format!(
-            "{value:>width$.precision$}",
-            value = value,
-            width = width,
-            precision = precision,
-        )
-    } else {
-        format!(
-            "{value:>0width$.precision$}",
-            value = value,
-            width = width,
-            precision = precision,
-        )
-    };
+    let value_as_str =
+        if *value == ExtendedBigDecimal::Infinity || *value == ExtendedBigDecimal::MinusInfinity {
+            format!(
+                "{value:>width$.precision$}",
+                value = value,
+                width = width,
+                precision = precision,
+            )
+        } else {
+            format!(
+                "{value:>0width$.precision$}",
+                value = value,
+                width = width,
+                precision = precision,
+            )
+        };
     write!(writer, "{}", value_as_str)
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/uutils/coreutils/issues/2870
Removed special format handling around -0.0 in seq