### PR TITLE
cp: move help strings to markdown file

### DIFF
--- a/src/uu/cp/cp.md
+++ b/src/uu/cp/cp.md
@@ -1,0 +1,12 @@
+# cp
+
+## About
+
+Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.
+
+## Usage
+```
+cp [OPTION]... [-T] SOURCE DEST
+cp [OPTION]... SOURCE... DIRECTORY
+cp [OPTION]... -t DIRECTORY SOURCE...
+```

--- a/src/uu/cp/cp.md
+++ b/src/uu/cp/cp.md
@@ -1,12 +1,12 @@
 # cp
 
-## About
-
-Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.
-
 ## Usage
 ```
 cp [OPTION]... [-T] SOURCE DEST
 cp [OPTION]... SOURCE... DIRECTORY
 cp [OPTION]... -t DIRECTORY SOURCE...
 ```
+
+## About
+
+Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -40,7 +40,7 @@ use uucore::error::{set_exit_code, UClapError, UError, UResult, UUsageError};
 use uucore::fs::{
     canonicalize, paths_refer_to_same_file, FileInformation, MissingHandling, ResolveMode,
 };
-use uucore::{crash, format_usage, prompt_yes, show_error, show_warning};
+use uucore::{crash, format_usage, help_section, help_usage, prompt_yes, show_error, show_warning};
 
 use crate::copydir::copy_directory;
 
@@ -228,13 +228,10 @@ pub struct Options {
     progress_bar: bool,
 }
 
-static ABOUT: &str = "Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.";
+const ABOUT: &str = help_section!("about", "cp.md");
 static EXIT_ERR: i32 = 1;
 
-const USAGE: &str = "\
-    {} [OPTION]... [-T] SOURCE DEST
-    {} [OPTION]... SOURCE... DIRECTORY
-    {} [OPTION]... -t DIRECTORY SOURCE...";
+const USAGE: &str = help_usage!("cp.md");
 
 // Argument constants
 mod options {


### PR DESCRIPTION
#4368 

After this PR,  `cp -h` gives the following output.
```shell
$ ./target/debug/coreutils cp -h
Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.

Usage: ./target/debug/coreutils cp [OPTION]... [-T] SOURCE DEST
./target/debug/coreutils cp [OPTION]... SOURCE... DIRECTORY
./target/debug/coreutils cp [OPTION]... -t DIRECTORY SOURCE...


Arguments:
  [paths]...  

Options:
  -t, --target-directory <target-directory>  copy all SOURCE arguments into target-directory
  -T, --no-target-directory                  Treat DEST as a regular file and not a directory
  -i, --interactive                          ask before overwriting files
  -l, --link                                 hard-link files instead of copying
  -n, --no-clobber                           don't overwrite a file that already exists
  -r, --recursive                            copy directories recursively [short aliases: R]
      --strip-trailing-slashes               remove any trailing slashes from each SOURCE argument
  -v, --verbose                              explicitly state what is being done
  -s, --symbolic-link                        make symbolic links instead of copying
  -f, --force                                if an existing destination file cannot be opened, remove it and try again (this option is ignored when the -n
                                             option is also used). Currently not implemented for Windows.
      --remove-destination                   remove each existing destination file before attempting to open it (contrast with --force). On Windows, currently
                                             only works for writeable files.
      --backup[=<CONTROL>]                   make a backup of each existing destination file
  -b                                         like --backup but does not accept an argument
  -S, --suffix <SUFFIX>                      override the usual backup suffix
  -u, --update                               copy only when the SOURCE file is newer than the destination file or when the destination file is missing
      --reflink[=<WHEN>]                     control clone/CoW copies. See below [possible values: auto, always, never]
      --attributes-only                      Don't copy the file data, just the attributes
      --preserve [<ATTR_LIST>...]            Preserve the specified attributes (default: mode, ownership (unix only), timestamps), if possible additional
                                             attributes: context, links, xattr, all [possible values: mode, ownership, timestamps, context, links, xattr, all]
  -p, --preserve-default-attributes          same as --preserve=mode,ownership(unix only),timestamps
      --no-preserve <ATTR_LIST>              don't preserve the specified attributes
      --parents                              use full source file name under DIRECTORY
  -P, --no-dereference                       never follow symbolic links in SOURCE
  -L, --dereference                          always follow symbolic links in SOURCE
  -H                                         follow command-line symbolic links in SOURCE
  -a, --archive                              Same as -dR --preserve=all
  -d                                         same as --no-dereference --preserve=links
  -x, --one-file-system                      stay on this file system
      --sparse <WHEN>                        control creation of sparse files. See below [possible values: never, auto, always]
      --copy-contents                        NotImplemented: copy contents of special files when recursive
      --context <CTX>                        NotImplemented: set SELinux security context of destination file to default type
  -g, --progress                             Display a progress bar. 
                                             Note: this feature is not supported by GNU coreutils.
  -h, --help                                 Print help information
  -V, --version                              Print version information

The backup suffix is '~', unless set with --suffix or SIMPLE_BACKUP_SUFFIX.
The version control method may be selected via the --backup option or through
the VERSION_CONTROL environment variable.  Here are the values:

  none, off       never make backups (even if --backup is given)
  numbered, t     make numbered backups
  existing, nil   numbered if numbered backups exist, simple otherwise
  simple, never   always make simple backups
```
