### PR TITLE
timeout: fix subprocess is never terminated

### DIFF
--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -48,6 +48,9 @@ pub trait ChildExt {
     /// send the signal to an unrelated process that recycled the PID.
     fn send_signal(&mut self, signal: usize) -> io::Result<()>;
 
+    /// Send a signal to a process group.
+    fn send_signal_group(&mut self, signal: usize) -> io::Result<()>;
+
     /// Wait for a process to finish or return after the specified duration.
     /// A `timeout` of zero disables the timeout.
     fn wait_or_timeout(&mut self, timeout: Duration) -> io::Result<Option<ExitStatus>>;
@@ -56,6 +59,18 @@ pub trait ChildExt {
 impl ChildExt for Child {
     fn send_signal(&mut self, signal: usize) -> io::Result<()> {
         if unsafe { libc::kill(self.id() as pid_t, signal as i32) } != 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn send_signal_group(&mut self, signal: usize) -> io::Result<()> {
+        // Ignore the signal, so we don't go into a signal loop.
+        if unsafe { libc::signal(signal as i32, libc::SIG_IGN) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if unsafe { libc::kill(0, signal as i32) } != 0 {
             Err(io::Error::last_os_error())
         } else {
             Ok(())

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -138,3 +138,19 @@ fn test_kill_after_long() {
         .no_stdout()
         .no_stderr();
 }
+
+#[test]
+fn test_kill_subprocess() {
+    new_ucmd!()
+        .args(&[
+            // Make sure the CI can spawn the subprocess.
+            "10",
+            "sh",
+            "-c",
+            "sh -c \"trap 'echo xyz' TERM; sleep 30\"",
+        ])
+        .fails()
+        .code_is(124)
+        .stdout_contains("xyz")
+        .stderr_contains("Terminated");
+}


### PR DESCRIPTION
Closes #4176.

This should also fix #4073.

Follow GNU's timeout behavior, send a signal to the process group to make sure subprocesses are cleaned up, and also send SIGCONT to the child and the whole process group after that.