### PR TITLE
chore: standardize creation of empty strings

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -186,7 +186,7 @@ jobs:
         fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
         fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
         # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-        S=$(cargo clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_UTILITY_LIST_OPTIONS }} -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
+        S=$(cargo clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_UTILITY_LIST_OPTIONS }} -- -W clippy::manual_string_new -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
         if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
   style_spellcheck:

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -172,6 +172,6 @@ fn basename(fullname: &str, suffix: &str) -> String {
             }
         }
 
-        None => "".to_owned(),
+        None => String::new(),
     }
 }

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -120,7 +120,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let escaped = matches.get_flag(options::ENABLE_BACKSLASH_ESCAPE);
     let values: Vec<String> = match matches.get_many::<String>(options::STRING) {
         Some(s) => s.map(|s| s.to_string()).collect(),
-        None => vec!["".to_string()],
+        None => vec![String::new()],
     };
 
     execute(no_newline, escaped, &values)

--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -163,7 +163,7 @@ impl<'a> Iterator for FileLines<'a> {
         // Err(true) indicates that this was a linebreak,
         // which is important to know when detecting mail headers
         if n.chars().all(char::is_whitespace) {
-            return Some(Line::NoFormatLine("".to_owned(), true));
+            return Some(Line::NoFormatLine(String::new(), true));
         }
 
         let (pmatch, poffset) = self.match_prefix(&n[..]);

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2400,7 +2400,7 @@ fn display_item_long(
             }
         };
 
-        let dfn = display_file_name(item, config, None, "".to_owned(), out).contents;
+        let dfn = display_file_name(item, config, None, String::new(), out).contents;
 
         write!(out, " {} {}{}", display_date(md, config), dfn, config.eol)?;
     } else {
@@ -2473,7 +2473,7 @@ fn display_item_long(
             write!(out, " {}", pad_right("?", padding.uname))?;
         }
 
-        let dfn = display_file_name(item, config, None, "".to_owned(), out).contents;
+        let dfn = display_file_name(item, config, None, String::new(), out).contents;
         let date_len = 12;
 
         writeln!(

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -293,7 +293,7 @@ impl Params {
         // For example, if `prefix` is "a/b/c/d", then `directory` is
         // "a/b/c" is `prefix` gets reassigned to "d".
         let (directory, prefix) = if prefix.ends_with(MAIN_SEPARATOR) {
-            (prefix, "".to_string())
+            (prefix, String::new())
         } else {
             let path = Path::new(&prefix);
             let directory = match path.parent() {

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -74,7 +74,7 @@ impl RoundMethod {
 }
 
 // Represents the options extracted from the --format argument provided by the user.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct FormatOptions {
     pub grouping: bool,
     pub padding: Option<isize>,
@@ -82,19 +82,6 @@ pub struct FormatOptions {
     pub prefix: String,
     pub suffix: String,
     pub zero_padding: bool,
-}
-
-impl Default for FormatOptions {
-    fn default() -> Self {
-        Self {
-            grouping: false,
-            padding: None,
-            precision: None,
-            prefix: String::new(),
-            suffix: String::new(),
-            zero_padding: false,
-        }
-    }
 }
 
 impl FromStr for FormatOptions {

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -90,8 +90,8 @@ impl Default for FormatOptions {
             grouping: false,
             padding: None,
             precision: None,
-            prefix: String::from(""),
-            suffix: String::from(""),
+            prefix: String::new(),
+            suffix: String::new(),
             zero_padding: false,
         }
     }
@@ -112,8 +112,8 @@ impl FromStr for FormatOptions {
         let mut iter = s.chars().peekable();
         let mut options = Self::default();
 
-        let mut padding = String::from("");
-        let mut precision = String::from("");
+        let mut padding = String::new();
+        let mut precision = String::new();
         let mut double_percentage_counter = 0;
 
         // '%' chars in the prefix, if any, must appear in blocks of even length, for example: "%%%%" and

--- a/src/uu/od/src/inputoffset.rs
+++ b/src/uu/od/src/inputoffset.rs
@@ -49,7 +49,7 @@ impl InputOffset {
             (Radix::Hexadecimal, Some(l)) => format!("{:06X} ({:06X})", self.byte_pos, l),
             (Radix::Octal, None) => format!("{:07o}", self.byte_pos),
             (Radix::Octal, Some(l)) => format!("{:07o} ({:07o})", self.byte_pos, l),
-            (Radix::NoPrefix, None) => String::from(""),
+            (Radix::NoPrefix, None) => String::new(),
             (Radix::NoPrefix, Some(l)) => format!("({:07o})", l),
         }
     }

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -322,7 +322,7 @@ fn current_tty() -> String {
                 .trim_start_matches("/dev/")
                 .to_owned()
         } else {
-            "".to_owned()
+            String::new()
         }
     }
 }
@@ -358,7 +358,7 @@ impl Who {
             let cur_tty = if self.my_line_only {
                 current_tty()
             } else {
-                "".to_owned()
+                String::new()
             };
 
             for ut in records {

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -169,7 +169,7 @@ impl MountInfo {
                 // Why do we cast this to i32?
                 self.dev_id = (stat.dev() as i32).to_string();
             } else {
-                self.dev_id = "".to_string();
+                self.dev_id = String::new();
             }
         }
         // set MountInfo::dummy
@@ -219,7 +219,7 @@ impl MountInfo {
                     + FIELDS_OFFSET
                     + 1;
                 let mut m = Self {
-                    dev_id: "".to_string(),
+                    dev_id: String::new(),
                     dev_name: raw[after_fields + 1].to_string(),
                     fs_type: raw[after_fields].to_string(),
                     mount_root: raw[3].to_string(),
@@ -233,10 +233,10 @@ impl MountInfo {
             }
             LINUX_MTAB => {
                 let mut m = Self {
-                    dev_id: "".to_string(),
+                    dev_id: String::new(),
                     dev_name: raw[0].to_string(),
                     fs_type: raw[2].to_string(),
-                    mount_root: "".to_string(),
+                    mount_root: String::new(),
                     mount_dir: raw[1].to_string(),
                     mount_option: raw[3].to_string(),
                     remote: false,
@@ -305,8 +305,8 @@ impl MountInfo {
             dev_name,
             fs_type: fs_type.unwrap_or_default(),
             mount_root,
-            mount_dir: "".to_string(),
-            mount_option: "".to_string(),
+            mount_dir: String::new(),
+            mount_option: String::new(),
             remote: false,
             dummy: false,
         };
@@ -324,7 +324,7 @@ impl MountInfo {
 impl From<StatFs> for MountInfo {
     fn from(statfs: StatFs) -> Self {
         let mut info = Self {
-            dev_id: "".to_string(),
+            dev_id: String::new(),
             dev_name: unsafe {
                 // spell-checker:disable-next-line
                 CStr::from_ptr(&statfs.f_mntfromname[0])
@@ -343,8 +343,8 @@ impl From<StatFs> for MountInfo {
                     .to_string_lossy()
                     .into_owned()
             },
-            mount_root: "".to_string(),
-            mount_option: "".to_string(),
+            mount_root: String::new(),
+            mount_option: String::new(),
             remote: false,
             dummy: false,
         };

--- a/src/uucore/src/lib/features/tokenize/num_format/formatters/decf.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/formatters/decf.rs
@@ -36,9 +36,9 @@ fn truncate(mut format: FormatPrimitive) -> FormatPrimitive {
         if trimmed.is_empty() {
             // If there are no nonzero digits after the decimal point,
             // use integer formatting by clearing post_decimal and suffix.
-            format.post_decimal = Some("".into());
+            format.post_decimal = Some(String::new());
             if format.suffix == Some("e+00".into()) {
-                format.suffix = Some("".into());
+                format.suffix = Some(String::new());
             }
         } else if trimmed.len() != post_dec.len() {
             // Otherwise, update the format to remove only the trailing
@@ -108,7 +108,7 @@ fn round(mut format: FormatPrimitive) -> FormatPrimitive {
         } else {
             // If the rounded post_decimal is entirely zeroes, discard
             // it and use integer formatting instead.
-            post_decimal_str = "".into();
+            post_decimal_str = String::new();
         }
 
         format.post_decimal = Some(post_decimal_str);

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1174,7 +1174,7 @@ fn test_ls_long_symlink_color() {
                 captures.get(1).unwrap().as_str().to_string(),
                 captures.get(2).unwrap().as_str().to_string(),
             ),
-            None => ("".to_string(), input.to_string()),
+            None => (String::new(), input.to_string()),
         }
     }
 

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -57,7 +57,7 @@ fn test_long_format_multiple_users() {
     // and an account that (probably) doesn't exist
     let runner = match std::env::var("USER") {
         Ok(user) => user,
-        Err(_) => "".to_string(),
+        Err(_) => String::new(),
     };
     let args = ["-l", "root", "root", "root", &runner, "no_such_user"];
     let ts = TestScenario::new(util_name!());

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -2485,8 +2485,8 @@ fn test_follow_inotify_only_regular() {
     p.kill().unwrap();
 
     let (buf_stdout, buf_stderr) = take_stdout_stderr(&mut p);
-    assert_eq!(buf_stdout, "".to_string());
-    assert_eq!(buf_stderr, "".to_string());
+    assert_eq!(buf_stdout, String::new());
+    assert_eq!(buf_stderr, String::new());
 }
 
 fn take_stdout_stderr(p: &mut std::process::Child) -> (String, String) {

--- a/tests/common/random.rs
+++ b/tests/common/random.rs
@@ -127,7 +127,7 @@ impl RandomString {
         D: Distribution<u8>,
     {
         if length == 0 {
-            return String::from("");
+            return String::new();
         } else if length == 1 {
             return if num_delimiter > 0 {
                 String::from(delimiter as char)

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -747,7 +747,7 @@ impl AtPath {
         log_info("resolve_link", self.plus_as_string(path));
         match fs::read_link(self.plus(path)) {
             Ok(p) => self.minus_as_string(p.to_str().unwrap()),
-            Err(_) => "".to_string(),
+            Err(_) => String::new(),
         }
     }
 
@@ -1483,7 +1483,7 @@ mod tests {
     #[test]
     fn test_code_is() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: Some(32),
@@ -1498,7 +1498,7 @@ mod tests {
     #[should_panic]
     fn test_code_is_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: Some(32),
@@ -1512,7 +1512,7 @@ mod tests {
     #[test]
     fn test_failure() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1527,7 +1527,7 @@ mod tests {
     #[should_panic]
     fn test_failure_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1541,7 +1541,7 @@ mod tests {
     #[test]
     fn test_success() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1556,7 +1556,7 @@ mod tests {
     #[should_panic]
     fn test_success_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1570,7 +1570,7 @@ mod tests {
     #[test]
     fn test_no_stderr_output() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1586,7 +1586,7 @@ mod tests {
     #[should_panic]
     fn test_no_stderr_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1602,7 +1602,7 @@ mod tests {
     #[should_panic]
     fn test_no_stdout_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1617,7 +1617,7 @@ mod tests {
     #[test]
     fn test_std_does_not_contain() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1633,7 +1633,7 @@ mod tests {
     #[should_panic]
     fn test_stdout_does_not_contain_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1649,7 +1649,7 @@ mod tests {
     #[should_panic]
     fn test_stderr_does_not_contain_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1664,7 +1664,7 @@ mod tests {
     #[test]
     fn test_stdout_matches() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1682,7 +1682,7 @@ mod tests {
     #[should_panic]
     fn test_stdout_matches_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1699,7 +1699,7 @@ mod tests {
     #[should_panic]
     fn test_stdout_not_matches_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1715,7 +1715,7 @@ mod tests {
     #[test]
     fn test_normalized_newlines_stdout_is() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,
@@ -1733,7 +1733,7 @@ mod tests {
     #[should_panic]
     fn test_normalized_newlines_stdout_is_fail() {
         let res = CmdResult {
-            bin_path: "".into(),
+            bin_path: String::new(),
             util_name: None,
             tmpd: None,
             code: None,


### PR DESCRIPTION
This PR fixes "empty String is being created manually" warnings when using `clippy::pedantic`.