### PR TITLE
mktemp: error on empty --suffix in some situations

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -224,6 +224,11 @@ fn find_last_contiguous_block_of_xs(s: &str) -> Option<(usize, usize)> {
 
 impl Params {
     fn from(options: Options) -> Result<Self, MkTempError> {
+        // The template argument must end in 'X' if a suffix option is given.
+        if options.suffix.is_some() && !options.template.ends_with('X') {
+            return Err(MkTempError::MustEndInX(options.template));
+        }
+
         // Get the start and end indices of the randomized part of the template.
         //
         // For example, if the template is "abcXXXXyz", then `i` is 3 and `j` is 7.
@@ -284,9 +289,6 @@ impl Params {
         let suffix = format!("{}{}", suffix_from_template, suffix_from_option);
         if suffix.contains(MAIN_SEPARATOR) {
             return Err(MkTempError::SuffixContainsDirSeparator(suffix));
-        }
-        if !suffix_from_template.is_empty() && !suffix_from_option.is_empty() {
-            return Err(MkTempError::MustEndInX(options.template));
         }
 
         // The number of random characters in the template.

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -619,3 +619,25 @@ fn test_three_contiguous_wildcard_blocks() {
     assert_matches_template!(template, filename);
     assert!(at.file_exists(filename));
 }
+
+/// Test that template must end in X even if `--suffix` is the empty string.
+#[test]
+fn test_suffix_must_end_in_x() {
+    new_ucmd!()
+        .args(&["--suffix=", "aXXXb"])
+        .fails()
+        .stderr_is("mktemp: with --suffix, template 'aXXXb' must end in X\n");
+}
+
+#[test]
+fn test_suffix_empty_template() {
+    new_ucmd!()
+        .args(&["--suffix=aXXXb", ""])
+        .fails()
+        .stderr_is("mktemp: with --suffix, template '' must end in X\n");
+
+    new_ucmd!()
+        .args(&["-d", "--suffix=aXXXb", ""])
+        .fails()
+        .stderr_is("mktemp: with --suffix, template '' must end in X\n");
+}


### PR DESCRIPTION
Make `mktemp` exit with an error if the `--suffix` option is the empty
string and the template argument does not end in an "X". Previously,
the program succeeded.

Before this commit,

    $ mktemp --suffix= aXXXb
    apBEb

After this commit,

    $ mktemp --suffix= aXXXb
    mktemp: with --suffix, template 'aXXXb' must end in X

This causes the test case `suffix7f` to pass in the file `tests/misc/mktemp.pl` in the GNU test suite.