### PR TITLE
cp: require preserve only certain attributes

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -405,12 +405,7 @@ pub(crate) fn copy_directory(
         }
     }
     // Copy the attributes from the root directory to the target directory.
-    copy_attributes(
-        root,
-        target,
-        &options.preserve_attributes,
-        &options.require_preserve_attributes,
-    )?;
+    copy_attributes(root, target, &options.attributes)?;
     Ok(())
 }
 

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -405,7 +405,12 @@ pub(crate) fn copy_directory(
         }
     }
     // Copy the attributes from the root directory to the target directory.
-    copy_attributes(root, target, &options.preserve_attributes)?;
+    copy_attributes(
+        root,
+        target,
+        &options.preserve_attributes,
+        &options.require_preserve_attributes,
+    )?;
     Ok(())
 }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -188,6 +188,8 @@ pub enum Preserve {
 }
 
 impl Preserve {
+    /// Preservation level should only increase, with no preservation being the lowest option,
+    /// preserve but don't require - middle, and preserve and require - top.
     pub(crate) fn max(&self, other: Self) -> Self {
         match (self, other) {
             (Self::Yes { required: true }, _) | (_, Self::Yes { required: true }) => {
@@ -698,6 +700,10 @@ impl Attributes {
         }
     }
 
+    /// Tries to match string containing a parameter to preserve with the corresponding entry in the
+    /// Attributes struct. The values are maximized, which means that, when the Attributes are
+    /// initialized with some preserve levels, and later found in the `--preserve=...` values, they
+    /// are updated to maximum of the one set already and the one found in the string from the user.
     fn try_set_from_string(&mut self, value: &str) -> Result<(), Error> {
         let preserve_yes_required = Preserve::Yes { required: true };
 
@@ -1011,6 +1017,8 @@ fn preserve_hardlinks(
     Ok(found_hard_link)
 }
 
+/// When handling errors, we don't always want to show them to the user. This function handles that.
+/// If the error is printed, returns true, false otherwise.
 fn show_error_if_needed(error: &Error) -> bool {
     match error {
         // When using --no-clobber, we don't want to show
@@ -1167,6 +1175,9 @@ impl OverwriteMode {
     }
 }
 
+/// Handles errors for attributes preservation. If the attribute is not required, and
+/// errored, tries to show error (see `show_error_if_needed` for additional behaviour details).
+/// If it's required, then the error is thrown.
 fn handle_preserve<F: Fn() -> CopyResult<()>>(p: &Preserve, f: F) -> CopyResult<()> {
     match p {
         Preserve::No => {}

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -799,14 +799,8 @@ impl Options {
         };
 
         #[cfg(not(feature = "feat_selinux"))]
-        if let Preserve::Yes { required } = attributes.context {
-            let selinux_disabled_error =
-                Error::Error("SELinux was not enabled during the compile time!".to_string());
-            if required {
-                return Err(selinux_disabled_error);
-            } else {
-                show_error_if_needed(&selinux_disabled_error);
-            }
+        if let Preserve::Yes { required : true } = attributes.context {
+            show_warning!("The context attribute will not be copied, because cp was compiled without SELinux support!");
         }
 
         let options = Self {

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -799,8 +799,14 @@ impl Options {
         };
 
         #[cfg(not(feature = "feat_selinux"))]
-        if let Preserve::Yes { required : true } = attributes.context {
-            show_warning!("The context attribute will not be copied, because cp was compiled without SELinux support!");
+        if let Preserve::Yes { required } = attributes.context {
+            let selinux_disabled_error =
+                Error::Error("SELinux was not enabled during the compile time!".to_string());
+            if required {
+                return Err(selinux_disabled_error);
+            } else {
+                show_error_if_needed(&selinux_disabled_error);
+            }
         }
 
         let options = Self {

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -701,20 +701,18 @@ impl Attributes {
     }
 
     /// Tries to match string containing a parameter to preserve with the corresponding entry in the
-    /// Attributes struct. The values are maximized, which means that, when the Attributes are
-    /// initialized with some preserve levels, and later found in the `--preserve=...` values, they
-    /// are updated to maximum of the one set already and the one found in the string from the user.
+    /// Attributes struct.
     fn try_set_from_string(&mut self, value: &str) -> Result<(), Error> {
         let preserve_yes_required = Preserve::Yes { required: true };
 
         match &*value.to_lowercase() {
-            "mode" => self.mode = self.mode.max(preserve_yes_required),
+            "mode" => self.mode = preserve_yes_required,
             #[cfg(unix)]
-            "ownership" => self.ownership = self.ownership.max(preserve_yes_required),
-            "timestamps" => self.timestamps = self.timestamps.max(preserve_yes_required),
-            "context" => self.context = self.context.max(preserve_yes_required),
-            "links" => self.links = self.links.max(preserve_yes_required),
-            "xattr" => self.xattr = self.xattr.max(preserve_yes_required),
+            "ownership" => self.ownership = preserve_yes_required,
+            "timestamps" => self.timestamps = preserve_yes_required,
+            "context" => self.context = preserve_yes_required,
+            "links" => self.links = preserve_yes_required,
+            "xattr" => self.xattr = preserve_yes_required,
             _ => {
                 return Err(Error::InvalidArgument(format!(
                     "invalid attribute {}",

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1174,7 +1174,7 @@ impl OverwriteMode {
 }
 
 /// Handles errors for attributes preservation. If the attribute is not required, and
-/// errored, tries to show error (see `show_error_if_needed` for additional behaviour details).
+/// errored, tries to show error (see `show_error_if_needed` for additional behavior details).
 /// If it's required, then the error is thrown.
 fn handle_preserve<F: Fn() -> CopyResult<()>>(p: &Preserve, f: F) -> CopyResult<()> {
     match p {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -957,7 +957,6 @@ fn test_cp_preserve_xattr() {
     // NOTICE: the ownership is not modified on the src file, because that requires root permissions
     let metadata_src = at.metadata(src_file);
     let metadata_dst = at.metadata(dst_file);
-    assert_ne!(metadata_src.mode(), metadata_dst.mode());
     assert_ne!(metadata_src.atime(), metadata_dst.atime());
     assert_ne!(metadata_src.atime_nsec(), metadata_dst.atime_nsec());
     assert_ne!(metadata_src.mtime(), metadata_dst.mtime());

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -908,7 +908,6 @@ fn test_cp_preserve_no_args() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_cp_preserve_all() {
     let (at, mut ucmd) = at_and_ucmd!();
     let src_file = "a";
@@ -916,6 +915,7 @@ fn test_cp_preserve_all() {
 
     // Prepare the source file
     at.touch(src_file);
+    #[cfg(unix)]
     at.set_mode(src_file, 0o0500);
 
     // TODO: create a destination that does not allow copying of xattr and context
@@ -925,11 +925,14 @@ fn test_cp_preserve_all() {
         .arg("--preserve=all")
         .succeeds();
 
-    // Assert that the mode, ownership, and timestamps are preserved
-    // NOTICE: the ownership is not modified on the src file, because that requires root permissions
-    let metadata_src = at.metadata(src_file);
-    let metadata_dst = at.metadata(dst_file);
-    assert_metadata_eq!(metadata_src, metadata_dst);
+    #[cfg(unix)]
+    {
+        // Assert that the mode, ownership, and timestamps are preserved
+        // NOTICE: the ownership is not modified on the src file, because that requires root permissions
+        let metadata_src = at.metadata(src_file);
+        let metadata_dst = at.metadata(dst_file);
+        assert_metadata_eq!(metadata_src, metadata_dst);
+    }
 }
 
 #[test]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -22,9 +22,7 @@ use filetime::FileTime;
 use rlimit::Resource;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::fs as std_fs;
-#[cfg(not(target_os = "freebsd"))]
 use std::thread::sleep;
-#[cfg(not(target_os = "freebsd"))]
 use std::time::Duration;
 
 static TEST_EXISTING_FILE: &str = "existing_file.txt";

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -957,7 +957,8 @@ fn test_cp_preserve_xattr() {
         .arg("--preserve=xattr")
         .succeeds();
 
-    #[cfg(not(target_os = "freebsd"))]
+    // FIXME: macos copy keeps the original mtime
+    #[cfg(not(any(target_os = "freebsd", target_os = "macos")))]
     {
         // Assert that the mode, ownership, and timestamps are *NOT* preserved
         // NOTICE: the ownership is not modified on the src file, because that requires root permissions

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -930,6 +930,16 @@ fn test_cp_preserve_xattr_succeeds() {
 }
 
 #[test]
+#[cfg(any(target_os = "android"))]
+fn test_cp_preserve_xattr_fails_on_android() {
+    new_ucmd!()
+        .arg(TEST_COPY_FROM_FOLDER_FILE)
+        .arg(TEST_HELLO_WORLD_DEST)
+        .arg("--preserve=xattr")
+        .fails();
+}
+
+#[test]
 // For now, disable the test on Windows. Symlinks aren't well support on Windows.
 // It works on Unix for now and it works locally when run from a powershell
 #[cfg(not(windows))]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -957,12 +957,15 @@ fn test_cp_preserve_xattr() {
         .arg("--preserve=xattr")
         .succeeds();
 
-    // Assert that the mode, ownership, and timestamps are *NOT* preserved
-    // NOTICE: the ownership is not modified on the src file, because that requires root permissions
-    let metadata_src = at.metadata(src_file);
-    let metadata_dst = at.metadata(dst_file);
-    assert_ne!(metadata_src.mtime(), metadata_dst.mtime());
-    // TODO: verify access time as well. It shouldn't change, however, it does change in this test.
+    #[cfg(not(target_os = "freebsd"))]
+    {
+        // Assert that the mode, ownership, and timestamps are *NOT* preserved
+        // NOTICE: the ownership is not modified on the src file, because that requires root permissions
+        let metadata_src = at.metadata(src_file);
+        let metadata_dst = at.metadata(dst_file);
+        assert_ne!(metadata_src.mtime(), metadata_dst.mtime());
+        // TODO: verify access time as well. It shouldn't change, however, it does change in this test.
+    }
 }
 
 #[test]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -908,6 +908,28 @@ fn test_cp_preserve_no_args() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_cp_preserve_all() {
+    // TODO: create a destination that does not allow copying of xattr and context
+    new_ucmd!()
+        .arg(TEST_COPY_FROM_FOLDER_FILE)
+        .arg(TEST_HELLO_WORLD_DEST)
+        .arg("--preserve=all")
+        .succeeds();
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_preserve_xattr() {
+    // TODO: create a destination that does not allow copying of xattr and context
+    new_ucmd!()
+        .arg(TEST_COPY_FROM_FOLDER_FILE)
+        .arg(TEST_HELLO_WORLD_DEST)
+        .arg("--preserve=xattr")
+        .succeeds();
+}
+
+#[test]
 // For now, disable the test on Windows. Symlinks aren't well support on Windows.
 // It works on Unix for now and it works locally when run from a powershell
 #[cfg(not(windows))]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -909,7 +909,7 @@ fn test_cp_preserve_no_args() {
 
 #[test]
 #[cfg(unix)]
-fn test_cp_preserve_all() {
+fn test_cp_preserve_all_succeeds() {
     // TODO: create a destination that does not allow copying of xattr and context
     new_ucmd!()
         .arg(TEST_COPY_FROM_FOLDER_FILE)
@@ -919,8 +919,8 @@ fn test_cp_preserve_all() {
 }
 
 #[test]
-#[cfg(unix)]
-fn test_cp_preserve_xattr() {
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_cp_preserve_xattr_succeeds() {
     // TODO: create a destination that does not allow copying of xattr and context
     new_ucmd!()
         .arg(TEST_COPY_FROM_FOLDER_FILE)

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -923,7 +923,7 @@ fn test_cp_preserve_all() {
         .arg("--preserve=all")
         .succeeds();
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "freebsd")))]
     {
         // Assert that the mode, ownership, and timestamps are preserved
         // NOTICE: the ownership is not modified on the src file, because that requires root permissions
@@ -941,9 +941,9 @@ fn test_cp_preserve_xattr() {
     let dst_file = "b";
 
     // Prepare the source file
-    at.make_file(src_file)
-        .set_permissions(PermissionsExt::from_mode(0o0500))
-        .unwrap();
+    at.touch(src_file);
+    #[cfg(unix)]
+    at.set_mode(src_file, 0o0500);
 
     // Sleep so that the time stats are different
     sleep(Duration::from_secs(1));

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -966,6 +966,16 @@ fn test_cp_preserve_xattr() {
 }
 
 #[test]
+#[cfg(all(target_os = "linux", not(feature = "feat_selinux")))]
+fn test_cp_preserve_all_context_fails_on_non_selinux() {
+    new_ucmd!()
+        .arg(TEST_COPY_FROM_FOLDER_FILE)
+        .arg(TEST_HELLO_WORLD_DEST)
+        .arg("--preserve=all,context")
+        .fails();
+}
+
+#[test]
 #[cfg(any(target_os = "android"))]
 fn test_cp_preserve_xattr_fails_on_android() {
     // Because of the SELinux extended attributes used on Android, trying to copy extended

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -909,29 +909,63 @@ fn test_cp_preserve_no_args() {
 
 #[test]
 #[cfg(unix)]
-fn test_cp_preserve_all_succeeds() {
+fn test_cp_preserve_all() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let src_file = "a";
+    let dst_file = "b";
+
+    // Prepare the source file
+    at.touch(src_file);
+    at.set_mode(src_file, 0o0500);
+
     // TODO: create a destination that does not allow copying of xattr and context
-    new_ucmd!()
-        .arg(TEST_COPY_FROM_FOLDER_FILE)
-        .arg(TEST_HELLO_WORLD_DEST)
+    // Copy
+    ucmd.arg(src_file)
+        .arg(dst_file)
         .arg("--preserve=all")
         .succeeds();
+
+    // Assert that the mode, ownership, and timestamps are preserved
+    // NOTICE: the ownership is not modified on the src file, because that requires root permissions
+    let metadata_src = at.metadata(src_file);
+    let metadata_dst = at.metadata(dst_file);
+    assert_metadata_eq!(metadata_src, metadata_dst);
 }
 
 #[test]
 #[cfg(all(unix, not(target_os = "android")))]
-fn test_cp_preserve_xattr_succeeds() {
+fn test_cp_preserve_xattr() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let src_file = "a";
+    let dst_file = "b";
+
+    // Prepare the source file
+    at.touch(src_file);
+    at.set_mode(src_file, 0o0500);
+
     // TODO: create a destination that does not allow copying of xattr and context
-    new_ucmd!()
-        .arg(TEST_COPY_FROM_FOLDER_FILE)
-        .arg(TEST_HELLO_WORLD_DEST)
+    // Copy
+    ucmd.arg(src_file)
+        .arg(dst_file)
         .arg("--preserve=xattr")
         .succeeds();
+
+    // Assert that the mode, ownership, and timestamps are *NOT* preserved
+    // NOTICE: the ownership is not modified on the src file, because that requires root permissions
+    let metadata_src = at.metadata(src_file);
+    let metadata_dst = at.metadata(dst_file);
+    assert_ne!(metadata_src.mode(), metadata_dst.mode());
+    assert_ne!(metadata_src.atime(), metadata_dst.atime());
+    assert_ne!(metadata_src.atime_nsec(), metadata_dst.atime_nsec());
+    assert_ne!(metadata_src.mtime(), metadata_dst.mtime());
 }
 
 #[test]
 #[cfg(any(target_os = "android"))]
 fn test_cp_preserve_xattr_fails_on_android() {
+    // Because of the SELinux extended attributes used on Android, trying to copy extended
+    // attributes has to fail in this case, since we specify `--preserve=xattr` and this puts it
+    // into the required attributes
     new_ucmd!()
         .arg(TEST_COPY_FROM_FOLDER_FILE)
         .arg(TEST_HELLO_WORLD_DEST)

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -943,8 +943,12 @@ fn test_cp_preserve_xattr() {
     let dst_file = "b";
 
     // Prepare the source file
-    at.touch(src_file);
-    at.set_mode(src_file, 0o0500);
+    at.make_file(src_file)
+        .set_permissions(PermissionsExt::from_mode(0o0500))
+        .unwrap();
+
+    // Sleep so that the time stats are different
+    sleep(Duration::from_secs(1));
 
     // TODO: create a destination that does not allow copying of xattr and context
     // Copy
@@ -957,9 +961,8 @@ fn test_cp_preserve_xattr() {
     // NOTICE: the ownership is not modified on the src file, because that requires root permissions
     let metadata_src = at.metadata(src_file);
     let metadata_dst = at.metadata(dst_file);
-    assert_ne!(metadata_src.atime(), metadata_dst.atime());
-    assert_ne!(metadata_src.atime_nsec(), metadata_dst.atime_nsec());
     assert_ne!(metadata_src.mtime(), metadata_dst.mtime());
+    // TODO: verify access time as well. It shouldn't change, however, it does change in this test.
 }
 
 #[test]


### PR DESCRIPTION
In GNU cp, there's a lot of special handling of errors based on using `-a`, `-p`, `--preserve=all`, `--preserve=xattr,context` etc. which is not handled properly at the moment. In this PR, an analogous behavior to that of `require_preserve_xattr`, `require_preserve_context`, and `require_preserve` flags in GNU cp code is implemented.

Somethings left todo are testing xattr permission denied case (outside of Android test), and also context permission denied case. One idea is making a simple user-space fuse FS with advanced xattr modification permission controls. This will be implemented in a separate PR here - https://github.com/uutils/coreutils/pull/4100.

Original PR: https://github.com/uutils/coreutils/pull/4095 (started implemeting testfs there, but it's a bit out of scope, so, I'm separating these PR's).

Closes #4079.