### PR TITLE
`tail`: Refactor handling of warnings and early exits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,6 +2984,7 @@ dependencies = [
 name = "uu_tail"
 version = "0.0.16"
 dependencies = [
+ "atty",
  "clap",
  "libc",
  "memchr",

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -22,6 +22,7 @@ memchr = "2.5.0"
 notify = { version = "=5.0.0", features=["macos_kqueue"]}
 uucore = { version=">=0.0.16", package="uucore", path="../../uucore", features=["ringbuffer", "lines"] }
 same-file = "1.0.6"
+atty = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_System_Threading", "Win32_Foundation"] }

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -7,7 +7,9 @@
 //! or at the end of piped stdin with [`LinesChunk`] or [`BytesChunk`].
 //!
 //! Use [`ReverseChunks::new`] to create a new iterator over chunks of bytes from the file.
+
 // spell-checker:ignore (ToDO) filehandle BUFSIZ
+
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{BufRead, Read, Seek, SeekFrom, Write};

--- a/src/uu/tail/src/follow/files.rs
+++ b/src/uu/tail/src/follow/files.rs
@@ -13,7 +13,6 @@ use std::collections::hash_map::Keys;
 use std::collections::HashMap;
 use std::fs::{File, Metadata};
 use std::io::{stdout, BufRead, BufReader, BufWriter};
-
 use std::path::{Path, PathBuf};
 use uucore::error::UResult;
 

--- a/src/uu/tail/src/follow/mod.rs
+++ b/src/uu/tail/src/follow/mod.rs
@@ -6,4 +6,4 @@
 mod files;
 mod watch;
 
-pub use watch::{follow, WatcherService};
+pub use watch::{follow, Observer};

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -107,6 +107,12 @@ impl Observer {
         files: FileHandling,
         pid: platform::Pid,
     ) -> Self {
+        let pid = if platform::supports_pid_checks(pid) {
+            pid
+        } else {
+            0
+        };
+
         Self {
             retry,
             follow,

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -13,8 +13,7 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher, WatcherKind};
 use std::collections::VecDeque;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::{self, channel, Receiver};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UResult, USimpleError};
 use uucore::show_error;
@@ -81,7 +80,7 @@ impl WatcherRx {
     }
 }
 
-pub struct WatcherService {
+pub struct Observer {
     /// Whether --retry was given on the command line
     pub retry: bool,
 
@@ -92,17 +91,21 @@ pub struct WatcherService {
     /// platform specific event driven method. Since `use_polling` is subject to
     /// change during runtime it is moved out of [`Settings`].
     pub use_polling: bool,
+
     pub watcher_rx: Option<WatcherRx>,
     pub orphans: Vec<PathBuf>,
     pub files: FileHandling,
+
+    pub pid: platform::Pid,
 }
 
-impl WatcherService {
+impl Observer {
     pub fn new(
         retry: bool,
         follow: Option<FollowMode>,
         use_polling: bool,
         files: FileHandling,
+        pid: platform::Pid,
     ) -> Self {
         Self {
             retry,
@@ -111,6 +114,7 @@ impl WatcherService {
             watcher_rx: None,
             orphans: Vec::new(),
             files,
+            pid,
         }
     }
 
@@ -120,6 +124,7 @@ impl WatcherService {
             settings.follow,
             settings.use_polling,
             FileHandling::from(settings),
+            settings.pid,
         )
     }
 
@@ -460,14 +465,12 @@ impl WatcherService {
     }
 }
 
-pub fn follow(mut watcher_service: WatcherService, settings: &Settings) -> UResult<()> {
-    if watcher_service.files.no_files_remaining(settings)
-        && !watcher_service.files.only_stdin_remaining()
-    {
+pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
+    if observer.files.no_files_remaining(settings) && !observer.files.only_stdin_remaining() {
         return Err(USimpleError::new(1, text::NO_FILES_REMAINING.to_string()));
     }
 
-    let mut process = platform::ProcessChecker::new(settings.pid);
+    let mut process = platform::ProcessChecker::new(observer.pid);
 
     let mut _event_counter = 0;
     let mut _timeout_counter = 0;
@@ -478,7 +481,7 @@ pub fn follow(mut watcher_service: WatcherService, settings: &Settings) -> UResu
 
         // If `--pid=p`, tail checks whether process p
         // is alive at least every `--sleep-interval=N` seconds
-        if settings.follow.is_some() && settings.pid != 0 && process.is_dead() {
+        if settings.follow.is_some() && observer.pid != 0 && process.is_dead() {
             // p is dead, tail will also terminate
             break;
         }
@@ -487,22 +490,20 @@ pub fn follow(mut watcher_service: WatcherService, settings: &Settings) -> UResu
         // If a path becomes an orphan during runtime, it will be added to orphans.
         // To be able to differentiate between the cases of test_retry8 and test_retry9,
         // here paths will not be removed from orphans if the path becomes available.
-        if watcher_service.follow_name_retry() {
-            for new_path in &watcher_service.orphans {
+        if observer.follow_name_retry() {
+            for new_path in &observer.orphans {
                 if new_path.exists() {
-                    let pd = watcher_service.files.get(new_path);
+                    let pd = observer.files.get(new_path);
                     let md = new_path.metadata().unwrap();
                     if md.is_tailable() && pd.reader.is_none() {
                         show_error!(
                             "{} has appeared;  following new file",
                             pd.display_name.quote()
                         );
-                        watcher_service.files.update_metadata(new_path, Some(md));
-                        watcher_service.files.update_reader(new_path)?;
-                        _read_some = watcher_service
-                            .files
-                            .tail_file(new_path, settings.verbose)?;
-                        watcher_service
+                        observer.files.update_metadata(new_path, Some(md));
+                        observer.files.update_reader(new_path)?;
+                        _read_some = observer.files.tail_file(new_path, settings.verbose)?;
+                        observer
                             .watcher_rx
                             .as_mut()
                             .unwrap()
@@ -514,7 +515,7 @@ pub fn follow(mut watcher_service: WatcherService, settings: &Settings) -> UResu
 
         // With  -f, sleep for approximately N seconds (default 1.0) between iterations;
         // We wake up if Notify sends an Event or if we wait more than `sleep_sec`.
-        let rx_result = watcher_service
+        let rx_result = observer
             .watcher_rx
             .as_mut()
             .unwrap()
@@ -529,9 +530,9 @@ pub fn follow(mut watcher_service: WatcherService, settings: &Settings) -> UResu
         match rx_result {
             Ok(Ok(event)) => {
                 if let Some(event_path) = event.paths.first() {
-                    if watcher_service.files.contains_key(event_path) {
+                    if observer.files.contains_key(event_path) {
                         // Handle Event if it is about a path that we are monitoring
-                        paths = watcher_service.handle_event(&event, settings)?;
+                        paths = observer.handle_event(&event, settings)?;
                     }
                 }
             }
@@ -540,8 +541,8 @@ pub fn follow(mut watcher_service: WatcherService, settings: &Settings) -> UResu
                 paths,
             })) if e.kind() == std::io::ErrorKind::NotFound => {
                 if let Some(event_path) = paths.first() {
-                    if watcher_service.files.contains_key(event_path) {
-                        let _ = watcher_service
+                    if observer.files.contains_key(event_path) {
+                        let _ = observer
                             .watcher_rx
                             .as_mut()
                             .unwrap()
@@ -566,16 +567,16 @@ pub fn follow(mut watcher_service: WatcherService, settings: &Settings) -> UResu
             Err(e) => return Err(USimpleError::new(1, format!("RecvTimeoutError: {}", e))),
         }
 
-        if watcher_service.use_polling && settings.follow.is_some() {
+        if observer.use_polling && settings.follow.is_some() {
             // Consider all files to potentially have new content.
             // This is a workaround because `Notify::PollWatcher`
             // does not recognize the "renaming" of files.
-            paths = watcher_service.files.keys().cloned().collect::<Vec<_>>();
+            paths = observer.files.keys().cloned().collect::<Vec<_>>();
         }
 
         // main print loop
         for path in &paths {
-            _read_some = watcher_service.files.tail_file(path, settings.verbose)?;
+            _read_some = observer.files.tail_file(path, settings.verbose)?;
         }
 
         if _timeout_counter == settings.max_unchanged_stats {

--- a/src/uu/tail/src/platform/mod.rs
+++ b/src/uu/tail/src/platform/mod.rs
@@ -11,7 +11,6 @@
 #[cfg(unix)]
 pub use self::unix::{
     //stdin_is_bad_fd, stdin_is_pipe_or_fifo, supports_pid_checks, Pid, ProcessChecker,
-    stdin_is_pipe_or_fifo,
     supports_pid_checks,
     Pid,
     ProcessChecker,

--- a/src/uu/tail/src/platform/unix.rs
+++ b/src/uu/tail/src/platform/unix.rs
@@ -11,8 +11,6 @@
 // spell-checker:ignore (ToDO) stdlib, ISCHR, GETFD
 // spell-checker:ignore (options) EPERM, ENOSYS
 
-use libc::S_IFCHR;
-use nix::sys::stat::fstat;
 use std::io::Error;
 
 pub type Pid = libc::pid_t;
@@ -44,13 +42,6 @@ pub fn supports_pid_checks(pid: self::Pid) -> bool {
 #[inline]
 fn get_errno() -> i32 {
     Error::last_os_error().raw_os_error().unwrap()
-}
-#[inline]
-pub fn stdin_is_pipe_or_fifo() -> bool {
-    // IFCHR means the file (stdin) is a character input device, which is the case of a terminal.
-    // We just need to check if stdin is not a character device here, because we are not interested
-    // in the type of stdin itself.
-    fstat(libc::STDIN_FILENO).map_or(false, |file| file.st_mode as libc::mode_t & S_IFCHR == 0)
 }
 
 //pub fn stdin_is_bad_fd() -> bool {

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -24,58 +24,61 @@ mod paths;
 mod platform;
 pub mod text;
 
+pub use args::uu_app;
+use args::{parse_args, FilterMode, Settings, Signum};
+use chunks::ReverseChunks;
+use follow::Observer;
+use paths::{FileExtTail, HeaderPrinter, Input, InputKind, MetadataExtTail};
 use same_file::Handle;
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, stdin, stdout, BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use uucore::{show, show_error, show_warning};
-
 use uucore::display::Quotable;
 use uucore::error::{get_exit_code, set_exit_code, FromIo, UError, UResult, USimpleError};
-
-pub use args::uu_app;
-use args::{parse_args, FilterMode, Settings, Signum};
-use chunks::ReverseChunks;
-use follow::WatcherService;
-use paths::{FileExtTail, Input, InputKind, InputService, MetadataExtTail};
+use uucore::{show, show_error};
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let settings = parse_args(args)?;
-    uu_tail(&settings)
-}
 
-fn uu_tail(settings: &Settings) -> UResult<()> {
-    // Mimic GNU's tail for `tail -F` and exit immediately
-    let mut input_service = InputService::from(settings);
-    let mut watcher_service = WatcherService::from(settings);
+    let mut observer = Observer::from(&settings);
 
-    if input_service.has_stdin() && watcher_service.follow_name() {
-        return Err(USimpleError::new(
-            1,
-            format!("cannot follow {} by name", text::DASH.quote()),
-        ));
+    match settings.check_warnings() {
+        args::CheckResult::NoPidSupport => observer.pid = 0,
+        args::CheckResult::Ok => {}
     }
 
-    watcher_service.start(settings)?;
+    match settings.verify() {
+        args::VerificationResult::CannotFollowStdinByName => {
+            return Err(USimpleError::new(
+                1,
+                format!("cannot follow {} by name", text::DASH.quote()),
+            ))
+        }
+        // Exit early if we do not output anything. Note, that this may break a pipe
+        // when tail is on the receiving side.
+        args::VerificationResult::NoOutput => return Ok(()),
+        args::VerificationResult::Ok => {}
+    }
+
+    uu_tail(&settings, observer)
+}
+
+fn uu_tail(settings: &Settings, mut observer: Observer) -> UResult<()> {
+    let mut printer = HeaderPrinter::new(settings.verbose, true);
+
+    observer.start(settings)?;
     // Do an initial tail print of each path's content.
     // Add `path` and `reader` to `files` map if `--follow` is selected.
-    for input in &input_service.inputs.clone() {
+    for input in &settings.inputs.clone() {
         match input.kind() {
             InputKind::File(path) if cfg!(not(unix)) || path != &PathBuf::from(text::DEV_STDIN) => {
-                tail_file(
-                    settings,
-                    &mut input_service,
-                    input,
-                    path,
-                    &mut watcher_service,
-                    0,
-                )?;
+                tail_file(settings, &mut printer, input, path, &mut observer, 0)?;
             }
             // File points to /dev/stdin here
             InputKind::File(_) | InputKind::Stdin => {
-                tail_stdin(settings, &mut input_service, input, &mut watcher_service)?;
+                tail_stdin(settings, &mut printer, input, &mut observer)?;
             }
         }
     }
@@ -90,9 +93,8 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
         the input file is not a FIFO, pipe, or regular file, it is unspecified whether or
         not the -f option shall be ignored.
         */
-
-        if !input_service.has_only_stdin() {
-            follow::follow(watcher_service, settings)?;
+        if !settings.has_only_stdin() {
+            follow::follow(observer, settings)?;
         }
     }
 
@@ -105,16 +107,12 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
 
 fn tail_file(
     settings: &Settings,
-    input_service: &mut InputService,
+    header_printer: &mut HeaderPrinter,
     input: &Input,
     path: &Path,
-    watcher_service: &mut WatcherService,
+    observer: &mut Observer,
     offset: u64,
 ) -> UResult<()> {
-    if watcher_service.follow_descriptor_retry() {
-        show_warning!("--retry only effective for the initial open");
-    }
-
     if !path.exists() {
         set_exit_code(1);
         show_error!(
@@ -122,11 +120,11 @@ fn tail_file(
             input.display_name,
             text::NO_SUCH_FILE
         );
-        watcher_service.add_bad_path(path, input.display_name.as_str(), false)?;
+        observer.add_bad_path(path, input.display_name.as_str(), false)?;
     } else if path.is_dir() {
         set_exit_code(1);
 
-        input_service.print_header(input);
+        header_printer.print_input(input);
         let err_msg = "Is a directory".to_string();
 
         show_error!("error reading '{}': {}", input.display_name, err_msg);
@@ -142,16 +140,16 @@ fn tail_file(
                 msg
             );
         }
-        if !(watcher_service.follow_name_retry()) {
+        if !(observer.follow_name_retry()) {
             // skip directory if not retry
             return Ok(());
         }
-        watcher_service.add_bad_path(path, input.display_name.as_str(), false)?;
+        observer.add_bad_path(path, input.display_name.as_str(), false)?;
     } else if input.is_tailable() {
         let metadata = path.metadata().ok();
         match File::open(path) {
             Ok(mut file) => {
-                input_service.print_header(input);
+                header_printer.print_input(input);
                 let mut reader;
                 if !settings.presume_input_pipe
                     && file.is_seekable(if input.is_stdin() { offset } else { 0 })
@@ -163,7 +161,7 @@ fn tail_file(
                     reader = BufReader::new(file);
                     unbounded_tail(&mut reader, settings)?;
                 }
-                watcher_service.add_path(
+                observer.add_path(
                     path,
                     input.display_name.as_str(),
                     Some(Box::new(reader)),
@@ -171,20 +169,20 @@ fn tail_file(
                 )?;
             }
             Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-                watcher_service.add_bad_path(path, input.display_name.as_str(), false)?;
+                observer.add_bad_path(path, input.display_name.as_str(), false)?;
                 show!(e.map_err_context(|| {
                     format!("cannot open '{}' for reading", input.display_name)
                 }));
             }
             Err(e) => {
-                watcher_service.add_bad_path(path, input.display_name.as_str(), false)?;
+                observer.add_bad_path(path, input.display_name.as_str(), false)?;
                 return Err(e.map_err_context(|| {
                     format!("cannot open '{}' for reading", input.display_name)
                 }));
             }
         }
     } else {
-        watcher_service.add_bad_path(path, input.display_name.as_str(), false)?;
+        observer.add_bad_path(path, input.display_name.as_str(), false)?;
     }
 
     Ok(())
@@ -192,9 +190,9 @@ fn tail_file(
 
 fn tail_stdin(
     settings: &Settings,
-    input_service: &mut InputService,
+    header_printer: &mut HeaderPrinter,
     input: &Input,
-    watcher_service: &mut WatcherService,
+    observer: &mut Observer,
 ) -> UResult<()> {
     match input.resolve() {
         // fifo
@@ -211,24 +209,20 @@ fn tail_stdin(
             }
             tail_file(
                 settings,
-                input_service,
+                header_printer,
                 input,
                 &path,
-                watcher_service,
+                observer,
                 stdin_offset,
             )?;
         }
         // pipe
         None => {
-            input_service.print_header(input);
+            header_printer.print_input(input);
             if !paths::stdin_is_bad_fd() {
                 let mut reader = BufReader::new(stdin());
                 unbounded_tail(&mut reader, settings)?;
-                watcher_service.add_stdin(
-                    input.display_name.as_str(),
-                    Some(Box::new(reader)),
-                    true,
-                )?;
+                observer.add_stdin(input.display_name.as_str(), Some(Box::new(reader)), true)?;
             } else {
                 set_exit_code(1);
                 show_error!(
@@ -417,7 +411,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
         FilterMode::Lines(Signum::Negative(count), sep) => {
             let mut chunks = chunks::LinesChunkBuffer::new(*sep, *count);
             chunks.fill(reader)?;
-            chunks.print(writer)?;
+            chunks.print(&mut writer)?;
         }
         FilterMode::Lines(Signum::PlusZero | Signum::Positive(1), _) => {
             io::copy(reader, &mut writer)?;
@@ -441,7 +435,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
         FilterMode::Bytes(Signum::Negative(count)) => {
             let mut chunks = chunks::BytesChunkBuffer::new(*count);
             chunks.fill(reader)?;
-            chunks.print(writer)?;
+            chunks.print(&mut writer)?;
         }
         FilterMode::Bytes(Signum::PlusZero | Signum::Positive(1)) => {
             io::copy(reader, &mut writer)?;

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -42,12 +42,7 @@ use uucore::{show, show_error};
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let settings = parse_args(args)?;
 
-    let mut observer = Observer::from(&settings);
-
-    match settings.check_warnings() {
-        args::CheckResult::NoPidSupport => observer.pid = 0,
-        args::CheckResult::Ok => {}
-    }
+    settings.check_warnings();
 
     match settings.verify() {
         args::VerificationResult::CannotFollowStdinByName => {
@@ -62,11 +57,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         args::VerificationResult::Ok => {}
     }
 
-    uu_tail(&settings, observer)
+    uu_tail(&settings)
 }
 
-fn uu_tail(settings: &Settings, mut observer: Observer) -> UResult<()> {
+fn uu_tail(settings: &Settings) -> UResult<()> {
     let mut printer = HeaderPrinter::new(settings.verbose, true);
+    let mut observer = Observer::from(settings);
 
     observer.start(settings)?;
     // Do an initial tail print of each path's content.

--- a/src/uu/tail/src/text.rs
+++ b/src/uu/tail/src/text.rs
@@ -19,3 +19,5 @@ pub static BACKEND: &str = "kqueue";
 #[cfg(target_os = "windows")]
 pub static BACKEND: &str = "ReadDirectoryChanges";
 pub static FD0: &str = "/dev/fd/0";
+pub static IS_A_DIRECTORY: &str = "Is a directory";
+pub static DEV_TTY: &str = "/dev/tty";

--- a/src/uu/tail/src/text.rs
+++ b/src/uu/tail/src/text.rs
@@ -21,3 +21,4 @@ pub static BACKEND: &str = "ReadDirectoryChanges";
 pub static FD0: &str = "/dev/fd/0";
 pub static IS_A_DIRECTORY: &str = "Is a directory";
 pub static DEV_TTY: &str = "/dev/tty";
+pub static DEV_PTMX: &str = "/dev/ptmx";

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -11,6 +11,7 @@ extern crate tail;
 
 use crate::common::random::*;
 use crate::common::util::*;
+use pretty_assertions::assert_eq;
 use rand::distributions::Alphanumeric;
 use std::char::from_digit;
 use std::io::Write;


### PR DESCRIPTION
Refactor

* printing of warnings because of problematic configuration by the user on the command line
* handling of early exits. 

This pr also adds the missing warning because of `--follow` being ineffective under some special circumstances.

The warnings and early exits are organized in dedidacted methods within the `Settings` struct providing:
* Clearer, less complex control flow and overall code structure
* `args::Settings::from` has no side effects anymore and the methods sole purpose is parsing and storing the initial configuration provided by the user
* It's simpler now to produce the warnings in the same order as gnu's tail does
* Early exits are organized in a more prominent place in the main module `tail`
* Fixes an issue with a warning which was printed multiple times instead of only once at the start of `tail`

This pr also adds more tests which originate from the main refactoring pr #3952. A lot of these tests (besides the ones testing the `warning` functionality) show some broken functionality of `tail` or a bug and are therefore (partly) `disabled_until_fixed`, here. However, many of them were fixed on the way of #3952 and are enabled there.

There's also some additional code cleanup:
* Remove `InputService` and move some of its functionality into `Settings`
* Remove unneeded `stdin_is_pipe_of_fifo` function