### PR TITLE
`dir`, `vdir`: fix incorrect regex in tests

### DIFF
--- a/tests/by-util/test_dir.rs
+++ b/tests/by-util/test_dir.rs
@@ -31,7 +31,7 @@ fn test_default_output() {
     scene
         .ucmd()
         .succeeds()
-        .stdout_does_not_match(&Regex::new("[rwx][^some-file1]").unwrap());
+        .stdout_does_not_match(&Regex::new("[rwx-]{10}.*some-file1$").unwrap());
 }
 
 #[test]
@@ -51,5 +51,5 @@ fn test_long_output() {
         .ucmd()
         .arg("-l")
         .succeeds()
-        .stdout_matches(&Regex::new("[rwx][^some-file1]").unwrap());
+        .stdout_matches(&Regex::new("[rwx-]{10}.*some-file1$").unwrap());
 }

--- a/tests/by-util/test_vdir.rs
+++ b/tests/by-util/test_vdir.rs
@@ -31,7 +31,7 @@ fn test_default_output() {
     scene
         .ucmd()
         .succeeds()
-        .stdout_matches(&Regex::new("[rwx][^some-file1]").unwrap());
+        .stdout_matches(&Regex::new("[rwx-]{10}.*some-file1$").unwrap());
 }
 
 #[test]
@@ -51,5 +51,5 @@ fn test_column_output() {
         .ucmd()
         .arg("-C")
         .succeeds()
-        .stdout_does_not_match(&Regex::new("[rwx][^some-file1]").unwrap());
+        .stdout_does_not_match(&Regex::new("[rwx-]{10}.*some-file1$").unwrap());
 }


### PR DESCRIPTION
The Windows tests are currently failing on all new PRs. This is due to an incorrect regex in the tests for `dir` and `vdir`. The regex was:
```regex
[rwx][^some-file1]
```
which was probably supposed to mean: "any of `rxw` but not `some-file1`". This is wrong because it matches any `r`, `w` or `x` that is not followed by the characters in `some-file1`. On my machine, my username is `terts` which then also matches. Secondly, it does not match `-` which is all we output on Windows. 

So what happened is that the Windows tests were only "correct", because the string `April` matched the regex until yesterday, making the Windows tests succeed until `April` was over and `May` began :).

I've change the regex to check both a string of `rwx-` characters and the filename:
```regex
[rwx-]{10}.*some-file1$
```