### PR TITLE
Replace deprecated value_of_os() with get_one()

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -359,7 +359,7 @@ fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<
 
     let mut files = matches.get_many::<PathBuf>("FILE").unwrap_or_default();
 
-    let mode = if let Some(path) = matches.value_of_os(options::REFERENCE) {
+    let mode = if let Some(path) = matches.get_one::<OsString>(options::REFERENCE) {
         CommandLineMode::ReferenceBased {
             reference: PathBuf::from(path),
         }
@@ -369,10 +369,10 @@ fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<
         || matches.contains_id(options::RANGE)
     {
         CommandLineMode::Custom {
-            user: matches.value_of_os(options::USER).map(Into::into),
-            role: matches.value_of_os(options::ROLE).map(Into::into),
-            the_type: matches.value_of_os(options::TYPE).map(Into::into),
-            range: matches.value_of_os(options::RANGE).map(Into::into),
+            user: matches.get_one::<OsString>(options::USER).map(Into::into),
+            role: matches.get_one::<OsString>(options::ROLE).map(Into::into),
+            the_type: matches.get_one::<OsString>(options::TYPE).map(Into::into),
+            range: matches.get_one::<OsString>(options::RANGE).map(Into::into),
         }
     } else if let Some(context) = files.next() {
         CommandLineMode::ContextBased {

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -7,9 +7,9 @@
 
 // spell-checker:ignore (ToDO) MAKEWORD addrs hashset
 
-use std::collections::hash_set::HashSet;
 use std::net::ToSocketAddrs;
 use std::str;
+use std::{collections::hash_set::HashSet, ffi::OsString};
 
 use clap::{crate_version, Arg, ArgMatches, Command};
 
@@ -65,7 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     #[cfg(windows)]
     let _handle = wsa::start().map_err_context(|| "failed to start Winsock".to_owned())?;
 
-    match matches.value_of_os(OPT_HOST) {
+    match matches.get_one::<OsString>(OPT_HOST) {
         None => display_hostname(&matches),
         Some(host) => hostname::set(host).map_err_context(|| "failed to set hostname".to_owned()),
     }

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -15,6 +15,7 @@ use memchr::{memchr3_iter, memchr_iter};
 use std::cmp::Ordering;
 use std::convert::From;
 use std::error::Error;
+use std::ffi::OsString;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Split, Stdin, Write};
@@ -627,7 +628,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     settings.key1 = get_field_number(keys, key1)?;
     settings.key2 = get_field_number(keys, key2)?;
 
-    if let Some(value_os) = matches.value_of_os("t") {
+    if let Some(value_os) = matches.get_one::<OsString>("t") {
         #[cfg(unix)]
         let value = value_os.as_bytes();
         #[cfg(not(unix))]

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -115,7 +115,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         suffix: backup_suffix,
         update: matches.contains_id(OPT_UPDATE),
         target_dir: matches
-            .value_of_os(OPT_TARGET_DIRECTORY)
+            .get_one::<OsString>(OPT_TARGET_DIRECTORY)
             .map(OsString::from),
         no_target_dir: matches.contains_id(OPT_NO_TARGET_DIRECTORY),
         verbose: matches.contains_id(OPT_VERBOSE),

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -226,10 +226,10 @@ fn parse_command_line(config: Command, args: impl uucore::Args) -> Result<Option
 
         let mode = CommandLineMode::CustomContext {
             compute_transition_context,
-            user: matches.value_of_os(options::USER).map(Into::into),
-            role: matches.value_of_os(options::ROLE).map(Into::into),
-            the_type: matches.value_of_os(options::TYPE).map(Into::into),
-            range: matches.value_of_os(options::RANGE).map(Into::into),
+            user: matches.get_one::<OsString>(options::USER).map(Into::into),
+            role: matches.get_one::<OsString>(options::ROLE).map(Into::into),
+            the_type: matches.get_one::<OsString>(options::TYPE).map(Into::into),
+            range: matches.get_one::<OsString>(options::RANGE).map(Into::into),
             command: args.next(),
         };
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1201,7 +1201,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    if let Some(arg) = matches.value_of_os(options::SEPARATOR) {
+    if let Some(arg) = matches.get_one::<OsString>(options::SEPARATOR) {
         let mut separator = arg.to_str().ok_or_else(|| {
             UUsageError::new(
                 2,

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -78,7 +78,7 @@ Try 'touch --help' for more information."##,
         )
     })?;
     let (mut atime, mut mtime) =
-        if let Some(reference) = matches.value_of_os(options::sources::REFERENCE) {
+        if let Some(reference) = matches.get_one::<OsString>(options::sources::REFERENCE) {
             stat(
                 Path::new(reference),
                 !matches.contains_id(options::NO_DEREF),

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -7,6 +7,7 @@
 
 /* last synced with: unlink (GNU coreutils) 8.21 */
 
+use std::ffi::OsString;
 use std::fs::remove_file;
 use std::path::Path;
 
@@ -22,7 +23,7 @@ static OPT_PATH: &str = "FILE";
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
-    let path: &Path = matches.value_of_os(OPT_PATH).unwrap().as_ref();
+    let path: &Path = matches.get_one::<OsString>(OPT_PATH).unwrap().as_ref();
 
     remove_file(path).map_err_context(|| format!("cannot unlink {}", path.quote()))
 }


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `value_of_os()` with `get_one().`