### PR TITLE
test_cp: temporarily disable non-working test on Android

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2019,7 +2019,8 @@ fn test_copy_same_symlink_no_dereference_dangling() {
     ucmd.args(&["-d", "a", "b"]).succeeds();
 }
 
-#[cfg(not(windows))]
+// TODO: enable for Android, when #3477 solved
+#[cfg(not(any(windows, target_os = "android")))]
 #[test]
 fn test_cp_parents_2_dirs() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Disable the test, until the issue resolved.

Related discussions:
- #4079
- #3477
- #4099