### PR TITLE
Replace deprecated is_present() with contains_id()

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -77,8 +77,8 @@ impl Config {
             .transpose()?;
 
         Ok(Self {
-            decode: options.is_present(options::DECODE),
-            ignore_garbage: options.is_present(options::IGNORE_GARBAGE),
+            decode: options.contains_id(options::DECODE),
+            ignore_garbage: options.contains_id(options::IGNORE_GARBAGE),
             wrap_cols: cols,
             to_read: file,
         })

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -54,13 +54,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     // too few arguments
-    if !matches.is_present(options::NAME) {
+    if !matches.contains_id(options::NAME) {
         return Err(UUsageError::new(1, "missing operand".to_string()));
     }
 
-    let opt_suffix = matches.is_present(options::SUFFIX);
-    let opt_multiple = matches.is_present(options::MULTIPLE);
-    let opt_zero = matches.is_present(options::ZERO);
+    let opt_suffix = matches.contains_id(options::SUFFIX);
+    let opt_multiple = matches.contains_id(options::MULTIPLE);
+    let opt_zero = matches.contains_id(options::ZERO);
     let multiple_paths = opt_suffix || opt_multiple;
     // too many arguments
     if !multiple_paths && matches.occurrences_of(options::NAME) > 2 {

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -58,7 +58,7 @@ fn parse_cmd_args(args: impl uucore::Args) -> UResult<(Config, Format)> {
         .with_exit_code(1)?;
     let format = ENCODINGS
         .iter()
-        .find(|encoding| matches.is_present(encoding.0))
+        .find(|encoding| matches.contains_id(encoding.0))
         .ok_or_else(|| UUsageError::new(BASE_CMD_PARSE_ERROR, "missing encoding type"))?
         .1;
     let config = Config::from(&matches)?;

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -190,9 +190,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().try_get_matches_from(args)?;
 
-    let number_mode = if matches.is_present(options::NUMBER_NONBLANK) {
+    let number_mode = if matches.contains_id(options::NUMBER_NONBLANK) {
         NumberingMode::NonEmpty
-    } else if matches.is_present(options::NUMBER) {
+    } else if matches.contains_id(options::NUMBER) {
         NumberingMode::All
     } else {
         NumberingMode::None
@@ -205,7 +205,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         options::SHOW_NONPRINTING.to_owned(),
     ]
     .iter()
-    .any(|v| matches.is_present(v));
+    .any(|v| matches.contains_id(v));
 
     let show_ends = vec![
         options::SHOW_ENDS.to_owned(),
@@ -213,7 +213,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         options::SHOW_NONPRINTING_ENDS.to_owned(),
     ]
     .iter()
-    .any(|v| matches.is_present(v));
+    .any(|v| matches.contains_id(v));
 
     let show_tabs = vec![
         options::SHOW_ALL.to_owned(),
@@ -221,9 +221,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         options::SHOW_NONPRINTING_TABS.to_owned(),
     ]
     .iter()
-    .any(|v| matches.is_present(v));
+    .any(|v| matches.contains_id(v));
 
-    let squeeze_blank = matches.is_present(options::SQUEEZE_BLANK);
+    let squeeze_blank = matches.contains_id(options::SQUEEZE_BLANK);
     let files: Vec<String> = match matches.values_of(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
         None => vec!["-".to_owned()],

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -315,11 +315,11 @@ struct Options {
 fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<Options> {
     let matches = config.try_get_matches_from(args)?;
 
-    let verbose = matches.is_present(options::VERBOSE);
+    let verbose = matches.contains_id(options::VERBOSE);
 
-    let (recursive_mode, affect_symlink_referent) = if matches.is_present(options::RECURSIVE) {
-        if matches.is_present(options::sym_links::FOLLOW_DIR_SYM_LINKS) {
-            if matches.is_present(options::dereference::NO_DEREFERENCE) {
+    let (recursive_mode, affect_symlink_referent) = if matches.contains_id(options::RECURSIVE) {
+        if matches.contains_id(options::sym_links::FOLLOW_DIR_SYM_LINKS) {
+            if matches.contains_id(options::dereference::NO_DEREFERENCE) {
                 return Err(Error::ArgumentsMismatch(format!(
                     "'--{}' with '--{}' require '-P'",
                     options::RECURSIVE,
@@ -328,8 +328,8 @@ fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<
             }
 
             (RecursiveMode::RecursiveAndFollowAllDirSymLinks, true)
-        } else if matches.is_present(options::sym_links::FOLLOW_ARG_DIR_SYM_LINK) {
-            if matches.is_present(options::dereference::NO_DEREFERENCE) {
+        } else if matches.contains_id(options::sym_links::FOLLOW_ARG_DIR_SYM_LINK) {
+            if matches.contains_id(options::dereference::NO_DEREFERENCE) {
                 return Err(Error::ArgumentsMismatch(format!(
                     "'--{}' with '--{}' require '-P'",
                     options::RECURSIVE,
@@ -339,7 +339,7 @@ fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<
 
             (RecursiveMode::RecursiveAndFollowArgDirSymLinks, true)
         } else {
-            if matches.is_present(options::dereference::DEREFERENCE) {
+            if matches.contains_id(options::dereference::DEREFERENCE) {
                 return Err(Error::ArgumentsMismatch(format!(
                     "'--{}' with '--{}' require either '-H' or '-L'",
                     options::RECURSIVE,
@@ -350,12 +350,12 @@ fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<
             (RecursiveMode::RecursiveButDoNotFollowSymLinks, false)
         }
     } else {
-        let no_dereference = matches.is_present(options::dereference::NO_DEREFERENCE);
+        let no_dereference = matches.contains_id(options::dereference::NO_DEREFERENCE);
         (RecursiveMode::NotRecursive, !no_dereference)
     };
 
     // By default, do not preserve root.
-    let preserve_root = matches.is_present(options::preserve_root::PRESERVE_ROOT);
+    let preserve_root = matches.contains_id(options::preserve_root::PRESERVE_ROOT);
 
     let mut files = matches.values_of_os("FILE").unwrap_or_default();
 
@@ -363,10 +363,10 @@ fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<
         CommandLineMode::ReferenceBased {
             reference: PathBuf::from(path),
         }
-    } else if matches.is_present(options::USER)
-        || matches.is_present(options::ROLE)
-        || matches.is_present(options::TYPE)
-        || matches.is_present(options::RANGE)
+    } else if matches.contains_id(options::USER)
+        || matches.contains_id(options::ROLE)
+        || matches.contains_id(options::TYPE)
+        || matches.contains_id(options::RANGE)
     {
         CommandLineMode::Custom {
             user: matches.value_of_os(options::USER).map(Into::into),

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -58,11 +58,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
-    let changes = matches.is_present(options::CHANGES);
-    let quiet = matches.is_present(options::QUIET);
-    let verbose = matches.is_present(options::VERBOSE);
-    let preserve_root = matches.is_present(options::PRESERVE_ROOT);
-    let recursive = matches.is_present(options::RECURSIVE);
+    let changes = matches.contains_id(options::CHANGES);
+    let quiet = matches.contains_id(options::QUIET);
+    let verbose = matches.contains_id(options::VERBOSE);
+    let preserve_root = matches.contains_id(options::PRESERVE_ROOT);
+    let recursive = matches.contains_id(options::RECURSIVE);
     let fmode = match matches.value_of(options::REFERENCE) {
         Some(fref) => match fs::metadata(fref) {
             Ok(meta) => Some(meta.mode()),

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -38,10 +38,10 @@ fn mkdelim(col: usize, opts: &ArgMatches) -> String {
         delim => delim,
     };
 
-    if col > 1 && !opts.is_present(options::COLUMN_1) {
+    if col > 1 && !opts.contains_id(options::COLUMN_1) {
         s.push_str(delim.as_ref());
     }
-    if col > 2 && !opts.is_present(options::COLUMN_2) {
+    if col > 2 && !opts.contains_id(options::COLUMN_2) {
         s.push_str(delim.as_ref());
     }
 
@@ -91,7 +91,7 @@ fn comm(a: &mut LineReader, b: &mut LineReader, opts: &ArgMatches) {
 
         match ord {
             Ordering::Less => {
-                if !opts.is_present(options::COLUMN_1) {
+                if !opts.contains_id(options::COLUMN_1) {
                     ensure_nl(ra);
                     print!("{}{}", delim[1], ra);
                 }
@@ -99,7 +99,7 @@ fn comm(a: &mut LineReader, b: &mut LineReader, opts: &ArgMatches) {
                 na = a.read_line(ra);
             }
             Ordering::Greater => {
-                if !opts.is_present(options::COLUMN_2) {
+                if !opts.contains_id(options::COLUMN_2) {
                     ensure_nl(rb);
                     print!("{}{}", delim[2], rb);
                 }
@@ -107,7 +107,7 @@ fn comm(a: &mut LineReader, b: &mut LineReader, opts: &ArgMatches) {
                 nb = b.read_line(rb);
             }
             Ordering::Equal => {
-                if !opts.is_present(options::COLUMN_3) {
+                if !opts.contains_id(options::COLUMN_3) {
                     ensure_nl(ra);
                     print!("{}{}", delim[3], ra);
                 }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -517,9 +517,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 impl ClobberMode {
     fn from_matches(matches: &ArgMatches) -> Self {
-        if matches.is_present(options::FORCE) {
+        if matches.contains_id(options::FORCE) {
             Self::Force
-        } else if matches.is_present(options::REMOVE_DESTINATION) {
+        } else if matches.contains_id(options::REMOVE_DESTINATION) {
             Self::RemoveDestination
         } else {
             Self::Standard
@@ -529,9 +529,9 @@ impl ClobberMode {
 
 impl OverwriteMode {
     fn from_matches(matches: &ArgMatches) -> Self {
-        if matches.is_present(options::INTERACTIVE) {
+        if matches.contains_id(options::INTERACTIVE) {
             Self::Interactive(ClobberMode::from_matches(matches))
-        } else if matches.is_present(options::NO_CLOBBER) {
+        } else if matches.contains_id(options::NO_CLOBBER) {
             Self::NoClobber
         } else {
             Self::Clobber(ClobberMode::from_matches(matches))
@@ -541,15 +541,15 @@ impl OverwriteMode {
 
 impl CopyMode {
     fn from_matches(matches: &ArgMatches) -> Self {
-        if matches.is_present(options::LINK) {
+        if matches.contains_id(options::LINK) {
             Self::Link
-        } else if matches.is_present(options::SYMBOLIC_LINK) {
+        } else if matches.contains_id(options::SYMBOLIC_LINK) {
             Self::SymLink
-        } else if matches.is_present(options::SPARSE) {
+        } else if matches.contains_id(options::SPARSE) {
             Self::Sparse
-        } else if matches.is_present(options::UPDATE) {
+        } else if matches.contains_id(options::UPDATE) {
             Self::Update
-        } else if matches.is_present(options::ATTRIBUTES_ONLY) {
+        } else if matches.contains_id(options::ATTRIBUTES_ONLY) {
             Self::AttrOnly
         } else {
             Self::Copy
@@ -610,14 +610,14 @@ impl Options {
         ];
 
         for not_implemented_opt in not_implemented_opts {
-            if matches.is_present(not_implemented_opt) {
+            if matches.contains_id(not_implemented_opt) {
                 return Err(Error::NotImplemented(not_implemented_opt.to_string()));
             }
         }
 
-        let recursive = matches.is_present(options::RECURSIVE)
-            || matches.is_present(options::RECURSIVE_ALIAS)
-            || matches.is_present(options::ARCHIVE);
+        let recursive = matches.contains_id(options::RECURSIVE)
+            || matches.contains_id(options::RECURSIVE_ALIAS)
+            || matches.contains_id(options::ARCHIVE);
 
         let backup_mode = match backup_control::determine_backup_mode(matches) {
             Err(e) => return Err(Error::Backup(format!("{}", e))),
@@ -629,13 +629,13 @@ impl Options {
         let overwrite = OverwriteMode::from_matches(matches);
 
         // Parse target directory options
-        let no_target_dir = matches.is_present(options::NO_TARGET_DIRECTORY);
+        let no_target_dir = matches.contains_id(options::NO_TARGET_DIRECTORY);
         let target_dir = matches
             .value_of(options::TARGET_DIRECTORY)
             .map(ToString::to_string);
 
         // Parse attributes to preserve
-        let mut preserve_attributes: Vec<Attribute> = if matches.is_present(options::PRESERVE) {
+        let mut preserve_attributes: Vec<Attribute> = if matches.contains_id(options::PRESERVE) {
             match matches.values_of(options::PRESERVE) {
                 None => DEFAULT_ATTRIBUTES.to_vec(),
                 Some(attribute_strs) => {
@@ -651,12 +651,12 @@ impl Options {
                     attributes
                 }
             }
-        } else if matches.is_present(options::ARCHIVE) {
+        } else if matches.contains_id(options::ARCHIVE) {
             // --archive is used. Same as --preserve=all
             add_all_attributes()
-        } else if matches.is_present(options::NO_DEREFERENCE_PRESERVE_LINKS) {
+        } else if matches.contains_id(options::NO_DEREFERENCE_PRESERVE_LINKS) {
             vec![Attribute::Links]
-        } else if matches.is_present(options::PRESERVE_DEFAULT_ATTRIBUTES) {
+        } else if matches.contains_id(options::PRESERVE_DEFAULT_ATTRIBUTES) {
             DEFAULT_ATTRIBUTES.to_vec()
         } else {
             vec![]
@@ -668,20 +668,20 @@ impl Options {
         preserve_attributes.sort_unstable();
 
         let options = Self {
-            attributes_only: matches.is_present(options::ATTRIBUTES_ONLY),
-            copy_contents: matches.is_present(options::COPY_CONTENTS),
+            attributes_only: matches.contains_id(options::ATTRIBUTES_ONLY),
+            copy_contents: matches.contains_id(options::COPY_CONTENTS),
             copy_mode: CopyMode::from_matches(matches),
             // No dereference is set with -p, -d and --archive
-            dereference: !(matches.is_present(options::NO_DEREFERENCE)
-                || matches.is_present(options::NO_DEREFERENCE_PRESERVE_LINKS)
-                || matches.is_present(options::ARCHIVE)
+            dereference: !(matches.contains_id(options::NO_DEREFERENCE)
+                || matches.contains_id(options::NO_DEREFERENCE_PRESERVE_LINKS)
+                || matches.contains_id(options::ARCHIVE)
                 || recursive)
-                || matches.is_present(options::DEREFERENCE),
-            one_file_system: matches.is_present(options::ONE_FILE_SYSTEM),
-            parents: matches.is_present(options::PARENTS),
-            update: matches.is_present(options::UPDATE),
-            verbose: matches.is_present(options::VERBOSE),
-            strip_trailing_slashes: matches.is_present(options::STRIP_TRAILING_SLASHES),
+                || matches.contains_id(options::DEREFERENCE),
+            one_file_system: matches.contains_id(options::ONE_FILE_SYSTEM),
+            parents: matches.contains_id(options::PARENTS),
+            update: matches.contains_id(options::UPDATE),
+            verbose: matches.contains_id(options::VERBOSE),
+            strip_trailing_slashes: matches.contains_id(options::STRIP_TRAILING_SLASHES),
             reflink_mode: {
                 if let Some(reflink) = matches.value_of(options::REFLINK) {
                     match reflink {

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -52,10 +52,10 @@ pub struct CsplitOptions {
 
 impl CsplitOptions {
     fn new(matches: &ArgMatches) -> Self {
-        let keep_files = matches.is_present(options::KEEP_FILES);
-        let quiet = matches.is_present(options::QUIET);
-        let elide_empty_files = matches.is_present(options::ELIDE_EMPTY_FILES);
-        let suppress_matched = matches.is_present(options::SUPPRESS_MATCHED);
+        let keep_files = matches.contains_id(options::KEEP_FILES);
+        let quiet = matches.contains_id(options::QUIET);
+        let elide_empty_files = matches.contains_id(options::ELIDE_EMPTY_FILES);
+        let suppress_matched = matches.contains_id(options::SUPPRESS_MATCHED);
 
         Self {
             split_name: crash_if_err!(

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -405,7 +405,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let delimiter_is_equal = args.contains(&"-d=".to_string()); // special case
     let matches = uu_app().get_matches_from(args);
 
-    let complement = matches.is_present(options::COMPLEMENT);
+    let complement = matches.contains_id(options::COMPLEMENT);
 
     let mode_parse = match (
         matches.value_of(options::BYTES),
@@ -422,7 +422,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                             .unwrap_or_default()
                             .to_owned(),
                     ),
-                    zero_terminated: matches.is_present(options::ZERO_TERMINATED),
+                    zero_terminated: matches.contains_id(options::ZERO_TERMINATED),
                 },
             )
         }),
@@ -436,7 +436,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                             .unwrap_or_default()
                             .to_owned(),
                     ),
-                    zero_terminated: matches.is_present(options::ZERO_TERMINATED),
+                    zero_terminated: matches.contains_id(options::ZERO_TERMINATED),
                 },
             )
         }),
@@ -453,8 +453,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     None => None,
                 };
 
-                let only_delimited = matches.is_present(options::ONLY_DELIMITED);
-                let zero_terminated = matches.is_present(options::ZERO_TERMINATED);
+                let only_delimited = matches.contains_id(options::ONLY_DELIMITED);
+                let zero_terminated = matches.contains_id(options::ZERO_TERMINATED);
 
                 match matches.value_of(options::DELIMITER) {
                     Some(mut delim) => {
@@ -509,12 +509,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         Err(_) => mode_parse,
         Ok(mode) => match mode {
             Mode::Bytes(_, _) | Mode::Characters(_, _)
-                if matches.is_present(options::DELIMITER) =>
+                if matches.contains_id(options::DELIMITER) =>
             {
                 Err("invalid input: The '--delimiter' ('-d') option only usable if printing a sequence of fields".into())
             }
             Mode::Bytes(_, _) | Mode::Characters(_, _)
-                if matches.is_present(options::ONLY_DELIMITED) =>
+                if matches.contains_id(options::ONLY_DELIMITED) =>
             {
                 Err("invalid input: The '--only-delimited' ('-s') option only usable if printing a sequence of fields".into())
             }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -160,7 +160,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(|mut iter| iter.next().unwrap_or(DATE).into())
     {
         Format::Iso8601(fmt)
-    } else if matches.is_present(OPT_RFC_EMAIL) {
+    } else if matches.contains_id(OPT_RFC_EMAIL) {
         Format::Rfc5322
     } else if let Some(fmt) = matches.value_of(OPT_RFC_3339).map(Into::into) {
         Format::Rfc3339(fmt)
@@ -188,7 +188,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let settings = Settings {
-        utc: matches.is_present(OPT_UNIVERSAL),
+        utc: matches.contains_id(OPT_UNIVERSAL),
         format,
         date_source,
         set_to,

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -716,8 +716,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .get_matches_from(dashed_args);
 
     match (
-        matches.is_present(options::INFILE),
-        matches.is_present(options::OUTFILE),
+        matches.contains_id(options::INFILE),
+        matches.contains_id(options::OUTFILE),
     ) {
         (true, true) => {
             let i = Input::<File>::new(&matches)?;

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -163,7 +163,7 @@ impl Default for BlockSize {
 }
 
 pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSizeError> {
-    if matches.is_present(OPT_BLOCKSIZE) {
+    if matches.contains_id(OPT_BLOCKSIZE) {
         let s = matches.value_of(OPT_BLOCKSIZE).unwrap();
         let bytes = parse_size(s)?;
 
@@ -172,7 +172,7 @@ pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSi
         } else {
             Err(ParseSizeError::ParseFailure(format!("{}", s.quote())))
         }
-    } else if matches.is_present(OPT_PORTABILITY) {
+    } else if matches.contains_id(OPT_PORTABILITY) {
         Ok(BlockSize::default())
     } else if let Some(bytes) = block_size_from_env() {
         Ok(BlockSize::Bytes(bytes))

--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -75,8 +75,8 @@ impl Column {
     /// than once in the command-line argument.
     pub(crate) fn from_matches(matches: &ArgMatches) -> Result<Vec<Self>, ColumnError> {
         match (
-            matches.is_present(OPT_PRINT_TYPE),
-            matches.is_present(OPT_INODES),
+            matches.contains_id(OPT_PRINT_TYPE),
+            matches.contains_id(OPT_INODES),
             matches.occurrences_of(OPT_OUTPUT) > 0,
         ) {
             (false, false, false) => Ok(vec![

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -181,9 +181,9 @@ impl Options {
         }
 
         Ok(Self {
-            show_local_fs: matches.is_present(OPT_LOCAL),
-            show_all_fs: matches.is_present(OPT_ALL),
-            sync: matches.is_present(OPT_SYNC),
+            show_local_fs: matches.contains_id(OPT_LOCAL),
+            show_all_fs: matches.contains_id(OPT_ALL),
+            sync: matches.contains_id(OPT_SYNC),
             block_size: read_block_size(matches).map_err(|e| match e {
                 ParseSizeError::InvalidSuffix(s) => OptionsError::InvalidSuffix(s),
                 ParseSizeError::SizeTooBig(_) => OptionsError::BlockSizeTooLarge(
@@ -192,13 +192,13 @@ impl Options {
                 ParseSizeError::ParseFailure(s) => OptionsError::InvalidBlockSize(s),
             })?,
             header_mode: {
-                if matches.is_present(OPT_HUMAN_READABLE_BINARY)
-                    || matches.is_present(OPT_HUMAN_READABLE_DECIMAL)
+                if matches.contains_id(OPT_HUMAN_READABLE_BINARY)
+                    || matches.contains_id(OPT_HUMAN_READABLE_DECIMAL)
                 {
                     HeaderMode::HumanReadable
-                } else if matches.is_present(OPT_PORTABILITY) {
+                } else if matches.contains_id(OPT_PORTABILITY) {
                     HeaderMode::PosixPortability
-                // is_present() doesn't work here, it always returns true because OPT_OUTPUT has
+                // contains_id() doesn't work here, it always returns true because OPT_OUTPUT has
                 // default values and hence is always present
                 } else if matches.occurrences_of(OPT_OUTPUT) > 0 {
                     HeaderMode::Output
@@ -207,9 +207,9 @@ impl Options {
                 }
             },
             human_readable: {
-                if matches.is_present(OPT_HUMAN_READABLE_BINARY) {
+                if matches.contains_id(OPT_HUMAN_READABLE_BINARY) {
                     Some(HumanReadable::Binary)
-                } else if matches.is_present(OPT_HUMAN_READABLE_DECIMAL) {
+                } else if matches.contains_id(OPT_HUMAN_READABLE_DECIMAL) {
                     Some(HumanReadable::Decimal)
                 } else {
                     None
@@ -217,7 +217,7 @@ impl Options {
             },
             include,
             exclude,
-            show_total: matches.is_present(OPT_TOTAL),
+            show_total: matches.contains_id(OPT_TOTAL),
             columns: Column::from_matches(matches).map_err(OptionsError::ColumnError)?,
         })
     }
@@ -434,7 +434,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     #[cfg(windows)]
     {
-        if matches.is_present(OPT_INODES) {
+        if matches.contains_id(OPT_INODES) {
             println!("{}: doesn't support -i option", uucore::util_name());
             return Ok(());
         }

--- a/src/uu/dir/src/dir.rs
+++ b/src/uu/dir/src/dir.rs
@@ -23,22 +23,22 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // We check if any options on formatting or quoting style have been given.
     // If not, we will use dir default formatting and quoting style options
 
-    if !matches.is_present(options::QUOTING_STYLE)
-        && !matches.is_present(options::quoting::C)
-        && !matches.is_present(options::quoting::ESCAPE)
-        && !matches.is_present(options::quoting::LITERAL)
+    if !matches.contains_id(options::QUOTING_STYLE)
+        && !matches.contains_id(options::quoting::C)
+        && !matches.contains_id(options::quoting::ESCAPE)
+        && !matches.contains_id(options::quoting::LITERAL)
     {
         default_quoting_style = true;
     }
-    if !matches.is_present(options::FORMAT)
-        && !matches.is_present(options::format::ACROSS)
-        && !matches.is_present(options::format::COLUMNS)
-        && !matches.is_present(options::format::COMMAS)
-        && !matches.is_present(options::format::LONG)
-        && !matches.is_present(options::format::LONG_NO_GROUP)
-        && !matches.is_present(options::format::LONG_NO_OWNER)
-        && !matches.is_present(options::format::LONG_NUMERIC_UID_GID)
-        && !matches.is_present(options::format::ONE_LINE)
+    if !matches.contains_id(options::FORMAT)
+        && !matches.contains_id(options::format::ACROSS)
+        && !matches.contains_id(options::format::COLUMNS)
+        && !matches.contains_id(options::format::COMMAS)
+        && !matches.contains_id(options::format::LONG)
+        && !matches.contains_id(options::format::LONG_NO_GROUP)
+        && !matches.contains_id(options::format::LONG_NO_OWNER)
+        && !matches.contains_id(options::format::LONG_NUMERIC_UID_GID)
+        && !matches.contains_id(options::format::ONE_LINE)
     {
         default_format_style = true;
     }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -77,9 +77,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // clap provides .conflicts_with / .conflicts_with_all, but we want to
     // manually handle conflicts so we can match the output of GNU coreutils
-    if (matches.is_present(options::C_SHELL) || matches.is_present(options::BOURNE_SHELL))
-        && (matches.is_present(options::PRINT_DATABASE)
-            || matches.is_present(options::PRINT_LS_COLORS))
+    if (matches.contains_id(options::C_SHELL) || matches.contains_id(options::BOURNE_SHELL))
+        && (matches.contains_id(options::PRINT_DATABASE)
+            || matches.contains_id(options::PRINT_LS_COLORS))
     {
         return Err(UUsageError::new(
             1,
@@ -88,14 +88,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    if matches.is_present(options::PRINT_DATABASE) && matches.is_present(options::PRINT_LS_COLORS) {
+    if matches.contains_id(options::PRINT_DATABASE) && matches.contains_id(options::PRINT_LS_COLORS)
+    {
         return Err(UUsageError::new(
             1,
             "options --print-database and --print-ls-colors are mutually exclusive",
         ));
     }
 
-    if matches.is_present(options::PRINT_DATABASE) {
+    if matches.contains_id(options::PRINT_DATABASE) {
         if !files.is_empty() {
             return Err(UUsageError::new(
                 1,
@@ -110,11 +111,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     }
 
-    let mut out_format = if matches.is_present(options::C_SHELL) {
+    let mut out_format = if matches.contains_id(options::C_SHELL) {
         OutputFmt::CShell
-    } else if matches.is_present(options::BOURNE_SHELL) {
+    } else if matches.contains_id(options::BOURNE_SHELL) {
         OutputFmt::Shell
-    } else if matches.is_present(options::PRINT_LS_COLORS) {
+    } else if matches.contains_id(options::PRINT_LS_COLORS) {
         OutputFmt::Display
     } else {
         OutputFmt::Unknown

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -36,7 +36,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
-    let separator = if matches.is_present(options::ZERO) {
+    let separator = if matches.contains_id(options::ZERO) {
         "\0"
     } else {
         "\n"

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -282,9 +282,9 @@ fn read_block_size(s: Option<&str>) -> u64 {
 }
 
 fn choose_size(matches: &ArgMatches, stat: &Stat) -> u64 {
-    if matches.is_present(options::INODES) {
+    if matches.contains_id(options::INODES) {
         stat.inodes
-    } else if matches.is_present(options::APPARENT_SIZE) || matches.is_present(options::BYTES) {
+    } else if matches.contains_id(options::APPARENT_SIZE) || matches.contains_id(options::BYTES) {
         stat.size
     } else {
         // The st_blocks field indicates the number of blocks allocated to the file, 512-byte units.
@@ -489,7 +489,7 @@ fn file_as_vec(filename: impl AsRef<Path>) -> Vec<String> {
 // Given the --exclude-from and/or --exclude arguments, returns the globset lists
 // to ignore the files
 fn get_glob_ignore(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
-    let mut excludes_from = if matches.is_present(options::EXCLUDE_FROM) {
+    let mut excludes_from = if matches.contains_id(options::EXCLUDE_FROM) {
         match matches.values_of(options::EXCLUDE_FROM) {
             Some(all_files) => {
                 let mut exclusion = Vec::<String>::new();
@@ -507,7 +507,7 @@ fn get_glob_ignore(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
         Vec::<String>::new()
     };
 
-    let mut excludes = if matches.is_present(options::EXCLUDE) {
+    let mut excludes = if matches.contains_id(options::EXCLUDE) {
         match matches.values_of(options::EXCLUDE) {
             Some(v) => {
                 // Read the various arguments
@@ -525,7 +525,7 @@ fn get_glob_ignore(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
         let mut builder = Vec::new();
         // Create the `Vec` of excludes
         for f in excludes {
-            if matches.is_present(options::VERBOSE) {
+            if matches.contains_id(options::VERBOSE) {
                 println!("adding {:?} to the exclude list ", &f);
             }
             match Pattern::new(&f) {
@@ -548,19 +548,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    let summarize = matches.is_present(options::SUMMARIZE);
+    let summarize = matches.contains_id(options::SUMMARIZE);
 
     let max_depth = parse_depth(matches.value_of(options::MAX_DEPTH), summarize)?;
 
     let options = Options {
-        all: matches.is_present(options::ALL),
+        all: matches.contains_id(options::ALL),
         max_depth,
-        total: matches.is_present(options::TOTAL),
-        separate_dirs: matches.is_present(options::SEPARATE_DIRS),
-        one_file_system: matches.is_present(options::ONE_FILE_SYSTEM),
-        dereference: matches.is_present(options::DEREFERENCE),
-        inodes: matches.is_present(options::INODES),
-        verbose: matches.is_present(options::VERBOSE),
+        total: matches.contains_id(options::TOTAL),
+        separate_dirs: matches.contains_id(options::SEPARATE_DIRS),
+        one_file_system: matches.contains_id(options::ONE_FILE_SYSTEM),
+        dereference: matches.contains_id(options::DEREFERENCE),
+        inodes: matches.contains_id(options::INODES),
+        verbose: matches.contains_id(options::VERBOSE),
     };
 
     let files = match matches.value_of(options::FILE) {
@@ -569,7 +569,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     if options.inodes
-        && (matches.is_present(options::APPARENT_SIZE) || matches.is_present(options::BYTES))
+        && (matches.contains_id(options::APPARENT_SIZE) || matches.contains_id(options::BYTES))
     {
         show_warning!("options --apparent-size and -b are ineffective with --inodes");
     }
@@ -581,19 +581,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .unwrap_or_else(|e| crash!(1, "{}", format_error_message(&e, s, options::THRESHOLD)))
     });
 
-    let multiplier: u64 = if matches.is_present(options::SI) {
+    let multiplier: u64 = if matches.contains_id(options::SI) {
         1000
     } else {
         1024
     };
     let convert_size_fn = {
-        if matches.is_present(options::HUMAN_READABLE) || matches.is_present(options::SI) {
+        if matches.contains_id(options::HUMAN_READABLE) || matches.contains_id(options::SI) {
             convert_size_human
-        } else if matches.is_present(options::BYTES) {
+        } else if matches.contains_id(options::BYTES) {
             convert_size_b
-        } else if matches.is_present(options::BLOCK_SIZE_1K) {
+        } else if matches.contains_id(options::BLOCK_SIZE_1K) {
             convert_size_k
-        } else if matches.is_present(options::BLOCK_SIZE_1M) {
+        } else if matches.contains_id(options::BLOCK_SIZE_1M) {
             convert_size_m
         } else {
             convert_size_other
@@ -609,7 +609,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let time_format_str = parse_time_style(matches.value_of("time-style"))?;
 
-    let line_separator = if matches.is_present(options::NULL) {
+    let line_separator = if matches.contains_id(options::NULL) {
         "\0"
     } else {
         "\n"
@@ -651,7 +651,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         continue;
                     }
 
-                    if matches.is_present(options::TIME) {
+                    if matches.contains_id(options::TIME) {
                         let tm = {
                             let secs = {
                                 match matches.value_of(options::TIME) {

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -115,8 +115,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .accept_any();
     let matches = uu_app().get_matches_from(args);
 
-    let no_newline = matches.is_present(options::NO_NEWLINE);
-    let escaped = matches.is_present(options::ENABLE_BACKSLASH_ESCAPE);
+    let no_newline = matches.contains_id(options::NO_NEWLINE);
+    let escaped = matches.contains_id(options::ENABLE_BACKSLASH_ESCAPE);
     let values: Vec<String> = match matches.values_of(options::STRING) {
         Some(s) => s.map(|s| s.to_string()).collect(),
         None => vec!["".to_string()],

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -175,8 +175,8 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
     let app = uu_app();
     let matches = app.get_matches_from(args);
 
-    let ignore_env = matches.is_present("ignore-environment");
-    let null = matches.is_present("null");
+    let ignore_env = matches.contains_id("ignore-environment");
+    let null = matches.contains_id("null");
     let running_directory = matches.value_of("chdir");
     let files = matches
         .values_of("file")

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -216,8 +216,8 @@ impl Options {
             None => (RemainingMode::None, vec![DEFAULT_TABSTOP]),
         };
 
-        let iflag = matches.is_present(options::INITIAL);
-        let uflag = !matches.is_present(options::NO_UTF8);
+        let iflag = matches.contains_id(options::INITIAL);
+        let uflag = !matches.contains_id(options::NO_UTF8);
 
         // avoid allocations when dumping out long sequences of spaces
         // by precomputing the longest string of spaces we will ever need

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -92,21 +92,21 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         tabwidth: 8,
     };
 
-    fmt_opts.tagged = matches.is_present(OPT_TAGGED_PARAGRAPH);
-    if matches.is_present(OPT_CROWN_MARGIN) {
+    fmt_opts.tagged = matches.contains_id(OPT_TAGGED_PARAGRAPH);
+    if matches.contains_id(OPT_CROWN_MARGIN) {
         fmt_opts.crown = true;
         fmt_opts.tagged = false;
     }
-    fmt_opts.mail = matches.is_present(OPT_PRESERVE_HEADERS);
-    fmt_opts.uniform = matches.is_present(OPT_UNIFORM_SPACING);
-    fmt_opts.quick = matches.is_present(OPT_QUICK);
-    if matches.is_present(OPT_SPLIT_ONLY) {
+    fmt_opts.mail = matches.contains_id(OPT_PRESERVE_HEADERS);
+    fmt_opts.uniform = matches.contains_id(OPT_UNIFORM_SPACING);
+    fmt_opts.quick = matches.contains_id(OPT_QUICK);
+    if matches.contains_id(OPT_SPLIT_ONLY) {
         fmt_opts.split_only = true;
         fmt_opts.crown = false;
         fmt_opts.tagged = false;
     }
-    fmt_opts.xprefix = matches.is_present(OPT_EXACT_PREFIX);
-    fmt_opts.xanti_prefix = matches.is_present(OPT_SKIP_PREFIX);
+    fmt_opts.xprefix = matches.contains_id(OPT_EXACT_PREFIX);
+    fmt_opts.xanti_prefix = matches.contains_id(OPT_SKIP_PREFIX);
 
     if let Some(s) = matches.value_of(OPT_PREFIX).map(String::from) {
         fmt_opts.prefix = s;
@@ -150,7 +150,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 ));
             }
         };
-        if !matches.is_present(OPT_WIDTH) {
+        if !matches.contains_id(OPT_WIDTH) {
             fmt_opts.width = cmp::max(fmt_opts.goal * 100 / 94, fmt_opts.goal + 3);
         } else if fmt_opts.goal > fmt_opts.width {
             return Err(USimpleError::new(1, "GOAL cannot be greater than WIDTH."));

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -38,8 +38,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let (args, obs_width) = handle_obsolete(&args[..]);
     let matches = uu_app().get_matches_from(args);
 
-    let bytes = matches.is_present(options::BYTES);
-    let spaces = matches.is_present(options::SPACES);
+    let bytes = matches.contains_id(options::BYTES);
+    let spaces = matches.contains_id(options::SPACES);
     let poss_width = match matches.value_of(options::WIDTH) {
         Some(v) => Some(v.to_owned()),
         None => obs_width,

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -161,31 +161,31 @@ fn detect_algo(
                     alg = Some(val);
                     output_bits = bits;
                 };
-                if matches.is_present("md5") {
+                if matches.contains_id("md5") {
                     set_or_crash("MD5", Box::new(Md5::new()), 128);
                 }
-                if matches.is_present("sha1") {
+                if matches.contains_id("sha1") {
                     set_or_crash("SHA1", Box::new(Sha1::new()), 160);
                 }
-                if matches.is_present("sha224") {
+                if matches.contains_id("sha224") {
                     set_or_crash("SHA224", Box::new(Sha224::new()), 224);
                 }
-                if matches.is_present("sha256") {
+                if matches.contains_id("sha256") {
                     set_or_crash("SHA256", Box::new(Sha256::new()), 256);
                 }
-                if matches.is_present("sha384") {
+                if matches.contains_id("sha384") {
                     set_or_crash("SHA384", Box::new(Sha384::new()), 384);
                 }
-                if matches.is_present("sha512") {
+                if matches.contains_id("sha512") {
                     set_or_crash("SHA512", Box::new(Sha512::new()), 512);
                 }
-                if matches.is_present("b2sum") {
+                if matches.contains_id("b2sum") {
                     set_or_crash("BLAKE2", Box::new(blake2b_simd::State::new()), 512);
                 }
-                if matches.is_present("b3sum") {
+                if matches.contains_id("b3sum") {
                     set_or_crash("BLAKE3", Box::new(blake3::Hasher::new()), 256);
                 }
-                if matches.is_present("sha3") {
+                if matches.contains_id("sha3") {
                     match matches.value_of("bits") {
                         Some(bits_str) => match (bits_str).parse::<usize>() {
                             Ok(224) => set_or_crash(
@@ -217,19 +217,19 @@ fn detect_algo(
                         None => crash!(1, "--bits required for SHA3"),
                     }
                 }
-                if matches.is_present("sha3-224") {
+                if matches.contains_id("sha3-224") {
                     set_or_crash("SHA3-224", Box::new(Sha3_224::new()), 224);
                 }
-                if matches.is_present("sha3-256") {
+                if matches.contains_id("sha3-256") {
                     set_or_crash("SHA3-256", Box::new(Sha3_256::new()), 256);
                 }
-                if matches.is_present("sha3-384") {
+                if matches.contains_id("sha3-384") {
                     set_or_crash("SHA3-384", Box::new(Sha3_384::new()), 384);
                 }
-                if matches.is_present("sha3-512") {
+                if matches.contains_id("sha3-512") {
                     set_or_crash("SHA3-512", Box::new(Sha3_512::new()), 512);
                 }
-                if matches.is_present("shake128") {
+                if matches.contains_id("shake128") {
                     match matches.value_of("bits") {
                         Some(bits_str) => match (bits_str).parse::<usize>() {
                             Ok(bits) => set_or_crash("SHAKE128", Box::new(Shake128::new()), bits),
@@ -238,7 +238,7 @@ fn detect_algo(
                         None => crash!(1, "--bits required for SHAKE-128"),
                     }
                 }
-                if matches.is_present("shake256") {
+                if matches.contains_id("shake256") {
                     match matches.value_of("bits") {
                         Some(bits_str) => match (bits_str).parse::<usize>() {
                             Ok(bits) => set_or_crash("SHAKE256", Box::new(Shake256::new()), bits),
@@ -287,20 +287,20 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
 
     let (name, algo, bits) = detect_algo(&binary_name, &matches);
 
-    let binary = if matches.is_present("binary") {
+    let binary = if matches.contains_id("binary") {
         true
-    } else if matches.is_present("text") {
+    } else if matches.contains_id("text") {
         false
     } else {
         binary_flag_default
     };
-    let check = matches.is_present("check");
-    let tag = matches.is_present("tag");
-    let nonames = matches.is_present("no-names");
-    let status = matches.is_present("status");
-    let quiet = matches.is_present("quiet") || status;
-    let strict = matches.is_present("strict");
-    let warn = matches.is_present("warn") && !status;
+    let check = matches.contains_id("check");
+    let tag = matches.contains_id("tag");
+    let nonames = matches.contains_id("no-names");
+    let status = matches.contains_id("status");
+    let quiet = matches.contains_id("quiet") || status;
+    let strict = matches.contains_id("strict");
+    let warn = matches.contains_id("warn") && !status;
 
     let opts = Options {
         algoname: name,

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -195,10 +195,10 @@ impl HeadOptions {
 
         let mut options = Self::default();
 
-        options.quiet = matches.is_present(options::QUIET_NAME);
-        options.verbose = matches.is_present(options::VERBOSE_NAME);
-        options.zeroed = matches.is_present(options::ZERO_NAME);
-        options.presume_input_pipe = matches.is_present(options::PRESUME_INPUT_PIPE);
+        options.quiet = matches.contains_id(options::QUIET_NAME);
+        options.verbose = matches.contains_id(options::VERBOSE_NAME);
+        options.zeroed = matches.contains_id(options::ZERO_NAME);
+        options.presume_input_pipe = matches.contains_id(options::PRESUME_INPUT_PIPE);
 
         options.mode = Mode::from(&matches)?;
 

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -118,7 +118,7 @@ fn display_hostname(matches: &ArgMatches) -> UResult<()> {
         .to_string_lossy()
         .into_owned();
 
-    if matches.is_present(OPT_IP_ADDRESS) {
+    if matches.contains_id(OPT_IP_ADDRESS) {
         // XXX: to_socket_addrs needs hostname:port so append a dummy port and remove it later.
         // This was originally supposed to use std::net::lookup_host, but that seems to be
         // deprecated.  Perhaps we should use the dns-lookup crate?
@@ -148,10 +148,10 @@ fn display_hostname(matches: &ArgMatches) -> UResult<()> {
 
         Ok(())
     } else {
-        if matches.is_present(OPT_SHORT) || matches.is_present(OPT_DOMAIN) {
+        if matches.contains_id(OPT_SHORT) || matches.contains_id(OPT_DOMAIN) {
             let mut it = hostname.char_indices().filter(|&ci| ci.1 == '.');
             if let Some(ci) = it.next() {
-                if matches.is_present(OPT_SHORT) {
+                if matches.contains_id(OPT_SHORT) {
                     println!("{}", &hostname[0..ci.0]);
                 } else {
                     println!("{}", &hostname[ci.0 + 1..]);

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -136,13 +136,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .unwrap_or_default();
 
     let mut state = State {
-        nflag: matches.is_present(options::OPT_NAME),
-        uflag: matches.is_present(options::OPT_EFFECTIVE_USER),
-        gflag: matches.is_present(options::OPT_GROUP),
-        gsflag: matches.is_present(options::OPT_GROUPS),
-        rflag: matches.is_present(options::OPT_REAL_ID),
-        zflag: matches.is_present(options::OPT_ZERO),
-        cflag: matches.is_present(options::OPT_CONTEXT),
+        nflag: matches.contains_id(options::OPT_NAME),
+        uflag: matches.contains_id(options::OPT_EFFECTIVE_USER),
+        gflag: matches.contains_id(options::OPT_GROUP),
+        gsflag: matches.contains_id(options::OPT_GROUPS),
+        rflag: matches.contains_id(options::OPT_REAL_ID),
+        zflag: matches.contains_id(options::OPT_ZERO),
+        cflag: matches.contains_id(options::OPT_CONTEXT),
 
         selinux_supported: {
             #[cfg(feature = "selinux")]
@@ -237,17 +237,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         };
 
         // GNU's `id` does not support the flags: -p/-P/-A.
-        if matches.is_present(options::OPT_PASSWORD) {
+        if matches.contains_id(options::OPT_PASSWORD) {
             // BSD's `id` ignores all but the first specified user
             pline(possible_pw.as_ref().map(|v| v.uid));
             return Ok(());
         };
-        if matches.is_present(options::OPT_HUMAN_READABLE) {
+        if matches.contains_id(options::OPT_HUMAN_READABLE) {
             // BSD's `id` ignores all but the first specified user
             pretty(possible_pw);
             return Ok(());
         }
-        if matches.is_present(options::OPT_AUDIT) {
+        if matches.contains_id(options::OPT_AUDIT) {
             // BSD's `id` ignores specified users
             auditid();
             return Ok(());

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -328,11 +328,11 @@ pub fn uu_app<'a>() -> Command<'a> {
 ///
 ///
 fn check_unimplemented(matches: &ArgMatches) -> UResult<()> {
-    if matches.is_present(OPT_NO_TARGET_DIRECTORY) {
+    if matches.contains_id(OPT_NO_TARGET_DIRECTORY) {
         Err(InstallError::Unimplemented(String::from("--no-target-directory, -T")).into())
-    } else if matches.is_present(OPT_PRESERVE_CONTEXT) {
+    } else if matches.contains_id(OPT_PRESERVE_CONTEXT) {
         Err(InstallError::Unimplemented(String::from("--preserve-context, -P")).into())
-    } else if matches.is_present(OPT_CONTEXT) {
+    } else if matches.contains_id(OPT_CONTEXT) {
         Err(InstallError::Unimplemented(String::from("--context, -Z")).into())
     } else {
         Ok(())
@@ -348,7 +348,7 @@ fn check_unimplemented(matches: &ArgMatches) -> UResult<()> {
 /// In event of failure, returns an integer intended as a program return code.
 ///
 fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
-    let main_function = if matches.is_present(OPT_DIRECTORY) {
+    let main_function = if matches.contains_id(OPT_DIRECTORY) {
         MainFunction::Directory
     } else {
         MainFunction::Standard
@@ -356,7 +356,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
 
     let considering_dir: bool = MainFunction::Directory == main_function;
 
-    let specified_mode: Option<u32> = if matches.is_present(OPT_MODE) {
+    let specified_mode: Option<u32> = if matches.contains_id(OPT_MODE) {
         let x = matches.value_of(OPT_MODE).ok_or(1)?;
         Some(mode::parse(x, considering_dir, get_umask()).map_err(|err| {
             show_error!("Invalid mode string: {}", err);
@@ -369,9 +369,9 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
     let backup_mode = backup_control::determine_backup_mode(matches)?;
     let target_dir = matches.value_of(OPT_TARGET_DIRECTORY).map(|d| d.to_owned());
 
-    let preserve_timestamps = matches.is_present(OPT_PRESERVE_TIMESTAMPS);
-    let compare = matches.is_present(OPT_COMPARE);
-    let strip = matches.is_present(OPT_STRIP);
+    let preserve_timestamps = matches.contains_id(OPT_PRESERVE_TIMESTAMPS);
+    let compare = matches.contains_id(OPT_COMPARE);
+    let strip = matches.contains_id(OPT_STRIP);
     if preserve_timestamps && compare {
         show_error!("Options --compare and --preserve-timestamps are mutually exclusive");
         return Err(1.into());
@@ -387,7 +387,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
         suffix: backup_control::determine_backup_suffix(matches),
         owner: matches.value_of(OPT_OWNER).unwrap_or("").to_string(),
         group: matches.value_of(OPT_GROUP).unwrap_or("").to_string(),
-        verbose: matches.is_present(OPT_VERBOSE),
+        verbose: matches.contains_id(OPT_VERBOSE),
         preserve_timestamps,
         compare,
         strip,
@@ -396,7 +396,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
                 .value_of(OPT_STRIP_PROGRAM)
                 .unwrap_or(DEFAULT_STRIP_PROGRAM),
         ),
-        create_leading: matches.is_present(OPT_CREATE_LEADING),
+        create_leading: matches.contains_id(OPT_CREATE_LEADING),
         target_dir,
     })
 }

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -623,7 +623,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     }
 
-    settings.ignore_case = matches.is_present("i");
+    settings.ignore_case = matches.contains_id("i");
     settings.key1 = get_field_number(keys, key1)?;
     settings.key2 = get_field_number(keys, key2)?;
 
@@ -669,19 +669,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         settings.empty = empty.as_bytes().to_vec();
     }
 
-    if matches.is_present("nocheck-order") {
+    if matches.contains_id("nocheck-order") {
         settings.check_order = CheckOrder::Disabled;
     }
 
-    if matches.is_present("check-order") {
+    if matches.contains_id("check-order") {
         settings.check_order = CheckOrder::Enabled;
     }
 
-    if matches.is_present("header") {
+    if matches.contains_id("header") {
         settings.headers = true;
     }
 
-    if matches.is_present("z") {
+    if matches.contains_id("z") {
         settings.line_ending = LineEnding::Nul;
     }
 

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -45,9 +45,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    let mode = if matches.is_present(options::TABLE) {
+    let mode = if matches.contains_id(options::TABLE) {
         Mode::Table
-    } else if matches.is_present(options::LIST) {
+    } else if matches.contains_id(options::LIST) {
         Mode::List
     } else {
         Mode::Kill

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -146,11 +146,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(PathBuf::from)
         .collect();
 
-    let symbolic = matches.is_present(options::SYMBOLIC);
+    let symbolic = matches.contains_id(options::SYMBOLIC);
 
-    let overwrite_mode = if matches.is_present(options::FORCE) {
+    let overwrite_mode = if matches.contains_id(options::FORCE) {
         OverwriteMode::Force
-    } else if matches.is_present(options::INTERACTIVE) {
+    } else if matches.contains_id(options::INTERACTIVE) {
         OverwriteMode::Interactive
     } else {
         OverwriteMode::NoClobber
@@ -160,7 +160,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let backup_suffix = backup_control::determine_backup_suffix(&matches);
 
     // When we have "-L" or "-L -P", false otherwise
-    let logical = matches.is_present(options::LOGICAL);
+    let logical = matches.contains_id(options::LOGICAL);
 
     let settings = Settings {
         overwrite: overwrite_mode,
@@ -168,13 +168,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         suffix: backup_suffix,
         symbolic,
         logical,
-        relative: matches.is_present(options::RELATIVE),
+        relative: matches.contains_id(options::RELATIVE),
         target_dir: matches
             .value_of(options::TARGET_DIRECTORY)
             .map(String::from),
-        no_target_dir: matches.is_present(options::NO_TARGET_DIRECTORY),
-        no_dereference: matches.is_present(options::NO_DEREFERENCE),
-        verbose: matches.is_present(options::VERBOSE),
+        no_target_dir: matches.contains_id(options::NO_TARGET_DIRECTORY),
+        no_dereference: matches.contains_id(options::NO_DEREFERENCE),
+        verbose: matches.contains_id(options::VERBOSE),
     };
 
     exec(&paths[..], &settings)

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -369,7 +369,7 @@ struct PaddingCollection {
 impl Config {
     #[allow(clippy::cognitive_complexity)]
     pub fn from(options: &clap::ArgMatches) -> UResult<Self> {
-        let context = options.is_present(options::CONTEXT);
+        let context = options.contains_id(options::CONTEXT);
         let (mut format, opt) = if let Some(format_) = options.value_of(options::FORMAT) {
             (
                 match format_ {
@@ -383,13 +383,13 @@ impl Config {
                 },
                 Some(options::FORMAT),
             )
-        } else if options.is_present(options::format::LONG) {
+        } else if options.contains_id(options::format::LONG) {
             (Format::Long, Some(options::format::LONG))
-        } else if options.is_present(options::format::ACROSS) {
+        } else if options.contains_id(options::format::ACROSS) {
             (Format::Across, Some(options::format::ACROSS))
-        } else if options.is_present(options::format::COMMAS) {
+        } else if options.contains_id(options::format::COMMAS) {
             (Format::Commas, Some(options::format::COMMAS))
-        } else if options.is_present(options::format::COLUMNS) {
+        } else if options.contains_id(options::format::COLUMNS) {
             (Format::Columns, Some(options::format::COLUMNS))
         } else if atty::is(atty::Stream::Stdout) {
             (Format::Columns, None)
@@ -435,9 +435,9 @@ impl Config {
             }
         }
 
-        let files = if options.is_present(options::files::ALL) {
+        let files = if options.contains_id(options::files::ALL) {
             Files::All
-        } else if options.is_present(options::files::ALMOST_ALL) {
+        } else if options.contains_id(options::files::ALMOST_ALL) {
             Files::AlmostAll
         } else {
             Files::Normal
@@ -454,15 +454,15 @@ impl Config {
                 // below should never happen as clap already restricts the values.
                 _ => unreachable!("Invalid field for --sort"),
             }
-        } else if options.is_present(options::sort::TIME) {
+        } else if options.contains_id(options::sort::TIME) {
             Sort::Time
-        } else if options.is_present(options::sort::SIZE) {
+        } else if options.contains_id(options::sort::SIZE) {
             Sort::Size
-        } else if options.is_present(options::sort::NONE) {
+        } else if options.contains_id(options::sort::NONE) {
             Sort::None
-        } else if options.is_present(options::sort::VERSION) {
+        } else if options.contains_id(options::sort::VERSION) {
             Sort::Version
-        } else if options.is_present(options::sort::EXTENSION) {
+        } else if options.contains_id(options::sort::EXTENSION) {
             Sort::Extension
         } else {
             Sort::Name
@@ -476,16 +476,16 @@ impl Config {
                 // below should never happen as clap already restricts the values.
                 _ => unreachable!("Invalid field for --time"),
             }
-        } else if options.is_present(options::time::ACCESS) {
+        } else if options.contains_id(options::time::ACCESS) {
             Time::Access
-        } else if options.is_present(options::time::CHANGE) {
+        } else if options.contains_id(options::time::CHANGE) {
             Time::Change
         } else {
             Time::Modification
         };
 
         let mut needs_color = match options.value_of(options::COLOR) {
-            None => options.is_present(options::COLOR),
+            None => options.contains_id(options::COLOR),
             Some(val) => match val {
                 "" | "always" | "yes" | "force" => true,
                 "auto" | "tty" | "if-tty" => atty::is(atty::Stream::Stdout),
@@ -499,14 +499,14 @@ impl Config {
                 .value_of(options::size::BLOCK_SIZE)
                 .unwrap()
                 .eq("si")
-            || options.is_present(options::size::SI);
+            || options.contains_id(options::size::SI);
         let opt_hr = (cmd_line_bs.is_some()
             && options
                 .value_of(options::size::BLOCK_SIZE)
                 .unwrap()
                 .eq("human-readable"))
-            || options.is_present(options::size::HUMAN_READABLE);
-        let opt_kb = options.is_present(options::size::KIBIBYTES);
+            || options.contains_id(options::size::HUMAN_READABLE);
+        let opt_kb = options.contains_id(options::size::KIBIBYTES);
 
         let bs_env_var = std::env::var_os("BLOCK_SIZE");
         let ls_bs_env_var = std::env::var_os("LS_BLOCK_SIZE");
@@ -555,12 +555,12 @@ impl Config {
         };
 
         let long = {
-            let author = options.is_present(options::AUTHOR);
-            let group = !options.is_present(options::NO_GROUP)
-                && !options.is_present(options::format::LONG_NO_GROUP);
-            let owner = !options.is_present(options::format::LONG_NO_OWNER);
+            let author = options.contains_id(options::AUTHOR);
+            let group = !options.contains_id(options::NO_GROUP)
+                && !options.contains_id(options::format::LONG_NO_GROUP);
+            let owner = !options.contains_id(options::format::LONG_NO_OWNER);
             #[cfg(unix)]
-            let numeric_uid_gid = options.is_present(options::format::LONG_NUMERIC_UID_GID);
+            let numeric_uid_gid = options.contains_id(options::format::LONG_NUMERIC_UID_GID);
             LongFormat {
                 author,
                 group,
@@ -604,9 +604,9 @@ impl Config {
         };
 
         #[allow(clippy::needless_bool)]
-        let mut show_control = if options.is_present(options::HIDE_CONTROL_CHARS) {
+        let mut show_control = if options.contains_id(options::HIDE_CONTROL_CHARS) {
             false
-        } else if options.is_present(options::SHOW_CONTROL_CHARS) {
+        } else if options.contains_id(options::SHOW_CONTROL_CHARS) {
             true
         } else {
             !atty::is(atty::Stream::Stdout)
@@ -647,13 +647,13 @@ impl Config {
                 },
                 _ => unreachable!("Should have been caught by Clap"),
             }
-        } else if options.is_present(options::quoting::LITERAL) {
+        } else if options.contains_id(options::quoting::LITERAL) {
             QuotingStyle::Literal { show_control }
-        } else if options.is_present(options::quoting::ESCAPE) {
+        } else if options.contains_id(options::quoting::ESCAPE) {
             QuotingStyle::C {
                 quotes: quoting_style::Quotes::None,
             }
-        } else if options.is_present(options::quoting::C) {
+        } else if options.contains_id(options::quoting::C) {
             QuotingStyle::C {
                 quotes: quoting_style::Quotes::Double,
             }
@@ -687,9 +687,9 @@ impl Config {
                 }
                 &_ => IndicatorStyle::None,
             }
-        } else if options.is_present(options::indicator_style::SLASH) {
+        } else if options.contains_id(options::indicator_style::SLASH) {
             IndicatorStyle::Slash
-        } else if options.is_present(options::indicator_style::FILE_TYPE) {
+        } else if options.contains_id(options::indicator_style::FILE_TYPE) {
             IndicatorStyle::FileType
         } else {
             IndicatorStyle::None
@@ -698,7 +698,7 @@ impl Config {
         let time_style = if let Some(field) = options.value_of(options::TIME_STYLE) {
             //If both FULL_TIME and TIME_STYLE are present
             //The one added last is dominant
-            if options.is_present(options::FULL_TIME)
+            if options.contains_id(options::FULL_TIME)
                 && options.indices_of(options::FULL_TIME).unwrap().last()
                     > options.indices_of(options::TIME_STYLE).unwrap().last()
             {
@@ -714,7 +714,7 @@ impl Config {
                     _ => unreachable!("Invalid field for --time-style"),
                 }
             }
-        } else if options.is_present(options::FULL_TIME) {
+        } else if options.contains_id(options::FULL_TIME) {
             TimeStyle::FullIso
         } else {
             TimeStyle::Locale
@@ -722,7 +722,7 @@ impl Config {
 
         let mut ignore_patterns: Vec<Pattern> = Vec::new();
 
-        if options.is_present(options::IGNORE_BACKUPS) {
+        if options.contains_id(options::IGNORE_BACKUPS) {
             ignore_patterns.push(Pattern::new("*~").unwrap());
             ignore_patterns.push(Pattern::new(".*~").unwrap());
         }
@@ -821,13 +821,13 @@ impl Config {
             None
         };
 
-        let dereference = if options.is_present(options::dereference::ALL) {
+        let dereference = if options.contains_id(options::dereference::ALL) {
             Dereference::All
-        } else if options.is_present(options::dereference::ARGS) {
+        } else if options.contains_id(options::dereference::ARGS) {
             Dereference::Args
-        } else if options.is_present(options::dereference::DIR_ARGS) {
+        } else if options.contains_id(options::dereference::DIR_ARGS) {
             Dereference::DirArgs
-        } else if options.is_present(options::DIRECTORY)
+        } else if options.contains_id(options::DIRECTORY)
             || indicator_style == IndicatorStyle::Classify
             || format == Format::Long
         {
@@ -840,18 +840,18 @@ impl Config {
             format,
             files,
             sort,
-            recursive: options.is_present(options::RECURSIVE),
-            reverse: options.is_present(options::REVERSE),
+            recursive: options.contains_id(options::RECURSIVE),
+            reverse: options.contains_id(options::REVERSE),
             dereference,
             ignore_patterns,
             size_format,
-            directory: options.is_present(options::DIRECTORY),
+            directory: options.contains_id(options::DIRECTORY),
             time,
             color,
             #[cfg(unix)]
-            inode: options.is_present(options::INODE),
+            inode: options.contains_id(options::INODE),
             long,
-            alloc_size: options.is_present(options::size::ALLOCATION_SIZE),
+            alloc_size: options.contains_id(options::size::ALLOCATION_SIZE),
             block_size,
             width,
             quoting_style,
@@ -868,8 +868,8 @@ impl Config {
                     false
                 }
             },
-            group_directories_first: options.is_present(options::GROUP_DIRECTORIES_FIRST),
-            eol: if options.is_present(options::ZERO) {
+            group_directories_first: options.contains_id(options::GROUP_DIRECTORIES_FIRST),
+            eol: if options.contains_id(options::ZERO) {
                 '\0'
             } else {
                 '\n'

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -98,8 +98,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let dirs = matches.values_of_os(options::DIRS).unwrap_or_default();
-    let verbose = matches.is_present(options::VERBOSE);
-    let recursive = matches.is_present(options::PARENTS);
+    let verbose = matches.contains_id(options::VERBOSE);
+    let recursive = matches.contains_id(options::PARENTS);
 
     match get_mode(&matches, mode_had_minus_prefix) {
         Ok(mode) => exec(dirs, recursive, mode, verbose),

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -34,10 +34,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    if matches.is_present(options::CONTEXT) {
+    if matches.contains_id(options::CONTEXT) {
         return Err(USimpleError::new(1, "--context is not implemented"));
     }
-    if matches.is_present(options::SE_LINUX_SECURITY_CONTEXT) {
+    if matches.contains_id(options::SE_LINUX_SECURITY_CONTEXT) {
         return Err(USimpleError::new(1, "-Z is not implemented"));
     }
 

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -104,7 +104,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .expect("Failed to get the first char");
 
     if ch == 'p' {
-        if matches.is_present("major") || matches.is_present("minor") {
+        if matches.contains_id("major") || matches.contains_id("minor") {
             Err(UUsageError::new(
                 1,
                 "Fifos do not have major and minor device numbers.",

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -147,7 +147,7 @@ struct Options {
 /// option. This function returns `true` in this case and `false`
 /// in all other cases.
 fn is_tmpdir_argument_actually_the_template(matches: &ArgMatches) -> bool {
-    if !matches.is_present(ARG_TEMPLATE) {
+    if !matches.contains_id(ARG_TEMPLATE) {
         if let Some(tmpdir) = matches.value_of(OPT_TMPDIR) {
             if !Path::new(tmpdir).is_dir() && tmpdir.contains("XXX") {
                 return true;
@@ -178,12 +178,12 @@ impl Options {
             (tmpdir, template)
         };
         Self {
-            directory: matches.is_present(OPT_DIRECTORY),
-            dry_run: matches.is_present(OPT_DRY_RUN),
-            quiet: matches.is_present(OPT_QUIET),
+            directory: matches.contains_id(OPT_DIRECTORY),
+            dry_run: matches.contains_id(OPT_DRY_RUN),
+            quiet: matches.contains_id(OPT_QUIET),
             tmpdir,
             suffix: matches.value_of(OPT_SUFFIX).map(String::from),
-            treat_as_template: matches.is_present(OPT_T),
+            treat_as_template: matches.contains_id(OPT_T),
             template,
         }
     }
@@ -326,7 +326,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if env::var("POSIXLY_CORRECT").is_ok() {
         // If POSIXLY_CORRECT was set, template MUST be the last argument.
-        if is_tmpdir_argument_actually_the_template(&matches) || matches.is_present(ARG_TEMPLATE) {
+        if is_tmpdir_argument_actually_the_template(&matches) || matches.contains_id(ARG_TEMPLATE) {
             // Template argument was provided, check if was the last one.
             if args.last().unwrap() != &options.template {
                 return Err(Box::new(MkTempError::TooManyTemplates));

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -54,7 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let mut buff = String::new();
-    let silent = matches.is_present(options::SILENT);
+    let silent = matches.contains_id(options::SILENT);
     if let Some(files) = matches.values_of(options::FILES) {
         let mut stdout = setup_term();
         let length = files.len();

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -80,7 +80,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .try_get_matches_from_mut(args)
         .unwrap_or_else(|e| e.exit());
 
-    if !matches.is_present(OPT_TARGET_DIRECTORY) && matches.occurrences_of(ARG_FILES) == 1 {
+    if !matches.contains_id(OPT_TARGET_DIRECTORY) && matches.occurrences_of(ARG_FILES) == 1 {
         app.error(
             ErrorKind::TooFewValues,
             format!(
@@ -113,13 +113,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         overwrite: overwrite_mode,
         backup: backup_mode,
         suffix: backup_suffix,
-        update: matches.is_present(OPT_UPDATE),
+        update: matches.contains_id(OPT_UPDATE),
         target_dir: matches
             .value_of_os(OPT_TARGET_DIRECTORY)
             .map(OsString::from),
-        no_target_dir: matches.is_present(OPT_NO_TARGET_DIRECTORY),
-        verbose: matches.is_present(OPT_VERBOSE),
-        strip_slashes: matches.is_present(OPT_STRIP_TRAILING_SLASHES),
+        no_target_dir: matches.contains_id(OPT_NO_TARGET_DIRECTORY),
+        verbose: matches.contains_id(OPT_VERBOSE),
+        strip_slashes: matches.contains_id(OPT_STRIP_TRAILING_SLASHES),
     };
 
     exec(&files[..], &behavior)
@@ -207,9 +207,9 @@ fn determine_overwrite_mode(matches: &ArgMatches) -> OverwriteMode {
     // overwrite options are supplied, only the last takes effect.
     // To default to no-clobber in that situation seems safer:
     //
-    if matches.is_present(OPT_NO_CLOBBER) {
+    if matches.contains_id(OPT_NO_CLOBBER) {
         OverwriteMode::NoClobber
-    } else if matches.is_present(OPT_INTERACTIVE) {
+    } else if matches.contains_id(OPT_INTERACTIVE) {
         OverwriteMode::Interactive
     } else {
         OverwriteMode::Force

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -48,7 +48,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let adjustment = match matches.value_of(options::ADJUSTMENT) {
         Some(nstr) => {
-            if !matches.is_present(options::COMMAND) {
+            if !matches.contains_id(options::COMMAND) {
                 return Err(UUsageError::new(
                     125,
                     "A command must be given with an adjustment.",
@@ -65,7 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
         }
         None => {
-            if !matches.is_present(options::COMMAND) {
+            if !matches.contains_id(options::COMMAND) {
                 println!("{}", niceness);
                 return Ok(());
             }

--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -28,7 +28,7 @@ fn parse_style(chars: &[char]) -> Result<crate::NumberingStyle, String> {
 pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) -> Vec<String> {
     // This vector holds error messages encountered.
     let mut errs: Vec<String> = vec![];
-    settings.renumber = !opts.is_present(options::NO_RENUMBER);
+    settings.renumber = !opts.contains_id(options::NO_RENUMBER);
     match opts.value_of(options::NUMBER_SEPARATOR) {
         None => {}
         Some(val) => {

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -60,7 +60,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         Err(_) => usize::MAX,
     };
 
-    let mut cores = if matches.is_present(OPT_ALL) {
+    let mut cores = if matches.contains_id(OPT_ALL) {
         num_cpus_all()
     } else {
         // OMP_NUM_THREADS doesn't have an impact on --all

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -193,7 +193,7 @@ impl OdOptions {
             line_bytes = min_bytes;
         }
 
-        let output_duplicates = matches.is_present(options::OUTPUT_DUPLICATES);
+        let output_duplicates = matches.contains_id(options::OUTPUT_DUPLICATES);
 
         let read_bytes = match matches.value_of(options::READ_BYTES) {
             None => None,

--- a/src/uu/od/src/parse_inputs.rs
+++ b/src/uu/od/src/parse_inputs.rs
@@ -18,7 +18,7 @@ impl CommandLineOpts for ArgMatches {
     }
 
     fn opts_present(&self, opts: &[&str]) -> bool {
-        opts.iter().any(|opt| self.is_present(opt))
+        opts.iter().any(|opt| self.contains_id(opt))
     }
 }
 

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -56,14 +56,14 @@ fn read_until<R: Read>(
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
-    let serial = matches.is_present(options::SERIAL);
+    let serial = matches.contains_id(options::SERIAL);
     let delimiters = matches.value_of(options::DELIMITER).unwrap();
     let files = matches
         .values_of(options::FILE)
         .unwrap()
         .map(|s| s.to_owned())
         .collect();
-    let line_ending = if matches.is_present(options::ZERO_TERMINATED) {
+    let line_ending = if matches.contains_id(options::ZERO_TERMINATED) {
         LineEnding::Nul
     } else {
         LineEnding::Newline

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -68,35 +68,35 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut include_idle = true;
 
     // If true, display a line at the top describing each field.
-    let include_heading = !matches.is_present(options::OMIT_HEADINGS);
+    let include_heading = !matches.contains_id(options::OMIT_HEADINGS);
 
     // if true, display the user's full name from pw_gecos.
     let mut include_fullname = true;
 
     // if true, display the user's ~/.project file when doing long format.
-    let include_project = !matches.is_present(options::OMIT_PROJECT_FILE);
+    let include_project = !matches.contains_id(options::OMIT_PROJECT_FILE);
 
     // if true, display the user's ~/.plan file when doing long format.
-    let include_plan = !matches.is_present(options::OMIT_PLAN_FILE);
+    let include_plan = !matches.contains_id(options::OMIT_PLAN_FILE);
 
     // if true, display the user's home directory and shell
     // when doing long format.
-    let include_home_and_shell = !matches.is_present(options::OMIT_HOME_DIR);
+    let include_home_and_shell = !matches.contains_id(options::OMIT_HOME_DIR);
 
     // if true, use the "short" output format.
-    let do_short_format = !matches.is_present(options::LONG_FORMAT);
+    let do_short_format = !matches.contains_id(options::LONG_FORMAT);
 
     /* if true, display the ut_host field. */
     let mut include_where = true;
 
-    if matches.is_present(options::OMIT_NAME) {
+    if matches.contains_id(options::OMIT_NAME) {
         include_fullname = false;
     }
-    if matches.is_present(options::OMIT_NAME_HOST) {
+    if matches.contains_id(options::OMIT_NAME_HOST) {
         include_fullname = false;
         include_where = false;
     }
-    if matches.is_present(options::OMIT_NAME_HOST_TIME) {
+    if matches.contains_id(options::OMIT_NAME_HOST_TIME) {
         include_fullname = false;
         include_idle = false;
         include_where = false;

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -394,12 +394,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    if matches.is_present(options::VERSION) {
+    if matches.contains_id(options::VERSION) {
         println!("{}", command.render_long_version());
         return Ok(());
     }
 
-    if matches.is_present(options::HELP) {
+    if matches.contains_id(options::HELP) {
         command.print_help()?;
         return Ok(());
     }
@@ -413,7 +413,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         files.insert(0, FILE_STDIN);
     }
 
-    let file_groups: Vec<_> = if matches.is_present(options::MERGE) {
+    let file_groups: Vec<_> = if matches.contains_id(options::MERGE) {
         vec![files]
     } else {
         files.into_iter().map(|i| vec![i]).collect()
@@ -477,7 +477,7 @@ fn recreate_arguments(args: &[String]) -> Vec<String> {
 }
 
 fn print_error(matches: &ArgMatches, err: &PrError) {
-    if !matches.is_present(options::NO_FILE_WARNINGS) {
+    if !matches.contains_id(options::NO_FILE_WARNINGS) {
         eprintln!("{}", err);
     }
 }
@@ -501,21 +501,21 @@ fn build_options(
     paths: &[&str],
     free_args: &str,
 ) -> Result<OutputOptions, PrError> {
-    let form_feed_used = matches.is_present(options::FORM_FEED);
+    let form_feed_used = matches.contains_id(options::FORM_FEED);
 
-    let is_merge_mode = matches.is_present(options::MERGE);
+    let is_merge_mode = matches.contains_id(options::MERGE);
 
-    if is_merge_mode && matches.is_present(options::COLUMN) {
+    if is_merge_mode && matches.contains_id(options::COLUMN) {
         let err_msg = String::from("cannot specify number of columns when printing in parallel");
         return Err(PrError::EncounteredErrors(err_msg));
     }
 
-    if is_merge_mode && matches.is_present(options::ACROSS) {
+    if is_merge_mode && matches.contains_id(options::ACROSS) {
         let err_msg = String::from("cannot specify both printing across and printing in parallel");
         return Err(PrError::EncounteredErrors(err_msg));
     }
 
-    let merge_files_print = if matches.is_present(options::MERGE) {
+    let merge_files_print = if matches.contains_id(options::MERGE) {
         Some(paths.len())
     } else {
         None
@@ -559,14 +559,14 @@ fn build_options(
             }
         })
         .or_else(|| {
-            if matches.is_present(options::NUMBER_LINES) {
+            if matches.contains_id(options::NUMBER_LINES) {
                 Some(NumberingMode::default())
             } else {
                 None
             }
         });
 
-    let double_space = matches.is_present(options::DOUBLE_SPACE);
+    let double_space = matches.contains_id(options::DOUBLE_SPACE);
 
     let content_line_separator = if double_space {
         "\n".repeat(2)
@@ -670,7 +670,7 @@ fn build_options(
     let page_length_le_ht = page_length < (HEADER_LINES_PER_PAGE + TRAILER_LINES_PER_PAGE);
 
     let display_header_and_trailer =
-        !(page_length_le_ht) && !matches.is_present(options::OMIT_HEADER);
+        !(page_length_le_ht) && !matches.contains_id(options::OMIT_HEADER);
 
     let content_lines_per_page = if page_length_le_ht {
         page_length
@@ -678,14 +678,14 @@ fn build_options(
         page_length - (HEADER_LINES_PER_PAGE + TRAILER_LINES_PER_PAGE)
     };
 
-    let page_separator_char = if matches.is_present(options::FORM_FEED) {
+    let page_separator_char = if matches.contains_id(options::FORM_FEED) {
         let bytes = vec![FF];
         String::from_utf8(bytes).unwrap()
     } else {
         "\n".to_string()
     };
 
-    let across_mode = matches.is_present(options::ACROSS);
+    let across_mode = matches.contains_id(options::ACROSS);
 
     let column_separator = match matches.value_of(options::COLUMN_STRING_SEPARATOR) {
         Some(x) => Some(x),
@@ -694,8 +694,8 @@ fn build_options(
     .map(ToString::to_string)
     .unwrap_or_else(|| DEFAULT_COLUMN_SEPARATOR.to_string());
 
-    let default_column_width = if matches.is_present(options::COLUMN_WIDTH)
-        && matches.is_present(options::COLUMN_CHAR_SEPARATOR)
+    let default_column_width = if matches.contains_id(options::COLUMN_WIDTH)
+        && matches.contains_id(options::COLUMN_CHAR_SEPARATOR)
     {
         DEFAULT_COLUMN_WIDTH_WITH_S_OPTION
     } else {
@@ -705,7 +705,7 @@ fn build_options(
     let column_width =
         parse_usize(matches, options::COLUMN_WIDTH).unwrap_or(Ok(default_column_width))?;
 
-    let page_width = if matches.is_present(options::JOIN_LINES) {
+    let page_width = if matches.contains_id(options::JOIN_LINES) {
         None
     } else {
         match parse_usize(matches, options::PAGE_WIDTH) {
@@ -741,7 +741,7 @@ fn build_options(
     });
 
     let offset_spaces = " ".repeat(parse_usize(matches, options::INDENT).unwrap_or(Ok(0))?);
-    let join_lines = matches.is_present(options::JOIN_LINES);
+    let join_lines = matches.contains_id(options::JOIN_LINES);
 
     let col_sep_for_printing = column_mode_options
         .as_ref()

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -27,7 +27,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 
-    let separator = if matches.is_present(OPT_NULL) {
+    let separator = if matches.contains_id(OPT_NULL) {
         "\x00"
     } else {
         "\n"

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -113,22 +113,22 @@ struct WordFilter {
 
 impl WordFilter {
     fn new(matches: &clap::ArgMatches, config: &Config) -> UResult<Self> {
-        let (o, oset): (bool, HashSet<String>) = if matches.is_present(options::ONLY_FILE) {
+        let (o, oset): (bool, HashSet<String>) = if matches.contains_id(options::ONLY_FILE) {
             let words =
                 read_word_filter_file(matches, options::ONLY_FILE).map_err_context(String::new)?;
             (true, words)
         } else {
             (false, HashSet::new())
         };
-        let (i, iset): (bool, HashSet<String>) = if matches.is_present(options::IGNORE_FILE) {
+        let (i, iset): (bool, HashSet<String>) = if matches.contains_id(options::IGNORE_FILE) {
             let words = read_word_filter_file(matches, options::IGNORE_FILE)
                 .map_err_context(String::new)?;
             (true, words)
         } else {
             (false, HashSet::new())
         };
-        let break_set: Option<HashSet<char>> = if matches.is_present(options::BREAK_FILE)
-            && !matches.is_present(options::WORD_REGEXP)
+        let break_set: Option<HashSet<char>> = if matches.contains_id(options::BREAK_FILE)
+            && !matches.contains_id(options::WORD_REGEXP)
         {
             let chars =
                 read_char_filter_file(matches, options::BREAK_FILE).map_err_context(String::new)?;
@@ -145,7 +145,7 @@ impl WordFilter {
             None
         };
         // Ignore empty string regex from cmd-line-args
-        let arg_reg: Option<String> = if matches.is_present(options::WORD_REGEXP) {
+        let arg_reg: Option<String> = if matches.contains_id(options::WORD_REGEXP) {
             match matches.value_of(options::WORD_REGEXP) {
                 Some(v) => {
                     if v.is_empty() {
@@ -228,50 +228,50 @@ impl Display for PtxError {
 fn get_config(matches: &clap::ArgMatches) -> UResult<Config> {
     let mut config: Config = Default::default();
     let err_msg = "parsing options failed";
-    if matches.is_present(options::TRADITIONAL) {
+    if matches.contains_id(options::TRADITIONAL) {
         config.gnu_ext = false;
         config.format = OutFormat::Roff;
         config.context_regex = "[^ \t\n]+".to_owned();
     } else {
         return Err(PtxError::NotImplemented("GNU extensions").into());
     }
-    if matches.is_present(options::SENTENCE_REGEXP) {
+    if matches.contains_id(options::SENTENCE_REGEXP) {
         return Err(PtxError::NotImplemented("-S").into());
     }
-    config.auto_ref = matches.is_present(options::AUTO_REFERENCE);
-    config.input_ref = matches.is_present(options::REFERENCES);
-    config.right_ref &= matches.is_present(options::RIGHT_SIDE_REFS);
-    config.ignore_case = matches.is_present(options::IGNORE_CASE);
-    if matches.is_present(options::MACRO_NAME) {
+    config.auto_ref = matches.contains_id(options::AUTO_REFERENCE);
+    config.input_ref = matches.contains_id(options::REFERENCES);
+    config.right_ref &= matches.contains_id(options::RIGHT_SIDE_REFS);
+    config.ignore_case = matches.contains_id(options::IGNORE_CASE);
+    if matches.contains_id(options::MACRO_NAME) {
         config.macro_name = matches
             .value_of(options::MACRO_NAME)
             .expect(err_msg)
             .to_string();
     }
-    if matches.is_present(options::FLAG_TRUNCATION) {
+    if matches.contains_id(options::FLAG_TRUNCATION) {
         config.trunc_str = matches
             .value_of(options::FLAG_TRUNCATION)
             .expect(err_msg)
             .to_string();
     }
-    if matches.is_present(options::WIDTH) {
+    if matches.contains_id(options::WIDTH) {
         config.line_width = matches
             .value_of(options::WIDTH)
             .expect(err_msg)
             .parse()
             .map_err(PtxError::ParseError)?;
     }
-    if matches.is_present(options::GAP_SIZE) {
+    if matches.contains_id(options::GAP_SIZE) {
         config.gap_size = matches
             .value_of(options::GAP_SIZE)
             .expect(err_msg)
             .parse()
             .map_err(PtxError::ParseError)?;
     }
-    if matches.is_present(options::FORMAT_ROFF) {
+    if matches.contains_id(options::FORMAT_ROFF) {
         config.format = OutFormat::Roff;
     }
-    if matches.is_present(options::FORMAT_TEX) {
+    if matches.contains_id(options::FORMAT_TEX) {
         config.format = OutFormat::Tex;
     }
     Ok(config)

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -125,7 +125,7 @@ fn logical_path() -> io::Result<PathBuf> {
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
-    let cwd = if matches.is_present(OPT_LOGICAL) {
+    let cwd = if matches.contains_id(OPT_LOGICAL) {
         logical_path()
     } else {
         physical_path()

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -36,23 +36,23 @@ const ARG_FILES: &str = "files";
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
-    let mut no_newline = matches.is_present(OPT_NO_NEWLINE);
-    let use_zero = matches.is_present(OPT_ZERO);
-    let silent = matches.is_present(OPT_SILENT) || matches.is_present(OPT_QUIET);
-    let verbose = matches.is_present(OPT_VERBOSE);
+    let mut no_newline = matches.contains_id(OPT_NO_NEWLINE);
+    let use_zero = matches.contains_id(OPT_ZERO);
+    let silent = matches.contains_id(OPT_SILENT) || matches.contains_id(OPT_QUIET);
+    let verbose = matches.contains_id(OPT_VERBOSE);
 
-    let res_mode = if matches.is_present(OPT_CANONICALIZE)
-        || matches.is_present(OPT_CANONICALIZE_EXISTING)
-        || matches.is_present(OPT_CANONICALIZE_MISSING)
+    let res_mode = if matches.contains_id(OPT_CANONICALIZE)
+        || matches.contains_id(OPT_CANONICALIZE_EXISTING)
+        || matches.contains_id(OPT_CANONICALIZE_MISSING)
     {
         ResolveMode::Logical
     } else {
         ResolveMode::None
     };
 
-    let can_mode = if matches.is_present(OPT_CANONICALIZE_EXISTING) {
+    let can_mode = if matches.contains_id(OPT_CANONICALIZE_EXISTING) {
         MissingHandling::Existing
-    } else if matches.is_present(OPT_CANONICALIZE_MISSING) {
+    } else if matches.contains_id(OPT_CANONICALIZE_MISSING) {
         MissingHandling::Missing
     } else {
         MissingHandling::Normal

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -51,13 +51,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(PathBuf::from)
         .collect();
 
-    let strip = matches.is_present(OPT_STRIP);
-    let zero = matches.is_present(OPT_ZERO);
-    let quiet = matches.is_present(OPT_QUIET);
-    let logical = matches.is_present(OPT_LOGICAL);
-    let can_mode = if matches.is_present(OPT_CANONICALIZE_EXISTING) {
+    let strip = matches.contains_id(OPT_STRIP);
+    let zero = matches.contains_id(OPT_ZERO);
+    let quiet = matches.contains_id(OPT_QUIET);
+    let logical = matches.contains_id(OPT_LOGICAL);
+    let can_mode = if matches.contains_id(OPT_CANONICALIZE_EXISTING) {
         MissingHandling::Existing
-    } else if matches.is_present(OPT_CANONICALIZE_MISSING) {
+    } else if matches.contains_id(OPT_CANONICALIZE_MISSING) {
         MissingHandling::Missing
     } else {
         MissingHandling::Normal

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -43,7 +43,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let absfrom = canonicalize(from, MissingHandling::Normal, ResolveMode::Logical)
         .map_err_context(String::new)?;
 
-    if matches.is_present(options::DIR) {
+    if matches.contains_id(options::DIR) {
         let base = Path::new(&matches.value_of(options::DIR).unwrap()).to_path_buf();
         let absbase = canonicalize(base, MissingHandling::Normal, ResolveMode::Logical)
             .map_err_context(String::new)?;

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -85,7 +85,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 
-    let force = matches.is_present(OPT_FORCE);
+    let force = matches.contains_id(OPT_FORCE);
 
     if files.is_empty() && !force {
         // Still check by hand and not use clap
@@ -95,11 +95,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let options = Options {
             force,
             interactive: {
-                if matches.is_present(OPT_PROMPT) {
+                if matches.contains_id(OPT_PROMPT) {
                     InteractiveMode::Always
-                } else if matches.is_present(OPT_PROMPT_MORE) {
+                } else if matches.contains_id(OPT_PROMPT_MORE) {
                     InteractiveMode::Once
-                } else if matches.is_present(OPT_INTERACTIVE) {
+                } else if matches.contains_id(OPT_INTERACTIVE) {
                     match matches.value_of(OPT_INTERACTIVE).unwrap() {
                         "never" => InteractiveMode::Never,
                         "once" => InteractiveMode::Once,
@@ -115,11 +115,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     InteractiveMode::Never
                 }
             },
-            one_fs: matches.is_present(OPT_ONE_FILE_SYSTEM),
-            preserve_root: !matches.is_present(OPT_NO_PRESERVE_ROOT),
-            recursive: matches.is_present(OPT_RECURSIVE) || matches.is_present(OPT_RECURSIVE_R),
-            dir: matches.is_present(OPT_DIR),
-            verbose: matches.is_present(OPT_VERBOSE),
+            one_fs: matches.contains_id(OPT_ONE_FILE_SYSTEM),
+            preserve_root: !matches.contains_id(OPT_NO_PRESERVE_ROOT),
+            recursive: matches.contains_id(OPT_RECURSIVE) || matches.contains_id(OPT_RECURSIVE_R),
+            dir: matches.contains_id(OPT_DIR),
+            verbose: matches.contains_id(OPT_VERBOSE),
         };
         if options.interactive == InteractiveMode::Once && (options.recursive || files.len() > 3) {
             let msg = if options.recursive {

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -34,9 +34,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let opts = Opts {
-        ignore: matches.is_present(OPT_IGNORE_FAIL_NON_EMPTY),
-        parents: matches.is_present(OPT_PARENTS),
-        verbose: matches.is_present(OPT_VERBOSE),
+        ignore: matches.contains_id(OPT_IGNORE_FAIL_NON_EMPTY),
+        parents: matches.contains_id(OPT_PARENTS),
+        verbose: matches.contains_id(OPT_VERBOSE),
     };
 
     for path in matches

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -209,7 +209,7 @@ struct Options {
 fn parse_command_line(config: Command, args: impl uucore::Args) -> Result<Options> {
     let matches = config.try_get_matches_from(args)?;
 
-    let compute_transition_context = matches.is_present(options::COMPUTE);
+    let compute_transition_context = matches.contains_id(options::COMPUTE);
 
     let mut args = matches
         .values_of_os("ARG")
@@ -217,10 +217,10 @@ fn parse_command_line(config: Command, args: impl uucore::Args) -> Result<Option
         .map(OsString::from);
 
     if compute_transition_context
-        || matches.is_present(options::USER)
-        || matches.is_present(options::ROLE)
-        || matches.is_present(options::TYPE)
-        || matches.is_present(options::RANGE)
+        || matches.contains_id(options::USER)
+        || matches.contains_id(options::ROLE)
+        || matches.contains_id(options::TYPE)
+        || matches.contains_id(options::RANGE)
     {
         // runcon [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] [COMMAND [args]]
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -66,7 +66,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let options = SeqOptions {
         separator: matches.value_of(OPT_SEPARATOR).unwrap_or("\n").to_string(),
         terminator: matches.value_of(OPT_TERMINATOR).unwrap_or("\n").to_string(),
-        widths: matches.is_present(OPT_WIDTHS),
+        widths: matches.contains_id(OPT_WIDTHS),
         format: matches.value_of(OPT_FORMAT),
     };
 

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -272,7 +272,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    if !matches.is_present(options::FILE) {
+    if !matches.contains_id(options::FILE) {
         return Err(UUsageError::new(1, "missing file operand"));
     }
 
@@ -298,13 +298,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // TODO: implement --random-source
 
-    let force = matches.is_present(options::FORCE);
-    let remove = matches.is_present(options::REMOVE);
+    let force = matches.contains_id(options::FORCE);
+    let remove = matches.contains_id(options::REMOVE);
     let size_arg = matches.value_of(options::SIZE).map(|s| s.to_string());
     let size = get_size(size_arg);
-    let exact = matches.is_present(options::EXACT) && size.is_none(); // if -s is given, ignore -x
-    let zero = matches.is_present(options::ZERO);
-    let verbose = matches.is_present(options::VERBOSE);
+    let exact = matches.contains_id(options::EXACT) && size.is_none(); // if -s is given, ignore -x
+    let zero = matches.contains_id(options::ZERO);
+    let verbose = matches.contains_id(options::VERBOSE);
 
     for path_str in matches.values_of(options::FILE).unwrap() {
         show_if_err!(wipe_file(

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -86,8 +86,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         },
         output: matches.value_of(options::OUTPUT).map(String::from),
         random_source: matches.value_of(options::RANDOM_SOURCE).map(String::from),
-        repeat: matches.is_present(options::REPEAT),
-        sep: if matches.is_present(options::ZERO_TERMINATED) {
+        repeat: matches.contains_id(options::REPEAT),
+        sep: if matches.contains_id(options::ZERO_TERMINATED) {
             0x00_u8
         } else {
             0x0a_u8

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1076,10 +1076,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    settings.debug = matches.is_present(options::DEBUG);
+    settings.debug = matches.contains_id(options::DEBUG);
 
     // check whether user specified a zero terminated list of files for input, otherwise read files from args
-    let mut files: Vec<OsString> = if matches.is_present(options::FILES0_FROM) {
+    let mut files: Vec<OsString> = if matches.contains_id(options::FILES0_FROM) {
         let files0_from: Vec<OsString> = matches
             .values_of_os(options::FILES0_FROM)
             .map(|v| v.map(ToOwned::to_owned).collect())
@@ -1104,27 +1104,27 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .unwrap_or_default()
     };
 
-    settings.mode = if matches.is_present(options::modes::HUMAN_NUMERIC)
+    settings.mode = if matches.contains_id(options::modes::HUMAN_NUMERIC)
         || matches.value_of(options::modes::SORT) == Some("human-numeric")
     {
         SortMode::HumanNumeric
-    } else if matches.is_present(options::modes::MONTH)
+    } else if matches.contains_id(options::modes::MONTH)
         || matches.value_of(options::modes::SORT) == Some("month")
     {
         SortMode::Month
-    } else if matches.is_present(options::modes::GENERAL_NUMERIC)
+    } else if matches.contains_id(options::modes::GENERAL_NUMERIC)
         || matches.value_of(options::modes::SORT) == Some("general-numeric")
     {
         SortMode::GeneralNumeric
-    } else if matches.is_present(options::modes::NUMERIC)
+    } else if matches.contains_id(options::modes::NUMERIC)
         || matches.value_of(options::modes::SORT) == Some("numeric")
     {
         SortMode::Numeric
-    } else if matches.is_present(options::modes::VERSION)
+    } else if matches.contains_id(options::modes::VERSION)
         || matches.value_of(options::modes::SORT) == Some("version")
     {
         SortMode::Version
-    } else if matches.is_present(options::modes::RANDOM)
+    } else if matches.contains_id(options::modes::RANDOM)
         || matches.value_of(options::modes::SORT) == Some("random")
     {
         settings.salt = Some(get_rand_string());
@@ -1133,9 +1133,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         SortMode::Default
     };
 
-    settings.dictionary_order = matches.is_present(options::DICTIONARY_ORDER);
-    settings.ignore_non_printing = matches.is_present(options::IGNORE_NONPRINTING);
-    if matches.is_present(options::PARALLEL) {
+    settings.dictionary_order = matches.contains_id(options::DICTIONARY_ORDER);
+    settings.ignore_non_printing = matches.contains_id(options::IGNORE_NONPRINTING);
+    if matches.contains_id(options::PARALLEL) {
         // "0" is default - threads = num of cores
         settings.threads = matches
             .value_of(options::PARALLEL)
@@ -1171,11 +1171,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         })?;
     }
 
-    settings.zero_terminated = matches.is_present(options::ZERO_TERMINATED);
-    settings.merge = matches.is_present(options::MERGE);
+    settings.zero_terminated = matches.contains_id(options::ZERO_TERMINATED);
+    settings.merge = matches.contains_id(options::MERGE);
 
-    settings.check = matches.is_present(options::check::CHECK);
-    if matches.is_present(options::check::CHECK_SILENT)
+    settings.check = matches.contains_id(options::check::CHECK);
+    if matches.contains_id(options::check::CHECK_SILENT)
         || matches!(
             matches.value_of(options::check::CHECK),
             Some(options::check::SILENT) | Some(options::check::QUIET)
@@ -1185,13 +1185,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         settings.check = true;
     };
 
-    settings.ignore_case = matches.is_present(options::IGNORE_CASE);
+    settings.ignore_case = matches.contains_id(options::IGNORE_CASE);
 
-    settings.ignore_leading_blanks = matches.is_present(options::IGNORE_LEADING_BLANKS);
+    settings.ignore_leading_blanks = matches.contains_id(options::IGNORE_LEADING_BLANKS);
 
-    settings.reverse = matches.is_present(options::REVERSE);
-    settings.stable = matches.is_present(options::STABLE);
-    settings.unique = matches.is_present(options::UNIQUE);
+    settings.reverse = matches.contains_id(options::REVERSE);
+    settings.stable = matches.contains_id(options::STABLE);
+    settings.unique = matches.contains_id(options::UNIQUE);
 
     if files.is_empty() {
         /* if no file, default to stdin */
@@ -1238,7 +1238,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     }
 
-    if !matches.is_present(options::KEY) {
+    if !matches.contains_id(options::KEY) {
         // add a default selector matching the whole line
         let key_settings = KeySettings::from(&settings);
         settings.selectors.push(

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -520,7 +520,7 @@ impl Settings {
             input: matches.value_of(ARG_INPUT).unwrap().to_owned(),
             prefix: matches.value_of(ARG_PREFIX).unwrap().to_owned(),
             filter: matches.value_of(OPT_FILTER).map(|s| s.to_owned()),
-            elide_empty_files: matches.is_present(OPT_ELIDE_EMPTY_FILES),
+            elide_empty_files: matches.contains_id(OPT_ELIDE_EMPTY_FILES),
         };
         #[cfg(windows)]
         if result.filter.is_some() {

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -477,7 +477,7 @@ impl Stater {
             .values_of_os(ARG_FILES)
             .map(|v| v.map(OsString::from).collect())
             .unwrap_or_default();
-        let format_str = if matches.is_present(options::PRINTF) {
+        let format_str = if matches.contains_id(options::PRINTF) {
             matches
                 .value_of(options::PRINTF)
                 .expect("Invalid format string")
@@ -485,9 +485,9 @@ impl Stater {
             matches.value_of(options::FORMAT).unwrap_or("")
         };
 
-        let use_printf = matches.is_present(options::PRINTF);
-        let terse = matches.is_present(options::TERSE);
-        let show_fs = matches.is_present(options::FILE_SYSTEM);
+        let use_printf = matches.contains_id(options::PRINTF);
+        let terse = matches.contains_id(options::TERSE);
+        let show_fs = matches.contains_id(options::FILE_SYSTEM);
 
         let default_tokens = if format_str.is_empty() {
             Self::generate_tokens(&Self::default_format(show_fs, terse, false), use_printf)?
@@ -513,7 +513,7 @@ impl Stater {
         };
 
         Ok(Self {
-            follow: matches.is_present(options::DEREFERENCE),
+            follow: matches.contains_id(options::DEREFERENCE),
             show_fs,
             from_user: !format_str.is_empty(),
             files,

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -120,7 +120,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         None => vec!["-".to_owned()],
     };
 
-    let sysv = matches.is_present(options::SYSTEM_V_COMPATIBLE);
+    let sysv = matches.contains_id(options::SYSTEM_V_COMPATIBLE);
 
     let print_names = if sysv {
         files.len() > 1 || files[0] != "-"

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -182,10 +182,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     #[allow(clippy::if_same_then_else)]
-    if matches.is_present(options::FILE_SYSTEM) {
+    if matches.contains_id(options::FILE_SYSTEM) {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
         syncfs(files);
-    } else if matches.is_present(options::DATA) {
+    } else if matches.contains_id(options::DATA) {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         fdatasync(files);
     } else {

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -43,8 +43,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    let before = matches.is_present(options::BEFORE);
-    let regex = matches.is_present(options::REGEX);
+    let before = matches.contains_id(options::BEFORE);
+    let regex = matches.contains_id(options::REGEX);
     let raw_separator = matches.value_of(options::SEPARATOR).unwrap_or("\n");
     let separator = if raw_separator.is_empty() {
         "\0"

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -138,7 +138,7 @@ impl Settings {
             ..Default::default()
         };
 
-        settings.follow = if matches.is_present(options::FOLLOW_RETRY) {
+        settings.follow = if matches.contains_id(options::FOLLOW_RETRY) {
             Some(FollowMode::Name)
         } else if matches.occurrences_of(options::FOLLOW) == 0 {
             None
@@ -160,7 +160,7 @@ impl Settings {
             }
         }
 
-        settings.use_polling = matches.is_present(options::USE_POLLING);
+        settings.use_polling = matches.contains_id(options::USE_POLLING);
 
         if let Some(s) = matches.value_of(options::MAX_UNCHANGED_STATS) {
             settings.max_unchanged_stats = match s.parse::<u32>() {
@@ -249,28 +249,28 @@ impl Settings {
         }
 
         settings.retry =
-            matches.is_present(options::RETRY) || matches.is_present(options::FOLLOW_RETRY);
+            matches.contains_id(options::RETRY) || matches.contains_id(options::FOLLOW_RETRY);
 
         if settings.retry && settings.follow.is_none() {
             show_warning!("--retry ignored; --retry is useful only when following");
         }
 
-        if matches.is_present(options::ZERO_TERM) {
+        if matches.contains_id(options::ZERO_TERM) {
             if let FilterMode::Lines(count, _) = settings.mode {
                 settings.mode = FilterMode::Lines(count, 0);
             }
         }
 
-        settings.stdin_is_pipe_or_fifo = matches.is_present(options::PRESUME_INPUT_PIPE);
+        settings.stdin_is_pipe_or_fifo = matches.contains_id(options::PRESUME_INPUT_PIPE);
 
         settings.paths = matches
             .values_of(options::ARG_FILES)
             .map(|v| v.map(PathBuf::from).collect())
             .unwrap_or_default();
 
-        settings.verbose = (matches.is_present(options::verbosity::VERBOSE)
+        settings.verbose = (matches.contains_id(options::verbosity::VERBOSE)
             || settings.paths.len() > 1)
-            && !matches.is_present(options::verbosity::QUIET);
+            && !matches.contains_id(options::verbosity::QUIET);
 
         Ok(settings)
     }

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -54,16 +54,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let options = Options {
-        append: matches.is_present(options::APPEND),
-        ignore_interrupts: matches.is_present(options::IGNORE_INTERRUPTS),
+        append: matches.contains_id(options::APPEND),
+        ignore_interrupts: matches.contains_id(options::IGNORE_INTERRUPTS),
         files: matches
             .values_of(options::FILE)
             .map(|v| v.map(ToString::to_string).collect())
             .unwrap_or_default(),
         output_error: {
-            if matches.is_present(options::IGNORE_PIPE_ERRORS) {
+            if matches.contains_id(options::IGNORE_PIPE_ERRORS) {
                 Some(OutputErrorMode::WarnNoPipe)
-            } else if matches.is_present(options::OUTPUT_ERROR) {
+            } else if matches.contains_id(options::OUTPUT_ERROR) {
                 if let Some(v) = matches.value_of(options::OUTPUT_ERROR) {
                     match v {
                         "warn" => Some(OutputErrorMode::Warn),

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -82,9 +82,9 @@ impl Config {
                 Err(err) => return Err(UUsageError::new(ExitStatus::TimeoutFailed.into(), err)),
             };
 
-        let preserve_status: bool = options.is_present(options::PRESERVE_STATUS);
-        let foreground = options.is_present(options::FOREGROUND);
-        let verbose = options.is_present(options::VERBOSE);
+        let preserve_status: bool = options.contains_id(options::PRESERVE_STATUS);
+        let foreground = options.contains_id(options::FOREGROUND);
+        let verbose = options.contains_id(options::VERBOSE);
 
         let command = options
             .values_of(options::COMMAND)

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -78,7 +78,10 @@ Try 'touch --help' for more information."##,
     })?;
     let (mut atime, mut mtime) =
         if let Some(reference) = matches.value_of_os(options::sources::REFERENCE) {
-            stat(Path::new(reference), !matches.is_present(options::NO_DEREF))?
+            stat(
+                Path::new(reference),
+                !matches.contains_id(options::NO_DEREF),
+            )?
         } else {
             let timestamp = if let Some(date) = matches.value_of(options::sources::DATE) {
                 parse_date(date)?
@@ -101,11 +104,11 @@ Try 'touch --help' for more information."##,
         let path = pathbuf.as_path();
 
         if !path.exists() {
-            if matches.is_present(options::NO_CREATE) {
+            if matches.contains_id(options::NO_CREATE) {
                 continue;
             }
 
-            if matches.is_present(options::NO_DEREF) {
+            if matches.contains_id(options::NO_DEREF) {
                 show!(USimpleError::new(
                     1,
                     format!(
@@ -122,21 +125,21 @@ Try 'touch --help' for more information."##,
             };
 
             // Minor optimization: if no reference time was specified, we're done.
-            if !matches.is_present(options::SOURCES) {
+            if !matches.contains_id(options::SOURCES) {
                 continue;
             }
         }
 
         // If changing "only" atime or mtime, grab the existing value of the other.
         // Note that "-a" and "-m" may be passed together; this is not an xor.
-        if matches.is_present(options::ACCESS)
-            || matches.is_present(options::MODIFICATION)
-            || matches.is_present(options::TIME)
+        if matches.contains_id(options::ACCESS)
+            || matches.contains_id(options::MODIFICATION)
+            || matches.contains_id(options::TIME)
         {
-            let st = stat(path, !matches.is_present(options::NO_DEREF))?;
+            let st = stat(path, !matches.contains_id(options::NO_DEREF))?;
             let time = matches.value_of(options::TIME).unwrap_or("");
 
-            if !(matches.is_present(options::ACCESS)
+            if !(matches.contains_id(options::ACCESS)
                 || time.contains(&"access".to_owned())
                 || time.contains(&"atime".to_owned())
                 || time.contains(&"use".to_owned()))
@@ -144,7 +147,7 @@ Try 'touch --help' for more information."##,
                 atime = st.0;
             }
 
-            if !(matches.is_present(options::MODIFICATION)
+            if !(matches.contains_id(options::MODIFICATION)
                 || time.contains(&"modify".to_owned())
                 || time.contains(&"mtime".to_owned()))
             {
@@ -152,7 +155,7 @@ Try 'touch --help' for more information."##,
             }
         }
 
-        if matches.is_present(options::NO_DEREF) {
+        if matches.contains_id(options::NO_DEREF) {
             set_symlink_file_times(path, atime, mtime)
         } else {
             filetime::set_file_times(path, atime, mtime)

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -48,10 +48,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
-    let delete_flag = matches.is_present(options::DELETE);
-    let complement_flag = matches.is_present(options::COMPLEMENT);
-    let squeeze_flag = matches.is_present(options::SQUEEZE);
-    let truncate_set1_flag = matches.is_present(options::TRUNCATE_SET1);
+    let delete_flag = matches.contains_id(options::DELETE);
+    let complement_flag = matches.contains_id(options::COMPLEMENT);
+    let squeeze_flag = matches.contains_id(options::SQUEEZE);
+    let truncate_set1_flag = matches.contains_id(options::TRUNCATE_SET1);
 
     let sets = matches
         .values_of(options::SETS)

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -129,8 +129,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if files.is_empty() {
         return Err(UUsageError::new(1, "missing file operand"));
     } else {
-        let io_blocks = matches.is_present(options::IO_BLOCKS);
-        let no_create = matches.is_present(options::NO_CREATE);
+        let io_blocks = matches.contains_id(options::IO_BLOCKS);
+        let no_create = matches.contains_id(options::NO_CREATE);
         let reference = matches.value_of(options::REFERENCE).map(String::from);
         let size = matches.value_of(options::SIZE).map(String::from);
         truncate(no_create, io_blocks, reference, size, &files)

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -30,7 +30,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    let silent = matches.is_present(options::SILENT);
+    let silent = matches.contains_id(options::SILENT);
 
     // Call libc function ttyname
     let tty = unsafe {

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -61,15 +61,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         PlatformInfo::new().map_err_context(|| "failed to create PlatformInfo".to_string())?;
     let mut output = String::new();
 
-    let all = matches.is_present(options::ALL);
-    let kernelname = matches.is_present(options::KERNELNAME);
-    let nodename = matches.is_present(options::NODENAME);
-    let kernelrelease = matches.is_present(options::KERNELRELEASE);
-    let kernelversion = matches.is_present(options::KERNELVERSION);
-    let machine = matches.is_present(options::MACHINE);
-    let processor = matches.is_present(options::PROCESSOR);
-    let hwplatform = matches.is_present(options::HWPLATFORM);
-    let os = matches.is_present(options::OS);
+    let all = matches.contains_id(options::ALL);
+    let kernelname = matches.contains_id(options::KERNELNAME);
+    let nodename = matches.contains_id(options::NODENAME);
+    let kernelrelease = matches.contains_id(options::KERNELRELEASE);
+    let kernelversion = matches.contains_id(options::KERNELVERSION);
+    let machine = matches.contains_id(options::MACHINE);
+    let processor = matches.contains_id(options::PROCESSOR);
+    let hwplatform = matches.contains_id(options::HWPLATFORM);
+    let os = matches.contains_id(options::OS);
 
     let none = !(all
         || kernelname

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -109,9 +109,9 @@ impl Options {
             Some(s) => tabstops_parse(&s.collect::<Vec<&str>>().join(","))?,
         };
 
-        let aflag = (matches.is_present(options::ALL) || matches.is_present(options::TABS))
-            && !matches.is_present(options::FIRST_ONLY);
-        let uflag = !matches.is_present(options::NO_UTF8);
+        let aflag = (matches.contains_id(options::ALL) || matches.contains_id(options::TABS))
+            && !matches.contains_id(options::FIRST_ONLY);
+        let uflag = !matches.contains_id(options::NO_UTF8);
 
         let files = match matches.value_of(options::FILE) {
             Some(v) => vec![v.to_string()],

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -274,18 +274,18 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let uniq = Uniq {
-        repeats_only: matches.is_present(options::REPEATED)
-            || matches.is_present(options::ALL_REPEATED),
-        uniques_only: matches.is_present(options::UNIQUE),
-        all_repeated: matches.is_present(options::ALL_REPEATED)
-            || matches.is_present(options::GROUP),
+        repeats_only: matches.contains_id(options::REPEATED)
+            || matches.contains_id(options::ALL_REPEATED),
+        uniques_only: matches.contains_id(options::UNIQUE),
+        all_repeated: matches.contains_id(options::ALL_REPEATED)
+            || matches.contains_id(options::GROUP),
         delimiters: get_delimiter(&matches),
-        show_counts: matches.is_present(options::COUNT),
+        show_counts: matches.contains_id(options::COUNT),
         skip_fields: opt_parsed(options::SKIP_FIELDS, &matches)?,
         slice_start: opt_parsed(options::SKIP_CHARS, &matches)?,
         slice_stop: opt_parsed(options::CHECK_CHARS, &matches)?,
-        ignore_case: matches.is_present(options::IGNORE_CASE),
-        zero_terminated: matches.is_present(options::ZERO_TERMINATED),
+        ignore_case: matches.contains_id(options::IGNORE_CASE),
+        zero_terminated: matches.contains_id(options::ZERO_TERMINATED),
     };
 
     if uniq.show_counts && uniq.all_repeated {
@@ -410,7 +410,7 @@ fn get_delimiter(matches: &ArgMatches) -> Delimiters {
         .or_else(|| matches.value_of(options::GROUP));
     if let Some(delimiter_arg) = value {
         Delimiters::from_str(delimiter_arg).unwrap() // All possible values for ALL_REPEATED are Delimiters (of type `&str`)
-    } else if matches.is_present(options::GROUP) {
+    } else if matches.contains_id(options::GROUP) {
         Delimiters::Separate
     } else {
         Delimiters::None

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -43,7 +43,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if uptime < 0 {
         Err(USimpleError::new(1, "could not retrieve system uptime"))
     } else {
-        if matches.is_present(options::SINCE) {
+        if matches.contains_id(options::SINCE) {
             let initial_date = Local.timestamp(Utc::now().timestamp() - uptime, 0);
             println!("{}", initial_date.format("%Y-%m-%d %H:%M:%S"));
             return Ok(());

--- a/src/uu/vdir/src/vdir.rs
+++ b/src/uu/vdir/src/vdir.rs
@@ -22,22 +22,22 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // We check if any options on formatting or quoting style have been given.
     // If not, we will use dir default formatting and quoting style options
 
-    if !matches.is_present(options::QUOTING_STYLE)
-        && !matches.is_present(options::quoting::C)
-        && !matches.is_present(options::quoting::ESCAPE)
-        && !matches.is_present(options::quoting::LITERAL)
+    if !matches.contains_id(options::QUOTING_STYLE)
+        && !matches.contains_id(options::quoting::C)
+        && !matches.contains_id(options::quoting::ESCAPE)
+        && !matches.contains_id(options::quoting::LITERAL)
     {
         default_quoting_style = true;
     }
-    if !matches.is_present(options::FORMAT)
-        && !matches.is_present(options::format::ACROSS)
-        && !matches.is_present(options::format::COLUMNS)
-        && !matches.is_present(options::format::COMMAS)
-        && !matches.is_present(options::format::LONG)
-        && !matches.is_present(options::format::LONG_NO_GROUP)
-        && !matches.is_present(options::format::LONG_NO_OWNER)
-        && !matches.is_present(options::format::LONG_NUMERIC_UID_GID)
-        && !matches.is_present(options::format::ONE_LINE)
+    if !matches.contains_id(options::FORMAT)
+        && !matches.contains_id(options::format::ACROSS)
+        && !matches.contains_id(options::format::COLUMNS)
+        && !matches.contains_id(options::format::COMMAS)
+        && !matches.contains_id(options::format::LONG)
+        && !matches.contains_id(options::format::LONG_NO_GROUP)
+        && !matches.contains_id(options::format::LONG_NO_OWNER)
+        && !matches.contains_id(options::format::LONG_NUMERIC_UID_GID)
+        && !matches.contains_id(options::format::ONE_LINE)
     {
         default_format_style = true;
     }

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -60,11 +60,11 @@ impl Settings {
         };
 
         let settings = Self {
-            show_bytes: matches.is_present(options::BYTES),
-            show_chars: matches.is_present(options::CHAR),
-            show_lines: matches.is_present(options::LINES),
-            show_words: matches.is_present(options::WORDS),
-            show_max_line_length: matches.is_present(options::MAX_LINE_LENGTH),
+            show_bytes: matches.contains_id(options::BYTES),
+            show_chars: matches.contains_id(options::CHAR),
+            show_lines: matches.contains_id(options::LINES),
+            show_words: matches.contains_id(options::WORDS),
+            show_max_line_length: matches.contains_id(options::MAX_LINE_LENGTH),
             files0_from_stdin_mode,
             title_quoting_style,
         };
@@ -264,7 +264,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 fn inputs(matches: &ArgMatches) -> UResult<Vec<Input>> {
     match matches.values_of_os(ARG_FILES) {
         Some(os_values) => {
-            if matches.is_present(options::FILES0_FROM) {
+            if matches.contains_id(options::FILES0_FROM) {
                 return Err(WcError::FilesDisabled(
                     "file operands cannot be combined with --files0-from".into(),
                 )

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -70,39 +70,39 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .unwrap_or_default();
 
     // If true, attempt to canonicalize hostnames via a DNS lookup.
-    let do_lookup = matches.is_present(options::LOOKUP);
+    let do_lookup = matches.contains_id(options::LOOKUP);
 
     // If true, display only a list of usernames and count of
     // the users logged on.
     // Ignored for 'who am i'.
-    let short_list = matches.is_present(options::COUNT);
+    let short_list = matches.contains_id(options::COUNT);
 
-    let all = matches.is_present(options::ALL);
+    let all = matches.contains_id(options::ALL);
 
     // If true, display a line at the top describing each field.
-    let include_heading = matches.is_present(options::HEADING);
+    let include_heading = matches.contains_id(options::HEADING);
 
     // If true, display a '+' for each user if mesg y, a '-' if mesg n,
     // or a '?' if their tty cannot be statted.
-    let include_mesg = all || matches.is_present(options::MESG) || matches.is_present("w");
+    let include_mesg = all || matches.contains_id(options::MESG) || matches.contains_id("w");
 
     // If true, display the last boot time.
-    let need_boottime = all || matches.is_present(options::BOOT);
+    let need_boottime = all || matches.contains_id(options::BOOT);
 
     // If true, display dead processes.
-    let need_deadprocs = all || matches.is_present(options::DEAD);
+    let need_deadprocs = all || matches.contains_id(options::DEAD);
 
     // If true, display processes waiting for user login.
-    let need_login = all || matches.is_present(options::LOGIN);
+    let need_login = all || matches.contains_id(options::LOGIN);
 
     // If true, display processes started by init.
-    let need_initspawn = all || matches.is_present(options::PROCESS);
+    let need_initspawn = all || matches.contains_id(options::PROCESS);
 
     // If true, display the last clock change.
-    let need_clockchange = all || matches.is_present(options::TIME);
+    let need_clockchange = all || matches.contains_id(options::TIME);
 
     // If true, display the current runlevel.
-    let need_runlevel = all || matches.is_present(options::RUNLEVEL);
+    let need_runlevel = all || matches.contains_id(options::RUNLEVEL);
 
     let use_defaults = !(all
         || need_boottime
@@ -111,10 +111,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         || need_initspawn
         || need_runlevel
         || need_clockchange
-        || matches.is_present(options::USERS));
+        || matches.contains_id(options::USERS));
 
     // If true, display user processes.
-    let need_users = all || matches.is_present(options::USERS) || use_defaults;
+    let need_users = all || matches.contains_id(options::USERS) || use_defaults;
 
     // If true, display the hours:minutes since each user has touched
     // the keyboard, or "." if within the last minute, or "old" if
@@ -128,7 +128,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let short_output = !include_exit && use_defaults;
 
     // If true, display info only for the controlling tty.
-    let my_line_only = matches.is_present(options::ONLY_HOSTNAME_USER) || files.len() == 2;
+    let my_line_only = matches.contains_id(options::ONLY_HOSTNAME_USER) || files.len() == 2;
 
     let mut who = Who {
         do_lookup,

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -470,25 +470,25 @@ pub fn chown_base<'a>(
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 
-    let preserve_root = matches.is_present(options::preserve_root::PRESERVE);
+    let preserve_root = matches.contains_id(options::preserve_root::PRESERVE);
 
-    let mut dereference = if matches.is_present(options::dereference::DEREFERENCE) {
+    let mut dereference = if matches.contains_id(options::dereference::DEREFERENCE) {
         Some(true)
-    } else if matches.is_present(options::dereference::NO_DEREFERENCE) {
+    } else if matches.contains_id(options::dereference::NO_DEREFERENCE) {
         Some(false)
     } else {
         None
     };
 
-    let mut traverse_symlinks = if matches.is_present(options::traverse::TRAVERSE) {
+    let mut traverse_symlinks = if matches.contains_id(options::traverse::TRAVERSE) {
         TraverseSymlinks::First
-    } else if matches.is_present(options::traverse::EVERY) {
+    } else if matches.contains_id(options::traverse::EVERY) {
         TraverseSymlinks::All
     } else {
         TraverseSymlinks::None
     };
 
-    let recursive = matches.is_present(options::RECURSIVE);
+    let recursive = matches.contains_id(options::RECURSIVE);
     if recursive {
         if traverse_symlinks == TraverseSymlinks::None {
             if dereference == Some(true) {
@@ -500,13 +500,13 @@ pub fn chown_base<'a>(
         traverse_symlinks = TraverseSymlinks::None;
     }
 
-    let verbosity_level = if matches.is_present(options::verbosity::CHANGES) {
+    let verbosity_level = if matches.contains_id(options::verbosity::CHANGES) {
         VerbosityLevel::Changes
-    } else if matches.is_present(options::verbosity::SILENT)
-        || matches.is_present(options::verbosity::QUIET)
+    } else if matches.contains_id(options::verbosity::SILENT)
+        || matches.contains_id(options::verbosity::QUIET)
     {
         VerbosityLevel::Silent
-    } else if matches.is_present(options::verbosity::VERBOSE) {
+    } else if matches.contains_id(options::verbosity::VERBOSE) {
         VerbosityLevel::Verbose
     } else {
         VerbosityLevel::Normal

--- a/src/uucore/src/lib/mods/backup_control.rs
+++ b/src/uucore/src/lib/mods/backup_control.rs
@@ -332,7 +332,7 @@ pub fn determine_backup_suffix(matches: &ArgMatches) -> String {
 /// }
 /// ```
 pub fn determine_backup_mode(matches: &ArgMatches) -> UResult<BackupMode> {
-    if matches.is_present(arguments::OPT_BACKUP) {
+    if matches.contains_id(arguments::OPT_BACKUP) {
         // Use method to determine the type of backups to make. When this option
         // is used but method is not specified, then the value of the
         // VERSION_CONTROL environment variable is used. And if VERSION_CONTROL
@@ -347,7 +347,7 @@ pub fn determine_backup_mode(matches: &ArgMatches) -> UResult<BackupMode> {
             // Default if no argument is provided to '--backup'
             Ok(BackupMode::ExistingBackup)
         }
-    } else if matches.is_present(arguments::OPT_BACKUP_NO_ARG) {
+    } else if matches.contains_id(arguments::OPT_BACKUP_NO_ARG) {
         // the short form of this option, -b does not accept any argument.
         // Using -b is equivalent to using --backup=existing.
         Ok(BackupMode::ExistingBackup)


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `is_present()` function with `contains_id()`.