### PR TITLE
numfmt: handle negative zero values

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -161,7 +161,11 @@ fn transform_from(s: &str, opts: &TransformOptions) -> Result<f64> {
     remove_suffix(i, suffix, &opts.from).map(|n| {
         // GNU numfmt doesn't round values if no --from argument is provided by the user
         if opts.from == Unit::None {
-            n
+            if n == -0.0 {
+                0.0
+            } else {
+                n
+            }
         } else if n < 0.0 {
             -n.abs().ceil()
         } else {

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -185,6 +185,11 @@ fn test_negative() {
 }
 
 #[test]
+fn test_negative_zero() {
+    new_ucmd!().pipe_in("-0\n-0.0").run().stdout_is("0\n0.0\n");
+}
+
+#[test]
 fn test_no_op() {
     new_ucmd!()
         .pipe_in("1024\n1234567")


### PR DESCRIPTION
GNU numfmt returns `0` if it is called with a negative zero (`numfmt -- -0`) whereas uutils numfmt returns `-0`. This PR fixes this issue and makes test `neg-6` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.