### PR TITLE
dd: open stdin from file descriptor when possible

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1514,3 +1514,17 @@ fn test_skip_input_fifo() {
     assert!(output.stdout.is_empty());
     assert_eq!(&output.stderr, b"1+0 records in\n1+0 records out\n");
 }
+
+/// Test for reading part of stdin from each of two child processes.
+#[cfg(all(not(windows), feature = "printf"))]
+#[test]
+fn test_multiple_processes_reading_stdin() {
+    // TODO Investigate if this is possible on Windows.
+    let printf = format!("{TESTS_BINARY} printf 'abcdef\n'");
+    let dd_skip = format!("{TESTS_BINARY} dd bs=1 skip=3 count=0");
+    let dd = format!("{TESTS_BINARY} dd");
+    UCommand::new()
+        .arg(format!("{printf} | ( {dd_skip} && {dd} ) 2> /dev/null"))
+        .succeeds()
+        .stdout_only("def\n");
+}


### PR DESCRIPTION
~This is a draft pull request because it includes the changes from pull request #4164. Review and merge that one first.~

This pull request causes `dd` to open stdin using its file descriptor so that a `dd skip=N` command in a subshell does not consume all bytes from stdin.

For example, before this commit, multiple instances of `dd` reading from stdin and appearing in a single command line would incorrectly result in an empty stdin for each instance of `dd` after the first:

    $ printf "abcdef\n" | (dd bs=1 skip=3 count=0 && dd)  2> /dev/null
    # incorrectly results in no output

After this commit, the `dd skip=3` process reads three bytes from the file descriptor referring to stdin without draining the remaining three bytes when it terminates:

    $ printf "abcdef\n" | (dd bs=1 skip=3 count=0 && dd)  2> /dev/null
    def

This implementation is inspired by #3662. I don't think this quite resolves #3008 but it is in the right direction. It does seem to get GNU test `tests/dd/skip-seek2.sh` to pass.