### PR TITLE
numfmt: implement --format

### DIFF
--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -1,9 +1,12 @@
+use std::str::FromStr;
+
 use crate::units::Unit;
 use uucore::ranges::Range;
 
 pub const DELIMITER: &str = "delimiter";
 pub const FIELD: &str = "field";
 pub const FIELD_DEFAULT: &str = "1";
+pub const FORMAT: &str = "format";
 pub const FROM: &str = "from";
 pub const FROM_DEFAULT: &str = "none";
 pub const FROM_UNIT: &str = "from-unit";
@@ -34,6 +37,7 @@ pub struct NumfmtOptions {
     pub delimiter: Option<String>,
     pub round: RoundMethod,
     pub suffix: Option<String>,
+    pub format: FormatOptions,
 }
 
 #[derive(Clone, Copy)]
@@ -66,5 +70,284 @@ impl RoundMethod {
             }
             Self::Nearest => f.round(),
         }
+    }
+}
+
+// Represents the options extracted from the --format argument provided by the user.
+#[derive(Debug, PartialEq)]
+pub struct FormatOptions {
+    pub grouping: bool,
+    pub padding: Option<isize>,
+    pub precision: usize,
+    pub prefix: String,
+    pub suffix: String,
+    pub zero_padding: bool,
+}
+
+impl Default for FormatOptions {
+    fn default() -> Self {
+        Self {
+            grouping: false,
+            padding: None,
+            precision: 0,
+            prefix: String::from(""),
+            suffix: String::from(""),
+            zero_padding: false,
+        }
+    }
+}
+
+impl FromStr for FormatOptions {
+    type Err = String;
+
+    // The recognized format is: [PREFIX]%[0]['][-][N][.][N]f[SUFFIX]
+    //
+    // The format defines the printing of a floating point argument '%f'.
+    // An optional quote (%'f) enables --grouping.
+    // An optional width value (%10f) will pad the number.
+    // An optional zero (%010f) will zero pad the number.
+    // An optional negative value (%-10f) will left align.
+    // An optional precision (%.1f) determines the precision of the number.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s.chars().peekable();
+        let mut options = Self::default();
+
+        let mut padding = String::from("");
+        let mut precision = String::from("");
+        let mut double_percentage_counter = 0;
+
+        // '%' chars in the prefix, if any, must appear in blocks of even length, for example: "%%%%" and
+        // "%% %%" are ok, "%%% %" is not ok. A single '%' is treated as the beginning of the
+        // floating point argument.
+        while let Some(c) = iter.next() {
+            match c {
+                '%' if iter.peek() == Some(&'%') => {
+                    iter.next();
+                    double_percentage_counter += 1;
+
+                    for _ in 0..2 {
+                        options.prefix.push('%');
+                    }
+                }
+                '%' => break,
+                _ => options.prefix.push(c),
+            }
+        }
+
+        // GNU numfmt drops a char from the prefix for every '%%' in the prefix, so we do the same
+        for _ in 0..double_percentage_counter {
+            options.prefix.pop();
+        }
+
+        if iter.peek().is_none() {
+            return if options.prefix == s {
+                Err(format!("format '{}' has no % directive", s))
+            } else {
+                Err(format!("format '{}' ends in %", s))
+            };
+        }
+
+        // GNU numfmt allows to mix the characters " ", "'", and "0" in any way, so we do the same
+        while matches!(iter.peek(), Some(' ') | Some('\'') | Some('0')) {
+            match iter.next().unwrap() {
+                ' ' => (),
+                '\'' => options.grouping = true,
+                '0' => options.zero_padding = true,
+                _ => unreachable!(),
+            }
+        }
+
+        if let Some('-') = iter.peek() {
+            iter.next();
+
+            match iter.peek() {
+                Some(c) if c.is_ascii_digit() => padding.push('-'),
+                _ => {
+                    return Err(format!(
+                        "invalid format '{}', directive must be %[0]['][-][N][.][N]f",
+                        s
+                    ))
+                }
+            }
+        }
+
+        while let Some(c) = iter.peek() {
+            if c.is_ascii_digit() {
+                padding.push(*c);
+                iter.next();
+            } else {
+                break;
+            }
+        }
+
+        if !padding.is_empty() {
+            if let Ok(p) = padding.parse() {
+                options.padding = Some(p);
+            } else {
+                return Err(format!("invalid format '{}' (width overflow)", s));
+            }
+        }
+
+        if let Some('.') = iter.peek() {
+            iter.next();
+
+            if matches!(iter.peek(), Some(' ') | Some('+') | Some('-')) {
+                return Err(format!("invalid precision in format '{}'", s));
+            }
+
+            while let Some(c) = iter.peek() {
+                if c.is_ascii_digit() {
+                    precision.push(*c);
+                    iter.next();
+                } else {
+                    break;
+                }
+            }
+
+            if !precision.is_empty() {
+                if let Ok(p) = precision.parse() {
+                    options.precision = p;
+                } else {
+                    return Err(format!("invalid precision in format '{}'", s));
+                }
+            }
+        }
+
+        if let Some('f') = iter.peek() {
+            iter.next();
+        } else {
+            return Err(format!(
+                "invalid format '{}', directive must be %[0]['][-][N][.][N]f",
+                s
+            ));
+        }
+
+        // '%' chars in the suffix, if any, must appear in blocks of even length, otherwise
+        // it is an error. For example: "%%%%" and "%% %%" are ok, "%%% %" is not ok.
+        while let Some(c) = iter.next() {
+            if c != '%' {
+                options.suffix.push(c);
+            } else if iter.peek() == Some(&'%') {
+                for _ in 0..2 {
+                    options.suffix.push('%');
+                }
+                iter.next();
+            } else {
+                return Err(format!("format '{}' has too many % directives", s));
+            }
+        }
+
+        Ok(options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_format() {
+        assert_eq!(FormatOptions::default(), "%f".parse().unwrap());
+        assert_eq!(FormatOptions::default(), "%  f".parse().unwrap());
+    }
+
+    #[test]
+    fn test_parse_format_with_invalid_formats() {
+        assert!("".parse::<FormatOptions>().is_err());
+        assert!("hello".parse::<FormatOptions>().is_err());
+        assert!("hello%".parse::<FormatOptions>().is_err());
+        assert!("%-f".parse::<FormatOptions>().is_err());
+        assert!("%d".parse::<FormatOptions>().is_err());
+        assert!("%4 f".parse::<FormatOptions>().is_err());
+        assert!("%f%".parse::<FormatOptions>().is_err());
+        assert!("%f%%%".parse::<FormatOptions>().is_err());
+        assert!("%%f".parse::<FormatOptions>().is_err());
+        assert!("%%%%f".parse::<FormatOptions>().is_err());
+        assert!("%.-1f".parse::<FormatOptions>().is_err());
+        assert!("%. 1f".parse::<FormatOptions>().is_err());
+        assert!("%18446744073709551616f".parse::<FormatOptions>().is_err());
+        assert!("%.18446744073709551616f".parse::<FormatOptions>().is_err());
+    }
+
+    #[test]
+    fn test_parse_format_with_prefix_and_suffix() {
+        let formats = vec![
+            ("--%f", "--", ""),
+            ("%f::", "", "::"),
+            ("--%f::", "--", "::"),
+            ("%f%%", "", "%%"),
+            ("%%%f", "%", ""),
+            ("%% %f", "%%", ""),
+        ];
+
+        for (format, expected_prefix, expected_suffix) in formats {
+            let options: FormatOptions = format.parse().unwrap();
+            assert_eq!(expected_prefix, options.prefix);
+            assert_eq!(expected_suffix, options.suffix);
+        }
+    }
+
+    #[test]
+    fn test_parse_format_with_padding() {
+        let mut expected_options = FormatOptions::default();
+        let formats = vec![("%12f", Some(12)), ("%-12f", Some(-12))];
+
+        for (format, expected_padding) in formats {
+            expected_options.padding = expected_padding;
+            assert_eq!(expected_options, format.parse().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_parse_format_with_precision() {
+        let mut expected_options = FormatOptions::default();
+        let formats = vec![
+            ("%6.2f", Some(6), 2),
+            ("%6.f", Some(6), 0),
+            ("%.2f", None, 2),
+            ("%.f", None, 0),
+        ];
+
+        for (format, expected_padding, expected_precision) in formats {
+            expected_options.padding = expected_padding;
+            expected_options.precision = expected_precision;
+            assert_eq!(expected_options, format.parse().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_parse_format_with_grouping() {
+        let expected_options = FormatOptions {
+            grouping: true,
+            ..Default::default()
+        };
+        assert_eq!(expected_options, "%'f".parse().unwrap());
+        assert_eq!(expected_options, "% ' f".parse().unwrap());
+        assert_eq!(expected_options, "%'''''''f".parse().unwrap());
+    }
+
+    #[test]
+    fn test_parse_format_with_zero_padding() {
+        let expected_options = FormatOptions {
+            padding: Some(10),
+            zero_padding: true,
+            ..Default::default()
+        };
+        assert_eq!(expected_options, "%010f".parse().unwrap());
+        assert_eq!(expected_options, "% 0 10f".parse().unwrap());
+        assert_eq!(expected_options, "%0000000010f".parse().unwrap());
+    }
+
+    #[test]
+    fn test_parse_format_with_grouping_and_zero_padding() {
+        let expected_options = FormatOptions {
+            grouping: true,
+            zero_padding: true,
+            ..Default::default()
+        };
+        assert_eq!(expected_options, "%0'f".parse().unwrap());
+        assert_eq!(expected_options, "%'0f".parse().unwrap());
+        assert_eq!(expected_options, "%0'0'0'f".parse().unwrap());
+        assert_eq!(expected_options, "%'0'0'0f".parse().unwrap());
     }
 }

--- a/src/uu/numfmt/src/units.rs
+++ b/src/uu/numfmt/src/units.rs
@@ -17,7 +17,7 @@ pub const IEC_BASES: [f64; 10] = [
 
 pub type WithI = bool;
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Unit {
     Auto,
     Si,

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -673,3 +673,241 @@ fn test_valid_but_forbidden_suffix() {
             ));
     }
 }
+
+#[test]
+fn test_format() {
+    new_ucmd!()
+        .args(&["--format=--%f--", "50"])
+        .succeeds()
+        .stdout_is("--50--\n");
+}
+
+#[test]
+fn test_format_with_separate_value() {
+    new_ucmd!()
+        .args(&["--format", "--%f--", "50"])
+        .succeeds()
+        .stdout_is("--50--\n");
+}
+
+#[test]
+fn test_format_padding_with_prefix_and_suffix() {
+    new_ucmd!()
+        .args(&["--format=--%6f--", "50"])
+        .succeeds()
+        .stdout_is("--    50--\n");
+}
+
+#[test]
+fn test_format_negative_padding_with_prefix_and_suffix() {
+    new_ucmd!()
+        .args(&["--format=--%-6f--", "50"])
+        .succeeds()
+        .stdout_is("--50    --\n");
+}
+
+#[test]
+fn test_format_with_format_padding_overriding_padding_option() {
+    new_ucmd!()
+        .args(&["--format=%6f", "--padding=10", "1234"])
+        .succeeds()
+        .stdout_is("  1234\n");
+}
+
+#[test]
+fn test_format_with_format_padding_overriding_implicit_padding() {
+    new_ucmd!()
+        .args(&["--format=%6f", "      1234"])
+        .succeeds()
+        .stdout_is("  1234\n");
+}
+
+#[test]
+fn test_format_with_negative_format_padding_and_suffix() {
+    new_ucmd!()
+        .args(&["--format=%-6f", "1234 ?"])
+        .succeeds()
+        .stdout_is("1234   ?\n");
+}
+
+#[test]
+fn test_format_with_zero_padding() {
+    let formats = vec!["%06f", "%0 6f"];
+
+    for format in formats {
+        new_ucmd!()
+            .args(&[format!("--format={}", format), String::from("1234")])
+            .succeeds()
+            .stdout_is("001234\n");
+    }
+}
+
+#[test]
+fn test_format_with_zero_padding_and_padding_option() {
+    new_ucmd!()
+        .args(&["--format=%06f", "--padding=8", "1234"])
+        .succeeds()
+        .stdout_is("  001234\n");
+}
+
+#[test]
+fn test_format_with_zero_padding_and_negative_padding_option() {
+    new_ucmd!()
+        .args(&["--format=%06f", "--padding=-8", "1234"])
+        .succeeds()
+        .stdout_is("001234  \n");
+}
+
+#[test]
+fn test_format_with_zero_padding_and_implicit_padding() {
+    new_ucmd!()
+        .args(&["--format=%06f", "    1234"])
+        .succeeds()
+        .stdout_is("  001234\n");
+}
+
+#[test]
+fn test_format_with_zero_padding_and_suffix() {
+    new_ucmd!()
+        .args(&["--format=%06f", "1234 ?"])
+        .succeeds()
+        .stdout_is("001234 ?\n");
+}
+
+#[test]
+fn test_format_with_precision() {
+    let values = vec![("0.99", "1.0"), ("1", "1.0"), ("1.01", "1.1")];
+
+    for (input, expected) in values {
+        new_ucmd!()
+            .args(&["--format=%.1f", input])
+            .succeeds()
+            .stdout_is(format!("{}\n", expected));
+    }
+
+    let values = vec![("0.99", "0.99"), ("1", "1.00"), ("1.01", "1.01")];
+
+    for (input, expected) in values {
+        new_ucmd!()
+            .args(&["--format=%.2f", input])
+            .succeeds()
+            .stdout_is(format!("{}\n", expected));
+    }
+}
+
+#[test]
+fn test_format_with_precision_and_down_rounding() {
+    let values = vec![("0.99", "0.9"), ("1", "1.0"), ("1.01", "1.0")];
+
+    for (input, expected) in values {
+        new_ucmd!()
+            .args(&["--format=%.1f", input, "--round=down"])
+            .succeeds()
+            .stdout_is(format!("{}\n", expected));
+    }
+}
+
+#[test]
+fn test_format_with_precision_and_to_arg() {
+    let values = vec![("%.1f", "10.0G"), ("%.4f", "9.9913G")];
+
+    for (format, expected) in values {
+        new_ucmd!()
+            .args(&[
+                format!("--format={}", format),
+                "9991239123".to_string(),
+                "--to=si".to_string(),
+            ])
+            .succeeds()
+            .stdout_is(format!("{}\n", expected));
+    }
+}
+
+#[test]
+fn test_format_without_percentage_directive() {
+    let invalid_formats = vec!["", "hello"];
+
+    for invalid_format in invalid_formats {
+        new_ucmd!()
+            .arg(format!("--format={}", invalid_format))
+            .fails()
+            .code_is(1)
+            .stderr_contains(format!("format '{}' has no % directive", invalid_format));
+    }
+}
+
+#[test]
+fn test_format_with_percentage_directive_at_end() {
+    let invalid_format = "hello%";
+
+    new_ucmd!()
+        .arg(format!("--format={}", invalid_format))
+        .fails()
+        .code_is(1)
+        .stderr_contains(format!("format '{}' ends in %", invalid_format));
+}
+
+#[test]
+fn test_format_with_too_many_percentage_directives() {
+    let invalid_format = "%f %f";
+
+    new_ucmd!()
+        .arg(format!("--format={}", invalid_format))
+        .fails()
+        .code_is(1)
+        .stderr_contains(format!(
+            "format '{}' has too many % directives",
+            invalid_format
+        ));
+}
+
+#[test]
+fn test_format_with_invalid_format() {
+    let invalid_formats = vec!["%d", "% -43 f"];
+
+    for invalid_format in invalid_formats {
+        new_ucmd!()
+            .arg(format!("--format={}", invalid_format))
+            .fails()
+            .code_is(1)
+            .stderr_contains(format!(
+                "invalid format '{}', directive must be %[0]['][-][N][.][N]f",
+                invalid_format
+            ));
+    }
+}
+
+#[test]
+fn test_format_with_width_overflow() {
+    let invalid_format = "%18446744073709551616f";
+    new_ucmd!()
+        .arg(format!("--format={}", invalid_format))
+        .fails()
+        .code_is(1)
+        .stderr_contains(format!(
+            "invalid format '{}' (width overflow)",
+            invalid_format
+        ));
+}
+
+#[test]
+fn test_format_with_invalid_precision() {
+    let invalid_formats = vec!["%.-1f", "%.+1f", "%. 1f", "%.18446744073709551616f"];
+
+    for invalid_format in invalid_formats {
+        new_ucmd!()
+            .arg(format!("--format={}", invalid_format))
+            .fails()
+            .code_is(1)
+            .stderr_contains(format!("invalid precision in format '{}'", invalid_format));
+    }
+}
+
+#[test]
+fn test_format_grouping_conflicts_with_to_option() {
+    new_ucmd!()
+        .args(&["--format=%'f", "--to=si"])
+        .fails()
+        .code_is(1)
+        .stderr_contains("grouping cannot be combined with --to");
+}


### PR DESCRIPTION
This PR implements `--format`:

> Use printf-style floating FORMAT string. The format string must contain one ‘%f’ directive, optionally with ‘'’, ‘-’, ‘0’, width or precision modifiers. The ‘'’ modifier will enable --grouping, the ‘-’ modifier will enable left-aligned --padding and the width modifier will enable right-aligned --padding. The ‘0’ width modifier (without the ‘-’ modifier) will generate leading zeros on the number, up to the specified width.

While the parsing of the format string is fully implemented, the handling of the `'` modifier (grouping) is not implemented and hence has no effect on the output.

This PR makes all `precision`, `fmt`, and `fmt-err` (with the exception of `fmt-err-9` and `fmt-err-11`) tests in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.