### PR TITLE
Clippy fixes in multiple crates

### DIFF
--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let p = Path::new(path);
             match p.parent() {
                 Some(d) => {
-                    if d.components().next() == None {
+                    if d.components().next().is_none() {
                         print!(".");
                     } else {
                         print_verbatim(d).unwrap();

--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -510,7 +510,7 @@ impl<'a> WordSplit<'a> {
                 word_start = Some(os);
                 break;
             } else if c == '\t' {
-                if beforetab == None {
+                if beforetab.is_none() {
                     beforetab = Some(aftertab);
                     aftertab = 0;
                 } else {

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -618,6 +618,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_arg_iterate_bad_encoding() {
+        #[allow(clippy::invalid_utf8_in_unchecked)]
         let invalid = unsafe { std::str::from_utf8_unchecked(b"\x80\x81") };
         // this arises from a conversion from OsString to &str
         assert!(

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -120,7 +120,7 @@ impl Uniq {
             let mut i = 0;
             let mut char_indices = line.char_indices();
             for _ in 0..skip_fields {
-                if char_indices.find(|(_, c)| !c.is_whitespace()) == None {
+                if char_indices.all(|(_, c)| c.is_whitespace()) {
                     return "";
                 }
                 match char_indices.find(|(_, c)| c.is_whitespace()) {

--- a/src/uucore/src/lib/mods/ranges.rs
+++ b/src/uucore/src/lib/mods/ranges.rs
@@ -162,7 +162,7 @@ pub fn contain(ranges: &[Range], n: usize) -> bool {
 mod test {
     use super::{complement, Range};
 
-    fn m(a: Vec<Range>, b: Vec<Range>) {
+    fn m(a: Vec<Range>, b: &[Range]) {
         assert_eq!(Range::merge(a), b);
     }
 
@@ -173,18 +173,18 @@ mod test {
     #[test]
     fn merging() {
         // Single element
-        m(vec![r(1, 2)], vec![r(1, 2)]);
+        m(vec![r(1, 2)], &[r(1, 2)]);
 
         // Disjoint in wrong order
-        m(vec![r(4, 5), r(1, 2)], vec![r(1, 2), r(4, 5)]);
+        m(vec![r(4, 5), r(1, 2)], &[r(1, 2), r(4, 5)]);
 
         // Two elements must be merged
-        m(vec![r(1, 3), r(2, 4), r(6, 7)], vec![r(1, 4), r(6, 7)]);
+        m(vec![r(1, 3), r(2, 4), r(6, 7)], &[r(1, 4), r(6, 7)]);
 
         // Two merges and a duplicate
         m(
             vec![r(1, 3), r(6, 7), r(2, 4), r(6, 7)],
-            vec![r(1, 4), r(6, 7)],
+            &[r(1, 4), r(6, 7)],
         );
 
         // One giant
@@ -196,19 +196,19 @@ mod test {
                 r(130, 140),
                 r(150, 160),
             ],
-            vec![r(10, 20), r(100, 200)],
+            &[r(10, 20), r(100, 200)],
         );
 
         // Last one joins the previous two
-        m(vec![r(10, 20), r(30, 40), r(20, 30)], vec![r(10, 40)]);
+        m(vec![r(10, 20), r(30, 40), r(20, 30)], &[r(10, 40)]);
 
         m(
             vec![r(10, 20), r(30, 40), r(50, 60), r(20, 30)],
-            vec![r(10, 40), r(50, 60)],
+            &[r(10, 40), r(50, 60)],
         );
 
         // Merge adjacent ranges
-        m(vec![r(1, 3), r(4, 6)], vec![r(1, 6)])
+        m(vec![r(1, 3), r(4, 6)], &[r(1, 6)]);
     }
 
     #[test]

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -241,6 +241,6 @@ mod tests {
                 "
             ),
             "{} [some] [options]"
-        )
+        );
     }
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -73,7 +73,7 @@ fn test_cp_existing_target() {
     assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
 
     // No backup should have been created
-    assert!(!at.file_exists(&*format!("{}~", TEST_EXISTING_FILE)));
+    assert!(!at.file_exists(&format!("{}~", TEST_EXISTING_FILE)));
 }
 
 #[test]
@@ -344,7 +344,7 @@ fn test_cp_arg_backup() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -360,7 +360,7 @@ fn test_cp_arg_backup_with_other_args() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -376,7 +376,7 @@ fn test_cp_arg_backup_arg_first() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -394,7 +394,7 @@ fn test_cp_arg_suffix() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}.bak", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}.bak", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -412,7 +412,7 @@ fn test_cp_arg_suffix_hyphen_value() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}-v", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}-v", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -431,7 +431,7 @@ fn test_cp_custom_backup_suffix_via_env() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}{}", TEST_HOW_ARE_YOU_SOURCE, suffix)),
+        at.read(&format!("{}{}", TEST_HOW_ARE_YOU_SOURCE, suffix)),
         "How are you?\n"
     );
 }
@@ -448,7 +448,7 @@ fn test_cp_backup_numbered_with_t() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -465,7 +465,7 @@ fn test_cp_backup_numbered() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -482,7 +482,7 @@ fn test_cp_backup_existing() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -499,7 +499,7 @@ fn test_cp_backup_nil() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -507,7 +507,7 @@ fn test_cp_backup_nil() {
 #[test]
 fn test_cp_numbered_if_existing_backup_existing() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let existing_backup = &*format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE);
+    let existing_backup = &format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE);
     at.touch(existing_backup);
 
     ucmd.arg("--backup=existing")
@@ -519,7 +519,7 @@ fn test_cp_numbered_if_existing_backup_existing() {
     assert!(at.file_exists(TEST_HOW_ARE_YOU_SOURCE));
     assert!(at.file_exists(existing_backup));
     assert_eq!(
-        at.read(&*format!("{}.~2~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}.~2~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -527,7 +527,7 @@ fn test_cp_numbered_if_existing_backup_existing() {
 #[test]
 fn test_cp_numbered_if_existing_backup_nil() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let existing_backup = &*format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE);
+    let existing_backup = &format!("{}.~1~", TEST_HOW_ARE_YOU_SOURCE);
 
     at.touch(existing_backup);
     ucmd.arg("--backup=nil")
@@ -539,7 +539,7 @@ fn test_cp_numbered_if_existing_backup_nil() {
     assert!(at.file_exists(TEST_HOW_ARE_YOU_SOURCE));
     assert!(at.file_exists(existing_backup));
     assert_eq!(
-        at.read(&*format!("{}.~2~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}.~2~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -556,7 +556,7 @@ fn test_cp_backup_simple() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }
@@ -591,7 +591,7 @@ fn test_cp_backup_never() {
 
     assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
     assert_eq!(
-        at.read(&*format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
+        at.read(&format!("{}~", TEST_HOW_ARE_YOU_SOURCE)),
         "How are you?\n"
     );
 }

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -996,7 +996,7 @@ fn test_install_backup_numbered_if_existing_backup_existing() {
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
     assert!(at.file_exists(file_b_backup));
-    assert!(at.file_exists(&*format!("{}.~2~", file_b)));
+    assert!(at.file_exists(&format!("{}.~2~", file_b)));
 }
 
 #[test]
@@ -1022,7 +1022,7 @@ fn test_install_backup_numbered_if_existing_backup_nil() {
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
     assert!(at.file_exists(file_b_backup));
-    assert!(at.file_exists(&*format!("{}.~2~", file_b)));
+    assert!(at.file_exists(&format!("{}.~2~", file_b)));
 }
 
 #[test]

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -475,7 +475,7 @@ fn test_mv_numbered_if_existing_backup_existing() {
 
     assert!(at.file_exists(file_b));
     assert!(at.file_exists(file_b_backup));
-    assert!(at.file_exists(&*format!("{}.~2~", file_b)));
+    assert!(at.file_exists(&format!("{}.~2~", file_b)));
 }
 
 #[test]
@@ -496,7 +496,7 @@ fn test_mv_numbered_if_existing_backup_nil() {
 
     assert!(at.file_exists(file_b));
     assert!(at.file_exists(file_b_backup));
-    assert!(at.file_exists(&*format!("{}.~2~", file_b)));
+    assert!(at.file_exists(&format!("{}.~2~", file_b)));
 }
 
 #[test]

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -257,14 +257,12 @@ fn test_filter() {
     // assert all characters are 'i' / no character is not 'i'
     // (assert that command succeeded)
     let glob = Glob::new(&at, ".", r"x[[:alpha:]][[:alpha:]]$");
-    assert!(
-        glob.collate().iter().find(|&&c| {
-            // is not i
-            c != (b'i')
+    assert!(!glob.collate().iter().any(|&c| {
+        // is not i
+        c != (b'i')
             // is not newline
             && c != (b'\n')
-        }) == None
-    );
+    }));
 }
 
 #[test]


### PR DESCRIPTION
I don't know how to resolve this one remaining warning:
```
warning: associated function `borrow_buffer` is never used
  --> src/uu/sort/src/chunks.rs:26:9
   |
26 |     pub buffer: Vec<u8>,
   |         ^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `uu_sort` (lib) generated 1 warning
```