### PR TITLE
uucore: add backport for Path::is_symlink()

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{ExitCode, UResult, USimpleError, UUsageError};
 use uucore::fs::display_permissions_unix;
+use uucore::fs::is_symlink;
 use uucore::libc::mode_t;
 #[cfg(not(windows))]
 use uucore::mode;
@@ -378,12 +379,5 @@ impl Chmoder {
             }
             Ok(())
         }
-    }
-}
-
-pub fn is_symlink<P: AsRef<Path>>(path: P) -> bool {
-    match fs::symlink_metadata(path) {
-        Ok(m) => m.file_type().is_symlink(),
-        Err(_) => false,
     }
 }

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -14,6 +14,7 @@ use clap::{crate_version, Arg, Command};
 use uucore::display::Quotable;
 use uucore::error::{UError, UResult};
 use uucore::format_usage;
+use uucore::fs::is_symlink;
 
 use std::borrow::Cow;
 use std::error::Error;
@@ -531,12 +532,5 @@ pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> Result<()>
         symlink_dir(src, dst)
     } else {
         symlink_file(src, dst)
-    }
-}
-
-pub fn is_symlink<P: AsRef<Path>>(path: P) -> bool {
-    match fs::symlink_metadata(path) {
-        Ok(m) => m.file_type().is_symlink(),
-        Err(_) => false,
     }
 }

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -16,6 +16,8 @@ use std::io;
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, strip_errno, UResult};
+
+#[cfg(unix)]
 use uucore::fs::is_symlink;
 use uucore::{format_usage, util_name};
 

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -8,6 +8,8 @@
 
 //! Set of functions to manage files and symlinks
 
+// spell-checker:ignore backport
+
 #[cfg(unix)]
 use libc::{
     mode_t, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK, S_IRGRP,

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -221,6 +221,16 @@ pub fn normalize_path(path: &Path) -> PathBuf {
     ret
 }
 
+/// Decide whether the given path is a symbolic link.
+///
+/// This function is essentially a backport of the
+/// [`std::path::Path::is_symlink`] function that exists in Rust
+/// version 1.58 and greater. This can be removed when the minimum
+/// supported version of Rust is 1.58.
+pub fn is_symlink<P: AsRef<Path>>(path: P) -> bool {
+    fs::symlink_metadata(path).map_or(false, |m| m.file_type().is_symlink())
+}
+
 fn resolve<P: AsRef<Path>>(original: P) -> Result<PathBuf, (bool, PathBuf, IOError)> {
     const MAX_LINKS_FOLLOWED: u32 = 255;
     let mut followed = 0;

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -10,7 +10,7 @@ use crate::error::strip_errno;
 use crate::error::UResult;
 use crate::error::USimpleError;
 pub use crate::features::entries;
-use crate::fs::resolve_relative_path;
+use crate::fs::{is_symlink, resolve_relative_path};
 use crate::show_error;
 use clap::Arg;
 use clap::ArgMatches;
@@ -274,12 +274,7 @@ impl ChownExecutor {
         let root = root.as_ref();
 
         // walkdir always dereferences the root directory, so we have to check it ourselves
-        // TODO: replace with `root.is_symlink()` once it is stable
-        if self.traverse_symlinks == TraverseSymlinks::None
-            && std::fs::symlink_metadata(root)
-                .map(|m| m.file_type().is_symlink())
-                .unwrap_or(false)
-        {
+        if self.traverse_symlinks == TraverseSymlinks::None && is_symlink(root) {
             return 0;
         }
 


### PR DESCRIPTION
Add a `uucore::fs::is_symlink()` function that takes in a
`std::path::Path` and decides whether the given path is a symbolic
link. This is essentially a backport of the `Path::is_symlink()`
function that appears in Rust version 1.58.0. This commit also
replaces some now-duplicate code in `chmod`, `cp`, `ln`, and `rmdir`
that checks whether a path is a symbolic link with a call to
`is_symlink()`.

Technically, this commit slightly changes the behavior of
`cp`. Previously, there was a line of code like this

    if fs::symlink_metadata(&source)?.file_type().is_symlink() {

where the `?` operator propagates an error from `symlink_metadata()`
to the caller. Now the line of code is

    if is_symlink(source) {

in which any error from `symlink_metadata()` has been converted to
just be a `false` value. I believe this is a satisfactory tradeoff to
make, since an error in accessing the file will likely cause an error
later in the same code path.

(This change was suggested in https://github.com/uutils/coreutils/pull/3692/files#r913039746.)