### PR TITLE
all: change remaining usage codes of 2 to 1 for GNU compat

### DIFF
--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -16,7 +16,7 @@ static SUMMARY: &str = "Determine architecture name for current machine.";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    uu_app().get_matches_from(args);
+    uu_app().try_get_matches_from(args)?;
 
     let uts = PlatformInfo::new().map_err_context(|| "cannot get system name".to_string())?;
     println!("{}", uts.machine().trim());

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -49,7 +49,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     //
     // Argument parsing
     //
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     // too few arguments
     if !matches.contains_id(options::NAME) {

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -54,7 +54,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let after_help = get_long_usage();
 
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let changes = matches.contains_id(options::CHANGES);
     let quiet = matches.contains_id(options::QUIET);

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -15,7 +15,7 @@ use std::ffi::CString;
 use std::io::Error;
 use std::path::Path;
 use std::process;
-use uucore::error::{set_exit_code, UResult};
+use uucore::error::{set_exit_code, UClapError, UResult};
 use uucore::libc::{self, chroot, setgid, setgroups, setuid};
 use uucore::{entries, format_usage};
 
@@ -35,7 +35,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args).with_exit_code(125)?;
 
     let default_shell: &'static str = "/bin/sh";
     let default_option: &'static str = "-i";

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -115,7 +115,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let files: Vec<String> = match matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -134,7 +134,7 @@ fn open_file(name: &str) -> io::Result<LineReader> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
     let filename1 = matches.value_of(options::FILE_1).unwrap();
     let filename2 = matches.value_of(options::FILE_2).unwrap();
     let mut f1 = open_file(filename1).map_err_context(|| filename1.to_string())?;

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -715,7 +715,7 @@ mod tests {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     // get the file to split
     let file_name = matches.value_of(options::FILE).unwrap();

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -401,7 +401,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
     let delimiter_is_equal = args.contains(&"-d=".to_string()); // special case
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let complement = matches.contains_id(options::COMPLEMENT);
 

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -144,7 +144,7 @@ impl<'a> From<&'a str> for Rfc3339Format {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let format = if let Some(form) = matches.value_of(OPT_FORMAT) {
         if !form.starts_with('+') {

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -712,7 +712,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app()
         //.after_help(TODO: Add note about multiplier strings here.)
-        .get_matches_from(dashed_args);
+        .try_get_matches_from(dashed_args)?;
 
     match (
         matches.contains_id(options::INFILE),

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -431,7 +431,7 @@ impl fmt::Display for DfError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     #[cfg(windows)]
     {

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -67,7 +67,7 @@ pub fn guess_syntax() -> OutputFmt {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(&args);
+    let matches = uu_app().try_get_matches_from(&args)?;
 
     let files = matches
         .get_many::<String>(options::FILE)

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -32,7 +32,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let after_help = get_long_usage();
 
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let separator = if matches.contains_id(options::ZERO) {
         "\0"

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -517,7 +517,7 @@ fn build_exclude_patterns(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let summarize = matches.contains_id(options::SUMMARIZE);
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -26,7 +26,7 @@ use std::iter::Iterator;
 use std::os::unix::process::ExitStatusExt;
 use std::process;
 use uucore::display::Quotable;
-use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::error::{UClapError, UResult, USimpleError, UUsageError};
 use uucore::format_usage;
 #[cfg(unix)]
 use uucore::signals::signal_name_by_value;
@@ -173,7 +173,7 @@ pub fn uu_app<'a>() -> Command<'a> {
 
 fn run_env(args: impl uucore::Args) -> UResult<()> {
     let app = uu_app();
-    let matches = app.get_matches_from(args);
+    let matches = app.try_get_matches_from(args).with_exit_code(125)?;
 
     let ignore_env = matches.contains_id("ignore-environment");
     let null = matches.contains_id("null");

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -271,7 +271,7 @@ fn expand_shortcuts(args: &[String]) -> Vec<String> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(expand_shortcuts(&args));
+    let matches = uu_app().try_get_matches_from(expand_shortcuts(&args))?;
 
     expand(&Options::new(&matches)?).map_err_context(|| "failed to write output".to_string())
 }

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -47,7 +47,7 @@ fn print_factors_str(
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
     let stdout = stdout();
     // We use a smaller buffer here to pass a gnu test. 4KiB appears to be the default pipe size for bash.
     let mut w = io::BufWriter::with_capacity(4 * 1024, stdout.lock());

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -67,7 +67,7 @@ pub struct FmtOptions {
 #[uucore::main]
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let mut files: Vec<String> = matches
         .get_many::<String>(ARG_FILES)

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -34,7 +34,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
     let (args, obs_width) = handle_obsolete(&args[..]);
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let bytes = matches.contains_id(options::BYTES);
     let spaces = matches.contains_id(options::SPACES);

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -70,7 +70,7 @@ fn infallible_gid2grp(gid: &u32) -> String {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let users: Vec<String> = matches
         .get_many::<String>(options::USERS)

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -284,7 +284,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     //        causes "error: " to be printed twice (once from crash!() and once from clap).  With
     //        the current setup, the name of the utility is not printed, but I think this is at
     //        least somewhat better from a user's perspective.
-    let matches = command.get_matches_from(args);
+    let matches = command.try_get_matches_from(args)?;
 
     let (name, algo, bits) = detect_algo(&binary_name, &matches);
 

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -61,7 +61,7 @@ mod wsa {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     #[cfg(windows)]
     let _handle = wsa::start().map_err_context(|| "failed to start Winsock".to_owned())?;

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -128,7 +128,9 @@ struct State {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let after_help = get_description();
 
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let users: Vec<String> = matches
         .get_many::<String>(options::ARG_USERS)

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -171,7 +171,7 @@ static ARG_FILES: &str = "files";
 ///
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let paths: Vec<String> = matches
         .get_many::<String>(ARG_FILES)

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -602,7 +602,7 @@ impl<'a> State<'a> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let keys = parse_field_number_option(matches.value_of("j"))?;
     let key1 = parse_field_number_option(matches.value_of("1"))?;

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -41,7 +41,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut args = args.collect_ignore();
     let obs_signal = handle_obsolete(&mut args);
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let mode = if matches.contains_id(options::TABLE) {
         Mode::Table

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -22,7 +22,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let files: Vec<_> = matches
         .get_many::<OsString>(options::FILES)

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -136,7 +136,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             long_usage,
             backup_control::BACKUP_CONTROL_LONG_HELP
         ))
-        .get_matches_from(args);
+        .try_get_matches_from(args)?;
 
     /* the list of files */
 

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -38,7 +38,7 @@ static ABOUT: &str = "Print user's login name";
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let _ = uu_app().get_matches_from(args);
+    let _ = uu_app().try_get_matches_from(args)?;
 
     match get_userlogin() {
         Some(userlogin) => println!("{}", userlogin),

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -96,7 +96,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Linux-specific options, not implemented
     // opts.optflag("Z", "context", "set SELinux security context" +
     // " of each created directory to CTX"),
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let dirs = matches
         .get_many::<OsString>(options::DIRS)

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -30,7 +30,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     if matches.contains_id(options::CONTEXT) {
         return Err(USimpleError::new(1, "--context is not implemented"));

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -86,7 +86,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // opts.optflag("Z", "", "set the SELinux security context to default type");
     // opts.optopt("", "context", "like -Z, or if CTX is specified then set the SELinux or SMACK security context to CTX");
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let mode = get_mode(&matches).map_err(|e| USimpleError::new(1, e))?;
 

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -77,9 +77,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         backup_control::BACKUP_CONTROL_LONG_HELP
     );
     let mut app = uu_app().after_help(&*help);
-    let matches = app
-        .try_get_matches_from_mut(args)
-        .unwrap_or_else(|e| e.exit());
+    let matches = app.try_get_matches_from_mut(args)?;
 
     if !matches.contains_id(OPT_TARGET_DIRECTORY)
         && matches

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -86,7 +86,7 @@ pub mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     // A mutable settings object, initialized with the defaults.
     let mut settings = Settings {

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -21,7 +21,7 @@ use std::io::Error;
 use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
-use uucore::error::{set_exit_code, UError, UResult};
+use uucore::error::{set_exit_code, UClapError, UError, UResult};
 use uucore::format_usage;
 
 static ABOUT: &str = "Run COMMAND ignoring hangup signals.";
@@ -88,7 +88,7 @@ impl Display for NohupError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args).with_exit_code(125)?;
 
     replace_fds()?;
 

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -32,7 +32,7 @@ const USAGE: &str = "{} [OPTIONS]...";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let ignore = match matches.value_of(OPT_IGNORE) {
         Some(numstr) => match numstr.trim().parse() {

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -229,7 +229,7 @@ fn concat_format_arg_and_value(args: &[String]) -> Vec<String> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(concat_format_arg_and_value(&args));
+    let matches = uu_app().try_get_matches_from(concat_format_arg_and_value(&args))?;
 
     let options = parse_options(&matches).map_err(NumfmtError::IllegalArgument)?;
 

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -259,9 +259,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let clap_opts = uu_app();
 
-    let clap_matches = clap_opts
-        .clone() // Clone to reuse clap_opts to print help
-        .get_matches_from(args.clone());
+    let clap_matches = clap_opts.try_get_matches_from(&args)?;
 
     let od_options = OdOptions::new(&clap_matches, &args)?;
 

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -54,7 +54,7 @@ fn read_until<R: Read>(
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let serial = matches.contains_id(options::SERIAL);
     let delimiters = matches.value_of(options::DELIMITER).unwrap();

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -41,7 +41,7 @@ const POSIX_NAME_MAX: usize = 14;
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     // set working mode
     let is_posix = matches.get_many::<String>(options::POSIX).is_some();

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -53,7 +53,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let after_help = get_long_usage();
 
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let users: Vec<String> = matches
         .get_many::<String>(options::USER)

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -724,8 +724,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    // let mut opts = Options::new();
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let mut input_files: Vec<String> = match &matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -124,7 +124,7 @@ fn logical_path() -> io::Result<PathBuf> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
     let cwd = if matches.contains_id(OPT_LOGICAL) {
         logical_path()
     } else {

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -34,7 +34,7 @@ const ARG_FILES: &str = "files";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let mut no_trailing_delimiter = matches.contains_id(OPT_NO_NEWLINE);
     let use_zero = matches.contains_id(OPT_ZERO);

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -81,7 +81,9 @@ fn get_long_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let long_usage = get_long_usage();
 
-    let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&long_usage[..])
+        .try_get_matches_from(args)?;
 
     let files: Vec<String> = matches
         .get_many::<String>(ARG_FILES)

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -33,7 +33,7 @@ static ARG_DIRS: &str = "dirs";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let opts = Opts {
         ignore: matches.contains_id(OPT_IGNORE_FAIL_NON_EMPTY),

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -59,7 +59,7 @@ type RangeFloat = (ExtendedBigDecimal, ExtendedBigDecimal, ExtendedBigDecimal);
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let numbers = matches
         .get_many::<String>(ARG_NUMBERS)

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -268,7 +268,7 @@ pub mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     if !matches.contains_id(options::FILE) {
         return Err(UUsageError::new(1, "missing file operand"));

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -58,7 +58,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let mode = if let Some(args) = matches.get_many::<String>(options::ECHO) {
         Mode::Echo(args.map(String::from).collect())

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -53,7 +53,7 @@ const AFTER_HELP: &str = "\
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
     match Settings::from(&matches) {
         Ok(settings) => split(&settings),
         Err(e) if e.requires_usage() => Err(UUsageError::new(1, format!("{}", e))),

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -985,7 +985,9 @@ for details about the options it supports.
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let long_usage = get_long_usage();
 
-    let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&long_usage[..])
+        .try_get_matches_from(args)?;
 
     let stater = Stater::new(&matches)?;
     let exit_status = stater.exec();

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -158,7 +158,7 @@ fn get_preload_env(tmp_dir: &mut TempDir) -> io::Result<(String, PathBuf)> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let options = ProgramOptions::try_from(&matches).map_err(|e| UUsageError::new(125, e.0))?;
 

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -139,7 +139,7 @@ ioctl_write_ptr_bad!(
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let opts = Options::from(&matches)?;
 

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -111,7 +111,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let files: Vec<String> = match matches.get_many::<String>(options::FILE) {
         Some(v) => v.clone().map(|v| v.to_owned()).collect(),

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -162,7 +162,7 @@ mod platform {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let files: Vec<String> = matches
         .get_many::<String>(ARG_FILES)

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -38,7 +38,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let before = matches.contains_id(options::BEFORE);
     let regex = matches.contains_id(options::REGEX);

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -295,7 +295,7 @@ impl Settings {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(arg_iterate(args)?);
+    let matches = uu_app().try_get_matches_from(arg_iterate(args)?)?;
     let mut settings = Settings::from(&matches)?;
 
     // skip expensive call to fstat if PRESUME_INPUT_PIPE is selected

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -51,7 +51,7 @@ enum OutputErrorMode {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let options = Options {
         append: matches.contains_id(options::APPEND),

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -19,7 +19,7 @@ use std::io::ErrorKind;
 use std::process::{self, Child, Stdio};
 use std::time::Duration;
 use uucore::display::Quotable;
-use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::error::{UClapError, UResult, USimpleError, UUsageError};
 use uucore::format_usage;
 use uucore::process::ChildExt;
 use uucore::signals::{signal_by_name_or_value, signal_name_by_value};
@@ -108,9 +108,7 @@ impl Config {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let command = uu_app();
-
-    let matches = command.get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args).with_exit_code(125)?;
 
     let config = Config::from(&matches)?;
     timeout(

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -69,7 +69,7 @@ fn dt_to_filename(tm: time::PrimitiveDateTime) -> FileTime {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let files = matches.get_many::<OsString>(ARG_FILES).ok_or_else(|| {
         USimpleError::new(

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -44,7 +44,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let after_help = get_long_usage();
 
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let delete_flag = matches.contains_id(options::DELETE);
     let complement_flag = matches.contains_id(options::COMPLEMENT);

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -27,7 +27,7 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
 
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let input = matches
         .value_of(options::FILE)

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -56,7 +56,7 @@ const HOST_OS: &str = "Redox";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let uname =
         PlatformInfo::new().map_err_context(|| "failed to create PlatformInfo".to_string())?;

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -167,7 +167,7 @@ fn expand_shortcuts(args: &[String]) -> Vec<String> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().get_matches_from(expand_shortcuts(&args));
+    let matches = uu_app().try_get_matches_from(expand_shortcuts(&args))?;
 
     unexpand(&Options::new(&matches)?).map_err_context(String::new)
 }

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -257,7 +257,9 @@ fn get_long_usage() -> String {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let long_usage = get_long_usage();
 
-    let matches = uu_app().after_help(&long_usage[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&long_usage[..])
+        .try_get_matches_from(args)?;
 
     let files: Vec<String> = matches
         .get_many::<String>(ARG_FILES)

--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -22,7 +22,7 @@ static OPT_PATH: &str = "FILE";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let path: &Path = matches.get_one::<OsString>(OPT_PATH).unwrap().as_ref();
 

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -36,7 +36,7 @@ extern "C" {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let (boot_time, user_count) = process_utmpx();
     let uptime = get_uptime(boot_time);

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -33,7 +33,9 @@ If FILE is not specified, use {}.  /var/log/wtmp as FILE is common.",
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let after_help = get_long_usage();
 
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let files: Vec<&Path> = matches
         .get_many::<OsString>(ARG_FILES)

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -196,7 +196,7 @@ impl Display for WcError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let inputs = inputs(&matches)?;
 

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -60,7 +60,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let after_help = get_long_usage();
 
-    let matches = uu_app().after_help(&after_help[..]).get_matches_from(args);
+    let matches = uu_app()
+        .after_help(&after_help[..])
+        .try_get_matches_from(args)?;
 
     let files: Vec<String> = matches
         .get_many::<String>(options::FILE)

--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -21,7 +21,7 @@ static ABOUT: &str = "Print the current username.";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    uu_app().get_matches_from(args);
+    uu_app().try_get_matches_from(args)?;
     let username = platform::get_username().map_err_context(|| "failed to get username".into())?;
     println_verbatim(&username).map_err_context(|| "failed to print username".into())?;
     Ok(())

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -26,7 +26,7 @@ const BUF_SIZE: usize = 16 * 1024;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let string = if let Some(values) = matches.get_many::<String>("STRING") {
         let mut result = values.fold(String::new(), |res, s| res + s + " ");

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -463,7 +463,7 @@ pub fn chown_base<'a>(
             .required(true)
             .min_values(1),
     );
-    let matches = command.get_matches_from(args);
+    let matches = command.try_get_matches_from(args)?;
 
     let files: Vec<String> = matches
         .get_many::<String>(options::ARG_FILES)

--- a/tests/by-util/test_arch.rs
+++ b/tests/by-util/test_arch.rs
@@ -12,3 +12,8 @@ fn test_arch_help() {
         .succeeds()
         .stdout_contains("architecture name");
 }
+
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -192,3 +192,8 @@ fn test_simple_format() {
         .code_is(1)
         .stderr_contains("extra operand 'c'");
 }
+
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -8,6 +8,11 @@ fn test_invalid_option() {
     new_ucmd!().arg("-w").arg("/").fails();
 }
 
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
 static DIR: &str = "/dev";
 
 // we should always get both arguments, regardless of whether --reference was used

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -562,6 +562,11 @@ fn test_no_operands() {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_mode_after_dash_dash() {
     let (at, ucmd) = at_and_ucmd!();
     run_single_test(

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -79,6 +79,11 @@ fn test_invalid_option() {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_chown_only_owner() {
     // test chown username file.txt
 

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -3,6 +3,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(125);
+}
+
+#[test]
 fn test_missing_operand() {
     let result = new_ucmd!().run();
 

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -3,6 +3,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_single_file() {
     new_ucmd!()
         .arg("lorem_ipsum.txt")

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -3,6 +3,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn ab_no_args() {
     new_ucmd!()
         .args(&["a", "b"])

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -8,6 +8,11 @@ fn generate(from: u32, to: u32) -> String {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_stdin() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["-", "10"])

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -40,6 +40,11 @@ static COMPLEX_SEQUENCE: &TestedSequence = &TestedSequence {
 };
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_byte_sequence() {
     for param in ["-b", "--bytes", "--byt"] {
         for example_seq in EXAMPLE_SEQUENCES {

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -6,6 +6,11 @@ use crate::common::util::*;
 use rust_users::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_date_email() {
     for param in ["--rfc-email", "--rfc-e", "-R"] {
         new_ucmd!().arg(param).succeeds();

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -75,6 +75,11 @@ fn build_ascii_block(n: usize) -> Vec<u8> {
     (0..=127).cycle().take(n).collect()
 }
 
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
 // Sanity Tests
 #[test]
 fn version() {

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -4,6 +4,11 @@ use std::collections::HashSet;
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_df_compatible_no_size_arg() {
     new_ucmd!().arg("-a").succeeds();
 }

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -5,6 +5,11 @@ extern crate dircolors;
 use self::dircolors::{guess_syntax, OutputFmt, StrUtils};
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_shell_syntax() {
     use std::env;
     let last = env::var("SHELL");

--- a/tests/by-util/test_dirname.rs
+++ b/tests/by-util/test_dirname.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_path_with_trailing_slashes() {
     new_ucmd!()
         .arg("/root/alpha/beta/gamma/delta/epsilon/omega//")

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -42,6 +42,11 @@ fn _du_basics(s: &str) {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_du_basics_subdir() {
     let ts = TestScenario::new(util_name!());
 

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -6,6 +6,11 @@ use std::path::Path;
 use tempfile::tempdir;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(125);
+}
+
+#[test]
 fn test_env_help() {
     new_ucmd!()
         .arg("--help")

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -3,6 +3,11 @@ use uucore::display::Quotable;
 // spell-checker:ignore (ToDO) taaaa tbbbb tcccc
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_with_tab() {
     new_ucmd!()
         .arg("with-tab.txt")

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -28,6 +28,11 @@ const NUM_PRIMES: usize = 10000;
 const NUM_TESTS: usize = 100;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_parallel() {
     use hex_literal::hex;
     use sha1::{Digest, Sha1};

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_fmt() {
     let result = new_ucmd!().arg("one-word-per-line.txt").run();
     //.stdout_is_fixture("call_graph.expected");

--- a/tests/by-util/test_fold.rs
+++ b/tests/by-util/test_fold.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_default_80_column_wrap() {
     new_ucmd!()
         .arg("lorem_ipsum.txt")

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -11,6 +11,12 @@ const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced 
 
 #[test]
 #[cfg(unix)]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
+#[cfg(unix)]
 fn test_groups() {
     let ts = TestScenario::new(util_name!());
     let result = ts.ucmd().run();

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -116,3 +116,8 @@ fn test_check_sha1() {
         .stdout_is("testf: OK\n")
         .stderr_is("");
 }
+
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -10,6 +10,11 @@ use crate::common::util::*;
 static INPUT: &str = "lorem_ipsum.txt";
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in_fixture(INPUT)

--- a/tests/by-util/test_hostname.rs
+++ b/tests/by-util/test_hostname.rs
@@ -28,3 +28,8 @@ fn test_hostname_full() {
         .succeeds()
         .stdout_contains(ls_short_res.stdout_str().trim());
 }
+
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -10,6 +10,11 @@ use crate::common::util::*;
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 #[cfg(unix)]
 fn test_id_no_specified_user() {
     let ts = TestScenario::new(util_name!());

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -10,6 +10,11 @@ use std::process::Command;
 use std::thread::sleep;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_install_basic() {
     let (at, mut ucmd) = at_and_ucmd!();
     let dir = "target_dir";

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -9,6 +9,11 @@ use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn empty_files() {
     new_ucmd!()
         .arg("empty.txt")

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -46,6 +46,11 @@ impl Drop for Target {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_kill_list_all_signals() {
     // Check for a few signals.  Do not try to be comprehensive.
     new_ucmd!()

--- a/tests/by-util/test_link.rs
+++ b/tests/by-util/test_link.rs
@@ -1,5 +1,10 @@
 use crate::common::util::*;
 
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
 #[cfg(not(target_os = "android"))]
 #[test]
 fn test_link_existing_file() {

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -2,6 +2,11 @@ use crate::common::util::*;
 use std::path::PathBuf;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_symlink_existing_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_symlink_existing_file";

--- a/tests/by-util/test_logname.rs
+++ b/tests/by-util/test_logname.rs
@@ -2,6 +2,11 @@ use crate::common::util::*;
 use std::env;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_normal() {
     let result = new_ucmd!().run();
     println!("env::var(CI).is_ok() = {}", env::var("CI").is_ok());

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -21,6 +21,11 @@ static TEST_DIR11: &str = "mkdir_test11/..";
 static TEST_DIR12: &str = "mkdir_test12";
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_mkdir_mkdir() {
     new_ucmd!().arg(TEST_DIR1).succeeds();
 }

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_create_fifo_missing_operand() {
     new_ucmd!().fails().stderr_is("mkfifo: missing operand");
 }

--- a/tests/by-util/test_mknod.rs
+++ b/tests/by-util/test_mknod.rs
@@ -1,5 +1,11 @@
 use crate::common::util::*;
 
+#[test]
+#[cfg(not(windows))]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
 #[cfg(not(windows))]
 #[test]
 fn test_mknod_help() {

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -5,6 +5,11 @@ use self::filetime::*;
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_mv_rename_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     let dir1 = "test_mv_rename_dir";

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_stdin_no_newline() {
     new_ucmd!()
         .pipe_in("No Newline")

--- a/tests/by-util/test_nohup.rs
+++ b/tests/by-util/test_nohup.rs
@@ -6,6 +6,11 @@ use std::thread::sleep;
 // All that can be tested is the side-effects.
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(125);
+}
+
+#[test]
 #[cfg(any(
     target_os = "linux",
     target_os = "android",

--- a/tests/by-util/test_nproc.rs
+++ b/tests/by-util/test_nproc.rs
@@ -2,6 +2,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_nproc() {
     let nproc: u8 = new_ucmd!().succeeds().stdout_str().trim().parse().unwrap();
     assert!(nproc > 0);

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -3,6 +3,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_should_not_round_floats() {
     new_ucmd!()
         .args(&["0.99", "1.01", "1.1", "1.22", ".1", "-0.1"])

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -24,6 +24,11 @@ static ALPHA_OUT: &str = "
 // XXX We could do a better job of ensuring that we have a fresh temp dir to ourselves,
 // not a general one full of other process leftovers.
 
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
 // Test that od can read one file and dump with default format
 #[test]
 fn test_file() {

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -129,6 +129,11 @@ static EXAMPLE_DATA: &[TestData] = &[
 ];
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_combine_pairs_of_lines() {
     for s in ["-s", "--serial"] {
         for d in ["-d", "--delimiters"] {

--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_default_mode() {
     // test the default mode
 

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -13,6 +13,11 @@ extern crate pinky;
 pub use self::pinky::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_capitalize() {
     assert_eq!("Zbnmasd", "zbnmasd".capitalize()); // spell-checker:disable-line
     assert_eq!("Abnmasd", "Abnmasd".capitalize()); // spell-checker:disable-line

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn gnu_ext_disabled_rightward_no_ref() {
     new_ucmd!()
         .args(&["-G", "-R", "input"])

--- a/tests/by-util/test_pwd.rs
+++ b/tests/by-util/test_pwd.rs
@@ -5,6 +5,11 @@ use std::path::PathBuf;
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_default() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.succeeds().stdout_is(at.root_dir_resolved() + "\n");

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -9,6 +9,11 @@ static NOT_A_DIRECTORY: &str = "Not a directory";
 static NOT_A_DIRECTORY: &str = "The directory name is invalid.";
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_resolve() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_rm_one_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_rm_one_file";

--- a/tests/by-util/test_rmdir.rs
+++ b/tests/by-util/test_rmdir.rs
@@ -21,6 +21,11 @@ const NOT_A_DIRECTORY: &str = "The directory name is invalid.";
 const NOT_A_DIRECTORY: &str = "Not a directory";
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_rmdir_empty_directory_no_parents() {
     let (at, mut ucmd) = at_and_ucmd!();
 

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -3,6 +3,11 @@ use crate::common::util::*;
 use std::io::Read;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_hex_rejects_sign_after_identifier() {
     new_ucmd!()
         .args(&["0x-123ABC"])

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_shred_remove() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_output_is_random_permutation() {
     let input_seq = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let input = input_seq

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -120,6 +120,11 @@ impl RandomFile {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_split_default() {
     let (at, mut ucmd) = at_and_ucmd!();
     let name = "split_default";

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -11,6 +11,11 @@ extern crate stat;
 pub use self::stat::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_scanners() {
     assert_eq!(Some((-5, 2)), "-5zxc".scan_num::<i32>());
     assert_eq!(Some((51, 2)), "51zxc".scan_num::<u32>());

--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -3,6 +3,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 #[ignore = "Fails because cargo test does not run in a tty"]
 fn runs() {
     new_ucmd!().succeeds();

--- a/tests/by-util/test_sum.rs
+++ b/tests/by-util/test_sum.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_bsd_single_file() {
     new_ucmd!()
         .arg("lorem_ipsum.txt")

--- a/tests/by-util/test_sync.rs
+++ b/tests/by-util/test_sync.rs
@@ -4,6 +4,11 @@ use std::fs;
 use tempfile::tempdir;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_sync_default() {
     new_ucmd!().succeeds();
 }

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -2,6 +2,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in("100\n200\n300\n400\n500")

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -31,6 +31,11 @@ static FOLLOW_NAME_SHORT_EXP: &str = "follow_name_short.expected";
 static FOLLOW_NAME_EXP: &str = "follow_name.expected";
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 #[cfg(all(unix, not(target_os = "android")))] // FIXME: fix this test for Android
 fn test_stdin_default() {
     new_ucmd!()

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -7,6 +7,11 @@ use crate::common::util::*;
 // spell-checker:ignore nopipe
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_tee_processing_multiple_operands() {
     // POSIX says: "Processing of at least 13 file operands shall be supported."
 

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -1,6 +1,11 @@
 // spell-checker:ignore dont
 use crate::common::util::*;
 
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(125);
+}
+
 // FIXME: this depends on the system having true and false in PATH
 //        the best solution is probably to generate some test binaries that we can call for any
 //        utility that requires executing another program (kill, for instance)

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -60,6 +60,11 @@ fn str_to_filetime(format: &str, s: &str) -> FileTime {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_touch_default() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_default_file";

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -2,6 +2,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_to_upper() {
     new_ucmd!()
         .args(&["a-z", "A-Z"])

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -1,6 +1,10 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+#[test]
 fn test_sort_call_graph() {
     new_ucmd!()
         .arg("call_graph.txt")

--- a/tests/by-util/test_uname.rs
+++ b/tests/by-util/test_uname.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_uname() {
     new_ucmd!().succeeds();
 }

--- a/tests/by-util/test_unexpand.rs
+++ b/tests/by-util/test_unexpand.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn unexpand_init_0() {
     new_ucmd!()
         .args(&["-t4"])

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -10,6 +10,11 @@ static SKIP_FIELDS: &str = "skip-fields.txt";
 static SORTED_ZERO_TERMINATED: &str = "sorted-zero-terminated.txt";
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in_fixture(INPUT)

--- a/tests/by-util/test_unlink.rs
+++ b/tests/by-util/test_unlink.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_unlink_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_unlink_file";

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -3,6 +3,11 @@ use self::regex::Regex;
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_uptime() {
     TestScenario::new(util_name!())
         .ucmd_keepenv()

--- a/tests/by-util/test_users.rs
+++ b/tests/by-util/test_users.rs
@@ -1,6 +1,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_users_no_arg() {
     new_ucmd!().succeeds();
 }

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -3,6 +3,11 @@ use crate::common::util::*;
 // spell-checker:ignore (flags) lwmcL clmwL ; (path) bogusfile emptyfile manyemptylines moby notrailingnewline onelongemptyline onelongword weirdchars
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_count_bytes_large_stdin() {
     for n in [
         0,

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -7,6 +7,11 @@
 
 use crate::common::util::*;
 
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
 #[cfg(unix)]
 #[test]
 #[ignore = "issue #3219"]

--- a/tests/by-util/test_whoami.rs
+++ b/tests/by-util/test_whoami.rs
@@ -6,6 +6,11 @@
 use crate::common::util::*;
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 #[cfg(unix)]
 fn test_normal() {
     let ts = TestScenario::new(util_name!());

--- a/tests/by-util/test_yes.rs
+++ b/tests/by-util/test_yes.rs
@@ -29,6 +29,11 @@ fn run(args: &[&str], expected: &[u8]) {
 }
 
 #[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
 fn test_simple() {
     run(&[], b"y\ny\ny\ny\n");
 }


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/3102

Changes the exit code for the utils below from 2 to 1. A few utils remain with more complicated errors.

- [x] arch
- [x] basename
- [x] chgrp
- [x] chmod
- [x] chown
- [x] cksum
- [x] comm
- [x] csplit
- [x] cut
- [x] date
- [x] dd
- [x] df
- [x] dircolors
- [x] dirname
- [x] du
- [x] expand
- [x] factor
- [x] fmt
- [x] fold
- [x] groups
- [x] head
- [x] hostname
- [x] id
- [x] install
- [x] join
- [x] kill
- [x] link
- [x] ln
- [x] logname
- [x] mkdir
- [x] mkfifo
- [x] mknod
- [x] mv
- [x] nl
- [x] nproc
- [x] numfmt
- [x] od
- [x] paste
- [x] pathchk
- [x] pinky
- [x] ptx
- [x] pwd
- [x] readlink
- [x] rm
- [x] rmdir
- [x] seq
- [x] shred
- [x] shuf
- [x] split
- [x] stat
- [x] stty
- [x] sum
- [x] sync
- [x] tac
- [x] tail
- [x] tee
- [x] touch
- [x] tr
- [x] tsort
- [x] uname
- [x] unexpand
- [x] uniq
- [x] unlink
- [x] uptime
- [x] users
- [x] wc
- [x] who
- [x] whoami
- [x] yes