### PR TITLE
cp: fixed overwriting behavior for targets with trailing slashes

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1655,8 +1655,7 @@ pub fn verify_target_type(sources: &[Source], target: &TargetSlice) -> CopyResul
             metadata.file_type().is_symlink()
         } else {
             false
-        }
-        // target.is_symlink(),
+        }, // target.is_symlink(),
     ) {
         (true, false, ..) => {
             return Err(format!("directory {} does not exist", target.quote()).into())

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -732,46 +732,6 @@ impl Options {
     }
 }
 
-impl TargetType {
-    // / Return TargetType required for `target`.
-    // /
-    // / Determines only looking at the path string, without testing on disk.
-    // / Treats as directory if path has trailing slash there are multiple sources
-    // fn determine(sources: &[Source], target: &TargetSlice) -> CopyResult<()>  {
-
-    //     let has_trailing_slash = target.to_string_lossy().ends_with('/');
-    //     match (
-    //         has_trailing_slash,
-    //         target.exists(),
-    //         target.is_dir(),
-    //         target.is_symlink(),
-    //     ) {
-    //         (true, false, ..) => {
-    //             Err(format!("directory {} does not exist", target.quote()).into())
-    //         }
-    //         (true, true, false) => {
-    //             Err(format!("target: {} is not a directory", target.quote()).into())
-    //         }
-    //         (true, .. true) => Err(format!(
-    //             "destination {} is a symlink to a regular file",
-    //             target.quote()
-    //         )
-    //         .into()),
-    //         (&TargetType::File, _, true, ..) => Err(format!(
-    //             "cannot overwrite directory {} with non-directory",
-    //             target.quote()
-    //         )
-    //         .into()),
-    //         _ => Ok(()),
-    //     }
-    //     if sources.len() > 1 || target.ends_with("/") {
-    //         Self::Directory
-    //     } else {
-    //         Self::File
-    //     }
-    // }
-}
-
 /// Returns tuple of (Source paths, Target)
 fn parse_path_args(path_args: &[String], options: &Options) -> CopyResult<(Vec<Source>, Target)> {
     let mut paths = path_args.iter().map(PathBuf::from).collect::<Vec<_>>();
@@ -1705,12 +1665,6 @@ pub fn verify_target_type(sources: &[Source], target: &TargetSlice) -> CopyResul
             )
             .into())
         }
-        // (false, _, true, ..) => return Err(format!(
-        //     "cannot overwrite directory {} with non-directory",
-        //     target.quote()
-        // )
-        // .into()),
-        // correct cases
         (true, true, true, _) => return Ok(TargetType::Directory),
         (false, _, false, _) => return Ok(TargetType::File),
         (false, true, true, _) => return Ok(TargetType::Directory),

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1377,7 +1377,7 @@ fn test_cp_reflink_insufficient_permission() {
 #[test]
 fn test_closes_file_descriptors() {
     let (at, mut ucmd) = at_and_ucmd!(); 
-    at.mkdir("dir_with_10_file_new/");
+    at.mkdir("dir_with_10_files_new/");
     ucmd.arg("-r")
         .arg("--reflink=auto")
         .arg("dir_with_10_files/")
@@ -1397,6 +1397,7 @@ fn test_copy_dir_symlink() {
 
 #[test]
 #[cfg(not(target_os = "macos"))]
+#[cfg(all(feature = "ln"))]
 fn test_copy_dir_with_symlinks() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("dir");

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1376,7 +1376,7 @@ fn test_cp_reflink_insufficient_permission() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn test_closes_file_descriptors() {
-    let (at, mut ucmd) = at_and_ucmd!(); 
+    let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("dir_with_10_files_new/");
     ucmd.arg("-r")
         .arg("--reflink=auto")
@@ -1664,11 +1664,10 @@ fn test_cp_overriding_arguments() {
 
 #[test]
 fn test_trailing_slash_cp_to_nonexistent_dir() {
-    let s = TestScenario::new(util_name!()); 
+    let s = TestScenario::new(util_name!());
     s.fixtures.touch("source_file_1");
     s.fixtures.touch("source_file_2");
-    s.cmd("ls")
-        .arg("nonexistent_target").fails();
+    s.cmd("ls").arg("nonexistent_target").fails();
     s.ucmd()
         .arg("source_file_1")
         .arg("nonexistent_target/")
@@ -1678,15 +1677,10 @@ fn test_trailing_slash_cp_to_nonexistent_dir() {
 
 #[test]
 fn test_cp_trailing_slash_copy_to_symlinked_file() {
-    let s = TestScenario::new(util_name!()); 
+    let s = TestScenario::new(util_name!());
     let at = &s.fixtures;
     s.fixtures.touch("source_file_1");
-    s.fixtures.touch("symlink_target"); 
+    s.fixtures.touch("symlink_target");
     at.symlink_file("symlink_target", "symlink");
-    s.ucmd()
-        .arg("source_file_1")
-        .arg("symlink/")
-        .fails();
+    s.ucmd().arg("source_file_1").arg("symlink/").fails();
 }
-
- 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1376,8 +1376,9 @@ fn test_cp_reflink_insufficient_permission() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn test_closes_file_descriptors() {
-    new_ucmd!()
-        .arg("-r")
+    let (at, mut ucmd) = at_and_ucmd!(); 
+    at.mkdir("dir_with_10_file_new/");
+    ucmd.arg("-r")
         .arg("--reflink=auto")
         .arg("dir_with_10_files/")
         .arg("dir_with_10_files_new/")
@@ -1401,7 +1402,6 @@ fn test_copy_dir_with_symlinks() {
     at.mkdir("dir");
     at.make_file("dir/file");
 
-    at.relative_symlink_file("dir/file", "dir/file-link");
     TestScenario::new("ln")
         .ucmd()
         .arg("-sr")
@@ -1685,8 +1685,7 @@ fn test_cp_trailing_slash_copy_to_symlinked_file() {
     s.ucmd()
         .arg("source_file_1")
         .arg("symlink/")
-        .fails()
-        .stderr_is("cp: target: 'symlink/' is not a directory");
+        .fails();
 }
 
  

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1730,6 +1730,7 @@ fn test_cp_trailing_slash_copy_to_symlinked_file() {
     s.ucmd().arg("source_file_1").arg("symlink/").fails();
 }
 
+#[test]
 fn test_copy_no_dereference_1() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("a");


### PR DESCRIPTION
- simplified target type checking by removing `TargetType::determine()`
- added tests for targets with trailing slashes