### PR TITLE
cat: move help strings to markdown file

### DIFF
--- a/src/uu/cat/cat.md
+++ b/src/uu/cat/cat.md
@@ -1,0 +1,11 @@
+# cat
+
+## Usage
+```
+cat [OPTION]... [FILE]...
+```
+
+## About
+
+Concatenate FILE(s), or standard input, to standard output
+With no FILE, or when FILE is -, read standard input.

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -33,11 +33,10 @@ use std::net::Shutdown;
 use std::os::unix::fs::FileTypeExt;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
-use uucore::format_usage;
+use uucore::{format_usage, help_section, help_usage};
 
-static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = "Concatenate FILE(s), or standard input, to standard output
-With no FILE, or when FILE is -, read standard input.";
+const USAGE: &str = help_usage!("cat.md");
+const ABOUT: &str = help_section!("about", "cat.md");
 
 #[derive(Error, Debug)]
 enum CatError {


### PR DESCRIPTION
#4368 

Now `cat -h` shows the following.

```shell
$ ./target/debug/coreutils cat -h
Concatenate FILE(s), or standard input, to standard output
With no FILE, or when FILE is -, read standard input.

Usage: ./target/debug/coreutils cat [OPTION]... [FILE]...


Options:
  -A, --show-all          equivalent to -vET
  -b, --number-nonblank   number nonempty output lines, overrides -n
  -e                      equivalent to -vE
  -E, --show-ends         display $ at end of each line
  -n, --number            number all output lines
  -s, --squeeze-blank     suppress repeated empty output lines
  -t, --t                 equivalent to -vT
  -T, --show-tabs         display TAB characters at ^I
  -v, --show-nonprinting  use ^ and M- notation, except for LF (\n) and TAB (\t)
  -h, --help              Print help information
  -V, --version           Print version information
```