### PR TITLE
mktemp: match GNU error message on too many args

### DIFF
--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -613,7 +613,11 @@ fn test_too_few_xs_suffix_directory() {
 
 #[test]
 fn test_too_many_arguments() {
-    new_ucmd!().args(&["-q", "a", "b"]).fails().code_is(1);
+    new_ucmd!()
+        .args(&["-q", "a", "b"])
+        .fails()
+        .code_is(1)
+        .usage_error("too many templates");
 }
 
 #[test]


### PR DESCRIPTION
Update the usage message when too many template arguments are given on the command line to match that of GNU mktemp:

    mktemp: too many templates
    Try 'mktemp --help' for more information.

This fixes the test case `too-many` in the GNU test suite file `tests/misc/mktemp.pl`.

(With this change and #3940, the GNU test file `tests/misc/mktemp.pl` should now be passing.)