### PR TITLE
uniq: set default missing value for "group" and "all-repeated" args

### DIFF
--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -319,7 +319,9 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .help("print all duplicate lines. Delimiting is done with blank lines. [default: none]")
                 .value_name("delimit-method")
                 .min_values(0)
-                .max_values(1),
+                .max_values(1)
+                .default_missing_value("none")
+                .require_equals(true),
         )
         .arg(
             Arg::new(options::GROUP)
@@ -334,6 +336,8 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .value_name("group-method")
                 .min_values(0)
                 .max_values(1)
+                .default_missing_value("separate")
+                .require_equals(true)
                 .conflicts_with_all(&[
                     options::REPEATED,
                     options::ALL_REPEATED,

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 // spell-checker:ignore nabcd
 use crate::common::util::*;
 
@@ -87,6 +89,20 @@ fn test_stdin_all_repeated() {
 }
 
 #[test]
+fn test_all_repeated_followed_by_filename() {
+    let filename = "test.txt";
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let mut file = at.make_file(filename);
+    file.write_all(b"a\na\n").unwrap();
+
+    ucmd.args(&["--all-repeated", filename])
+        .run()
+        .success()
+        .stdout_is("a\na\n");
+}
+
+#[test]
 fn test_stdin_all_repeated_separate() {
     new_ucmd!()
         .args(&["--all-repeated=separate"])
@@ -158,6 +174,20 @@ fn test_group() {
         .pipe_in_fixture(INPUT)
         .run()
         .stdout_is_fixture("group.expected");
+}
+
+#[test]
+fn test_group_followed_by_filename() {
+    let filename = "test.txt";
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let mut file = at.make_file(filename);
+    file.write_all(b"a\na\n").unwrap();
+
+    ucmd.args(&["--group", filename])
+        .run()
+        .success()
+        .stdout_is("a\na\n");
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes the following clap error that occurs when calling uniq like `uniq --group <(printf "a\na\n")`
```
error: "/dev/fd/63" isn't a valid value for '--group [<group-method>...]'
        [possible values: separate, prepend, append, both]
```
It makes the tests `131` and `136` in https://github.com/coreutils/coreutils/blob/master/tests/misc/uniq.pl pass.

I didn't add a test for this change because I couldn't figure out how to test it. The existing test cases `131` and `136` in `test_uniq.rs` already work fine without this change, using `run_piped_stdin`.