### PR TITLE
test/cp: fix test_copy_through_dangling_symlink_no_dereference_permissions

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1742,19 +1742,27 @@ fn test_copy_through_dangling_symlink_no_dereference_permissions() {
         .succeeds()
         .no_stderr()
         .no_stdout();
-    assert!(at.symlink_exists("d2"));
+    assert!(at.symlink_exists("d2"), "symlink wasn't created");
 
     // `-p` means `--preserve=mode,ownership,timestamps`
     #[cfg(unix)]
     {
         let metadata1 = at.symlink_metadata("dangle");
         let metadata2 = at.symlink_metadata("d2");
-        assert_eq!(metadata1.mode(), metadata2.mode());
-        assert_eq!(metadata1.uid(), metadata2.uid());
-        assert_eq!(metadata1.atime(), metadata2.atime());
-        assert_eq!(metadata1.atime_nsec(), metadata2.atime_nsec());
-        assert_eq!(metadata1.mtime(), metadata2.mtime());
-        assert_eq!(metadata1.mtime_nsec(), metadata2.mtime_nsec());
+        assert_eq!(metadata1.mode(), metadata2.mode(), "mode is different");
+        assert_eq!(metadata1.uid(), metadata2.uid(), "uid is different");
+        assert_eq!(metadata1.atime(), metadata2.atime(), "atime is different");
+        assert_eq!(
+            metadata1.atime_nsec(),
+            metadata2.atime_nsec(),
+            "atime_nsec is different"
+        );
+        assert_eq!(metadata1.mtime(), metadata2.mtime(), "mtime is different");
+        assert_eq!(
+            metadata1.mtime_nsec(),
+            metadata2.mtime_nsec(),
+            "mtime_nsec is different"
+        );
     }
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -22,9 +22,7 @@ use filetime::FileTime;
 use rlimit::Resource;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::fs as std_fs;
-#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::thread::sleep;
-#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::time::Duration;
 use uucore::display::Quotable;
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1732,6 +1732,8 @@ fn test_copy_through_dangling_symlink_no_dereference_permissions() {
     let (at, mut ucmd) = at_and_ucmd!();
     //               target name    link name
     at.symlink_file("no-such-file", "dangle");
+    // to check if access time and modification time didn't change
+    sleep(Duration::from_millis(5000));
     //          don't dereference the link
     //           |    copy permissions, too
     //           |      |    from the link
@@ -1753,7 +1755,6 @@ fn test_copy_through_dangling_symlink_no_dereference_permissions() {
         assert_eq!(metadata1.uid(), metadata2.uid());
         assert_eq!(metadata1.atime(), metadata2.atime());
         assert_eq!(metadata1.mtime(), metadata2.mtime());
-        assert_eq!(metadata1.ctime(), metadata2.ctime());
     }
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1754,7 +1754,9 @@ fn test_copy_through_dangling_symlink_no_dereference_permissions() {
         assert_eq!(metadata1.mode(), metadata2.mode());
         assert_eq!(metadata1.uid(), metadata2.uid());
         assert_eq!(metadata1.atime(), metadata2.atime());
+        assert_eq!(metadata1.atime_nsec(), metadata2.atime_nsec());
         assert_eq!(metadata1.mtime(), metadata2.mtime());
+        assert_eq!(metadata1.mtime_nsec(), metadata2.mtime_nsec());
     }
 }
 


### PR DESCRIPTION
The test checked `-p` option that shouldn't change timestamps.

According to coreutils documentation, it shouldn't change `atime` and `mtime`, but changes `ctime`. 

```
     ‘timestamps’
          Preserve the times of last access and last modification, when
          possible.

...

     Using ‘--preserve’ with no ATTRIBUTE_LIST is equivalent to
     ‘--preserve=mode,ownership,timestamps’.
```
GNU coreutils `cp` works like it's written in documentation in this case.

The test was passing most of the time, because it was checking the timestamp in seconds, and in a single second both the original link and copied link were created, so their timestamps were equal. Sometimes it was failing, for instance here https://github.com/uutils/coreutils/runs/7711138977?check_suite_focus=true.

- added 5 seconds timeout between file creation and copy, so that timestamps are for sure different (after adding this it started failing every time because of `ctime` has been changed by 5)
- removed `ctime` checking
- made `atime` and `mtime` checking more accurate, started checking `atime_nsec` and `mtime_nsec` as well