### PR TITLE
split: implement round-robin arg to --number

### DIFF
--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -743,3 +743,19 @@ fn test_hex_suffix() {
     assert_eq!(at.read("x0b"), "c");
     assert_eq!(at.read("x0c"), "");
 }
+
+#[test]
+fn test_round_robin() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let file_read = |f| {
+        let mut s = String::new();
+        at.open(f).read_to_string(&mut s).unwrap();
+        s
+    };
+
+    ucmd.args(&["-n", "r/2", "fivelines.txt"]).succeeds();
+
+    assert_eq!(file_read("xaa"), "1\n3\n5\n");
+    assert_eq!(file_read("xab"), "2\n4\n");
+}


### PR DESCRIPTION
~*Help wanted!* This change was previously merged in pull request #3205. Unfortunately, it resulted in an issue with the GNU test suite; see issue #3268. The change was subsequently reverted in pull request #3269. I am re-creating this pull request hoping that someone can diagnose the issue with the GNU test case `tests/split/filter.sh` as described in issue #3269.~ That issue no longer seems to be present on this branch after I rebased.

-----

Implement distributing lines of a file in a round-robin manner to a
specified number of chunks. For example,

    $ (seq 1 10 | split -n r/3) && head -v xa[abc]
    ==> xaa <==
    1
    4
    7
    10

    ==> xab <==
    2
    5
    8

    ==> xac <==
    3
    6
    9