### PR TITLE
df: fix incorrect whitespace between columns

### DIFF
--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -183,4 +183,31 @@ impl Column {
             _ => Err(()),
         }
     }
+
+    /// Return the alignment of the specified column.
+    pub(crate) fn alignment(column: &Self) -> Alignment {
+        match column {
+            Self::Source | Self::Target | Self::File | Self::Fstype => Alignment::Left,
+            _ => Alignment::Right,
+        }
+    }
+
+    /// Return the minimum width of the specified column.
+    pub(crate) fn min_width(column: &Self) -> usize {
+        match column {
+            // 14 = length of "Filesystem" plus 4 spaces
+            Self::Source => 14,
+            // the shortest headers have a length of 4 chars so we use that as the minimum width
+            _ => 4,
+        }
+    }
+}
+
+/// A column's alignment.
+///
+/// We define our own `Alignment` enum instead of using `std::fmt::Alignment` because df doesn't
+/// have centered columns and hence a `Center` variant is not needed.
+pub(crate) enum Alignment {
+    Left,
+    Right,
 }

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -25,7 +25,7 @@ use std::path::Path;
 use crate::blocks::{block_size_from_matches, BlockSize};
 use crate::columns::{Column, ColumnError};
 use crate::filesystem::Filesystem;
-use crate::table::{DisplayRow, Header, Row};
+use crate::table::Table;
 
 static ABOUT: &str = "Show information about the file system on which each FILE resides,\n\
                       or all file systems by default.";
@@ -380,26 +380,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    // The running total of filesystem sizes and usage.
-    //
-    // This accumulator is computed in case we need to display the
-    // total counts in the last row of the table.
-    let mut total = Row::new("total");
+    // This can happen if paths are given as command-line arguments
+    // but none of the paths exist.
+    if filesystems.is_empty() {
+        return Ok(());
+    }
 
-    println!("{}", Header::new(&opt));
-    for filesystem in filesystems {
-        // If the filesystem is not empty, or if the options require
-        // showing all filesystems, then print the data as a row in
-        // the output table.
-        if opt.show_all_fs || filesystem.usage.blocks > 0 {
-            let row = Row::from(filesystem);
-            println!("{}", DisplayRow::new(&row, &opt));
-            total += row;
-        }
-    }
-    if opt.show_total {
-        println!("{}", DisplayRow::new(&total, &opt));
-    }
+    println!("{}", Table::new(&opt, filesystems));
 
     Ok(())
 }


### PR DESCRIPTION
The main idea behind this PR is to introduce a `Table` struct to print a table. The print process now consists of two steps: 1) calculate the widths of the columns and 2) print the data. 

`Header` and `DisplayRow` (which has been renamed to `RowFormatter` (I'm not sure about this name, I struggled to find a name for it)) no longer do any output, they simply prepare the strings used by the table.

Fixes #3194.