### PR TITLE
deps: update phf to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,18 +1392,18 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
 dependencies = [
  "phf_shared",
  "rand",
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ uudoc = [ "zip" ]
 clap = { version = "3.2", features = ["wrap_help", "cargo"] }
 clap_complete = "3.1"
 once_cell = "1.13.1"
-phf = "0.10.1"
+phf = "0.11.1"
 selinux = { version="0.3", optional = true }
 textwrap = { version="0.15", features=["terminal_size"] }
 uucore = { version=">=0.0.16", package="uucore", path="src/uucore" }
@@ -410,7 +410,7 @@ nix = { version = "0.25", default-features = false, features = ["process", "sign
 rust-users = { version="0.11", package="users" }
 
 [build-dependencies]
-phf_codegen = "0.10.0"
+phf_codegen = "0.11.1"
 
 [[bin]]
 name = "coreutils"


### PR DESCRIPTION
This one is not handled correctly by dependabot, because we need to update `phf` and `phf_codegen` at the same time.