### PR TITLE
Add dd in GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,6 +62,7 @@ PROGS       := \
 	csplit \
 	cut \
 	date \
+	dd \
 	df \
 	dircolors \
 	dirname \


### PR DESCRIPTION
Hi,

Don't know if `dd` is deliberately not in `GNUmakefile`, if that is the case feel free to close this PR.
Otherwise, would be nice to have it in.

Dylan
