### PR TITLE
df: add support for --total option

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -309,7 +309,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect();
     println!("{}", Header::new(&opt));
     for row in data {
-        println!("{}", DisplayRow::new(row, &opt));
+        println!("{}", DisplayRow::new(&row, &opt));
     }
 
     Ok(())

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -120,7 +120,7 @@ impl From<Filesystem> for Row {
 /// The `options` control how the information in the row gets displayed.
 pub(crate) struct DisplayRow<'a> {
     /// The data in this row.
-    row: Row,
+    row: &'a Row,
 
     /// Options that control how to display the data.
     options: &'a Options,
@@ -135,7 +135,7 @@ pub(crate) struct DisplayRow<'a> {
 
 impl<'a> DisplayRow<'a> {
     /// Instantiate this struct.
-    pub(crate) fn new(row: Row, options: &'a Options) -> Self {
+    pub(crate) fn new(row: &'a Row, options: &'a Options) -> Self {
         Self { row, options }
     }
 
@@ -354,7 +354,7 @@ mod tests {
             inodes_usage: Some(0.2),
         };
         assert_eq!(
-            DisplayRow::new(row, &options).to_string(),
+            DisplayRow::new(&row, &options).to_string(),
             "my_device                 100           25           75   25% my_mount        "
         );
     }
@@ -385,7 +385,7 @@ mod tests {
             inodes_usage: Some(0.2),
         };
         assert_eq!(
-            DisplayRow::new(row, &options).to_string(),
+            DisplayRow::new(&row, &options).to_string(),
             "my_device        my_type          100           25           75   25% my_mount        "
         );
     }
@@ -416,7 +416,7 @@ mod tests {
             inodes_usage: Some(0.2),
         };
         assert_eq!(
-            DisplayRow::new(row, &options).to_string(),
+            DisplayRow::new(&row, &options).to_string(),
             "my_device                  10            2            8   20% my_mount        "
         );
     }
@@ -447,7 +447,7 @@ mod tests {
             inodes_usage: Some(0.2),
         };
         assert_eq!(
-            DisplayRow::new(row, &options).to_string(),
+            DisplayRow::new(&row, &options).to_string(),
             "my_device        my_type         4.0k         1.0k         3.0k   25% my_mount        "
         );
     }
@@ -478,7 +478,7 @@ mod tests {
             inodes_usage: Some(0.2),
         };
         assert_eq!(
-            DisplayRow::new(row, &options).to_string(),
+            DisplayRow::new(&row, &options).to_string(),
             "my_device        my_type        4.0Ki        1.0Ki        3.0Ki   25% my_mount        "
         );
     }

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -1,3 +1,4 @@
+// spell-checker:ignore udev
 use crate::common::util::*;
 
 #[test]
@@ -75,6 +76,49 @@ fn test_output_option() {
 #[test]
 fn test_type_option() {
     new_ucmd!().args(&["-t", "ext4", "-t", "ext3"]).succeeds();
+}
+
+#[test]
+fn test_total() {
+    // Example output:
+    //
+    //     Filesystem            1K-blocks     Used Available Use% Mounted on
+    //     udev                    3858016        0   3858016   0% /dev
+    //     ...
+    //     /dev/loop14               63488    63488         0 100% /snap/core20/1361
+    //     total                 258775268 98099712 148220200  40% -
+    let output = new_ucmd!().arg("--total").succeeds().stdout_move_str();
+
+    // Skip the header line.
+    let lines: Vec<&str> = output.lines().skip(1).collect();
+
+    // Parse the values from the last row.
+    let last_line = lines.last().unwrap();
+    let mut iter = last_line.split_whitespace();
+    assert_eq!(iter.next().unwrap(), "total");
+    let reported_total_size = iter.next().unwrap().parse().unwrap();
+    let reported_total_used = iter.next().unwrap().parse().unwrap();
+    let reported_total_avail = iter.next().unwrap().parse().unwrap();
+
+    // Loop over each row except the last, computing the sum of each column.
+    let mut computed_total_size = 0;
+    let mut computed_total_used = 0;
+    let mut computed_total_avail = 0;
+    let n = lines.len();
+    for line in &lines[..n - 1] {
+        let mut iter = line.split_whitespace();
+        iter.next().unwrap();
+        computed_total_size += iter.next().unwrap().parse::<u64>().unwrap();
+        computed_total_used += iter.next().unwrap().parse::<u64>().unwrap();
+        computed_total_avail += iter.next().unwrap().parse::<u64>().unwrap();
+    }
+
+    // Check that the sum of each column matches the reported value in
+    // the last row.
+    assert_eq!(computed_total_size, reported_total_size);
+    assert_eq!(computed_total_used, reported_total_used);
+    assert_eq!(computed_total_avail, reported_total_avail);
+    // TODO We could also check here that the use percentage matches.
 }
 
 // ToDO: more tests...


### PR DESCRIPTION
This pull request adds support for the `--total` option to `df`, which displays the total of each numeric column. For example,

    $ df --total
    Filesystem            1K-blocks     Used Available Use% Mounted on
    udev                    3858016        0   3858016   0% /dev
    ...
    /dev/loop14               63488    63488         0 100% /snap/core20/1361
    total                 258775268 98099712 148220200  40% -