### PR TITLE
remove NAME constants

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -35,7 +35,6 @@ use std::os::unix::fs::FileTypeExt;
 use std::os::unix::net::UnixStream;
 use uucore::format_usage;
 
-static NAME: &str = "cat";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
 static ABOUT: &str = "Concatenate FILE(s), or standard input, to standard output
 With no FILE, or when FILE is -, read standard input.";
@@ -236,7 +235,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -18,7 +18,6 @@ use uucore::{format_usage, show};
 const CRC_TABLE_LEN: usize = 256;
 const CRC_TABLE: [u32; CRC_TABLE_LEN] = generate_crc_table();
 
-const NAME: &str = "cksum";
 const USAGE: &str = "{} [OPTIONS] [FILE]...";
 const ABOUT: &str = "Print CRC and size for each file";
 
@@ -139,7 +138,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -23,7 +23,6 @@ use uucore::{format_usage, show, show_error, show_if_err};
 mod searcher;
 mod whitespace_searcher;
 
-static NAME: &str = "cut";
 static USAGE: &str =
     "{} [-d|-w] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+";
 static ABOUT: &str =
@@ -654,7 +653,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -13,7 +13,6 @@ use std::str::Chars;
 use uucore::error::{FromIo, UResult};
 use uucore::format_usage;
 
-const NAME: &str = "echo";
 const ABOUT: &str = "display a line of text";
 const USAGE: &str = "{} [OPTIONS]... [STRING]...";
 const AFTER_HELP: &str = r#"
@@ -129,7 +128,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         // TrailingVarArg specifies the final positional argument is a VarArg
         // and it doesn't attempts the parse any further args.
         // Final argument must have multiple(true) or the usage string equivalent.

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -17,7 +17,6 @@ use uucore::format_usage;
 
 const TAB_WIDTH: usize = 8;
 
-static NAME: &str = "fold";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
 static ABOUT: &str = "Writes each file (or standard input if no files are given)
  to standard output whilst breaking long lines";
@@ -63,7 +62,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -12,7 +12,6 @@ use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
 use uucore::{format_usage, show};
 
-static NAME: &str = "mkfifo";
 static USAGE: &str = "{} [OPTION]... NAME...";
 static ABOUT: &str = "Create a FIFO with the given name.";
 
@@ -67,7 +66,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -18,7 +18,6 @@ use uucore::format_usage;
 
 mod helper;
 
-static NAME: &str = "nl";
 static ABOUT: &str = "number lines of files";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
 
@@ -141,7 +140,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .about(ABOUT)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -21,7 +21,6 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
 use uucore::format_usage;
 
-static NAME: &str = "ptx";
 const USAGE: &str = "\
     {} [OPTION]... [INPUT]...
     {} -G [OPTION]... [INPUT [OUTPUT]]";
@@ -747,7 +746,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .about(ABOUT)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -25,7 +25,6 @@ enum Mode {
     InputRange((usize, usize)),
 }
 
-static NAME: &str = "shuf";
 static USAGE: &str = "\
     {} [OPTION]... [FILE]
     {} -e [OPTION]... [ARG]...
@@ -127,7 +126,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .about(ABOUT)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -30,7 +30,6 @@ use uucore::format_usage;
 use flags::BAUD_RATES;
 use flags::{CONTROL_FLAGS, INPUT_FLAGS, LOCAL_FLAGS, OUTPUT_FLAGS};
 
-const NAME: &str = "stty";
 const USAGE: &str = "\
     {} [-F DEVICE | --file=DEVICE] [SETTING]...
     {} [-F DEVICE | --file=DEVICE] [-a|--all]
@@ -324,7 +323,6 @@ fn apply_flag<T: TermiosFlag>(
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(SUMMARY)

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -15,7 +15,6 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::{format_usage, show};
 
-static NAME: &str = "sum";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
 static ABOUT: &str = "Checksum and count the blocks in a file.\n\n\
                       With no FILE, or when FILE is -, read standard input.";
@@ -148,7 +147,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -23,7 +23,6 @@ use uucore::{format_usage, show};
 
 use crate::error::TacError;
 
-static NAME: &str = "tac";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
 static ABOUT: &str = "Write each file to standard output, last line first.";
 
@@ -62,7 +61,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -21,7 +21,6 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
 use uucore::{crash, crash_if_err, format_usage};
 
-static NAME: &str = "unexpand";
 static USAGE: &str = "{} [OPTION]... [FILE]...";
 static ABOUT: &str = "Convert blanks in each FILE to tabs, writing to standard output.\n\n\
                       With no FILE, or when FILE is -, read standard input.";
@@ -172,7 +171,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .name(NAME)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)


### PR DESCRIPTION
This PR removes `NAME` constants some utils define to set the program's name used by clap. This seems unnecessary because the name is already set by passing the value of `uucore::util_name()` to clap.