### PR TITLE
`rm`: fix help text mistakenly being used as the long option

### DIFF
--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -155,7 +155,7 @@ pub fn uu_app<'a>() -> Command<'a> {
         .arg(
             Arg::new(OPT_PROMPT)
             .short('i')
-            .long("prompt before every removal")
+            .help("prompt before every removal")
         )
         .arg(
             Arg::new(OPT_PROMPT_MORE)


### PR DESCRIPTION
Fixes #3668