### PR TITLE
mktemp: only replace last contiguous block of Xs

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -6,7 +6,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (paths) GPGHome
+// spell-checker:ignore (paths) GPGHome findxs
 
 use clap::{crate_version, Arg, ArgMatches, Command};
 use uucore::display::{println_verbatim, Quotable};

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -572,3 +572,25 @@ fn test_too_few_xs_suffix_directory() {
 fn test_too_many_arguments() {
     new_ucmd!().args(&["-q", "a", "b"]).fails().code_is(1);
 }
+
+#[test]
+fn test_two_contiguous_wildcard_blocks() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let template = "XXX_XXX";
+    let result = ucmd.arg(template).succeeds();
+    let filename = result.no_stderr().stdout_str().trim_end();
+    assert_eq!(&filename[..4], "XXX_");
+    assert_matches_template!(template, filename);
+    assert!(at.file_exists(filename));
+}
+
+#[test]
+fn test_three_contiguous_wildcard_blocks() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let template = "XXX_XXX_XXX";
+    let result = ucmd.arg(template).succeeds();
+    let filename = result.no_stderr().stdout_str().trim_end();
+    assert_eq!(&filename[..8], "XXX_XXX_");
+    assert_matches_template!(template, filename);
+    assert!(at.file_exists(filename));
+}


### PR DESCRIPTION
Fix a bug in which `mktemp` would replace everything in the template
argument from the first 'X' to the last 'X' with random bytes, instead
of just replacing the last contiguous block of 'X's.

Before this commit,

    $ mktemp XXX_XXX
    2meCpfM

After this commit,

    $ mktemp XXX_XXX
    XXX_Rp5

This fixes test cases `suffix2f` and `suffix2d` in
`tests/misc/mktemp.pl` in the GNU coreutils test suite.