### PR TITLE
nohup: move help strings to markdown file

### DIFF
--- a/src/uu/nohup/nohup.md
+++ b/src/uu/nohup/nohup.md
@@ -1,0 +1,15 @@
+# nohup
+
+```
+nohup COMMAND [ARG]...
+nohup FLAG
+```
+
+Run COMMAND ignoring hangup signals.
+
+## After Help
+
+If standard input is terminal, it'll be replaced with /dev/null.
+If standard output is terminal, it'll be appended to nohup.out instead,
+or $HOME/nohup.out, if nohup.out open failed.
+If standard error is terminal, it'll be redirected to stdout.

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -20,18 +20,11 @@ use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UClapError, UError, UResult};
-use uucore::{format_usage, show_error};
+use uucore::{format_usage, help_about, help_section, help_usage, show_error};
 
-static ABOUT: &str = "Run COMMAND ignoring hangup signals.";
-static LONG_HELP: &str = "
-If standard input is terminal, it'll be replaced with /dev/null.
-If standard output is terminal, it'll be appended to nohup.out instead,
-or $HOME/nohup.out, if nohup.out open failed.
-If standard error is terminal, it'll be redirected to stdout.
-";
-const USAGE: &str = "\
-    {} COMMAND [ARG]...
-    {} FLAG";
+const ABOUT: &str = help_about!("nohup.md");
+const AFTER_HELP: &str = help_section!("after help", "nohup.md");
+const USAGE: &str = help_usage!("nohup.md");
 static NOHUP_OUT: &str = "nohup.out";
 // exit codes that match the GNU implementation
 static EXIT_CANCELED: i32 = 125;
@@ -116,7 +109,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .after_help(LONG_HELP)
+        .after_help(AFTER_HELP)
         .override_usage(format_usage(USAGE))
         .arg(
             Arg::new(options::CMD)


### PR DESCRIPTION
#4368 

Now `nohup -h` outputs the following.

```shell
$ ./target/debug/coreutils nohup --h   
Run COMMAND ignoring hangup signals.

Usage: ./target/debug/coreutils nohup COMMAND [ARG]...
./target/debug/coreutils nohup FLAG

Options:
  -h, --help     Print help information
  -V, --version  Print version information

If standard input is terminal, it'll be replaced with /dev/null.
If standard output is terminal, it'll be appended to nohup.out instead,
or $HOME/nohup.out, if nohup.out open failed.
If standard error is terminal, it'll be redirected to stdout.
```