### PR TITLE
Chown - Check for dangerous root operations through folders and symlinks

### DIFF
--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -241,7 +241,7 @@ impl ChownExecutor {
         //     (argument is symlink && should follow argument && resolved to be '/')
         // )
 
-        if self.is_dangerous(&path) {
+        if self.is_dangerous(path) {
             return 1;
         }
 
@@ -320,7 +320,7 @@ impl ChownExecutor {
             };
             let path = entry.path();
 
-            if self.is_dangerous(&path) {
+            if self.is_dangerous(path) {
                 return 1;
             }
 

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -212,7 +212,13 @@ impl ChownExecutor {
 
             if let Some(p) = may_exist {
                 if p.parent().is_none() {
-                    show_error!("it is dangerous to operate recursively on '/'");
+                    let display_path = if p == path {
+                        "'/'".to_owned()
+                    } else {
+                        format!("'{}' (same as '/')", path.display())
+                    };
+
+                    show_error!("it is dangerous to operate recursively on {}", display_path);
                     show_error!("use --no-preserve-root to override this failsafe");
                     return true;
                 }

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -85,7 +85,7 @@ fn test_preserve_root() {
             .arg("-R")
             .arg("bin").arg(d)
             .fails()
-            .stderr_is("chgrp: it is dangerous to operate recursively on '/'\nchgrp: use --no-preserve-root to override this failsafe");
+            .stderr_contains("chgrp: it is dangerous to operate recursively");
     }
 }
 
@@ -104,7 +104,7 @@ fn test_preserve_root_symlink() {
             .arg("-HR")
             .arg("bin").arg(file)
             .fails()
-            .stderr_is("chgrp: it is dangerous to operate recursively on '/'\nchgrp: use --no-preserve-root to override this failsafe");
+            .stderr_contains("chgrp: it is dangerous to operate recursively");
     }
 
     let (at, mut ucmd) = at_and_ucmd!();
@@ -113,7 +113,7 @@ fn test_preserve_root_symlink() {
         .arg("-HR")
         .arg("bin").arg(format!(".//{}/..//..//../../", file))
         .fails()
-        .stderr_is("chgrp: it is dangerous to operate recursively on '/'\nchgrp: use --no-preserve-root to override this failsafe");
+        .stderr_contains("chgrp: it is dangerous to operate recursively");
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.symlink_file("/", "/tmp/__root__");
@@ -121,7 +121,7 @@ fn test_preserve_root_symlink() {
         .arg("-R")
         .arg("bin").arg("/tmp/__root__/.")
         .fails()
-        .stderr_is("chgrp: it is dangerous to operate recursively on '/'\nchgrp: use --no-preserve-root to override this failsafe");
+        .stderr_contains("chgrp: it is dangerous to operate recursively");
 
     use std::fs;
     fs::remove_file("/tmp/__root__").unwrap();

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -83,7 +83,8 @@ fn test_preserve_root() {
         new_ucmd!()
             .arg("--preserve-root")
             .arg("-R")
-            .arg("bin").arg(d)
+            .arg("bin")
+            .arg(d)
             .fails()
             .stderr_contains("chgrp: it is dangerous to operate recursively");
     }
@@ -102,7 +103,8 @@ fn test_preserve_root_symlink() {
         at.symlink_file(d, file);
         ucmd.arg("--preserve-root")
             .arg("-HR")
-            .arg("bin").arg(file)
+            .arg("bin")
+            .arg(file)
             .fails()
             .stderr_contains("chgrp: it is dangerous to operate recursively");
     }
@@ -111,7 +113,8 @@ fn test_preserve_root_symlink() {
     at.symlink_file("///usr", file);
     ucmd.arg("--preserve-root")
         .arg("-HR")
-        .arg("bin").arg(format!(".//{}/..//..//../../", file))
+        .arg("bin")
+        .arg(format!(".//{}/..//..//../../", file))
         .fails()
         .stderr_contains("chgrp: it is dangerous to operate recursively");
 
@@ -119,7 +122,8 @@ fn test_preserve_root_symlink() {
     at.symlink_file("/", "/tmp/__root__");
     ucmd.arg("--preserve-root")
         .arg("-R")
-        .arg("bin").arg("/tmp/__root__/.")
+        .arg("bin")
+        .arg("/tmp/__root__/.")
         .fails()
         .stderr_contains("chgrp: it is dangerous to operate recursively");
 

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -3,8 +3,6 @@
 use crate::common::util::*;
 #[cfg(target_os = "linux")]
 use rust_users::get_effective_uid;
-#[cfg(unix)]
-use std::os::unix::fs::symlink as symlink_file;
 
 extern crate chown;
 
@@ -625,7 +623,7 @@ fn test_root_preserve_indirect() {
     let (at, mut ucmd) = at_and_ucmd!();
 
     at.mkdir("test");
-    symlink_file("/", "test/root");
+    at.symlink_file("/", "test/root");
 
     let result = ucmd
         .arg("-RL")

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -620,15 +620,24 @@ fn test_root_preserve() {
 #[test]
 #[cfg(unix)]
 fn test_root_preserve_indirect() {
-    let (at, mut ucmd) = at_and_ucmd!();
+    let scene = TestScenario::new(util_name!());
 
+    let result = scene.cmd("whoami").run();
+    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
+        return;
+    }
+    let user_name = String::from(result.stdout_str().trim());
+
+    assert!(!user_name.is_empty());
+
+    let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("test");
     at.symlink_file("/", "test/root");
 
     let result = ucmd
         .arg("-RL")
         .arg("--preserve-root")
-        .arg("1000")
+        .arg(user_name)
         .arg("test")
         .fails();
     result.stderr_contains(&"chown: it is dangerous to operate recursively");

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -3,6 +3,8 @@
 use crate::common::util::*;
 #[cfg(target_os = "linux")]
 use rust_users::get_effective_uid;
+#[cfg(unix)]
+use std::os::unix::fs::symlink as symlink_file;
 
 extern crate chown;
 
@@ -613,6 +615,23 @@ fn test_root_preserve() {
         .arg("-R")
         .arg(user_name)
         .arg("/")
+        .fails();
+    result.stderr_contains(&"chown: it is dangerous to operate recursively");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_root_preserve_indirect() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("test");
+    symlink_file("/", "test/root");
+
+    let result = ucmd
+        .arg("-RL")
+        .arg("--preserve-root")
+        .arg("1000")
+        .arg("test")
         .fails();
     result.stderr_contains(&"chown: it is dangerous to operate recursively");
 }


### PR DESCRIPTION
Resolves #1709. Chown will now check for recursive operations on `/`, even if these occur as part of a separate operation on a directory or symlink.

This should significantly speed up the GNU test suite. Right now, the test `chown/preserve-root` takes about 7 minutes to complete, because UUtils attempts to update the owner of every single file. With this PR, the operation is aborted in less than 1 second. 