### PR TITLE
split: fix "backticks are unbalanced" warnings

### DIFF
--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -59,7 +59,7 @@ impl SuffixType {
 /// This iterator yields filenames for use with ``split``.
 ///
 /// The `prefix` is prepended to each filename and the
-/// `additional_suffix1 is appended to each filename.
+/// `additional_suffix1` is appended to each filename.
 ///
 /// If `suffix_length` is 0, then the variable portion of the filename
 /// that identifies the current chunk will have a dynamically

--- a/src/uu/split/src/number.rs
+++ b/src/uu/split/src/number.rs
@@ -67,7 +67,7 @@ impl Error for Overflow {}
 ///
 /// For the [`DynamicWidthNumber`], the digits are not unique in the
 /// sense that repeatedly incrementing the number will eventually
-/// yield `vec![0, 0]`, `vec![0, 0, 0], `vec![0, 0, 0, 0]`, etc.
+/// yield `vec![0, 0]`, `vec![0, 0, 0]`, `vec![0, 0, 0, 0]`, etc.
 /// That's okay because each of these numbers will be displayed
 /// differently and we only intend to use these numbers for display
 /// purposes and not for mathematical purposes.
@@ -95,7 +95,7 @@ impl Number {
     ///
     /// For the [`DynamicWidthNumber`], the digits are not unique in the
     /// sense that repeatedly incrementing the number will eventually
-    /// yield `vec![0, 0]`, `vec![0, 0, 0], `vec![0, 0, 0, 0]`, etc.
+    /// yield `vec![0, 0]`, `vec![0, 0, 0]`, `vec![0, 0, 0, 0]`, etc.
     /// That's okay because each of these numbers will be displayed
     /// differently and we only intend to use these numbers for display
     /// purposes and not for mathematical purposes.


### PR DESCRIPTION
This PR fixes some "backticks are unbalanced" warnings when using `clippy::pedantic`.