### PR TITLE
timeout: support long form of --kill-after arg

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -134,7 +134,9 @@ pub fn uu_app<'a>() -> Command<'a> {
         )
         .arg(
             Arg::new(options::KILL_AFTER)
+                .long(options::KILL_AFTER)
                 .short('k')
+                .help("also send a KILL signal if COMMAND is still running this long after the initial signal was sent")
                 .takes_value(true))
         .arg(
             Arg::new(options::PRESERVE_STATUS)

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -105,3 +105,13 @@ fn test_invalid_signal() {
         .fails()
         .usage_error("'invalid': invalid signal");
 }
+
+/// Test that the long form of the `--kill-after` argument is recognized.
+#[test]
+fn test_kill_after_long() {
+    new_ucmd!()
+        .args(&["--kill-after=1", "1", "sleep", "0"])
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+}


### PR DESCRIPTION
Add support for the long form of the `--kill-after`
argument. Previously only the short form `-k` was supported.