### PR TITLE
od: fix missing usage in user docs

### DIFF
--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -51,8 +51,7 @@ use uucore::InvalidEncodingHandling;
 const PEEK_BUFFER_SIZE: usize = 4; // utf-8 can be 4 bytes
 static ABOUT: &str = "dump files in octal and other formats";
 
-static USAGE: &str = r#"
-    od [OPTION]... [--] [FILENAME]...
+static USAGE: &str = r#"od [OPTION]... [--] [FILENAME]...
     od [-abcdDefFhHiIlLoOsxX] [FILENAME] [[+][0x]OFFSET[.][b]]
     od --traditional [OPTION]... [FILENAME] [[+][0x]OFFSET[.][b] [[+][0x]LABEL[.][b]]]"#;
 


### PR DESCRIPTION
This change is needed to fix missing USAGE section for `od` in user docs.

With reference to this issue
https://github.com/uutils/coreutils/issues/2991, and missing USAGE
section from `od docs` at
https://uutils.github.io/coreutils-docs/user/utils/od.html, it was
found that the USAGE for `od` was starts with an empty line and uudoc
only takes 1st line for using in USAGE section in docs.
This resulted in empty line in usage section for `od`

Fixes #2991 