### PR TITLE
dircolors: update error message

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -83,8 +83,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     {
         return Err(UUsageError::new(
             1,
-            "the options to output dircolors' internal database and\nto select a shell \
-             syntax are mutually exclusive",
+            "the options to output non shell syntax,\n\
+             and to select a shell syntax are mutually exclusive",
         ));
     }
 


### PR DESCRIPTION
This PR updates the error message that is shown when calling `dircolors -b --print-database` or `dircolors -b --print-database`. Instead of the error message from GNU dircolors 8.x, it is now using the error message from GNU dircolors 9.x.

This change also makes the test `print_clash2` pass in https://github.com/coreutils/coreutils/blob/master/tests/misc/dircolors.pl