### PR TITLE
dd: reuse buffer for the most common cases

### DIFF
--- a/src/uu/dd/BENCHMARKING.md
+++ b/src/uu/dd/BENCHMARKING.md
@@ -1,0 +1,62 @@
+# Benchmarking dd
+
+`dd` is a utility used for copying and converting files. It is often used for
+writing directly to devices, such as when writing an `.iso` file directly to a
+drive.
+
+## Understanding dd
+
+At the core, `dd` has a simple loop of operation. It reads in `blocksize` bytes
+from an input, optionally performs a conversion on the bytes, and then writes
+`blocksize` bytes to an output file.
+
+In typical usage, the performance of `dd` is dominated by the speed at which it
+can read or write to the filesystem. For those scenarios it is best to optimize
+the blocksize for the performance of the devices being read/written to. Devices
+typically have an optimal block size that they work best at, so for maximum
+performance `dd` should be using a block size, or multiple of the block size,
+that the underlying devices prefer.
+
+For benchmarking `dd` itself we will use fast special files provided by the
+operating system that work out of RAM, `/dev/zero` and `/dev/null`. This reduces
+the time taken reading/writing files to a minimum and maximises the percentage
+time we spend in the `dd` tool itself, but care still needs to be taken to
+understand where we are benchmarking the `dd` tool and where we are just
+benchmarking memory performance.
+
+The main parameter to vary for a `dd` benchmark is the blocksize, but benchmarks
+testing the conversions that are supported by `dd` could also be interesting.
+
+`dd` has a convenient `count` argument, that will copy `count` blocks of data
+from the input to the output, which is useful for benchmarking.
+
+## Blocksize Benchmarks
+
+When measuring the impact of blocksize on the throughput, we want to avoid
+testing the startup time of `dd`. `dd` itself will give a report on the
+throughput speed once complete, but it's probably better to use an external
+tool, such as `hyperfine` to measure the performance.
+
+Benchmarks should be sized so that they run for a handful of seconds at a
+minimum to avoid measuring the startup time unnecessarily. The total time will
+be roughly equivalent to the total bytes copied (`blocksize` x `count`).
+
+Some useful invocations for testing would be the following:
+
+```
+hyperfine "./target/release/dd bs=4k count=1000000 < /dev/zero > /dev/null"
+hyperfine "./target/release/dd bs=1M count=20000 < /dev/zero > /dev/null"
+hyperfine "./target/release/dd bs=1G count=10 < /dev/zero > /dev/null"
+```
+
+Choosing what to benchmark depends greatly on what you want to measure.
+Typically you would choose a small blocksize for measuring the performance of
+`dd`, as that would maximize the overhead introduced by the `dd` tool. `dd`
+typically does some set amount of work per block which only depends on the size
+of the block if conversions are used.
+
+As an example, https://github.com/uutils/coreutils/pull/3600 made a change to
+reuse the same buffer between block copies, avoiding the need to reallocate a
+new block of memory for each copy. The impact of that change mostly had an
+impact on large block size copies because those are the circumstances where the
+memory performance dominated the total performance.

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -606,7 +606,7 @@ impl Write for Output<io::Stdout> {
 /// Read helper performs read operations common to all dd reads, and dispatches the buffer to relevant helper functions as dictated by the operations requested by the user.
 fn read_helper<R: Read>(
     i: &mut Input<R>,
-    mut buf: &mut Vec<u8>,
+    buf: &mut Vec<u8>,
     bsize: usize,
 ) -> std::io::Result<ReadStat> {
     // Local Helper Fns -------------------------------------------------
@@ -621,8 +621,8 @@ fn read_helper<R: Read>(
     buf.resize(bsize, BUF_INIT_BYTE);
 
     let mut rstat = match i.cflags.sync {
-        Some(ch) => i.fill_blocks(&mut buf, ch)?,
-        _ => i.fill_consecutive(&mut buf)?,
+        Some(ch) => i.fill_blocks(buf, ch)?,
+        _ => i.fill_consecutive(buf)?,
     };
     // Return early if no data
     if rstat.reads_complete == 0 && rstat.reads_partial == 0 {
@@ -631,7 +631,7 @@ fn read_helper<R: Read>(
 
     // Perform any conv=x[,x...] options
     if i.cflags.swab {
-        perform_swab(&mut buf);
+        perform_swab(buf);
     }
 
     match i.cflags.mode {


### PR DESCRIPTION
This is purely a performance improvement for the case of large blocksizes in dd. This reuses a single buffer instead of reallocating the buffer for each block.

For the uncommon case of dealing with conversions, this still creates a copy of the buffer and so doesn't confer any benefit. That section of the codebase requires some more complex refactoring that is probably better to change separately. See #3293 by @jfinkels 

Some very rough benchmarks piping from `/dev/zero` to `/dev/null` show an improvement of about 3x with large buffer sizes, and minor speedups with smaller buffers. Real world usage will see less benefit since there will usually be more time spent reading/writing the buffers.

Testing can be done with something like:

```
time ./target/release/dd status=progress bs=1G count=10 < /dev/zero > /dev/null
```

| | bs=4k count=1000000 | bs=1G count=10 |
| --- | --- | --- |
| (Reused Buffer) dd | 2.02s | 1.94s |
| Coreutils dd | 2.18s | 6.04s |
| GNU dd | 1.26s | 1.16s |