### PR TITLE
dd: correctly account for partial record written

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -334,16 +334,13 @@ where
         let mut bytes_total = 0;
 
         for chunk in buf.chunks(self.obs) {
-            match self.write(chunk)? {
-                wlen if wlen < chunk.len() => {
-                    writes_partial += 1;
-                    bytes_total += wlen;
-                }
-                wlen => {
-                    writes_complete += 1;
-                    bytes_total += wlen;
-                }
+            let wlen = self.write(chunk)?;
+            if wlen < self.obs {
+                writes_partial += 1;
+            } else {
+                writes_complete += 1;
             }
+            bytes_total += wlen;
         }
 
         Ok(WriteStat {

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -692,5 +692,15 @@ fn test_seek_do_not_overwrite() {
     assert_eq!(at.read("outfile"), "a2");
 }
 
+#[test]
+fn test_partial_records_out() {
+    new_ucmd!()
+        .args(&["bs=2", "status=noxfer"])
+        .pipe_in("abc")
+        .succeeds()
+        .stdout_is("abc")
+        .stderr_is("1+1 records in\n1+1 records out\n");
+}
+
 // conv=[ascii,ebcdic,ibm], conv=[ucase,lcase], conv=[block,unblock], conv=sync
 // TODO: Move conv tests from unit test module


### PR DESCRIPTION
Correct the accounting for partial records written by `dd` to the
output file. After this commit, if fewer than `obs` bytes are written,
then that is counted as a partial record. For example,

    $ printf 'abc' | dd bs=2 status=noxfer > /dev/null
    1+1 records in
    1+1 records out

That is, one complete record and one partial record are read from the
input, one complete record and one partial record are written to the
output. Previously, `dd` reported two complete records and zero
partial records written to the output in this case.

This fixes the failing test case I reported in a comment https://github.com/uutils/coreutils/issues/3042#issuecomment-1030665705 but the original issue #3042 remains.