### PR TITLE
Use `u64` instead of `ino_t`/`dev_t` types

### DIFF
--- a/src/uu/chcon/src/errors.rs
+++ b/src/uu/chcon/src/errors.rs
@@ -14,6 +14,9 @@ pub(crate) enum Error {
     #[error("No files are specified")]
     MissingFiles,
 
+    #[error("Data is out of range")]
+    OutOfRange,
+
     #[error("{0}")]
     ArgumentsMismatch(String),
 


### PR DESCRIPTION
Closes #3775.