### PR TITLE
ls: add support for +FORMAT in timestyle

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1653,6 +1653,7 @@ fn test_ls_styles() {
     let re_iso = Regex::new(r"[a-z-]* \d* \w* \w* \d* \d{2}-\d{2} \d{2}:\d{2} test\n").unwrap();
     let re_locale =
         Regex::new(r"[a-z-]* \d* \w* \w* \d* [A-Z][a-z]{2} ( |\d)\d \d{2}:\d{2} test\n").unwrap();
+    let re_custom_format = Regex::new(r"[a-z-]* \d* \w* \w* \d* \d{4}__\d{2} test\n").unwrap();
 
     //full-iso
     let result = scene
@@ -1674,6 +1675,17 @@ fn test_ls_styles() {
     //locale
     let result = scene.ucmd().arg("-l").arg("--time-style=locale").succeeds();
     assert!(re_locale.is_match(result.stdout_str()));
+
+    //+FORMAT
+    let result = scene
+        .ucmd()
+        .arg("-l")
+        .arg("--time-style=+%Y__%M")
+        .succeeds();
+    assert!(re_custom_format.is_match(result.stdout_str()));
+
+    // Also fails due to not having full clap support for time_styles
+    scene.ucmd().arg("-l").arg("-time-style=invalid").fails();
 
     //Overwrite options tests
     let result = scene


### PR DESCRIPTION
Hello,
This PR addresses issue #3625, which adds support to the `+FORMAT` date in `--time-style`. Given the dynamic argument, I created a custom parsing function to accommodate for the new format. 

I have added the corresponding tests, but probably my code added might not be up to standards, as I am new at it and trying to improve, and basically doing what the borrow checker tells me every time :). I would be more than happy to make changes to improve it. 

I did notice using the +Format on the linked issue, namely `$ TIME_STYLE="+%Y-%m-%d %H:%M:%S.%N %z" ls exe -al` breaks with 
```
thread 'main' panicked at 'a Display implementation returned an error unexpectedly: Error', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/alloc/src/string.rs:2406:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Basically, it fails by providing `time.format("%Y-%m-%d %H:%M:%S.%N %z" )`, but it looks more on the crate used. 

Thanks for guidance and potential feedback :) 