### PR TITLE
strip release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,3 +401,6 @@ path = "src/bin/coreutils.rs"
 [[bin]]
 name = "uudoc"
 path = "src/bin/uudoc.rs"
+
+[profile.release]
+strip = true


### PR DESCRIPTION
The release of [Rust 1.59](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html#creating-stripped-binaries) brings support for [stripping binaries with Cargo](https://doc.rust-lang.org/beta/cargo/reference/profiles.html#strip). A local test on my machine brings the multicall binary built from `main` down from 13712424 bytes to 8328216, so about a 40% savings. I haven't tested the individual utils, but since each one is apparently bringing in at least the standard library's debug symbols, the savings will probably be pretty big. For earlier releases of Cargo, this will cause a (harmless) `unused manifest key` warning.