### PR TITLE
sort: version_cmp should keep the trailing 0 for comparison

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1861,8 +1861,9 @@ fn sort_entries(entries: &mut [PathData], config: &Config, out: &mut BufWriter<S
         Sort::Size => entries.sort_by_key(|k| Reverse(k.md(out).map(|md| md.len()).unwrap_or(0))),
         // The default sort in GNU ls is case insensitive
         Sort::Name => entries.sort_by(|a, b| a.display_name.cmp(&b.display_name)),
-        Sort::Version => entries
-            .sort_by(|a, b| version_cmp(&a.p_buf.to_string_lossy(), &b.p_buf.to_string_lossy())),
+        Sort::Version => entries.sort_by(|a, b| {
+            version_cmp(&a.p_buf.to_string_lossy(), &b.p_buf.to_string_lossy(), true)
+        }),
         Sort::Extension => entries.sort_by(|a, b| {
             a.p_buf
                 .extension()

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1630,7 +1630,7 @@ fn compare_by<'a>(
                 general_numeric_compare(a_float, b_float)
             }
             SortMode::Month => month_compare(a_str, b_str),
-            SortMode::Version => version_cmp(a_str, b_str),
+            SortMode::Version => version_cmp(a_str, b_str, false),
             SortMode::Default => custom_str_cmp(
                 a_str,
                 b_str,
@@ -1911,7 +1911,7 @@ mod tests {
         let a = "1.2.3-alpha2";
         let b = "1.4.0";
 
-        assert_eq!(Ordering::Less, version_cmp(a, b));
+        assert_eq!(Ordering::Less, version_cmp(a, b, true));
     }
 
     #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2291,6 +2291,8 @@ fn test_ls_version_sort() {
         "a01.0000001",
         "a01.001",
         "a001.01",
+        "string start 5.4.0 end of str",
+        "string start 5.04.0 end of str",
     ] {
         at.touch(filename);
     }
@@ -2318,6 +2320,8 @@ fn test_ls_version_sort() {
         "b20",
         "b20a",
         "b20b",
+        "'string start 5.04.0 end of str'",
+        "'string start 5.4.0 end of str'",
         "", // because of '\n' at the end of the output
     ];
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -135,6 +135,16 @@ fn test_version_empty_lines() {
 }
 
 #[test]
+fn test_version_stable() {
+    let input = "string start 5.4.0 end of str\nstring start 5.04.0 end of str\n";
+    new_ucmd!()
+        .args(&["--stable", "--sort=version"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(input);
+}
+
+#[test]
 fn test_human_numeric_whitespace() {
     test_helper(
         "human-numeric-whitespace",


### PR DESCRIPTION
Fix misc/sort-version.sh

This is the demo that I did at fosdem 
https://www.youtube.com/watch?v=90Q5N1qT7BQ
