### PR TITLE
numfmt: round values if precision is 0

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -272,14 +272,13 @@ fn transform_to(
     let (i2, s) = consider_suffix(s, &opts.to, round_method, precision)?;
     let i2 = i2 / (opts.to_unit as f64);
     Ok(match s {
-        None if precision > 0 => {
+        None => {
             format!(
                 "{:.precision$}",
                 round_with_precision(i2, round_method, precision),
                 precision = precision
             )
         }
-        None => format!("{}", i2),
         Some(s) if precision > 0 => {
             format!(
                 "{:.precision$}{}",

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -530,12 +530,38 @@ fn test_round() {
         new_ucmd!()
             .args(&[
                 "--to=si",
-                &format!("--round={}", method),
+                &format!("--round={method}"),
                 "--",
                 "9001",
                 "-9001",
                 "9099",
                 "-9099",
+            ])
+            .succeeds()
+            .stdout_only(exp.join("\n") + "\n");
+    }
+}
+
+#[test]
+fn test_round_with_to_unit() {
+    for (method, exp) in [
+        ("from-zero", ["6", "-6", "5.9", "-5.9", "5.86", "-5.86"]),
+        ("towards-zero", ["5", "-5", "5.8", "-5.8", "5.85", "-5.85"]),
+        ("up", ["6", "-5", "5.9", "-5.8", "5.86", "-5.85"]),
+        ("down", ["5", "-6", "5.8", "-5.9", "5.85", "-5.86"]),
+        ("nearest", ["6", "-6", "5.9", "-5.9", "5.86", "-5.86"]),
+    ] {
+        new_ucmd!()
+            .args(&[
+                "--to-unit=1024",
+                &format!("--round={method}"),
+                "--",
+                "6000",
+                "-6000",
+                "6000.0",
+                "-6000.0",
+                "6000.00",
+                "-6000.00",
             ])
             .succeeds()
             .stdout_only(exp.join("\n") + "\n");


### PR DESCRIPTION
GNU numfmt rounds the result of `numfmt --round=from-zero --to-unit=1024 -- 6000` to `6` whereas uutils numfmt doesn't do any rounding in this case and returns `5.859375`. The rounding works fine, however, if the precision is > 0, for example, if `6000` is changed to `6000.0` (precision = 1), both tools return `5.9`.

This PR fixes this issue and makes the tests `round-1`, `round-1-up`, `round-1-down`, `round-1-to-zero`, and `round-1-near` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.