### PR TITLE
df: fix output if input path is a file system

### DIFF
--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -68,7 +68,7 @@ where
         path.as_ref().to_path_buf()
     };
     let matches = mounts.iter().filter(|mi| path.starts_with(&mi.mount_dir));
-    matches.max_by_key(|mi| mi.mount_dir.len())
+    matches.min_by_key(|mi| mi.mount_dir.len())
 }
 
 impl Filesystem {

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -488,3 +488,22 @@ fn test_nonexistent_file() {
         .stderr_is("df: does-not-exist: No such file or directory\n")
         .stdout_is("File\n.\n");
 }
+
+#[test]
+fn test_file_system_as_input_path() {
+    let fs = new_ucmd!()
+        .args(&[
+            "--output=source",
+            std::env::current_exe().unwrap().to_str().unwrap(),
+        ])
+        .succeeds()
+        .stdout_move_str();
+    let fs = fs.lines().nth(1).unwrap();
+
+    let actual = new_ucmd!()
+        .args(&["--output=source", fs])
+        .succeeds()
+        .stdout_move_str();
+    let actual = actual.lines().nth(1).unwrap();
+    assert_eq!(actual, fs);
+}


### PR DESCRIPTION
For example, `df --out=source,target /dev/sda8` now shows:
```
Filesystem     Mounted on
/dev/sda8      /
```
instead of
```
Filesystem     Mounted on
dev            /dev
```

Fixes #3246.