### PR TITLE
od: remove "width = width" from format strings

### DIFF
--- a/src/uu/od/src/prn_float.rs
+++ b/src/uu/od/src/prn_float.rs
@@ -47,7 +47,7 @@ fn format_flo32(f: f32) -> String {
 
     if f.classify() == FpCategory::Subnormal {
         // subnormal numbers will be normal as f64, so will print with a wrong precision
-        format!("{:width$e}", f, width = width) // subnormal numbers
+        format!("{:width$e}", f) // subnormal numbers
     } else {
         format_float(f64::from(f), width, precision)
     }
@@ -60,12 +60,12 @@ fn format_flo64(f: f64) -> String {
 fn format_float(f: f64, width: usize, precision: usize) -> String {
     if !f.is_normal() {
         if f == -0.0 && f.is_sign_negative() {
-            return format!("{:>width$}", "-0", width = width);
+            return format!("{:>width$}", "-0");
         }
         if f == 0.0 || !f.is_finite() {
-            return format!("{:width$}", f, width = width);
+            return format!("{:width$}", f);
         }
-        return format!("{:width$e}", f, width = width); // subnormal numbers
+        return format!("{:width$e}", f); // subnormal numbers
     }
 
     let mut l = f.abs().log10().floor() as i32;
@@ -77,16 +77,11 @@ fn format_float(f: f64, width: usize, precision: usize) -> String {
     }
 
     if l >= 0 && l <= (precision as i32 - 1) {
-        format!(
-            "{:width$.dec$}",
-            f,
-            width = width,
-            dec = (precision - 1) - l as usize
-        )
+        format!("{:width$.dec$}", f, dec = (precision - 1) - l as usize)
     } else if l == -1 {
-        format!("{:width$.dec$}", f, width = width, dec = precision)
+        format!("{:width$.dec$}", f, dec = precision)
     } else {
-        format!("{:width$.dec$e}", f, width = width, dec = precision - 1)
+        format!("{:width$.dec$e}", f, dec = precision - 1)
     }
 }
 


### PR DESCRIPTION
This PR removes unnecessary `width = width` from format strings.