### PR TITLE
tac: move help strings to markdown file

### DIFF
--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -19,12 +19,12 @@ use std::{
 use uucore::display::Quotable;
 use uucore::error::UError;
 use uucore::error::UResult;
-use uucore::{format_usage, show};
+use uucore::{format_usage, help_about, help_usage, show};
 
 use crate::error::TacError;
 
-static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = "Write each file to standard output, last line first.";
+static USAGE: &str = help_usage!("tac.md");
+static ABOUT: &str = help_about!("tac.md");
 
 mod options {
     pub static BEFORE: &str = "before";

--- a/src/uu/tac/tac.md
+++ b/src/uu/tac/tac.md
@@ -1,0 +1,7 @@
+# tac
+
+```
+tac [OPTION]... [FILE]...
+```
+
+Write each file to standard output, last line first.


### PR DESCRIPTION
#4368 

`tac -h` outputs the following.

```shell
$ ./target/debug/coreutils tac -h
Write each file to standard output, last line first.

Usage: ./target/debug/coreutils tac [OPTION]... [FILE]...

Options:
  -b, --before              attach the separator before instead of after
  -r, --regex               interpret the sequence as a regular expression
  -s, --separator <STRING>  use STRING as the separator instead of newline
  -h, --help                Print help information
  -V, --version             Print version information
```