### PR TITLE
Setup `cargo-deny`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -20,6 +20,13 @@ env:
 on: [push, pull_request]
 
 jobs:
+  cargo-deny:
+    name: Style/cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
   style_deps:
     ## ToDO: [2021-11-10; rivy] 'Style/deps' needs more informative output and better integration of results into the GHA dashboard
     name: Style/deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,16 @@ uutils: add new utility
 gitignore: add temporary files
 ```
 
+## cargo-deny
+
+This project uses [cargo-deny](https://github.com/EmbarkStudios/cargo-deny/) to
+detect duplicate dependencies, checks licenses, etc. To run it locally, first
+install it and then run with:
+
+```
+cargo deny --all-features check all
+```
+
 ## Licensing
 
 uutils is distributed under the terms of the MIT License; see the `LICENSE` file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37978dab2ca789938a83b2f8bc1ef32db6633af9051a6cd409eff72cbaaa79a"
 dependencies = [
- "paste 1.0.6",
+ "paste",
 ]
 
 [[package]]
@@ -1433,28 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
 
 [[package]]
 name = "peeking_take_while"
@@ -1573,12 +1554,6 @@ dependencies = [
  "quote 1.0.14",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -2559,7 +2534,7 @@ dependencies = [
  "clap 3.0.10",
  "coz",
  "num-traits",
- "paste 0.1.18",
+ "paste",
  "quickcheck",
  "rand",
  "smallvec",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,74 @@
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "warn"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+]
+copyleft = "allow"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+exceptions = [
+    { allow = ["OpenSSL"], name = "ring" },
+]
+
+[[licenses.clarify]]
+name = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+highlight = "all"
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    # duplicated in blake2d_simd / blake3
+    { name = "arrayvec", version = "=0.7.2" },
+    # duplicated in flimit/unix_socket (many others use 1.0.0)
+    { name = "cfg-if", version = "=0.1.10" },
+    # duplicated in ordered-multimap (many others use 0.11.2)
+    { name = "hashbrown", version = "=0.9.1" },
+    # duplicated in kernel32-sys (many others use 0.3.9)
+    { name = "winapi", version = "=0.2.8" },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -22,10 +22,12 @@ allow = [
     "Apache-2.0",
     "ISC",
     "BSD-2-Clause",
+    "BSD-2-Clause-FreeBSD",
     "BSD-3-Clause",
     "CC0-1.0",
+    "MPL-2.0", # XXX considered copyleft?
 ]
-copyleft = "allow"
+copyleft = "deny"
 allow-osi-fsf-free = "neither"
 default = "deny"
 confidence-threshold = 0.8
@@ -52,16 +54,29 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 multiple-versions = "deny"
 wildcards = "allow"
 highlight = "all"
-# Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    # duplicated in blake2d_simd / blake3
+    # blake2d_simd uses an old version
     { name = "arrayvec", version = "=0.7.2" },
-    # duplicated in flimit/unix_socket (many others use 1.0.0)
+    # flimit/unix_socket use old versions
     { name = "cfg-if", version = "=0.1.10" },
-    # duplicated in ordered-multimap (many others use 0.11.2)
+    # ordered-multimap uses an old version
     { name = "hashbrown", version = "=0.9.1" },
-    # duplicated in kernel32-sys (many others use 0.3.9)
+    # kernel32-sys uses an old version
     { name = "winapi", version = "=0.2.8" },
+    # bindgen 0.59.2 uses an old version of clap, which in turn uses other old dependencies
+    { name = "clap", version = "=2.34.0" },
+    { name = "strsim", version = "=0.8.0" },
+    { name = "textwrap", version = "=0.11.0" },
+    # cpp_common uses an old version
+    { name = "cpp_common", version = "=0.4.0" },
+    # quickcheck uses an old version
+    { name = "env_logger", version = "=0.8.4" },
+    # cpp_ crates uses old stuff
+    { name = "memchr", version = "=1.0.2" },
+    { name = "quote", version = "=0.3.15" },
+    { name = "unicode-xid", version = "=0.0.4" },
+    # exacl uses an old version
+    { name = "nix", version = "=0.21.0" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,5 @@
+# spell-checker:ignore SSLeay RUSTSEC
+
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
@@ -54,30 +56,34 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 multiple-versions = "deny"
 wildcards = "allow"
 highlight = "all"
+
+# For each duplicate dependency, indicate the name of the dependency which
+# introduces it.
+# spell-checker: disable
 skip = [
-    # blake2d_simd uses an old version
+    # blake2d_simd
     { name = "arrayvec", version = "=0.7.2" },
-    # flimit/unix_socket use old versions
+    # flimit/unix_socket
     { name = "cfg-if", version = "=0.1.10" },
-    # ordered-multimap uses an old version
+    # ordered-multimap
     { name = "hashbrown", version = "=0.9.1" },
-    # kernel32-sys uses an old version
+    # kernel32-sys
     { name = "winapi", version = "=0.2.8" },
-    # bindgen 0.59.2 uses an old version of clap, which in turn uses other old dependencies
+    # bindgen 0.59.2
     { name = "clap", version = "=2.34.0" },
     { name = "strsim", version = "=0.8.0" },
     { name = "textwrap", version = "=0.11.0" },
-    # cpp_common uses an old version
     { name = "cpp_common", version = "=0.4.0" },
-    # quickcheck uses an old version
+    # quickcheck
     { name = "env_logger", version = "=0.8.4" },
-    # cpp_ crates uses old stuff
+    # cpp_*
     { name = "memchr", version = "=1.0.2" },
     { name = "quote", version = "=0.3.15" },
     { name = "unicode-xid", version = "=0.0.4" },
-    # exacl uses an old version
+    # exacl
     { name = "nix", version = "=0.21.0" },
 ]
+# spell-checker: enable
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -23,7 +23,7 @@ smallvec = "1.7"  # TODO(nicoo): Use `union` feature, requires Rust 1.49 or late
 uucore = { version = ">=0.0.8", package = "uucore", path = "../../uucore" }
 
 [dev-dependencies]
-paste = "0.1.18"
+paste = "1.0.6"
 quickcheck = "1.0.3"
 
 [[bin]]


### PR DESCRIPTION
This sets up [cargo-deny](https://github.com/EmbarkStudios/cargo-deny/), a cargo tool that allows going through all the transitive dependencies, and check for allowed licenses, security advisories in those, duplicate dependencies, etc.

Full available configuration is documented on https://embarkstudios.github.io/cargo-deny/checks/index.html. I've kept only the bare minimum set of options that make it useful in my opinion:

- set up a list of allowed licenses (that reflect which licenses are currently in use in the project), and deny other licenses
- detect transitive duplicate dependencies, and allow-list all the ones that don't depend on this project but on other dependencies.
  - this helped find one duplicate dependency which we controlled, and I could remove it easily (first commit in that PR)
- display rustsec advisories as warnings in the output, but don't cause errors and hard block on them, as this can cause CI failures in unexpected ways

Also sets up CI to run it automatically, and added small instructions in the `CONTRIBUTING.md` file to explain how to run locally.