### PR TITLE
Revert "build(deps): bump actions/github-script from 3.1.0 to 6.3.1"

### DIFF
--- a/.github/workflows/GnuComment.yml
+++ b/.github/workflows/GnuComment.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v6.3.1
+        uses: actions/github-script@v3.1.0
         with:
           script: |
             // List all artifacts from GnuTests
@@ -38,7 +38,7 @@ jobs:
       - run: unzip comment.zip
 
       - name: 'Comment on PR'
-        uses: actions/github-script@v6.3.1
+        uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Reverts uutils/coreutils#4021

Broke the comment https://github.com/uutils/coreutils/pull/4021#issuecomment-1274135706
