### PR TITLE
`tail`: Cargo.toml: Remove unneeded features of uucore and the nix dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,6 @@ dependencies = [
  "fundu",
  "libc",
  "memchr",
- "nix",
  "notify",
  "same-file",
  "uucore",

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -20,7 +20,7 @@ clap = { workspace=true }
 libc = { workspace=true }
 memchr = { workspace=true }
 notify = { workspace=true }
-uucore = { workspace=true, features=["ringbuffer", "lines"] }
+uucore = { workspace=true }
 same-file = { workspace=true }
 atty = { workspace=true }
 fundu = { workspace=true }
@@ -28,9 +28,6 @@ fundu = { workspace=true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace=true, features = ["Win32_System_Threading", "Win32_Foundation"] }
 winapi-util = { workspace=true }
-
-[target.'cfg(unix)'.dependencies]
-nix = { workspace=true, features = ["fs"] }
 
 [[bin]]
 name = "tail"


### PR DESCRIPTION
This pr removes the unused features `ringbuffer` and `lines` of the `uucore` dependency. The `nix` dependency wasn't in use either, so it's removed, too.