### PR TITLE
uucore_procs: extract "about" and "usage" info from new help structure

### DIFF
--- a/src/uu/base32/base32.md
+++ b/src/uu/base32/base32.md
@@ -1,11 +1,8 @@
 # base32
 
-## Usage
 ```
 base32 [OPTION]... [FILE]
 ```
-
-## About
 
 encode/decode data and print to standard output
 With no FILE, or when FILE is -, read standard input.

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -8,11 +8,11 @@
 use std::io::{stdin, Read};
 
 use clap::Command;
-use uucore::{encoding::Format, error::UResult, help_section, help_usage};
+use uucore::{encoding::Format, error::UResult, help_about, help_usage};
 
 pub mod base_common;
 
-const ABOUT: &str = help_section!("about", "base32.md");
+const ABOUT: &str = help_about!("base32.md");
 const USAGE: &str = help_usage!("base32.md");
 
 #[uucore::main]

--- a/src/uu/base64/base64.md
+++ b/src/uu/base64/base64.md
@@ -1,11 +1,8 @@
 # base64
 
-## Usage
 ```
 base64 [OPTION]... [FILE]
 ```
-
-## About
 
 encode/decode data and print to standard output
 With no FILE, or when FILE is -, read standard input.

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -9,11 +9,11 @@
 use uu_base32::base_common;
 pub use uu_base32::uu_app;
 
-use uucore::{encoding::Format, error::UResult, help_section, help_usage};
+use uucore::{encoding::Format, error::UResult, help_about, help_usage};
 
 use std::io::{stdin, Read};
 
-const ABOUT: &str = help_section!("about", "base64.md");
+const ABOUT: &str = help_about!("base64.md");
 const USAGE: &str = help_usage!("base64.md");
 
 #[uucore::main]

--- a/src/uu/cat/cat.md
+++ b/src/uu/cat/cat.md
@@ -1,11 +1,8 @@
 # cat
 
-## Usage
 ```
 cat [OPTION]... [FILE]...
 ```
-
-## About
 
 Concatenate FILE(s), or standard input, to standard output
 With no FILE, or when FILE is -, read standard input.

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -33,10 +33,10 @@ use std::net::Shutdown;
 use std::os::unix::fs::FileTypeExt;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
-use uucore::{format_usage, help_section, help_usage};
+use uucore::{format_usage, help_about, help_usage};
 
 const USAGE: &str = help_usage!("cat.md");
-const ABOUT: &str = help_section!("about", "cat.md");
+const ABOUT: &str = help_about!("cat.md");
 
 #[derive(Error, Debug)]
 enum CatError {

--- a/src/uu/cp/cp.md
+++ b/src/uu/cp/cp.md
@@ -1,12 +1,9 @@
 # cp
 
-## Usage
 ```
 cp [OPTION]... [-T] SOURCE DEST
 cp [OPTION]... SOURCE... DIRECTORY
 cp [OPTION]... -t DIRECTORY SOURCE...
 ```
-
-## About
 
 Copy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -40,7 +40,7 @@ use uucore::error::{set_exit_code, UClapError, UError, UResult, UUsageError};
 use uucore::fs::{
     canonicalize, paths_refer_to_same_file, FileInformation, MissingHandling, ResolveMode,
 };
-use uucore::{crash, format_usage, help_section, help_usage, prompt_yes, show_error, show_warning};
+use uucore::{crash, format_usage, help_about, help_usage, prompt_yes, show_error, show_warning};
 
 use crate::copydir::copy_directory;
 
@@ -228,10 +228,10 @@ pub struct Options {
     progress_bar: bool,
 }
 
-const ABOUT: &str = help_section!("about", "cp.md");
-static EXIT_ERR: i32 = 1;
-
+const ABOUT: &str = help_about!("cp.md");
 const USAGE: &str = help_usage!("cp.md");
+
+static EXIT_ERR: i32 = 1;
 
 // Argument constants
 mod options {

--- a/src/uu/dd/dd.md
+++ b/src/uu/dd/dd.md
@@ -1,7 +1,11 @@
 <!-- spell-checker:ignore convs iseek oseek -->
 # dd
 
-## About
+```
+dd [OPERAND]...
+dd OPTION
+```
+
 Copy, and optionally convert, a file system resource
 
 ## After Help

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -39,11 +39,11 @@ use clap::{crate_version, Arg, Command};
 use gcd::Gcd;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::help_section;
-use uucore::show_error;
+use uucore::{format_usage, help_about, help_section, help_usage, show_error};
 
-const ABOUT: &str = help_section!("about", "dd.md");
+const ABOUT: &str = help_about!("dd.md");
 const AFTER_HELP: &str = help_section!("after help", "dd.md");
+const USAGE: &str = help_usage!("dd.md");
 const BUF_INIT_BYTE: u8 = 0xDD;
 
 /// Final settings after parsing
@@ -832,6 +832,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .after_help(AFTER_HELP)
         .infer_long_args(true)
         .arg(Arg::new(options::OPERANDS).num_args(1..))

--- a/src/uu/expr/expr.md
+++ b/src/uu/expr/expr.md
@@ -1,14 +1,11 @@
 # expr
 
-## About
-
-Print the value of `EXPRESSION` to standard output
-
-## Usage
 ```
 expr [EXPRESSION]
 expr [OPTIONS]
 ```
+
+Print the value of `EXPRESSION` to standard output
 
 ## After help
 

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -8,7 +8,7 @@
 use clap::{crate_version, Arg, ArgAction, Command};
 use uucore::{
     error::{UResult, USimpleError},
-    format_usage, help_section, help_usage,
+    format_usage, help_about, help_section, help_usage,
 };
 
 mod syntax_tree;
@@ -23,7 +23,7 @@ mod options {
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
-        .about(help_section!("about", "expr.md"))
+        .about(help_about!("expr.md"))
         .override_usage(format_usage(help_usage!("expr.md")))
         .after_help(help_section!("after help", "expr.md"))
         .infer_long_args(true)

--- a/src/uu/numfmt/numfmt.md
+++ b/src/uu/numfmt/numfmt.md
@@ -1,12 +1,9 @@
 <!-- spell-checker:ignore N'th M'th -->
 # numfmt
 
-## Usage
 ```
 numfmt [OPTION]... [NUMBER]...
 ```
-
-## About
 
 Convert numbers from/to human-readable strings
 

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -14,16 +14,15 @@ use std::io::{BufRead, Write};
 use units::{IEC_BASES, SI_BASES};
 use uucore::display::Quotable;
 use uucore::error::UResult;
-use uucore::format_usage;
 use uucore::ranges::Range;
-use uucore::{help_section, help_usage};
+use uucore::{format_usage, help_about, help_section, help_usage};
 
 pub mod errors;
 pub mod format;
 pub mod options;
 mod units;
 
-const ABOUT: &str = help_section!("about", "numfmt.md");
+const ABOUT: &str = help_about!("numfmt.md");
 const AFTER_HELP: &str = help_section!("after help", "numfmt.md");
 const USAGE: &str = help_usage!("numfmt.md");
 

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -13,7 +13,9 @@ use uucore::fsext::{
     pretty_filetype, pretty_fstype, pretty_time, read_fs_list, statfs, BirthTime, FsMeta,
 };
 use uucore::libc::mode_t;
-use uucore::{entries, format_usage, help_section, help_usage, show_error, show_warning};
+use uucore::{
+    entries, format_usage, help_about, help_section, help_usage, show_error, show_warning,
+};
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::borrow::Cow;
@@ -24,7 +26,7 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::prelude::OsStrExt;
 use std::path::Path;
 
-const ABOUT: &str = help_section!("about", "stat.md");
+const ABOUT: &str = help_about!("stat.md");
 const USAGE: &str = help_usage!("stat.md");
 const LONG_USAGE: &str = help_section!("long usage", "stat.md");
 

--- a/src/uu/stat/stat.md
+++ b/src/uu/stat/stat.md
@@ -1,13 +1,10 @@
 # stat
 
-## About
-
-Display file or file system status.
-
-## Usage
 ```
 stat [OPTION]... FILE...
 ```
+
+Display file or file system status.
 
 ## Long Usage
 


### PR DESCRIPTION
This PR adds the implementation for the new help structure discussed in https://github.com/uutils/coreutils/issues/4368, which no longer uses `Usage` and `About` headers:

````
# numfmt
```
numfmt [OPTION]... [NUMBER]...
```

Convert numbers from/to human-readable strings
````

The PR 

- adds a new `help_about` macro to get the about text from the help file
- modifies the existing `help_usage` macro accordingly
- updates all help files to the new structure
- replaces the usage of `help_section!("about", "example.md")` with `help_about!("example.md")`