### PR TITLE
GnuComment: convert loaded text into string

### DIFF
--- a/.github/workflows/GnuComment.yml
+++ b/.github/workflows/GnuComment.yml
@@ -48,5 +48,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: fs.readFileSync('./result.txt')
+              body: String(fs.readFileSync('./result.txt')),
             });


### PR DESCRIPTION
Merging this immediately as it has only to do with the comment workflow

I think we're very close to getting it right: https://github.com/uutils/coreutils/actions/runs/3214546794