### PR TITLE
numfmt: show error if --padding is zero

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -103,7 +103,14 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
     let transform = TransformOptions { from, to };
 
     let padding = match args.value_of(options::PADDING) {
-        Some(s) => s.parse::<isize>().map_err(|err| err.to_string()),
+        Some(s) => s
+            .parse::<isize>()
+            .map_err(|_| s)
+            .and_then(|n| match n {
+                0 => Err(s),
+                _ => Ok(n),
+            })
+            .map_err(|s| format!("invalid padding value {}", s.quote())),
         None => Ok(0),
     }?;
 

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -593,3 +593,17 @@ fn test_invalid_argument_returns_status_1() {
         .fails()
         .code_is(1);
 }
+
+#[test]
+fn test_invalid_padding_value() {
+    let padding_values = vec!["A", "0"];
+
+    for padding_value in padding_values {
+        new_ucmd!()
+            .arg(format!("--padding={}", padding_value))
+            .arg("5")
+            .fails()
+            .code_is(1)
+            .stderr_contains(format!("invalid padding value '{}'", padding_value));
+    }
+}


### PR DESCRIPTION
GNU numfmt shows an "invalid padding error" when using `--padding=0` whereas uutils numfmt doesn't.

This PR adds the same behavior and makes the tests `pad-3` and `pad-3.1` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.