### PR TITLE
kill: move help strings to markdown file

### DIFF
--- a/src/uu/kill/kill.md
+++ b/src/uu/kill/kill.md
@@ -1,0 +1,7 @@
+# kill
+
+```
+kill [OPTIONS]... PID...
+```
+
+Send signal to processes or list information about signals.

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -14,10 +14,10 @@ use std::io::Error;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::signals::{signal_by_name_or_value, ALL_SIGNALS};
-use uucore::{format_usage, show};
+use uucore::{format_usage, help_about, help_usage, show};
 
-static ABOUT: &str = "Send signal to processes or list information about signals.";
-const USAGE: &str = "{} [OPTIONS]... PID...";
+static ABOUT: &str = help_about!("kill.md");
+const USAGE: &str = help_usage!("kill.md");
 
 pub mod options {
     pub static PIDS_OR_SIGNALS: &str = "pids_or_signals";


### PR DESCRIPTION
#4368 

`kill -h` shows the following.

```shell
$ ./target/debug/coreutils kill -h   
Send signal to processes or list information about signals.

Usage: ./target/debug/coreutils kill [OPTIONS]... PID...

Options:
  -l, --list             Lists signals
  -t, --table            Lists table of signals
  -s, --signal <signal>  Sends given signal instead of SIGTERM
  -h, --help             Print help information
  -V, --version          Print version information
```