### PR TITLE
GNU ci: compress logs before upload

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -137,6 +137,8 @@ jobs:
             echo "::error ::Failed to find summary of test results (missing '${SUITE_LOG_FILE}'); failing early"
             exit 1
           fi
+          # Compress logs before upload (fails otherwise)
+          gzip ${{ steps.vars.outputs.TEST_LOGS_GLOB }}
     - name: Reserve SHA1/ID of 'test-summary'
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Failed with 
```
A 500 status code has been received, will attempt to retry the upload
Exponential backoff for retry #1. Waiting for 5416 milliseconds before continuing the upload at offset 0
An error has been caught http-client index 0, retrying the upload
Error: Client has already been disposed.
    at HttpClient.request (/home/runner/work/_actions/actions/upload-artifact/v2/dist/index.js:6081:19)
    at HttpClient.sendStream (/home/runner/work/_actions/actions/upload-artifact/v2/dist/index.js:6042:21)
    at UploadHttpClient.<anonymous> (/home/runner/work/_actions/actions/upload-artifact/v2/dist/index.js:7208:37)
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/actions/upload-artifact/v2/dist/index.js:6923:71
    at new Promise (<anonymous>)
    at module.exports.608.__awaiter (/home/runner/work/_actions/actions/upload-artifact/v2/dist/index.js:6919:12)
    at uploadChunkRequest (/home/runner/work/_actions/actions/upload-artifact/v2/dist/index.js:7206:46)
    at UploadHttpClient.<anonymous> (/home/runner/work/_actions/actions/upload-artifact/v2/dist/index.js:7243:38)
    at Generator.next (<anonymous>)
Exponential backoff for retry #1. Waiting for 5138 milliseconds before continuing the upload at offset 0
```