### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -17,6 +17,9 @@ env:
 
 on: [push, pull_request]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   cargo-deny:
     name: Style/cargo-deny
@@ -532,6 +535,9 @@ jobs:
         path: size-result.json
 
   build:
+    permissions:
+      contents: write # to create GitHub release (softprops/action-gh-release)
+
     name: Build
     needs: [ min_version, deps ]
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -6,6 +6,9 @@ name: GnuTests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   gnu:
     permissions:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.