### PR TITLE
mktemp: include suffix in error message

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -267,7 +267,11 @@ fn parse_template<'a>(
     let rand = right - left;
 
     if rand < 3 {
-        return Err(MkTempError::TooFewXs(temp.into()));
+        let s = match suffix {
+            None => temp.into(),
+            Some(s) => format!("{}{}", temp, s),
+        };
+        return Err(MkTempError::TooFewXs(s));
     }
 
     let mut suf = &temp[right..];

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -527,3 +527,19 @@ fn test_suffix_path_separator() {
         .fails()
         .stderr_only("mktemp: invalid suffix '\\b', contains directory separator\n");
 }
+
+#[test]
+fn test_too_few_xs_suffix() {
+    new_ucmd!()
+        .args(&["--suffix=X", "aXX"])
+        .fails()
+        .stderr_only("mktemp: too few X's in template 'aXXX'\n");
+}
+
+#[test]
+fn test_too_few_xs_suffix_directory() {
+    new_ucmd!()
+        .args(&["-d", "--suffix=X", "aXX"])
+        .fails()
+        .stderr_only("mktemp: too few X's in template 'aXXX'\n");
+}


### PR DESCRIPTION
Include the suffix in the error message produced by `mktemp` when
there are too few Xs in the template. Before this commit,

    $ mktemp --suffix=X aXX
    mktemp: too few X's in template 'aXX'

After this commit,

    $ mktemp --suffix=X aXX
    mktemp: too few X's in template 'aXXX'

This matches the behavior of GNU `mktemp`.