### PR TITLE
printf: Support float -> int truncation with %g

### DIFF
--- a/src/uucore/src/lib/features/tokenize/num_format/formatters/decf.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/formatters/decf.rs
@@ -56,7 +56,10 @@ impl Formatter for Decf {
         // strip trailing zeroes
         if let Some(ref post_dec) = f_sci.post_decimal {
             let trimmed = post_dec.trim_end_matches('0');
-            if trimmed.len() != post_dec.len() {
+            if trimmed.is_empty() {
+                f_sci.post_decimal = Some(String::new());
+                f_sci.suffix = Some(String::new());
+            } else if trimmed.len() != post_dec.len() {
                 f_sci.post_decimal = Some(trimmed.to_owned());
             }
         }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -437,3 +437,24 @@ fn stop_after_additional_escape() {
         .succeeds()
         .stdout_only("ABC");
 }
+
+#[test]
+fn sub_general_float() {
+    new_ucmd!()
+        .args(&["%g", "3.1"])
+        .succeeds()
+        .stdout_only("3.1");
+}
+
+#[test]
+fn sub_general_truncate_to_integer() {
+    new_ucmd!().args(&["%g", "3.0"]).succeeds().stdout_only("3");
+}
+
+#[test]
+fn sub_general_prefix_with_spaces() {
+    new_ucmd!()
+        .args(&["%5g", "3.1"])
+        .succeeds()
+        .stdout_only("  3.1");
+}


### PR DESCRIPTION
Resolves #2775. If a float can be losslessly expressed as an integer, `%g` will truncate it. If not, `%g` will use the same formatting as `%f`.