### PR TITLE
printf: Default left-justify integer conversion to 1 width

### DIFF
--- a/src/uucore/src/lib/features/tokenize/sub.rs
+++ b/src/uucore/src/lib/features/tokenize/sub.rs
@@ -152,7 +152,11 @@ impl SubParser {
             if parser.min_width_is_asterisk {
                 CanAsterisk::Asterisk
             } else {
-                CanAsterisk::Fixed(parser.min_width_tmp.map(|x| x.parse::<isize>().unwrap()))
+                CanAsterisk::Fixed(
+                    parser
+                        .min_width_tmp
+                        .map(|x| x.parse::<isize>().unwrap_or(1)),
+                )
             },
             if parser.second_field_is_asterisk {
                 CanAsterisk::Asterisk

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -447,6 +447,14 @@ fn sub_any_specifiers_after_period() {
 }
 
 #[test]
+fn unspecified_left_justify_is_1_width() {
+    new_ucmd!()
+        .args(&["%-o"]) //spell-checker:disable-line
+        .succeeds()
+        .stdout_only("0");
+}
+
+#[test]
 fn sub_any_specifiers_after_second_param() {
     new_ucmd!()
         .args(&["%0.0ztlhLji", "3"]) //spell-checker:disable-line


### PR DESCRIPTION
When using left-justify with integer conversion (like `printf '%-o'`),
default the minimum width to 1.

Closes: https://github.com/uutils/coreutils/issues/3050

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>