### PR TITLE
Fix random errors for piped input on macos

### DIFF
--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -75,7 +75,10 @@ impl Input {
             }
             InputKind::File(_) | InputKind::Stdin => {
                 if cfg!(unix) {
-                    PathBuf::from(text::DEV_STDIN).canonicalize().ok()
+                    match PathBuf::from(text::DEV_STDIN).canonicalize().ok() {
+                        Some(path) if path != PathBuf::from(text::FD0) => Some(path),
+                        Some(_) | None => None,
+                    }
                 } else {
                     None
                 }

--- a/src/uu/tail/src/text.rs
+++ b/src/uu/tail/src/text.rs
@@ -18,3 +18,4 @@ pub static BACKEND: &str = "inotify";
 pub static BACKEND: &str = "kqueue";
 #[cfg(target_os = "windows")]
 pub static BACKEND: &str = "ReadDirectoryChanges";
+pub static FD0: &str = "/dev/fd/0";


### PR DESCRIPTION
Fix the random errors around piped input, mainly on macos but in theory also possible on other unix systems. When we canonicalize a path to find out if we can treat input from `Stdin` as fifo (we get a resulting path here) or pipe, (we don't) then it may happen sometimes that the canonicalized path points to `/dev/fd/0`. We should treat this result like a pipe.

A different solution also may have been to remove the guards from the is_tailable() method, but I've found putting the solution into the `resolve()` method being more explicit. The `is_tailable()` method should be refactored anyways also because of @niyaznigmatullin comment here https://github.com/uutils/coreutils/pull/3919#discussion_r968150006

