### PR TITLE
uutils: Remove use of mem::uninitialized

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -41,8 +41,6 @@ extern crate uucore;
 
 use clap::{crate_version, Arg, Command};
 use std::ffi::CStr;
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
-use std::mem::MaybeUninit;
 use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::error::UResult;
@@ -545,6 +543,8 @@ fn auditid() {}
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn auditid() {
+    use std::mem::MaybeUninit;
+
     let mut auditinfo: MaybeUninit<audit::c_auditinfo_addr_t> = MaybeUninit::uninit();
     let address = auditinfo.as_mut_ptr();
     if unsafe { audit::getaudit(address) } < 0 {

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -41,7 +41,6 @@ extern crate uucore;
 
 use clap::{crate_version, Arg, Command};
 use std::ffi::CStr;
-use std::mem::MaybeUninit;
 use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::error::UResult;

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -41,6 +41,8 @@ extern crate uucore;
 
 use clap::{crate_version, Arg, Command};
 use std::ffi::CStr;
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+use std::mem::MaybeUninit;
 use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::error::UResult;

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -41,6 +41,7 @@ extern crate uucore;
 
 use clap::{crate_version, Arg, Command};
 use std::ffi::CStr;
+use std::mem::MaybeUninit;
 use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::error::UResult;
@@ -543,13 +544,15 @@ fn auditid() {}
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn auditid() {
-    #[allow(deprecated)]
-    let mut auditinfo: audit::c_auditinfo_addr_t = unsafe { std::mem::uninitialized() };
-    let address = &mut auditinfo as *mut audit::c_auditinfo_addr_t;
+    let mut auditinfo: MaybeUninit<audit::c_auditinfo_addr_t> = MaybeUninit::uninit();
+    let address = auditinfo.as_mut_ptr();
     if unsafe { audit::getaudit(address) } < 0 {
         println!("couldn't retrieve information");
         return;
     }
+
+    // SAFETY: getaudit wrote a valid struct to auditinfo
+    let auditinfo = unsafe { auditinfo.assume_init() };
 
     println!("auid={}", auditinfo.ai_auid);
     println!("mask.success=0x{:x}", auditinfo.ai_mask.am_success);

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -71,7 +71,6 @@ mod platform {
     use self::winapi::um::winbase;
     use self::winapi::um::winnt;
     use std::fs::OpenOptions;
-    use std::mem;
     use std::os::windows::prelude::*;
     use std::path::Path;
     use uucore::crash;

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -99,8 +99,7 @@ mod platform {
     }
 
     unsafe fn find_first_volume() -> (String, winnt::HANDLE) {
-        #[allow(deprecated)]
-        let mut name: [winnt::WCHAR; minwindef::MAX_PATH] = mem::uninitialized();
+        let mut name: [winnt::WCHAR; minwindef::MAX_PATH] = [0; minwindef::MAX_PATH];
         let handle = winapi::um::fileapi::FindFirstVolumeW(
             name.as_mut_ptr(),
             name.len() as minwindef::DWORD,
@@ -118,8 +117,7 @@ mod platform {
         let (first_volume, next_volume_handle) = find_first_volume();
         let mut volumes = vec![first_volume];
         loop {
-            #[allow(deprecated)]
-            let mut name: [winnt::WCHAR; minwindef::MAX_PATH] = mem::uninitialized();
+            let mut name: [winnt::WCHAR; minwindef::MAX_PATH] = [0; minwindef::MAX_PATH];
             if winapi::um::fileapi::FindNextVolumeW(
                 next_volume_handle,
                 name.as_mut_ptr(),


### PR DESCRIPTION
I don't have hardware to test this, so I'm just going to trust the CI here. It's a reasonably simple enough change in any case.