### PR TITLE
numfmt: enable ignored test

### DIFF
--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -295,11 +295,9 @@ fn test_leading_whitespace_in_free_argument_should_imply_padding() {
 }
 
 #[test]
-#[ignore]
 fn test_should_calculate_implicit_padding_per_free_argument() {
     new_ucmd!()
         .args(&["--from=auto", "   1Ki", "        2K"])
-        .pipe_in("   1Ki\n        2K")
         .run()
         .stdout_is("  1024\n      2000\n");
 }


### PR DESCRIPTION
This PR enables the test `test_should_calculate_implicit_padding_per_free_argument()` and removes a line that seems unnecessary.