### PR TITLE
cp: use sparse copy on --sparse=always

### DIFF
--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -113,6 +113,7 @@ pub(crate) fn copy_on_write(
     source_is_fifo: bool,
 ) -> CopyResult<()> {
     let result = match (reflink_mode, sparse_mode) {
+        (ReflinkMode::Never, SparseMode::Always) => sparse_copy(source, dest),
         (ReflinkMode::Never, _) => std::fs::copy(source, dest).map(|_| ()),
         (ReflinkMode::Auto, SparseMode::Always) => sparse_copy(source, dest),
 


### PR DESCRIPTION
Correct the behavior of `cp --reflink=never --sparse=always` so that it performs a sparse copy (_Edit:_ on Linux). Before this commit, it was incorrectly performing a dense copy.

This should cause the GNU test suite file `tests/cp/sparse.sh` to pass.