### PR TITLE
tail: fix stdin redirect (#3842)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "libc",
  "nix",
  "notify",
+ "same-file",
  "uucore",
  "winapi",
  "winapi-util",

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "3.2", features = ["wrap_help", "cargo"] }
 libc = "0.2.132"
 notify = { version = "=5.0.0-pre.16", features=["macos_kqueue"]}
 uucore = { version=">=0.0.15", package="uucore", path="../../uucore", features=["ringbuffer", "lines"] }
+same-file = "1.0.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version="0.3", features=["fileapi", "handleapi", "processthreadsapi", "synchapi", "winbase"] }

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -30,7 +30,8 @@ pub struct ReverseChunks<'a> {
 
 impl<'a> ReverseChunks<'a> {
     pub fn new(file: &'a mut File) -> ReverseChunks<'a> {
-        let size = file.seek(SeekFrom::End(0)).unwrap();
+        let current = file.seek(SeekFrom::Current(0)).unwrap();
+        let size = file.seek(SeekFrom::End(0)).unwrap() - current;
         let max_blocks_to_read = (size as f64 / BLOCK_SIZE as f64).ceil() as usize;
         let block_idx = 0;
         ReverseChunks {

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -30,7 +30,11 @@ pub struct ReverseChunks<'a> {
 
 impl<'a> ReverseChunks<'a> {
     pub fn new(file: &'a mut File) -> ReverseChunks<'a> {
-        let current = file.seek(SeekFrom::Current(0)).unwrap();
+        let current = if cfg!(unix) {
+            file.seek(SeekFrom::Current(0)).unwrap()
+        } else {
+            0
+        };
         let size = file.seek(SeekFrom::End(0)).unwrap() - current;
         let max_blocks_to_read = (size as f64 / BLOCK_SIZE as f64).ceil() as usize;
         let block_idx = 0;

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -503,8 +503,11 @@ fn uu_tail(mut settings: Settings) -> UResult<()> {
                     }
 
                     let mut reader;
-                    if file.is_seekable(settings.stdin_offset)
-                        && metadata.as_ref().unwrap().get_block_size() > 0
+                    if file.is_seekable(if display_name.is_stdin() {
+                        settings.stdin_offset
+                    } else {
+                        0
+                    }) && metadata.as_ref().unwrap().get_block_size() > 0
                     {
                         bounded_tail(&mut file, &settings);
                         reader = BufReader::new(file);

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -436,9 +436,9 @@ fn uu_tail(mut settings: Settings) -> UResult<()> {
 
         let metadata = path.metadata().ok();
 
-        if display_name.is_stdin() && path_is_tailable {
+        if display_name.is_stdin() && path_is_tailable && !path.is_file() {
             if settings.verbose {
-                files.print_header(Path::new(text::STDIN_HEADER), !first_header);
+                files.print_header(&display_name, !first_header);
                 first_header = false;
             }
 
@@ -452,7 +452,7 @@ fn uu_tail(mut settings: Settings) -> UResult<()> {
                         PathData {
                             reader: Some(Box::new(reader)),
                             metadata: None,
-                            display_name: PathBuf::from(text::STDIN_HEADER),
+                            display_name,
                         },
                         true,
                     );
@@ -476,7 +476,7 @@ fn uu_tail(mut settings: Settings) -> UResult<()> {
             match File::open(&path) {
                 Ok(mut file) => {
                     if settings.verbose {
-                        files.print_header(&path, !first_header);
+                        files.print_header(&display_name, !first_header);
                         first_header = false;
                     }
                     let mut reader;

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -95,6 +95,26 @@ fn test_stdin_redirect_file() {
 }
 
 #[test]
+#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))] // FIXME: make this work not just on Linux
+fn test_stdin_redirect_offset() {
+    // inspired by: "gnu/tests/tail-2/start-middle.sh"
+    use std::io::{Seek, SeekFrom};
+
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.write("k", "1\n2\n");
+    let mut fh = std::fs::File::open(at.plus("k")).unwrap();
+    fh.seek(SeekFrom::Start(2)).unwrap();
+
+    ts.ucmd()
+        .set_stdin(fh)
+        .run()
+        .stdout_is("2\n")
+        .succeeded();
+}
+
+#[test]
 fn test_nc_0_wo_follow() {
     // verify that -[nc]0 without -f, exit without reading
 

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -76,6 +76,7 @@ fn test_stdin_redirect_file() {
         .set_stdin(std::fs::File::open(at.plus("f")).unwrap())
         .arg("-v")
         .run()
+        .no_stderr()
         .stdout_is("==> standard input <==\nfoo")
         .succeeded();
 

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -107,11 +107,7 @@ fn test_stdin_redirect_offset() {
     let mut fh = std::fs::File::open(at.plus("k")).unwrap();
     fh.seek(SeekFrom::Start(2)).unwrap();
 
-    ts.ucmd()
-        .set_stdin(fh)
-        .run()
-        .stdout_is("2\n")
-        .succeeded();
+    ts.ucmd().set_stdin(fh).run().stdout_is("2\n").succeeded();
 }
 
 #[test]


### PR DESCRIPTION
This fixes a bug where calling `tail - < file.txt` would result
in invoking `unbounded_tail()`.
However, it is a stdin redirect to a seekable regular file and
therefore `bounded_tail` should be invoked as if `tail file.txt` had
been called.

fix #3842