### PR TITLE
expand: improve plus specifier handling

### DIFF
--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -186,10 +186,9 @@ fn tabstops_parse(s: &str) -> Result<(RemainingMode, Vec<usize>), ParseError> {
     // then just use the default tabstops.
     if nums.is_empty() {
         nums = vec![DEFAULT_TABSTOP];
-        remaining_mode = RemainingMode::None;
     }
 
-    if nums.len() == 1 {
+    if nums.len() < 2 {
         remaining_mode = RemainingMode::None;
     }
     Ok((remaining_mode, nums))

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -348,7 +348,16 @@ fn next_tabstop(tabstops: &[usize], col: usize, remaining_mode: &RemainingMode) 
     match remaining_mode {
         RemainingMode::Plus => match tabstops[0..num_tabstops - 1].iter().find(|&&t| t > col) {
             Some(t) => t - col,
-            None => tabstops[num_tabstops - 1] - 1,
+            None => {
+                let step_size = tabstops[num_tabstops - 1];
+                let last_before_repeating = tabstops[num_tabstops-2];
+                let mut r = last_before_repeating+step_size;
+
+                while col >= r {
+                    r += step_size;
+                }
+                r - col
+            }
         },
         RemainingMode::Slash => match tabstops[0..num_tabstops - 1].iter().find(|&&t| t > col) {
             Some(t) => t - col,
@@ -376,7 +385,7 @@ enum CharType {
 
 fn expand(options: &Options) -> std::io::Result<()> {
     use self::CharType::*;
-    println!("{:?}", options);
+    
     let mut output = BufWriter::new(stdout());
     let ts = options.tabstops.as_ref();
     let mut buf = Vec::new();

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -38,7 +38,7 @@ static DEFAULT_TABSTOP: usize = 8;
 
 /// The mode to use when replacing tabs beyond the last one specified in
 /// the `--tabs` argument.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq)]
 enum RemainingMode {
     None,
     Slash,
@@ -195,7 +195,6 @@ fn tabstops_parse(s: &str) -> Result<(RemainingMode, Vec<usize>), ParseError> {
     Ok((remaining_mode, nums))
 }
 
-#[derive(Debug)]
 struct Options {
     files: Vec<String>,
     tabstops: Vec<usize>,
@@ -345,11 +344,11 @@ fn next_tabstop(tabstops: &[usize], col: usize, remaining_mode: &RemainingMode) 
             Some(t) => t - col,
             None => {
                 let step_size = tabstops[num_tabstops - 1];
-                let last_fixed_tabstop = tabstops[num_tabstops-2];
-                let characters_since_last_tabstop = col-last_fixed_tabstop;
+                let last_fixed_tabstop = tabstops[num_tabstops - 2];
+                let characters_since_last_tabstop = col - last_fixed_tabstop;
 
-                let steps_required = 1 + characters_since_last_tabstop/step_size;
-                steps_required*step_size-characters_since_last_tabstop
+                let steps_required = 1 + characters_since_last_tabstop / step_size;
+                steps_required * step_size - characters_since_last_tabstop
             }
         },
         RemainingMode::Slash => match tabstops[0..num_tabstops - 1].iter().find(|&&t| t > col) {
@@ -378,7 +377,7 @@ enum CharType {
 
 fn expand(options: &Options) -> std::io::Result<()> {
     use self::CharType::*;
-    
+
     let mut output = BufWriter::new(stdout());
     let ts = options.tabstops.as_ref();
     let mut buf = Vec::new();

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -38,7 +38,7 @@ static DEFAULT_TABSTOP: usize = 8;
 
 /// The mode to use when replacing tabs beyond the last one specified in
 /// the `--tabs` argument.
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 enum RemainingMode {
     None,
     Slash,
@@ -126,12 +126,8 @@ fn tabstops_parse(s: &str) -> Result<(RemainingMode, Vec<usize>), ParseError> {
         let bytes = word.as_bytes();
         for i in 0..bytes.len() {
             match bytes[i] {
-                b'+' => {
-                    remaining_mode = RemainingMode::Plus;
-                }
-                b'/' => {
-                    remaining_mode = RemainingMode::Slash;
-                }
+                b'+' => remaining_mode = RemainingMode::Plus,
+                b'/' => remaining_mode = RemainingMode::Slash,
                 _ => {
                     // Parse a number from the byte sequence.
                     let s = from_utf8(&bytes[i..]).unwrap();
@@ -190,10 +186,16 @@ fn tabstops_parse(s: &str) -> Result<(RemainingMode, Vec<usize>), ParseError> {
     // then just use the default tabstops.
     if nums.is_empty() {
         nums = vec![DEFAULT_TABSTOP];
+        remaining_mode = RemainingMode::None;
+    }
+
+    if nums.len() == 1 {
+        remaining_mode = RemainingMode::None;
     }
     Ok((remaining_mode, nums))
 }
 
+#[derive(Debug)]
 struct Options {
     files: Vec<String>,
     tabstops: Vec<usize>,
@@ -374,7 +376,7 @@ enum CharType {
 
 fn expand(options: &Options) -> std::io::Result<()> {
     use self::CharType::*;
-
+    println!("{:?}", options);
     let mut output = BufWriter::new(stdout());
     let ts = options.tabstops.as_ref();
     let mut buf = Vec::new();

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -275,7 +275,7 @@ fn test_tabs_shortcut() {
         .args(&["-2", "-5", "-7"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //          01234567890
+        //               01234567890
         .stdout_is("  a  b c");
 }
 
@@ -285,7 +285,7 @@ fn test_comma_separated_tabs_shortcut() {
         .args(&["-2,5", "-7"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //          01234567890
+        //               01234567890
         .stdout_is("  a  b c");
 }
 
@@ -295,6 +295,66 @@ fn test_tabs_and_tabs_shortcut_mixed() {
         .args(&["-2", "--tabs=5", "-7"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //          01234567890
+        //               01234567890
         .stdout_is("  a  b c");
+}
+
+#[test]
+fn test_ignore_initial_plus() {
+    new_ucmd!()
+        .args(&["--tabs=+3"])
+        .pipe_in("\ta\tb\tc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("   a  b  c");
+}
+
+#[test]
+fn test_ignore_initial_pluses() {
+    new_ucmd!()
+        .args(&["--tabs=++3"])
+        .pipe_in("\ta\tb\tc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("   a  b  c");
+}
+
+#[test]
+fn test_ignore_initial_slash() {
+    new_ucmd!()
+        .args(&["--tabs=/3"])
+        .pipe_in("\ta\tb\tc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("   a  b  c");
+}
+
+#[test]
+fn test_ignore_initial_slashes() {
+    new_ucmd!()
+        .args(&["--tabs=//3"])
+        .pipe_in("\ta\tb\tc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("   a  b  c");
+}
+
+#[test]
+fn test_ignore_initial_plus_slash_combination() {
+    new_ucmd!()
+        .args(&["--tabs=+/3"])
+        .pipe_in("\ta\tb\tc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("   a  b  c");
+}
+
+#[test]
+fn test_comma_with_plus_and_multi_character_values() {
+    new_ucmd!()
+        .args(&["--tabs=3,+6"])
+        .pipe_in("\taaa\tbbbb\tcccc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("   aaa   bbb   ccc");
 }

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -350,21 +350,41 @@ fn test_ignore_initial_plus_slash_combination() {
 }
 
 #[test]
-fn test_comma_with_plus_and_multi_character_values() {
+fn test_comma_with_plus_1() {
     new_ucmd!()
         .args(&["--tabs=3,+6"])
-        .pipe_in("\taaa\tbbb\tccc")
+        .pipe_in("\t111\t222\t333")
         .succeeds()
         //               01234567890
-        .stdout_is("   aaa   bbb   ccc");
+        .stdout_is("   111   222   333");
 }
 
 #[test]
-fn test_comma_with_plus_and_multi_character_values() {
+fn test_comma_with_plus_2() {
     new_ucmd!()
-        .args(&["--tabs=3,+6"])
-        .pipe_in("\taaa\tbbb\tccc")
+        .args(&["--tabs=1,+5"])
+        .pipe_in("\ta\tb\tc")
         .succeeds()
         //               01234567890
-        .stdout_is("   aaa   bbb   ccc");
+        .stdout_is(" a    b    c");
+}
+
+#[test]
+fn test_comma_with_plus_3() {
+    new_ucmd!()
+        .args(&["--tabs=2,+5"])
+        .pipe_in("a\tb\tc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("a b    c");
+}
+
+#[test]
+fn test_comma_with_plus_4() {
+    new_ucmd!()
+        .args(&["--tabs=1,3,+5"])
+        .pipe_in("a\tb\tc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("a  b    c");
 }

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -275,7 +275,7 @@ fn test_tabs_shortcut() {
         .args(&["-2", "-5", "-7"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("  a  b c");
 }
 
@@ -285,7 +285,7 @@ fn test_comma_separated_tabs_shortcut() {
         .args(&["-2,5", "-7"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("  a  b c");
 }
 
@@ -295,7 +295,7 @@ fn test_tabs_and_tabs_shortcut_mixed() {
         .args(&["-2", "--tabs=5", "-7"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("  a  b c");
 }
 
@@ -305,7 +305,7 @@ fn test_ignore_initial_plus() {
         .args(&["--tabs=+3"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("   a  b  c");
 }
 
@@ -315,7 +315,7 @@ fn test_ignore_initial_pluses() {
         .args(&["--tabs=++3"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("   a  b  c");
 }
 
@@ -325,7 +325,7 @@ fn test_ignore_initial_slash() {
         .args(&["--tabs=/3"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("   a  b  c");
 }
 
@@ -335,7 +335,7 @@ fn test_ignore_initial_slashes() {
         .args(&["--tabs=//3"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("   a  b  c");
 }
 
@@ -345,7 +345,7 @@ fn test_ignore_initial_plus_slash_combination() {
         .args(&["--tabs=+/3"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("   a  b  c");
 }
 
@@ -355,7 +355,7 @@ fn test_comma_with_plus_1() {
         .args(&["--tabs=3,+6"])
         .pipe_in("\t111\t222\t333")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("   111   222   333");
 }
 
@@ -365,7 +365,7 @@ fn test_comma_with_plus_2() {
         .args(&["--tabs=1,+5"])
         .pipe_in("\ta\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is(" a    b    c");
 }
 
@@ -375,7 +375,7 @@ fn test_comma_with_plus_3() {
         .args(&["--tabs=2,+5"])
         .pipe_in("a\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("a b    c");
 }
 
@@ -385,6 +385,6 @@ fn test_comma_with_plus_4() {
         .args(&["--tabs=1,3,+5"])
         .pipe_in("a\tb\tc")
         .succeeds()
-        //               01234567890
+        //          01234567890
         .stdout_is("a  b    c");
 }

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -353,7 +353,17 @@ fn test_ignore_initial_plus_slash_combination() {
 fn test_comma_with_plus_and_multi_character_values() {
     new_ucmd!()
         .args(&["--tabs=3,+6"])
-        .pipe_in("\taaa\tbbbb\tcccc")
+        .pipe_in("\taaa\tbbb\tccc")
+        .succeeds()
+        //               01234567890
+        .stdout_is("   aaa   bbb   ccc");
+}
+
+#[test]
+fn test_comma_with_plus_and_multi_character_values() {
+    new_ucmd!()
+        .args(&["--tabs=3,+6"])
+        .pipe_in("\taaa\tbbb\tccc")
         .succeeds()
         //               01234567890
         .stdout_is("   aaa   bbb   ccc");


### PR DESCRIPTION
This PR fixes a bug when using the plus specifier in the expand tool.

In the existing solution, when using the plus specifier, `next_tabstop` always returns the current step size - 1, which doesn't account for the potentially varying size of columns.

This implementation will instead calculate the number of steps required find the first tabstop after the current column, which should work for longer column values.

It also adds a check that  disengages the plus specifier if only one tabstop is specified, as the plus specifier requires at least one fixed tabstop to work.

By fixing these two issues, expand.pl appears to pass without failures on my machine.