### PR TITLE
unexpand: implement "tabs" shortcuts

### DIFF
--- a/tests/by-util/test_unexpand.rs
+++ b/tests/by-util/test_unexpand.rs
@@ -157,6 +157,41 @@ fn unexpand_read_from_two_file() {
 }
 
 #[test]
+fn test_tabs_shortcut() {
+    new_ucmd!()
+        .arg("-3")
+        .pipe_in("   a   b")
+        .run()
+        .stdout_is("\ta   b");
+}
+
+#[test]
+fn test_tabs_shortcut_combined_with_all_arg() {
+    fn run_cmd(all_arg: &str) {
+        new_ucmd!()
+            .args(&[all_arg, "-3"])
+            .pipe_in("a  b  c")
+            .run()
+            .stdout_is("a\tb\tc");
+    }
+
+    let all_args = vec!["-a", "--all"];
+
+    for arg in all_args {
+        run_cmd(arg);
+    }
+}
+
+#[test]
+fn test_comma_separated_tabs_shortcut() {
+    new_ucmd!()
+        .args(&["-a", "-3,9"])
+        .pipe_in("a  b     c")
+        .run()
+        .stdout_is("a\tb\tc");
+}
+
+#[test]
 fn test_tabs_cannot_be_zero() {
     new_ucmd!()
         .arg("--tabs=0")


### PR DESCRIPTION
This PR adds support for shortcuts like `-1` and `-1,2` which are translated to `--tabs=1 --first-only` and `--tabs=1 --tabs=2 --first-only`, respectively. `--first-only` is omitted if `-a` or `--all` is provided.

It makes the tests `u1` - `u8` in https://github.com/coreutils/coreutils/blob/master/tests/misc/unexpand.pl pass.