### PR TITLE
CI: switch back to use `output-type` in GNU tests with coverage

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -329,9 +329,9 @@ jobs:
         mkdir -p "${COVERAGE_REPORT_DIR}"
         sudo chown -R "$(whoami)" "${COVERAGE_REPORT_DIR}"
         # display coverage files
-        grcov . --output-types files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+        grcov . --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
         # generate coverage report
-        grcov . --output-types lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+        grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
         echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
Switch back to using `output-type` in GNU tests with coverage. In GNU tests with coverage `grcov` is fetched from `crates.io` unlike in our tests, where we are building the latest repository commit. Fixes issue from run: https://github.com/uutils/coreutils/actions/runs/3467904909/jobs/5793205069

`grcov` supported `output-type` after their "breaking" `output-types`-introduction https://github.com/mozilla/grcov/commit/ee1604c22da3558616c4621235ef7890e668a6b2