### PR TITLE
pr,seq: simplify format strings

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1200,11 +1200,10 @@ fn get_formatted_line_number(opts: &OutputOptions, line_number: usize, index: us
             format!(
                 "{:>width$}{}",
                 &line_str[line_str.len() - width..],
-                separator,
-                width = width
+                separator
             )
         } else {
-            format!("{:>width$}{}", line_str, separator, width = width)
+            format!("{:>width$}{}", line_str, separator)
         }
     } else {
         String::new()

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -210,19 +210,9 @@ fn write_value_float(
 ) -> std::io::Result<()> {
     let value_as_str =
         if *value == ExtendedBigDecimal::Infinity || *value == ExtendedBigDecimal::MinusInfinity {
-            format!(
-                "{value:>width$.precision$}",
-                value = value,
-                width = width,
-                precision = precision,
-            )
+            format!("{value:>width$.precision$}")
         } else {
-            format!(
-                "{value:>0width$.precision$}",
-                value = value,
-                width = width,
-                precision = precision,
-            )
+            format!("{value:>0width$.precision$}")
         };
     write!(writer, "{}", value_as_str)
 }
@@ -237,9 +227,9 @@ fn write_value_int(
 ) -> std::io::Result<()> {
     let value_as_str = if pad {
         if *value == ExtendedBigInt::MinusZero && is_first_iteration {
-            format!("-{value:>0width$}", value = value, width = width - 1,)
+            format!("-{value:>0width$}", width = width - 1)
         } else {
-            format!("{value:>0width$}", value = value, width = width,)
+            format!("{value:>0width$}")
         }
     } else if *value == ExtendedBigInt::MinusZero && is_first_iteration {
         format!("-{}", value)


### PR DESCRIPTION
This PR is similar to #4263 and removes unnecessary `x = x` in format strings.