### PR TITLE
dd: remove spurious zero multiplier warning

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -325,6 +325,14 @@ impl std::str::FromStr for StatusLevel {
     }
 }
 
+fn show_zero_multiplier_warning() {
+    show_warning!(
+        "{} is a zero multiplier; use {} if that is intended",
+        "0x".quote(),
+        "00x".quote()
+    );
+}
+
 /// Parse bytes using str::parse, then map error if needed.
 fn parse_bytes_only(s: &str) -> Result<usize, ParseError> {
     s.parse()
@@ -357,13 +365,6 @@ fn parse_bytes_only(s: &str) -> Result<usize, ParseError> {
 /// assert_eq!(parse_bytes_no_x("2k").unwrap(), 2 * 1024);
 /// ```
 fn parse_bytes_no_x(s: &str) -> Result<usize, ParseError> {
-    if s == "0" {
-        show_warning!(
-            "{} is a zero multiplier; use {} if that is intended",
-            "0x".quote(),
-            "00x".quote()
-        );
-    }
     let (num, multiplier) = match (s.find('c'), s.rfind('w'), s.rfind('b')) {
         (None, None, None) => match uucore::parse_size::parse_size(s) {
             Ok(n) => (n, 1),
@@ -401,13 +402,20 @@ fn parse_bytes_with_opt_multiplier(s: &str) -> Result<usize, ParseError> {
 
     // Split on the 'x' characters. Each component will be parsed
     // individually, then multiplied together.
-    let mut total = 1;
-    for part in s.split('x') {
-        let num = parse_bytes_no_x(part).map_err(|e| e.with_arg(s.to_string()))?;
-        total *= num;
+    let parts: Vec<&str> = s.split('x').collect();
+    if parts.len() == 1 {
+        parse_bytes_no_x(parts[0]).map_err(|e| e.with_arg(s.to_string()))
+    } else {
+        let mut total = 1;
+        for part in parts {
+            if part == "0" {
+                show_zero_multiplier_warning();
+            }
+            let num = parse_bytes_no_x(part).map_err(|e| e.with_arg(s.to_string()))?;
+            total *= num;
+        }
+        Ok(total)
     }
-
-    Ok(total)
 }
 
 pub fn parse_ibs(matches: &Matches) -> Result<usize, ParseError> {

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -202,6 +202,13 @@ fn test_x_multiplier() {
 fn test_zero_multiplier_warning() {
     for arg in ["count", "seek", "skip"] {
         new_ucmd!()
+            .args(&[format!("{}=0", arg).as_str(), "status=none"])
+            .pipe_in("")
+            .succeeds()
+            .no_stdout()
+            .no_stderr();
+
+        new_ucmd!()
             .args(&[format!("{}=00x1", arg).as_str(), "status=none"])
             .pipe_in("")
             .succeeds()
@@ -1062,4 +1069,13 @@ fn test_all_valid_ascii_ebcdic_ascii_roundtrip_conv_test() {
         .pipe_in(tmp)
         .succeeds()
         .stdout_is_fixture_bytes("all-valid-ascii-chars-37eff01866ba3f538421b30b7cbefcac.test");
+}
+
+#[test]
+fn test_skip_zero() {
+    new_ucmd!()
+        .args(&["skip=0", "status=noxfer"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is("0+0 records in\n0+0 records out\n");
 }


### PR DESCRIPTION
Fix a bug in which `dd` was inappropriately showing a warning about a
"0x" multiplier when there was no "x" character in the argument.

This is a regression I introduced in pull request #3085. I have added a test case to prevent this from happening in the future.