### PR TITLE
`df`: add support for `--output`

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -120,8 +120,11 @@ impl Options {
     }
 }
 
+/// Determine the fields to display based on the arguments.
 fn parse_field_selectors(matches: &ArgMatches) -> UResult<Vec<String>> {
     let mut field_selectors = vec![];
+    // Check for invalid or duplicate fields and throw the
+    // corresponding error.
     matches
         .values_of(OPT_OUTPUT)
         .unwrap()
@@ -140,22 +143,28 @@ fn parse_field_selectors(matches: &ArgMatches) -> UResult<Vec<String>> {
             }
             Ok(())
         })?;
-    if matches.is_present(OPT_PRINT_TYPE) {
-        field_selectors.insert(1, "fstype".to_string());
-    }
-    if matches.is_present(OPT_INODES) {
-        let inode_fields = [
-            "itotal".to_string(),
-            "iused".to_string(),
-            "iavail".to_string(),
-            "ipcent".to_string(),
-        ];
-        let type_offset = if matches.is_present(OPT_PRINT_TYPE) {
-            1
-        } else {
-            0
-        };
-        field_selectors.splice(1 + type_offset..5 + type_offset, inode_fields);
+    // This if check shouldn't be necessary - however, the
+    // `--output` argument, in spite of having `conficts_with_all`
+    // for -i, -T, and -P, fails to throw an error. The check stops
+    // -i or -T from displaying a duplicate column.
+    if matches.occurrences_of(OPT_OUTPUT) == 0 {
+        if matches.is_present(OPT_PRINT_TYPE) {
+            field_selectors.insert(1, "fstype".to_string());
+        }
+        if matches.is_present(OPT_INODES) {
+            let inode_fields = [
+                "itotal".to_string(),
+                "iused".to_string(),
+                "iavail".to_string(),
+                "ipcent".to_string(),
+            ];
+            let type_offset = if matches.is_present(OPT_PRINT_TYPE) {
+                1
+            } else {
+                0
+            };
+            field_selectors.splice(1 + type_offset..5 + type_offset, inode_fields);
+        }
     }
     Ok(field_selectors)
 }

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -109,7 +109,7 @@ impl From<Filesystem> for Row {
             inodes_usage: if files == 0 {
                 None
             } else {
-                Some(ffree as f64 / files as f64)
+                Some((files - ffree) as f64 / files as f64)
             },
         }
     }

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -271,7 +271,44 @@ impl fmt::Display for Header<'_> {
 mod tests {
 
     use crate::table::{DisplayRow, Header, Row};
-    use crate::Options;
+    use crate::{uu_app, Options};
+
+    #[test]
+    fn test_default_field_selector_parsing() {
+        let matches = uu_app().get_matches_from(vec!["df", "--output"]);
+        let options = Options::from(&matches).unwrap();
+        assert_eq!(
+            options.field_selectors,
+            vec![
+                "source", "fstype", "itotal", "iused", "iavail", "ipcent", "size", "used", "avail",
+                "pcent", "target",
+            ]
+        )
+    }
+
+    #[test]
+    fn test_specified_field_selector_parsing() {
+        let matches = uu_app().get_matches_from(vec![
+            "df",
+            "--output=target,pcent,avail,used,size,ipcent,iavail,iused,itotal,fstype,source",
+        ]);
+        let options = Options::from(&matches).unwrap();
+        assert_eq!(
+            options.field_selectors,
+            vec![
+                "target", "pcent", "avail", "used", "size", "ipcent", "iavail", "iused", "itotal",
+                "fstype", "source",
+            ]
+        )
+    }
+
+    #[test]
+    fn test_multiple_field_selector_parsing() {
+        let matches =
+            uu_app().get_matches_from(vec!["df", "--output=used", "--output", "--output=avail"]);
+        let options = Options::from(&matches).unwrap();
+        assert_eq!(options.field_selectors, vec!["used", "avail"])
+    }
 
     #[test]
     fn test_header_display() {
@@ -287,11 +324,8 @@ mod tests {
 
     #[test]
     fn test_header_display_fs_type() {
-        let options = Options {
-            human_readable_base: -1,
-            show_fs_type: true,
-            ..Default::default()
-        };
+        let matches = uu_app().get_matches_from(vec!["df", "--print-type"]);
+        let options = Options::from(&matches).unwrap();
         assert_eq!(
             Header::new(&options).to_string(),
             "Filesystem       Type     1k-blocks         Used    Available  Use% Mounted on       "
@@ -300,11 +334,8 @@ mod tests {
 
     #[test]
     fn test_header_display_inode() {
-        let options = Options {
-            human_readable_base: -1,
-            show_inode_instead: true,
-            ..Default::default()
-        };
+        let matches = uu_app().get_matches_from(vec!["df", "--inodes"]);
+        let options = Options::from(&matches).unwrap();
         assert_eq!(
             Header::new(&options).to_string(),
             "Filesystem             Inodes        IUsed        IFree IUse% Mounted on       "
@@ -367,11 +398,8 @@ mod tests {
 
     #[test]
     fn test_row_display_fs_type() {
-        let options = Options {
-            human_readable_base: -1,
-            show_fs_type: true,
-            ..Default::default()
-        };
+        let matches = uu_app().get_matches_from(vec!["df", "--print-type"]);
+        let options = Options::from(&matches).unwrap();
         let row = Row {
             fs_device: "my_device".to_string(),
             fs_type: "my_type".to_string(),
@@ -398,11 +426,8 @@ mod tests {
 
     #[test]
     fn test_row_display_inodes() {
-        let options = Options {
-            human_readable_base: -1,
-            show_inode_instead: true,
-            ..Default::default()
-        };
+        let matches = uu_app().get_matches_from(vec!["df", "--inodes"]);
+        let options = Options::from(&matches).unwrap();
         let row = Row {
             fs_device: "my_device".to_string(),
             fs_type: "my_type".to_string(),
@@ -429,11 +454,8 @@ mod tests {
 
     #[test]
     fn test_row_display_human_readable_si() {
-        let options = Options {
-            human_readable_base: 1000,
-            show_fs_type: true,
-            ..Default::default()
-        };
+        let matches = uu_app().get_matches_from(vec!["df", "--print-type", "-H"]);
+        let options = Options::from(&matches).unwrap();
         let row = Row {
             fs_device: "my_device".to_string(),
             fs_type: "my_type".to_string(),
@@ -460,11 +482,8 @@ mod tests {
 
     #[test]
     fn test_row_display_human_readable_binary() {
-        let options = Options {
-            human_readable_base: 1024,
-            show_fs_type: true,
-            ..Default::default()
-        };
+        let matches = uu_app().get_matches_from(vec!["df", "--print-type", "-h"]);
+        let options = Options::from(&matches).unwrap();
         let row = Row {
             fs_device: "my_device".to_string(),
             fs_type: "my_type".to_string(),

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -1,3 +1,4 @@
+// spell-checker:ignore itotal iused iavail ipcent pcent
 use crate::common::util::*;
 
 #[test]
@@ -37,24 +38,23 @@ fn test_df_output() {
     }
 }
 
+#[test]
+fn test_df_specified_output_selectors() {
+    new_ucmd!().arg("--output=target,pcent,avail,used,size,ipcent,iavail,iused,itotal,fstype,source").arg("-total").succeeds().
+    stdout_only("Mounted on        Use%    Available         Used    1k-blocks IUse%        IFree        IUsed       Inodes Type  Filesystem       \n");
+}
+
 /// Test that the order of rows in the table does not change across executions.
 #[test]
 fn test_order_same() {
-    // TODO When #3057 is resolved, we should just use
-    //
-    //     new_ucmd!().arg("--output=source").succeeds().stdout_move_str();
-    //
-    // instead of parsing the entire `df` table as a string.
-    let output1 = new_ucmd!().succeeds().stdout_move_str();
-    let output2 = new_ucmd!().succeeds().stdout_move_str();
-    let output1: Vec<String> = output1
-        .lines()
-        .map(|l| String::from(l.split_once(' ').unwrap().0))
-        .collect();
-    let output2: Vec<String> = output2
-        .lines()
-        .map(|l| String::from(l.split_once(' ').unwrap().0))
-        .collect();
+    let output1 = new_ucmd!()
+        .arg("--output=source")
+        .succeeds()
+        .stdout_move_str();
+    let output2 = new_ucmd!()
+        .arg("--output=source")
+        .succeeds()
+        .stdout_move_str();
     assert_eq!(output1, output2);
 }
 
@@ -70,6 +70,7 @@ fn test_output_option() {
     new_ucmd!().arg("--output").succeeds();
     new_ucmd!().arg("--output=source,target").succeeds();
     new_ucmd!().arg("--output=invalid_option").fails();
+    new_ucmd!().arg("--output=size,size").fails();
 }
 
 #[test]


### PR DESCRIPTION
I didn't include `file` in the field selectors, because it appears we don't have it yet.

I also don't have a Mac, so I wasn't able to directly see if my changes broke anything with the Capacity header (though the test still passes), and couldn't find anything about it being the `FIELD_LIST`.

The Display implementation changes keep the same indentations as before, but consequently it can make many rows be misaligned and hard to read. The misalignment already seemed to be a problem before, so I can go ahead and make an issue for it unless you want me to try and address it in this ticket.