### PR TITLE
numfmt: allow ' ' as field separator

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -160,7 +160,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
 
     let fields = args.get_one::<String>(options::FIELD).unwrap().as_str();
     // a lone "-" means "all fields", even as part of a list of fields
-    let fields = if fields.split(',').any(|x| x == "-") {
+    let fields = if fields.split(&[',', ' ']).any(|x| x == "-") {
         vec![Range {
             low: 1,
             high: std::usize::MAX,

--- a/src/uucore/src/lib/mods/ranges.rs
+++ b/src/uucore/src/lib/mods/ranges.rs
@@ -75,7 +75,7 @@ impl Range {
     pub fn from_list(list: &str) -> Result<Vec<Self>, String> {
         let mut ranges = Vec::new();
 
-        for item in list.split(',') {
+        for item in list.split(&[',', ' ']) {
             let range_item = FromStr::from_str(item)
                 .map_err(|e| format!("range {} was invalid: {}", item.quote(), e))?;
             ranges.push(range_item);

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -373,6 +373,11 @@ fn test_format_selected_fields() {
         .args(&["--from=auto", "--field", "1,4,3", "1K 2K 3K 4K 5K 6K"])
         .succeeds()
         .stdout_only("1000 2K 3000 4000 5K 6K\n");
+
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "1,4 3", "1K 2K 3K 4K 5K 6K"])
+        .succeeds()
+        .stdout_only("1000 2K 3000 4000 5K 6K\n");
 }
 
 #[test]
@@ -401,7 +406,7 @@ fn test_format_selected_field_range() {
 
 #[test]
 fn test_format_all_fields() {
-    let all_fields_patterns = vec!["-", "-,3", "3,-", "1,-,3"];
+    let all_fields_patterns = vec!["-", "-,3", "3,-", "1,-,3", "- 3"];
 
     for pattern in all_fields_patterns {
         new_ucmd!()


### PR DESCRIPTION
GNU numfmt allows ' ' (space) as a field separator, for example `--field "1,2 4"`, whereas uutils numfmt shows an error. This PR fixes this issue and makes the test `field-range-18` in https://github.com/coreutils/coreutils/blob/master/tests/misc/numfmt.pl pass.