### PR TITLE
docs: document env -f/--file in GNU extensions

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -5,6 +5,11 @@ features that are not supported by GNU coreutils. We take care not to introduce
 features that are incompatible with the GNU coreutils. Below is a list of uutils
 extensions.
 
+## `env`
+
+`env` has an additional `-f`/`--file` flag that can parse `.env` files and set
+variables accordingly. This feature is adopted from `dotenv` style packages.
+
 ## `cp`
 
 `cp` can display a progress bar when the `-g`/`--progress` flag is set.
@@ -36,4 +41,5 @@ therefore welcomed.
 
 ## `cut`
 
-`cut` can separate fields by whitespace (Space and Tab) with `-w` flag. This feature is adopted from [FreeBSD](https://www.freebsd.org/cgi/man.cgi?cut).
+`cut` can separate fields by whitespace (Space and Tab) with `-w` flag. This
+feature is adopted from [FreeBSD](https://www.freebsd.org/cgi/man.cgi?cut).


### PR DESCRIPTION
Found this GNU extension in the code while trying to figure out where the `hashbrown` dependency comes from (it comes from `rust-ini` which is used as a parser for `.env` files).