### PR TITLE
ls: Implement --zero flag. (#2929)

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -752,7 +752,7 @@ impl Config {
         //  - `--format=single-column`
         //  - `--color=none`
         //  - `--quoting-style=literal`
-        // Current GNU ls implementation allows `--zero` behaviour to be
+        // Current GNU ls implementation allows `--zero` Behavior to be
         // overridden by later flags.
         let zero_formats_opts = [
             options::format::ACROSS,

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -773,8 +773,7 @@ impl Config {
             options::quoting::ESCAPE,
             options::quoting::LITERAL,
         ];
-        let get_last =
-            |flag: &str| -> usize { options.indices_of(flag).and_then(|x| x.last()).unwrap_or(0) };
+        let get_last = |flag: &str| -> usize { options.index_of(flag).unwrap_or(0) };
         if get_last(options::ZERO)
             > zero_formats_opts
                 .into_iter()
@@ -994,6 +993,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 Arg::new(options::ZERO)
                     .long(options::ZERO)
                     .conflicts_with(options::DIRED)
+                    .overrides_with(options::ZERO)
                     .help("List entries separated by ASCII NUL characters."),
             )
             .arg(

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -849,6 +849,12 @@ fn test_ls_zero() {
         .succeeds()
         .stdout_only("0-test-zero\x002-test-zero\x003-test-zero\x00");
 
+    scene
+        .ucmd()
+        .args(&["--zero", "--quoting-style=c", "--zero"])
+        .succeeds()
+        .stdout_only("0-test-zero\x002-test-zero\x003-test-zero\x00");
+
     #[cfg(unix)]
     {
         at.touch(&at.plus_as_string("1\ntest-zero"));

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -878,13 +878,17 @@ fn test_ls_zero() {
             .ucmd()
             .args(&["--zero", "--quoting-style=c"])
             .succeeds()
-            .stdout_only("\"0-test-zero\"\x00\"1\\ntest-zero\"\x00\"2-test-zero\"\x00\"3-test-zero\"\x00");
+            .stdout_only(
+                "\"0-test-zero\"\x00\"1\\ntest-zero\"\x00\"2-test-zero\"\x00\"3-test-zero\"\x00",
+            );
 
         scene
             .ucmd()
             .args(&["--zero", "--color=always"])
             .succeeds()
-            .stdout_only("\x1b[1;34m0-test-zero\x1b[0m\x001\ntest-zero\x002-test-zero\x003-test-zero\x00");
+            .stdout_only(
+                "\x1b[1;34m0-test-zero\x1b[0m\x001\ntest-zero\x002-test-zero\x003-test-zero\x00",
+            );
 
         scene
             .ucmd()

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -797,6 +797,116 @@ fn test_ls_commas() {
 }
 
 #[test]
+fn test_ls_zero() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("0-test-zero");
+    at.touch(&at.plus_as_string("2-test-zero"));
+    at.touch(&at.plus_as_string("3-test-zero"));
+
+    let ignored_opts = [
+        "--quoting-style=c",
+        "--color=always",
+        "-m",
+        "--hide-control-chars",
+    ];
+
+    scene
+        .ucmd()
+        .arg("--zero")
+        .succeeds()
+        .stdout_only("0-test-zero\x002-test-zero\x003-test-zero\x00");
+
+    for opt in ignored_opts {
+        scene
+            .ucmd()
+            .args(&[opt, "--zero"])
+            .succeeds()
+            .stdout_only("0-test-zero\x002-test-zero\x003-test-zero\x00");
+    }
+
+    scene
+        .ucmd()
+        .args(&["--zero", "--quoting-style=c"])
+        .succeeds()
+        .stdout_only("\"0-test-zero\"\x00\"2-test-zero\"\x00\"3-test-zero\"\x00");
+
+    scene
+        .ucmd()
+        .args(&["--zero", "--color=always"])
+        .succeeds()
+        .stdout_only("\x1b[1;34m0-test-zero\x1b[0m\x002-test-zero\x003-test-zero\x00");
+
+    scene
+        .ucmd()
+        .args(&["--zero", "-m"])
+        .succeeds()
+        .stdout_only("0-test-zero, 2-test-zero, 3-test-zero\x00");
+
+    scene
+        .ucmd()
+        .args(&["--zero", "--hide-control-chars"])
+        .succeeds()
+        .stdout_only("0-test-zero\x002-test-zero\x003-test-zero\x00");
+
+    #[cfg(unix)]
+    {
+        at.touch(&at.plus_as_string("1\ntest-zero"));
+
+        let ignored_opts = [
+            "--quoting-style=c",
+            "--color=always",
+            "-m",
+            "--hide-control-chars",
+        ];
+
+        scene
+            .ucmd()
+            .arg("--zero")
+            .succeeds()
+            .stdout_only("0-test-zero\x001\ntest-zero\x002-test-zero\x003-test-zero\x00");
+
+        for opt in ignored_opts {
+            scene
+                .ucmd()
+                .args(&[opt, "--zero"])
+                .succeeds()
+                .stdout_only("0-test-zero\x001\ntest-zero\x002-test-zero\x003-test-zero\x00");
+        }
+
+        scene
+            .ucmd()
+            .args(&["--zero", "--quoting-style=c"])
+            .succeeds()
+            .stdout_only("\"0-test-zero\"\x00\"1\\ntest-zero\"\x00\"2-test-zero\"\x00\"3-test-zero\"\x00");
+
+        scene
+            .ucmd()
+            .args(&["--zero", "--color=always"])
+            .succeeds()
+            .stdout_only("\x1b[1;34m0-test-zero\x1b[0m\x001\ntest-zero\x002-test-zero\x003-test-zero\x00");
+
+        scene
+            .ucmd()
+            .args(&["--zero", "-m"])
+            .succeeds()
+            .stdout_only("0-test-zero, 1\ntest-zero, 2-test-zero, 3-test-zero\x00");
+
+        scene
+            .ucmd()
+            .args(&["--zero", "--hide-control-chars"])
+            .succeeds()
+            .stdout_only("0-test-zero\x001?test-zero\x002-test-zero\x003-test-zero\x00");
+    }
+
+    scene
+        .ucmd()
+        .args(&["-l", "--zero"])
+        .succeeds()
+        .stdout_contains("total ");
+}
+
+#[test]
 fn test_ls_commas_trailing() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
Fixes #2929

(Full disclosure, I am very new to rust, and contributing mainly as a learning exercise. But I hope this change can be useful).

This flag can be used to provide a easy machine parseable output from
ls, as discussed in the GNU bug report
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=49716.

There are some peculiarities with this flag:

 - Current implementation of GNU ls of the `--zero` flag implies some
   other flags. Those can be overridden by setting those flags after
   `--zero` in the command line.
 - This flag is not compatible with `--dired`. This patch is not 100%
   compliant with GNU ls: GNU ls `--zero` will fail if `--dired` and
   `-l` are set, while with this patch only `--dired` is needed for the
   command to fail.

We also add `--dired` flag to the parser, with no additional behaviour
change.

Testing done:
```
$ bash util/build-gnu.sh
 [...]
$ bash util/run-gnu-test.sh tests/ls/zero-option.sh
 [...]
 PASS: tests/ls/zero-option.sh
 ============================================================================
 Testsuite summary for GNU coreutils 9.1.36-8ec11
 ============================================================================
 # TOTAL: 1
 # PASS:  1
 # SKIP:  0
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0
 # ERROR: 0
 ============================================================================
```