### PR TITLE
`uucore`: Fix #4298: Fails to build on s390x (and riscv64)

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -115,6 +115,7 @@ impl FileInformation {
             not(target_os = "android"),
             not(target_os = "freebsd"),
             not(target_arch = "aarch64"),
+            not(target_arch = "riscv64"),
             target_pointer_width = "64"
         ))]
         return self.0.st_nlink;
@@ -125,6 +126,7 @@ impl FileInformation {
                 target_os = "android",
                 target_os = "freebsd",
                 target_arch = "aarch64",
+                target_arch = "riscv64",
                 not(target_pointer_width = "64")
             )
         ))]

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -619,6 +619,7 @@ impl FsMeta for StatFs {
             not(target_vendor = "apple"),
             not(target_os = "android"),
             not(target_os = "freebsd"),
+            not(target_arch = "s390x"),
             target_pointer_width = "64"
         ))]
         return self.f_bsize;
@@ -626,6 +627,7 @@ impl FsMeta for StatFs {
             not(target_env = "musl"),
             not(target_os = "freebsd"),
             any(
+                target_arch = "s390x",
                 target_vendor = "apple",
                 target_os = "android",
                 not(target_pointer_width = "64")
@@ -681,6 +683,7 @@ impl FsMeta for StatFs {
             not(target_vendor = "apple"),
             not(target_os = "android"),
             not(target_os = "freebsd"),
+            not(target_arch = "s390x"),
             target_pointer_width = "64"
         ))]
         return self.f_type;
@@ -690,6 +693,7 @@ impl FsMeta for StatFs {
                 target_vendor = "apple",
                 target_os = "android",
                 target_os = "freebsd",
+                target_arch = "s390x",
                 not(target_pointer_width = "64")
             )
         ))]


### PR DESCRIPTION
I ran the builds locally with `cross` without the errors occurring in the failed builds here https://buildd.debian.org/status/logs.php?pkg=rust-coreutils&ver=0.0.17-1

The commands I used were:
```
$ cross build --target s390x-unknown-linux-gnu --features unix
$ cross build --target riscv64gc-unknown-linux-gnu --features unix
```

Closes #4298 