### PR TITLE
mktemp: exit with status 1 on usage errors

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -91,7 +91,7 @@ impl Display for MkTempError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let template = matches.value_of(ARG_TEMPLATE).unwrap();
     let tmpdir = matches.value_of(OPT_TMPDIR).unwrap_or_default();

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -558,3 +558,8 @@ fn test_too_few_xs_suffix_directory() {
         .fails()
         .stderr_only("mktemp: too few X's in template 'aXXX'\n");
 }
+
+#[test]
+fn test_too_many_arguments() {
+    new_ucmd!().args(&["-q", "a", "b"]).fails().code_is(1);
+}


### PR DESCRIPTION
This matches the exit status used by GNU mktemp on usage errors.