### PR TITLE
numfmt: preserve trailing zeros

### DIFF
--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -78,7 +78,7 @@ impl RoundMethod {
 pub struct FormatOptions {
     pub grouping: bool,
     pub padding: Option<isize>,
-    pub precision: usize,
+    pub precision: Option<usize>,
     pub prefix: String,
     pub suffix: String,
     pub zero_padding: bool,
@@ -89,7 +89,7 @@ impl Default for FormatOptions {
         Self {
             grouping: false,
             padding: None,
-            precision: 0,
+            precision: None,
             prefix: String::from(""),
             suffix: String::from(""),
             zero_padding: false,
@@ -206,10 +206,12 @@ impl FromStr for FormatOptions {
 
             if !precision.is_empty() {
                 if let Ok(p) = precision.parse() {
-                    options.precision = p;
+                    options.precision = Some(p);
                 } else {
                     return Err(format!("invalid precision in format '{}'", s));
                 }
+            } else {
+                options.precision = Some(0);
             }
         }
 
@@ -302,10 +304,10 @@ mod tests {
     fn test_parse_format_with_precision() {
         let mut expected_options = FormatOptions::default();
         let formats = vec![
-            ("%6.2f", Some(6), 2),
-            ("%6.f", Some(6), 0),
-            ("%.2f", None, 2),
-            ("%.f", None, 0),
+            ("%6.2f", Some(6), Some(2)),
+            ("%6.f", Some(6), Some(0)),
+            ("%.2f", None, Some(2)),
+            ("%.f", None, Some(0)),
         ];
 
         for (format, expected_padding, expected_precision) in formats {

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -11,6 +11,14 @@ fn test_should_not_round_floats() {
 }
 
 #[test]
+fn test_should_preserve_trailing_zeros() {
+    new_ucmd!()
+        .args(&["0.1000", "10.00"])
+        .succeeds()
+        .stdout_is("0.1000\n10.00\n");
+}
+
+#[test]
 fn test_from_si() {
     new_ucmd!()
         .args(&["--from=si"])
@@ -820,6 +828,18 @@ fn test_format_with_precision_and_to_arg() {
             ])
             .succeeds()
             .stdout_is(format!("{}\n", expected));
+    }
+}
+
+#[test]
+fn test_format_preserve_trailing_zeros_if_no_precision_is_specified() {
+    let values = vec!["10.0", "0.0100"];
+
+    for value in values {
+        new_ucmd!()
+            .args(&["--format=%f", value])
+            .succeeds()
+            .stdout_is(format!("{}\n", value));
     }
 }
 


### PR DESCRIPTION
GNU numfmt preserves trailing zeros if no precision is specified. For example, `numfmt 10.00` returns `10.00`. uutils numfmt doesn't preserve trailing zeros and returns just `10`. This PR fixes this issue.