### PR TITLE
timeout: give usage error on invalid time interval

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -19,7 +19,7 @@ use std::io::ErrorKind;
 use std::process::{self, Child, Stdio};
 use std::time::Duration;
 use uucore::display::Quotable;
-use uucore::error::{UResult, USimpleError};
+use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::process::ChildExt;
 use uucore::signals::{signal_by_name_or_value, signal_name_by_value};
 use uucore::{format_usage, InvalidEncodingHandling};
@@ -72,7 +72,7 @@ impl Config {
         let duration =
             match uucore::parse_time::from_str(options.value_of(options::DURATION).unwrap()) {
                 Ok(duration) => duration,
-                Err(err) => return Err(USimpleError::new(1, err)),
+                Err(err) => return Err(UUsageError::new(1, err)),
             };
 
         let preserve_status: bool = options.is_present(options::PRESERVE_STATUS);

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -12,6 +12,14 @@ fn test_subcommand_return_code() {
 }
 
 #[test]
+fn test_invalid_time_interval() {
+    new_ucmd!()
+        .args(&["xyz", "sleep", "0"])
+        .fails()
+        .usage_error("invalid time interval 'xyz'");
+}
+
+#[test]
 fn test_command_with_args() {
     new_ucmd!()
         .args(&["1700", "echo", "-n", "abcd"])


### PR DESCRIPTION

For example,
```
$ ./target/debug/timeout xyz sleep 0
./target/debug/timeout: invalid time interval 'xyz'
Try './target/debug/timeout --help' for more information.
```

This matches the behavior of GNU timeout.

Previously, the usage message was not being displayed.
