### PR TITLE
Weird env variable names should trigger an error.

### DIFF
--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -40,16 +40,21 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     }
 
-    let mut not_found = false;
+    let mut error_found = false;
     for env_var in variables {
+        // we silently ignore a=b as variable but we trigger an error
+        if env_var.contains('=') {
+            error_found = true;
+            continue;
+        }
         if let Ok(var) = env::var(env_var) {
             print!("{}{}", var, separator);
         } else {
-            not_found = true;
+            error_found = true;
         }
     }
 
-    if not_found {
+    if error_found {
         Err(1.into())
     } else {
         Ok(())

--- a/tests/by-util/test_printenv.rs
+++ b/tests/by-util/test_printenv.rs
@@ -28,3 +28,12 @@ fn test_get_var() {
     assert!(!result.stdout_str().is_empty());
     assert_eq!(result.stdout_str().trim(), "VALUE");
 }
+
+#[test]
+fn test_ignore_equal_var() {
+    let scene = TestScenario::new(util_name!());
+    // tested by gnu/tests/misc/printenv.sh
+    let result = scene.ucmd().env("a=b", "c").arg("a=b").fails();
+
+    assert!(result.stdout_str().is_empty());
+}


### PR DESCRIPTION
For example `env a=b=c printenv a=b` should fail

Tested by tests/misc/printenv.sh