### PR TITLE
split: avoid writing final empty chunk with -C

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -858,6 +858,11 @@ impl<'a> Write for LineBytesChunkWriter<'a> {
         // Loop until we have written all bytes in the input buffer
         // (or an IO error occurs).
         loop {
+            // If the buffer is empty, then we are done writing.
+            if buf.is_empty() {
+                return Ok(total_bytes_written);
+            }
+
             // If we have filled the current chunk with bytes, then
             // start a new chunk and initialize its corresponding
             // writer.
@@ -875,12 +880,6 @@ impl<'a> Write for LineBytesChunkWriter<'a> {
 
             // Find the first newline character in the buffer.
             match memchr::memchr(b'\n', buf) {
-                // If there is no newline character and the buffer is
-                // empty, then we are done writing.
-                None if buf.is_empty() => {
-                    return Ok(total_bytes_written);
-                }
-
                 // If there is no newline character and the buffer is
                 // not empty, then write as many bytes as we can and
                 // then move on to the next chunk if necessary.

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -634,3 +634,24 @@ fn test_line_bytes_no_final_newline() {
     assert_eq!(at.read("xae"), "3\n");
     assert_eq!(at.read("xaf"), "4");
 }
+
+#[test]
+fn test_line_bytes_no_empty_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-C", "1"])
+        .pipe_in("1\n2222\n3\n4")
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert_eq!(at.read("xaa"), "1");
+    assert_eq!(at.read("xab"), "\n");
+    assert_eq!(at.read("xac"), "2");
+    assert_eq!(at.read("xad"), "2");
+    assert_eq!(at.read("xae"), "2");
+    assert_eq!(at.read("xaf"), "2");
+    assert_eq!(at.read("xag"), "\n");
+    assert_eq!(at.read("xah"), "3");
+    assert_eq!(at.read("xai"), "\n");
+    assert_eq!(at.read("xaj"), "4");
+    assert!(!at.plus("xak").exists());
+}


### PR DESCRIPTION
Fix a bug in which a final empty file was written when using `split
--line-bytes` mode.