### PR TITLE
numfmt: show "invalid suffix" error for "i" suffix

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -79,7 +79,7 @@ fn parse_suffix(s: &str) -> Result<(f64, Option<Suffix>)> {
         Some('E') => Some((RawSuffix::E, with_i)),
         Some('Z') => Some((RawSuffix::Z, with_i)),
         Some('Y') => Some((RawSuffix::Y, with_i)),
-        Some('0'..='9') => None,
+        Some('0'..='9') if !with_i => None,
         _ => return Err(format!("invalid suffix in input: {}", s.quote())),
     };
 

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -208,11 +208,16 @@ fn test_should_report_invalid_empty_number_on_blank_stdin() {
 
 #[test]
 fn test_should_report_invalid_suffix_on_stdin() {
-    new_ucmd!()
-        .args(&["--from=auto"])
-        .pipe_in("1k")
-        .run()
-        .stderr_is("numfmt: invalid suffix in input: '1k'\n");
+    for c in b'a'..=b'z' {
+        new_ucmd!()
+            .args(&["--from=auto"])
+            .pipe_in(format!("1{}", c as char))
+            .run()
+            .stderr_is(format!(
+                "numfmt: invalid suffix in input: '1{}'\n",
+                c as char
+            ));
+    }
 
     // GNU numfmt reports this one as “invalid number”
     new_ucmd!()


### PR DESCRIPTION
So far, all numbers with an invalid suffix cause an "invalid suffix" error. The exception are numbers with an "i" suffix, they cause an "invalid number" error. This PR removes this exception.

This makes the `auto-suf-si-i` test in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.