### PR TITLE
Docs: Fix the platform icons not showing up in some browsers

### DIFF
--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -7,7 +7,7 @@
     }
     .additional {
         position: absolute;
-        top: 0em;
+        top: 0.5em;
         right: 0;
         display: flex;
         gap: 5px;
@@ -15,7 +15,7 @@
         font-size: 1.3em;
     }
     .platforms {
-        font-size: 1.5em;
+        font-size: 2rem;
     }
     dd > p {
         margin-top: 0.2em;

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -144,7 +144,7 @@ impl<'a, 'b> MDWriter<'a, 'b> {
                     .iter()
                     .any(|u| u == self.name)
             {
-                writeln!(self.w, "<i class=\"fa-brands fa-{}\"></i>", icon)?;
+                writeln!(self.w, "<i class=\"fa fa-brands fa-{}\"></i>", icon)?;
             }
         }
         writeln!(self.w, "</div>")?;


### PR DESCRIPTION
The `fa` class was missing in the platform icons, which sets the FontAwesome font as the font for the icons. My browser probably had FontAwesome set as a fallback, making it work there. Other browsers don't and hence the icons were not showing up.

The `fa` class also changes the size, so I had to adjust the size and the margin a bit too.