### PR TITLE
Migrate from `winapi` to `windows-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1264,7 +1264,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1469,7 +1469,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1790,7 +1790,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2029,7 +2029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -3181,8 +3181,8 @@ dependencies = [
  "uucore_procs",
  "walkdir",
  "wild",
- "winapi",
  "winapi-util",
+ "windows-sys 0.42.0",
  "z85",
 ]
 
@@ -3334,12 +3334,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3348,10 +3369,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3360,16 +3393,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
  "filetime",
  "time",
  "uucore",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,7 +2498,7 @@ dependencies = [
  "clap 4.0.17",
  "hostname",
  "uucore",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,6 @@ dependencies = [
  "selinux",
  "uucore",
  "walkdir",
- "winapi",
  "xattr",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,7 +2308,7 @@ dependencies = [
  "clap 4.0.17",
  "libc",
  "uucore",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,8 +2968,8 @@ dependencies = [
  "notify",
  "same-file",
  "uucore",
- "winapi",
  "winapi-util",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,7 +2800,7 @@ dependencies = [
  "remove_dir_all 0.7.0",
  "uucore",
  "walkdir",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
  "clap 4.0.17",
  "glob",
  "uucore",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,7 @@ dependencies = [
  "libc",
  "nix",
  "uucore",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,7 +3147,7 @@ dependencies = [
  "clap 4.0.17",
  "libc",
  "uucore",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,13 @@ skip = [
     { name = "clap", version = "=3.2.22" },
     # bindgen (via selinux-sys & fts-sys)
     { name = "clap_lex", version = "=0.2.4" },
+    # windows-sys (via terminal_size, crossterm -> parking_lot, notify -> filetime)
+    { name = "windows-sys", version = "=0.36.1" },
+    { name = "windows_aarch64_msvc", version = "=0.36.1" },
+    { name = "windows_i686_gnu", version = "=0.36.1" },
+    { name = "windows_i686_msvc", version = "=0.36.1" },
+    { name = "windows_x86_64_gnu", version = "=0.36.1" },
+    { name = "windows_x86_64_msvc", version = "=0.36.1" },
 ]
 # spell-checker: enable
 

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -27,9 +27,6 @@ selinux = { version="0.3", optional=true }
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=["entries", "fs", "perms", "mode"] }
 walkdir = "2.2"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version="0.3", features=["fileapi"] }
-
 [target.'cfg(unix)'.dependencies]
 xattr="0.2.3"
 exacl= { version = "0.9.0", optional=true }

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -23,7 +23,7 @@ uucore = { version=">=0.0.16", package="uucore", path="../../uucore" }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["minwinbase", "sysinfoapi", "minwindef"] }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_Foundation", "Win32_System_SystemInformation"] }
 
 [[bin]]
 name = "date"

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -23,10 +23,7 @@ use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
 use uucore::{format_usage, show_error};
 #[cfg(windows)]
-use winapi::{
-    shared::minwindef::WORD,
-    um::{minwinbase::SYSTEMTIME, sysinfoapi::SetSystemTime},
-};
+use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};
 
 // Options
 const DATE: &str = "date";
@@ -409,16 +406,16 @@ fn set_system_datetime(date: DateTime<Utc>) -> UResult<()> {
 /// https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime
 fn set_system_datetime(date: DateTime<Utc>) -> UResult<()> {
     let system_time = SYSTEMTIME {
-        wYear: date.year() as WORD,
-        wMonth: date.month() as WORD,
+        wYear: date.year() as u16,
+        wMonth: date.month() as u16,
         // Ignored
         wDayOfWeek: 0,
-        wDay: date.day() as WORD,
-        wHour: date.hour() as WORD,
-        wMinute: date.minute() as WORD,
-        wSecond: date.second() as WORD,
+        wDay: date.day() as u16,
+        wHour: date.hour() as u16,
+        wMinute: date.minute() as u16,
+        wSecond: date.second() as u16,
         // TODO: be careful of leap seconds - valid range is [0, 999] - how to handle?
-        wMilliseconds: ((date.nanosecond() / 1_000_000) % 1000) as WORD,
+        wMilliseconds: ((date.nanosecond() / 1_000_000) % 1000) as u16,
     };
 
     let result = unsafe { SetSystemTime(&system_time) };

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version="0.3", features=[] }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
 
 [[bin]]
 name = "du"

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -20,11 +20,11 @@ hostname = { version = "0.3", features = ["set"] }
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=["wide"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version="0.3", features=["sysinfoapi", "winsock2"] }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_Networking_WinSock", "Win32_Foundation"] }
 
 [[bin]]
 name = "hostname"
 path = "src/main.rs"
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs", "winapi"]
+normal = ["uucore_procs"]

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -32,15 +32,14 @@ static OPT_HOST: &str = "host";
 mod wsa {
     use std::io;
 
-    use winapi::shared::minwindef::MAKEWORD;
-    use winapi::um::winsock2::{WSACleanup, WSAStartup, WSADATA};
+    use windows_sys::Win32::Networking::WinSock::{WSACleanup, WSAStartup, WSADATA};
 
     pub(super) struct WsaHandle(());
 
     pub(super) fn start() -> io::Result<WsaHandle> {
         let err = unsafe {
             let mut data = std::mem::MaybeUninit::<WSADATA>::uninit();
-            WSAStartup(MAKEWORD(2, 2), data.as_mut_ptr())
+            WSAStartup(0x0202, data.as_mut_ptr())
         };
         if err != 0 {
             Err(io::Error::from_raw_os_error(err))

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -21,7 +21,7 @@ remove_dir_all = "0.7.0"
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=["fs"] }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version="0.3", features=[] }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_Storage_FileSystem"] }
 
 [[bin]]
 name = "rm"

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -510,7 +510,7 @@ use std::os::windows::prelude::MetadataExt;
 
 #[cfg(windows)]
 fn is_symlink_dir(metadata: &fs::Metadata) -> bool {
-    use winapi::um::winnt::FILE_ATTRIBUTE_DIRECTORY;
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
 
     metadata.file_type().is_symlink()
         && ((metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY) != 0)

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -23,11 +23,11 @@ uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=[
 nix = "0.25"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "std", "winbase", "winerror"] }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_Storage_FileSystem", "Win32_System_WindowsProgramming", "Win32_Foundation"] }
 
 [[bin]]
 name = "sync"
 path = "src/main.rs"
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs", "winapi"]
+normal = ["uucore_procs"]

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -70,29 +70,27 @@ mod platform {
 
 #[cfg(windows)]
 mod platform {
-    extern crate winapi;
-    use self::winapi::shared::minwindef;
-    use self::winapi::shared::winerror;
-    use self::winapi::um::handleapi;
-    use self::winapi::um::winbase;
-    use self::winapi::um::winnt;
     use std::fs::OpenOptions;
     use std::os::windows::prelude::*;
     use std::path::Path;
     use uucore::crash;
     use uucore::wide::{FromWide, ToWide};
+    use windows_sys::Win32::Foundation::{
+        GetLastError, ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE, MAX_PATH,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        FindFirstVolumeW, FindNextVolumeW, FindVolumeClose, FlushFileBuffers, GetDriveTypeW,
+    };
+    use windows_sys::Win32::System::WindowsProgramming::DRIVE_FIXED;
 
     unsafe fn flush_volume(name: &str) {
         let name_wide = name.to_wide_null();
-        if winapi::um::fileapi::GetDriveTypeW(name_wide.as_ptr()) == winbase::DRIVE_FIXED {
+        if GetDriveTypeW(name_wide.as_ptr()) == DRIVE_FIXED {
             let sliced_name = &name[..name.len() - 1]; // eliminate trailing backslash
             match OpenOptions::new().write(true).open(sliced_name) {
                 Ok(file) => {
-                    if winapi::um::fileapi::FlushFileBuffers(file.as_raw_handle()) == 0 {
-                        crash!(
-                            winapi::um::errhandlingapi::GetLastError() as i32,
-                            "failed to flush file buffer"
-                        );
+                    if FlushFileBuffers(file.as_raw_handle() as HANDLE) == 0 {
+                        crash!(GetLastError() as i32, "failed to flush file buffer");
                     }
                 }
                 Err(e) => crash!(
@@ -103,17 +101,11 @@ mod platform {
         }
     }
 
-    unsafe fn find_first_volume() -> (String, winnt::HANDLE) {
-        let mut name: [winnt::WCHAR; minwindef::MAX_PATH] = [0; minwindef::MAX_PATH];
-        let handle = winapi::um::fileapi::FindFirstVolumeW(
-            name.as_mut_ptr(),
-            name.len() as minwindef::DWORD,
-        );
-        if handle == handleapi::INVALID_HANDLE_VALUE {
-            crash!(
-                winapi::um::errhandlingapi::GetLastError() as i32,
-                "failed to find first volume"
-            );
+    unsafe fn find_first_volume() -> (String, HANDLE) {
+        let mut name: [u16; MAX_PATH as usize] = [0; MAX_PATH as usize];
+        let handle = FindFirstVolumeW(name.as_mut_ptr(), name.len() as u32);
+        if handle == INVALID_HANDLE_VALUE {
+            crash!(GetLastError() as i32, "failed to find first volume");
         }
         (String::from_wide_null(&name), handle)
     }
@@ -122,16 +114,11 @@ mod platform {
         let (first_volume, next_volume_handle) = find_first_volume();
         let mut volumes = vec![first_volume];
         loop {
-            let mut name: [winnt::WCHAR; minwindef::MAX_PATH] = [0; minwindef::MAX_PATH];
-            if winapi::um::fileapi::FindNextVolumeW(
-                next_volume_handle,
-                name.as_mut_ptr(),
-                name.len() as minwindef::DWORD,
-            ) == 0
-            {
-                match winapi::um::errhandlingapi::GetLastError() {
-                    winerror::ERROR_NO_MORE_FILES => {
-                        winapi::um::fileapi::FindVolumeClose(next_volume_handle);
+            let mut name: [u16; MAX_PATH as usize] = [0; MAX_PATH as usize];
+            if FindNextVolumeW(next_volume_handle, name.as_mut_ptr(), name.len() as u32) == 0 {
+                match GetLastError() {
+                    ERROR_NO_MORE_FILES => {
+                        FindVolumeClose(next_volume_handle);
                         return volumes;
                     }
                     err => crash!(err as i32, "failed to find next volume"),

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -24,7 +24,7 @@ uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=[
 same-file = "1.0.6"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version="0.3", features=["fileapi", "handleapi", "processthreadsapi", "synchapi", "winbase"] }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_System_Threading", "Win32_Foundation"] }
 winapi-util = { version="0.1.5" }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/uu/tail/src/platform/windows.rs
+++ b/src/uu/tail/src/platform/windows.rs
@@ -6,17 +6,12 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+use windows_sys::Win32::Foundation::{CloseHandle, BOOL, HANDLE, WAIT_FAILED, WAIT_OBJECT_0};
+use windows_sys::Win32::System::Threading::{
+    OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+};
 
-extern crate winapi;
-
-use self::winapi::shared::minwindef::DWORD;
-use self::winapi::um::handleapi::CloseHandle;
-use self::winapi::um::processthreadsapi::OpenProcess;
-use self::winapi::um::synchapi::WaitForSingleObject;
-use self::winapi::um::winbase::{WAIT_FAILED, WAIT_OBJECT_0};
-use self::winapi::um::winnt::{HANDLE, SYNCHRONIZE};
-
-pub type Pid = DWORD;
+pub type Pid = u32;
 
 pub struct ProcessChecker {
     dead: bool,
@@ -26,10 +21,10 @@ pub struct ProcessChecker {
 impl ProcessChecker {
     pub fn new(process_id: self::Pid) -> Self {
         #[allow(non_snake_case)]
-        let FALSE = 0i32;
-        let h = unsafe { OpenProcess(SYNCHRONIZE, FALSE, process_id as DWORD) };
+        let FALSE: BOOL = 0;
+        let h = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, FALSE, process_id) };
         Self {
-            dead: h.is_null(),
+            dead: h == 0,
             handle: h,
         }
     }

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -21,7 +21,7 @@ time = { version = "0.3", features = ["parsing", "formatting", "local-offset", "
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=["libc"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3" }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
 
 [[bin]]
 name = "touch"

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=["entries"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["lmcons"] }
+windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_NetworkManagement_NetManagement", "Win32_System_WindowsProgramming", "Win32_Foundation"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.135"

--- a/src/uu/whoami/src/platform/windows.rs
+++ b/src/uu/whoami/src/platform/windows.rs
@@ -10,17 +10,15 @@
 use std::ffi::OsString;
 use std::io;
 use std::os::windows::ffi::OsStringExt;
-
-use winapi::shared::lmcons;
-use winapi::shared::minwindef::DWORD;
-use winapi::um::winbase;
+use windows_sys::Win32::NetworkManagement::NetManagement::UNLEN;
+use windows_sys::Win32::System::WindowsProgramming::GetUserNameW;
 
 pub fn get_username() -> io::Result<OsString> {
-    const BUF_LEN: DWORD = lmcons::UNLEN + 1;
+    const BUF_LEN: u32 = UNLEN + 1;
     let mut buffer = [0_u16; BUF_LEN as usize];
     let mut len = BUF_LEN;
     // SAFETY: buffer.len() == len
-    if unsafe { winbase::GetUserNameW(buffer.as_mut_ptr(), &mut len) } == 0 {
+    if unsafe { GetUserNameW(buffer.as_mut_ptr(), &mut len) } == 0 {
         return Err(io::Error::last_os_error());
     }
     Ok(OsString::from_wide(&buffer[..len as usize - 1]))

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -45,16 +45,16 @@ clap = "4.0"
 once_cell = "1.13"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "winerror"] }
 winapi-util = { version= "0.1.5", optional=true }
+windows-sys = { version = "0.42.0", optional = true, default-features = false, features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_WindowsProgramming"] }
 
 [features]
 default = []
 # * non-default features
 encoding = ["data-encoding", "data-encoding-macro", "z85", "thiserror"]
 entries = ["libc"]
-fs = ["libc", "nix", "winapi-util"]
-fsext = ["libc", "nix", "time"]
+fs = ["libc", "nix", "winapi-util", "windows-sys"]
+fsext = ["libc", "nix", "time", "windows-sys"]
 lines = []
 memo = ["itertools"]
 mode = ["libc"]

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -81,9 +81,10 @@ impl FileInformation {
             let mut open_options = OpenOptions::new();
             let mut custom_flags = 0;
             if !dereference {
-                custom_flags |= winapi::um::winbase::FILE_FLAG_OPEN_REPARSE_POINT;
+                custom_flags |=
+                    windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
             }
-            custom_flags |= winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+            custom_flags |= windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
             open_options.custom_flags(custom_flags);
             let file = open_options.read(true).open(path.as_ref())?;
             Self::from_file(&file)

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -6,8 +6,8 @@
 // * feature-gated external crates (re-shared as public internal modules)
 #[cfg(feature = "libc")]
 pub extern crate libc;
-#[cfg(feature = "winapi")]
-pub extern crate winapi;
+#[cfg(all(feature = "windows-sys", target_os = "windows"))]
+pub extern crate windows_sys;
 
 //## internal modules
 


### PR DESCRIPTION
`winapi` is not being maintained, and `windows-sys` is maintained by Microsoft itself, as I understand.

Changed all direct dependencies from `winapi` to `windows-sys`. 

As I understand some other crates we use are also working in this direction.