### PR TITLE
sleep: give usage error on invalid time interval

### DIFF
--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -9,7 +9,7 @@ use std::thread;
 use std::time::Duration;
 
 use uucore::{
-    error::{UResult, USimpleError},
+    error::{UResult, UUsageError},
     format_usage,
 };
 
@@ -64,7 +64,7 @@ fn sleep(args: &[&str]) -> UResult<()> {
             Duration::new(0, 0),
             |result, arg| match uucore::parse_time::from_str(&arg[..]) {
                 Ok(m) => Ok(m.saturating_add(result)),
-                Err(f) => Err(USimpleError::new(1, f)),
+                Err(f) => Err(UUsageError::new(1, f)),
             },
         )?;
     thread::sleep(sleep_dur);

--- a/tests/by-util/test_sleep.rs
+++ b/tests/by-util/test_sleep.rs
@@ -4,6 +4,14 @@ use crate::common::util::*;
 use std::time::{Duration, Instant};
 
 #[test]
+fn test_invalid_time_interval() {
+    new_ucmd!()
+        .arg("xyz")
+        .fails()
+        .usage_error("invalid time interval 'xyz'");
+}
+
+#[test]
 fn test_sleep_no_suffix() {
     let millis_100 = Duration::from_millis(100);
     let before_test = Instant::now();


### PR DESCRIPTION
For example,

    $ sleep xyz
    sleep: invalid time interval 'xyz'
    Try 'sleep --help' for more information.

This matches the behavior of GNU sleep.