### PR TITLE
install: fix bad target directory permissions

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -558,12 +558,6 @@ fn standard(mut paths: Vec<String>, b: &Behavior) -> UResult<()> {
                 if let Err(e) = fs::create_dir_all(to_create) {
                     return Err(InstallError::CreateDirFailed(to_create.to_path_buf(), e).into());
                 }
-
-                // Silent the warning as we want to the error message
-                #[allow(clippy::question_mark)]
-                if mode::chmod(to_create, b.mode()).is_err() {
-                    return Err(InstallError::ChmodFailed(to_create.to_path_buf()).into());
-                }
             }
         }
     }

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -125,6 +125,37 @@ fn test_install_ancestors_mode_directories() {
 }
 
 #[test]
+fn test_install_ancestors_mode_directories_with_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let ancestor1 = "ancestor1";
+    let ancestor2 = "ancestor1/ancestor2";
+    let target_file = "ancestor1/ancestor2/target_file";
+    let directories_arg = "-D";
+    let mode_arg = "--mode=200";
+    let file = "file";
+    let probe = "probe";
+
+    at.mkdir(probe);
+    let default_perms = at.metadata(probe).permissions().mode();
+
+    at.touch(file);
+
+    ucmd.args(&[mode_arg, directories_arg, file, target_file])
+        .succeeds()
+        .no_stderr();
+
+    assert!(at.dir_exists(ancestor1));
+    assert!(at.dir_exists(ancestor2));
+    assert!(at.file_exists(target_file));
+
+    assert_eq!(default_perms, at.metadata(ancestor1).permissions().mode());
+    assert_eq!(default_perms, at.metadata(ancestor2).permissions().mode());
+
+    // Expected mode only on the target_file.
+    assert_eq!(0o100_200_u32, at.metadata(target_file).permissions().mode());
+}
+
+#[test]
 fn test_install_parent_directories() {
     let (at, mut ucmd) = at_and_ucmd!();
     let ancestor1 = "ancestor1";


### PR DESCRIPTION
* Correct bug that set the last directory to the mode the file should have been set to.
* Add unit test to verify correct functionality.
* Fixes #4360 