### PR TITLE
uucore: fix invalid enum variant in docstring

### DIFF
--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -189,8 +189,8 @@ impl ConversionResult {
 pub trait Args: Iterator<Item = OsString> + Sized {
     /// Converts each iterator item to a String and collects these into a vector
     /// On invalid encoding, the result will depend on the argument. This method allows to either drop entries with illegal encoding
-    /// completely (```InvalidEncodingHandling::Ignore```), convert them using lossy-conversion (```InvalidEncodingHandling::Lossy```) which will
-    /// result in strange strings or can chosen to panic (```InvalidEncodingHandling::Panic```).
+    /// completely (```InvalidEncodingHandling::Ignore```), convert them using lossy-conversion (```InvalidEncodingHandling::ConvertLossy```)
+    /// which will result in strange strings or can chosen to panic (```InvalidEncodingHandling::Panic```).
     /// # Arguments
     /// * `handling` - This switch allows to switch the behavior, when invalid encoding is encountered
     /// # Panics


### PR DESCRIPTION
Replaces the non-existing `InvalidEncodingHandling::Lossy` enum variant in the docstring with the existing `InvalidEncodingHandling::ConvertLossy` enum variant.