### PR TITLE
dd: fix output issues

### DIFF
--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -505,6 +505,7 @@ mod tests {
                 ..Default::default()
             },
             duration: Duration::new(1, 0), // one second
+            complete: false,
         }
     }
 
@@ -613,10 +614,7 @@ mod tests {
         let mut iter = cursor.get_ref().split(|v| *v == b'\n');
         assert_eq!(iter.next().unwrap(), b"0+0 records in");
         assert_eq!(iter.next().unwrap(), b"0+0 records out");
-        assert_eq!(
-            iter.next().unwrap(),
-            b"0 bytes (0 B, 0 B) copied, 1.0 s, 0 B/s"
-        );
+        assert_eq!(iter.next().unwrap(), b"0 bytes copied, 1.0 s, 0 B/s");
         assert_eq!(iter.next().unwrap(), b"");
         assert!(iter.next().is_none());
     }
@@ -635,10 +633,7 @@ mod tests {
         prog_update.write_prog_line(&mut cursor, rewrite).unwrap();
         prog_update.write_transfer_stats(&mut cursor, true).unwrap();
         let mut iter = cursor.get_ref().split(|v| *v == b'\n');
-        assert_eq!(
-            iter.next().unwrap(),
-            b"\r0 bytes (0 B, 0 B) copied, 1.0 s, 0 B/s"
-        );
+        assert_eq!(iter.next().unwrap(), b"\r0 bytes copied, 1.0 s, 0 B/s");
         assert_eq!(iter.next().unwrap(), b"0+0 records in");
         assert_eq!(iter.next().unwrap(), b"0+0 records out");
         assert_eq!(iter.next().unwrap(), b"0 bytes copied, 1.0 s, 0 B/s");

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -44,15 +44,26 @@ pub(crate) struct ProgUpdate {
 
     /// The time period over which the reads and writes were measured.
     pub(crate) duration: Duration,
+
+    /// The status of the write.
+    ///
+    /// True if the write is completed, false if still in-progress.
+    pub(crate) complete: bool,
 }
 
 impl ProgUpdate {
     /// Instantiate this struct.
-    pub(crate) fn new(read_stat: ReadStat, write_stat: WriteStat, duration: Duration) -> Self {
+    pub(crate) fn new(
+        read_stat: ReadStat,
+        write_stat: WriteStat,
+        duration: Duration,
+        complete: bool,
+    ) -> Self {
         Self {
             read_stat,
             write_stat,
             duration,
+            complete,
         }
     }
 
@@ -183,7 +194,10 @@ impl ProgUpdate {
     /// assert_eq!(iter.next().unwrap(), b"");
     /// assert!(iter.next().is_none());
     /// ```
-    fn write_transfer_stats(&self, w: &mut impl Write) -> std::io::Result<()> {
+    fn write_transfer_stats(&self, w: &mut impl Write, new_line: bool) -> std::io::Result<()> {
+        if new_line {
+            writeln!(w)?;
+        }
         self.write_io_lines(w)?;
         let rewrite = false;
         self.write_prog_line(w, rewrite)?;
@@ -210,9 +224,22 @@ impl ProgUpdate {
     /// Write all summary statistics.
     ///
     /// See [`ProgUpdate::write_transfer_stats`] for more information.
-    pub(crate) fn print_transfer_stats(&self) {
+    pub(crate) fn print_transfer_stats(&self, new_line: bool) {
         let mut stderr = std::io::stderr();
-        self.write_transfer_stats(&mut stderr).unwrap();
+        self.write_transfer_stats(&mut stderr, new_line).unwrap();
+    }
+
+    /// Write all the final statistics.
+    pub(crate) fn print_final_stats(
+        &self,
+        print_level: Option<StatusLevel>,
+        progress_printed: bool,
+    ) {
+        match print_level {
+            Some(StatusLevel::None) => {}
+            Some(StatusLevel::Noxfer) => self.print_io_lines(),
+            Some(StatusLevel::Progress) | None => self.print_transfer_stats(progress_printed),
+        }
     }
 }
 
@@ -365,9 +392,16 @@ pub(crate) fn gen_prog_updater(
     print_level: Option<StatusLevel>,
 ) -> impl Fn() {
     move || {
+        let mut progress_printed = false;
         while let Ok(update) = rx.recv() {
+            // Print the final read/write statistics.
+            if update.complete {
+                update.print_final_stats(print_level, progress_printed);
+                return;
+            }
             if Some(StatusLevel::Progress) == print_level {
                 update.reprint_prog_line();
+                progress_printed = true;
             }
         }
     }
@@ -412,19 +446,29 @@ pub(crate) fn gen_prog_updater(
             }
         });
 
-        let mut progress_as_secs = 0;
+        // Holds the state of whether we have printed the current progress.
+        // This is needed so that we know whether or not to print a newline
+        // character before outputting non-progress data.
+        let mut progress_printed = false;
         while let Ok(update) = rx.recv() {
-            // (Re)print status line if progress is requested.
-            if Some(StatusLevel::Progress) == print_level
-                && update.duration.as_secs() >= progress_as_secs
-            {
-                update.reprint_prog_line();
-                progress_as_secs = update.duration.as_secs() + 1;
+            // Print the final read/write statistics.
+            if update.complete {
+                update.print_final_stats(print_level, progress_printed);
+                return;
             }
-            // Handle signals
-            if let SIGUSR1_USIZE = sigval.load(Ordering::Relaxed) {
-                update.print_transfer_stats();
-            };
+            // (Re)print status line if progress is requested.
+            if Some(StatusLevel::Progress) == print_level && !update.complete {
+                update.reprint_prog_line();
+                progress_printed = true;
+            }
+            // Handle signals and set the signal to un-seen.
+            // This will print a maximum of 1 time per second, even though it
+            // should be printing on every SIGUSR1.
+            if let SIGUSR1_USIZE = sigval.swap(0, Ordering::Relaxed) {
+                update.print_transfer_stats(progress_printed);
+                // Reset the progress printed, since print_transfer_stats always prints a newline.
+                progress_printed = false;
+            }
         }
     }
 }
@@ -458,10 +502,12 @@ mod tests {
         let read_stat = ReadStat::new(1, 2, 3);
         let write_stat = WriteStat::new(4, 5, 6);
         let duration = Duration::new(789, 0);
+        let complete = false;
         let prog_update = ProgUpdate {
             read_stat,
             write_stat,
             duration,
+            complete,
         };
 
         let mut cursor = Cursor::new(vec![]);
@@ -478,6 +524,7 @@ mod tests {
             read_stat: Default::default(),
             write_stat: Default::default(),
             duration: Duration::new(1, 0), // one second
+            complete: false,
         };
 
         let mut cursor = Cursor::new(vec![]);
@@ -501,10 +548,41 @@ mod tests {
             read_stat: Default::default(),
             write_stat: Default::default(),
             duration: Duration::new(1, 0), // one second
+            complete: false,
         };
         let mut cursor = Cursor::new(vec![]);
-        prog_update.write_transfer_stats(&mut cursor).unwrap();
+        prog_update
+            .write_transfer_stats(&mut cursor, false)
+            .unwrap();
         let mut iter = cursor.get_ref().split(|v| *v == b'\n');
+        assert_eq!(iter.next().unwrap(), b"0+0 records in");
+        assert_eq!(iter.next().unwrap(), b"0+0 records out");
+        assert_eq!(
+            iter.next().unwrap(),
+            b"0 bytes (0 B, 0 B) copied, 1.0 s, 0 B/s"
+        );
+        assert_eq!(iter.next().unwrap(), b"");
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn write_final_transfer_stats() {
+        // Tests the formatting of the final statistics written after a progress line.
+        let prog_update = ProgUpdate {
+            read_stat: Default::default(),
+            write_stat: Default::default(),
+            duration: Duration::new(1, 0), // one second
+            complete: false,
+        };
+        let mut cursor = Cursor::new(vec![]);
+        let rewrite = true;
+        prog_update.write_prog_line(&mut cursor, rewrite).unwrap();
+        prog_update.write_transfer_stats(&mut cursor, true).unwrap();
+        let mut iter = cursor.get_ref().split(|v| *v == b'\n');
+        assert_eq!(
+            iter.next().unwrap(),
+            b"\r0 bytes (0 B, 0 B) copied, 1.0 s, 0 B/s"
+        );
         assert_eq!(iter.next().unwrap(), b"0+0 records in");
         assert_eq!(iter.next().unwrap(), b"0+0 records out");
         assert_eq!(

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -168,7 +168,8 @@ impl ProgUpdate {
     /// This is a convenience method that calls
     /// [`ProgUpdate::write_io_lines`] and
     /// [`ProgUpdate::write_prog_line`] in that order. The information
-    /// is written to `w`.
+    /// is written to `w`. It optionally begins by writing a new line,
+    /// intended to handle the case of an existing progress line.
     ///
     /// # Examples
     ///
@@ -183,7 +184,7 @@ impl ProgUpdate {
     ///     duration: Duration::new(1, 0), // one second
     /// };
     /// let mut cursor = Cursor::new(vec![]);
-    /// prog_update.write_transfer_stats(&mut cursor).unwrap();
+    /// prog_update.write_transfer_stats(&mut cursor, false).unwrap();
     /// let mut iter = cursor.get_ref().split(|v| *v == b'\n');
     /// assert_eq!(iter.next().unwrap(), b"0+0 records in");
     /// assert_eq!(iter.next().unwrap(), b"0+0 records out");


### PR DESCRIPTION
This change fixes multiple issues with the output of dd, that were easiest to complete in a single PR.

1. Correctly respect SIGUSR1 signals, by marking the setting as 'seen' once we have responded to it.
2. Fix a race condition in the output by moving all output into a single thread.
3. Fixes the bad combination of an existing 'progress' line and final output which can result in printing both on the same line.
4. Moves the check for whether output is needed (only every 1 second) into the main thread to reduce thread-to-thread communication.

The performance uplift of fixing the overzealous thread communication is significant for small blocksizes, and stacks with the buffer changes in #3600.



  | bs=4k count=1000000 | bs=1M count=20000 | bs=1G count=10
-- | -- | -- | --
Coreutils dd | 2.14s | 1.98s | 5.98s
Coreutils dd (Reused buffer #3600) | 1.99s | 1.60s | 1.95s
Coreutils dd (this change, output updates) | 1.29s | 1.79s | 5.96s
Coreutils dd (buffer+output) | 1.15s | 1.42s | 1.90s
GNU dd | 1.15s | 1.07s | 1.13s