### PR TITLE
dd: correct order and phrasing of truncated record

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -779,13 +779,15 @@ fn print_io_lines(update: &ProgUpdate) {
         "{}+{} records in",
         update.read_stat.reads_complete, update.read_stat.reads_partial
     );
-    if update.read_stat.records_truncated > 0 {
-        eprintln!("{} truncated records", update.read_stat.records_truncated);
-    }
     eprintln!(
         "{}+{} records out",
         update.write_stat.writes_complete, update.write_stat.writes_partial
     );
+    match update.read_stat.records_truncated {
+        0 => {}
+        1 => eprintln!("1 truncated record"),
+        n => eprintln!("{} truncated records", n),
+    }
 }
 // Print the progress line of a status update:
 // <byte-count> bytes (<base-1000-size>, <base-2-size>) copied, <time> s, <base-2-rate>/s

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1079,3 +1079,19 @@ fn test_skip_zero() {
         .no_stdout()
         .stderr_is("0+0 records in\n0+0 records out\n");
 }
+
+#[test]
+fn test_truncated_record() {
+    new_ucmd!()
+        .args(&["cbs=1", "conv=block", "status=noxfer"])
+        .pipe_in("ab")
+        .succeeds()
+        .stdout_is("a")
+        .stderr_is("0+1 records in\n0+1 records out\n1 truncated record\n");
+    new_ucmd!()
+        .args(&["cbs=1", "conv=block", "status=noxfer"])
+        .pipe_in("ab\ncd\n")
+        .succeeds()
+        .stdout_is("ac")
+        .stderr_is("0+1 records in\n0+1 records out\n2 truncated records\n");
+}


### PR DESCRIPTION
Place the "truncated records" line below the "records out" line in the
status report produced by `dd` and properly handle the singularization
of the word "record" in the case of 1 truncated record. This matches
the behavior of GNU `dd`.

For example

    $ printf "ab" | dd cbs=1 conv=block status=noxfer > /dev/null
    0+1 records in
    0+1 records out
    1 truncated record

    $ printf "ab\ncd\n" | dd cbs=1 conv=block status=noxfer > /dev/null
    0+1 records in
    0+1 records out
    2 truncated records