### PR TITLE
split: error when --additional-suffix contains /

### DIFF
--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -228,6 +228,14 @@ fn test_split_additional_suffix() {
     assert_eq!(glob.collate(), at.read_bytes(name));
 }
 
+#[test]
+fn test_additional_suffix_no_slash() {
+    new_ucmd!()
+        .args(&["--additional-suffix", "a/b"])
+        .fails()
+        .usage_error("invalid suffix 'a/b', contains directory separator");
+}
+
 // note: the test_filter* tests below are unix-only
 // windows support has been waived for now because of the difficulty of getting
 // the `cmd` call right


### PR DESCRIPTION
Make `split` terminate with a usage error when the
`--additional-suffix` argument contains a directory separator
character.

This should cause the GNU test `tests/split/additional-suffix.sh` to pass.