### PR TITLE
sort: wait when SIGINT was raised for the program to finish properly

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1267,7 +1267,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     settings.init_precomputed();
 
-    exec(&mut files, &settings, output, &mut tmp_dir)
+    let result = exec(&mut files, &settings, output, &mut tmp_dir);
+    tmp_dir.wait_if_signal();
+    result
 }
 
 pub fn uu_app<'a>() -> Command<'a> {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1268,6 +1268,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     settings.init_precomputed();
 
     let result = exec(&mut files, &settings, output, &mut tmp_dir);
+    // Wait here if `SIGINT` was received,
+    // for signal handler to do its work and terminate the program.
     tmp_dir.wait_if_signal();
     result
 }

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -71,7 +71,7 @@ impl TmpDirWrapper {
     }
 
     pub fn wait_if_signal(&self) {
-        let _ = self.lock.lock().unwrap();
+        let _lock = self.lock.lock().unwrap();
     }
 }
 

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -69,6 +69,10 @@ impl TmpDirWrapper {
             path,
         ))
     }
+
+    pub fn wait_if_signal(&self) {
+        let _ = self.lock.lock().unwrap();
+    }
 }
 
 /// Remove the directory at `path` by deleting its child files and then itself.

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -45,7 +45,8 @@ impl TmpDirWrapper {
         let path = self.temp_dir.as_ref().unwrap().path().to_owned();
         let lock = self.lock.clone();
         ctrlc::set_handler(move || {
-            // Take the lock so that `next_file_path` returns no new file path.
+            // Take the lock so that `next_file_path` returns no new file path,
+            // and the program doesn't terminate before the handler has finished
             let _lock = lock.lock().unwrap();
             if let Err(e) = remove_tmp_dir(&path) {
                 show_error!("failed to delete temporary directory: {}", e);
@@ -70,6 +71,7 @@ impl TmpDirWrapper {
         ))
     }
 
+    /// Function just waits if signal handler was called
     pub fn wait_if_signal(&self) {
         let _lock = self.lock.lock().unwrap();
     }


### PR DESCRIPTION
- I hope it fixes #3623 issue

I think that `test_tmp_files_deleted_on_sigint` was failing, because sometimes the program finished before signal handling was finished, so the directory wasn't removed after all. I tested locally it was failing sometimes, after the fix I didn't see it failing.

- Added wait for lock just before the program finishes if the lock was taken by the signal handler