### PR TITLE
tests: print stdout in error msg for no_stdout()

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -221,7 +221,7 @@ impl CmdResult {
         assert!(
             self.stdout.is_empty(),
             "Expected stdout to be empty, but it's:\n{}",
-            self.stderr_str()
+            self.stdout_str()
         );
         self
     }


### PR DESCRIPTION
Fix a bug in which the error message displayed when using
`CmdResult::no_stdout()` was incorrectly showing stderr when it should
have been showing stdout.