### PR TITLE
Implement a fast path for character counting in wc.

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -135,6 +135,13 @@ pub(crate) fn count_bytes_and_lines_fast<R: Read>(
     }
 }
 
+/// Returns a WordCount that counts the number of Unicode characters encoded in UTF-8 read via a Reader.
+///
+/// This corresponds to the `-m` command line flag to wc.
+///
+/// # Arguments
+///
+/// * `R` - A Reader from which the UTF-8 stream will be read.
 pub(crate) fn count_chars_fast<R: Read>(handle: &mut R) -> (WordCount, Option<io::Error>) {
     /// Mask of the value bits of a continuation byte
     const CONT_MASK: u8 = 0b0011_1111u8;

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -13,7 +13,7 @@ extern crate uucore;
 mod count_fast;
 mod countable;
 mod word_count;
-use count_fast::{count_bytes_and_lines_fast, count_bytes_fast};
+use count_fast::{count_bytes_and_lines_fast, count_bytes_fast, count_chars_fast};
 use countable::WordCountable;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
@@ -315,6 +315,7 @@ fn word_count_from_reader<T: WordCountable>(
     ) {
         // Specialize scanning loop to improve the performance.
         (false, false, false, false, false) => unreachable!(),
+        (false, true, false, false, false) => count_chars_fast(&mut reader),
         (true, false, false, false, false) => {
             // Fast path when only show_bytes is true.
             let (bytes, error) = count_bytes_fast(&mut reader);


### PR DESCRIPTION
When wc is invoked with only the -m flag, we only need to count the
number of Unicode characters in the input. In order to do so, we don't
actually need to decode the input bytes into characters. Rather, we can
simply count the number of non-continuation bytes in the UTF-8 stream,
since every character will contain exactly one non-continuation byte.

On my laptop, this speeds up `wc -m odyssey1024.txt` from 745ms to
109ms.