### PR TITLE
`clap` exit code

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -90,7 +90,7 @@ pub fn parse_base_cmd_args(args: impl uucore::Args, about: &str, usage: &str) ->
     let arg_list = args
         .collect_str(InvalidEncodingHandling::ConvertLossy)
         .accept_any();
-    Config::from(&command.get_matches_from(arg_list))
+    Config::from(&command.try_get_matches_from(arg_list)?)
 }
 
 pub fn base_app<'a>(about: &'a str, usage: &'a str) -> Command<'a> {

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -188,7 +188,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let number_mode = if matches.is_present(options::NUMBER_NONBLANK) {
         NumberingMode::NonEmpty

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -57,7 +57,7 @@ use std::path::{Path, PathBuf, StripPrefixError};
 use std::str::FromStr;
 use std::string::ToString;
 use uucore::backup_control::{self, BackupMode};
-use uucore::error::{set_exit_code, ExitCode, UError, UResult};
+use uucore::error::{set_exit_code, ExitCode, UClapError, UError, UResult};
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
 use walkdir::WalkDir;
 
@@ -485,7 +485,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 app.print_help()?;
             }
             clap::ErrorKind::DisplayVersion => println!("{}", app.render_version()),
-            _ => return Err(Box::new(e)),
+            _ => return Err(Box::new(e.with_exit_code(1))),
         };
     } else if let Ok(matches) = matches {
         let options = Options::from_matches(&matches)?;

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -17,7 +17,7 @@ use std::ptr;
 
 use clap::{crate_version, Arg, Command};
 use uucore::{
-    error::{set_exit_code, UResult, USimpleError, UUsageError},
+    error::{set_exit_code, UClapError, UResult, USimpleError, UUsageError},
     format_usage,
 };
 
@@ -35,7 +35,7 @@ const USAGE: &str = "{} [OPTIONS] [COMMAND [ARGS]]";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args).with_exit_code(125)?;
 
     let mut niceness = unsafe {
         nix::errno::Errno::clear();

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -58,3 +58,8 @@ fn test_command_where_command_takes_n_flag() {
         .run()
         .stdout_is("a");
 }
+
+#[test]
+fn test_invalid_argument() {
+    new_ucmd!().arg("--invalid").fails().code_is(125);
+}


### PR DESCRIPTION
Step towards fixing:
- https://github.com/uutils/coreutils/issues/3331
- https://github.com/uutils/coreutils/issues/3102

To my surprise, `clap::Error` could already be used as a `UResult` due to excellent work by @shoriminimoe, which means that the exit code cal already be set to 1 by making this change in `uumain`:
```rust
let matches = uu_app().get_matches_from(args);
// to
let matches = uu_app().try_get_matches_from(args)?;
```

So, I added one additional bit of functionality to customize the error code:
```rust
use uucore::error::UClapError;
// -- snip --
let matches = uu_app().try_get_matches_from(args).with_exit_code(125)?;
```
With this change we should be able to go through all utils and fix up all the exit codes.

There is just one thing that I'm not sure about. The `UResult` implementation of `clap::Error` currently uses exit code `1`, which is (intentionally) different from the standard clap exit code of `2`. I'm thinking maybe the default should be `2` now that we can customize the exit code, so that the case where we differ from standard clap becomes explicit. @sylvestre what do you think?

Leaving this as a draft to wait for feedback and then I'll fix up the other utils.
