### PR TITLE
mkdir: move help strings to markdown file

### DIFF
--- a/src/uu/mkdir/mkdir.md
+++ b/src/uu/mkdir/mkdir.md
@@ -1,0 +1,11 @@
+# mkdir
+
+```
+mkdir [OPTION]... [USER]
+```
+
+Create the given DIRECTORY(ies) if they do not exist
+
+## Long Usage
+
+Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.

--- a/src/uu/mkdir/mkdir.md
+++ b/src/uu/mkdir/mkdir.md
@@ -6,6 +6,6 @@ mkdir [OPTION]... [USER]
 
 Create the given DIRECTORY(ies) if they do not exist
 
-## Long Usage
+## After Help
 
 Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -24,7 +24,7 @@ static DEFAULT_PERM: u32 = 0o755;
 
 const ABOUT: &str = help_about!("mkdir.md");
 const USAGE: &str = help_usage!("mkdir.md");
-const LONG_USAGE: &str = help_section!("long usage", "mkdir.md");
+const AFTER_HELP: &str = help_section!("after help", "mkdir.md");
 
 mod options {
     pub const MODE: &str = "mode";
@@ -89,7 +89,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Linux-specific options, not implemented
     // opts.optflag("Z", "context", "set SELinux security context" +
     // " of each created directory to CTX"),
-    let matches = uu_app().after_help(LONG_USAGE).try_get_matches_from(args)?;
+    let matches = uu_app().after_help(AFTER_HELP).try_get_matches_from(args)?;
 
     let dirs = matches
         .get_many::<OsString>(options::DIRS)

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -18,14 +18,13 @@ use uucore::error::{UResult, USimpleError};
 #[cfg(not(windows))]
 use uucore::mode;
 use uucore::{display::Quotable, fs::dir_strip_dot_for_creation};
-use uucore::{format_usage, show, show_if_err};
+use uucore::{format_usage, help_about, help_section, help_usage, show, show_if_err};
 
 static DEFAULT_PERM: u32 = 0o755;
 
-const ABOUT: &str = "Create the given DIRECTORY(ies) if they do not exist";
-const USAGE: &str = "{} [OPTION]... [USER]";
-const LONG_USAGE: &str =
-    "Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.";
+const ABOUT: &str = help_about!("mkdir.md");
+const USAGE: &str = help_usage!("mkdir.md");
+const LONG_USAGE: &str = help_section!("long usage", "mkdir.md");
 
 mod options {
     pub const MODE: &str = "mode";


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`mkdir -h` outputs the following.
```
$ ./target/debug/coreutils mkdir -h
Create the given DIRECTORY(ies) if they do not exist

Usage:  ./target/debug/coreutils mkdir [OPTION]... [USER]

Arguments:
  [dirs]...  

Options:
  -m, --mode <mode>  set file mode (not implemented on windows)
  -p, --parents      make parent directories as needed
  -v, --verbose      print a message for each printed directory
  -h, --help         Print help information
  -V, --version      Print version information

Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.
```