### PR TITLE
docs: add installation page with package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ uutils has both user and developer documentation available:
 Both can also be generated locally, the instructions for that can be found in the
 [coreutils docs](https://github.com/uutils/coreutils-docs) repository.
 
-<!-- ANCHOR: installation (this mark is needed for mdbook) -->
+<!-- ANCHOR: build (this mark is needed for mdbook) -->
 ## Requirements
 
 * Rust (`cargo`, `rustc`)
@@ -197,15 +197,6 @@ Installing with `make` installs shell completions for all installed utilities
 for `bash`, `fish` and `zsh`. Completions for `elvish` and `powershell` can also
 be generated; See `Manually install shell completions`.
 
-### NixOS
-
-The [standard package set](https://nixos.org/nixpkgs/manual/) of [NixOS](https://nixos.org/)
-provides this package out of the box since 18.03:
-
-```shell
-$ nix-env -iA nixos.uutils-coreutils
-```
-
 ### Manually install shell completions
 
 The `coreutils` binary can generate completions for the `bash`, `elvish`, `fish`, `powershell`
@@ -263,7 +254,7 @@ To uninstall from a custom parent directory:
 # DESTDIR is also supported
 $ make PREFIX=/my/path uninstall
 ```
-<!-- ANCHOR_END: installation (this mark is needed for mdbook) -->
+<!-- ANCHOR_END: build (this mark is needed for mdbook) -->
 
 ## Testing
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,3 +7,7 @@ title = "uutils Documentation"
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/cargo/tree/master/src/doc/src"
+
+[preprocessor.toc]
+command = "mdbook-toc"
+renderer = ["html"]

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -1,0 +1,3 @@
+# Build from source
+
+{{#include ../../README.md:build }}

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,3 +1,101 @@
 # Installation
 
-{{#include ../../README.md:installation }}
+This is a list of uutils packages in various distributions and package managers.
+Note that these are packaged by third-parties and the packages might contains
+patches.
+
+You can also [build uutils from source](/build.md).
+
+<!-- toc -->
+
+## Cargo
+[![crates.io package](https://repology.org/badge/version-for-repo/crates_io/uutils-coreutils.svg)](https://repology.org/project/uutils-coreutils/versions)
+
+```bash
+# Linux
+cargo install coreutils --features unix
+# MacOs
+cargo install coreutils --features macos
+# Windows
+cargo install coreutils --features windows
+```
+
+## Linux
+### Alpine
+
+[![Alpine Linux Edge package](https://repology.org/badge/version-for-repo/alpine_edge/uutils-coreutils.svg)](https://pkgs.alpinelinux.org/packages?name=uutils-coreutils)
+
+```bash
+apk update uutils-coreutils
+```
+
+> **Note**: Requires the `edge` repository.
+
+### Arch
+
+[![Arch package](https://repology.org/badge/version-for-repo/arch/uutils-coreutils.svg)](https://archlinux.org/packages/community/x86_64/uutils-coreutils/)
+
+```bash
+pacman -S uutils-coreutils
+```
+
+### Debian
+
+[![Debian Unstable package](https://repology.org/badge/version-for-repo/debian_unstable/uutils-coreutils.svg)](https://packages.debian.org/sid/source/rust-coreutils)
+
+```bash
+apt install rust-coreutils
+```
+
+> **Note**: Requires the `unstable` repository.
+
+### Manjaro
+![Manjaro Stable package](https://repology.org/badge/version-for-repo/manjaro_stable/uutils-coreutils.svg)
+[![Manjaro Testing package](https://repology.org/badge/version-for-repo/manjaro_testing/uutils-coreutils.svg)](https://repology.org/project/uutils-coreutils/versions)
+[![Manjaro Unstable package](https://repology.org/badge/version-for-repo/manjaro_unstable/uutils-coreutils.svg)](https://repology.org/project/uutils-coreutils/versions)
+
+```bash
+pacman -S uutils-coreutils
+# or
+pamac install uutils-coreutils
+```
+
+### NixOS
+[![nixpkgs unstable package](https://repology.org/badge/version-for-repo/nix_unstable/uutils-coreutils.svg)](https://repology.org/project/uutils-coreutils/versions)
+
+```bash
+nix-env -iA nixos.uutils-coreutils
+```
+
+## MacOS
+
+### Homebrew
+[![Homebrew package](https://repology.org/badge/version-for-repo/homebrew/uutils-coreutils.svg)](https://formulae.brew.sh/formula/uutils-coreutils)
+
+```bash
+brew install uutils-coreutils
+```
+
+### MacPorts
+[![MacPorts package](https://repology.org/badge/version-for-repo/macports/uutils-coreutils.svg)](https://ports.macports.org/port/coreutils-uutils/)
+
+```
+port install coreutils-uutils
+```
+
+## Windows
+
+### Scoop
+[![Scoop package](https://repology.org/badge/version-for-repo/scoop/uutils-coreutils.svg)](https://scoop.sh/#/apps?q=uutils-coreutils&s=0&d=1&o=true)
+
+```bash
+scoop install uutils-coreutils
+```
+
+## Non-standard packages
+
+### `coreutils-hybrid` (AUR)
+
+[![AUR package](https://repology.org/badge/version-for-repo/aur/coreutils-hybrid.svg)](https://aur.archlinux.org/packages/coreutils-hybrid)
+
+A GNU coreutils / uutils coreutils hybrid package. Uses stable uutils programs mixed with GNU counterparts if uutils counterpart is unfinished or buggy.

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -41,6 +41,7 @@ fn main() -> io::Result<()> {
         \n\
         [Introduction](index.md)\n\
         * [Installation](installation.md)\n\
+        * [Build from source](build.md)\n\
         * [Contributing](contributing.md)\n\
         * [GNU test coverage](test_coverage.md)\n\
         \n\


### PR DESCRIPTION
Since uutils is now packaged in a few repositories, I think it's about time we start documenting them. Currently, only Nix is mentioned in the `README.md`. Adding all distributions to the `README.md` would be a bit too long though, so I made a page in the documentation instead. I've called this page "Installation" and have renamed the old "Installation" page to "Build from source".

For each distribution/package manager, I have added a badge showing the currently packaged version (via repology.org) and instructions for installation. I also added a little note if uutils is currently only available in an unstable/edge repository.

Note: The table of contents only shows up with `mdbook-toc`. I wish `mdbook` would adopt these kinds of features, but it doesn't yet :) I'll add `mdbook-toc` to the coreutils-docs CI once this is merged.

![image](https://user-images.githubusercontent.com/11643477/195883157-f5c29146-4e1e-4c42-9c5c-5201c2da61cb.png)
