### PR TITLE
df: fix "Size" column header

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -413,10 +413,9 @@ fn test_block_size_with_suffix() {
     assert_eq!(get_header("1KiB"), "1K-blocks");
     assert_eq!(get_header("1MiB"), "1M-blocks");
     assert_eq!(get_header("1GiB"), "1G-blocks");
-    // TODO enable the following asserts when #3193 is resolved
-    //assert_eq!(get_header("1KB"), "1kB-blocks");
-    //assert_eq!(get_header("1MB"), "1MB-blocks");
-    //assert_eq!(get_header("1GB"), "1GB-blocks");
+    assert_eq!(get_header("1KB"), "1kB-blocks");
+    assert_eq!(get_header("1MB"), "1MB-blocks");
+    assert_eq!(get_header("1GB"), "1GB-blocks");
 }
 
 #[test]


### PR DESCRIPTION
Implement "Size" column header for block sizes that are not multiples of 1024.

Fixes #3193.