### PR TITLE
docs: show supported platforms for each util

### DIFF
--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -5,10 +5,17 @@
     main {
         position: relative;
     }
-    .version {
+    .additional {
         position: absolute;
-        top: 1em;
+        top: 0em;
         right: 0;
+        display: flex;
+        gap: 5px;
+        align-items: center;
+        font-size: 1.3em;
+    }
+    .platforms {
+        font-size: 1.5em;
     }
     dd > p {
         margin-top: 0.2em;


### PR DESCRIPTION
A few examples:

- A util that supports Linux (unix) and Mac:
![image](https://user-images.githubusercontent.com/11643477/162206993-a23e2251-5ca8-408c-8214-99838b9d2d98.png)

- A utils that requires SELinux (and thus supports only Linux):
![image](https://user-images.githubusercontent.com/11643477/162207078-8cccb004-ee0c-4389-b5b9-60c56eb14687.png)

- A util that supports all platforms:
![image](https://user-images.githubusercontent.com/11643477/162207168-729d2359-c11f-45e7-9d6b-a481e22cebdb.png)

The data is collected by running `./util/show-utils.sh` with different feature sets.

I also refactored the `uudoc` code a bit. I wanted to include FreeBSD as well, but the icon for that was only added in FontAwesome 5, which mdbook does not use yet.