### PR TITLE
unexpand: set value name of arg

### DIFF
--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -134,6 +134,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .long(options::TABS)
                 .help("use comma separated LIST of tab positions or have tabs N characters apart instead of 8 (enables -a)")
                 .takes_value(true)
+                .value_name("N, LIST")
         )
         .arg(
             Arg::new(options::NO_UTF8)


### PR DESCRIPTION
This PR fixes an inconsistency in the help output when using `--help`. It changes `-t, --tabs <tabs>` to `-t, --tabs <N, LIST>`, making it consistent with the corresponding help text which mentions `N` and `LIST`.