### PR TITLE
Implement wc fast paths that skip Unicode decoding.

### DIFF
--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -105,6 +105,33 @@ fn test_utf8_chars() {
 }
 
 #[test]
+fn test_utf8_bytes_chars() {
+    new_ucmd!()
+        .arg("-cm")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("    442     513\n");
+}
+
+#[test]
+fn test_utf8_bytes_lines() {
+    new_ucmd!()
+        .arg("-cl")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     25     513\n");
+}
+
+#[test]
+fn test_utf8_bytes_chars_lines() {
+    new_ucmd!()
+        .arg("-cml")
+        .pipe_in_fixture("UTF_8_weirdchars.txt")
+        .run()
+        .stdout_is("     25     442     513\n");
+}
+
+#[test]
 fn test_utf8_chars_words() {
     new_ucmd!()
         .arg("-mw")


### PR DESCRIPTION
Byte, character, and line counting can all be done on the raw bytes
of the incoming stream without decoding the Unicode characters. This
fact was previously exploited in specific fast paths for counting
characters and counting lines. This change unifies those fast paths into
a single shared fast paths, using const generics to specialize the
function for each use case. This has the benefit of making sure that all
combinations of these Unicode-oblivious fast paths benefit from the same
optimization.

On my laptop, this speeds up `wc -clm odyssey1024.txt` from 840ms to
120ms. I experimented with using a filter loop for line counting, but
continuing to use the bytecount crate came out ahead by a significant
margin.