### PR TITLE
maintenance: remove redundant examples folder

### DIFF
--- a/examples/busybox-core.rs
+++ b/examples/busybox-core.rs
@@ -1,1 +1,0 @@
-include!("../src/bin/coreutils.rs");

--- a/examples/uuc.rs
+++ b/examples/uuc.rs
@@ -1,1 +1,0 @@
-include!("../src/bin/coreutils.rs");


### PR DESCRIPTION
These examples only duplicated the multicall binary via an `include!` and are therefore not necessary.