### PR TITLE
uucore(memo): replace err_conv with result

### DIFF
--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -284,7 +284,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         None => vec![],
     };
 
-    memo::Memo::run_all(format_string, &values[..]);
+    memo::Memo::run_all(format_string, &values[..])?;
     Ok(())
 }
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -5,6 +5,7 @@
 // TODO: Support -f flag
 // spell-checker:ignore (ToDO) istr chiter argptr ilen extendedbigdecimal extendedbigint numberparse
 use std::io::{stdout, ErrorKind, Write};
+use std::process::exit;
 
 use clap::{crate_version, App, AppSettings, Arg};
 use num_traits::Zero;
@@ -12,6 +13,7 @@ use num_traits::Zero;
 use uucore::error::FromIo;
 use uucore::error::UResult;
 use uucore::memo::Memo;
+use uucore::show;
 
 mod error;
 mod extendedbigdecimal;
@@ -287,7 +289,10 @@ fn print_seq(
         match format {
             Some(f) => {
                 let s = format!("{}", value);
-                Memo::run_all(f, &[s]);
+                if let Err(x) = Memo::run_all(f, &[s]) {
+                    show!(x);
+                    exit(1);
+                }
             }
             None => write_value_float(
                 &mut stdout,
@@ -349,7 +354,10 @@ fn print_seq_integers(
         match format {
             Some(f) => {
                 let s = format!("{}", value);
-                Memo::run_all(f, &[s]);
+                if let Err(x) = Memo::run_all(f, &[s]) {
+                    show!(x);
+                    exit(1);
+                }
             }
             None => write_value_int(&mut stdout, &value, padding, pad, is_first_iteration)?,
         }

--- a/src/uucore/src/lib/features/tokenize/token.rs
+++ b/src/uucore/src/lib/features/tokenize/token.rs
@@ -4,6 +4,8 @@ use std::iter::Peekable;
 use std::slice::Iter;
 use std::str::Chars;
 
+use crate::error::UResult;
+
 // A token object is an object that can print the expected output
 // of a contiguous segment of the format string, and
 // requires at most 1 argument
@@ -27,5 +29,5 @@ pub trait Tokenizer {
     fn from_it(
         it: &mut PutBackN<Chars>,
         args: &mut Peekable<Iter<String>>,
-    ) -> Option<Box<dyn Token>>;
+    ) -> UResult<Option<Box<dyn Token>>>;
 }

--- a/src/uucore/src/lib/features/tokenize/unescaped_text.rs
+++ b/src/uucore/src/lib/features/tokenize/unescaped_text.rs
@@ -13,6 +13,8 @@ use std::process::exit;
 use std::slice::Iter;
 use std::str::Chars;
 
+use crate::error::UResult;
+
 use super::token;
 
 const EXIT_OK: i32 = 0;
@@ -266,8 +268,8 @@ impl token::Tokenizer for UnescapedText {
     fn from_it(
         it: &mut PutBackN<Chars>,
         _: &mut Peekable<Iter<String>>,
-    ) -> Option<Box<dyn token::Token>> {
-        Self::from_it_core(it, false)
+    ) -> UResult<Option<Box<dyn token::Token>>> {
+        Ok(Self::from_it_core(it, false))
     }
 }
 impl token::Token for UnescapedText {


### PR DESCRIPTION
This PR addresses https://github.com/uutils/coreutils/issues/2917

Some questions/thoughts:

- Results propagate all the way up to the utility that calls it - to do so, I needed to modify the `Tokenizer` trait to return a result, and consequently also modified `UnescapedText`, though it has nothing to do with `err_conv()`.
- Both `Sub` and `UnescapedText` (which impl `Tokenizer`) can still reach conditions to exit without propagating, but I didn't change them since those exits don't use `err_conv()`.
- I wrote this PR so that `printf` and `seq` should behave similarly to what they do currently.
- I return `UResult`s that err with `UUsageError`s, although I'm wondering if I should use `SimpleError`s or something else entirely.

Let me know what I should change to make this better!