### PR TITLE
Simplify invalid encoding handling

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -87,9 +87,7 @@ impl Config {
 
 pub fn parse_base_cmd_args(args: impl uucore::Args, about: &str, usage: &str) -> UResult<Config> {
     let command = base_app(about, usage);
-    let arg_list = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let arg_list = args.collect_str(InvalidEncodingHandling::ConvertLossy);
     Config::from(&command.try_get_matches_from(arg_list)?)
 }
 

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -12,7 +12,7 @@ use std::io::{stdout, Read, Write};
 use uucore::display::Quotable;
 use uucore::encoding::{wrap_print, Data, Format};
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 use std::fs::File;
 use std::io::{BufReader, Stdin};
@@ -87,7 +87,7 @@ impl Config {
 
 pub fn parse_base_cmd_args(args: impl uucore::Args, about: &str, usage: &str) -> UResult<Config> {
     let command = base_app(about, usage);
-    let arg_list = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let arg_list = args.collect_lossy();
     Config::from(&command.try_get_matches_from(arg_list)?)
 }
 

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -28,9 +28,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     // Since options have to go before names,
     // if the first argument is not an option, then there is no option,

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -11,7 +11,7 @@ use clap::{crate_version, Arg, Command};
 use std::path::{is_separator, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = r#"Print NAME with any leading directory components removed
 If specified, also remove a trailing SUFFIX"#;
@@ -28,7 +28,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     // Since options have to go before names,
     // if the first argument is not an option, then there is no option,

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -52,10 +52,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 fn parse_cmd_args(args: impl uucore::Args) -> UResult<(Config, Format)> {
     let matches = uu_app()
-        .try_get_matches_from(
-            args.collect_str(InvalidEncodingHandling::ConvertLossy)
-                .accept_any(),
-        )
+        .try_get_matches_from(args.collect_str(InvalidEncodingHandling::ConvertLossy))
         .with_exit_code(1)?;
     let format = ENCODINGS
         .iter()

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -14,7 +14,6 @@ use uu_base32::base_common::{self, Config, BASE_CMD_PARSE_ERROR};
 use uucore::{
     encoding::Format,
     error::{UResult, UUsageError},
-    InvalidEncodingHandling,
 };
 
 use std::io::{stdin, Read};
@@ -52,7 +51,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 fn parse_cmd_args(args: impl uucore::Args) -> UResult<(Config, Format)> {
     let matches = uu_app()
-        .try_get_matches_from(args.collect_str(InvalidEncodingHandling::ConvertLossy))
+        .try_get_matches_from(args.collect_lossy())
         .with_exit_code(1)?;
     let format = ENCODINGS
         .iter()

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -184,9 +184,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().try_get_matches_from(args)?;
 

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -36,7 +36,7 @@ use std::net::Shutdown;
 use std::os::unix::fs::FileTypeExt;
 #[cfg(unix)]
 use unix_socket::UnixStream;
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static NAME: &str = "cat";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
@@ -184,7 +184,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().try_get_matches_from(args)?;
 

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -18,7 +18,7 @@ use uucore::fs::is_symlink;
 use uucore::libc::mode_t;
 #[cfg(not(windows))]
 use uucore::mode;
-use uucore::{format_usage, show_error, InvalidEncodingHandling};
+use uucore::{format_usage, show_error};
 
 static ABOUT: &str = "Change the mode of each FILE to MODE.
  With --reference, change the mode of each FILE to that of RFILE.";
@@ -46,7 +46,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let mut args = args.collect_lossy();
 
     // Before we can parse 'args' with clap (and previously getopts),
     // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -46,9 +46,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let mut args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     // Before we can parse 'args' with clap (and previously getopts),
     // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -33,9 +33,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use std::process;
 use uucore::error::{set_exit_code, UResult};
 use uucore::libc::{self, chroot, setgid, setgroups, setuid};
-use uucore::{entries, format_usage, InvalidEncodingHandling};
+use uucore::{entries, format_usage};
 
 static ABOUT: &str = "Run COMMAND with root directory set to NEWROOT.";
 static USAGE: &str = "{} [OPTION]... NEWROOT [COMMAND [ARG]...]";
@@ -33,7 +33,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -12,7 +12,6 @@ use std::io::{self, stdin, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::InvalidEncodingHandling;
 use uucore::{format_usage, show};
 
 // NOTE: CRC_TABLE_LEN *must* be <= 256 as we cast 0..CRC_TABLE_LEN to u8
@@ -114,7 +113,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -114,9 +114,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -13,7 +13,7 @@ use std::io::{self, stdin, BufRead, BufReader, Stdin};
 use std::path::Path;
 use uucore::error::FromIo;
 use uucore::error::UResult;
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 use clap::{crate_version, Arg, ArgMatches, Command};
 
@@ -132,7 +132,7 @@ fn open_file(name: &str) -> io::Result<LineReader> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
     let filename1 = matches.value_of(options::FILE_1).unwrap();

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -132,9 +132,7 @@ fn open_file(name: &str) -> io::Result<LineReader> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
     let filename1 = matches.value_of(options::FILE_1).unwrap();

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -16,7 +16,7 @@ use clap::{crate_version, Arg, ArgMatches, Command};
 use regex::Regex;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 mod csplit_error;
 mod patterns;
@@ -713,7 +713,7 @@ mod tests {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -713,9 +713,7 @@ mod tests {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -398,9 +398,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let delimiter_is_equal = args.contains(&"-d=".to_string()); // special case
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -19,8 +19,8 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 
 use self::searcher::Searcher;
+use uucore::format_usage;
 use uucore::ranges::Range;
-use uucore::{format_usage, InvalidEncodingHandling};
 
 mod searcher;
 
@@ -398,7 +398,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let delimiter_is_equal = args.contains(&"-d=".to_string()); // special case
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -37,7 +37,7 @@ use clap::{crate_version, Arg, ArgMatches, Command};
 use gcd::Gcd;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::{show_error, InvalidEncodingHandling};
+use uucore::show_error;
 
 const ABOUT: &str = "copy, and optionally convert, a file system resource";
 const BUF_INIT_BYTE: u8 = 0xDD;
@@ -706,7 +706,7 @@ fn append_dashes_if_not_present(mut acc: Vec<String>, mut s: String) -> Vec<Stri
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let dashed_args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
+        .collect_ignore()
         .into_iter()
         .fold(Vec::new(), append_dashes_if_not_present);
 

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -707,7 +707,6 @@ fn append_dashes_if_not_present(mut acc: Vec<String>, mut s: String) -> Vec<Stri
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let dashed_args = args
         .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any()
         .into_iter()
         .fold(Vec::new(), append_dashes_if_not_present);
 

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -65,9 +65,7 @@ pub fn guess_syntax() -> OutputFmt {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(&args);
 

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -65,7 +65,7 @@ pub fn guess_syntax() -> OutputFmt {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(&args);
 
@@ -276,7 +276,7 @@ enum ParseState {
 }
 
 use std::collections::HashMap;
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 fn parse<T>(lines: T, fmt: &OutputFmt, fp: &str) -> Result<String, String>
 where

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -28,9 +28,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let after_help = get_long_usage();
 

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -9,7 +9,7 @@ use clap::{crate_version, Arg, Command};
 use std::path::Path;
 use uucore::display::print_verbatim;
 use uucore::error::{UResult, UUsageError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = "strip last component from file name";
 const USAGE: &str = "{} [OPTION] NAME...";
@@ -28,7 +28,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let after_help = get_long_usage();
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -39,7 +39,6 @@ use uucore::error::{UError, UResult};
 use uucore::format_usage;
 use uucore::parse_glob;
 use uucore::parse_size::{parse_size, ParseSizeError};
-use uucore::InvalidEncodingHandling;
 #[cfg(windows)]
 use winapi::shared::minwindef::{DWORD, LPVOID};
 #[cfg(windows)]
@@ -516,7 +515,7 @@ fn build_exclude_patterns(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
 #[uucore::main]
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -516,9 +516,7 @@ fn build_exclude_patterns(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
 #[uucore::main]
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -110,9 +110,7 @@ fn print_escaped(input: &str, mut output: impl Write) -> io::Result<bool> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
     let matches = uu_app().get_matches_from(args);
 
     let no_newline = matches.contains_id(options::NO_NEWLINE);

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -11,7 +11,7 @@ use std::io::{self, Write};
 use std::iter::Peekable;
 use std::str::Chars;
 use uucore::error::{FromIo, UResult};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 const NAME: &str = "echo";
 const ABOUT: &str = "display a line of text";
@@ -110,7 +110,7 @@ fn print_escaped(input: &str, mut output: impl Write) -> io::Result<bool> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
     let matches = uu_app().get_matches_from(args);
 
     let no_newline = matches.contains_id(options::NO_NEWLINE);

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -22,7 +22,7 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = "Convert tabs in each FILE to spaces, writing to standard output.
  With no FILE, or when FILE is -, read standard input.";
@@ -269,7 +269,7 @@ fn expand_shortcuts(args: &[String]) -> Vec<String> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(expand_shortcuts(&args));
 

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -269,9 +269,7 @@ fn expand_shortcuts(args: &[String]) -> Vec<String> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(expand_shortcuts(&args));
 

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -33,9 +33,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     // For expr utility we do not want getopts.
     // The following usage should work without escaping hyphens: `expr -15 = 1 +  2 \* \( 3 - -4 \)`

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -7,7 +7,6 @@
 
 use clap::{crate_version, Arg, Command};
 use uucore::error::{UResult, USimpleError};
-use uucore::InvalidEncodingHandling;
 
 mod syntax_tree;
 mod tokens;
@@ -33,7 +32,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     // For expr utility we do not want getopts.
     // The following usage should work without escaping hyphens: `expr -15 = 1 +  2 \* \( 3 - -4 \)`

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -31,9 +31,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let (args, obs_width) = handle_obsolete(&args[..]);
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -13,7 +13,7 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 const TAB_WIDTH: usize = 8;
 
@@ -31,7 +31,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let (args, obs_width) = handle_obsolete(&args[..]);
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -16,8 +16,8 @@ use nix::unistd::Pid;
 use std::io::Error;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
+use uucore::format_usage;
 use uucore::signals::{signal_by_name_or_value, ALL_SIGNALS};
-use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Send signal to processes or list information about signals.";
 const USAGE: &str = "{} [OPTIONS]... PID...";
@@ -38,7 +38,7 @@ pub enum Mode {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let mut args = args.collect_ignore();
     let obs_signal = handle_obsolete(&mut args);
 
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -38,9 +38,7 @@ pub enum Mode {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let mut args = args.collect_str(InvalidEncodingHandling::Ignore);
     let obs_signal = handle_obsolete(&mut args);
 
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -37,9 +37,7 @@ static ABOUT: &str = "Print user's login name";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let _ = uu_app().get_matches_from(args);
 

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -15,7 +15,6 @@ extern crate uucore;
 use clap::{crate_version, Command};
 use std::ffi::CStr;
 use uucore::error::UResult;
-use uucore::InvalidEncodingHandling;
 
 extern "C" {
     // POSIX requires using getlogin (or equivalent code)
@@ -37,7 +36,7 @@ static ABOUT: &str = "Print user's login name";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let _ = uu_app().get_matches_from(args);
 

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -15,10 +15,10 @@ use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
+use uucore::format_usage;
 #[cfg(not(windows))]
 use uucore::mode;
 use uucore::{display::Quotable, fs::dir_strip_dot_for_creation};
-use uucore::{format_usage, InvalidEncodingHandling};
 
 static DEFAULT_PERM: u32 = 0o755;
 
@@ -83,7 +83,7 @@ fn strip_minus_from_mode(args: &mut Vec<String>) -> bool {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let mut args = args.collect_lossy();
 
     // Before we can parse 'args' with clap (and previously getopts),
     // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -83,9 +83,7 @@ fn strip_minus_from_mode(args: &mut Vec<String>) -> bool {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let mut args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     // Before we can parse 'args' with clap (and previously getopts),
     // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -28,9 +28,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -11,9 +11,9 @@ extern crate uucore;
 use clap::{crate_version, Arg, Command};
 use libc::mkfifo;
 use std::ffi::CString;
+use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::format_usage;
-use uucore::{display::Quotable, InvalidEncodingHandling};
 
 static NAME: &str = "mkfifo";
 static USAGE: &str = "{} [OPTION]... NAME...";
@@ -28,7 +28,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -15,7 +15,7 @@ use libc::{S_IFBLK, S_IFCHR, S_IFIFO, S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOT
 
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = "Create the special file NAME of the given TYPE.";
 static USAGE: &str = "{} [OPTION]... NAME TYPE [MAJOR MINOR]";
@@ -81,7 +81,7 @@ fn _mknod(file_name: &str, mode: mode_t, dev: dev_t) -> i32 {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
     // Linux-specific options, not implemented
     // opts.optflag("Z", "", "set the SELinux security context to default type");
     // opts.optopt("", "context", "like -Z, or if CTX is specified then set the SELinux or SMACK security context to CTX");

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -81,9 +81,7 @@ fn _mknod(file_name: &str, mode: mode_t, dev: dev_t) -> i32 {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
     // Linux-specific options, not implemented
     // opts.optflag("Z", "", "set the SELinux security context to default type");
     // opts.optopt("", "context", "like -Z, or if CTX is specified then set the SELinux or SMACK security context to CTX");

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -11,7 +11,7 @@
 use clap::{crate_version, Arg, ArgMatches, Command};
 use uucore::display::{println_verbatim, Quotable};
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 use std::env;
 use std::error::Error;
@@ -316,7 +316,7 @@ impl Params {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().try_get_matches_from(&args)?;
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -11,7 +11,7 @@
 use clap::{crate_version, Arg, ArgMatches, Command};
 use uucore::display::{println_verbatim, Quotable};
 use uucore::error::{FromIo, UError, UResult};
-use uucore::format_usage;
+use uucore::{format_usage, InvalidEncodingHandling};
 
 use std::env;
 use std::error::Error;
@@ -316,7 +316,7 @@ impl Params {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str_lossy().accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().try_get_matches_from(&args)?;
 

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -84,9 +84,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -14,7 +14,7 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::iter::repeat;
 use std::path::Path;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 mod helper;
 
@@ -84,7 +84,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -22,7 +22,7 @@ use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UError, UResult};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = "Run COMMAND ignoring hangup signals.";
 static LONG_HELP: &str = "
@@ -86,7 +86,7 @@ impl Display for NohupError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -86,9 +86,7 @@ impl Display for NohupError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -261,9 +261,7 @@ fn concat_format_arg_and_value(args: &[String]) -> Vec<String> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(concat_format_arg_and_value(&args));
 

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -16,8 +16,8 @@ use std::io::{BufRead, Write};
 use units::{IEC_BASES, SI_BASES};
 use uucore::display::Quotable;
 use uucore::error::UResult;
+use uucore::format_usage;
 use uucore::ranges::Range;
-use uucore::{format_usage, InvalidEncodingHandling};
 
 pub mod errors;
 pub mod format;
@@ -261,7 +261,7 @@ fn concat_format_arg_and_value(args: &[String]) -> Vec<String> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(concat_format_arg_and_value(&args));
 

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -48,7 +48,6 @@ use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::format_usage;
 use uucore::parse_size::ParseSizeError;
-use uucore::InvalidEncodingHandling;
 
 const PEEK_BUFFER_SIZE: usize = 4; // utf-8 can be 4 bytes
 static ABOUT: &str = "dump files in octal and other formats";
@@ -256,7 +255,7 @@ impl OdOptions {
 /// opens the input and calls `odfunc` to process the input.
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let clap_opts = uu_app();
 

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -256,9 +256,7 @@ impl OdOptions {
 /// opens the input and calls `odfunc` to process the input.
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let clap_opts = uu_app();
 

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::io::{ErrorKind, Write};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UResult, UUsageError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 // operating mode
 enum Mode {
@@ -39,7 +39,7 @@ const POSIX_NAME_MAX: usize = 14;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -39,9 +39,7 @@ const POSIX_NAME_MAX: usize = 14;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -20,7 +20,7 @@ use std::os::unix::fs::MetadataExt;
 
 use clap::{crate_version, Arg, Command};
 use std::path::PathBuf;
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = "lightweight finger";
 const USAGE: &str = "{} [OPTION]... [USER]...";
@@ -49,7 +49,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let after_help = get_long_usage();
 

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -49,9 +49,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let after_help = get_long_usage();
 

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -378,7 +378,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(uucore::InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let opt_args = recreate_arguments(&args);
 

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -378,9 +378,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(uucore::InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(uucore::InvalidEncodingHandling::Ignore);
 
     let opt_args = recreate_arguments(&args);
 

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -4,7 +4,6 @@
 
 use clap::{crate_version, Arg, Command};
 use uucore::error::{UResult, UUsageError};
-use uucore::InvalidEncodingHandling;
 use uucore::{format_usage, memo};
 
 const VERSION: &str = "version";
@@ -271,7 +270,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
     let matches = uu_app().get_matches_from(args);
 
     let format_string = matches

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -271,9 +271,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
     let matches = uu_app().get_matches_from(args);
 
     let format_string = matches

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -722,9 +722,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     // let mut opts = Options::new();
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -19,7 +19,7 @@ use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::num::ParseIntError;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static NAME: &str = "ptx";
 const USAGE: &str = "\
@@ -722,7 +722,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     // let mut opts = Options::new();
     let matches = uu_app().get_matches_from(args);

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -27,9 +27,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -12,8 +12,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
+use uucore::format_usage;
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
-use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Convert TO destination to the relative path from the FROM dir.
 If FROM path is omitted, current working dir will be used.";
@@ -27,7 +27,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -20,7 +20,7 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, util_name, InvalidEncodingHandling};
+use uucore::{format_usage, util_name};
 
 #[macro_use]
 extern crate uucore;
@@ -266,7 +266,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -266,9 +266,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -56,9 +56,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 mod rand_read_adapter;
 
@@ -56,7 +56,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1055,9 +1055,7 @@ fn make_sort_mode_arg<'a>(mode: &'a str, short: char, help: &'a str) -> Arg<'a> 
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
     let mut settings: GlobalSettings = Default::default();
 
     let matches = match uu_app().try_get_matches_from(args) {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -47,9 +47,9 @@ use std::str::Utf8Error;
 use unicode_width::UnicodeWidthStr;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, strip_errno, UError, UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 use uucore::parse_size::{parse_size, ParseSizeError};
 use uucore::version_cmp::version_cmp;
-use uucore::{format_usage, InvalidEncodingHandling};
 
 use crate::tmp_dir::TmpDirWrapper;
 
@@ -1055,7 +1055,7 @@ fn make_sort_mode_arg<'a>(mode: &'a str, short: char, help: &'a str) -> Arg<'a> 
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
     let mut settings: GlobalSettings = Default::default();
 
     let matches = match uu_app().try_get_matches_from(args) {

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -156,9 +156,7 @@ fn get_preload_env(tmp_dir: &mut TempDir) -> io::Result<(String, PathBuf)> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -19,8 +19,8 @@ use std::process;
 use tempfile::tempdir;
 use tempfile::TempDir;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 use uucore::parse_size::parse_size;
-use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str =
     "Run COMMAND, with modified buffering operations for its standard streams.\n\n\
@@ -156,7 +156,7 @@ fn get_preload_env(tmp_dir: &mut TempDir) -> io::Result<(String, PathBuf)> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -109,9 +109,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -16,7 +16,7 @@ use std::io::{stdin, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static NAME: &str = "sum";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
@@ -109,7 +109,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -19,7 +19,6 @@ use std::{
 use uucore::display::Quotable;
 use uucore::error::UError;
 use uucore::error::UResult;
-use uucore::InvalidEncodingHandling;
 use uucore::{format_usage, show};
 
 use crate::error::TacError;
@@ -37,7 +36,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -37,9 +37,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -20,9 +20,9 @@ use std::process::{self, Child, Stdio};
 use std::time::Duration;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::format_usage;
 use uucore::process::ChildExt;
 use uucore::signals::{signal_by_name_or_value, signal_name_by_value};
-use uucore::{format_usage, InvalidEncodingHandling};
 
 static ABOUT: &str = "Start COMMAND, and kill it if still running after DURATION.";
 const USAGE: &str = "{} [OPTION] DURATION COMMAND...";
@@ -106,7 +106,7 @@ impl Config {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let command = uu_app();
 

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -106,9 +106,7 @@ impl Config {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let command = uu_app();
 

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -18,8 +18,8 @@ use std::io::{stdin, stdout, BufReader, BufWriter};
 use uucore::{format_usage, show};
 
 use crate::operation::DeleteOperation;
+use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
-use uucore::{display::Quotable, InvalidEncodingHandling};
 
 static ABOUT: &str = "translate or delete characters";
 const USAGE: &str = "{} [OPTION]... SET1 [SET2]";
@@ -40,7 +40,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let after_help = get_long_usage();
 

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -40,9 +40,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let after_help = get_long_usage();
 

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -12,7 +12,7 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = "Topological sort the strings in FILE.
 Strings are defined as any sequence of tokens separated by whitespace (tab, space, or newline).
@@ -25,7 +25,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -25,9 +25,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -13,7 +13,7 @@ use clap::{crate_version, Arg, Command};
 use std::ffi::CStr;
 use std::io::Write;
 use uucore::error::UResult;
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
 const USAGE: &str = "{} [OPTION]...";
@@ -24,7 +24,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
+    let args = args.collect_lossy();
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -24,9 +24,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::ConvertLossy)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::ConvertLossy);
 
     let matches = uu_app().get_matches_from(args);
 

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -21,7 +21,7 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 static NAME: &str = "unexpand";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
@@ -165,7 +165,7 @@ fn expand_shortcuts(args: &[String]) -> Vec<String> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let matches = uu_app().get_matches_from(expand_shortcuts(&args));
 

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -165,9 +165,7 @@ fn expand_shortcuts(args: &[String]) -> Vec<String> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let matches = uu_app().get_matches_from(expand_shortcuts(&args));
 

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -18,7 +18,7 @@ use std::ffi::CStr;
 use std::fmt::Write;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
-use uucore::{format_usage, InvalidEncodingHandling};
+use uucore::format_usage;
 
 mod options {
     pub const ALL: &str = "all";
@@ -56,7 +56,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_str(InvalidEncodingHandling::Ignore);
+    let args = args.collect_ignore();
 
     let after_help = get_long_usage();
 

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -56,9 +56,7 @@ fn get_long_usage() -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args
-        .collect_str(InvalidEncodingHandling::Ignore)
-        .accept_any();
+    let args = args.collect_str(InvalidEncodingHandling::Ignore);
 
     let after_help = get_long_usage();
 

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -153,7 +153,6 @@ pub fn execution_phrase() -> &'static str {
 pub enum InvalidEncodingHandling {
     Ignore,
     ConvertLossy,
-    Panic,
 }
 
 #[must_use]
@@ -192,11 +191,9 @@ pub trait Args: Iterator<Item = OsString> + Sized {
     /// Converts each iterator item to a String and collects these into a vector
     /// On invalid encoding, the result will depend on the argument. This method allows to either drop entries with illegal encoding
     /// completely (```InvalidEncodingHandling::Ignore```), convert them using lossy-conversion (```InvalidEncodingHandling::ConvertLossy```)
-    /// which will result in strange strings or can chosen to panic (```InvalidEncodingHandling::Panic```).
+    /// which will result in strange strings or can chosen to panic.
     /// # Arguments
     /// * `handling` - This switch allows to switch the behavior, when invalid encoding is encountered
-    /// # Panics
-    /// * Occurs, when invalid encoding is encountered and handling is set to ```InvalidEncodingHandling::Panic```
     fn collect_str(self, handling: InvalidEncodingHandling) -> ConversionResult {
         let mut full_conversion = true;
         let result_vector: Vec<String> = self
@@ -212,9 +209,6 @@ pub trait Args: Iterator<Item = OsString> + Sized {
                         InvalidEncodingHandling::Ignore => Err(String::new()),
                         InvalidEncodingHandling::ConvertLossy => {
                             Err(s_ret.to_string_lossy().into_owned())
-                        }
-                        InvalidEncodingHandling::Panic => {
-                            panic!("Broken encoding found but caller cannot handle it")
                         }
                     }
                 }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -30,7 +30,7 @@ use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 use tempfile::TempDir;
-use uucore::{Args, InvalidEncodingHandling};
+use uucore::Args;
 
 #[cfg(windows)]
 static PROGNAME: &str = concat!(env!("CARGO_PKG_NAME"), ".exe");
@@ -1021,7 +1021,7 @@ impl UCommand {
         let strings = args
             .iter()
             .map(|s| s.as_ref().to_os_string())
-            .collect_str(InvalidEncodingHandling::Ignore);
+            .collect_ignore();
 
         for s in strings {
             self.comm_string.push(' ');

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1021,8 +1021,7 @@ impl UCommand {
         let strings = args
             .iter()
             .map(|s| s.as_ref().to_os_string())
-            .collect_str(InvalidEncodingHandling::Ignore)
-            .accept_any();
+            .collect_str(InvalidEncodingHandling::Ignore);
 
         for s in strings {
             self.comm_string.push(' ');


### PR DESCRIPTION
The `InvalidEncodingHandling` for `uucore::Args` was introduced (for good reason) in https://github.com/uutils/coreutils/pull/1852, but seemed to be unnecessarily complex. A few things stuck out to me:

- No util should panic on invalid input, so the `Panic` variant can be removed.
- We don't want to print anything when we encounter an invalid string (GNU doesn't do that either).
- All utils are using `accept_any` (and not `accept_lossy` or `accept_complete`)
- If only `accept_any` is used, then the intermediate `ConversionResult` is useless and can be removed.
- Finally, the `collect_str` was overly complex and becomes much nicer when split into two smaller methods.

This cleans up a lot, but I don't think it's quite done yet. In particular:
- I don't think any util should use `collect_ignore`, but I didn't want to go through every util that does this (which are 23 utils) to check :)
- We should be able to get rid of the construction of a `Vec` and instead create an `Iterator`.
- It bugs me that `uucore::Args` does not require `ExactSizeIterator`, requiring collecting it into a `Vec` to get the length, like in https://github.com/uutils/coreutils/pull/3784.
- Clap's invalid encoding handling is improving steadily and we should look into using that.