### PR TITLE
fix -h and --help discrepancies

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -28,7 +28,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if let Ok(matches) = command.try_get_matches_from_mut(args) {
         let error = if matches.index_of("help").is_some() {
-            command.print_long_help()
+            command.print_help()
         } else if matches.index_of("version").is_some() {
             writeln!(std::io::stdout(), "{}", command.render_version())
         } else {

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -399,7 +399,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     if matches.is_present(options::HELP) {
-        command.print_long_help()?;
+        command.print_help()?;
         return Ok(());
     }
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1272,6 +1272,7 @@ pub fn uu_app<'a>() -> Command<'a> {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .after_help(LONG_HELP_KEYS)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .arg(
@@ -1421,7 +1422,6 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .short('k')
                 .long(options::KEY)
                 .help("sort by a key")
-                .long_help(LONG_HELP_KEYS)
                 .multiple_occurrences(true)
                 .number_of_values(1)
                 .takes_value(true),
@@ -1466,8 +1466,7 @@ pub fn uu_app<'a>() -> Command<'a> {
         .arg(
             Arg::new(options::COMPRESS_PROG)
                 .long(options::COMPRESS_PROG)
-                .help("compress temporary files with PROG, decompress with PROG -d")
-                .long_help("PROG has to take input from stdin and output to stdout")
+                .help("compress temporary files with PROG, decompress with PROG -d; PROG has to take input from stdin and output to stdout")
                 .value_name("PROG"),
         )
         .arg(

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -22,7 +22,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if let Ok(matches) = command.try_get_matches_from_mut(args) {
         let error = if matches.index_of("help").is_some() {
-            command.print_long_help()
+            command.print_help()
         } else if matches.index_of("version").is_some() {
             writeln!(std::io::stdout(), "{}", command.render_version())
         } else {

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -127,7 +127,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(options::TABS)
                 .short('t')
                 .long(options::TABS)
-                .long_help("use comma separated LIST of tab positions or have tabs N characters apart instead of 8 (enables -a)")
+                .help("use comma separated LIST of tab positions or have tabs N characters apart instead of 8 (enables -a)")
                 .takes_value(true)
         )
         .arg(

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -183,8 +183,6 @@ sed -i -e "s~  sed -n \"1s/'\\\/'/'OPT'/p\" < err >> pat || framework_failure_~ 
 sed -i -e "s/rcexp=1$/rcexp=2\n  case \"\$prg\" in chcon|runcon) return;; esac/" -e "s/rcexp=125 ;;/rcexp=2 ;;\ncp|truncate|pr) rcexp=1;;/" tests/misc/usage_vs_getopt.sh
 # GNU has option=[SUFFIX], clap is <SUFFIX>
 sed -i -e "s/cat opts/sed -i -e \"s| <.\*>$||g\" opts/" tests/misc/usage_vs_getopt.sh
-# Strip empty lines for the diff - see https://github.com/uutils/coreutils/issues/3370
-sed -i -e "s~out 2>err1~out  2>err1\nsed '/^$/d' out > out\nsed '/^$/d' help > help~" tests/misc/usage_vs_getopt.sh
 # for some reasons, some stuff are duplicated, strip that
 sed -i -e "s/provoked error./provoked error\ncat pat |sort -u > pat/" tests/misc/usage_vs_getopt.sh
 


### PR DESCRIPTION
Just a tiny commit that addresses the `-h` and `--help` differences mentioned in https://github.com/uutils/coreutils/issues/3370 - it seems like there are differences when long help is printed, which either occurred when `print_long_help()` was called or `--help` was used on a command that had `long_help()` description in one of its argument.

I removed all calls to long_help since it appears that other commands output their `--help` to be the same as `-h` (argument and description start on the same line). So now the changed commands (like `false`)  look like 

```
...
OPTIONS:
        --help       Print help information
        --version    Print version information
```
like other commands, as opposed to 
```
...
OPTIONS:
        --help
            Print help information

        --version
            Print version information
```
I also moved `sort -k`'s long help to the after help section, since that seemed to be to be similar to how GNU does it while also making sort's `--help` conform with how the other commands' `--help` are formatted.