### PR TITLE
`tests/common/util`: Add possibility to set timeout for UCommand and UChild. Add `rstest` with timeout macro to dev dependencies

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -36,6 +36,7 @@ quickcheck
 rand_chacha
 ringbuffer
 rlimit
+rstest
 smallvec
 tempdir
 tempfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "rand_pcg",
  "regex",
  "rlimit",
+ "rstest",
  "selinux",
  "sha1",
  "tempfile",
@@ -882,6 +883,101 @@ checksum = "32bd98333d10742c0b048272ebf4cb05336d415423b853961c92ccb398966a03"
 dependencies = [
  "bindgen",
  "libc",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+
+[[package]]
+name = "futures-task"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1518,6 +1614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1875,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1915,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1854,6 +1991,12 @@ dependencies = [
  "dunce",
  "walkdir",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -1934,6 +2077,15 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,6 +400,7 @@ uucore = { version=">=0.0.16", package="uucore", path="src/uucore", features=["e
 walkdir = "2.2"
 atty = "0.2"
 hex-literal = "0.3.1"
+rstest = "0.16.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 procfs = { version = "0.14", default-features = false }

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -10,7 +10,7 @@
 
 use crate::common::util::*;
 
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 #[path = "../../src/uu/factor/sieve.rs"]
 mod sieve;
@@ -35,7 +35,7 @@ fn test_invalid_arg() {
 fn test_parallel() {
     use hex_literal::hex;
     use sha1::{Digest, Sha1};
-    use std::fs::OpenOptions;
+    use std::{fs::OpenOptions, time::Duration};
     use tempfile::TempDir;
     // factor should only flush the buffer at line breaks
     let n_integers = 100_000;
@@ -55,6 +55,7 @@ fn test_parallel() {
     for child in (0..10)
         .map(|_| {
             new_ucmd!()
+                .timeout(Duration::from_secs(240))
                 .set_stdout(output.try_clone().unwrap())
                 .pipe_in(input_string.clone())
                 .run_no_wait()
@@ -275,6 +276,7 @@ fn run(input_string: &[u8], output_string: &[u8]) {
     );
     // now run factor
     new_ucmd!()
+        .timeout(Duration::from_secs(240))
         .pipe_in(input_string)
         .run()
         .stdout_is(String::from_utf8(output_string.to_owned()).unwrap());

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -5,6 +5,8 @@
 
 // spell-checker:ignore (words) ints
 
+use std::time::Duration;
+
 use crate::common::util::*;
 
 fn test_helper(file_name: &str, possible_args: &[&str]) {
@@ -948,6 +950,7 @@ fn test_compress_fail() {
 fn test_merge_batches() {
     TestScenario::new(util_name!())
         .ucmd_keepenv()
+        .timeout(Duration::from_secs(120))
         .args(&["ext_sort.txt", "-n", "-S", "150b"])
         .succeeds()
         .stdout_only_fixture("ext_sort.expected");

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1641,8 +1641,8 @@ impl UChild {
                     format!("wait: Timeout of '{}s' reached", timeout.as_secs_f64()),
                 )),
                 Err(RecvTimeoutError::Disconnected) => {
-                    handle.join().unwrap().unwrap();
-                    panic!("Error receiving from waiting thread because of unexpected disconnect")
+                    handle.join().expect("Panic caused disconnect").unwrap();
+                    panic!("Error receiving from waiting thread because of unexpected disconnect");
                 }
             }
         } else {


### PR DESCRIPTION
This pr adds a builder method `UCommand::timeout` to set a timeout as `Duration` which is applied in `UChild::wait_with_output` and all dependent methods like `UCommand:run`, `UChild::wait` etc. The default timeout in `UChild::kill` can also be overwritten that way.

With `rstest` comes a `timeout` macro which can be used in test functions to complete the needs for setting timeouts in tests. 

Closes #4226 