### PR TITLE
tr: fix octal interpretation of repeat count string

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -279,7 +279,7 @@ impl Sequence {
         )(input)
         .map(|(l, (c, cnt_str))| {
             let result = if cnt_str.starts_with('0') {
-                match  usize::from_str_radix(cnt_str, 8) {
+                match usize::from_str_radix(cnt_str, 8) {
                     Ok(0) => Ok(Self::CharStar(c)),
                     Ok(count) => Ok(Self::CharRepeat(c, count)),
                     Err(_) => Err(BadSequence::InvalidRepeatCount(cnt_str.to_string())),
@@ -291,10 +291,7 @@ impl Sequence {
                     Err(_) => Err(BadSequence::InvalidRepeatCount(cnt_str.to_string())),
                 }
             };
-            (
-                l,
-                result,
-            )
+            (l, result)
         })
     }
 

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -870,6 +870,26 @@ fn check_against_gnu_tr_tests_o_rep_2() {
 }
 
 #[test]
+fn octal_repeat_count_test() {
+    //below will result in 8'x' and 4'y' as octal 010 = decimal 8
+    new_ucmd!()
+        .args(&["abcdefghijkl", "[x*010]y"])
+        .pipe_in("abcdefghijklmnop")
+        .succeeds()
+        .stdout_is("xxxxxxxxyyyymnop");
+}
+
+#[test]
+fn non_octal_repeat_count_test() {
+    //below will result in 10'x' and 2'y' as the 10 does not have 0 prefix
+    new_ucmd!()
+        .args(&["abcdefghijkl", "[x*10]y"])
+        .pipe_in("abcdefghijklmnop")
+        .succeeds()
+        .stdout_is("xxxxxxxxxxyymnop");
+}
+
+#[test]
 fn check_against_gnu_tr_tests_esc() {
     // ['esc', qw('a\-z' A-Z), {IN=>'abc-z'}, {OUT=>'AbcBC'}],
     new_ucmd!()

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore aabbaa aabbcc aabc abbb abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn 
+// spell-checker:ignore aabbaa aabbcc aabc abbb abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn
 use crate::common::util::*;
 
 #[test]

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore aabbaa aabbcc aabc abbb abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz
+// spell-checker:ignore aabbaa aabbcc aabc abbb abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn 
 use crate::common::util::*;
 
 #[test]

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -873,20 +873,20 @@ fn check_against_gnu_tr_tests_o_rep_2() {
 fn octal_repeat_count_test() {
     //below will result in 8'x' and 4'y' as octal 010 = decimal 8
     new_ucmd!()
-        .args(&["abcdefghijkl", "[x*010]y"])
-        .pipe_in("abcdefghijklmnop")
+        .args(&["ABCdefghijkl", "[x*010]Y"])
+        .pipe_in("ABCdefghijklmn12")
         .succeeds()
-        .stdout_is("xxxxxxxxyyyymnop");
+        .stdout_is("xxxxxxxxYYYYmn12");
 }
 
 #[test]
 fn non_octal_repeat_count_test() {
     //below will result in 10'x' and 2'y' as the 10 does not have 0 prefix
     new_ucmd!()
-        .args(&["abcdefghijkl", "[x*10]y"])
-        .pipe_in("abcdefghijklmnop")
+        .args(&["ABCdefghijkl", "[x*10]Y"])
+        .pipe_in("ABCdefghijklmn12")
         .succeeds()
-        .stdout_is("xxxxxxxxxxyymnop");
+        .stdout_is("xxxxxxxxxxYYmn12");
 }
 
 #[test]


### PR DESCRIPTION
Closes #3168 

Fix repeat count processing of `tr` to interpret as octal only if prefixed with `0`.