### PR TITLE
od: move help strings to markdown file

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -16,7 +16,7 @@ use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::signals::{signal_by_name_or_value, ALL_SIGNALS};
 use uucore::{format_usage, help_about, help_usage, show};
 
-static ABOUT: &str = help_about!("kill.md");
+const ABOUT: &str = help_about!("kill.md");
 const USAGE: &str = help_usage!("kill.md");
 
 pub mod options {

--- a/src/uu/od/od.md
+++ b/src/uu/od/od.md
@@ -1,0 +1,49 @@
+# od
+
+```
+od [OPTION]... [--] [FILENAME]...
+od [-abcdDefFhHiIlLoOsxX] [FILENAME] [[+][0x]OFFSET[.][b]]
+od --traditional [OPTION]... [FILENAME] [[+][0x]OFFSET[.][b] [[+][0x]LABEL[.][b]]]
+```
+
+Dump files in octal and other formats
+
+## After Help
+
+Displays data in various human-readable formats. If multiple formats are
+specified, the output will contain all formats in the order they appear on the
+command line. Each format will be printed on a new line. Only the line
+containing the first format will be prefixed with the offset.
+
+If no filename is specified, or it is "-", stdin will be used. After a "--", no
+more options will be recognized. This allows for filenames starting with a "-".
+
+If a filename is a valid number which can be used as an offset in the second
+form, you can force it to be recognized as a filename if you include an option
+like "-j0", which is only valid in the first form.
+
+RADIX is one of o,d,x,n for octal, decimal, hexadecimal or none.
+
+BYTES is decimal by default, octal if prefixed with a "0", or hexadecimal if
+prefixed with "0x". The suffixes b, KB, K, MB, M, GB, G, will multiply the
+number with 512, 1000, 1024, 1000^2, 1024^2, 1000^3, 1024^3, 1000^2, 1024^2.
+
+OFFSET and LABEL are octal by default, hexadecimal if prefixed with "0x" or
+decimal if a "." suffix is added. The "b" suffix will multiply with 512.
+
+TYPE contains one or more format specifications consisting of:
+    a       for printable 7-bits ASCII
+    c       for utf-8 characters or octal for undefined characters
+    d[SIZE] for signed decimal
+    f[SIZE] for floating point
+    o[SIZE] for octal
+    u[SIZE] for unsigned decimal
+    x[SIZE] for hexadecimal
+SIZE is the number of bytes which can be the number 1, 2, 4, 8 or 16,
+    or C, I, S, L for 1, 2, 4, 8 bytes for integer types,
+    or F, D, L for 4, 8, 16 bytes for floating point.
+Any type specification can have a "z" suffix, which will add a ASCII dump at
+    the end of the line.
+
+If an error occurred, a diagnostic message will be printed to stderr, and the
+exitcode will be non-zero.

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -44,57 +44,15 @@ use clap::ArgAction;
 use clap::{crate_version, parser::ValueSource, Arg, ArgMatches, Command};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
 use uucore::parse_size::ParseSizeError;
-use uucore::show_error;
-use uucore::show_warning;
+use uucore::{format_usage, help_about, help_section, help_usage, show_error, show_warning};
 
 const PEEK_BUFFER_SIZE: usize = 4; // utf-8 can be 4 bytes
-static ABOUT: &str = "Dump files in octal and other formats";
+const ABOUT: &str = help_about!("od.md");
 
-static USAGE: &str = "\
-    {} [OPTION]... [--] [FILENAME]...
-    {} [-abcdDefFhHiIlLoOsxX] [FILENAME] [[+][0x]OFFSET[.][b]]
-    {} --traditional [OPTION]... [FILENAME] [[+][0x]OFFSET[.][b] [[+][0x]LABEL[.][b]]]";
+const USAGE: &str = help_usage!("od.md");
 
-static LONG_HELP: &str = r#"
-Displays data in various human-readable formats. If multiple formats are
-specified, the output will contain all formats in the order they appear on the
-command line. Each format will be printed on a new line. Only the line
-containing the first format will be prefixed with the offset.
-
-If no filename is specified, or it is "-", stdin will be used. After a "--", no
-more options will be recognized. This allows for filenames starting with a "-".
-
-If a filename is a valid number which can be used as an offset in the second
-form, you can force it to be recognized as a filename if you include an option
-like "-j0", which is only valid in the first form.
-
-RADIX is one of o,d,x,n for octal, decimal, hexadecimal or none.
-
-BYTES is decimal by default, octal if prefixed with a "0", or hexadecimal if
-prefixed with "0x". The suffixes b, KB, K, MB, M, GB, G, will multiply the
-number with 512, 1000, 1024, 1000^2, 1024^2, 1000^3, 1024^3, 1000^2, 1024^2.
-
-OFFSET and LABEL are octal by default, hexadecimal if prefixed with "0x" or
-decimal if a "." suffix is added. The "b" suffix will multiply with 512.
-
-TYPE contains one or more format specifications consisting of:
-    a       for printable 7-bits ASCII
-    c       for utf-8 characters or octal for undefined characters
-    d[SIZE] for signed decimal
-    f[SIZE] for floating point
-    o[SIZE] for octal
-    u[SIZE] for unsigned decimal
-    x[SIZE] for hexadecimal
-SIZE is the number of bytes which can be the number 1, 2, 4, 8 or 16,
-    or C, I, S, L for 1, 2, 4, 8 bytes for integer types,
-    or F, D, L for 4, 8, 16 bytes for floating point.
-Any type specification can have a "z" suffix, which will add a ASCII dump at
-    the end of the line.
-
-If an error occurred, a diagnostic message will be printed to stderr, and the
-exitcode will be non-zero."#;
+const AFTER_HELP: &str = help_section!("after help", "od.md");
 
 pub(crate) mod options {
     pub const HELP: &str = "help";
@@ -295,7 +253,7 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
-        .after_help(LONG_HELP)
+        .after_help(AFTER_HELP)
         .trailing_var_arg(true)
         .dont_delimit_trailing_values(true)
         .infer_long_args(true)


### PR DESCRIPTION
#4368 

With this PR, `od --help` outputs the following.

```shell
$ ./target/debug/coreutils od --help
Dump files in octal and other formats

Usage: ./target/debug/coreutils od [OPTION]... [--] [FILENAME]...
./target/debug/coreutils od [-abcdDefFhHiIlLoOsxX] [FILENAME] [[+][0x]OFFSET[.][b]]
./target/debug/coreutils od --traditional [OPTION]... [FILENAME] [[+][0x]OFFSET[.][b] [[+][0x]LABEL[.][b]]]

Options:
      --help                   Print help information.
  -A, --address-radix <RADIX>  Select the base in which file offsets are printed.
  -j, --skip-bytes <BYTES>     Skip bytes input bytes before formatting and writing.
  -N, --read-bytes <BYTES>     limit dump to BYTES input bytes
      --endian <big|little>    byte order to use for multi-byte formats [possible values: big, little]
  -S, --strings <BYTES>        NotImplemented: output strings of at least BYTES graphic chars. 3 is assumed when BYTES is not specified.
  -a                           named characters, ignoring high-order bit
  -b                           octal bytes
  -c                           ASCII characters or backslash escapes
  -d                           unsigned decimal 2-byte units
  -D                           unsigned decimal 4-byte units
  -o                           octal 2-byte units
  -I                           decimal 8-byte units
  -L                           decimal 8-byte units
  -i                           decimal 4-byte units
  -l                           decimal 8-byte units
  -x                           hexadecimal 2-byte units
  -h                           hexadecimal 2-byte units
  -O                           octal 4-byte units
  -s                           decimal 2-byte units
  -X                           hexadecimal 4-byte units
  -H                           hexadecimal 4-byte units
  -e                           floating point double precision (64-bit) units
  -f                           floating point double precision (32-bit) units
  -F                           floating point double precision (64-bit) units
  -t, --format <TYPE>          select output format or formats
  -v, --output-duplicates      do not use * to mark line suppression
  -w, --width [<BYTES>]        output BYTES bytes per output line. 32 is implied when BYTES is not specified.
      --traditional            compatibility mode with one input, offset and label.
  -V, --version                Print version information

Displays data in various human-readable formats. If multiple formats are
specified, the output will contain all formats in the order they appear on the
command line. Each format will be printed on a new line. Only the line
containing the first format will be prefixed with the offset.

If no filename is specified, or it is "-", stdin will be used. After a "--", no
more options will be recognized. This allows for filenames starting with a "-".

If a filename is a valid number which can be used as an offset in the second
form, you can force it to be recognized as a filename if you include an option
like "-j0", which is only valid in the first form.

RADIX is one of o,d,x,n for octal, decimal, hexadecimal or none.

BYTES is decimal by default, octal if prefixed with a "0", or hexadecimal if
prefixed with "0x". The suffixes b, KB, K, MB, M, GB, G, will multiply the
number with 512, 1000, 1024, 1000^2, 1024^2, 1000^3, 1024^3, 1000^2, 1024^2.

OFFSET and LABEL are octal by default, hexadecimal if prefixed with "0x" or
decimal if a "." suffix is added. The "b" suffix will multiply with 512.

TYPE contains one or more format specifications consisting of:
    a       for printable 7-bits ASCII
    c       for utf-8 characters or octal for undefined characters
    d[SIZE] for signed decimal
    f[SIZE] for floating point
    o[SIZE] for octal
    u[SIZE] for unsigned decimal
    x[SIZE] for hexadecimal
SIZE is the number of bytes which can be the number 1, 2, 4, 8 or 16,
    or C, I, S, L for 1, 2, 4, 8 bytes for integer types,
    or F, D, L for 4, 8, 16 bytes for floating point.
Any type specification can have a "z" suffix, which will add a ASCII dump at
    the end of the line.

If an error occurred, a diagnostic message will be printed to stderr, and the
exitcode will be non-zero.
```