### PR TITLE
df: fix calculation of Use% in "total" row

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -140,7 +140,7 @@ fn test_total() {
 #[test]
 fn test_use_percentage() {
     let output = new_ucmd!()
-        .args(&["--output=used,avail,pcent"])
+        .args(&["--total", "--output=used,avail,pcent"])
         .succeeds()
         .stdout_move_str();
 


### PR DESCRIPTION
Change formula from: `Used/Size * 100` to `Used/(Used + Avail) * 100`. This formula also works if `Used` and `Avail` do not add up to `Size`, which is the case if there are reserved disk blocks.

This PR is an addition to #3309 and fixes the same issue for the calculation of the `Use%` value in the `total` row.