### PR TITLE
Fix `sleep` argument parsing and errors

### DIFF
--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -9,8 +9,8 @@ use std::thread;
 use std::time::Duration;
 
 use uucore::{
-    error::{UResult, UUsageError},
-    format_usage,
+    error::{UResult, USimpleError, UUsageError},
+    format_usage, show,
 };
 
 use clap::{crate_version, Arg, ArgAction, Command};
@@ -33,12 +33,21 @@ mod options {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
-    if let Some(values) = matches.get_many::<String>(options::NUMBER) {
-        let numbers = values.map(|s| s.as_str()).collect::<Vec<_>>();
-        return sleep(&numbers);
-    }
+    let numbers = matches
+        .get_many::<String>(options::NUMBER)
+        .ok_or_else(|| {
+            USimpleError::new(
+                1,
+                format!(
+                    "missing operand\nTry '{} --help' for more information.",
+                    uucore::execution_phrase()
+                ),
+            )
+        })?
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>();
 
-    Ok(())
+    return sleep(&numbers);
 }
 
 pub fn uu_app() -> Command {
@@ -52,20 +61,24 @@ pub fn uu_app() -> Command {
             Arg::new(options::NUMBER)
                 .help("pause for NUMBER seconds")
                 .value_name(options::NUMBER)
-                .action(ArgAction::Append)
-                .required(true),
+                .action(ArgAction::Append),
         )
 }
 
 fn sleep(args: &[&str]) -> UResult<()> {
-    let sleep_dur =
-        args.iter().try_fold(
-            Duration::new(0, 0),
-            |result, arg| match uucore::parse_time::from_str(&arg[..]) {
-                Ok(m) => Ok(m.saturating_add(result)),
-                Err(f) => Err(UUsageError::new(1, f)),
-            },
-        )?;
+    let mut arg_error = false;
+    let intervals = args.iter().map(|s| match uucore::parse_time::from_str(s) {
+        Ok(result) => result,
+        Err(err) => {
+            arg_error = true;
+            show!(USimpleError::new(1, err));
+            Duration::new(0, 0)
+        }
+    });
+    let sleep_dur = intervals.fold(Duration::new(0, 0), |acc, n| acc + n);
+    if arg_error {
+        return Err(UUsageError::new(1, ""));
+    };
     thread::sleep(sleep_dur);
     Ok(())
 }

--- a/tests/by-util/test_sleep.rs
+++ b/tests/by-util/test_sleep.rs
@@ -9,6 +9,10 @@ fn test_invalid_time_interval() {
         .arg("xyz")
         .fails()
         .usage_error("invalid time interval 'xyz'");
+    new_ucmd!()
+        .args(&["--", "-1"])
+        .fails()
+        .usage_error("invalid time interval '-1'");
 }
 
 #[test]
@@ -75,7 +79,7 @@ fn test_sleep_zero_duration() {
 
 #[test]
 fn test_sleep_no_argument() {
-    new_ucmd!().fails();
+    new_ucmd!().fails().usage_error("missing operand");
 }
 
 #[test]


### PR DESCRIPTION
This changes argument parsing and errors to better match GNU practices.

Associated tests are added and updated.