### PR TITLE
cp: disable "extra_unused_lifetimes" lint

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+#![allow(clippy::extra_unused_lifetimes)]
 
 // This file is part of the uutils coreutils package.
 //


### PR DESCRIPTION
With the new Rust version there is now a clippy warning:
```
warning: this lifetime isn't used in the impl
   --> src/uu/cp/src/cp.rs:61:1
    |
61  | / quick_error! {
62  | |     #[derive(Debug)]
63  | |     pub enum Error {
64  | |         /// Simple io::Error wrapper
...   |
105 | |     }
106 | | }
    | |_^
```
This PR simply disables the corresponding lint as I don't know how to fix it otherwise.