### PR TITLE
CI/android: add 60 min timeout for cargo test to see where it's stuck

### DIFF
--- a/util/android-commands.sh
+++ b/util/android-commands.sh
@@ -120,7 +120,7 @@ build () {
 
 tests () {
     probe='/sdcard/tests.probe'
-    command="'cd ~/coreutils && cargo test --features feat_os_unix_android --no-fail-fast >/sdcard/tests.log 2>&1; echo \$? >$probe'"
+    command="'cd ~/coreutils && timeout --preserve-status --verbose -k 1m 60m cargo test --features feat_os_unix_android --no-fail-fast >/sdcard/tests.log 2>&1; echo \$? >$probe'"
     run_termux_command "$command" "$probe"
     return_code=$?
     adb pull /sdcard/tests.log .


### PR DESCRIPTION
When the job is stopped on timeout exceeded we don't see what `cargo test` has printed

- added 60 minutes timeout for `cargo test` run, so that it prints what `cargo` printed