### PR TITLE
comm: use delimiter on "total" line

### DIFF
--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -72,6 +72,14 @@ fn total_with_suppressed_regular_output() {
 }
 
 #[test]
+fn total_with_output_delimiter() {
+    new_ucmd!()
+        .args(&["--total", "--output-delimiter=word", "a", "b"])
+        .succeeds()
+        .stdout_is_fixture("ab_total_delimiter_word.expected");
+}
+
+#[test]
 fn output_delimiter() {
     new_ucmd!()
         .args(&["--output-delimiter=word", "a", "b"])

--- a/tests/fixtures/comm/ab_total_delimiter_word.expected
+++ b/tests/fixtures/comm/ab_total_delimiter_word.expected
@@ -1,0 +1,4 @@
+a
+wordb
+wordwordz
+1word1word1wordtotal


### PR DESCRIPTION
This PR makes the `total` line use the delimiter specified with `--output-delimiter` and refactors the delimiter handling.