### PR TITLE
printf: fix printf sci notation round up

### DIFF
--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -229,11 +229,35 @@ fn sub_num_float() {
 }
 
 #[test]
+fn sub_num_float_e_round() {
+    new_ucmd!()
+        .args(&["%e", "99999999"])
+        .succeeds()
+        .stdout_only("1.000000e+08");
+}
+
+#[test]
+fn sub_num_float_e_no_round() {
+    new_ucmd!()
+        .args(&["%e", "99999994"])
+        .succeeds()
+        .stdout_only("9.999999e+07");
+}
+
+#[test]
 fn sub_num_float_round() {
     new_ucmd!()
         .args(&["two is %f", "1.9999995"])
         .succeeds()
         .stdout_only("two is 2.000000");
+}
+
+#[test]
+fn sub_num_float_round_nines_dec() {
+    new_ucmd!()
+        .args(&["%f", "0.99999999"])
+        .succeeds()
+        .stdout_only("1.000000");
 }
 
 #[test]


### PR DESCRIPTION
fixes #3088

update `round_terminal_digit`
- Return `bool` (along with pre- and post-decimal formatted strings) indicating if we have rounded in such a way that the decimal place, or mantissa for `%e/%E` format specifiers, should change

update `_round_str_from`
- Accept `before_dec: bool` argument indicating if the numeric string to be rounded is before or after decimal place. This is used to round a `9` to a `1` in the most significant position in a pre-decimal string.

This fixes similar cases for `printf` with `%e`, `%E`, and `%f`:
```shell
$ printf "%e\n" 0.99999999
1.000000e+00  # was 0.000000e-01

$ printf "%f\n" 99999.9999999
100000.000000  # was 00000.000000
```

I also noticed that `%g`/`%G` doesn't perform as expected, but I can open a separate issue for that if needed.
```shell
$ pritnf "%g\n" 99  # GNU
99

$ printf  "%g\n" 99  # uutils/coreutils
99.0
```
