### PR TITLE
readlink: GNU compatibility

### DIFF
--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -80,7 +80,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         };
         match path_result {
             Ok(path) => {
-                show(&path, no_trailing_delimiter, use_zero).map_err_context(String::new)?
+                show(&path, no_trailing_delimiter, use_zero).map_err_context(String::new)?;
             }
             Err(err) => {
                 if verbose {

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -79,7 +79,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             canonicalize(&p, can_mode, res_mode)
         };
         match path_result {
-            Ok(path) => show(&path, no_trailing_delimiter, use_zero).map_err_context(String::new)?,
+            Ok(path) => {
+                show(&path, no_trailing_delimiter, use_zero).map_err_context(String::new)?
+            }
             Err(err) => {
                 if verbose {
                     return Err(USimpleError::new(

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -36,7 +36,7 @@ const ARG_FILES: &str = "files";
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
-    let mut no_newline = matches.contains_id(OPT_NO_NEWLINE);
+    let mut no_trailing_delimiter = matches.contains_id(OPT_NO_NEWLINE);
     let use_zero = matches.contains_id(OPT_ZERO);
     let silent = matches.contains_id(OPT_SILENT) || matches.contains_id(OPT_QUIET);
     let verbose = matches.contains_id(OPT_VERBOSE);
@@ -66,9 +66,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Err(UUsageError::new(1, "missing operand"));
     }
 
-    if no_newline && files.len() > 1 && !silent {
+    if no_trailing_delimiter && files.len() > 1 && !silent {
         show_error!("ignoring --no-newline with multiple arguments");
-        no_newline = false;
+        no_trailing_delimiter = false;
     }
 
     for f in &files {
@@ -79,7 +79,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             canonicalize(&p, can_mode, res_mode)
         };
         match path_result {
-            Ok(path) => show(&path, no_newline, use_zero).map_err_context(String::new)?,
+            Ok(path) => show(&path, no_trailing_delimiter, use_zero).map_err_context(String::new)?,
             Err(err) => {
                 if verbose {
                     return Err(USimpleError::new(
@@ -167,12 +167,12 @@ pub fn uu_app<'a>() -> Command<'a> {
         )
 }
 
-fn show(path: &Path, no_newline: bool, use_zero: bool) -> std::io::Result<()> {
+fn show(path: &Path, no_trailing_delimiter: bool, use_zero: bool) -> std::io::Result<()> {
     let path = path.to_str().unwrap();
-    if use_zero {
-        print!("{}\0", path);
-    } else if no_newline {
+    if no_trailing_delimiter {
         print!("{}", path);
+    } else if use_zero {
+        print!("{}\0", path);
     } else {
         println!("{}", path);
     }

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -3,6 +3,11 @@ use crate::common::util::*;
 
 static GIBBERISH: &str = "supercalifragilisticexpialidocious";
 
+#[cfg(not(windows))]
+static NOT_A_DIRECTORY: &str = "Not a directory";
+#[cfg(windows)]
+static NOT_A_DIRECTORY: &str = "The directory name is invalid.";
+
 #[test]
 fn test_resolve() {
     let scene = TestScenario::new(util_name!());
@@ -92,7 +97,7 @@ fn test_trailing_slash_regular_file() {
         .args(&["-ev", "./regfile/"])
         .fails()
         .code_is(1)
-        .stderr_contains("Not a directory")
+        .stderr_contains(NOT_A_DIRECTORY)
         .no_stdout();
     scene
         .ucmd()
@@ -112,7 +117,7 @@ fn test_trailing_slash_symlink_to_regular_file() {
         .args(&["-ev", "./link/"])
         .fails()
         .code_is(1)
-        .stderr_contains("Not a directory")
+        .stderr_contains(NOT_A_DIRECTORY)
         .no_stdout();
     scene
         .ucmd()
@@ -124,7 +129,7 @@ fn test_trailing_slash_symlink_to_regular_file() {
         .args(&["-ev", "./link/more"])
         .fails()
         .code_is(1)
-        .stderr_contains("Not a directory")
+        .stderr_contains(NOT_A_DIRECTORY)
         .no_stdout();
 }
 
@@ -206,19 +211,19 @@ fn test_canonicalize_trailing_slash_regfile() {
             .args(&["-fv", &format!("./{}/", name)])
             .fails()
             .code_is(1)
-            .stderr_contains("Not a directory");
+            .stderr_contains(NOT_A_DIRECTORY);
         scene
             .ucmd()
             .args(&["-fv", &format!("{}/more", name)])
             .fails()
             .code_is(1)
-            .stderr_contains("Not a directory");
+            .stderr_contains(NOT_A_DIRECTORY);
         scene
             .ucmd()
             .args(&["-fv", &format!("./{}/more/", name)])
             .fails()
             .code_is(1)
-            .stderr_contains("Not a directory");
+            .stderr_contains(NOT_A_DIRECTORY);
     }
 }
 

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -297,28 +297,27 @@ fn test_canonicalize_trailing_slash_subdir_missing() {
     let at = &scene.fixtures;
     at.mkdir("subdir");
     at.relative_symlink_file("subdir/missing", "link4");
-    for name in ["link4"] {
-        scene
-            .ucmd()
-            .args(&["-f", name])
-            .succeeds()
-            .stdout_contains(path_concat!("subdir", "missing"));
-        scene
-            .ucmd()
-            .args(&["-f", &format!("./{}/", name)])
-            .succeeds()
-            .stdout_contains(path_concat!("subdir", "missing"));
-        scene
-            .ucmd()
-            .args(&["-f", &format!("{}/more", name)])
-            .fails()
-            .code_is(1);
-        scene
-            .ucmd()
-            .args(&["-f", &format!("./{}/more/", name)])
-            .fails()
-            .code_is(1);
-    }
+    let name = "link4";
+    scene
+        .ucmd()
+        .args(&["-f", name])
+        .succeeds()
+        .stdout_contains(path_concat!("subdir", "missing"));
+    scene
+        .ucmd()
+        .args(&["-f", &format!("./{}/", name)])
+        .succeeds()
+        .stdout_contains(path_concat!("subdir", "missing"));
+    scene
+        .ucmd()
+        .args(&["-f", &format!("{}/more", name)])
+        .fails()
+        .code_is(1);
+    scene
+        .ucmd()
+        .args(&["-f", &format!("./{}/more/", name)])
+        .fails()
+        .code_is(1);
 }
 
 #[test]

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -341,3 +341,34 @@ fn test_canonicalize_trailing_slash_symlink_loop() {
             .no_stdout();
     }
 }
+
+#[test]
+#[cfg(not(windows))]
+fn test_delimiters() {
+    new_ucmd!()
+        .args(&["--zero", "-n", "-m", "/a"])
+        .succeeds()
+        .stdout_only("/a");
+    new_ucmd!()
+        .args(&["-n", "-m", "/a"])
+        .succeeds()
+        .stdout_only("/a");
+    new_ucmd!()
+        .args(&["--zero", "-m", "/a"])
+        .succeeds()
+        .stdout_only("/a\0");
+    new_ucmd!()
+        .args(&["-m", "/a"])
+        .succeeds()
+        .stdout_only("/a\n");
+    new_ucmd!()
+        .args(&["--zero", "-n", "-m", "/a", "/a"])
+        .succeeds()
+        .stderr_contains("ignoring --no-newline with multiple arguments")
+        .stdout_is("/a\0/a\0");
+    new_ucmd!()
+        .args(&["-n", "-m", "/a", "/a"])
+        .succeeds()
+        .stderr_contains("ignoring --no-newline with multiple arguments")
+        .stdout_is("/a\n/a\n");
+}

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -324,23 +324,22 @@ fn test_canonicalize_trailing_slash_subdir_missing() {
 fn test_canonicalize_trailing_slash_symlink_loop() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
-    at.relative_symlink_file("link5", "link5");
-    for name in ["link5"] {
-        scene.ucmd().args(&["-f", name]).fails().code_is(1);
-        scene
-            .ucmd()
-            .args(&["-f", &format!("./{}/", name)])
-            .fails()
-            .code_is(1);
-        scene
-            .ucmd()
-            .args(&["-f", &format!("{}/more", name)])
-            .fails()
-            .code_is(1);
-        scene
-            .ucmd()
-            .args(&["-f", &format!("./{}/more/", name)])
-            .fails()
-            .code_is(1);
-    }
+    let name = "link5";
+    at.relative_symlink_file(name, name);
+    scene.ucmd().args(&["-f", name]).fails().code_is(1);
+    scene
+        .ucmd()
+        .args(&["-f", &format!("./{}/", name)])
+        .fails()
+        .code_is(1);
+    scene
+        .ucmd()
+        .args(&["-f", &format!("{}/more", name)])
+        .fails()
+        .code_is(1);
+    scene
+        .ucmd()
+        .args(&["-f", &format!("./{}/more/", name)])
+        .fails()
+        .code_is(1);
 }

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -126,10 +126,9 @@ fn test_trailing_slash_symlink_to_regular_file() {
         .stdout_contains("regfile");
     scene
         .ucmd()
-        .args(&["-ev", "./link/more"])
+        .args(&["-e", "./link/more"])
         .fails()
         .code_is(1)
-        .stderr_contains(NOT_A_DIRECTORY)
         .no_stdout();
 }
 

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -164,7 +164,8 @@ fn test_trailing_slash_symlink_to_directory() {
         .args(&["-ev", "./link/more"])
         .fails()
         .code_is(1)
-        .stderr_contains("No such file or directory");
+        .stderr_contains("No such file or directory")
+        .no_stdout();
 }
 
 #[test]
@@ -189,7 +190,8 @@ fn test_trailing_slash_symlink_to_missing() {
             .args(&["-ev", query])
             .fails()
             .code_is(1)
-            .stderr_contains("No such file or directory");
+            .stderr_contains("No such file or directory")
+            .no_stdout();
     }
 }
 
@@ -210,19 +212,22 @@ fn test_canonicalize_trailing_slash_regfile() {
             .args(&["-fv", &format!("./{}/", name)])
             .fails()
             .code_is(1)
-            .stderr_contains(NOT_A_DIRECTORY);
+            .stderr_contains(NOT_A_DIRECTORY)
+            .no_stdout();
         scene
             .ucmd()
             .args(&["-fv", &format!("{}/more", name)])
             .fails()
             .code_is(1)
-            .stderr_contains(NOT_A_DIRECTORY);
+            .stderr_contains(NOT_A_DIRECTORY)
+            .no_stdout();
         scene
             .ucmd()
             .args(&["-fv", &format!("./{}/more/", name)])
             .fails()
             .code_is(1)
-            .stderr_contains(NOT_A_DIRECTORY);
+            .stderr_contains(NOT_A_DIRECTORY)
+            .no_stdout();
     }
 }
 
@@ -257,12 +262,14 @@ fn test_canonicalize_trailing_slash_subdir() {
             .ucmd()
             .args(&["-f", &format!("{}/more/more2", name)])
             .fails()
-            .code_is(1);
+            .code_is(1)
+            .no_stdout();
         scene
             .ucmd()
             .args(&["-f", &format!("./{}/more/more2/", name)])
             .fails()
-            .code_is(1);
+            .code_is(1)
+            .no_stdout();
     }
 }
 
@@ -286,12 +293,14 @@ fn test_canonicalize_trailing_slash_missing() {
             .ucmd()
             .args(&["-f", &format!("{}/more", name)])
             .fails()
-            .code_is(1);
+            .code_is(1)
+            .no_stdout();
         scene
             .ucmd()
             .args(&["-f", &format!("./{}/more/", name)])
             .fails()
-            .code_is(1);
+            .code_is(1)
+            .no_stdout();
     }
 }
 
@@ -301,49 +310,34 @@ fn test_canonicalize_trailing_slash_subdir_missing() {
     let at = &scene.fixtures;
     at.mkdir("subdir");
     at.relative_symlink_file("subdir/missing", "link4");
-    let name = "link4";
-    scene
-        .ucmd()
-        .args(&["-f", name])
-        .succeeds()
-        .stdout_contains(path_concat!("subdir", "missing"));
-    scene
-        .ucmd()
-        .args(&["-f", &format!("./{}/", name)])
-        .succeeds()
-        .stdout_contains(path_concat!("subdir", "missing"));
-    scene
-        .ucmd()
-        .args(&["-f", &format!("{}/more", name)])
-        .fails()
-        .code_is(1);
-    scene
-        .ucmd()
-        .args(&["-f", &format!("./{}/more/", name)])
-        .fails()
-        .code_is(1);
+    for query in ["link4", "./link4/"] {
+        scene
+            .ucmd()
+            .args(&["-f", query])
+            .succeeds()
+            .stdout_contains(path_concat!("subdir", "missing"));
+    }
+    for query in ["link4/more", "./link4/more/"] {
+        scene
+            .ucmd()
+            .args(&["-f", query])
+            .fails()
+            .code_is(1)
+            .no_stdout();
+    }
 }
 
 #[test]
 fn test_canonicalize_trailing_slash_symlink_loop() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
-    let name = "link5";
-    at.relative_symlink_file(name, name);
-    scene.ucmd().args(&["-f", name]).fails().code_is(1);
-    scene
-        .ucmd()
-        .args(&["-f", &format!("./{}/", name)])
-        .fails()
-        .code_is(1);
-    scene
-        .ucmd()
-        .args(&["-f", &format!("{}/more", name)])
-        .fails()
-        .code_is(1);
-    scene
-        .ucmd()
-        .args(&["-f", &format!("./{}/more/", name)])
-        .fails()
-        .code_is(1);
+    at.relative_symlink_file("link5", "link5");
+    for query in ["link5", "./link5/", "link5/more", "./link5/more/"] {
+        scene
+            .ucmd()
+            .args(&["-f", query])
+            .fails()
+            .code_is(1)
+            .no_stdout();
+    }
 }

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -1,3 +1,4 @@
+// spell-checker:ignore regfile
 use crate::common::util::*;
 
 static GIBBERISH: &str = "supercalifragilisticexpialidocious";

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -364,3 +364,92 @@ fn test_relative() {
         .succeeds()
         .stdout_is(".\nusr\n"); // spell-checker:disable-line
 }
+
+#[test]
+fn test_realpath_trailing_slash() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("file");
+    at.mkdir("dir");
+    at.relative_symlink_file("file", "link_file");
+    at.relative_symlink_dir("dir", "link_dir");
+    at.relative_symlink_dir("no_dir", "link_no_dir");
+    scene
+        .ucmd()
+        .arg("link_file")
+        .succeeds()
+        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+    scene.ucmd().arg("link_file/").fails().code_is(1);
+    scene
+        .ucmd()
+        .arg("link_dir")
+        .succeeds()
+        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .arg("link_dir/")
+        .succeeds()
+        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .arg("link_no_dir")
+        .succeeds()
+        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .arg("link_no_dir/")
+        .succeeds()
+        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .args(&["-e", "link_file"])
+        .succeeds()
+        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+    scene.ucmd().args(&["-e", "link_file/"]).fails().code_is(1);
+    scene
+        .ucmd()
+        .args(&["-e", "link_dir"])
+        .succeeds()
+        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .args(&["-e", "link_dir/"])
+        .succeeds()
+        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+    scene.ucmd().args(&["-e", "link_no_dir"]).fails().code_is(1);
+    scene
+        .ucmd()
+        .args(&["-e", "link_no_dir/"])
+        .fails()
+        .code_is(1);
+    scene
+        .ucmd()
+        .args(&["-m", "link_file"])
+        .succeeds()
+        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .args(&["-m", "link_file/"])
+        .succeeds()
+        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .args(&["-m", "link_dir"])
+        .succeeds()
+        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .args(&["-m", "link_dir/"])
+        .succeeds()
+        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .args(&["-m", "link_no_dir"])
+        .succeeds()
+        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+    scene
+        .ucmd()
+        .args(&["-m", "link_no_dir/"])
+        .succeeds()
+        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+}


### PR DESCRIPTION
- Added checking for "Not a directory" error when using `-e` option and the given path is not a directory
- Added checking for "Not a directory" error when using `-f` option and the parent of the given path is not a directory
- Added tests for `readlink` and `realpath` for using trailing slashes
- Fixed behavior when both `--no-newline` and `--zero` were used, it shouldn't print the delimiter even if it's `--zero`.
- Added tests for delimiter options usage

Tests `readlink/can-e.sh`, `readlink/can-f.sh` and `readlink/multi.sh` should pass now