### PR TITLE
Replace deprecated values_of() with get_many()

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -39,7 +39,7 @@ pub mod options {
 
 impl Config {
     pub fn from(options: &clap::ArgMatches) -> UResult<Self> {
-        let file: Option<String> = match options.values_of(options::FILE) {
+        let file: Option<String> = match options.get_many::<String>(options::FILE) {
             Some(mut values) => {
                 let name = values.next().unwrap();
                 if let Some(extra_op) = values.next() {

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -69,7 +69,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             format!(
                 "extra operand {}",
                 matches
-                    .values_of(options::NAME)
+                    .get_many::<String>(options::NAME)
                     .unwrap()
                     .nth(2)
                     .unwrap()
@@ -81,7 +81,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let suffix = if opt_suffix {
         matches.value_of(options::SUFFIX).unwrap()
     } else if !opt_multiple && matches.occurrences_of(options::NAME) > 1 {
-        matches.values_of(options::NAME).unwrap().nth(1).unwrap()
+        matches
+            .get_many::<String>(options::NAME)
+            .unwrap()
+            .nth(1)
+            .unwrap()
     } else {
         ""
     };
@@ -91,9 +95,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     //
 
     let paths: Vec<_> = if multiple_paths {
-        matches.values_of(options::NAME).unwrap().collect()
+        matches.get_many::<String>(options::NAME).unwrap().collect()
     } else {
-        matches.values_of(options::NAME).unwrap().take(1).collect()
+        matches
+            .get_many::<String>(options::NAME)
+            .unwrap()
+            .take(1)
+            .collect()
     };
 
     let line_ending = if opt_zero { "\0" } else { "\n" };

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -224,7 +224,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     .any(|v| matches.contains_id(v));
 
     let squeeze_blank = matches.contains_id(options::SQUEEZE_BLANK);
-    let files: Vec<String> = match matches.values_of(options::FILE) {
+    let files: Vec<String> = match matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
         None => vec!["-".to_owned()],
     };

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -83,7 +83,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         modes.to_string()
     };
     let mut files: Vec<String> = matches
-        .values_of(options::FILE)
+        .get_many::<String>(options::FILE)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
     let cmode = if fmode.is_some() {

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -52,8 +52,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Err(ChrootError::NoSuchDirectory(format!("{}", newroot.display())).into());
     }
 
-    let commands = match matches.values_of(options::COMMAND) {
-        Some(v) => v.collect(),
+    let commands = match matches.get_many::<String>(options::COMMAND) {
+        Some(v) => v.map(|s| s.as_str()).collect(),
         None => vec![],
     };
 

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -120,7 +120,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    let files: Vec<String> = match matches.values_of(options::FILE) {
+    let files: Vec<String> = match matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
         None => vec![],
     };

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -503,7 +503,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
 
         let paths: Vec<String> = matches
-            .values_of(options::PATHS)
+            .get_many::<String>(options::PATHS)
             .map(|v| v.map(ToString::to_string).collect())
             .unwrap_or_default();
 
@@ -642,7 +642,7 @@ impl Options {
 
         // Parse attributes to preserve
         let mut preserve_attributes: Vec<Attribute> = if matches.contains_id(options::PRESERVE) {
-            match matches.values_of(options::PRESERVE) {
+            match matches.get_many::<String>(options::PRESERVE) {
                 None => DEFAULT_ATTRIBUTES.to_vec(),
                 Some(attribute_strs) => {
                     let mut attributes = Vec::new();

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -724,9 +724,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // get the patterns to split on
     let patterns: Vec<String> = matches
-        .values_of(options::PATTERN)
+        .get_many::<String>(options::PATTERN)
         .unwrap()
-        .map(str::to_string)
+        .map(|s| s.to_string())
         .collect();
     let patterns = patterns::get_patterns(&patterns[..])?;
     let options = CsplitOptions::new(&matches);

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -523,9 +523,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let files: Vec<String> = matches
-        .values_of(options::FILE)
+        .get_many::<String>(options::FILE)
         .unwrap_or_default()
-        .map(str::to_owned)
+        .map(|s| s.to_owned())
         .collect();
 
     match mode_parse {

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -156,8 +156,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let form = form[1..].to_string();
         Format::Custom(form)
     } else if let Some(fmt) = matches
-        .values_of(OPT_ISO_8601)
-        .map(|mut iter| iter.next().unwrap_or(DATE).into())
+        .get_many::<String>(OPT_ISO_8601)
+        .map(|mut iter| iter.next().unwrap_or(&DATE.to_string()).as_str().into())
     {
         Format::Iso8601(fmt)
     } else if matches.contains_id(OPT_RFC_EMAIL) {

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -529,7 +529,7 @@ fn parse_flag_list<T: std::str::FromStr<Err = ParseError>>(
     matches: &Matches,
 ) -> Result<Vec<T>, ParseError> {
     matches
-        .values_of(tag)
+        .get_many::<String>(tag)
         .unwrap_or_default()
         .map(|f| f.parse())
         .collect()

--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -93,7 +93,10 @@ impl Column {
                 // Unwrapping should not panic because in this arm of
                 // the `match` statement, we know that `OPT_OUTPUT`
                 // is non-empty.
-                let names = matches.values_of(OPT_OUTPUT).unwrap();
+                let names = matches
+                    .get_many::<String>(OPT_OUTPUT)
+                    .unwrap()
+                    .map(|s| s.as_str());
                 let mut seen: Vec<&str> = vec![];
                 let mut columns = vec![];
                 for name in names {

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -442,7 +442,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let opt = Options::from(&matches).map_err(DfError::OptionsError)?;
     // Get the list of filesystems to display in the output table.
-    let filesystems: Vec<Filesystem> = match matches.values_of(OPT_PATHS) {
+    let filesystems: Vec<Filesystem> = match matches.get_many::<String>(OPT_PATHS) {
         None => {
             let filesystems = get_all_filesystems(&opt)
                 .map_err_context(|| "cannot read table of mounted file systems".into())?;
@@ -454,7 +454,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             filesystems
         }
         Some(paths) => {
-            let paths: Vec<&str> = paths.collect();
+            let paths: Vec<_> = paths.collect();
             let filesystems = get_named_filesystems(&paths, &opt)
                 .map_err_context(|| "cannot read table of mounted file systems".into())?;
 

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -72,7 +72,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(&args);
 
     let files = matches
-        .values_of(options::FILE)
+        .get_many::<String>(options::FILE)
         .map_or(vec![], |file_values| file_values.collect());
 
     // clap provides .conflicts_with / .conflicts_with_all, but we want to

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -43,9 +43,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let dirnames: Vec<String> = matches
-        .values_of(options::DIR)
+        .get_many::<String>(options::DIR)
         .unwrap_or_default()
-        .map(str::to_owned)
+        .map(|s| s.to_owned())
         .collect();
 
     if !dirnames.is_empty() {

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -491,12 +491,12 @@ fn file_as_vec(filename: impl AsRef<Path>) -> Vec<String> {
 // to ignore the files
 fn build_exclude_patterns(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
     let exclude_from_iterator = matches
-        .values_of(options::EXCLUDE_FROM)
+        .get_many::<String>(options::EXCLUDE_FROM)
         .unwrap_or_default()
         .flat_map(|f| file_as_vec(&f));
 
     let excludes_iterator = matches
-        .values_of(options::EXCLUDE)
+        .get_many::<String>(options::EXCLUDE)
         .unwrap_or_default()
         .map(|v| v.to_owned());
 
@@ -538,7 +538,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let files = match matches.value_of(options::FILE) {
-        Some(_) => matches.values_of(options::FILE).unwrap().collect(),
+        Some(_) => matches
+            .get_many::<String>(options::FILE)
+            .unwrap()
+            .map(|s| s.as_str())
+            .collect(),
         None => vec!["."],
     };
 

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -117,7 +117,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let no_newline = matches.contains_id(options::NO_NEWLINE);
     let escaped = matches.contains_id(options::ENABLE_BACKSLASH_ESCAPE);
-    let values: Vec<String> = match matches.values_of(options::STRING) {
+    let values: Vec<String> = match matches.get_many::<String>(options::STRING) {
         Some(s) => s.map(|s| s.to_string()).collect(),
         None => vec!["".to_string()],
     };

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -178,14 +178,14 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
     let ignore_env = matches.contains_id("ignore-environment");
     let null = matches.contains_id("null");
     let running_directory = matches.value_of("chdir");
-    let files = matches
-        .values_of("file")
-        .map(Iterator::collect)
-        .unwrap_or_else(|| Vec::with_capacity(0));
-    let unsets = matches
-        .values_of("unset")
-        .map(Iterator::collect)
-        .unwrap_or_else(|| Vec::with_capacity(0));
+    let files = match matches.get_many::<String>("file") {
+        Some(v) => v.map(|s| s.as_str()).collect(),
+        None => Vec::with_capacity(0),
+    };
+    let unsets = match matches.get_many::<String>("unset") {
+        Some(v) => v.map(|s| s.as_str()).collect(),
+        None => Vec::with_capacity(0),
+    };
 
     let mut opts = Options {
         ignore_env,
@@ -222,7 +222,7 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
             begin_prog_opts = parse_name_value_opt(&mut opts, external)?;
         }
 
-        if let Some(mut iter) = matches.values_of("") {
+        if let Some(mut iter) = matches.get_many::<String>("") {
             // read NAME=VALUE arguments (and up to a single program argument)
             while !begin_prog_opts {
                 if let Some(opt) = iter.next() {

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -211,8 +211,8 @@ struct Options {
 
 impl Options {
     fn new(matches: &ArgMatches) -> Result<Self, ParseError> {
-        let (remaining_mode, tabstops) = match matches.values_of(options::TABS) {
-            Some(s) => tabstops_parse(&s.collect::<Vec<&str>>().join(","))?,
+        let (remaining_mode, tabstops) = match matches.get_many::<String>(options::TABS) {
+            Some(s) => tabstops_parse(&s.map(|s| s.as_str()).collect::<Vec<_>>().join(","))?,
             None => (RemainingMode::None, vec![DEFAULT_TABSTOP]),
         };
 
@@ -232,7 +232,7 @@ impl Options {
             .unwrap(); // length of tabstops is guaranteed >= 1
         let tspaces = " ".repeat(nspaces);
 
-        let files: Vec<String> = match matches.values_of(options::FILES) {
+        let files: Vec<String> = match matches.get_many::<String>(options::FILES) {
             Some(s) => s.map(|v| v.to_string()).collect(),
             None => vec!["-".to_owned()],
         };

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -53,7 +53,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut w = io::BufWriter::with_capacity(4 * 1024, stdout.lock());
     let mut factors_buffer = String::new();
 
-    if let Some(values) = matches.values_of(options::NUMBER) {
+    if let Some(values) = matches.get_many::<String>(options::NUMBER) {
         for number in values {
             if let Err(e) = print_factors_str(number, &mut w, &mut factors_buffer) {
                 show_warning!("{}: {}", number.maybe_quote(), e);

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -70,7 +70,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let mut files: Vec<String> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -55,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         None => 80,
     };
 
-    let files = match matches.values_of(options::FILE) {
+    let files = match matches.get_many::<String>(options::FILE) {
         Some(v) => v.map(|v| v.to_owned()).collect(),
         None => vec!["-".to_owned()],
     };

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -73,7 +73,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let users: Vec<String> = matches
-        .values_of(options::USERS)
+        .get_many::<String>(options::USERS)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -202,7 +202,7 @@ impl HeadOptions {
 
         options.mode = Mode::from(&matches)?;
 
-        options.files = match matches.values_of(options::FILES_NAME) {
+        options.files = match matches.get_many::<String>(options::FILES_NAME) {
             Some(v) => v.map(|s| s.to_owned()).collect(),
             None => vec!["-".to_owned()],
         };

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -131,7 +131,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let users: Vec<String> = matches
-        .values_of(options::ARG_USERS)
+        .get_many::<String>(options::ARG_USERS)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -174,7 +174,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let paths: Vec<String> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -608,14 +608,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mut settings: Settings = Default::default();
 
-    let v_values = matches.values_of("v");
+    let v_values = matches.get_many::<String>("v");
     if v_values.is_some() {
         settings.print_joined = false;
     }
 
     let unpaired = v_values
         .unwrap_or_default()
-        .chain(matches.values_of("a").unwrap_or_default());
+        .chain(matches.get_many("a").unwrap_or_default());
     for file_num in unpaired {
         match parse_file_number(file_num)? {
             FileNum::File1 => settings.print_unpaired1 = true,

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -54,7 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let pids_or_signals: Vec<String> = matches
-        .values_of(options::PIDS_OR_SIGNALS)
+        .get_many::<String>(options::PIDS_OR_SIGNALS)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -141,7 +141,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     /* the list of files */
 
     let paths: Vec<PathBuf> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .unwrap()
         .map(PathBuf::from)
         .collect();

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -730,7 +730,11 @@ impl Config {
             ignore_patterns.push(Pattern::new(".*~").unwrap());
         }
 
-        for pattern in options.values_of(options::IGNORE).into_iter().flatten() {
+        for pattern in options
+            .get_many::<String>(options::IGNORE)
+            .into_iter()
+            .flatten()
+        {
             match Pattern::new(pattern) {
                 Ok(p) => {
                     ignore_patterns.push(p);
@@ -740,7 +744,11 @@ impl Config {
         }
 
         if files == Files::Normal {
-            for pattern in options.values_of(options::HIDE).into_iter().flatten() {
+            for pattern in options
+                .get_many::<String>(options::HIDE)
+                .into_iter()
+                .flatten()
+            {
                 match Pattern::new(pattern) {
                     Ok(p) => {
                         ignore_patterns.push(p);

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -49,7 +49,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         None => 0o666,
     };
 
-    let fifos: Vec<String> = match matches.values_of(options::FIFO) {
+    let fifos: Vec<String> = match matches.get_many::<String>(options::FIFO) {
         Some(v) => v.clone().map(|s| s.to_owned()).collect(),
         None => return Err(USimpleError::new(1, "missing operand")),
     };

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -55,11 +55,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mut buff = String::new();
     let silent = matches.contains_id(options::SILENT);
-    if let Some(files) = matches.values_of(options::FILES) {
+    if let Some(files) = matches.get_many::<String>(options::FILES) {
         let mut stdout = setup_term();
         let length = files.len();
 
-        let mut files_iter = files.peekable();
+        let mut files_iter = files.map(|s| s.as_str()).peekable();
         while let (Some(file), next_file) = (files_iter.next(), files_iter.peek()) {
             let file = Path::new(file);
             if file.is_dir() {

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -79,7 +79,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let cstrs: Vec<CString> = matches
-        .values_of(options::COMMAND)
+        .get_many::<String>(options::COMMAND)
         .unwrap()
         .map(|x| CString::new(x.as_bytes()).unwrap())
         .collect();

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -116,7 +116,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let mut read_stdin = false;
-    let files: Vec<String> = match matches.values_of(options::FILE) {
+    let files: Vec<String> = match matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
         None => vec!["-".to_owned()],
     };

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -101,7 +101,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let cstrs: Vec<CString> = matches
-        .values_of(options::CMD)
+        .get_many::<String>(options::CMD)
         .unwrap()
         .map(|x| CString::new(x.as_bytes()).unwrap())
         .collect();

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -269,8 +269,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let options = parse_options(&matches).map_err(NumfmtError::IllegalArgument)?;
 
-    let result = match matches.values_of(options::NUMBER) {
-        Some(values) => handle_args(values, &options),
+    let result = match matches.get_many::<String>(options::NUMBER) {
+        Some(values) => handle_args(values.map(|s| s.as_str()), &options),
         None => {
             let stdin = std::io::stdin();
             let mut locked_stdin = stdin.lock();

--- a/src/uu/od/src/parse_inputs.rs
+++ b/src/uu/od/src/parse_inputs.rs
@@ -12,8 +12,8 @@ pub trait CommandLineOpts {
 /// Implementation for `getopts`
 impl CommandLineOpts for ArgMatches {
     fn inputs(&self) -> Vec<&str> {
-        self.values_of(options::FILENAME)
-            .map(|values| values.collect())
+        self.get_many::<String>(options::FILENAME)
+            .map(|values| values.map(|s| s.as_str()).collect())
             .unwrap_or_default()
     }
 

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -59,7 +59,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let serial = matches.contains_id(options::SERIAL);
     let delimiters = matches.value_of(options::DELIMITER).unwrap();
     let files = matches
-        .values_of(options::FILE)
+        .get_many::<String>(options::FILE)
         .unwrap()
         .map(|s| s.to_owned())
         .collect();

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -46,9 +46,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     // set working mode
-    let is_posix = matches.values_of(options::POSIX).is_some();
-    let is_posix_special = matches.values_of(options::POSIX_SPECIAL).is_some();
-    let is_portability = matches.values_of(options::PORTABILITY).is_some();
+    let is_posix = matches.get_many::<String>(options::POSIX).is_some();
+    let is_posix_special = matches.get_many::<String>(options::POSIX_SPECIAL).is_some();
+    let is_portability = matches.get_many::<String>(options::PORTABILITY).is_some();
 
     let mode = if (is_posix && is_posix_special) || is_portability {
         Mode::Both
@@ -61,7 +61,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     // take necessary actions
-    let paths = matches.values_of(options::PATH);
+    let paths = matches.get_many::<String>(options::PATH);
     if paths.is_none() {
         return Err(UUsageError::new(1, "missing operand"));
     }

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -58,7 +58,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let users: Vec<String> = matches
-        .values_of(options::USER)
+        .get_many::<String>(options::USER)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -405,8 +405,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let mut files = matches
-        .values_of(options::FILES)
-        .map(|v| v.collect::<Vec<_>>())
+        .get_many::<String>(options::FILES)
+        .map(|v| v.map(|s| s.as_str()).collect::<Vec<_>>())
         .unwrap_or_default()
         .clone();
     if files.is_empty() {

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -23,7 +23,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let variables: Vec<String> = matches
-        .values_of(ARG_VARIABLES)
+        .get_many::<String>(ARG_VARIABLES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -279,7 +279,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let format_string = matches
         .value_of(options::FORMATSTRING)
         .ok_or_else(|| UUsageError::new(1, "missing operand"))?;
-    let values: Vec<String> = match matches.values_of(options::ARGUMENT) {
+    let values: Vec<String> = match matches.get_many::<String>(options::ARGUMENT) {
         Some(s) => s.map(|s| s.to_string()).collect(),
         None => vec![],
     };

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -729,7 +729,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // let mut opts = Options::new();
     let matches = uu_app().get_matches_from(args);
 
-    let mut input_files: Vec<String> = match &matches.values_of(options::FILE) {
+    let mut input_files: Vec<String> = match &matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
         None => vec!["-".to_string()],
     };

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -59,7 +59,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let files: Vec<String> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
     if files.is_empty() {

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -46,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     /*  the list of files */
 
     let paths: Vec<PathBuf> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .unwrap()
         .map(PathBuf::from)
         .collect();

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -81,7 +81,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -61,7 +61,10 @@ type RangeFloat = (ExtendedBigDecimal, ExtendedBigDecimal, ExtendedBigDecimal);
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
-    let numbers = matches.values_of(ARG_NUMBERS).unwrap().collect::<Vec<_>>();
+    let numbers = matches
+        .get_many::<String>(ARG_NUMBERS)
+        .unwrap()
+        .collect::<Vec<_>>();
 
     let options = SeqOptions {
         separator: matches.value_of(OPT_SEPARATOR).unwrap_or("\n").to_string(),

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -306,7 +306,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let zero = matches.contains_id(options::ZERO);
     let verbose = matches.contains_id(options::VERBOSE);
 
-    for path_str in matches.values_of(options::FILE).unwrap() {
+    for path_str in matches.get_many::<String>(options::FILE).unwrap() {
         show_if_err!(wipe_file(
             path_str, iterations, remove, size, exact, zero, verbose, force,
         ));

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -33,8 +33,8 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
-    if let Some(values) = matches.values_of(options::NUMBER) {
-        let numbers = values.collect::<Vec<_>>();
+    if let Some(values) = matches.get_many::<String>(options::NUMBER) {
+        let numbers = values.map(|s| s.as_str()).collect::<Vec<_>>();
         return sleep(&numbers);
     }
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1228,7 +1228,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         settings.separator = Some(separator.chars().next().unwrap());
     }
 
-    if let Some(values) = matches.values_of(options::KEY) {
+    if let Some(values) = matches.get_many::<String>(options::KEY) {
         for value in values {
             let selector = FieldSelector::parse(value, &settings)?;
             if selector.settings.mode == SortMode::Random && settings.salt.is_none() {

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -115,7 +115,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    let files: Vec<String> = match matches.values_of(options::FILE) {
+    let files: Vec<String> = match matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),
         None => vec!["-".to_owned()],
     };

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -168,7 +168,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let files: Vec<String> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -52,8 +52,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         raw_separator
     };
 
-    let files: Vec<&str> = match matches.values_of(options::FILE) {
-        Some(v) => v.collect(),
+    let files: Vec<&str> = match matches.get_many::<String>(options::FILE) {
+        Some(v) => v.map(|s| s.as_str()).collect(),
         None => vec!["-"],
     };
 

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -264,7 +264,7 @@ impl Settings {
         settings.stdin_is_pipe_or_fifo = matches.contains_id(options::PRESUME_INPUT_PIPE);
 
         settings.paths = matches
-            .values_of(options::ARG_FILES)
+            .get_many::<String>(options::ARG_FILES)
             .map(|v| v.map(PathBuf::from).collect())
             .unwrap_or_default();
 

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -57,7 +57,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         append: matches.contains_id(options::APPEND),
         ignore_interrupts: matches.contains_id(options::IGNORE_INTERRUPTS),
         files: matches
-            .values_of(options::FILE)
+            .get_many::<String>(options::FILE)
             .map(|v| v.map(ToString::to_string).collect())
             .unwrap_or_default(),
         output_error: {

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -87,7 +87,7 @@ impl Config {
         let verbose = options.contains_id(options::VERBOSE);
 
         let command = options
-            .values_of(options::COMMAND)
+            .get_many::<String>(options::COMMAND)
             .unwrap()
             .map(String::from)
             .collect::<Vec<_>>();

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -54,7 +54,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let truncate_set1_flag = matches.contains_id(options::TRUNCATE_SET1);
 
     let sets = matches
-        .values_of(options::SETS)
+        .get_many::<String>(options::SETS)
         .map(|v| {
             v.map(ToString::to_string)
                 .map(|input| convert::reduce_octal_to_char(&input))

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -122,7 +122,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         })?;
 
     let files: Vec<String> = matches
-        .values_of(options::ARG_FILES)
+        .get_many::<String>(options::ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -104,9 +104,9 @@ struct Options {
 
 impl Options {
     fn new(matches: &clap::ArgMatches) -> Result<Self, ParseError> {
-        let tabstops = match matches.values_of(options::TABS) {
+        let tabstops = match matches.get_many::<String>(options::TABS) {
             None => vec![DEFAULT_TABSTOP],
-            Some(s) => tabstops_parse(&s.collect::<Vec<&str>>().join(","))?,
+            Some(s) => tabstops_parse(&s.map(|s| s.as_str()).collect::<Vec<_>>().join(","))?,
         };
 
         let aflag = (matches.contains_id(options::ALL) || matches.contains_id(options::TABS))

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -260,7 +260,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
-        .values_of(ARG_FILES)
+        .get_many::<String>(ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -65,7 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let files: Vec<String> = matches
-        .values_of(options::FILE)
+        .get_many::<String>(options::FILE)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -28,7 +28,7 @@ const BUF_SIZE: usize = 16 * 1024;
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
-    let string = if let Some(values) = matches.values_of("STRING") {
+    let string = if let Some(values) = matches.get_many::<String>("STRING") {
         let mut result = values.fold(String::new(), |res, s| res + s + " ");
         result.pop();
         result.push('\n');

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -466,7 +466,7 @@ pub fn chown_base<'a>(
     let matches = command.get_matches_from(args);
 
     let files: Vec<String> = matches
-        .values_of(options::ARG_FILES)
+        .get_many::<String>(options::ARG_FILES)
         .map(|v| v.map(ToString::to_string).collect())
         .unwrap_or_default();
 


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `values_of()` with `get_many()`.