### PR TITLE
df: show error if provided block size is zero

### DIFF
--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -7,7 +7,10 @@ use crate::OPT_BLOCKSIZE;
 use clap::ArgMatches;
 use std::{env, fmt};
 
-use uucore::parse_size::{parse_size, ParseSizeError};
+use uucore::{
+    display::Quotable,
+    parse_size::{parse_size, ParseSizeError},
+};
 
 /// The first ten powers of 1024.
 const IEC_BASES: [u128; 10] = [
@@ -180,7 +183,13 @@ impl Default for BlockSize {
 pub(crate) fn block_size_from_matches(matches: &ArgMatches) -> Result<BlockSize, ParseSizeError> {
     if matches.is_present(OPT_BLOCKSIZE) {
         let s = matches.value_of(OPT_BLOCKSIZE).unwrap();
-        Ok(BlockSize::Bytes(parse_size(s)?))
+        let bytes = parse_size(s)?;
+
+        if bytes > 0 {
+            Ok(BlockSize::Bytes(bytes))
+        } else {
+            Err(ParseSizeError::ParseFailure(format!("{}", s.quote())))
+        }
     } else {
         Ok(Default::default())
     }

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -465,6 +465,16 @@ fn test_invalid_block_size() {
         .arg("--block-size=x")
         .fails()
         .stderr_contains("invalid --block-size argument 'x'");
+
+    new_ucmd!()
+        .arg("--block-size=0")
+        .fails()
+        .stderr_contains("invalid --block-size argument '0'");
+
+    new_ucmd!()
+        .arg("--block-size=0K")
+        .fails()
+        .stderr_contains("invalid --block-size argument '0K'");
 }
 
 #[test]


### PR DESCRIPTION
Show an `invalid --block-size argument '0'` error, instead of crashing because of a division by zero, if the user provides `0` as block size argument 