### PR TITLE
break GNU on purpose for testing CI

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -34,7 +34,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         result.push('\n');
         Cow::from(result)
     } else {
-        Cow::from("y\n")
+        Cow::from("n\n")
     };
 
     let mut buffer = [0; BUF_SIZE];


### PR DESCRIPTION
Testing https://github.com/uutils/coreutils/pull/4010 by breaking the `yes` gnu test.

If all goes well, a comment should appear below after the GnuComment workflow (which runs after GnuTests).