### PR TITLE
`uucore/process`: remove custom `ExitStatus`

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -11,6 +11,7 @@ mod status;
 use crate::status::ExitStatus;
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::io::ErrorKind;
+use std::os::unix::process::ExitStatusExt;
 use std::process::{self, Child, Stdio};
 use std::time::Duration;
 use uucore::display::Quotable;


### PR DESCRIPTION
As far as I can tell, all this functionality is covered by `ExitStatusExt` in `std` and it's only used in timeout.