### PR TITLE
dircolors: test for correct error for -bp and -cp

### DIFF
--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -87,7 +87,14 @@ fn test_no_env() {
 
 #[test]
 fn test_exclusive_option() {
-    new_ucmd!().arg("-cp").fails();
+    new_ucmd!()
+        .arg("-bp")
+        .fails()
+        .stderr_contains("mutually exclusive");
+    new_ucmd!()
+        .arg("-cp")
+        .fails()
+        .stderr_contains("mutually exclusive");
 }
 
 fn test_helper(file_name: &str, term: &str) {


### PR DESCRIPTION
This PR expands an existing test to ensure that a "mutually exclusive" error is shown when using `-bp` or `-cp`.