### PR TITLE
du: move help strings to markdown file

### DIFF
--- a/src/uu/du/du.md
+++ b/src/uu/du/du.md
@@ -7,7 +7,7 @@ du [OPTION]... --files0-from=F
 
 Estimate file space usage
 
-## Long Help
+## After Help
 
 Display values are in units of the first available SIZE from --block-size,
 and the DU_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.

--- a/src/uu/du/du.md
+++ b/src/uu/du/du.md
@@ -1,12 +1,9 @@
 # du
 
-## Usage
 ```
 du [OPTION]... [FILE]...
 du [OPTION]... --files0-from=F
 ```
-
-## About
 
 Estimate file space usage
 

--- a/src/uu/du/du.md
+++ b/src/uu/du/du.md
@@ -1,0 +1,27 @@
+# du
+
+## Usage
+```
+du [OPTION]... [FILE]...
+du [OPTION]... --files0-from=F
+```
+
+## About
+
+Estimate file space usage
+
+## Long Help
+
+Display values are in units of the first available SIZE from --block-size,
+and the DU_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.
+Otherwise, units default to 1024 bytes (or 512 if POSIXLY_CORRECT is set).
+
+SIZE is an integer and optional unit (example: 10M is 10*1024*1024).
+Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB,... (powers
+of 1000).
+
+PATTERN allows some advanced exclusions. For example, the following syntaxes
+are supported:
+? will match only one character
+* will match zero or more characters
+{a,b} will match a or b

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -76,7 +76,7 @@ mod options {
 }
 
 const ABOUT: &str = help_about!("du.md");
-const LONG_HELP: &str = help_section!("long help", "du.md");
+const AFTER_HELP: &str = help_section!("after help", "du.md");
 const USAGE: &str = help_usage!("du.md");
 
 // TODO: Support Z & Y (currently limited by size of u64)
@@ -691,7 +691,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .after_help(LONG_HELP)
+        .after_help(AFTER_HELP)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .disable_help_flag(true)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -36,7 +36,7 @@ use uucore::error::FromIo;
 use uucore::error::{UError, UResult};
 use uucore::parse_glob;
 use uucore::parse_size::{parse_size, ParseSizeError};
-use uucore::{crash, format_usage, show, show_error, show_warning};
+use uucore::{crash, format_usage, help_section, help_usage, show, show_error, show_warning};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
 #[cfg(windows)]
@@ -73,25 +73,9 @@ mod options {
     pub const FILE: &str = "FILE";
 }
 
-const ABOUT: &str = "Estimate file space usage";
-const LONG_HELP: &str = "
-Display values are in units of the first available SIZE from --block-size,
-and the DU_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.
-Otherwise, units default to 1024 bytes (or 512 if POSIXLY_CORRECT is set).
-
-SIZE is an integer and optional unit (example: 10M is 10*1024*1024).
-Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB,... (powers
-of 1000).
-
-PATTERN allows some advanced exclusions. For example, the following syntaxes
-are supported:
-? will match only one character
-* will match zero or more characters
-{a,b} will match a or b
-";
-const USAGE: &str = "\
-    {} [OPTION]... [FILE]...
-    {} [OPTION]... --files0-from=F";
+const ABOUT: &str = help_section!("about", "du.md");
+const LONG_HELP: &str = help_section!("long help", "du.md");
+const USAGE: &str = help_usage!("du.md");
 
 // TODO: Support Z & Y (currently limited by size of u64)
 const UNITS: [(char, u32); 6] = [('E', 6), ('P', 5), ('T', 4), ('G', 3), ('M', 2), ('K', 1)];

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -36,7 +36,9 @@ use uucore::error::FromIo;
 use uucore::error::{UError, UResult};
 use uucore::parse_glob;
 use uucore::parse_size::{parse_size, ParseSizeError};
-use uucore::{crash, format_usage, help_section, help_usage, show, show_error, show_warning};
+use uucore::{
+    crash, format_usage, help_about, help_section, help_usage, show, show_error, show_warning,
+};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
 #[cfg(windows)]
@@ -73,7 +75,7 @@ mod options {
     pub const FILE: &str = "FILE";
 }
 
-const ABOUT: &str = help_section!("about", "du.md");
+const ABOUT: &str = help_about!("du.md");
 const LONG_HELP: &str = help_section!("long help", "du.md");
 const USAGE: &str = help_usage!("du.md");
 


### PR DESCRIPTION
#4368

`du --help` outputs the following.

```shell
$ ./target/debug/coreutils du --help
Estimate file space usage

Usage: ./target/debug/coreutils du [OPTION]... [FILE]...
./target/debug/coreutils du [OPTION]... --files0-from=F


Options:
      --help                 Print help information.
  -a, --all                  write counts for all files, not just directories
      --apparent-size        print apparent sizes, rather than disk usage although the apparent size is usually smaller, it may be larger due to holes in
                             ('sparse') files, internal fragmentation, indirect blocks, and the like
  -B, --block-size <SIZE>    scale sizes by SIZE before printing them. E.g., '-BM' prints sizes in units of 1,048,576 bytes. See SIZE format below.
  -b, --bytes                equivalent to '--apparent-size --block-size=1'
  -c, --total                produce a grand total
  -d, --max-depth <N>        print the total for a directory (or file, with --all) only if it is N or fewer levels below the command line argument;  --max-depth=0
                             is the same as --summarize
  -h, --human-readable       print sizes in human readable format (e.g., 1K 234M 2G)
      --inodes               list inode usage information instead of block usage like --block-size=1K
  -k                         like --block-size=1K
  -l, --count-links          count sizes many times if hard linked
  -L, --dereference          dereference all symbolic links
  -m                         like --block-size=1M
  -0, --null                 end each output line with 0 byte rather than newline
  -S, --separate-dirs        do not include size of subdirectories
  -s, --summarize            display only a total for each argument
      --si                   like -h, but use powers of 1000 not 1024
  -x, --one-file-system      skip directories on different file systems
  -t, --threshold <SIZE>     exclude entries smaller than SIZE if positive, or entries greater than SIZE if negative
  -v, --verbose              verbose mode (option not present in GNU/Coreutils)
      --exclude <PATTERN>    exclude files that match PATTERN
  -X, --exclude-from <FILE>  exclude files that match any pattern in FILE
      --time[=<WORD>...]     show time of the last modification of any file in the directory, or any of its subdirectories. If WORD is given, show time as WORD
                             instead of modification time: atime, access, use, ctime, status, birth or creation [possible values: atime, access, use, ctime,
                             status, birth, creation]
      --time-style <STYLE>   show times using style STYLE: full-iso, long-iso, iso, +FORMAT FORMAT is interpreted like 'date'
  -V, --version              Print version information

Display values are in units of the first available SIZE from --block-size,
and the DU_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.
Otherwise, units default to 1024 bytes (or 512 if POSIXLY_CORRECT is set).

SIZE is an integer and optional unit (example: 10M is 10*1024*1024).
Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB,... (powers
of 1000).

PATTERN allows some advanced exclusions. For example, the following syntaxes
are supported:
? will match only one character
* will match zero or more characters
{a,b} will match a or b
```