### PR TITLE
mkdir: fix permission mode when use "-m +"

### DIFF
--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -40,6 +40,10 @@ pub fn parse_symbolic(
     umask: u32,
     considering_dir: bool,
 ) -> Result<u32, String> {
+    if mode == "+" {
+        return Ok(fperm | 0o775 & !umask);
+    }
+
     let (mask, pos) = parse_levels(mode);
     if pos == mode.len() {
         return Err(format!("invalid mode ({})", mode));

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -100,6 +100,16 @@ fn test_symbolic_alteration() {
 
 #[test]
 #[cfg(not(windows))]
+fn test_no_symbolic() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    ucmd.arg("-m").arg("+").arg(TEST_DIR1).succeeds();
+    let perms = at.metadata(TEST_DIR1).permissions().mode();
+    assert_eq!(perms, 0o40775);
+}
+
+#[test]
+#[cfg(not(windows))]
 fn test_multi_symbolic() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
Fixes #3645 