### PR TITLE
ls: Remove unnecessary trailing space when using the comma format (-m)

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1874,7 +1874,12 @@ fn display_additional_leading_info(
         } else {
             "?".to_owned()
         };
-        write!(result, "{} ", pad_left(&s, padding.block_size)).unwrap();
+        // extra space is insert to align the sizes, as needed for all formats, except for the comma format.
+        if config.format == Format::Commas {
+            write!(result, "{} ", s).unwrap();
+        } else {
+            write!(result, "{} ", pad_left(&s, padding.block_size)).unwrap();
+        };
     }
     Ok(result)
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -804,6 +804,30 @@ fn test_ls_commas() {
 }
 
 #[test]
+fn test_ls_commas_trailing() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch(&at.plus_as_string("test-commas-trailing-2"));
+
+    at.touch(&at.plus_as_string("test-commas-trailing-1"));
+    at.append(
+        "test-commas-trailing-1",
+        &(0..2000)
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+
+    scene
+        .ucmd()
+        .arg("-sm")
+        .arg("./test-commas-trailing-1")
+        .arg("./test-commas-trailing-2")
+        .succeeds()
+        .stdout_matches(&Regex::new(r"\S$").unwrap()); // matches if there is no whitespace at the end of stdout.
+}
+
+#[test]
 fn test_ls_long() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
unnecessary trailing space was being added. because we were padding for alignment,
which is not required with -m

fixes #3608

Signed-off-by: anastygnome <noreplygitemail@protonmail.com>