### PR TITLE
split: handle no final newline with --line-bytes

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -886,7 +886,7 @@ impl<'a> Write for LineBytesChunkWriter<'a> {
                 // then move on to the next chunk if necessary.
                 None => {
                     let end = self.num_bytes_remaining_in_current_chunk;
-                    let num_bytes_written = self.inner.write(&buf[..end])?;
+                    let num_bytes_written = self.inner.write(&buf[..end.min(buf.len())])?;
                     self.num_bytes_remaining_in_current_chunk -= num_bytes_written;
                     total_bytes_written += num_bytes_written;
                     buf = &buf[num_bytes_written..];

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -618,3 +618,19 @@ fn test_line_bytes() {
     assert_eq!(at.read("xac"), "cccc\ndd\n");
     assert_eq!(at.read("xad"), "ee\n");
 }
+
+#[test]
+fn test_line_bytes_no_final_newline() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-C", "2"])
+        .pipe_in("1\n2222\n3\n4")
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert_eq!(at.read("xaa"), "1\n");
+    assert_eq!(at.read("xab"), "22");
+    assert_eq!(at.read("xac"), "22");
+    assert_eq!(at.read("xad"), "\n");
+    assert_eq!(at.read("xae"), "3\n");
+    assert_eq!(at.read("xaf"), "4");
+}


### PR DESCRIPTION
Fix a panic due to out-of-bounds indexing when using `split
--line-bytes` with an input that had no trailing newline.