### PR TITLE
df: --output w/o "=" doesn't expect further args

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -388,6 +388,8 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(OPT_OUTPUT)
                 .long("output")
                 .takes_value(true)
+                .min_values(0)
+                .require_equals(true)
                 .use_value_delimiter(true)
                 .multiple_occurrences(true)
                 .possible_values(OUTPUT_FIELD_LIST)

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -81,6 +81,11 @@ fn test_output_option() {
 }
 
 #[test]
+fn test_output_option_without_equals_sign() {
+    new_ucmd!().arg("--output").arg(".").succeeds();
+}
+
+#[test]
 fn test_type_option() {
     new_ucmd!().args(&["-t", "ext4", "-t", "ext3"]).succeeds();
 }


### PR DESCRIPTION
Previously, `df --output .` was treated as `df --output=.` and hence `.` was interpreted as a column name (and caused an error). With this commit, `.` is treated as an argument on its own.

Fixes #3324