### PR TITLE
tests: fixed some tests on Windows

### DIFF
--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -159,7 +159,7 @@ fn test_mkdir_trailing_dot() {
         .arg(TEST_DIR11)
         .succeeds()
         .stdout_contains("created directory 'mkdir_test11'");
-    let result = scene2.cmd("ls").arg("-al").run();
+    let result = scene2.ucmd().arg("-al").run();
     println!("ls dest {}", result.stdout_str());
 }
 

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -393,9 +393,9 @@ fn test_same_device_inode() {
 fn test_newer_file() {
     let scenario = TestScenario::new(util_name!());
 
-    scenario.cmd("touch").arg("regular_file").succeeds();
+    scenario.fixtures.touch("regular_file");
     sleep(std::time::Duration::from_millis(1000));
-    scenario.cmd("touch").arg("newer_file").succeeds();
+    scenario.fixtures.touch("newer_file");
 
     scenario
         .ucmd()


### PR DESCRIPTION
Tests used system `touch` and `ls`.

Windows systems usually don't have coreutils installed.

Changed to `AtPath::touch` and `uu_ls` calls.