### PR TITLE
CI: change python-pyinotify to python3-pyinotify

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         ## Install dependencies
         sudo apt-get update
-        sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq valgrind libexpect-perl
+        sudo apt-get install autoconf autopoint bison texinfo gperf gcc g++ gdb python3-pyinotify jq valgrind libexpect-perl
     - name: Add various locales
       shell: bash
       run: |
@@ -286,7 +286,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install autoconf autopoint bison texinfo gperf gcc g++ gdb python-pyinotify jq valgrind libexpect-perl -y
+        sudo apt install autoconf autopoint bison texinfo gperf gcc g++ gdb python3-pyinotify jq valgrind libexpect-perl -y
     - name: Add various locales
       run: |
         echo "Before:"


### PR DESCRIPTION
This PR is an attempt to fix the failing CI GNU tests by removing the `python-pyinotify` dependency because the package is no longer in ubuntu.