### PR TITLE
numfmt: allow "-" in field list

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -158,12 +158,15 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         Ok(0)
     }?;
 
-    let fields = match args.get_one::<String>(options::FIELD).unwrap().as_str() {
-        "-" => vec![Range {
+    let fields = args.get_one::<String>(options::FIELD).unwrap().as_str();
+    // a lone "-" means "all fields", even as part of a list of fields
+    let fields = if fields.split(',').any(|x| x == "-") {
+        vec![Range {
             low: 1,
             high: std::usize::MAX,
-        }],
-        v => Range::from_list(v)?,
+        }]
+    } else {
+        Range::from_list(fields)?
     };
 
     let format = match args.get_one::<String>(options::FORMAT) {

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -401,10 +401,14 @@ fn test_format_selected_field_range() {
 
 #[test]
 fn test_format_all_fields() {
-    new_ucmd!()
-        .args(&["--from=auto", "--field", "-", "1K 2K 3K 4K 5K 6K"])
-        .succeeds()
-        .stdout_only("1000 2000 3000 4000 5000 6000\n");
+    let all_fields_patterns = vec!["-", "-,3", "3,-", "1,-,3"];
+
+    for pattern in all_fields_patterns {
+        new_ucmd!()
+            .args(&["--from=auto", "--field", pattern, "1K 2K 3K 4K 5K 6K"])
+            .succeeds()
+            .stdout_only("1000 2000 3000 4000 5000 6000\n");
+    }
 }
 
 #[test]


### PR DESCRIPTION
GNU numfmt allows `-` (all fields) in a list of fields, for example `--field 1,-,3`, whereas uutils numfmt shows an `invalid range with no endpoint` error. This PR fixes this issue and makes the test `field-range-19` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.