### PR TITLE
chmod: move help strings to markdown file

### DIFF
--- a/src/uu/chmod/chmod.md
+++ b/src/uu/chmod/chmod.md
@@ -1,3 +1,5 @@
+<!-- spell-checker:ignore RFILE ugoa -->
+
 # chmod
 
 ```

--- a/src/uu/chmod/chmod.md
+++ b/src/uu/chmod/chmod.md
@@ -9,6 +9,6 @@ chmod [OPTION]... --reference=RFILE FILE...
 Change the mode of each FILE to MODE.
 With --reference, change the mode of each FILE to that of RFILE.
 
-## Long Usage
+## After Help
 
 Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.

--- a/src/uu/chmod/chmod.md
+++ b/src/uu/chmod/chmod.md
@@ -1,0 +1,14 @@
+# chmod
+
+```
+chmod [OPTION]... MODE[,MODE]... FILE...
+chmod [OPTION]... OCTAL-MODE FILE...
+chmod [OPTION]... --reference=RFILE FILE...
+```
+
+Change the mode of each FILE to MODE.
+With --reference, change the mode of each FILE to that of RFILE.
+
+## Long Usage
+
+Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -17,16 +17,11 @@ use uucore::fs::display_permissions_unix;
 use uucore::libc::mode_t;
 #[cfg(not(windows))]
 use uucore::mode;
-use uucore::{format_usage, show, show_error};
+use uucore::{format_usage, show, show_error, help_about, help_usage, help_section};
 
-const ABOUT: &str = "Change the mode of each FILE to MODE.\n\
-    With --reference, change the mode of each FILE to that of RFILE.";
-const USAGE: &str = "\
-       {} [OPTION]... MODE[,MODE]... FILE...
-       {} [OPTION]... OCTAL-MODE FILE...
-       {} [OPTION]... --reference=RFILE FILE...";
-const LONG_USAGE: &str =
-    "Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.";
+const ABOUT: &str = help_about!("chmod.md");
+const USAGE: &str = help_usage!("chmod.md");
+const LONG_USAGE: &str = help_section!("long usage", "chmod.md");
 
 mod options {
     pub const CHANGES: &str = "changes";

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -17,7 +17,7 @@ use uucore::fs::display_permissions_unix;
 use uucore::libc::mode_t;
 #[cfg(not(windows))]
 use uucore::mode;
-use uucore::{format_usage, show, show_error, help_about, help_usage, help_section};
+use uucore::{format_usage, help_about, help_section, help_usage, show, show_error};
 
 const ABOUT: &str = help_about!("chmod.md");
 const USAGE: &str = help_usage!("chmod.md");

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -21,7 +21,7 @@ use uucore::{format_usage, show, show_error, help_about, help_usage, help_sectio
 
 const ABOUT: &str = help_about!("chmod.md");
 const USAGE: &str = help_usage!("chmod.md");
-const LONG_USAGE: &str = help_section!("long usage", "chmod.md");
+const LONG_USAGE: &str = help_section!("after help", "chmod.md");
 
 mod options {
     pub const CHANGES: &str = "changes";


### PR DESCRIPTION
#4368 

Now `chmod -h` shows the following:
```
$ ./target/debug/coreutils chmod -h
Change the mode of each FILE to MODE.
With --reference, change the mode of each FILE to that of RFILE.

Usage: ./target/debug/coreutils chmod [OPTION]... MODE[,MODE]... FILE...
./target/debug/coreutils chmod [OPTION]... OCTAL-MODE FILE...
./target/debug/coreutils chmod [OPTION]... --reference=RFILE FILE...

Arguments:
  [MODE]     
  [FILE]...  

Options:
  -c, --changes            like verbose but report only when a change is made
  -f, --quiet              suppress most error messages [aliases: silent]
  -v, --verbose            output a diagnostic for every file processed
      --no-preserve-root   do not treat '/' specially (the default)
      --preserve-root      fail to operate recursively on '/'
  -R, --recursive          change files and directories recursively
      --reference <RFILE>  use RFILE's mode instead of MODE values
  -h, --help               Print help information
  -V, --version            Print version information

Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.
```