### PR TITLE
Replace deprecated values_of_os() with get_many()

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -357,7 +357,7 @@ fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<
     // By default, do not preserve root.
     let preserve_root = matches.contains_id(options::preserve_root::PRESERVE_ROOT);
 
-    let mut files = matches.values_of_os("FILE").unwrap_or_default();
+    let mut files = matches.get_many::<PathBuf>("FILE").unwrap_or_default();
 
     let mode = if let Some(path) = matches.value_of_os(options::REFERENCE) {
         CommandLineMode::ReferenceBased {

--- a/src/uu/dir/src/dir.rs
+++ b/src/uu/dir/src/dir.rs
@@ -6,6 +6,7 @@
 // * that was distributed with this source code.
 
 use clap::Command;
+use std::ffi::OsString;
 use std::path::Path;
 use uu_ls::{options, Config, Format};
 use uucore::error::UResult;
@@ -55,7 +56,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let locs = matches
-        .values_of_os(options::PATHS)
+        .get_many::<OsString>(options::PATHS)
         .map(|v| v.map(Path::new).collect())
         .unwrap_or_else(|| vec![Path::new(".")]);
 

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -320,8 +320,8 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
         warn,
     };
 
-    match matches.values_of_os("FILE") {
-        Some(files) => hashsum(opts, files),
+    match matches.get_many::<OsString>("FILE") {
+        Some(files) => hashsum(opts, files.map(|f| f.as_os_str())),
         None => hashsum(opts, iter::once(OsStr::new("-"))),
     }
 }

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -5,6 +5,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 use clap::{crate_version, Arg, Command};
+use std::ffi::OsString;
 use std::fs::hard_link;
 use std::path::Path;
 use uucore::display::Quotable;
@@ -23,7 +24,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let files: Vec<_> = matches
-        .values_of_os(options::FILES)
+        .get_many::<OsString>(options::FILES)
         .unwrap_or_default()
         .collect();
     let old = Path::new(files[0]);

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -898,7 +898,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let config = Config::from(&matches)?;
 
     let locs = matches
-        .values_of_os(options::PATHS)
+        .get_many::<OsString>(options::PATHS)
         .map(|v| v.map(Path::new).collect())
         .unwrap_or_else(|| vec![Path::new(".")]);
 

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -10,7 +10,9 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, Arg, ArgMatches, Command, OsValues};
+use clap::parser::ValuesRef;
+use clap::{crate_version, Arg, ArgMatches, Command};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use uucore::error::FromIo;
@@ -95,7 +97,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // " of each created directory to CTX"),
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
-    let dirs = matches.values_of_os(options::DIRS).unwrap_or_default();
+    let dirs = matches
+        .get_many::<OsString>(options::DIRS)
+        .unwrap_or_default();
     let verbose = matches.contains_id(options::VERBOSE);
     let recursive = matches.contains_id(options::PARENTS);
 
@@ -143,7 +147,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 /**
  * Create the list of new directories
  */
-fn exec(dirs: OsValues, recursive: bool, mode: u32, verbose: bool) -> UResult<()> {
+fn exec(dirs: ValuesRef<OsString>, recursive: bool, mode: u32, verbose: bool) -> UResult<()> {
     for dir in dirs {
         // Special case to match GNU's behavior:
         // mkdir -p foo/. should work and just create foo/

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -92,7 +92,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let files: Vec<OsString> = matches
-        .values_of_os(ARG_FILES)
+        .get_many::<OsString>(ARG_FILES)
         .unwrap_or_default()
         .map(|v| v.to_os_string())
         .collect();

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -11,6 +11,7 @@
 extern crate uucore;
 
 use clap::{crate_version, Arg, Command};
+use std::ffi::OsString;
 use std::fs::{read_dir, remove_dir};
 use std::io;
 use std::path::Path;
@@ -40,7 +41,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     for path in matches
-        .values_of_os(ARG_DIRS)
+        .get_many::<OsString>(ARG_DIRS)
         .unwrap_or_default()
         .map(Path::new)
     {

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -212,7 +212,7 @@ fn parse_command_line(config: Command, args: impl uucore::Args) -> Result<Option
     let compute_transition_context = matches.contains_id(options::COMPUTE);
 
     let mut args = matches
-        .values_of_os("ARG")
+        .get_many::<OsString>("ARG")
         .unwrap_or_default()
         .map(OsString::from);
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1079,7 +1079,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // check whether user specified a zero terminated list of files for input, otherwise read files from args
     let mut files: Vec<OsString> = if matches.contains_id(options::FILES0_FROM) {
         let files0_from: Vec<OsString> = matches
-            .values_of_os(options::FILES0_FROM)
+            .get_many::<OsString>(options::FILES0_FROM)
             .map(|v| v.map(ToOwned::to_owned).collect())
             .unwrap_or_default();
 
@@ -1097,7 +1097,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         files
     } else {
         matches
-            .values_of_os(options::FILES)
+            .get_many::<OsString>(options::FILES)
             .map(|v| v.map(ToOwned::to_owned).collect())
             .unwrap_or_default()
     };

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -474,7 +474,7 @@ impl Stater {
 
     fn new(matches: &ArgMatches) -> UResult<Self> {
         let files = matches
-            .values_of_os(ARG_FILES)
+            .get_many::<OsString>(ARG_FILES)
             .map(|v| v.map(OsString::from).collect())
             .unwrap_or_default();
         let format_str = if matches.contains_id(options::PRINTF) {

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -14,6 +14,7 @@ extern crate uucore;
 
 use clap::{crate_version, Arg, ArgGroup, Command};
 use filetime::*;
+use std::ffi::OsString;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use time::macros::{format_description, offset, time};
@@ -69,7 +70,7 @@ fn dt_to_filename(tm: time::PrimitiveDateTime) -> FileTime {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
-    let files = matches.values_of_os(ARG_FILES).ok_or_else(|| {
+    let files = matches.get_many::<OsString>(ARG_FILES).ok_or_else(|| {
         USimpleError::new(
             1,
             r##"missing file operand

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -8,6 +8,7 @@
 
 // spell-checker:ignore (paths) wtmp
 
+use std::ffi::OsString;
 use std::path::Path;
 
 use clap::{crate_version, Arg, Command};
@@ -35,7 +36,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
 
     let files: Vec<&Path> = matches
-        .values_of_os(ARG_FILES)
+        .get_many::<OsString>(ARG_FILES)
         .map(|v| v.map(AsRef::as_ref).collect())
         .unwrap_or_default();
 

--- a/src/uu/vdir/src/vdir.rs
+++ b/src/uu/vdir/src/vdir.rs
@@ -6,6 +6,7 @@
 // * that was distributed with this source code.
 
 use clap::Command;
+use std::ffi::OsString;
 use std::path::Path;
 use uu_ls::{options, Config, Format};
 use uucore::error::UResult;
@@ -54,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let locs = matches
-        .values_of_os(options::PATHS)
+        .get_many::<OsString>(options::PATHS)
         .map(|v| v.map(Path::new).collect())
         .unwrap_or_else(|| vec![Path::new(".")]);
     uu_ls::list(locs, &config)

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -24,7 +24,7 @@ use clap::{crate_version, Arg, ArgMatches, Command};
 
 use std::cmp::max;
 use std::error::Error;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
@@ -262,7 +262,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 }
 
 fn inputs(matches: &ArgMatches) -> UResult<Vec<Input>> {
-    match matches.values_of_os(ARG_FILES) {
+    match matches.get_many::<OsString>(ARG_FILES) {
         Some(os_values) => {
             if matches.contains_id(options::FILES0_FROM) {
                 return Err(WcError::FilesDisabled(
@@ -271,7 +271,7 @@ fn inputs(matches: &ArgMatches) -> UResult<Vec<Input>> {
                 .into());
             }
 
-            Ok(os_values.map(Input::from).collect())
+            Ok(os_values.map(|s| Input::from(s.as_os_str())).collect())
         }
         None => match matches.value_of(options::FILES0_FROM) {
             Some(files_0_from) => create_paths_from_files0(files_0_from),


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `values_of_os()` with `get_many().`