### PR TITLE
cut: add whitespace option for separating fields

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -29,3 +29,7 @@ We provide a simple implementation of `more`, which is not part of GNU
 coreutils. We do not aim for full compatibility with the `more` utility from
 `util-linux`. Features from more modern pagers (like `less` and `bat`) are
 therefore welcomed.
+
+## `cut`
+
+`cut` can separate fields by whitespace (Space and Tab) with `-w` flag. This feature is adopted from [FreeBSD](https://www.freebsd.org/cgi/man.cgi?cut).

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -353,7 +353,6 @@ fn cut_fields_whitespace<R: Read>(
     Ok(())
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> UResult<()> {
     let newline_char = if opts.zero_terminated { b'\0' } else { b'\n' };
     match opts.delimiter {
@@ -362,7 +361,7 @@ fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> URes
             ranges,
             opts.only_delimited,
             newline_char,
-            opts.out_delimiter.as_deref().unwrap_or("\t")
+            opts.out_delimiter.as_deref().unwrap_or("\t"),
         ),
         Delimiter::String(ref delimiter) => {
             if let Some(ref o_delim) = opts.out_delimiter {

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -357,24 +357,22 @@ fn cut_fields_whitespace<R: Read>(
 fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> UResult<()> {
     let newline_char = if opts.zero_terminated { b'\0' } else { b'\n' };
     match opts.delimiter {
-        Delimiter::Whitespace => {
-            return cut_fields_whitespace(
-                reader,
-                ranges,
-                opts.only_delimited,
-                newline_char,
-                match opts.out_delimiter {
-                    Some(ref delim) => delim,
-                    _ => "\t",
-                },
-            )
-        }
+        Delimiter::Whitespace => cut_fields_whitespace(
+            reader,
+            ranges,
+            opts.only_delimited,
+            newline_char,
+            match opts.out_delimiter {
+                Some(ref delim) => delim,
+                _ => "\t",
+            },
+        ),
         Delimiter::String(ref delimiter) => {
             if let Some(ref o_delim) = opts.out_delimiter {
                 return cut_fields_delimiter(
                     reader,
                     ranges,
-                    &delimiter,
+                    delimiter,
                     opts.only_delimited,
                     newline_char,
                     o_delim,

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -615,7 +615,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Err("invalid input: The '--delimiter' ('-d') option only usable if printing a sequence of fields".into())
             }
             Mode::Bytes(_, _) | Mode::Characters(_, _)
-                if matches.contains_id(options::WHITESPACE_DELIMITED) =>
+                if matches.get_flag(options::WHITESPACE_DELIMITED) =>
             {
                 Err("invalid input: The '-w' option only usable if printing a sequence of fields".into())
             }

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -585,7 +585,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                             ))
                         }
                     }
-
                     None => Ok(Mode::Fields(
                         ranges,
                         FieldOptions {

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -352,7 +352,7 @@ fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> URes
             match opts.out_delimiter {
                 Some(ref delim) => delim,
                 _ => "\t",
-            }
+            },
         );
     }
     if let Some(ref o_delim) = opts.out_delimiter {

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -290,7 +290,10 @@ fn cut_fields_whitespace<R: Read>(
 
             return Ok(true);
         }
-
+        // The logic is identical to `cut_fields_delimiter` function above, which uses
+        // `Searcher` that iterates over and returns the first position of the delimiter character.
+        // The main difference is that `WhitespaceSearcher` returns a pair of the first and last
+        // delimiter character positions, since each delimiter sequence length can vary.
         for &Range { low, high } in ranges {
             if low - fields_pos > 0 {
                 low_idx = match delim_search.nth(low - fields_pos - 1) {

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -263,6 +263,7 @@ fn cut_fields_delimiter<R: Read>(
     Ok(())
 }
 
+#[allow(clippy::cognitive_complexity)]
 fn cut_fields_whitespace<R: Read>(
     reader: R,
     ranges: &[Range],

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -90,6 +90,7 @@ static LONG_HELP: &str = "
         If the -w option is provided, fields will be separated by any number
         of  whitespace characters (Space and Tab). The output delimiter will
         be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
+        This is an extension adopted from FreeBSD.
 
     Optionally Filter based on delimiter
         If the --only-delimited (-s) flag is provided, only lines which
@@ -675,7 +676,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::WHITESPACE_DELIMITED)
                 .short('w')
-                .help("Use any number of whitespace (Space, Tab) to separate fields in the input source.")
+                .help("Use any number of whitespace (Space, Tab) to separate fields in the input source (FreeBSD extension).")
                 .value_name("WHITESPACE")
                 .action(ArgAction::SetTrue),
         )

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -296,13 +296,17 @@ fn cut_fields_whitespace<R: Read>(
         // delimiter character positions, since each delimiter sequence length can vary.
         for &Range { low, high } in ranges {
             if low - fields_pos > 0 {
+                // current field is not in the range, so jump to the field corresponding to the
+                // beginning of the range if any
                 low_idx = match delim_search.nth(low - fields_pos - 1) {
                     Some((_, last)) => last,
                     None => break,
                 };
             }
 
+            // at this point, current field is the first in the range
             for _ in 0..=high - low {
+                // skip printing delimiter if this is the first matching field for this line
                 if print_delim {
                     out.write_all(out_delim.as_bytes())?;
                 } else {
@@ -310,6 +314,7 @@ fn cut_fields_whitespace<R: Read>(
                 }
 
                 match delim_search.next() {
+                    // print the current field up to the next whitespace
                     Some((first, last)) => {
                         let segment = &line[low_idx..first];
 
@@ -319,6 +324,7 @@ fn cut_fields_whitespace<R: Read>(
                         fields_pos = high + 1;
                     }
                     None => {
+                        // this is the last field in the line, so print the rest
                         let segment = &line[low_idx..];
 
                         out.write_all(segment)?;

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -264,7 +264,6 @@ fn cut_fields_delimiter<R: Read>(
     Ok(())
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn cut_fields_whitespace<R: Read>(
     reader: R,
     ranges: &[Range],

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -88,7 +88,7 @@ static LONG_HELP: &str = "
         If not set, a default delimiter of Tab will be used.
 
         If the -w option is provided, fields will be separated by any number
-        of  whitespace characters (Space and Tab). The output delimiter will
+        of whitespace characters (Space and Tab). The output delimiter will
         be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
         This is an extension adopted from FreeBSD.
 

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -362,10 +362,7 @@ fn cut_fields<R: Read>(reader: R, ranges: &[Range], opts: &FieldOptions) -> URes
             ranges,
             opts.only_delimited,
             newline_char,
-            match opts.out_delimiter {
-                Some(ref delim) => delim,
-                _ => "\t",
-            },
+            opts.out_delimiter.as_deref().unwrap_or("\t")
         ),
         Delimiter::String(ref delimiter) => {
             if let Some(ref o_delim) = opts.out_delimiter {

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -120,7 +120,7 @@ struct Options {
 
 enum Delimiter {
     Whitespace,
-    String(String), // one char long, String because of UTF8 representation
+    String(String), // FIXME: use char?
 }
 
 struct FieldOptions {

--- a/src/uu/cut/src/whitespace_searcher.rs
+++ b/src/uu/cut/src/whitespace_searcher.rs
@@ -1,0 +1,96 @@
+// This file is part of the uutils coreutils package.
+//
+// (c) Rolf Morel <rolfmorel@gmail.com>
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use memchr::memchr2;
+
+pub struct WhitespaceSearcher<'a> {
+    haystack: &'a [u8],
+    position: usize,
+}
+
+impl<'a> WhitespaceSearcher<'a> {
+    pub fn new(haystack: &'a [u8]) -> WhitespaceSearcher<'a> {
+        WhitespaceSearcher {
+            haystack,
+            position: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for WhitespaceSearcher<'a> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(match_idx) = memchr2(b' ', b'\t', self.haystack) {
+                let mut skip = match_idx + 1;
+                while skip < self.haystack.len()
+                    && (self.haystack[skip] == b' ' || self.haystack[skip] == b'\t')
+                {
+                    skip += 1;
+                }
+                let match_pos = self.position + match_idx;
+                self.haystack = &self.haystack[skip..];
+                self.position += skip;
+                return Some((match_pos, self.position));
+            } else {
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_space() {
+        let iter = WhitespaceSearcher::new(" . . ".as_bytes());
+        let items: Vec<(usize, usize)> = iter.collect();
+        assert_eq!(vec![(0, 1), (2, 3), (4, 5)], items);
+    }
+
+    #[test]
+    fn test_tab() {
+        let iter = WhitespaceSearcher::new("\t.\t.\t".as_bytes());
+        let items: Vec<(usize, usize)> = iter.collect();
+        assert_eq!(vec![(0, 1), (2, 3), (4, 5)], items);
+    }
+
+    #[test]
+    fn test_empty() {
+        let iter = WhitespaceSearcher::new("".as_bytes());
+        let items: Vec<(usize, usize)> = iter.collect();
+        assert_eq!(vec![] as Vec<(usize, usize)>, items);
+    }
+
+    fn test_multispace(line: &[u8], expected: &[(usize, usize)]) {
+        let iter = WhitespaceSearcher::new(line);
+        let items: Vec<(usize, usize)> = iter.collect();
+        assert_eq!(expected, items);
+    }
+
+    #[test]
+    fn test_multispace_normal() {
+        test_multispace(
+            "...  ... \t...\t ... \t ...".as_bytes(),
+            &[(3, 5), (8, 10), (13, 15), (18, 21)],
+        );
+    }
+
+    #[test]
+    fn test_multispace_begin() {
+        test_multispace(" \t\t...".as_bytes(), &[(0, 3)]);
+    }
+
+    #[test]
+    fn test_multispace_end() {
+        test_multispace("...\t  ".as_bytes(), &[(3, 6)]);
+    }
+}

--- a/src/uu/cut/src/whitespace_searcher.rs
+++ b/src/uu/cut/src/whitespace_searcher.rs
@@ -25,8 +25,8 @@ impl<'a> Iterator for WhitespaceSearcher<'a> {
     type Item = (usize, usize);
 
     // Iterate over sequences of consecutive whitespace (space and/or tab) characters.
-    // Returns (first, last) positions of each sequence, where `first` is inclusive and `last` is exclusive.
-    // The delimiter sequence byte-length is equal to `last - first`
+    // Returns (first, last) positions of each sequence, where `haystack[first..last]`
+    // corresponds to the delimiter.
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(match_idx) = memchr2(b' ', b'\t', self.haystack) {
             let mut skip = match_idx + 1;

--- a/src/uu/cut/src/whitespace_searcher.rs
+++ b/src/uu/cut/src/whitespace_searcher.rs
@@ -1,11 +1,9 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Rolf Morel <rolfmorel@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// cSpell:ignore multispace
+// spell-checker:ignore multispace
 
 use memchr::memchr2;
 

--- a/src/uu/cut/src/whitespace_searcher.rs
+++ b/src/uu/cut/src/whitespace_searcher.rs
@@ -24,6 +24,9 @@ impl<'a> WhitespaceSearcher<'a> {
 impl<'a> Iterator for WhitespaceSearcher<'a> {
     type Item = (usize, usize);
 
+    // Iterate over sequences of consecutive whitespace (space and/or tab) characters.
+    // Returns (first, last) positions of each sequence, where `first` is inclusive and `last` is exclusive.
+    // The delimiter sequence byte-length is equal to `last - first`
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(match_idx) = memchr2(b' ', b'\t', self.haystack) {
             let mut skip = match_idx + 1;

--- a/src/uu/cut/src/whitespace_searcher.rs
+++ b/src/uu/cut/src/whitespace_searcher.rs
@@ -35,9 +35,9 @@ impl<'a> Iterator for WhitespaceSearcher<'a> {
             let match_pos = self.position + match_idx;
             self.haystack = &self.haystack[skip..];
             self.position += skip;
-            return Some((match_pos, self.position));
+            Some((match_pos, self.position))
         } else {
-            return None;
+            None
         }
     }
 }

--- a/src/uu/cut/src/whitespace_searcher.rs
+++ b/src/uu/cut/src/whitespace_searcher.rs
@@ -5,6 +5,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+// cSpell:ignore multispace
+
 use memchr::memchr2;
 
 pub struct WhitespaceSearcher<'a> {

--- a/src/uu/cut/src/whitespace_searcher.rs
+++ b/src/uu/cut/src/whitespace_searcher.rs
@@ -25,21 +25,19 @@ impl<'a> Iterator for WhitespaceSearcher<'a> {
     type Item = (usize, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(match_idx) = memchr2(b' ', b'\t', self.haystack) {
-                let mut skip = match_idx + 1;
-                while skip < self.haystack.len()
-                    && (self.haystack[skip] == b' ' || self.haystack[skip] == b'\t')
-                {
-                    skip += 1;
-                }
-                let match_pos = self.position + match_idx;
-                self.haystack = &self.haystack[skip..];
-                self.position += skip;
-                return Some((match_pos, self.position));
-            } else {
-                return None;
+        if let Some(match_idx) = memchr2(b' ', b'\t', self.haystack) {
+            let mut skip = match_idx + 1;
+            while skip < self.haystack.len()
+                && (self.haystack[skip] == b' ' || self.haystack[skip] == b'\t')
+            {
+                skip += 1;
             }
+            let match_pos = self.position + match_idx;
+            self.haystack = &self.haystack[skip..];
+            self.position += skip;
+            return Some((match_pos, self.position));
+        } else {
+            return None;
         }
     }
 }

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -82,6 +82,16 @@ fn test_field_sequence() {
 }
 
 #[test]
+fn test_whitespace_delimited() {
+    for param in ["-w"] {
+        new_ucmd!()
+            .args(&[param, "-f", COMPLEX_SEQUENCE.sequence, INPUT])
+            .succeeds()
+            .stdout_only_fixture("whitespace_delimited.expected");
+    }
+}
+
+#[test]
 fn test_specify_delimiter() {
     for param in ["-d", "--delimiter", "--del"] {
         new_ucmd!()

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -92,6 +92,30 @@ fn test_whitespace_delimited() {
 }
 
 #[test]
+fn test_whitespace_with_explicit_delimiter() {
+    new_ucmd!()
+        .args(&["-w", "-f", COMPLEX_SEQUENCE.sequence, "-d:"])
+        .fails()
+        .code_is(1);
+}
+
+#[test]
+fn test_whitespace_with_byte() {
+    new_ucmd!()
+        .args(&["-w", "-b", COMPLEX_SEQUENCE.sequence])
+        .fails()
+        .code_is(1);
+}
+
+#[test]
+fn test_whitespace_with_char() {
+    new_ucmd!()
+        .args(&["-c", COMPLEX_SEQUENCE.sequence, "-w"])
+        .fails()
+        .code_is(1);
+}
+
+#[test]
 fn test_specify_delimiter() {
     for param in ["-d", "--delimiter", "--del"] {
         new_ucmd!()

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -83,12 +83,10 @@ fn test_field_sequence() {
 
 #[test]
 fn test_whitespace_delimited() {
-    for param in ["-w"] {
-        new_ucmd!()
-            .args(&[param, "-f", COMPLEX_SEQUENCE.sequence, INPUT])
-            .succeeds()
-            .stdout_only_fixture("whitespace_delimited.expected");
-    }
+    new_ucmd!()
+        .args(&["-w", "-f", COMPLEX_SEQUENCE.sequence, INPUT])
+        .succeeds()
+        .stdout_only_fixture("whitespace_delimited.expected");
 }
 
 #[test]

--- a/tests/fixtures/cut/whitespace_delimited.expected
+++ b/tests/fixtures/cut/whitespace_delimited.expected
@@ -1,0 +1,5 @@
+foo:bar:baz:qux:quux
+one:two:three:four:five:six:seven
+alpha:beta:gamma:delta:epsilon:zeta:eta:theta:iota:kappa:lambda:mu
+the	quick	fox	over	the	dog
+sally	sells	down	the	seashore	are	the	seashells	sally	sells


### PR DESCRIPTION
**TLDR**: "-w" flag in cut is an extension option implemented in [FreeBSD](https://www.freebsd.org/cgi/man.cgi?cut). This option proves to be useful when cutting fields separated by one or more whitespaces. GNU coreutils does not currently implement this option. This PR implements -w option and adds test cases. The performance difference compared to FreeBSD's cut implementation is about 9x.

**Example use case**: "ls" or "ps" returns columns separated by multiple inconsistent whitespaces. We can use -w option to select columns, e.g. "ps | cut -w -f1" to print only pids.

**Implementation**: For best performance, I created a new function (cut_fields_whitespace) dedicated for -w option. Performance of "cut -f" before and after this PR is essentially the same, as show below:

Before
```
$ hyperfine -w3 "./target/release/coreutils cut -f2-4,8 data.tsv"
Benchmark 1: ./target/release/coreutils cut -f2-4,8 data.tsv
  Time (mean ± σ):      1.126 s ±  0.006 s    [User: 1.035 s, System: 0.090 s]
  Range (min … max):    1.118 s …  1.138 s    10 runs

$  hyperfine -w3 "./target/release/coreutils cut -f2-4,8 -d' ' data.tsv"
Benchmark 1: ./target/release/coreutils cut -f2-4,8 -d' ' data.tsv
  Time (mean ± σ):      1.026 s ±  0.003 s    [User: 0.940 s, System: 0.086 s]
  Range (min … max):    1.023 s …  1.031 s    10 runs
```

After
```
$ hyperfine -w3 "./target/release/coreutils cut -f2-4,8 data.tsv"
Benchmark 1: ./target/release/coreutils cut -f2-4,8 data.tsv
  Time (mean ± σ):      1.127 s ±  0.021 s    [User: 1.037 s, System: 0.089 s]
  Range (min … max):    1.110 s …  1.169 s    10 runs

$ hyperfine -w3 "./target/release/coreutils cut -f2-4,8 -d' ' data.tsv"
Benchmark 1: ./target/release/coreutils cut -f2-4,8 -d' ' data.tsv
  Time (mean ± σ):      1.045 s ±  0.026 s    [User: 0.956 s, System: 0.088 s]
  Range (min … max):    1.025 s …  1.103 s    10 runs
```

The performance of "cut -w -f" compared to FreeBSD is about 9x faster:
```
$ hyperfine -w3 "./target/release/coreutils cut -f2-4,8 -w data.tsv" "/usr/bin/cut -f2-4,8 -w data.tsv"
Benchmark 1: ./target/release/coreutils cut -f2-4,8 -w data.tsv
  Time (mean ± σ):      1.242 s ±  0.003 s    [User: 1.153 s, System: 0.088 s]
  Range (min … max):    1.240 s …  1.249 s    10 runs

Benchmark 2: /usr/bin/cut -f2-4,8 -w data.tsv
  Time (mean ± σ):     11.529 s ±  0.089 s    [User: 11.385 s, System: 0.131 s]
  Range (min … max):   11.451 s … 11.731 s    10 runs

Summary
  './target/release/coreutils cut -f2-4,8 -w data.tsv' ran
    9.28 ± 0.08 times faster than '/usr/bin/cut -f2-4,8 -w data.tsv'
```