### PR TITLE
Run GNU coverage job on pull requests

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -201,7 +201,6 @@ jobs:
   gnu_coverage:
     name: Run GNU tests with coverage
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Checkout code uutil
       uses: actions/checkout@v2


### PR DESCRIPTION
GNU coverage job now takes around one hour to finish thanks to contributors' work. Run it on pull requests to compare the GNU coverage report. https://github.com/uutils/coreutils/pull/3045#issuecomment-1058721351