### PR TITLE
dd: pad partial record with spaces in some cases

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore fname, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, availible, behaviour, bmax, bremain, btotal, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, outfile, parseargs, rlen, rmax, rposition, rremain, rsofar, rstat, sigusr, sigval, wlen, wstat abcdefghijklm abcdefghi
+// spell-checker:ignore fname, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, availible, behaviour, bmax, bremain, btotal, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, outfile, parseargs, rlen, rmax, rposition, rremain, rsofar, rstat, sigusr, sigval, wlen, wstat abcdefghijklm abcdefghi nabcde nabcdefg abcdefg
 
 use crate::common::util::*;
 
@@ -1101,4 +1101,27 @@ fn test_truncated_record() {
 #[test]
 fn test_outfile_dev_null() {
     new_ucmd!().arg("of=/dev/null").succeeds().no_stdout();
+}
+
+#[test]
+fn test_block_sync() {
+    new_ucmd!()
+        .args(&["ibs=5", "cbs=5", "conv=block,sync", "status=noxfer"])
+        .pipe_in("012\nabcde\n")
+        .succeeds()
+        // blocks:    1    2
+        .stdout_is("012  abcde")
+        .stderr_is("2+0 records in\n0+1 records out\n");
+
+    // It seems that a partial record in is represented as an
+    // all-spaces block at the end of the output. The "1 truncated
+    // record" line is present in the status report due to the line
+    // "abcdefg\n" being truncated to "abcde".
+    new_ucmd!()
+        .args(&["ibs=5", "cbs=5", "conv=block,sync", "status=noxfer"])
+        .pipe_in("012\nabcdefg\n")
+        .succeeds()
+        // blocks:    1    2    3
+        .stdout_is("012  abcde     ")
+        .stderr_is("2+1 records in\n0+1 records out\n1 truncated record\n");
 }


### PR DESCRIPTION
If `conv=block,sync` command-line arguments are given and there is at
least one partial record read from the input (for example, if the
length of the input is not divisible by the value of the `ibs`
argument), then output an extra block of `cbs` spaces.

For example, no extra spaces are printed in this example because the
input is of length 10, a multiple of `ibs`:

    $ printf "012\nabcde\n" \
    > | dd ibs=5 cbs=5 conv=block,sync status=noxfer \
    > && echo $
    012  abcde$
    2+0 records in
    0+1 records out

But in this example, 5 extra spaces are printed because the length of
the input is not a multiple of `ibs`:

    $ printf "012\nabcdefg\n" \
    > | dd ibs=5 cbs=5 conv=block,sync status=noxfer \
    > && echo $
    012  abcde     $
    2+1 records in
    0+1 records out
    1 truncated record\n

The number of spaces printed is the size of the conversion block,
given by `cbs`.

(I came to this understanding of the program logic by reverse-engineering the output of GNU `dd`, so I may be wrong about it.)