### PR TITLE
dd: show warning if skipping past end of input

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -42,6 +42,7 @@ use gcd::Gcd;
 use signal_hook::consts::signal;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::show_error;
 use uucore::InvalidEncodingHandling;
 
 const ABOUT: &str = "copy, and optionally convert, a file system resource";
@@ -80,8 +81,12 @@ impl Input<io::Stdin> {
         };
 
         if let Some(amt) = skip {
-            i.force_fill(amt.try_into().unwrap())
+            let num_bytes_read = i
+                .force_fill(amt.try_into().unwrap())
                 .map_err_context(|| "failed to read input".to_string())?;
+            if num_bytes_read < amt {
+                show_error!("'standard input': cannot skip to specified offset");
+            }
         }
 
         Ok(i)

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -624,5 +624,18 @@ fn test_seek_bytes() {
         .stdout_is("\0\0\0\0\0\0\0\0abcdefghijklm\n");
 }
 
+/// Test for skipping beyond the number of bytes in a file.
+#[test]
+fn test_skip_beyond_file() {
+    new_ucmd!()
+        .args(&["bs=1", "skip=5", "count=0", "status=noxfer"])
+        .pipe_in("abcd")
+        .succeeds()
+        .no_stdout()
+        .stderr_contains(
+            "'standard input': cannot skip to specified offset\n0+0 records in\n0+0 records out\n",
+        );
+}
+
 // conv=[ascii,ebcdic,ibm], conv=[ucase,lcase], conv=[block,unblock], conv=sync
 // TODO: Move conv tests from unit test module


### PR DESCRIPTION
Show a warning if the `skip=N` command-line argument would cause `dd`
to skip past the end of the input. For example:

    $ printf "abcd" | dd bs=1 skip=5 count=0 status=noxfer
    'standard input': cannot skip to specified offset
    0+0 records in
    0+0 records out

This matches the behavior of GNU dd.