### PR TITLE
`stat`: Adds support to read a filename redirected to stdin

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -471,11 +471,18 @@ impl Stater {
     }
 
     fn new(matches: &ArgMatches) -> UResult<Self> {
-        let files: Vec<String> = matches
+        let mut files: Vec<String> = matches
             .values_of(ARG_FILES)
             .map(|v| v.map(ToString::to_string).collect())
             .unwrap_or_default();
-
+        #[cfg(unix)]
+        if files.contains(&String::from("-")) {
+            files = Vec::from([Path::new("/dev/stdin")
+                .canonicalize()?
+                .into_os_string()
+                .into_string()
+                .unwrap()]);
+        }
         let format_str = if matches.is_present(options::PRINTF) {
             matches
                 .value_of(options::PRINTF)


### PR DESCRIPTION
### Explanation:
`touch f && stat - > f` creates an empty file and stat after seeing `-` tries to find the file which is being redirected to stdin and prints details for that file.

### Solution:
On detecting `-`, canonicalize `/dev/stdin` which will point to the file which is being redirected to stdin

**NOTE** stat doesn't read the content of the file, and this can be verified

Fixes #3241 