### PR TITLE
CI: increase the FreeBSD memory limit to 4096

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -847,7 +847,7 @@ jobs:
         job:
           - { os: macos-12 , features: unix } ## GHA MacOS-11.0 VM won't have VirtualBox; refs: <https://github.com/actions/virtual-environments/issues/4060> , <https://github.com/actions/virtual-environments/pull/4010>
     env:
-      mem: 2048
+      mem: 4096
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Closes #4163

There are some edge cases where SSH disconnection leads to unexpected issues.
Increase the memory limit to prevent the SSH disconnection.

See https://github.com/uutils/coreutils/issues/4163#issuecomment-1321052947