### PR TITLE
du,stty: replace deprecated is_present()

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -501,7 +501,7 @@ fn build_exclude_patterns(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
 
     let mut exclude_patterns = Vec::new();
     for f in excludes_iterator.chain(exclude_from_iterator) {
-        if matches.is_present(options::VERBOSE) {
+        if matches.contains_id(options::VERBOSE) {
             println!("adding {:?} to the exclude list ", &f);
         }
         match parse_glob::from_str(&f) {
@@ -637,7 +637,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     continue;
                 }
 
-                if matches.is_present(options::TIME) {
+                if matches.contains_id(options::TIME) {
                     let tm = {
                         let secs = {
                             match matches.get_one::<String>(options::TIME) {

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -100,8 +100,8 @@ struct Options<'a> {
 impl<'a> Options<'a> {
     fn from(matches: &'a ArgMatches) -> io::Result<Self> {
         Ok(Self {
-            all: matches.is_present(options::ALL),
-            save: matches.is_present(options::SAVE),
+            all: matches.contains_id(options::ALL),
+            save: matches.contains_id(options::SAVE),
             file: match matches.get_one::<String>(options::FILE) {
                 Some(_f) => todo!(),
                 None => stdout().as_raw_fd(),


### PR DESCRIPTION
This PR replaces the usage of clap's deprecated `is_present()` with `contains_id()`.