### PR TITLE
install: When install --strip-program=foor fails, remove the target file

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -594,13 +594,19 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> UResult<()> {
         match process::Command::new(&b.strip_program).arg(to).output() {
             Ok(o) => {
                 if !o.status.success() {
+                    // Follow GNU's behavior: if strip fails, removes the target
+                    let _ = fs::remove_file(to);
                     return Err(InstallError::StripProgramFailed(
                         String::from_utf8(o.stderr).unwrap_or_default(),
                     )
                     .into());
                 }
             }
-            Err(e) => return Err(InstallError::StripProgramFailed(e.to_string()).into()),
+            Err(e) => {
+                // Follow GNU's behavior: if strip fails, removes the target
+                let _ = fs::remove_file(to);
+                return Err(InstallError::StripProgramFailed(e.to_string()).into());
+            }
         }
     }
 

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -607,7 +607,11 @@ fn test_install_and_strip_with_program() {
 #[test]
 #[cfg(not(windows))]
 fn test_install_and_strip_with_invalid_program() {
-    new_ucmd!()
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene
+        .ucmd()
         .arg("-s")
         .arg("--strip-program")
         .arg("/bin/date")
@@ -615,12 +619,17 @@ fn test_install_and_strip_with_invalid_program() {
         .arg(STRIP_TARGET_FILE)
         .fails()
         .stderr_contains("strip program failed");
+    assert!(!at.file_exists(STRIP_TARGET_FILE));
 }
 
 #[test]
 #[cfg(not(windows))]
 fn test_install_and_strip_with_non_existent_program() {
-    new_ucmd!()
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene
+        .ucmd()
         .arg("-s")
         .arg("--strip-program")
         .arg("/usr/bin/non_existent_program")
@@ -628,6 +637,7 @@ fn test_install_and_strip_with_non_existent_program() {
         .arg(STRIP_TARGET_FILE)
         .fails()
         .stderr_contains("No such file or directory");
+    assert!(!at.file_exists(STRIP_TARGET_FILE));
 }
 
 #[test]


### PR DESCRIPTION
Should fix:
tests/install/strip-program.sh