### PR TITLE
numfmt: reject suffix if unit is "none"

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -130,6 +130,12 @@ fn remove_suffix(i: f64, s: Option<Suffix>, u: &Unit) -> Result<f64> {
             "missing 'i' suffix in input: '{}{:?}' (e.g Ki/Mi/Gi)",
             i, raw_suffix
         )),
+        (Some((raw_suffix, with_i)), &Unit::None) => Err(format!(
+            "rejecting suffix in input: '{}{:?}{}' (consider using --from)",
+            i,
+            raw_suffix,
+            if with_i { "i" } else { "" }
+        )),
         (None, _) => Ok(i),
         (_, _) => Err("This suffix is unsupported for specified unit".to_owned()),
     }

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -646,3 +646,19 @@ fn test_invalid_unit_size() {
         }
     }
 }
+
+#[test]
+fn test_valid_but_forbidden_suffix() {
+    let numbers = vec!["12K", "12Ki"];
+
+    for number in numbers {
+        new_ucmd!()
+            .arg(number)
+            .fails()
+            .code_is(2)
+            .stderr_contains(format!(
+                "rejecting suffix in input: '{}' (consider using --from)",
+                number
+            ));
+    }
+}


### PR DESCRIPTION
Show a "reject suffix"-error if the user provides a number with valid suffix but without a unit. For example, `numfmt 12K` and `numfmt 12K --from=none` fail whereas `numfmt 12K --from=si` doesn't.

This PR makes the test `strtod-10` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.