### PR TITLE
df: allow multiple occurrences of --output arg

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -389,6 +389,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .long("output")
                 .takes_value(true)
                 .use_value_delimiter(true)
+                .multiple_occurrences(true)
                 .possible_values(OUTPUT_FIELD_LIST)
                 .default_missing_values(&OUTPUT_FIELD_LIST)
                 .default_values(&["source", "size", "used", "avail", "pcent", "target"])

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -222,6 +222,18 @@ fn test_output_selects_columns() {
     );
 }
 
+#[test]
+fn test_output_multiple_occurrences() {
+    let output = new_ucmd!()
+        .args(&["--output=source", "--output=target"])
+        .succeeds()
+        .stdout_move_str();
+    assert_eq!(
+        output.lines().next().unwrap(),
+        "Filesystem       Mounted on       "
+    );
+}
+
 // TODO Fix the spacing.
 #[test]
 fn test_output_file_all_filesystems() {


### PR DESCRIPTION
Allow multiple occurrences of the `--output` argument. For example,

    $ df --output=source --output=target | head -n1
    Filesystem                Mounted on