### PR TITLE
Realpath symlinks handling, solves issue #3669

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -351,7 +351,7 @@ fn cat_path(
 
             if let Some(out_info) = out_info {
                 if out_info.file_size() != 0
-                    && FileInformation::from_file(&file).as_ref() == Some(out_info)
+                    && FileInformation::from_file(&file).ok().as_ref() == Some(out_info)
                 {
                     return Err(CatError::OutputIsInput);
                 }
@@ -367,7 +367,7 @@ fn cat_path(
 }
 
 fn cat_files(files: &[String], options: &OutputOptions) -> UResult<()> {
-    let out_info = FileInformation::from_file(&std::io::stdout());
+    let out_info = FileInformation::from_file(&std::io::stdout()).ok();
 
     let mut state = OutputState {
         line_number: 1,

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -787,11 +787,7 @@ fn preserve_hardlinks(
             let info = match FileInformation::from_path(source, false) {
                 Ok(info) => info,
                 Err(e) => {
-                    return Err(format!(
-                        "cannot stat {}: {}",
-                        source.quote(),
-                        e,
-                    ).into());
+                    return Err(format!("cannot stat {}: {}", source.quote(), e,).into());
                 }
             };
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1227,7 +1227,7 @@ fn symlink_file(
     {
         std::os::windows::fs::symlink_file(source, dest).context(context)?;
     }
-    if let Some(file_info) = FileInformation::from_path(dest, false) {
+    if let Ok(file_info) = FileInformation::from_path(dest, false) {
         symlinked_files.insert(file_info);
     }
     Ok(())

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -98,6 +98,23 @@ impl FileInformation {
             self.0.file_size()
         }
     }
+
+    #[cfg(windows)]
+    pub fn file_index(&self) -> u64 {
+        self.0.file_index()
+    }
+
+    pub fn number_of_links(&self) -> u64 {
+        #[cfg(unix)]
+        return self.0.st_nlink;
+        #[cfg(windows)]
+        return self.0.number_of_links();
+    }
+
+    #[cfg(unix)]
+    pub fn inode(&self) -> u64 {
+        self.0.st_ino
+    }
 }
 
 #[cfg(unix)]

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -368,7 +368,7 @@ pub fn canonicalize<P: AsRef<Path>>(
                         return Err(Error::new(
                             ErrorKind::InvalidInput,
                             "Too many levels of symbolic links",
-                        )); // try to raise symlink loop error, TODO use ErrorKind::FilesystemLoop when stable
+                        )); // TODO use ErrorKind::FilesystemLoop when stable
                     }
                 }
                 result.pop();

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -17,12 +17,12 @@ use libc::{
     S_IXUSR,
 };
 use std::borrow::Cow;
+use std::collections::{HashSet, VecDeque};
 use std::env;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::hash::Hash;
-use std::io::Error as IOError;
-use std::io::Result as IOResult;
-use std::io::{Error, ErrorKind};
+use std::io::{Error, ErrorKind, Result as IOResult};
 #[cfg(unix)]
 use std::os::unix::{fs::MetadataExt, io::AsRawFd};
 use std::path::{Component, Path, PathBuf};
@@ -233,47 +233,49 @@ pub fn is_symlink<P: AsRef<Path>>(path: P) -> bool {
     fs::symlink_metadata(path).map_or(false, |m| m.file_type().is_symlink())
 }
 
-fn resolve<P: AsRef<Path>>(original: P) -> Result<PathBuf, (bool, PathBuf, IOError)> {
-    const MAX_LINKS_FOLLOWED: u32 = 255;
-    let mut followed = 0;
-    let mut result = original.as_ref().to_path_buf();
-    let mut symlink_is_absolute = false;
-    let mut first_resolution = None;
+fn resolve_symlink<P: AsRef<Path>>(path: P) -> IOResult<Option<PathBuf>> {
+    let result = if fs::symlink_metadata(&path)?.file_type().is_symlink() {
+        Some(fs::read_link(&path)?)
+    } else {
+        None
+    };
+    Ok(result)
+}
 
-    loop {
-        if followed == MAX_LINKS_FOLLOWED {
-            return Err((
-                symlink_is_absolute,
-                // When we hit MAX_LINKS_FOLLOWED we should return the first resolution (that's what GNU does - for whatever reason)
-                first_resolution.unwrap(),
-                Error::new(ErrorKind::InvalidInput, "maximum links followed"),
-            ));
-        }
+enum OwningComponent {
+    Prefix(OsString),
+    RootDir,
+    CurDir,
+    ParentDir,
+    Normal(OsString),
+}
 
-        match fs::symlink_metadata(&result) {
-            Ok(meta) => {
-                if !meta.file_type().is_symlink() {
-                    break;
-                }
-            }
-            Err(e) => return Err((symlink_is_absolute, result, e)),
-        }
-
-        followed += 1;
-        match fs::read_link(&result) {
-            Ok(path) => {
-                result.pop();
-                symlink_is_absolute = path.is_absolute();
-                result.push(path);
-            }
-            Err(e) => return Err((symlink_is_absolute, result, e)),
-        }
-
-        if first_resolution.is_none() {
-            first_resolution = Some(result.clone());
+impl OwningComponent {
+    fn as_os_str(&self) -> &OsStr {
+        match self {
+            OwningComponent::Prefix(s) => s.as_os_str(),
+            OwningComponent::RootDir => Component::RootDir.as_os_str(),
+            OwningComponent::CurDir => Component::CurDir.as_os_str(),
+            OwningComponent::ParentDir => Component::ParentDir.as_os_str(),
+            OwningComponent::Normal(s) => s.as_os_str(),
         }
     }
-    Ok(result)
+
+    fn from(comp: &Component) -> Self {
+        match comp {
+            Component::Prefix(_) => OwningComponent::Prefix(comp.as_os_str().to_os_string()),
+            Component::RootDir => OwningComponent::RootDir,
+            Component::CurDir => OwningComponent::CurDir,
+            Component::ParentDir => OwningComponent::ParentDir,
+            Component::Normal(s) => OwningComponent::Normal(s.to_os_string()),
+        }
+    }
+}
+
+impl<'a> Into<OwningComponent> for Component<'a> {
+    fn into(self) -> OwningComponent {
+        OwningComponent::from(&self)
+    }
 }
 
 /// Return the canonical, absolute form of a path.
@@ -307,7 +309,7 @@ pub fn canonicalize<P: AsRef<Path>>(
     miss_mode: MissingHandling,
     res_mode: ResolveMode,
 ) -> IOResult<PathBuf> {
-    // Create an absolute path
+    const SYMLINKS_TO_LOOK_FOR_LOOPS: i32 = 20;
     let original = original.as_ref();
     let original = if original.is_absolute() {
         original.to_path_buf()
@@ -315,86 +317,64 @@ pub fn canonicalize<P: AsRef<Path>>(
         let current_dir = env::current_dir()?;
         dunce::canonicalize(current_dir)?.join(original)
     };
-
+    let path = if res_mode == ResolveMode::Logical {
+        normalize_path(&original)
+    } else {
+        original
+    };
+    let mut parts: VecDeque<OwningComponent> = path.components().map(|part| part.into()).collect();
     let mut result = PathBuf::new();
-    let mut parts = vec![];
-
-    // Split path by directory separator; add prefix (Windows-only) and root
-    // directory to final path buffer; add remaining parts to temporary
-    // vector for canonicalization.
-    for part in original.components() {
+    let mut followed_symlinks = 0;
+    let mut visited_files = HashSet::new();
+    while let Some(part) = parts.pop_front() {
         match part {
-            Component::Prefix(_) | Component::RootDir => {
-                result.push(part.as_os_str());
-            }
-            Component::CurDir => (),
-            Component::ParentDir => {
-                if res_mode == ResolveMode::Logical {
-                    parts.pop();
-                } else {
-                    parts.push(part.as_os_str());
-                }
-            }
-            Component::Normal(_) => {
-                parts.push(part.as_os_str());
-            }
-        }
-    }
-
-    // Resolve the symlinks where possible
-    if !parts.is_empty() {
-        for part in parts[..parts.len() - 1].iter() {
-            result.push(part);
-
-            //resolve as we go to handle long relative paths on windows
-            if res_mode == ResolveMode::Physical {
-                result = normalize_path(&result);
-            }
-
-            if res_mode == ResolveMode::None {
+            OwningComponent::Prefix(s) => {
+                result.push(s);
                 continue;
             }
-
-            match resolve(&result) {
-                Err((_, path, e)) => {
-                    if miss_mode == MissingHandling::Missing {
-                        result = path;
-                    } else {
-                        return Err(e);
+            OwningComponent::RootDir | OwningComponent::Normal(..) => {
+                result.push(part.as_os_str());
+            }
+            OwningComponent::CurDir => {}
+            OwningComponent::ParentDir => {
+                result.pop();
+            }
+        }
+        if res_mode == ResolveMode::None {
+            continue;
+        }
+        match resolve_symlink(&result) {
+            Ok(Some(link_path)) => {
+                for link_part in link_path.components().rev() {
+                    parts.push_front(link_part.into());
+                }
+                if followed_symlinks < SYMLINKS_TO_LOOK_FOR_LOOPS {
+                    followed_symlinks += 1;
+                } else {
+                    let file_info =
+                        FileInformation::from_path(&result.parent().unwrap(), false).unwrap();
+                    let mut path_to_follow = PathBuf::new();
+                    for part in parts.iter() {
+                        path_to_follow.push(part.as_os_str());
+                    }
+                    if !visited_files.insert((file_info, path_to_follow)) {
+                        result.metadata()?; // try to make ELOOP like error, TODO use ErrorKind::FilesystemLoop when stable
+                        return Err(Error::new(
+                            ErrorKind::InvalidInput,
+                            "Too many levels of symbolic links",
+                        ));
                     }
                 }
-                Ok(path) => {
-                    result = path;
-                }
+                result.pop();
             }
-        }
-
-        result.push(parts.last().unwrap());
-
-        if res_mode == ResolveMode::None {
-            return Ok(result);
-        }
-
-        match resolve(&result) {
-            Err((is_absolute, path, err)) => {
-                // If the resolved symlink is an absolute path and non-existent,
-                // `realpath` throws no such file error.
+            Err(e) => {
                 if miss_mode == MissingHandling::Existing
-                    || (err.kind() == ErrorKind::NotFound
-                        && is_absolute
-                        && miss_mode == MissingHandling::Normal)
+                    || (miss_mode == MissingHandling::Normal && !parts.is_empty())
                 {
-                    return Err(err);
-                } else {
-                    result = path;
+                    return Err(e);
                 }
             }
-            Ok(path) => {
-                result = path;
-            }
-        }
-        if res_mode == ResolveMode::Physical {
-            result = normalize_path(&result);
+            _ => {}
         }
     }
     Ok(result)

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -354,7 +354,7 @@ pub fn canonicalize<P: AsRef<Path>>(
                         path_to_follow.push(part.as_os_str());
                     }
                     if !visited_files.insert((file_info, path_to_follow)) {
-                        result.metadata()?; // try to make ELOOP like error, TODO use ErrorKind::FilesystemLoop when stable
+                        result.metadata()?; // try to raise symlink loop error, TODO use ErrorKind::FilesystemLoop when stable
                         return Err(Error::new(
                             ErrorKind::InvalidInput,
                             "Too many levels of symbolic links",

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -253,28 +253,24 @@ enum OwningComponent {
 impl OwningComponent {
     fn as_os_str(&self) -> &OsStr {
         match self {
-            OwningComponent::Prefix(s) => s.as_os_str(),
-            OwningComponent::RootDir => Component::RootDir.as_os_str(),
-            OwningComponent::CurDir => Component::CurDir.as_os_str(),
-            OwningComponent::ParentDir => Component::ParentDir.as_os_str(),
-            OwningComponent::Normal(s) => s.as_os_str(),
-        }
-    }
-
-    fn from(comp: &Component) -> Self {
-        match comp {
-            Component::Prefix(_) => OwningComponent::Prefix(comp.as_os_str().to_os_string()),
-            Component::RootDir => OwningComponent::RootDir,
-            Component::CurDir => OwningComponent::CurDir,
-            Component::ParentDir => OwningComponent::ParentDir,
-            Component::Normal(s) => OwningComponent::Normal(s.to_os_string()),
+            Self::Prefix(s) => s.as_os_str(),
+            Self::RootDir => Component::RootDir.as_os_str(),
+            Self::CurDir => Component::CurDir.as_os_str(),
+            Self::ParentDir => Component::ParentDir.as_os_str(),
+            Self::Normal(s) => s.as_os_str(),
         }
     }
 }
 
-impl<'a> Into<OwningComponent> for Component<'a> {
-    fn into(self) -> OwningComponent {
-        OwningComponent::from(&self)
+impl<'a> From<Component<'a>> for OwningComponent {
+    fn from(comp: Component<'a>) -> Self {
+        match comp {
+            Component::Prefix(_) => Self::Prefix(comp.as_os_str().to_os_string()),
+            Component::RootDir => Self::RootDir,
+            Component::CurDir => Self::CurDir,
+            Component::ParentDir => Self::ParentDir,
+            Component::Normal(s) => Self::Normal(s.to_os_string()),
+        }
     }
 }
 
@@ -354,7 +350,7 @@ pub fn canonicalize<P: AsRef<Path>>(
                     let file_info =
                         FileInformation::from_path(&result.parent().unwrap(), false).unwrap();
                     let mut path_to_follow = PathBuf::new();
-                    for part in parts.iter() {
+                    for part in &parts {
                         path_to_follow.push(part.as_os_str());
                     }
                     if !visited_files.insert((file_info, path_to_follow)) {

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -106,14 +106,14 @@ impl FileInformation {
 
     pub fn number_of_links(&self) -> u64 {
         #[cfg(unix)]
-        return self.0.st_nlink;
+        return self.0.st_nlink as u64;
         #[cfg(windows)]
-        return self.0.number_of_links();
+        return self.0.number_of_links() as u64;
     }
 
     #[cfg(unix)]
     pub fn inode(&self) -> u64 {
-        self.0.st_ino
+        self.0.st_ino as u64
     }
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1539,6 +1539,16 @@ fn test_copy_through_dangling_symlink_no_dereference() {
 }
 
 #[test]
+fn test_copy_through_dangling_symlink_no_dereference_2() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("file");
+    at.symlink_file("nonexistent", "target");
+    ucmd.args(&["-P", "file", "target"])
+        .fails()
+        .stderr_only("cp: not writing through dangling symlink 'target'");
+}
+
+#[test]
 #[cfg(unix)]
 fn test_cp_archive_on_nonexistent_file() {
     new_ucmd!()
@@ -1659,4 +1669,50 @@ fn test_cp_overriding_arguments() {
             .succeeds();
         s.fixtures.remove("file2");
     }
+}
+
+#[test]
+fn test_copy_no_dereference_1() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("a");
+    at.mkdir("b");
+    at.touch("a/foo");
+    at.write("a/foo", "bar");
+    at.relative_symlink_file("../a/foo", "b/foo");
+    ucmd.args(&["-P", "a/foo", "b"]).fails();
+}
+
+#[test]
+fn test_abuse_existing() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("a");
+    at.mkdir("b");
+    at.mkdir("c");
+    at.relative_symlink_file("../t", "a/1");
+    at.touch("b/1");
+    at.write("b/1", "hello");
+    at.relative_symlink_file("../t", "c/1");
+    at.touch("t");
+    at.write("t", "i");
+    ucmd.args(&["-dR", "a/1", "b/1", "c"])
+        .fails()
+        .stderr_contains(format!("will not copy 'b/1' through just-created symlink 'c{}1'", if cfg!(windows) { "\\" } else { "/" }));
+    assert_eq!(at.read("t"), "i");
+}
+
+#[test]
+fn test_copy_same_symlink_no_dereference() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.relative_symlink_file("t", "a");
+    at.relative_symlink_file("t", "b");
+    at.touch("t");
+    ucmd.args(&["-d", "a", "b"]).succeeds();
+}
+
+#[test]
+fn test_copy_same_symlink_no_dereference_dangling() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.relative_symlink_file("t", "a");
+    at.relative_symlink_file("t", "b");
+    ucmd.args(&["-d", "a", "b"]).succeeds();
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1492,13 +1492,12 @@ fn test_copy_through_just_created_symlink() {
         at.mkdir("a");
         at.mkdir("b");
         at.mkdir("c");
-        #[cfg(unix)]
-        fs::symlink("../t", at.plus("a/1")).unwrap();
-        #[cfg(target_os = "windows")]
-        symlink_file("../t", at.plus("a/1")).unwrap();
+        at.relative_symlink_file("../t", "a/1");
         at.touch("b/1");
+        at.write("b/1", "hello");
         if create_t {
             at.touch("t");
+            at.write("t", "world");
         }
         ucmd.arg("--no-dereference")
             .arg("a/1")
@@ -1510,6 +1509,9 @@ fn test_copy_through_just_created_symlink() {
             } else {
                 "cp: will not copy 'b/1' through just-created symlink 'c\\1'"
             });
+        if create_t {
+            assert_eq!(at.read("a/1"), "world");
+        }
     }
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1696,7 +1696,10 @@ fn test_abuse_existing() {
     at.write("t", "i");
     ucmd.args(&["-dR", "a/1", "b/1", "c"])
         .fails()
-        .stderr_contains(format!("will not copy 'b/1' through just-created symlink 'c{}1'", if cfg!(windows) { "\\" } else { "/" }));
+        .stderr_contains(format!(
+            "will not copy 'b/1' through just-created symlink 'c{}1'",
+            if cfg!(windows) { "\\" } else { "/" }
+        ));
     assert_eq!(at.read("t"), "i");
 }
 

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -156,7 +156,7 @@ fn test_realpath_dangling() {
     at.symlink_file("nonexistent-file", "link");
     ucmd.arg("link")
         .succeeds()
-        .stdout_only(at.plus_as_string("nonexistent-file\n"));
+        .stdout_contains(at.plus_as_string("nonexistent-file\n"));
 }
 
 #[test]

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -166,8 +166,8 @@ fn test_realpath_loop() {
     at.symlink_file("3", "2");
     at.symlink_file("1", "3");
     ucmd.arg("1")
-        .succeeds()
-        .stdout_only(at.plus_as_string("2\n"));
+        .fails()
+        .stderr_contains("realpath: 1: Too many levels of symbolic links");
 }
 
 #[test]

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -241,7 +241,6 @@ fn test_realpath_when_symlink_is_absolute_and_enoent() {
 }
 
 #[test]
-#[ignore = "issue #3669"]
 fn test_realpath_when_symlink_part_is_missing() {
     let (at, mut ucmd) = at_and_ucmd!();
 

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -258,8 +258,8 @@ fn test_realpath_when_symlink_part_is_missing() {
 
     ucmd.args(&["dir1/foo1", "dir1/foo2", "dir1/foo3", "dir1/foo4"])
         .run()
-        .stdout_contains(at.plus_as_string(&expect1) + "\n")
-        .stdout_contains(at.plus_as_string(&expect2) + "\n")
+        .stdout_contains(expect1 + "\n")
+        .stdout_contains(expect2 + "\n")
         .stderr_contains("realpath: dir1/foo2: No such file or directory\n")
         .stderr_contains("realpath: dir1/foo4: No such file or directory\n");
 }

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -155,8 +155,8 @@ fn test_realpath_dangling() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.symlink_file("nonexistent-file", "link");
     ucmd.arg("link")
-        .fails()
-        .stderr_contains("realpath: link: No such file or directory");
+        .succeeds()
+        .stdout_only(at.plus_as_string("nonexistent-file\n"));
 }
 
 #[test]

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -1,6 +1,6 @@
 use crate::common::util::*;
 
-use std::path::Path;
+use std::path::{Path, MAIN_SEPARATOR};
 
 static GIBBERISH: &str = "supercalifragilisticexpialidocious";
 
@@ -167,7 +167,7 @@ fn test_realpath_loop() {
     at.symlink_file("1", "3");
     ucmd.arg("1")
         .fails()
-        .stderr_contains("realpath: 1: Too many levels of symbolic links");
+        .stderr_contains("Too many levels of symbolic links");
 }
 
 #[test]
@@ -253,10 +253,13 @@ fn test_realpath_when_symlink_part_is_missing() {
     at.relative_symlink_file("../dir2/baz", "dir1/foo3");
     at.symlink_file("dir3/bar", "dir1/foo4");
 
+    let expect1 = format!("dir2{}bar", MAIN_SEPARATOR);
+    let expect2 = format!("dir2{}baz", MAIN_SEPARATOR);
+
     ucmd.args(&["dir1/foo1", "dir1/foo2", "dir1/foo3", "dir1/foo4"])
         .run()
-        .stdout_contains(at.plus_as_string("dir2/bar") + "\n")
-        .stdout_contains(at.plus_as_string("dir2/baz") + "\n")
+        .stdout_contains(at.plus_as_string(&expect1) + "\n")
+        .stdout_contains(at.plus_as_string(&expect2) + "\n")
         .stderr_contains("realpath: dir1/foo2: No such file or directory\n")
         .stderr_contains("realpath: dir1/foo4: No such file or directory\n");
 }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -22,7 +22,7 @@ use std::io::{Read, Result, Write};
 use std::os::unix::fs::{symlink as symlink_dir, symlink as symlink_file};
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir, symlink_file};
-use std::path::{Path, PathBuf};
+use std::path::{MAIN_SEPARATOR, Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::rc::Rc;
 use std::thread::sleep;
@@ -702,11 +702,13 @@ impl AtPath {
     }
 
     pub fn relative_symlink_file(&self, original: &str, link: &str) {
+        #[cfg(windows)]
+        let original = original.replace("/", &MAIN_SEPARATOR.to_string());
         log_info(
             "symlink",
-            &format!("{},{}", original, &self.plus_as_string(link)),
+            &format!("{},{}", &original, &self.plus_as_string(link)),
         );
-        symlink_file(original, &self.plus(link)).unwrap();
+        symlink_file(&original, &self.plus(link)).unwrap();
     }
 
     pub fn symlink_dir(&self, original: &str, link: &str) {
@@ -722,11 +724,13 @@ impl AtPath {
     }
 
     pub fn relative_symlink_dir(&self, original: &str, link: &str) {
+        #[cfg(windows)]
+        let original = original.replace("/", &MAIN_SEPARATOR.to_string());
         log_info(
             "symlink",
-            &format!("{},{}", original, &self.plus_as_string(link)),
+            &format!("{},{}", &original, &self.plus_as_string(link)),
         );
-        symlink_dir(original, &self.plus(link)).unwrap();
+        symlink_dir(&original, &self.plus(link)).unwrap();
     }
 
     pub fn is_symlink(&self, path: &str) -> bool {

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -22,7 +22,9 @@ use std::io::{Read, Result, Write};
 use std::os::unix::fs::{symlink as symlink_dir, symlink as symlink_file};
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir, symlink_file};
-use std::path::{Path, PathBuf, MAIN_SEPARATOR};
+#[cfg(windows)]
+use std::path::MAIN_SEPARATOR;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::rc::Rc;
 use std::thread::sleep;

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -705,7 +705,7 @@ impl AtPath {
 
     pub fn relative_symlink_file(&self, original: &str, link: &str) {
         #[cfg(windows)]
-        let original = original.replace("/", &MAIN_SEPARATOR.to_string());
+        let original = original.replace('/', &MAIN_SEPARATOR.to_string());
         log_info(
             "symlink",
             &format!("{},{}", &original, &self.plus_as_string(link)),
@@ -727,7 +727,7 @@ impl AtPath {
 
     pub fn relative_symlink_dir(&self, original: &str, link: &str) {
         #[cfg(windows)]
-        let original = original.replace("/", &MAIN_SEPARATOR.to_string());
+        let original = original.replace('/', &MAIN_SEPARATOR.to_string());
         log_info(
             "symlink",
             &format!("{},{}", &original, &self.plus_as_string(link)),

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -22,7 +22,7 @@ use std::io::{Read, Result, Write};
 use std::os::unix::fs::{symlink as symlink_dir, symlink as symlink_file};
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir, symlink_file};
-use std::path::{MAIN_SEPARATOR, Path, PathBuf};
+use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::process::{Child, Command, Stdio};
 use std::rc::Rc;
 use std::thread::sleep;


### PR DESCRIPTION
Fixes issue #3669 
- Made better component-wise symlink handling, if any part of the path inside symlink is non-existent it fails now
- Fixed test for dangling symlink which was mistakenly changed to failing, try: 

        $ ln -s nonexisting link
        $ realpath link
    It should print path to `nonexisting` as GNU version does

- Fixed test for looping symlink, GNU version does make an error

        $ ln -s 1 2
        $ ln -s 2 3
        $ ln -s 3 1
        $ realpath 1
    It should fail with Too many levels of symbolic links