### PR TITLE
dd: Error message of invalid args is matched with GNU

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -146,7 +146,7 @@ impl Input<File> {
                 }
 
                 opts.open(fname)
-                    .map_err_context(|| "failed to open input file".to_string())?
+                    .map_err_context(|| format!("failed to open {}", fname.quote()))?
             };
 
             // The --skip and --iseek flags are additive. On a file, they seek.

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1189,28 +1189,17 @@ fn test_final_stats_si_iec() {
 }
 
 #[test]
-fn test_cbs_invalid_arg_gnu_compatibility() {
-    let result = new_ucmd!().args(&["cbs="]).pipe_in("").fails();
-
-    result.stderr_is("dd: invalid number: ‘’");
-
-    let result = new_ucmd!().args(&["cbs=29d"]).pipe_in("").fails();
-
-    result.stderr_is("dd: invalid number: ‘29d’");
-}
-
-#[test]
 fn test_invalid_number_arg_gnu_compatibility() {
     let commands = vec!["bs", "cbs", "count", "ibs", "obs", "seek", "skip"];
 
     for command in commands {
         new_ucmd!()
-            .args(&[format!("{command}=")])
+            .args(&[format!("{}=", command)])
             .fails()
             .stderr_is("dd: invalid number: ‘’");
 
         new_ucmd!()
-            .args(&[format!("{command}=29d")])
+            .args(&[format!("{}=29d", command)])
             .fails()
             .stderr_is("dd: invalid number: ‘29d’");
     }
@@ -1222,12 +1211,12 @@ fn test_invalid_flag_arg_gnu_compatibility() {
 
     for command in commands {
         new_ucmd!()
-            .args(&[format!("{command}=")])
+            .args(&[format!("{}=", command)])
             .fails()
             .stderr_is("dd: invalid input flag: ‘’\nTry 'dd --help' for more information.");
 
         new_ucmd!()
-            .args(&[format!("{command}=29d")])
+            .args(&[format!("{}=29d", command)])
             .fails()
             .stderr_is("dd: invalid input flag: ‘29d’\nTry 'dd --help' for more information.");
     }
@@ -1236,24 +1225,24 @@ fn test_invalid_flag_arg_gnu_compatibility() {
 #[test]
 fn test_invalid_file_arg_gnu_compatibility() {
     new_ucmd!()
-        .args(&[format!("if=")])
+        .args(&["if="])
         .fails()
         .stderr_is("dd: failed to open '': No such file or directory");
 
     new_ucmd!()
-        .args(&[format!("if=81as9bn8as9g302az8ns9.pdf.zip.pl.com")])
+        .args(&["if=81as9bn8as9g302az8ns9.pdf.zip.pl.com"])
         .fails()
         .stderr_is(
             "dd: failed to open '81as9bn8as9g302az8ns9.pdf.zip.pl.com': No such file or directory",
         );
 
     new_ucmd!()
-        .args(&[format!("of=")])
+        .args(&["of="])
         .fails()
         .stderr_is("dd: failed to open '': No such file or directory");
 
     new_ucmd!()
-        .args(&[format!("of=81as9bn8as9g302az8ns9.pdf.zip.pl.com")])
+        .args(&["of=81as9bn8as9g302az8ns9.pdf.zip.pl.com"])
         .pipe_in("")
         .succeeds();
 }

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1187,3 +1187,73 @@ fn test_final_stats_si_iec() {
     let s = result.stderr_str();
     assert!(s.starts_with("2+0 records in\n2+0 records out\n1024 bytes (1 KB, 1024 B) copied,"));
 }
+
+#[test]
+fn test_cbs_invalid_arg_gnu_compatibility() {
+    let result = new_ucmd!().args(&["cbs="]).pipe_in("").fails();
+
+    result.stderr_is("dd: invalid number: ‘’");
+
+    let result = new_ucmd!().args(&["cbs=29d"]).pipe_in("").fails();
+
+    result.stderr_is("dd: invalid number: ‘29d’");
+}
+
+#[test]
+fn test_invalid_number_arg_gnu_compatibility() {
+    let commands = vec!["bs", "cbs", "count", "ibs", "obs", "seek", "skip"];
+
+    for command in commands {
+        new_ucmd!()
+            .args(&[format!("{command}=")])
+            .fails()
+            .stderr_is("dd: invalid number: ‘’");
+
+        new_ucmd!()
+            .args(&[format!("{command}=29d")])
+            .fails()
+            .stderr_is("dd: invalid number: ‘29d’");
+    }
+}
+
+#[test]
+fn test_invalid_flag_arg_gnu_compatibility() {
+    let commands = vec!["iflag", "oflag"];
+
+    for command in commands {
+        new_ucmd!()
+            .args(&[format!("{command}=")])
+            .fails()
+            .stderr_is("dd: invalid input flag: ‘’\nTry 'dd --help' for more information.");
+
+        new_ucmd!()
+            .args(&[format!("{command}=29d")])
+            .fails()
+            .stderr_is("dd: invalid input flag: ‘29d’\nTry 'dd --help' for more information.");
+    }
+}
+
+#[test]
+fn test_invalid_file_arg_gnu_compatibility() {
+    new_ucmd!()
+        .args(&[format!("if=")])
+        .fails()
+        .stderr_is("dd: failed to open '': No such file or directory");
+
+    new_ucmd!()
+        .args(&[format!("if=81as9bn8as9g302az8ns9.pdf.zip.pl.com")])
+        .fails()
+        .stderr_is(
+            "dd: failed to open '81as9bn8as9g302az8ns9.pdf.zip.pl.com': No such file or directory",
+        );
+
+    new_ucmd!()
+        .args(&[format!("of=")])
+        .fails()
+        .stderr_is("dd: failed to open '': No such file or directory");
+
+    new_ucmd!()
+        .args(&[format!("of=81as9bn8as9g302az8ns9.pdf.zip.pl.com")])
+        .pipe_in("")
+        .succeeds();
+}


### PR DESCRIPTION
Fixes #3363

Error message of invalid arguments is now matched with GNU. PR also contains tests for this situation.