### PR TITLE
fix MIRI crash of long running unit test

### DIFF
--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -77,12 +77,12 @@ fn test_parallel() {
 }
 
 #[test]
-fn test_first_100000_integers() {
+fn test_first_1000_integers() {
     extern crate sha1;
     use hex_literal::hex;
     use sha1::{Digest, Sha1};
 
-    let n_integers = 100_000;
+    let n_integers = 1000;
     let mut input_string = String::new();
     for i in 0..=n_integers {
         input_string.push_str(&(format!("{} ", i))[..]);
@@ -91,13 +91,13 @@ fn test_first_100000_integers() {
     println!("STDIN='{}'", input_string);
     let result = new_ucmd!().pipe_in(input_string.as_bytes()).succeeds();
 
-    // `seq 0 100000 | factor | sha1sum` => "4ed2d8403934fa1c76fe4b84c5d4b8850299c359"
+    // `seq 0 1000 | factor | sha1sum` => "c734327bd18b90fca5762f671672b5eda19f7dca"
     let mut hasher = Sha1::new();
     hasher.update(result.stdout());
     let hash_check = hasher.finalize();
     assert_eq!(
         hash_check[..],
-        hex!("4ed2d8403934fa1c76fe4b84c5d4b8850299c359")
+        hex!("c734327bd18b90fca5762f671672b5eda19f7dca")
     );
 }
 


### PR DESCRIPTION
Factoring 10,000 integers was causing MIRI to not just fail but crash on OSX. This isn't really a unit test anyway. Reduced it to a more sane 1000 integers.