### PR TITLE
pr: remove commented out code line

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -470,7 +470,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 fn recreate_arguments(args: &[String]) -> Vec<String> {
     let column_page_option = Regex::new(r"^[-+]\d+.*").unwrap();
     let num_regex = Regex::new(r"^[^-]\d*$").unwrap();
-    //let a_file: Regex = Regex::new(r"^[^-+].*").unwrap();
     let n_regex = Regex::new(r"^-n\s*$").unwrap();
     let mut arguments = args.to_owned();
     let num_option = args.iter().find_position(|x| n_regex.is_match(x.trim()));


### PR DESCRIPTION
This PR removes a code line that was commented out in relation to a `FIXME` (https://github.com/uutils/coreutils/commit/bc2b385744e045d5f5499e0c8c4c44be0ae649d6#diff-25a81e8809feab14c3f702e683fc8a77ab5a724ecd40842cd79f6ca4c6c8d31fR448). The `FIXME` has been fixed in the meantime, but the commented out line remained.