### PR TITLE
tty: should not return 2 when --help is used

### DIFF
--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -12,7 +12,7 @@
 use clap::{crate_version, Arg, Command};
 use std::ffi::CStr;
 use std::io::Write;
-use uucore::error::{UResult, UUsageError};
+use uucore::error::UResult;
 use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
@@ -28,9 +28,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
 
-    let matches = uu_app()
-        .try_get_matches_from(args)
-        .map_err(|e| UUsageError::new(2, format!("{}", e)))?;
+    let matches = uu_app().get_matches_from(args);
 
     let silent = matches.is_present(options::SILENT);
 

--- a/tests/by-util/test_tty.rs
+++ b/tests/by-util/test_tty.rs
@@ -65,6 +65,11 @@ fn test_wrong_argument() {
 }
 
 #[test]
+fn test_help() {
+    new_ucmd!().args(&["--help"]).succeeds();
+}
+
+#[test]
 // FixME: freebsd panic
 #[cfg(all(unix, not(target_os = "freebsd")))]
 fn test_stdout_fail() {


### PR DESCRIPTION
This is impacting
gnu/tests/misc/usage_vs_getopt.sh