### PR TITLE
Remove deprecated `unix_socket` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "constant_time_eq",
  "digest",
 ]
@@ -222,12 +222,6 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -362,7 +356,6 @@ dependencies = [
  "textwrap 0.15.0",
  "time",
  "unindent",
- "unix_socket",
  "users",
  "uu_arch",
  "uu_base32",
@@ -589,7 +582,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -598,7 +591,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -608,7 +601,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -620,7 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "once_cell",
@@ -633,7 +626,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -753,7 +746,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "socket2",
  "winapi 0.3.9",
@@ -827,7 +820,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "windows-sys",
@@ -899,7 +892,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -1018,7 +1011,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1105,7 +1098,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi 0.3.9",
 ]
 
@@ -1125,7 +1118,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1220,7 +1213,7 @@ checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
 dependencies = [
  "autocfg",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
  "pin-utils",
@@ -1416,7 +1409,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1722,7 +1715,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ordered-multimap",
 ]
 
@@ -1785,7 +1778,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -1796,7 +1789,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -1929,7 +1922,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -2095,16 +2088,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
-name = "unix_socket"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
-]
-
-[[package]]
 name = "users"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,7 +2159,6 @@ dependencies = [
  "clap 3.2.17",
  "nix",
  "thiserror",
- "unix_socket",
  "uucore",
 ]
 
@@ -3208,7 +3190,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -406,7 +406,6 @@ rlimit = "0.8.3"
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.25", default-features = false, features = ["process", "signal", "user"] }
 rust-users = { version="0.11", package="users" }
-unix_socket = "0.5.0"
 
 [build-dependencies]
 phf_codegen = "0.10.0"

--- a/deny.toml
+++ b/deny.toml
@@ -66,8 +66,6 @@ highlight = "all"
 skip = [
     # blake2d_simd
     { name = "arrayvec", version = "=0.7.2" },
-    # flimit/unix_socket
-    { name = "cfg-if", version = "=0.1.10" },
     # kernel32-sys
     { name = "winapi", version = "=0.2.8" },
     # bindgen 0.59.2

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -21,7 +21,6 @@ atty = "0.2"
 uucore = { version=">=0.0.15", package="uucore", path="../../uucore", features=["fs", "pipes"] }
 
 [target.'cfg(unix)'.dependencies]
-unix_socket = "0.5.0"
 nix = { version = "0.25", default-features = false }
 
 [[bin]]

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -10,9 +10,6 @@
 
 // spell-checker:ignore (ToDO) nonprint nonblank nonprinting
 
-#[cfg(unix)]
-extern crate unix_socket;
-
 // last synced with: cat (GNU coreutils) 8.13
 use clap::{crate_version, Arg, Command};
 use std::fs::{metadata, File};
@@ -35,7 +32,7 @@ use std::net::Shutdown;
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
 #[cfg(unix)]
-use unix_socket::UnixStream;
+use std::os::unix::net::UnixStream;
 use uucore::format_usage;
 
 static NAME: &str = "cat";

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -453,9 +453,9 @@ fn test_dev_full_show_all() {
 #[ignore]
 fn test_domain_socket() {
     use std::io::prelude::*;
+    use std::os::unix::net::UnixListener;
     use std::sync::{Arc, Barrier};
     use std::thread;
-    use unix_socket::UnixListener;
 
     let dir = tempfile::Builder::new()
         .prefix("unix_socket")

--- a/tests/by-util/test_dir.rs
+++ b/tests/by-util/test_dir.rs
@@ -3,8 +3,6 @@ extern crate libc;
 extern crate regex;
 #[cfg(not(windows))]
 extern crate tempfile;
-#[cfg(unix)]
-extern crate unix_socket;
 
 use self::regex::Regex;
 use crate::common::util::*;

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5,8 +5,6 @@ extern crate libc;
 extern crate regex;
 #[cfg(not(windows))]
 extern crate tempfile;
-#[cfg(unix)]
-extern crate unix_socket;
 
 use self::regex::Regex;
 use crate::common::util::*;
@@ -2037,7 +2035,7 @@ fn test_ls_indicator_style() {
     // Test sockets. Because the canonical way of making sockets to test is with
     // TempDir, we need a separate test.
     {
-        use self::unix_socket::UnixListener;
+        use std::os::unix::net::UnixListener;
 
         let dir = tempfile::Builder::new()
             .prefix("unix_socket")

--- a/tests/by-util/test_vdir.rs
+++ b/tests/by-util/test_vdir.rs
@@ -3,8 +3,6 @@ extern crate libc;
 extern crate regex;
 #[cfg(not(windows))]
 extern crate tempfile;
-#[cfg(unix)]
-extern crate unix_socket;
 
 use self::regex::Regex;
 use crate::common::util::*;


### PR DESCRIPTION
The crate became deprecated, since there is `std::os::unix::net` library

- Removed it, and changed to `std::os::unix::net`