### PR TITLE
mktemp: allow default missing value

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -440,6 +440,9 @@ pub fn uu_app() -> Command {
                      may contain slashes, but mktemp creates only the final component",
                 )
                 .value_name("DIR")
+                // Allows use of default argument just by setting --tmpdir. Else,
+                // use provided input to generate tmpdir
+                .num_args(0..=1)
                 .value_hint(clap::ValueHint::DirPath),
         )
         .arg(

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -825,3 +825,9 @@ fn test_nonexistent_dir_prefix() {
         );
     }
 }
+
+#[test]
+fn test_default_missing_value() {
+    let scene = TestScenario::new(util_name!());
+    scene.ucmd().arg("-d").arg("--tmpdir").succeeds();
+}


### PR DESCRIPTION
Hello,

This PR closes issue #4075, where `--tmpdir` would not work when no value was set. 