### PR TITLE
touch: show error on -h with nonexistent file

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -83,8 +83,18 @@ Try 'touch --help' for more information."##,
     for filename in files {
         let path = Path::new(filename);
         if !path.exists() {
-            // no-dereference included here for compatibility
-            if matches.is_present(options::NO_CREATE) || matches.is_present(options::NO_DEREF) {
+            if matches.is_present(options::NO_CREATE) {
+                continue;
+            }
+
+            if matches.is_present(options::NO_DEREF) {
+                show!(USimpleError::new(
+                    1,
+                    format!(
+                        "setting times of {}: No such file or directory",
+                        filename.quote()
+                    )
+                ));
                 continue;
             }
 

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -539,3 +539,16 @@ fn test_touch_no_args() {
 Try 'touch --help' for more information."##,
     );
 }
+
+#[test]
+fn test_no_dereference_no_file() {
+    new_ucmd!()
+        .args(&["-h", "not-a-file"])
+        .fails()
+        .stderr_contains("setting times of 'not-a-file': No such file or directory");
+    new_ucmd!()
+        .args(&["-h", "not-a-file-1", "not-a-file-2"])
+        .fails()
+        .stderr_contains("setting times of 'not-a-file-1': No such file or directory")
+        .stderr_contains("setting times of 'not-a-file-2': No such file or directory");
+}


### PR DESCRIPTION
Show an error message when running `touch -h` on a nonexistent file.

This matches the behavior of GNU touch:
```
$ touch -h not-a-file
touch: setting times of 'not-a-file': No such file or directory
```