### PR TITLE
gnu-tests: rollback to `ubuntu-20.04` for gnu-tests until fixed

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read  # for actions/checkout to fetch code
       pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: Run GNU tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Initialize workflow variables
       id: vars
@@ -265,7 +265,7 @@ jobs:
 
   gnu_coverage:
     name: Run GNU tests with coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code uutil
       uses: actions/checkout@v3


### PR DESCRIPTION
GNU tests are not working properly after `ubuntu-latest` changed to 22.04. Explicitly specifying Ubuntu version as `ubuntu-20.04` for GNUTests CI, until there is a fix for `ubuntu-latest`.

The issue when using `ubuntu-latest`:
 - #4186