### PR TITLE
hashsum: Refactor `uu_app` to isolate non-"GNU Coreutils" options

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -104,21 +104,25 @@ pub fn main() {
                 );
 
                 let map_value = format!("({krate}::uumain, {krate}::uu_app_common)", krate = krate);
+                let map_value_bits =
+                    format!("({krate}::uumain, {krate}::uu_app_bits)", krate = krate);
+                let map_value_b3sum =
+                    format!("({krate}::uumain, {krate}::uu_app_b3sum)", krate = krate);
                 phf_map.entry("md5sum", &map_value);
                 phf_map.entry("sha1sum", &map_value);
                 phf_map.entry("sha224sum", &map_value);
                 phf_map.entry("sha256sum", &map_value);
                 phf_map.entry("sha384sum", &map_value);
                 phf_map.entry("sha512sum", &map_value);
-                phf_map.entry("sha3sum", &map_value);
+                phf_map.entry("sha3sum", &map_value_bits);
                 phf_map.entry("sha3-224sum", &map_value);
                 phf_map.entry("sha3-256sum", &map_value);
                 phf_map.entry("sha3-384sum", &map_value);
                 phf_map.entry("sha3-512sum", &map_value);
-                phf_map.entry("shake128sum", &map_value);
-                phf_map.entry("shake256sum", &map_value);
+                phf_map.entry("shake128sum", &map_value_bits);
+                phf_map.entry("shake256sum", &map_value_bits);
                 phf_map.entry("b2sum", &map_value);
-                phf_map.entry("b3sum", &map_value);
+                phf_map.entry("b3sum", &map_value_b3sum);
                 tf.write_all(
                     format!(
                         "#[path=\"{dir}/test_{krate}.rs\"]\nmod test_{krate};\n",


### PR DESCRIPTION
Several binaries have been added to `hashsum` that have never been part
of GNU Coreutils:

- `sha3*sum` (uutils/coreutils#869)
- `shake*sum` (uutils/coreutils#987)
- `b3sum` (uutils/coreutils#3108 and uutils/coreutils#3164)

In particular, the `--bits` option, and the `--no-names` option added in
uutils/coreutils#3361, are not valid for any GNU Coreutils `*sum` binary
(as of Coreutils 9.0).

This commit refactors the argument parsing so that `--bits` and
`--no-names` become invalid options for the binaries intended to match
the GNU Coreutils API, instead of being ignored options. It also
refactors the custom binary name handling to distinguish between
binaries intended to match the GNU Coreutils API, and binaries that
don't have that constraint.

Part of uutils/coreutils#2930.