### PR TITLE
Freebsd pkg has been remamed to rust-coreutils

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -111,7 +111,7 @@ port install coreutils-uutils
 [![FreeBSD port](https://repology.org/badge/version-for-repo/freebsd/uutils-coreutils.svg)](https://repology.org/project/uutils-coreutils/versions)
 
 ```sh
-pkg install uutils
+pkg install rust-coreutils
 ```
 
 ## Windows


### PR DESCRIPTION
https://cgit.FreeBSD.org/ports/commit/?id=8014b050aa2f5d3e016d48c98865eabb0e6b12fe