### PR TITLE
mktemp: combine `--tmpdir` and subdirectory info

### DIFF
--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -27,6 +27,18 @@ const TMPDIR: &str = "TMPDIR";
 #[cfg(windows)]
 const TMPDIR: &str = "TMP";
 
+/// An assertion that uses [`matches_template`] and adds a helpful error message.
+macro_rules! assert_matches_template {
+    ($template:expr, $s:expr) => {{
+        assert!(
+            matches_template($template, $s),
+            "\"{}\" != \"{}\"",
+            $template,
+            $s
+        );
+    }};
+}
+
 #[test]
 fn test_mktemp_mktemp() {
     let scene = TestScenario::new(util_name!());
@@ -417,6 +429,21 @@ fn test_mktemp_directory_tmpdir() {
     assert!(PathBuf::from(result.stdout_str().trim()).is_dir());
 }
 
+/// Test for combining `--tmpdir` and a template with a subdirectory.
+#[test]
+fn test_tmpdir_template_has_subdirectory() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("a");
+    #[cfg(not(windows))]
+    let (template, joined) = ("a/bXXXX", "./a/bXXXX");
+    #[cfg(windows)]
+    let (template, joined) = (r"a\bXXXX", r".\a\bXXXX");
+    let result = ucmd.args(&["--tmpdir=.", template]).succeeds();
+    let filename = result.no_stderr().stdout_str().trim_end();
+    assert_matches_template!(joined, filename);
+    assert!(at.file_exists(filename));
+}
+
 /// Test that an absolute path is disallowed when --tmpdir is provided.
 #[test]
 fn test_tmpdir_absolute_path() {
@@ -464,18 +491,6 @@ fn matches_template(template: &str, s: &str) -> bool {
         }
     }
     true
-}
-
-/// An assertion that uses [`matches_template`] and adds a helpful error message.
-macro_rules! assert_matches_template {
-    ($template:expr, $s:expr) => {{
-        assert!(
-            matches_template($template, $s),
-            "\"{}\" != \"{}\"",
-            $template,
-            $s
-        );
-    }};
 }
 
 /// Test that the file is created in the directory given by the template.
@@ -550,6 +565,16 @@ fn test_suffix_path_separator() {
         .arg(r"aXXX\b")
         .fails()
         .stderr_only("mktemp: invalid suffix '\\b', contains directory separator\n");
+    #[cfg(not(windows))]
+    new_ucmd!()
+        .arg("XXX/..")
+        .fails()
+        .stderr_only("mktemp: invalid suffix '/..', contains directory separator\n");
+    #[cfg(windows)]
+    new_ucmd!()
+        .arg(r"XXX\..")
+        .fails()
+        .stderr_only("mktemp: invalid suffix '\\..', contains directory separator\n");
 }
 
 #[test]


### PR DESCRIPTION
Combine the directory given in `--tmpdir` with any subdirectory
structure appearing in the prefix of the template string. For example,

    $ mktemp --tmpdir=a b/cXXX
    a/b/cNqJ

Previously, this would have incorrectly exited with an error message.