### PR TITLE
wc: compute number widths using total file sizes

### DIFF
--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -181,7 +181,8 @@ fn test_file_one_long_word() {
         .stdout_is("    1     1 10001 10001 10000 onelongword.txt\n");
 }
 
-/// Test that the number of bytes in the file dictate the display width.
+/// Test that the total size of all the files in the input dictates
+/// the display width.
 ///
 /// The width in digits of any count is the width in digits of the
 /// number of bytes in the file, regardless of whether the number of
@@ -203,6 +204,27 @@ fn test_file_bytes_dictate_width() {
         .args(&["-lw", "emptyfile.txt"])
         .run()
         .stdout_is("0 0 emptyfile.txt\n");
+
+    // lorem_ipsum.txt contains 772 bytes, and alice_in_wonderland.txt contains
+    // 302 bytes. The total is 1074 bytes, which has a width of 4
+    new_ucmd!()
+        .args(&["-lwc", "alice_in_wonderland.txt", "lorem_ipsum.txt"])
+        .run()
+        .stdout_is(
+            "   5   57  302 alice_in_wonderland.txt\n  13  109  772 \
+                    lorem_ipsum.txt\n  18  166 1074 total\n",
+        );
+
+    // . is a directory, so minimum_width should get set to 7
+    #[cfg(not(windows))]
+    const STDOUT: &str = "      0       0       0 emptyfile.txt\n      0       0       0 \
+                          .\n      0       0       0 total\n";
+    #[cfg(windows)]
+    const STDOUT: &str = "      0       0       0 emptyfile.txt\n      0       0       0 total\n";
+    new_ucmd!()
+        .args(&["-lwc", "emptyfile.txt", "."])
+        .run()
+        .stdout_is(STDOUT);
 }
 
 /// Test that getting counts from a directory is an error.


### PR DESCRIPTION
Previously, individual file sizes were used to compute the number width, which
would cause misalignment when the total has a greater number of digits, and is
different from the behavior of GNU wc

```
$ ./target/debug/wc -w -l -m -c -L deny.toml GNUmakefile
  95  422 3110 3110   85 deny.toml
 349  865 6996 6996  196 GNUmakefile
 444 1287 10106 10106  196 total
$ wc -w -l -m -c -L deny.toml GNUmakefile
   95   422  3110  3110    85 deny.toml
  349   865  6996  6996   196 GNUmakefile
  444  1287 10106 10106   196 total
```