### PR TITLE
include ---presume-input-pipe in head and tail

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -35,6 +35,7 @@ mod options {
     pub const VERBOSE_NAME: &str = "VERBOSE";
     pub const ZERO_NAME: &str = "ZERO";
     pub const FILES_NAME: &str = "FILE";
+    pub const PRESUME_INPUT_PIPE: &str = "-PRESUME-INPUT-PIPE";
 }
 mod parse;
 mod take;
@@ -93,6 +94,12 @@ pub fn uu_app<'a>() -> App<'a> {
                 .long("verbose")
                 .help("always print headers giving file names")
                 .overrides_with_all(&[options::QUIET_NAME, options::VERBOSE_NAME]),
+        )
+        .arg(
+            Arg::new(options::PRESUME_INPUT_PIPE)
+                .long("-presume-input-pipe")
+                .alias("-presume-input-pipe")
+                .hide(true),
         )
         .arg(
             Arg::new(options::ZERO_NAME)
@@ -173,6 +180,7 @@ struct HeadOptions {
     pub quiet: bool,
     pub verbose: bool,
     pub zeroed: bool,
+    pub presume_input_pipe: bool,
     pub mode: Mode,
     pub files: Vec<String>,
 }
@@ -187,6 +195,7 @@ impl HeadOptions {
         options.quiet = matches.is_present(options::QUIET_NAME);
         options.verbose = matches.is_present(options::VERBOSE_NAME);
         options.zeroed = matches.is_present(options::ZERO_NAME);
+        options.presume_input_pipe = matches.is_present(options::PRESUME_INPUT_PIPE);
 
         options.mode = Mode::from(&matches)?;
 
@@ -423,8 +432,8 @@ fn head_file(input: &mut std::fs::File, options: &HeadOptions) -> std::io::Resul
 fn uu_head(options: &HeadOptions) -> UResult<()> {
     let mut first = true;
     for file in &options.files {
-        let res = match file.as_str() {
-            "-" => {
+        let res = match (file.as_str(), options.presume_input_pipe) {
+            (_, true) | ("-", false) => {
                 if (options.files.len() > 1 && !options.quiet) || options.verbose {
                     if !first {
                         println!();
@@ -460,7 +469,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
                     }
                 }
             }
-            name => {
+            (name, false) => {
                 let mut file = match std::fs::File::open(name) {
                     Ok(f) => f,
                     Err(err) => {
@@ -551,6 +560,7 @@ mod tests {
         assert_eq!(options("-n 15").unwrap().mode, Mode::FirstLines(15));
         assert_eq!(options("--bytes 15").unwrap().mode, Mode::FirstBytes(15));
         assert_eq!(options("-c 15").unwrap().mode, Mode::FirstBytes(15));
+        assert!(options("---presume-input-pipe").unwrap().presume_input_pipe);
     }
     #[test]
     fn test_options_errors() {

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -63,6 +63,7 @@ pub mod options {
     pub static SLEEP_INT: &str = "sleep-interval";
     pub static ZERO_TERM: &str = "zero-terminated";
     pub static ARG_FILES: &str = "files";
+    pub static PRESUME_INPUT_PIPE: &str = "-presume-input-pipe";
 }
 
 #[derive(Debug)]
@@ -87,6 +88,7 @@ struct Settings {
     follow: bool,
     pid: platform::Pid,
     files: Vec<String>,
+    presume_input_pipe: bool,
 }
 
 impl Settings {
@@ -148,6 +150,7 @@ impl Settings {
 
         settings.verbose = matches.is_present(options::verbosity::VERBOSE);
         settings.quiet = matches.is_present(options::verbosity::QUIET);
+        settings.presume_input_pipe = matches.is_present(options::PRESUME_INPUT_PIPE);
 
         settings.files = match matches.values_of(options::ARG_FILES) {
             Some(v) => v.map(|s| s.to_owned()).collect(),
@@ -192,7 +195,7 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
         }
         first_header = false;
 
-        if use_stdin {
+        if use_stdin || settings.presume_input_pipe {
             let mut reader = BufReader::new(stdin());
             unbounded_tail(&mut reader, settings)?;
 
@@ -338,6 +341,12 @@ pub fn uu_app<'a>() -> App<'a> {
                 .short('z')
                 .long(options::ZERO_TERM)
                 .help("Line delimiter is NUL, not newline"),
+        )
+        .arg(
+            Arg::new(options::PRESUME_INPUT_PIPE)
+                .long(options::PRESUME_INPUT_PIPE)
+                .alias(options::PRESUME_INPUT_PIPE)
+                .hide(true),
         )
         .arg(
             Arg::new(options::ARG_FILES)

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -18,6 +18,15 @@ fn test_stdin_default() {
 }
 
 #[test]
+fn test_presume_input_pipe_default() {
+    new_ucmd!()
+        .args(&["---presume-input-pipe"])
+        .pipe_in_fixture(INPUT)
+        .run()
+        .stdout_is_fixture("lorem_ipsum_default.expected");
+}
+
+#[test]
 fn test_stdin_1_line_obsolete() {
     new_ucmd!()
         .args(&["-1"])
@@ -48,6 +57,15 @@ fn test_stdin_negative_23_line() {
 fn test_stdin_5_chars() {
     new_ucmd!()
         .args(&["-c", "5"])
+        .pipe_in_fixture(INPUT)
+        .run()
+        .stdout_is_fixture("lorem_ipsum_5_chars.expected");
+}
+
+#[test]
+fn test_presume_input_pipe_5_chars() {
+    new_ucmd!()
+        .args(&["-c", "5", "---presume-input-pipe"])
         .pipe_in_fixture(INPUT)
         .run()
         .stdout_is_fixture("lorem_ipsum_5_chars.expected");

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -24,6 +24,15 @@ fn test_stdin_default() {
 }
 
 #[test]
+fn test_presume_input_pipe_default() {
+    new_ucmd!()
+        .arg("---presume-input-pipe")
+        .pipe_in_fixture(FOOBAR_TXT)
+        .run()
+        .stdout_is_fixture("foobar_stdin_default.expected");
+}
+
+#[test]
 fn test_stdin_explicit() {
     new_ucmd!()
         .pipe_in_fixture(FOOBAR_TXT)


### PR DESCRIPTION
Closes #2907 

Include `---presume-input-pipe` option in head.rs and tail.rs