### PR TITLE
mktemp: correct error message on absolute path

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -139,11 +139,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let dry_run = matches.is_present(OPT_DRY_RUN);
     let suppress_file_err = matches.is_present(OPT_QUIET);
 
-    let (prefix, rand, suffix) = parse_template(template, matches.value_of(OPT_SUFFIX))?;
-
-    if matches.is_present(OPT_TMPDIR) && PathBuf::from(prefix).is_absolute() {
+    // If `--tmpdir` is given, the template cannot be an absolute
+    // path. For example, `mktemp --tmpdir=a /XXX` is not allowed.
+    if matches.is_present(OPT_TMPDIR) && PathBuf::from(template).is_absolute() {
         return Err(MkTempError::InvalidTemplate(template.into()).into());
     }
+
+    let (prefix, rand, suffix) = parse_template(template, matches.value_of(OPT_SUFFIX))?;
 
     let res = if dry_run {
         dry_exec(tmpdir, prefix, rand, suffix)

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -414,6 +414,22 @@ fn test_mktemp_directory_tmpdir() {
     assert!(PathBuf::from(result.stdout_str().trim()).is_dir());
 }
 
+/// Test that an absolute path is disallowed when --tmpdir is provided.
+#[test]
+fn test_tmpdir_absolute_path() {
+    #[cfg(windows)]
+    let path = r"C:\XXX";
+    #[cfg(not(windows))]
+    let path = "/XXX";
+    new_ucmd!()
+        .args(&["--tmpdir=a", path])
+        .fails()
+        .stderr_only(format!(
+            "mktemp: invalid template, '{}'; with --tmpdir, it may not be absolute\n",
+            path
+        ));
+}
+
 /// Decide whether a string matches a given template.
 ///
 /// In the template, the character `'X'` is treated as a wildcard,


### PR DESCRIPTION
Correct the error message produced by `mktemp` when `--tmpdir` is
given and the template is an absolute path:

    $ mktemp --tmpdir=a /XXX
    mktemp: invalid template, '/XXX'; with --tmpdir, it may not be absolute