### PR TITLE
docs: fix invalid test status in gnu-full-result

### DIFF
--- a/util/gnu-json-result.py
+++ b/util/gnu-json-result.py
@@ -3,9 +3,9 @@ Extract the GNU logs into a JSON file.
 """
 
 import json
-from pathlib import Path
+import re
 import sys
-from os import environ
+from pathlib import Path
 
 out = {}
 
@@ -20,7 +20,11 @@ for filepath in test_dir.glob("**/*.log"):
     try:
         with open(path) as f:
             content = f.read()
-            current[path.name] = content.split("\n")[-2].split(" ")[0]
+            result = re.search(
+                r"(PASS|FAIL|SKIP|ERROR) [^ ]+ \(exit status: \d+\)$", content
+            )
+            if result:
+                current[path.name] = result.group(1)
     except:
         pass
 


### PR DESCRIPTION
Closes #4276

Use regex to extract the test status from the log. The origin method will fail to extract status from the following:

#### /gnu/tests/split/line-bytes.log

```
00101201230123401234501234560123456701234567801234567890123456789001012012301234012345012345601234567012345678012345678901234567890010120123012340123450123456012345670123456780123456789012345678900101201230123401234501234560123456701234567801234567890123456789001012012301234012345012345601234567012345678012345678901234567890010120123012340123450123456012345670123456780123456789012345678900101201230123401234501234560123456701234567801234567890123456789001012012301234012345012345601234567012345678012345678901234567890010120123012340123450123456012345670123456780123456789012345678900101201230123401234501234560123456701234567801234567890123456789PASS tests/split/line-bytes.sh (exit status: 0)
```

#### /gnu/tests/misc/nice.log

```
diff -u /dev/null err
--- /dev/null   1970-01-01
+++ err 1970-01-01
+nice: warning: setpriority: Permission denied (os error 13)PASS tests/misc/nice.sh (exit status: 0
```