### PR TITLE
`tail`: fix argument parsing of sleep interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fundu"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925250bc259498d4008ee072bf16586083ab2c491aa4b06b3c4d0a6556cebd74"
+
+[[package]]
 name = "futures"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,6 +3100,7 @@ version = "0.0.17"
 dependencies = [
  "atty",
  "clap",
+ "fundu",
  "libc",
  "memchr",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) libselinux gethostid procfs bigdecimal kqueue
+# spell-checker:ignore (libs) libselinux gethostid procfs bigdecimal kqueue fundu
 
 [package]
 name = "coreutils"
@@ -282,6 +282,7 @@ filetime = "0.2"
 fnv = "1.0.7"
 fs_extra = "1.1.0"
 fts-sys = "0.2"
+fundu = "0.3.0"
 gcd = "2.2"
 glob = "0.3.0"
 half = "2.1"

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -1,3 +1,4 @@
+# spell-checker:ignore (libs) kqueue fundu
 [package]
 name = "uu_tail"
 version = "0.0.17"
@@ -22,6 +23,7 @@ notify = { workspace=true }
 uucore = { workspace=true, features=["ringbuffer", "lines"] }
 same-file = { workspace=true }
 atty = { workspace=true }
+fundu = { workspace=true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace=true, features = ["Win32_System_Threading", "Win32_Foundation"] }


### PR DESCRIPTION
Like discussed, I've extracted this from the refactoring pr of tail, which fixes the parsing of the sleep interval.

The main intend of this pr is to match the behavior of gnu's tail and properly parse a string in f64 format to a Duration.

Short summary:
* The sleep interval is a `f64` instead of a `f32`
* `Duration::from_secs_f64` panics and `Duration::try_from_secs_f64` is not stable, so we need a separate function to accomplish the conversion from `f64` to a `Duration`.