### PR TITLE
`chroot`: set exit codes to 125, 126 or 127 for errors from chroot itself

### DIFF
--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -80,7 +80,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .status()
     {
         Ok(status) => status,
-        Err(e) => return Err(ChrootError::CommandFailed(command[0].to_string(), e).into()),
+        Err(e) => {
+            return Err(if e.kind() == std::io::ErrorKind::NotFound {
+                ChrootError::CommandNotFound(command[0].to_string(), e)
+            } else {
+                ChrootError::CommandFailed(command[0].to_string(), e)
+            }
+            .into())
+        }
     };
 
     let code = if pstatus.success() {

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -9,7 +9,9 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_missing_operand() {
-    let result = new_ucmd!().run();
+    let result = new_ucmd!().fails();
+
+    result.code_is(125);
 
     assert!(result
         .stderr_str()
@@ -27,7 +29,7 @@ fn test_enter_chroot_fails() {
     at.mkdir("jail");
 
     let result = ucmd.arg("jail").fails();
-
+    result.code_is(125);
     assert!(result
         .stderr_str()
         .starts_with("chroot: cannot chroot to 'jail': Operation not permitted (os error 1)"));
@@ -41,7 +43,8 @@ fn test_no_such_directory() {
 
     ucmd.arg("a")
         .fails()
-        .stderr_is("chroot: cannot change root directory to 'a': no such directory");
+        .stderr_is("chroot: cannot change root directory to 'a': no such directory")
+        .code_is(125);
 }
 
 #[test]
@@ -51,7 +54,7 @@ fn test_invalid_user_spec() {
     at.mkdir("a");
 
     let result = ucmd.arg("a").arg("--userspec=ARABA:").fails();
-
+    result.code_is(125);
     assert!(result.stderr_str().starts_with("chroot: invalid userspec"));
 }
 
@@ -91,7 +94,9 @@ fn test_preference_of_userspec() {
         .arg("-G")
         .arg("ABC,DEF")
         .arg(format!("--userspec={}:{}", username, group_name))
-        .run();
+        .fails();
+
+    result.code_is(125);
 
     println!("result.stdout = {}", result.stdout_str());
     println!("result.stderr = {}", result.stderr_str());


### PR DESCRIPTION
Implements this part of the GNU docs:
```
   Exit status:
     125 if ‘chroot’ itself fails
     126 if COMMAND is found but cannot be invoked
     127 if COMMAND cannot be found
     the exit status of COMMAND otherwise
```

I think we can only reliably test the the 125 case, and not the 126 and 127 cases, but if someone has ideas about how to do that I'd be happy to add it.