### PR TITLE
Coverage jobs should start at the same time as others

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -969,7 +969,6 @@ jobs:
 
   coverage:
     name: Code Coverage
-    needs: build
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
No need to wait for the regular builds
esp as they might have intermittent