### PR TITLE
cargo: Fix cargo clippy doc warnings

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -27,7 +27,7 @@ const fn generate_crc_table() -> [u32; CRC_TABLE_LEN] {
 
     let mut i = 0;
     while i < CRC_TABLE_LEN {
-        table[i] = crc_entry(i as u8) as u32;
+        table[i] = crc_entry(i as u8);
 
         i += 1;
     }

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -228,7 +228,7 @@ impl<'a> SplitWriter<'a> {
     /// The creation of the split file may fail with some [`io::Error`].
     fn new_writer(&mut self) -> io::Result<()> {
         let file_name = self.options.split_name.get(self.counter);
-        let file = File::create(&file_name)?;
+        let file = File::create(file_name)?;
         self.current_writer = Some(BufWriter::new(file));
         self.counter += 1;
         self.size = 0;

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -715,7 +715,7 @@ fn calc_loop_bsize(
         Some(Num::Bytes(bmax)) => {
             let bmax: u128 = (*bmax).try_into().unwrap();
             let bremain: u128 = bmax - wstat.bytes_total;
-            cmp::min(ideal_bsize as u128, bremain as u128) as usize
+            cmp::min(ideal_bsize as u128, bremain) as usize
         }
         None => ideal_bsize,
     }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -67,7 +67,7 @@ pub fn guess_syntax() -> OutputFmt {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
-    let matches = uu_app().try_get_matches_from(&args)?;
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let files = matches
         .get_many::<String>(options::FILE)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -143,7 +143,7 @@ impl Stat {
             path,
             is_dir: metadata.is_dir(),
             size: metadata.len(),
-            blocks: metadata.blocks() as u64,
+            blocks: metadata.blocks(),
             inodes: 1,
             inode: Some(file_info),
             created: birth_u64(&metadata),
@@ -188,7 +188,7 @@ fn birth_u64(meta: &Metadata) -> Option<u64> {
     meta.created()
         .ok()
         .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-        .map(|e| e.as_secs() as u64)
+        .map(|e| e.as_secs())
 }
 
 #[cfg(windows)]
@@ -807,7 +807,7 @@ pub fn uu_app() -> Command {
         //         .short('P')
         //         .long("no-dereference")
         //         .help("don't follow any symbolic links (this is the default)")
-        //         .action(ArgAction::SetTrue),        
+        //         .action(ArgAction::SetTrue),
         // )
         .arg(
             Arg::new(options::BLOCK_SIZE_1M)

--- a/src/uu/factor/build.rs
+++ b/src/uu/factor/build.rs
@@ -37,7 +37,7 @@ mod sieve;
 #[cfg_attr(test, allow(dead_code))]
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let mut file = File::create(&Path::new(&out_dir).join("prime_table.rs")).unwrap();
+    let mut file = File::create(Path::new(&out_dir).join("prime_table.rs")).unwrap();
 
     // By default, we print the multiplicative inverses mod 2^64 of the first 1k primes
     const DEFAULT_SIZE: usize = 320;

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -274,9 +274,7 @@ fn fold_file<T: Read>(mut file: BufReader<T>, spaces: bool, width: usize) -> URe
                     last_space = if spaces { Some(output.len()) } else { None };
                 }
                 '\x08' => {
-                    if col_count > 0 {
-                        col_count -= 1;
-                    }
+                    col_count = col_count.saturating_sub(1);
                 }
                 _ if spaces && ch.is_whitespace() => {
                     last_space = Some(output.len());

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -438,7 +438,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
         } else {
             source.to_path_buf()
         };
-        fs::hard_link(&p, dst).map_err_context(|| {
+        fs::hard_link(p, dst).map_err_context(|| {
             format!(
                 "failed to create hard link {} => {}",
                 source.quote(),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2702,7 +2702,14 @@ fn file_is_executable(md: &Metadata) -> bool {
     // S_IXUSR -> user has execute permission
     // S_IXGRP -> group has execute permission
     // S_IXOTH -> other users have execute permission
-    md.mode() & ((S_IXUSR | S_IXGRP | S_IXOTH) as u32) != 0
+    #[cfg(all(
+        not(target_os = "android"),
+        not(target_os = "freebsd"),
+        not(target_vendor = "apple")
+    ))]
+    return md.mode() & (S_IXUSR | S_IXGRP | S_IXOTH) != 0;
+    #[cfg(any(target_os = "android", target_os = "freebsd", target_vendor = "apple"))]
+    return md.mode() & ((S_IXUSR | S_IXGRP | S_IXOTH) as u32) != 0;
 }
 
 fn classify_file(path: &PathData, out: &mut BufWriter<Stdout>) -> Option<char> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2702,13 +2702,7 @@ fn file_is_executable(md: &Metadata) -> bool {
     // S_IXUSR -> user has execute permission
     // S_IXGRP -> group has execute permission
     // S_IXOTH -> other users have execute permission
-    #[cfg(all(
-        not(target_os = "android"),
-        not(target_os = "freebsd"),
-        not(target_vendor = "apple")
-    ))]
-    return md.mode() & (S_IXUSR | S_IXGRP | S_IXOTH) != 0;
-    #[cfg(any(target_os = "android", target_os = "freebsd", target_vendor = "apple"))]
+    #[allow(clippy::unnecessary_cast)]
     return md.mode() & ((S_IXUSR | S_IXGRP | S_IXOTH) as u32) != 0;
 }
 

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -564,7 +564,7 @@ fn rename_symlink_fallback(from: &Path, to: &Path) -> io::Result<()> {
     let path_symlink_points_to = fs::read_link(from)?;
     #[cfg(unix)]
     {
-        unix::fs::symlink(&path_symlink_points_to, to).and_then(|_| fs::remove_file(from))?;
+        unix::fs::symlink(path_symlink_points_to, to).and_then(|_| fs::remove_file(from))?;
     }
     #[cfg(windows)]
     {

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -277,17 +277,15 @@ impl Pinky {
 
         let mesg;
         let last_change;
+
         match pts_path.metadata() {
+            #[allow(clippy::unnecessary_cast)]
             Ok(meta) => {
-                #[cfg(all(
-                    not(target_os = "android"),
-                    not(target_os = "freebsd"),
-                    not(target_vendor = "apple")
-                ))]
-                let iwgrp = S_IWGRP;
-                #[cfg(any(target_os = "android", target_os = "freebsd", target_vendor = "apple"))]
-                let iwgrp = S_IWGRP as u32;
-                mesg = if meta.mode() & iwgrp != 0 { ' ' } else { '*' };
+                mesg = if meta.mode() & S_IWGRP as u32 != 0 {
+                    ' '
+                } else {
+                    '*'
+                };
                 last_change = meta.atime();
             }
             _ => {

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -279,11 +279,15 @@ impl Pinky {
         let last_change;
         match pts_path.metadata() {
             Ok(meta) => {
-                mesg = if meta.mode() & (S_IWGRP as u32) != 0 {
-                    ' '
-                } else {
-                    '*'
-                };
+                #[cfg(all(
+                    not(target_os = "android"),
+                    not(target_os = "freebsd"),
+                    not(target_vendor = "apple")
+                ))]
+                let iwgrp = S_IWGRP;
+                #[cfg(any(target_os = "android", target_os = "freebsd", target_vendor = "apple"))]
+                let iwgrp = S_IWGRP as u32;
+                mesg = if meta.mode() & iwgrp != 0 { ' ' } else { '*' };
                 last_change = meta.atime();
             }
             _ => {

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -439,7 +439,7 @@ fn get_output_chunks(
 ) -> (String, String, String, String) {
     // Chunk size logics are mostly copied from the GNU ptx source.
     // https://github.com/MaiZure/coreutils-8.3/blob/master/src/ptx.c#L1234
-    let half_line_size = (config.line_width / 2) as usize;
+    let half_line_size = config.line_width / 2;
     let max_before_size = cmp::max(half_line_size as isize - config.gap_size as isize, 0) as usize;
     let max_after_size = cmp::max(
         half_line_size as isize
@@ -500,7 +500,7 @@ fn get_output_chunks(
     let (tail_beg, _) = trim_idx(all_after, after_end, all_after.len());
 
     // end = begin + max length
-    let tail_end = cmp::min(all_after.len(), tail_beg + max_tail_size) as usize;
+    let tail_end = cmp::min(all_after.len(), tail_beg + max_tail_size);
     // in case that falls in the middle of a word, trim away the word.
     let tail_end = trim_broken_word_right(all_after, tail_beg, tail_end);
 

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -147,7 +147,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(Into::into)
         .unwrap_or(cwd);
 
-    println_verbatim(&cwd).map_err_context(|| "failed to print current directory".to_owned())?;
+    println_verbatim(cwd).map_err_context(|| "failed to print current directory".to_owned())?;
 
     Ok(())
 }

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -259,7 +259,7 @@ fn resolve_path(
 
     let abs = process_relative(abs, relative_base, relative_to);
 
-    print_verbatim(&abs)?;
+    print_verbatim(abs)?;
     stdout().write_all(&[line_ending])?;
     Ok(())
 }

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -520,6 +520,13 @@ fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata
     let mode = metadata.permissions().mode();
     // Check if directory has user write permissions
     // Why is S_IWUSR showing up as a u16 on macos?
+    #[cfg(all(
+        not(target_os = "android"),
+        not(target_vendor = "apple"),
+        not(target_os = "freebsd")
+    ))]
+    let user_writable = (mode & libc::S_IWUSR) != 0;
+    #[cfg(any(target_os = "android", target_os = "freebsd", target_vendor = "apple"))]
     let user_writable = (mode & (libc::S_IWUSR as u32)) != 0;
     if !user_writable {
         prompt_yes!("remove write-protected directory {}?", path.quote())

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -520,13 +520,7 @@ fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata
     let mode = metadata.permissions().mode();
     // Check if directory has user write permissions
     // Why is S_IWUSR showing up as a u16 on macos?
-    #[cfg(all(
-        not(target_os = "android"),
-        not(target_vendor = "apple"),
-        not(target_os = "freebsd")
-    ))]
-    let user_writable = (mode & libc::S_IWUSR) != 0;
-    #[cfg(any(target_os = "android", target_os = "freebsd", target_vendor = "apple"))]
+    #[allow(clippy::unnecessary_cast)]
     let user_writable = (mode & (libc::S_IWUSR as u32)) != 0;
     if !user_writable {
         prompt_yes!("remove write-protected directory {}?", path.quote())

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1115,7 +1115,7 @@ where
     // of bytes per chunk.
     let metadata = metadata(&settings.input).unwrap();
     let num_bytes = metadata.len();
-    let chunk_size = (num_bytes / (num_chunks as u64)) as usize;
+    let chunk_size = (num_bytes / num_chunks) as usize;
 
     // This object is responsible for creating the filename for each chunk.
     let mut filename_iterator = FilenameIterator::new(
@@ -1188,7 +1188,7 @@ where
     // of bytes per chunk.
     let metadata = metadata(&settings.input).unwrap();
     let num_bytes = metadata.len();
-    let chunk_size = (num_bytes / (num_chunks as u64)) as usize;
+    let chunk_size = (num_bytes / num_chunks) as usize;
 
     // Write to stdout instead of to a file.
     let stdout = std::io::stdout();

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -52,7 +52,7 @@ mod platform {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub unsafe fn do_syncfs(files: Vec<String>) -> isize {
         for path in files {
-            let f = File::open(&path).unwrap();
+            let f = File::open(path).unwrap();
             let fd = f.as_raw_fd();
             libc::syscall(libc::SYS_syncfs, fd);
         }
@@ -62,7 +62,7 @@ mod platform {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub unsafe fn do_fdatasync(files: Vec<String>) -> isize {
         for path in files {
-            let f = File::open(&path).unwrap();
+            let f = File::open(path).unwrap();
             let fd = f.as_raw_fd();
             libc::syscall(libc::SYS_fdatasync, fd);
         }

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -160,7 +160,10 @@ fn get_uptime(boot_time: Option<time_t>) -> i64 {
     proc_uptime.unwrap_or_else(|| match boot_time {
         Some(t) => {
             let now = Local::now().timestamp();
-            let boottime = t as i64;
+            #[cfg(target_pointer_width = "64")]
+            let boottime: i64 = t;
+            #[cfg(not(target_pointer_width = "64"))]
+            let boottime: i64 = t.into();
             now - boottime
         }
         None => -1,

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -474,11 +474,15 @@ impl Who {
         let last_change;
         match p.metadata() {
             Ok(meta) => {
-                mesg = if meta.mode() & (S_IWGRP as u32) != 0 {
-                    '+'
-                } else {
-                    '-'
-                };
+                #[cfg(all(
+                    not(target_os = "android"),
+                    not(target_os = "freebsd"),
+                    not(target_vendor = "apple")
+                ))]
+                let iwgrp = S_IWGRP;
+                #[cfg(any(target_os = "android", target_os = "freebsd", target_vendor = "apple"))]
+                let iwgrp = S_IWGRP as u32;
+                mesg = if meta.mode() & iwgrp != 0 { '+' } else { '-' };
                 last_change = meta.atime();
             }
             _ => {

--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -20,7 +20,7 @@ static ABOUT: &str = "Print the current username.";
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     uu_app().try_get_matches_from(args)?;
     let username = platform::get_username().map_err_context(|| "failed to get username".into())?;
-    println_verbatim(&username).map_err_context(|| "failed to print username".into())?;
+    println_verbatim(username).map_err_context(|| "failed to print username".into())?;
     Ok(())
 }
 

--- a/src/uucore/src/lib/features/tokenize/num_format/num_format.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/num_format.rs
@@ -61,11 +61,11 @@ fn get_provided(str_in_opt: Option<&String>) -> Option<u8> {
                                 if !ignored.is_empty() {
                                     warn_char_constant_ign(&ignored);
                                 }
-                                second_byte as u8
+                                second_byte
                             }
                             // no byte after quote
                             None => {
-                                let so_far = (ch as u8 as char).to_string();
+                                let so_far = (ch as char).to_string();
                                 warn_expected_numeric(&so_far);
                                 0_u8
                             }

--- a/src/uucore/src/lib/features/tokenize/sub.rs
+++ b/src/uucore/src/lib/features/tokenize/sub.rs
@@ -195,7 +195,7 @@ impl SubParser {
         // into min_width, second_field, field_char
         for ch in it {
             self.text_so_far.push(ch);
-            match ch as char {
+            match ch {
                 '-' | '*' | '0'..='9' => {
                     if !self.past_decimal {
                         if self.min_width_is_asterisk || self.specifiers_found {
@@ -421,7 +421,7 @@ impl Sub {
                 "{}",
                 match field.min_width {
                     Some(min_width) => {
-                        let diff: isize = min_width.abs() as isize - pre_min_width.len() as isize;
+                        let diff: isize = min_width.abs() - pre_min_width.len() as isize;
                         if diff > 0 {
                             let mut final_str = String::new();
                             // definitely more efficient ways

--- a/src/uucore/src/lib/features/tokenize/unescaped_text.rs
+++ b/src/uucore/src/lib/features/tokenize/unescaped_text.rs
@@ -217,7 +217,7 @@ impl UnescapedText {
                 if !addchar {
                     addchar = true;
                 }
-                match ch as char {
+                match ch {
                     x if x != '\\' && x != '%' => {
                         // lazy branch eval
                         // remember this fn could be called

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -41,7 +41,7 @@ use std::sync::atomic::AtomicBool;
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-/// Whether we were called as a multicall binary ("coreutils <utility>")
+/// Whether we were called as a multicall binary (`coreutils <utility>`)
 pub static UTILITY_IS_SECOND_ARG: AtomicBool = AtomicBool::new(false);
 
 //====


### PR DESCRIPTION
This'll fix the newly arrived `clippy` warnings and a `doc` warning.

These clippy warnings were mostly related to a needless conversion like `u64 -> u64` on some platforms. I removed these generic conversions, but the conversions could then only be applied specific to the `target_os`, `target_env`, etc. I've applied the `#[cfg(...)]` like they were reported from the ci runs, but there are a systems involved I'm not familiar with, so please double check these newly added `#[cfg(...)]` attributes.

Some of the conversion were realized with a `as TYPE` although the conversions were not safe like `i64` to `u64`, so I've changed them to use `try_into().unwrap()`.