### PR TITLE
Don't panic when canonicalizing a nonexistent path

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -299,9 +299,8 @@ pub fn canonicalize<P: AsRef<Path>>(
     let original = if original.is_absolute() {
         original.to_path_buf()
     } else {
-        dunce::canonicalize(env::current_dir().unwrap())
-            .unwrap()
-            .join(original)
+        let current_dir = env::current_dir()?;
+        dunce::canonicalize(current_dir)?.join(original)
     };
 
     let mut result = PathBuf::new();


### PR DESCRIPTION
Update uucore::fs::canonicalize to return an Error if called on a relative path from a directory which doesn't exist. Previously, this situation would panic, which affected GNU tests like this:

```
cd "$pwd/$tmp/removed" || framework_failure_

# Skip this test if the system doesn't let you remove the working directory.
if rmdir ../removed 2>/dev/null; then
  v=$(returns_ 1 readlink -e .) || fail=1
  test -z "$v" || fail=1
fi
```