### PR TITLE
`dir` & `vdir`: fix docs not showing up on the documentation website

### DIFF
--- a/src/uu/dir/src/dir.rs
+++ b/src/uu/dir/src/dir.rs
@@ -13,7 +13,7 @@ use uucore::quoting_style::{Quotes, QuotingStyle};
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let command = uu_ls::uu_app();
+    let command = uu_app();
 
     let matches = command.get_matches_from(args);
 
@@ -64,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 // To avoid code duplication, we reuse ls uu_app function which has the same
 // arguments. However, coreutils won't compile if one of the utils is missing
-// an uu_app function, so we need this dummy one.
+// an uu_app function, so we return the `ls` app.
 pub fn uu_app<'a>() -> Command<'a> {
-    Command::new(uucore::util_name())
+    uu_ls::uu_app()
 }

--- a/src/uu/vdir/src/vdir.rs
+++ b/src/uu/vdir/src/vdir.rs
@@ -13,7 +13,7 @@ use uucore::quoting_style::{Quotes, QuotingStyle};
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let command = uu_ls::uu_app();
+    let command = uu_app();
     let matches = command.get_matches_from(args);
 
     let mut default_quoting_style = false;
@@ -64,5 +64,5 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 // arguments. However, coreutils won't compile if one of the utils is missing
 // an uu_app function, so we need this dummy one.
 pub fn uu_app<'a>() -> Command<'a> {
-    Command::new(uucore::util_name())
+    uu_ls::uu_app()
 }


### PR DESCRIPTION
`uudoc` was getting a dummy `clap` app to generate documentation from. Now the `App` from `ls` is returned instead, so that it actually shows something.

See https://uutils.github.io/coreutils-docs/user/utils/dir.html

We still need to figure out a way to document them separately too, so that we can highlight the difference with `ls`.

**Before**
![image](https://user-images.githubusercontent.com/11643477/185237854-3d43fd03-3394-4a0b-9853-810699e6f288.png)

**After**
![image](https://user-images.githubusercontent.com/11643477/185237934-2cf5c51f-d1f6-4628-910d-53dc5e98101a.png)
