### PR TITLE
install: verbose - list all created directories

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -464,6 +464,19 @@ fn standard(mut paths: Vec<String>, b: &Behavior) -> UResult<()> {
     } else {
         if let Some(parent) = target.parent() {
             if !parent.exists() && b.create_leading {
+                if b.verbose {
+                    let mut result = PathBuf::new();
+                    // When creating directories with -Dv, show directory creations step
+                    // by step
+                    for part in parent.components() {
+                        result.push(part.as_os_str());
+                        if !Path::new(part.as_os_str()).is_dir() {
+                            // Don't display when the directory already exists
+                            println!("install: creating directory {}", result.quote());
+                        }
+                    }
+                }
+
                 if let Err(e) = fs::create_dir_all(parent) {
                     return Err(InstallError::CreateDirFailed(parent.to_path_buf(), e).into());
                 }

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore (words) helloworld objdump
+// spell-checker:ignore (words) helloworld objdump n'source
 
 use crate::common::util::*;
 use filetime::FileTime;
@@ -1173,4 +1173,30 @@ fn test_install_dir_dot() {
     assert!(at.dir_exists("dir3"));
     assert!(at.dir_exists("dir4/cal"));
     assert!(at.dir_exists("dir5/cali"));
+}
+
+#[test]
+fn test_install_dir_req_verbose() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let file_1 = "source_file1";
+    let dest_dir = "sub4";
+    at.touch(file_1);
+    scene
+        .ucmd()
+        .arg("-Dv")
+        .arg(file_1)
+        .arg("sub3/a/b/c/file")
+        .succeeds()
+        .stdout_contains("install: creating directory 'sub3'\ninstall: creating directory 'sub3/a'\ninstall: creating directory 'sub3/a/b'\ninstall: creating directory 'sub3/a/b/c'\n'source_file1' -> 'sub3/a/b/c/file'");
+
+    at.mkdir(dest_dir);
+    scene
+        .ucmd()
+        .arg("-Dv")
+        .arg(file_1)
+        .arg("sub4/a/b/c/file")
+        .succeeds()
+        .stdout_contains("install: creating directory 'sub4/a'\ninstall: creating directory 'sub4/a/b'\ninstall: creating directory 'sub4/a/b/c'\n'source_file1' -> 'sub4/a/b/c/file'");
 }


### PR DESCRIPTION
```
$ install -Dv source_file1 sub3/a/b/c/file
install: creating directory 'sub3'
install: creating directory 'sub3/a'
install: creating directory 'sub3/a/b'
install: creating directory 'sub3/a/b/c'
'source_file1' -> 'sub3/a/b/c/file'
```

Necessary step for tests/install/basic-1.sh
