### PR TITLE
mktemp: uncomment fixed test case

### DIFF
--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -704,16 +704,18 @@ fn test_tmpdir_env_var() {
     assert_suffix_matches_template!("tmp.XXXXXXXXXX", filename);
     assert!(at.file_exists(filename));
 
-    // FIXME This is not working because --tmpdir is configured to
-    // require a value.
-    //
-    // // `TMPDIR=. mktemp --tmpdir`
-    // let (at, mut ucmd) = at_and_ucmd!();
-    // let result = ucmd.env(TMPDIR, ".").arg("--tmpdir").succeeds();
-    // let filename = result.no_stderr().stdout_str().trim_end();
-    // let template = format!(".{}tmp.XXXXXXXXXX", MAIN_SEPARATOR);
-    // assert_matches_template!(&template, filename);
-    // assert!(at.file_exists(filename));
+    // `TMPDIR=. mktemp --tmpdir`
+    let (at, mut ucmd) = at_and_ucmd!();
+    let result = ucmd.env(TMPDIR, ".").arg("--tmpdir").succeeds();
+    let filename = result.no_stderr().stdout_str().trim_end();
+    #[cfg(not(windows))]
+    {
+        let template = format!(".{MAIN_SEPARATOR}tmp.XXXXXXXXXX");
+        assert_matches_template!(&template, filename);
+    }
+    #[cfg(windows)]
+    assert_suffix_matches_template!("tmp.XXXXXXXXXX", filename);
+    assert!(at.file_exists(filename));
 
     // `TMPDIR=. mktemp --tmpdir XXX`
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Uncomment a test case fixed by commit
53c4b0b81e528adc340dd803bf597fa3fad1bb4c (pull request https://github.com/uutils/coreutils/pull/4091).