### PR TITLE
expand: remove empty line from error message

### DIFF
--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -93,7 +93,7 @@ fn tabstops_parse(s: &str) -> (RemainingMode, Vec<usize>) {
 
                     // Tab size must be positive.
                     if num == 0 {
-                        crash!(1, "{}\n", "tab size cannot be 0");
+                        crash!(1, "tab size cannot be 0");
                     }
 
                     // Tab sizes must be ascending.


### PR DESCRIPTION
This PR simply removes an unnecessary `\n`.