### PR TITLE
Fix clippy warnings with Rust 1.63

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -49,7 +49,7 @@ use winapi::um::minwinbase::{FileIdInfo, FileStandardInfo};
 #[cfg(windows)]
 use winapi::um::winbase::GetFileInformationByHandleEx;
 #[cfg(windows)]
-use winapi::um::winnt::{FILE_ID_128, ULONGLONG};
+use winapi::um::winnt::FILE_ID_128;
 
 mod options {
     pub const HELP: &str = "help";
@@ -254,7 +254,7 @@ fn get_file_info(path: &Path) -> Option<FileInfo> {
         if success != 0 {
             result = Some(FileInfo {
                 file_id: std::mem::transmute::<FILE_ID_128, u128>(file_info.FileId),
-                dev_id: std::mem::transmute::<ULONGLONG, u64>(file_info.VolumeSerialNumber),
+                dev_id: file_info.VolumeSerialNumber,
             });
         }
     }

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -74,7 +74,7 @@ impl RoundMethod {
 }
 
 // Represents the options extracted from the --format argument provided by the user.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct FormatOptions {
     pub grouping: bool,
     pub padding: Option<isize>,

--- a/src/uu/numfmt/src/units.rs
+++ b/src/uu/numfmt/src/units.rs
@@ -17,7 +17,7 @@ pub const IEC_BASES: [f64; 10] = [
 
 pub type WithI = bool;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Unit {
     Auto,
     Si,

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -491,7 +491,7 @@ fn pathbuf_from_stdout() -> UResult<PathBuf> {
         // to a u32.
         let ret = unsafe {
             GetFinalPathNameByHandleW(
-                std::mem::transmute(handle),
+                handle,
                 file_path_buffer.as_mut_ptr(),
                 file_path_buffer.len() as u32,
                 FILE_NAME_OPENED,

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -1,3 +1,5 @@
+// TODO fix broken links
+#![allow(rustdoc::broken_intra_doc_links)]
 //! Macros for the uucore utilities.
 //!
 //! This module bundles all macros used across the uucore utilities. These
@@ -28,7 +30,7 @@
 //! - Terminate util execution
 //!   - Crash program: [`crash!`], [`crash_if_err!`]
 
-// spell-checker:ignore sourcepath targetpath
+// spell-checker:ignore sourcepath targetpath rustdoc
 
 use std::sync::atomic::AtomicBool;
 

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -1,3 +1,5 @@
+// TODO fix broken links
+#![allow(rustdoc::broken_intra_doc_links)]
 //! All utils return exit with an exit code. Usually, the following scheme is used:
 //! * `0`: succeeded
 //! * `1`: minor problems
@@ -48,7 +50,7 @@
 //! * Using [`ExitCode`] is not recommended but can be useful for converting utils to use
 //!   [`UResult`].
 
-// spell-checker:ignore uioerror
+// spell-checker:ignore uioerror rustdoc
 
 use clap;
 use std::{

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -404,8 +404,8 @@ fn test_with_pr_core_utils_tests() {
     for test_case in test_cases {
         let (flags, input_file, expected_file, return_code) = test_case;
         let mut scenario = new_ucmd!();
-        let input_file_path = input_file.get(0).unwrap();
-        let test_file_path = expected_file.get(0).unwrap();
+        let input_file_path = input_file.first().unwrap();
+        let test_file_path = expected_file.first().unwrap();
         let value = file_last_modified_time(&scenario, test_file_path);
         let mut arguments: Vec<&str> = flags
             .split(' ')

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -982,7 +982,7 @@ impl UCommand {
         tmpd: Rc<TempDir>,
         env_clear: bool,
     ) -> Self {
-        let tmpd_path_buf = String::from(&(*tmpd.as_ref().path().to_str().unwrap()));
+        let tmpd_path_buf = String::from(tmpd.as_ref().path().to_str().unwrap());
         let mut ucmd: Self = Self::new(bin_path, util_name, tmpd_path_buf, env_clear);
         ucmd.tmpd = Some(tmpd);
         ucmd
@@ -1296,7 +1296,7 @@ pub fn check_coreutil_version(
     std::str::from_utf8(&version_check.stdout).unwrap()
         .split('\n')
         .collect::<Vec<_>>()
-        .get(0)
+        .first()
         .map_or_else(
             || Err(format!("{}: unexpected output format for reference coreutil: '{} --version'", UUTILS_WARNING, util_name)),
             |s| {


### PR DESCRIPTION
This PR fixes two clippy warnings caused by a new [lint](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) added in Rust 1.63.