### PR TITLE
tail: remove unused "_event_counter"; rename "_timeout_counter" to "timeout_counter"

### DIFF
--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -479,7 +479,7 @@ pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
 
     let mut process = platform::ProcessChecker::new(observer.pid);
 
-    let mut _timeout_counter = 0;
+    let mut timeout_counter = 0;
 
     // main follow loop
     loop {
@@ -528,7 +528,7 @@ pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
             .receiver
             .recv_timeout(settings.sleep_sec);
         if rx_result.is_ok() {
-            _timeout_counter = 0;
+            timeout_counter = 0;
         }
 
         let mut paths = vec![]; // Paths worth checking for new content to print
@@ -567,7 +567,7 @@ pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
             }
             Ok(Err(e)) => return Err(USimpleError::new(1, format!("NotifyError: {e}"))),
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                _timeout_counter += 1;
+                timeout_counter += 1;
             }
             Err(e) => return Err(USimpleError::new(1, format!("RecvTimeoutError: {e}"))),
         }
@@ -584,7 +584,7 @@ pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
             _read_some = observer.files.tail_file(path, settings.verbose)?;
         }
 
-        if _timeout_counter == settings.max_unchanged_stats {
+        if timeout_counter == settings.max_unchanged_stats {
             /*
             TODO: [2021-10; jhscheer] implement timeout_counter for each file.
             ‘--max-unchanged-stats=n’

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -479,7 +479,6 @@ pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
 
     let mut process = platform::ProcessChecker::new(observer.pid);
 
-    let mut _event_counter = 0;
     let mut _timeout_counter = 0;
 
     // main follow loop
@@ -529,7 +528,6 @@ pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
             .receiver
             .recv_timeout(settings.sleep_sec);
         if rx_result.is_ok() {
-            _event_counter += 1;
             _timeout_counter = 0;
         }
 


### PR DESCRIPTION
This PR removes the `_event_counter` var. This variable is increased but never read. It also renames the `_timeout_counter` var to `timeout_counter`, because the `_` at the beginning indicates the var will not be used which is not the case.