### PR TITLE
df: error on duplicate columns in --output arg

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -264,3 +264,11 @@ fn test_output_file_specific_files() {
         ]
     );
 }
+
+#[test]
+fn test_output_field_no_more_than_once() {
+    new_ucmd!()
+        .arg("--output=target,source,target")
+        .fails()
+        .usage_error("option --output: field 'target' used more than once");
+}


### PR DESCRIPTION
Print a usage error when duplicat column names are specified to the
`--output` command-line argument. For example,

    $ df --output=source,source
    df: option --output: field ‘source’ used more than once
    Try 'df --help' for more information.