### PR TITLE
Revert "hashsum: test b3sum::test_nonames for real"

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -276,10 +276,11 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     };
     let check = matches.get_flag("check");
     let tag = matches.get_flag("tag");
-    let nonames = *matches
-        .try_get_one("no-names")
-        .unwrap_or(Some(&false))
-        .unwrap();
+    let nonames = if binary_name == "b3sum" {
+        matches.get_flag("no-names")
+    } else {
+        false
+    };
     let status = matches.get_flag("status");
     let quiet = matches.get_flag("quiet") || status;
     let strict = matches.get_flag("strict");

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -34,7 +34,7 @@ macro_rules! test_digest {
         fn test_nonames() {
             let ts = TestScenario::new("hashsum");
             // EXPECTED_FILE has no newline character at the end
-            if DIGEST_ARG == "--b3sum" {
+            if DIGEST_ARG == "b3sum" {
                 // Option only available on b3sum
                 assert_eq!(format!("{0}\n{0}\n", ts.fixtures.read(EXPECTED_FILE)),
                        ts.ucmd().arg(DIGEST_ARG).arg(BITS_ARG).arg("--no-names").arg("input.txt").arg("-").pipe_in_fixture("input.txt")


### PR DESCRIPTION
Reverts uutils/coreutils#4027

to see if we regressed because of this or not :)
