### PR TITLE
mkdir: gnu compat: add support of mkdir -p foo/.

### DIFF
--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -11,6 +11,8 @@ static TEST_DIR6: &str = "mkdir_test6";
 static TEST_FILE7: &str = "mkdir_test7";
 static TEST_DIR8: &str = "mkdir_test8/mkdir_test8_1/mkdir_test8_2";
 static TEST_DIR9: &str = "mkdir_test9/../mkdir_test9_1/../mkdir_test9_2";
+static TEST_DIR10: &str = "mkdir_test10/.";
+static TEST_DIR11: &str = "mkdir_test11/..";
 
 #[test]
 fn test_mkdir_mkdir() {
@@ -122,4 +124,30 @@ fn test_recursive_reporting() {
         .stdout_contains("created directory 'mkdir_test9'")
         .stdout_contains("created directory 'mkdir_test9/../mkdir_test9_1'")
         .stdout_contains("created directory 'mkdir_test9/../mkdir_test9_1/../mkdir_test9_2'");
+}
+
+#[test]
+fn test_mkdir_trailing_dot() {
+    let scene2 = TestScenario::new("ls");
+    new_ucmd!()
+        .arg("-p")
+        .arg("-v")
+        .arg("mkdir_test10-2")
+        .succeeds();
+
+    new_ucmd!()
+        .arg("-p")
+        .arg("-v")
+        .arg(TEST_DIR10)
+        .succeeds()
+        .stdout_contains("created directory 'mkdir_test10'");
+
+    new_ucmd!()
+        .arg("-p")
+        .arg("-v")
+        .arg(TEST_DIR11)
+        .succeeds()
+        .stdout_contains("created directory 'mkdir_test11'");
+    let result = scene2.cmd("ls").arg("-al").run();
+    println!("ls dest {}", result.stdout_str());
 }


### PR DESCRIPTION
I agree it is ugly but it is GNU's behavior.
`Warning: Congrats! The gnu test tests/mkdir/p-slashdot is now passing!`

This:
`    std::fs::create_dir("d2/.")?;`
doesn't create d2/
