### PR TITLE
df: fix "Size" header for multiples of 1000 & 1024

### DIFF
--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -73,7 +73,7 @@ fn to_magnitude_and_suffix_1024(n: u128) -> Result<String, ()> {
     Err(())
 }
 
-/// Convert a number, except multiples of 1024, into a string like "12kB" or "34MB".
+/// Convert a number into a string like "12kB" or "34MB".
 ///
 /// Powers of 1000 become "1kB", "1MB", "1GB", etc.
 ///
@@ -110,7 +110,7 @@ fn to_magnitude_and_suffix_not_powers_of_1024(n: u128) -> Result<String, ()> {
 ///
 /// If the number is too large to represent.
 fn to_magnitude_and_suffix(n: u128) -> Result<String, ()> {
-    if n % 1024 == 0 {
+    if n % 1024 == 0 && n % 1000 != 0 {
         to_magnitude_and_suffix_1024(n)
     } else {
         to_magnitude_and_suffix_not_powers_of_1024(n)
@@ -237,6 +237,13 @@ mod tests {
         assert_eq!(to_magnitude_and_suffix(999_000_001).unwrap(), "1GB");
         assert_eq!(to_magnitude_and_suffix(1_000_000_000).unwrap(), "1GB");
         assert_eq!(to_magnitude_and_suffix(1_000_000_001).unwrap(), "1.1GB");
+    }
+
+    #[test]
+    fn test_to_magnitude_and_suffix_multiples_of_1000_and_1024() {
+        assert_eq!(to_magnitude_and_suffix(128_000).unwrap(), "128kB");
+        assert_eq!(to_magnitude_and_suffix(1000 * 1024).unwrap(), "1.1MB");
+        assert_eq!(to_magnitude_and_suffix(1_000_000_000_000).unwrap(), "1TB");
     }
 
     #[test]

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -392,6 +392,11 @@ fn test_block_size_1024() {
     assert_eq!(get_header(2 * 1024 * 1024), "2M-blocks");
     assert_eq!(get_header(1024 * 1024 * 1024), "1G-blocks");
     assert_eq!(get_header(34 * 1024 * 1024 * 1024), "34G-blocks");
+
+    // multiples of both 1024 and 1000
+    assert_eq!(get_header(128_000), "128kB-blocks");
+    assert_eq!(get_header(1000 * 1024), "1.1MB-blocks");
+    assert_eq!(get_header(1_000_000_000_000), "1TB-blocks");
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes an issue with the "Size" header for block sizes that are multiples of both 1000 and 1024. So far, such block sizes were handled as multiples of 1024 with the corresponding suffixes (e.g. "K", "M", "G"). Now they are handled as multiples of 1000 with suffixes like "kB", "MB", and "GB", in the same way as is done by GNU df.

Example: `128_000` now becomes `128kB` instead of `125K`.