### PR TITLE
mktemp: error on path separator in template prefix

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -41,7 +41,12 @@ enum MkTempError {
     PersistError(PathBuf),
     MustEndInX(String),
     TooFewXs(String),
-    ContainsDirSeparator(String),
+
+    /// The template prefix contains a path separator (e.g. `"a/bXXX"`).
+    PrefixContainsDirSeparator(String),
+
+    /// The template suffix contains a path separator (e.g. `"XXXa/b"`).
+    SuffixContainsDirSeparator(String),
     InvalidTemplate(String),
 }
 
@@ -56,7 +61,14 @@ impl Display for MkTempError {
             PersistError(p) => write!(f, "could not persist file {}", p.quote()),
             MustEndInX(s) => write!(f, "with --suffix, template {} must end in X", s.quote()),
             TooFewXs(s) => write!(f, "too few X's in template {}", s.quote()),
-            ContainsDirSeparator(s) => {
+            PrefixContainsDirSeparator(s) => {
+                write!(
+                    f,
+                    "invalid template, {}, contains directory separator",
+                    s.quote()
+                )
+            }
+            SuffixContainsDirSeparator(s) => {
                 write!(
                     f,
                     "invalid suffix {}, contains directory separator",
@@ -252,8 +264,12 @@ fn parse_template<'a>(
         }
     };
 
+    if prefix.chars().any(is_separator) {
+        return Err(MkTempError::PrefixContainsDirSeparator(temp.into()));
+    }
+
     if suf.chars().any(is_separator) {
-        return Err(MkTempError::ContainsDirSeparator(suf.into()));
+        return Err(MkTempError::SuffixContainsDirSeparator(suf.into()));
     }
 
     Ok((prefix, rand, suf))
@@ -352,11 +368,7 @@ mod tests {
 
     #[test]
     fn test_parse_template_errors() {
-        // TODO This should be an error as well, but we are not
-        // catching it just yet. A future commit will correct this.
-        //
-        //     assert!(parse_template("a/bXXX", None).is_err());
-        //
+        assert!(parse_template("a/bXXX", None).is_err());
         assert!(parse_template("XXXa/b", None).is_err());
         assert!(parse_template("XX", None).is_err());
         assert!(parse_template("XXXabc", Some("def")).is_err());

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -2,6 +2,8 @@
 
 use crate::common::util::*;
 
+use uucore::display::Quotable;
+
 use std::path::PathBuf;
 use tempfile::tempdir;
 
@@ -481,4 +483,16 @@ fn test_respect_template_directory() {
     let filename = result.no_stderr().stdout_str().trim_end();
     assert_matches_template!(template, filename);
     assert!(at.file_exists(filename));
+}
+
+/// Test that a template with a path separator is invalid.
+#[test]
+fn test_template_path_separator() {
+    new_ucmd!()
+        .args(&["-t", "a/bXXX"])
+        .fails()
+        .stderr_only(format!(
+            "mktemp: invalid template, {}, contains directory separator\n",
+            "a/bXXX".quote()
+        ));
 }


### PR DESCRIPTION
Correct the error that arises from a path separator in the prefix
portion of a template argument provided to `mktemp`. Before this
commit, the error message was incorrect:

    $ mktemp -t a/bXXX
    mktemp: failed to create file via template 'a/bXXX': No such file or directory (os error 2) at path "/tmp/a/bege"

After this commit, the error message is correct:

    $ mktemp -t a/bXXX
    mktemp: invalid template, 'a/bXXX', contains directory separator

The code was failing to check for a path separator in the prefix
portion of the template.