### PR TITLE
clippy fixes from nightly rust

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -408,23 +408,21 @@ enum RecursiveMode {
 impl RecursiveMode {
     fn is_recursive(self) -> bool {
         match self {
-            RecursiveMode::NotRecursive => false,
+            Self::NotRecursive => false,
 
-            RecursiveMode::RecursiveButDoNotFollowSymLinks
-            | RecursiveMode::RecursiveAndFollowAllDirSymLinks
-            | RecursiveMode::RecursiveAndFollowArgDirSymLinks => true,
+            Self::RecursiveButDoNotFollowSymLinks
+            | Self::RecursiveAndFollowAllDirSymLinks
+            | Self::RecursiveAndFollowArgDirSymLinks => true,
         }
     }
 
     fn fts_open_options(self) -> c_int {
         match self {
-            RecursiveMode::NotRecursive | RecursiveMode::RecursiveButDoNotFollowSymLinks => {
-                fts_sys::FTS_PHYSICAL
-            }
+            Self::NotRecursive | Self::RecursiveButDoNotFollowSymLinks => fts_sys::FTS_PHYSICAL,
 
-            RecursiveMode::RecursiveAndFollowAllDirSymLinks => fts_sys::FTS_LOGICAL,
+            Self::RecursiveAndFollowAllDirSymLinks => fts_sys::FTS_LOGICAL,
 
-            RecursiveMode::RecursiveAndFollowArgDirSymLinks => {
+            Self::RecursiveAndFollowArgDirSymLinks => {
                 fts_sys::FTS_PHYSICAL | fts_sys::FTS_COMFOLLOW
             }
         }

--- a/src/uu/chroot/src/error.rs
+++ b/src/uu/chroot/src/error.rs
@@ -55,25 +55,25 @@ impl UError for ChrootError {
 impl Display for ChrootError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            ChrootError::CannotEnter(s, e) => write!(f, "cannot chroot to {}: {}", s.quote(), e,),
-            ChrootError::CommandFailed(s, e) => {
+            Self::CannotEnter(s, e) => write!(f, "cannot chroot to {}: {}", s.quote(), e,),
+            Self::CommandFailed(s, e) => {
                 write!(f, "failed to run command {}: {}", s.to_string().quote(), e,)
             }
-            ChrootError::InvalidUserspec(s) => write!(f, "invalid userspec: {}", s.quote(),),
-            ChrootError::MissingNewRoot => write!(
+            Self::InvalidUserspec(s) => write!(f, "invalid userspec: {}", s.quote(),),
+            Self::MissingNewRoot => write!(
                 f,
                 "Missing operand: NEWROOT\nTry '{} --help' for more information.",
                 uucore::execution_phrase(),
             ),
-            ChrootError::NoSuchGroup(s) => write!(f, "no such group: {}", s.maybe_quote(),),
-            ChrootError::NoSuchDirectory(s) => write!(
+            Self::NoSuchGroup(s) => write!(f, "no such group: {}", s.maybe_quote(),),
+            Self::NoSuchDirectory(s) => write!(
                 f,
                 "cannot change root directory to {}: no such directory",
                 s.quote(),
             ),
-            ChrootError::SetGidFailed(s, e) => write!(f, "cannot set gid to {}: {}", s, e),
-            ChrootError::SetGroupsFailed(e) => write!(f, "cannot set groups: {}", e),
-            ChrootError::SetUserFailed(s, e) => {
+            Self::SetGidFailed(s, e) => write!(f, "cannot set gid to {}: {}", s, e),
+            Self::SetGroupsFailed(e) => write!(f, "cannot set groups: {}", e),
+            Self::SetUserFailed(s, e) => {
                 write!(f, "cannot set user to {}: {}", s.maybe_quote(), e)
             }
         }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1093,8 +1093,8 @@ fn copy_directory(
 impl OverwriteMode {
     fn verify(&self, path: &Path) -> CopyResult<()> {
         match *self {
-            OverwriteMode::NoClobber => Err(Error::NotAllFilesCopied),
-            OverwriteMode::Interactive(_) => {
+            Self::NoClobber => Err(Error::NotAllFilesCopied),
+            Self::Interactive(_) => {
                 if prompt_yes!("{}: overwrite {}? ", uucore::util_name(), path.quote()) {
                     Ok(())
                 } else {
@@ -1104,7 +1104,7 @@ impl OverwriteMode {
                     )))
                 }
             }
-            OverwriteMode::Clobber(_) => Ok(()),
+            Self::Clobber(_) => Ok(()),
         }
     }
 }

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -100,16 +100,16 @@ impl std::fmt::Display for ParseError {
             Self::StatusLevelNotRecognized(arg) => {
                 write!(f, "status=LEVEL not recognized -> {}", arg)
             }
-            ParseError::BsOutOfRange => {
+            Self::BsOutOfRange => {
                 write!(f, "bs=N cannot fit into memory")
             }
-            ParseError::IbsOutOfRange => {
+            Self::IbsOutOfRange => {
                 write!(f, "ibs=N cannot fit into memory")
             }
-            ParseError::ObsOutOfRange => {
+            Self::ObsOutOfRange => {
                 write!(f, "obs=N cannot fit into memory")
             }
-            ParseError::CbsOutOfRange => {
+            Self::CbsOutOfRange => {
                 write!(f, "cbs=N cannot fit into memory")
             }
             Self::Unimplemented(arg) => {

--- a/src/uu/expr/src/tokens.rs
+++ b/src/uu/expr/src/tokens.rs
@@ -65,7 +65,7 @@ impl Token {
         }
     }
     fn is_a_close_paren(&self) -> bool {
-        matches!(*self, Token::ParClose)
+        matches!(*self, Self::ParClose)
     }
 }
 

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -50,9 +50,9 @@ impl UError for GroupsError {}
 impl Display for GroupsError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            GroupsError::GetGroupsFailed => write!(f, "failed to fetch groups"),
-            GroupsError::GroupNotFound(gid) => write!(f, "cannot find name for group ID {}", gid),
-            GroupsError::UserNotFound(user) => write!(f, "{}: no such user", user.quote()),
+            Self::GetGroupsFailed => write!(f, "failed to fetch groups"),
+            Self::GroupNotFound(gid) => write!(f, "cannot find name for group ID {}", gid),
+            Self::UserNotFound(user) => write!(f, "{}: no such user", user.quote()),
         }
     }
 }

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -473,8 +473,8 @@ impl UError for HashsumError {}
 impl std::fmt::Display for HashsumError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            HashsumError::InvalidRegex => write!(f, "invalid regular expression"),
-            HashsumError::InvalidFormat => Ok(()),
+            Self::InvalidRegex => write!(f, "invalid regular expression"),
+            Self::InvalidFormat => Ok(()),
         }
     }
 }

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -58,7 +58,7 @@ impl std::error::Error for NohupError {}
 impl UError for NohupError {
     fn code(&self) -> i32 {
         match self {
-            NohupError::OpenFailed(code, _) | NohupError::OpenFailed2(code, _, _, _) => *code,
+            Self::OpenFailed(code, _) | Self::OpenFailed2(code, _, _, _) => *code,
             _ => 2,
         }
     }
@@ -67,9 +67,9 @@ impl UError for NohupError {
 impl Display for NohupError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            NohupError::CannotDetach => write!(f, "Cannot detach from console"),
-            NohupError::CannotReplace(s, e) => write!(f, "Cannot replace {}: {}", s, e),
-            NohupError::OpenFailed(_, e) => {
+            Self::CannotDetach => write!(f, "Cannot detach from console"),
+            Self::CannotReplace(s, e) => write!(f, "Cannot replace {}: {}", s, e),
+            Self::OpenFailed(_, e) => {
                 write!(f, "failed to open {}: {}", NOHUP_OUT.quote(), e)
             }
             NohupError::OpenFailed2(_, e1, s, e2) => write!(

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -42,23 +42,23 @@ pub enum RoundMethod {
 impl RoundMethod {
     pub fn round(&self, f: f64) -> f64 {
         match self {
-            RoundMethod::Up => f.ceil(),
-            RoundMethod::Down => f.floor(),
-            RoundMethod::FromZero => {
+            Self::Up => f.ceil(),
+            Self::Down => f.floor(),
+            Self::FromZero => {
                 if f < 0.0 {
                     f.floor()
                 } else {
                     f.ceil()
                 }
             }
-            RoundMethod::TowardsZero => {
+            Self::TowardsZero => {
                 if f < 0.0 {
                     f.ceil()
                 } else {
                     f.floor()
                 }
             }
-            RoundMethod::Nearest => f.round(),
+            Self::Nearest => f.round(),
         }
     }
 }

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -174,11 +174,11 @@ impl UError for PtxError {}
 impl Display for PtxError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            PtxError::DumbFormat => {
+            Self::DumbFormat => {
                 write!(f, "There is no dumb format with GNU extensions disabled")
             }
-            PtxError::NotImplemented(s) => write!(f, "{} not implemented yet", s),
-            PtxError::ParseError(e) => e.fmt(f),
+            Self::NotImplemented(s) => write!(f, "{} not implemented yet", s),
+            Self::ParseError(e) => e.fmt(f),
         }
     }
 }

--- a/src/uu/seq/src/extendedbigdecimal.rs
+++ b/src/uu/seq/src/extendedbigdecimal.rs
@@ -92,7 +92,7 @@ impl ExtendedBigDecimal {
     /// The smallest integer greater than or equal to this number.
     pub fn ceil(self) -> ExtendedBigInt {
         match self {
-            ExtendedBigDecimal::BigDecimal(x) => ExtendedBigInt::BigInt(ceil(x)),
+            Self::BigDecimal(x) => ExtendedBigInt::BigInt(ceil(x)),
             other => From::from(other),
         }
     }
@@ -100,7 +100,7 @@ impl ExtendedBigDecimal {
     /// The largest integer less than or equal to this number.
     pub fn floor(self) -> ExtendedBigInt {
         match self {
-            ExtendedBigDecimal::BigDecimal(x) => ExtendedBigInt::BigInt(floor(x)),
+            Self::BigDecimal(x) => ExtendedBigInt::BigInt(floor(x)),
             other => From::from(other),
         }
     }
@@ -121,17 +121,17 @@ impl From<ExtendedBigInt> for ExtendedBigDecimal {
 impl Display for ExtendedBigDecimal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExtendedBigDecimal::BigDecimal(x) => {
+            Self::BigDecimal(x) => {
                 let (n, p) = x.as_bigint_and_exponent();
                 match p {
                     0 => Self::BigDecimal(BigDecimal::new(n * 10, 1)).fmt(f),
                     _ => x.fmt(f),
                 }
             }
-            ExtendedBigDecimal::Infinity => f32::INFINITY.fmt(f),
-            ExtendedBigDecimal::MinusInfinity => f32::NEG_INFINITY.fmt(f),
-            ExtendedBigDecimal::MinusZero => (-0.0f32).fmt(f),
-            ExtendedBigDecimal::Nan => "nan".fmt(f),
+            Self::Infinity => f32::INFINITY.fmt(f),
+            Self::MinusInfinity => f32::NEG_INFINITY.fmt(f),
+            Self::MinusZero => (-0.0f32).fmt(f),
+            Self::Nan => "nan".fmt(f),
         }
     }
 }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -181,7 +181,7 @@ impl UError for SortError {
 impl Display for SortError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SortError::Disorder {
+            Self::Disorder {
                 file,
                 line_number,
                 line,
@@ -199,7 +199,7 @@ impl Display for SortError {
                     Ok(())
                 }
             }
-            SortError::OpenFailed { path, error } => {
+            Self::OpenFailed { path, error } => {
                 write!(
                     f,
                     "open failed: {}: {}",
@@ -207,10 +207,10 @@ impl Display for SortError {
                     strip_errno(error)
                 )
             }
-            SortError::ParseKeyError { key, msg } => {
+            Self::ParseKeyError { key, msg } => {
                 write!(f, "failed to parse key {}: {}", key.quote(), msg)
             }
-            SortError::ReadFailed { path, error } => {
+            Self::ReadFailed { path, error } => {
                 write!(
                     f,
                     "cannot read: {}: {}",
@@ -218,17 +218,17 @@ impl Display for SortError {
                     strip_errno(error)
                 )
             }
-            SortError::OpenTmpFileFailed { error } => {
+            Self::OpenTmpFileFailed { error } => {
                 write!(f, "failed to open temporary file: {}", strip_errno(error))
             }
-            SortError::CompressProgExecutionFailed { code } => {
+            Self::CompressProgExecutionFailed { code } => {
                 write!(f, "couldn't execute compress program: errno {}", code)
             }
-            SortError::CompressProgTerminatedAbnormally { prog } => {
+            Self::CompressProgTerminatedAbnormally { prog } => {
                 write!(f, "{} terminated abnormally", prog.quote())
             }
-            SortError::TmpDirCreationFailed => write!(f, "could not create temporary directory"),
-            SortError::Uft8Error { error } => write!(f, "{}", error),
+            Self::TmpDirCreationFailed => write!(f, "could not create temporary directory"),
+            Self::Uft8Error { error } => write!(f, "{}", error),
         }
     }
 }
@@ -247,13 +247,13 @@ enum SortMode {
 impl SortMode {
     fn get_short_name(&self) -> Option<char> {
         match self {
-            SortMode::Numeric => Some('n'),
-            SortMode::HumanNumeric => Some('h'),
-            SortMode::GeneralNumeric => Some('g'),
-            SortMode::Month => Some('M'),
-            SortMode::Version => Some('V'),
-            SortMode::Random => Some('R'),
-            SortMode::Default => None,
+            Self::Numeric => Some('n'),
+            Self::HumanNumeric => Some('h'),
+            Self::GeneralNumeric => Some('g'),
+            Self::Month => Some('M'),
+            Self::Version => Some('V'),
+            Self::Random => Some('R'),
+            Self::Default => None,
         }
     }
 }

--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -46,9 +46,9 @@ impl SuffixType {
     /// The radix to use when representing the suffix string as digits.
     pub fn radix(&self) -> u8 {
         match self {
-            SuffixType::Alphabetic => 26,
-            SuffixType::Decimal => 10,
-            SuffixType::Hexadecimal => 16,
+            Self::Alphabetic => 26,
+            Self::Decimal => 10,
+            Self::Hexadecimal => 16,
         }
     }
 }

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -37,20 +37,20 @@ pub enum BadSequence {
 impl Display for BadSequence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BadSequence::MissingCharClassName => writeln!(f, "missing character class name '[::]'"),
-            BadSequence::MissingEquivalentClassChar => {
+            Self::MissingCharClassName => writeln!(f, "missing character class name '[::]'"),
+            Self::MissingEquivalentClassChar => {
                 writeln!(f, "missing equivalence class character '[==]'")
             }
-            BadSequence::MultipleCharRepeatInSet2 => {
+            Self::MultipleCharRepeatInSet2 => {
                 writeln!(f, "only one [c*] repeat construct may appear in string2")
             }
-            BadSequence::CharRepeatInSet1 => {
+            Self::CharRepeatInSet1 => {
                 writeln!(f, "the [c*] repeat construct may not appear in string1")
             }
-            BadSequence::InvalidRepeatCount(count) => {
+            Self::InvalidRepeatCount(count) => {
                 writeln!(f, "invalid repeat count '{}' in [c*n] construct", count)
             }
-            BadSequence::EmptySet2WhenNotTruncatingSet1 => {
+            Self::EmptySet2WhenNotTruncatingSet1 => {
                 writeln!(f, "when not truncating set1, string2 must be non-empty")
             }
         }
@@ -83,20 +83,20 @@ pub enum Sequence {
 impl Sequence {
     pub fn flatten(&self) -> Box<dyn Iterator<Item = char>> {
         match self {
-            Sequence::Char(c) => Box::new(std::iter::once(*c)),
-            Sequence::CharRange(l, r) => Box::new((*l..=*r).flat_map(std::char::from_u32)),
-            Sequence::CharStar(c) => Box::new(std::iter::repeat(*c)),
-            Sequence::CharRepeat(c, n) => Box::new(std::iter::repeat(*c).take(*n)),
-            Sequence::Alnum => Box::new(('0'..='9').chain('A'..='Z').chain('a'..='z')),
-            Sequence::Alpha => Box::new(('A'..='Z').chain('a'..='z')),
-            Sequence::Blank => Box::new(unicode_table::BLANK.iter().cloned()),
-            Sequence::Control => Box::new(
+            Self::Char(c) => Box::new(std::iter::once(*c)),
+            Self::CharRange(l, r) => Box::new((*l..=*r).flat_map(std::char::from_u32)),
+            Self::CharStar(c) => Box::new(std::iter::repeat(*c)),
+            Self::CharRepeat(c, n) => Box::new(std::iter::repeat(*c).take(*n)),
+            Self::Alnum => Box::new(('0'..='9').chain('A'..='Z').chain('a'..='z')),
+            Self::Alpha => Box::new(('A'..='Z').chain('a'..='z')),
+            Self::Blank => Box::new(unicode_table::BLANK.iter().cloned()),
+            Self::Control => Box::new(
                 (0..=31)
                     .chain(std::iter::once(127))
                     .flat_map(std::char::from_u32),
             ),
-            Sequence::Digit => Box::new('0'..='9'),
-            Sequence::Graph => Box::new(
+            Self::Digit => Box::new('0'..='9'),
+            Self::Graph => Box::new(
                 (48..=57) // digit
                     .chain(65..=90) // uppercase
                     .chain(97..=122) // lowercase
@@ -108,8 +108,8 @@ impl Sequence {
                     .chain(std::iter::once(32)) // space
                     .flat_map(std::char::from_u32),
             ),
-            Sequence::Lower => Box::new('a'..='z'),
-            Sequence::Print => Box::new(
+            Self::Lower => Box::new('a'..='z'),
+            Self::Print => Box::new(
                 (48..=57) // digit
                     .chain(65..=90) // uppercase
                     .chain(97..=122) // lowercase
@@ -120,16 +120,16 @@ impl Sequence {
                     .chain(123..=126)
                     .flat_map(std::char::from_u32),
             ),
-            Sequence::Punct => Box::new(
+            Self::Punct => Box::new(
                 (33..=47)
                     .chain(58..=64)
                     .chain(91..=96)
                     .chain(123..=126)
                     .flat_map(std::char::from_u32),
             ),
-            Sequence::Space => Box::new(unicode_table::SPACES.iter().cloned()),
-            Sequence::Upper => Box::new('A'..='Z'),
-            Sequence::Xdigit => Box::new(('0'..='9').chain('A'..='F').chain('a'..='f')),
+            Self::Space => Box::new(unicode_table::SPACES.iter().cloned()),
+            Self::Upper => Box::new('A'..='Z'),
+            Self::Xdigit => Box::new(('0'..='9').chain('A'..='F').chain('a'..='f')),
         }
     }
 

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -620,7 +620,7 @@ impl From<i32> for Box<dyn UError> {
 /// Implementations for clap::Error
 impl UError for clap::Error {
     fn code(&self) -> i32 {
-        match self.kind {
+        match self.kind() {
             clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => 0,
             _ => 1,
         }


### PR DESCRIPTION
This fixes many but not all warnings produced by `cargo +nightly clippy --workspace --all-targets --all-features --` (as appears in `.pre-commit-config.yaml`).