### PR TITLE
Upgrade nix to 0.24.1, ctrlc to 3.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
+checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
 dependencies = [
  "nix",
  "winapi 0.3.9",
@@ -1139,15 +1139,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,7 +401,7 @@ hex-literal = "0.3.1"
 rlimit = "0.8.3"
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false, features = ["process", "signal", "user"] }
 rust-users = { version="0.10", package="users" }
 unix_socket = "0.5.0"
 

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -22,7 +22,7 @@ uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=[
 
 [target.'cfg(unix)'.dependencies]
 unix_socket = "0.5.0"
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false }
 
 [[bin]]
 name = "cat"

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -23,7 +23,7 @@ unicode-width = "0.1.7"
 unicode-segmentation = "1.9.0"
 
 [target.'cfg(all(unix, not(target_os = "fuchsia")))'.dependencies]
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false }
 
 [[bin]]
 name = "more"

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/nice.rs"
 [dependencies]
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
 libc = "0.2.121"
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
 
 [[bin]]

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -23,7 +23,7 @@ uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=[
 winapi = { version="0.3", features=["fileapi", "handleapi", "processthreadsapi", "synchapi", "winbase"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false }
 
 [[bin]]
 name = "tail"

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/timeout.rs"
 [dependencies]
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
 libc = "0.2.121"
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false, features = ["signal"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["process", "signals"] }
 
 [[bin]]

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -22,7 +22,7 @@ utf-8 = "0.7.6"
 unicode-width = "0.1.8"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false }
 libc = "0.2"
 
 [[bin]]

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "3.1", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["pipes"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-nix = "0.23.1"
+nix = { version = "0.24.1", default-features = false }
 
 [[bin]]
 name = "yes"

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -1,3 +1,5 @@
+# spell-checker:ignore (features) zerocopy
+
 [package]
 name = "uucore"
 version = "0.0.13"
@@ -35,7 +37,7 @@ os_display = "0.1.3"
 
 [target.'cfg(unix)'.dependencies]
 walkdir = { version="2.3.2", optional=true }
-nix = { version="0.23.1", optional=true }
+nix = { version = "0.24.1", optional = true, default-features = false, features = ["fs", "uio", "zerocopy"] }
 
 [dev-dependencies]
 clap = "3.1"

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -1,11 +1,13 @@
 /// Thin pipe-related wrappers around functions from the `nix` crate.
 use std::fs::File;
 #[cfg(any(target_os = "linux", target_os = "android"))]
+use std::io::IoSlice;
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::FromRawFd;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use nix::{fcntl::SpliceFFlags, sys::uio::IoVec};
+use nix::fcntl::SpliceFFlags;
 
 pub use nix::{Error, Result};
 
@@ -63,7 +65,7 @@ pub fn splice_exact(source: &impl AsRawFd, target: &impl AsRawFd, len: usize) ->
 pub fn vmsplice(target: &impl AsRawFd, bytes: &[u8]) -> Result<usize> {
     nix::fcntl::vmsplice(
         target.as_raw_fd(),
-        &[IoVec::from_slice(bytes)],
+        &[IoSlice::new(bytes)],
         SpliceFFlags::empty(),
     )
 }


### PR DESCRIPTION
Limit nix features, which should help compile times slightly.

Replace usage of deprecated nix functionality with std equivalent.