### PR TITLE
df: show error if same type is included & excluded

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -96,6 +96,21 @@ fn test_exclude_type_option() {
 }
 
 #[test]
+fn test_include_exclude_same_type() {
+    new_ucmd!()
+        .args(&["-t", "ext4", "-x", "ext4"])
+        .fails()
+        .stderr_is("df: file system type 'ext4' both selected and excluded");
+    new_ucmd!()
+        .args(&["-t", "ext4", "-x", "ext4", "-t", "ext3", "-x", "ext3"])
+        .fails()
+        .stderr_is(
+            "df: file system type 'ext4' both selected and excluded\n\
+             df: file system type 'ext3' both selected and excluded",
+        );
+}
+
+#[test]
 fn test_total() {
     // Example output:
     //


### PR DESCRIPTION
Any file system type specified to be included and excluded is listed with a separate line in the error message.