### PR TITLE
basenc: error code on wrong usage, usage test

### DIFF
--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -18,6 +18,7 @@ use uucore::{
 };
 
 use std::io::{stdin, Read};
+use uucore::error::UClapError;
 
 static ABOUT: &str = "\
 With no FILE, or when FILE is -, read standard input.
@@ -49,10 +50,12 @@ pub fn uu_app<'a>() -> Command<'a> {
 }
 
 fn parse_cmd_args(args: impl uucore::Args) -> UResult<(Config, Format)> {
-    let matches = uu_app().get_matches_from(
-        args.collect_str(InvalidEncodingHandling::ConvertLossy)
-            .accept_any(),
-    );
+    let matches = uu_app()
+        .try_get_matches_from(
+            args.collect_str(InvalidEncodingHandling::ConvertLossy)
+                .accept_any(),
+        )
+        .with_exit_code(1)?;
     let format = ENCODINGS
         .iter()
         .find(|encoding| matches.is_present(encoding.0))

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -183,7 +183,7 @@ sed -i "s/\(\(b2[ml]_[69]\|b32h_[56]\|z85_8\|z85_35\).*OUT=>\)[^}]*\(.*\)/\1\"\"
 sed -i "s/\$prog: invalid input/\$prog: error: invalid input/g" tests/misc/basenc.pl
 
 # basenc: swap out error message for unexpected arg
-sed -i "s/  {ERR=>\"\$prog: foobar\\\\n\" \. \$try_help }/  {ERR=>\"error: Found argument '--foobar' which wasn't expected, or isn't valid in this context\n\nUSAGE:\n    basenc [OPTION]... [FILE]\n\nFor more information try --help\n\"}]/" tests/misc/basenc.pl
+sed -i "s/  {ERR=>\"\$prog: foobar\\\\n\" \. \$try_help }/  {ERR=>\"error: Found argument '--foobar' which wasn't expected, or isn't valid in this context\n\n\tIf you tried to supply \`--foobar\` as a value rather than a flag, use \`-- --foobar\`\n\nUSAGE:\n    basenc [OPTION]... [FILE]\n\nFor more information try --help\n\"}]/" tests/misc/basenc.pl
 sed -i "s/  {ERR_SUBST=>\"s\/(unrecognized|unknown) option \[-' \]\*foobar\[' \]\*\/foobar\/\"}],//" tests/misc/basenc.pl
 
 # Remove the check whether a util was built. Otherwise tests against utils like "arch" are not run.


### PR DESCRIPTION
- Changed error code of `basenc` to 1 on wrong usage
- Fixed usage test to comply with clap output