### PR TITLE
timeout: produce usage error on invalid signal

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -57,7 +57,10 @@ impl Config {
                 let signal_result = signal_by_name_or_value(signal_);
                 match signal_result {
                     None => {
-                        unreachable!("invalid signal {}", signal_.quote());
+                        return Err(UUsageError::new(
+                            ExitStatus::TimeoutFailed.into(),
+                            format!("{}: invalid signal", signal_.quote()),
+                        ))
                     }
                     Some(signal_value) => signal_value,
                 }

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -97,3 +97,11 @@ fn test_negative_interval() {
         .fails()
         .usage_error("invalid time interval '-1'");
 }
+
+#[test]
+fn test_invalid_signal() {
+    new_ucmd!()
+        .args(&["-s", "invalid", "1", "sleep", "0"])
+        .fails()
+        .usage_error("'invalid': invalid signal");
+}


### PR DESCRIPTION
Produce a usage error on an invalid signal argument. For example,

    $ timeout --signal=invalid 1 sleep 0
    timeout: 'invalid': invalid signal
    Try 'timeout --help' for more information.