### PR TITLE
du: use USimpleError instead of set_exit_code

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -435,9 +435,7 @@ fn test_du_no_permission() {
     ts.ccmd("chmod").arg("-r").arg(SUB_DIR_LINKS).succeeds();
 
     let result = ts.ucmd().arg(SUB_DIR_LINKS).fails();
-    result.stderr_contains(
-        "du: cannot read directory 'subdir/links': Permission denied (os error 13)",
-    );
+    result.stderr_contains("du: cannot read directory 'subdir/links': Permission denied");
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {


### PR DESCRIPTION
Fixes #3389

@tertsdiepraam is this what you meant? I found that `UResult` is meant to be returned at the end, but since we want to display the errors quickly, during the path traversal, we probably want to use `USimpleError`.