### PR TITLE
cp: Replace ioctl-sys by libc for the call to ficlone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,12 +996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ioctl-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd11f3a29434026f5ff98c730b668ba74b1033637b8817940b54d040696133c"
-
-[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,7 +2223,6 @@ dependencies = [
  "clap 3.1.18",
  "exacl",
  "filetime",
- "ioctl-sys",
  "libc",
  "quick-error",
  "selinux",

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -27,9 +27,6 @@ selinux = { version="0.2", optional=true }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["entries", "fs", "perms", "mode"] }
 walkdir = "2.2"
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-ioctl-sys = "0.8"
-
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version="0.3", features=["fileapi"] }
 


### PR DESCRIPTION
because ioctl fails to build on some archs:
https://buildd.debian.org/status/fetch.php?pkg=rust-coreutils&arch=ppc64el&ver=0.0.14-2&stamp=1654852034&raw=0
and it isn't maintained upstream - https://github.com/dcuddeback/ioctl-rs last commit in 2017