### PR TITLE
mktemp: fix error msg when suffix has path sep.

### DIFF
--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -496,3 +496,18 @@ fn test_template_path_separator() {
             "a/bXXX".quote()
         ));
 }
+
+/// Test that a suffix with a path separator is invalid.
+#[test]
+fn test_suffix_path_separator() {
+    #[cfg(not(windows))]
+    new_ucmd!()
+        .arg("aXXX/b")
+        .fails()
+        .stderr_only("mktemp: invalid suffix '/b', contains directory separator\n");
+    #[cfg(windows)]
+    new_ucmd!()
+        .arg(r"aXXX\b")
+        .fails()
+        .stderr_only("mktemp: invalid suffix '\\b', contains directory separator\n");
+}


### PR DESCRIPTION
Correct the error message when the template argument contains a path
separator in its suffix. Before this commit:

    $ mktemp aXXX/b
    mktemp: too few X's in template 'b'

After this commit:

    $ mktemp aXXX/b
    mktemp: invalid suffix '/b', contains directory separator

This error message is more appropriate and matches the behavior of GNU
mktemp.