### PR TITLE
expand: allow multiple "tabs" args

### DIFF
--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -132,8 +132,8 @@ struct Options {
 
 impl Options {
     fn new(matches: &ArgMatches) -> Self {
-        let (remaining_mode, tabstops) = match matches.value_of(options::TABS) {
-            Some(s) => tabstops_parse(s),
+        let (remaining_mode, tabstops) = match matches.values_of(options::TABS) {
+            Some(s) => tabstops_parse(&s.collect::<Vec<&str>>().join(",")),
             None => (RemainingMode::None, vec![DEFAULT_TABSTOP]),
         };
 
@@ -195,6 +195,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .short('t')
                 .value_name("N, LIST")
                 .takes_value(true)
+                .multiple_occurrences(true)
                 .help("have tabs N characters apart, not 8 or use comma separated list of explicit tab positions"),
         )
         .arg(

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -74,6 +74,15 @@ fn test_tabs_mixed_style_list() {
 }
 
 #[test]
+fn test_multiple_tabs_args() {
+    new_ucmd!()
+        .args(&["--tabs=3", "--tabs=6", "--tabs=9"])
+        .pipe_in("a\tb\tc\td\te")
+        .succeeds()
+        .stdout_is("a  b  c  d e");
+}
+
+#[test]
 fn test_tabs_empty_string() {
     new_ucmd!()
         .args(&["--tabs", ""])


### PR DESCRIPTION
This PR allows the use of something like `expand --tabs=3 --tabs=6` which so far caused a clap error message.