### PR TITLE
df/uniq: suppress lint errors

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -148,6 +148,7 @@ impl fmt::Display for OptionsError {
                 "option --output: field {} used more than once",
                 s.quote()
             ),
+            #[allow(clippy::print_in_format_impl)]
             Self::FilesystemTypeBothSelectedAndExcluded(types) => {
                 for t in types {
                     eprintln!(

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -5,6 +5,9 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
+// TODO remove this when https://github.com/rust-lang/rust-clippy/issues/6902 is fixed
+#![allow(clippy::use_self)]
+
 use clap::{crate_version, Arg, ArgMatches, Command};
 use std::fs::File;
 use std::io::{self, stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};


### PR DESCRIPTION
This PR is more of a workaround and suppresses a clippy lint error that was introduced with Rust 1.61.

I don't know how to fix this in a clean way because of some magic behavior of `writeln!` I couldn't figure out (it adds `df: ` to the output when it's called the first time, but not in subsequent calls). This was also the reason I used `eprintln!`...