### PR TITLE
dd: show warning when using 0x size multiplier

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -13,6 +13,7 @@ use super::*;
 use std::error::Error;
 use uucore::error::UError;
 use uucore::parse_size::ParseSizeError;
+use uucore::show_warning;
 
 pub type Matches = ArgMatches;
 
@@ -356,6 +357,13 @@ fn parse_bytes_only(s: &str) -> Result<usize, ParseError> {
 /// assert_eq!(parse_bytes_no_x("2k").unwrap(), 2 * 1024);
 /// ```
 fn parse_bytes_no_x(s: &str) -> Result<usize, ParseError> {
+    if s == "0" {
+        show_warning!(
+            "{} is a zero multiplier; use {} if that is intended",
+            "0x".quote(),
+            "00x".quote()
+        );
+    }
     let (num, multiplier) = match (s.find('c'), s.rfind('w'), s.rfind('b')) {
         (None, None, None) => match uucore::parse_size::parse_size(s) {
             Ok(n) => (n, 1),

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -199,6 +199,39 @@ fn test_x_multiplier() {
 }
 
 #[test]
+fn test_zero_multiplier_warning() {
+    for arg in ["count", "seek", "skip"] {
+        new_ucmd!()
+            .args(&[format!("{}=00x1", arg).as_str(), "status=none"])
+            .pipe_in("")
+            .succeeds()
+            .no_stdout()
+            .no_stderr();
+
+        new_ucmd!()
+            .args(&[format!("{}=0x1", arg).as_str(), "status=none"])
+            .pipe_in("")
+            .succeeds()
+            .no_stdout()
+            .stderr_contains("warning: '0x' is a zero multiplier; use '00x' if that is intended");
+
+        new_ucmd!()
+            .args(&[format!("{}=0x0x1", arg).as_str(), "status=none"])
+            .pipe_in("")
+            .succeeds()
+            .no_stdout()
+            .stderr_is("dd: warning: '0x' is a zero multiplier; use '00x' if that is intended\ndd: warning: '0x' is a zero multiplier; use '00x' if that is intended\n");
+
+        new_ucmd!()
+            .args(&[format!("{}=1x0x1", arg).as_str(), "status=none"])
+            .pipe_in("")
+            .succeeds()
+            .no_stdout()
+            .stderr_contains("warning: '0x' is a zero multiplier; use '00x' if that is intended");
+    }
+}
+
+#[test]
 fn test_final_stats_noxfer() {
     new_ucmd!()
         .args(&["status=noxfer"])


### PR DESCRIPTION
Show a warning when a block size includes "0x" since this is
ambiguous: the user may have meant "multiply the next number by zero"
or they may have meant "the following characters should be interpreted
as a hexadecimal number".

This fixes a test case in the GNU test suite file `tests/dd/misc.sh`.