### PR TITLE
numfmt: show error if "i" suffix is missing

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -98,7 +98,6 @@ fn parse_suffix(s: &str) -> Result<(f64, Option<Suffix>)> {
 
 fn remove_suffix(i: f64, s: Option<Suffix>, u: &Unit) -> Result<f64> {
     match (s, u) {
-        (None, _) => Ok(i),
         (Some((raw_suffix, false)), &Unit::Auto) | (Some((raw_suffix, false)), &Unit::Si) => {
             match raw_suffix {
                 RawSuffix::K => Ok(i * 1e3),
@@ -123,6 +122,15 @@ fn remove_suffix(i: f64, s: Option<Suffix>, u: &Unit) -> Result<f64> {
             RawSuffix::Z => Ok(i * IEC_BASES[7]),
             RawSuffix::Y => Ok(i * IEC_BASES[8]),
         },
+        (None, &Unit::Iec(true)) => Err(format!(
+            "missing 'i' suffix in input: '{}' (e.g Ki/Mi/Gi)",
+            i
+        )),
+        (Some((raw_suffix, false)), &Unit::Iec(true)) => Err(format!(
+            "missing 'i' suffix in input: '{}{:?}' (e.g Ki/Mi/Gi)",
+            i, raw_suffix
+        )),
+        (None, _) => Ok(i),
         (_, _) => Err("This suffix is unsupported for specified unit".to_owned()),
     }
 }

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -30,12 +30,19 @@ fn test_from_iec_i() {
 }
 
 #[test]
-#[ignore] // FIXME: GNU from iec-i requires suffix
 fn test_from_iec_i_requires_suffix() {
-    new_ucmd!()
-        .args(&["--from=iec-i", "1024"])
-        .fails()
-        .stderr_is("numfmt: missing 'i' suffix in input: '1024' (e.g Ki/Mi/Gi)");
+    let numbers = vec!["1024", "10M"];
+
+    for number in numbers {
+        new_ucmd!()
+            .args(&["--from=iec-i", number])
+            .fails()
+            .code_is(2)
+            .stderr_is(format!(
+                "numfmt: missing 'i' suffix in input: '{}' (e.g Ki/Mi/Gi)",
+                number
+            ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
GNU numfmt requires an "i"-suffix when using `--from=iec-i` and shows an error otherwise. This PR adds the same behavior to uutils numfmt and makes the test `strtod-11` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.