### PR TITLE
cp: assume --reflink=always on no value

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -428,6 +428,8 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .overrides_with_all(MODE_ARGS)
                 .require_equals(true)
                 .default_missing_value("auto")
+                .value_parser(["auto", "always", "never"])
+                .min_values(0)
                 .help("control clone/CoW copies. See below"),
         )
         .arg(

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -426,6 +426,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("WHEN")
                 .overrides_with_all(MODE_ARGS)
+                .default_missing_value("auto")
                 .help("control clone/CoW copies. See below"),
         )
         .arg(

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -426,6 +426,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .takes_value(true)
                 .value_name("WHEN")
                 .overrides_with_all(MODE_ARGS)
+                .require_equals(true)
                 .default_missing_value("auto")
                 .help("control clone/CoW copies. See below"),
         )

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -427,7 +427,7 @@ pub fn uu_app<'a>() -> Command<'a> {
                 .value_name("WHEN")
                 .overrides_with_all(MODE_ARGS)
                 .require_equals(true)
-                .default_missing_value("auto")
+                .default_missing_value("always")
                 .value_parser(["auto", "always", "never"])
                 .min_values(0)
                 .help("control clone/CoW copies. See below"),

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1369,7 +1369,7 @@ fn test_cp_reflink_bad() {
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_EXISTING_FILE)
         .fails()
-        .stderr_contains("invalid argument");
+        .stderr_contains("error: \"bad\" isn't a valid value for '--reflink[=<WHEN>...]'");
 }
 
 #[test]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1336,6 +1336,19 @@ fn test_cp_reflink_auto() {
 
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+fn test_cp_reflink_none() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.arg("--reflink")
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_EXISTING_FILE)
+        .succeeds();
+
+    // Check the content of the destination file
+    assert_eq!(at.read(TEST_EXISTING_FILE), "Hello, World!\n");
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
 fn test_cp_reflink_never() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.arg("--reflink=never")


### PR DESCRIPTION
Set the value of `--reflink` to `always` if it's specified without one.

This also changes the behavior of the `bad` case. The test has been updated, but this creates a difference in behavior:

GNU
```
$ cp --reflink=bad never g

cp: invalid argument ‘bad’ for ‘--reflink’
Valid arguments are:
  - ‘auto’
  - ‘always’
  - ‘never’
Try 'cp --help' for more information.
```

uutils
```
$ .../coreutils/target/debug/coreutils cp --reflink=bad f g
error: "bad" isn't a valid value for '--reflink[=<WHEN>...]'
        [possible values: auto, always, never]

For more information try --help
```

If this is an issue, I can try fixing this as well.

Closes #3984.