### PR TITLE
CI: update actions to run on Node 16

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -70,11 +70,7 @@ jobs:
         rustup default nightly
     - uses: Swatinem/rust-cache@v2
     - name: Install `cargo-udeps`
-      uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-udeps
-        version: latest
-        use-tool-cache: false
+      run: cargo install cargo-udeps
       env:
         RUSTUP_TOOLCHAIN: stable
     - name: Detect unused dependencies
@@ -1016,22 +1012,7 @@ jobs:
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: "`grcov` ~ install"
       id: build_grcov
-      shell: bash
-      run: |
-        git clone https://github.com/mozilla/grcov.git ~/grcov/
-        cd ~/grcov
-        # Hardcode the version of crossbeam-epoch. See
-        # https://github.com/uutils/coreutils/issues/3680
-        sed -i -e "s|tempfile =|crossbeam-epoch = \"=0.9.8\"\ntempfile =|" Cargo.toml
-        cargo install --path .
-        cd -
-# Uncomment when the upstream issue
-# https://github.com/mozilla/grcov/issues/849 is fixed
-#      uses: actions-rs/install@v0.1
-#      with:
-#        crate: grcov
-#        version: latest
-#        use-tool-cache: false
+      run: cargo install grcov
     - name: Generate coverage data (via `grcov`)
       id: coverage
       shell: bash
@@ -1043,9 +1024,9 @@ jobs:
         # GRCOV_EXCLUDE_OPTION='--excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"' ## `grcov` ignores these params when passed as an environment variable (why?)
         mkdir -p "${COVERAGE_REPORT_DIR}"
         # display coverage files
-        ~/.cargo/bin/grcov . --output-types files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+        ~/.cargo/bin/grcov . --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
         # generate coverage report
-        ~/.cargo/bin/grcov . --output-types lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+        ~/.cargo/bin/grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
         echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v3

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -360,10 +360,7 @@ jobs:
         RUSTUP_TOOLCHAIN=stable cargo fetch --locked --quiet
         RUSTUP_TOOLCHAIN=stable cargo tree --all --locked --no-dev-dependencies --no-indent ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} | grep -vE "$PWD" | sort --unique
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: -v ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
+      run: cargo test -v ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
       env:
         RUSTFLAGS: "-Awarnings --cfg unsound_local_offset"
 
@@ -441,10 +438,7 @@ jobs:
         profile: minimal # minimal component installation (ie, no documentation)
     - uses: Swatinem/rust-cache@v2
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
 
   build_rust_nightly:
     name: Build/nightly
@@ -468,10 +462,7 @@ jobs:
         profile: minimal # minimal component installation (ie, no documentation)
     - uses: Swatinem/rust-cache@v2
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
 
   compute_size:
     name: Binary sizes
@@ -626,11 +617,11 @@ jobs:
         CARGO_FEATURES_OPTION='' ;
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features=${{ matrix.job.features }}' ; fi
         outputs CARGO_FEATURES_OPTION
-        # * CARGO_USE_CROSS (truthy)
-        CARGO_USE_CROSS='true' ; case '${{ matrix.job.use-cross }}' in ''|0|f|false|n|no) unset CARGO_USE_CROSS ;; esac;
-        outputs CARGO_USE_CROSS
+        # * CARGO_CMD
+        CARGO_CMD='cross' ; case '${{ matrix.job.use-cross }}' in ''|0|f|false|n|no) CARGO_CMD='cargo' ;; esac;
+        outputs CARGO_CMD
         # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
-        if [ -n "${CARGO_USE_CROSS}" ] && [ ! -e "Cross.toml" ] ; then
+        if [ "${CARGO_CMD}" = 'cross' ] && [ ! -e "Cross.toml" ] ; then
           cargo install --version 0.2.1 cross
           printf "[build.env]\npassthrough = [\"CI\"]\n" > Cross.toml
         fi
@@ -723,26 +714,20 @@ jobs:
         cargo fetch --locked --quiet
         cargo tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --all --no-dev-dependencies --no-indent | grep -vE "$PWD" | sort --unique
     - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
-        command: build
-        args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
-        toolchain: ${{ env.RUST_MIN_SRV }}
+      shell: bash
+      run: |
+        ${{ steps.vars.outputs.CARGO_CMD }} +${{ env.RUST_MIN_SRV }} build --release \
+        --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
-        command: test
-        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
-        toolchain: ${{ env.RUST_MIN_SRV }}
+      shell: bash
+      run: |
+        ${{ steps.vars.outputs.CARGO_CMD }} +${{ env.RUST_MIN_SRV }} test --target=${{ matrix.job.target }} \
+        ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
     - name: Test individual utilities
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
-        command: test
-        args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
-        toolchain: ${{ env.RUST_MIN_SRV }}
+      shell: bash
+      run: |
+        ${{ steps.vars.outputs.CARGO_CMD }} +${{ env.RUST_MIN_SRV }} test --target=${{ matrix.job.target }} \
+        ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
     - name: Archive executable artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -1035,10 +1020,7 @@ jobs:
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo -n "-puu_${u} "; done;)"
         outputs CARGO_UTILITY_LIST_OPTIONS
     - name: Test uucore
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-fail-fast -p uucore
+      run: cargo test --no-fail-fast -p uucore
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""
@@ -1046,10 +1028,7 @@ jobs:
         RUSTDOCFLAGS: "-Cpanic=abort"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
+      run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""
@@ -1057,10 +1036,7 @@ jobs:
         RUSTDOCFLAGS: "-Cpanic=abort"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Test individual utilities
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-fail-fast ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
+      run: cargo test --no-fail-fast ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -45,7 +45,6 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -71,6 +70,7 @@ jobs:
         toolchain: nightly
         default: true
         profile: minimal
+    - uses: Swatinem/rust-cache@v2
     - name: Install `cargo-udeps`
       uses: actions-rs/install@v0.1
       with:
@@ -103,7 +103,6 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -128,6 +127,7 @@ jobs:
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
         components: rustfmt
+    - uses: Swatinem/rust-cache@v2
     - name: "`cargo fmt` testing"
       shell: bash
       run: |
@@ -153,7 +153,6 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -189,6 +188,7 @@ jobs:
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
         components: clippy
+    - uses: Swatinem/rust-cache@v2
     - name: "`cargo clippy` lint testing"
       shell: bash
       run: |
@@ -263,7 +263,6 @@ jobs:
 #          - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -293,6 +292,7 @@ jobs:
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
         components: clippy
+    - uses: Swatinem/rust-cache@v2
     - name: "`cargo doc` with warnings"
       shell: bash
       run: |
@@ -308,7 +308,6 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -326,6 +325,7 @@ jobs:
         toolchain: ${{ env.RUST_MIN_SRV }}
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: Confirm MinSRV compatible 'Cargo.lock'
       shell: bash
       run: |
@@ -377,13 +377,13 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: "`cargo update` testing"
       shell: bash
       run: |
@@ -402,13 +402,13 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: "`make build`"
       shell: bash
       run: |
@@ -433,13 +433,13 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: Test
       uses: actions-rs/cargo@v1
       with:
@@ -460,13 +460,13 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: Test
       uses: actions-rs/cargo@v1
       with:
@@ -484,7 +484,6 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Install dependencies
       shell: bash
       run: |
@@ -497,6 +496,7 @@ jobs:
         toolchain: stable
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: "`make install`"
       shell: bash
       run: |
@@ -556,7 +556,6 @@ jobs:
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -686,6 +685,9 @@ jobs:
         target: ${{ matrix.job.target }}
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.job.os }}-${{ matrix.job.target }}
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars
       shell: bash
@@ -801,7 +803,6 @@ jobs:
           - { os: ubuntu-latest }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -813,6 +814,7 @@ jobs:
         toolchain: stable
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: "Run BusyBox test suite"
       shell: bash
       run: |
@@ -967,7 +969,6 @@ jobs:
           - { os: windows-latest , features: windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     # - name: Reattach HEAD ## may be needed for accurate code coverage info
     #   run: git checkout ${{ github.head_ref }}
     - name: Initialize workflow variables
@@ -1022,6 +1023,7 @@ jobs:
         toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars
       shell: bash

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -65,11 +65,9 @@ jobs:
     ## note: requires 'nightly' toolchain b/c `cargo-udeps` uses the `rustc` '-Z save-analysis' option
     ## * ... ref: <https://github.com/est31/cargo-udeps/issues/73>
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        default: true
-        profile: minimal
+      run: |
+        rustup toolchain install nightly --profile minimal
+        rustup default nightly
     - uses: Swatinem/rust-cache@v2
     - name: Install `cargo-udeps`
       uses: actions-rs/install@v0.1
@@ -121,12 +119,10 @@ jobs:
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
         outputs CARGO_FEATURES_OPTION
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: rustfmt
+      run: |
+        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
+        rustup toolchain install stable -c rustfmt --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "`cargo fmt` testing"
       shell: bash
@@ -182,12 +178,9 @@ jobs:
           macos-latest) brew install coreutils ;; # needed for show-utils.sh
         esac
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: clippy
+      run: |
+        rustup toolchain install stable -c clippy --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "`cargo clippy` lint testing"
       shell: bash
@@ -286,12 +279,9 @@ jobs:
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo -n "-puu_${u} "; done;)"
         outputs CARGO_UTILITY_LIST_OPTIONS
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: clippy
+      run: |
+        rustup toolchain install stable -c clippy --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "`cargo doc` with warnings"
       shell: bash
@@ -320,11 +310,9 @@ jobs:
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
         outputs CARGO_FEATURES_OPTION
     - name: Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.RUST_MIN_SRV }}
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install ${{ env.RUST_MIN_SRV }} --profile minimal
+        rustup default ${{ env.RUST_MIN_SRV }}
     - uses: Swatinem/rust-cache@v2
     - name: Confirm MinSRV compatible 'Cargo.lock'
       shell: bash
@@ -375,11 +363,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "`cargo update` testing"
       shell: bash
@@ -400,11 +386,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "`make build`"
       shell: bash
@@ -431,11 +415,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: Test
       run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
@@ -455,11 +437,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install nightly --profile minimal
+        rustup default nightly
     - uses: Swatinem/rust-cache@v2
     - name: Test
       run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
@@ -482,11 +462,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install jq
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "`make install`"
       shell: bash
@@ -670,12 +648,9 @@ jobs:
             ;;
         esac
     - name: rust toolchain ~ install
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.RUST_MIN_SRV }}
-        target: ${{ matrix.job.target }}
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install ${{ env.RUST_MIN_SRV }} -t ${{ matrix.job.target }} --profile minimal
+        rustup default ${{ env.RUST_MIN_SRV }}
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.job.os }}-${{ matrix.job.target }}
@@ -794,11 +769,9 @@ jobs:
         ## Install/setup prerequisites
         make prepare-busytest
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "Run BusyBox test suite"
       shell: bash
@@ -1003,11 +976,9 @@ jobs:
             ;;
         esac
     - name: rust toolchain ~ install
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install ${{ steps.vars.outputs.TOOLCHAIN }} --profile minimal
+        rustup default ${{ steps.vars.outputs.TOOLCHAIN }}
     - uses: Swatinem/rust-cache@v2
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -37,11 +37,9 @@ jobs:
         RUST_MIN_SRV=$(grep -P "^\s+RUST_MIN_SRV:" .github/workflows/CICD.yml | grep -Po "(?<=\x22)\d+[.]\d+(?:[.]\d+)?(?=\x22)" )
         outputs RUST_MIN_SRV
     - name: Install `rust` toolchain (v${{ steps.vars.outputs.RUST_MIN_SRV }})
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ steps.vars.outputs.RUST_MIN_SRV }}
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup toolchain install ${{ steps.vars.outputs.RUST_MIN_SRV }} --profile minimal
+        rustup default ${{ steps.vars.outputs.RUST_MIN_SRV }}
     - uses: Swatinem/rust-cache@v2
     - name: Ensure updated 'Cargo.lock'
       shell: bash
@@ -103,12 +101,10 @@ jobs:
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
         outputs CARGO_FEATURES_OPTION
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: rustfmt
+      run: |
+        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
+        rustup toolchain install stable -c rustfmt --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: "`cargo fmt`"
       shell: bash

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -27,7 +27,6 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize job variables
       id: vars
       shell: bash
@@ -43,6 +42,7 @@ jobs:
         toolchain: ${{ steps.vars.outputs.RUST_MIN_SRV }}
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+    - uses: Swatinem/rust-cache@v2
     - name: Ensure updated 'Cargo.lock'
       shell: bash
       run: |
@@ -91,7 +91,6 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Initialize job variables
       id: vars
       shell: bash
@@ -110,6 +109,7 @@ jobs:
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
         components: rustfmt
+    - uses: Swatinem/rust-cache@v2
     - name: "`cargo fmt`"
       shell: bash
       run: |

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -310,11 +310,7 @@ jobs:
     - name: Run GNU tests
       run: bash uutils/util/run-gnu-test.sh
     - name: "`grcov` ~ install"
-      uses: actions-rs/install@v0.1
-      with:
-        crate: grcov
-        version: latest
-        use-tool-cache: false
+      run: cargo install grcov
     - name: Generate coverage data (via `grcov`)
       id: coverage
       run: |

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -66,12 +66,10 @@ jobs:
         workflow_conclusion: completed ## continually recalibrates to last commit of default branch with a successful GnuTests (ie, "self-heals" from GnuTest regressions, but needs more supervision for/of regressions)
         path: "${{ steps.vars.outputs.path_reference }}"
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: rustfmt
+      run: |
+        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
+        rustup toolchain install stable -c rustfmt --profile minimal
+        rustup default stable
     - name: Install dependencies
       shell: bash
       run: |
@@ -281,12 +279,10 @@ jobs:
         ref: 'v9.1'
         submodules: recursive
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: rustfmt
+      run: |
+        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
+        rustup toolchain install nightly -c rustfmt --profile minimal
+        rustup default nightly
     - name: Install dependencies
       run: |
         sudo apt update


### PR DESCRIPTION
Closes #4154.

1. remove use of `actions-rs/cargo`
> `actions-rs/cargo` is currently inactive and has an issue like https://github.com/actions-rs/cargo/issues/216
2. remove use of `actions-rs/toolchain`
> `actions-rs/toolchain` is currently inactive and has an issue like https://github.com/actions-rs/toolchain/issues/219
3. `Swatinem/rust-cache` should happen after the toolchain. See https://github.com/Swatinem/rust-cache
4. fix `rust-cache` cache conflict. See [Post Run Swatinem/rust-cache@v2](https://github.com/uutils/coreutils/actions/runs/3501453143/jobs/5865167599)
5. replace `actions-rs/install` with cargo install, since with `Swatinem/rust-cache` the binary can be cached
> `actions-rs/install` is currently inactive and has an issue like https://github.com/actions-rs/toolchain/issues/219