### PR TITLE
Rust Edition 2021

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -994,7 +994,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast -p uucore
+        args: --no-fail-fast -p uucore
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""
@@ -1016,7 +1016,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
+        args: --no-fail-fast ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -759,7 +759,7 @@ jobs:
       with:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: test
-        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
+        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
         toolchain: ${{ env.RUST_MIN_SRV }}
     - name: Archive executable artifacts
       uses: actions/upload-artifact@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/uutils/coreutils"
 readme = "README.md"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 build = "build.rs"
 

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/arch"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/arch.rs"

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/base32"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/base32.rs"

--- a/src/uu/base64/Cargo.toml
+++ b/src/uu/base64/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/base64"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/base64.rs"

--- a/src/uu/basename/Cargo.toml
+++ b/src/uu/basename/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/basename"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/basename.rs"

--- a/src/uu/basenc/Cargo.toml
+++ b/src/uu/basenc/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/basenc"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/basenc.rs"

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cat"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/cat.rs"

--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chcon"
 keywords = ["coreutils", "uutils", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/chcon.rs"

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chgrp"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/chgrp.rs"

--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chmod"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/chmod.rs"

--- a/src/uu/chown/Cargo.toml
+++ b/src/uu/chown/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chown"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/chown.rs"

--- a/src/uu/chroot/Cargo.toml
+++ b/src/uu/chroot/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chroot"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/chroot.rs"

--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cksum"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/cksum.rs"

--- a/src/uu/comm/Cargo.toml
+++ b/src/uu/comm/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/comm"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/comm.rs"

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cp"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/cp.rs"

--- a/src/uu/csplit/Cargo.toml
+++ b/src/uu/csplit/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ls"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/csplit.rs"

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cut"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/cut.rs"

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/date"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/date.rs"

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/dd"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/dd.rs"

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -23,7 +23,6 @@ mod blocks;
 use blocks::conv_block_unblock_helper;
 
 use std::cmp;
-use std::convert::TryInto;
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, Write};

--- a/src/uu/dd/src/parseargs/unit_tests.rs
+++ b/src/uu/dd/src/parseargs/unit_tests.rs
@@ -10,7 +10,7 @@ fn unimplemented_flags_should_error_non_linux() {
     let mut succeeded = Vec::new();
 
     // The following flags are only implemented in linux
-    for &flag in &[
+    for flag in [
         "direct",
         "directory",
         "dsync",
@@ -47,7 +47,7 @@ fn unimplemented_flags_should_error() {
     let mut succeeded = Vec::new();
 
     // The following flags are not implemented
-    for &flag in &["cio", "nocache", "nolinks", "text", "binary"] {
+    for flag in ["cio", "nocache", "nolinks", "text", "binary"] {
         let args = vec![
             String::from("dd"),
             format!("--iflag={}", flag),

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/df"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/df.rs"

--- a/src/uu/dircolors/Cargo.toml
+++ b/src/uu/dircolors/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/dircolors"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/dircolors.rs"

--- a/src/uu/dirname/Cargo.toml
+++ b/src/uu/dirname/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/dirname"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/dirname.rs"

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/du"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/du.rs"

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -253,7 +253,7 @@ fn read_block_size(s: Option<&str>) -> u64 {
         parse_size(s)
             .unwrap_or_else(|e| crash!(1, "{}", format_error_message(&e, s, options::BLOCK_SIZE)))
     } else {
-        for env_var in &["DU_BLOCK_SIZE", "BLOCK_SIZE", "BLOCKSIZE"] {
+        for env_var in ["DU_BLOCK_SIZE", "BLOCK_SIZE", "BLOCKSIZE"] {
             if let Ok(env_size) = env::var(env_var) {
                 if let Ok(v) = parse_size(&env_size) {
                     return v;

--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/echo"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/echo.rs"

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/env"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/env.rs"

--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/expand"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/expand.rs"

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/expr"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/expr.rs"

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 num-traits = "0.2.13" # used in src/numerics.rs, which is included by build.rs

--- a/src/uu/false/Cargo.toml
+++ b/src/uu/false/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/false"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/false.rs"

--- a/src/uu/fmt/Cargo.toml
+++ b/src/uu/fmt/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/fmt"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/fmt.rs"

--- a/src/uu/fold/Cargo.toml
+++ b/src/uu/fold/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/fold"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/fold.rs"

--- a/src/uu/groups/Cargo.toml
+++ b/src/uu/groups/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/groups"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/groups.rs"

--- a/src/uu/hashsum/Cargo.toml
+++ b/src/uu/hashsum/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/hashsum"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/hashsum.rs"

--- a/src/uu/head/Cargo.toml
+++ b/src/uu/head/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/head"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/head.rs"

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -6,7 +6,6 @@
 // spell-checker:ignore (vars) zlines BUFWRITER seekable
 
 use clap::{crate_version, Arg, ArgMatches, Command};
-use std::convert::{TryFrom, TryInto};
 use std::ffi::OsString;
 use std::io::{self, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
 use uucore::display::Quotable;

--- a/src/uu/hostid/Cargo.toml
+++ b/src/uu/hostid/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/hostid"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/hostid.rs"

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/hostname"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/hostname.rs"

--- a/src/uu/id/Cargo.toml
+++ b/src/uu/id/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/id"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/id.rs"

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/install"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/install.rs"

--- a/src/uu/join/Cargo.toml
+++ b/src/uu/join/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/join"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/join.rs"

--- a/src/uu/kill/Cargo.toml
+++ b/src/uu/kill/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/kill"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/kill.rs"

--- a/src/uu/link/Cargo.toml
+++ b/src/uu/link/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/link"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/link.rs"

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ln"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/ln.rs"

--- a/src/uu/logname/Cargo.toml
+++ b/src/uu/logname/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/logname"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/logname.rs"

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ls"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/ls.rs"

--- a/src/uu/mkdir/Cargo.toml
+++ b/src/uu/mkdir/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mkdir"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/mkdir.rs"

--- a/src/uu/mkfifo/Cargo.toml
+++ b/src/uu/mkfifo/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mkfifo"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/mkfifo.rs"

--- a/src/uu/mknod/Cargo.toml
+++ b/src/uu/mknod/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mknod"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "uu_mknod"

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mktemp"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/mktemp.rs"

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/more"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/more.rs"

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mv"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/mv.rs"

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nice"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/nice.rs"

--- a/src/uu/nl/Cargo.toml
+++ b/src/uu/nl/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nl"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/nl.rs"

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nohup"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/nohup.rs"

--- a/src/uu/nproc/Cargo.toml
+++ b/src/uu/nproc/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nproc"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/nproc.rs"

--- a/src/uu/numfmt/Cargo.toml
+++ b/src/uu/numfmt/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/numfmt"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/numfmt.rs"

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/od"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/od.rs"

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -29,7 +29,6 @@ mod prn_float;
 mod prn_int;
 
 use std::cmp;
-use std::convert::TryFrom;
 
 use crate::byteorder_io::*;
 use crate::formatteriteminfo::*;

--- a/src/uu/paste/Cargo.toml
+++ b/src/uu/paste/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/paste"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/paste.rs"

--- a/src/uu/pathchk/Cargo.toml
+++ b/src/uu/pathchk/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pathchk"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/pathchk.rs"

--- a/src/uu/pinky/Cargo.toml
+++ b/src/uu/pinky/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pinky"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/pinky.rs"

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pr"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/pr.rs"

--- a/src/uu/printenv/Cargo.toml
+++ b/src/uu/printenv/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/printenv"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/printenv.rs"

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/printf"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/printf.rs"

--- a/src/uu/ptx/Cargo.toml
+++ b/src/uu/ptx/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ptx"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/ptx.rs"

--- a/src/uu/pwd/Cargo.toml
+++ b/src/uu/pwd/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pwd"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/pwd.rs"

--- a/src/uu/readlink/Cargo.toml
+++ b/src/uu/readlink/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/readlink"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/readlink.rs"

--- a/src/uu/realpath/Cargo.toml
+++ b/src/uu/realpath/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/realpath"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/realpath.rs"

--- a/src/uu/relpath/Cargo.toml
+++ b/src/uu/relpath/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/relpath"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/relpath.rs"

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/rm"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/rm.rs"

--- a/src/uu/rmdir/Cargo.toml
+++ b/src/uu/rmdir/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/rmdir"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/rmdir.rs"

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/runcon"
 keywords = ["coreutils", "uutils", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/runcon.rs"

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/seq"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/seq.rs"

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -3,7 +3,6 @@
 //!
 //! This module provides an implementation of [`FromStr`] for the
 //! [`PreciseNumber`] struct.
-use std::convert::TryInto;
 use std::str::FromStr;
 
 use bigdecimal::BigDecimal;

--- a/src/uu/shred/Cargo.toml
+++ b/src/uu/shred/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/shred"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/shred.rs"

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/shuf"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/shuf.rs"

--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sleep"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/sleep.rs"

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sort"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/sort.rs"

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -33,7 +33,6 @@ use numeric_str_cmp::{human_numeric_str_cmp, numeric_str_cmp, NumInfo, NumInfoPa
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use std::cmp::Ordering;
-use std::convert::TryFrom;
 use std::env;
 use std::error::Error;
 use std::ffi::{OsStr, OsString};

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1636,7 +1636,7 @@ fn get_leading_gen(input: &str) -> Range<usize> {
     let leading_whitespace_len = input.len() - trimmed.len();
 
     // check for inf, -inf and nan
-    for allowed_prefix in &["inf", "-inf", "nan"] {
+    for allowed_prefix in ["inf", "-inf", "nan"] {
         if trimmed.is_char_boundary(allowed_prefix.len())
             && trimmed[..allowed_prefix.len()].eq_ignore_ascii_case(allowed_prefix)
         {

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/split"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/split.rs"

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -14,7 +14,6 @@ mod platform;
 use crate::filenames::FilenameIterator;
 use crate::filenames::SuffixType;
 use clap::{crate_version, Arg, ArgMatches, Command};
-use std::convert::TryInto;
 use std::env;
 use std::fmt;
 use std::fs::{metadata, File};

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/stat"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/stat.rs"

--- a/src/uu/stdbuf/Cargo.toml
+++ b/src/uu/stdbuf/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/stdbuf"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/stdbuf.rs"

--- a/src/uu/stdbuf/src/libstdbuf/Cargo.toml
+++ b/src/uu/stdbuf/src/libstdbuf/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/stdbuf"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "libstdbuf"

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -11,7 +11,6 @@
 extern crate uucore;
 
 use clap::{crate_version, Arg, ArgMatches, Command};
-use std::convert::{TryFrom, TryInto};
 use std::fs::File;
 use std::io::{self, Write};
 use std::os::unix::process::ExitStatusExt;

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sum"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/sum.rs"

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sync"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/sync.rs"

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tac"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/tac.rs"

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tail"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/tail.rs"

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -22,7 +22,6 @@ use chunks::ReverseChunks;
 
 use clap::{Arg, Command};
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use std::ffi::OsString;
 use std::fmt;
 use std::fs::{File, Metadata};

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tee"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/tee.rs"

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/test"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/test.rs"

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/timeout"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/timeout.rs"

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/touch"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/touch.rs"

--- a/src/uu/tr/Cargo.toml
+++ b/src/uu/tr/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tr"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/tr.rs"

--- a/src/uu/true/Cargo.toml
+++ b/src/uu/true/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/true"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/true.rs"

--- a/src/uu/truncate/Cargo.toml
+++ b/src/uu/truncate/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/truncate"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/truncate.rs"

--- a/src/uu/tsort/Cargo.toml
+++ b/src/uu/tsort/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tsort"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/tsort.rs"

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tty"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/tty.rs"

--- a/src/uu/uname/Cargo.toml
+++ b/src/uu/uname/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/uname"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/uname.rs"

--- a/src/uu/unexpand/Cargo.toml
+++ b/src/uu/unexpand/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/unexpand"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/unexpand.rs"

--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/uniq"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/uniq.rs"

--- a/src/uu/unlink/Cargo.toml
+++ b/src/uu/unlink/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/unlink"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/unlink.rs"

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/uptime"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/uptime.rs"

--- a/src/uu/users/Cargo.toml
+++ b/src/uu/users/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/users"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/users.rs"

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/wc"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/wc.rs"

--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/who"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/who.rs"

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/whoami"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/whoami.rs"

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/uutils/coreutils"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/yes"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "src/yes.rs"

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/uutils/coreutils/tree/main/src/uucore"
 # readme = "README.md"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 path="src/lib/lib.rs"

--- a/src/uucore/src/lib/features/entries.rs
+++ b/src/uucore/src/lib/features/entries.rs
@@ -41,7 +41,6 @@ use libc::{c_char, c_int, gid_t, uid_t};
 use libc::{getgrgid, getgrnam, getgroups};
 use libc::{getpwnam, getpwuid, group, passwd};
 
-use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::io::Error as IOError;
 use std::io::ErrorKind;

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -99,8 +99,6 @@ impl FileInformation {
     pub fn file_size(&self) -> u64 {
         #[cfg(unix)]
         {
-            use std::convert::TryInto;
-
             assert!(self.0.st_size >= 0, "File size is negative");
             self.0.st_size.try_into().unwrap()
         }

--- a/src/uucore/src/lib/parser/parse_size.rs
+++ b/src/uucore/src/lib/parser/parse_size.rs
@@ -5,7 +5,6 @@
 
 // spell-checker:ignore (ToDO) hdsf ghead gtail
 
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 

--- a/src/uucore_procs/Cargo.toml
+++ b/src/uucore_procs/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/uutils/coreutils/tree/main/src/uucore_procs"
 # readme = "README.md"
 keywords = ["cross-platform", "proc-macros", "uucore", "uutils"]
 # categories = ["os"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/tests/benches/factor/Cargo.toml
+++ b/tests/benches/factor/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["nicoo <nicoo@debian.org>"]
 license = "MIT"
 description = "Benchmarks for the uu_factor integer factorization tool"
 homepage = "https://github.com/uutils/coreutils"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 uu_factor = { path = "../../../src/uu/factor" }

--- a/tests/benches/factor/benches/table.rs
+++ b/tests/benches/factor/benches/table.rs
@@ -1,6 +1,5 @@
 use array_init::array_init;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use std::convert::TryInto;
 use uu_factor::{table::*, Factors};
 
 fn table(c: &mut Criterion) {

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -34,7 +34,7 @@ fn test_base32_encode_file() {
 
 #[test]
 fn test_decode() {
-    for decode_param in &["-d", "--decode", "--dec"] {
+    for decode_param in ["-d", "--decode", "--dec"] {
         let input = "JBSWY3DPFQQFO33SNRSCC===\n"; // spell-checker:disable-line
         new_ucmd!()
             .arg(decode_param)
@@ -56,7 +56,7 @@ fn test_garbage() {
 
 #[test]
 fn test_ignore_garbage() {
-    for ignore_garbage_param in &["-i", "--ignore-garbage", "--ig"] {
+    for ignore_garbage_param in ["-i", "--ignore-garbage", "--ig"] {
         let input = "JBSWY\x013DPFQ\x02QFO33SNRSCC===\n"; // spell-checker:disable-line
         new_ucmd!()
             .arg("-d")
@@ -69,7 +69,7 @@ fn test_ignore_garbage() {
 
 #[test]
 fn test_wrap() {
-    for wrap_param in &["-w", "--wrap", "--wr"] {
+    for wrap_param in ["-w", "--wrap", "--wr"] {
         let input = "The quick brown fox jumps over the lazy dog.";
         new_ucmd!()
             .arg(wrap_param)
@@ -84,7 +84,7 @@ fn test_wrap() {
 
 #[test]
 fn test_wrap_no_arg() {
-    for wrap_param in &["-w", "--wrap"] {
+    for wrap_param in ["-w", "--wrap"] {
         let ts = TestScenario::new(util_name!());
         let expected_stderr = &format!(
             "error: The argument '--wrap <wrap>\' requires a value but none was \
@@ -102,7 +102,7 @@ fn test_wrap_no_arg() {
 
 #[test]
 fn test_wrap_bad_arg() {
-    for wrap_param in &["-w", "--wrap"] {
+    for wrap_param in ["-w", "--wrap"] {
         new_ucmd!()
             .arg(wrap_param)
             .arg("b")

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -26,7 +26,7 @@ fn test_base64_encode_file() {
 
 #[test]
 fn test_decode() {
-    for decode_param in &["-d", "--decode", "--dec"] {
+    for decode_param in ["-d", "--decode", "--dec"] {
         let input = "aGVsbG8sIHdvcmxkIQ=="; // spell-checker:disable-line
         new_ucmd!()
             .arg(decode_param)
@@ -48,7 +48,7 @@ fn test_garbage() {
 
 #[test]
 fn test_ignore_garbage() {
-    for ignore_garbage_param in &["-i", "--ignore-garbage", "--ig"] {
+    for ignore_garbage_param in ["-i", "--ignore-garbage", "--ig"] {
         let input = "aGVsbG8sIHdvcmxkIQ==\0"; // spell-checker:disable-line
         new_ucmd!()
             .arg("-d")
@@ -61,7 +61,7 @@ fn test_ignore_garbage() {
 
 #[test]
 fn test_wrap() {
-    for wrap_param in &["-w", "--wrap", "--wr"] {
+    for wrap_param in ["-w", "--wrap", "--wr"] {
         let input = "The quick brown fox jumps over the lazy dog.";
         new_ucmd!()
             .arg(wrap_param)
@@ -75,7 +75,7 @@ fn test_wrap() {
 
 #[test]
 fn test_wrap_no_arg() {
-    for wrap_param in &["-w", "--wrap"] {
+    for wrap_param in ["-w", "--wrap"] {
         new_ucmd!().arg(wrap_param).fails().stderr_contains(
             &"The argument '--wrap <wrap>' requires a value but none was supplied",
         );
@@ -84,7 +84,7 @@ fn test_wrap_no_arg() {
 
 #[test]
 fn test_wrap_bad_arg() {
-    for wrap_param in &["-w", "--wrap"] {
+    for wrap_param in ["-w", "--wrap"] {
         new_ucmd!()
             .arg(wrap_param)
             .arg("b")

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 
 #[test]
 fn test_help() {
-    for help_flg in &["-h", "--help"] {
+    for help_flg in ["-h", "--help"] {
         new_ucmd!()
             .arg(&help_flg)
             .succeeds()
@@ -17,7 +17,7 @@ fn test_help() {
 
 #[test]
 fn test_version() {
-    for version_flg in &["-V", "--version"] {
+    for version_flg in ["-V", "--version"] {
         assert!(new_ucmd!()
             .arg(&version_flg)
             .succeeds()
@@ -61,7 +61,7 @@ fn test_do_not_remove_suffix() {
 
 #[test]
 fn test_multiple_param() {
-    for &multiple_param in &["-a", "--multiple", "--mul"] {
+    for multiple_param in ["-a", "--multiple", "--mul"] {
         let path = "/foo/bar/baz";
         new_ucmd!()
             .args(&[multiple_param, path, path])
@@ -72,7 +72,7 @@ fn test_multiple_param() {
 
 #[test]
 fn test_suffix_param() {
-    for &suffix_param in &["-s", "--suffix", "--suf"] {
+    for suffix_param in ["-s", "--suffix", "--suf"] {
         let path = "/foo/bar/baz.exe";
         new_ucmd!()
             .args(&[suffix_param, ".exe", path, path])
@@ -83,7 +83,7 @@ fn test_suffix_param() {
 
 #[test]
 fn test_zero_param() {
-    for &zero_param in &["-z", "--zero", "--ze"] {
+    for zero_param in ["-z", "--zero", "--ze"] {
         let path = "/foo/bar/baz";
         new_ucmd!()
             .args(&[zero_param, "-a", path, path])

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -19,7 +19,7 @@ fn test_output_simple() {
 #[test]
 fn test_no_options() {
     // spell-checker:disable-next-line
-    for fixture in &["empty.txt", "alpha.txt", "nonewline.txt"] {
+    for fixture in ["empty.txt", "alpha.txt", "nonewline.txt"] {
         // Give fixture through command line file argument
         new_ucmd!()
             .args(&[fixture])
@@ -36,7 +36,7 @@ fn test_no_options() {
 #[test]
 #[cfg(any(target_vendor = "apple", target_os = "linux", target_os = "android"))]
 fn test_no_options_big_input() {
-    for &n in &[
+    for n in [
         0,
         1,
         42,
@@ -114,7 +114,7 @@ fn test_closes_file_descriptors() {
 fn test_piped_to_regular_file() {
     use std::fs::read_to_string;
 
-    for &append in &[true, false] {
+    for append in [true, false] {
         let s = TestScenario::new(util_name!());
         let file_path = s.fixtures.plus("file.txt");
 
@@ -139,7 +139,7 @@ fn test_piped_to_regular_file() {
 #[test]
 #[cfg(unix)]
 fn test_piped_to_dev_null() {
-    for &append in &[true, false] {
+    for append in [true, false] {
         let s = TestScenario::new(util_name!());
         {
             let dev_null = OpenOptions::new()
@@ -159,7 +159,7 @@ fn test_piped_to_dev_null() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
 fn test_piped_to_dev_full() {
-    for &append in &[true, false] {
+    for append in [true, false] {
         let s = TestScenario::new(util_name!());
         {
             let dev_full = OpenOptions::new()
@@ -192,7 +192,7 @@ fn test_directory_and_file() {
     let s = TestScenario::new(util_name!());
     s.fixtures.mkdir("test_directory2");
     // spell-checker:disable-next-line
-    for fixture in &["empty.txt", "alpha.txt", "nonewline.txt"] {
+    for fixture in ["empty.txt", "alpha.txt", "nonewline.txt"] {
         s.ucmd()
             .args(&["test_directory2", fixture])
             .fails()
@@ -264,7 +264,7 @@ fn test_numbered_lines_no_trailing_newline() {
 
 #[test]
 fn test_stdin_show_nonprinting() {
-    for same_param in &["-v", "--show-nonprinting", "--show-non"] {
+    for same_param in ["-v", "--show-nonprinting", "--show-non"] {
         new_ucmd!()
             .args(&[same_param])
             .pipe_in("\t\0\n")
@@ -275,7 +275,7 @@ fn test_stdin_show_nonprinting() {
 
 #[test]
 fn test_stdin_show_tabs() {
-    for same_param in &["-T", "--show-tabs", "--show-ta"] {
+    for same_param in ["-T", "--show-tabs", "--show-ta"] {
         new_ucmd!()
             .args(&[same_param])
             .pipe_in("\t\0\n")
@@ -286,7 +286,7 @@ fn test_stdin_show_tabs() {
 
 #[test]
 fn test_stdin_show_ends() {
-    for &same_param in &["-E", "--show-ends", "--show-e"] {
+    for same_param in ["-E", "--show-ends", "--show-e"] {
         new_ucmd!()
             .args(&[same_param, "-"])
             .pipe_in("\t\0\n\t")
@@ -317,7 +317,7 @@ fn test_show_ends_crlf() {
 
 #[test]
 fn test_stdin_show_all() {
-    for same_param in &["-A", "--show-all", "--show-a"] {
+    for same_param in ["-A", "--show-all", "--show-a"] {
         new_ucmd!()
             .args(&[same_param])
             .pipe_in("\t\0\n")
@@ -346,7 +346,7 @@ fn test_stdin_nonprinting_and_tabs() {
 
 #[test]
 fn test_stdin_squeeze_blank() {
-    for same_param in &["-s", "--squeeze-blank", "--squeeze"] {
+    for same_param in ["-s", "--squeeze-blank", "--squeeze"] {
         new_ucmd!()
             .arg(same_param)
             .pipe_in("\n\na\n\n\n\n\nb\n\n\n")
@@ -358,7 +358,7 @@ fn test_stdin_squeeze_blank() {
 #[test]
 fn test_stdin_number_non_blank() {
     // spell-checker:disable-next-line
-    for same_param in &["-b", "--number-nonblank", "--number-non"] {
+    for same_param in ["-b", "--number-nonblank", "--number-non"] {
         new_ucmd!()
             .arg(same_param)
             .arg("-")
@@ -371,7 +371,7 @@ fn test_stdin_number_non_blank() {
 #[test]
 fn test_non_blank_overrides_number() {
     // spell-checker:disable-next-line
-    for &same_param in &["-b", "--number-nonblank"] {
+    for same_param in ["-b", "--number-nonblank"] {
         new_ucmd!()
             .args(&[same_param, "-"])
             .pipe_in("\na\nb\n\n\nc")
@@ -382,7 +382,7 @@ fn test_non_blank_overrides_number() {
 
 #[test]
 fn test_squeeze_blank_before_numbering() {
-    for &same_param in &["-s", "--squeeze-blank"] {
+    for same_param in ["-s", "--squeeze-blank"] {
         new_ucmd!()
             .args(&[same_param, "-n", "-"])
             .pipe_in("a\n\n\nb")

--- a/tests/by-util/test_chcon.rs
+++ b/tests/by-util/test_chcon.rs
@@ -23,7 +23,7 @@ fn help() {
 
 #[test]
 fn reference_errors() {
-    for args in &[
+    for args in [
         &["--verbose", "--reference"] as &[&str],
         &["--verbose", "--reference=/dev/null"],
         &["--verbose", "--reference=/inexistent", "/dev/null"],
@@ -34,7 +34,7 @@ fn reference_errors() {
 
 #[test]
 fn recursive_errors() {
-    for args in &[
+    for args in [
         &["--verbose", "-P"] as &[&str],
         &["--verbose", "-H"],
         &["--verbose", "-L"],

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -60,7 +60,7 @@ fn test_1() {
 #[test]
 fn test_fail_silently() {
     if get_effective_gid() != 0 {
-        for opt in &["-f", "--silent", "--quiet", "--sil", "--qui"] {
+        for opt in ["-f", "--silent", "--quiet", "--sil", "--qui"] {
             new_ucmd!()
                 .arg(opt)
                 .arg("bin")
@@ -74,7 +74,7 @@ fn test_fail_silently() {
 #[test]
 fn test_preserve_root() {
     // It's weird that on OS X, `realpath /etc/..` returns '/private'
-    for d in &[
+    for d in [
         "/",
         "/////tmp///../../../../",
         "../../../../../../../../../../../../../../",
@@ -92,7 +92,7 @@ fn test_preserve_root() {
 #[test]
 fn test_preserve_root_symlink() {
     let file = "test_chgrp_symlink2root";
-    for d in &[
+    for d in [
         "/",
         "////tmp//../../../../",
         "..//../../..//../..//../../../../../../../../",
@@ -299,7 +299,7 @@ fn test_traverse_symlinks() {
     }
     let (first_group, second_group) = (groups[0], groups[1]);
 
-    for &(args, traverse_first, traverse_second) in &[
+    for (args, traverse_first, traverse_second) in [
         (&[][..] as &[&str], false, false),
         (&["-H"][..], true, false),
         (&["-P"][..], false, false),

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -532,7 +532,7 @@ fn test_chmod_strip_minus_from_mode() {
 
 #[test]
 fn test_chmod_keep_setgid() {
-    for &(from, arg, to) in &[
+    for (from, arg, to) in [
         (0o7777, "777", 0o46777),
         (0o7777, "=777", 0o40777),
         (0o7777, "0777", 0o46777),

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -76,7 +76,7 @@ fn output_delimiter_require_arg() {
 #[cfg_attr(not(feature = "test_unimplemented"), ignore)]
 #[test]
 fn zero_terminated() {
-    for &param in &["-z", "--zero-terminated"] {
+    for param in ["-z", "--zero-terminated"] {
         new_ucmd!()
             .args(&[param, "a", "b"])
             .fails()

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1469,7 +1469,7 @@ fn test_canonicalize_symlink() {
 
 #[test]
 fn test_copy_through_just_created_symlink() {
-    for &create_t in &[true, false] {
+    for create_t in [true, false] {
         let (at, mut ucmd) = at_and_ucmd!();
         at.mkdir("a");
         at.mkdir("b");
@@ -1606,7 +1606,7 @@ fn test_cp_dir_vs_file() {
 fn test_cp_overriding_arguments() {
     let s = TestScenario::new(util_name!());
     s.fixtures.touch("file1");
-    for (arg1, arg2) in &[
+    for (arg1, arg2) in [
         #[cfg(not(windows))]
         ("--remove-destination", "--force"),
         #[cfg(not(windows))]

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -41,7 +41,7 @@ static COMPLEX_SEQUENCE: &TestedSequence = &TestedSequence {
 
 #[test]
 fn test_byte_sequence() {
-    for &param in &["-b", "--bytes", "--byt"] {
+    for param in ["-b", "--bytes", "--byt"] {
         for example_seq in EXAMPLE_SEQUENCES {
             new_ucmd!()
                 .args(&[param, example_seq.sequence, INPUT])
@@ -53,7 +53,7 @@ fn test_byte_sequence() {
 
 #[test]
 fn test_char_sequence() {
-    for &param in &["-c", "--characters", "--char"] {
+    for param in ["-c", "--characters", "--char"] {
         for example_seq in EXAMPLE_SEQUENCES {
             //as of coreutils 8.25 a char range is effectively the same as a byte range; there is no distinct treatment of utf8 chars.
             new_ucmd!()
@@ -66,7 +66,7 @@ fn test_char_sequence() {
 
 #[test]
 fn test_field_sequence() {
-    for &param in &["-f", "--fields", "--fie"] {
+    for param in ["-f", "--fields", "--fie"] {
         for example_seq in EXAMPLE_SEQUENCES {
             new_ucmd!()
                 .args(&[param, example_seq.sequence, INPUT])
@@ -78,7 +78,7 @@ fn test_field_sequence() {
 
 #[test]
 fn test_specify_delimiter() {
-    for &param in &["-d", "--delimiter", "--del"] {
+    for param in ["-d", "--delimiter", "--del"] {
         new_ucmd!()
             .args(&[param, ":", "-f", COMPLEX_SEQUENCE.sequence, INPUT])
             .succeeds()
@@ -115,7 +115,7 @@ fn test_output_delimiter() {
 
 #[test]
 fn test_complement() {
-    for param in &["--complement", "--com"] {
+    for param in ["--complement", "--com"] {
         new_ucmd!()
             .args(&["-d_", param, "-f", "2"])
             .pipe_in("9_1\n8_2\n7_3")
@@ -135,7 +135,7 @@ fn test_zero_terminated() {
 
 #[test]
 fn test_only_delimited() {
-    for param in &["-s", "--only-delimited", "--only-del"] {
+    for param in ["-s", "--only-delimited", "--only-del"] {
         new_ucmd!()
             .args(&["-d_", param, "-f", "1"])
             .pipe_in("91\n82\n7_3")

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -7,7 +7,7 @@ use rust_users::*;
 
 #[test]
 fn test_date_email() {
-    for param in &["--rfc-email", "--rfc-e", "-R"] {
+    for param in ["--rfc-email", "--rfc-e", "-R"] {
         new_ucmd!().arg(param).succeeds();
     }
 }
@@ -23,7 +23,7 @@ fn test_date_rfc_3339() {
     let re = Regex::new(rfc_regexp).unwrap();
 
     // Check that the output matches the regexp
-    for param in &["--rfc-3339", "--rfc-3"] {
+    for param in ["--rfc-3339", "--rfc-3"] {
         scene
             .ucmd()
             .arg(format!("{}=ns", param))
@@ -40,21 +40,21 @@ fn test_date_rfc_3339() {
 
 #[test]
 fn test_date_rfc_8601() {
-    for param in &["--iso-8601", "--i"] {
+    for param in ["--iso-8601", "--i"] {
         new_ucmd!().arg(format!("{}=ns", param)).succeeds();
     }
 }
 
 #[test]
 fn test_date_rfc_8601_second() {
-    for param in &["--iso-8601", "--i"] {
+    for param in ["--iso-8601", "--i"] {
         new_ucmd!().arg(format!("{}=second", param)).succeeds();
     }
 }
 
 #[test]
 fn test_date_utc() {
-    for param in &["--universal", "--utc", "--uni", "--u"] {
+    for param in ["--universal", "--utc", "--uni", "--u"] {
         new_ucmd!().arg(param).succeeds();
     }
 }

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -463,7 +463,7 @@ fn test_zeros_to_stdout() {
 #[cfg(target_pointer_width = "32")]
 #[test]
 fn test_oversized_bs_32_bit() {
-    for bs_param in &["bs", "ibs", "obs", "cbs"] {
+    for bs_param in ["bs", "ibs", "obs", "cbs"] {
         new_ucmd!()
             .args(&[format!("{}=5GB", bs_param)])
             .run()

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -83,7 +83,7 @@ fn test_unset_invalid_variables() {
 
     // Cannot test input with \0 in it, since output will also contain \0. rlimit::prlimit fails
     // with this error: Error { kind: InvalidInput, message: "nul byte found in provided data" }
-    for var in &["", "a=b"] {
+    for var in ["", "a=b"] {
         new_ucmd!().arg("-u").arg(var).run().stderr_only(format!(
             "env: cannot unset {}: Invalid argument",
             var.quote()

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -49,7 +49,7 @@ fn test_id_single_user() {
         .code_is(exp_result.code());
 
     // u/g/G z/n
-    for &opt in &["--user", "--group", "--groups"] {
+    for opt in ["--user", "--group", "--groups"] {
         let mut args = vec![opt];
         args.extend_from_slice(&test_users);
         exp_result = unwrap_or_return!(expected_result(&ts, &args));
@@ -108,7 +108,7 @@ fn test_id_single_user_non_existing() {
 #[cfg(unix)]
 fn test_id_name() {
     let ts = TestScenario::new(util_name!());
-    for &opt in &["--user", "--group", "--groups"] {
+    for opt in ["--user", "--group", "--groups"] {
         let args = [opt, "--name"];
         let result = ts.ucmd().args(&args).run();
         let exp_result = unwrap_or_return!(expected_result(&ts, &args));
@@ -127,7 +127,7 @@ fn test_id_name() {
 #[cfg(unix)]
 fn test_id_real() {
     let ts = TestScenario::new(util_name!());
-    for &opt in &["--user", "--group", "--groups"] {
+    for opt in ["--user", "--group", "--groups"] {
         let args = [opt, "--real"];
         let result = ts.ucmd().args(&args).run();
         let exp_result = unwrap_or_return!(expected_result(&ts, &args));
@@ -188,7 +188,7 @@ fn test_id_multiple_users() {
         .code_is(exp_result.code());
 
     // u/g/G z/n
-    for &opt in &["--user", "--group", "--groups"] {
+    for opt in ["--user", "--group", "--groups"] {
         let mut args = vec![opt];
         args.extend_from_slice(&test_users);
         exp_result = unwrap_or_return!(expected_result(&ts, &args));
@@ -256,7 +256,7 @@ fn test_id_multiple_users_non_existing() {
         .code_is(exp_result.code());
 
     // u/g/G z/n
-    for &opt in &["--user", "--group", "--groups"] {
+    for opt in ["--user", "--group", "--groups"] {
         let mut args = vec![opt];
         args.extend_from_slice(&test_users);
         exp_result = unwrap_or_return!(expected_result(&ts, &args));
@@ -297,14 +297,14 @@ fn test_id_multiple_users_non_existing() {
 #[cfg(unix)]
 fn test_id_default_format() {
     let ts = TestScenario::new(util_name!());
-    for &opt1 in &["--name", "--real"] {
+    for opt1 in ["--name", "--real"] {
         // id: cannot print only names or real IDs in default format
         let args = [opt1];
         ts.ucmd()
             .args(&args)
             .fails()
             .stderr_only(unwrap_or_return!(expected_result(&ts, &args)).stderr_str());
-        for &opt2 in &["--user", "--group", "--groups"] {
+        for opt2 in ["--user", "--group", "--groups"] {
             // u/g/G n/r
             let args = [opt2, opt1];
             let result = ts.ucmd().args(&args).run();
@@ -315,7 +315,7 @@ fn test_id_default_format() {
                 .code_is(exp_result.code());
         }
     }
-    for &opt2 in &["--user", "--group", "--groups"] {
+    for opt2 in ["--user", "--group", "--groups"] {
         // u/g/G
         let args = [opt2];
         ts.ucmd()
@@ -329,20 +329,20 @@ fn test_id_default_format() {
 #[cfg(unix)]
 fn test_id_zero() {
     let ts = TestScenario::new(util_name!());
-    for z_flag in &["-z", "--zero"] {
+    for z_flag in ["-z", "--zero"] {
         // id: option --zero not permitted in default format
         ts.ucmd()
             .args(&[z_flag])
             .fails()
             .stderr_only(unwrap_or_return!(expected_result(&ts, &[z_flag])).stderr_str());
-        for &opt1 in &["--name", "--real"] {
+        for opt1 in ["--name", "--real"] {
             // id: cannot print only names or real IDs in default format
             let args = [opt1, z_flag];
             ts.ucmd()
                 .args(&args)
                 .fails()
                 .stderr_only(unwrap_or_return!(expected_result(&ts, &args)).stderr_str());
-            for &opt2 in &["--user", "--group", "--groups"] {
+            for opt2 in ["--user", "--group", "--groups"] {
                 // u/g/G n/r z
                 let args = [opt2, z_flag, opt1];
                 let result = ts.ucmd().args(&args).run();
@@ -353,7 +353,7 @@ fn test_id_zero() {
                     .code_is(exp_result.code());
             }
         }
-        for &opt2 in &["--user", "--group", "--groups"] {
+        for opt2 in ["--user", "--group", "--groups"] {
             // u/g/G z
             let args = [opt2, z_flag];
             ts.ucmd()
@@ -373,18 +373,18 @@ fn test_id_context() {
         return;
     }
     let ts = TestScenario::new(util_name!());
-    for c_flag in &["-Z", "--context"] {
+    for c_flag in ["-Z", "--context"] {
         ts.ucmd()
             .args(&[c_flag])
             .succeeds()
             .stdout_only(unwrap_or_return!(expected_result(&ts, &[c_flag])).stdout_str());
-        for &z_flag in &["-z", "--zero"] {
+        for z_flag in ["-z", "--zero"] {
             let args = [c_flag, z_flag];
             ts.ucmd()
                 .args(&args)
                 .succeeds()
                 .stdout_only(unwrap_or_return!(expected_result(&ts, &args)).stdout_str());
-            for &opt1 in &["--name", "--real"] {
+            for opt1 in ["--name", "--real"] {
                 // id: cannot print only names or real IDs in default format
                 let args = [opt1, c_flag];
                 ts.ucmd()
@@ -396,7 +396,7 @@ fn test_id_context() {
                     .args(&args)
                     .succeeds()
                     .stdout_only(unwrap_or_return!(expected_result(&ts, &args)).stdout_str());
-                for &opt2 in &["--user", "--group", "--groups"] {
+                for opt2 in ["--user", "--group", "--groups"] {
                     // u/g/G n/r z Z
                     // for now, we print clap's standard response for "conflicts_with" instead of:
                     // id: cannot print "only" of more than one choice
@@ -409,7 +409,7 @@ fn test_id_context() {
                     //     .code_is(exp_result.code());
                 }
             }
-            for &opt2 in &["--user", "--group", "--groups"] {
+            for opt2 in ["--user", "--group", "--groups"] {
                 // u/g/G z Z
                 // for now, we print clap's standard response for "conflicts_with" instead of:
                 // id: cannot print "only" of more than one choice

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -604,7 +604,7 @@ fn test_ls_width() {
     at.touch(&at.plus_as_string("test-width-3"));
     at.touch(&at.plus_as_string("test-width-4"));
 
-    for option in &[
+    for option in [
         "-w 100",
         "-w=100",
         "--width=100",
@@ -619,7 +619,7 @@ fn test_ls_width() {
             .stdout_only("test-width-1  test-width-2  test-width-3  test-width-4\n");
     }
 
-    for option in &["-w 50", "-w=50", "--width=50", "--width 50", "--wid=50"] {
+    for option in ["-w 50", "-w=50", "--width=50", "--width 50", "--wid=50"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -628,7 +628,7 @@ fn test_ls_width() {
             .stdout_only("test-width-1  test-width-3\ntest-width-2  test-width-4\n");
     }
 
-    for option in &["-w 25", "-w=25", "--width=25", "--width 25", "--wid=25"] {
+    for option in ["-w 25", "-w=25", "--width=25", "--width 25", "--wid=25"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -637,7 +637,7 @@ fn test_ls_width() {
             .stdout_only("test-width-1\ntest-width-2\ntest-width-3\ntest-width-4\n");
     }
 
-    for option in &["-w 0", "-w=0", "--width=0", "--width 0", "--wid=0"] {
+    for option in ["-w 0", "-w=0", "--width=0", "--width 0", "--wid=0"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -653,7 +653,7 @@ fn test_ls_width() {
         .fails()
         .stderr_contains("invalid line width");
 
-    for option in &["-w 1a", "-w=1a", "--width=1a", "--width 1a", "--wid 1a"] {
+    for option in ["-w 1a", "-w=1a", "--width=1a", "--width 1a", "--wid 1a"] {
         scene
             .ucmd()
             .args(&option.split(' ').collect::<Vec<_>>())
@@ -1088,9 +1088,9 @@ fn test_ls_long_total_size() {
         let result = scene.ucmd().arg(arg).succeeds();
         result.stdout_contains(expected_prints["long_vanilla"]);
 
-        for arg2 in &["-h", "--human-readable", "--si"] {
+        for arg2 in ["-h", "--human-readable", "--si"] {
             let result = scene.ucmd().arg(arg).arg(arg2).succeeds();
-            result.stdout_contains(if *arg2 == "--si" {
+            result.stdout_contains(if arg2 == "--si" {
                 expected_prints["long_si"]
             } else {
                 expected_prints["long_human_readable"]
@@ -1158,7 +1158,7 @@ fn test_ls_long_formats() {
             .stdout_matches(&re_three_num);
     }
 
-    for arg in &[
+    for arg in [
         "-l",                     // only group and owner
         "-g --author",            // only author and group
         "-o --author",            // only author and owner
@@ -1184,7 +1184,7 @@ fn test_ls_long_formats() {
         }
     }
 
-    for arg in &[
+    for arg in [
         "-g",            // only group
         "-gl",           // only group
         "-o",            // only owner
@@ -1213,7 +1213,7 @@ fn test_ls_long_formats() {
         }
     }
 
-    for arg in &[
+    for arg in [
         "-og",
         "-ogl",
         "-lgo",
@@ -1255,7 +1255,7 @@ fn test_ls_oneline() {
 
     // Bit of a weird situation: in the tests oneline and columns have the same output,
     // except on Windows.
-    for option in &["-1", "--format=single-column"] {
+    for option in ["-1", "--format=single-column"] {
         scene
             .ucmd()
             .arg(option)
@@ -1376,7 +1376,7 @@ fn test_ls_long_ctime() {
 
     at.touch("test-long-ctime-1");
 
-    for arg in &["-c", "--time=ctime", "--time=status"] {
+    for arg in ["-c", "--time=ctime", "--time=status"] {
         let result = scene.ucmd().arg("-l").arg(arg).succeeds();
 
         // Should show the time on Unix, but question marks on windows.
@@ -1537,7 +1537,7 @@ fn test_ls_order_time() {
 
     // 3 was accessed last in the read
     // So the order should be 2 3 4 1
-    for arg in &["-u", "--time=atime", "--time=access", "--time=use"] {
+    for arg in ["-u", "--time=atime", "--time=access", "--time=use"] {
         let result = scene.ucmd().arg("-t").arg(arg).succeeds();
         at.open("test-3").metadata().unwrap().accessed().unwrap();
         at.open("test-4").metadata().unwrap().accessed().unwrap();
@@ -1656,7 +1656,7 @@ fn test_ls_color() {
     assert!(!result.stdout_str().contains(z_with_colors));
 
     // Color should be enabled
-    for param in &["--color", "--col", "--color=always", "--col=always"] {
+    for param in ["--color", "--col", "--color=always", "--col=always"] {
         scene
             .ucmd()
             .arg(param)
@@ -2034,7 +2034,7 @@ fn test_ls_success_on_c_drv_root_windows() {
 fn test_ls_version_sort() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
-    for filename in &[
+    for filename in [
         "a2",
         "b1",
         "b20",
@@ -2130,7 +2130,7 @@ fn test_ls_quoting_style() {
             .succeeds()
             .stdout_only("'one'$'\\n''two'\n");
 
-        for (arg, correct) in &[
+        for (arg, correct) in [
             ("--quoting-style=literal", "one?two"),
             ("-N", "one?two"),
             ("--literal", "one?two"),
@@ -2154,7 +2154,7 @@ fn test_ls_quoting_style() {
                 .stdout_only(format!("{}\n", correct));
         }
 
-        for (arg, correct) in &[
+        for (arg, correct) in [
             ("--quoting-style=literal", "one\ntwo"),
             ("-N", "one\ntwo"),
             ("--literal", "one\ntwo"),
@@ -2170,7 +2170,7 @@ fn test_ls_quoting_style() {
                 .stdout_only(format!("{}\n", correct));
         }
 
-        for (arg, correct) in &[
+        for (arg, correct) in [
             ("--quoting-style=literal", "one\\two"),
             ("-N", "one\\two"),
             ("--quoting-style=c", "\"one\\\\two\""),
@@ -2195,7 +2195,7 @@ fn test_ls_quoting_style() {
         // Tests for a character that forces quotation in shell-style escaping
         // after a character in a dollar expression
         at.touch("one\n&two");
-        for (arg, correct) in &[
+        for (arg, correct) in [
             ("--quoting-style=shell-escape", "'one'$'\\n''&two'"),
             ("--quoting-style=shell-escape-always", "'one'$'\\n''&two'"),
         ] {
@@ -2215,7 +2215,7 @@ fn test_ls_quoting_style() {
         .succeeds()
         .stdout_only("'one two'\n");
 
-    for (arg, correct) in &[
+    for (arg, correct) in [
         ("--quoting-style=literal", "one two"),
         ("-N", "one two"),
         ("--literal", "one two"),
@@ -2241,7 +2241,7 @@ fn test_ls_quoting_style() {
 
     scene.ucmd().arg("one").succeeds().stdout_only("one\n");
 
-    for (arg, correct) in &[
+    for (arg, correct) in [
         ("--quoting-style=literal", "one"),
         ("-N", "one"),
         ("--quoting-style=c", "\"one\""),
@@ -2649,7 +2649,7 @@ fn test_ls_deref_command_line_dir() {
 fn test_ls_sort_extension() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
-    for filename in &[
+    for filename in [
         "file1",
         "file2",
         "anotherFile",
@@ -2831,7 +2831,7 @@ fn test_ls_context2() {
         return;
     }
     let ts = TestScenario::new(util_name!());
-    for c_flag in &["-Z", "--context"] {
+    for c_flag in ["-Z", "--context"] {
         ts.ucmd()
             .args(&[c_flag, &"/"])
             .succeeds()
@@ -2851,7 +2851,7 @@ fn test_ls_context_format() {
     // NOTE:
     // --format=long/verbose matches the output of GNU's ls for --context
     // except for the size count which may differ to the size count reported by GNU's ls.
-    for word in &[
+    for word in [
         "across",
         "commas",
         "horizontal",

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -42,7 +42,7 @@ fn test_padding_with_overflow() {
 #[test]
 fn test_sections_and_styles() {
     // spell-checker:disable
-    for &(fixture, output) in &[
+    for (fixture, output) in [
         (
             "section.txt",
             "\nHEADER1\nHEADER2\n\n1  |BODY1\n2  \

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -484,7 +484,7 @@ fn test_delimiter_with_padding_and_fields() {
 
 #[test]
 fn test_round() {
-    for (method, exp) in &[
+    for (method, exp) in [
         ("from-zero", ["9.1K", "-9.1K", "9.1K", "-9.1K"]),
         ("towards-zero", ["9.0K", "-9.0K", "9.0K", "-9.0K"]),
         ("up", ["9.1K", "-9.0K", "9.1K", "-9.0K"]),

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -70,12 +70,12 @@ fn test_2files() {
     let file1 = tmpdir.join("test1");
     let file2 = tmpdir.join("test2");
 
-    for &(n, a) in &[(1, "a"), (2, "b")] {
+    for (n, a) in [(1, "a"), (2, "b")] {
         println!("number: {} letter:{}", n, a);
     }
 
     // spell-checker:disable-next-line
-    for &(path, data) in &[(&file1, "abcdefghijklmnop"), (&file2, "qrstuvwxyz\n")] {
+    for (path, data) in [(&file1, "abcdefghijklmnop"), (&file2, "qrstuvwxyz\n")] {
         let mut f = File::create(&path).unwrap();
         assert!(
             f.write_all(data.as_bytes()).is_ok(),
@@ -127,7 +127,7 @@ fn test_from_mixed() {
 
     // spell-checker:disable-next-line
     let (data1, data2, data3) = ("abcdefg", "hijklmnop", "qrstuvwxyz\n");
-    for &(path, data) in &[(&file1, data1), (&file3, data3)] {
+    for (path, data) in [(&file1, data1), (&file3, data3)] {
         let mut f = File::create(&path).unwrap();
         assert!(
             f.write_all(data.as_bytes()).is_ok(),

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -82,8 +82,8 @@ static EXAMPLE_DATA: &[TestData] = &[
 
 #[test]
 fn test_combine_pairs_of_lines() {
-    for &s in &["-s", "--serial"] {
-        for &d in &["-d", "--delimiters"] {
+    for s in ["-s", "--serial"] {
+        for d in ["-d", "--delimiters"] {
             new_ucmd!()
                 .args(&[s, d, "\t\n", "html_colors.txt"])
                 .run()
@@ -94,7 +94,7 @@ fn test_combine_pairs_of_lines() {
 
 #[test]
 fn test_multi_stdin() {
-    for &d in &["-d", "--delimiters"] {
+    for d in ["-d", "--delimiters"] {
         new_ucmd!()
             .args(&[d, "\t\n", "-", "-"])
             .pipe_in_fixture("html_colors.txt")

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -69,7 +69,7 @@ fn test_with_long_header_option() {
     let test_file_path = "test_one_page.log";
     let expected_test_file_path = "test_one_page_header.log.expected";
     let header = "new file";
-    for args in &[&["-h", header][..], &["--header=new file"][..]] {
+    for args in [&["-h", header][..], &["--header=new file"][..]] {
         let mut scenario = new_ucmd!();
         let value = file_last_modified_time(&scenario, test_file_path);
         scenario
@@ -87,7 +87,7 @@ fn test_with_long_header_option() {
 fn test_with_double_space_option() {
     let test_file_path = "test_one_page.log";
     let expected_test_file_path = "test_one_page_double_line.log.expected";
-    for &arg in &["-d", "--double-space"] {
+    for arg in ["-d", "--double-space"] {
         let mut scenario = new_ucmd!();
         let value = file_last_modified_time(&scenario, test_file_path);
         scenario
@@ -183,7 +183,7 @@ fn test_with_page_range() {
     let test_file_path = "test.log";
     let expected_test_file_path = "test_page_range_1.log.expected";
     let expected_test_file_path1 = "test_page_range_2.log.expected";
-    for &arg in &["--pages=15", "+15"] {
+    for arg in ["--pages=15", "+15"] {
         let mut scenario = new_ucmd!();
         let value = file_last_modified_time(&scenario, test_file_path);
         scenario
@@ -194,7 +194,7 @@ fn test_with_page_range() {
                 &[("{last_modified_time}", &value)],
             );
     }
-    for &arg in &["--pages=15:17", "+15:17"] {
+    for arg in ["--pages=15:17", "+15:17"] {
         let mut scenario = new_ucmd!();
         let value = file_last_modified_time(&scenario, test_file_path);
         scenario
@@ -222,7 +222,7 @@ fn test_with_no_header_trailer_option() {
 #[test]
 fn test_with_page_length_option() {
     let test_file_path = "test.log";
-    for (arg, expected) in &[
+    for (arg, expected) in [
         ("100", "test_page_length.log.expected"),
         ("5", "test_page_length1.log.expected"),
     ] {
@@ -265,7 +265,7 @@ fn test_with_stdin() {
 fn test_with_column() {
     let test_file_path = "column.log";
     let expected_test_file_path = "column.log.expected";
-    for arg in &["-3", "--column=3"] {
+    for arg in ["-3", "--column=3"] {
         let mut scenario = new_ucmd!();
         let value = file_last_modified_time(&scenario, test_file_path);
         scenario
@@ -293,7 +293,7 @@ fn test_with_column_across_option() {
 #[test]
 fn test_with_column_across_option_and_column_separator() {
     let test_file_path = "column.log";
-    for (arg, expected) in &[
+    for (arg, expected) in [
         ("-s|", "column_across_sep.log.expected"),
         ("-Sdivide", "column_across_sep1.log.expected"),
     ] {

--- a/tests/by-util/test_runcon.rs
+++ b/tests/by-util/test_runcon.rs
@@ -22,11 +22,11 @@ fn help() {
 fn print() {
     new_ucmd!().succeeds();
 
-    for &flag in &["-c", "--compute"] {
+    for flag in ["-c", "--compute"] {
         new_ucmd!().arg(flag).succeeds();
     }
 
-    for &flag in &[
+    for flag in [
         "-t", "--type", "-u", "--user", "-r", "--role", "-l", "--range",
     ] {
         new_ucmd!().args(&[flag, "example"]).succeeds();
@@ -57,7 +57,7 @@ fn invalid() {
     // TODO: Enable this code once the issue is fixed in the clap version we're using.
     //new_ucmd!().arg("--compute=example").fails().code_is(1);
 
-    for &flag in &[
+    for flag in [
         "-t", "--type", "-u", "--user", "-r", "--role", "-l", "--range",
     ] {
         new_ucmd!().arg(flag).fails().code_is(1);
@@ -119,7 +119,7 @@ fn custom_context() {
     let args = &["--compute", "--range=s0", "/bin/true"];
     new_ucmd!().args(args).succeeds();
 
-    for &(ctx, u, r) in &[
+    for (ctx, u, r) in [
         ("unconfined_u:unconfined_r:unconfined_t:s0", u_ud, r_ud),
         ("system_u:unconfined_r:unconfined_t:s0", "system_u", r_ud),
         ("unconfined_u:system_r:unconfined_t:s0", u_ud, "system_r"),

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -220,7 +220,7 @@ fn test_random_shuffle_contains_all_lines() {
 
 #[test]
 fn test_random_shuffle_two_runs_not_the_same() {
-    for arg in &["-R", "-k1,1R"] {
+    for arg in ["-R", "-k1,1R"] {
         // check to verify that two random shuffles are not equal; this has the
         // potential to fail in the very unlikely event that the random order is the same
         // as the starting order, or if both random sorts end up having the same order.
@@ -407,7 +407,7 @@ fn test_mixed_floats_ints_chars_numeric_stable() {
 
 #[test]
 fn test_numeric_floats_and_ints2() {
-    for numeric_sort_param in &["-n", "--numeric-sort"] {
+    for numeric_sort_param in ["-n", "--numeric-sort"] {
         let input = "1.444\n8.013\n1\n-8\n1.04\n-1";
         new_ucmd!()
             .arg(numeric_sort_param)
@@ -419,7 +419,7 @@ fn test_numeric_floats_and_ints2() {
 
 #[test]
 fn test_numeric_floats2() {
-    for numeric_sort_param in &["-n", "--numeric-sort"] {
+    for numeric_sort_param in ["-n", "--numeric-sort"] {
         let input = "1.444\n8.013\n1.58590\n-8.90880\n1.040000000\n-.05";
         new_ucmd!()
             .arg(numeric_sort_param)
@@ -439,7 +439,7 @@ fn test_numeric_floats_with_nan2() {
 
 #[test]
 fn test_human_block_sizes2() {
-    for human_numeric_sort_param in &["-h", "--human-numeric-sort", "--sort=human-numeric"] {
+    for human_numeric_sort_param in ["-h", "--human-numeric-sort", "--sort=human-numeric"] {
         let input = "8981K\n909991M\n-8T\n21G\n0.8M";
         new_ucmd!()
             .arg(human_numeric_sort_param)
@@ -461,7 +461,7 @@ fn test_human_numeric_zero_stable() {
 
 #[test]
 fn test_month_default2() {
-    for month_sort_param in &["-M", "--month-sort", "--sort=month"] {
+    for month_sort_param in ["-M", "--month-sort", "--sort=month"] {
         let input = "JAn\nMAY\n000may\nJun\nFeb";
         new_ucmd!()
             .arg(month_sort_param)
@@ -555,7 +555,7 @@ fn test_keys_invalid_char_zero() {
 #[test]
 fn test_keys_with_options() {
     let input = "aa 3 cc\ndd 1 ff\ngg 2 cc\n";
-    for param in &[
+    for param in [
         &["-k", "2,2n"][..],
         &["-k", "2n,2"][..],
         &["-k", "2,2", "-n"][..],
@@ -571,7 +571,7 @@ fn test_keys_with_options() {
 #[test]
 fn test_keys_with_options_blanks_start() {
     let input = "aa   3 cc\ndd  1 ff\ngg         2 cc\n";
-    for param in &[&["-k", "2b,2"][..], &["-k", "2,2", "-b"][..]] {
+    for param in [&["-k", "2b,2"][..], &["-k", "2,2", "-b"][..]] {
         new_ucmd!()
             .args(param)
             .pipe_in(input)
@@ -761,7 +761,7 @@ fn test_pipe() {
 
 #[test]
 fn test_check() {
-    for diagnose_arg in &["-c", "--check", "--check=diagnose-first"] {
+    for diagnose_arg in ["-c", "--check", "--check=diagnose-first"] {
         new_ucmd!()
             .arg(diagnose_arg)
             .arg("check_fail.txt")
@@ -779,7 +779,7 @@ fn test_check() {
 
 #[test]
 fn test_check_silent() {
-    for silent_arg in &["-C", "--check=silent", "--check=quiet"] {
+    for silent_arg in ["-C", "--check=silent", "--check=quiet"] {
         new_ucmd!()
             .arg(silent_arg)
             .arg("check_fail.txt")
@@ -803,7 +803,7 @@ fn test_check_unique() {
 #[test]
 fn test_dictionary_and_nonprinting_conflicts() {
     let conflicting_args = ["n", "h", "g", "M"];
-    for restricted_arg in &["d", "i"] {
+    for restricted_arg in ["d", "i"] {
         for conflicting_arg in &conflicting_args {
             new_ucmd!()
                 .arg(&format!("-{}{}", restricted_arg, conflicting_arg))

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -236,7 +236,7 @@ fn test_symlinks() {
 
     let mut tested: bool = false;
     // arbitrarily chosen symlinks with hope that the CI environment provides at least one of them
-    for file in &[
+    for file in [
         "/bin/sh",
         "/bin/sudoedit",
         "/usr/bin/ex",

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -522,7 +522,7 @@ fn test_tail_bytes_for_funny_files() {
     // gnu/tests/tail-2/tail-c.sh
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
-    for &file in &["/proc/version", "/sys/kernel/profiling"] {
+    for file in ["/proc/version", "/sys/kernel/profiling"] {
         if !at.file_exists(file) {
             continue;
         }

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -9,7 +9,7 @@ fn test_tee_processing_multiple_operands() {
     // POSIX says: "Processing of at least 13 file operands shall be supported."
 
     let content = "tee_sample_content";
-    for &n in &[1, 2, 12, 13] {
+    for n in [1, 2, 12, 13] {
         let files = (1..=n).map(|x| x.to_string()).collect::<Vec<_>>();
         let (at, mut ucmd) = at_and_ucmd!();
 

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -39,7 +39,7 @@ fn test_command_with_args() {
 
 #[test]
 fn test_verbose() {
-    for &verbose_flag in &["-v", "--verbose"] {
+    for verbose_flag in ["-v", "--verbose"] {
         new_ucmd!()
             .args(&[verbose_flag, ".1", "sleep", "10"])
             .fails()

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -333,7 +333,7 @@ fn test_touch_reference() {
     at.touch(file_a);
     set_file_times(&at, file_a, start_of_year, start_of_year);
     assert!(at.file_exists(file_a));
-    for &opt in &["-r", "--ref", "--reference"] {
+    for opt in ["-r", "--ref", "--reference"] {
         scenario
             .ccmd("touch")
             .args(&[opt, file_a, file_b])

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -7,7 +7,7 @@ use crate::common::util::*;
 
 #[test]
 fn test_count_bytes_large_stdin() {
-    for &n in &[
+    for n in [
         0,
         1,
         42,

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -12,7 +12,7 @@ use crate::common::util::*;
 #[ignore = "issue #3219"]
 fn test_count() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-q", "--count", "--c"] {
+    for opt in ["-q", "--count", "--c"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -22,7 +22,7 @@ fn test_count() {
 #[test]
 fn test_boot() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-b", "--boot", "--b"] {
+    for opt in ["-b", "--boot", "--b"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -33,7 +33,7 @@ fn test_boot() {
 #[ignore = "issue #3219"]
 fn test_heading() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-H", "--heading", "--head"] {
+    for opt in ["-H", "--heading", "--head"] {
         // allow whitespace variation
         // * minor whitespace differences occur between platform built-in outputs;
         //   specifically number of TABs between "TIME" and "COMMENT" may be variant
@@ -52,7 +52,7 @@ fn test_heading() {
 #[ignore = "issue #3219"]
 fn test_short() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-s", "--short", "--s"] {
+    for opt in ["-s", "--short", "--s"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -62,7 +62,7 @@ fn test_short() {
 #[test]
 fn test_login() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-l", "--login", "--log"] {
+    for opt in ["-l", "--login", "--log"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -80,7 +80,7 @@ fn test_m() {
 #[test]
 fn test_process() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-p", "--process", "--p"] {
+    for opt in ["-p", "--process", "--p"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -90,7 +90,7 @@ fn test_process() {
 #[test]
 fn test_runlevel() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-r", "--runlevel", "--r"] {
+    for opt in ["-r", "--runlevel", "--r"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
 
@@ -103,7 +103,7 @@ fn test_runlevel() {
 #[test]
 fn test_time() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-t", "--time", "--t"] {
+    for opt in ["-t", "--time", "--t"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -120,7 +120,7 @@ fn test_mesg() {
     // --writable
     //     same as -T
     let ts = TestScenario::new(util_name!());
-    for opt in &[
+    for opt in [
         "-T",
         "-w",
         "--mesg",
@@ -157,7 +157,7 @@ fn test_too_many_args() {
 #[ignore = "issue #3219"]
 fn test_users() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-u", "--users", "--us"] {
+    for opt in ["-u", "--users", "--us"] {
         let actual = ts.ucmd().arg(opt).succeeds().stdout_move_str();
         let expect = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         println!("actual: {:?}", actual);
@@ -192,7 +192,7 @@ fn test_lookup() {
 #[test]
 fn test_dead() {
     let ts = TestScenario::new(util_name!());
-    for opt in &["-d", "--dead", "--de"] {
+    for opt in ["-d", "--dead", "--de"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }
@@ -226,7 +226,7 @@ fn test_all() {
     }
 
     let ts = TestScenario::new(util_name!());
-    for opt in &["-a", "--all", "--a"] {
+    for opt in ["-a", "--all", "--a"] {
         let expected_stdout = unwrap_or_return!(expected_result(&ts, &[opt])).stdout_move_str();
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
     }

--- a/tests/by-util/test_yes.rs
+++ b/tests/by-util/test_yes.rs
@@ -55,7 +55,7 @@ fn test_long_input() {
 fn test_piped_to_dev_full() {
     use std::fs::OpenOptions;
 
-    for &append in &[true, false] {
+    for append in [true, false] {
         {
             let dev_full = OpenOptions::new()
                 .write(true)


### PR DESCRIPTION
Finishing what I started for https://github.com/uutils/coreutils/issues/3342. I bumped the edition for all crates to 2021 and made some simple changes that this enabled. In particular:
- `TryInto` and `TryFrom` are now part of the prelude and no longer need to be explicitly imported
- Arrays implement `IntoIterator`, so they don't need to be prefixed with a `&` to iterate over them.