### PR TITLE
cp: fix `cp --force --backup f f` fails on macOS

### DIFF
--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -52,7 +52,10 @@ pub(crate) fn copy_on_write(
                 flags: u32,
             ) -> libc::c_int = std::mem::transmute(raw_pfn);
             error = pfn(src.as_ptr(), dst.as_ptr(), 0);
-            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::AlreadyExists {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::AlreadyExists
+                // Only remove the `dest` if the `source` and `dest` are not the same
+                && source != dest
+            {
                 // clonefile(2) fails if the destination exists.  Remove it and try again.  Do not
                 // bother to check if removal worked because we're going to try to clone again.
                 let _ = fs::remove_file(dest);

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2290,16 +2290,9 @@ fn test_same_file_force() {
 }
 
 /// Test that copying file to itself with forced backup succeeds.
-#[cfg(all(not(windows), not(target_os = "macos")))]
+#[cfg(all(not(windows)))]
 #[test]
 fn test_same_file_force_backup() {
-    // TODO This test should work on macos, but the command was
-    // causing an error:
-    //
-    //     cp: 'f' -> 'f': No such file or directory (os error 2)
-    //
-    // I couldn't figure out how to fix it, so I just skipped this
-    // test on macos.
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("f");
     ucmd.args(&["--force", "--backup", "f", "f"])


### PR DESCRIPTION
Closes #4080.