### PR TITLE
`uucore`: add `prompt_yes` macro

### DIFF
--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -11,7 +11,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
 use uucore::fs::{make_path_relative_to, paths_refer_to_same_file};
-use uucore::{format_usage, show_error};
+use uucore::{format_usage, prompt_yes, show_error};
 
 use std::borrow::Cow;
 use std::error::Error;
@@ -19,7 +19,6 @@ use std::ffi::OsString;
 use std::fmt::Display;
 use std::fs;
 
-use std::io::stdin;
 #[cfg(any(unix, target_os = "redox"))]
 use std::os::unix::fs::symlink;
 #[cfg(windows)]
@@ -410,8 +409,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
         match settings.overwrite {
             OverwriteMode::NoClobber => {}
             OverwriteMode::Interactive => {
-                print!("{}: overwrite {}? ", uucore::util_name(), dst.quote());
-                if !read_yes() {
+                if !prompt_yes!("overwrite {}?", dst.quote()) {
                     return Ok(());
                 }
 
@@ -457,17 +455,6 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
         }
     }
     Ok(())
-}
-
-fn read_yes() -> bool {
-    let mut s = String::new();
-    match stdin().read_line(&mut s) {
-        Ok(_) => match s.char_indices().next() {
-            Some((_, x)) => x == 'y' || x == 'Y',
-            _ => false,
-        },
-        _ => false,
-    }
 }
 
 fn simple_backup_path(path: &Path, suffix: &str) -> PathBuf {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -236,7 +236,7 @@ fn test_cp_arg_interactive() {
         .pipe_in("N\n")
         .succeeds()
         .no_stdout()
-        .stderr_is("cp: overwrite 'b'?  [y/N]:");
+        .stderr_is("cp: overwrite 'b'? ");
 }
 
 #[test]

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -117,7 +117,7 @@ fn test_symlink_interactive() {
         .args(&["-i", "-s", file, link])
         .pipe_in("n")
         .succeeds()
-        .no_stderr();
+        .no_stdout();
 
     assert!(at.file_exists(file));
     assert!(!at.is_symlink(link));
@@ -127,7 +127,7 @@ fn test_symlink_interactive() {
         .args(&["-i", "-s", file, link])
         .pipe_in("Yesh") // spell-checker:disable-line
         .succeeds()
-        .no_stderr();
+        .no_stdout();
 
     assert!(at.file_exists(file));
     assert!(at.is_symlink(link));

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -166,7 +166,7 @@ fn test_mv_interactive() {
         .arg(file_b)
         .pipe_in("n")
         .succeeds()
-        .no_stderr();
+        .no_stdout();
 
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -178,7 +178,7 @@ fn test_mv_interactive() {
         .arg(file_b)
         .pipe_in("Yesh") // spell-checker:disable-line
         .succeeds()
-        .no_stderr();
+        .no_stdout();
 
     assert!(!at.file_exists(file_a));
     assert!(at.file_exists(file_b));

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -460,24 +460,10 @@ fn test_rm_prompts() {
     let mut child: Child = scene.ucmd().arg("-ri").arg("a").run_no_wait();
 
     let mut child_stdin = child.stdin.take().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
-    child_stdin.write_all(yes.as_bytes()).unwrap();
-    child_stdin.flush().unwrap();
+    for _ in 0..9 {
+        child_stdin.write_all(yes.as_bytes()).unwrap();
+        child_stdin.flush().unwrap();
+    }
 
     let output = child.wait_with_output().unwrap();
 
@@ -494,10 +480,10 @@ fn test_rm_prompts() {
 
     trimmed_output.sort();
 
-    assert!(trimmed_output.len() == answers.len());
+    assert_eq!(trimmed_output.len(), answers.len());
 
     for (i, checking_string) in trimmed_output.iter().enumerate() {
-        assert!(checking_string == answers[i]);
+        assert_eq!(checking_string, answers[i]);
     }
 
     assert!(!at.dir_exists("a"));
@@ -530,7 +516,10 @@ fn test_rm_force_prompts_order() {
     let output = child.wait_with_output().unwrap();
     let string_output =
         String::from_utf8(output.stderr).expect("Couldn't convert output.stderr to string");
-    assert!(string_output.trim() == "rm: remove regular empty file 'empty'?");
+    assert_eq!(
+        string_output.trim(),
+        "rm: remove regular empty file 'empty'?"
+    );
     assert!(!at.file_exists(empty_file));
 
     at.touch(empty_file);


### PR DESCRIPTION
Several utils (`cp`, `ln`, `rm` and `mv`) have some places where they prompt the user for  `yes` or `no`. Currently, they use custom implementation with slightly different details (different suffix, printing to stdout instead stderr, etc.). Therefore, I wanted to unify them. I've moved `prompt_yes` from `cp` to `uucore` with slight modifications. It supports `format!`-style syntax, puts the util name up from ~and adds `[y/N]:` to the end~.

`cp` had a suffix of `[y/N]:`, but none of the other utils did. GNU also does not have it (not even for `cp`). I removed it because it broke too many GNU tests.