### PR TITLE
arch: move help strings to a markdown file

### DIFF
--- a/src/uu/arch/arch.md
+++ b/src/uu/arch/arch.md
@@ -1,4 +1,3 @@
-<!-- spell-checker:ignore N'th M'th -->
 # arch
 
 ## Usage
@@ -11,7 +10,7 @@ arch
 Display machine architecture
 ```
 
-## Summary
+## After Help
 ```
 Determine architecture name for current machine.
 ```

--- a/src/uu/arch/arch.md
+++ b/src/uu/arch/arch.md
@@ -1,0 +1,17 @@
+<!-- spell-checker:ignore N'th M'th -->
+# arch
+
+## Usage
+```
+arch
+```
+
+## About
+```
+Display machine architecture
+```
+
+## Summary
+```
+Determine architecture name for current machine.
+```

--- a/src/uu/arch/arch.md
+++ b/src/uu/arch/arch.md
@@ -1,11 +1,9 @@
 # arch
 
-## Usage
 ```
 arch
 ```
 
-## About
 ```
 Display machine architecture
 ```

--- a/src/uu/arch/arch.md
+++ b/src/uu/arch/arch.md
@@ -4,11 +4,11 @@
 arch
 ```
 
-```
+
 Display machine architecture
-```
+
 
 ## After Help
-```
+
 Determine architecture name for current machine.
-```
+

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -10,9 +10,10 @@ use platform_info::*;
 
 use clap::{crate_version, Command};
 use uucore::error::{FromIo, UResult};
+use uucore::{help_section};
 
 static ABOUT: &str = help_section!("about", "arch.md");
-static SUMMARY: &str = help_section("summary", "arch.md");
+static SUMMARY: &str = help_section!("after help", "arch.md");
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -11,8 +11,8 @@ use platform_info::*;
 use clap::{crate_version, Command};
 use uucore::error::{FromIo, UResult};
 
-static ABOUT: &str = "Display machine architecture";
-static SUMMARY: &str = "Determine architecture name for current machine.";
+static ABOUT: &str = help_section!("about", "arch.md");
+static SUMMARY: &str = help_section("summary", "arch.md");
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -10,9 +10,9 @@ use platform_info::*;
 
 use clap::{crate_version, Command};
 use uucore::error::{FromIo, UResult};
-use uucore::{help_section};
+use uucore::{help_about, help_section};
 
-static ABOUT: &str = help_section!("about", "arch.md");
+static ABOUT: &str = help_about!("arch.md");
 static SUMMARY: &str = help_section!("after help", "arch.md");
 
 #[uucore::main]

--- a/src/uu/numfmt/numfmt.md
+++ b/src/uu/numfmt/numfmt.md
@@ -1,3 +1,4 @@
+<!-- spell-checker:ignore N'th M'th -->
 # numfmt
 
 ```

--- a/src/uu/numfmt/numfmt.md
+++ b/src/uu/numfmt/numfmt.md
@@ -1,4 +1,3 @@
-<!-- spell-checker:ignore N'th M'th -->
 # numfmt
 
 ## Usage


### PR DESCRIPTION
This change moves the `about` and `summary` help strings to `arch.md` in the `arch` directory