### PR TITLE
shuf: move help strings to markdown file

### DIFF
--- a/src/uu/shuf/shuf.md
+++ b/src/uu/shuf/shuf.md
@@ -1,0 +1,11 @@
+# shuf
+
+```
+shuf [OPTION]... [FILE]
+shuf -e [OPTION]... [ARG]...
+shuf -i LO-HI [OPTION]...;
+```
+
+Shuffle the input by outputting a random permutation of input lines.
+Each output permutation is equally likely.
+With no FILE, or when FILE is -, read standard input.

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 mod rand_read_adapter;
 
@@ -25,14 +25,8 @@ enum Mode {
     InputRange((usize, usize)),
 }
 
-static USAGE: &str = "\
-    {} [OPTION]... [FILE]
-    {} -e [OPTION]... [ARG]...
-    {} -i LO-HI [OPTION]...";
-static ABOUT: &str = "\
-    Shuffle the input by outputting a random permutation of input lines. \
-    Each output permutation is equally likely. \
-    With no FILE, or when FILE is -, read standard input.";
+static USAGE: &str = help_usage!("shuf.md");
+static ABOUT: &str = help_about!("shuf.md");
 
 struct Options {
     head_count: usize,


### PR DESCRIPTION
#4368 

`shuf -h` outputs the following.
```
$ ./target/debug/coreutils shuf -h
Shuffle the input by outputting a random permutation of input lines.
Each output permutation is equally likely.
With no FILE, or when FILE is -, read standard input.

Usage: ./target/debug/coreutils shuf [OPTION]... [FILE]
./target/debug/coreutils shuf -e [OPTION]... [ARG]...
./target/debug/coreutils shuf -i LO-HI [OPTION]...;

Arguments:
  [file]  

Options:
  -e, --echo [<ARG>...]       treat each ARG as an input line
  -i, --input-range <LO-HI>   treat each number LO through HI as an input line
  -n, --head-count <COUNT>    output at most COUNT lines
  -o, --output <FILE>         write result to FILE instead of standard output
      --random-source <FILE>  get random bytes from FILE
  -r, --repeat                output lines can be repeated
  -z, --zero-terminated       line delimiter is NUL, not newline
  -h, --help                  Print help information
  -V, --version               Print version information
```