### PR TITLE
factor: enable `union` feature for `smallvec`

### DIFF
--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "3.2", features = ["wrap_help", "cargo"] }
 coz = { version = "0.1.3", optional = true }
 num-traits = "0.2.15" # Needs at least version 0.2.15 for "OverflowingAdd"
 rand = { version = "0.8", features = ["small_rng"] }
-smallvec = "1.9"  # TODO(nicoo): Use `union` feature, requires Rust 1.49 or later.
+smallvec = { version = "1.9", features = ["union"] }
 uucore = { version=">=0.0.15", package="uucore", path="../../uucore" }
 
 [dev-dependencies]


### PR DESCRIPTION
Done TODO

`union` feature optimizes memory for `smallvec`, from https://docs.rs/smallvec/latest/smallvec/#union:

> When the union feature is enabled smallvec will track its state (inline or spilled) without the use of an enum tag, reducing the size of the smallvec by one machine word. This means that there is potentially no space overhead compared to Vec. Note that smallvec can still be larger than Vec if the inline buffer is larger than two machine words.