### PR TITLE
cp: remove empty line from version output

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -552,7 +552,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             clap::error::ErrorKind::DisplayHelp => {
                 app.print_help()?;
             }
-            clap::error::ErrorKind::DisplayVersion => println!("{}", app.render_version()),
+            clap::error::ErrorKind::DisplayVersion => print!("{}", app.render_version()),
             _ => return Err(Box::new(e.with_exit_code(1))),
         };
     } else if let Ok(matches) = matches {


### PR DESCRIPTION
This PR changes the output of `--version` from

```
cp 0.0.16

```
to 

```
cp 0.0.16
```
