### PR TITLE
uu: use normal use declarations to import macros

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -18,6 +18,9 @@ use indicatif::ProgressBar;
 use uucore::display::Quotable;
 use uucore::error::UIoError;
 use uucore::fs::{canonicalize, FileInformation, MissingHandling, ResolveMode};
+use uucore::show;
+use uucore::show_error;
+use uucore::uio_error;
 use walkdir::{DirEntry, WalkDir};
 
 use crate::{

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -11,11 +11,7 @@
 
 // spell-checker:ignore (ToDO) copydir ficlone fiemap ftruncate linkgs lstat nlink nlinks pathbuf pwrite reflink strs xattrs symlinked deduplicated advcpmv
 
-#[macro_use]
-extern crate quick_error;
-#[macro_use]
-extern crate uucore;
-
+use quick_error::quick_error;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::env;
@@ -40,10 +36,10 @@ use quick_error::ResultExt;
 use uucore::backup_control::{self, BackupMode};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UClapError, UError, UResult, UUsageError};
-use uucore::format_usage;
 use uucore::fs::{
     canonicalize, paths_refer_to_same_file, FileInformation, MissingHandling, ResolveMode,
 };
+use uucore::{crash, crash_if_err, format_usage, show_error, show_warning};
 
 mod copydir;
 use crate::copydir::copy_directory;

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -2,9 +2,6 @@
 // spell-checker:ignore rustdoc
 #![allow(rustdoc::private_intra_doc_links)]
 
-#[macro_use]
-extern crate uucore;
-
 use std::cmp::Ordering;
 use std::io::{self, BufReader};
 use std::{
@@ -16,7 +13,7 @@ use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use regex::Regex;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::format_usage;
+use uucore::{crash_if_err, format_usage};
 
 mod csplit_error;
 mod patterns;

--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -2,6 +2,7 @@
 
 use crate::csplit_error::CsplitError;
 use regex::Regex;
+use uucore::show_warning;
 
 /// The definition of a pattern to match on a line.
 #[derive(Debug)]

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) delim sourcefiles
 
-#[macro_use]
-extern crate uucore;
-
 use bstr::io::BufReadExt;
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::fs::File;
@@ -19,8 +16,8 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 
 use self::searcher::Searcher;
-use uucore::format_usage;
 use uucore::ranges::Range;
+use uucore::{format_usage, show, show_error, show_if_err};
 
 mod searcher;
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-#[macro_use]
-extern crate uucore;
-
 use chrono::prelude::DateTime;
 use chrono::Local;
 use clap::ArgAction;
@@ -37,9 +34,9 @@ use std::{error::Error, fmt::Display};
 use uucore::display::{print_verbatim, Quotable};
 use uucore::error::FromIo;
 use uucore::error::{UError, UResult};
-use uucore::format_usage;
 use uucore::parse_glob;
 use uucore::parse_size::{parse_size, ParseSizeError};
+use uucore::{crash, format_usage, show, show_error, show_warning};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
 #[cfg(windows)]

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -10,13 +10,7 @@
 
 // spell-checker:ignore (ToDO) chdir execvp progname subcommand subcommands unsets setenv putenv spawnp SIGSEGV SIGBUS sigaction
 
-#[macro_use]
-extern crate clap;
-
-#[macro_use]
-extern crate uucore;
-
-use clap::{Arg, ArgAction, Command};
+use clap::{crate_name, crate_version, Arg, ArgAction, Command};
 use ini::Ini;
 #[cfg(unix)]
 use nix::sys::signal::{raise, sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
@@ -29,7 +23,7 @@ use std::os::unix::process::ExitStatusExt;
 use std::process;
 use uucore::display::Quotable;
 use uucore::error::{UClapError, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, show_warning};
 
 const ABOUT: &str = "set each NAME to VALUE in the environment and run COMMAND";
 const USAGE: &str = "{} [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]";

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -9,9 +9,6 @@
 
 // spell-checker:ignore (ToDO) ctype cwidth iflag nbytes nspaces nums tspaces uflag Preprocess
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::error::Error;
 use std::fmt;
@@ -22,7 +19,7 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::format_usage;
+use uucore::{crash, format_usage};
 
 static ABOUT: &str = "Convert tabs in each FILE to spaces, writing to standard output.
  With no FILE, or when FILE is -, read standard input.";

--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -6,9 +6,6 @@
 // * For the full copyright and license information, please view the LICENSE file
 // * that was distributed with this source code.
 
-#[macro_use]
-extern crate uucore;
-
 use std::error::Error;
 use std::fmt::Write as FmtWrite;
 use std::io::BufRead;
@@ -19,6 +16,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 pub use factor::*;
 use uucore::display::Quotable;
 use uucore::error::UResult;
+use uucore::{show_error, show_warning};
 
 mod miller_rabin;
 pub mod numeric;

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) PSKIP linebreak ostream parasplit tabwidth xanti xprefix
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::cmp;
 use std::fs::File;
@@ -17,7 +14,7 @@ use std::io::{stdin, stdout, Write};
 use std::io::{BufReader, BufWriter, Read};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, show_warning};
 
 use self::linebreak::break_lines;
 use self::parasplit::ParagraphStream;

--- a/src/uu/fmt/src/linebreak.rs
+++ b/src/uu/fmt/src/linebreak.rs
@@ -12,6 +12,8 @@ use std::i64;
 use std::io::{BufWriter, Stdout, Write};
 use std::mem;
 
+use uucore::crash;
+
 use crate::parasplit::{ParaWords, Paragraph, WordInfo};
 use crate::FmtOptions;
 

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -15,15 +15,13 @@
 
 // spell-checker:ignore (ToDO) passwd
 
-#[macro_use]
-extern crate uucore;
 use std::error::Error;
 use std::fmt::Display;
 use uucore::{
     display::Quotable,
     entries::{get_groups_gnu, gid2grp, Locate, Passwd},
     error::{UError, UResult},
-    format_usage,
+    format_usage, show,
 };
 
 use clap::{crate_version, Arg, ArgAction, Command};

--- a/src/uu/hashsum/src/digest.rs
+++ b/src/uu/hashsum/src/digest.rs
@@ -6,12 +6,6 @@
 //! [`DigestWriter`] struct provides a wrapper around [`Digest`] that
 //! implements the [`Write`] trait, for use in situations where calling
 //! [`write`] would be useful.
-extern crate digest;
-extern crate md5;
-extern crate sha1;
-extern crate sha2;
-extern crate sha3;
-
 use std::io::Write;
 
 use hex::encode;

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -9,18 +9,13 @@
 
 // spell-checker:ignore (ToDO) algo, algoname, regexes, nread, nonames
 
-#[macro_use]
-extern crate clap;
-
-#[macro_use]
-extern crate uucore;
-
 mod digest;
 
 use self::digest::Digest;
 use self::digest::DigestWriter;
 
 use clap::builder::ValueParser;
+use clap::crate_version;
 use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use hex::encode;
@@ -37,8 +32,10 @@ use std::io::{self, stdin, BufRead, BufReader, Read};
 use std::iter;
 use std::num::ParseIntError;
 use std::path::Path;
+use uucore::crash;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
+use uucore::show_warning;
 
 const NAME: &str = "hashsum";
 

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -36,19 +36,16 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::ffi::CStr;
 use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};
 use uucore::error::UResult;
 use uucore::error::{set_exit_code, USimpleError};
-use uucore::format_usage;
 pub use uucore::libc;
 use uucore::libc::{getlogin, uid_t};
 use uucore::process::{getegid, geteuid, getgid, getuid};
+use uucore::{format_usage, show_error};
 
 macro_rules! cstr2cow {
     ($v:expr) => {

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -9,9 +9,6 @@
 
 mod mode;
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use file_diff::diff;
 use filetime::{set_file_times, FileTime};
@@ -19,10 +16,10 @@ use uucore::backup_control::{self, BackupMode};
 use uucore::display::Quotable;
 use uucore::entries::{grp2gid, usr2uid};
 use uucore::error::{FromIo, UError, UIoError, UResult, UUsageError};
-use uucore::format_usage;
 use uucore::fs::dir_strip_dot_for_creation;
 use uucore::mode::get_umask;
 use uucore::perms::{wrap_chown, Verbosity, VerbosityLevel};
+use uucore::{format_usage, show, show_error, show_if_err, uio_error};
 
 use libc::{getegid, geteuid};
 use std::error::Error;

--- a/src/uu/install/src/mode.rs
+++ b/src/uu/install/src/mode.rs
@@ -22,7 +22,7 @@ pub fn parse(mode_string: &str, considering_dir: bool, umask: u32) -> Result<u32
 #[cfg(any(unix, target_os = "redox"))]
 pub fn chmod(path: &Path, mode: u32) -> Result<(), ()> {
     use std::os::unix::fs::PermissionsExt;
-    use uucore::display::Quotable;
+    use uucore::{display::Quotable, show_error};
     fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|err| {
         show_error!("{}: chmod failed with error {}", path.maybe_quote(), err);
     })

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) autoformat FILENUM whitespaces pairable unpairable nocheck
 
-#[macro_use]
-extern crate uucore;
-
 use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgAction, Command};
 use memchr::{memchr3_iter, memchr_iter};
@@ -25,6 +22,7 @@ use std::num::IntErrorKind;
 use std::os::unix::ffi::OsStrExt;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UError, UResult, USimpleError};
+use uucore::{crash, crash_if_err};
 
 static NAME: &str = "join";
 

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -7,17 +7,14 @@
 
 // spell-checker:ignore (ToDO) signalname pids killpg
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use std::io::Error;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
-use uucore::format_usage;
 use uucore::signals::{signal_by_name_or_value, ALL_SIGNALS};
+use uucore::{format_usage, show};
 
 static ABOUT: &str = "Send signal to processes or list information about signals.";
 const USAGE: &str = "{} [OPTIONS]... PID...";

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -7,14 +7,11 @@
 
 // spell-checker:ignore (ToDO) srcpath targetpath EEXIST
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::format_usage;
 use uucore::fs::{make_path_relative_to, paths_refer_to_same_file};
+use uucore::{format_usage, show_error};
 
 use std::borrow::Cow;
 use std::error::Error;

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -9,12 +9,9 @@
 
 // spell-checker:ignore (ToDO) getlogin userlogin
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Command};
 use std::ffi::CStr;
-use uucore::error::UResult;
+use uucore::{error::UResult, show_error};
 
 extern "C" {
     // POSIX requires using getlogin (or equivalent code)

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) cpio svgz webm somegroup nlink rmvb xspf tabsize dired
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{
     builder::{NonEmptyStringValueParser, ValueParser},
     crate_version, Arg, ArgAction, Command,
@@ -48,7 +45,6 @@ use unicode_width::UnicodeWidthStr;
 use uucore::libc::{dev_t, major, minor};
 #[cfg(unix)]
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
-use uucore::parse_glob;
 use uucore::quoting_style::{escape_name, QuotingStyle};
 use uucore::{
     display::Quotable,
@@ -58,6 +54,7 @@ use uucore::{
     parse_size::parse_size,
     version_cmp::version_cmp,
 };
+use uucore::{parse_glob, show, show_error, show_warning};
 
 #[cfg(not(feature = "selinux"))]
 static CONTEXT_HELP_TEXT: &str = "print any security context of each file (not enabled)";

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) ugoa cmode
 
-#[macro_use]
-extern crate uucore;
-
 use clap::builder::ValueParser;
 use clap::parser::ValuesRef;
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
@@ -18,10 +15,10 @@ use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
 #[cfg(not(windows))]
 use uucore::mode;
 use uucore::{display::Quotable, fs::dir_strip_dot_for_creation};
+use uucore::{format_usage, show, show_if_err};
 
 static DEFAULT_PERM: u32 = 0o755;
 

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -5,15 +5,12 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use libc::mkfifo;
 use std::ffi::CString;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, show};
 
 static NAME: &str = "mkfifo";
 static USAGE: &str = "{} [OPTION]... NAME...";

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -14,9 +14,6 @@ use std::{
     time::Duration,
 };
 
-#[cfg(all(unix, not(target_os = "fuchsia")))]
-extern crate nix;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use crossterm::event::KeyEventKind;
 use crossterm::{

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -10,9 +10,6 @@
 
 mod error;
 
-#[macro_use]
-extern crate uucore;
-
 use clap::builder::ValueParser;
 use clap::{crate_version, error::ErrorKind, Arg, ArgAction, ArgMatches, Command};
 use std::env;
@@ -27,7 +24,7 @@ use std::path::{Path, PathBuf};
 use uucore::backup_control::{self, BackupMode};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, show, show_if_err};
 
 use fs_extra::dir::{move_dir, CopyOptions as DirCopyOptions};
 

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) getpriority execvp setpriority nstr PRIO cstrs ENOENT
 
-#[macro_use]
-extern crate uucore;
-
 use libc::{c_char, c_int, execvp, PRIO_PROCESS};
 use std::ffi::CString;
 use std::io::Error;
@@ -18,7 +15,7 @@ use std::ptr;
 use clap::{crate_version, Arg, ArgAction, Command};
 use uucore::{
     error::{set_exit_code, UClapError, UResult, USimpleError, UUsageError},
-    format_usage,
+    format_usage, show_error, show_warning,
 };
 
 pub mod options {

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) execvp SIGHUP cproc vprocmgr cstrs homeout
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use libc::{c_char, dup2, execvp, signal};
 use libc::{SIGHUP, SIG_IGN};
@@ -22,7 +19,7 @@ use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UClapError, UError, UResult};
-use uucore::format_usage;
+use uucore::{format_usage, show_error};
 
 static ABOUT: &str = "Run COMMAND ignoring hangup signals.";
 static LONG_HELP: &str = "

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -6,6 +6,7 @@ use std::io::BufReader;
 use std::vec::Vec;
 
 use uucore::display::Quotable;
+use uucore::show_error;
 
 pub enum InputSource<'a> {
     FileName(&'a str),

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -8,9 +8,6 @@
 // spell-checker:ignore (clap) dont
 // spell-checker:ignore (ToDO) formatteriteminfo inputdecoder inputoffset mockstream nrofbytes partialreader odfunc multifile exitcode
 
-#[macro_use]
-extern crate uucore;
-
 mod byteorder_io;
 mod formatteriteminfo;
 mod inputdecoder;
@@ -49,6 +46,8 @@ use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::format_usage;
 use uucore::parse_size::ParseSizeError;
+use uucore::show_error;
+use uucore::show_warning;
 
 const PEEK_BUFFER_SIZE: usize = 4; // utf-8 can be 4 bytes
 static ABOUT: &str = "dump files in octal and other formats";

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -6,9 +6,6 @@
 
 // spell-checker:ignore (ToDO) adFfmprt, kmerge
 
-#[macro_use]
-extern crate quick_error;
-
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use itertools::Itertools;
 use quick_error::ResultExt;
@@ -21,6 +18,7 @@ use std::os::unix::fs::FileTypeExt;
 use time::macros::format_description;
 use time::OffsetDateTime;
 
+use quick_error::quick_error;
 use uucore::display::Quotable;
 use uucore::error::UResult;
 

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -7,17 +7,14 @@
 
 // spell-checker:ignore (ToDO) errno
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::fs;
 use std::io::{stdout, Write};
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
+use uucore::{format_usage, show_error};
 
 const ABOUT: &str = "Print value of a symbolic link or canonical file name.";
 const USAGE: &str = "{} [OPTION]... [FILE]...";

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) retcode
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{
     builder::NonEmptyStringValueParser, crate_version, Arg, ArgAction, ArgMatches, Command,
 };
@@ -17,7 +14,6 @@ use std::{
     io::{stdout, Write},
     path::{Path, PathBuf},
 };
-use uucore::error::UClapError;
 use uucore::fs::make_path_relative_to;
 use uucore::{
     display::{print_verbatim, Quotable},
@@ -25,6 +21,7 @@ use uucore::{
     format_usage,
     fs::{canonicalize, MissingHandling, ResolveMode},
 };
+use uucore::{error::UClapError, show, show_if_err};
 
 static ABOUT: &str = "print the resolved path";
 const USAGE: &str = "{} [OPTION]... FILE...";

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (path) eacces
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, parser::ValueSource, Arg, ArgAction, Command};
 use remove_dir_all::remove_dir_all;
 use std::collections::VecDeque;
@@ -19,7 +16,7 @@ use std::ops::BitOr;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, show_error};
 use walkdir::{DirEntry, WalkDir};
 
 #[derive(Eq, PartialEq, Clone, Copy)]

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) ENOTDIR
 
-#[macro_use]
-extern crate uucore;
-
 use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::ffi::OsString;
@@ -19,7 +16,7 @@ use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, strip_errno, UResult};
 
-use uucore::{format_usage, util_name};
+use uucore::{format_usage, show_error, util_name};
 
 static ABOUT: &str = "Remove the DIRECTORY(ies), if they are empty.";
 const USAGE: &str = "{} [OPTION]... DIRECTORY...";

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -20,10 +20,7 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, util_name};
-
-#[macro_use]
-extern crate uucore;
+use uucore::{format_usage, show, show_if_err, util_name};
 
 const BLOCK_SIZE: usize = 512;
 const NAME_CHARSET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_.";

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -13,9 +13,6 @@
 
 // spell-checker:ignore (misc) HFKJFK Mbdfhn
 
-#[macro_use]
-extern crate uucore;
-
 mod check;
 mod chunks;
 mod custom_str_cmp;

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use tempfile::TempDir;
-use uucore::error::{UResult, USimpleError};
+use uucore::{
+    error::{UResult, USimpleError},
+    show_error,
+};
 
 use crate::SortError;
 

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -5,8 +5,6 @@
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 
-#[macro_use]
-extern crate uucore;
 use clap::builder::ValueParser;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
@@ -15,7 +13,7 @@ use uucore::fsext::{
     pretty_filetype, pretty_fstype, pretty_time, read_fs_list, statfs, BirthTime, FsMeta,
 };
 use uucore::libc::mode_t;
-use uucore::{entries, format_usage};
+use uucore::{entries, format_usage, has, show_error, show_warning};
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::borrow::Cow;

--- a/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
+++ b/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
@@ -1,14 +1,10 @@
 // spell-checker:ignore (ToDO) IOFBF IOLBF IONBF cstdio setvbuf
 
-#[macro_use]
-extern crate cpp;
-
-#[macro_use]
-extern crate uucore;
-
+use cpp::cpp;
 use libc::{c_char, c_int, size_t, FILE, _IOFBF, _IOLBF, _IONBF};
 use std::env;
 use std::ptr;
+use uucore::crash;
 
 cpp! {{
     #include <cstdio>

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -7,9 +7,6 @@
 
 // spell-checker:ignore (ToDO) tempdir dyld dylib dragonflybsd optgrps libstdbuf
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::fs::File;
 use std::io::{self, Write};
@@ -19,8 +16,8 @@ use std::process;
 use tempfile::tempdir;
 use tempfile::TempDir;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
 use uucore::parse_size::parse_size;
+use uucore::{crash, format_usage};
 
 static ABOUT: &str =
     "Run COMMAND, with modified buffering operations for its standard streams.\n\n\
@@ -101,6 +98,8 @@ fn preload_strings() -> (&'static str, &'static str) {
     target_vendor = "apple"
 )))]
 fn preload_strings() -> (&'static str, &'static str) {
+    use uucore::crash;
+
     crash!(1, "Command not supported for this operating system!")
 }
 

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -7,16 +7,13 @@
 
 // spell-checker:ignore (ToDO) sysv
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::fs::File;
 use std::io::{stdin, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, show};
 
 static NAME: &str = "sum";
 static USAGE: &str = "{} [OPTION]... [FILE]...";

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -7,13 +7,14 @@
 
 use crate::paths::Input;
 use crate::{parse, platform, Quotable};
+use clap::crate_version;
 use clap::{parser::ValueSource, Arg, ArgAction, ArgMatches, Command};
 use std::collections::VecDeque;
 use std::ffi::OsString;
 use std::time::Duration;
 use uucore::error::{UResult, USimpleError, UUsageError};
-use uucore::format_usage;
 use uucore::parse_size::{parse_size, ParseSizeError};
+use uucore::{format_usage, show_warning};
 
 const ABOUT: &str = "\
     Print the last 10 lines of each FILE to standard output.\n\

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -17,6 +17,7 @@ use std::sync::mpsc;
 use std::sync::mpsc::{channel, Receiver};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UResult, USimpleError};
+use uucore::show_error;
 
 pub struct WatcherRx {
     watcher: Box<dyn Watcher>,

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -16,13 +16,6 @@
 // spell-checker:ignore (shell/tools)
 // spell-checker:ignore (misc)
 
-#[macro_use]
-extern crate clap;
-
-#[macro_use]
-extern crate uucore;
-extern crate core;
-
 pub mod args;
 pub mod chunks;
 mod follow;
@@ -36,6 +29,7 @@ use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, stdin, stdout, BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use uucore::{show, show_error, show_warning};
 
 use uucore::display::Quotable;
 use uucore::error::{get_exit_code, set_exit_code, FromIo, UError, UResult, USimpleError};

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -5,9 +5,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-#[macro_use]
-extern crate uucore;
-
 use clap::{builder::PossibleValue, crate_version, Arg, ArgAction, Command};
 use retain_mut::RetainMut;
 use std::fs::OpenOptions;
@@ -15,7 +12,7 @@ use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
 use std::path::PathBuf;
 use uucore::display::Quotable;
 use uucore::error::UResult;
-use uucore::format_usage;
+use uucore::{format_usage, show_error};
 
 // spell-checker:ignore nopipe
 

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -8,11 +8,6 @@
 // spell-checker:ignore (ToDO) tstr sigstr cmdname setpgid sigchld getpid
 mod status;
 
-#[macro_use]
-extern crate uucore;
-
-extern crate clap;
-
 use crate::status::ExitStatus;
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::io::ErrorKind;
@@ -20,9 +15,9 @@ use std::process::{self, Child, Stdio};
 use std::time::Duration;
 use uucore::display::Quotable;
 use uucore::error::{UClapError, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
 use uucore::process::ChildExt;
 use uucore::signals::{signal_by_name_or_value, signal_name_by_value};
+use uucore::{format_usage, show_error};
 
 static ABOUT: &str = "Start COMMAND, and kill it if still running after DURATION.";
 const USAGE: &str = "{} [OPTION] DURATION COMMAND...";

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -9,9 +9,6 @@
 // spell-checker:ignore (ToDO) filetime strptime utcoff strs datetime MMDDhhmm clapv PWSTR lpszfilepath hresult mktime YYYYMMDDHHMM YYMMDDHHMM DATETIME YYYYMMDDHHMMS subsecond
 pub extern crate filetime;
 
-#[macro_use]
-extern crate uucore;
-
 use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgAction, ArgGroup, Command};
 use filetime::*;
@@ -22,7 +19,7 @@ use time::macros::{format_description, offset, time};
 use time::Duration;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, show};
 
 static ABOUT: &str = "Update the access and modification times of each FILE to the current time.";
 const USAGE: &str = "{} [OPTION]... [USER]";

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -5,8 +5,6 @@
 
 // spell-checker:ignore (ToDO) allocs bset dflag cflag sflag tflag
 
-extern crate nom;
-
 mod convert;
 mod operation;
 mod unicode_table;

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -9,8 +9,6 @@
 
 // spell-checker:ignore (ToDO) nums aflag uflag scol prevtab amode ctype cwidth nbytes lastcol pctype Preprocess
 
-#[macro_use]
-extern crate uucore;
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::error::Error;
 use std::fmt;
@@ -21,7 +19,7 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::format_usage;
+use uucore::{crash, crash_if_err, format_usage};
 
 static NAME: &str = "unexpand";
 static USAGE: &str = "{} [OPTION]... [FILE]...";

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -7,9 +7,6 @@
 
 // cSpell:ignore wc wc's
 
-#[macro_use]
-extern crate uucore;
-
 mod count_fast;
 mod countable;
 mod word_count;
@@ -18,7 +15,7 @@ use count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast};
 use countable::WordCountable;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
-use uucore::format_usage;
+use uucore::{format_usage, show};
 use word_count::{TitledWordCount, WordCount};
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};

--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -7,10 +7,7 @@
 
 /* last synced with: whoami (GNU coreutils) 8.21 */
 
-#[macro_use]
-extern crate clap;
-
-use clap::Command;
+use clap::{crate_version, Command};
 
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};


### PR DESCRIPTION
Closes #4149.

1. replace `#[macro_use]` with `UseDeclaration`
2. remove unused `extern crate`