### PR TITLE
Clippy: Don't use `from_*` method names that take `self`

### DIFF
--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -69,7 +69,7 @@ pub(crate) fn test<A: Arithmetic + Basis>(m: A) -> Result {
             continue;
         }
 
-        let a = m.from_u64(_a);
+        let a = m.to_mod(_a);
 
         // x = a^r mod n
         let mut x = m.pow(a, r);

--- a/src/uu/factor/src/numeric/montgomery.rs
+++ b/src/uu/factor/src/numeric/montgomery.rs
@@ -16,7 +16,7 @@ pub(crate) trait Arithmetic: Copy + Sized {
 
     fn new(m: u64) -> Self;
     fn modulus(&self) -> u64;
-    fn from_u64(&self, n: u64) -> Self::ModInt;
+    fn to_mod(&self, n: u64) -> Self::ModInt;
     fn to_u64(&self, n: Self::ModInt) -> u64;
     fn add(&self, a: Self::ModInt, b: Self::ModInt) -> Self::ModInt;
     fn mul(&self, a: Self::ModInt, b: Self::ModInt) -> Self::ModInt;
@@ -47,13 +47,13 @@ pub(crate) trait Arithmetic: Copy + Sized {
     }
 
     fn one(&self) -> Self::ModInt {
-        self.from_u64(1)
+        self.to_mod(1)
     }
     fn minus_one(&self) -> Self::ModInt {
-        self.from_u64(self.modulus() - 1)
+        self.to_mod(self.modulus() - 1)
     }
     fn zero(&self) -> Self::ModInt {
-        self.from_u64(0)
+        self.to_mod(0)
     }
 }
 
@@ -113,7 +113,7 @@ impl<T: DoubleInt> Arithmetic for Montgomery<T> {
         self.n.as_u64()
     }
 
-    fn from_u64(&self, x: u64) -> Self::ModInt {
+    fn to_mod(&self, x: u64) -> Self::ModInt {
         // TODO: optimise!
         debug_assert!(x < self.n.as_u64());
         let r = T::from_double_width(
@@ -189,9 +189,9 @@ mod tests {
             let n = 2 * n + 1;
             let m = Montgomery::<A>::new(n);
             for x in 0..n {
-                let m_x = m.from_u64(x);
+                let m_x = m.to_mod(x);
                 for y in 0..=x {
-                    let m_y = m.from_u64(y);
+                    let m_y = m.to_mod(y);
                     println!("{n:?}, {x:?}, {y:?}", n = n, x = x, y = y);
                     assert_eq!((x + y) % n, m.to_u64(m.add(m_x, m_y)));
                 }
@@ -205,9 +205,9 @@ mod tests {
             let n = 2 * n + 1;
             let m = Montgomery::<A>::new(n);
             for x in 0..n {
-                let m_x = m.from_u64(x);
+                let m_x = m.to_mod(x);
                 for y in 0..=x {
-                    let m_y = m.from_u64(y);
+                    let m_y = m.to_mod(y);
                     assert_eq!((x * y) % n, m.to_u64(m.mul(m_x, m_y)));
                 }
             }
@@ -220,7 +220,7 @@ mod tests {
             let n = 2 * n + 1;
             let m = Montgomery::<A>::new(n);
             for x in 0..n {
-                let x_ = m.from_u64(x);
+                let x_ = m.to_mod(x);
                 assert_eq!(x, m.to_u64(x_));
             }
         }

--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -18,7 +18,7 @@ pub(crate) fn find_divisor<A: Arithmetic>(n: A) -> u64 {
     let mut rand = {
         let range = Uniform::new(1, n.modulus());
         let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
-        move || n.from_u64(range.sample(&mut rng))
+        move || n.to_mod(range.sample(&mut rng))
     };
 
     let quadratic = |a, b| move |x| n.add(n.mul(a, n.mul(x, x)), b);

--- a/src/uucore/src/lib/features/tokenize/num_format/formatters/base_conv/mod.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/formatters/base_conv/mod.rs
@@ -179,7 +179,7 @@ pub fn str_to_arrnum(src: &str, radix_def_src: &dyn RadixDef) -> Vec<u8> {
     let mut intermed_in: Vec<u8> = Vec::new();
     for c in src.chars() {
         #[allow(clippy::single_match)]
-        match radix_def_src.from_char(c) {
+        match radix_def_src.parse_char(c) {
             Some(u) => {
                 intermed_in.push(u);
             }
@@ -193,7 +193,7 @@ pub fn arrnum_to_str(src: &[u8], radix_def_dest: &dyn RadixDef) -> String {
     let mut str_out = String::new();
     for u in src.iter() {
         #[allow(clippy::single_match)]
-        match radix_def_dest.from_u8(*u) {
+        match radix_def_dest.format_u8(*u) {
             Some(c) => {
                 str_out.push(c);
             }
@@ -219,8 +219,8 @@ pub fn base_conv_str(
 
 pub trait RadixDef {
     fn get_max(&self) -> u8;
-    fn from_char(&self, x: char) -> Option<u8>;
-    fn from_u8(&self, x: u8) -> Option<char>;
+    fn parse_char(&self, x: char) -> Option<u8>;
+    fn format_u8(&self, x: u8) -> Option<char>;
 }
 pub struct RadixTen;
 
@@ -232,13 +232,13 @@ impl RadixDef for RadixTen {
     fn get_max(&self) -> u8 {
         10
     }
-    fn from_char(&self, c: char) -> Option<u8> {
+    fn parse_char(&self, c: char) -> Option<u8> {
         match c {
             '0'..='9' => Some(c as u8 - ZERO_ASC),
             _ => None,
         }
     }
-    fn from_u8(&self, u: u8) -> Option<char> {
+    fn format_u8(&self, u: u8) -> Option<char> {
         match u {
             0..=9 => Some((ZERO_ASC + u) as char),
             _ => None,
@@ -250,7 +250,7 @@ impl RadixDef for RadixHex {
     fn get_max(&self) -> u8 {
         16
     }
-    fn from_char(&self, c: char) -> Option<u8> {
+    fn parse_char(&self, c: char) -> Option<u8> {
         match c {
             '0'..='9' => Some(c as u8 - ZERO_ASC),
             'A'..='F' => Some(c as u8 + 10 - UPPER_A_ASC),
@@ -258,7 +258,7 @@ impl RadixDef for RadixHex {
             _ => None,
         }
     }
-    fn from_u8(&self, u: u8) -> Option<char> {
+    fn format_u8(&self, u: u8) -> Option<char> {
         match u {
             0..=9 => Some((ZERO_ASC + u) as char),
             10..=15 => Some((UPPER_A_ASC + (u - 10)) as char),


### PR DESCRIPTION
This was reported as an error in Clippy 1.60 and makes some PR builds fail. We could also ignore the error if we want to do that instead.