### PR TITLE
ls: fix double quoting when color is enabled

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2325,6 +2325,20 @@ fn test_ls_quoting_style() {
 }
 
 #[test]
+fn test_ls_quoting_and_color() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.touch("one two");
+    scene
+        .ucmd()
+        .arg("--color")
+        .arg("one two")
+        .succeeds()
+        .stdout_only("'one two'\n");
+}
+
+#[test]
 fn test_ls_ignore_hide() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
When color was enabled the escape_name function was called twice which led to names like `hello world` being displayed as `"'hello world'"`.

This double quoting also led to an incorrect calculation of the width of the name, which is now also fixed.

Fixes #3584