### PR TITLE
touch: add support for some relative times

### DIFF
--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -512,6 +512,98 @@ fn test_touch_set_date7() {
     assert_eq!(mtime, expected);
 }
 
+/// Test for setting the date by a relative time unit.
+#[test]
+fn test_touch_set_date_relative_smoke() {
+    // From the GNU documentation:
+    //
+    // > The unit of time displacement may be selected by the string
+    // > ‘year’ or ‘month’ for moving by whole years or months.  These
+    // > are fuzzy units, as years and months are not all of equal
+    // > duration.  More precise units are ‘fortnight’ which is worth 14
+    // > days, ‘week’ worth 7 days, ‘day’ worth 24 hours, ‘hour’ worth
+    // > 60 minutes, ‘minute’ or ‘min’ worth 60 seconds, and ‘second’ or
+    // > ‘sec’ worth one second.  An ‘s’ suffix on these units is
+    // > accepted and ignored.
+    //
+    let times = [
+        // "-1 year", "+1 year", "-1 years", "+1 years",
+        // "-1 month", "+1 month", "-1 months", "+1 months",
+        "-1 fortnight",
+        "+1 fortnight",
+        "-1 fortnights",
+        "+1 fortnights",
+        "fortnight",
+        "fortnights",
+        "-1 week",
+        "+1 week",
+        "-1 weeks",
+        "+1 weeks",
+        "week",
+        "weeks",
+        "-1 day",
+        "+1 day",
+        "-1 days",
+        "+1 days",
+        "day",
+        "days",
+        "-1 hour",
+        "+1 hour",
+        "-1 hours",
+        "+1 hours",
+        "hour",
+        "hours",
+        "-1 minute",
+        "+1 minute",
+        "-1 minutes",
+        "+1 minutes",
+        "minute",
+        "minutes",
+        "-1 min",
+        "+1 min",
+        "-1 mins",
+        "+1 mins",
+        "min",
+        "mins",
+        "-1 second",
+        "+1 second",
+        "-1 seconds",
+        "+1 seconds",
+        "second",
+        "seconds",
+        "-1 sec",
+        "+1 sec",
+        "-1 secs",
+        "+1 secs",
+        "sec",
+        "secs",
+    ];
+    for time in times {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("f");
+        ucmd.args(&["-d", time, "f"])
+            .succeeds()
+            .no_stderr()
+            .no_stdout();
+    }
+
+    // From the GNU documentation:
+    //
+    // > The string ‘tomorrow’ is worth one day in the future
+    // > (equivalent to ‘day’), the string ‘yesterday’ is worth one day
+    // > in the past (equivalent to ‘day ago’).
+    //
+    let times = ["yesterday", "tomorrow", "now"];
+    for time in times {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("f");
+        ucmd.args(&["-d", time, "f"])
+            .succeeds()
+            .no_stderr()
+            .no_stdout();
+    }
+}
+
 #[test]
 fn test_touch_set_date_wrong_format() {
     let (_at, mut ucmd) = at_and_ucmd!();

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -137,7 +137,7 @@ sed -i 's|sort |/usr/bin/sort |' tests/ls/hyperlink.sh tests/misc/test-N.sh
 sed -i 's|split |/usr/bin/split |' tests/misc/factor-parallel.sh
 sed -i 's|id -|/usr/bin/id -|' tests/misc/runcon-no-reorder.sh
 # tests/ls/abmon-align.sh - https://github.com/uutils/coreutils/issues/3505
-sed -i 's|touch |/usr/bin/touch |' tests/cp/preserve-link.sh tests/cp/reflink-perm.sh tests/ls/block-size.sh tests/mv/update.sh tests/misc/ls-time.sh tests/misc/stat-nanoseconds.sh tests/misc/time-style.sh tests/misc/test-N.sh tests/ls/abmon-align.sh
+sed -i 's|touch |/usr/bin/touch |' tests/cp/reflink-perm.sh tests/ls/block-size.sh tests/mv/update.sh tests/misc/ls-time.sh tests/misc/stat-nanoseconds.sh tests/misc/time-style.sh tests/misc/test-N.sh tests/ls/abmon-align.sh
 sed -i 's|ln -|/usr/bin/ln -|' tests/cp/link-deref.sh
 sed -i 's|cp |/usr/bin/cp |' tests/mv/hard-2.sh
 sed -i 's|paste |/usr/bin/paste |' tests/misc/od-endian.sh


### PR DESCRIPTION
For example,

    $ touch -d "+1 days" f

It doesn't support all relative times. For example, "+1days" and "11:00 tomorrow" and many more still don't work.

Fixes #3964.