### PR TITLE
Tick after creating progress bar to draw it

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -971,16 +971,16 @@ fn copy(sources: &[Source], target: &TargetSlice, options: &Options) -> CopyResu
     let mut symlinked_files = HashSet::new();
 
     let progress_bar = if options.progress_bar {
-        Some(
-            ProgressBar::new(disk_usage(sources, options.recursive)?)
-                .with_style(
-                    ProgressStyle::with_template(
-                        "{msg}: [{elapsed_precise}] {wide_bar} {bytes:>7}/{total_bytes:7}",
-                    )
-                    .unwrap(),
+        let pb = ProgressBar::new(disk_usage(sources, options.recursive)?)
+            .with_style(
+                ProgressStyle::with_template(
+                    "{msg}: [{elapsed_precise}] {wide_bar} {bytes:>7}/{total_bytes:7}",
                 )
-                .with_message(uucore::util_name()),
-        )
+                .unwrap(),
+            )
+            .with_message(uucore::util_name());
+        pb.tick();
+        Some(pb)
     } else {
         None
     };


### PR DESCRIPTION
There's a small (imo) bug in the `cp` progress bar that I noticed while implementing the feature for `mv`: The progress bar only gets drawn **after** the first file is done copying. This PR changes that by forcing a draw immediately after creating the progress bar.