### PR TITLE
cut: fix argument parsing for the delimiter

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -402,6 +402,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect_str(InvalidEncodingHandling::Ignore)
         .accept_any();
 
+    let delimiter_is_equal = args.contains(&"-d=".to_string()); // special case
     let matches = uu_app().get_matches_from(args);
 
     let complement = matches.is_present(options::COMPLEMENT);
@@ -460,11 +461,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         // GNU's `cut` supports `-d=` to set the delimiter to `=`.
                         // Clap parsing is limited in this situation, see:
                         // https://github.com/uutils/coreutils/issues/2424#issuecomment-863825242
-                        // Since clap parsing handles `-d=` as delimiter explicitly set to "" and
-                        // an empty delimiter is not accepted by GNU's `cut` (and makes no sense),
-                        // we can use this as basis for a simple workaround:
-                        if delim.is_empty() {
+                        if delimiter_is_equal {
                             delim = "=";
+                        } else if delim == "''" {
+                            // treat `''` as empty delimiter
+                            delim = "";
                         }
                         if delim.chars().count() > 1 {
                             Err("invalid input: The '--delimiter' ('-d') option expects empty or 1 character long, but was provided a value 2 characters or longer".into())

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -172,10 +172,28 @@ fn test_directory_and_no_such_file() {
 }
 
 #[test]
-fn test_equal_as_delimiter() {
+fn test_equal_as_delimiter1() {
     new_ucmd!()
         .args(&["-f", "2", "-d="])
         .pipe_in("--dir=./out/lib")
         .succeeds()
         .stdout_only("./out/lib\n");
+}
+
+#[test]
+fn test_equal_as_delimiter2() {
+    new_ucmd!()
+        .args(&["-f2", "--delimiter="])
+        .pipe_in("a=b\n")
+        .succeeds()
+        .stdout_only("a=b\n");
+}
+
+#[test]
+fn test_equal_as_delimiter3() {
+    new_ucmd!()
+        .args(&["-f", "1,2", "-d", "''", "--output-delimiter=Z"])
+        .pipe_in("ab\0cd\n")
+        .succeeds()
+        .stdout_only_bytes("abZcd\n");
 }


### PR DESCRIPTION
This fixes the argument parsing for the delimiter for the two special
cases `-d=` and `-d ''`.

This is an addendum to #2428, it fixes the two issues raised here: https://github.com/uutils/coreutils/pull/2428#issuecomment-863944719 and here: https://github.com/uutils/coreutils/pull/2428#issuecomment-1094304470