### PR TITLE
chmod: allow verbose and quiet flags to be used more than once

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -110,6 +110,7 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
+        .args_override_self(true)
         .infer_long_args(true)
         .arg(
             Arg::new(options::CHANGES)

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -650,3 +650,24 @@ fn test_chmod_file_symlink_after_non_existing_file() {
         0o100764
     );
 }
+
+#[test]
+fn test_quiet_n_verbose_used_multiple_times() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("file");
+    scene
+        .ucmd()
+        .arg("u+x")
+        .arg("--verbose")
+        .arg("--verbose")
+        .arg("file")
+        .succeeds();
+    scene
+        .ucmd()
+        .arg("u+x")
+        .arg("--quiet")
+        .arg("--quiet")
+        .arg("file")
+        .succeeds();
+}


### PR DESCRIPTION
Closes #4409.  Based on feedback from PR #4402 