### PR TITLE
test_printf: add test for additional escape (\c)

### DIFF
--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -429,3 +429,11 @@ fn sub_any_specifiers_after_second_param() {
         .succeeds()
         .stdout_only("3");
 }
+
+#[test]
+fn stop_after_additional_escape() {
+    new_ucmd!()
+        .args(&["A%sC\\cD%sF", "B", "E"]) //spell-checker:disable-line
+        .succeeds()
+        .stdout_only("ABC");
+}


### PR DESCRIPTION
Using this escaped character will cause `printf` to stop generating characters.

For instance,

```rust
hbina@akarin ~/g/uutils (hbina-add-test-for-additional-escape)> cargo run --quiet -- printf "%s\c%s" a b
a⏎
```

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>