### PR TITLE
cp: preserve hard links when target already exists

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -228,6 +228,11 @@ impl CmdResult {
         self
     }
 
+    /// Assert that there is output to neither stderr nor stdout.
+    pub fn no_output(&self) -> &Self {
+        self.no_stdout().no_stderr()
+    }
+
     /// asserts that the command resulted in stdout stream output that equals the
     /// passed in value, trailing whitespace are kept to force strict comparison (#1235)
     /// stdout_only is a better choice unless stderr may or will be non-empty


### PR DESCRIPTION
Prevent a panic in `cp -a` when the target of a hard link already exists in the target directory structure.

For example,

    $ mkdir -p src dest/src
    $ touch src/f dest/src/f
    $ ln src/f src/link
    $ cp -a src dest

The `cp` command now succeeds without error.

This should cause the GNU test suite file `tests/cp/preserve-link.sh` to pass.