### PR TITLE
expand: allow specifier only with last value

### DIFF
--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -227,6 +227,24 @@ fn test_tabs_with_specifier_not_at_start() {
 }
 
 #[test]
+fn test_tabs_with_specifier_only_allowed_with_last_value() {
+    fn run_cmd(arg: &str, specifier: &str) {
+        let expected_msg = format!(
+            "{} specifier only allowed with the last value",
+            specifier.quote()
+        );
+        new_ucmd!().arg(arg).fails().stderr_contains(expected_msg);
+    }
+    run_cmd("--tabs=/1,2,3", "/");
+    run_cmd("--tabs=1,/2,3", "/");
+    new_ucmd!().arg("--tabs=1,2,/3").succeeds();
+
+    run_cmd("--tabs=+1,2,3", "+");
+    run_cmd("--tabs=1,+2,3", "+");
+    new_ucmd!().arg("--tabs=1,2,+3").succeeds();
+}
+
+#[test]
 fn test_tabs_with_invalid_chars() {
     new_ucmd!()
         .arg("--tabs=x")


### PR DESCRIPTION
This PR shows an error if a specifier is provided, but not only with the last value. For example, `expand --tabs=/1,2` and `expand --tabs=/1,/2` will now fail. It fixes tests `e5` and `e6` in the GNU test suite.