### PR TITLE
tail: fix GNU test 'misc/tail'

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -13,6 +13,7 @@ use fundu::DurationParser;
 use is_terminal::IsTerminal;
 use same_file::Handle;
 use std::collections::VecDeque;
+use std::ffi::OsString;
 use std::time::Duration;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::parse_size::{parse_size, ParseSizeError};
@@ -144,7 +145,7 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn from_obsolete_args(args: &parse::ObsoleteArgs, name: Option<&str>) -> Self {
+    pub fn from_obsolete_args(args: &parse::ObsoleteArgs, name: Option<OsString>) -> Self {
         let mut settings: Self = Self {
             sleep_sec: Duration::from_secs_f32(1.0),
             max_unchanged_stats: 5,
@@ -159,7 +160,7 @@ impl Settings {
         }
         settings.mode = FilterMode::from_obsolete_args(args);
         let input = if let Some(name) = name {
-            Input::from(name.to_string())
+            Input::from(&name)
         } else {
             Input::default()
         };
@@ -249,7 +250,7 @@ impl Settings {
 
         let mut inputs: VecDeque<Input> = matches
             .get_many::<String>(options::ARG_FILES)
-            .map(|v| v.map(|string| Input::from(string.clone())).collect())
+            .map(|v| v.map(|string| Input::from(&string)).collect())
             .unwrap_or_default();
 
         // apply default and add '-' to inputs if none is present
@@ -575,7 +576,10 @@ mod tests {
 
     #[test]
     fn test_parse_obsolete_settings_f() {
-        let args = ObsoleteArgs { follow: true, ..Default::default() };
+        let args = ObsoleteArgs {
+            follow: true,
+            ..Default::default()
+        };
         let result = Settings::from_obsolete_args(&args, None);
         assert_eq!(result.follow, Some(FollowMode::Descriptor));
 

--- a/src/uu/tail/src/parse.rs
+++ b/src/uu/tail/src/parse.rs
@@ -7,92 +7,67 @@ use std::ffi::OsString;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum ParseError {
-    Syntax,
     Overflow,
+    Context,
 }
 /// Parses obsolete syntax
-/// tail -NUM\[kmzv\] // spell-checker:disable-line
+/// tail -\[NUM\]\[bl\]\[f\] and tail +\[NUM\]\[bcl\]\[f\] // spell-checker:disable-line
 pub fn parse_obsolete(src: &str) -> Option<Result<impl Iterator<Item = OsString>, ParseError>> {
-    let mut chars = src.char_indices();
-    if let Some((_, '-')) = chars.next() {
-        let mut num_end = 0usize;
-        let mut has_num = false;
-        let mut last_char = 0 as char;
-        for (n, c) in &mut chars {
-            if c.is_ascii_digit() {
-                has_num = true;
-                num_end = n;
-            } else {
-                last_char = c;
-                break;
-            }
-        }
-        if has_num {
-            match src[1..=num_end].parse::<usize>() {
-                Ok(num) => {
-                    let mut quiet = false;
-                    let mut verbose = false;
-                    let mut zero_terminated = false;
-                    let mut multiplier = None;
-                    let mut c = last_char;
-                    loop {
-                        // not that here, we only match lower case 'k', 'c', and 'm'
-                        match c {
-                            // we want to preserve order
-                            // this also saves us 1 heap allocation
-                            'q' => {
-                                quiet = true;
-                                verbose = false;
-                            }
-                            'v' => {
-                                verbose = true;
-                                quiet = false;
-                            }
-                            'z' => zero_terminated = true,
-                            'c' => multiplier = Some(1),
-                            'b' => multiplier = Some(512),
-                            'k' => multiplier = Some(1024),
-                            'm' => multiplier = Some(1024 * 1024),
-                            '\0' => {}
-                            _ => return Some(Err(ParseError::Syntax)),
-                        }
-                        if let Some((_, next)) = chars.next() {
-                            c = next;
-                        } else {
-                            break;
-                        }
-                    }
-                    let mut options = Vec::new();
-                    if quiet {
-                        options.push(OsString::from("-q"));
-                    }
-                    if verbose {
-                        options.push(OsString::from("-v"));
-                    }
-                    if zero_terminated {
-                        options.push(OsString::from("-z"));
-                    }
-                    if let Some(n) = multiplier {
-                        options.push(OsString::from("-c"));
-                        let num = match num.checked_mul(n) {
-                            Some(n) => n,
-                            None => return Some(Err(ParseError::Overflow)),
-                        };
-                        options.push(OsString::from(format!("{num}")));
-                    } else {
-                        options.push(OsString::from("-n"));
-                        options.push(OsString::from(format!("{num}")));
-                    }
-                    Some(Ok(options.into_iter()))
-                }
-                Err(_) => Some(Err(ParseError::Overflow)),
-            }
+    let mut chars = src.chars();
+    let sign = chars.next()?;
+    if sign != '+' && sign != '-' {
+        return None;
+    }
+
+    let numbers: String = chars.clone().take_while(|&c| c.is_ascii_digit()).collect();
+    let has_num = !numbers.is_empty();
+    let num: usize = if has_num {
+        if let Ok(num) = numbers.parse() {
+            num
         } else {
-            None
+            return Some(Err(ParseError::Overflow));
         }
     } else {
-        None
+        10
+    };
+
+    let mut follow = false;
+    let mut mode = None;
+    let mut first_char = true;
+    for char in chars.skip_while(|&c| c.is_ascii_digit()) {
+        if sign == '-' && char == 'c' && !has_num {
+            // special case: -c should be handled by clap (is ambiguous)
+            return None;
+        } else if char == 'f' {
+            follow = true;
+        } else if first_char && (char == 'b' || char == 'c' || char == 'l') {
+            mode = Some(char);
+        } else if has_num && sign == '-' {
+            return Some(Err(ParseError::Context));
+        } else {
+            return None;
+        }
+        first_char = false;
     }
+
+    let mut options = Vec::new();
+    if follow {
+        options.push(OsString::from("-f"));
+    }
+    let mode = mode.unwrap_or('l');
+    if mode == 'b' || mode == 'c' {
+        options.push(OsString::from("-c"));
+        let n = if mode == 'b' { 512 } else { 1 };
+        let num = match num.checked_mul(n) {
+            Some(n) => n,
+            None => return Some(Err(ParseError::Overflow)),
+        };
+        options.push(OsString::from(format!("{sign}{num}")));
+    } else {
+        options.push(OsString::from("-n"));
+        options.push(OsString::from(format!("{sign}{num}")));
+    }
+    Some(Ok(options.into_iter()))
 }
 
 #[cfg(test)]
@@ -113,40 +88,35 @@ mod tests {
     }
     #[test]
     fn test_parse_numbers_obsolete() {
-        assert_eq!(obsolete("-5"), obsolete_result(&["-n", "5"]));
-        assert_eq!(obsolete("-100"), obsolete_result(&["-n", "100"]));
-        assert_eq!(obsolete("-5m"), obsolete_result(&["-c", "5242880"]));
-        assert_eq!(obsolete("-1k"), obsolete_result(&["-c", "1024"]));
-        assert_eq!(obsolete("-2b"), obsolete_result(&["-c", "1024"]));
-        assert_eq!(obsolete("-1mmk"), obsolete_result(&["-c", "1024"]));
-        assert_eq!(obsolete("-1vz"), obsolete_result(&["-v", "-z", "-n", "1"]));
-        assert_eq!(
-            obsolete("-1vzqvq"), // spell-checker:disable-line
-            obsolete_result(&["-q", "-z", "-n", "1"])
-        );
-        assert_eq!(obsolete("-1vzc"), obsolete_result(&["-v", "-z", "-c", "1"]));
-        assert_eq!(
-            obsolete("-105kzm"),
-            obsolete_result(&["-z", "-c", "110100480"])
-        );
+        assert_eq!(obsolete("+2c"), obsolete_result(&["-c", "+2"]));
+        assert_eq!(obsolete("-5"), obsolete_result(&["-n", "-5"]));
+        assert_eq!(obsolete("-100"), obsolete_result(&["-n", "-100"]));
+        assert_eq!(obsolete("-2b"), obsolete_result(&["-c", "-1024"]));
     }
     #[test]
     fn test_parse_errors_obsolete() {
-        assert_eq!(obsolete("-5n"), Some(Err(ParseError::Syntax)));
-        assert_eq!(obsolete("-5c5"), Some(Err(ParseError::Syntax)));
+        assert_eq!(obsolete("-5n"), Some(Err(ParseError::Context)));
+        assert_eq!(obsolete("-5c5"), Some(Err(ParseError::Context)));
+        assert_eq!(obsolete("-1vzc"), Some(Err(ParseError::Context)));
+        assert_eq!(obsolete("-5m"), Some(Err(ParseError::Context)));
+        assert_eq!(obsolete("-1k"), Some(Err(ParseError::Context)));
+        assert_eq!(obsolete("-1mmk"), Some(Err(ParseError::Context)));
+        assert_eq!(obsolete("-105kzm"), Some(Err(ParseError::Context)));
+        assert_eq!(obsolete("-1vz"), Some(Err(ParseError::Context)));
+        assert_eq!(
+            obsolete("-1vzqvq"), // spell-checker:disable-line
+            Some(Err(ParseError::Context))
+        );
     }
     #[test]
     fn test_parse_obsolete_no_match() {
         assert_eq!(obsolete("-k"), None);
         assert_eq!(obsolete("asd"), None);
+        assert_eq!(obsolete("-cc"), None);
     }
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_parse_obsolete_overflow_x64() {
-        assert_eq!(
-            obsolete("-1000000000000000m"),
-            Some(Err(ParseError::Overflow))
-        );
         assert_eq!(
             obsolete("-10000000000000000000000"),
             Some(Err(ParseError::Overflow))
@@ -156,6 +126,5 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     fn test_parse_obsolete_overflow_x32() {
         assert_eq!(obsolete("-42949672960"), Some(Err(ParseError::Overflow)));
-        assert_eq!(obsolete("-42949672k"), Some(Err(ParseError::Overflow)));
     }
 }

--- a/src/uu/tail/src/parse.rs
+++ b/src/uu/tail/src/parse.rs
@@ -3,6 +3,8 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
+use std::ffi::OsString;
+
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct ObsoleteArgs {
     pub num: u64,
@@ -27,20 +29,31 @@ pub enum ParseError {
     OutOfRange,
     Overflow,
     Context,
+    InvalidEncoding,
 }
 /// Parses obsolete syntax
-/// tail -\[NUM\]\[bl\]\[f\] and tail +\[NUM\]\[bcl\]\[f\] // spell-checker:disable-line
-pub fn parse_obsolete(src: &str) -> Option<Result<ObsoleteArgs, ParseError>> {
-    let mut chars = src.chars();
-    let sign = chars.next()?;
-    if sign != '+' && sign != '-' {
+/// tail -\[NUM\]\[bcl\]\[f\] and tail +\[NUM\]\[bcl\]\[f\] // spell-checker:disable-line
+pub fn parse_obsolete(src: &OsString) -> Option<Result<ObsoleteArgs, ParseError>> {
+    let mut rest = match src.to_str() {
+        Some(src) => src,
+        None => return Some(Err(ParseError::InvalidEncoding)),
+    };
+    let sign = if let Some(r) = rest.strip_prefix('-') {
+        rest = r;
+        '-'
+    } else if let Some(r) = rest.strip_prefix('+') {
+        rest = r;
+        '+'
+    } else {
         return None;
-    }
+    };
 
-    let numbers: String = chars.clone().take_while(|&c| c.is_ascii_digit()).collect();
-    let has_num = !numbers.is_empty();
+    let end_num = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    let has_num = !rest[..end_num].is_empty();
     let num: u64 = if has_num {
-        if let Ok(num) = numbers.parse() {
+        if let Ok(num) = rest[..end_num].parse() {
             num
         } else {
             return Some(Err(ParseError::OutOfRange));
@@ -48,25 +61,30 @@ pub fn parse_obsolete(src: &str) -> Option<Result<ObsoleteArgs, ParseError>> {
     } else {
         10
     };
+    rest = &rest[end_num..];
 
-    let mut follow = false;
-    let mut mode = 'l';
-    let mut first_char = true;
-    for char in chars.skip_while(|&c| c.is_ascii_digit()) {
-        if !has_num && first_char && sign == '-' && (char == 'c' || char == 'f') {
-            // special cases: -c, -f should be handled by clap (are ambiguous)
-            return None;
-        } else if char == 'f' {
-            follow = true;
-        } else if first_char && (char == 'b' || char == 'c' || char == 'l') {
-            mode = char;
-        } else if has_num && sign == '-' {
+    let mode = if let Some(r) = rest.strip_prefix('l') {
+        rest = r;
+        'l'
+    } else if let Some(r) = rest.strip_prefix('c') {
+        rest = r;
+        'c'
+    } else if let Some(r) = rest.strip_prefix('b') {
+        rest = r;
+        'b'
+    } else {
+        'l'
+    };
+
+    let follow = rest.contains('f');
+    if !rest.chars().all(|f| f == 'f') {
+        // GNU allows an arbitrary amount of following fs, but nothing else
+        if sign == '-' && has_num {
             return Some(Err(ParseError::Context));
-        } else {
-            return None;
         }
-        first_char = false;
+        return None;
     }
+
     let multiplier = if mode == 'b' { 512 } else { 1 };
     let num = match num.checked_mul(multiplier) {
         Some(n) => n,
@@ -87,7 +105,7 @@ mod tests {
     #[test]
     fn test_parse_numbers_obsolete() {
         assert_eq!(
-            parse_obsolete("+2c"),
+            parse_obsolete(&OsString::from("+2c")),
             Some(Ok(ObsoleteArgs {
                 num: 2,
                 plus: true,
@@ -96,7 +114,7 @@ mod tests {
             }))
         );
         assert_eq!(
-            parse_obsolete("-5"),
+            parse_obsolete(&OsString::from("-5")),
             Some(Ok(ObsoleteArgs {
                 num: 5,
                 plus: false,
@@ -105,7 +123,7 @@ mod tests {
             }))
         );
         assert_eq!(
-            parse_obsolete("+100f"),
+            parse_obsolete(&OsString::from("+100f")),
             Some(Ok(ObsoleteArgs {
                 num: 100,
                 plus: true,
@@ -114,7 +132,7 @@ mod tests {
             }))
         );
         assert_eq!(
-            parse_obsolete("-2b"),
+            parse_obsolete(&OsString::from("-2b")),
             Some(Ok(ObsoleteArgs {
                 num: 1024,
                 plus: false,
@@ -125,23 +143,47 @@ mod tests {
     }
     #[test]
     fn test_parse_errors_obsolete() {
-        assert_eq!(parse_obsolete("-5n"), Some(Err(ParseError::Context)));
-        assert_eq!(parse_obsolete("-5c5"), Some(Err(ParseError::Context)));
-        assert_eq!(parse_obsolete("-1vzc"), Some(Err(ParseError::Context)));
-        assert_eq!(parse_obsolete("-5m"), Some(Err(ParseError::Context)));
-        assert_eq!(parse_obsolete("-1k"), Some(Err(ParseError::Context)));
-        assert_eq!(parse_obsolete("-1mmk"), Some(Err(ParseError::Context)));
-        assert_eq!(parse_obsolete("-105kzm"), Some(Err(ParseError::Context)));
-        assert_eq!(parse_obsolete("-1vz"), Some(Err(ParseError::Context)));
         assert_eq!(
-            parse_obsolete("-1vzqvq"), // spell-checker:disable-line
+            parse_obsolete(&OsString::from("-5n")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-5c5")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-1vzc")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-5m")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-1k")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-1mmk")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-105kzm")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-1vz")),
+            Some(Err(ParseError::Context))
+        );
+        assert_eq!(
+            parse_obsolete(&OsString::from("-1vzqvq")), // spell-checker:disable-line
             Some(Err(ParseError::Context))
         );
     }
     #[test]
     fn test_parse_obsolete_no_match() {
-        assert_eq!(parse_obsolete("-k"), None);
-        assert_eq!(parse_obsolete("asd"), None);
-        assert_eq!(parse_obsolete("-cc"), None);
+        assert_eq!(parse_obsolete(&OsString::from("-k")), None);
+        assert_eq!(parse_obsolete(&OsString::from("asd")), None);
+        assert_eq!(parse_obsolete(&OsString::from("-cc")), None);
     }
 }

--- a/src/uu/tail/src/parse.rs
+++ b/src/uu/tail/src/parse.rs
@@ -3,16 +3,34 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-use std::ffi::OsString;
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+pub struct ObsoleteArgs {
+    pub num: u64,
+    pub plus: bool,
+    pub lines: bool,
+    pub follow: bool,
+}
+
+impl Default for ObsoleteArgs {
+    fn default() -> Self {
+        Self {
+            num: 10,
+            plus: false,
+            lines: true,
+            follow: false,
+        }
+    }
+}
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum ParseError {
+    OutOfRange,
     Overflow,
     Context,
 }
 /// Parses obsolete syntax
 /// tail -\[NUM\]\[bl\]\[f\] and tail +\[NUM\]\[bcl\]\[f\] // spell-checker:disable-line
-pub fn parse_obsolete(src: &str) -> Option<Result<impl Iterator<Item = OsString>, ParseError>> {
+pub fn parse_obsolete(src: &str) -> Option<Result<ObsoleteArgs, ParseError>> {
     let mut chars = src.chars();
     let sign = chars.next()?;
     if sign != '+' && sign != '-' {
@@ -21,27 +39,27 @@ pub fn parse_obsolete(src: &str) -> Option<Result<impl Iterator<Item = OsString>
 
     let numbers: String = chars.clone().take_while(|&c| c.is_ascii_digit()).collect();
     let has_num = !numbers.is_empty();
-    let num: usize = if has_num {
+    let num: u64 = if has_num {
         if let Ok(num) = numbers.parse() {
             num
         } else {
-            return Some(Err(ParseError::Overflow));
+            return Some(Err(ParseError::OutOfRange));
         }
     } else {
         10
     };
 
     let mut follow = false;
-    let mut mode = None;
+    let mut mode = 'l';
     let mut first_char = true;
     for char in chars.skip_while(|&c| c.is_ascii_digit()) {
-        if sign == '-' && char == 'c' && !has_num {
-            // special case: -c should be handled by clap (is ambiguous)
+        if !has_num && first_char && sign == '-' && (char == 'c' || char == 'f') {
+            // special cases: -c, -f should be handled by clap (are ambiguous)
             return None;
         } else if char == 'f' {
             follow = true;
         } else if first_char && (char == 'b' || char == 'c' || char == 'l') {
-            mode = Some(char);
+            mode = char;
         } else if has_num && sign == '-' {
             return Some(Err(ParseError::Context));
         } else {
@@ -49,82 +67,81 @@ pub fn parse_obsolete(src: &str) -> Option<Result<impl Iterator<Item = OsString>
         }
         first_char = false;
     }
+    let multiplier = if mode == 'b' { 512 } else { 1 };
+    let num = match num.checked_mul(multiplier) {
+        Some(n) => n,
+        None => return Some(Err(ParseError::Overflow)),
+    };
 
-    let mut options = Vec::new();
-    if follow {
-        options.push(OsString::from("-f"));
-    }
-    let mode = mode.unwrap_or('l');
-    if mode == 'b' || mode == 'c' {
-        options.push(OsString::from("-c"));
-        let n = if mode == 'b' { 512 } else { 1 };
-        let num = match num.checked_mul(n) {
-            Some(n) => n,
-            None => return Some(Err(ParseError::Overflow)),
-        };
-        options.push(OsString::from(format!("{sign}{num}")));
-    } else {
-        options.push(OsString::from("-n"));
-        options.push(OsString::from(format!("{sign}{num}")));
-    }
-    Some(Ok(options.into_iter()))
+    Some(Ok(ObsoleteArgs {
+        num,
+        plus: sign == '+',
+        lines: mode == 'l',
+        follow,
+    }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn obsolete(src: &str) -> Option<Result<Vec<String>, ParseError>> {
-        let r = parse_obsolete(src);
-        match r {
-            Some(s) => match s {
-                Ok(v) => Some(Ok(v.map(|s| s.to_str().unwrap().to_owned()).collect())),
-                Err(e) => Some(Err(e)),
-            },
-            None => None,
-        }
-    }
-    fn obsolete_result(src: &[&str]) -> Option<Result<Vec<String>, ParseError>> {
-        Some(Ok(src.iter().map(|s| s.to_string()).collect()))
-    }
     #[test]
     fn test_parse_numbers_obsolete() {
-        assert_eq!(obsolete("+2c"), obsolete_result(&["-c", "+2"]));
-        assert_eq!(obsolete("-5"), obsolete_result(&["-n", "-5"]));
-        assert_eq!(obsolete("-100"), obsolete_result(&["-n", "-100"]));
-        assert_eq!(obsolete("-2b"), obsolete_result(&["-c", "-1024"]));
+        assert_eq!(
+            parse_obsolete("+2c"),
+            Some(Ok(ObsoleteArgs {
+                num: 2,
+                plus: true,
+                lines: false,
+                follow: false,
+            }))
+        );
+        assert_eq!(
+            parse_obsolete("-5"),
+            Some(Ok(ObsoleteArgs {
+                num: 5,
+                plus: false,
+                lines: true,
+                follow: false,
+            }))
+        );
+        assert_eq!(
+            parse_obsolete("+100f"),
+            Some(Ok(ObsoleteArgs {
+                num: 100,
+                plus: true,
+                lines: true,
+                follow: true,
+            }))
+        );
+        assert_eq!(
+            parse_obsolete("-2b"),
+            Some(Ok(ObsoleteArgs {
+                num: 1024,
+                plus: false,
+                lines: false,
+                follow: false,
+            }))
+        );
     }
     #[test]
     fn test_parse_errors_obsolete() {
-        assert_eq!(obsolete("-5n"), Some(Err(ParseError::Context)));
-        assert_eq!(obsolete("-5c5"), Some(Err(ParseError::Context)));
-        assert_eq!(obsolete("-1vzc"), Some(Err(ParseError::Context)));
-        assert_eq!(obsolete("-5m"), Some(Err(ParseError::Context)));
-        assert_eq!(obsolete("-1k"), Some(Err(ParseError::Context)));
-        assert_eq!(obsolete("-1mmk"), Some(Err(ParseError::Context)));
-        assert_eq!(obsolete("-105kzm"), Some(Err(ParseError::Context)));
-        assert_eq!(obsolete("-1vz"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-5n"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-5c5"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-1vzc"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-5m"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-1k"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-1mmk"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-105kzm"), Some(Err(ParseError::Context)));
+        assert_eq!(parse_obsolete("-1vz"), Some(Err(ParseError::Context)));
         assert_eq!(
-            obsolete("-1vzqvq"), // spell-checker:disable-line
+            parse_obsolete("-1vzqvq"), // spell-checker:disable-line
             Some(Err(ParseError::Context))
         );
     }
     #[test]
     fn test_parse_obsolete_no_match() {
-        assert_eq!(obsolete("-k"), None);
-        assert_eq!(obsolete("asd"), None);
-        assert_eq!(obsolete("-cc"), None);
-    }
-    #[test]
-    #[cfg(target_pointer_width = "64")]
-    fn test_parse_obsolete_overflow_x64() {
-        assert_eq!(
-            obsolete("-10000000000000000000000"),
-            Some(Err(ParseError::Overflow))
-        );
-    }
-    #[test]
-    #[cfg(target_pointer_width = "32")]
-    fn test_parse_obsolete_overflow_x32() {
-        assert_eq!(obsolete("-42949672960"), Some(Err(ParseError::Overflow)));
+        assert_eq!(parse_obsolete("-k"), None);
+        assert_eq!(parse_obsolete("asd"), None);
+        assert_eq!(parse_obsolete("-cc"), None);
     }
 }

--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -28,8 +28,7 @@ pub struct Input {
 
 impl Input {
     pub fn from<T: AsRef<OsStr>>(string: &T) -> Self {
-        let valid_string = string.as_ref().to_str();
-        let kind = if valid_string.is_some() && valid_string.unwrap() == text::DASH {
+        let kind = if string.as_ref() == Path::new(text::DASH) {
             InputKind::Stdin
         } else {
             InputKind::File(PathBuf::from(string.as_ref()))

--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -6,6 +6,7 @@
 // spell-checker:ignore tailable seekable stdlib (stdlib)
 
 use crate::text;
+use std::ffi::OsStr;
 use std::fs::{File, Metadata};
 use std::io::{Seek, SeekFrom};
 #[cfg(unix)]
@@ -26,21 +27,21 @@ pub struct Input {
 }
 
 impl Input {
-    // TODO: from &str may be the better choice
-    pub fn from(string: String) -> Self {
-        let kind = if string == text::DASH {
+    pub fn from<T: AsRef<OsStr>>(string: &T) -> Self {
+        let valid_string = string.as_ref().to_str();
+        let kind = if valid_string.is_some() && valid_string.unwrap() == text::DASH {
             InputKind::Stdin
         } else {
-            InputKind::File(PathBuf::from(&string))
+            InputKind::File(PathBuf::from(string.as_ref()))
         };
 
         let display_name = match kind {
-            InputKind::File(_) => string,
+            InputKind::File(_) => string.as_ref().to_string_lossy().to_string(),
             InputKind::Stdin => {
                 if cfg!(unix) {
                     text::STDIN_HEADER.to_string()
                 } else {
-                    string
+                    string.as_ref().to_string_lossy().to_string()
                 }
             }
         };

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -4768,7 +4768,6 @@ fn test_obsolete_encoding_unix() {
 
     let scene = TestScenario::new(util_name!());
     let invalid_utf8_arg = OsStr::from_bytes(&[b'-', INVALID_UTF8, b'b']);
-    let valid_utf8_arg = OsStr::from_bytes(&[b'-', b'b']);
 
     scene
         .ucmd()
@@ -4776,13 +4775,6 @@ fn test_obsolete_encoding_unix() {
         .fails()
         .no_stdout()
         .stderr_is("tail: bad argument encoding: '-�b'\n")
-        .code_is(1);
-    scene
-        .ucmd()
-        .args(&[valid_utf8_arg, invalid_utf8_arg])
-        .fails()
-        .no_stdout()
-        .stderr_is("tail: bad argument encoding\n")
         .code_is(1);
 }
 
@@ -4794,7 +4786,6 @@ fn test_obsolete_encoding_windows() {
 
     let scene = TestScenario::new(util_name!());
     let invalid_utf16_arg = OsString::from_wide(&['-' as u16, INVALID_UTF16, 'b' as u16]);
-    let valid_utf16_arg = OsString::from("-b");
 
     scene
         .ucmd()
@@ -4802,12 +4793,5 @@ fn test_obsolete_encoding_windows() {
         .fails()
         .no_stdout()
         .stderr_is("tail: bad argument encoding: '-�b'\n")
-        .code_is(1);
-    scene
-        .ucmd()
-        .args(&[&valid_utf16_arg, &invalid_utf16_arg])
-        .fails()
-        .no_stdout()
-        .stderr_is("tail: bad argument encoding\n")
         .code_is(1);
 }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -4475,3 +4475,239 @@ fn test_args_sleep_interval_when_illegal_argument_then_usage_error(#[case] sleep
         .usage_error(format!("invalid number of seconds: '{sleep_interval}'"))
         .code_is(1);
 }
+
+#[test]
+fn test_gnu_args_plus_c() {
+    let scene = TestScenario::new(util_name!());
+
+    // obs-plus-c1
+    scene
+        .ucmd()
+        .arg("+2c")
+        .pipe_in("abcd")
+        .succeeds()
+        .stdout_only("bcd");
+    // obs-plus-c2
+    scene
+        .ucmd()
+        .arg("+8c")
+        .pipe_in("abcd")
+        .succeeds()
+        .stdout_only("");
+    // obs-plus-x1: same as +10c
+    scene
+        .ucmd()
+        .arg("+c")
+        .pipe_in(format!("x{}z", "y".repeat(10)))
+        .succeeds()
+        .stdout_only("yyz");
+}
+
+#[test]
+fn test_gnu_args_c() {
+    let scene = TestScenario::new(util_name!());
+
+    // obs-c3
+    scene
+        .ucmd()
+        .arg("-1c")
+        .pipe_in("abcd")
+        .succeeds()
+        .stdout_only("d");
+    // obs-c4
+    scene
+        .ucmd()
+        .arg("-9c")
+        .pipe_in("abcd")
+        .succeeds()
+        .stdout_only("abcd");
+    // obs-c5
+    scene
+        .ucmd()
+        .arg("-12c")
+        .pipe_in(format!("x{}z", "y".repeat(12)))
+        .succeeds()
+        .stdout_only(&format!("{}z", "y".repeat(11)));
+}
+
+#[test]
+fn test_gnu_args_l() {
+    let scene = TestScenario::new(util_name!());
+
+    // obs-l1
+    scene
+        .ucmd()
+        .arg("-1l")
+        .pipe_in("x")
+        .succeeds()
+        .stdout_only("x");
+    // obs-l2
+    scene
+        .ucmd()
+        .arg("-1l")
+        .pipe_in("x\ny\n")
+        .succeeds()
+        .stdout_only("y\n");
+    // obs-l3
+    scene
+        .ucmd()
+        .arg("-1l")
+        .pipe_in("x\ny")
+        .succeeds()
+        .stdout_only("y");
+    // obs-l: same as -10l
+    scene
+        .ucmd()
+        .arg("-l")
+        .pipe_in(format!("x{}z", "y\n".repeat(10)))
+        .succeeds()
+        .stdout_only(&format!("{}z", "y\n".repeat(9)));
+}
+
+#[test]
+fn test_gnu_args_plus_l() {
+    let scene = TestScenario::new(util_name!());
+
+    // obs-plus-l4
+    scene
+        .ucmd()
+        .arg("+1l")
+        .pipe_in("x\ny\n")
+        .succeeds()
+        .stdout_only("x\ny\n");
+    // ops-plus-l5
+    scene
+        .ucmd()
+        .arg("+2l")
+        .pipe_in("x\ny\n")
+        .succeeds()
+        .stdout_only("y\n");
+    // obs-plus-x2: same as +10l
+    scene
+        .ucmd()
+        .arg("+l")
+        .pipe_in(format!("x\n{}z", "y\n".repeat(10)))
+        .succeeds()
+        .stdout_only("y\ny\nz");
+}
+
+#[test]
+fn test_gnu_args_number() {
+    let scene = TestScenario::new(util_name!());
+
+    // obs-1
+    scene
+        .ucmd()
+        .arg("-1")
+        .pipe_in("x")
+        .succeeds()
+        .stdout_only("x");
+    // obs-2
+    scene
+        .ucmd()
+        .arg("-1")
+        .pipe_in("x\ny\n")
+        .succeeds()
+        .stdout_only("y\n");
+    // obs-3
+    scene
+        .ucmd()
+        .arg("-1")
+        .pipe_in("x\ny")
+        .succeeds()
+        .stdout_only("y");
+}
+
+#[test]
+fn test_gnu_args_plus_number() {
+    let scene = TestScenario::new(util_name!());
+
+    // obs-plus-4
+    scene
+        .ucmd()
+        .arg("+1")
+        .pipe_in("x\ny\n")
+        .succeeds()
+        .stdout_only("x\ny\n");
+    // ops-plus-5
+    scene
+        .ucmd()
+        .arg("+2")
+        .pipe_in("x\ny\n")
+        .succeeds()
+        .stdout_only("y\n");
+}
+
+#[test]
+fn test_gnu_args_b() {
+    let scene = TestScenario::new(util_name!());
+
+    // obs-b
+    scene
+        .ucmd()
+        .arg("-b")
+        .pipe_in("x\n".repeat(512 * 10 / 2 + 1))
+        .succeeds()
+        .stdout_only(&"x\n".repeat(512 * 10 / 2));
+}
+
+#[test]
+fn test_gnu_args_err() {
+    let scene = TestScenario::new(util_name!());
+
+    // err-1
+    scene
+        .ucmd()
+        .arg("+cl")
+        .fails()
+        .no_stdout()
+        .stderr_is("tail: cannot open '+cl' for reading: No such file or directory\n")
+        .code_is(1);
+    // err-2
+    scene
+        .ucmd()
+        .arg("-cl")
+        .fails()
+        .no_stdout()
+        .stderr_is("tail: invalid number of bytes: 'l'\n")
+        .code_is(1);
+    // err-3
+    scene
+        .ucmd()
+        .arg("+2cz")
+        .fails()
+        .no_stdout()
+        .stderr_is("tail: cannot open '+2cz' for reading: No such file or directory\n")
+        .code_is(1);
+    // err-4
+    scene
+        .ucmd()
+        .arg("-2cX")
+        .fails()
+        .no_stdout()
+        .stderr_is("tail: option used in invalid context -- 2\n")
+        .code_is(1);
+    // err-5
+    scene
+        .ucmd()
+        .arg("-c99999999999999999999")
+        .fails()
+        .no_stdout()
+        .stderr_is("tail: invalid number of bytes: '99999999999999999999'\n")
+        .code_is(1);
+    // err-6
+    scene
+        .ucmd()
+        .arg("-c --")
+        .fails()
+        .no_stdout()
+        .stderr_is("tail: invalid number of bytes: '-'\n")
+        .code_is(1);
+    scene
+        .ucmd()
+        .arg("-5cz")
+        .fails()
+        .no_stdout()
+        .stderr_is("tail: option used in invalid context -- 5\n")
+        .code_is(1);
+}

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -4737,11 +4737,9 @@ fn test_gnu_args_f() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
-    let mut p = scene
-        .ucmd()
-        .set_stdin(Stdio::piped())
-        .arg("+f")
-        .run_no_wait();
+    let source = "file";
+    at.touch(source);
+    let mut p = scene.ucmd().args(&["+f", source]).run_no_wait();
     p.make_assertion_with_delay(500).is_alive();
     p.kill()
         .make_assertion()
@@ -4749,9 +4747,11 @@ fn test_gnu_args_f() {
         .no_stderr()
         .no_stdout();
 
-    let source = "file";
-    at.touch(source);
-    let mut p = scene.ucmd().args(&["+f", source]).run_no_wait();
+    let mut p = scene
+        .ucmd()
+        .set_stdin(Stdio::piped())
+        .arg("+f")
+        .run_no_wait();
     p.make_assertion_with_delay(500).is_alive();
     p.kill()
         .make_assertion()


### PR DESCRIPTION
Hi!

This PR targets compatibility to `gnu/tests/misc/tail.pl`.
It's not fully achieved (yet) as some error messages don't fit 1:1 (e.g. a couple of additional `Try 'tail --help' for more information.`). Most of the code is to work around clap, which interprets a couple of arguments as input files.

I imported most of the perl tests to the code base.

Please feel free to respond if I should handle something differently (add tests/comments, split commit, ...) or if this is not needed at all :smile: 

Best regards
bb