### PR TITLE
timeout: return 125 on invalid time interval args

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -68,14 +68,18 @@ impl Config {
             _ => uucore::signals::signal_by_name_or_value("TERM").unwrap(),
         };
 
-        let kill_after = options
-            .value_of(options::KILL_AFTER)
-            .map(|time| uucore::parse_time::from_str(time).unwrap());
+        let kill_after = match options.value_of(options::KILL_AFTER) {
+            None => None,
+            Some(kill_after) => match uucore::parse_time::from_str(kill_after) {
+                Ok(k) => Some(k),
+                Err(err) => return Err(UUsageError::new(ExitStatus::TimeoutFailed.into(), err)),
+            },
+        };
 
         let duration =
             match uucore::parse_time::from_str(options.value_of(options::DURATION).unwrap()) {
                 Ok(duration) => duration,
-                Err(err) => return Err(UUsageError::new(1, err)),
+                Err(err) => return Err(UUsageError::new(ExitStatus::TimeoutFailed.into(), err)),
             };
 
         let preserve_status: bool = options.is_present(options::PRESERVE_STATUS);

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -16,6 +16,16 @@ fn test_invalid_time_interval() {
     new_ucmd!()
         .args(&["xyz", "sleep", "0"])
         .fails()
+        .code_is(125)
+        .usage_error("invalid time interval 'xyz'");
+}
+
+#[test]
+fn test_invalid_kill_after() {
+    new_ucmd!()
+        .args(&["-k", "xyz", "1", "sleep", "0"])
+        .fails()
+        .code_is(125)
         .usage_error("invalid time interval 'xyz'");
 }
 


### PR DESCRIPTION
Exit with status 125 (indicating an error in `timeout` itself) when
the timeout duration is invalid or the "kill after" duration is
invalid.