### PR TITLE
test/tail: ignore broken pipe for tail -n 0

### DIFF
--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1011,6 +1011,7 @@ fn test_positive_zero_lines() {
     ts.ucmd()
         .args(&["-n", "0"])
         .pipe_in("a\nb\nc\nd\ne\n")
+        .ignore_stdin_write_error()
         .succeeds()
         .no_stderr()
         .no_stdout();


### PR DESCRIPTION
Add `ignore_stdin_write_error` for `tail -n 0` test. 

It doesn't read stdin at all, so process can already finish when trying to write to pipe.

Was failing sometimes with broken pipe, for example here: https://github.com/uutils/coreutils/runs/7723319030?check_suite_focus=true