### PR TITLE
mktemp: respect POSIXLY_CORRECT env var when parsing args

### DIFF
--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -641,3 +641,25 @@ fn test_suffix_empty_template() {
         .fails()
         .stderr_is("mktemp: with --suffix, template '' must end in X\n");
 }
+
+#[test]
+fn test_mktemp_with_posixly_correct() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ucmd()
+        .env("POSIXLY_CORRECT", "1")
+        .args(&["aXXXX", "--suffix=b"])
+        .fails()
+        .stderr_is(&format!(
+            "mktemp: too many templates\nTry '{} {} --help' for more information.\n",
+            scene.bin_path.to_string_lossy(),
+            scene.util_name
+        ));
+
+    scene
+        .ucmd()
+        .env("POSIXLY_CORRECT", "1")
+        .args(&["--suffix=b", "aXXXX"])
+        .succeeds();
+}


### PR DESCRIPTION
Fix issue #3587.

Now the GNU test suite `suffix9f` in `tests/misc/mktemp.pl` can pass.
