### PR TITLE
Implement the --sync flag for df. (fixes #3564)

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -29,6 +29,11 @@ fn test_df_compatible_si() {
 }
 
 #[test]
+fn test_df_compatible_sync() {
+    new_ucmd!().arg("--sync").succeeds();
+}
+
+#[test]
 fn test_df_arguments_override_themselves() {
     new_ucmd!().args(&["--help", "--help"]).succeeds();
     new_ucmd!().arg("-aa").succeeds();


### PR DESCRIPTION
This PR reuses the defined --sync flag for df, which was previously a
no-op, assigns its default value and uses the fact that
get_all_filesystems takes CLI options as a parameter to perform a sync
operation before any fs call.

Fixes #3564

Signed-off-by: anastygnome <noreplygitemail@protonmail.com>