### PR TITLE
wc: specialize scanning loop on settings.

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -313,6 +313,7 @@ fn word_count_from_reader<T: WordCountable>(
         settings.show_max_line_length,
         settings.show_words,
     ) {
+        // Specialize scanning loop to improve the performance.
         (false, false, false, false, false) => (WordCount::default(), None),
         (true, false, false, false, false) => {
             // Fast path when only show_bytes is true.

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -317,13 +317,13 @@ fn word_count_from_reader<T: WordCountable>(
         (true, false, false, false, false) => {
             // Fast path when only show_bytes is true.
             let (bytes, error) = count_bytes_fast(&mut reader);
-            return (
+            (
                 WordCount {
                     bytes,
                     ..WordCount::default()
                 },
                 error,
-            );
+            )
         }
         (false, false, true, false, false) | (true, false, true, false, false) => {
             // Fast path when only (show_bytes || show_lines) is true.

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -314,7 +314,7 @@ fn word_count_from_reader<T: WordCountable>(
         settings.show_words,
     ) {
         // Specialize scanning loop to improve the performance.
-        (false, false, false, false, false) => (WordCount::default(), None),
+        (false, false, false, false, false) => unreachable!(),
         (true, false, false, false, false) => {
             // Fast path when only show_bytes is true.
             let (bytes, error) = count_bytes_fast(&mut reader);

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -60,7 +60,107 @@ fn test_utf8() {
 }
 
 #[test]
-fn test_utf8_extra() {
+fn test_utf8_words() {
+    new_ucmd!()
+        .arg("-w")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("87\n");
+}
+
+#[test]
+fn test_utf8_line_length_words() {
+    new_ucmd!()
+        .arg("-Lw")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     87      48\n");
+}
+
+#[test]
+fn test_utf8_line_length_chars() {
+    new_ucmd!()
+        .arg("-Lm")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("    442      48\n");
+}
+
+#[test]
+fn test_utf8_line_length_chars_words() {
+    new_ucmd!()
+        .arg("-Lmw")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     87     442      48\n");
+}
+
+#[test]
+fn test_utf8_chars() {
+    new_ucmd!()
+        .arg("-m")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("442\n");
+}
+
+#[test]
+fn test_utf8_chars_words() {
+    new_ucmd!()
+        .arg("-mw")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     87     442\n");
+}
+
+#[test]
+fn test_utf8_line_length_lines() {
+    new_ucmd!()
+        .arg("-Ll")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     25      48\n");
+}
+
+#[test]
+fn test_utf8_line_length_lines_words() {
+    new_ucmd!()
+        .arg("-Llw")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     25      87      48\n");
+}
+
+#[test]
+fn test_utf8_lines_chars() {
+    new_ucmd!()
+        .arg("-ml")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     25     442\n");
+}
+
+#[test]
+fn test_utf8_lines_words_chars() {
+    new_ucmd!()
+        .arg("-mlw")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     25      87     442\n");
+}
+
+#[test]
+fn test_utf8_line_length_lines_chars() {
+    new_ucmd!()
+        .arg("-Llm")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     25     442      48\n");
+}
+
+
+#[test]
+fn test_utf8_all() {
     new_ucmd!()
         .arg("-lwmcL")
         .pipe_in_fixture("UTF_8_weirdchars.txt")

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -158,7 +158,6 @@ fn test_utf8_line_length_lines_chars() {
         .stdout_is("     25     442      48\n");
 }
 
-
 #[test]
 fn test_utf8_all() {
     new_ucmd!()


### PR DESCRIPTION
The primary computational loop in wc (iterating over all the
characters and computing word lengths, etc) is configured by a
number of boolean options that control the text-scanning behavior.
If we monomorphize the code loop for each possible combination of
scanning configurations, the rustc is able to generate better code
for each instantiation, at the least by removing the conditional
checks on each iteration, and possibly by allowing things like
vectorization.

On my computer (aarch64/macos), I am seeing at least a 5% performance
improvement in release builds on all wc flag configurations
(other than those that were already specialized) against
odyssey1024.txt, with wc -l showing the greatest improvement at 15%.