### PR TITLE
pr: migrate from `chrono` to `time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,11 +2620,11 @@ dependencies = [
 name = "uu_pr"
 version = "0.0.15"
 dependencies = [
- "chrono",
  "clap",
  "itertools",
  "quick-error",
  "regex",
+ "time 0.3.14",
  "uucore",
 ]
 

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/pr.rs"
 
 [dependencies]
 clap = { version = "3.2", features = ["wrap_help", "cargo"] }
+time = { version = "0.3", features = ["local-offset", "macros", "formatting"] }
 uucore = { version=">=0.0.15", package="uucore", path="../../uucore", features=["entries"] }
-chrono = { version="^0.4.19", default-features=false, features=["std", "alloc", "clock"]}
 quick-error = "2.0.1"
 itertools = "0.10.0"
 regex = "1.6"


### PR DESCRIPTION
It seems that `chrono` is the reason of deadlock or UB in android CI. 