### PR TITLE
cp: add `-H` option

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -498,6 +498,11 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .help("always follow symbolic links in SOURCE"),
         )
         .arg(
+            Arg::new(options::CLI_SYMBOLIC_LINKS)
+                .short('H')
+                .help("follow command-line symbolic links in SOURCE"),
+        )
+        .arg(
             Arg::new(options::ARCHIVE)
                 .short('a')
                 .long(options::ARCHIVE)
@@ -543,11 +548,6 @@ pub fn uu_app<'a>() -> Command<'a> {
                     "NotImplemented: set SELinux security context of destination file to \
                     default type",
                 ),
-        )
-        .arg(
-            Arg::new(options::CLI_SYMBOLIC_LINKS)
-                .short('H')
-                .help("NotImplemented: follow command-line symbolic links in SOURCE"),
         )
         // END TODO
         .arg(

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -14,7 +14,7 @@ use clap::{crate_version, Arg, Command};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
 use uucore::format_usage;
-use uucore::fs::{is_symlink, make_path_relative_to, paths_refer_to_same_file};
+use uucore::fs::{make_path_relative_to, paths_refer_to_same_file};
 
 use std::borrow::Cow;
 use std::error::Error;
@@ -318,7 +318,7 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
             if settings.no_dereference && matches!(settings.overwrite, OverwriteMode::Force) {
                 // In that case, we don't want to do link resolution
                 // We need to clean the target
-                if is_symlink(target_dir) {
+                if target_dir.is_symlink() {
                     if target_dir.is_file() {
                         if let Err(e) = fs::remove_file(target_dir) {
                             show_error!("Could not update {}: {}", target_dir.quote(), e);
@@ -387,7 +387,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
         src.into()
     };
 
-    if is_symlink(dst) || dst.exists() {
+    if dst.is_symlink() || dst.exists() {
         backup_path = match settings.backup {
             BackupMode::NoBackup => None,
             BackupMode::SimpleBackup => Some(simple_backup_path(dst, &settings.suffix)),
@@ -415,7 +415,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
                 // In case of error, don't do anything
             }
             OverwriteMode::Force => {
-                if !is_symlink(dst) && paths_refer_to_same_file(src, dst, true) {
+                if !dst.is_symlink() && paths_refer_to_same_file(src, dst, true) {
                     return Err(LnError::SameFile(src.to_owned(), dst.to_owned()).into());
                 }
                 if fs::remove_file(dst).is_ok() {};
@@ -427,7 +427,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
     if settings.symbolic {
         symlink(&source, dst)?;
     } else {
-        let p = if settings.logical && is_symlink(&source) {
+        let p = if settings.logical && source.is_symlink() {
             // if we want to have an hard link,
             // source is a symlink and -L is passed
             // we want to resolve the symlink to create the hardlink

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -19,8 +19,6 @@ use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, strip_errno, UResult};
 
-#[cfg(unix)]
-use uucore::fs::is_symlink;
 use uucore::{format_usage, util_name};
 
 static ABOUT: &str = "Remove the DIRECTORY(ies), if they are empty.";
@@ -78,7 +76,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 if error.raw_os_error() == Some(libc::ENOTDIR) && bytes.ends_with(b"/") {
                     // Strip the trailing slash or .symlink_metadata() will follow the symlink
                     let no_slash: &Path = OsStr::from_bytes(&bytes[..bytes.len() - 1]).as_ref();
-                    if is_symlink(no_slash) && points_to_directory(no_slash).unwrap_or(true) {
+                    if no_slash.is_symlink() && points_to_directory(no_slash).unwrap_or(true) {
                         show_error!(
                             "failed to remove {}: Symbolic link not followed",
                             path.quote()

--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -7,6 +7,9 @@
 
 //! Utilities for reading files as chunks.
 
+#![allow(dead_code)]
+// Ignores non-used warning for `borrow_buffer` in `Chunk`
+
 use std::{
     io::{ErrorKind, Read},
     sync::mpsc::SyncSender,

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -235,16 +235,6 @@ pub fn normalize_path(path: &Path) -> PathBuf {
     ret
 }
 
-/// Decide whether the given path is a symbolic link.
-///
-/// This function is essentially a backport of the
-/// [`std::path::Path::is_symlink`] function that exists in Rust
-/// version 1.58 and greater. This can be removed when the minimum
-/// supported version of Rust is 1.58.
-pub fn is_symlink<P: AsRef<Path>>(path: P) -> bool {
-    fs::symlink_metadata(path).map_or(false, |m| m.file_type().is_symlink())
-}
-
 fn resolve_symlink<P: AsRef<Path>>(path: P) -> IOResult<Option<PathBuf>> {
     let result = if fs::symlink_metadata(&path)?.file_type().is_symlink() {
         Some(fs::read_link(&path)?)

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -10,7 +10,7 @@ use crate::error::strip_errno;
 use crate::error::UResult;
 use crate::error::USimpleError;
 pub use crate::features::entries;
-use crate::fs::{is_symlink, resolve_relative_path};
+use crate::fs::resolve_relative_path;
 use crate::show_error;
 use clap::Arg;
 use clap::ArgMatches;
@@ -274,7 +274,7 @@ impl ChownExecutor {
         let root = root.as_ref();
 
         // walkdir always dereferences the root directory, so we have to check it ourselves
-        if self.traverse_symlinks == TraverseSymlinks::None && is_symlink(root) {
+        if self.traverse_symlinks == TraverseSymlinks::None && root.is_symlink() {
             return 0;
         }
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -751,6 +751,15 @@ impl AtPath {
         }
     }
 
+    pub fn read_symlink(&self, path: &str) -> String {
+        log_info("read_symlink", self.plus_as_string(path));
+        fs::read_link(&self.plus(path))
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
     pub fn symlink_metadata(&self, path: &str) -> fs::Metadata {
         match fs::symlink_metadata(&self.plus(path)) {
             Ok(m) => m,


### PR DESCRIPTION
- Add `-H` option for `cp`
- Got rid of `canonicalize` calls from `cp`, since `canonicalize` is a very general and costly operation `cp` doesn't need it. It was used only to resolve symlinks, but this is done automatically when reading file, or by using `metadata` instead of `symlink_metadata`. The only place where `canonicalize` is still used is when using `hard_link` function. There is no function in Rust library to create hard link that resolves the symlink if the path is the symlink. Probably we need to implement this function in the future.
- Removed `is_symlink` from `uucore/fs`. From Rust 1.58 `Path` has `is_symlink` method.