### PR TITLE
mktemp: Fix behavior of short-long options of tmpdir

### DIFF
--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -827,3 +827,63 @@ fn test_default_missing_value() {
     let scene = TestScenario::new(util_name!());
     scene.ucmd().arg("-d").arg("--tmpdir").succeeds();
 }
+
+#[test]
+fn test_missing_xs_tmpdir_template() {
+    let scene = TestScenario::new(util_name!());
+    scene
+        .ucmd()
+        .arg("--tmpdir")
+        .arg(TEST_TEMPLATE3)
+        .fails()
+        .no_stdout()
+        .stderr_contains("too few X's in template");
+    scene
+        .ucmd()
+        .arg("--tmpdir=foobar")
+        .fails()
+        .no_stdout()
+        .stderr_contains("failed to create file via template");
+}
+
+#[test]
+fn test_both_tmpdir_flags_present() {
+    let scene = TestScenario::new(util_name!());
+    scene
+        .ucmd()
+        .arg("-p")
+        .arg(".")
+        .arg("--tmpdir")
+        .arg("foobarXXXX")
+        .succeeds()
+        .no_stderr()
+        .stdout_contains("/tmp/foobar");
+    scene
+        .ucmd()
+        .arg("-p")
+        .arg(".")
+        .arg("--tmpdir=foobarXXXX")
+        .fails()
+        .no_stdout()
+        .stderr_contains("failed to create file via template");
+    scene
+        .ucmd()
+        .arg("--tmpdir")
+        .arg("foobarXXXX")
+        .arg("-p")
+        .arg(".")
+        .succeeds()
+        .no_stderr()
+        .stdout_contains("./foobar");
+}
+
+#[test]
+fn test_missing_short_tmpdir_flag() {
+    let scene = TestScenario::new(util_name!());
+    scene
+        .ucmd()
+        .arg("-p")
+        .fails()
+        .no_stdout()
+        .stderr_contains("requires a value but none was supplied");
+}


### PR DESCRIPTION
Hi, 
This PR started addressing issue #4175, which it fixed but I tried to go a bit further when tinkering with the ways tmpdir option is given.

Previously using something such as `mktemp -p <path> --tmpdir <path2>` would error out since from claps perspective its a single option used twice. However, this is very much allowed in GNU. Therefore, I managed to include that behavior by adding a second short flag `-p` and use independent of `--tmpdir`, as suggested by @tertsdiepraam. 

I also managed to remove some of the previous workarounds to solve some other issues, but of course introduced some new workarounds. 

One last note, is that this introduces a bit of undesired empty line (see after `-p <DIR>`) in the help message due to the new argument, that I am not sure how to fix, so if anyone knows how to, please feel free to help :D 

`uu_mktemp --help` yields now
```
.....
  -p <DIR>   
      --tmpdir[=<DIR>]   interpret TEMPLATE relative to DIR.....
....
```
instead of the way before
```
-p , --tmpdir [<DIR>] interpret TEMPLATE relative to DIR......
```
``` 