### PR TITLE
date: Catch panic from invalid format string

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -244,15 +244,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Ok(date) => {
                     // GNU `date` uses `%N` for nano seconds, however crate::chrono uses `%f`
                     let format_string = &format_string.replace("%N", "%f");
-                    //Hack to work around panic in chrono,
-                    //TODO - removed when a fix for https://github.com/chronotope/chrono/issues/623 is released
-                    if StrftimeItems::new(format_string).any(|i| i == Item::Error) {
+                    // Hack to work around panic in chrono,
+                    // TODO - remove when a fix for https://github.com/chronotope/chrono/issues/623 is released
+                    let format_items = StrftimeItems::new(format_string);
+                    if format_items.clone().any(|i| i == Item::Error) {
                         return Err(USimpleError::new(
                             1,
                             format!("invalid format {}", format_string.replace("%f", "%N")),
                         ));
                     }
-                    let formatted = date.format(format_string).to_string().replace("%f", "%N");
+                    let formatted = date
+                        .format_with_items(format_items)
+                        .to_string()
+                        .replace("%f", "%N");
                     println!("{}", formatted);
                 }
                 Err((input, _err)) => show_error!("invalid date {}", input.quote()),

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -244,7 +244,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Ok(date) => {
                     // GNU `date` uses `%N` for nano seconds, however crate::chrono uses `%f`
                     let format_string = &format_string.replace("%N", "%f");
-                    //Hack to work around panic in chrony,
+                    //Hack to work around panic in chrono,
                     //TODO - removed when a fix for https://github.com/chronotope/chrono/issues/623 is released
                     if StrftimeItems::new(format_string).any(|i| i == Item::Error) {
                         return Err(USimpleError::new(

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -225,3 +225,10 @@ fn test_date_set_valid_4() {
         assert!(result.stderr_str().starts_with("date: invalid date "));
     }
 }
+
+#[test]
+fn test_invalid_format_string() {
+    let result = new_ucmd!().arg("+%!").fails();
+    result.no_stdout();
+    assert!(result.stderr_str().starts_with("date: invalid format "));
+}


### PR DESCRIPTION
Currently if you  pass `date` an invalid format string you will get a panic inside the chrony library. This adds a check to catch this case and return an error message instead.
Once chrony handles this case itself this code can be removed.