### PR TITLE
`shuf`: remove custom logic for bounded randomization

### DIFF
--- a/src/uu/shuf/BENCHMARKING.md
+++ b/src/uu/shuf/BENCHMARKING.md
@@ -1,0 +1,28 @@
+# Benchmarking shuf
+
+`shuf` is a simple utility, but there are at least two important cases
+benchmark: with and without repetition.
+
+When benchmarking changes, make sure to always build with the `--release` flag.
+You can compare with another branch by compiling on that branch and than
+renaming the executable from `shuf` to `shuf.old`.
+
+## Without repetition
+
+By default, `shuf` samples without repetition. To benchmark only the
+randomization and not IO, we can pass the `-i` flag with a range of numbers to
+randomly sample from. An example of a command that works well for testing:
+
+```shell
+hyperfine --warmup 10 "target/release/shuf -i 0-10000000"
+```
+
+## With repetition
+
+When repetition is allowed, `shuf` works very differently under the hood, so it
+should be benchmarked separately. In this case we have to pass the `-n` flag or
+the command will run forever. An example of a hyperfine command is
+
+```shell
+hyperfine --warmup 10 "target/release/shuf -r -n 10000000 -i 0-1000"
+```

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -8,7 +8,8 @@
 // spell-checker:ignore (ToDO) cmdline evec seps rvec fdata
 
 use clap::{crate_version, App, AppSettings, Arg};
-use rand::Rng;
+use rand::prelude::SliceRandom;
+use rand::RngCore;
 use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use uucore::display::Quotable;
@@ -254,40 +255,35 @@ fn shuf_bytes(input: &mut Vec<&[u8]>, opts: Options) -> UResult<()> {
         None => WrappedRng::RngDefault(rand::thread_rng()),
     };
 
-    // we're generating a random usize. To keep things fair, we take this number mod ceil(log2(length+1))
-    let mut len_mod = 1;
-    let mut len = input.len();
-    while len > 0 {
-        len >>= 1;
-        len_mod <<= 1;
+    if input.is_empty() {
+        return Ok(());
     }
 
-    let mut count = opts.head_count;
-    while count > 0 && !input.is_empty() {
-        let mut r = input.len();
-        while r >= input.len() {
-            r = rng.next_usize() % len_mod;
+    if opts.repeat {
+        for _ in 0..opts.head_count {
+            // Returns None is the slice is empty. We checked this before, so
+            // this is safe.
+            let r = input.choose(&mut rng).unwrap();
+
+            output
+                .write_all(r)
+                .map_err_context(|| "write failed".to_string())?;
+            output
+                .write_all(&[opts.sep])
+                .map_err_context(|| "write failed".to_string())?;
         }
-
-        // write the randomly chosen value and the separator
-        output
-            .write_all(input[r])
-            .map_err_context(|| "write failed".to_string())?;
-        output
-            .write_all(&[opts.sep])
-            .map_err_context(|| "write failed".to_string())?;
-
-        // if we do not allow repeats, remove the chosen value from the input vector
-        if !opts.repeat {
-            // shrink the mask if we will drop below a power of 2
-            if input.len() % 2 == 0 && len_mod > 2 {
-                len_mod >>= 1;
-            }
-            input.swap_remove(r);
+    } else {
+        let (shuffled, _) = input.partial_shuffle(&mut rng, opts.head_count);
+        for r in shuffled {
+            output
+                .write_all(r)
+                .map_err_context(|| "write failed".to_string())?;
+            output
+                .write_all(&[opts.sep])
+                .map_err_context(|| "write failed".to_string())?;
         }
-
-        count -= 1;
     }
+
     Ok(())
 }
 
@@ -311,11 +307,32 @@ enum WrappedRng {
     RngDefault(rand::rngs::ThreadRng),
 }
 
-impl WrappedRng {
-    fn next_usize(&mut self) -> usize {
-        match *self {
-            WrappedRng::RngFile(ref mut r) => r.gen(),
-            WrappedRng::RngDefault(ref mut r) => r.gen(),
+impl RngCore for WrappedRng {
+    fn next_u32(&mut self) -> u32 {
+        match self {
+            Self::RngFile(r) => r.next_u32(),
+            Self::RngDefault(r) => r.next_u32(),
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        match self {
+            Self::RngFile(r) => r.next_u64(),
+            Self::RngDefault(r) => r.next_u64(),
+        }
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        match self {
+            Self::RngFile(r) => r.fill_bytes(dest),
+            Self::RngDefault(r) => r.fill_bytes(dest),
+        }
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        match self {
+            Self::RngFile(r) => r.try_fill_bytes(dest),
+            Self::RngDefault(r) => r.try_fill_bytes(dest),
         }
     }
 }

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -288,17 +288,16 @@ fn shuf_bytes(input: &mut Vec<&[u8]>, opts: Options) -> UResult<()> {
 }
 
 fn parse_range(input_range: &str) -> Result<(usize, usize), String> {
-    let split: Vec<&str> = input_range.split('-').collect();
-    if split.len() != 2 {
-        Err(format!("invalid input range: {}", input_range.quote()))
-    } else {
-        let begin = split[0]
+    if let Some((from, to)) = input_range.split_once('-') {
+        let begin = from
             .parse::<usize>()
-            .map_err(|_| format!("invalid input range: {}", split[0].quote()))?;
-        let end = split[1]
+            .map_err(|_| format!("invalid input range: {}", from.quote()))?;
+        let end = to
             .parse::<usize>()
-            .map_err(|_| format!("invalid input range: {}", split[1].quote()))?;
+            .map_err(|_| format!("invalid input range: {}", to.quote()))?;
         Ok((begin, end + 1))
+    } else {
+        Err(format!("invalid input range: {}", input_range.quote()))
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/3098

Updates `shuf` to use more high-level functions from `rand` instead of having custom implementations.

The result is slightly slower (but hopefully more correct) in the case where no repeats are allowed: (`./shuf` is this branch, `./shuf.old` is the main branch and `shuf` is GNU)
```
❯ hyperfine --warmup 10 "./shuf -i 0-10000000" "./shuf.old -i 0-10000000" "shuf -i 0-10000000"                                                                                               14:32:53
Benchmark 1: ./shuf -i 0-10000000
  Time (mean ± σ):      1.521 s ±  0.024 s    [User: 1.327 s, System: 0.190 s]
  Range (min … max):    1.485 s …  1.555 s    10 runs
 
Benchmark 2: ./shuf.old -i 0-10000000
  Time (mean ± σ):      1.135 s ±  0.018 s    [User: 0.930 s, System: 0.203 s]
  Range (min … max):    1.109 s …  1.175 s    10 runs
 
Benchmark 3: shuf -i 0-10000000
  Time (mean ± σ):      1.533 s ±  0.031 s    [User: 1.502 s, System: 0.028 s]
  Range (min … max):    1.493 s …  1.594 s    10 runs
 
Summary
  './shuf.old -i 0-10000000' ran
    1.34 ± 0.03 times faster than './shuf -i 0-10000000'
    1.35 ± 0.03 times faster than 'shuf -i 0-10000000'
```

At the same time, when we allow repetition, we see a 2 times (!) speedup:
```
❯ hyperfine --warmup 10 "./shuf -r -n 10000000 -i 0-1000" "./shuf.old -r -n 10000000 -i 0-1000" "shuf -r -n 10000000 -i 0-1000"                                                              14:36:36
Benchmark 1: ./shuf -r -n 10000000 -i 0-1000
  Time (mean ± σ):      88.8 ms ±   2.5 ms    [User: 85.3 ms, System: 3.4 ms]
  Range (min … max):    84.8 ms …  96.5 ms    32 runs
 
Benchmark 2: ./shuf.old -r -n 10000000 -i 0-1000
  Time (mean ± σ):     184.7 ms ±   3.7 ms    [User: 179.5 ms, System: 4.6 ms]
  Range (min … max):   179.9 ms … 194.9 ms    15 runs
 
Benchmark 3: shuf -r -n 10000000 -i 0-1000
  Time (mean ± σ):     941.2 ms ±  15.0 ms    [User: 934.6 ms, System: 4.8 ms]
  Range (min … max):   901.5 ms … 955.7 ms    10 runs
 
Summary
  './shuf -r -n 10000000 -i 0-1000' ran
    2.08 ± 0.07 times faster than './shuf.old -r -n 10000000 -i 0-1000'
   10.60 ± 0.34 times faster than 'shuf -r -n 10000000 -i 0-1000'
```

@salsifis Could you repeat your experiment with this branch to verify that this fixes the issue?