### PR TITLE
timeout: fix bug in --preserve-status mode

### DIFF
--- a/src/uu/timeout/src/status.rs
+++ b/src/uu/timeout/src/status.rs
@@ -1,0 +1,51 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+//! Exit status codes produced by `timeout`.
+use std::convert::From;
+use uucore::error::UError;
+
+/// Enumerates the exit statuses produced by `timeout`.
+///
+/// Use [`Into::into`] (or [`From::from`]) to convert an enumeration
+/// member into a numeric status code. You can also convert into a
+/// [`UError`].
+///
+/// # Examples
+///
+/// Convert into an [`i32`]:
+///
+/// ```rust,ignore
+/// assert_eq!(i32::from(ExitStatus::CommandTimedOut), 124);
+/// ```
+pub(crate) enum ExitStatus {
+    /// When the child process times out and `--preserve-status` is not specified.
+    CommandTimedOut,
+
+    /// When `timeout` itself fails.
+    TimeoutFailed,
+
+    /// When a signal is sent to the child process or `timeout` itself.
+    SignalSent(usize),
+
+    /// When there is a failure while waiting for the child process to terminate.
+    WaitingFailed,
+}
+
+impl From<ExitStatus> for i32 {
+    fn from(exit_status: ExitStatus) -> Self {
+        match exit_status {
+            ExitStatus::CommandTimedOut => 124,
+            ExitStatus::TimeoutFailed => 125,
+            ExitStatus::SignalSent(s) => 128 + s as Self,
+            ExitStatus::WaitingFailed => 124,
+        }
+    }
+}
+
+impl From<ExitStatus> for Box<dyn UError> {
+    fn from(exit_status: ExitStatus) -> Self {
+        Box::from(i32::from(exit_status))
+    }
+}

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -282,7 +282,13 @@ fn timeout(
             report_if_verbose(signal, &cmd[0], verbose);
             process.send_signal(signal)?;
             match kill_after {
-                None => Err(ExitStatus::CommandTimedOut.into()),
+                None => {
+                    if preserve_status {
+                        Err(ExitStatus::SignalSent(signal).into())
+                    } else {
+                        Err(ExitStatus::CommandTimedOut.into())
+                    }
+                }
                 Some(kill_after) => {
                     match wait_or_kill_process(
                         process,

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -53,3 +53,14 @@ fn test_command_empty_args() {
         .fails()
         .stderr_contains("timeout: empty string");
 }
+
+#[test]
+fn test_preserve_status() {
+    new_ucmd!()
+        .args(&["--preserve-status", ".1", "sleep", "10"])
+        .fails()
+        // 128 + SIGTERM = 128 + 15
+        .code_is(128 + 15)
+        .no_stderr()
+        .no_stdout();
+}


### PR DESCRIPTION
This pull request fixes a bug where `timeout --preserve-status` was not correctly preserving the status code of the child process if it timed out. When that happens, the status code of the child process is considered to be the signal number (in this case, `SIGTERM`). The exit status of `timeout` is then 128 plus the numeric code associated with `SIGTERM`.

Before this pull request:
```
$ ./target/release/timeout --preserve-status .1 sleep 10; echo $?
124
```
After this pull request 
```
$ ./target/release/timeout --preserve-status .1 sleep 10; echo $?
143
```
This now matches the behavior of GNU timeout.

This pull request also includes a commit that adds the `ExitStatus` enumeration in a new module `status.rs` to
contain all the magic numbers in the `timeout` utility.