### PR TITLE
clippy: use type name instead of Default::default

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -491,8 +491,8 @@ impl<'a> Output<'a> {
         // These objects are counters, initialized to zero. After each
         // iteration of the main loop, each will be incremented by the
         // number of blocks read and written, respectively.
-        let mut rstat = Default::default();
-        let mut wstat = Default::default();
+        let mut rstat = ReadStat::default();
+        let mut wstat = WriteStat::default();
 
         // The time at which the main loop starts executing.
         //

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -105,11 +105,11 @@ impl Default for Options {
         Self {
             show_local_fs: Default::default(),
             show_all_fs: Default::default(),
-            block_size: Default::default(),
-            human_readable: Default::default(),
-            header_mode: Default::default(),
-            include: Default::default(),
-            exclude: Default::default(),
+            block_size: BlockSize::default(),
+            human_readable: Option::default(),
+            header_mode: HeaderMode::default(),
+            include: Option::default(),
+            exclude: Option::default(),
             sync: Default::default(),
             show_total: Default::default(),
             columns: vec![

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -149,7 +149,7 @@ impl Mode {
                 Ok(Self::FirstLines(n))
             }
         } else {
-            Ok(Default::default())
+            Ok(Self::default())
         }
     }
 }

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -606,7 +606,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let key1 = parse_field_number_option(matches.get_one::<String>("1").map(|s| s.as_str()))?;
     let key2 = parse_field_number_option(matches.get_one::<String>("2").map(|s| s.as_str()))?;
 
-    let mut settings: Settings = Default::default();
+    let mut settings = Settings::default();
 
     let v_values = matches.get_many::<String>("v");
     if v_values.is_some() {

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -227,7 +227,7 @@ impl Display for PtxError {
 }
 
 fn get_config(matches: &clap::ArgMatches) -> UResult<Config> {
-    let mut config: Config = Default::default();
+    let mut config = Config::default();
     let err_msg = "parsing options failed";
     if matches.get_flag(options::TRADITIONAL) {
         config.gnu_ext = false;

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -676,7 +676,7 @@ impl<'a> Line<'a> {
                 || settings
                     .selectors
                     .last()
-                    .map_or(true, |selector| selector != &Default::default()))
+                    .map_or(true, |selector| selector != &FieldSelector::default()))
         {
             // A last resort comparator is in use, underline the whole line.
             if self.line.is_empty() {
@@ -1049,7 +1049,7 @@ fn make_sort_mode_arg(mode: &'static str, short: char, help: &'static str) -> Ar
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
-    let mut settings: GlobalSettings = Default::default();
+    let mut settings = GlobalSettings::default();
 
     let matches = match uu_app().try_get_matches_from(args) {
         Ok(t) => t,
@@ -1761,7 +1761,7 @@ fn get_rand_string() -> [u8; 16] {
 }
 
 fn get_hash<T: Hash>(t: &T) -> u64 {
-    let mut s: FnvHasher = Default::default();
+    let mut s = FnvHasher::default();
     t.hash(&mut s);
     s.finish()
 }

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -31,7 +31,7 @@ impl TmpDirWrapper {
             parent_path: path,
             size: 0,
             temp_dir: None,
-            lock: Default::default(),
+            lock: Arc::default(),
         }
     }
 

--- a/src/uucore/src/lib/features/tokenize/num_format/formatters/float_common.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/formatters/float_common.rs
@@ -226,7 +226,7 @@ pub fn get_primitive_dec(
     last_dec_place: usize,
     sci_mode: Option<bool>,
 ) -> FormatPrimitive {
-    let mut f: FormatPrimitive = Default::default();
+    let mut f = FormatPrimitive::default();
 
     // add negative sign section
     if initial_prefix.sign == -1 {

--- a/src/uucore/src/lib/features/tokenize/num_format/formatters/intf.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/formatters/intf.rs
@@ -121,7 +121,7 @@ impl Intf {
     // get a FormatPrimitive of the maximum value for the field char
     //  and given sign
     fn get_max(field_char: char, sign: i8) -> FormatPrimitive {
-        let mut fmt_primitive: FormatPrimitive = Default::default();
+        let mut fmt_primitive = FormatPrimitive::default();
         fmt_primitive.pre_decimal = Some(String::from(match field_char {
             'd' | 'i' => match sign {
                 1 => "9223372036854775807",
@@ -160,7 +160,7 @@ impl Intf {
         match field_char {
             'i' | 'd' => match i64::from_str_radix(segment, radix_in as u32) {
                 Ok(i) => {
-                    let mut fmt_prim: FormatPrimitive = Default::default();
+                    let mut fmt_prim = FormatPrimitive::default();
                     if sign == -1 {
                         fmt_prim.prefix = Some(String::from("-"));
                     }
@@ -171,7 +171,7 @@ impl Intf {
             },
             _ => match u64::from_str_radix(segment, radix_in as u32) {
                 Ok(u) => {
-                    let mut fmt_prim: FormatPrimitive = Default::default();
+                    let mut fmt_prim = FormatPrimitive::default();
                     let u_f = if sign == -1 { u64::MAX - (u - 1) } else { u };
                     fmt_prim.pre_decimal = Some(match field_char {
                         'X' => format!("{:X}", u_f),
@@ -235,7 +235,7 @@ impl Formatter for Intf {
                 )
             } else {
                 // otherwise just do a straight string copy.
-                let mut fmt_prim: FormatPrimitive = Default::default();
+                let mut fmt_prim = FormatPrimitive::default();
 
                 // this is here and not earlier because
                 // zero doesn't get a sign, and conv_from_segment

--- a/src/uucore/src/lib/features/tokenize/num_format/num_format.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/num_format.rs
@@ -218,7 +218,7 @@ pub fn num_format(field: &FormatField, in_str_opt: Option<&String>) -> Option<St
         // if we can get an assumed value from looking at the first
         // few characters, use that value to create the FormatPrimitive
         if let Some(provided_num) = get_provided(in_str_opt) {
-            let mut tmp : FormatPrimitive = Default::default();
+            let mut tmp = FormatPrimitive::default();
             match field_char {
                 'u' | 'i' | 'd' => {
                     tmp.pre_decimal = Some(


### PR DESCRIPTION
This PR fixes warnings caused by the `default_trait_access` lint (https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access) when running `clippy::pedantic`.