### PR TITLE
`ci/tests`: Run cargo test with RUST_BACKTRACE=1

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -347,6 +347,7 @@ jobs:
       run: cargo test -v ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
       env:
         RUSTFLAGS: "-Awarnings --cfg unsound_local_offset"
+        RUST_BACKTRACE: "1"
 
   deps:
     name: Dependencies
@@ -394,6 +395,8 @@ jobs:
       shell: bash
       run: |
         make test
+      env:
+        RUST_BACKTRACE: "1"
 
 
   build_rust_stable:
@@ -417,6 +420,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Test
       run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      env:
+        RUST_BACKTRACE: "1"
 
   build_rust_nightly:
     name: Build/nightly
@@ -439,6 +444,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Test
       run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      env:
+        RUST_BACKTRACE: "1"
 
   compute_size:
     name: Binary sizes
@@ -597,7 +604,7 @@ jobs:
         # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
         if [ "${CARGO_CMD}" = 'cross' ] && [ ! -e "Cross.toml" ] ; then
           cargo install --version 0.2.1 cross
-          printf "[build.env]\npassthrough = [\"CI\"]\n" > Cross.toml
+          printf "[build.env]\npassthrough = [\"CI\", \"RUST_BACKTRACE\"]\n" > Cross.toml
         fi
         # * test only library and/or binaries for arm-type targets
         unset CARGO_TEST_OPTIONS ; case '${{ matrix.job.target }}' in aarch64-* | arm-*) CARGO_TEST_OPTIONS="--bins" ;; esac;
@@ -694,11 +701,15 @@ jobs:
       run: |
         ${{ steps.vars.outputs.CARGO_CMD }} +${{ env.RUST_MIN_SRV }} test --target=${{ matrix.job.target }} \
         ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      env:
+        RUST_BACKTRACE: "1"
     - name: Test individual utilities
       shell: bash
       run: |
         ${{ steps.vars.outputs.CARGO_CMD }} +${{ env.RUST_MIN_SRV }} test --target=${{ matrix.job.target }} \
         ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
+      env:
+        RUST_BACKTRACE: "1"
     - name: Archive executable artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -1023,6 +1034,7 @@ jobs:
           cd "${WORKSPACE}"
           unset FAULT
           cargo build || FAULT=1
+          export RUST_BACKTRACE=1
           if (test -z "\$FAULT"); then cargo test --features '${{ matrix.job.features }}' || FAULT=1 ; fi
           if (test -z "\$FAULT"); then cargo test --all-features -p uucore || FAULT=1 ; fi
           # Clean to avoid to rsync back the files
@@ -1113,6 +1125,7 @@ jobs:
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
+        RUST_BACKTRACE: "1"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Test
       run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
@@ -1121,6 +1134,7 @@ jobs:
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
+        RUST_BACKTRACE: "1"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Test individual utilities
       run: cargo test --no-fail-fast ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
@@ -1129,6 +1143,7 @@ jobs:
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
+        RUST_BACKTRACE: "1"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: "`grcov` ~ install"
       id: build_grcov

--- a/util/android-commands.sh
+++ b/util/android-commands.sh
@@ -120,6 +120,7 @@ build () {
 
 tests () {
     probe='/sdcard/tests.probe'
+    export RUST_BACKTRACE=1
     command="'cd ~/coreutils && timeout --preserve-status --verbose -k 1m 60m cargo test --features feat_os_unix_android --no-fail-fast >/sdcard/tests.log 2>&1; echo \$? >$probe'"
     run_termux_command "$command" "$probe"
     return_code=$?


### PR DESCRIPTION
This pr will enable printing the backtrace in the CI for failing tests when run with `cargo test`

Closes #4250