### PR TITLE
Suspend the progress bar before printing the copied files.

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1351,6 +1351,7 @@ fn copy_file(
 
     if options.verbose {
         if let Some(pb) = progress_bar {
+            // Suspend (hide) the progress bar so the println won't overlap with the progress bar.
             pb.suspend(|| {
                 println!("{}", context_for(source, dest));
             });

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1350,7 +1350,13 @@ fn copy_file(
     }
 
     if options.verbose {
-        println!("{}", context_for(source, dest));
+        if let Some(pb) = progress_bar {
+            pb.suspend(|| {
+                println!("{}", context_for(source, dest));
+            });
+        } else {
+            println!("{}", context_for(source, dest));
+        }
     }
 
     // Calculate the context upfront before canonicalizing the path


### PR DESCRIPTION
closes #4178

This PR suspends the progress bar when printing the copied files with the `--verbose` flag.

![ok](https://user-images.githubusercontent.com/2089000/203613997-56fd5595-8139-4edf-89e3-c0e14b948cf1.png)
