### PR TITLE
rmdir: move help strings to markdown file

### DIFF
--- a/src/uu/rmdir/rmdir.md
+++ b/src/uu/rmdir/rmdir.md
@@ -1,0 +1,7 @@
+# rmdir
+
+```
+rmdir [OPTION]... DIRECTORY...
+```
+
+Remove the DIRECTORY(ies), if they are empty.

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -16,10 +16,10 @@ use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, strip_errno, UResult};
 
-use uucore::{format_usage, show_error, util_name};
+use uucore::{format_usage, help_about, help_usage, show_error, util_name};
 
-static ABOUT: &str = "Remove the DIRECTORY(ies), if they are empty.";
-const USAGE: &str = "{} [OPTION]... DIRECTORY...";
+static ABOUT: &str = help_about!("rmdir.md");
+const USAGE: &str = help_usage!("rmdir.md");
 static OPT_IGNORE_FAIL_NON_EMPTY: &str = "ignore-fail-on-non-empty";
 static OPT_PARENTS: &str = "parents";
 static OPT_VERBOSE: &str = "verbose";


### PR DESCRIPTION
#4368 

`rmdir -h` outputs the following.

```
$ ./target/debug/coreutils rmdir -h
Remove the DIRECTORY(ies), if they are empty.

Usage: ./target/debug/coreutils rmdir [OPTION]... DIRECTORY...

Arguments:
  [dirs]...  

Options:
      --ignore-fail-on-non-empty  ignore each failure that is solely because a directory is non-empty
  -p, --parents                   remove DIRECTORY and its ancestors; e.g.,
                                                    'rmdir -p a/b/c' is similar to rmdir a/b/c a/b a
  -v, --verbose                   output a diagnostic for every directory processed
  -h, --help                      Print help information
  -V, --version                   Print version information
```