### PR TITLE
run cargo upgrade and fix any incompatibilites

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -13,7 +13,7 @@ env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"
   PROJECT_AUTH: "uutils"
-  RUST_MIN_SRV: "1.56.0" ## MSRV v1.56.0
+  RUST_MIN_SRV: "1.62.0" ## MSRV v1.62.0
   # * style job configuration
   STYLE_FAIL_ON_FAULT: true ## (bool) fail the build if a style job contains a fault (error or warning); may be overridden on a per-job basis
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,9 +899,12 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
- "memchr 2.5.0",
+ "memchr",
 ]
 
 [[package]]
@@ -114,7 +114,7 @@ dependencies = [
  "log",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -168,7 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
- "memchr 2.5.0",
+ "memchr",
  "regex-automata",
 ]
 
@@ -472,28 +472,17 @@ dependencies = [
 
 [[package]]
 name = "cpp_build"
-version = "0.4.0"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47531e7e09532ad4827098729794f5e1a5b1c2ccbb5e295498d2e7ab451c445"
+checksum = "16f4d303b8ec35fb3afd7e963e2c898117f1e49930becb703e4a7ac528ad2dd0"
 dependencies = [
  "cc",
- "cpp_common 0.4.0",
- "cpp_syn",
- "cpp_synmap",
- "cpp_synom",
+ "cpp_common",
  "lazy_static",
-]
-
-[[package]]
-name = "cpp_common"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e39149a7943affa02f5b6e347ca2840a129cc78d5883ee229f0f1c4027d628"
-dependencies = [
- "cpp_syn",
- "cpp_synom",
- "lazy_static",
- "quote 0.3.15",
+ "proc-macro2",
+ "regex",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -515,42 +504,11 @@ checksum = "7fdaa01904c12a8989dbfa110b41ef27efc432ac9934f691b9732f01cb64dc01"
 dependencies = [
  "aho-corasick",
  "byteorder",
- "cpp_common 0.5.7",
+ "cpp_common",
  "lazy_static",
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "syn",
-]
-
-[[package]]
-name = "cpp_syn"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8cd649bf5b3804d92fe12a60c7698f5a538a6033ed8a668bf5241d4d4f1644e"
-dependencies = [
- "cpp_synom",
- "quote 0.3.15",
- "unicode-xid",
-]
-
-[[package]]
-name = "cpp_synmap"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e4f9cdbe2874edd3ffe53718ee5d8b89e2a970057b2c93d3214104f2e90b6"
-dependencies = [
- "cpp_syn",
- "cpp_synom",
- "memchr 1.0.2",
-]
-
-[[package]]
-name = "cpp_synom"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc8da5694233b646150c785118f77835ad0a49680c7f312a10ef30957c67b6d"
-dependencies = [
- "unicode-xid",
 ]
 
 [[package]]
@@ -663,7 +621,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
- "quote 1.0.18",
+ "quote",
  "syn",
 ]
 
@@ -1128,15 +1086,6 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
@@ -1204,7 +1153,7 @@ version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
- "memchr 2.5.0",
+ "memchr",
  "minimal-lexical",
 ]
 
@@ -1360,7 +1309,7 @@ dependencies = [
  "Inflector",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "syn",
 ]
 
@@ -1488,7 +1437,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "syn",
  "version_check",
 ]
@@ -1500,7 +1449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "version_check",
 ]
 
@@ -1529,12 +1478,6 @@ dependencies = [
  "log",
  "rand",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -1630,7 +1573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
- "memchr 2.5.0",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1868,7 +1811,7 @@ checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "rustversion",
  "syn",
 ]
@@ -1886,7 +1829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1994,7 +1937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
  "syn",
 ]
 
@@ -2062,9 +2005,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "unindent"
@@ -2252,7 +2195,7 @@ dependencies = [
  "atty",
  "bstr",
  "clap 3.1.18",
- "memchr 2.5.0",
+ "memchr",
  "uucore",
 ]
 
@@ -2420,7 +2363,7 @@ dependencies = [
  "digest",
  "hex",
  "md-5",
- "memchr 2.5.0",
+ "memchr",
  "regex",
  "sha1",
  "sha2",
@@ -2433,7 +2376,7 @@ name = "uu_head"
 version = "0.0.14"
 dependencies = [
  "clap 3.1.18",
- "memchr 2.5.0",
+ "memchr",
  "uucore",
 ]
 
@@ -2482,7 +2425,7 @@ name = "uu_join"
 version = "0.0.14"
 dependencies = [
  "clap 3.1.18",
- "memchr 2.5.0",
+ "memchr",
  "uucore",
 ]
 
@@ -2803,7 +2746,7 @@ name = "uu_shuf"
 version = "0.0.14"
 dependencies = [
  "clap 3.1.18",
- "memchr 2.5.0",
+ "memchr",
  "rand",
  "rand_core",
  "uucore",
@@ -2827,7 +2770,7 @@ dependencies = [
  "ctrlc",
  "fnv",
  "itertools",
- "memchr 2.5.0",
+ "memchr",
  "ouroboros",
  "rand",
  "rayon",
@@ -2841,7 +2784,7 @@ name = "uu_split"
 version = "0.0.14"
 dependencies = [
  "clap 3.1.18",
- "memchr 2.5.0",
+ "memchr",
  "uucore",
 ]
 
@@ -2896,7 +2839,7 @@ name = "uu_tac"
 version = "0.0.14"
 dependencies = [
  "clap 3.1.18",
- "memchr 2.5.0",
+ "memchr",
  "memmap2",
  "regex",
  "uucore",
@@ -3131,7 +3074,7 @@ name = "uucore_procs"
 version = "0.0.14"
 dependencies = [
  "proc-macro2",
- "quote 1.0.18",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,18 +1359,18 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "32ba0c43d7a1b6492b2924a62290cfd83987828af037b0743b38e6ab092aee58"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
 dependencies = [
  "phf_shared",
  "rand",
@@ -1388,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "9dd5609d4b2df87167f908a32e1b146ce309c16cf35df76bc11f440b756048e4"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b561dcf059c85bbe388e0a7b0a1469acb3934cc0cfa148613a830629e3049"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
  "glob",
  "libc",
@@ -261,15 +261,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "terminal_size",
@@ -278,18 +278,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.1.4"
+version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -321,7 +321,7 @@ version = "0.0.14"
 dependencies = [
  "atty",
  "chrono",
- "clap 3.1.18",
+ "clap 3.2.12",
  "clap_complete",
  "conv",
  "filetime",
@@ -340,7 +340,7 @@ dependencies = [
  "sha1",
  "tempfile",
  "textwrap 0.15.0",
- "time 0.3.9",
+ "time 0.3.11",
  "unindent",
  "unix_socket",
  "users",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -552,26 +552,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -607,9 +607,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -710,9 +710,9 @@ checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "env_logger"
@@ -778,13 +778,11 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if 1.0.0",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -840,13 +838,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -866,15 +864,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -925,12 +917,12 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -979,9 +971,9 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "kernel32-sys"
@@ -995,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97caf428b83f7c86809b7450722cd1f2b1fc7fb23aa7b9dee7e72ed14d048352"
+checksum = "4d6112e8f37b59803ac47a42d14f1f3a59bbf72fc6857ffc5be455e28a691f8e"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1116,18 +1108,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -1271,7 +1263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1285,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.1"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "ouroboros"
@@ -1324,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1455,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -1481,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -1638,9 +1630,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "same-file"
@@ -1824,9 +1816,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1954,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa",
  "libc",
@@ -1978,9 +1970,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2051,7 +2043,7 @@ checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 name = "uu_arch"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "platform-info",
  "uucore",
 ]
@@ -2060,7 +2052,7 @@ dependencies = [
 name = "uu_base32"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2076,7 +2068,7 @@ dependencies = [
 name = "uu_basename"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2084,7 +2076,7 @@ dependencies = [
 name = "uu_basenc"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uu_base32",
  "uucore",
 ]
@@ -2094,7 +2086,7 @@ name = "uu_cat"
 version = "0.0.14"
 dependencies = [
  "atty",
- "clap 3.1.18",
+ "clap 3.2.12",
  "nix",
  "thiserror",
  "unix_socket",
@@ -2105,7 +2097,7 @@ dependencies = [
 name = "uu_chcon"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "fts-sys",
  "libc",
  "selinux",
@@ -2117,7 +2109,7 @@ dependencies = [
 name = "uu_chgrp"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2125,7 +2117,7 @@ dependencies = [
 name = "uu_chmod"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2134,7 +2126,7 @@ dependencies = [
 name = "uu_chown"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2142,7 +2134,7 @@ dependencies = [
 name = "uu_chroot"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2150,7 +2142,7 @@ dependencies = [
 name = "uu_cksum"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2158,7 +2150,7 @@ dependencies = [
 name = "uu_comm"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2166,7 +2158,7 @@ dependencies = [
 name = "uu_cp"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "exacl",
  "filetime",
  "libc",
@@ -2182,7 +2174,7 @@ dependencies = [
 name = "uu_csplit"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "regex",
  "thiserror",
  "uucore",
@@ -2194,7 +2186,7 @@ version = "0.0.14"
 dependencies = [
  "atty",
  "bstr",
- "clap 3.1.18",
+ "clap 3.2.12",
  "memchr",
  "uucore",
 ]
@@ -2204,7 +2196,7 @@ name = "uu_date"
 version = "0.0.14"
 dependencies = [
  "chrono",
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
  "winapi 0.3.9",
@@ -2215,7 +2207,7 @@ name = "uu_dd"
 version = "0.0.14"
 dependencies = [
  "byte-unit",
- "clap 3.1.18",
+ "clap 3.2.12",
  "gcd",
  "libc",
  "signal-hook",
@@ -2226,7 +2218,7 @@ dependencies = [
 name = "uu_df"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "unicode-width",
  "uucore",
 ]
@@ -2235,7 +2227,7 @@ dependencies = [
 name = "uu_dir"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "selinux",
  "uu_ls",
  "uucore",
@@ -2245,7 +2237,7 @@ dependencies = [
 name = "uu_dircolors"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "glob",
  "uucore",
 ]
@@ -2254,7 +2246,7 @@ dependencies = [
 name = "uu_dirname"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2263,7 +2255,7 @@ name = "uu_du"
 version = "0.0.14"
 dependencies = [
  "chrono",
- "clap 3.1.18",
+ "clap 3.2.12",
  "glob",
  "uucore",
  "winapi 0.3.9",
@@ -2273,7 +2265,7 @@ dependencies = [
 name = "uu_echo"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2281,7 +2273,7 @@ dependencies = [
 name = "uu_env"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "rust-ini",
  "uucore",
 ]
@@ -2290,7 +2282,7 @@ dependencies = [
 name = "uu_expand"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "unicode-width",
  "uucore",
 ]
@@ -2299,7 +2291,7 @@ dependencies = [
 name = "uu_expr"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "num-bigint",
  "num-traits",
  "onig",
@@ -2310,7 +2302,7 @@ dependencies = [
 name = "uu_factor"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "coz",
  "num-traits",
  "paste",
@@ -2324,7 +2316,7 @@ dependencies = [
 name = "uu_false"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2332,7 +2324,7 @@ dependencies = [
 name = "uu_fmt"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "unicode-width",
  "uucore",
 ]
@@ -2341,7 +2333,7 @@ dependencies = [
 name = "uu_fold"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2349,7 +2341,7 @@ dependencies = [
 name = "uu_groups"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2359,7 +2351,7 @@ version = "0.0.14"
 dependencies = [
  "blake2b_simd",
  "blake3",
- "clap 3.1.18",
+ "clap 3.2.12",
  "digest",
  "hex",
  "md-5",
@@ -2375,7 +2367,7 @@ dependencies = [
 name = "uu_head"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "memchr",
  "uucore",
 ]
@@ -2384,7 +2376,7 @@ dependencies = [
 name = "uu_hostid"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2393,7 +2385,7 @@ dependencies = [
 name = "uu_hostname"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "hostname",
  "uucore",
  "winapi 0.3.9",
@@ -2403,7 +2395,7 @@ dependencies = [
 name = "uu_id"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "selinux",
  "uucore",
 ]
@@ -2412,11 +2404,11 @@ dependencies = [
 name = "uu_install"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "file_diff",
  "filetime",
  "libc",
- "time 0.3.9",
+ "time 0.3.11",
  "uucore",
 ]
 
@@ -2424,7 +2416,7 @@ dependencies = [
 name = "uu_join"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "memchr",
  "uucore",
 ]
@@ -2433,7 +2425,7 @@ dependencies = [
 name = "uu_kill"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "nix",
  "uucore",
 ]
@@ -2442,7 +2434,7 @@ dependencies = [
 name = "uu_link"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2450,7 +2442,7 @@ dependencies = [
 name = "uu_ln"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2458,7 +2450,7 @@ dependencies = [
 name = "uu_logname"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2469,7 +2461,7 @@ version = "0.0.14"
 dependencies = [
  "atty",
  "chrono",
- "clap 3.1.18",
+ "clap 3.2.12",
  "glob",
  "lscolors",
  "number_prefix",
@@ -2485,7 +2477,7 @@ dependencies = [
 name = "uu_mkdir"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2493,7 +2485,7 @@ dependencies = [
 name = "uu_mkfifo"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2502,7 +2494,7 @@ dependencies = [
 name = "uu_mknod"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2511,7 +2503,7 @@ dependencies = [
 name = "uu_mktemp"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "rand",
  "tempfile",
  "uucore",
@@ -2522,7 +2514,7 @@ name = "uu_more"
 version = "0.0.14"
 dependencies = [
  "atty",
- "clap 3.1.18",
+ "clap 3.2.12",
  "crossterm",
  "nix",
  "unicode-segmentation",
@@ -2534,7 +2526,7 @@ dependencies = [
 name = "uu_mv"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "fs_extra",
  "uucore",
 ]
@@ -2543,7 +2535,7 @@ dependencies = [
 name = "uu_nice"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "nix",
  "uucore",
@@ -2553,7 +2545,7 @@ dependencies = [
 name = "uu_nl"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "regex",
  "uucore",
 ]
@@ -2563,7 +2555,7 @@ name = "uu_nohup"
 version = "0.0.14"
 dependencies = [
  "atty",
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2572,7 +2564,7 @@ dependencies = [
 name = "uu_nproc"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "num_cpus",
  "uucore",
@@ -2582,7 +2574,7 @@ dependencies = [
 name = "uu_numfmt"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2591,7 +2583,7 @@ name = "uu_od"
 version = "0.0.14"
 dependencies = [
  "byteorder",
- "clap 3.1.18",
+ "clap 3.2.12",
  "half",
  "uucore",
 ]
@@ -2600,7 +2592,7 @@ dependencies = [
 name = "uu_paste"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2608,7 +2600,7 @@ dependencies = [
 name = "uu_pathchk"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2617,7 +2609,7 @@ dependencies = [
 name = "uu_pinky"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2626,7 +2618,7 @@ name = "uu_pr"
 version = "0.0.14"
 dependencies = [
  "chrono",
- "clap 3.1.18",
+ "clap 3.2.12",
  "itertools",
  "quick-error",
  "regex",
@@ -2637,7 +2629,7 @@ dependencies = [
 name = "uu_printenv"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2645,7 +2637,7 @@ dependencies = [
 name = "uu_printf"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2653,7 +2645,7 @@ dependencies = [
 name = "uu_ptx"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "regex",
  "uucore",
 ]
@@ -2662,7 +2654,7 @@ dependencies = [
 name = "uu_pwd"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2670,7 +2662,7 @@ dependencies = [
 name = "uu_readlink"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2678,7 +2670,7 @@ dependencies = [
 name = "uu_realpath"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2686,7 +2678,7 @@ dependencies = [
 name = "uu_relpath"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2694,7 +2686,7 @@ dependencies = [
 name = "uu_rm"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "remove_dir_all 0.7.0",
  "uucore",
  "walkdir",
@@ -2705,7 +2697,7 @@ dependencies = [
 name = "uu_rmdir"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2714,7 +2706,7 @@ dependencies = [
 name = "uu_runcon"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "selinux",
  "thiserror",
@@ -2726,7 +2718,7 @@ name = "uu_seq"
 version = "0.0.14"
 dependencies = [
  "bigdecimal",
- "clap 3.1.18",
+ "clap 3.2.12",
  "num-bigint",
  "num-traits",
  "uucore",
@@ -2736,7 +2728,7 @@ dependencies = [
 name = "uu_shred"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "rand",
  "uucore",
 ]
@@ -2745,7 +2737,7 @@ dependencies = [
 name = "uu_shuf"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "memchr",
  "rand",
  "rand_core",
@@ -2756,7 +2748,7 @@ dependencies = [
 name = "uu_sleep"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2765,7 +2757,7 @@ name = "uu_sort"
 version = "0.0.14"
 dependencies = [
  "binary-heap-plus",
- "clap 3.1.18",
+ "clap 3.2.12",
  "compare",
  "ctrlc",
  "fnv",
@@ -2783,7 +2775,7 @@ dependencies = [
 name = "uu_split"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "memchr",
  "uucore",
 ]
@@ -2792,7 +2784,7 @@ dependencies = [
 name = "uu_stat"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2800,7 +2792,7 @@ dependencies = [
 name = "uu_stdbuf"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "tempfile",
  "uu_stdbuf_libstdbuf",
  "uucore",
@@ -2820,7 +2812,7 @@ dependencies = [
 name = "uu_sum"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2828,7 +2820,7 @@ dependencies = [
 name = "uu_sync"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
  "winapi 0.3.9",
@@ -2838,7 +2830,7 @@ dependencies = [
 name = "uu_tac"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "memchr",
  "memmap2",
  "regex",
@@ -2849,7 +2841,7 @@ dependencies = [
 name = "uu_tail"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "nix",
  "notify",
@@ -2862,7 +2854,7 @@ dependencies = [
 name = "uu_tee"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2871,7 +2863,7 @@ dependencies = [
 name = "uu_test"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "redox_syscall",
  "uucore",
@@ -2881,7 +2873,7 @@ dependencies = [
 name = "uu_timeout"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "nix",
  "uucore",
@@ -2891,9 +2883,9 @@ dependencies = [
 name = "uu_touch"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "filetime",
- "time 0.3.9",
+ "time 0.3.11",
  "uucore",
  "winapi 0.3.9",
 ]
@@ -2902,7 +2894,7 @@ dependencies = [
 name = "uu_tr"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "nom",
  "uucore",
 ]
@@ -2911,7 +2903,7 @@ dependencies = [
 name = "uu_true"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2919,7 +2911,7 @@ dependencies = [
 name = "uu_truncate"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2927,7 +2919,7 @@ dependencies = [
 name = "uu_tsort"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2936,7 +2928,7 @@ name = "uu_tty"
 version = "0.0.14"
 dependencies = [
  "atty",
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
 ]
@@ -2945,7 +2937,7 @@ dependencies = [
 name = "uu_uname"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "platform-info",
  "uucore",
 ]
@@ -2954,7 +2946,7 @@ dependencies = [
 name = "uu_unexpand"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "unicode-width",
  "uucore",
 ]
@@ -2963,7 +2955,7 @@ dependencies = [
 name = "uu_uniq"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "strum",
  "strum_macros",
  "uucore",
@@ -2973,7 +2965,7 @@ dependencies = [
 name = "uu_unlink"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2982,7 +2974,7 @@ name = "uu_uptime"
 version = "0.0.14"
 dependencies = [
  "chrono",
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2990,7 +2982,7 @@ dependencies = [
 name = "uu_users"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -2998,7 +2990,7 @@ dependencies = [
 name = "uu_vdir"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "selinux",
  "uu_ls",
  "uucore",
@@ -3009,7 +3001,7 @@ name = "uu_wc"
 version = "0.0.14"
 dependencies = [
  "bytecount",
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "nix",
  "unicode-width",
@@ -3021,7 +3013,7 @@ dependencies = [
 name = "uu_who"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "uucore",
 ]
 
@@ -3029,7 +3021,7 @@ dependencies = [
 name = "uu_whoami"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "uucore",
  "winapi 0.3.9",
@@ -3039,7 +3031,7 @@ dependencies = [
 name = "uu_yes"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "libc",
  "nix",
  "uucore",
@@ -3049,7 +3041,7 @@ dependencies = [
 name = "uucore"
 version = "0.0.14"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.12",
  "data-encoding",
  "data-encoding-macro",
  "dns-lookup",
@@ -3060,7 +3052,7 @@ dependencies = [
  "once_cell",
  "os_display",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "uucore_procs",
  "walkdir",
  "wild",
@@ -3079,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d5d669b51467dcf7b2f1a796ce0f955f05f01cafda6c19d6e95f730df29238"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,12 +1660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "retain_mut"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
-
-[[package]]
 name = "rlimit"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,7 +2912,6 @@ version = "0.0.14"
 dependencies = [
  "clap 3.1.18",
  "libc",
- "retain_mut",
  "uucore",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ uudoc = [ "zip" ]
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
 clap_complete = "3.1"
 once_cell = "1.13.0"
-phf = "0.10.1"
+phf = "0.11"
 selinux = { version="0.2", optional = true }
 textwrap = { version="0.15", features=["terminal_size"] }
 uucore = { version=">=0.0.11", package="uucore", path="src/uucore" }
@@ -407,7 +407,7 @@ rust-users = { version="0.11", package="users" }
 unix_socket = "0.5.0"
 
 [build-dependencies]
-phf_codegen = "0.10.0"
+phf_codegen = "0.11.0"
 
 [[bin]]
 name = "coreutils"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Both can also be generated locally, the instructions for that can be found in th
 ### Rust Version
 
 uutils follows Rust's release channels and is tested against stable, beta and nightly.
-The current oldest supported version of the Rust compiler is `1.56`.
+The current oldest supported version of the Rust compiler is `1.62`.
 
 ## Building
 

--- a/deny.toml
+++ b/deny.toml
@@ -11,7 +11,6 @@ unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
 ignore = [
-    "RUSTSEC-2020-0159",
     "RUSTSEC-2020-0071",
     #"RUSTSEC-0000-0000",
 ]
@@ -29,27 +28,13 @@ allow = [
     "BSD-2-Clause-FreeBSD",
     "BSD-3-Clause",
     "CC0-1.0",
-    "MPL-2.0", # XXX considered copyleft?
+    "Unicode-DFS-2016",
 ]
 copyleft = "deny"
 allow-osi-fsf-free = "neither"
 default = "deny"
 confidence-threshold = 0.8
-exceptions = [
-    { allow = ["OpenSSL"], name = "ring" },
-]
 
-[[licenses.clarify]]
-name = "ring"
-# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
-# https://spdx.org/licenses/OpenSSL.html
-# ISC - Both BoringSSL and ring use this for their new files
-# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
-# license, for third_party/fiat, which, unlike other third_party directories, is
-# compiled into non-test libraries, is included below."
-# OpenSSL - Obviously
-expression = "ISC AND MIT AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
@@ -69,27 +54,19 @@ skip = [
     { name = "arrayvec", version = "=0.7.2" },
     # flimit/unix_socket
     { name = "cfg-if", version = "=0.1.10" },
-    # indexmap
-    { name = "hashbrown", version = "=0.11.2" },
     # kernel32-sys
     { name = "winapi", version = "=0.2.8" },
     # bindgen 0.59.2
     { name = "clap", version = "=2.34.0" },
     { name = "strsim", version = "=0.8.0" },
     { name = "textwrap", version = "=0.11.0" },
-    { name = "cpp_common", version = "=0.4.0" },
     # quickcheck
     { name = "env_logger", version = "=0.8.4" },
     # tempfile
     { name = "remove_dir_all", version = "=0.5.3" },
-    # cpp_*
-    { name = "memchr", version = "=1.0.2" },
-    { name = "quote", version = "=0.3.15" },
-    { name = "unicode-xid", version = "=0.0.4" },
     # chrono
     { name = "time", version = "=0.1.44" },
 ]
-# spell-checker: enable
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:

--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -5,7 +5,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use clap::{Arg, Command};
+use clap::{value_parser, Arg, Command};
 use clap_complete::Shell;
 use std::cmp;
 use std::ffi::OsStr;
@@ -147,7 +147,7 @@ fn gen_completions<T: uucore::Args>(
         )
         .arg(
             Arg::new("shell")
-                .possible_values(Shell::possible_values())
+                .value_parser(value_parser!(Shell))
                 .required(true),
         )
         .get_matches_from(std::iter::once(OsString::from("completion")).chain(args));

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/od.rs"
 [dependencies]
 byteorder = "1.3.2"
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
-half = "1.6"
+half = "2.1"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
 
 [[bin]]

--- a/src/uu/stdbuf/src/libstdbuf/Cargo.toml
+++ b/src/uu/stdbuf/src/libstdbuf/Cargo.toml
@@ -22,4 +22,4 @@ libc = "0.2"
 uucore = { version=">=0.0.11", package="uucore", path="../../../../uucore" }
 
 [build-dependencies]
-cpp_build = "0.4"
+cpp_build = "0.5.7"

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/tee.rs"
 [dependencies]
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
 libc = "0.2.126"
-retain_mut = "=0.1.7" # ToDO: [2021-01-01; rivy; maint/MinSRV] ~ v0.1.5 uses const generics which aren't stabilized until rust v1.51.0
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["libc"] }
 
 [[bin]]

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -9,7 +9,6 @@
 extern crate uucore;
 
 use clap::{crate_version, Arg, Command, PossibleValue};
-use retain_mut::RetainMut;
 use std::fs::OpenOptions;
 use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
 use std::path::PathBuf;
@@ -304,7 +303,7 @@ impl Write for MultiWriter {
         let mut aborted = None;
         let mode = self.output_error_mode.clone();
         let mut errors = 0;
-        RetainMut::retain_mut(&mut self.writers, |writer| {
+        self.writers.retain_mut(|writer| {
             let result = writer.write_all(buf);
             match result {
                 Err(f) => {
@@ -335,7 +334,7 @@ impl Write for MultiWriter {
         let mut aborted = None;
         let mode = self.output_error_mode.clone();
         let mut errors = 0;
-        RetainMut::retain_mut(&mut self.writers, |writer| {
+        self.writers.retain_mut(|writer| {
             let result = writer.flush();
             match result {
                 Err(f) => {

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -86,13 +86,8 @@ fn test_wrap() {
 fn test_wrap_no_arg() {
     for wrap_param in ["-w", "--wrap"] {
         let ts = TestScenario::new(util_name!());
-        let expected_stderr = &format!(
-            "error: The argument '--wrap <wrap>\' requires a value but none was \
-                               supplied\n\nUSAGE:\n    {1} {0} [OPTION]... [FILE]\n\nFor more \
-                               information try --help",
-            ts.util_name,
-            ts.bin_path.to_string_lossy()
-        );
+        let expected_stderr = "error: The argument '--wrap <wrap>\' requires a value but none was \
+                               supplied\n\nFor more information try --help";
         ts.ucmd()
             .arg(wrap_param)
             .fails()


### PR DESCRIPTION
Some of the libraries were getting somewhat out of date. I'm not sure why dependbot doesn't pick all these up, but good to do this occasionally assuming the updates don't break anything.