### PR TITLE
df: move Filesystem to filesystem.rs

### DIFF
--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -2,6 +2,11 @@
 //  *
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
+//! Provides a summary representation of a filesystem.
+//!
+//! A [`Filesystem`] struct represents a device containing a
+//! filesystem mounted at a particular directory. It also includes
+//! information on amount of space available and amount of space used.
 #[cfg(windows)]
 use std::path::Path;
 
@@ -9,9 +14,19 @@ use std::path::Path;
 use uucore::fsext::statfs;
 use uucore::fsext::{FsUsage, MountInfo};
 
+/// Summary representation of a filesystem.
+///
+/// A [`Filesystem`] struct represents a device containing a
+/// filesystem mounted at a particular directory. The
+/// [`Filesystem::mount_info`] field exposes that information. The
+/// [`Filesystem::usage`] field provides information on the amount of
+/// space available on the filesystem and the amount of space used.
 #[derive(Debug, Clone)]
 pub(crate) struct Filesystem {
+    /// Information about the mounted device, mount directory, and related options.
     pub mount_info: MountInfo,
+
+    /// Information about the amount of space used on the filesystem.
     pub usage: FsUsage,
 }
 

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -1,0 +1,40 @@
+//  * This file is part of the uutils coreutils package.
+//  *
+//  * For the full copyright and license information, please view the LICENSE
+//  * file that was distributed with this source code.
+#[cfg(windows)]
+use std::path::Path;
+
+#[cfg(unix)]
+use uucore::fsext::statfs;
+use uucore::fsext::{FsUsage, MountInfo};
+
+#[derive(Debug, Clone)]
+pub(crate) struct Filesystem {
+    pub mount_info: MountInfo,
+    pub usage: FsUsage,
+}
+
+impl Filesystem {
+    // TODO: resolve uuid in `mount_info.dev_name` if exists
+    pub(crate) fn new(mount_info: MountInfo) -> Option<Self> {
+        let _stat_path = if !mount_info.mount_dir.is_empty() {
+            mount_info.mount_dir.clone()
+        } else {
+            #[cfg(unix)]
+            {
+                mount_info.dev_name.clone()
+            }
+            #[cfg(windows)]
+            {
+                // On windows, we expect the volume id
+                mount_info.dev_id.clone()
+            }
+        };
+        #[cfg(unix)]
+        let usage = FsUsage::new(statfs(_stat_path).ok()?);
+        #[cfg(windows)]
+        let usage = FsUsage::new(Path::new(&_stat_path));
+        Some(Self { mount_info, usage })
+    }
+}

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -12,7 +12,8 @@
 use number_prefix::NumberPrefix;
 
 use crate::columns::Column;
-use crate::{BlockSize, Filesystem, Options};
+use crate::filesystem::Filesystem;
+use crate::{BlockSize, Options};
 use uucore::fsext::{FsUsage, MountInfo};
 
 use std::fmt;


### PR DESCRIPTION
This pull request moves the `Filesystem` struct into a new module `filesystem.rs`. There are on other changes to the code; this move is just in preparation for some further refactors to improve the code readability.