### PR TITLE
ls: add already listed message

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1500,7 +1500,7 @@ impl PathData {
         // nearly free compared to a metadata() call on a Path
         fn get_file_type(
             de: &DirEntry,
-            p_buf: &PathBuf,
+            p_buf: &Path,
             must_dereference: bool,
         ) -> OnceCell<Option<FileType>> {
             if must_dereference {
@@ -1517,7 +1517,7 @@ impl PathData {
             }
         }
         let ft = match de {
-            Some(ref de) => get_file_type(&de, &p_buf, must_dereference),
+            Some(ref de) => get_file_type(de, &p_buf, must_dereference),
             None => OnceCell::new(),
         };
 

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -79,9 +79,12 @@ impl FileInformation {
             use std::fs::OpenOptions;
             use std::os::windows::prelude::*;
             let mut open_options = OpenOptions::new();
+            let mut custom_flags = 0;
             if !dereference {
-                open_options.custom_flags(winapi::um::winbase::FILE_FLAG_OPEN_REPARSE_POINT);
+                custom_flags |= winapi::um::winbase::FILE_FLAG_OPEN_REPARSE_POINT;
             }
+            custom_flags |= winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+            open_options.custom_flags(custom_flags);
             let file = open_options.read(true).open(path.as_ref())?;
             Self::from_file(&file)
         }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3065,3 +3065,52 @@ fn test_ls_quoting_color() {
         .succeeds()
         .stdout_contains("\'need quoting\'");
 }
+
+#[test]
+fn test_ls_dereference_looped_symlinks_recursive() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("loop");
+    at.relative_symlink_dir("../loop", "loop/sub");
+
+    ucmd.args(&["-RL", "loop"]).fails().stderr_contains("not listing already-listed directory");
+}
+
+#[test]
+fn test_dereference_dangling_color() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.relative_symlink_file("wat", "nonexistent");
+    let out_exp = ucmd.args(&["--color"]).run().stdout_move_str();
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.relative_symlink_file("wat", "nonexistent");
+    ucmd.args(&["-L", "--color"]).fails().code_is(1).stderr_contains("No such file or directory").stdout_is(out_exp);
+}
+
+#[test]
+fn test_dereference_symlink_dir_color() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir1");
+    at.mkdir("dir1/link");
+    let out_exp = ucmd.args(&["--color", "dir1"]).run().stdout_move_str();
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir1");
+    at.mkdir("dir2");
+    at.relative_symlink_dir("../dir2", "dir1/link");
+    ucmd.args(&["-L", "--color", "dir1"]).succeeds().stdout_is(out_exp);
+}
+
+#[test]
+fn test_dereference_symlink_file_color() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir1");
+    at.touch("dir1/link");
+    let out_exp = ucmd.args(&["--color", "dir1"]).run().stdout_move_str();
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir1");
+    at.touch("file");
+    at.relative_symlink_file("../file", "dir1/link");
+    ucmd.args(&["-L", "--color", "dir1"]).succeeds().stdout_is(out_exp);
+}

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3073,7 +3073,9 @@ fn test_ls_dereference_looped_symlinks_recursive() {
     at.mkdir("loop");
     at.relative_symlink_dir("../loop", "loop/sub");
 
-    ucmd.args(&["-RL", "loop"]).fails().stderr_contains("not listing already-listed directory");
+    ucmd.args(&["-RL", "loop"])
+        .fails()
+        .stderr_contains("not listing already-listed directory");
 }
 
 #[test]
@@ -3084,7 +3086,11 @@ fn test_dereference_dangling_color() {
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.relative_symlink_file("wat", "nonexistent");
-    ucmd.args(&["-L", "--color"]).fails().code_is(1).stderr_contains("No such file or directory").stdout_is(out_exp);
+    ucmd.args(&["-L", "--color"])
+        .fails()
+        .code_is(1)
+        .stderr_contains("No such file or directory")
+        .stdout_is(out_exp);
 }
 
 #[test]
@@ -3098,7 +3104,9 @@ fn test_dereference_symlink_dir_color() {
     at.mkdir("dir1");
     at.mkdir("dir2");
     at.relative_symlink_dir("../dir2", "dir1/link");
-    ucmd.args(&["-L", "--color", "dir1"]).succeeds().stdout_is(out_exp);
+    ucmd.args(&["-L", "--color", "dir1"])
+        .succeeds()
+        .stdout_is(out_exp);
 }
 
 #[test]
@@ -3112,5 +3120,7 @@ fn test_dereference_symlink_file_color() {
     at.mkdir("dir1");
     at.touch("file");
     at.relative_symlink_file("../file", "dir1/link");
-    ucmd.args(&["-L", "--color", "dir1"]).succeeds().stdout_is(out_exp);
+    ucmd.args(&["-L", "--color", "dir1"])
+        .succeeds()
+        .stdout_is(out_exp);
 }


### PR DESCRIPTION
- When recursively dereferencing (`-RL`) `ls` is called and there is a descendant that links to its parent, the directory is not listed again, and an error message is printed
- for `-L` dereference parameter coloring and name printing is fixed (`->` shouldn't be printed for symlinks)
- Some tests added for `-L` and "already listed"