### PR TITLE
split: fix `---io` for clap 4

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -157,9 +157,8 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(OPT_IO)
-                .long(OPT_IO)
+                .long("io")
                 .alias(OPT_IO)
-                .takes_value(true)
                 .hide(true),
         )
         .arg(


### PR DESCRIPTION
Seems that #4009 was tested for old `clap`.

Fix changes for `clap` version 4