### PR TITLE
df: use blocksize of 512 if POSIXLY_CORRECT is set

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -32,6 +32,13 @@ use crate::table::Table;
 static ABOUT: &str = "Show information about the file system on which each FILE resides,\n\
                       or all file systems by default.";
 const USAGE: &str = "{} [OPTION]... [FILE]...";
+const LONG_HELP: &str = "Display values are in units of the first available SIZE from --block-size,
+and the DF_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.
+Otherwise, units default to 1024 bytes (or 512 if POSIXLY_CORRECT is set).
+
+SIZE is an integer and optional unit (example: 10M is 10*1024*1024).
+Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB,... (powers
+of 1000).";
 
 static OPT_HELP: &str = "help";
 static OPT_ALL: &str = "all";
@@ -427,6 +434,7 @@ pub fn uu_app<'a>() -> Command<'a> {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
+        .after_help(LONG_HELP)
         .infer_long_args(true)
         .arg(
             Arg::new(OPT_HELP)

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -376,6 +376,26 @@ fn test_iuse_percentage() {
 }
 
 #[test]
+fn test_default_block_size() {
+    let output = new_ucmd!()
+        .arg("--output=size")
+        .succeeds()
+        .stdout_move_str();
+    let header = output.lines().next().unwrap().to_string();
+
+    assert_eq!(header, "1K-blocks");
+
+    let output = new_ucmd!()
+        .arg("--output=size")
+        .env("POSIXLY_CORRECT", "1")
+        .succeeds()
+        .stdout_move_str();
+    let header = output.lines().next().unwrap().to_string();
+
+    assert_eq!(header, "512B-blocks");
+}
+
+#[test]
 fn test_block_size_1024() {
     fn get_header(block_size: u64) -> String {
         let output = new_ucmd!()


### PR DESCRIPTION
Use a default block size of 512 bytes (instead of 1024 bytes) if the `POSIXLY_CORRECT` environment variable is set.