### PR TITLE
dd: interpret Stdin as File to seek it

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -61,7 +61,6 @@ impl Input<io::Stdin> {
         let iseek =
             parseargs::parse_seek_skip_amt(&ibs, iflags.skip_bytes, matches, options::ISEEK)?;
         let count = parseargs::parse_count(&iflags, matches)?;
-        #[cfg(any(target_family = "unix", target_family = "wasi"))]
         let i = Self {
             src: io::stdin(),
             ibs,

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -37,7 +37,7 @@ use clap::{crate_version, Arg, ArgMatches, Command};
 use gcd::Gcd;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::{show_error, InvalidEncodingHandling};
+use uucore::InvalidEncodingHandling;
 
 const ABOUT: &str = "copy, and optionally convert, a file system resource";
 const BUF_INIT_BYTE: u8 = 0xDD;
@@ -266,20 +266,6 @@ impl<R: Read> Input<R> {
             reads_partial,
             records_truncated: 0,
         })
-    }
-
-    /// Skips amount_to_read bytes from the Input by copying into a sink
-    fn read_skip(&mut self, amount_to_read: u64) -> std::io::Result<()> {
-        let copy_result = io::copy(&mut self.src.by_ref().take(amount_to_read), &mut io::sink());
-        if let Ok(n) = copy_result {
-            if n != amount_to_read {
-                io::Result::Err(io::Error::new(io::ErrorKind::UnexpectedEof, ""))
-            } else {
-                Ok(())
-            }
-        } else {
-            io::Result::Err(copy_result.unwrap_err())
-        }
     }
 }
 

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1186,3 +1186,16 @@ fn test_final_stats_si_iec() {
     let s = result.stderr_str();
     assert!(s.starts_with("2+0 records in\n2+0 records out\n1024 bytes (1 KB, 1024 B) copied,"));
 }
+
+#[test]
+fn test_partial_skip_stdin() {
+    let input = "abc\ndef\n";
+    // build_test_file!("infile.txt", input.as_bytes());
+    new_ucmd!()
+        .args(&["status=none", "bs=1", "skip=1", "count=0"])
+        .pipe_in(input)
+        .succeeds()
+        .no_stderr()
+        .stdout_is("bc")
+        .success();
+}


### PR DESCRIPTION
It fixes a test including `dd` from `tests/misc/head-c.sh`.
Corresponding issue: https://github.com/uutils/coreutils/issues/3008#

I expected that `tests/dd/not-rewound.sh` would also be fixed, but unfortunately, it is not the case. It seems that https://github.com/uutils/coreutils/issues/3626 is still relevant.

#### Background

An attempt to skip bytes by `read_skip` leads to consuming all stdin by a rust application. Another approach to tackle this is to interpret `stdin` as `File`. More details in https://github.com/uutils/coreutils/issues/3008#issuecomment-1136024931