### PR TITLE
Replace possible_values() with value_parser()

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -142,12 +142,14 @@ fn gen_completions<T: uucore::Args>(
         .about("Prints completions to stdout")
         .arg(
             Arg::new("utility")
-                .possible_values(all_utilities)
+                .value_parser(clap::builder::PossibleValuesParser::new(all_utilities))
                 .required(true),
         )
         .arg(
             Arg::new("shell")
-                .possible_values(Shell::possible_values())
+                .value_parser(clap::builder::PossibleValuesParser::new(
+                    Shell::possible_values(),
+                ))
                 .required(true),
         )
         .get_matches_from(std::iter::once(OsString::from("completion")).chain(args));

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -401,7 +401,7 @@ pub fn uu_app<'a>() -> Command<'a> {
              .takes_value(true)
              .multiple_occurrences(true)
              .use_value_delimiter(true)
-             .possible_values(PRESERVABLE_ATTRIBUTES)
+             .value_parser(clap::builder::PossibleValuesParser::new(PRESERVABLE_ATTRIBUTES))
              .min_values(0)
              .value_name("ATTR_LIST")
              .overrides_with_all(&[options::ARCHIVE, options::PRESERVE_DEFAULT_ATTRIBUTES, options::NO_PRESERVE])
@@ -451,7 +451,7 @@ pub fn uu_app<'a>() -> Command<'a> {
              .long(options::SPARSE)
              .takes_value(true)
              .value_name("WHEN")
-             .possible_values(["never", "auto", "always"])
+             .value_parser(["never", "auto", "always"])
              .help("NotImplemented: control creation of sparse files. See below"))
 
         // TODO: implement the following args

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -559,7 +559,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .require_equals(true)
                 .use_value_delimiter(true)
                 .multiple_occurrences(true)
-                .possible_values(OUTPUT_FIELD_LIST)
+                .value_parser(OUTPUT_FIELD_LIST)
                 .default_missing_values(&OUTPUT_FIELD_LIST)
                 .default_values(&["source", "size", "used", "avail", "pcent", "target"])
                 .conflicts_with_all(&[OPT_INODES, OPT_PORTABILITY, OPT_PRINT_TYPE])

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -895,7 +895,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .value_name("WORD")
                 .require_equals(true)
                 .min_values(0)
-                .possible_values(&["atime", "access", "use", "ctime", "status", "birth", "creation"])
+                .value_parser(["atime", "access", "use", "ctime", "status", "birth", "creation"])
                 .help(
                     "show time of the last modification of any file in the \
                     directory, or any of its subdirectories. If WORD is given, show time as WORD instead \

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -713,7 +713,7 @@ When FILE1 or FILE2 (not both) is -, read standard input.",
                 .short('a')
                 .multiple_occurrences(true)
                 .number_of_values(1)
-                .possible_values(&["1", "2"])
+                .value_parser(["1", "2"])
                 .value_name("FILENUM")
                 .help(
                     "also print unpairable lines from file FILENUM, where
@@ -725,7 +725,7 @@ FILENUM is 1 or 2, corresponding to FILE1 or FILE2",
                 .short('v')
                 .multiple_occurrences(true)
                 .number_of_values(1)
-                .possible_values(&["1", "2"])
+                .value_parser(["1", "2"])
                 .value_name("FILENUM")
                 .help("like -a FILENUM, but suppress joined output lines"),
         )

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -911,7 +911,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     .long(options::FORMAT)
                     .help("Set the display format.")
                     .takes_value(true)
-                    .possible_values(&[
+                    .value_parser([
                         "long",
                         "verbose",
                         "single-column",
@@ -1042,7 +1042,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     .long(options::QUOTING_STYLE)
                     .takes_value(true)
                     .help("Set quoting style.")
-                    .possible_values(&[
+                    .value_parser([
                         "literal",
                         "shell",
                         "shell-always",
@@ -1120,7 +1120,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     )
                     .value_name("field")
                     .takes_value(true)
-                    .possible_values(&[
+                    .value_parser([
                         "atime", "access", "use", "ctime", "status", "birth", "creation",
                     ])
                     .hide_possible_values(true)
@@ -1182,7 +1182,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     .help("Sort by <field>: name, none (-U), time (-t), size (-S) or extension (-X)")
                     .value_name("field")
                     .takes_value(true)
-                    .possible_values(&["name", "none", "time", "size", "version", "extension"])
+                    .value_parser(["name", "none", "time", "size", "version", "extension"])
                     .require_equals(true)
                     .overrides_with_all(&[
                         options::SORT,
@@ -1411,7 +1411,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     .long(options::COLOR)
                     .help("Color output based on file type.")
                     .takes_value(true)
-                    .possible_values(&[
+                    .value_parser([
                         "always", "yes", "force", "auto", "tty", "if-tty", "never", "no", "none",
                     ])
                     .require_equals(true)
@@ -1425,7 +1425,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                         none (default),  slash (-p), file-type (--file-type), classify (-F)",
                     )
                     .takes_value(true)
-                    .possible_values(&["none", "slash", "file-type", "classify"])
+                    .value_parser(["none", "slash", "file-type", "classify"])
                     .overrides_with_all(&[
                         options::indicator_style::FILE_TYPE,
                         options::indicator_style::SLASH,
@@ -1456,7 +1456,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     )
                     .takes_value(true)
                     .value_name("when")
-                    .possible_values(&[
+                    .value_parser([
                         "always", "yes", "force", "auto", "tty", "if-tty", "never", "no", "none",
                     ])
                     .default_missing_value("always")
@@ -1498,7 +1498,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     .help("time/date format with -l; see TIME_STYLE below")
                     .value_name("TIME_STYLE")
                     .env("TIME_STYLE")
-                    .possible_values(&["full-iso", "long-iso", "iso", "locale"])
+                    .value_parser(["full-iso", "long-iso", "iso", "locale"])
                     .overrides_with_all(&[options::TIME_STYLE]),
             )
             .arg(

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -375,7 +375,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 )
                 .value_name("METHOD")
                 .default_value("from-zero")
-                .possible_values(&["up", "down", "from-zero", "towards-zero", "nearest"]),
+                .value_parser(["up", "down", "from-zero", "towards-zero", "nearest"]),
         )
         .arg(
             Arg::new(options::SUFFIX)

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -332,7 +332,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(options::ENDIAN)
                 .long(options::ENDIAN)
                 .help("byte order to use for multi-byte formats")
-                .possible_values(&["big", "little"])
+                .value_parser(["big", "little"])
                 .value_name("big|little"),
         )
         .arg(

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1286,7 +1286,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(options::modes::SORT)
                 .long(options::modes::SORT)
                 .takes_value(true)
-                .possible_values(&[
+                .value_parser([
                     "general-numeric",
                     "human-numeric",
                     "month",
@@ -1351,7 +1351,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .require_equals(true)
                 .min_values(0)
-                .possible_values(&[
+                .value_parser([
                     options::check::SILENT,
                     options::check::QUIET,
                     options::check::DIAGNOSE_FIRST,

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -585,7 +585,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .min_values(0)
                 .max_values(1)
                 .require_equals(true)
-                .possible_values(&["descriptor", "name"])
+                .value_parser(["descriptor", "name"])
                 .help("Print the file as it grows"),
         )
         .arg(

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -122,7 +122,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .require_equals(true)
                 .min_values(0)
                 .max_values(1)
-                .possible_values([
+                .value_parser([
                     PossibleValue::new("warn")
                         .help("produce warnings for errors writing to any output"),
                     PossibleValue::new("warn-nopipe")

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -234,7 +234,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                      equivalent to -m",
                 )
                 .value_name("WORD")
-                .possible_values(&["access", "atime", "use"])
+                .value_parser(["access", "atime", "use"])
                 .takes_value(true),
         )
         .arg(

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -311,7 +311,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(options::ALL_REPEATED)
                 .short('D')
                 .long(options::ALL_REPEATED)
-                .possible_values(&[
+                .value_parser([
                     "none",
                     "prepend",
                     "separate"
@@ -326,7 +326,7 @@ pub fn uu_app<'a>() -> Command<'a> {
         .arg(
             Arg::new(options::GROUP)
                 .long(options::GROUP)
-                .possible_values(&[
+                .value_parser([
                     "separate",
                     "prepend",
                     "append",


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `possible_values()` with `value_parser()`.