### PR TITLE
cp: Do not dereference symlink even when dangling - fix issue #3364

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1507,6 +1507,18 @@ fn test_copy_through_dangling_symlink() {
 }
 
 #[test]
+fn test_copy_through_dangling_symlink_no_dereference() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.symlink_file("no-such-file", "dangle");
+    ucmd.arg("-P")
+        .arg("dangle")
+        .arg("d2")
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
 #[cfg(unix)]
 fn test_cp_archive_on_nonexistent_file() {
     new_ucmd!()


### PR DESCRIPTION
Fixes an issue with cp not copying symlinks in spite of the -P  (no dereference option) 
fixes #3364
```console
> ln -s no-such-file dangle
> LANG=C cp dangle d2
cp: cannot stat 'dangle': No such file or directory
[1]> LANG=C cp -P dangle d2
> rm d2
>  ./uu_cp dangle d2
cp: cannot stat 'dangle': No such file or directory
[1]> ./uu_cp -P dangle d2
> rm d2
```