### PR TITLE
`tests/tail`: Fix tests to reflect changes from the refactoring #3905

### DIFF
--- a/tests/common/random.rs
+++ b/tests/common/random.rs
@@ -311,4 +311,30 @@ mod tests {
         );
         assert!(random_string.as_bytes().ends_with(&[0]));
     }
+
+    /// Originally used to exclude an error within the `random` module. The two
+    /// affected tests timed out on windows, but only in the ci. These tests are
+    /// also the source for the concrete numbers. The timed out tests are
+    /// `test_tail.rs::test_pipe_when_lines_option_given_input_size_has_multiple_size_of_buffer_size`
+    /// `test_tail.rs::test_pipe_when_bytes_option_given_input_size_has_multiple_size_of_buffer_size`.
+    #[test]
+    fn test_generate_random_strings_when_length_is_around_critical_buffer_sizes() {
+        let length = 8192 * 3;
+        let random_string = RandomString::generate(AlphanumericNewline, length);
+        assert_eq!(length, random_string.len());
+
+        let length = 8192 * 3 + 1;
+        let random_string =
+            RandomString::generate_with_delimiter(&Alphanumeric, b'\n', 100, true, length);
+        assert_eq!(length, random_string.len());
+        assert_eq!(
+            100,
+            random_string
+                .as_bytes()
+                .iter()
+                .filter(|p| **p == b'\n')
+                .count()
+        );
+        assert!(!random_string.as_bytes().ends_with(&[0]));
+    }
 }


### PR DESCRIPTION
This is a follow up pr to #3905 (refactoring tail), in which the tests for tail are updated to reflect the current state of tail's implementation. 

I removed all cfg attributes from the tests which limited the tests by vendor, os ([ci 8594](https://github.com/uutils/coreutils/actions/runs/3101684375)), then added cfg attributes again for the tests failing in the ci for a specific target os ([ci 8604](https://github.com/uutils/coreutils/actions/runs/3107790421), [ci 8605](https://github.com/uutils/coreutils/actions/runs/3108275942), [ci 8606](https://github.com/uutils/coreutils/actions/runs/3109053464), [ci 8607](https://github.com/uutils/coreutils/actions/runs/3109572586)). This is a quick overview over the outcome and the main differences to before the refactoring:

+ Piped input: works now for all platforms; worked before for all oses but windows and android
+ Redirected input: before: linux; after: all but apple
+ There are also some additional general and --follow tests working
+ ... See diff to main or the summary below

<details>
<summary>Summary and curated diff from this branch to main</summary>

```diff
-#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))]
+#[cfg(not(target_vendor = "apple"))]
test_stdin_redirect_file

-#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))]
+#[cfg(not(target_vendor = "apple"))]
test_stdin_redirect_offset

 #[test]
-#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))]
+#[cfg(all(not(target_vendor = "apple"), not(target_os = "windows")))]
test_stdin_redirect_offset2

-#[cfg(all(unix, not(target_os = "freebsd")))]
+#[cfg(unix)]
test_permission_denied

-#[cfg(all(unix, not(target_os = "freebsd")))]
+#[cfg(unix)]
test_permission_denied_multiple
-#[cfg(target_os = "linux")]
test_follow_redirect_stdin_name_retry

-#[cfg(not(target_os = "macos"))]
-#[cfg(all(unix, not(any(target_os = "android", target_os = "freebsd"))))]
+#[cfg(all(
+    not(target_vendor = "apple"),
+    not(target_os = "windows"),
+    not(target_os = "android"),
+    not(target_os = "freebsd")
+))]
test_stdin_redirect_dir

-#[cfg(target_os = "linux")]
test_follow_stdin_descriptor

-#[cfg(target_os = "linux")]
test_follow_stdin_name_retry

-#[cfg(target_os = "linux")]
-#[cfg(disable_until_fixed)]
test_follow_bad_fd

-#[cfg(unix)]
+#[cfg(not(target_os = "windows"))]
test_follow_single

-#[cfg(unix)]
+#[cfg(not(target_os = "windows"))]
test_follow_non_utf8_bytes

-#[cfg(unix)]
+#[cfg(not(target_os = "windows"))]
test_follow_multiple

-#[cfg(unix)]
+#[cfg(not(target_os = "windows"))]
test_follow_name_multiple

-#[cfg(unix)]
test_follow_multiple_untailable

-#[cfg(all(unix, not(target_os = "android")))]
test_follow_stdin_pipe

-#[cfg(unix)]
+#[cfg(not(target_os = "windows"))]
test_follow_invalid_pid

-#[cfg(disable_until_fixed)]
+#[cfg(all(
+    not(target_vendor = "apple"),
+    not(target_os = "windows"),
+    not(target_os = "android")
+))]
test_follow_with_pid

-#[cfg(all(unix, not(target_os = "android")))]
test_bytes_stdin

-#[cfg(all(unix, not(target_os = "android")))]
test_positive_bytes

-#[cfg(all(unix, not(target_os = "android")))]
test_positive_zero_bytes

-#[cfg(all(unix, not(target_os = "android")))]
test_positive_lines

-#[cfg(all(unix, not(target_os = "android")))]
test_obsolete_syntax_positive_lines

-#[cfg(all(unix, not(target_os = "android")))]
test_small_file

-#[cfg(all(unix, not(target_os = "android")))]
test_obsolete_syntax_small_file

-#[cfg(all(unix, not(target_os = "android")))]
test_positive_zero_lines

-#[cfg(all(unix, not(target_os = "android")))]
test_invalid_num

-#[cfg(all(unix, not(target_os = "android")))]
test_num_with_undocumented_sign_bytes

-#[cfg(unix)]
test_retry1

-#[cfg(unix)]
test_retry2

-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
test_retry6

-#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "freebsd")))]
test_retry9

-#[cfg(target_os = "linux")]
+#[cfg(all(
+    not(target_vendor = "apple"),
+    not(target_os = "windows"),
+    not(target_os = "freebsd")
+))]
test_follow_descriptor_vs_rename1

-#[cfg(target_os = "linux")]
+#[cfg(all(
+    not(target_vendor = "apple"),
+    not(target_os = "windows"),
+    not(target_os = "freebsd")
+))]
test_follow_descriptor_vs_rename2

-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
test_follow_name_remove

 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(all(
+    not(target_os = "windows"),
+    not(target_os = "android"),
+    not(target_os = "freebsd")
+))]
test_follow_name_truncate1

-#[cfg(target_os = "linux")]
+#[cfg(all(
+    not(target_os = "windows"),
+    not(target_os = "android"),
+    not(target_os = "freebsd")
+))]
test_follow_name_truncate2

-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
test_follow_name_truncate3

-#[cfg(unix)]
+#[cfg(not(target_os = "windows"))]
test_follow_name_truncate4

-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "windows"))]
test_follow_truncate_fast

-#[cfg(target_os = "linux")]
+#[cfg(all(
+    not(target_vendor = "apple"),
+    not(target_os = "windows"),
+    not(target_os = "freebsd")
+))]
test_follow_name_move_create2

-#[cfg(all(unix, not(target_os = "freebsd")))]
+#[cfg(not(target_os = "windows"))]
test_follow_inotify_only_regular

-#[cfg(unix)]
take_stdout_stderr

-#[cfg(all(unix, not(target_os = "android")))]
test_no_trailing_newline

-#[cfg(all(unix, not(target_os = "android")))]
test_lines_zero_terminated

-#[cfg(all(unix, not(target_os = "android")))]
test_presume_input_pipe_default

-#[cfg(unix)]
+#[cfg(not(windows))]
test_fifo

-#[cfg(all(not(target_os = "android"), not(target_os = "windows")))]
mod pipe_tests
```

</details>


For completeness:
I needed to keep 2 piped input tests for windows switched off which are not working in the ci because the tests timed out. I couldn't reproduce locally why they are hanging and they ran successfully in a Windows 10 Virtualbox image.

Fixes #3881

