### PR TITLE
df: show error if all types are excluded

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -287,6 +287,7 @@ fn get_all_filesystems(opt: &Options) -> Vec<Filesystem> {
     mounts
         .into_iter()
         .filter_map(|m| Filesystem::new(m, None))
+        .filter(|fs| opt.show_all_fs || fs.usage.blocks > 0)
         .collect()
 }
 
@@ -362,7 +363,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let filesystems = get_all_filesystems(&opt);
 
             if filesystems.is_empty() {
-                return Err(USimpleError::new(1, "No file systems processed"));
+                return Err(USimpleError::new(1, "no file systems processed"));
             }
 
             filesystems

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -1,4 +1,6 @@
 // spell-checker:ignore udev pcent iuse itotal iused ipcent
+use std::collections::HashSet;
+
 use crate::common::util::*;
 
 #[test]
@@ -202,6 +204,27 @@ fn test_type_option() {
 #[test]
 fn test_exclude_type_option() {
     new_ucmd!().args(&["-x", "ext4", "-x", "ext3"]).succeeds();
+}
+
+#[test]
+fn test_exclude_all_types() {
+    let fs_types = new_ucmd!()
+        .arg("--output=fstype")
+        .succeeds()
+        .stdout_move_str();
+    let fs_types: HashSet<_> = fs_types.lines().skip(1).collect();
+
+    let mut args = Vec::new();
+
+    for fs_type in fs_types {
+        args.push("-x");
+        args.push(fs_type.trim_end());
+    }
+
+    new_ucmd!()
+        .args(&args)
+        .fails()
+        .stderr_contains("no file systems processed");
 }
 
 #[test]


### PR DESCRIPTION
`coreutils df -x ext4 -x tmpfs -x devtmpfs -x vfat` will now show an error (this is on my machine, on other machines you might have to specify other types to get the error).

Fixes #3409.