### PR TITLE
wc: perform lseek once to correct the result from count_bytes_fast path

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -7,8 +7,7 @@ use super::WordCountable;
 use std::io::{self, ErrorKind, Read};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use libc::S_IFIFO;
-use libc::S_IFLNK;
+use libc::{S_IFIFO, S_IFLNK};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::{fs::OpenOptions, os::unix::io::AsRawFd};
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -1,4 +1,4 @@
-// cSpell:ignore lseek
+// cSpell:ignore lseek TYPEISSHM TYPEISTMO
 
 use crate::word_count::WordCount;
 

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -464,3 +464,35 @@ fn test_files0_from_with_stdin_try_read_from_stdin() {
         .stderr_contains(MSG)
         .stdout_is("");
 }
+
+#[cfg(unix)]
+#[test]
+fn test_bash() {
+    let scene = TestScenario::new(util_name!());
+
+    let first = scene
+        .cmd("bash")
+        .arg("-c")
+        .arg(format!(
+            "(dd ibs=1 skip=0 count=0 status=none; {} wc -c) < lorem_ipsum.txt",
+            scene.bin_path.to_str().unwrap()
+        ))
+        .succeeds()
+        .stdout_str()
+        .trim_end()
+        .parse::<i32>()
+        .unwrap();
+    let second = scene
+        .cmd("bash")
+        .arg("-c")
+        .arg(format!(
+            "(dd ibs=1 skip=3 count=0 status=none; {} wc -c) < lorem_ipsum.txt",
+            scene.bin_path.to_str().unwrap()
+        ))
+        .succeeds()
+        .stdout_str()
+        .trim_end()
+        .parse::<i32>()
+        .unwrap();
+    assert!(first > second);
+}


### PR DESCRIPTION
When using stdin, its possible that the given stdin does not start from the beginning. An example,

```bash
hbina@akarin:~/git/uutils$ stat --format='%s' /etc/group
1088
hbina@akarin:~/git/uutils$ (dd ibs=2 skip=1 count=0; wc -c) < /etc/group
0+0 records in
0+0 records out
0 bytes copied, 1.4948e-05 s, 0.0 kB/s
1086
hbina@akarin:~/git/uutils$ (dd ibs=2 skip=1 count=0; cargo run -- wc -c) < /etc/group
0+0 records in
0+0 records out
0 bytes copied, 1.4948e-05 s, 0.0 kB/s
1088
```

See: https://github.com/uutils/coreutils/issues/3977#issuecomment-1257208684

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>