### PR TITLE
split: elide all chunks when input file is empty

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -984,6 +984,13 @@ where
         (num_chunks, chunk_size)
     };
 
+    // If we would have written zero chunks of output, then terminate
+    // immediately. This happens on `split -e -n 3 /dev/null`, for
+    // example.
+    if num_chunks == 0 {
+        return Ok(());
+    }
+
     let num_chunks: usize = num_chunks
         .try_into()
         .map_err(|_| USimpleError::new(1, "Number of chunks too big"))?;

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -572,6 +572,19 @@ fn test_elide_empty_files() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_elide_dev_null() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-e", "-n", "3", "/dev/null"])
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert!(!at.plus("xaa").exists());
+    assert!(!at.plus("xab").exists());
+    assert!(!at.plus("xac").exists());
+}
+
+#[test]
 fn test_lines() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
Fix a bug in the behavior of `split -e -n NUM` when the input file is empty. Previously, it would panic due to overflow when subtracting 1 from 0. After this change, it will terminate successfully and produce no output chunks.

This will fix one of the GNU test cases in `tests/split/filter.sh`.