### PR TITLE
df: always round up usage percentage (#3208)

### DIFF
--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -222,7 +222,7 @@ impl<'a> DisplayRow<'a> {
     fn percentage(fraction: Option<f64>) -> String {
         match fraction {
             None => "-".to_string(),
-            Some(x) => format!("{:.0}%", 100.0 * x),
+            Some(x) => format!("{:.0}%", (100.0 * x).ceil()),
         }
     }
 
@@ -549,6 +549,36 @@ mod tests {
         assert_eq!(
             DisplayRow::new(&row, &options).to_string(),
             "my_device        my_type        4.0Ki        1.0Ki        3.0Ki   25% my_mount        "
+        );
+    }
+
+    #[test]
+    fn test_row_display_round_up_usage() {
+        let options = Options {
+            block_size: BlockSize::Bytes(1),
+            ..Default::default()
+        };
+        let row = Row {
+            fs_device: "my_device".to_string(),
+            fs_type: "my_type".to_string(),
+            fs_mount: "my_mount".to_string(),
+
+            bytes: 100,
+            bytes_used: 25,
+            bytes_free: 75,
+            bytes_usage: Some(0.251),
+
+            #[cfg(target_os = "macos")]
+            bytes_capacity: Some(0.5),
+
+            inodes: 10,
+            inodes_used: 2,
+            inodes_free: 8,
+            inodes_usage: Some(0.2),
+        };
+        assert_eq!(
+            DisplayRow::new(row, &options).to_string(),
+            "my_device                 100           25           75   26% my_mount        "
         );
     }
 }

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -120,7 +120,40 @@ fn test_total() {
     assert_eq!(computed_total_size, reported_total_size);
     assert_eq!(computed_total_used, reported_total_used);
     assert_eq!(computed_total_avail, reported_total_avail);
-    // TODO We could also check here that the use percentage matches.
+}
+
+#[test]
+fn test_use_percentage() {
+    // Example output:
+    //
+    //     Filesystem            1K-blocks     Used Available Use% Mounted on
+    //     udev                    3858016        0   3858016   0% /dev
+    //     ...
+    //     /dev/loop14               63488    63488         0 100% /snap/core20/1361
+    let output = new_ucmd!().succeeds().stdout_move_str();
+
+    // Skip the header line.
+    let lines: Vec<&str> = output.lines().skip(1).collect();
+
+    for line in lines {
+        let mut iter = line.split_whitespace();
+        iter.next();
+        let reported_size = iter.next().unwrap().parse::<f64>().unwrap();
+        let reported_used = iter.next().unwrap().parse::<f64>().unwrap();
+        // Skip "Available" column
+        iter.next();
+        if cfg!(target_os = "macos") {
+            // Skip "Capacity" column
+            iter.next();
+        }
+        let reported_percentage = iter.next().unwrap();
+        let reported_percentage = reported_percentage[..reported_percentage.len() - 1]
+            .parse::<u8>()
+            .unwrap();
+        let computed_percentage = (100.0 * (reported_used / reported_size)).ceil() as u8;
+
+        assert_eq!(computed_percentage, reported_percentage);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Always round up the usage percent. For example, `25.1%` is now rounded to `26%,` previously it was rounded to `25%.`