### PR TITLE
clippy: fix some "unnested or-patterns" warnings

### DIFF
--- a/src/uu/csplit/src/split_name.rs
+++ b/src/uu/csplit/src/split_name.rs
@@ -81,18 +81,16 @@ impl SplitName {
                                      * zero padding
                                      */
                                     // decimal
-                                    ("0", "d") | ("0", "i") | ("0", "u") => {
-                                        Box::new(move |n: usize| -> String {
-                                            format!(
-                                                "{}{}{:0width$}{}",
-                                                prefix,
-                                                before,
-                                                n,
-                                                after,
-                                                width = n_digits
-                                            )
-                                        })
-                                    }
+                                    ("0", "d" | "i" | "u") => Box::new(move |n: usize| -> String {
+                                        format!(
+                                            "{}{}{:0width$}{}",
+                                            prefix,
+                                            before,
+                                            n,
+                                            after,
+                                            width = n_digits
+                                        )
+                                    }),
                                     // octal
                                     ("0", "o") => Box::new(move |n: usize| -> String {
                                         format!(
@@ -168,18 +166,16 @@ impl SplitName {
                                      * Left adjusted
                                      */
                                     // decimal
-                                    ("-", "d") | ("-", "i") | ("-", "u") => {
-                                        Box::new(move |n: usize| -> String {
-                                            format!(
-                                                "{}{}{:<#width$}{}",
-                                                prefix,
-                                                before,
-                                                n,
-                                                after,
-                                                width = n_digits
-                                            )
-                                        })
-                                    }
+                                    ("-", "d" | "i" | "u") => Box::new(move |n: usize| -> String {
+                                        format!(
+                                            "{}{}{:<#width$}{}",
+                                            prefix,
+                                            before,
+                                            n,
+                                            after,
+                                            width = n_digits
+                                        )
+                                    }),
                                     // octal
                                     ("-", "o") => Box::new(move |n: usize| -> String {
                                         format!(

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -505,7 +505,7 @@ fn parse_bytes_no_x(full: &str, s: &str) -> Result<u64, ParseError> {
     let (num, multiplier) = match (s.find('c'), s.rfind('w'), s.rfind('b')) {
         (None, None, None) => match parser.parse(s) {
             Ok(n) => (n, 1),
-            Err(ParseSizeError::InvalidSuffix(_)) | Err(ParseSizeError::ParseFailure(_)) => {
+            Err(ParseSizeError::InvalidSuffix(_) | ParseSizeError::ParseFailure(_)) => {
                 return Err(ParseError::InvalidNumber(full.to_string()))
             }
             Err(ParseSizeError::SizeTooBig(_)) => {

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -135,7 +135,7 @@ impl FromStr for FormatOptions {
         }
 
         // GNU numfmt allows to mix the characters " ", "'", and "0" in any way, so we do the same
-        while matches!(iter.peek(), Some(' ') | Some('\'') | Some('0')) {
+        while matches!(iter.peek(), Some(' ' | '\'' | '0')) {
             match iter.next().unwrap() {
                 ' ' => (),
                 '\'' => options.grouping = true,
@@ -178,7 +178,7 @@ impl FromStr for FormatOptions {
         if let Some('.') = iter.peek() {
             iter.next();
 
-            if matches!(iter.peek(), Some(' ') | Some('+') | Some('-')) {
+            if matches!(iter.peek(), Some(' ' | '+' | '-')) {
                 return Err(format!("invalid precision in format '{}'", s));
             }
 

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -55,28 +55,26 @@ fn od_format_type(type_char: FormatType, byte_size: u8) -> Option<FormatterItemI
 
         (FormatType::DecimalInt, 1) => Some(FORMAT_ITEM_DEC8S),
         (FormatType::DecimalInt, 2) => Some(FORMAT_ITEM_DEC16S),
-        (FormatType::DecimalInt, 0) | (FormatType::DecimalInt, 4) => Some(FORMAT_ITEM_DEC32S),
+        (FormatType::DecimalInt, 0 | 4) => Some(FORMAT_ITEM_DEC32S),
         (FormatType::DecimalInt, 8) => Some(FORMAT_ITEM_DEC64S),
 
         (FormatType::OctalInt, 1) => Some(FORMAT_ITEM_OCT8),
         (FormatType::OctalInt, 2) => Some(FORMAT_ITEM_OCT16),
-        (FormatType::OctalInt, 0) | (FormatType::OctalInt, 4) => Some(FORMAT_ITEM_OCT32),
+        (FormatType::OctalInt, 0 | 4) => Some(FORMAT_ITEM_OCT32),
         (FormatType::OctalInt, 8) => Some(FORMAT_ITEM_OCT64),
 
         (FormatType::UnsignedInt, 1) => Some(FORMAT_ITEM_DEC8U),
         (FormatType::UnsignedInt, 2) => Some(FORMAT_ITEM_DEC16U),
-        (FormatType::UnsignedInt, 0) | (FormatType::UnsignedInt, 4) => Some(FORMAT_ITEM_DEC32U),
+        (FormatType::UnsignedInt, 0 | 4) => Some(FORMAT_ITEM_DEC32U),
         (FormatType::UnsignedInt, 8) => Some(FORMAT_ITEM_DEC64U),
 
         (FormatType::HexadecimalInt, 1) => Some(FORMAT_ITEM_HEX8),
         (FormatType::HexadecimalInt, 2) => Some(FORMAT_ITEM_HEX16),
-        (FormatType::HexadecimalInt, 0) | (FormatType::HexadecimalInt, 4) => {
-            Some(FORMAT_ITEM_HEX32)
-        }
+        (FormatType::HexadecimalInt, 0 | 4) => Some(FORMAT_ITEM_HEX32),
         (FormatType::HexadecimalInt, 8) => Some(FORMAT_ITEM_HEX64),
 
         (FormatType::Float, 2) => Some(FORMAT_ITEM_F16),
-        (FormatType::Float, 0) | (FormatType::Float, 4) => Some(FORMAT_ITEM_F32),
+        (FormatType::Float, 0 | 4) => Some(FORMAT_ITEM_F32),
         (FormatType::Float, 8) => Some(FORMAT_ITEM_F64),
 
         _ => None,

--- a/src/uu/od/src/parse_nrofbytes.rs
+++ b/src/uu/od/src/parse_nrofbytes.rs
@@ -20,11 +20,11 @@ pub fn parse_number_of_bytes(s: &str) -> Result<u64, ParseSizeError> {
             multiply = 512;
             len -= 1;
         }
-        Some('k') | Some('K') => {
+        Some('k' | 'K') => {
             multiply = 1024;
             len -= 1;
         }
-        Some('m') | Some('M') => {
+        Some('m' | 'M') => {
             multiply = 1024 * 1024;
             len -= 1;
         }
@@ -50,8 +50,8 @@ pub fn parse_number_of_bytes(s: &str) -> Result<u64, ParseSizeError> {
         Some('B') if radix != 16 => {
             len -= 2;
             multiply = match ends_with.next() {
-                Some('k') | Some('K') => 1000,
-                Some('m') | Some('M') => 1000 * 1000,
+                Some('k' | 'K') => 1000,
+                Some('m' | 'M') => 1000 * 1000,
                 Some('G') => 1000 * 1000 * 1000,
                 #[cfg(target_pointer_width = "64")]
                 Some('T') => 1000 * 1000 * 1000 * 1000,

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1201,7 +1201,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             matches
                 .get_one::<String>(options::check::CHECK)
                 .map(|s| s.as_str()),
-            Some(options::check::SILENT) | Some(options::check::QUIET)
+            Some(options::check::SILENT | options::check::QUIET)
         )
     {
         settings.check_silent = true;
@@ -1695,7 +1695,7 @@ fn get_leading_gen(input: &str) -> Range<usize> {
 
     let first = char_indices.peek();
 
-    if matches!(first, Some((_, NEGATIVE)) | Some((_, POSITIVE))) {
+    if matches!(first, Some((_, NEGATIVE) | (_, POSITIVE))) {
         char_indices.next();
     }
 

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -233,9 +233,7 @@ fn open(
             Err(f) => {
                 show_error!("{}: {}", name.maybe_quote(), f);
                 match output_error {
-                    Some(OutputErrorMode::Exit) | Some(OutputErrorMode::ExitNoPipe) => {
-                        return Err(f)
-                    }
+                    Some(OutputErrorMode::Exit | OutputErrorMode::ExitNoPipe) => return Err(f),
                     _ => Box::new(sink()),
                 }
             }

--- a/src/uucore/src/lib/features/tokenize/num_format/formatters/float_common.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/formatters/float_common.rs
@@ -67,7 +67,7 @@ impl FloatAnalysis {
         let mut pos_before_first_nonzero_after_decimal: Option<usize> = None;
         for c in str_it {
             match c {
-                e @ '0'..='9' | e @ 'A'..='F' | e @ 'a'..='f' => {
+                e @ ('0'..='9' | 'A'..='F' | 'a'..='f') => {
                     if !hex_input {
                         match e {
                             '0'..='9' => {}


### PR DESCRIPTION
This PR fixes some "unnested or-patterns" warnings from the [unnested_or_patterns](https://rust-lang.github.io/rust-clippy/master/index.html#unnested_or_patterns) lint when using `clippy::pedantic`. I fixed only the warnings where I think the result is an improvement in readability.