### PR TITLE
`chroot`: set trailing var arg

### DIFF
--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -98,6 +98,7 @@ pub fn uu_app<'a>() -> Command<'a> {
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
+        .trailing_var_arg(true)
         .arg(
             Arg::new(options::NEWROOT)
                 .value_hint(clap::ValueHint::DirPath)


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/3783

In the issue the `-c` flag should be passed to `/bin/sh` and not be parsed by `chroot`. This is fixed by simply allowing hyphen values.

@Lunarequest, could you verify that this solves the issue?