### PR TITLE
Fix a specific test in Windows

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -765,6 +765,7 @@ fn test_output_file_specific_files() {
     assert_eq!(actual, vec!["File", "a   ", "b   ", "c   "]);
 }
 
+#[cfg(not(windows))]
 #[test]
 fn test_file_column_width_if_filename_contains_unicode_chars() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -777,6 +778,21 @@ fn test_file_column_width_if_filename_contains_unicode_chars() {
     let actual = output.lines().next().unwrap();
     // expected width: 7 chars (length of äöü.txt) + 1 char (column separator)
     assert_eq!(actual, "File    Mounted on");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_file_column_width_if_filename_contains_unicode_chars() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("äöü.txt");
+
+    let output = ucmd
+        .args(&["--output=file,target", "äöü.txt"])
+        .succeeds()
+        .stdout_move_str();
+    let actual = output.lines().next().unwrap();
+    // expected width: 7 chars (length of äöü.txt) + 1 char (column separator)
+    assert_eq!(actual, "File Mounted on");
 }
 
 #[test]


### PR DESCRIPTION
The test `test_file_column_width_if_filename_contains_unicode_chars` is failing on my Windows machine.

```powershell
---- test_df::test_file_column_width_if_filename_contains_unicode_chars stdout ----
current_directory_resolved:
touch: C:\Users\Hanif\AppData\Local\Temp\.tmpMbdOpG\äöü.txt
run: C:\Users\Hanif\git\uutils\target\debug\coreutils.exe df --output=file,target äöü.txt
thread 'test_df::test_file_column_width_if_filename_contains_unicode_chars' panicked at 'assertion failed: `(left == right)`
  left: `"File Mounted on"`,
 right: `"File    Mounted on"`', C:\Users\Hanif\git\uutils\tests\by-util\test_df.rs:779:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_df::test_file_column_width_if_filename_contains_unicode_chars

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1713 filtered out; finished in 1.53s

error: test failed, to rerun pass '--test tests'
```

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.43262@gmail.com>