### PR TITLE
df: set min width of "Used" column to 5

### DIFF
--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -197,6 +197,7 @@ impl Column {
         match column {
             // 14 = length of "Filesystem" plus 4 spaces
             Self::Source => 14,
+            Self::Used => 5,
             // the shortest headers have a length of 4 chars so we use that as the minimum width
             _ => 4,
         }


### PR DESCRIPTION
While creating issue #3479 I noticed that the `Used` column from GNU df is one char wider than the one from uutils df, 5 chars vs. 4 chars. This PR fixes this minor detail.