### PR TITLE
dependencies: make `winapi` dependency only for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,9 +1489,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "platform-info"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84332c4de03d567e6f5ea143e35e63ceed534a34f768218aabf57879d7edf2a0"
+checksum = "95f26dfd50c79dacf549a8a784734fff83a5e42736487464d782fc8a3a2f5563"
 dependencies = [
  "libc",
  "winapi 0.3.9",

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 path = "src/arch.rs"
 
 [dependencies]
-platform-info = "0.2"
+platform-info = "1.0.0"
 clap = { version = "3.2", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
 

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -18,6 +18,8 @@ path = "src/hostname.rs"
 clap = { version = "3.2", features = ["wrap_help", "cargo"] }
 hostname = { version = "0.3", features = ["set"] }
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["wide"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version="0.3", features=["sysinfoapi", "winsock2"] }
 
 [[bin]]

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -18,6 +18,8 @@ path = "src/sync.rs"
 clap = { version = "3.2", features = ["wrap_help", "cargo"] }
 libc = "0.2.126"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore", features=["wide"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "std", "winbase", "winerror"] }
 
 [[bin]]

--- a/src/uu/uname/Cargo.toml
+++ b/src/uu/uname/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/uname.rs"
 
 [dependencies]
 clap = { version = "3.2", features = ["wrap_help", "cargo"] }
-platform-info = "0.2"
+platform-info = "1.0.0"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }
 
 [[bin]]


### PR DESCRIPTION
- Updated `platform-info` version to `1.0.0` in dependencies
- Made `winapi` dependencies only for Windows target