### PR TITLE
env: add program signal messages

### DIFF
--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/env.rs"
 [dependencies]
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
 rust-ini = "0.17.0"
-uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
+uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["signals"]}
 
 [[bin]]
 name = "env"


### PR DESCRIPTION
Addresses https://github.com/uutils/coreutils/issues/3188.

1. These changes don't print the error output as described in the issue, but they do provide similar information and replicate what I get when encountering a signal termination (x86_64 Fedora 35, GNU coreutils 8.32):

```
$ env ./a.out
Segmentation fault (core dumped)
$ ~/repo/coreutils/target/debug/env ./a.out 
Segmentation fault (core dumped)
```
2. I'm not entirely sure how to test/get code coverage for this; ideas are welcome. For testing my changes, I essentially compared outputs of a c program that an exception, and changed the exception to check for any discrepancies:

```c
#include <signal.h>

int main() {
        raise(SIGSEGV);
}
```
3. I use unsafe code and add `libc` as a dependency in order to convert a signal number into a name. If there's reservations about this, I could instead have output like `terminated by signal 11`. I try to describe my logic for thinking this is safe in a comment.