### PR TITLE
Replace deprecated value_of() with get_one()

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -152,7 +152,7 @@ fn gen_completions<T: uucore::Args>(
         )
         .get_matches_from(std::iter::once(OsString::from("completion")).chain(args));
 
-    let utility = matches.value_of("utility").unwrap();
+    let utility = matches.get_one::<String>("utility").unwrap();
     let shell = matches.get_one::<Shell>("shell").unwrap().to_owned();
 
     let mut command = if utility == "coreutils" {

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -65,7 +65,7 @@ impl Config {
         };
 
         let cols = options
-            .value_of(options::WRAP)
+            .get_one::<String>(options::WRAP)
             .map(|num| {
                 num.parse::<usize>().map_err(|_| {
                     USimpleError::new(

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -82,7 +82,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let suffix = if opt_suffix {
-        matches.value_of(options::SUFFIX).unwrap()
+        matches.get_one::<String>(options::SUFFIX).unwrap()
     } else if !opt_multiple && name_args_count > 1 {
         matches
             .get_many::<String>(options::NAME)

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -26,12 +26,15 @@ const USAGE: &str = "\
     {} [OPTION]... --reference=RFILE FILE...";
 
 fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>, IfFrom)> {
-    let dest_gid = if let Some(file) = matches.value_of(options::REFERENCE) {
+    let dest_gid = if let Some(file) = matches.get_one::<String>(options::REFERENCE) {
         fs::metadata(&file)
             .map(|meta| Some(meta.gid()))
             .map_err_context(|| format!("failed to get attributes of {}", file.quote()))?
     } else {
-        let group = matches.value_of(options::ARG_GROUP).unwrap_or_default();
+        let group = matches
+            .get_one::<String>(options::ARG_GROUP)
+            .map(|s| s.as_str())
+            .unwrap_or_default();
         if group.is_empty() {
             None
         } else {

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -62,7 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let verbose = matches.contains_id(options::VERBOSE);
     let preserve_root = matches.contains_id(options::PRESERVE_ROOT);
     let recursive = matches.contains_id(options::RECURSIVE);
-    let fmode = match matches.value_of(options::REFERENCE) {
+    let fmode = match matches.get_one::<String>(options::REFERENCE) {
         Some(fref) => match fs::metadata(fref) {
             Ok(meta) => Some(meta.mode()),
             Err(err) => {
@@ -74,7 +74,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         },
         None => None,
     };
-    let modes = matches.value_of(options::MODE).unwrap(); // should always be Some because required
+    let modes = matches.get_one::<String>(options::MODE).unwrap(); // should always be Some because required
     let cmode = if mode_had_minus_prefix {
         // clap parsing is finished, now put prefix back
         format!("-{}", modes)

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -26,7 +26,7 @@ const USAGE: &str = "\
     {} [OPTION]... --reference=RFILE FILE...";
 
 fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>, IfFrom)> {
-    let filter = if let Some(spec) = matches.value_of(options::FROM) {
+    let filter = if let Some(spec) = matches.get_one::<String>(options::FROM) {
         match parse_spec(spec, ':')? {
             (Some(uid), None) => IfFrom::User(uid),
             (None, Some(gid)) => IfFrom::Group(gid),
@@ -39,13 +39,13 @@ fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Optio
 
     let dest_uid: Option<u32>;
     let dest_gid: Option<u32>;
-    if let Some(file) = matches.value_of(options::REFERENCE) {
+    if let Some(file) = matches.get_one::<String>(options::REFERENCE) {
         let meta = fs::metadata(&file)
             .map_err_context(|| format!("failed to get attributes of {}", file.quote()))?;
         dest_gid = Some(meta.gid());
         dest_uid = Some(meta.uid());
     } else {
-        let (u, g) = parse_spec(matches.value_of(options::ARG_OWNER).unwrap(), ':')?;
+        let (u, g) = parse_spec(matches.get_one::<String>(options::ARG_OWNER).unwrap(), ':')?;
         dest_uid = u;
         dest_gid = g;
     }

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -43,7 +43,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let default_option: &'static str = "-i";
     let user_shell = std::env::var("SHELL");
 
-    let newroot: &Path = match matches.value_of(options::NEWROOT) {
+    let newroot: &Path = match matches.get_one::<String>(options::NEWROOT) {
         Some(v) => Path::new(v),
         None => return Err(ChrootError::MissingNewRoot.into()),
     };
@@ -165,10 +165,19 @@ pub fn uu_app<'a>() -> Command<'a> {
 }
 
 fn set_context(root: &Path, options: &clap::ArgMatches) -> UResult<()> {
-    let userspec_str = options.value_of(options::USERSPEC);
-    let user_str = options.value_of(options::USER).unwrap_or_default();
-    let group_str = options.value_of(options::GROUP).unwrap_or_default();
-    let groups_str = options.value_of(options::GROUPS).unwrap_or_default();
+    let userspec_str = options.get_one::<String>(options::USERSPEC);
+    let user_str = options
+        .get_one::<String>(options::USER)
+        .map(|s| s.as_str())
+        .unwrap_or_default();
+    let group_str = options
+        .get_one::<String>(options::GROUP)
+        .map(|s| s.as_str())
+        .unwrap_or_default();
+    let groups_str = options
+        .get_one::<String>(options::GROUPS)
+        .map(|s| s.as_str())
+        .unwrap_or_default();
     let skip_chdir = options.contains_id(options::SKIP_CHDIR);
     let userspec = match userspec_str {
         Some(u) => {

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -33,7 +33,7 @@ mod options {
 
 fn mkdelim(col: usize, opts: &ArgMatches) -> String {
     let mut s = String::new();
-    let delim = match opts.value_of(options::DELIMITER).unwrap() {
+    let delim = match opts.get_one::<String>(options::DELIMITER).unwrap().as_str() {
         "" => "\0",
         delim => delim,
     };
@@ -135,8 +135,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
     let matches = uu_app().try_get_matches_from(args)?;
-    let filename1 = matches.value_of(options::FILE_1).unwrap();
-    let filename2 = matches.value_of(options::FILE_2).unwrap();
+    let filename1 = matches.get_one::<String>(options::FILE_1).unwrap();
+    let filename2 = matches.get_one::<String>(options::FILE_2).unwrap();
     let mut f1 = open_file(filename1).map_err_context(|| filename1.to_string())?;
     let mut f2 = open_file(filename2).map_err_context(|| filename2.to_string())?;
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -722,7 +722,7 @@ impl Options {
         // Parse target directory options
         let no_target_dir = matches.contains_id(options::NO_TARGET_DIRECTORY);
         let target_dir = matches
-            .value_of(options::TARGET_DIRECTORY)
+            .get_one::<String>(options::TARGET_DIRECTORY)
             .map(ToString::to_string);
 
         // Parse attributes to preserve
@@ -775,8 +775,8 @@ impl Options {
             verbose: matches.contains_id(options::VERBOSE),
             strip_trailing_slashes: matches.contains_id(options::STRIP_TRAILING_SLASHES),
             reflink_mode: {
-                if let Some(reflink) = matches.value_of(options::REFLINK) {
-                    match reflink {
+                if let Some(reflink) = matches.get_one::<String>(options::REFLINK) {
+                    match reflink.as_str() {
                         "always" => ReflinkMode::Always,
                         "auto" => ReflinkMode::Auto,
                         "never" => ReflinkMode::Never,
@@ -802,17 +802,22 @@ impl Options {
                     }
                 }
             },
-            sparse_mode: match matches.value_of(options::SPARSE) {
-                Some("always") => SparseMode::Always,
-                Some("auto") => SparseMode::Auto,
-                Some("never") => SparseMode::Never,
-                Some(val) => {
-                    return Err(Error::InvalidArgument(format!(
-                        "invalid argument {} for \'sparse\'",
-                        val
-                    )));
+            sparse_mode: {
+                if let Some(val) = matches.get_one::<String>(options::SPARSE) {
+                    match val.as_str() {
+                        "always" => SparseMode::Always,
+                        "auto" => SparseMode::Auto,
+                        "never" => SparseMode::Never,
+                        _ => {
+                            return Err(Error::InvalidArgument(format!(
+                                "invalid argument {} for \'sparse\'",
+                                val
+                            )))
+                        }
+                    }
+                } else {
+                    SparseMode::Auto
                 }
-                None => SparseMode::Auto,
             },
             backup: backup_mode,
             backup_suffix,

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -61,9 +61,15 @@ impl CsplitOptions {
             split_name: crash_if_err!(
                 1,
                 SplitName::new(
-                    matches.value_of(options::PREFIX).map(str::to_string),
-                    matches.value_of(options::SUFFIX_FORMAT).map(str::to_string),
-                    matches.value_of(options::DIGITS).map(str::to_string)
+                    matches
+                        .get_one::<String>(options::PREFIX)
+                        .map(|s| s.to_owned()),
+                    matches
+                        .get_one::<String>(options::SUFFIX_FORMAT)
+                        .map(|s| s.to_owned()),
+                    matches
+                        .get_one::<String>(options::DIGITS)
+                        .map(|s| s.to_owned())
                 )
             ),
             keep_files,
@@ -718,7 +724,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
     // get the file to split
-    let file_name = matches.value_of(options::FILE).unwrap();
+    let file_name = matches.get_one::<String>(options::FILE).unwrap();
 
     // get the patterns to split on
     let patterns: Vec<String> = matches

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -406,9 +406,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let complement = matches.contains_id(options::COMPLEMENT);
 
     let mode_parse = match (
-        matches.value_of(options::BYTES),
-        matches.value_of(options::CHARACTERS),
-        matches.value_of(options::FIELDS),
+        matches.get_one::<String>(options::BYTES),
+        matches.get_one::<String>(options::CHARACTERS),
+        matches.get_one::<String>(options::FIELDS),
     ) {
         (Some(byte_ranges), None, None) => list_to_ranges(byte_ranges, complement).map(|ranges| {
             Mode::Bytes(
@@ -416,7 +416,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Options {
                     out_delim: Some(
                         matches
-                            .value_of(options::OUTPUT_DELIMITER)
+                            .get_one::<String>(options::OUTPUT_DELIMITER)
+                            .map(|s| s.as_str())
                             .unwrap_or_default()
                             .to_owned(),
                     ),
@@ -430,7 +431,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Options {
                     out_delim: Some(
                         matches
-                            .value_of(options::OUTPUT_DELIMITER)
+                            .get_one::<String>(options::OUTPUT_DELIMITER)
+                            .map(|s| s.as_str())
                             .unwrap_or_default()
                             .to_owned(),
                     ),
@@ -440,7 +442,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }),
         (None, None, Some(field_ranges)) => {
             list_to_ranges(field_ranges, complement).and_then(|ranges| {
-                let out_delim = match matches.value_of(options::OUTPUT_DELIMITER) {
+                let out_delim = match matches.get_one::<String>(options::OUTPUT_DELIMITER) {
                     Some(s) => {
                         if s.is_empty() {
                             Some("\0".to_owned())
@@ -454,7 +456,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 let only_delimited = matches.contains_id(options::ONLY_DELIMITED);
                 let zero_terminated = matches.contains_id(options::ZERO_TERMINATED);
 
-                match matches.value_of(options::DELIMITER) {
+                match matches.get_one::<String>(options::DELIMITER).map(|s| s.as_str()) {
                     Some(mut delim) => {
                         // GNU's `cut` supports `-d=` to set the delimiter to `=`.
                         // Clap parsing is limited in this situation, see:

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -146,7 +146,7 @@ impl<'a> From<&'a str> for Rfc3339Format {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
-    let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
+    let format = if let Some(form) = matches.get_one::<String>(OPT_FORMAT) {
         if !form.starts_with('+') {
             return Err(USimpleError::new(
                 1,
@@ -162,21 +162,24 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         Format::Iso8601(fmt)
     } else if matches.contains_id(OPT_RFC_EMAIL) {
         Format::Rfc5322
-    } else if let Some(fmt) = matches.value_of(OPT_RFC_3339).map(Into::into) {
+    } else if let Some(fmt) = matches
+        .get_one::<String>(OPT_RFC_3339)
+        .map(|s| s.as_str().into())
+    {
         Format::Rfc3339(fmt)
     } else {
         Format::Default
     };
 
-    let date_source = if let Some(date) = matches.value_of(OPT_DATE) {
+    let date_source = if let Some(date) = matches.get_one::<String>(OPT_DATE) {
         DateSource::Custom(date.into())
-    } else if let Some(file) = matches.value_of(OPT_FILE) {
+    } else if let Some(file) = matches.get_one::<String>(OPT_FILE) {
         DateSource::File(file.into())
     } else {
         DateSource::Now
     };
 
-    let set_to = match matches.value_of(OPT_SET).map(parse_date) {
+    let set_to = match matches.get_one::<String>(OPT_SET).map(parse_date) {
         None => None,
         Some(Err((input, _err))) => {
             return Err(USimpleError::new(

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -164,7 +164,7 @@ impl Default for BlockSize {
 
 pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSizeError> {
     if matches.contains_id(OPT_BLOCKSIZE) {
-        let s = matches.value_of(OPT_BLOCKSIZE).unwrap();
+        let s = matches.get_one::<String>(OPT_BLOCKSIZE).unwrap();
         let bytes = parse_size(s)?;
 
         if bytes > 0 {

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -188,7 +188,10 @@ impl Options {
             block_size: read_block_size(matches).map_err(|e| match e {
                 ParseSizeError::InvalidSuffix(s) => OptionsError::InvalidSuffix(s),
                 ParseSizeError::SizeTooBig(_) => OptionsError::BlockSizeTooLarge(
-                    matches.value_of(OPT_BLOCKSIZE).unwrap().to_string(),
+                    matches
+                        .get_one::<String>(OPT_BLOCKSIZE)
+                        .unwrap()
+                        .to_string(),
                 ),
                 ParseSizeError::ParseFailure(s) => OptionsError::InvalidBlockSize(s),
             })?,

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -521,7 +521,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let summarize = matches.contains_id(options::SUMMARIZE);
 
-    let max_depth = parse_depth(matches.value_of(options::MAX_DEPTH), summarize)?;
+    let max_depth = parse_depth(
+        matches
+            .get_one::<String>(options::MAX_DEPTH)
+            .map(|s| s.as_str()),
+        summarize,
+    )?;
 
     let options = Options {
         all: matches.contains_id(options::ALL),
@@ -534,7 +539,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         verbose: matches.contains_id(options::VERBOSE),
     };
 
-    let files = match matches.value_of(options::FILE) {
+    let files = match matches.get_one::<String>(options::FILE) {
         Some(_) => matches
             .get_many::<String>(options::FILE)
             .unwrap()
@@ -549,9 +554,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         show_warning!("options --apparent-size and -b are ineffective with --inodes");
     }
 
-    let block_size = read_block_size(matches.value_of(options::BLOCK_SIZE));
+    let block_size = read_block_size(
+        matches
+            .get_one::<String>(options::BLOCK_SIZE)
+            .map(|s| s.as_str()),
+    );
 
-    let threshold = matches.value_of(options::THRESHOLD).map(|s| {
+    let threshold = matches.get_one::<String>(options::THRESHOLD).map(|s| {
         Threshold::from_str(s)
             .unwrap_or_else(|e| crash!(1, "{}", format_error_message(&e, s, options::THRESHOLD)))
     });
@@ -582,7 +591,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    let time_format_str = parse_time_style(matches.value_of("time-style"))?;
+    let time_format_str =
+        parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?;
 
     let line_separator = if matches.contains_id(options::NULL) {
         "\0"
@@ -630,8 +640,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 if matches.is_present(options::TIME) {
                     let tm = {
                         let secs = {
-                            match matches.value_of(options::TIME) {
-                                Some(s) => match s {
+                            match matches.get_one::<String>(options::TIME) {
+                                Some(s) => match s.as_str() {
                                     "ctime" | "status" => stat.modified,
                                     "access" | "atime" | "use" => stat.accessed,
                                     "birth" | "creation" => stat

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -177,7 +177,7 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
 
     let ignore_env = matches.contains_id("ignore-environment");
     let null = matches.contains_id("null");
-    let running_directory = matches.value_of("chdir");
+    let running_directory = matches.get_one::<String>("chdir").map(|s| s.as_str());
     let files = match matches.get_many::<String>("file") {
         Some(v) => v.map(|s| s.as_str()).collect(),
         None => Vec::with_capacity(0),

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -108,17 +108,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     fmt_opts.xprefix = matches.contains_id(OPT_EXACT_PREFIX);
     fmt_opts.xanti_prefix = matches.contains_id(OPT_SKIP_PREFIX);
 
-    if let Some(s) = matches.value_of(OPT_PREFIX).map(String::from) {
+    if let Some(s) = matches.get_one::<String>(OPT_PREFIX).map(String::from) {
         fmt_opts.prefix = s;
         fmt_opts.use_prefix = true;
     };
 
-    if let Some(s) = matches.value_of(OPT_SKIP_PREFIX).map(String::from) {
+    if let Some(s) = matches.get_one::<String>(OPT_SKIP_PREFIX).map(String::from) {
         fmt_opts.anti_prefix = s;
         fmt_opts.use_anti_prefix = true;
     };
 
-    if let Some(s) = matches.value_of(OPT_WIDTH) {
+    if let Some(s) = matches.get_one::<String>(OPT_WIDTH) {
         fmt_opts.width = match s.parse::<usize>() {
             Ok(t) => t,
             Err(e) => {
@@ -140,7 +140,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         fmt_opts.goal = cmp::min(fmt_opts.width * 94 / 100, fmt_opts.width - 3);
     };
 
-    if let Some(s) = matches.value_of(OPT_GOAL) {
+    if let Some(s) = matches.get_one::<String>(OPT_GOAL) {
         fmt_opts.goal = match s.parse::<usize>() {
             Ok(t) => t,
             Err(e) => {
@@ -157,7 +157,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    if let Some(s) = matches.value_of(OPT_TAB_WIDTH) {
+    if let Some(s) = matches.get_one::<String>(OPT_TAB_WIDTH) {
         fmt_opts.tabwidth = match s.parse::<usize>() {
             Ok(t) => t,
             Err(e) => {

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -38,7 +38,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let bytes = matches.contains_id(options::BYTES);
     let spaces = matches.contains_id(options::SPACES);
-    let poss_width = match matches.value_of(options::WIDTH) {
+    let poss_width = match matches.get_one::<String>(options::WIDTH) {
         Some(v) => Some(v.to_owned()),
         None => obs_width,
     };

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -80,7 +80,7 @@ fn detect_algo(
             Box::new(blake3::Hasher::new()) as Box<dyn Digest>,
             256,
         ),
-        "sha3sum" => match matches.value_of("bits") {
+        "sha3sum" => match matches.get_one::<String>("bits") {
             Some(bits_str) => match (bits_str).parse::<usize>() {
                 Ok(224) => (
                     "SHA3-224",
@@ -130,7 +130,7 @@ fn detect_algo(
             Box::new(Sha3_512::new()) as Box<dyn Digest>,
             512,
         ),
-        "shake128sum" => match matches.value_of("bits") {
+        "shake128sum" => match matches.get_one::<String>("bits") {
             Some(bits_str) => match (bits_str).parse::<usize>() {
                 Ok(bits) => (
                     "SHAKE128",
@@ -141,7 +141,7 @@ fn detect_algo(
             },
             None => crash!(1, "--bits required for SHAKE-128"),
         },
-        "shake256sum" => match matches.value_of("bits") {
+        "shake256sum" => match matches.get_one::<String>("bits") {
             Some(bits_str) => match (bits_str).parse::<usize>() {
                 Ok(bits) => (
                     "SHAKE256",
@@ -187,7 +187,7 @@ fn detect_algo(
                     set_or_crash("BLAKE3", Box::new(blake3::Hasher::new()), 256);
                 }
                 if matches.contains_id("sha3") {
-                    match matches.value_of("bits") {
+                    match matches.get_one::<String>("bits") {
                         Some(bits_str) => match (bits_str).parse::<usize>() {
                             Ok(224) => set_or_crash(
                                 "SHA3-224",
@@ -231,7 +231,7 @@ fn detect_algo(
                     set_or_crash("SHA3-512", Box::new(Sha3_512::new()), 512);
                 }
                 if matches.contains_id("shake128") {
-                    match matches.value_of("bits") {
+                    match matches.get_one::<String>("bits") {
                         Some(bits_str) => match (bits_str).parse::<usize>() {
                             Ok(bits) => set_or_crash("SHAKE128", Box::new(Shake128::new()), bits),
                             Err(err) => crash!(1, "{}", err),
@@ -240,7 +240,7 @@ fn detect_algo(
                     }
                 }
                 if matches.contains_id("shake256") {
-                    match matches.value_of("bits") {
+                    match matches.get_one::<String>("bits") {
                         Some(bits_str) => match (bits_str).parse::<usize>() {
                             Ok(bits) => set_or_crash("SHAKE256", Box::new(Shake256::new()), bits),
                             Err(err) => crash!(1, "{}", err),

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -130,7 +130,7 @@ impl Default for Mode {
 
 impl Mode {
     fn from(matches: &ArgMatches) -> Result<Self, String> {
-        if let Some(v) = matches.value_of(options::BYTES_NAME) {
+        if let Some(v) = matches.get_one::<String>(options::BYTES_NAME) {
             let (n, all_but_last) =
                 parse::parse_num(v).map_err(|err| format!("invalid number of bytes: {}", err))?;
             if all_but_last {
@@ -138,7 +138,7 @@ impl Mode {
             } else {
                 Ok(Self::FirstBytes(n))
             }
-        } else if let Some(v) = matches.value_of(options::LINES_NAME) {
+        } else if let Some(v) = matches.get_one::<String>(options::LINES_NAME) {
             let (n, all_but_last) =
                 parse::parse_num(v).map_err(|err| format!("invalid number of lines: {}", err))?;
             if all_but_last {

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -357,7 +357,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
     let considering_dir: bool = MainFunction::Directory == main_function;
 
     let specified_mode: Option<u32> = if matches.contains_id(OPT_MODE) {
-        let x = matches.value_of(OPT_MODE).ok_or(1)?;
+        let x = matches.get_one::<String>(OPT_MODE).ok_or(1)?;
         Some(mode::parse(x, considering_dir, get_umask()).map_err(|err| {
             show_error!("Invalid mode string: {}", err);
             1
@@ -367,7 +367,9 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
     };
 
     let backup_mode = backup_control::determine_backup_mode(matches)?;
-    let target_dir = matches.value_of(OPT_TARGET_DIRECTORY).map(|d| d.to_owned());
+    let target_dir = matches
+        .get_one::<String>(OPT_TARGET_DIRECTORY)
+        .map(|d| d.to_owned());
 
     let preserve_timestamps = matches.contains_id(OPT_PRESERVE_TIMESTAMPS);
     let compare = matches.contains_id(OPT_COMPARE);
@@ -385,15 +387,24 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
         specified_mode,
         backup_mode,
         suffix: backup_control::determine_backup_suffix(matches),
-        owner: matches.value_of(OPT_OWNER).unwrap_or("").to_string(),
-        group: matches.value_of(OPT_GROUP).unwrap_or("").to_string(),
+        owner: matches
+            .get_one::<String>(OPT_OWNER)
+            .map(|s| s.as_str())
+            .unwrap_or("")
+            .to_string(),
+        group: matches
+            .get_one::<String>(OPT_GROUP)
+            .map(|s| s.as_str())
+            .unwrap_or("")
+            .to_string(),
         verbose: matches.contains_id(OPT_VERBOSE),
         preserve_timestamps,
         compare,
         strip,
         strip_program: String::from(
             matches
-                .value_of(OPT_STRIP_PROGRAM)
+                .get_one::<String>(OPT_STRIP_PROGRAM)
+                .map(|s| s.as_str())
                 .unwrap_or(DEFAULT_STRIP_PROGRAM),
         ),
         create_leading: matches.contains_id(OPT_CREATE_LEADING),

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -604,9 +604,9 @@ impl<'a> State<'a> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
-    let keys = parse_field_number_option(matches.value_of("j"))?;
-    let key1 = parse_field_number_option(matches.value_of("1"))?;
-    let key2 = parse_field_number_option(matches.value_of("2"))?;
+    let keys = parse_field_number_option(matches.get_one::<String>("j").map(|s| s.as_str()))?;
+    let key1 = parse_field_number_option(matches.get_one::<String>("1").map(|s| s.as_str()))?;
+    let key2 = parse_field_number_option(matches.get_one::<String>("2").map(|s| s.as_str()))?;
 
     let mut settings: Settings = Default::default();
 
@@ -655,7 +655,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         };
     }
 
-    if let Some(format) = matches.value_of("o") {
+    if let Some(format) = matches.get_one::<String>("o") {
         if format == "auto" {
             settings.autoformat = true;
         } else {
@@ -667,7 +667,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     }
 
-    if let Some(empty) = matches.value_of("e") {
+    if let Some(empty) = matches.get_one::<String>("e") {
         settings.empty = empty.as_bytes().to_vec();
     }
 
@@ -687,8 +687,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         settings.line_ending = LineEnding::Nul;
     }
 
-    let file1 = matches.value_of("file1").unwrap();
-    let file2 = matches.value_of("file2").unwrap();
+    let file1 = matches.get_one::<String>("file1").unwrap();
+    let file2 = matches.get_one::<String>("file2").unwrap();
 
     if file1 == "-" && file2 == "-" {
         return Err(USimpleError::new(1, "both files cannot be standard input"));

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -60,7 +60,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         Mode::Kill => {
             let sig = if let Some(signal) = obs_signal {
                 signal
-            } else if let Some(signal) = matches.value_of(options::SIGNAL) {
+            } else if let Some(signal) = matches.get_one::<String>(options::SIGNAL) {
                 parse_signal_value(signal)?
             } else {
                 15_usize //SIGTERM

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -170,7 +170,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         logical,
         relative: matches.contains_id(options::RELATIVE),
         target_dir: matches
-            .value_of(options::TARGET_DIRECTORY)
+            .get_one::<String>(options::TARGET_DIRECTORY)
             .map(String::from),
         no_target_dir: matches.contains_id(options::NO_TARGET_DIRECTORY),
         no_dereference: matches.contains_id(options::NO_DEREFERENCE),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -374,9 +374,9 @@ impl Config {
     #[allow(clippy::cognitive_complexity)]
     pub fn from(options: &clap::ArgMatches) -> UResult<Self> {
         let context = options.contains_id(options::CONTEXT);
-        let (mut format, opt) = if let Some(format_) = options.value_of(options::FORMAT) {
+        let (mut format, opt) = if let Some(format_) = options.get_one::<String>(options::FORMAT) {
             (
-                match format_ {
+                match format_.as_str() {
                     "long" | "verbose" => Format::Long,
                     "single-column" => Format::OneLine,
                     "columns" | "vertical" => Format::Columns,
@@ -447,8 +447,8 @@ impl Config {
             Files::Normal
         };
 
-        let sort = if let Some(field) = options.value_of(options::SORT) {
-            match field {
+        let sort = if let Some(field) = options.get_one::<String>(options::SORT) {
+            match field.as_str() {
                 "none" => Sort::None,
                 "name" => Sort::Name,
                 "time" => Sort::Time,
@@ -472,8 +472,8 @@ impl Config {
             Sort::Name
         };
 
-        let time = if let Some(field) = options.value_of(options::TIME) {
-            match field {
+        let time = if let Some(field) = options.get_one::<String>(options::TIME) {
+            match field.as_str() {
                 "ctime" | "status" => Time::Change,
                 "access" | "atime" | "use" => Time::Access,
                 "birth" | "creation" => Time::Birth,
@@ -488,25 +488,25 @@ impl Config {
             Time::Modification
         };
 
-        let mut needs_color = match options.value_of(options::COLOR) {
+        let mut needs_color = match options.get_one::<String>(options::COLOR) {
             None => options.contains_id(options::COLOR),
-            Some(val) => match val {
+            Some(val) => match val.as_str() {
                 "" | "always" | "yes" | "force" => true,
                 "auto" | "tty" | "if-tty" => atty::is(atty::Stream::Stdout),
                 /* "never" | "no" | "none" | */ _ => false,
             },
         };
 
-        let cmd_line_bs = options.value_of(options::size::BLOCK_SIZE);
+        let cmd_line_bs = options.get_one::<String>(options::size::BLOCK_SIZE);
         let opt_si = cmd_line_bs.is_some()
             && options
-                .value_of(options::size::BLOCK_SIZE)
+                .get_one::<String>(options::size::BLOCK_SIZE)
                 .unwrap()
                 .eq("si")
             || options.contains_id(options::size::SI);
         let opt_hr = (cmd_line_bs.is_some()
             && options
-                .value_of(options::size::BLOCK_SIZE)
+                .get_one::<String>(options::size::BLOCK_SIZE)
                 .unwrap()
                 .eq("human-readable"))
             || options.contains_id(options::size::HUMAN_READABLE);
@@ -574,7 +574,7 @@ impl Config {
             }
         };
 
-        let width = match options.value_of(options::WIDTH) {
+        let width = match options.get_one::<String>(options::WIDTH) {
             Some(x) => {
                 if x.starts_with('0') && x.len() > 1 {
                     // Read number as octal
@@ -617,7 +617,7 @@ impl Config {
         };
 
         let opt_quoting_style = options
-            .value_of(options::QUOTING_STYLE)
+            .get_one::<String>(options::QUOTING_STYLE)
             .map(|cmd_line_qs| cmd_line_qs.to_owned());
 
         let mut quoting_style = if let Some(style) = opt_quoting_style {
@@ -670,16 +670,18 @@ impl Config {
             }
         };
 
-        let indicator_style = if let Some(field) = options.value_of(options::INDICATOR_STYLE) {
-            match field {
+        let indicator_style = if let Some(field) =
+            options.get_one::<String>(options::INDICATOR_STYLE)
+        {
+            match field.as_str() {
                 "none" => IndicatorStyle::None,
                 "file-type" => IndicatorStyle::FileType,
                 "classify" => IndicatorStyle::Classify,
                 "slash" => IndicatorStyle::Slash,
                 &_ => IndicatorStyle::None,
             }
-        } else if let Some(field) = options.value_of(options::indicator_style::CLASSIFY) {
-            match field {
+        } else if let Some(field) = options.get_one::<String>(options::indicator_style::CLASSIFY) {
+            match field.as_str() {
                 "never" | "no" | "none" => IndicatorStyle::None,
                 "always" | "yes" | "force" => IndicatorStyle::Classify,
                 "auto" | "tty" | "if-tty" => {
@@ -699,7 +701,7 @@ impl Config {
             IndicatorStyle::None
         };
 
-        let time_style = if let Some(field) = options.value_of(options::TIME_STYLE) {
+        let time_style = if let Some(field) = options.get_one::<String>(options::TIME_STYLE) {
             //If both FULL_TIME and TIME_STYLE are present
             //The one added last is dominant
             if options.contains_id(options::FULL_TIME)
@@ -709,7 +711,7 @@ impl Config {
                 TimeStyle::FullIso
             } else {
                 //Clap handles the env variable "TIME_STYLE"
-                match field {
+                match field.as_str() {
                     "full-iso" => TimeStyle::FullIso,
                     "long-iso" => TimeStyle::LongIso,
                     "iso" => TimeStyle::Iso,

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -50,7 +50,7 @@ fn get_mode(matches: &ArgMatches, mode_had_minus_prefix: bool) -> Result<u32, St
     // Translate a ~str in octal form to u16, default to 755
     // Not tested on Windows
     let mut new_mode = DEFAULT_PERM;
-    match matches.value_of(options::MODE) {
+    match matches.get_one::<String>(options::MODE) {
         Some(m) => {
             for mode in m.split(',') {
                 if mode.contains(digits) {

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -39,7 +39,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Err(USimpleError::new(1, "-Z is not implemented"));
     }
 
-    let mode = match matches.value_of(options::MODE) {
+    let mode = match matches.get_one::<String>(options::MODE) {
         Some(m) => match usize::from_str_radix(m, 8) {
             Ok(m) => m,
             Err(e) => return Err(USimpleError::new(1, format!("invalid mode: {}", e))),

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -90,12 +90,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mode = get_mode(&matches).map_err(|e| USimpleError::new(1, e))?;
 
-    let file_name = matches.value_of("name").expect("Missing argument 'NAME'");
+    let file_name = matches
+        .get_one::<String>("name")
+        .expect("Missing argument 'NAME'");
 
     // Only check the first character, to allow mnemonic usage like
     // 'mknod /dev/rst0 character 18 0'.
     let ch = matches
-        .value_of("type")
+        .get_one::<String>("type")
         .expect("Missing argument 'TYPE'")
         .chars()
         .next()
@@ -113,7 +115,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             Ok(())
         }
     } else {
-        match (matches.value_of("major"), matches.value_of("minor")) {
+        match (
+            matches.get_one::<String>("major"),
+            matches.get_one::<String>("minor"),
+        ) {
             (None, None) | (_, None) | (None, _) => {
                 return Err(UUsageError::new(
                     1,
@@ -188,7 +193,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 }
 
 fn get_mode(matches: &ArgMatches) -> Result<mode_t, String> {
-    match matches.value_of("mode") {
+    match matches.get_one::<String>("mode") {
         None => Ok(MODE_RW_UGO),
         Some(str_mode) => uucore::mode::parse_mode(str_mode)
             .map_err(|e| format!("invalid mode ({})", e))

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -158,7 +158,7 @@ struct Options {
 /// in all other cases.
 fn is_tmpdir_argument_actually_the_template(matches: &ArgMatches) -> bool {
     if !matches.contains_id(ARG_TEMPLATE) {
-        if let Some(tmpdir) = matches.value_of(OPT_TMPDIR) {
+        if let Some(tmpdir) = matches.get_one::<String>(OPT_TMPDIR) {
             if !Path::new(tmpdir).is_dir() && tmpdir.contains("XXX") {
                 return true;
             }
@@ -177,13 +177,13 @@ impl Options {
         // See https://github.com/clap-rs/clap/pull/1587
         let (tmpdir, template) = if is_tmpdir_argument_actually_the_template(matches) {
             let tmpdir = Some(env::temp_dir().display().to_string());
-            let template = matches.value_of(OPT_TMPDIR).unwrap().to_string();
+            let template = matches.get_one::<String>(OPT_TMPDIR).unwrap().to_string();
             (tmpdir, template)
         } else {
             // If no template argument is given, `--tmpdir` is implied.
-            match matches.value_of(ARG_TEMPLATE) {
+            match matches.get_one::<String>(ARG_TEMPLATE) {
                 None => {
-                    let tmpdir = match matches.value_of(OPT_TMPDIR) {
+                    let tmpdir = match matches.get_one::<String>(OPT_TMPDIR) {
                         None => Some(env::temp_dir().display().to_string()),
                         Some(tmpdir) => Some(tmpdir.to_string()),
                     };
@@ -191,7 +191,7 @@ impl Options {
                     (tmpdir, template.to_string())
                 }
                 Some(template) => {
-                    let tmpdir = matches.value_of(OPT_TMPDIR).map(String::from);
+                    let tmpdir = matches.get_one::<String>(OPT_TMPDIR).map(String::from);
                     (tmpdir, template.to_string())
                 }
             }
@@ -201,7 +201,7 @@ impl Options {
             dry_run: matches.contains_id(OPT_DRY_RUN),
             quiet: matches.contains_id(OPT_QUIET),
             tmpdir,
-            suffix: matches.value_of(OPT_SUFFIX).map(String::from),
+            suffix: matches.get_one::<String>(OPT_SUFFIX).map(String::from),
             treat_as_template: matches.contains_id(OPT_T),
             template,
         }

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -46,7 +46,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    let adjustment = match matches.value_of(options::ADJUSTMENT) {
+    let adjustment = match matches.get_one::<String>(options::ADJUSTMENT) {
         Some(nstr) => {
             if !matches.contains_id(options::COMMAND) {
                 return Err(UUsageError::new(

--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -29,15 +29,15 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
     // This vector holds error messages encountered.
     let mut errs: Vec<String> = vec![];
     settings.renumber = !opts.contains_id(options::NO_RENUMBER);
-    match opts.value_of(options::NUMBER_SEPARATOR) {
+    match opts.get_one::<String>(options::NUMBER_SEPARATOR) {
         None => {}
         Some(val) => {
             settings.number_separator = val.to_owned();
         }
     }
-    match opts.value_of(options::NUMBER_FORMAT) {
+    match opts.get_one::<String>(options::NUMBER_FORMAT) {
         None => {}
-        Some(val) => match val {
+        Some(val) => match val.as_str() {
             "ln" => {
                 settings.number_format = crate::NumberFormat::Left;
             }
@@ -52,7 +52,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         },
     }
-    match opts.value_of(options::BODY_NUMBERING) {
+    match opts.get_one::<String>(options::BODY_NUMBERING) {
         None => {}
         Some(val) => {
             let chars: Vec<char> = val.chars().collect();
@@ -66,7 +66,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         }
     }
-    match opts.value_of(options::FOOTER_NUMBERING) {
+    match opts.get_one::<String>(options::FOOTER_NUMBERING) {
         None => {}
         Some(val) => {
             let chars: Vec<char> = val.chars().collect();
@@ -80,7 +80,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         }
     }
-    match opts.value_of(options::HEADER_NUMBERING) {
+    match opts.get_one::<String>(options::HEADER_NUMBERING) {
         None => {}
         Some(val) => {
             let chars: Vec<char> = val.chars().collect();
@@ -94,7 +94,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         }
     }
-    match opts.value_of(options::LINE_INCREMENT) {
+    match opts.get_one::<String>(options::LINE_INCREMENT) {
         None => {}
         Some(val) => {
             let conv: Option<u64> = val.parse().ok();
@@ -106,7 +106,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         }
     }
-    match opts.value_of(options::NUMBER_WIDTH) {
+    match opts.get_one::<String>(options::NUMBER_WIDTH) {
         None => {}
         Some(val) => {
             let conv: Option<usize> = val.parse().ok();
@@ -118,7 +118,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         }
     }
-    match opts.value_of(options::STARTING_LINE_NUMBER) {
+    match opts.get_one::<String>(options::STARTING_LINE_NUMBER) {
         None => {}
         Some(val) => {
             let conv: Option<u64> = val.parse().ok();
@@ -130,7 +130,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         }
     }
-    match opts.value_of(options::JOIN_BLANK_LINES) {
+    match opts.get_one::<String>(options::JOIN_BLANK_LINES) {
         None => {}
         Some(val) => {
             let conv: Option<u64> = val.parse().ok();

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -34,7 +34,7 @@ const USAGE: &str = "{} [OPTIONS]...";
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
-    let ignore = match matches.value_of(OPT_IGNORE) {
+    let ignore = match matches.get_one::<String>(OPT_IGNORE) {
         Some(numstr) => match numstr.trim().parse() {
             Ok(num) => num,
             Err(e) => {

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -119,10 +119,10 @@ fn parse_unit_size_suffix(s: &str) -> Option<usize> {
 }
 
 fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
-    let from = parse_unit(args.value_of(options::FROM).unwrap())?;
-    let to = parse_unit(args.value_of(options::TO).unwrap())?;
-    let from_unit = parse_unit_size(args.value_of(options::FROM_UNIT).unwrap())?;
-    let to_unit = parse_unit_size(args.value_of(options::TO_UNIT).unwrap())?;
+    let from = parse_unit(args.get_one::<String>(options::FROM).unwrap())?;
+    let to = parse_unit(args.get_one::<String>(options::TO).unwrap())?;
+    let from_unit = parse_unit_size(args.get_one::<String>(options::FROM_UNIT).unwrap())?;
+    let to_unit = parse_unit_size(args.get_one::<String>(options::TO_UNIT).unwrap())?;
 
     let transform = TransformOptions {
         from,
@@ -131,7 +131,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         to_unit,
     };
 
-    let padding = match args.value_of(options::PADDING) {
+    let padding = match args.get_one::<String>(options::PADDING) {
         Some(s) => s
             .parse::<isize>()
             .map_err(|_| s)
@@ -144,7 +144,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
     }?;
 
     let header = if args.value_source(options::HEADER) == Some(ValueSource::CommandLine) {
-        let value = args.value_of(options::HEADER).unwrap();
+        let value = args.get_one::<String>(options::HEADER).unwrap();
 
         value
             .parse::<usize>()
@@ -158,7 +158,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         Ok(0)
     }?;
 
-    let fields = match args.value_of(options::FIELD).unwrap() {
+    let fields = match args.get_one::<String>(options::FIELD).unwrap().as_str() {
         "-" => vec![Range {
             low: 1,
             high: std::usize::MAX,
@@ -166,7 +166,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         v => Range::from_list(v)?,
     };
 
-    let format = match args.value_of(options::FORMAT) {
+    let format = match args.get_one::<String>(options::FORMAT) {
         Some(s) => s.parse()?,
         None => FormatOptions::default(),
     };
@@ -175,16 +175,18 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         return Err("grouping cannot be combined with --to".to_string());
     }
 
-    let delimiter = args.value_of(options::DELIMITER).map_or(Ok(None), |arg| {
-        if arg.len() == 1 {
-            Ok(Some(arg.to_string()))
-        } else {
-            Err("the delimiter must be a single character".to_string())
-        }
-    })?;
+    let delimiter = args
+        .get_one::<String>(options::DELIMITER)
+        .map_or(Ok(None), |arg| {
+            if arg.len() == 1 {
+                Ok(Some(arg.to_string()))
+            } else {
+                Err("the delimiter must be a single character".to_string())
+            }
+        })?;
 
     // unwrap is fine because the argument has a default value
-    let round = match args.value_of(options::ROUND).unwrap() {
+    let round = match args.get_one::<String>(options::ROUND).unwrap().as_str() {
         "up" => RoundMethod::Up,
         "down" => RoundMethod::Down,
         "from-zero" => RoundMethod::FromZero,
@@ -193,7 +195,9 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         _ => unreachable!("Should be restricted by clap"),
     };
 
-    let suffix = args.value_of(options::SUFFIX).map(|s| s.to_owned());
+    let suffix = args
+        .get_one::<String>(options::SUFFIX)
+        .map(|s| s.to_owned());
 
     Ok(NumfmtOptions {
         transform,

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -124,19 +124,22 @@ struct OdOptions {
 
 impl OdOptions {
     fn new(matches: &ArgMatches, args: &[String]) -> UResult<Self> {
-        let byte_order = match matches.value_of(options::ENDIAN) {
-            None => ByteOrder::Native,
-            Some("little") => ByteOrder::Little,
-            Some("big") => ByteOrder::Big,
-            Some(s) => {
-                return Err(USimpleError::new(
-                    1,
-                    format!("Invalid argument --endian={}", s),
-                ));
+        let byte_order = if let Some(s) = matches.get_one::<String>(options::ENDIAN) {
+            match s.as_str() {
+                "little" => ByteOrder::Little,
+                "big" => ByteOrder::Big,
+                _ => {
+                    return Err(USimpleError::new(
+                        1,
+                        format!("Invalid argument --endian={}", s),
+                    ))
+                }
             }
+        } else {
+            ByteOrder::Native
         };
 
-        let mut skip_bytes = match matches.value_of(options::SKIP_BYTES) {
+        let mut skip_bytes = match matches.get_one::<String>(options::SKIP_BYTES) {
             None => 0,
             Some(s) => match parse_number_of_bytes(s) {
                 Ok(n) => n,
@@ -164,7 +167,7 @@ impl OdOptions {
 
         let formats = parse_format_flags(args).map_err(|e| USimpleError::new(1, e))?;
 
-        let mut line_bytes = match matches.value_of(options::WIDTH) {
+        let mut line_bytes = match matches.get_one::<String>(options::WIDTH) {
             None => 16,
             Some(s) => {
                 if matches.value_source(options::WIDTH) == Some(ValueSource::CommandLine) {
@@ -194,7 +197,7 @@ impl OdOptions {
 
         let output_duplicates = matches.contains_id(options::OUTPUT_DUPLICATES);
 
-        let read_bytes = match matches.value_of(options::READ_BYTES) {
+        let read_bytes = match matches.get_one::<String>(options::READ_BYTES) {
             None => None,
             Some(s) => match parse_number_of_bytes(s) {
                 Ok(n) => Some(n),
@@ -207,7 +210,7 @@ impl OdOptions {
             },
         };
 
-        let radix = match matches.value_of(options::ADDRESS_RADIX) {
+        let radix = match matches.get_one::<String>(options::ADDRESS_RADIX) {
             None => Radix::Octal,
             Some(s) => {
                 let st = s.as_bytes();

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -57,7 +57,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
     let serial = matches.contains_id(options::SERIAL);
-    let delimiters = matches.value_of(options::DELIMITER).unwrap();
+    let delimiters = matches.get_one::<String>(options::DELIMITER).unwrap();
     let files = matches
         .get_many::<String>(options::FILE)
         .unwrap()

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -470,7 +470,7 @@ fn parse_usize(matches: &ArgMatches, opt: &str) -> Option<Result<usize, PrError>
         })
     };
     matches
-        .value_of(opt)
+        .get_one::<String>(opt)
         .map(|i| (i.to_string(), format!("-{}", opt)))
         .map(from_parse_error_to_pr_error)
 }
@@ -501,7 +501,8 @@ fn build_options(
     };
 
     let header = matches
-        .value_of(options::HEADER)
+        .get_one::<String>(options::HEADER)
+        .map(|s| s.as_str())
         .unwrap_or(if is_merge_mode || paths[0] == FILE_STDIN {
             ""
         } else {
@@ -514,7 +515,7 @@ fn build_options(
         parse_usize(matches, options::FIRST_LINE_NUMBER).unwrap_or(Ok(default_first_number))?;
 
     let number = matches
-        .value_of(options::NUMBER_LINES)
+        .get_one::<String>(options::NUMBER_LINES)
         .map(|i| {
             let parse_result = i.parse::<usize>();
 
@@ -596,7 +597,7 @@ fn build_options(
     };
 
     let invalid_pages_map = |i: String| {
-        let unparsed_value = matches.value_of(options::PAGES).unwrap();
+        let unparsed_value = matches.get_one::<String>(options::PAGES).unwrap();
         i.parse::<usize>().map_err(|_e| {
             PrError::EncounteredErrors(format!(
                 "invalid --pages argument {}",
@@ -606,7 +607,7 @@ fn build_options(
     };
 
     let start_page = match matches
-        .value_of(options::PAGES)
+        .get_one::<String>(options::PAGES)
         .map(|i| {
             let x: Vec<_> = i.split(':').collect();
             x[0].to_string()
@@ -618,7 +619,7 @@ fn build_options(
     };
 
     let end_page = match matches
-        .value_of(options::PAGES)
+        .get_one::<String>(options::PAGES)
         .filter(|i| i.contains(':'))
         .map(|i| {
             let x: Vec<_> = i.split(':').collect();
@@ -668,9 +669,9 @@ fn build_options(
 
     let across_mode = matches.contains_id(options::ACROSS);
 
-    let column_separator = match matches.value_of(options::COLUMN_STRING_SEPARATOR) {
+    let column_separator = match matches.get_one::<String>(options::COLUMN_STRING_SEPARATOR) {
         Some(x) => Some(x),
-        None => matches.value_of(options::COLUMN_CHAR_SEPARATOR),
+        None => matches.get_one::<String>(options::COLUMN_CHAR_SEPARATOR),
     }
     .map(ToString::to_string)
     .unwrap_or_else(|| DEFAULT_COLUMN_SEPARATOR.to_string());

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -274,7 +274,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let format_string = matches
-        .value_of(options::FORMATSTRING)
+        .get_one::<String>(options::FORMATSTRING)
         .ok_or_else(|| UUsageError::new(1, "missing operand"))?;
     let values: Vec<String> = match matches.get_many::<String>(options::ARGUMENT) {
         Some(s) => s.map(|s| s.to_string()).collect(),

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -78,7 +78,7 @@ fn read_word_filter_file(
     option: &str,
 ) -> std::io::Result<HashSet<String>> {
     let filename = matches
-        .value_of(option)
+        .get_one::<String>(option)
         .expect("parsing options failed!")
         .to_string();
     let file = File::open(filename)?;
@@ -95,7 +95,9 @@ fn read_char_filter_file(
     matches: &clap::ArgMatches,
     option: &str,
 ) -> std::io::Result<HashSet<char>> {
-    let filename = matches.value_of(option).expect("parsing options failed!");
+    let filename = matches
+        .get_one::<String>(option)
+        .expect("parsing options failed!");
     let mut reader = File::open(filename)?;
     let mut buffer = String::new();
     reader.read_to_string(&mut buffer)?;
@@ -146,7 +148,7 @@ impl WordFilter {
         };
         // Ignore empty string regex from cmd-line-args
         let arg_reg: Option<String> = if matches.contains_id(options::WORD_REGEXP) {
-            match matches.value_of(options::WORD_REGEXP) {
+            match matches.get_one::<String>(options::WORD_REGEXP) {
                 Some(v) => {
                     if v.is_empty() {
                         None
@@ -244,26 +246,26 @@ fn get_config(matches: &clap::ArgMatches) -> UResult<Config> {
     config.ignore_case = matches.contains_id(options::IGNORE_CASE);
     if matches.contains_id(options::MACRO_NAME) {
         config.macro_name = matches
-            .value_of(options::MACRO_NAME)
+            .get_one::<String>(options::MACRO_NAME)
             .expect(err_msg)
             .to_string();
     }
     if matches.contains_id(options::FLAG_TRUNCATION) {
         config.trunc_str = matches
-            .value_of(options::FLAG_TRUNCATION)
+            .get_one::<String>(options::FLAG_TRUNCATION)
             .expect(err_msg)
             .to_string();
     }
     if matches.contains_id(options::WIDTH) {
         config.line_width = matches
-            .value_of(options::WIDTH)
+            .get_one::<String>(options::WIDTH)
             .expect(err_msg)
             .parse()
             .map_err(PtxError::ParseError)?;
     }
     if matches.contains_id(options::GAP_SIZE) {
         config.gap_size = matches
-            .value_of(options::GAP_SIZE)
+            .get_one::<String>(options::GAP_SIZE)
             .expect(err_msg)
             .parse()
             .map_err(PtxError::ParseError)?;

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -179,8 +179,12 @@ fn prepare_relative_options(
     can_mode: MissingHandling,
     resolve_mode: ResolveMode,
 ) -> UResult<(Option<PathBuf>, Option<PathBuf>)> {
-    let relative_to = matches.value_of(OPT_RELATIVE_TO).map(PathBuf::from);
-    let relative_base = matches.value_of(OPT_RELATIVE_BASE).map(PathBuf::from);
+    let relative_to = matches
+        .get_one::<String>(OPT_RELATIVE_TO)
+        .map(PathBuf::from);
+    let relative_base = matches
+        .get_one::<String>(OPT_RELATIVE_BASE)
+        .map(PathBuf::from);
     let relative_to = canonicalize_relative_option(relative_to, can_mode, resolve_mode)?;
     let relative_base = canonicalize_relative_option(relative_base, can_mode, resolve_mode)?;
     if let (Some(base), Some(to)) = (relative_base.as_deref(), relative_to.as_deref()) {

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -31,8 +31,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().get_matches_from(args);
 
-    let to = Path::new(matches.value_of(options::TO).unwrap()).to_path_buf(); // required
-    let from = match matches.value_of(options::FROM) {
+    let to = Path::new(matches.get_one::<String>(options::TO).unwrap()).to_path_buf(); // required
+    let from = match matches.get_one::<String>(options::FROM) {
         Some(p) => Path::new(p).to_path_buf(),
         None => env::current_dir().unwrap(),
     };
@@ -42,7 +42,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map_err_context(String::new)?;
 
     if matches.contains_id(options::DIR) {
-        let base = Path::new(&matches.value_of(options::DIR).unwrap()).to_path_buf();
+        let base = Path::new(&matches.get_one::<String>(options::DIR).unwrap()).to_path_buf();
         let absbase = canonicalize(base, MissingHandling::Normal, ResolveMode::Logical)
             .map_err_context(String::new)?;
         if !absto.as_path().starts_with(absbase.as_path())

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -105,7 +105,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 } else if matches.contains_id(OPT_PROMPT_MORE) {
                     InteractiveMode::Once
                 } else if matches.contains_id(OPT_INTERACTIVE) {
-                    match matches.value_of(OPT_INTERACTIVE).unwrap() {
+                    match matches.get_one::<String>(OPT_INTERACTIVE).unwrap().as_str() {
                         "never" => InteractiveMode::Never,
                         "once" => InteractiveMode::Once,
                         "always" => InteractiveMode::Always,

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -67,10 +67,18 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect::<Vec<_>>();
 
     let options = SeqOptions {
-        separator: matches.value_of(OPT_SEPARATOR).unwrap_or("\n").to_string(),
-        terminator: matches.value_of(OPT_TERMINATOR).unwrap_or("\n").to_string(),
+        separator: matches
+            .get_one::<String>(OPT_SEPARATOR)
+            .map(|s| s.as_str())
+            .unwrap_or("\n")
+            .to_string(),
+        terminator: matches
+            .get_one::<String>(OPT_TERMINATOR)
+            .map(|s| s.as_str())
+            .unwrap_or("\n")
+            .to_string(),
         widths: matches.contains_id(OPT_WIDTHS),
-        format: matches.value_of(OPT_FORMAT),
+        format: matches.get_one::<String>(OPT_FORMAT).map(|s| s.as_str()),
     };
 
     let first = if numbers.len() > 1 {

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -274,7 +274,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Err(UUsageError::new(1, "missing file operand"));
     }
 
-    let iterations = match matches.value_of(options::ITERATIONS) {
+    let iterations = match matches.get_one::<String>(options::ITERATIONS) {
         Some(s) => match s.parse::<usize>() {
             Ok(u) => u,
             Err(_) => {
@@ -298,7 +298,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let force = matches.contains_id(options::FORCE);
     let remove = matches.contains_id(options::REMOVE);
-    let size_arg = matches.value_of(options::SIZE).map(|s| s.to_string());
+    let size_arg = matches
+        .get_one::<String>(options::SIZE)
+        .map(|s| s.to_string());
     let size = get_size(size_arg);
     let exact = matches.contains_id(options::EXACT) && size.is_none(); // if -s is given, ignore -x
     let zero = matches.contains_id(options::ZERO);

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -62,7 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mode = if let Some(args) = matches.get_many::<String>(options::ECHO) {
         Mode::Echo(args.map(String::from).collect())
-    } else if let Some(range) = matches.value_of(options::INPUT_RANGE) {
+    } else if let Some(range) = matches.get_one::<String>(options::INPUT_RANGE) {
         match parse_range(range) {
             Ok(m) => Mode::InputRange(m),
             Err(msg) => {
@@ -70,7 +70,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
         }
     } else {
-        Mode::Default(matches.value_of(options::FILE).unwrap_or("-").to_string())
+        Mode::Default(
+            matches
+                .get_one::<String>(options::FILE)
+                .map(|s| s.as_str())
+                .unwrap_or("-")
+                .to_string(),
+        )
     };
 
     let options = Options {
@@ -85,8 +91,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Err(msg) => return Err(USimpleError::new(1, msg)),
             }
         },
-        output: matches.value_of(options::OUTPUT).map(String::from),
-        random_source: matches.value_of(options::RANDOM_SOURCE).map(String::from),
+        output: matches.get_one::<String>(options::OUTPUT).map(String::from),
+        random_source: matches
+            .get_one::<String>(options::RANDOM_SOURCE)
+            .map(String::from),
         repeat: matches.contains_id(options::REPEAT),
         sep: if matches.contains_id(options::ZERO_TERMINATED) {
             0x00_u8

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1104,27 +1104,45 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     settings.mode = if matches.contains_id(options::modes::HUMAN_NUMERIC)
-        || matches.value_of(options::modes::SORT) == Some("human-numeric")
+        || matches
+            .get_one::<String>(options::modes::SORT)
+            .map(|s| s.as_str())
+            == Some("human-numeric")
     {
         SortMode::HumanNumeric
     } else if matches.contains_id(options::modes::MONTH)
-        || matches.value_of(options::modes::SORT) == Some("month")
+        || matches
+            .get_one::<String>(options::modes::SORT)
+            .map(|s| s.as_str())
+            == Some("month")
     {
         SortMode::Month
     } else if matches.contains_id(options::modes::GENERAL_NUMERIC)
-        || matches.value_of(options::modes::SORT) == Some("general-numeric")
+        || matches
+            .get_one::<String>(options::modes::SORT)
+            .map(|s| s.as_str())
+            == Some("general-numeric")
     {
         SortMode::GeneralNumeric
     } else if matches.contains_id(options::modes::NUMERIC)
-        || matches.value_of(options::modes::SORT) == Some("numeric")
+        || matches
+            .get_one::<String>(options::modes::SORT)
+            .map(|s| s.as_str())
+            == Some("numeric")
     {
         SortMode::Numeric
     } else if matches.contains_id(options::modes::VERSION)
-        || matches.value_of(options::modes::SORT) == Some("version")
+        || matches
+            .get_one::<String>(options::modes::SORT)
+            .map(|s| s.as_str())
+            == Some("version")
     {
         SortMode::Version
     } else if matches.contains_id(options::modes::RANDOM)
-        || matches.value_of(options::modes::SORT) == Some("random")
+        || matches
+            .get_one::<String>(options::modes::SORT)
+            .map(|s| s.as_str())
+            == Some("random")
     {
         settings.salt = Some(get_rand_string());
         SortMode::Random
@@ -1137,7 +1155,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if matches.contains_id(options::PARALLEL) {
         // "0" is default - threads = num of cores
         settings.threads = matches
-            .value_of(options::PARALLEL)
+            .get_one::<String>(options::PARALLEL)
             .map(String::from)
             .unwrap_or_else(|| "0".to_string());
         env::set_var("RAYON_NUM_THREADS", &settings.threads);
@@ -1145,7 +1163,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     settings.buffer_size =
         matches
-            .value_of(options::BUF_SIZE)
+            .get_one::<String>(options::BUF_SIZE)
             .map_or(Ok(DEFAULT_BUF_SIZE), |s| {
                 GlobalSettings::parse_byte_count(s).map_err(|e| {
                     USimpleError::new(2, format_error_message(&e, s, options::BUF_SIZE))
@@ -1154,14 +1172,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mut tmp_dir = TmpDirWrapper::new(
         matches
-            .value_of(options::TMP_DIR)
+            .get_one::<String>(options::TMP_DIR)
             .map(PathBuf::from)
             .unwrap_or_else(env::temp_dir),
     );
 
-    settings.compress_prog = matches.value_of(options::COMPRESS_PROG).map(String::from);
+    settings.compress_prog = matches
+        .get_one::<String>(options::COMPRESS_PROG)
+        .map(String::from);
 
-    if let Some(n_merge) = matches.value_of(options::BATCH_SIZE) {
+    if let Some(n_merge) = matches.get_one::<String>(options::BATCH_SIZE) {
         settings.merge_batch_size = n_merge.parse().map_err(|_| {
             UUsageError::new(
                 2,
@@ -1176,7 +1196,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     settings.check = matches.contains_id(options::check::CHECK);
     if matches.contains_id(options::check::CHECK_SILENT)
         || matches!(
-            matches.value_of(options::check::CHECK),
+            matches
+                .get_one::<String>(options::check::CHECK)
+                .map(|s| s.as_str()),
             Some(options::check::SILENT) | Some(options::check::QUIET)
         )
     {
@@ -1262,7 +1284,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         open(file)?;
     }
 
-    let output = Output::new(matches.value_of(options::OUTPUT))?;
+    let output = Output::new(
+        matches
+            .get_one::<String>(options::OUTPUT)
+            .map(|s| s.as_str()),
+    )?;
 
     settings.init_precomputed();
 

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -375,22 +375,22 @@ impl Strategy {
         ) {
             (false, false, false, false) => Ok(Self::Lines(1000)),
             (true, false, false, false) => {
-                let s = matches.value_of(OPT_LINES).unwrap();
+                let s = matches.get_one::<String>(OPT_LINES).unwrap();
                 let n = parse_size(s).map_err(StrategyError::Lines)?;
                 Ok(Self::Lines(n))
             }
             (false, true, false, false) => {
-                let s = matches.value_of(OPT_BYTES).unwrap();
+                let s = matches.get_one::<String>(OPT_BYTES).unwrap();
                 let n = parse_size(s).map_err(StrategyError::Bytes)?;
                 Ok(Self::Bytes(n))
             }
             (false, false, true, false) => {
-                let s = matches.value_of(OPT_LINE_BYTES).unwrap();
+                let s = matches.get_one::<String>(OPT_LINE_BYTES).unwrap();
                 let n = parse_size(s).map_err(StrategyError::Bytes)?;
                 Ok(Self::LineBytes(n))
             }
             (false, false, false, true) => {
-                let s = matches.value_of(OPT_NUMBER).unwrap();
+                let s = matches.get_one::<String>(OPT_NUMBER).unwrap();
                 let number_type = NumberType::from(s).map_err(StrategyError::NumberType)?;
                 Ok(Self::Number(number_type))
             }
@@ -489,13 +489,16 @@ impl fmt::Display for SettingsError {
 impl Settings {
     /// Parse a strategy from the command-line arguments.
     fn from(matches: &ArgMatches) -> Result<Self, SettingsError> {
-        let additional_suffix = matches.value_of(OPT_ADDITIONAL_SUFFIX).unwrap().to_string();
+        let additional_suffix = matches
+            .get_one::<String>(OPT_ADDITIONAL_SUFFIX)
+            .unwrap()
+            .to_string();
         if additional_suffix.contains('/') {
             return Err(SettingsError::SuffixContainsSeparator(additional_suffix));
         }
         let strategy = Strategy::from(matches).map_err(SettingsError::Strategy)?;
         let suffix_type = suffix_type_from(matches);
-        let suffix_length_str = matches.value_of(OPT_SUFFIX_LENGTH).unwrap();
+        let suffix_length_str = matches.get_one::<String>(OPT_SUFFIX_LENGTH).unwrap();
         let suffix_length: usize = suffix_length_str
             .parse()
             .map_err(|_| SettingsError::SuffixNotParsable(suffix_length_str.to_string()))?;
@@ -517,9 +520,9 @@ impl Settings {
             additional_suffix,
             verbose: matches.value_source("verbose") == Some(ValueSource::CommandLine),
             strategy,
-            input: matches.value_of(ARG_INPUT).unwrap().to_owned(),
-            prefix: matches.value_of(ARG_PREFIX).unwrap().to_owned(),
-            filter: matches.value_of(OPT_FILTER).map(|s| s.to_owned()),
+            input: matches.get_one::<String>(ARG_INPUT).unwrap().to_owned(),
+            prefix: matches.get_one::<String>(ARG_PREFIX).unwrap().to_owned(),
+            filter: matches.get_one::<String>(OPT_FILTER).map(|s| s.to_owned()),
             elide_empty_files: matches.contains_id(OPT_ELIDE_EMPTY_FILES),
         };
         #[cfg(windows)]

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -512,10 +512,13 @@ impl Stater {
             .unwrap_or_default();
         let format_str = if matches.contains_id(options::PRINTF) {
             matches
-                .value_of(options::PRINTF)
+                .get_one::<String>(options::PRINTF)
                 .expect("Invalid format string")
         } else {
-            matches.value_of(options::FORMAT).unwrap_or("")
+            matches
+                .get_one::<String>(options::FORMAT)
+                .map(|s| s.as_str())
+                .unwrap_or("")
         };
 
         let use_printf = matches.contains_id(options::PRINTF);

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -105,8 +105,8 @@ fn preload_strings() -> (&'static str, &'static str) {
 }
 
 fn check_option(matches: &ArgMatches, name: &str) -> Result<BufferType, ProgramOptionsError> {
-    match matches.value_of(name) {
-        Some(value) => match value {
+    match matches.get_one::<String>(name) {
+        Some(value) => match value.as_str() {
             "L" => {
                 if name == options::INPUT {
                     Err(ProgramOptionsError(

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -102,7 +102,7 @@ impl<'a> Options<'a> {
         Ok(Self {
             all: matches.is_present(options::ALL),
             save: matches.is_present(options::SAVE),
-            file: match matches.value_of(options::FILE) {
+            file: match matches.get_one::<String>(options::FILE) {
                 Some(_f) => todo!(),
                 None => stdout().as_raw_fd(),
             },

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -42,7 +42,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let before = matches.contains_id(options::BEFORE);
     let regex = matches.contains_id(options::REGEX);
-    let raw_separator = matches.value_of(options::SEPARATOR).unwrap_or("\n");
+    let raw_separator = matches
+        .get_one::<String>(options::SEPARATOR)
+        .map(|s| s.as_str())
+        .unwrap_or("\n");
     let separator = if raw_separator.is_empty() {
         "\0"
     } else {

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -63,7 +63,7 @@ pub enum FilterMode {
 impl FilterMode {
     fn from(matches: &ArgMatches) -> UResult<Self> {
         let zero_term = matches.contains_id(options::ZERO_TERM);
-        let mode = if let Some(arg) = matches.value_of(options::BYTES) {
+        let mode = if let Some(arg) = matches.get_one::<String>(options::BYTES) {
             match parse_num(arg) {
                 Ok(signum) => Self::Bytes(signum),
                 Err(e) => {
@@ -73,7 +73,7 @@ impl FilterMode {
                     ))
                 }
             }
-        } else if let Some(arg) = matches.value_of(options::LINES) {
+        } else if let Some(arg) = matches.get_one::<String>(options::LINES) {
             match parse_num(arg) {
                 Ok(signum) => {
                     let delimiter = if zero_term { 0 } else { b'\n' };
@@ -138,7 +138,8 @@ impl Settings {
             Some(FollowMode::Name)
         } else if matches.value_source(options::FOLLOW) != Some(ValueSource::CommandLine) {
             None
-        } else if matches.value_of(options::FOLLOW) == Some("name") {
+        } else if matches.get_one::<String>(options::FOLLOW) == Some(String::from("name")).as_ref()
+        {
             Some(FollowMode::Name)
         } else {
             Some(FollowMode::Descriptor)
@@ -151,7 +152,7 @@ impl Settings {
             show_warning!("--retry ignored; --retry is useful only when following");
         }
 
-        if let Some(s) = matches.value_of(options::SLEEP_INT) {
+        if let Some(s) = matches.get_one::<String>(options::SLEEP_INT) {
             settings.sleep_sec = match s.parse::<f32>() {
                 Ok(s) => Duration::from_secs_f32(s),
                 Err(_) => {
@@ -165,7 +166,7 @@ impl Settings {
 
         settings.use_polling = matches.contains_id(options::USE_POLLING);
 
-        if let Some(s) = matches.value_of(options::MAX_UNCHANGED_STATS) {
+        if let Some(s) = matches.get_one::<String>(options::MAX_UNCHANGED_STATS) {
             settings.max_unchanged_stats = match s.parse::<u32>() {
                 Ok(s) => s,
                 Err(_) => {
@@ -180,7 +181,7 @@ impl Settings {
             }
         }
 
-        if let Some(pid_str) = matches.value_of(options::PID) {
+        if let Some(pid_str) = matches.get_one::<String>(options::PID) {
             match pid_str.parse() {
                 Ok(pid) => {
                     // NOTE: on unix platform::Pid is i32, on windows platform::Pid is u32

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -64,8 +64,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             if matches.contains_id(options::IGNORE_PIPE_ERRORS) {
                 Some(OutputErrorMode::WarnNoPipe)
             } else if matches.contains_id(options::OUTPUT_ERROR) {
-                if let Some(v) = matches.value_of(options::OUTPUT_ERROR) {
-                    match v {
+                if let Some(v) = matches.get_one::<String>(options::OUTPUT_ERROR) {
+                    match v.as_str() {
                         "warn" => Some(OutputErrorMode::Warn),
                         "warn-nopipe" => Some(OutputErrorMode::WarnNoPipe),
                         "exit" => Some(OutputErrorMode::Exit),

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -52,7 +52,7 @@ struct Config {
 
 impl Config {
     fn from(options: &clap::ArgMatches) -> UResult<Self> {
-        let signal = match options.value_of(options::SIGNAL) {
+        let signal = match options.get_one::<String>(options::SIGNAL) {
             Some(signal_) => {
                 let signal_result = signal_by_name_or_value(signal_);
                 match signal_result {
@@ -68,7 +68,7 @@ impl Config {
             _ => uucore::signals::signal_by_name_or_value("TERM").unwrap(),
         };
 
-        let kill_after = match options.value_of(options::KILL_AFTER) {
+        let kill_after = match options.get_one::<String>(options::KILL_AFTER) {
             None => None,
             Some(kill_after) => match uucore::parse_time::from_str(kill_after) {
                 Ok(k) => Some(k),
@@ -76,11 +76,12 @@ impl Config {
             },
         };
 
-        let duration =
-            match uucore::parse_time::from_str(options.value_of(options::DURATION).unwrap()) {
-                Ok(duration) => duration,
-                Err(err) => return Err(UUsageError::new(ExitStatus::TimeoutFailed.into(), err)),
-            };
+        let duration = match uucore::parse_time::from_str(
+            options.get_one::<String>(options::DURATION).unwrap(),
+        ) {
+            Ok(duration) => duration,
+            Err(err) => return Err(UUsageError::new(ExitStatus::TimeoutFailed.into(), err)),
+        };
 
         let preserve_status: bool = options.contains_id(options::PRESERVE_STATUS);
         let foreground = options.contains_id(options::FOREGROUND);

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -85,9 +85,9 @@ Try 'touch --help' for more information."##,
                 !matches.contains_id(options::NO_DEREF),
             )?
         } else {
-            let timestamp = if let Some(date) = matches.value_of(options::sources::DATE) {
+            let timestamp = if let Some(date) = matches.get_one::<String>(options::sources::DATE) {
                 parse_date(date)?
-            } else if let Some(current) = matches.value_of(options::sources::CURRENT) {
+            } else if let Some(current) = matches.get_one::<String>(options::sources::CURRENT) {
                 parse_timestamp(current)?
             } else {
                 local_dt_to_filetime(time::OffsetDateTime::now_local().unwrap())
@@ -143,7 +143,10 @@ Try 'touch --help' for more information."##,
             || matches.contains_id(options::TIME)
         {
             let st = stat(path, !matches.contains_id(options::NO_DEREF))?;
-            let time = matches.value_of(options::TIME).unwrap_or("");
+            let time = matches
+                .get_one::<String>(options::TIME)
+                .map(|s| s.as_str())
+                .unwrap_or("");
 
             if !(matches.contains_id(options::ACCESS)
                 || time.contains(&"access".to_owned())

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -131,8 +131,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     } else {
         let io_blocks = matches.contains_id(options::IO_BLOCKS);
         let no_create = matches.contains_id(options::NO_CREATE);
-        let reference = matches.value_of(options::REFERENCE).map(String::from);
-        let size = matches.value_of(options::SIZE).map(String::from);
+        let reference = matches
+            .get_one::<String>(options::REFERENCE)
+            .map(String::from);
+        let size = matches.get_one::<String>(options::SIZE).map(String::from);
         truncate(no_create, io_blocks, reference, size, &files)
     }
 }

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -30,7 +30,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
     let input = matches
-        .value_of(options::FILE)
+        .get_one::<String>(options::FILE)
         .expect("Value is required by clap");
 
     let mut stdin_buf;

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -113,7 +113,7 @@ impl Options {
             && !matches.contains_id(options::FIRST_ONLY);
         let uflag = !matches.contains_id(options::NO_UTF8);
 
-        let files = match matches.value_of(options::FILE) {
+        let files = match matches.get_one::<String>(options::FILE) {
             Some(v) => vec![v.to_string()],
             None => vec!["-".to_owned()],
         };

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -229,7 +229,7 @@ fn get_line_string(io_line: io::Result<Vec<u8>>) -> UResult<String> {
 }
 
 fn opt_parsed<T: FromStr>(opt_name: &str, matches: &ArgMatches) -> UResult<Option<T>> {
-    Ok(match matches.value_of(opt_name) {
+    Ok(match matches.get_one::<String>(opt_name) {
         Some(arg_str) => Some(arg_str.parse().map_err(|_| {
             USimpleError::new(
                 1,
@@ -408,8 +408,8 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 fn get_delimiter(matches: &ArgMatches) -> Delimiters {
     let value = matches
-        .value_of(options::ALL_REPEATED)
-        .or_else(|| matches.value_of(options::GROUP));
+        .get_one::<String>(options::ALL_REPEATED)
+        .or_else(|| matches.get_one::<String>(options::GROUP));
     if let Some(delimiter_arg) = value {
         Delimiters::from_str(delimiter_arg).unwrap() // All possible values for ALL_REPEATED are Delimiters (of type `&str`)
     } else if matches.contains_id(options::GROUP) {

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -55,7 +55,7 @@ impl Settings {
             show_control: false,
         };
 
-        let files0_from_stdin_mode = match matches.value_of(options::FILES0_FROM) {
+        let files0_from_stdin_mode = match matches.get_one::<String>(options::FILES0_FROM) {
             Some(files_0_from) => files_0_from == STDIN_REPR,
             None => false,
         };
@@ -274,7 +274,7 @@ fn inputs(matches: &ArgMatches) -> UResult<Vec<Input>> {
 
             Ok(os_values.map(|s| Input::from(s.as_os_str())).collect())
         }
-        None => match matches.value_of(options::FILES0_FROM) {
+        None => match matches.get_one::<String>(options::FILES0_FROM) {
             Some(files_0_from) => create_paths_from_files0(files_0_from),
             None => Ok(vec![Input::Stdin(StdinKind::Implicit)]),
         },

--- a/src/uucore/src/lib/mods/backup_control.rs
+++ b/src/uucore/src/lib/mods/backup_control.rs
@@ -245,7 +245,7 @@ pub mod arguments {
 /// This function directly takes [`clap::ArgMatches`] as argument and looks for
 /// the '-S' and '--suffix' arguments itself.
 pub fn determine_backup_suffix(matches: &ArgMatches) -> String {
-    let supplied_suffix = matches.value_of(arguments::OPT_SUFFIX);
+    let supplied_suffix = matches.get_one::<String>(arguments::OPT_SUFFIX);
     if let Some(suffix) = supplied_suffix {
         String::from(suffix)
     } else {
@@ -337,7 +337,7 @@ pub fn determine_backup_mode(matches: &ArgMatches) -> UResult<BackupMode> {
         // is used but method is not specified, then the value of the
         // VERSION_CONTROL environment variable is used. And if VERSION_CONTROL
         // is not set, the default backup type is 'existing'.
-        if let Some(method) = matches.value_of(arguments::OPT_BACKUP) {
+        if let Some(method) = matches.get_one::<String>(arguments::OPT_BACKUP) {
             // Second argument is for the error string that is returned.
             match_method(method, "backup type")
         } else if let Ok(method) = env::var("VERSION_CONTROL") {


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `value_of()` with `get_one()`.