### PR TITLE
join: improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,6 +2444,7 @@ name = "uu_join"
 version = "0.0.12"
 dependencies = [
  "clap 3.0.10",
+ "memchr 2.4.1",
  "uucore",
 ]
 

--- a/src/uu/join/BENCHMARKING.md
+++ b/src/uu/join/BENCHMARKING.md
@@ -1,0 +1,55 @@
+# Benchmarking join
+
+<!-- spell-checker:ignore (words) CSVs nocheck hotpaths -->
+
+## Performance profile
+
+The amount of time spent in which part of the code can vary depending on the files being joined and the flags used.
+A benchmark with `-j` and `-i` shows the following time:
+
+| Function/Method  | Fraction of Samples | Why? |
+| ---------------- | ------------------- | ---- |
+| `Line::new`      | 27% | Linear search for field separators, plus some vector operations. |
+| `read_until`     | 22% | Mostly libc reading file contents, with a few vector operations to represent them. |
+| `Input::compare` | 20% | ~2/3 making the keys lowercase, ~1/3 comparing them. |
+| `print_fields`   | 11% | Writing to and flushing the buffer. |
+| Other            | 20% | |
+| libc             | 25% | I/O and memory allocation. |
+
+More detailed profiles can be obtained via [flame graphs](https://github.com/flamegraph-rs/flamegraph):
+```
+cargo flamegraph --bin join --package uu_join -- file1 file2 > /dev/null
+```
+You may need to add the following lines to the top-level `Cargo.toml` to get full stack traces:
+```
+[profile.release]
+debug = true
+```
+
+## How to benchmark
+
+Benchmarking typically requires files large enough to ensure that the benchmark is not overwhelmed by background system noise; say, on the order of tens of MB.
+While `join` operates on line-oriented data, and not properly formatted CSVs (e.g., `join` is not designed to accommodate escaped or quoted delimiters),
+in practice many CSV datasets will function well after being sorted.
+
+Like most of the utils, the recommended tool for benchmarking is [hyperfine](https://github.com/sharkdp/hyperfine).
+To benchmark your changes:
+ - checkout the main branch (without your changes), do a `--release` build, and back up the executable produced at `target/release/join`
+ - checkout your working branch (with your changes), do a `--release` build
+ - run
+   ```
+   hyperfine -w 5 "/path/to/main/branch/build/join file1 file2" "/path/to/working/branch/build/join file1 file2"
+   ```
+   - you'll likely need to add additional options to both commands, such as a field separator, or if you're benchmarking some particular behavior
+   - you can also optionally benchmark against GNU's join
+
+## What to benchmark
+
+The following options can have a non-trivial impact on performance:
+ - `-a`/`-v` if one of the two files has significantly more lines than the other
+ - `-j`/`-1`/`-2` cause work to be done to grab the appropriate field
+ - `-i` adds a call to `to_ascii_lowercase()` that adds some time for allocating and dropping memory for the lowercase key
+ - `--nocheck-order` causes some calls of `Input::compare` to be skipped
+
+The content of the files being joined has a very significant impact on the performance.
+Things like how long each line is, how many fields there are, how long the key fields are, how many lines there are, how many lines can be joined, and how many lines each line can be joined with all change the behavior of the hotpaths.

--- a/src/uu/join/Cargo.toml
+++ b/src/uu/join/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/join.rs"
 [dependencies]
 clap = { version = "3.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
+memchr = "2"
 
 [[bin]]
 name = "join"

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -339,8 +339,7 @@ fn wrong_line_order() {
         .fails()
         .stdout_does_not_contain("7 g f 4 fg")
         .stderr_is(&format!(
-            "{0} {1}: fields_4.txt:5: is not sorted: 11 g 5 gh",
-            ts.bin_path.to_string_lossy(),
+            "{0}: fields_4.txt:5: is not sorted: 11 g 5 gh",
             ts.util_name
         ));
 }
@@ -366,8 +365,7 @@ fn both_files_wrong_line_order() {
         .fails()
         .stdout_does_not_contain("5 e 3 ef")
         .stderr_is(&format!(
-            "{0} {1}: fields_5.txt:4: is not sorted: 3",
-            ts.bin_path.to_string_lossy(),
+            "{0}: fields_5.txt:4: is not sorted: 3",
             ts.util_name
         ));
 }


### PR DESCRIPTION
This adds a series of performance improvements to join:
 - Lock and buffer stdout, to save on costs in our single-thread use case and prevent overhead from things like writing single newlines.
 - Use faster techniques for finding and keeping track of fields.
 - Make an intelligent guess of how many fields there will be, rather than repeatedly growing every single line.

See the following benchmarks (each of the join executables has the cumulative improvements up to that commit, not just the respective one):
```shell
$ hyperfine -w 5 \
 "~/Documents/coreutils/join.main -i -t, -j14 kitch_bench.csv wr_bench.csv" \
 "~/Documents/coreutils/join.buffered -i -t, -j14 kitch_bench.csv wr_bench.csv" \
 "~/Documents/coreutils/join.field_parsing -i -t, -j14 kitch_bench.csv wr_bench.csv" \
 "~/Documents/coreutils/join.field_guess -i -t, -j14 kitch_bench.csv wr_bench.csv" \
 "join -i -t, -j14 kitch_bench.csv wr_bench.csv"
Benchmark 1: ~/Documents/coreutils/join.main -i -t, -j14 kitch_bench.csv wr_bench.csv
  Time (mean ± σ):     701.5 ms ±   8.5 ms    [User: 658.5 ms, System: 42.9 ms]
  Range (min … max):   690.4 ms … 716.4 ms    10 runs
 
Benchmark 2: ~/Documents/coreutils/join.buffered -i -t, -j14 kitch_bench.csv wr_bench.csv
  Time (mean ± σ):     471.3 ms ±  12.7 ms    [User: 444.6 ms, System: 26.6 ms]
  Range (min … max):   457.1 ms … 500.9 ms    10 runs
 
Benchmark 3: ~/Documents/coreutils/join.field_parsing -i -t, -j14 kitch_bench.csv wr_bench.csv
  Time (mean ± σ):     257.2 ms ±   4.4 ms    [User: 227.4 ms, System: 29.7 ms]
  Range (min … max):   252.2 ms … 266.7 ms    11 runs
 
Benchmark 4: ~/Documents/coreutils/join.field_guess -i -t, -j14 kitch_bench.csv wr_bench.csv
  Time (mean ± σ):     194.8 ms ±   4.1 ms    [User: 170.4 ms, System: 24.6 ms]
  Range (min … max):   188.3 ms … 202.9 ms    15 runs
 
Benchmark 5: join -i -t, -j14 kitch_bench.csv wr_bench.csv
  Time (mean ± σ):     240.0 ms ±   5.5 ms    [User: 212.6 ms, System: 27.5 ms]
  Range (min … max):   233.7 ms … 251.4 ms    12 runs
 
Summary
  '~/Documents/coreutils/join.field_guess -i -t, -j14 kitch_bench.csv wr_bench.csv' ran
    1.23 ± 0.04 times faster than 'join -i -t, -j14 kitch_bench.csv wr_bench.csv'
    1.32 ± 0.04 times faster than '~/Documents/coreutils/join.field_parsing -i -t, -j14 kitch_bench.csv wr_bench.csv'
    2.42 ± 0.08 times faster than '~/Documents/coreutils/join.buffered -i -t, -j14 kitch_bench.csv wr_bench.csv'
    3.60 ± 0.09 times faster than '~/Documents/coreutils/join.main -i -t, -j14 kitch_bench.csv wr_bench.csv'
```

The GNU join tested is from the GNU coreutils 8.32, from the default package shipped in Ubuntu 21.10. The `kitch_bench.csv` and `wr_bench.csv` files are made of public [address data](https://github.com/jtracey/WaterlooRegionAddresses), with some minor post-processing (IIRC, just sorting the [generated originals](https://github.com/jtracey/WaterlooRegionAddresses/blob/main/DEVELOPING.md), but I could have forgotten another step or two). They are 14 MiB and 38 MiB, respectively, with many but not entirely common records. As you can see, all told, we're now 3.6x faster than the main branch currently, and 1.2x faster than GNU.

Also included is a commit adding some minor improvements to error handling (necessary to allow flushing stdout if we're about to terminate from unordered lines; without this, the GNU test will occasionally fail), and a commit adding documentation on benchmarking join.

The last of these optimizations, guessing how many fields there will be, has a minor worst-case scenario: we guess that the number of fields in a line is going to be the greatest number of fields we've seen in a line yet in this file, which in the typical case of "every line has the same number of fields" works perfectly, but in the unusual case of "a single line at the start with far more fields than any other line in the file", causes some memory overhead. Since each `Line` is only kept in memory long enough to find all its matches, and the process would need enough memory for the single long `Line` anyway, this shouldn't be much of an issue.