### PR TITLE
cp: modify archive flag to copy dir contents rather than dir

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -93,7 +93,7 @@ impl<'a> Context<'a> {
     fn new(root: &'a Path, target: &'a Path) -> std::io::Result<Self> {
         let current_dir = env::current_dir()?;
         let root_path = current_dir.join(root);
-        let root_parent = if target.exists() {
+        let root_parent = if target.exists() && !root.to_str().unwrap().ends_with("/.") {
             root_path.parent().map(|p| p.to_path_buf())
         } else {
             Some(root_path)

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2532,3 +2532,14 @@ fn test_src_base_dot() {
         .no_stdout();
     assert!(!at.dir_exists("y/x"));
 }
+
+#[test]
+#[cfg(not(windows))]
+fn test_cp_archive_on_directory_ending_dot() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir1");
+    at.mkdir("dir2");
+    at.touch("dir1/file");
+    ucmd.args(&["-a", "dir1/.", "dir2"]).succeeds();
+    assert!(at.file_exists("dir2/file"));
+}


### PR DESCRIPTION
Hello,
This PR fixes #3886 to handle copying source's directory contents rather than the directory itself. 

Its my first ever Rust PR. Thanks for the helpful responses, and in case something else needs to be added, i can do so np.

Thanks:) 