### PR TITLE
numfmt: implement "--to-unit" & "--from-unit"

### DIFF
--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -6,6 +6,8 @@ pub const FIELD: &str = "field";
 pub const FIELD_DEFAULT: &str = "1";
 pub const FROM: &str = "from";
 pub const FROM_DEFAULT: &str = "none";
+pub const FROM_UNIT: &str = "from-unit";
+pub const FROM_UNIT_DEFAULT: &str = "1";
 pub const HEADER: &str = "header";
 pub const HEADER_DEFAULT: &str = "1";
 pub const NUMBER: &str = "NUMBER";
@@ -14,10 +16,14 @@ pub const ROUND: &str = "round";
 pub const SUFFIX: &str = "suffix";
 pub const TO: &str = "to";
 pub const TO_DEFAULT: &str = "none";
+pub const TO_UNIT: &str = "to-unit";
+pub const TO_UNIT_DEFAULT: &str = "1";
 
 pub struct TransformOptions {
     pub from: Unit,
+    pub from_unit: usize,
     pub to: Unit,
+    pub to_unit: usize,
 }
 
 pub struct NumfmtOptions {

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -607,3 +607,35 @@ fn test_invalid_padding_value() {
             .stderr_contains(format!("invalid padding value '{}'", padding_value));
     }
 }
+
+#[test]
+fn test_from_unit() {
+    new_ucmd!()
+        .args(&["--from-unit=512", "4"])
+        .succeeds()
+        .stdout_is("2048\n");
+}
+
+#[test]
+fn test_to_unit() {
+    new_ucmd!()
+        .args(&["--to-unit=512", "2048"])
+        .succeeds()
+        .stdout_is("4\n");
+}
+
+#[test]
+fn test_invalid_unit_size() {
+    let commands = vec!["from", "to"];
+    let invalid_sizes = vec!["A", "0", "18446744073709551616"];
+
+    for command in commands {
+        for invalid_size in &invalid_sizes {
+            new_ucmd!()
+                .arg(format!("--{}-unit={}", command, invalid_size))
+                .fails()
+                .code_is(1)
+                .stderr_contains(format!("invalid unit size: '{}'", invalid_size));
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the `--to-unit` and `--from-unit` options.

It makes the tests `unit-1` - `unit-10` (with the exception of `unit-8`) in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.