### PR TITLE
Fix `parse_size` to use u64 rather than usize for better 32-bit support

### DIFF
--- a/src/uu/dd/src/datastructures.rs
+++ b/src/uu/dd/src/datastructures.rs
@@ -83,8 +83,8 @@ pub struct OFlags {
 /// then becomes Bytes(N)
 #[derive(Debug, PartialEq)]
 pub enum CountType {
-    Reads(usize),
-    Bytes(usize),
+    Reads(u64),
+    Bytes(u64),
 }
 
 #[derive(Debug)]

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -31,6 +31,10 @@ pub enum ParseError {
     BlockUnblockWithoutCBS,
     StatusLevelNotRecognized(String),
     Unimplemented(String),
+    BsOutOfRange,
+    IbsOutOfRange,
+    ObsOutOfRange,
+    CbsOutOfRange,
 }
 
 impl ParseError {
@@ -48,6 +52,10 @@ impl ParseError {
             Self::BlockUnblockWithoutCBS => Self::BlockUnblockWithoutCBS,
             Self::StatusLevelNotRecognized(_) => Self::StatusLevelNotRecognized(s),
             Self::Unimplemented(_) => Self::Unimplemented(s),
+            Self::BsOutOfRange => Self::BsOutOfRange,
+            Self::IbsOutOfRange => Self::IbsOutOfRange,
+            Self::ObsOutOfRange => Self::ObsOutOfRange,
+            Self::CbsOutOfRange => Self::CbsOutOfRange,
         }
     }
 }
@@ -91,6 +99,18 @@ impl std::fmt::Display for ParseError {
             }
             Self::StatusLevelNotRecognized(arg) => {
                 write!(f, "status=LEVEL not recognized -> {}", arg)
+            }
+            ParseError::BsOutOfRange => {
+                write!(f, "bs=N cannot fit into memory")
+            }
+            ParseError::IbsOutOfRange => {
+                write!(f, "ibs=N cannot fit into memory")
+            }
+            ParseError::ObsOutOfRange => {
+                write!(f, "ibs=N cannot fit into memory")
+            }
+            ParseError::CbsOutOfRange => {
+                write!(f, "cbs=N cannot fit into memory")
             }
             Self::Unimplemented(arg) => {
                 write!(f, "feature not implemented on this system -> {}", arg)
@@ -334,7 +354,7 @@ fn show_zero_multiplier_warning() {
 }
 
 /// Parse bytes using str::parse, then map error if needed.
-fn parse_bytes_only(s: &str) -> Result<usize, ParseError> {
+fn parse_bytes_only(s: &str) -> Result<u64, ParseError> {
     s.parse()
         .map_err(|_| ParseError::MultiplierStringParseFailure(s.to_string()))
 }
@@ -364,7 +384,7 @@ fn parse_bytes_only(s: &str) -> Result<usize, ParseError> {
 /// assert_eq!(parse_bytes_no_x("2b").unwrap(), 2 * 512);
 /// assert_eq!(parse_bytes_no_x("2k").unwrap(), 2 * 1024);
 /// ```
-fn parse_bytes_no_x(s: &str) -> Result<usize, ParseError> {
+fn parse_bytes_no_x(s: &str) -> Result<u64, ParseError> {
     let (num, multiplier) = match (s.find('c'), s.rfind('w'), s.rfind('b')) {
         (None, None, None) => match uucore::parse_size::parse_size(s) {
             Ok(n) => (n, 1),
@@ -387,7 +407,7 @@ fn parse_bytes_no_x(s: &str) -> Result<usize, ParseError> {
 /// Parse byte and multiplier like 512, 5KiB, or 1G.
 /// Uses uucore::parse_size, and adds the 'w' and 'c' suffixes which are mentioned
 /// in dd's info page.
-fn parse_bytes_with_opt_multiplier(s: &str) -> Result<usize, ParseError> {
+fn parse_bytes_with_opt_multiplier(s: &str) -> Result<u64, ParseError> {
     // TODO On my Linux system, there seems to be a maximum block size of 4096 bytes:
     //
     //     $ printf "%0.sa" {1..10000} | dd bs=4095 count=1 status=none | wc -c
@@ -420,9 +440,27 @@ fn parse_bytes_with_opt_multiplier(s: &str) -> Result<usize, ParseError> {
 
 pub fn parse_ibs(matches: &Matches) -> Result<usize, ParseError> {
     if let Some(mixed_str) = matches.value_of(options::BS) {
-        parse_bytes_with_opt_multiplier(mixed_str)
+        parse_bytes_with_opt_multiplier(mixed_str)?
+            .try_into()
+            .map_err(|_| ParseError::BsOutOfRange)
     } else if let Some(mixed_str) = matches.value_of(options::IBS) {
-        parse_bytes_with_opt_multiplier(mixed_str)
+        parse_bytes_with_opt_multiplier(mixed_str)?
+            .try_into()
+            .map_err(|_| ParseError::IbsOutOfRange)
+    } else {
+        Ok(512)
+    }
+}
+
+pub fn parse_obs(matches: &Matches) -> Result<usize, ParseError> {
+    if let Some(mixed_str) = matches.value_of("bs") {
+        parse_bytes_with_opt_multiplier(mixed_str)?
+            .try_into()
+            .map_err(|_| ParseError::BsOutOfRange)
+    } else if let Some(mixed_str) = matches.value_of("obs") {
+        parse_bytes_with_opt_multiplier(mixed_str)?
+            .try_into()
+            .map_err(|_| ParseError::ObsOutOfRange)
     } else {
         Ok(512)
     }
@@ -430,7 +468,9 @@ pub fn parse_ibs(matches: &Matches) -> Result<usize, ParseError> {
 
 fn parse_cbs(matches: &Matches) -> Result<Option<usize>, ParseError> {
     if let Some(s) = matches.value_of(options::CBS) {
-        let bytes = parse_bytes_with_opt_multiplier(s)?;
+        let bytes = parse_bytes_with_opt_multiplier(s)?
+            .try_into()
+            .map_err(|_| ParseError::CbsOutOfRange)?;
         Ok(Some(bytes))
     } else {
         Ok(None)
@@ -444,16 +484,6 @@ pub(crate) fn parse_status_level(matches: &Matches) -> Result<Option<StatusLevel
             Ok(Some(st))
         }
         None => Ok(None),
-    }
-}
-
-pub fn parse_obs(matches: &Matches) -> Result<usize, ParseError> {
-    if let Some(mixed_str) = matches.value_of("bs") {
-        parse_bytes_with_opt_multiplier(mixed_str)
-    } else if let Some(mixed_str) = matches.value_of("obs") {
-        parse_bytes_with_opt_multiplier(mixed_str)
-    } else {
-        Ok(512)
     }
 }
 
@@ -715,13 +745,13 @@ pub fn parse_skip_amt(
     ibs: &usize,
     iflags: &IFlags,
     matches: &Matches,
-) -> Result<Option<usize>, ParseError> {
+) -> Result<Option<u64>, ParseError> {
     if let Some(amt) = matches.value_of(options::SKIP) {
         let n = parse_bytes_with_opt_multiplier(amt)?;
         if iflags.skip_bytes {
             Ok(Some(n))
         } else {
-            Ok(Some(ibs * n))
+            Ok(Some(*ibs as u64 * n))
         }
     } else {
         Ok(None)
@@ -733,13 +763,13 @@ pub fn parse_seek_amt(
     obs: &usize,
     oflags: &OFlags,
     matches: &Matches,
-) -> Result<Option<usize>, ParseError> {
+) -> Result<Option<u64>, ParseError> {
     if let Some(amt) = matches.value_of(options::SEEK) {
         let n = parse_bytes_with_opt_multiplier(amt)?;
         if oflags.seek_bytes {
             Ok(Some(n))
         } else {
-            Ok(Some(obs * n))
+            Ok(Some(*obs as u64 * n))
         }
     } else {
         Ok(None)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -12,7 +12,6 @@ use chrono::prelude::DateTime;
 use chrono::Local;
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::collections::HashSet;
-use std::convert::TryFrom;
 use std::env;
 use std::fs;
 #[cfg(not(windows))]
@@ -248,7 +247,7 @@ fn get_file_info(path: &Path) -> Option<FileInfo> {
     result
 }
 
-fn read_block_size(s: Option<&str>) -> usize {
+fn read_block_size(s: Option<&str>) -> u64 {
     if let Some(s) = s {
         parse_size(s)
             .unwrap_or_else(|e| crash!(1, "{}", format_error_message(&e, s, options::BLOCK_SIZE)))
@@ -483,7 +482,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         show_warning!("options --apparent-size and -b are ineffective with --inodes");
     }
 
-    let block_size = u64::try_from(read_block_size(matches.value_of(options::BLOCK_SIZE))).unwrap();
+    let block_size = read_block_size(matches.value_of(options::BLOCK_SIZE));
 
     let threshold = matches.value_of(options::THRESHOLD).map(|s| {
         Threshold::from_str(s)
@@ -807,7 +806,7 @@ impl FromStr for Threshold {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let offset = if s.starts_with(&['-', '+'][..]) { 1 } else { 0 };
 
-        let size = u64::try_from(parse_size(&s[offset..])?).unwrap();
+        let size = parse_size(&s[offset..])?;
 
         if s.starts_with('-') {
             Ok(Self::Upper(size))

--- a/src/uu/head/src/parse.rs
+++ b/src/uu/head/src/parse.rs
@@ -97,7 +97,7 @@ pub fn parse_obsolete(src: &str) -> Option<Result<impl Iterator<Item = OsString>
 }
 /// Parses an -c or -n argument,
 /// the bool specifies whether to read from the end
-pub fn parse_num(src: &str) -> Result<(usize, bool), ParseSizeError> {
+pub fn parse_num(src: &str) -> Result<(u64, bool), ParseSizeError> {
     let mut size_string = src.trim();
     let mut all_but_last = false;
 

--- a/src/uu/head/src/take.rs
+++ b/src/uu/head/src/take.rs
@@ -69,7 +69,7 @@ where
 /// details.
 pub struct TakeLines<T> {
     inner: T,
-    limit: usize,
+    limit: u64,
     separator: u8,
 }
 
@@ -103,7 +103,7 @@ impl<T: Read> Read for TakeLines<T> {
 ///
 /// The `separator` defines the character to interpret as the line
 /// ending. For the usual notion of "line", set this to `b'\n'`.
-pub fn take_lines<R>(reader: R, limit: usize, separator: u8) -> TakeLines<R> {
+pub fn take_lines<R>(reader: R, limit: u64, separator: u8) -> TakeLines<R> {
     TakeLines {
         inner: reader,
         limit,

--- a/src/uu/od/src/inputoffset.rs
+++ b/src/uu/od/src/inputoffset.rs
@@ -11,15 +11,15 @@ pub struct InputOffset {
     /// The radix to print the byte offset. NoPrefix will not print a byte offset.
     radix: Radix,
     /// The current position. Initialize at `new`, increase using `increase_position`.
-    byte_pos: usize,
+    byte_pos: u64,
     /// An optional label printed in parentheses, typically different from `byte_pos`,
     /// but will increase with the same value if `byte_pos` in increased.
-    label: Option<usize>,
+    label: Option<u64>,
 }
 
 impl InputOffset {
     /// creates a new `InputOffset` using the provided values.
-    pub fn new(radix: Radix, byte_pos: usize, label: Option<usize>) -> Self {
+    pub fn new(radix: Radix, byte_pos: u64, label: Option<u64>) -> Self {
         Self {
             radix,
             byte_pos,
@@ -28,7 +28,7 @@ impl InputOffset {
     }
 
     /// Increase `byte_pos` and `label` if a label is used.
-    pub fn increase_position(&mut self, n: usize) {
+    pub fn increase_position(&mut self, n: u64) {
         self.byte_pos += n;
         if let Some(l) = self.label {
             self.label = Some(l + n);

--- a/src/uu/od/src/parse_inputs.rs
+++ b/src/uu/od/src/parse_inputs.rs
@@ -32,7 +32,7 @@ impl<'a> CommandLineOpts for ArgMatches {
 #[derive(PartialEq, Debug)]
 pub enum CommandLineInputs {
     FileNames(Vec<String>),
-    FileAndOffset((String, usize, Option<usize>)),
+    FileAndOffset((String, u64, Option<u64>)),
 }
 
 /// Interprets the command line inputs of od.
@@ -141,7 +141,7 @@ pub fn parse_inputs_traditional(input_strings: &[&str]) -> Result<CommandLineInp
 }
 
 /// parses format used by offset and label on the command line
-pub fn parse_offset_operand(s: &str) -> Result<usize, &'static str> {
+pub fn parse_offset_operand(s: &str) -> Result<u64, &'static str> {
     let mut start = 0;
     let mut len = s.len();
     let mut radix = 8;
@@ -164,7 +164,7 @@ pub fn parse_offset_operand(s: &str) -> Result<usize, &'static str> {
             radix = 10;
         }
     }
-    match usize::from_str_radix(&s[start..len], radix) {
+    match u64::from_str_radix(&s[start..len], radix) {
         Ok(i) => Ok(i * multiply),
         Err(_) => Err("parse failed"),
     }
@@ -332,7 +332,7 @@ mod tests {
         .unwrap_err();
     }
 
-    fn parse_offset_operand_str(s: &str) -> Result<usize, &'static str> {
+    fn parse_offset_operand_str(s: &str) -> Result<u64, &'static str> {
         parse_offset_operand(&String::from(s))
     }
 

--- a/src/uu/od/src/parse_nrofbytes.rs
+++ b/src/uu/od/src/parse_nrofbytes.rs
@@ -1,6 +1,6 @@
 use uucore::parse_size::{parse_size, ParseSizeError};
 
-pub fn parse_number_of_bytes(s: &str) -> Result<usize, ParseSizeError> {
+pub fn parse_number_of_bytes(s: &str) -> Result<u64, ParseSizeError> {
     let mut start = 0;
     let mut len = s.len();
     let mut radix = 16;
@@ -65,7 +65,7 @@ pub fn parse_number_of_bytes(s: &str) -> Result<usize, ParseSizeError> {
         _ => {}
     }
 
-    let factor = match usize::from_str_radix(&s[start..len], radix) {
+    let factor = match u64::from_str_radix(&s[start..len], radix) {
         Ok(f) => f,
         Err(e) => return Err(ParseSizeError::ParseFailure(e.to_string())),
     };

--- a/src/uu/od/src/partialreader.rs
+++ b/src/uu/od/src/partialreader.rs
@@ -15,15 +15,15 @@ const MAX_SKIP_BUFFER: usize = 16 * 1024;
 /// number of bytes.
 pub struct PartialReader<R> {
     inner: R,
-    skip: usize,
-    limit: Option<usize>,
+    skip: u64,
+    limit: Option<u64>,
 }
 
 impl<R> PartialReader<R> {
     /// Create a new `PartialReader` wrapping `inner`, which will skip
     /// `skip` bytes, and limits the output to `limit` bytes. Set `limit`
     /// to `None` if there should be no limit.
-    pub fn new(inner: R, skip: usize, limit: Option<usize>) -> Self {
+    pub fn new(inner: R, skip: u64, limit: Option<u64>) -> Self {
         Self { inner, skip, limit }
     }
 }
@@ -34,7 +34,7 @@ impl<R: Read> Read for PartialReader<R> {
             let mut bytes = [0; MAX_SKIP_BUFFER];
 
             while self.skip > 0 {
-                let skip_count = cmp::min(self.skip, MAX_SKIP_BUFFER);
+                let skip_count: usize = cmp::min(self.skip as usize, MAX_SKIP_BUFFER);
 
                 match self.inner.read(&mut bytes[..skip_count])? {
                     0 => {
@@ -44,7 +44,7 @@ impl<R: Read> Read for PartialReader<R> {
                             "tried to skip past end of input",
                         ));
                     }
-                    n => self.skip -= n,
+                    n => self.skip -= n as u64,
                 }
             }
         }
@@ -53,15 +53,15 @@ impl<R: Read> Read for PartialReader<R> {
             None => self.inner.read(out),
             Some(0) => Ok(0),
             Some(ref mut limit) => {
-                let slice = if *limit > out.len() {
+                let slice = if *limit > (out.len() as u64) {
                     out
                 } else {
-                    &mut out[0..*limit]
+                    &mut out[0..(*limit as usize)]
                 };
                 match self.inner.read(slice) {
                     Err(e) => Err(e),
                     Ok(r) => {
-                        *limit -= r;
+                        *limit -= r as u64;
                         Ok(r)
                     }
                 }
@@ -145,7 +145,11 @@ mod tests {
     fn test_read_skipping_huge_number() {
         let mut v = [0; 10];
         // test if it does not eat all memory....
-        let mut sut = PartialReader::new(Cursor::new(&b"abcdefgh"[..]), usize::max_value(), None);
+        let mut sut = PartialReader::new(
+            Cursor::new(&b"abcdefgh"[..]),
+            usize::max_value() as u64,
+            None,
+        );
 
         sut.read(v.as_mut()).unwrap_err();
     }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -33,6 +33,7 @@ use numeric_str_cmp::{human_numeric_str_cmp, numeric_str_cmp, NumInfo, NumInfoPa
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use std::cmp::Ordering;
+use std::convert::TryFrom;
 use std::env;
 use std::error::Error;
 use std::ffi::{OsStr, OsString};
@@ -354,7 +355,13 @@ impl GlobalSettings {
             } else if size_string.ends_with('b') {
                 size_string.pop();
             }
-            parse_size(&size_string)
+            let size = parse_size(&size_string)?;
+            usize::try_from(size).map_err(|_| {
+                ParseSizeError::SizeTooBig(format!(
+                    "Buffer size {} does not fit in address space",
+                    size
+                ))
+            })
         } else {
             Err(ParseSizeError::ParseFailure("invalid suffix".to_string()))
         }

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -11,7 +11,7 @@
 extern crate uucore;
 
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::fs::File;
 use std::io::{self, Write};
 use std::os::unix::process::ExitStatusExt;
@@ -117,7 +117,14 @@ fn check_option(matches: &ArgMatches, name: &str) -> Result<BufferType, ProgramO
             }
             x => parse_size(x).map_or_else(
                 |e| crash!(125, "invalid mode {}", e),
-                |m| Ok(BufferType::Size(m)),
+                |m| {
+                    Ok(BufferType::Size(m.try_into().map_err(|_| {
+                        ProgramOptionsError(format!(
+                            "invalid mode {}: Value too large for defined data type",
+                            x
+                        ))
+                    })?))
+                },
             ),
         },
         None => Ok(BufferType::Default),

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -7,7 +7,6 @@
 
 // spell-checker:ignore (ToDO) RFILE refsize rfilename fsize tsize
 use clap::{crate_version, App, AppSettings, Arg};
-use std::convert::TryFrom;
 use std::fs::{metadata, OpenOptions};
 use std::io::ErrorKind;
 #[cfg(unix)]
@@ -20,13 +19,13 @@ use uucore::parse_size::{parse_size, ParseSizeError};
 
 #[derive(Debug, Eq, PartialEq)]
 enum TruncateMode {
-    Absolute(usize),
-    Extend(usize),
-    Reduce(usize),
-    AtMost(usize),
-    AtLeast(usize),
-    RoundDown(usize),
-    RoundUp(usize),
+    Absolute(u64),
+    Extend(u64),
+    Reduce(u64),
+    AtMost(u64),
+    AtLeast(u64),
+    RoundDown(u64),
+    RoundUp(u64),
 }
 
 impl TruncateMode {
@@ -55,7 +54,7 @@ impl TruncateMode {
     /// let fsize = 3;
     /// assert_eq!(mode.to_size(fsize), 0);
     /// ```
-    fn to_size(&self, fsize: usize) -> usize {
+    fn to_size(&self, fsize: u64) -> u64 {
         match self {
             TruncateMode::Absolute(size) => *size,
             TruncateMode::Extend(size) => fsize + size,
@@ -192,10 +191,10 @@ pub fn uu_app<'a>() -> App<'a> {
 ///
 /// If the file could not be opened, or there was a problem setting the
 /// size of the file.
-fn file_truncate(filename: &str, create: bool, size: usize) -> std::io::Result<()> {
+fn file_truncate(filename: &str, create: bool, size: u64) -> std::io::Result<()> {
     let path = Path::new(filename);
     let f = OpenOptions::new().write(true).create(create).open(path)?;
-    f.set_len(u64::try_from(size).unwrap())
+    f.set_len(size)
 }
 
 /// Truncate files to a size relative to a given file.
@@ -244,7 +243,7 @@ fn truncate_reference_and_size(
         ),
         _ => e.map_err_context(String::new),
     })?;
-    let fsize = metadata.len() as usize;
+    let fsize = metadata.len();
     let tsize = mode.to_size(fsize);
     for filename in filenames {
         #[cfg(unix)]
@@ -292,7 +291,7 @@ fn truncate_reference_file_only(
         ),
         _ => e.map_err_context(String::new),
     })?;
-    let tsize = metadata.len() as usize;
+    let tsize = metadata.len();
     for filename in filenames {
         #[cfg(unix)]
         if std::fs::metadata(filename)?.file_type().is_fifo() {
@@ -350,7 +349,7 @@ fn truncate_size_only(size_string: &str, filenames: &[String], create: bool) -> 
             }
             Err(_) => 0,
         };
-        let tsize = mode.to_size(fsize as usize);
+        let tsize = mode.to_size(fsize);
         match file_truncate(filename, create, tsize) {
             Ok(_) => continue,
             Err(e) if e.kind() == ErrorKind::NotFound && !create => continue,

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -302,14 +302,7 @@ fn test_head_invalid_num() {
     {
         let sizes = ["1000G", "10T"];
         for size in &sizes {
-            new_ucmd!()
-                .args(&["-c", size])
-                .fails()
-                .code_is(1)
-                .stderr_only(format!(
-                    "head: invalid number of bytes: '{}': Value too large for defined data type",
-                    size
-                ));
+            new_ucmd!().args(&["-c", size]).succeeds();
         }
     }
     new_ucmd!()

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -337,14 +337,7 @@ fn test_split_invalid_bytes_size() {
     {
         let sizes = ["1000G", "10T"];
         for size in &sizes {
-            new_ucmd!()
-                .args(&["-b", size])
-                .fails()
-                .code_is(1)
-                .stderr_only(format!(
-                    "split: invalid number of bytes: '{}': Value too large for defined data type",
-                    size
-                ));
+            new_ucmd!().args(&["-b", size]).succeeds();
         }
     }
 }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -485,10 +485,7 @@ fn test_tail_invalid_num() {
                 .args(&["-c", size])
                 .fails()
                 .code_is(1)
-                .stderr_only(format!(
-                    "tail: invalid number of bytes: '{}': Value too large for defined data type",
-                    size
-                ));
+                .stderr_only("tail: Insufficient addressable memory");
         }
     }
     new_ucmd!()

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -319,13 +319,6 @@ fn test_truncate_bytes_size() {
         .fails()
         .code_is(1)
         .stderr_only("truncate: Invalid number: '1Y': Value too large for defined data type");
-    #[cfg(target_pointer_width = "32")]
-    {
-        let sizes = ["1000G", "10T"];
-        for size in &sizes {
-            new_ucmd!().args(&["--size", size, "file"]).succeeds();
-        }
-    }
 }
 
 /// Test that truncating a non-existent file creates that file.

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -323,14 +323,7 @@ fn test_truncate_bytes_size() {
     {
         let sizes = ["1000G", "10T"];
         for size in &sizes {
-            new_ucmd!()
-                .args(&["--size", size, "file"])
-                .fails()
-                .code_is(1)
-                .stderr_only(format!(
-                    "truncate: Invalid number: '{}': Value too large for defined data type",
-                    size
-                ));
+            new_ucmd!().args(&["--size", size, "file"]).succeeds();
         }
     }
 }


### PR DESCRIPTION
Using usize limits 32-bit platforms to operate only on sizes of 4GiB or
less. While 32-bit platforms only have 4GiB of addressable memory, not all
operations require the data to be entirely in memory, so this limitation
can be lifted if we use u64 instead of usize.

The following utilities have been adjusted to use this new type where possible -
- stdbuf
- od 
- tail 
- head 
- du
- dd
- truncate (Thanks @Gilnaa)
- split (Thanks @Gilnaa)
- sort (Thanks @Gilnaa)

The most obvious utility that benefits from this change is `dd`, it's not uncommon
to perform >4GiB `dd` operations on disks/files - and without this PR 32-bit platforms
cannot currently do that with the current state of uutils/coreutils.

Ideally the function would return u128 and the utilities would truncate it
to usize / u64 as they see fit, but I thought it was a bit excessive and
couldn't think of reasonable uses for it (u64 goes up to 16 exabytes).

Note that technically this PR actually makes 128-bit platforms worse
because u64 is smaller than usize on those platforms, but I don't think
that's too big of a problem