### PR TITLE
Multiple fixes and tests added for `expr`

### DIFF
--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -74,7 +74,7 @@ fn process_expr(token_strings: &[&str]) -> Result<String, String> {
 
 fn print_expr_ok(expr_result: &str) -> UResult<()> {
     println!("{}", expr_result);
-    if expr_result == "0" || expr_result.is_empty() {
+    if expr_result.parse::<i32>() == Ok(0) || expr_result.is_empty() {
         Err(1.into())
     } else {
         Ok(())

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -478,7 +478,7 @@ fn prefix_operator_index(values: &[String]) -> String {
     for (current_idx, ch_h) in haystack.chars().enumerate() {
         for ch_n in needles.chars() {
             if ch_n == ch_h {
-                return current_idx.to_string();
+                return (current_idx + 1).to_string();
             }
         }
     }

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -3,6 +3,34 @@
 use crate::common::util::*;
 
 #[test]
+fn test_simple_values() {
+    // null or 0 => EXIT_VALUE == 1
+    new_ucmd!()
+        .args(&[""])
+        .fails()
+        .status_code(1)
+        .stdout_only("\n");
+    new_ucmd!()
+        .args(&["0"])
+        .fails()
+        .status_code(1)
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["00"])
+        .fails()
+        .status_code(1)
+        .stdout_only("00\n");
+    new_ucmd!()
+        .args(&["-0"])
+        .fails()
+        .status_code(1)
+        .stdout_only("-0\n");
+
+    // non-null and non-0 => EXIT_VALUE = 0
+    new_ucmd!().args(&["1"]).succeeds().stdout_only("1\n");
+}
+
+#[test]
 fn test_simple_arithmetic() {
     new_ucmd!()
         .args(&["1", "+", "1"])

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -109,6 +109,14 @@ fn test_index() {
         .succeeds()
         .stdout_only("1\n");
     new_ucmd!()
+        .args(&["index", "αbc_δef", "δ"])
+        .succeeds()
+        .stdout_only("5\n");
+    new_ucmd!()
+        .args(&["index", "αbc_δef", "δf"])
+        .succeeds()
+        .stdout_only("5\n");
+    new_ucmd!()
         .args(&["index", "αbcdef", "fb"])
         .succeeds()
         .stdout_only("2\n");

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore αbcdef
+// spell-checker:ignore αbcdef ; (people) kkos
 
 use crate::common::util::*;
 
@@ -177,6 +177,27 @@ fn test_length_mb() {
         .args(&["length", "αbcdef"])
         .succeeds()
         .stdout_only("6\n");
+}
+
+#[test]
+fn test_regex() {
+    // FixME: [2022-12-19; rivy] test disabled as it currently fails due to 'oniguruma' bug (see GH:kkos/oniguruma/issues/279)
+    // new_ucmd!()
+    //     .args(&["a^b", ":", "a^b"])
+    //     .succeeds()
+    //     .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["a^b", ":", "a\\^b"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["a$b", ":", "a\\$b"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
+        .succeeds()
+        .stdout_only("2\n");
 }
 
 #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -98,6 +98,31 @@ fn test_and() {
 }
 
 #[test]
+fn test_index() {
+    new_ucmd!()
+        .args(&["index", "αbcdef", "x"])
+        .fails()
+        .status_code(1)
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["index", "αbcdef", "α"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["index", "αbcdef", "fb"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["index", "αbcdef", "f"])
+        .succeeds()
+        .stdout_only("6\n");
+    new_ucmd!()
+        .args(&["index", "αbcdef_f", "f"])
+        .succeeds()
+        .stdout_only("6\n");
+}
+
+#[test]
 fn test_length_fail() {
     new_ucmd!().args(&["length", "αbcdef", "1"]).fails();
 }


### PR DESCRIPTION
I ran into several bugs in `expr` when using it to test some other coreutils implementations (eg, [vlang coreutils](https://github.com/vlang/coreutils)). Here's a commit set that implements tests against those errors and fixes for them.

I've left one test in, but disabled, for a secondary [bug in the oniguruma](https://github.com/kkos/oniguruma/issues/279) regex implementation. I'll re-address when that bug is fixed.