### PR TITLE
gnu-tests/F-headers: increase number of attempts

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -170,7 +170,7 @@ sed -i -e "s|---dis ||g" tests/tail-2/overlay-headers.sh
 
 # F-headers.sh test sometime fails (but only in CI),
 # just testing inotify should make it more stable
-sed -i -e "s| '---disable-inotify'||g" tests/tail-2/F-headers.sh
+sed -i -e "s|check_tail_output \.1 7|check_tail_output .1 9|g" -e "s| '---disable-inotify'||g" tests/tail-2/F-headers.sh
 
 test -f "${UU_BUILD_DIR}/getlimits" || cp src/getlimits "${UU_BUILD_DIR}"
 

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -170,7 +170,7 @@ sed -i -e "s|---dis ||g" tests/tail-2/overlay-headers.sh
 
 # F-headers.sh test sometime fails (but only in CI),
 # just testing inotify should make it more stable
-sed -i -e "s|check_tail_output \.1 7|check_tail_output .1 9|g" -e "s| '---disable-inotify'||g" tests/tail-2/F-headers.sh
+sed -i -e "s|check_tail_output \.1 7|check_tail_output .1 12|g" -e "s| '---disable-inotify'||g" tests/tail-2/F-headers.sh
 
 test -f "${UU_BUILD_DIR}/getlimits" || cp src/getlimits "${UU_BUILD_DIR}"
 


### PR DESCRIPTION
Related PR #3618 

Since this test is still not stable, I propose to try to increase the number of attempts from 7 to 9, and total delay will increase from 12.7 seconds to 51.1 seconds.

As I understand tests are being run in parallel, there are three tests with this delay, so this won't result in too much additional running time, 2 minutes tops for this test. And when it succeeds it stops, so it's only slow when it fails. And it sleeps most of the time not using resources.