### PR TITLE
all: add `format_usage` function

### DIFF
--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -76,7 +76,7 @@ fn write_usage(w: &mut impl Write, app: &mut App, name: &str) -> io::Result<()> 
         .filter(|l| !l.is_empty())
         .collect::<Vec<_>>()
         .join("\n");
-    usage = usage.replace(app.get_name(), name);
+    usage = usage.replace(uucore::execution_phrase(), name);
     writeln!(w, "{}", usage)?;
     writeln!(w, "```")
 }

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -22,16 +22,13 @@ to attempt to recover from any other non-alphabet bytes in the
 encoded stream.
 ";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
-}
+const USAGE: &str = "{} [OPTION]... [FILE]";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let format = Format::Base32;
-    let usage = usage();
 
-    let config: base_common::Config = base_common::parse_base_cmd_args(args, ABOUT, &usage)?;
+    let config: base_common::Config = base_common::parse_base_cmd_args(args, ABOUT, USAGE)?;
 
     // Create a reference to stdin so we can return a locked stdin from
     // parse_base_cmd_args
@@ -48,5 +45,5 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app<'a>() -> App<'a> {
-    base_common::base_app(ABOUT)
+    base_common::base_app(ABOUT, USAGE)
 }

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -12,7 +12,7 @@ use std::io::{stdout, Read, Write};
 use uucore::display::Quotable;
 use uucore::encoding::{wrap_print, Data, Format};
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 use std::fs::File;
 use std::io::{BufReader, Stdin};
@@ -86,17 +86,18 @@ impl Config {
 }
 
 pub fn parse_base_cmd_args(args: impl uucore::Args, about: &str, usage: &str) -> UResult<Config> {
-    let app = base_app(about).override_usage(usage);
+    let app = base_app(about, usage);
     let arg_list = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
     Config::from(&app.get_matches_from(arg_list))
 }
 
-pub fn base_app(about: &str) -> App {
+pub fn base_app<'a>(about: &'a str, usage: &'a str) -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(about)
+        .override_usage(format_usage(usage))
         .setting(AppSettings::InferLongArgs)
         // Format arguments.
         .arg(

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -23,16 +23,13 @@ to attempt to recover from any other non-alphabet bytes in the
 encoded stream.
 ";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
-}
+const USAGE: &str = "{0} [OPTION]... [FILE]";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let format = Format::Base64;
-    let usage = usage();
 
-    let config: base_common::Config = base_common::parse_base_cmd_args(args, ABOUT, &usage)?;
+    let config: base_common::Config = base_common::parse_base_cmd_args(args, ABOUT, USAGE)?;
 
     // Create a reference to stdin so we can return a locked stdin from
     // parse_base_cmd_args

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -11,18 +11,13 @@ use clap::{crate_version, App, AppSettings, Arg};
 use std::path::{is_separator, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static SUMMARY: &str = "Print NAME with any leading directory components removed
 If specified, also remove a trailing SUFFIX";
 
-fn usage() -> String {
-    format!(
-        "{0} NAME [SUFFIX]
-    {0} OPTION... NAME...",
-        uucore::execution_phrase()
-    )
-}
+const USAGE: &str = "{} NAME [SUFFIX]
+    {} OPTION... NAME...";
 
 pub mod options {
     pub static MULTIPLE: &str = "multiple";
@@ -36,11 +31,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
-    let usage = usage();
     //
     // Argument parsing
     //
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     // too few arguments
     if !matches.is_present(options::NAME) {
@@ -97,6 +91,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::MULTIPLE)

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -38,12 +38,10 @@ const ENCODINGS: &[(&str, Format)] = &[
     ("z85", Format::Z85),
 ];
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]", uucore::execution_phrase())
-}
+const USAGE: &str = "{} [OPTION]... [FILE]";
 
 pub fn uu_app<'a>() -> App<'a> {
-    let mut app = base_common::base_app(ABOUT);
+    let mut app = base_common::base_app(ABOUT, USAGE);
     for encoding in ENCODINGS {
         app = app.arg(Arg::new(encoding.0).long(encoding.0));
     }
@@ -51,8 +49,7 @@ pub fn uu_app<'a>() -> App<'a> {
 }
 
 fn parse_cmd_args(args: impl uucore::Args) -> UResult<(Config, Format)> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(
+    let matches = uu_app().get_matches_from(
         args.collect_str(InvalidEncodingHandling::ConvertLossy)
             .accept_any(),
     );

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -36,10 +36,10 @@ use std::net::Shutdown;
 use std::os::unix::fs::FileTypeExt;
 #[cfg(unix)]
 use unix_socket::UnixStream;
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static NAME: &str = "cat";
-static SYNTAX: &str = "[OPTION]... [FILE]...";
+static USAGE: &str = "{} [OPTION]... [FILE]...";
 static SUMMARY: &str = "Concatenate FILE(s), or standard input, to standard output
  With no FILE, or when FILE is -, read standard input.";
 
@@ -243,7 +243,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(SYNTAX)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 use uucore::{display::Quotable, show_error, show_warning};
 
 use clap::{App, AppSettings, Arg};
@@ -22,6 +23,10 @@ use errors::*;
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = "Change the SELinux security context of each FILE to CONTEXT. \n\
                       With --reference, change the security context of each FILE to that of RFILE.";
+const USAGE: &str = "\
+    {} [OPTION]... CONTEXT FILE... \n    \
+    {} [OPTION]... [-u USER] [-r ROLE] [-l RANGE] [-t TYPE] FILE... \n    \
+    {} [OPTION]... --reference=RFILE FILE...";
 
 pub mod options {
     pub static VERBOSE: &str = "verbose";
@@ -52,20 +57,9 @@ pub mod options {
     }
 }
 
-fn get_usage() -> String {
-    format!(
-        "{0} [OPTION]... CONTEXT FILE... \n    \
-         {0} [OPTION]... [-u USER] [-r ROLE] [-l RANGE] [-t TYPE] FILE... \n    \
-         {0} [OPTION]... --reference=RFILE FILE...",
-        uucore::execution_phrase()
-    )
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
-
-    let config = uu_app().override_usage(usage.as_ref());
+    let config = uu_app();
 
     let options = match parse_command_line(config, args) {
         Ok(r) => r,
@@ -164,6 +158,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(VERSION)
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::dereference::DEREFERENCE)

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -10,6 +10,7 @@
 use uucore::display::Quotable;
 pub use uucore::entries;
 use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::format_usage;
 use uucore::perms::{chown_base, options, IfFrom};
 
 use clap::{App, AppSettings, Arg, ArgMatches};
@@ -20,12 +21,9 @@ use std::os::unix::fs::MetadataExt;
 static ABOUT: &str = "Change the group of each FILE to GROUP.";
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn get_usage() -> String {
-    format!(
-        "{0} [OPTION]... GROUP FILE...\n    {0} [OPTION]... --reference=RFILE FILE...",
-        uucore::execution_phrase()
-    )
-}
+const USAGE: &str = "\
+    {} [OPTION]... GROUP FILE...\n    \
+    {} [OPTION]... --reference=RFILE FILE...";
 
 fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>, IfFrom)> {
     let dest_gid = if let Some(file) = matches.value_of(options::REFERENCE) {
@@ -53,21 +51,14 @@ fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>,
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
-
-    chown_base(
-        uu_app().override_usage(&usage[..]),
-        args,
-        options::ARG_GROUP,
-        parse_gid_and_uid,
-        true,
-    )
+    chown_base(uu_app(), args, options::ARG_GROUP, parse_gid_and_uid, true)
 }
 
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(VERSION)
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::verbosity::CHANGES)

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -17,7 +17,7 @@ use uucore::fs::display_permissions_unix;
 use uucore::libc::mode_t;
 #[cfg(not(windows))]
 use uucore::mode;
-use uucore::{show_error, InvalidEncodingHandling};
+use uucore::{format_usage, show_error, InvalidEncodingHandling};
 use walkdir::WalkDir;
 
 static ABOUT: &str = "Change the mode of each FILE to MODE.
@@ -35,14 +35,10 @@ mod options {
     pub const FILE: &str = "FILE";
 }
 
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... MODE[,MODE]... FILE...
-or: {0} [OPTION]... OCTAL-MODE FILE...
-or: {0} [OPTION]... --reference=RFILE FILE...",
-        uucore::execution_phrase()
-    )
-}
+const USAGE: &str = "\
+    {} [OPTION]... MODE[,MODE]... FILE...
+    {} [OPTION]... OCTAL-MODE FILE...
+    {} [OPTION]... --reference=RFILE FILE...";
 
 fn get_long_usage() -> String {
     String::from("Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.")
@@ -58,13 +54,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").
     let mode_had_minus_prefix = mode::strip_minus_from_mode(&mut args);
 
-    let usage = usage();
     let after_help = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let changes = matches.is_present(options::CHANGES);
     let quiet = matches.is_present(options::QUIET);
@@ -125,6 +117,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::CHANGES)

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -9,6 +9,7 @@
 
 use uucore::display::Quotable;
 pub use uucore::entries::{self, Group, Locate, Passwd};
+use uucore::format_usage;
 use uucore::perms::{chown_base, options, IfFrom};
 
 use uucore::error::{FromIo, UResult, USimpleError};
@@ -20,12 +21,9 @@ use std::os::unix::fs::MetadataExt;
 
 static ABOUT: &str = "change file owner and group";
 
-fn get_usage() -> String {
-    format!(
-        "{0} [OPTION]... [OWNER][:[GROUP]] FILE...\n{0} [OPTION]... --reference=RFILE FILE...",
-        uucore::execution_phrase()
-    )
-}
+const USAGE: &str = "\
+    {} [OPTION]... [OWNER][:[GROUP]] FILE...
+    {} [OPTION]... --reference=RFILE FILE...";
 
 fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>, IfFrom)> {
     let filter = if let Some(spec) = matches.value_of(options::FROM) {
@@ -56,10 +54,8 @@ fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Optio
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
-
     chown_base(
-        uu_app().override_usage(&usage[..]),
+        uu_app(),
         args,
         options::ARG_OWNER,
         parse_gid_uid_and_filter,
@@ -71,6 +67,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::verbosity::CHANGES)

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -17,10 +17,10 @@ use std::path::Path;
 use std::process::Command;
 use uucore::error::{set_exit_code, UResult};
 use uucore::libc::{self, chroot, setgid, setgroups, setuid};
-use uucore::{entries, InvalidEncodingHandling};
+use uucore::{entries, format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Run COMMAND with root directory set to NEWROOT.";
-static SYNTAX: &str = "[OPTION]... NEWROOT [COMMAND [ARG]...]";
+static USAGE: &str = "{} [OPTION]... NEWROOT [COMMAND [ARG]...]";
 
 mod options {
     pub const NEWROOT: &str = "newroot";
@@ -95,7 +95,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .override_usage(SYNTAX)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::NEWROOT)

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -12,15 +12,15 @@ use std::io::{self, stdin, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::show;
 use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, show};
 
 // NOTE: CRC_TABLE_LEN *must* be <= 256 as we cast 0..CRC_TABLE_LEN to u8
 const CRC_TABLE_LEN: usize = 256;
 const CRC_TABLE: [u32; CRC_TABLE_LEN] = generate_crc_table();
 
 const NAME: &str = "cksum";
-const SYNTAX: &str = "[OPTIONS] [FILE]...";
+const USAGE: &str = "{} [OPTIONS] [FILE]...";
 const SUMMARY: &str = "Print CRC and size for each file";
 
 const fn generate_crc_table() -> [u32; CRC_TABLE_LEN] {
@@ -145,7 +145,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .name(NAME)
         .version(crate_version!())
         .about(SUMMARY)
-        .override_usage(SYNTAX)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -13,12 +13,13 @@ use std::io::{self, stdin, BufRead, BufReader, Stdin};
 use std::path::Path;
 use uucore::error::FromIo;
 use uucore::error::UResult;
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
 static ABOUT: &str = "compare two sorted files line by line";
 static LONG_HELP: &str = "";
+const USAGE: &str = "{} [OPTION]... FILE1 FILE2";
 
 mod options {
     pub const COLUMN_1: &str = "1";
@@ -28,10 +29,6 @@ mod options {
     pub const DELIMITER_DEFAULT: &str = "\t";
     pub const FILE_1: &str = "FILE1";
     pub const FILE_2: &str = "FILE2";
-}
-
-fn usage() -> String {
-    format!("{} [OPTION]... FILE1 FILE2", uucore::execution_phrase())
 }
 
 fn mkdelim(col: usize, opts: &ArgMatches) -> String {
@@ -132,12 +129,11 @@ fn open_file(name: &str) -> io::Result<LineReader> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
     let filename1 = matches.value_of(options::FILE_1).unwrap();
     let filename2 = matches.value_of(options::FILE_2).unwrap();
     let mut f1 = open_file(filename1).map_err_context(|| filename1.to_string())?;
@@ -152,6 +148,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::COLUMN_1)

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -19,6 +19,7 @@ extern crate quick_error;
 extern crate uucore;
 
 use uucore::display::Quotable;
+use uucore::format_usage;
 use uucore::fs::FileInformation;
 #[cfg(windows)]
 use winapi::um::fileapi::CreateFileW;
@@ -230,14 +231,10 @@ static ABOUT: &str = "Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.";
 static LONG_HELP: &str = "";
 static EXIT_ERR: i32 = 1;
 
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... [-T] SOURCE DEST
-    {0} [OPTION]... SOURCE... DIRECTORY
-    {0} [OPTION]... -t DIRECTORY SOURCE...",
-        uucore::execution_phrase()
-    )
-}
+const USAGE: &str = "\
+    {} [OPTION]... [-T] SOURCE DEST
+    {} [OPTION]... SOURCE... DIRECTORY
+    {} [OPTION]... -t DIRECTORY SOURCE...";
 
 // Argument constants
 mod options {
@@ -300,6 +297,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::TARGET_DIRECTORY)
              .short('t')
@@ -456,14 +454,12 @@ pub fn uu_app<'a>() -> App<'a> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let matches = uu_app()
         .after_help(&*format!(
             "{}\n{}",
             LONG_HELP,
             backup_control::BACKUP_CONTROL_LONG_HELP
         ))
-        .override_usage(&usage[..])
         .get_matches_from(args);
 
     let options = Options::from_matches(&matches)?;

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -16,7 +16,7 @@ use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use regex::Regex;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 mod csplit_error;
 mod patterns;
@@ -27,6 +27,7 @@ use crate::split_name::SplitName;
 
 static SUMMARY: &str = "split a file into sections determined by context lines";
 static LONG_HELP: &str = "Output pieces of FILE separated by PATTERN(s) to files 'xx00', 'xx01', ..., and output byte counts of each piece to standard output.";
+const USAGE: &str = "{} [OPTION]... FILE PATTERN...";
 
 mod options {
     pub const SUFFIX_FORMAT: &str = "suffix-format";
@@ -38,13 +39,6 @@ mod options {
     pub const ELIDE_EMPTY_FILES: &str = "elide-empty-files";
     pub const FILE: &str = "file";
     pub const PATTERN: &str = "pattern";
-}
-
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... FILE PATTERN...",
-        uucore::execution_phrase()
-    )
 }
 
 /// Command line options for csplit.
@@ -719,12 +713,11 @@ mod tests {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     // get the file to split
     let file_name = matches.value_of(options::FILE).unwrap();
@@ -757,6 +750,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SUFFIX_FORMAT)

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -20,13 +20,13 @@ use uucore::error::{FromIo, UResult, USimpleError};
 
 use self::searcher::Searcher;
 use uucore::ranges::Range;
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 mod searcher;
 
 static NAME: &str = "cut";
-static SYNTAX: &str =
-    "[-d] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+";
+static USAGE: &str =
+    "{} [-d] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+";
 static SUMMARY: &str =
     "Prints specified byte or field columns from each line of stdin or the input files";
 static LONG_HELP: &str = "
@@ -537,7 +537,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(SYNTAX)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .after_help(LONG_HELP)
         .setting(AppSettings::InferLongArgs)

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -21,7 +21,7 @@ use uucore::display::Quotable;
 #[cfg(not(any(target_os = "macos", target_os = "redox")))]
 use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
-use uucore::show_error;
+use uucore::{format_usage, show_error};
 #[cfg(windows)]
 use winapi::{
     shared::minwindef::WORD,
@@ -38,8 +38,10 @@ const MINUTE: &str = "minute";
 const SECOND: &str = "second";
 const NS: &str = "ns";
 
-const NAME: &str = "date";
 const ABOUT: &str = "print or set the system date and time";
+const USAGE: &str = "\
+    {} [OPTION]... [+FORMAT]...
+    {} [OPTION]... [MMDDhhmm[[CC]YY][.ss]]";
 
 const OPT_DATE: &str = "date";
 const OPT_FORMAT: &str = "format";
@@ -142,12 +144,7 @@ impl<'a> From<&'a str> for Rfc3339Format {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let syntax = format!(
-        "{0} [OPTION]... [+FORMAT]...
- {0} [OPTION]... [MMDDhhmm[[CC]YY][.ss]]",
-        NAME
-    );
-    let matches = uu_app().override_usage(&syntax[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
         if !form.starts_with('+') {
@@ -261,6 +258,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_DATE)

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -7,10 +7,10 @@
 // that was distributed with this source code.
 mod table;
 
-use uucore::error::UResult;
 #[cfg(unix)]
 use uucore::fsext::statfs_fn;
 use uucore::fsext::{read_fs_list, FsUsage, MountInfo};
+use uucore::{error::UResult, format_usage};
 
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
@@ -28,6 +28,7 @@ use crate::table::{DisplayRow, Header, Row};
 
 static ABOUT: &str = "Show information about the file system on which each FILE resides,\n\
                       or all file systems by default.";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 
 static OPT_ALL: &str = "all";
 static OPT_BLOCKSIZE: &str = "blocksize";
@@ -92,10 +93,6 @@ impl Options {
 struct Filesystem {
     mount_info: MountInfo,
     usage: FsUsage,
-}
-
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 impl FsSelector {
@@ -256,8 +253,7 @@ fn filter_mount_list(vmi: Vec<MountInfo>, paths: &[String], opt: &Options) -> Ve
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let paths: Vec<String> = matches
         .values_of(OPT_PATHS)
@@ -293,6 +289,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_ALL)

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -24,7 +24,7 @@ mod options {
     pub const FILE: &str = "FILE";
 }
 
-static SYNTAX: &str = "[OPTION]... [FILE]";
+static USAGE: &str = "{} [OPTION]... [FILE]";
 static SUMMARY: &str = "Output commands to set the LS_COLORS environment variable.";
 static LONG_HELP: &str = "
  If FILE is specified, read it to determine which colors to use for which
@@ -61,19 +61,13 @@ pub fn guess_syntax() -> OutputFmt {
     }
 }
 
-fn usage() -> String {
-    format!("{0} {1}", uucore::execution_phrase(), SYNTAX)
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(&args);
+    let matches = uu_app().get_matches_from(&args);
 
     let files = matches
         .values_of(options::FILE)
@@ -165,6 +159,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(LONG_HELP)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BOURNE_SHELL)
@@ -257,7 +252,7 @@ enum ParseState {
     Pass,
 }
 use std::collections::HashMap;
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 fn parse<T>(lines: T, fmt: &OutputFmt, fp: &str) -> Result<String, String>
 where

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -9,17 +9,14 @@ use clap::{crate_version, App, AppSettings, Arg};
 use std::path::Path;
 use uucore::display::print_verbatim;
 use uucore::error::{UResult, UUsageError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "strip last component from file name";
+const USAGE: &str = "{} [OPTION] NAME...";
 
 mod options {
     pub const ZERO: &str = "zero";
     pub const DIR: &str = "dir";
-}
-
-fn usage() -> String {
-    format!("{0} [OPTION] NAME...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -35,13 +32,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = usage();
     let after_help = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let separator = if matches.is_present(options::ZERO) {
         "\0"
@@ -87,6 +80,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .about(ABOUT)
         .version(crate_version!())
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ZERO)

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -11,11 +11,11 @@ use std::io::{self, Write};
 use std::iter::Peekable;
 use std::str::Chars;
 use uucore::error::{FromIo, UResult};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 const NAME: &str = "echo";
 const SUMMARY: &str = "display a line of text";
-const USAGE: &str = "[OPTIONS]... [STRING]...";
+const USAGE: &str = "{} [OPTIONS]... [STRING]...";
 const AFTER_HELP: &str = r#"
  Echo the STRING(s) to standard output.
 
@@ -138,7 +138,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(SUMMARY)
         .after_help(AFTER_HELP)
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .arg(
             Arg::new(options::NO_NEWLINE)
                 .short('n')

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -25,8 +25,9 @@ use std::iter::Iterator;
 use std::process::Command;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 
-const USAGE: &str = "env [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]";
+const USAGE: &str = "{} [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]";
 const AFTER_HELP: &str = "\
 A mere - implies -i. If no COMMAND, print the resulting environment.
 ";
@@ -125,7 +126,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .author(crate_authors!())
         .about(crate_description!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .after_help(AFTER_HELP)
         .setting(AppSettings::AllowExternalSubcommands)
         .setting(AppSettings::InferLongArgs)

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -19,9 +19,11 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
+use uucore::format_usage;
 
 static ABOUT: &str = "Convert tabs in each FILE to spaces, writing to standard output.
  With no FILE, or when FILE is -, read standard input.";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 
 pub mod options {
     pub static TABS: &str = "tabs";
@@ -33,10 +35,6 @@ pub mod options {
 static LONG_HELP: &str = "";
 
 static DEFAULT_TABSTOP: usize = 8;
-
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
-}
 
 /// The mode to use when replacing tabs beyond the last one specified in
 /// the `--tabs` argument.
@@ -173,8 +171,7 @@ impl Options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     expand(&Options::new(&matches)).map_err_context(|| "failed to write output".to_string())
 }
@@ -184,6 +181,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::INITIAL)

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -17,6 +17,7 @@ use std::io::{stdin, stdout, Write};
 use std::io::{BufReader, BufWriter, Read};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::format_usage;
 
 use self::linebreak::break_lines;
 use self::parasplit::ParagraphStream;
@@ -25,6 +26,7 @@ mod linebreak;
 mod parasplit;
 
 static ABOUT: &str = "Reformat paragraphs from input files (or stdin) to stdout.";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 static MAX_WIDTH: usize = 2500;
 
 static OPT_CROWN_MARGIN: &str = "crown-margin";
@@ -42,10 +44,6 @@ static OPT_QUICK: &str = "quick";
 static OPT_TAB_WIDTH: &str = "tab-width";
 
 static ARG_FILES: &str = "files";
-
-fn usage() -> String {
-    format!("{} [OPTION]... [FILE]...", uucore::execution_phrase())
-}
 
 pub type FileOrStdReader = BufReader<Box<dyn Read + 'static>>;
 pub struct FmtOptions {
@@ -69,9 +67,7 @@ pub struct FmtOptions {
 #[uucore::main]
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let mut files: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -226,6 +222,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_CROWN_MARGIN)

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -13,12 +13,12 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 const TAB_WIDTH: usize = 8;
 
 static NAME: &str = "fold";
-static SYNTAX: &str = "[OPTION]... [FILE]...";
+static USAGE: &str = "{} [OPTION]... [FILE]...";
 static SUMMARY: &str = "Writes each file (or standard input if no files are given)
  to standard output whilst breaking long lines";
 
@@ -67,7 +67,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(SYNTAX)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -23,6 +23,7 @@ use uucore::{
     display::Quotable,
     entries::{get_groups_gnu, gid2grp, Locate, Passwd},
     error::{UError, UResult},
+    format_usage,
 };
 
 use clap::{crate_version, App, AppSettings, Arg};
@@ -34,9 +35,7 @@ static ABOUT: &str = "Print group memberships for each USERNAME or, \
                       if no USERNAME is specified, for\nthe current process \
                       (which may differ if the groups data‐base has changed).";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [USERNAME]...", uucore::execution_phrase())
-}
+const USAGE: &str = "{} [OPTION]... [USERNAME]...";
 
 #[derive(Debug)]
 enum GroupsError {
@@ -71,9 +70,7 @@ fn infallible_gid2grp(gid: &u32) -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let users: Vec<String> = matches
         .values_of(options::USERS)
@@ -109,6 +106,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::USERS)

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -12,7 +12,7 @@ use std::io::{self, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::lines::lines;
-use uucore::show;
+use uucore::{format_usage, show};
 
 const BUF_SIZE: usize = 65536;
 
@@ -26,7 +26,7 @@ const ABOUT: &str = "\
                      \n\
                      Mandatory arguments to long flags are mandatory for short flags too.\
                      ";
-const USAGE: &str = "head [FLAG]... [FILE]...";
+const USAGE: &str = "{} [FLAG]... [FILE]...";
 
 mod options {
     pub const BYTES_NAME: &str = "BYTES";
@@ -45,7 +45,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES_NAME)

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -9,9 +9,9 @@
 
 use clap::{crate_version, App, AppSettings};
 use libc::c_long;
-use uucore::error::UResult;
+use uucore::{error::UResult, format_usage};
 
-static SYNTAX: &str = "[options]";
+const USAGE: &str = "{} [options]";
 const SUMMARY: &str = "Print the numeric identifier (in hexadecimal) for the current host";
 
 // currently rust libc interface doesn't include gethostid
@@ -30,7 +30,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(SUMMARY)
-        .override_usage(SYNTAX)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
 }
 

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -13,9 +13,13 @@ use std::str;
 
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 
-use uucore::error::{FromIo, UResult};
+use uucore::{
+    error::{FromIo, UResult},
+    format_usage,
+};
 
 static ABOUT: &str = "Display or set the system's host name.";
+const USAGE: &str = "{} [OPTION]... [HOSTNAME]";
 
 static OPT_DOMAIN: &str = "domain";
 static OPT_IP_ADDRESS: &str = "ip-address";
@@ -54,14 +58,9 @@ mod wsa {
     }
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [HOSTNAME]", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     #[cfg(windows)]
     let _handle = wsa::start().map_err_context(|| "failed to start Winsock".to_owned())?;
@@ -76,6 +75,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_DOMAIN)

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -45,6 +45,7 @@ use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::error::UResult;
 use uucore::error::{set_exit_code, USimpleError};
+use uucore::format_usage;
 pub use uucore::libc;
 use uucore::libc::{getlogin, uid_t};
 use uucore::process::{getegid, geteuid, getgid, getuid};
@@ -57,6 +58,7 @@ macro_rules! cstr2cow {
 
 static ABOUT: &str = "Print user and group information for each specified USER,
 or (when USER omitted) for the current user.";
+const USAGE: &str = "{} [OPTION]... [USER]...";
 
 #[cfg(not(feature = "selinux"))]
 static CONTEXT_HELP_TEXT: &str = "print only the security context of the process (not enabled)";
@@ -75,10 +77,6 @@ mod options {
     pub const OPT_REAL_ID: &str = "real";
     pub const OPT_ZERO: &str = "zero"; // BSD's id does not have this
     pub const ARG_USERS: &str = "USER";
-}
-
-fn usage() -> String {
-    format!("{0} [OPTION]... [USER]...", uucore::execution_phrase())
 }
 
 fn get_description() -> String {
@@ -128,13 +126,9 @@ struct State {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let after_help = get_description();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let users: Vec<String> = matches
         .values_of(options::ARG_USERS)
@@ -351,6 +345,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::OPT_AUDIT)

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -19,6 +19,7 @@ use uucore::backup_control::{self, BackupMode};
 use uucore::display::Quotable;
 use uucore::entries::{grp2gid, usr2uid};
 use uucore::error::{FromIo, UError, UIoError, UResult};
+use uucore::format_usage;
 use uucore::mode::get_umask;
 use uucore::perms::{wrap_chown, Verbosity, VerbosityLevel};
 
@@ -144,6 +145,7 @@ impl Behavior {
 
 static ABOUT: &str = "Copy SOURCE to DEST or multiple SOURCE(s) to the existing
  DIRECTORY, while setting permission modes and owner/group";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 
 static OPT_COMPARE: &str = "compare";
 static OPT_DIRECTORY: &str = "directory";
@@ -163,19 +165,13 @@ static OPT_CONTEXT: &str = "context";
 
 static ARG_FILES: &str = "files";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
-}
-
 /// Main install utility function, called from main.rs.
 ///
 /// Returns a program return code.
 ///
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let paths: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -196,6 +192,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             backup_control::arguments::backup()

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -16,9 +16,10 @@ use std::io::Error;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::signals::{signal_by_name_or_value, ALL_SIGNALS};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Send signal to processes or list information about signals.";
+const USAGE: &str = "{} [OPTIONS]... PID...";
 
 pub mod options {
     pub static PIDS_OR_SIGNALS: &str = "pids_of_signals";
@@ -42,8 +43,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .accept_any();
     let obs_signal = handle_obsolete(&mut args);
 
-    let usage = format!("{} [OPTIONS]... PID...", uucore::execution_phrase());
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let mode = if matches.is_present(options::TABLE) || matches.is_present(options::TABLE_OLD) {
         Mode::Table
@@ -82,6 +82,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::LIST)

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -9,21 +9,18 @@ use std::fs::hard_link;
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
+use uucore::format_usage;
 
 static ABOUT: &str = "Call the link function to create a link named FILE2 to an existing FILE1.";
+const USAGE: &str = "{} FILE1 FILE2";
 
 pub mod options {
     pub static FILES: &str = "FILES";
 }
 
-fn usage() -> String {
-    format!("{0} FILE1 FILE2", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let files: Vec<_> = matches
         .values_of_os(options::FILES)
@@ -40,6 +37,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILES)

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -13,6 +13,7 @@ extern crate uucore;
 use clap::{crate_version, App, AppSettings, Arg};
 use uucore::display::Quotable;
 use uucore::error::{UError, UResult};
+use uucore::format_usage;
 
 use std::borrow::Cow;
 use std::error::Error;
@@ -90,16 +91,6 @@ impl UError for LnError {
     }
 }
 
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... [-T] TARGET LINK_NAME   (1st form)
-       {0} [OPTION]... TARGET                  (2nd form)
-       {0} [OPTION]... TARGET... DIRECTORY     (3rd form)
-       {0} [OPTION]... -t DIRECTORY TARGET...  (4th form)",
-        uucore::execution_phrase()
-    )
-}
-
 fn long_usage() -> String {
     String::from(
         " In the 1st form, create a link to TARGET with the name LINK_NAME.
@@ -115,6 +106,11 @@ fn long_usage() -> String {
 }
 
 static ABOUT: &str = "change file owner and group";
+const USAGE: &str = "\
+    {} [OPTION]... [-T] TARGET LINK_NAME
+    {} [OPTION]... TARGET
+    {} [OPTION]... TARGET... DIRECTORY
+    {} [OPTION]... -t DIRECTORY TARGET...";
 
 mod options {
     pub const FORCE: &str = "force";
@@ -131,11 +127,9 @@ static ARG_FILES: &str = "files";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let long_usage = long_usage();
 
     let matches = uu_app()
-        .override_usage(&usage[..])
         .after_help(&*format!(
             "{}\n{}",
             long_usage,
@@ -183,6 +177,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(backup_control::arguments::backup())
         .arg(backup_control::arguments::backup_no_args())

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -35,17 +35,13 @@ fn get_userlogin() -> Option<String> {
 
 static SUMMARY: &str = "Print user's login name";
 
-fn usage() -> &'static str {
-    uucore::execution_phrase()
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let _ = uu_app().override_usage(usage()).get_matches_from(args);
+    let _ = uu_app().get_matches_from(args);
 
     match get_userlogin() {
         Some(userlogin) => println!("{}", userlogin),
@@ -58,6 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
+        .override_usage(uucore::execution_phrase())
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -48,16 +48,14 @@ use uucore::{
 use unicode_width::UnicodeWidthStr;
 #[cfg(unix)]
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
-use uucore::{fs::display_permissions, version_cmp::version_cmp};
+use uucore::{format_usage, fs::display_permissions, version_cmp::version_cmp};
 
 #[cfg(not(feature = "selinux"))]
 static CONTEXT_HELP_TEXT: &str = "print any security context of each file (not enabled)";
 #[cfg(feature = "selinux")]
 static CONTEXT_HELP_TEXT: &str = "print any security context of each file";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
-}
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 
 pub mod options {
 
@@ -707,9 +705,7 @@ impl Config {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let app = uu_app().override_usage(&usage[..]);
+    let app = uu_app();
 
     let matches = app.get_matches_from(args);
 
@@ -726,6 +722,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
+        .override_usage(format_usage(USAGE))
         .about(
             "By default, ls will list the files and contents of any directories on \
             the command line, expect that it will ignore files and directories \

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -17,11 +17,13 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 #[cfg(not(windows))]
 use uucore::mode;
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static DEFAULT_PERM: u32 = 0o755;
 
 static ABOUT: &str = "Create the given DIRECTORY(ies) if they do not exist";
+const USAGE: &str = "{} [OPTION]... [USER]";
+
 mod options {
     pub const MODE: &str = "mode";
     pub const PARENTS: &str = "parents";
@@ -29,9 +31,6 @@ mod options {
     pub const DIRS: &str = "dirs";
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [USER]", uucore::execution_phrase())
-}
 fn get_long_usage() -> String {
     String::from("Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.")
 }
@@ -87,17 +86,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Before we can parse 'args' with clap (and previously getopts),
     // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").
     let mode_had_minus_prefix = strip_minus_from_mode(&mut args);
-
-    let usage = usage();
     let after_help = get_long_usage();
 
     // Linux-specific options, not implemented
     // opts.optflag("Z", "context", "set SELinux security context" +
     // " of each created directory to CTX"),
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let dirs = matches.values_of_os(options::DIRS).unwrap_or_default();
     let verbose = matches.is_present(options::VERBOSE);
@@ -113,6 +107,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::MODE)

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -12,10 +12,11 @@ use clap::{crate_version, App, AppSettings, Arg};
 use libc::mkfifo;
 use std::ffi::CString;
 use uucore::error::{UResult, USimpleError};
+use uucore::format_usage;
 use uucore::{display::Quotable, InvalidEncodingHandling};
 
 static NAME: &str = "mkfifo";
-static USAGE: &str = "mkfifo [OPTION]... NAME...";
+static USAGE: &str = "{} [OPTION]... NAME...";
 static SUMMARY: &str = "Create a FIFO with the given name.";
 
 mod options {
@@ -73,7 +74,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -15,10 +15,10 @@ use libc::{S_IFBLK, S_IFCHR, S_IFIFO, S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOT
 
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UResult, USimpleError, UUsageError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Create the special file NAME of the given TYPE.";
-static USAGE: &str = "mknod [OPTION]... NAME TYPE [MAJOR MINOR]";
+static USAGE: &str = "{} [OPTION]... NAME TYPE [MAJOR MINOR]";
 static LONG_HELP: &str = "Mandatory arguments to long options are mandatory for short options too.
 -m, --mode=MODE    set file permission bits to MODE, not a=rw - umask
 --help     display this help and exit
@@ -146,7 +146,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .after_help(LONG_HELP)
         .about(ABOUT)
         .setting(AppSettings::InferLongArgs)

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -11,6 +11,7 @@
 use clap::{crate_version, App, AppSettings, Arg};
 use uucore::display::{println_verbatim, Quotable};
 use uucore::error::{FromIo, UError, UResult};
+use uucore::format_usage;
 
 use std::env;
 use std::error::Error;
@@ -22,6 +23,7 @@ use rand::Rng;
 use tempfile::Builder;
 
 static ABOUT: &str = "create a temporary file or directory.";
+const USAGE: &str = "{} [OPTION]... [TEMPLATE]";
 
 static DEFAULT_TEMPLATE: &str = "tmp.XXXXXXXXXX";
 
@@ -33,10 +35,6 @@ static OPT_TMPDIR: &str = "tmpdir";
 static OPT_T: &str = "t";
 
 static ARG_TEMPLATE: &str = "template";
-
-fn usage() -> String {
-    format!("{0} [OPTION]... [TEMPLATE]", uucore::execution_phrase())
-}
 
 #[derive(Debug)]
 enum MkTempError {
@@ -76,9 +74,7 @@ impl Display for MkTempError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let template = matches.value_of(ARG_TEMPLATE).unwrap();
     let tmpdir = matches.value_of(OPT_TMPDIR).unwrap_or_default();
@@ -139,6 +135,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_DIRECTORY)

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -26,6 +26,7 @@ use std::path::{Path, PathBuf};
 use uucore::backup_control::{self, BackupMode};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 
 use fs_extra::dir::{move_dir, CopyOptions as DirCopyOptions};
 
@@ -51,6 +52,10 @@ pub enum OverwriteMode {
 
 static ABOUT: &str = "Move SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.";
 static LONG_HELP: &str = "";
+const USAGE: &str = "\
+    {} [OPTION]... [-T] SOURCE DEST
+    {} [OPTION]... SOURCE... DIRECTORY
+    {} [OPTION]... -t DIRECTORY SOURCE...";
 
 static OPT_FORCE: &str = "force";
 static OPT_INTERACTIVE: &str = "interactive";
@@ -63,26 +68,14 @@ static OPT_VERBOSE: &str = "verbose";
 
 static ARG_FILES: &str = "files";
 
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... [-T] SOURCE DEST
-{0} [OPTION]... SOURCE... DIRECTORY
-{0} [OPTION]... -t DIRECTORY SOURCE...",
-        uucore::execution_phrase()
-    )
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
     let matches = uu_app()
         .after_help(&*format!(
             "{}\n{}",
             LONG_HELP,
             backup_control::BACKUP_CONTROL_LONG_HELP
         ))
-        .override_usage(&usage[..])
         .get_matches_from(args);
 
     let files: Vec<OsString> = matches
@@ -123,6 +116,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
     .arg(
         backup_control::arguments::backup()

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -16,31 +16,26 @@ use std::io::Error;
 use std::ptr;
 
 use clap::{crate_version, App, AppSettings, Arg};
-use uucore::error::{set_exit_code, UResult, USimpleError, UUsageError};
+use uucore::{
+    error::{set_exit_code, UResult, USimpleError, UUsageError},
+    format_usage,
+};
 
 pub mod options {
     pub static ADJUSTMENT: &str = "adjustment";
     pub static COMMAND: &str = "COMMAND";
 }
 
-fn usage() -> String {
-    format!(
-        "
-  {0} [OPTIONS] [COMMAND [ARGS]]
-
-Run COMMAND with an adjusted niceness, which affects process scheduling.
-With no COMMAND, print the current niceness.  Niceness values range from at
-least -20 (most favorable to the process) to 19 (least favorable to the
-process).",
-        uucore::execution_phrase()
-    )
-}
+const ABOUT: &str = "\
+    Run COMMAND with an adjusted niceness, which affects process scheduling. \
+    With no COMMAND, print the current niceness.  Niceness values range from at \
+    least -20 (most favorable to the process) to 19 (least favorable to the \
+    process).";
+const USAGE: &str = "{} [OPTIONS] [COMMAND [ARGS]]";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let mut niceness = unsafe {
         nix::errno::Errno::clear();
@@ -109,6 +104,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::TrailingVarArg)
         .setting(AppSettings::InferLongArgs)
         .version(crate_version!())

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -14,13 +14,12 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::iter::repeat;
 use std::path::Path;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 mod helper;
 
 static NAME: &str = "nl";
-static USAGE: &str = "nl [OPTION]... [FILE]...";
-// A regular expression matching everything.
+static USAGE: &str = "{} [OPTION]... [FILE]...";
 
 // Settings store options used by nl to produce its output.
 pub struct Settings {
@@ -144,7 +143,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -11,6 +11,7 @@ use clap::{crate_version, App, AppSettings, Arg};
 use std::env;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
+use uucore::format_usage;
 
 #[cfg(target_os = "linux")]
 pub const _SC_NPROCESSORS_CONF: libc::c_int = 83;
@@ -25,15 +26,11 @@ static OPT_ALL: &str = "all";
 static OPT_IGNORE: &str = "ignore";
 
 static ABOUT: &str = "Print the number of cores available to the current process.";
-
-fn usage() -> String {
-    format!("{0} [OPTIONS]...", uucore::execution_phrase())
-}
+const USAGE: &str = "{} [OPTIONS]...";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let mut ignore = match matches.value_of(OPT_IGNORE) {
         Some(numstr) => match numstr.parse() {
@@ -75,6 +72,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_ALL)

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -15,6 +15,7 @@ use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::io::{BufRead, Write};
 use uucore::display::Quotable;
 use uucore::error::UResult;
+use uucore::format_usage;
 use uucore::ranges::Range;
 
 pub mod errors;
@@ -50,10 +51,7 @@ FIELDS supports cut(1) style field ranges:
   -    all fields
 Multiple fields/ranges can be separated with commas
 ";
-
-fn usage() -> String {
-    format!("{0} [OPTION]... [NUMBER]...", uucore::execution_phrase())
-}
+const USAGE: &str = "{} [OPTION]... [NUMBER]...";
 
 fn handle_args<'a>(args: impl Iterator<Item = &'a str>, options: &NumfmtOptions) -> UResult<()> {
     for l in args {
@@ -166,9 +164,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let options = parse_options(&matches).map_err(NumfmtError::IllegalArgument)?;
 
@@ -195,6 +191,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::AllowNegativeNumbers)
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -45,15 +45,17 @@ use crate::prn_char::format_ascii_dump;
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
+use uucore::format_usage;
 use uucore::parse_size::ParseSizeError;
 use uucore::InvalidEncodingHandling;
 
 const PEEK_BUFFER_SIZE: usize = 4; // utf-8 can be 4 bytes
 static ABOUT: &str = "dump files in octal and other formats";
 
-static USAGE: &str = r#"od [OPTION]... [--] [FILENAME]...
-    od [-abcdDefFhHiIlLoOsxX] [FILENAME] [[+][0x]OFFSET[.][b]]
-    od --traditional [OPTION]... [FILENAME] [[+][0x]OFFSET[.][b] [[+][0x]LABEL[.][b]]]"#;
+static USAGE: &str = "\
+    {} [OPTION]... [--] [FILENAME]...
+    {} [-abcdDefFhHiIlLoOsxX] [FILENAME] [[+][0x]OFFSET[.][b]]
+    {} --traditional [OPTION]... [FILENAME] [[+][0x]OFFSET[.][b] [[+][0x]LABEL[.][b]]]";
 
 static LONG_HELP: &str = r#"
 Displays data in various human-readable formats. If multiple formats are
@@ -289,7 +291,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .after_help(LONG_HELP)
         .setting(
             AppSettings::TrailingVarArg |

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::io::{ErrorKind, Write};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UResult, UUsageError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 // operating mode
 enum Mode {
@@ -24,6 +24,7 @@ enum Mode {
 }
 
 static ABOUT: &str = "Check whether file names are valid or portable";
+const USAGE: &str = "{} [OPTION]... NAME...";
 
 mod options {
     pub const POSIX: &str = "posix";
@@ -36,18 +37,13 @@ mod options {
 const POSIX_PATH_MAX: usize = 256;
 const POSIX_NAME_MAX: usize = 14;
 
-fn usage() -> String {
-    format!("{0} [OPTION]... NAME...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     // set working mode
     let is_posix = matches.values_of(options::POSIX).is_some();
@@ -92,6 +88,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::POSIX)

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -20,11 +20,12 @@ use std::os::unix::fs::MetadataExt;
 
 use clap::{crate_version, App, AppSettings, Arg};
 use std::path::PathBuf;
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 const BUFSIZE: usize = 1024;
 
 static ABOUT: &str = "pinky - lightweight finger";
+const USAGE: &str = "{} [OPTION]... [USER]...";
 
 mod options {
     pub const LONG_FORMAT: &str = "long_format";
@@ -37,10 +38,6 @@ mod options {
     pub const OMIT_NAME_HOST: &str = "omit_name_host";
     pub const OMIT_NAME_HOST_TIME: &str = "omit_name_host_time";
     pub const USER: &str = "user";
-}
-
-fn usage() -> String {
-    format!("{0} [OPTION]... [USER]...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -57,13 +54,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = usage();
     let after_help = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let users: Vec<String> = matches
         .values_of(options::USER)
@@ -136,6 +129,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::LONG_FORMAT)

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -9,23 +9,18 @@
 
 use clap::{crate_version, App, AppSettings, Arg};
 use std::env;
-use uucore::error::UResult;
+use uucore::{error::UResult, format_usage};
 
 static ABOUT: &str = "Display the values of the specified environment VARIABLE(s), or (with no VARIABLE) display name and value pairs for them all.";
+const USAGE: &str = "{} [VARIABLE]... [OPTION]...";
 
 static OPT_NULL: &str = "null";
 
 static ARG_VARIABLES: &str = "variables";
 
-fn usage() -> String {
-    format!("{0} [VARIABLE]... [OPTION]...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let variables: Vec<String> = matches
         .values_of(ARG_VARIABLES)
@@ -65,6 +60,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_NULL)

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -4,12 +4,12 @@
 
 use clap::{crate_version, App, AppSettings, Arg};
 use uucore::error::{UResult, UUsageError};
-use uucore::memo;
 use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, memo};
 
 const VERSION: &str = "version";
 const HELP: &str = "help";
-const USAGE: &str = "printf FORMATSTRING [ARGUMENT]...";
+const USAGE: &str = "{} FORMATSTRING [ARGUMENT]...";
 const ABOUT: &str = "Print output based off of the format string and proceeding arguments.";
 const AFTER_HELP: &str = "
 basic anonymous string templating:
@@ -294,7 +294,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(AFTER_HELP)
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .arg(Arg::new(HELP).long(HELP).help("Print help information"))
         .arg(
             Arg::new(VERSION)

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -19,15 +19,17 @@ use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::num::ParseIntError;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static NAME: &str = "ptx";
-static BRIEF: &str = "Usage: ptx [OPTION]... [INPUT]...   (without -G) or: \
-                 ptx -G [OPTION]... [INPUT [OUTPUT]] \n Output a permuted index, \
-                 including context, of the words in the input files. \n\n Mandatory \
-                 arguments to long options are mandatory for short options too.\n
-                 With no FILE, or when FILE is -, read standard input. \
-                Default is '-F /'.";
+const USAGE: &str = "\
+    {} [OPTION]... [INPUT]...
+    {} -G [OPTION]... [INPUT [OUTPUT]]";
+
+const ABOUT: &str = "\
+    Output a permuted index, including context, of the words in the input files. \n\n\
+    Mandatory arguments to long options are mandatory for short options too.\n\
+    With no FILE, or when FILE is -, read standard input. Default is '-F /'.";
 
 #[derive(Debug)]
 enum OutFormat {
@@ -703,8 +705,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
+        .about(ABOUT)
         .version(crate_version!())
-        .override_usage(BRIEF)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE)

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -9,11 +9,13 @@ use clap::{crate_version, App, AppSettings, Arg};
 use std::env;
 use std::io;
 use std::path::PathBuf;
+use uucore::format_usage;
 
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
 
 static ABOUT: &str = "Display the full filename of the current working directory.";
+const USAGE: &str = "{} [OPTION]... FILE...";
 static OPT_LOGICAL: &str = "logical";
 static OPT_PHYSICAL: &str = "physical";
 
@@ -120,15 +122,9 @@ fn logical_path() -> io::Result<PathBuf> {
     }
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
     let cwd = if matches.is_present(OPT_LOGICAL) {
         logical_path()
     } else {
@@ -156,6 +152,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_LOGICAL)

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -16,9 +16,11 @@ use std::io::{stdout, Write};
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
 
 const ABOUT: &str = "Print value of a symbolic link or canonical file name.";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 const OPT_CANONICALIZE: &str = "canonicalize";
 const OPT_CANONICALIZE_MISSING: &str = "canonicalize-missing";
 const OPT_CANONICALIZE_EXISTING: &str = "canonicalize-existing";
@@ -30,14 +32,9 @@ const OPT_ZERO: &str = "zero";
 
 const ARG_FILES: &str = "files";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let mut no_newline = matches.is_present(OPT_NO_NEWLINE);
     let use_zero = matches.is_present(OPT_ZERO);
@@ -102,6 +99,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_help(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_CANONICALIZE)

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -18,10 +18,12 @@ use std::{
 use uucore::{
     display::{print_verbatim, Quotable},
     error::{FromIo, UResult},
+    format_usage,
     fs::{canonicalize, MissingHandling, ResolveMode},
 };
 
 static ABOUT: &str = "print the resolved path";
+const USAGE: &str = "{} [OPTION]... FILE...";
 
 static OPT_QUIET: &str = "quiet";
 static OPT_STRIP: &str = "strip";
@@ -33,15 +35,9 @@ const OPT_CANONICALIZE_EXISTING: &str = "canonicalize-existing";
 
 static ARG_FILES: &str = "files";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     /*  the list of files */
 
@@ -78,6 +74,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_QUIET)

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -13,10 +13,11 @@ use std::path::{Path, PathBuf};
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Convert TO destination to the relative path from the FROM dir.
 If FROM path is omitted, current working dir will be used.";
+const USAGE: &str = "{} [-d DIR] TO [FROM]";
 
 mod options {
     pub const DIR: &str = "DIR";
@@ -24,18 +25,13 @@ mod options {
     pub const FROM: &str = "FROM";
 }
 
-fn usage() -> String {
-    format!("{} [-d DIR] TO [FROM]", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
-    let usage = usage();
 
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let to = Path::new(matches.value_of(options::TO).unwrap()).to_path_buf(); // required
     let from = match matches.value_of(options::FROM) {
@@ -86,6 +82,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::DIR).short('d').takes_value(true).help(
             "If any of FROM and TO is not subpath of DIR, output absolute path instead of relative",

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -19,6 +19,7 @@ use std::ops::BitOr;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 use walkdir::{DirEntry, WalkDir};
 
 #[derive(Eq, PartialEq, Clone, Copy)]
@@ -40,6 +41,7 @@ struct Options {
 }
 
 static ABOUT: &str = "Remove (unlink) the FILE(s)";
+const USAGE: &str = "{} [OPTION]... FILE...";
 static OPT_DIR: &str = "dir";
 static OPT_INTERACTIVE: &str = "interactive";
 static OPT_FORCE: &str = "force";
@@ -54,10 +56,6 @@ static OPT_VERBOSE: &str = "verbose";
 static PRESUME_INPUT_TTY: &str = "-presume-input-tty";
 
 static ARG_FILES: &str = "files";
-
-fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
-}
 
 fn get_long_usage() -> String {
     String::from(
@@ -78,13 +76,9 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let long_usage = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&long_usage[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -149,6 +143,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_FORCE)

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -16,24 +16,19 @@ use std::io;
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, strip_errno, UResult};
-use uucore::util_name;
+use uucore::{format_usage, util_name};
 
 static ABOUT: &str = "Remove the DIRECTORY(ies), if they are empty.";
+const USAGE: &str = "{} [OPTION]... DIRECTORY...";
 static OPT_IGNORE_FAIL_NON_EMPTY: &str = "ignore-fail-on-non-empty";
 static OPT_PARENTS: &str = "parents";
 static OPT_VERBOSE: &str = "verbose";
 
 static ARG_DIRS: &str = "dirs";
 
-fn usage() -> String {
-    format!("{0} [OPTION]... DIRECTORY...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let opts = Opts {
         ignore: matches.is_present(OPT_IGNORE_FAIL_NON_EMPTY),
@@ -179,6 +174,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(OPT_IGNORE_FAIL_NON_EMPTY)

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -4,6 +4,7 @@ use uucore::error::{UResult, UUsageError};
 
 use clap::{App, AppSettings, Arg};
 use selinux::{OpaqueSecurityContext, SecurityClass, SecurityContext};
+use uucore::format_usage;
 
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
@@ -18,6 +19,9 @@ use errors::{Error, Result, RunconError};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const ABOUT: &str = "Run command with specified security context.";
+const USAGE: &str = "\
+    {} [CONTEXT COMMAND [ARG...]]
+    {} [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]";
 const DESCRIPTION: &str = "Run COMMAND with completely-specified CONTEXT, or with current or \
                       transitioned security context modified by one or more of \
                       LEVEL, ROLE, TYPE, and USER.\n\n\
@@ -36,19 +40,9 @@ pub mod options {
     pub const RANGE: &str = "range";
 }
 
-fn get_usage() -> String {
-    format!(
-        "{0} [CONTEXT COMMAND [ARG...]]\n    \
-         {0} [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]",
-        uucore::execution_phrase()
-    )
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = get_usage();
-
-    let config = uu_app().override_usage(usage.as_ref());
+    let config = uu_app();
 
     let options = match parse_command_line(config, args) {
         Ok(r) => r,
@@ -114,6 +108,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(VERSION)
         .about(ABOUT)
         .after_help(DESCRIPTION)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::COMPUTE)

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -11,6 +11,7 @@ use num_traits::Zero;
 
 use uucore::error::FromIo;
 use uucore::error::UResult;
+use uucore::format_usage;
 use uucore::memo::Memo;
 
 mod error;
@@ -25,6 +26,10 @@ use crate::number::Number;
 use crate::number::PreciseNumber;
 
 static ABOUT: &str = "Display numbers from FIRST to LAST, in steps of INCREMENT.";
+const USAGE: &str = "\
+    {} [OPTION]... LAST
+    {} [OPTION]... FIRST LAST
+    {} [OPTION]... FIRST INCREMENT LAST";
 static OPT_SEPARATOR: &str = "separator";
 static OPT_TERMINATOR: &str = "terminator";
 static OPT_WIDTHS: &str = "widths";
@@ -32,14 +37,6 @@ static OPT_FORMAT: &str = "format";
 
 static ARG_NUMBERS: &str = "numbers";
 
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... LAST
-    {0} [OPTION]... FIRST LAST
-    {0} [OPTION]... FIRST INCREMENT LAST",
-        uucore::execution_phrase()
-    )
-}
 #[derive(Clone)]
 struct SeqOptions<'a> {
     separator: String,
@@ -60,8 +57,7 @@ type RangeFloat = (ExtendedBigDecimal, ExtendedBigDecimal, ExtendedBigDecimal);
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let numbers = matches.values_of(ARG_NUMBERS).unwrap().collect::<Vec<_>>();
 
@@ -150,6 +146,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .setting(AppSettings::InferLongArgs)
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .arg(
             Arg::new(OPT_SEPARATOR)
                 .short('s')

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -20,7 +20,7 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::{util_name, InvalidEncodingHandling};
+use uucore::{format_usage, util_name, InvalidEncodingHandling};
 
 #[macro_use]
 extern crate uucore;
@@ -214,10 +214,7 @@ impl<'a> BytesGenerator<'a> {
 static ABOUT: &str = "Overwrite the specified FILE(s) repeatedly, in order to make it harder\n\
 for even very expensive hardware probing to recover the data.
 ";
-
-fn usage() -> String {
-    format!("{} [OPTION]... FILE...", uucore::execution_phrase())
-}
+const USAGE: &str = "{} [OPTION]... FILE...";
 
 static AFTER_HELP: &str =
     "Delete FILE(s) if --remove (-u) is specified.  The default is not to remove\n\
@@ -273,11 +270,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = usage();
-
-    let app = uu_app().override_usage(&usage[..]);
-
-    let matches = app.get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     if !matches.is_present(options::FILE) {
         return Err(UUsageError::new(1, "missing file operand"));
@@ -326,6 +319,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(AFTER_HELP)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FORCE)

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{execution_phrase, InvalidEncodingHandling};
+use uucore::{format_usage, InvalidEncodingHandling};
 
 mod rand_read_adapter;
 
@@ -25,10 +25,14 @@ enum Mode {
 }
 
 static NAME: &str = "shuf";
-static USAGE: &str = r#"shuf [OPTION]... [FILE]
-    or:  shuf -e [OPTION]... [ARG]...
-    or:  shuf -i LO-HI [OPTION]..."#;
-static ABOUT: &str = "Shuffle the input by outputting a random permutation of input lines. Each output permutation is equally likely.";
+static USAGE: &str = "\
+    {} [OPTION]... [FILE]
+    {} -e [OPTION]... [ARG]...
+    {} -i LO-HI [OPTION]...";
+static ABOUT: &str = "\
+    Shuffle the input by outputting a random permutation of input lines.\
+    Each output permutation is equally likely.\
+    With no FILE, or when FILE is -, read standard input.";
 
 struct Options {
     head_count: usize,
@@ -55,9 +59,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = uu_app()
-        .override_usage(&USAGE.replace(NAME, execution_phrase())[..])
-        .get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let mode = if let Some(args) = matches.values_of(options::ECHO) {
         Mode::Echo(args.map(String::from).collect())
@@ -122,7 +124,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .name(NAME)
         .about(ABOUT)
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ECHO)

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -8,11 +8,17 @@
 use std::thread;
 use std::time::Duration;
 
-use uucore::error::{UResult, USimpleError};
+use uucore::{
+    error::{UResult, USimpleError},
+    format_usage,
+};
 
 use clap::{crate_version, App, AppSettings, Arg};
 
 static ABOUT: &str = "Pause for NUMBER seconds.";
+const USAGE: &str = "\
+    {} NUMBER[SUFFIX]...
+    {} OPTION";
 static LONG_HELP: &str = "Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the default),
 'm' for minutes, 'h' for hours or 'd' for days.  Unlike most implementations
 that require NUMBER be an integer, here NUMBER may be an arbitrary floating
@@ -23,19 +29,9 @@ mod options {
     pub const NUMBER: &str = "NUMBER";
 }
 
-fn usage() -> String {
-    format!(
-        "{0} {1}[SUFFIX]... \n    {0} OPTION",
-        uucore::execution_phrase(),
-        options::NUMBER
-    )
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     if let Some(values) = matches.values_of(options::NUMBER) {
         let numbers = values.collect::<Vec<_>>();
@@ -50,6 +46,7 @@ pub fn uu_app<'a>() -> App<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(LONG_HELP)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::NUMBER)

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -8,13 +8,13 @@
 #[macro_use]
 extern crate uucore;
 use uucore::display::Quotable;
-use uucore::entries;
 use uucore::error::{UResult, USimpleError};
 use uucore::fs::display_permissions;
 use uucore::fsext::{
     pretty_filetype, pretty_fstype, pretty_time, read_fs_list, statfs, BirthTime, FsMeta,
 };
 use uucore::libc::mode_t;
+use uucore::{entries, format_usage};
 
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::borrow::Cow;
@@ -87,6 +87,7 @@ macro_rules! print_adjusted {
 }
 
 static ABOUT: &str = "Display file or file system status.";
+const USAGE: &str = "{} [OPTION]... FILE...";
 
 pub mod options {
     pub static DEREFERENCE: &str = "dereference";
@@ -893,10 +894,6 @@ impl Stater {
     }
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
-}
-
 fn get_long_usage() -> String {
     String::from(
         "
@@ -957,13 +954,9 @@ for details about the options it supports.
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let long_usage = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&long_usage[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
 
     let stater = Stater::new(&matches)?;
     let exit_status = stater.exec();
@@ -978,6 +971,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::DEREFERENCE)

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -16,10 +16,10 @@ use std::io::{stdin, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static NAME: &str = "sum";
-static USAGE: &str = "sum [OPTION]... [FILE]...";
+static USAGE: &str = "{} [OPTION]... [FILE]...";
 static SUMMARY: &str = "Checksum and count the blocks in a file.\n\
                         With no FILE, or when  FILE is -, read standard input.";
 
@@ -144,7 +144,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -13,8 +13,10 @@ use clap::{crate_version, App, AppSettings, Arg};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
+use uucore::format_usage;
 
 static ABOUT: &str = "Synchronize cached writes to persistent storage";
+const USAGE: &str = "{} [OPTION]... FILE...";
 pub mod options {
     pub static FILE_SYSTEM: &str = "file-system";
     pub static DATA: &str = "data";
@@ -157,15 +159,9 @@ mod platform {
     }
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]... FILE...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let files: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -198,6 +194,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::FILE_SYSTEM)

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -19,13 +19,13 @@ use std::{
 use uucore::display::Quotable;
 use uucore::error::UError;
 use uucore::error::UResult;
-use uucore::show;
 use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, show};
 
 use crate::error::TacError;
 
 static NAME: &str = "tac";
-static USAGE: &str = "[OPTION]... [FILE]...";
+static USAGE: &str = "{} [OPTION]... [FILE]...";
 static SUMMARY: &str = "Write each file to standard output, last line first.";
 
 mod options {
@@ -64,7 +64,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -31,6 +31,7 @@ use std::thread::sleep;
 use std::time::Duration;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::format_usage;
 use uucore::lines::lines;
 use uucore::parse_size::{parse_size, ParseSizeError};
 use uucore::ringbuffer::RingBuffer;
@@ -47,7 +48,7 @@ const ABOUT: &str = "\
                      \n\
                      Mandatory arguments to long flags are mandatory for short flags too.\
                      ";
-const USAGE: &str = "tail [FLAG]... [FILE]...";
+const USAGE: &str = "{} [FLAG]... [FILE]...";
 
 pub mod options {
     pub mod verbosity {
@@ -277,7 +278,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES)

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -15,11 +15,13 @@ use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
 use std::path::PathBuf;
 use uucore::display::Quotable;
 use uucore::error::UResult;
+use uucore::format_usage;
 
 #[cfg(unix)]
 use uucore::libc;
 
 static ABOUT: &str = "Copy standard input to each FILE, and also to standard output.";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 
 mod options {
     pub const APPEND: &str = "append";
@@ -34,15 +36,9 @@ struct Options {
     files: Vec<String>,
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let options = Options {
         append: matches.is_present(options::APPEND),
@@ -63,6 +59,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .after_help("If a FILE is -, it refers to a file named - .")
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -15,12 +15,14 @@ use parser::{parse, Operator, Symbol, UnaryOperator};
 use std::ffi::{OsStr, OsString};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
+use uucore::format_usage;
 
-const USAGE: &str = "test EXPRESSION
-or:  test
-or:  [ EXPRESSION ]
-or:  [ ]
-or:  [ OPTION";
+const USAGE: &str = "\
+    {} EXPRESSION
+    {}
+    [ EXPRESSION ]
+    [ ]
+    [ OPTION";
 
 // We use after_help so that this comes after the usage string (it would come before if we used about)
 const AFTER_HELP: &str = "
@@ -92,7 +94,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .after_help(AFTER_HELP)
 }
 
@@ -109,7 +111,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
             App::new(binary_name)
                 .version(crate_version!())
                 .about(ABOUT)
-                .override_usage(USAGE)
+                .override_usage(format_usage(USAGE))
                 .after_help(AFTER_HELP)
                 // Disable printing of -h and -v as valid alternatives for --help and --version,
                 // since we don't recognize -h and -v as help/version flags.

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -20,16 +20,10 @@ use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::process::ChildExt;
 use uucore::signals::{signal_by_name_or_value, signal_name_by_value};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Start COMMAND, and kill it if still running after DURATION.";
-
-fn usage() -> String {
-    format!(
-        "{0} [OPTION] DURATION COMMAND...",
-        uucore::execution_phrase()
-    )
-}
+const USAGE: &str = "{} [OPTION] DURATION COMMAND...";
 
 const ERR_EXIT_STATUS: i32 = 125;
 
@@ -106,9 +100,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = usage();
-
-    let app = uu_app().override_usage(&usage[..]);
+    let app = uu_app();
 
     let matches = app.get_matches_from(args);
 
@@ -128,6 +120,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new("timeout")
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .arg(
             Arg::new(options::FOREGROUND)
                 .long(options::FOREGROUND)

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -19,8 +19,10 @@ use std::fs::{self, File};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
+use uucore::format_usage;
 
 static ABOUT: &str = "Update the access and modification times of each FILE to the current time.";
+const USAGE: &str = "{} [OPTION]... [USER]";
 pub mod options {
     // Both SOURCES and sources are needed as we need to be able to refer to the ArgGroup.
     pub static SOURCES: &str = "sources";
@@ -48,15 +50,9 @@ fn local_tm_to_filetime(tm: time::Tm) -> FileTime {
     FileTime::from_unix_time(ts.sec as i64, ts.nsec as u32)
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]... [USER]", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let files = matches.values_of_os(ARG_FILES).ok_or_else(|| {
         USimpleError::new(
@@ -149,6 +145,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ACCESS)

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -15,13 +15,14 @@ use clap::{crate_version, App, AppSettings, Arg};
 use nom::AsBytes;
 use operation::{translate_input, Sequence, SqueezeOperation, TranslateOperation};
 use std::io::{stdin, stdout, BufReader, BufWriter};
-use uucore::show;
+use uucore::{format_usage, show};
 
 use crate::operation::DeleteOperation;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::{display::Quotable, InvalidEncodingHandling};
 
 static ABOUT: &str = "translate or delete characters";
+const USAGE: &str = "{} [OPTION]... SET1 [SET2]";
 
 mod options {
     pub const COMPLEMENT: &str = "complement";
@@ -29,10 +30,6 @@ mod options {
     pub const SQUEEZE: &str = "squeeze-repeats";
     pub const TRUNCATE_SET1: &str = "truncate-set1";
     pub const SETS: &str = "sets";
-}
-
-fn get_usage() -> String {
-    format!("{} [OPTION]... SET1 [SET2]", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -47,13 +44,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let usage = get_usage();
     let after_help = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let delete_flag = matches.is_present(options::DELETE);
     let complement_flag = matches.is_present(options::COMPLEMENT);
@@ -148,6 +141,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .setting(AppSettings::InferLongArgs)
         .arg(

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -15,6 +15,7 @@ use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 use uucore::parse_size::{parse_size, ParseSizeError};
 
 #[derive(Debug, Eq, PartialEq)]
@@ -74,6 +75,7 @@ impl TruncateMode {
 }
 
 static ABOUT: &str = "Shrink or extend the size of each file to the specified size.";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 
 pub mod options {
     pub static IO_BLOCKS: &str = "io-blocks";
@@ -81,10 +83,6 @@ pub mod options {
     pub static REFERENCE: &str = "reference";
     pub static SIZE: &str = "size";
     pub static ARG_FILES: &str = "files";
-}
-
-fn usage() -> String {
-    format!("{0} [OPTION]... [FILE]...", uucore::execution_phrase())
 }
 
 fn get_long_usage() -> String {
@@ -111,11 +109,9 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let long_usage = get_long_usage();
 
     let matches = uu_app()
-        .override_usage(&usage[..])
         .after_help(&long_usage[..])
         .try_get_matches_from(args)
         .map_err(|e| {
@@ -146,6 +142,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::IO_BLOCKS)

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -12,7 +12,7 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static SUMMARY: &str = "Topological sort the strings in FILE.
 Strings are defined as any sequence of tokens separated by whitespace (tab, space, or newline).
@@ -96,7 +96,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::FILE).default_value("-").hide(true))

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -13,27 +13,22 @@ use clap::{crate_version, App, AppSettings, Arg};
 use std::ffi::CStr;
 use std::io::Write;
 use uucore::error::{UResult, UUsageError};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
+const USAGE: &str = "{} [OPTION]...";
 
 mod options {
     pub const SILENT: &str = "silent";
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let args = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
     let matches = uu_app()
-        .override_usage(&usage[..])
         .try_get_matches_from(args)
         .map_err(|e| UUsageError::new(2, format!("{}", e)))?;
 
@@ -75,6 +70,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SILENT)

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -12,9 +12,13 @@
 
 use clap::{crate_version, App, AppSettings, Arg};
 use platform_info::*;
-use uucore::error::{FromIo, UResult};
+use uucore::{
+    error::{FromIo, UResult},
+    format_usage,
+};
 
 const ABOUT: &str = "Print certain system information.  With no OPTION, same as -s.";
+const USAGE: &str = "{} [OPTION]...";
 
 pub mod options {
     pub static ALL: &str = "all";
@@ -49,8 +53,7 @@ const HOST_OS: &str = "Redox";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = format!("{} [OPTION]...", uucore::execution_phrase());
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let uname =
         PlatformInfo::new().map_err_context(|| "failed to create PlatformInfo".to_string())?;
@@ -122,6 +125,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::ALL)
             .short('a')

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -18,10 +18,10 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 static NAME: &str = "unexpand";
-static USAGE: &str = "unexpand [OPTION]... [FILE]...";
+static USAGE: &str = "{} [OPTION]... [FILE]...";
 static SUMMARY: &str = "Convert blanks in each FILE to tabs, writing to standard output.\n\
                         With no FILE, or when FILE is -, read standard input.";
 
@@ -106,7 +106,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .name(NAME)
         .version(crate_version!())
-        .override_usage(USAGE)
+        .override_usage(format_usage(USAGE))
         .about(SUMMARY)
         .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(options::FILE).hide(true).multiple_occurrences(true))

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -13,8 +13,10 @@ use std::str::FromStr;
 use strum_macros::{AsRefStr, EnumString};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::format_usage;
 
 static ABOUT: &str = "Report or omit repeated lines.";
+const USAGE: &str = "{} [OPTION]... [INPUT [OUTPUT]]...";
 pub mod options {
     pub static ALL_REPEATED: &str = "all-repeated";
     pub static CHECK_CHARS: &str = "check-chars";
@@ -239,13 +241,6 @@ fn opt_parsed<T: FromStr>(opt_name: &str, matches: &ArgMatches) -> UResult<Optio
     })
 }
 
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... [INPUT [OUTPUT]]...",
-        uucore::execution_phrase()
-    )
-}
-
 fn get_long_usage() -> String {
     String::from(
         "Filter adjacent matching lines from INPUT (or standard input),\n\
@@ -257,13 +252,9 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let long_usage = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&long_usage[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
         .values_of(ARG_FILES)
@@ -303,6 +294,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ALL_REPEATED)

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -11,6 +11,7 @@
 use chrono::{Local, TimeZone, Utc};
 use clap::{crate_version, App, AppSettings, Arg};
 
+use uucore::format_usage;
 // import crate time from utmpx
 pub use uucore::libc;
 use uucore::libc::time_t;
@@ -20,6 +21,7 @@ use uucore::error::{UResult, USimpleError};
 static ABOUT: &str = "Display the current time, the length of time the system has been up,\n\
                       the number of users on the system, and the average number of jobs\n\
                       in the run queue over the last 1, 5 and 15 minutes.";
+const USAGE: &str = "{} [OPTION]...";
 pub mod options {
     pub static SINCE: &str = "since";
 }
@@ -32,14 +34,9 @@ extern "C" {
     fn GetTickCount() -> uucore::libc::uint32_t;
 }
 
-fn usage() -> String {
-    format!("{0} [OPTION]...", uucore::execution_phrase())
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let (boot_time, user_count) = process_utmpx();
     let uptime = get_uptime(boot_time);
@@ -66,6 +63,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::SINCE)

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -12,15 +12,13 @@ use std::path::Path;
 
 use clap::{crate_version, App, AppSettings, Arg};
 use uucore::error::UResult;
+use uucore::format_usage;
 use uucore::utmpx::{self, Utmpx};
 
 static ABOUT: &str = "Print the user names of users currently logged in to the current host";
+const USAGE: &str = "{} [FILE]";
 
 static ARG_FILES: &str = "files";
-
-fn usage() -> String {
-    format!("{0} [FILE]", uucore::execution_phrase())
-}
 
 fn get_long_usage() -> String {
     format!(
@@ -32,13 +30,9 @@ If FILE is not specified, use {}.  /var/log/wtmp as FILE is common.",
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
     let after_help = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let files: Vec<&Path> = matches
         .values_of_os(ARG_FILES)
@@ -68,6 +62,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(Arg::new(ARG_FILES).takes_value(true).max_values(1))
 }

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -15,6 +15,7 @@ use count_fast::{count_bytes_and_lines_fast, count_bytes_fast};
 use countable::WordCountable;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
+use uucore::format_usage;
 use word_count::{TitledWordCount, WordCount};
 
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
@@ -81,7 +82,8 @@ impl Settings {
 }
 
 static ABOUT: &str = "Display newline, word, and byte counts for each FILE, and a total line if
-more than one FILE is specified.";
+more than one FILE is specified. With no FILE, or when FILE is -, read standard input.";
+const USAGE: &str = "{} [OPTION]... [FILE]...";
 
 pub mod options {
     pub static BYTES: &str = "bytes";
@@ -94,14 +96,6 @@ pub mod options {
 
 static ARG_FILES: &str = "files";
 static STDIN_REPR: &str = "-";
-
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... [FILE]...
- With no FILE, or when FILE is -, read standard input.",
-        uucore::execution_phrase()
-    )
-}
 
 enum StdinKind {
     /// Stdin specified on command-line with "-".
@@ -180,9 +174,7 @@ impl Display for WcError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let usage = usage();
-
-    let matches = uu_app().override_usage(&usage[..]).get_matches_from(args);
+    let matches = uu_app().get_matches_from(args);
 
     let inputs = inputs(&matches)?;
 
@@ -195,6 +187,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::BYTES)

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -17,7 +17,7 @@ use std::borrow::Cow;
 use std::ffi::CStr;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
-use uucore::InvalidEncodingHandling;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 mod options {
     pub const ALL: &str = "all";
@@ -38,18 +38,12 @@ mod options {
 }
 
 static ABOUT: &str = "Print information about users who are currently logged in.";
+const USAGE: &str = "{} [OPTION]... [ FILE | ARG1 ARG2 ]";
 
 #[cfg(any(target_os = "linux"))]
 static RUNLEVEL_HELP: &str = "print current runlevel";
 #[cfg(not(target_os = "linux"))]
 static RUNLEVEL_HELP: &str = "print current runlevel (This is meaningless on non Linux)";
-
-fn usage() -> String {
-    format!(
-        "{0} [OPTION]... [ FILE | ARG1 ARG2 ]",
-        uucore::execution_phrase()
-    )
-}
 
 fn get_long_usage() -> String {
     format!(
@@ -65,13 +59,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let usage = usage();
     let after_help = get_long_usage();
 
-    let matches = uu_app()
-        .override_usage(&usage[..])
-        .after_help(&after_help[..])
-        .get_matches_from(args);
+    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
         .values_of(options::FILE)
@@ -165,6 +155,7 @@ pub fn uu_app<'a>() -> App<'a> {
     App::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .setting(AppSettings::InferLongArgs)
         .arg(
             Arg::new(options::ALL)

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -15,9 +15,12 @@ extern crate clap;
 
 use clap::{App, AppSettings, Arg};
 use uucore::error::{UResult, USimpleError};
+use uucore::format_usage;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod splice;
+
+const USAGE: &str = "{} [STRING]...";
 
 // it's possible that using a smaller or larger buffer might provide better performance on some
 // systems, but honestly this is good enough
@@ -48,6 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app<'a>() -> App<'a> {
     app_from_crate!()
+        .override_usage(format_usage(USAGE))
         .arg(Arg::new("STRING").index(1).multiple_occurrences(true))
         .setting(AppSettings::InferLongArgs)
 }

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -94,6 +94,15 @@ macro_rules! bin {
     };
 }
 
+/// Generate the usage string for clap.
+///
+/// This function replaces all occurrences of `{}` with the execution phrase
+/// and leaks the result to return a `&'static str`. It does **not** support
+/// more advanced formatting features such as `{0}`.
+pub fn format_usage(s: &str) -> &'static str {
+    &*Box::leak(s.replace("{}", crate::execution_phrase()).into_boxed_str())
+}
+
 pub fn get_utility_is_second_arg() -> bool {
     crate::macros::UTILITY_IS_SECOND_ARG.load(Ordering::SeqCst)
 }


### PR DESCRIPTION
This should correct the usage strings in both the `--help` and user documentation. Previously, sometimes the name of the utils did not show up correctly, or the default `clap` usage was shown instead of the custom usage strings. The function intentionally leaks a string because of lifetimes, but I think that's fine because the function is only called once per execution. With this change, I could move the `override_usage` calls into the `uu_app` functions so that they're picked up by the docs.

With the [PR on multiline usage](https://github.com/uutils/coreutils/pull/3137), this should show the correct usage strings across all utils.