### PR TITLE
timeout: add a test for empty arg

### DIFF
--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -45,3 +45,11 @@ fn test_zero_timeout() {
         .no_stderr()
         .no_stdout();
 }
+
+#[test]
+fn test_command_empty_args() {
+    new_ucmd!()
+        .args(&["", ""])
+        .fails()
+        .stderr_contains("timeout: empty string");
+}


### PR DESCRIPTION
To make sure we don't regress on https://github.com/uutils/coreutils/pull/3206
