### PR TITLE
Improve coverage / error messages from `parse_size` PR

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -107,7 +107,7 @@ impl std::fmt::Display for ParseError {
                 write!(f, "ibs=N cannot fit into memory")
             }
             ParseError::ObsOutOfRange => {
-                write!(f, "ibs=N cannot fit into memory")
+                write!(f, "obs=N cannot fit into memory")
             }
             ParseError::CbsOutOfRange => {
                 write!(f, "cbs=N cannot fit into memory")

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -438,10 +438,10 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
                 // must be converted from u64 to usize to fit in memory. If such conversion fails,
                 // it means the platform doesn't have enough memory to hold the buffer, so we fail.
                 if let Mode::AllButLastLines(n) | Mode::AllButLastBytes(n) = options.mode {
-                    if let Err(n) = usize::try_from(n) {
+                    if let Err(e) = usize::try_from(n) {
                         show!(USimpleError::new(
                             1,
-                            format!("{}: number of bytes is too large", n)
+                            format!("{}: number of bytes is too large", e)
                         ));
                         continue;
                     };

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -652,7 +652,10 @@ where
     // bytes in the file. This ensures that we don't write empty
     // files. Otherwise, just write the `num_chunks - num_bytes` empty
     // files.
-    let metadata = metadata(&settings.input).unwrap();
+    let metadata = metadata(&settings.input).map_err(|_| {
+        USimpleError::new(1, format!("{}: cannot determine file size", settings.input))
+    })?;
+
     let num_bytes = metadata.len();
     let will_have_empty_files = settings.elide_empty_files && num_chunks > num_bytes;
     let (num_chunks, chunk_size) = if will_have_empty_files {

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -120,7 +120,7 @@ fn check_option(matches: &ArgMatches, name: &str) -> Result<BufferType, ProgramO
                 |m| {
                     Ok(BufferType::Size(m.try_into().map_err(|_| {
                         ProgramOptionsError(format!(
-                            "invalid mode {}: Value too large for defined data type",
+                            "invalid mode '{}': Value too large for defined data type",
                             x
                         ))
                     })?))

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -460,6 +460,20 @@ fn test_zeros_to_stdout() {
         .success();
 }
 
+#[cfg(target_pointer_width = "32")]
+#[test]
+fn test_oversized_bs_32_bit() {
+    for bs_param in &["bs", "ibs", "obs", "cbs"] {
+        new_ucmd!()
+            .args(&[format!("{}=5GB", bs_param)])
+            .run()
+            .no_stdout()
+            .failure()
+            .status_code(1)
+            .stderr_is(format!("dd: {}=N cannot fit into memory\n", bs_param));
+    }
+}
+
 #[test]
 fn test_to_stdout_with_ibs_obs() {
     let output: Vec<_> = String::from("y\n").bytes().cycle().take(1024).collect();

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -305,6 +305,16 @@ fn test_head_invalid_num() {
             new_ucmd!().args(&["-c", size]).succeeds();
         }
     }
+    #[cfg(target_pointer_width = "32")]
+    {
+        let sizes = ["-1000G", "-10T"];
+        for size in &sizes {
+            new_ucmd!()
+                .args(&["-c", size])
+                .fails()
+                .stderr_is("head: out of range integral type conversion attempted: number of bytes is too large");
+        }
+    }
     new_ucmd!()
         .args(&["-c", "-³"])
         .fails()

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -342,6 +342,31 @@ fn test_split_invalid_bytes_size() {
     }
 }
 
+#[test]
+fn test_split_chunks_num_chunks_oversized_32() {
+    #[cfg(target_pointer_width = "32")]
+    {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.touch("file");
+        scene
+            .ucmd()
+            .args(&["--number", "5000000000", "file"])
+            .fails()
+            .code_is(1)
+            .stderr_only("split: Number of chunks too big");
+    }
+}
+
+#[test]
+fn test_split_stdin_num_chunks() {
+    new_ucmd!()
+        .args(&["--number=1"])
+        .fails()
+        .code_is(1)
+        .stderr_only("split: -: cannot determine file size");
+}
+
 fn file_read(at: &AtPath, filename: &str) -> String {
     let mut s = String::new();
     at.open(filename).read_to_string(&mut s).unwrap();

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -75,5 +75,15 @@ fn test_stdbuf_invalid_mode_fails() {
             .fails()
             .code_is(125)
             .stderr_contains("stdbuf: invalid mode '1Y': Value too large for defined data type");
+        #[cfg(target_pointer_width = "32")]
+        {
+            new_ucmd!()
+                .args(&[*option, "5GB", "head"])
+                .fails()
+                .code_is(125)
+                .stderr_contains(
+                    "stdbuf: invalid mode '5GB': Value too large for defined data type",
+                );
+        }
     }
 }


### PR DESCRIPTION
https://github.com/uutils/coreutils/pull/3084 (2a333ab3919484c5a8cacb294e705dbc2408ce78) had some
missing coverage and was merged before I had a chance to fix it.

This PR adds some coverage / improved error messages that were missing
from that previous PR.