### PR TITLE
cp: make `--preserve` use the defaults when empty

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -745,7 +745,12 @@ impl Options {
                             attributes.push(Attribute::from_str(attribute_str)?);
                         }
                     }
-                    attributes
+                    // `--preserve` case, use the defaults
+                    if attributes.is_empty() {
+                        DEFAULT_ATTRIBUTES.to_vec()
+                    } else {
+                        attributes
+                    }
                 }
             }
         } else if matches.get_flag(options::ARCHIVE) {


### PR DESCRIPTION
`cp --preserve` with no arguments doesn't use the default attributes. This PR fixes it.

Tests for various preserve cases will be added here: https://github.com/uutils/coreutils/pull/4099.

Closes #4122.