### PR TITLE
rm: Added descend messages for interactive mode Fixes #3817

### DIFF
--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -311,7 +311,7 @@ fn handle_dir(path: &Path, options: &Options) -> bool {
                         if options.interactive == InteractiveMode::Always {
                             for not_descend in &not_descended {
                                 if entry.path().starts_with(not_descend) {
-                                    continue 'outer
+                                    continue 'outer;
                                 }
                             }
                         }
@@ -326,7 +326,6 @@ fn handle_dir(path: &Path, options: &Options) -> bool {
                             } else {
                                 dirs.push_back(entry);
                             }
-                            
                         } else {
                             had_err = remove_file(entry.path(), options).bitor(had_err);
                         }

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -317,7 +317,9 @@ fn handle_dir(path: &Path, options: &Options) -> bool {
                         }
                         let file_type = entry.file_type();
                         if file_type.is_dir() {
-                            if options.interactive == InteractiveMode::Always {
+                            if options.interactive == InteractiveMode::Always
+                                && fs::read_dir(entry.path()).unwrap().count() != 0
+                            {
                                 if prompt_descend(entry.path()) {
                                     dirs.push_back(entry);
                                 } else {

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -368,11 +368,7 @@ fn test_rm_descend_directory() {
     at.touch(file_1);
     at.touch(file_2);
 
-    let mut child: Child = scene
-        .ccmd("rm")
-        .arg("-ri")
-        .arg("a")
-        .run_no_wait();
+    let mut child: Child = scene.ccmd("rm").arg("-ri").arg("a").run_no_wait();
 
     let mut child_stdin = child.stdin.take().unwrap();
     child_stdin.write_all("y\n".as_bytes()).unwrap();

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -368,7 +368,7 @@ fn test_rm_descend_directory() {
     at.touch(file_1);
     at.touch(file_2);
 
-    let mut child: Child = scene.ccmd("rm").arg("-ri").arg("a").run_no_wait();
+    let mut child: Child = scene.ucmd().arg("-ri").arg("a").run_no_wait();
 
     let mut child_stdin = child.stdin.take().unwrap();
     child_stdin.write_all("y\n".as_bytes()).unwrap();

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -355,9 +355,12 @@ fn test_rm_interactive_never() {
 
 #[test]
 fn test_rm_descend_directory() {
+    // This test descends into each directory and deletes the files and folders inside of them
+    // This test will have the rm process asks 6 question and us answering Y to them will delete all the files and folders
     use std::io::Write;
     use std::process::Child;
 
+    // Needed for talking with stdin on platforms where CRLF or LF matters
     const END_OF_LINE: &str = if cfg!(windows) { "\r\n" } else { "\n" };
 
     let yes = format!("y{}", END_OF_LINE);
@@ -374,6 +377,7 @@ fn test_rm_descend_directory() {
 
     let mut child: Child = scene.ucmd().arg("-ri").arg("a").run_no_wait();
 
+    // Needed so that we can talk to the rm program
     let mut child_stdin = child.stdin.take().unwrap();
     child_stdin.write_all(yes.as_bytes()).unwrap();
     child_stdin.flush().unwrap();

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -358,11 +358,7 @@ fn test_rm_descend_directory() {
     use std::io::Write;
     use std::process::Child;
 
-    const END_OF_LINE: &str = if cfg!(windows) {
-        "\r\n"
-    } else {
-        "\n"
-    };
+    const END_OF_LINE: &str = if cfg!(windows) { "\r\n" } else { "\n" };
 
     let yes = format!("y{}", END_OF_LINE);
     let no = format!("n{}", END_OF_LINE);

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -361,7 +361,6 @@ fn test_rm_descend_directory() {
     const END_OF_LINE: &str = if cfg!(windows) { "\r\n" } else { "\n" };
 
     let yes = format!("y{}", END_OF_LINE);
-    let no = format!("n{}", END_OF_LINE);
 
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -378,19 +377,23 @@ fn test_rm_descend_directory() {
     let mut child_stdin = child.stdin.take().unwrap();
     child_stdin.write_all(yes.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
-    child_stdin.write_all(no.as_bytes()).unwrap();
+    child_stdin.write_all(yes.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
     child_stdin.write_all(yes.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
-    child_stdin.write_all(no.as_bytes()).unwrap();
+    child_stdin.write_all(yes.as_bytes()).unwrap();
+    child_stdin.flush().unwrap();
+    child_stdin.write_all(yes.as_bytes()).unwrap();
+    child_stdin.flush().unwrap();
+    child_stdin.write_all(yes.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
 
     child.wait_with_output().unwrap();
 
-    assert!(at.dir_exists("a/b"));
-    assert!(at.dir_exists("a"));
+    assert!(!at.dir_exists("a/b"));
+    assert!(!at.dir_exists("a"));
     assert!(!at.file_exists(file_1));
-    assert!(at.file_exists(file_2));
+    assert!(!at.file_exists(file_2));
 }
 
 #[test]

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -354,6 +354,45 @@ fn test_rm_interactive_never() {
 }
 
 #[test]
+fn test_rm_descend_directory() {
+    use std::io::Write;
+    use std::process::Child;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let file_1 = "a/at.txt";
+    let file_2 = "a/b/bt.txt";
+
+    at.mkdir_all("a/b/");
+    at.touch(file_1);
+    at.touch(file_2);
+
+    let mut child: Child = scene
+        .ccmd("rm")
+        .arg("-ri")
+        .arg("a")
+        .run_no_wait();
+
+    let mut child_stdin = child.stdin.take().unwrap();
+    child_stdin.write_all("y\n".as_bytes()).unwrap();
+    child_stdin.flush().unwrap();
+    child_stdin.write_all("n\n".as_bytes()).unwrap();
+    child_stdin.flush().unwrap();
+    child_stdin.write_all("y\n".as_bytes()).unwrap();
+    child_stdin.flush().unwrap();
+    child_stdin.write_all("n\n".as_bytes()).unwrap();
+    child_stdin.flush().unwrap();
+
+    child.wait_with_output().unwrap();
+
+    assert!(at.dir_exists("a/b"));
+    assert!(at.dir_exists("a"));
+    assert!(!at.file_exists(file_1));
+    assert!(at.file_exists(file_2));
+}
+
+#[test]
 #[ignore = "issue #3722"]
 fn test_rm_directory_rights_rm1() {
     let (at, mut ucmd) = at_and_ucmd!();

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -358,6 +358,15 @@ fn test_rm_descend_directory() {
     use std::io::Write;
     use std::process::Child;
 
+    const END_OF_LINE: &str = if cfg!(windows) {
+        "\r\n"
+    } else {
+        "\n"
+    };
+
+    let yes = format!("y{}", END_OF_LINE);
+    let no = format!("n{}", END_OF_LINE);
+
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
@@ -371,13 +380,13 @@ fn test_rm_descend_directory() {
     let mut child: Child = scene.ucmd().arg("-ri").arg("a").run_no_wait();
 
     let mut child_stdin = child.stdin.take().unwrap();
-    child_stdin.write_all("y\n".as_bytes()).unwrap();
+    child_stdin.write_all(yes.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
-    child_stdin.write_all("n\n".as_bytes()).unwrap();
+    child_stdin.write_all(no.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
-    child_stdin.write_all("y\n".as_bytes()).unwrap();
+    child_stdin.write_all(yes.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
-    child_stdin.write_all("n\n".as_bytes()).unwrap();
+    child_stdin.write_all(no.as_bytes()).unwrap();
     child_stdin.flush().unwrap();
 
     child.wait_with_output().unwrap();


### PR DESCRIPTION
Added descend functionality for rm's interactive mode

Setup
```
mkdir -p a/b/
touch a/at.txt a/b/bt.txt
rm -ri a
```
Current
```
rm: remove file 'test/a/b/bt.txt'? y
rm: remove file 'test/a/at.txt'? y
rm: remove directory 'test/a/b'? y
rm: remove directory 'test/a'? y
```
GNU
```
rm: descend into directory 'a'? y
rm: descend into directory 'a/b'? y
rm: remove regular empty file 'a/b/bt.txt'? y
rm: remove directory 'a/b'? y
rm: remove regular empty file 'a/at.txt'? y
rm: remove directory 'a'? y
```
After Commit (Using the same answers as before)
```
rm: descend into directory 'test/a'? y
rm: descend into directory 'test/a/b'? y
rm: remove file 'test/a/b/bt.txt'? y
rm: remove file 'test/a/at.txt'? y
rm: remove directory 'test/a/b'? y
rm: remove directory 'test/a'? y
```
After Commit (Don't descend into a/b)
```
rm: descend into directory 'test/a'? y
rm: descend into directory 'test/a/b'? n
rm: remove file 'test/a/at.txt'? y
rm: remove directory 'test/a'? y
./uutils/target/debug/rm: cannot remove 'test/a': Directory not empty
```