### PR TITLE
Rust 1.59 Clippy lints

### DIFF
--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -204,7 +204,7 @@ fn write_options(w: &mut impl Write, app: &App) -> io::Result<()> {
         writeln!(
             w,
             "<dd>\n\n{}\n\n</dd>",
-            arg.get_help().unwrap_or_default().replace("\n", "<br />")
+            arg.get_help().unwrap_or_default().replace('\n', "<br />")
         )?;
     }
     writeln!(w, "</dl>\n")

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1644,11 +1644,7 @@ fn test_ls_indicator_style() {
     // Same test as above, but with the alternate flags.
     let options = vec!["--classify", "--file-type", "-p"];
     for opt in options {
-        scene
-            .ucmd()
-            .arg(opt.to_string())
-            .succeeds()
-            .stdout_contains(&"/");
+        scene.ucmd().arg(opt).succeeds().stdout_contains(&"/");
     }
 
     // Classify and File-Type all contain indicators for pipes and links.

--- a/tests/by-util/test_relpath.rs
+++ b/tests/by-util/test_relpath.rs
@@ -64,7 +64,7 @@ const TESTS: [TestCase; 10] = [
 #[allow(clippy::needless_lifetimes)]
 fn convert_path<'a>(path: &'a str) -> Cow<'a, str> {
     #[cfg(windows)]
-    return path.replace("/", "\\").into();
+    return path.replace('/', "\\").into();
     #[cfg(not(windows))]
     return path.into();
 }


### PR DESCRIPTION
I think this clippy lint was improved with Rust 1.59 and therefore suddenly the CI fails.