### PR TITLE
expr: Use chars().count() as we can have some multibytes chars

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -10,7 +10,7 @@
 //! * `<https://en.wikipedia.org/wiki/Shunting-yard_algorithm>`
 //!
 
-// spell-checker:ignore (ToDO) binop binops ints paren prec
+// spell-checker:ignore (ToDO) binop binops ints paren prec multibytes
 
 use num_bigint::BigInt;
 use num_traits::{One, Zero};
@@ -465,7 +465,9 @@ fn operator_match(values: &[String]) -> Result<String, String> {
 
 fn prefix_operator_length(values: &[String]) -> String {
     assert!(values.len() == 1);
-    values[0].len().to_string()
+    // Use chars().count() as we can have some multibytes chars
+    // See https://github.com/uutils/coreutils/issues/3132
+    values[0].chars().count().to_string()
 }
 
 fn prefix_operator_index(values: &[String]) -> String {

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -1,3 +1,5 @@
+// spell-checker:ignore αbcdef
+
 use crate::common::util::*;
 
 #[test]
@@ -93,6 +95,27 @@ fn test_and() {
         .stdout_only("foo\n");
 
     new_ucmd!().args(&["", "&", "1"]).run().stdout_is("0\n");
+}
+
+#[test]
+fn test_length_fail() {
+    new_ucmd!().args(&["length", "αbcdef", "1"]).fails();
+}
+
+#[test]
+fn test_length() {
+    new_ucmd!()
+        .args(&["length", "abcdef"])
+        .succeeds()
+        .stdout_only("6\n");
+}
+
+#[test]
+fn test_length_mb() {
+    new_ucmd!()
+        .args(&["length", "αbcdef"])
+        .succeeds()
+        .stdout_only("6\n");
 }
 
 #[test]


### PR DESCRIPTION
Partially fixes #3132
Fixes one of the test of tests/misc/expr-multibyte