### PR TITLE
Disable default features for `procfs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,11 +236,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -343,7 +340,7 @@ dependencies = [
  "sha1",
  "tempfile",
  "textwrap",
- "time 0.3.14",
+ "time",
  "unindent",
  "users",
  "uu_arch",
@@ -868,7 +865,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1172,7 +1169,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1512,8 +1509,6 @@ checksum = "2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818"
 dependencies = [
  "bitflags",
  "byteorder",
- "chrono",
- "flate2",
  "hex",
  "lazy_static",
  "rustix",
@@ -1961,17 +1956,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2427,7 +2411,7 @@ dependencies = [
  "file_diff",
  "filetime",
  "libc",
- "time 0.3.14",
+ "time",
  "uucore",
 ]
 
@@ -2916,7 +2900,7 @@ version = "0.0.15"
 dependencies = [
  "clap",
  "filetime",
- "time 0.3.14",
+ "time",
  "uucore",
  "winapi",
 ]
@@ -3084,7 +3068,7 @@ dependencies = [
  "once_cell",
  "os_display",
  "thiserror",
- "time 0.3.14",
+ "time",
  "uucore_procs",
  "walkdir",
  "wild",
@@ -3123,12 +3107,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,7 +402,7 @@ atty = "0.2"
 hex-literal = "0.3.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
-procfs = "0.14"
+procfs = { version = "0.14", default-features = false }
 rlimit = "0.8.3"
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -66,10 +66,6 @@ highlight = "all"
 skip = [
     # blake2d_simd
     { name = "arrayvec", version = "=0.7.2" },
-    # bindgen 0.59.2
-    { name = "clap", version = "=2.34.0" },
-    { name = "strsim", version = "=0.8.0" },
-    { name = "textwrap", version = "=0.11.0" },
     # quickcheck
     { name = "env_logger", version = "=0.8.4" },
     # tempfile

--- a/deny.toml
+++ b/deny.toml
@@ -66,10 +66,6 @@ highlight = "all"
 skip = [
     # blake2d_simd
     { name = "arrayvec", version = "=0.7.2" },
-    # chrono
-    { name = "time", version = "=0.1.44" },
-    # chrono => time (the same as the line above)
-    { name = "wasi", "version" = "0.10.0+wasi-snapshot-preview1" },
     # bindgen 0.59.2
     { name = "clap", version = "=2.34.0" },
     { name = "strsim", version = "=0.8.0" },


### PR DESCRIPTION
It required using `chrono` dependency with features that use old insecure `time` crate version.
Plus this change just makes less dependencies.
