### PR TITLE
ptx: fix warning from unnecessary_join lint

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -174,8 +174,7 @@ impl WordFilter {
                             } else {
                                 c.to_string()
                             })
-                            .collect::<Vec<String>>()
-                            .join("")
+                            .collect::<String>()
                     )
                 } else if config.gnu_ext {
                     "\\w+".to_owned()


### PR DESCRIPTION
This PR fixes a warning from the [unnecessary_join](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_join) lint and replaces `.collect::<Vec<String>>().join("")` with `.collect::<String>()`