### PR TITLE
mkdir.rs: Fix a clippy warning on clippy::ptr-arg

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -69,7 +69,7 @@ fn get_mode(matches: &ArgMatches, mode_had_minus_prefix: bool) -> Result<u32, St
 }
 
 #[cfg(windows)]
-fn strip_minus_from_mode(_args: &mut Vec<String>) -> bool {
+fn strip_minus_from_mode(_args: &mut [String]) -> bool {
     false
 }
 


### PR DESCRIPTION
```
error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
  --> src\uu\mkdir\src/mkdir.rs:72:33
   |
72 | fn strip_minus_from_mode(_args: &mut Vec<String>) -> bool {
   |                                 ^^^^^^^^^^^^^^^^ help: change this to: `&mut [String]`
   |
   = note: `-D clippy::ptr-arg` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
```