### PR TITLE
`sort`: allow a sort mode to appear multiple times

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -458,7 +458,7 @@ impl KeySettings {
     }
 
     fn set_sort_mode(&mut self, mode: SortMode) -> Result<(), String> {
-        if self.mode != SortMode::Default {
+        if self.mode != SortMode::Default && self.mode != mode {
             return Err(format!(
                 "options '-{}{}' are incompatible",
                 self.mode.get_short_name().unwrap(),

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1156,3 +1156,8 @@ fn test_tmp_files_deleted_on_sigint() {
     // `sort` should have deleted the temporary directory again.
     assert!(read_dir(at.plus("tmp_dir")).unwrap().next().is_none());
 }
+
+#[test]
+fn test_same_sort_mode_twice() {
+    new_ucmd!().args(&["-k", "2n,2n", "empty.txt"]).succeeds();
+}


### PR DESCRIPTION
A test case for this is `sort -k 2n,2n` which should be accepted, because `n` is compatible with itself.

I think the only case we were missing was the case where a mode is given twice. All other combinations are probably incompatible.

Resolves #4129.