### PR TITLE
Replace deprecated occurrences_of()

### DIFF
--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -60,8 +60,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let opt_multiple = matches.contains_id(options::MULTIPLE);
     let opt_zero = matches.contains_id(options::ZERO);
     let multiple_paths = opt_suffix || opt_multiple;
+    let name_args_count = matches
+        .get_many::<String>(options::NAME)
+        .map(|n| n.len())
+        .unwrap_or(0);
+
     // too many arguments
-    if !multiple_paths && matches.occurrences_of(options::NAME) > 2 {
+    if !multiple_paths && name_args_count > 2 {
         return Err(UUsageError::new(
             1,
             format!(
@@ -78,7 +83,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let suffix = if opt_suffix {
         matches.value_of(options::SUFFIX).unwrap()
-    } else if !opt_multiple && matches.occurrences_of(options::NAME) > 1 {
+    } else if !opt_multiple && name_args_count > 1 {
         matches
             .get_many::<String>(options::NAME)
             .unwrap()

--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -4,7 +4,7 @@
 //  * file that was distributed with this source code.
 // spell-checker:ignore itotal iused iavail ipcent pcent squashfs
 use crate::{OPT_INODES, OPT_OUTPUT, OPT_PRINT_TYPE};
-use clap::ArgMatches;
+use clap::{ArgMatches, ValueSource};
 
 /// The columns in the output table produced by `df`.
 ///
@@ -77,7 +77,7 @@ impl Column {
         match (
             matches.contains_id(OPT_PRINT_TYPE),
             matches.contains_id(OPT_INODES),
-            matches.occurrences_of(OPT_OUTPUT) > 0,
+            matches.value_source(OPT_OUTPUT) == Some(ValueSource::CommandLine),
         ) {
             (false, false, false) => Ok(vec![
                 Self::Source,

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -20,7 +20,7 @@ use uucore::fsext::{read_fs_list, MountInfo};
 use uucore::parse_size::ParseSizeError;
 use uucore::{format_usage, show};
 
-use clap::{crate_version, Arg, ArgMatches, Command};
+use clap::{crate_version, Arg, ArgMatches, Command, ValueSource};
 
 use std::error::Error;
 use std::fmt;
@@ -200,7 +200,7 @@ impl Options {
                     HeaderMode::PosixPortability
                 // contains_id() doesn't work here, it always returns true because OPT_OUTPUT has
                 // default values and hence is always present
-                } else if matches.occurrences_of(OPT_OUTPUT) > 0 {
+                } else if matches.value_source(OPT_OUTPUT) == Some(ValueSource::CommandLine) {
                     HeaderMode::Output
                 } else {
                     HeaderMode::Default

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -80,7 +80,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .try_get_matches_from_mut(args)
         .unwrap_or_else(|e| e.exit());
 
-    if !matches.contains_id(OPT_TARGET_DIRECTORY) && matches.occurrences_of(ARG_FILES) == 1 {
+    if !matches.contains_id(OPT_TARGET_DIRECTORY)
+        && matches
+            .get_many::<OsString>(ARG_FILES)
+            .map(|f| f.len())
+            .unwrap_or(0)
+            == 1
+    {
         app.error(
             ErrorKind::TooFewValues,
             format!(

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -9,7 +9,7 @@ use crate::errors::*;
 use crate::format::format_and_print;
 use crate::options::*;
 use crate::units::{Result, Unit};
-use clap::{crate_version, Arg, ArgMatches, Command};
+use clap::{crate_version, Arg, ArgMatches, Command, ValueSource};
 use std::io::{BufRead, Write};
 use units::{IEC_BASES, SI_BASES};
 use uucore::display::Quotable;
@@ -143,20 +143,19 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         None => Ok(0),
     }?;
 
-    let header = match args.occurrences_of(options::HEADER) {
-        0 => Ok(0),
-        _ => {
-            let value = args.value_of(options::HEADER).unwrap();
+    let header = if args.value_source(options::HEADER) == Some(ValueSource::CommandLine) {
+        let value = args.value_of(options::HEADER).unwrap();
 
-            value
-                .parse::<usize>()
-                .map_err(|_| value)
-                .and_then(|n| match n {
-                    0 => Err(value),
-                    _ => Ok(n),
-                })
-                .map_err(|value| format!("invalid header value {}", value.quote()))
-        }
+        value
+            .parse::<usize>()
+            .map_err(|_| value)
+            .and_then(|n| match n {
+                0 => Err(value),
+                _ => Ok(n),
+            })
+            .map_err(|value| format!("invalid header value {}", value.quote()))
+    } else {
+        Ok(0)
     }?;
 
     let fields = match args.value_of(options::FIELD).unwrap() {

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -43,7 +43,7 @@ use crate::parse_nrofbytes::parse_number_of_bytes;
 use crate::partialreader::*;
 use crate::peekreader::*;
 use crate::prn_char::format_ascii_dump;
-use clap::{crate_version, AppSettings, Arg, ArgMatches, Command};
+use clap::{crate_version, AppSettings, Arg, ArgMatches, Command, ValueSource};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::format_usage;
@@ -167,9 +167,7 @@ impl OdOptions {
         let mut line_bytes = match matches.value_of(options::WIDTH) {
             None => 16,
             Some(s) => {
-                if matches.occurrences_of(options::WIDTH) == 0 {
-                    16
-                } else {
+                if matches.value_source(options::WIDTH) == Some(ValueSource::CommandLine) {
                     match parse_number_of_bytes(s) {
                         Ok(n) => usize::try_from(n)
                             .map_err(|_| USimpleError::new(1, format!("‘{}‘ is too large", s)))?,
@@ -180,6 +178,8 @@ impl OdOptions {
                             ))
                         }
                     }
+                } else {
+                    16
                 }
             }
         };

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -28,7 +28,7 @@ mod platform;
 use crate::files::FileHandling;
 use chunks::ReverseChunks;
 
-use clap::{Arg, Command};
+use clap::{Arg, Command, ValueSource};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher, WatcherKind};
 use std::collections::{HashMap, VecDeque};
 use std::ffi::OsString;
@@ -140,7 +140,7 @@ impl Settings {
 
         settings.follow = if matches.contains_id(options::FOLLOW_RETRY) {
             Some(FollowMode::Name)
-        } else if matches.occurrences_of(options::FOLLOW) == 0 {
+        } else if matches.value_source(options::FOLLOW) != Some(ValueSource::CommandLine) {
             None
         } else if matches.value_of(options::FOLLOW) == Some("name") {
             Some(FollowMode::Name)


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `occurrences_of()` with either `value_source()` or `get_many .len()`. The first is used if the number of arguments doesn't matter, and the latter if it does.