### PR TITLE
Revert "df: remove trailing spaces in rightmost column"

### DIFF
--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -401,21 +401,12 @@ impl fmt::Display for Table {
         while let Some(row) = row_iter.next() {
             let mut col_iter = row.iter().enumerate().peekable();
             while let Some((i, elem)) = col_iter.next() {
-                let is_last_col = col_iter.peek().is_none();
-
                 match self.alignments[i] {
-                    Alignment::Left => {
-                        if is_last_col {
-                            // no trailing spaces in last column
-                            write!(f, "{}", elem)?;
-                        } else {
-                            write!(f, "{:<width$}", elem, width = self.widths[i])?;
-                        }
-                    }
+                    Alignment::Left => write!(f, "{:<width$}", elem, width = self.widths[i])?,
                     Alignment::Right => write!(f, "{:>width$}", elem, width = self.widths[i])?,
                 }
 
-                if !is_last_col {
+                if col_iter.peek().is_some() {
                     // column separator
                     write!(f, " ")?;
                 }

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -425,7 +425,7 @@ fn test_output_selects_columns() {
         .args(&["--output=source"])
         .succeeds()
         .stdout_move_str();
-    assert_eq!(output.lines().next().unwrap(), "Filesystem");
+    assert_eq!(output.lines().next().unwrap().trim_end(), "Filesystem");
 
     let output = new_ucmd!()
         .args(&["--output=source,target"])
@@ -484,7 +484,7 @@ fn test_output_file_all_filesystems() {
     let mut lines = output.lines();
     assert_eq!(lines.next().unwrap(), "File");
     for line in lines {
-        assert_eq!(line, "-");
+        assert_eq!(line, "-   ");
     }
 }
 
@@ -503,7 +503,7 @@ fn test_output_file_specific_files() {
         .succeeds()
         .stdout_move_str();
     let actual: Vec<&str> = output.lines().collect();
-    assert_eq!(actual, vec!["File", "a", "b", "c"]);
+    assert_eq!(actual, vec!["File", "a   ", "b   ", "c   "]);
 }
 
 #[test]
@@ -538,5 +538,5 @@ fn test_nonexistent_file() {
         .args(&["--output=file", "does-not-exist", "."])
         .fails()
         .stderr_is("df: does-not-exist: No such file or directory\n")
-        .stdout_is("File\n.\n");
+        .stdout_is("File\n.   \n");
 }


### PR DESCRIPTION
Reverts uutils/coreutils#3423
to see if it fixes the GNU tests
