### PR TITLE
ln: symlink --force, src and dst are same file

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -18,7 +18,7 @@ extern crate uucore;
 
 use uucore::display::Quotable;
 use uucore::format_usage;
-use uucore::fs::FileInformation;
+use uucore::fs::{paths_refer_to_same_file, FileInformation};
 
 use std::borrow::Cow;
 
@@ -1655,17 +1655,6 @@ pub fn verify_target_type(target: &Path, target_type: &TargetType) -> CopyResult
 pub fn localize_to_target(root: &Path, source: &Path, target: &Path) -> CopyResult<PathBuf> {
     let local_to_root = source.strip_prefix(&root)?;
     Ok(target.join(&local_to_root))
-}
-
-pub fn paths_refer_to_same_file(p1: &Path, p2: &Path, dereference: bool) -> bool {
-    // We have to take symlinks and relative paths into account.
-    let res1 = FileInformation::from_path(p1, dereference);
-    let res2 = FileInformation::from_path(p2, dereference);
-
-    match (res1, res2) {
-        (Ok(info1), Ok(info2)) => info1 == info2,
-        _ => false,
-    }
 }
 
 pub fn path_has_prefix(p1: &Path, p2: &Path) -> io::Result<bool> {

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -477,6 +477,17 @@ pub fn dir_strip_dot_for_creation(path: &Path) -> PathBuf {
     }
 }
 
+/// Checks if `p1` and `p2` are the same file.
+/// If error happens when trying to get files' metadata, returns false
+pub fn paths_refer_to_same_file<P: AsRef<Path>>(p1: P, p2: P, dereference: bool) -> bool {
+    if let Ok(info1) = FileInformation::from_path(p1, dereference) {
+        if let Ok(info2) = FileInformation::from_path(p2, dereference) {
+            return info1 == info2;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -702,3 +702,16 @@ fn test_hard_logical_dir_fail() {
         .fails()
         .stderr_contains("failed to link 'link-to-dir'");
 }
+
+#[test]
+fn test_symlink_remove_existing_same_src_and_dest() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("a");
+    at.write("a", "sample");
+    ucmd.args(&["-sf", "a", "a"])
+        .fails()
+        .code_is(1)
+        .stderr_contains("Same file");
+    assert!(at.file_exists("a") && !at.symlink_exists("a"));
+    assert_eq!(at.read("a"), "sample");
+}


### PR DESCRIPTION
- When creating symlink from `src` to `dst`, when `dst` is regular file and `src` is either the same regular file or links to `dst`, raise "same file" error
- Moved `paths_refer_to_same_file` from `cp.rs` to common `fs.rs` to use it in `ln.rs` as well
- Added test