### PR TITLE
Fix a bug in split where chunking would be skipped when the chunk size

### DIFF
--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -696,5 +696,5 @@ fn test_multiple_of_input_chunk() {
     for filename in glob.collect() {
         assert_eq!(glob.directory.metadata(&filename).len(), 8 * 1024);
     }
-    assert_eq!(glob.collate(), at.read_bytes(name))
+    assert_eq!(glob.collate(), at.read_bytes(name));
 }

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -683,3 +683,18 @@ fn test_guard_input() {
         .stderr_only("split: 'xaa' would overwrite input; aborting");
     assert_eq!(at.read("xaa"), "1\n2\n3\n");
 }
+
+#[test]
+fn test_multiple_of_input_chunk() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let name = "multiple_of_input_chunk";
+    RandomFile::new(&at, name).add_bytes(16 * 1024);
+    ucmd.args(&["-b", "8K", name, "b"]).succeeds();
+
+    let glob = Glob::new(&at, ".", r"b[[:alpha:]][[:alpha:]]$");
+    assert_eq!(glob.count(), 2);
+    for filename in glob.collect() {
+        assert_eq!(glob.directory.metadata(&filename).len(), 8 * 1024);
+    }
+    assert_eq!(glob.collate(), at.read_bytes(name))
+}


### PR DESCRIPTION
happened to be an exact divisor of the buffer size used to read the
input stream.

The issue here was that file was being split byte-wise in chunks of 1G.
The input stream was being read in chunks of 8KB, which evenly divides
the chunk size. Because the check to allocate the next output chunk was
done at the bottom of the loop previously, it would never occur because
the current input chunk was fully consumed at that point. By moving the
check to the top of the loop (but still late enough that we know we have
bytes to write) we resolve this issue.

This scenario is unfortunately hard to write a test for, since we don't
explicitly control the input chunk size.

Fixes https://github.com/uutils/coreutils/issues/3790