### PR TITLE
numfmt: allow hyphen values for --field option

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -275,6 +275,7 @@ pub fn uu_app() -> Command {
                 .long(options::FIELD)
                 .help("replace the numbers in these input fields; see FIELDS below")
                 .value_name("FIELDS")
+                .allow_hyphen_values(true)
                 .default_value(options::FIELD_DEFAULT),
         )
         .arg(

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -376,6 +376,14 @@ fn test_format_selected_fields() {
 }
 
 #[test]
+fn test_format_implied_range_and_field() {
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "-2,4", "1K 2K 3K 4K 5K 6K"])
+        .succeeds()
+        .stdout_only("1000 2000 3K 4000 5K 6K\n");
+}
+
+#[test]
 fn test_should_succeed_if_selected_field_out_of_range() {
     new_ucmd!()
         .args(&["--from=auto", "--field", "9", "1K 2K 3K"])


### PR DESCRIPTION
When specifying `--field -2,4`, GNU numfmt interprets it as the range `1-2` and the field `4` whereas uutils numfmt fails with a clap error because of the `-`. This PR fixes this issue and makes the tests `field-range-14` and `field-range-15` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.