### PR TITLE
`ls`, `stat`: Show more info in long format on Windows

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -401,12 +401,26 @@ pub fn canonicalize<P: AsRef<Path>>(
 }
 
 #[cfg(not(unix))]
-#[allow(unused_variables)]
 pub fn display_permissions(metadata: &fs::Metadata, display_file_type: bool) -> String {
+    let write = if metadata.permissions().readonly() {
+        '-'
+    } else {
+        'w'
+    };
+
     if display_file_type {
-        return String::from("----------");
+        let file_type = if metadata.is_symlink() {
+            'l'
+        } else if metadata.is_dir() {
+            'd'
+        } else {
+            '-'
+        };
+
+        format!("{0}r{1}xr{1}xr{1}x", file_type, write)
+    } else {
+        format!("r{0}xr{0}xr{0}x", write)
     }
-    String::from("---------")
 }
 
 #[cfg(unix)]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -964,7 +964,7 @@ fn test_ls_long() {
         let result = scene.ucmd().arg(arg).arg("test-long").succeeds();
         #[cfg(not(windows))]
         result.stdout_matches(&Regex::new(r"[-bcCdDlMnpPsStTx?]([r-][w-][xt-]){3}.*").unwrap());
-        
+
         #[cfg(windows)]
         result.stdout_matches(&Regex::new(r"[-dl](r[w-]x){3}.*").unwrap());
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -964,9 +964,9 @@ fn test_ls_long() {
         let result = scene.ucmd().arg(arg).arg("test-long").succeeds();
         #[cfg(not(windows))]
         result.stdout_matches(&Regex::new(r"[-bcCdDlMnpPsStTx?]([r-][w-][xt-]){3}.*").unwrap());
-
+        
         #[cfg(windows)]
-        result.stdout_contains("---------- 1 somebody somegroup");
+        result.stdout_matches(&Regex::new(r"[-dl](r[w-]x){3}.*").unwrap());
     }
 }
 


### PR DESCRIPTION
Fixes a bit of https://github.com/uutils/coreutils/issues/3544

I kept the format identical to the format and Unix and approximated the permissions for Windows. Here's an example of the output:
```
total 0
drwxrwxrwx 1 somebody somegroup 0 Oct  9 00:36 directory
-rwxrwxrwx 1 somebody somegroup 0 Oct  9 00:30 link
-rwxrwxrwx 1 somebody somegroup 0 Oct  9 00:30 read-and-write
-r-xr-xr-x 1 somebody somegroup 0 Oct  9 00:30 readonly
```

Unfortunately, I can't get the link to work under Wine. I'm not sure if it's an issue with Wine or with the util (it'd be great if someone on Windows could test this. @AndreasBrostrom, maybe?)