### PR TITLE
df: show error when file argument does not exist

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -28,16 +28,18 @@ fn test_df_compatible_si() {
 
 #[test]
 fn test_df_output() {
-    // TODO These should fail because `-total` should have two dashes,
-    // not just one. But they don't fail.
-    if cfg!(target_os = "macos") {
-        new_ucmd!().arg("-H").arg("-total").succeeds().
-        stdout_only("Filesystem               Size         Used    Available     Capacity  Use% Mounted on       \n");
+    let expected = if cfg!(target_os = "macos") {
+        "Filesystem               Size         Used    Available     Capacity  Use% Mounted on       "
     } else {
-        new_ucmd!().arg("-H").arg("-total").succeeds().stdout_only(
-            "Filesystem               Size         Used    Available  Use% Mounted on       \n",
-        );
-    }
+        "Filesystem               Size         Used    Available  Use% Mounted on       "
+    };
+    let output = new_ucmd!()
+        .arg("-H")
+        .arg("--total")
+        .succeeds()
+        .stdout_move_str();
+    let actual = output.lines().take(1).collect::<Vec<&str>>()[0];
+    assert_eq!(actual, expected);
 }
 
 /// Test that the order of rows in the table does not change across executions.

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -297,3 +297,16 @@ fn test_output_field_no_more_than_once() {
         .fails()
         .usage_error("option --output: field 'target' used more than once");
 }
+
+#[test]
+fn test_nonexistent_file() {
+    new_ucmd!()
+        .arg("does-not-exist")
+        .fails()
+        .stderr_only("df: does-not-exist: No such file or directory");
+    new_ucmd!()
+        .args(&["--output=file", "does-not-exist", "."])
+        .fails()
+        .stderr_is("df: does-not-exist: No such file or directory\n")
+        .stdout_is("File            \n.               \n");
+}


### PR DESCRIPTION
For example:

    $ df not-a-file
    df: not-a-file: No such file or directory

Fixes #3373.