### PR TITLE
df: remove unreachable code

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -382,12 +382,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    // This can happen if paths are given as command-line arguments
-    // but none of the paths exist.
-    if filesystems.is_empty() {
-        return Ok(());
-    }
-
     println!("{}", Table::new(&opt, filesystems));
 
     Ok(())


### PR DESCRIPTION
It's a code snippet that likely sneaked in due to overlapping PRs and doesn't do anything, because the `return` is unreachable.