### PR TITLE
tests/util: Fix path resolution of test executable

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -36,11 +36,6 @@ use std::{env, hint, thread};
 use tempfile::{Builder, TempDir};
 use uucore::Args;
 
-#[cfg(windows)]
-static PROGNAME: &str = concat!(env!("CARGO_PKG_NAME"), ".exe");
-#[cfg(not(windows))]
-static PROGNAME: &str = env!("CARGO_PKG_NAME");
-
 static TESTS_DIR: &str = "tests";
 static FIXTURES_DIR: &str = "fixtures";
 
@@ -1101,13 +1096,7 @@ impl TestScenario {
     pub fn new(util_name: &str) -> Self {
         let tmpd = Rc::new(TempDir::new().unwrap());
         let ts = Self {
-            bin_path: {
-                // Instead of hard coding the path relative to the current
-                // directory, use Cargo's OUT_DIR to find path to executable.
-                // This allows tests to be run using profiles other than debug.
-                let target_dir = path_concat!(env!("OUT_DIR"), "..", "..", "..", PROGNAME);
-                PathBuf::from(AtPath::new(Path::new(&target_dir)).root_dir_resolved())
-            },
+            bin_path: PathBuf::from(env!("CARGO_BIN_EXE_coreutils")),
             util_name: String::from(util_name),
             fixtures: AtPath::new(tmpd.as_ref().path()),
             tmpd,


### PR DESCRIPTION
All tests failed when running the tests in a windows virtualbox with the uutils repo located in a shared folder. The `AtPath::root_dir_resolved` method stripped away the necessary `\\?\` prefix and the `coreutils` test executable couldn't be executed.

Using `env!(CARGO_BIN_EXE_coreutils)` is simpler, platform independent and more reliable in my opinion and I was able to run the test suite in a virtualbox shared folder. Note the `\\?\` prefix would also be necessary if running the tests on a network drive. See also here for a description of the file naming model on windows: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file

However, I'm not sure if the change that would be introduced by this pr has other implications I'm not aware of.