### PR TITLE
docs: fix usage string since clap 4

### DIFF
--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -170,7 +170,7 @@ impl<'a, 'b> MDWriter<'a, 'b> {
             .render_usage()
             .to_string()
             .lines()
-            .skip(1)
+            .map(|l| l.strip_prefix("Usage:").unwrap_or(l))
             .map(|l| l.trim())
             .filter(|l| !l.is_empty())
             .collect::<Vec<_>>()


### PR DESCRIPTION
In the current docs, the first line of the usage string is skipped: https://uutils.github.io/user/utils/b2sum.html. This removes the skip and strips the `Usage:` string.