### PR TITLE
test_realpath: fixed test to be the one that was supposed to be

### DIFF
--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -220,11 +220,8 @@ fn test_realpath_when_symlink_is_absolute_and_enoent() {
         .arg("dir1/foo2")
         .arg("dir1/foo3")
         .run()
-        .stdout_is(format!(
-            "{}\n{}\n",
-            at.plus_as_string("dir2/bar"),
-            at.plus_as_string("dir2/baz")
-        ))
+        .stdout_contains("/dir2/bar\n")
+        .stdout_contains("/dir2/baz\n")
         .stderr_is("realpath: dir1/foo2: No such file or directory\n");
 
     #[cfg(windows)]

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -220,10 +220,11 @@ fn test_realpath_when_symlink_is_absolute_and_enoent() {
         .arg("dir1/foo2")
         .arg("dir1/foo3")
         .run()
-        .stdout_is(format!("{}\n{}\n",
-                           at.plus_as_string("dir2/bar"),
-                           at.plus_as_string("dir2/baz"))
-        )
+        .stdout_is(format!(
+            "{}\n{}\n",
+            at.plus_as_string("dir2/bar"),
+            at.plus_as_string("dir2/baz")
+        ))
         .stderr_is("realpath: dir1/foo2: No such file or directory\n");
 
     #[cfg(windows)]

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -235,7 +235,7 @@ fn test_realpath_when_symlink_is_absolute_and_enoent() {
 }
 
 #[test]
-#[ignore]
+#[ignore = "issue #3669"]
 fn test_realpath_when_symlink_part_is_missing() {
     let (at, mut ucmd) = at_and_ucmd!();
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -702,8 +702,8 @@ impl AtPath {
     }
 
     pub fn relative_symlink_file(&self, original: &str, link: &str) {
-        log_info("symlink", &format!("{},{}", original, link));
-        symlink_file(original, link).unwrap();
+        log_info("symlink", &format!("{},{}", original, &self.plus_as_string(link)));
+        symlink_file(original, &self.plus(link)).unwrap();
     }
 
     pub fn symlink_dir(&self, original: &str, link: &str) {
@@ -716,6 +716,11 @@ impl AtPath {
             ),
         );
         symlink_dir(&self.plus(original), &self.plus(link)).unwrap();
+    }
+
+    pub fn relative_symlink_dir(&self, original: &str, link: &str) {
+        log_info("symlink", &format!("{},{}", original, &self.plus_as_string(link)));
+        symlink_dir(original, &self.plus(link)).unwrap();
     }
 
     pub fn is_symlink(&self, path: &str) -> bool {

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -702,7 +702,10 @@ impl AtPath {
     }
 
     pub fn relative_symlink_file(&self, original: &str, link: &str) {
-        log_info("symlink", &format!("{},{}", original, &self.plus_as_string(link)));
+        log_info(
+            "symlink",
+            &format!("{},{}", original, &self.plus_as_string(link)),
+        );
         symlink_file(original, &self.plus(link)).unwrap();
     }
 
@@ -719,7 +722,10 @@ impl AtPath {
     }
 
     pub fn relative_symlink_dir(&self, original: &str, link: &str) {
-        log_info("symlink", &format!("{},{}", original, &self.plus_as_string(link)));
+        log_info(
+            "symlink",
+            &format!("{},{}", original, &self.plus_as_string(link)),
+        );
         symlink_dir(original, &self.plus(link)).unwrap();
     }
 


### PR DESCRIPTION
- Fixed test to be the one from #3037 PR
- Added another test that doesn't pass now, but checks #3669 issue: `test_realpath_when_symlink_part_is_missing`
- Made `relative_symlink_file` more alike with other methods
- Added `relative_symlink_dir` that calls `symlink_dir` instead of `symlink_file`