### PR TITLE
yes: move help strings to markdown file

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -12,13 +12,13 @@ use std::io::{self, Result, Write};
 
 use clap::{Arg, ArgAction, Command};
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod splice;
 
-const ABOUT: &str = "Repeatedly display a line with STRING (or 'y')";
-const USAGE: &str = "{} [STRING]...";
+const ABOUT: &str = help_about!("yes.md");
+const USAGE: &str = help_usage!("yes.md");
 
 // it's possible that using a smaller or larger buffer might provide better performance on some
 // systems, but honestly this is good enough

--- a/src/uu/yes/yes.md
+++ b/src/uu/yes/yes.md
@@ -1,0 +1,7 @@
+# yes
+
+```
+yes [STRING]...
+```
+
+Repeatedly display a line with STRING (or 'y')


### PR DESCRIPTION
#4368

`yes -h` outputs the following.

```shell
$ ./target/debug/coreutils yes -h
Repeatedly display a line with STRING (or 'y')

Usage: ./target/debug/coreutils yes [STRING]...

Arguments:
  [STRING]...  

Options:
  -h, --help  Print help information
```