### PR TITLE
numfmt: don't round floats if --from is "none"

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -145,7 +145,16 @@ fn transform_from(s: &str, opts: &TransformOptions) -> Result<f64> {
     let (i, suffix) = parse_suffix(s)?;
     let i = i * (opts.from_unit as f64);
 
-    remove_suffix(i, suffix, &opts.from).map(|n| if n < 0.0 { -n.abs().ceil() } else { n.ceil() })
+    remove_suffix(i, suffix, &opts.from).map(|n| {
+        // GNU numfmt doesn't round values if no --from argument is provided by the user
+        if opts.from == Unit::None {
+            n
+        } else if n < 0.0 {
+            -n.abs().ceil()
+        } else {
+            n.ceil()
+        }
+    })
 }
 
 /// Divide numerator by denominator, with rounding.

--- a/src/uu/numfmt/src/units.rs
+++ b/src/uu/numfmt/src/units.rs
@@ -17,6 +17,7 @@ pub const IEC_BASES: [f64; 10] = [
 
 pub type WithI = bool;
 
+#[derive(PartialEq)]
 pub enum Unit {
     Auto,
     Si,

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -3,6 +3,14 @@
 use crate::common::util::*;
 
 #[test]
+fn test_should_not_round_floats() {
+    new_ucmd!()
+        .args(&["0.99", "1.01", "1.1", "1.22", ".1", "-0.1"])
+        .succeeds()
+        .stdout_is("0.99\n1.01\n1.1\n1.22\n0.1\n-0.1\n");
+}
+
+#[test]
 fn test_from_si() {
     new_ucmd!()
         .args(&["--from=si"])


### PR DESCRIPTION
So far uutils numfmt rounds floats up if `--from` is not specified. For example, `numfmt 0.1` returns `1`. GNU numfmt doesn't do any rounding in this case, i.e., it returns `0.1` in the aforementioned example.

This PR fixes this behavior and makes the tests `float-1`, `float-2`, `neg-5`, and `leading-2` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.