### PR TITLE
realpath: add "--no-symlinks" alias

### DIFF
--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -86,6 +86,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(OPT_STRIP)
                 .short('s')
                 .long(OPT_STRIP)
+                .visible_alias("no-symlinks")
                 .help("Only strip '.' and '..' components, but don't resolve symbolic links"),
         )
         .arg(

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -65,50 +65,56 @@ fn test_realpath_file_and_links_zero() {
 
 #[test]
 fn test_realpath_file_and_links_strip() {
+    let strip_args = ["-s", "--strip", "--no-symlinks"];
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     at.touch("foo");
     at.symlink_file("foo", "bar");
 
-    scene
-        .ucmd()
-        .arg("foo")
-        .arg("-s")
-        .succeeds()
-        .stdout_contains("foo\n");
+    for strip_arg in strip_args {
+        scene
+            .ucmd()
+            .arg("foo")
+            .arg(strip_arg)
+            .succeeds()
+            .stdout_contains("foo\n");
 
-    scene
-        .ucmd()
-        .arg("bar")
-        .arg("-s")
-        .succeeds()
-        .stdout_contains("bar\n");
+        scene
+            .ucmd()
+            .arg("bar")
+            .arg(strip_arg)
+            .succeeds()
+            .stdout_contains("bar\n");
+    }
 }
 
 #[test]
 fn test_realpath_file_and_links_strip_zero() {
+    let strip_args = ["-s", "--strip", "--no-symlinks"];
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     at.touch("foo");
     at.symlink_file("foo", "bar");
 
-    scene
-        .ucmd()
-        .arg("foo")
-        .arg("-s")
-        .arg("-z")
-        .succeeds()
-        .stdout_contains("foo\u{0}");
+    for strip_arg in strip_args {
+        scene
+            .ucmd()
+            .arg("foo")
+            .arg(strip_arg)
+            .arg("-z")
+            .succeeds()
+            .stdout_contains("foo\u{0}");
 
-    scene
-        .ucmd()
-        .arg("bar")
-        .arg("-s")
-        .arg("-z")
-        .succeeds()
-        .stdout_contains("bar\u{0}");
+        scene
+            .ucmd()
+            .arg("bar")
+            .arg(strip_arg)
+            .arg("-z")
+            .succeeds()
+            .stdout_contains("bar\u{0}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
GNU realpath has a `--no-symlinks` alias for the `-s` and `--strip` arguments. This PR adds it to uutils realpath.