### PR TITLE
ptx: move help strings to markdown file

### DIFF
--- a/src/uu/ptx/ptx.md
+++ b/src/uu/ptx/ptx.md
@@ -1,0 +1,10 @@
+# ptx
+
+```
+ptx [OPTION]... [INPUT]...
+ptx -G [OPTION]... [INPUT [OUTPUT]]
+```
+
+Output a permuted index, including context, of the words in the input files.
+Mandatory arguments to long options are mandatory for short options too.
+With no FILE, or when FILE is -, read standard input. Default is '-F /'.

--- a/src/uu/ptx/ptx.md
+++ b/src/uu/ptx/ptx.md
@@ -5,6 +5,7 @@ ptx [OPTION]... [INPUT]...
 ptx -G [OPTION]... [INPUT [OUTPUT]]
 ```
 
+Produce a permuted index of file contents
 Output a permuted index, including context, of the words in the input files.
 Mandatory arguments to long options are mandatory for short options too.
 With no FILE, or when FILE is -, read standard input. Default is '-F /'.

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -19,16 +19,10 @@ use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::num::ParseIntError;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
-const USAGE: &str = "\
-    {} [OPTION]... [INPUT]...
-    {} -G [OPTION]... [INPUT [OUTPUT]]";
-
-const ABOUT: &str = "\
-    Output a permuted index, including context, of the words in the input files. \n\n\
-    Mandatory arguments to long options are mandatory for short options too.\n\
-    With no FILE, or when FILE is -, read standard input. Default is '-F /'.";
+const USAGE: &str = help_usage!("ptx.md");
+const ABOUT: &str = help_about!("ptx.md");
 
 const REGEX_CHARCLASS: &str = "^-]\\";
 


### PR DESCRIPTION
#4368 

`ptx -h` outputs the following.
```
$ ./target/debug/coreutils ptx -h
Output a permuted index, including context, of the words in the input files.
Mandatory arguments to long options are mandatory for short options too.
With no FILE, or when FILE is -, read standard input. Default is '-F /'.

Usage: ./target/debug/coreutils ptx [OPTION]... [INPUT]...  
./target/debug/coreutils ptx -G [OPTION]... [INPUT [OUTPUT]]

Options:
  -A, --auto-reference            output automatically generated references
  -G, --traditional               behave more like System V 'ptx'
  -F, --flag-truncation <STRING>  use STRING for flagging line truncations
  -M, --macro-name <STRING>       macro name to use instead of 'xx'
  -O, --format=roff               generate output as roff directives
  -R, --right-side-refs           put references at right, not counted in -w
  -S, --sentence-regexp <REGEXP>  for end of lines or end of sentences
  -T, --format=tex                generate output as TeX directives
  -W, --word-regexp <REGEXP>      use REGEXP to match each keyword
  -b, --break-file <FILE>         word break characters in this FILE
  -f, --ignore-case               fold lower case to upper case for sorting
  -g, --gap-size <NUMBER>         gap size in columns between output fields
  -i, --ignore-file <FILE>        read ignore word list from FILE
  -o, --only-file <FILE>          read only word list from this FILE
  -r, --references                first field of each line is a reference
  -w, --width <NUMBER>            output width in columns, reference excluded
  -h, --help                      Print help information
  -V, --version                   Print version information
```