### PR TITLE
dircolors: make -b & -c args overridable

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -166,6 +166,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .long("sh")
                 .short('b')
                 .visible_alias("bourne-shell")
+                .overrides_with(options::C_SHELL)
                 .help("output Bourne shell code to set LS_COLORS")
                 .display_order(1),
         )
@@ -174,6 +175,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .long("csh")
                 .short('c')
                 .visible_alias("c-shell")
+                .overrides_with(options::BOURNE_SHELL)
                 .help("output C shell code to set LS_COLORS")
                 .display_order(2),
         )

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -1,3 +1,4 @@
+// spell-checker:ignore overridable
 use crate::common::util::*;
 
 extern crate dircolors;
@@ -77,6 +78,19 @@ fn test_csh_default() {
         .arg("-c")
         .run()
         .stdout_is_fixture("csh_def.expected");
+}
+#[test]
+fn test_overridable_args() {
+    new_ucmd!()
+        .env("TERM", "screen")
+        .arg("-bc")
+        .run()
+        .stdout_is_fixture("csh_def.expected");
+    new_ucmd!()
+        .env("TERM", "screen")
+        .arg("-cb")
+        .run()
+        .stdout_is_fixture("bash_def.expected");
 }
 
 #[test]


### PR DESCRIPTION
This PR makes `-b` and `-c` overridable, i.e. `-bc` is handled as if `-c` was provided, and `-cb` as if `-b` was provided, the latest argument "wins".