### PR TITLE
add option to pass an input file of filenames to paste

### DIFF
--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -65,11 +65,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let file = File::open(input_file)?;
         let buf = BufReader::new(file);
         buf.lines().collect::<Result<Vec<_>, _>>()?
-    } else {matches
-        .get_many::<String>(options::FILE)
-        .unwrap()
-        .map(|s| s.to_owned())
-        .collect()
+    } else {
+        matches
+            .get_many::<String>(options::FILE)
+            .unwrap()
+            .map(|s| s.to_owned())
+            .collect()
     };
     let line_ending = if matches.contains_id(options::ZERO_TERMINATED) {
         LineEnding::Nul
@@ -121,7 +122,6 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .value_name("FILE")
                 .value_hint(clap::ValueHint::FilePath),
         )
-
 }
 
 fn paste(


### PR DESCRIPTION
Sometimes I need to merge a large number of files (tens of thousands), which usually gives `Argument list too long at` errors. Therefore, it would be nice if an input file holding a list of filenames could be passed to `paste` in addition to reading the filenames from the command line. This PR adds a CLI parameter `-f` for this behavior. 