### PR TITLE
du: Return non zero error code when dealing with permissions errors

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -31,7 +31,7 @@ use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 use std::{error::Error, fmt::Display};
 use uucore::display::{print_verbatim, Quotable};
-use uucore::error::{UError, UResult};
+use uucore::error::{set_exit_code, UError, UResult};
 use uucore::format_usage;
 use uucore::parse_size::{parse_size, ParseSizeError};
 use uucore::InvalidEncodingHandling;
@@ -301,6 +301,7 @@ fn du(
                     my_stat.path.quote(),
                     e
                 );
+                set_exit_code(1);
                 return Box::new(iter::once(my_stat));
             }
         };
@@ -340,8 +341,12 @@ fn du(
                             let description = format!("cannot access {}", entry.path().quote());
                             let error_message = "Permission denied";
                             show_error_custom_description!(description, "{}", error_message);
+                            set_exit_code(1);
                         }
-                        _ => show_error!("cannot access {}: {}", entry.path().quote(), error),
+                        _ => {
+                            set_exit_code(1);
+                            show_error!("cannot access {}: {}", entry.path().quote(), error);
+                        }
                     },
                 },
                 Err(error) => show_error!("{}", error),

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -429,7 +429,7 @@ fn test_du_no_permission() {
 
     ts.ccmd("chmod").arg("-r").arg(SUB_DIR_LINKS).succeeds();
 
-    let result = ts.ucmd().arg(SUB_DIR_LINKS).run(); // TODO: replace with ".fails()" once `du` is fixed
+    let result = ts.ucmd().arg(SUB_DIR_LINKS).fails();
     result.stderr_contains(
         "du: cannot read directory 'subdir/links': Permission denied (os error 13)",
     );
@@ -447,6 +447,21 @@ fn test_du_no_permission() {
     }
 
     _du_no_permission(result.stdout_str());
+}
+
+#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "chmod")]
+#[test]
+fn test_du_no_exec_permission() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.mkdir_all("d/no-x/y");
+
+    ts.ccmd("chmod").arg("u=rw").arg("d/no-x").succeeds();
+
+    let result = ts.ucmd().arg("d/no-x").fails();
+    result.stderr_contains("du: cannot access 'd/no-x/y': Permission denied");
 }
 
 #[cfg(target_vendor = "apple")]


### PR DESCRIPTION
Make the tests/du/no-x.sh & long-sloop.sh pass