### PR TITLE
hashsum: add --no-names option from official b3sum tool

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -7,7 +7,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) algo, algoname, regexes, nread
+// spell-checker:ignore (ToDO) algo, algoname, regexes, nread, nonames
 
 #[macro_use]
 extern crate clap;

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -46,6 +46,7 @@ struct Options {
     binary: bool,
     check: bool,
     tag: bool,
+    nonames: bool,
     status: bool,
     quiet: bool,
     strict: bool,
@@ -316,6 +317,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     };
     let check = matches.is_present("check");
     let tag = matches.is_present("tag");
+    let nonames = matches.is_present("no-names");
     let status = matches.is_present("status");
     let quiet = matches.is_present("quiet") || status;
     let strict = matches.is_present("strict");
@@ -328,6 +330,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
         binary,
         check,
         tag,
+        nonames,
         status,
         quiet,
         strict,
@@ -369,6 +372,11 @@ pub fn uu_app_common<'a>() -> Command<'a> {
             Arg::new("tag")
                 .long("tag")
                 .help("create a BSD-style checksum"),
+        )
+        .arg(
+            Arg::new("no-names")
+                .long("no-names")
+                .help("Omits filenames in the output (option not present in GNU/Coreutils)"),
         )
         .arg(
             Arg::new("text")
@@ -602,6 +610,8 @@ where
             .map_err_context(|| "failed to read input".to_string())?;
             if options.tag {
                 println!("{} ({}) = {}", options.algoname, filename.display(), sum);
+            } else if options.nonames {
+                println!("{}", sum);
             } else {
                 println!("{} {}{}", sum, binary_marker, filename.display());
             }

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore checkfile
+// spell-checker:ignore checkfile, nonames
 macro_rules! get_hash(
     ($str:expr) => (
         $str.split(' ').collect::<Vec<&str>>()[0]

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -30,6 +30,16 @@ macro_rules! test_digest {
         }
 
         #[test]
+        fn test_nonames() {
+            let ts = TestScenario::new("hashsum");
+            // EXPECTED_FILE has no newline character at the end
+            assert_eq!(format!("{0}\n{0}\n", ts.fixtures.read(EXPECTED_FILE)),
+                       ts.ucmd().arg(DIGEST_ARG).arg(BITS_ARG).arg("--no-names").arg("input.txt").arg("-").pipe_in_fixture("input.txt")
+                       .succeeds().no_stderr().stdout_str()
+                       );
+        }
+
+        #[test]
         fn test_check() {
             let ts = TestScenario::new("hashsum");
             ts.ucmd()


### PR DESCRIPTION
The official b3sum tool has a --no-names option for only printing the
hashes, omitting the filenames. This is quite handy when used from
scripts because it spares the postprocessing with "cut" or "awk".
Since the installed b3sum symlink would also serve as a drop-in for the
official tool, the --no-names option is expected to exist for
compatibility.

Add a --no-names option not only for b3sum but for hashsum in general
(and maybe GNU coreutils will also feel inspired to add this option).

Closes https://github.com/uutils/coreutils/issues/3360