### PR TITLE
split: Don't overwrite files

### DIFF
--- a/src/uu/split/src/platform/mod.rs
+++ b/src/uu/split/src/platform/mod.rs
@@ -1,8 +1,12 @@
 #[cfg(unix)]
 pub use self::unix::instantiate_current_writer;
+#[cfg(unix)]
+pub use self::unix::paths_refer_to_same_file;
 
 #[cfg(windows)]
 pub use self::windows::instantiate_current_writer;
+#[cfg(windows)]
+pub use self::windows::paths_refer_to_same_file;
 
 #[cfg(unix)]
 mod unix;

--- a/src/uu/split/src/platform/unix.rs
+++ b/src/uu/split/src/platform/unix.rs
@@ -1,8 +1,11 @@
 use std::env;
 use std::io::Write;
-use std::io::{BufWriter, Result};
+use std::io::{BufWriter, Error, ErrorKind, Result};
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use uucore::crash;
+use uucore::fs;
+use uucore::fs::FileInformation;
 
 /// A writer that writes to a shell_process' stdin
 ///
@@ -66,7 +69,7 @@ impl FilterWriter {
     ///
     /// * `command` - The shell command to execute
     /// * `filepath` - Path of the output file (forwarded to command as $FILE)
-    fn new(command: &str, filepath: &str) -> Self {
+    fn new(command: &str, filepath: &str) -> Result<Self> {
         // set $FILE, save previous value (if there was one)
         let _with_env_var_set = WithEnvVarSet::new("FILE", filepath);
 
@@ -75,10 +78,9 @@ impl FilterWriter {
                 .arg("-c")
                 .arg(command)
                 .stdin(Stdio::piped())
-                .spawn()
-                .expect("Couldn't spawn filter command");
+                .spawn()?;
 
-        Self { shell_process }
+        Ok(Self { shell_process })
     }
 }
 
@@ -107,19 +109,35 @@ impl Drop for FilterWriter {
 pub fn instantiate_current_writer(
     filter: &Option<String>,
     filename: &str,
-) -> BufWriter<Box<dyn Write>> {
+) -> Result<BufWriter<Box<dyn Write>>> {
     match filter {
-        None => BufWriter::new(Box::new(
+        None => Ok(BufWriter::new(Box::new(
             // write to the next file
             std::fs::OpenOptions::new()
                 .write(true)
                 .create(true)
+                .truncate(true)
                 .open(std::path::Path::new(&filename))
-                .unwrap(),
-        ) as Box<dyn Write>),
-        Some(ref filter_command) => BufWriter::new(Box::new(
+                .map_err(|_| {
+                    Error::new(
+                        ErrorKind::Other,
+                        format!("unable to open '{}'; aborting", filename),
+                    )
+                })?,
+        ) as Box<dyn Write>)),
+        Some(ref filter_command) => Ok(BufWriter::new(Box::new(
             // spawn a shell command and write to it
-            FilterWriter::new(filter_command, filename),
-        ) as Box<dyn Write>),
+            FilterWriter::new(filter_command, filename)?,
+        ) as Box<dyn Write>)),
     }
+}
+
+pub fn paths_refer_to_same_file(p1: &str, p2: &str) -> bool {
+    // We have to take symlinks and relative paths into account.
+    let p1 = if p1 == "-" {
+        FileInformation::from_file(&std::io::stdin())
+    } else {
+        FileInformation::from_path(Path::new(&p1), true)
+    };
+    fs::infos_refer_to_same_file(p1, FileInformation::from_path(Path::new(p2), true))
 }

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -480,8 +480,20 @@ pub fn dir_strip_dot_for_creation(path: &Path) -> PathBuf {
 /// Checks if `p1` and `p2` are the same file.
 /// If error happens when trying to get files' metadata, returns false
 pub fn paths_refer_to_same_file<P: AsRef<Path>>(p1: P, p2: P, dereference: bool) -> bool {
-    if let Ok(info1) = FileInformation::from_path(p1, dereference) {
-        if let Ok(info2) = FileInformation::from_path(p2, dereference) {
+    infos_refer_to_same_file(
+        FileInformation::from_path(p1, dereference),
+        FileInformation::from_path(p2, dereference),
+    )
+}
+
+/// Checks if `p1` and `p2` are the same file information.
+/// If error happens when trying to get files' metadata, returns false
+pub fn infos_refer_to_same_file(
+    info1: IOResult<FileInformation>,
+    info2: IOResult<FileInformation>,
+) -> bool {
+    if let Ok(info1) = info1 {
+        if let Ok(info2) = info2 {
             return info1 == info2;
         }
     }

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -655,3 +655,31 @@ fn test_line_bytes_no_empty_file() {
     assert_eq!(at.read("xaj"), "4");
     assert!(!at.plus("xak").exists());
 }
+
+#[test]
+fn test_guard_input() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    ts.ucmd()
+        .args(&["-C", "6"])
+        .pipe_in("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert_eq!(at.read("xaa"), "1\n2\n3\n");
+
+    ts.ucmd()
+        .args(&["-C", "6"])
+        .pipe_in("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert_eq!(at.read("xaa"), "1\n2\n3\n");
+
+    ts.ucmd()
+        .args(&["-C", "6", "xaa"])
+        .fails()
+        .stderr_only("split: 'xaa' would overwrite input; aborting");
+    assert_eq!(at.read("xaa"), "1\n2\n3\n");
+}


### PR DESCRIPTION
Check that a file exists by calling create_new and changing the
interface of instantiate_current_writer to return a Result rather
than calling unwrap.