### PR TITLE
test/dd: fix broken pipe in test_bytes_oseek_bytes_trunc_oflag

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1155,6 +1155,7 @@ fn test_bytes_oseek_bytes_trunc_oflag() {
     new_ucmd!()
         .args(&["oseek=8", "oflag=seek_bytes", "bs=2", "count=0"])
         .pipe_in("abcdefghijklm")
+        .ignore_stdin_write_error()
         .succeeds()
         .stdout_is_fixture_bytes("dd-bytes-null-trunc.spec");
 }


### PR DESCRIPTION
Fixes #3581 

I think that happens because `count=0` is stated, `dd` won't read anything from stdin. So the process could finish before we wrote something to stdin pipe, and broken pipe error is raised.

- Add `ignore_stdin_write_error` for this test