### PR TITLE
basename: move help strings to markdown file

### DIFF
--- a/src/uu/basename/basename.md
+++ b/src/uu/basename/basename.md
@@ -1,12 +1,9 @@
 # basename
 
-## Usage
 ```
 basename NAME [SUFFIX]
 basename OPTION... NAME...
 ```
-
-## About
 
 Print NAME with any leading directory components removed
 If specified, also remove a trailing SUFFIX

--- a/src/uu/basename/basename.md
+++ b/src/uu/basename/basename.md
@@ -1,0 +1,12 @@
+# basename
+
+## Usage
+```
+basename NAME [SUFFIX]
+basename OPTION... NAME...
+```
+
+## About
+
+Print NAME with any leading directory components removed
+If specified, also remove a trailing SUFFIX

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -11,7 +11,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use std::path::{is_separator, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
-use uucore::{format_usage, help_usage, help_about};
+use uucore::{format_usage, help_about, help_usage};
 
 static ABOUT: &str = help_about!("basename.md");
 

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -11,13 +11,11 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use std::path::{is_separator, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, help_usage, help_section};
 
-static ABOUT: &str = r#"Print NAME with any leading directory components removed
-If specified, also remove a trailing SUFFIX"#;
+static ABOUT: &str = help_section!("about","basename.md");
 
-const USAGE: &str = "{} NAME [SUFFIX]
-    {} OPTION... NAME...";
+const USAGE: &str = help_usage!("basename.md");
 
 pub mod options {
     pub static MULTIPLE: &str = "multiple";

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -11,9 +11,9 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use std::path::{is_separator, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
-use uucore::{format_usage, help_usage, help_section};
+use uucore::{format_usage, help_usage, help_about};
 
-static ABOUT: &str = help_section!("about","basename.md");
+static ABOUT: &str = help_about!("basename.md");
 
 const USAGE: &str = help_usage!("basename.md");
 


### PR DESCRIPTION
#4368 

Now `basename -h` shows the following:
```
$ ./target/debug/coreutils basename -h
Print NAME with any leading directory components removed
If specified, also remove a trailing SUFFIX

Usage: ./target/debug/coreutils basename NAME [SUFFIX]
./target/debug/coreutils basename OPTION... NAME...

Options:
  -a, --multiple         support multiple arguments and treat each as a NAME
  -s, --suffix <SUFFIX>  remove a trailing SUFFIX; implies -a
  -z, --zero             end each output line with NUL, not newline
  -h, --help             Print help information
  -V, --version          Print version information
```