### PR TITLE
dd: don't error when outfile is /dev/null

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1095,3 +1095,10 @@ fn test_truncated_record() {
         .stdout_is("ac")
         .stderr_is("0+1 records in\n0+1 records out\n2 truncated records\n");
 }
+
+/// Test that the output file can be `/dev/null`.
+#[cfg(unix)]
+#[test]
+fn test_outfile_dev_null() {
+    new_ucmd!().arg("of=/dev/null").succeeds().no_stdout();
+}


### PR DESCRIPTION
Prevent `dd` from terminating with an error when given the
command-line argument `of=/dev/null`. This commit allows the call to
`File::set_len()` to result in an error without causing the process to
terminate prematurely.

Before this change:
```
$ : | ./target/debug/dd of=/dev/null
./target/debug/dd: failed to truncate output file: Invalid input
```

After this change:
```
$ : | ./target/debug/dd of=/dev/null
0+0 records in
0+0 records out
0 bytes (0 B, 0 B) copied, 0.0 s, 0 B/s
```

This matches the behavior of GNU `dd`.