### PR TITLE
tail: handle events after tailed and before watcher starts watching

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -787,28 +787,26 @@ fn follow(files: &mut FileHandling, settings: &mut Settings) -> UResult<()> {
                     } else {
                         // nothing changed
                     }
-                } else {
-                    if let Some(old_md) = &data.metadata {
-                        if !old_md.is_tailable() {
-                            show_error!("{} has become accessible", display_name.quote());
-                            files.update_reader(path)?;
-                        } else if data.reader.is_none() {
-                            show_error!(
-                                "{} has appeared;  following new file",
-                                display_name.quote()
-                            );
-                            files.update_reader(path)?;
-                        } else if !old_md.file_id_eq(&new_md) {
-                            show_error!(
-                                "{} has been replaced;  following new file",
-                                display_name.quote()
-                            );
-                            files.update_reader(path)?;
-                        }
-                    } else {
-                        show_error!("{} has appeared;  following new file", display_name.quote());
+                } else if let Some(old_md) = &data.metadata {
+                    if !old_md.is_tailable() {
+                        show_error!("{} has become accessible", display_name.quote());
+                        files.update_reader(path)?;
+                    } else if data.reader.is_none() {
+                        show_error!(
+                            "{} has appeared;  following new file",
+                            display_name.quote()
+                        );
+                        files.update_reader(path)?;
+                    } else if !old_md.file_id_eq(&new_md) {
+                        show_error!(
+                            "{} has been replaced;  following new file",
+                            display_name.quote()
+                        );
                         files.update_reader(path)?;
                     }
+                } else {
+                    show_error!("{} has appeared;  following new file", display_name.quote());
+                    files.update_reader(path)?;
                 }
                 files.update_metadata(path, Some(new_md));
                 files.tail_file(path, settings.verbose)?;

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -792,10 +792,7 @@ fn follow(files: &mut FileHandling, settings: &mut Settings) -> UResult<()> {
                         show_error!("{} has become accessible", display_name.quote());
                         files.update_reader(path)?;
                     } else if data.reader.is_none() {
-                        show_error!(
-                            "{} has appeared;  following new file",
-                            display_name.quote()
-                        );
+                        show_error!("{} has appeared;  following new file", display_name.quote());
                         files.update_reader(path)?;
                     } else if !old_md.file_id_eq(&new_md) {
                         show_error!(


### PR DESCRIPTION
When `--follow=name` read again all the files after watcher has been set up, if file changed just before the watcher started watching and after tail has happened.

This is done only when not using polling.

Tested with this sleep: sleep after all the files tailed and before watcher has been set up. For instance `F-headers.sh` didn't work without the fix if this line added, but starts working after the fix.

```rust
fn follow(files: &mut FileHandling, settings: &mut Settings) -> UResult<()> {
+    thread::sleep(Duration::from_millis(4000));
    let mut process = platform::ProcessChecker::new(settings.pid);
```

Probably fixes #3765 even without changing the testcase.