### PR TITLE
Bump bstr 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,13 +172,14 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
 dependencies = [
- "lazy_static",
  "memchr",
+ "once_cell",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1844,6 +1845,12 @@ dependencies = [
  "dunce",
  "walkdir",
 ]
+
+[[package]]
+name = "serde"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 
 [[package]]
 name = "sha1"

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/cut.rs"
 clap = { version = "4.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore" }
 memchr = "2"
-bstr = "0.2"
+bstr = "1.0"
 atty = "0.2"
 
 [[bin]]

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -145,7 +145,7 @@ fn list_to_ranges(list: &str, complement: bool) -> Result<Vec<Range>, String> {
 
 fn cut_bytes<R: Read>(reader: R, ranges: &[Range], opts: &Options) -> UResult<()> {
     let newline_char = if opts.zero_terminated { b'\0' } else { b'\n' };
-    let buf_in = BufReader::new(reader);
+    let mut buf_in = BufReader::new(reader);
     let mut out = stdout_writer();
     let delim = opts
         .out_delim
@@ -189,7 +189,7 @@ fn cut_fields_delimiter<R: Read>(
     newline_char: u8,
     out_delim: &str,
 ) -> UResult<()> {
-    let buf_in = BufReader::new(reader);
+    let mut buf_in = BufReader::new(reader);
     let mut out = stdout_writer();
     let input_delim_len = delim.len();
 
@@ -273,7 +273,7 @@ fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> URes
         );
     }
 
-    let buf_in = BufReader::new(reader);
+    let mut buf_in = BufReader::new(reader);
     let mut out = stdout_writer();
     let delim_len = opts.delimiter.len();
 


### PR DESCRIPTION
Fixed the reason it was failing to update automatically.

 - `for_byte_record_with_terminator` method now requires for `BufReader` to be mutable

Also it brought `serde` to `Cargo.lock` because of this: https://github.com/rust-lang/cargo/issues/10801