### PR TITLE
CI: fix FreeBSD CI passed when tests failed

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -948,7 +948,7 @@ jobs:
           unset FAULT
           cargo build || FAULT=1
           if (test -z "\$FAULT"); then cargo test --features '${{ matrix.job.features }}' || FAULT=1 ; fi
-          if (test -z "\$FAULT"); then cargo test --features '${{ matrix.job.features }}' -p uucore || FAULT=1 ; fi
+          if (test -z "\$FAULT"); then cargo test --all-features -p uucore || FAULT=1 ; fi
           # Clean to avoid to rsync back the files
           cargo clean
           if (test -n "\$FAULT"); then exit 1 ; fi

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -939,14 +939,16 @@ jobs:
           cargo -V
           rustc -V
           #
+          # To ensure that files are cleaned up, we don't want to exit on error
+          set +e
           cd "${WORKSPACE}"
           unset FAULT
           cargo build || FAULT=1
-          cargo test --features "${{ matrix.job.features }}" || FAULT=1
-          cargo test --features "${{ matrix.job.features }}" -p uucore || FAULT=1
+          if (test -z "\$FAULT"); then cargo test --features '${{ matrix.job.features }}' || FAULT=1 ; fi
+          if (test -z "\$FAULT"); then cargo test --features '${{ matrix.job.features }}' -p uucore || FAULT=1 ; fi
           # Clean to avoid to rsync back the files
           cargo clean
-          if (test -n "$FAULT"); then exit 1 ; fi
+          if (test -n "\$FAULT"); then exit 1 ; fi
           EOF
 
   coverage:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -908,6 +908,9 @@ jobs:
           # * NOTE: All steps need to be run in this block, otherwise, we are operating back on the mac host
           set -e
           #
+          # We need a file-descriptor file system to test test_ls::test_ls_io_errors
+          mount -t fdescfs fdesc /dev/fd
+          #
           TEST_USER=tester
           REPO_NAME=${GITHUB_WORKSPACE##*/}
           WORKSPACE_PARENT="/Users/runner/work/${REPO_NAME}"

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -896,7 +896,7 @@ fn test_cp_preserve_no_args() {
         .arg("--preserve")
         .succeeds();
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "freebsd")))]
     {
         // Assert that the mode, ownership, and timestamps are preserved
         // NOTICE: the ownership is not modified on the src file, because that requires root permissions
@@ -1834,7 +1834,7 @@ fn test_copy_through_dangling_symlink_no_dereference_permissions() {
     assert!(at.symlink_exists("d2"), "symlink wasn't created");
 
     // `-p` means `--preserve=mode,ownership,timestamps`
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "freebsd")))]
     {
         let metadata1 = at.symlink_metadata("dangle");
         let metadata2 = at.symlink_metadata("d2");
@@ -2310,9 +2310,15 @@ fn test_same_file_force_backup() {
 }
 
 /// Test for copying the contents of a FIFO as opposed to the FIFO object itself.
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "freebsd")))]
 #[test]
 fn test_copy_contents_fifo() {
+    // TODO this test should work on FreeBSD, but the command was
+    // causing an error:
+    //
+    // cp: 'fifo' -> 'outfile': the source path is neither a regular file nor a symlink to a regular file
+    //
+    // the underlying `std::fs:copy` doesn't support copying fifo on freeBSD
     let scenario = TestScenario::new(util_name!());
     let at = &scenario.fixtures;
 


### PR DESCRIPTION
Closes #3779.

Check that FreeBSD CI failed when the builds or tests failed here: https://github.com/miles170/coreutils/actions/runs/3488640374/jobs/5837818835