### PR TITLE
chore: fix wildcards that match single variant

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -287,7 +287,7 @@ where
         OutputFmt::Shell => result.push_str("LS_COLORS='"),
         OutputFmt::CShell => result.push_str("setenv LS_COLORS '"),
         OutputFmt::Display => (),
-        _ => unreachable!(),
+        OutputFmt::Unknown => unreachable!(),
     }
 
     let mut table: HashMap<&str, &str> = HashMap::with_capacity(48);
@@ -405,7 +405,7 @@ where
             // remove latest "\n"
             result.pop();
         }
-        _ => unreachable!(),
+        OutputFmt::Unknown => unreachable!(),
     }
 
     Ok(result)

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -634,7 +634,7 @@ where
         match bad_format.cmp(&1) {
             Ordering::Equal => show_warning!("{} line is improperly formatted", bad_format),
             Ordering::Greater => show_warning!("{} lines are improperly formatted", bad_format),
-            _ => {}
+            Ordering::Less => {}
         };
         if failed_cksum > 0 {
             show_warning!("{} computed checksum did NOT match", failed_cksum);
@@ -644,7 +644,7 @@ where
             Ordering::Greater => {
                 show_warning!("{} listed files could not be read", failed_open_file);
             }
-            _ => {}
+            Ordering::Less => {}
         }
     }
 

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -126,7 +126,7 @@ impl<'a> BytesGenerator<'a> {
     fn new(total_bytes: u64, gen_type: PassType<'a>, exact: bool) -> BytesGenerator {
         let rng = match gen_type {
             PassType::Random => Some(RefCell::new(rand::thread_rng())),
-            _ => None,
+            PassType::Pattern(_) => None,
         };
 
         let bytes = [0; BLOCK_SIZE];

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -396,7 +396,7 @@ pub fn canonicalize<P: AsRef<Path>>(
                 read_dir(parent)?;
             }
         }
-        _ => {}
+        MissingHandling::Missing => {}
     }
     Ok(result)
 }

--- a/src/uucore/src/lib/mods/quoting_style.rs
+++ b/src/uucore/src/lib/mods/quoting_style.rs
@@ -278,7 +278,7 @@ pub fn escape_name(name: &OsStr, style: &QuotingStyle) -> String {
             match quotes {
                 Quotes::Single => format!("'{}'", escaped_str),
                 Quotes::Double => format!("\"{}\"", escaped_str),
-                _ => escaped_str,
+                Quotes::None => escaped_str,
             }
         }
         QuotingStyle::Shell {


### PR DESCRIPTION
This PR fixes "wildcard matches only a single variant and will also match any future added variants" warnings from the [match_wildcard_for_single_variant](https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants) lint when using `clippy::pedantic`.