### PR TITLE
uucore: error on negative interval in parse_time::from_str()

### DIFF
--- a/src/uucore/src/lib/parser/parse_time.rs
+++ b/src/uucore/src/lib/parser/parse_time.rs
@@ -63,6 +63,10 @@ pub fn from_str(string: &str) -> Result<Duration, String> {
         .parse::<f64>()
         .map_err(|e| format!("invalid time interval {}: {}", string.quote(), e))?;
 
+    if num < 0. {
+        return Err(format!("invalid time interval {}", string.quote()));
+    }
+
     const NANOS_PER_SEC: u32 = 1_000_000_000;
     let whole_secs = num.trunc();
     let nanos = (num.fract() * (NANOS_PER_SEC as f64)).trunc();
@@ -104,5 +108,10 @@ mod tests {
     #[test]
     fn test_error_invalid_magnitude() {
         assert!(from_str("12abc3s").is_err());
+    }
+
+    #[test]
+    fn test_negative() {
+        assert!(from_str("-1").is_err());
     }
 }

--- a/tests/by-util/test_sleep.rs
+++ b/tests/by-util/test_sleep.rs
@@ -149,3 +149,11 @@ fn test_sum_overflow() {
         .no_stderr()
         .no_stdout();
 }
+
+#[test]
+fn test_negative_interval() {
+    new_ucmd!()
+        .args(&["--", "-1"])
+        .fails()
+        .usage_error("invalid time interval '-1'");
+}

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -89,3 +89,11 @@ fn test_dont_overflow() {
         .no_stderr()
         .no_stdout();
 }
+
+#[test]
+fn test_negative_interval() {
+    new_ucmd!()
+        .args(&["--", "-1", "sleep", "0"])
+        .fails()
+        .usage_error("invalid time interval '-1'");
+}


### PR DESCRIPTION
Return an error when a negative interval is provided as the argument
to `uucore::parse_time::from_str()`, since a `Duration` should only be
non-negative.

This corrects the behavior of `timeout` and `sleep` to match that of GNU. For example,
```
$ sleep -- -1
sleep: invalid time interval ‘-1’
Try 'sleep --help' for more information.
```