### PR TITLE
`tests/util`: Don't trim output in `CmdResult::stdout_matches` and `stdout_does_not_match`

### DIFF
--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -68,10 +68,10 @@ fn test_date_utc() {
 fn test_date_format_y() {
     let scene = TestScenario::new(util_name!());
 
-    let mut re = Regex::new(r"^\d{4}$").unwrap();
+    let mut re = Regex::new(r"^\d{4}\n$").unwrap();
     scene.ucmd().arg("+%Y").succeeds().stdout_matches(&re);
 
-    re = Regex::new(r"^\d{2}$").unwrap();
+    re = Regex::new(r"^\d{2}\n$").unwrap();
     scene.ucmd().arg("+%y").succeeds().stdout_matches(&re);
 }
 
@@ -82,7 +82,7 @@ fn test_date_format_m() {
     let mut re = Regex::new(r"\S+").unwrap();
     scene.ucmd().arg("+%b").succeeds().stdout_matches(&re);
 
-    re = Regex::new(r"^\d{2}$").unwrap();
+    re = Regex::new(r"^\d{2}\n$").unwrap();
     scene.ucmd().arg("+%m").succeeds().stdout_matches(&re);
 }
 
@@ -96,7 +96,7 @@ fn test_date_format_day() {
     re = Regex::new(r"\S+").unwrap();
     scene.ucmd().arg("+%A").succeeds().stdout_matches(&re);
 
-    re = Regex::new(r"^\d{1}$").unwrap();
+    re = Regex::new(r"^\d{1}\n$").unwrap();
     scene.ucmd().arg("+%u").succeeds().stdout_matches(&re);
 }
 
@@ -117,7 +117,7 @@ fn test_date_issue_3780() {
 #[test]
 fn test_date_nano_seconds() {
     // %N     nanoseconds (000000000..999999999)
-    let re = Regex::new(r"^\d{1,9}$").unwrap();
+    let re = Regex::new(r"^\d{1,9}\n$").unwrap();
     new_ucmd!().arg("+%N").succeeds().stdout_matches(&re);
 }
 

--- a/tests/by-util/test_dir.rs
+++ b/tests/by-util/test_dir.rs
@@ -49,5 +49,5 @@ fn test_long_output() {
         .ucmd()
         .arg("-l")
         .succeeds()
-        .stdout_matches(&Regex::new("[rwx-]{10}.*some-file1$").unwrap());
+        .stdout_matches(&Regex::new("[rwx-]{10}.*some-file1\n$").unwrap());
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -950,7 +950,7 @@ fn test_ls_commas_trailing() {
         .arg("./test-commas-trailing-1")
         .arg("./test-commas-trailing-2")
         .succeeds()
-        .stdout_matches(&Regex::new(r"\S$").unwrap()); // matches if there is no whitespace at the end of stdout.
+        .stdout_matches(&Regex::new(r"\S\n$").unwrap());
 }
 
 #[test]

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -300,7 +300,7 @@ fn test_relative_base_not_prefix_of_relative_to() {
         .succeeds();
 
     #[cfg(windows)]
-    result.stdout_matches(&Regex::new(r"^.*:\\usr\n.*:\\usr\\local$").unwrap());
+    result.stdout_matches(&Regex::new(r"^.*:\\usr\n.*:\\usr\\local\n$").unwrap());
 
     #[cfg(not(windows))]
     result.stdout_is("/usr\n/usr/local\n");
@@ -344,7 +344,7 @@ fn test_relative() {
     #[cfg(not(windows))]
     result.stdout_is("/tmp\n.\n");
     #[cfg(windows)]
-    result.stdout_matches(&Regex::new(r"^.*:\\tmp\n\.$").unwrap());
+    result.stdout_matches(&Regex::new(r"^.*:\\tmp\n\.\n$").unwrap());
 
     new_ucmd!()
         .args(&["-sm", "--relative-base=/", "--relative-to=/", "/", "/usr"])
@@ -357,7 +357,7 @@ fn test_relative() {
     #[cfg(not(windows))]
     result.stdout_is("/tmp\n.\n");
     #[cfg(windows)]
-    result.stdout_matches(&Regex::new(r"^.*:\\tmp\n\.$").unwrap());
+    result.stdout_matches(&Regex::new(r"^.*:\\tmp\n\.\n$").unwrap());
 
     new_ucmd!()
         .args(&["-sm", "--relative-base=/", "/", "/usr"])

--- a/tests/by-util/test_vdir.rs
+++ b/tests/by-util/test_vdir.rs
@@ -29,7 +29,7 @@ fn test_default_output() {
     scene
         .ucmd()
         .succeeds()
-        .stdout_matches(&Regex::new("[rwx-]{10}.*some-file1$").unwrap());
+        .stdout_matches(&Regex::new("[rwx-]{10}.*some-file1\n$").unwrap());
 }
 
 #[test]

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -686,7 +686,7 @@ impl CmdResult {
     #[track_caller]
     pub fn stdout_matches(&self, regex: &regex::Regex) -> &Self {
         assert!(
-            regex.is_match(self.stdout_str().trim()),
+            regex.is_match(self.stdout_str()),
             "Stdout does not match regex:\n{}",
             self.stdout_str()
         );
@@ -696,7 +696,7 @@ impl CmdResult {
     #[track_caller]
     pub fn stdout_does_not_match(&self, regex: &regex::Regex) -> &Self {
         assert!(
-            !regex.is_match(self.stdout_str().trim()),
+            !regex.is_match(self.stdout_str()),
             "Stdout matches regex:\n{}",
             self.stdout_str()
         );

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -603,7 +603,7 @@ impl CmdResult {
 
     /// asserts that
     /// 1.  the command resulted in stderr stream output that equals the
-    ///     passed in value, when both are trimmed of trailing whitespace
+    ///     passed in value
     /// 2.  the command resulted in empty (zero-length) stdout stream output
     #[track_caller]
     pub fn stderr_only<T: AsRef<str>>(&self, msg: T) -> &Self {
@@ -628,7 +628,7 @@ impl CmdResult {
 
     /// asserts that
     /// 1.  the command resulted in stderr stream output that equals the
-    ///     the following format when both are trimmed of trailing whitespace
+    ///     the following format
     ///     `"{util_name}: {msg}\nTry '{bin_path} {util_name} --help' for more information."`
     ///     This the expected format when a `UUsageError` is returned or when `show_error!` is called
     ///     `msg` should be the same as the one provided to `UUsageError::new` or `show_error!`


### PR DESCRIPTION
Like discussed in #4261, this pr removes the trimming of the `stdout` in `CmdResult::stdout_matches` and `CmdResult::stdout_does_not_match`. 

The tests using these methdos are adjusted to match the trailing newline instead of ignoring it.