### PR TITLE
Fix clippy octal-escapes warning

### DIFF
--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -128,9 +128,9 @@ fn test_complement() {
 fn test_zero_terminated() {
     new_ucmd!()
         .args(&["-d_", "-z", "-f", "1"])
-        .pipe_in("9_1\n8_2\n\07_3")
+        .pipe_in("9_1\n8_2\n\x007_3")
         .succeeds()
-        .stdout_only("9\07\0");
+        .stdout_only("9\x007\0");
 }
 
 #[test]

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -220,9 +220,9 @@ fn test_zero_terminated() {
 fn test_obsolete_extras() {
     new_ucmd!()
         .args(&["-5zv"])
-        .pipe_in("1\02\03\04\05\06")
+        .pipe_in("1\x002\x003\x004\x005\x006")
         .succeeds()
-        .stdout_is("==> standard input <==\n1\02\03\04\05\0");
+        .stdout_is("==> standard input <==\n1\x002\x003\x004\x005\0");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #3080 