### PR TITLE
Discuss seq parsing

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -146,7 +146,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .setting(AppSettings::TrailingVarArg)
-        .setting(AppSettings::AllowHyphenValues)
+        .setting(AppSettings::AllowNegativeNumbers)
         .setting(AppSettings::InferLongArgs)
         .version(crate_version!())
         .about(ABOUT)

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -82,6 +82,33 @@ fn test_rejects_non_floats() {
 }
 
 #[test]
+fn test_accepts_option_argument_directly() {
+    new_ucmd!()
+        .arg("-s,")
+        .arg("2")
+        .succeeds()
+        .stdout_is("1,2\n");
+}
+
+#[test]
+fn test_option_with_detected_negative_argument() {
+    new_ucmd!()
+        .arg("-s,")
+        .args(&["-1", "2"])
+        .succeeds()
+        .stdout_is("-1,0,1,2\n");
+}
+
+#[test]
+fn test_negative_number_as_separator() {
+    new_ucmd!()
+        .arg("-s")
+        .args(&["-1", "2"])
+        .succeeds()
+        .stdout_is("1-12\n");
+}
+
+#[test]
 fn test_invalid_float() {
     new_ucmd!()
         .args(&["1e2.3"])

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -20,14 +20,14 @@ fn test_hex_rejects_sign_after_identifier() {
         .args(&["-0x-123ABC"])
         .fails()
         .no_stdout()
-        .stderr_contains("invalid floating point argument: '-0x-123ABC'")
-        .stderr_contains("for more information.");
+        .stderr_contains("which wasn't expected, or isn't valid in this context")
+        .stderr_contains("For more information try --help");
     new_ucmd!()
         .args(&["-0x+123ABC"])
         .fails()
         .no_stdout()
-        .stderr_contains("invalid floating point argument: '-0x+123ABC'")
-        .stderr_contains("for more information.");
+        .stderr_contains("which wasn't expected, or isn't valid in this context")
+        .stderr_contains("For more information try --help");
 }
 
 #[test]


### PR DESCRIPTION
This changes the parser to accept arguments to short flags again. The root of the problem is clap's overly restrictive parsing code, specifically this line:

https://github.com/clap-rs/clap/blob/5c3868ea4cb8063731d8526e8e97414942a987ae/src/parse/parser.rs#L994-L995

This means that `-s,` is not accepted when `AllowHyphenValues` is on, as it contains `,` which isn't a short option flag. This is despite the short option taking an argument. As we can see from the surrounding code the treatment is very different if we merely activate `AllowNegativeNumbers`. This, still, isn't _exactly_ the same parser style as GNU `seq`. In particular, that program matches value arguments by the expression: `-[0-9.].*` (regex style) instead. This implies that the _error message_ for negative non-numbers, but also for negative numbers whose format isn't recognized by the standard `<f64 as FromStr>` impl, such as `-0x.ep-3` differs.

In short, I believe that solving both #2729 and #2660 isn't reliably possible with the current `clap` version.

I've tried a hacky way, however judged the resulting code as _far_ too complex as we need to semantically know which arguments are option values, i.e. it was more like a fully customized parser than a short hack..

We don't need to accept this PR. This is mostly to summarize my findings on my weekend journey on #2729 . We can escalate this problem to clap, to create some parser settings and version where the parser works as expected. Or we can do nothing on this issue and prioritize the number formats of #2660 which require `AllowHyphenValues`.

Closes: #2729 