### PR TITLE
test_sort: Fix timeout issue `test_tmp_files_deleted_on_sigint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "pretty_assertions",
  "procfs",
  "rand",
+ "rand_pcg",
  "regex",
  "rlimit",
  "selinux",
@@ -1662,6 +1663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,7 +391,6 @@ glob = "0.3.0"
 libc = "0.2"
 pretty_assertions = "1"
 rand = "0.8"
-rand_pcg = "0.3"
 regex = "1.6"
 sha1 = { version="0.10", features=["std"] }
 tempfile = "3"
@@ -409,6 +408,7 @@ rlimit = "0.8.3"
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.25", default-features = false, features = ["process", "signal", "user"] }
 rust-users = { version="0.11", package="users" }
+rand_pcg = "0.3"
 
 [build-dependencies]
 phf_codegen = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,6 +391,7 @@ glob = "0.3.0"
 libc = "0.2"
 pretty_assertions = "1"
 rand = "0.8"
+rand_pcg = "0.3"
 regex = "1.6"
 sha1 = { version="0.10", features=["std"] }
 tempfile = "3"

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1117,8 +1117,23 @@ fn test_tmp_files_deleted_on_sigint() {
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("tmp_dir");
+    let file_name = "big_file_to_sort.txt";
+    {
+        use rand::Rng;
+        use std::io::Write;
+        let mut file = at.make_file(file_name);
+        // approximately 20 MB
+        for _ in 0..40 {
+            let lines = rand::thread_rng()
+                .sample_iter(rand::distributions::uniform::Uniform::new(0, 10007))
+                .take(100000)
+                .map(|x| x.to_string() + "\n")
+                .collect::<String>();
+            file.write_all(lines.as_bytes()).unwrap();
+        }
+    }
     ucmd.args(&[
-        "ext_sort.txt",
+        file_name,
         "--buffer-size=1", // with a small buffer size `sort` will be forced to create a temporary directory very soon.
         "--temporary-directory=tmp_dir",
     ]);

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1119,13 +1119,13 @@ fn test_tmp_files_deleted_on_sigint() {
     at.mkdir("tmp_dir");
     let file_name = "big_file_to_sort.txt";
     {
-        use rand::Rng;
+        use rand::{Rng, SeedableRng};
         use std::io::Write;
         let mut file = at.make_file(file_name);
         // approximately 20 MB
         for _ in 0..40 {
-            let lines = rand::thread_rng()
-                .sample_iter(rand::distributions::uniform::Uniform::new(0, 10007))
+            let lines = rand_pcg::Pcg32::seed_from_u64(123)
+                .sample_iter(rand::distributions::uniform::Uniform::new(0, 10000))
                 .take(100000)
                 .map(|x| x.to_string() + "\n")
                 .collect::<String>();

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1124,7 +1124,14 @@ fn test_tmp_files_deleted_on_sigint() {
     ]);
     let mut child = ucmd.run_no_wait();
     // wait a short amount of time so that `sort` can create a temporary directory.
-    std::thread::sleep(Duration::from_millis(100));
+    let mut timeout = Duration::from_millis(100);
+    for _ in 0..5 {
+        std::thread::sleep(timeout);
+        if read_dir(at.plus("tmp_dir")).unwrap().next().is_some() {
+            break;
+        }
+        timeout *= 2;
+    }
     // `sort` should have created a temporary directory.
     assert!(read_dir(at.plus("tmp_dir")).unwrap().next().is_some());
     // kill sort with SIGINT


### PR DESCRIPTION
I've seen that test `test_sort:;test_tmp_files_deleted_on_sigint` still sometimes fails, in a line where it checks that `sort` has created the temporary directory and it exists, so the test fails not finding the temporary directory.

- Wait more for the temporary directory to be created by `sort`. Before the change it slept for 0.1 seconds and right after that
asserted if `sort` has created the directory. Sometimes `sort` didn't manage to create the directory in 0.1 seconds. So the change is: now it tries to wait for `timeout` starting with 0.1 seconds, and if directory was not found, it tries 4 more times, each time increasing the time twice. Once the directory is found it breaks.
- Use a new generated file. Before, the sort could work faster and we could be late with sending the signal. Now we create a new big file, `sort` for sure can't process it in a minute, so we can safely wait for the temporary directory to be created and send a signal afterwards.
- Use `Pcg32` random number generator to be reproducible