### PR TITLE
ls: Add proper quotes on symlink with --quoting-style=shell-escape

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2568,7 +2568,8 @@ fn display_file_name(
                 }
             } else {
                 // If no coloring is required, we just use target as is.
-                name.push_str(&target.to_string_lossy());
+                // Apply the right quoting
+                name.push_str(&escape_name(&target.as_os_str(), &config.quoting_style));
             }
         }
     }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2478,7 +2478,7 @@ fn display_file_name(
 
     if let Some(ls_colors) = &config.color {
         if let Ok(metadata) = path.p_buf.symlink_metadata() {
-            name = color_name(ls_colors, &path.p_buf, name, &metadata);
+            name = color_name(ls_colors, &path.p_buf, &name, &metadata, config);
         }
     }
 
@@ -2562,14 +2562,15 @@ fn display_file_name(
                     name.push_str(&color_name(
                         ls_colors,
                         &target_data.p_buf,
-                        target.to_string_lossy().into_owned(),
+                        &target.to_string_lossy(),
                         &target_metadata,
+                        config,
                     ));
                 }
             } else {
                 // If no coloring is required, we just use target as is.
                 // Apply the right quoting
-                name.push_str(&escape_name(&target.as_os_str(), &config.quoting_style));
+                name.push_str(&escape_name(target.as_os_str(), &config.quoting_style));
             }
         }
     }
@@ -2594,10 +2595,19 @@ fn display_file_name(
     }
 }
 
-fn color_name(ls_colors: &LsColors, path: &Path, name: String, md: &Metadata) -> String {
+fn color_name(
+    ls_colors: &LsColors,
+    path: &Path,
+    name: &str,
+    md: &Metadata,
+    config: &Config,
+) -> String {
     match ls_colors.style_for_path_with_metadata(path, Some(md)) {
-        Some(style) => style.to_ansi_term_style().paint(name).to_string(),
-        None => name,
+        Some(style) => {
+            let p = escape_name(OsStr::new(&name), &config.quoting_style);
+            return style.to_ansi_term_style().paint(p).to_string();
+        }
+        None => escape_name(OsStr::new(&name), &config.quoting_style),
     }
 }
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2913,3 +2913,43 @@ fn test_ls_multiple_a_A() {
         .stdout_does_not_contain(".")
         .stdout_does_not_contain("..");
 }
+
+#[test]
+fn test_ls_quoting() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ccmd("ln")
+        .arg("-s")
+        .arg("'need quoting'")
+        .arg("symlink")
+        .succeeds();
+    scene
+        .ucmd()
+        .arg("-l")
+        .arg("--quoting-style=shell-escape")
+        .arg("symlink")
+        .succeeds()
+        .stdout_contains("\'need quoting\'");
+}
+
+//#[test]
+// Enable when support with color is added
+fn test_ls_quoting_auto() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ccmd("ln")
+        .arg("-s")
+        .arg("'need quoting'")
+        .arg("symlink")
+        .succeeds();
+    scene
+        .ucmd()
+        .arg("-l")
+        .arg("--quoting-style=shell-escape")
+        .arg("--color=auto")
+        .arg("symlink")
+        .succeeds()
+        .stdout_contains("\'need quoting\'");
+}

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2933,9 +2933,8 @@ fn test_ls_quoting() {
         .stdout_contains("\'need quoting\'");
 }
 
-//#[test]
-// Enable when support with color is added
-fn test_ls_quoting_auto() {
+#[test]
+fn test_ls_quoting_color() {
     let scene = TestScenario::new(util_name!());
 
     scene


### PR DESCRIPTION
Should fix tests/ls/symlink-quote.sh