### PR TITLE
df: detect over-mounted device

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -403,7 +403,7 @@ where
             Err(FsError::MountMissing) => {
                 show!(USimpleError::new(1, "no file systems processed"));
             }
-            Err(FsError::Overmounted) => {
+            Err(FsError::OverMounted) => {
                 show!(USimpleError::new(
                     1,
                     format!(

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -407,8 +407,8 @@ where
                 show!(USimpleError::new(
                     1,
                     format!(
-                        "cannot access '{}': over-mounted by another device",
-                        path.as_ref().display()
+                        "cannot access {}: over-mounted by another device",
+                        path.as_ref().quote()
                     )
                 ));
             }

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -394,16 +394,14 @@ where
     for path in paths {
         match Filesystem::from_path(&mounts, path) {
             Ok(fs) => result.push(fs),
-            Err(FsError::NoMountFound) => {
-                // this happens if specified file system type != file system type of the file
-                if path.as_ref().exists() {
-                    show!(USimpleError::new(1, "no file systems processed"));
-                } else {
-                    show!(USimpleError::new(
-                        1,
-                        format!("{}: No such file or directory", path.as_ref().display())
-                    ));
-                }
+            Err(FsError::InvalidPath) => {
+                show!(USimpleError::new(
+                    1,
+                    format!("{}: No such file or directory", path.as_ref().display())
+                ));
+            }
+            Err(FsError::MountMissing) => {
+                show!(USimpleError::new(1, "no file systems processed"));
             }
             Err(FsError::Overmounted) => {
                 show!(USimpleError::new(

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -407,7 +407,7 @@ where
                 show!(USimpleError::new(
                     1,
                     format!(
-                        "cannot access {}: over-mounted by another device",
+                        "cannot access '{}': over-mounted by another device",
                         path.as_ref().display()
                     )
                 ));

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -39,14 +39,14 @@ pub(crate) struct Filesystem {
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum FsError {
-    Overmounted,
+    OverMounted,
     InvalidPath,
     MountMissing,
 }
 
-/// Check whether `mount` has been overmounted.
+/// Check whether `mount` has been over-mounted.
 ///
-/// `mount` is considered overmounted if it there is an element in
+/// `mount` is considered over-mounted if it there is an element in
 /// `mounts` after mount that has the same mount_dir.
 fn is_over_mounted(mounts: &[MountInfo], mount: &MountInfo) -> bool {
     let last_mount_for_dir = mounts
@@ -137,14 +137,14 @@ impl Filesystem {
     }
 
     /// Find and create the filesystem from the given mount
-    /// after checking that the it hasn't been overmounted
+    /// after checking that the it hasn't been over-mounted
     pub(crate) fn from_mount(
         mounts: &[MountInfo],
         mount: &MountInfo,
         file: Option<String>,
     ) -> Result<Self, FsError> {
         if is_over_mounted(mounts, mount) {
-            Err(FsError::Overmounted)
+            Err(FsError::OverMounted)
         } else {
             Self::new(mount.clone(), file).ok_or(FsError::MountMissing)
         }
@@ -314,7 +314,7 @@ mod tests {
 
             assert_eq!(
                 Filesystem::from_mount(&mounts, &mounts[0], None).unwrap_err(),
-                FsError::Overmounted
+                FsError::OverMounted
             );
         }
     }

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -143,11 +143,14 @@ impl Filesystem {
         mount: &MountInfo,
         file: Option<String>,
     ) -> Result<Self, FsError> {
-        if is_over_mounted(mounts, mount) {
-            Err(FsError::OverMounted)
-        } else {
-            Self::new(mount.clone(), file).ok_or(FsError::MountMissing)
+        #[cfg(unix)]
+        {
+            if is_over_mounted(mounts, mount) {
+                return Err(FsError::OverMounted);
+            }
         }
+
+        Self::new(mount.clone(), file).ok_or(FsError::MountMissing)
     }
 
     /// Find and create the filesystem that best matches a given path.

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -37,7 +37,7 @@ pub(crate) struct Filesystem {
     pub usage: FsUsage,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum FsError {
     Overmounted,
     InvalidPath,
@@ -215,7 +215,19 @@ mod tests {
 
         #[test]
         fn test_empty_mounts() {
-            assert!(mount_info_from_path(&[], "/", false).is_none());
+            assert_eq!(
+                mount_info_from_path(&[], "/", false).unwrap_err(),
+                FsError::MountMissing
+            );
+        }
+
+        #[test]
+        fn test_bad_path() {
+            assert_eq!(
+                // This path better not exist....
+                mount_info_from_path(&[], "/ksjhdkljflksdjfklsdjfksdjlkfjsd", true).unwrap_err(),
+                FsError::InvalidPath
+            );
         }
 
         #[test]
@@ -242,13 +254,19 @@ mod tests {
         #[test]
         fn test_no_match() {
             let mounts = [mount_info("/foo")];
-            assert!(mount_info_from_path(&mounts, "/bar", false).is_none());
+            assert_eq!(
+                mount_info_from_path(&mounts, "/bar", false).unwrap_err(),
+                FsError::MountMissing
+            );
         }
 
         #[test]
         fn test_partial_match() {
             let mounts = [mount_info("/foo/bar")];
-            assert!(mount_info_from_path(&mounts, "/foo/baz", false).is_none());
+            assert_eq!(
+                mount_info_from_path(&mounts, "/foo/baz", false).unwrap_err(),
+                FsError::MountMissing
+            );
         }
 
         #[test]
@@ -279,9 +297,9 @@ mod tests {
 
             let mounts = [mount_info1, mount_info2];
 
-            assert!(
-                Filesystem::from_mount(&mounts, &mounts[0], None).unwrap_err()
-                    == FsError::Overmounted
+            assert_eq!(
+                Filesystem::from_mount(&mounts, &mounts[0], None).unwrap_err(),
+                FsError::Overmounted
             );
         }
     }

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -229,7 +229,7 @@ mod tests {
         fn test_bad_path() {
             assert_eq!(
                 // This path better not exist....
-                mount_info_from_path(&[], "/ksjhdkljflksdjfklsdjfksdjlkfjsd", true).unwrap_err(),
+                mount_info_from_path(&[], "/non-existent-path", true).unwrap_err(),
                 FsError::InvalidPath
             );
         }


### PR DESCRIPTION
Addresses #3970 - Still needs some cleanup around the error handling. Feedback appreciated!

I added Filesystem::from_mount to ensure only valid (i.e. non-overmounted) Filesystem structs are created. I guess the next step for that would be making `Filesystem::new` unavailable outside of `filesystem.rs`
