### PR TITLE
cp: fix `cp-i` GNU test

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -35,7 +35,7 @@ use std::fs;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
-use std::io::{stdin, stdout, Write};
+use std::io::{stderr, stdin, Write};
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
@@ -118,9 +118,9 @@ macro_rules! or_continue(
 /// answered yes.
 macro_rules! prompt_yes(
     ($($args:tt)+) => ({
-        print!($($args)+);
-        print!(" [y/N]: ");
-        crash_if_err!(1, stdout().flush());
+        eprint!($($args)+);
+        eprint!(" [y/N]: ");
+        crash_if_err!(1, stderr().flush());
         let mut s = String::new();
         match stdin().read_line(&mut s) {
             Ok(_) => match s.char_indices().next() {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -204,6 +204,8 @@ fn test_cp_arg_interactive() {
         .arg("-i")
         .pipe_in("N\n")
         .succeeds()
+        .no_stdout()
+        .stderr_contains(format!("overwrite '{}'?", TEST_HOW_ARE_YOU_SOURCE))
         .stderr_contains("Not overwriting");
 }
 


### PR DESCRIPTION
uutils `cp` in interactive mode used to write to stdout asking for overwrite. GNU version writes to stderr.

Changed: write to stderr to make compatible with GNU.