### PR TITLE
sum, unexpand: fix output of about string

### DIFF
--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -17,8 +17,8 @@ use uucore::{format_usage, show};
 
 static NAME: &str = "sum";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = r#"Checksum and count the blocks in a file.
-                        With no FILE, or when  FILE is -, read standard input."#;
+static ABOUT: &str = "Checksum and count the blocks in a file.\n\n\
+                      With no FILE, or when FILE is -, read standard input.";
 
 // This can be replaced with usize::div_ceil once it is stabilized.
 // This implementation approach is optimized for when `b` is a constant,

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -23,8 +23,8 @@ use uucore::{crash, crash_if_err, format_usage};
 
 static NAME: &str = "unexpand";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = r#"Convert blanks in each FILE to tabs, writing to standard output.
-                        With no FILE, or when FILE is -, read standard input."#;
+static ABOUT: &str = "Convert blanks in each FILE to tabs, writing to standard output.\n\n\
+                      With no FILE, or when FILE is -, read standard input.";
 
 const DEFAULT_TABSTOP: usize = 8;
 


### PR DESCRIPTION
This PR changes the output of the about string from

```
Checksum and count the blocks in a file.
                        With no FILE, or when  FILE is -, read standard input.
```
to

```
Checksum and count the blocks in a file.

With no FILE, or when FILE is -, read standard input.
```