### PR TITLE
CICD fixes/maintainence

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -160,34 +160,38 @@ jobs:
     - name: Compare test failures VS reference
       shell: bash
       run: |
+        have_new_failures=""
         REF_LOG_FILE='${{ steps.vars.outputs.path_reference }}/test-logs/test-suite.log'
         REF_SUMMARY_FILE='${{ steps.vars.outputs.path_reference }}/test-summary/gnu-result.json'
         if test -f "${REF_LOG_FILE}"; then
-          echo "Reference SHA1/ID (of '${REF_SUMMARY_FILE}'): $(sha1sum -- "${REF_SUMMARY_FILE}")"
+          echo "Reference SHA1/ID: $(sha1sum -- "${REF_SUMMARY_FILE}")"
           REF_FAILING=$(sed -n "s/^FAIL: \([[:print:]]\+\).*/\1/p" "${REF_LOG_FILE}" | sort)
           NEW_FAILING=$(sed -n "s/^FAIL: \([[:print:]]\+\).*/\1/p" '${{ steps.vars.outputs.path_GNU_tests }}/test-suite.log' | sort)
-          for LINE in $REF_FAILING
+          for LINE in ${REF_FAILING}
           do
-            if ! grep -Fxq $LINE<<<"$NEW_FAILING"; then
-              echo "::warning ::Congrats! The gnu test $LINE is now passing!"
+            if ! grep -Fxq ${LINE}<<<"${NEW_FAILING}"; then
+              echo "::warning ::Congrats! The gnu test ${LINE} is now passing!"
             fi
           done
-          for LINE in $NEW_FAILING
+          for LINE in ${NEW_FAILING}
           do
-            if ! grep -Fxq $LINE<<<"$REF_FAILING"
+            if ! grep -Fxq ${LINE}<<<"${REF_FAILING}"
             then
-              echo "::error ::GNU test failed: $LINE. $LINE is passing on '${{ steps.vars.outputs.repo_default_branch }}'. Maybe you have to rebase?"
+              echo "::error ::GNU test failed: ${LINE}. ${LINE} is passing on '${{ steps.vars.outputs.repo_default_branch }}'. Maybe you have to rebase?"
+              have_new_failures="true"
             fi
           done
         else
           echo "::warning ::Skipping test failure comparison; no prior reference test logs are available."
         fi
+        if test -n "${have_new_failures}" ; then exit -1 ; fi
     - name: Compare test summary VS reference
+      if: success() || failure() # run regardless of prior step success/failure
       shell: bash
       run: |
         REF_SUMMARY_FILE='${{ steps.vars.outputs.path_reference }}/test-summary/gnu-result.json'
         if test -f "${REF_SUMMARY_FILE}"; then
-          echo "Reference SHA1/ID (of '${REF_SUMMARY_FILE}'): $(sha1sum -- "${REF_SUMMARY_FILE}")"
+          echo "Reference SHA1/ID: $(sha1sum -- "${REF_SUMMARY_FILE}")"
           mv "${REF_SUMMARY_FILE}" main-gnu-result.json
           python uutils/util/compare_gnu_result.py
         else


### PR DESCRIPTION
- surfaces GnuTest test comparison failures more prominently
- removes GNU factor tests for 'debug' builds (which were failing due to "Termination" by timeout when using the debug version of `factor`)