### PR TITLE
Fix some double deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset",
  "scopeguard",
 ]
 
@@ -636,12 +636,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.2.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
+checksum = "1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71"
 dependencies = [
  "nix",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1206,9 +1206,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -1295,15 +1295,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -1340,16 +1331,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2104,6 +2095,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size 0.2.2",
+ "terminal_size",
 ]
 
 [[package]]
@@ -285,16 +285,15 @@ checksum = "120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3"
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size 0.1.17",
  "unicode-width",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1095,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
  "number_prefix",
@@ -2182,16 +2181,6 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
@@ -2207,7 +2196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
  "smawk",
- "terminal_size 0.2.2",
+ "terminal_size",
  "unicode-linebreak",
  "unicode-width",
 ]
@@ -2749,7 +2738,7 @@ dependencies = [
  "once_cell",
  "selinux",
  "term_grid",
- "terminal_size 0.2.2",
+ "terminal_size",
  "unicode-width",
  "uucore",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,13 +128,13 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.4",
+ "constant_time_eq",
  "digest",
 ]
 
@@ -295,12 +295,6 @@ dependencies = [
  "unicode-width",
  "windows-sys",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,7 +411,7 @@ procfs = { version = "0.14", default-features = false }
 rlimit = "0.8.3"
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = { version = "0.25", default-features = false, features = ["process", "signal", "user"] }
+nix = { version = "0.26", default-features = false, features = ["process", "signal", "user"] }
 rust-users = { version="0.11", package="users" }
 rand_pcg = "0.3"
 

--- a/deny.toml
+++ b/deny.toml
@@ -59,12 +59,8 @@ highlight = "all"
 # introduces it.
 # spell-checker: disable
 skip = [
-    # blake2d_simd
-    { name = "arrayvec", version = "=0.7.2" },
     # tempfile
     { name = "remove_dir_all", version = "=0.5.3" },
-    # blake2b_simd
-    { name = "constant_time_eq", version = "=0.1.5"},
 ]
 # spell-checker: enable
 

--- a/deny.toml
+++ b/deny.toml
@@ -65,10 +65,6 @@ skip = [
     { name = "env_logger", version = "=0.8.4" },
     # tempfile
     { name = "remove_dir_all", version = "=0.5.3" },
-    # console (via indicatif)
-    { name = "terminal_size", version = "=0.1.17" },
-    # nix
-    { name = "memoffset", version = "=0.6.5"},
     # blake2b_simd
     { name = "constant_time_eq", version = "=0.1.5"},
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -61,8 +61,6 @@ highlight = "all"
 skip = [
     # blake2d_simd
     { name = "arrayvec", version = "=0.7.2" },
-    # quickcheck
-    { name = "env_logger", version = "=0.8.4" },
     # tempfile
     { name = "remove_dir_all", version = "=0.5.3" },
     # blake2b_simd

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -21,7 +21,7 @@ atty = "0.2"
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore", features=["fs", "pipes"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.25", default-features = false }
+nix = { version = "0.26", default-features = false }
 
 [[bin]]
 name = "cat"

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -20,7 +20,7 @@ rust-ini = "0.18.0"
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore", features=["signals"]}
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.25", default-features = false, features = ["signal"] }
+nix = { version = "0.26", default-features = false, features = ["signal"] }
 
 
 [[bin]]

--- a/src/uu/hashsum/Cargo.toml
+++ b/src/uu/hashsum/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1.7.1"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
 sha3 = "0.10.6"
-blake2b_simd = "1.0.0"
+blake2b_simd = "1.0.1"
 blake3 = "1.3.2"
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore" }
 

--- a/src/uu/kill/Cargo.toml
+++ b/src/uu/kill/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/kill.rs"
 
 [dependencies]
 clap = { version = "4.0", features = ["wrap_help", "cargo"] }
-nix = { version = "0.25", features = ["signal"] }
+nix = { version = "0.26", features = ["signal"] }
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore", features=["signals"] }
 
 [[bin]]

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -23,7 +23,7 @@ unicode-width = "0.1.7"
 unicode-segmentation = "1.9.0"
 
 [target.'cfg(all(unix, not(target_os = "fuchsia")))'.dependencies]
-nix = { version = "0.25", default-features = false }
+nix = { version = "0.26", default-features = false }
 
 [[bin]]
 name = "more"

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/nice.rs"
 [dependencies]
 clap = { version = "4.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.137"
-nix = { version = "0.25", default-features = false }
+nix = { version = "0.26", default-features = false }
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore" }
 
 [[bin]]

--- a/src/uu/stty/Cargo.toml
+++ b/src/uu/stty/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/stty.rs"
 [dependencies]
 clap = { version = "4.0", features = ["wrap_help", "cargo"] }
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore" }
-nix = { version="0.25", features = ["term"] }
+nix = { version="0.26", features = ["term"] }
 
 [[bin]]
 name = "stty"

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2.137"
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore", features=["wide"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-nix = "0.25"
+nix = "0.26"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.42.0", default-features = false, features = ["Win32_Storage_FileSystem", "Win32_System_WindowsProgramming", "Win32_Foundation"] }

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -29,7 +29,7 @@ windows-sys = { version = "0.42.0", default-features = false, features = ["Win32
 winapi-util = { version="0.1.5" }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.25", features = ["fs"] }
+nix = { version = "0.26", features = ["fs"] }
 
 [[bin]]
 name = "tail"

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/timeout.rs"
 [dependencies]
 clap = { version = "4.0", features = ["wrap_help", "cargo"] }
 libc = "0.2.137"
-nix = { version = "0.25", default-features = false, features = ["signal"] }
+nix = { version = "0.26", default-features = false, features = ["signal"] }
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore", features=["process", "signals"] }
 
 [[bin]]

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/tty.rs"
 
 [dependencies]
 clap = { version = "4.0", features = ["wrap_help", "cargo"] }
-nix = "0.25"
+nix = "0.26"
 atty = "0.2"
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore", features=["fs"] }
 

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -22,7 +22,7 @@ utf-8 = "0.7.6"
 unicode-width = "0.1.8"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.25", default-features = false }
+nix = { version = "0.26", default-features = false }
 libc = "0.2"
 
 [[bin]]

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2.137"
 uucore = { version=">=0.0.17", package="uucore", path="../../uucore", features=["pipes"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-nix = { version = "0.25", default-features = false }
+nix = { version = "0.26", default-features = false }
 
 [[bin]]
 name = "yes"

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -38,7 +38,7 @@ os_display = "0.1.3"
 
 [target.'cfg(unix)'.dependencies]
 walkdir = { version="2.3.2", optional=true }
-nix = { version = "0.25", default-features = false, features = ["fs", "uio", "zerocopy"] }
+nix = { version = "0.26", default-features = false, features = ["fs", "uio", "zerocopy"] }
 
 [dev-dependencies]
 clap = "4.0"


### PR DESCRIPTION
Updated some dependencies to remove some duplicate transitive dependencies, so we can remove this from `deny.toml`:
```toml
skip = [
    ...
    # console (via indicatif)
    { name = "terminal_size", version = "=0.1.17" },
    # nix
    { name = "memoffset", version = "=0.6.5"},
    ...
]
```

(I've been reading the [comments at phoronix](https://www.phoronix.com/forums/forum/phoronix/latest-phoronix-articles/1371662-the-rust-implementation-of-gnu-coreutils-is-becoming-remarkably-robust/page8#post1371870) 😄) 