### PR TITLE
Replace allow_invalid_utf8() with value_parser()

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::upper_case_acronyms)]
 
+use clap::builder::ValueParser;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::format_usage;
 use uucore::{display::Quotable, show_error, show_warning};
@@ -203,7 +204,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     "Use security context of RFILE, rather than specifying \
                      a CONTEXT value.",
                 )
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::USER)
@@ -213,7 +214,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .value_name("USER")
                 .value_hint(clap::ValueHint::Username)
                 .help("Set user USER in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::ROLE)
@@ -222,7 +223,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("ROLE")
                 .help("Set role ROLE in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::TYPE)
@@ -231,7 +232,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("TYPE")
                 .help("Set type TYPE in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::RANGE)
@@ -240,7 +241,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("RANGE")
                 .help("Set range RANGE in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::RECURSIVE)
@@ -298,7 +299,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .multiple_occurrences(true)
                 .value_hint(clap::ValueHint::FilePath)
                 .min_values(1)
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
 }
 

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -12,6 +12,7 @@ mod filesystem;
 mod table;
 
 use blocks::HumanReadable;
+use clap::builder::ValueParser;
 use table::HeaderMode;
 use uucore::display::Quotable;
 use uucore::error::FromIo;
@@ -585,7 +586,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(OPT_TYPE)
                 .short('t')
                 .long("type")
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .takes_value(true)
                 .value_name("TYPE")
                 .multiple_occurrences(true)
@@ -602,7 +603,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(OPT_EXCLUDE_TYPE)
                 .short('x')
                 .long("exclude-type")
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .takes_value(true)
                 .value_name("TYPE")
                 .use_value_delimiter(true)

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -20,6 +20,7 @@ mod digest;
 use self::digest::Digest;
 use self::digest::DigestWriter;
 
+use clap::builder::ValueParser;
 use clap::{Arg, ArgMatches, Command};
 use hex::encode;
 use md5::Md5;
@@ -392,7 +393,7 @@ pub fn uu_app_common<'a>() -> Command<'a> {
                 .multiple_occurrences(true)
                 .value_name("FILE")
                 .value_hint(clap::ValueHint::FilePath)
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
 }
 

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -11,6 +11,7 @@ use std::net::ToSocketAddrs;
 use std::str;
 use std::{collections::hash_set::HashSet, ffi::OsString};
 
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgMatches, Command};
 
 use uucore::{
@@ -107,7 +108,7 @@ pub fn uu_app<'a>() -> Command<'a> {
         )
         .arg(
             Arg::new(OPT_HOST)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::Hostname),
         )
 }

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -10,6 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, Command};
 use memchr::{memchr3_iter, memchr_iter};
 use std::cmp::Ordering;
@@ -762,7 +763,7 @@ FILENUM is 1 or 2, corresponding to FILE1 or FILE2",
                 .short('t')
                 .takes_value(true)
                 .value_name("CHAR")
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .help("use CHAR as input and output field separator"),
         )
         .arg(

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -1,3 +1,4 @@
+use clap::builder::ValueParser;
 //  * This file is part of the uutils coreutils package.
 //  *
 //  * (c) Michael Gehring <mg@ebfe.org>
@@ -48,6 +49,6 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .max_values(2)
                 .takes_value(true)
                 .value_hint(clap::ValueHint::AnyPath)
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
-use clap::{crate_version, Arg, Command};
+use clap::{builder::ValueParser, crate_version, Arg, Command};
 use glob::Pattern;
 use lscolors::LsColors;
 use number_prefix::NumberPrefix;
@@ -1536,7 +1536,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                     .multiple_occurrences(true)
                     .takes_value(true)
                     .value_hint(clap::ValueHint::AnyPath)
-                    .allow_invalid_utf8(true)
+                    .value_parser(ValueParser::os_string())
             )
             .after_help(
                 "The TIME_STYLE argument can be full-iso, long-iso, iso. \

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -10,6 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
+use clap::builder::ValueParser;
 use clap::parser::ValuesRef;
 use clap::{crate_version, Arg, ArgMatches, Command};
 use std::ffi::OsString;
@@ -139,7 +140,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .multiple_occurrences(true)
                 .takes_value(true)
                 .min_values(1)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::DirPath),
         )
 }

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -13,6 +13,7 @@ mod error;
 #[macro_use]
 extern crate uucore;
 
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgMatches, Command, ErrorKind};
 use std::env;
 use std::ffi::OsString;
@@ -172,7 +173,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .value_name("DIRECTORY")
                 .value_hint(clap::ValueHint::DirPath)
                 .conflicts_with(OPT_NO_TARGET_DIRECTORY)
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(OPT_NO_TARGET_DIRECTORY)
@@ -196,7 +197,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .min_values(1)
                 .required(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::AnyPath),
         )
 }

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -10,6 +10,7 @@
 #[macro_use]
 extern crate uucore;
 
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, Command};
 use std::ffi::OsString;
 use std::fs::{read_dir, remove_dir};
@@ -195,7 +196,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .min_values(1)
                 .required(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::DirPath),
         )
 }

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -1,5 +1,6 @@
 // spell-checker:ignore (vars) RFILE
 
+use clap::builder::ValueParser;
 use uucore::error::{UResult, UUsageError};
 
 use clap::{Arg, Command};
@@ -124,7 +125,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("USER")
                 .help("Set user USER in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::ROLE)
@@ -133,7 +134,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("ROLE")
                 .help("Set role ROLE in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::TYPE)
@@ -142,7 +143,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("TYPE")
                 .help("Set type TYPE in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::RANGE)
@@ -151,12 +152,12 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("RANGE")
                 .help("Set range RANGE in the target security context.")
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new("ARG")
                 .multiple_occurrences(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::CommandName),
         )
         // Once "ARG" is parsed, everything after that belongs to it.

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -25,6 +25,7 @@ mod numeric_str_cmp;
 mod tmp_dir;
 
 use chunks::LineData;
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, Command};
 use custom_str_cmp::custom_str_cmp;
 use ext_sort::ext_sort;
@@ -1437,7 +1438,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .long(options::SEPARATOR)
                 .help("custom separator for -k")
                 .takes_value(true)
-                .allow_invalid_utf8(true),
+                .value_parser(ValueParser::os_string()),
         )
         .arg(
             Arg::new(options::ZERO_TERMINATED)
@@ -1489,7 +1490,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("NUL_FILES")
                 .multiple_occurrences(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::FilePath),
         )
         .arg(
@@ -1501,7 +1502,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(options::FILES)
                 .multiple_occurrences(true)
                 .takes_value(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::FilePath),
         )
 }

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -7,6 +7,7 @@
 
 #[macro_use]
 extern crate uucore;
+use clap::builder::ValueParser;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::fs::display_permissions;
@@ -1043,7 +1044,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(ARG_FILES)
                 .multiple_occurrences(true)
                 .takes_value(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .min_values(1)
                 .value_hint(clap::ValueHint::FilePath),
         )

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -12,6 +12,7 @@ pub extern crate filetime;
 #[macro_use]
 extern crate uucore;
 
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgGroup, Command};
 use filetime::*;
 use std::ffi::OsString;
@@ -227,7 +228,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .long(options::sources::REFERENCE)
                 .help("use this file's times instead of the current time")
                 .value_name("FILE")
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::AnyPath),
         )
         .arg(
@@ -247,7 +248,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .multiple_occurrences(true)
                 .takes_value(true)
                 .min_values(1)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::AnyPath),
         )
         .group(ArgGroup::new(options::SOURCES).args(&[

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -11,6 +11,7 @@ use std::ffi::OsString;
 use std::fs::remove_file;
 use std::path::Path;
 
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, Command};
 
 use uucore::display::Quotable;
@@ -37,7 +38,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(OPT_PATH)
                 .required(true)
                 .hide(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::AnyPath),
         )
 }

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -13,6 +13,7 @@ extern crate uucore;
 mod count_fast;
 mod countable;
 mod word_count;
+use clap::builder::ValueParser;
 use count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast};
 use countable::WordCountable;
 use unicode_width::UnicodeWidthChar;
@@ -256,7 +257,7 @@ pub fn uu_app<'a>() -> Command<'a> {
             Arg::new(ARG_FILES)
                 .multiple_occurrences(true)
                 .takes_value(true)
-                .allow_invalid_utf8(true)
+                .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::FilePath),
         )
 }


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `allow_invalid_utf8()` with `value_parser()`.