### PR TITLE
mv: add OverwriteMode match in specific case

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -258,6 +258,16 @@ fn exec(files: &[OsString], b: &Behavior) -> UResult<()> {
                     move_files_into_dir(&[source.clone()], target, b)
                 }
             } else if target.exists() && source.is_dir() {
+                match b.overwrite {
+                    OverwriteMode::NoClobber => return Ok(()),
+                    OverwriteMode::Interactive => {
+                        println!("{}: overwrite {}? ", uucore::util_name(), target.quote());
+                        if !read_yes() {
+                            return Ok(());
+                        }
+                    }
+                    OverwriteMode::Force => {}
+                };
                 Err(MvError::NonDirectoryToDirectory(
                     source.quote().to_string(),
                     target.quote().to_string(),

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -748,6 +748,19 @@ fn test_mv_errors() {
         .fails()
         .stderr_str()
         .is_empty());
+
+    // $ at.mkdir dir && at.touch file
+    // $ mv -i dir file
+    // err == mv: cannot overwrite non-directory 'file' with directory 'dir'
+    assert!(!scene
+        .ucmd()
+        .arg("-i")
+        .arg(dir)
+        .arg(file_a)
+        .pipe_in("y")
+        .fails()
+        .stderr_str()
+        .is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Check OverwriteMode and act depending on its value, specifically in the
the case of overwriting a non-directory with a directory
fixes #3337 