### PR TITLE
cp: preserve permissions when copying directory and don't terminate early on inaccessible file

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1206,6 +1206,14 @@ impl OverwriteMode {
     }
 }
 
+/// Copy the specified attributes from one path to another.
+fn copy_attributes(source: &Path, dest: &Path, attributes: &[Attribute]) -> CopyResult<()> {
+    for attribute in attributes {
+        copy_attribute(source, dest, attribute)?;
+    }
+    Ok(())
+}
+
 fn copy_attribute(source: &Path, dest: &Path, attribute: &Attribute) -> CopyResult<()> {
     let context = &*format!("{} -> {}", source.quote(), dest.quote());
     let source_metadata = fs::symlink_metadata(source).context(context)?;
@@ -1545,9 +1553,7 @@ fn copy_file(
         // the user does not have permission to write to the file.
         fs::set_permissions(dest, dest_permissions).ok();
     }
-    for attribute in &options.preserve_attributes {
-        copy_attribute(source, dest, attribute)?;
-    }
+    copy_attributes(source, dest, &options.preserve_attributes)?;
     Ok(())
 }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1183,7 +1183,8 @@ fn copy_directory(
             }
         }
     }
-
+    // Copy the attributes from the root directory to the target directory.
+    copy_attributes(root, target, &options.preserve_attributes)?;
     Ok(())
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -48,6 +48,27 @@ static TEST_MOUNT_OTHER_FILESYSTEM_FILE: &str = "mount/DO_NOT_copy_me.txt";
 #[cfg(unix)]
 static TEST_NONEXISTENT_FILE: &str = "nonexistent_file.txt";
 
+/// Assert that mode, ownership, and permissions of two metadata objects match.
+#[cfg(not(windows))]
+macro_rules! assert_metadata_eq {
+    ($m1:expr, $m2:expr) => {{
+        assert_eq!($m1.mode(), $m2.mode(), "mode is different");
+        assert_eq!($m1.uid(), $m2.uid(), "uid is different");
+        assert_eq!($m1.atime(), $m2.atime(), "atime is different");
+        assert_eq!(
+            $m1.atime_nsec(),
+            $m2.atime_nsec(),
+            "atime_nsec is different"
+        );
+        assert_eq!($m1.mtime(), $m2.mtime(), "mtime is different");
+        assert_eq!(
+            $m1.mtime_nsec(),
+            $m2.mtime_nsec(),
+            "mtime_nsec is different"
+        );
+    }};
+}
+
 #[test]
 fn test_cp_cp() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -1787,20 +1808,7 @@ fn test_copy_through_dangling_symlink_no_dereference_permissions() {
     {
         let metadata1 = at.symlink_metadata("dangle");
         let metadata2 = at.symlink_metadata("d2");
-        assert_eq!(metadata1.mode(), metadata2.mode(), "mode is different");
-        assert_eq!(metadata1.uid(), metadata2.uid(), "uid is different");
-        assert_eq!(metadata1.atime(), metadata2.atime(), "atime is different");
-        assert_eq!(
-            metadata1.atime_nsec(),
-            metadata2.atime_nsec(),
-            "atime_nsec is different"
-        );
-        assert_eq!(metadata1.mtime(), metadata2.mtime(), "mtime is different");
-        assert_eq!(
-            metadata1.mtime_nsec(),
-            metadata2.mtime_nsec(),
-            "mtime_nsec is different"
-        );
+        assert_metadata_eq!(metadata1, metadata2);
     }
 }
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -19,7 +19,7 @@ use std::ffi::OsStr;
 use std::fs::{self, hard_link, File, OpenOptions};
 use std::io::{BufWriter, Read, Result, Write};
 #[cfg(unix)]
-use std::os::unix::fs::{symlink as symlink_dir, symlink as symlink_file};
+use std::os::unix::fs::{symlink as symlink_dir, symlink as symlink_file, PermissionsExt};
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir, symlink_file};
 #[cfg(windows)]
@@ -820,6 +820,20 @@ impl AtPath {
         } else {
             s
         }
+    }
+
+    /// Set the permissions of the specified file.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is an error loading the metadata
+    /// or setting the permissions of the file.
+    #[cfg(not(windows))]
+    pub fn set_mode(&self, filename: &str, mode: u32) {
+        let path = self.plus(filename);
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(mode);
+        std::fs::set_permissions(&path, perms).unwrap();
     }
 }
 


### PR DESCRIPTION
This pull request includes two related fixes to `cp`.

First, we make cp preserve the permissions of a directory when copying it. Before this commit,

    cp -pR src/ dest/

failed to copy the permissions of `src/` to `dest/`. After this commit, the permissions are correctly copied.

Second, we make stop `cp` from terminating prematurely if a file in a directory is inaccesible due to insufficient permissions.

These two changes fix on assertion in GNU test suite file `tests/cp/fail-perm.sh` (but it will not be passing yet).