### PR TITLE
cp: remove interactive mode message on 'no'

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1041,14 +1041,8 @@ impl OverwriteMode {
         match *self {
             Self::NoClobber => Err(Error::NotAllFilesCopied),
             Self::Interactive(_) => {
-                if prompt_yes!("{}: overwrite {}? ", uucore::util_name(), path.quote()) {
-                    Ok(())
-                } else {
-                    Err(Error::Skipped(format!(
-                        "Not overwriting {} at user request",
-                        path.quote()
-                    )))
-                }
+                prompt_yes!("{}: overwrite {}? ", uucore::util_name(), path.quote());
+                Ok(())
             }
             Self::Clobber(_) => Ok(()),
         }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -82,7 +82,7 @@ quick_error! {
         StripPrefixError(err: StripPrefixError) { from() }
 
         /// Result of a skipped file
-        Skipped(reason: String) { display("{}", reason) }
+        Skipped { }
 
         /// Result of a skipped file
         InvalidArgument(description: String) { display("{}", description) }
@@ -967,9 +967,7 @@ fn copy(sources: &[Source], target: &TargetSlice, options: &Options) -> CopyResu
                         // When using --no-clobber, we don't want to show
                         // an error message
                         Error::NotAllFilesCopied => (),
-                        Error::Skipped(_) => {
-                            show_error!("{}", error);
-                        }
+                        Error::Skipped => (),
                         _ => {
                             show_error!("{}", error);
                             non_fatal_errors = true;
@@ -1041,8 +1039,11 @@ impl OverwriteMode {
         match *self {
             Self::NoClobber => Err(Error::NotAllFilesCopied),
             Self::Interactive(_) => {
-                prompt_yes!("{}: overwrite {}? ", uucore::util_name(), path.quote());
-                Ok(())
+                if prompt_yes!("{}: overwrite {}? ", uucore::util_name(), path.quote()) {
+                    Ok(())
+                } else {
+                    Err(Error::Skipped)
+                }
             }
             Self::Clobber(_) => Ok(()),
         }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -232,10 +232,6 @@ fn test_cp_arg_interactive() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("a");
     at.touch("b");
-    // TODO The prompt in GNU cp is different, and it doesn't have the
-    // response either.
-    //
-    // See <https://github.com/uutils/coreutils/issues/4023>.
     ucmd.args(&["-i", "a", "b"])
         .pipe_in("N\n")
         .succeeds()

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -312,8 +312,7 @@ fn test_cp_arg_no_clobber_twice() {
         .arg("--no-clobber")
         .arg("source.txt")
         .arg("dest.txt")
-        .succeeds()
-        .stdout_does_not_contain("Not overwriting");
+        .succeeds();
 
     assert_eq!(at.read("source.txt"), "some-content");
     // Should be empty as the "no-clobber" should keep

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -240,7 +240,7 @@ fn test_cp_arg_interactive() {
         .pipe_in("N\n")
         .succeeds()
         .no_stdout()
-        .stderr_is("cp: overwrite 'b'?  [y/N]: cp: Not overwriting 'b' at user request\n");
+        .stderr_is("cp: overwrite 'b'?  [y/N]:");
 }
 
 #[test]


### PR DESCRIPTION
Removes the error message on 'no' option in interactive mode for cp for the overwrite prompt.

Relevant link - https://github.com/uutils/coreutils/issues/4000#issuecomment-1287779975

Closes #4023.