### PR TITLE
df: fix "File" column width for unicode filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ version = "0.0.13"
 dependencies = [
  "clap 3.1.8",
  "number_prefix",
+ "unicode-width",
  "uucore",
 ]
 

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/df.rs"
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
 number_prefix = "0.4"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["libc", "fsext"] }
+unicode-width = "0.1.9"
 
 [[bin]]
 name = "df"

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -8,6 +8,7 @@
 //! A table ([`Table`]) comprises a header row ([`Header`]) and a
 //! collection of data rows ([`Row`]), one per filesystem.
 use number_prefix::NumberPrefix;
+use unicode_width::UnicodeWidthStr;
 
 use crate::columns::{Alignment, Column};
 use crate::filesystem::Filesystem;
@@ -362,8 +363,8 @@ impl Table {
                 total += row;
 
                 for (i, value) in values.iter().enumerate() {
-                    if value.len() > widths[i] {
-                        widths[i] = value.len();
+                    if UnicodeWidthStr::width(value.as_str()) > widths[i] {
+                        widths[i] = UnicodeWidthStr::width(value.as_str());
                     }
                 }
 

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -165,6 +165,7 @@ fn test_output_mp_repeat() {
     assert_eq!(3, output1.len());
     assert_eq!(output1[1], output1[2]);
 }
+
 #[test]
 fn test_output_conflict_options() {
     for option in ["-i", "-T", "-P"] {
@@ -428,6 +429,20 @@ fn test_output_file_specific_files() {
         .stdout_move_str();
     let actual: Vec<&str> = output.lines().collect();
     assert_eq!(actual, vec!["File", "a   ", "b   ", "c   "]);
+}
+
+#[test]
+fn test_file_column_width_if_filename_contains_unicode_chars() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("äöü.txt");
+
+    let output = ucmd
+        .args(&["--output=file,target", "äöü.txt"])
+        .succeeds()
+        .stdout_move_str();
+    let actual = output.lines().next().unwrap();
+    // expected width: 7 chars (length of äöü.txt) + 1 char (column separator)
+    assert_eq!(actual, "File    Mounted on");
 }
 
 #[test]


### PR DESCRIPTION
Use Unicode-aware function instead of `str::len()` when calculating column widths.