### PR TITLE
link: move help strings to markdown file

### DIFF
--- a/src/uu/link/link.md
+++ b/src/uu/link/link.md
@@ -1,0 +1,7 @@
+# link
+
+```
+link FILE1 FILE2
+```
+
+Call the link function to create a link named FILE2 to an existing FILE1.

--- a/src/uu/link/src/link.rs
+++ b/src/uu/link/src/link.rs
@@ -11,10 +11,10 @@ use std::fs::hard_link;
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Call the link function to create a link named FILE2 to an existing FILE1.";
-const USAGE: &str = "{} FILE1 FILE2";
+static ABOUT: &str = help_about!("link.md");
+const USAGE: &str = help_usage!("link.md");
 
 pub mod options {
     pub static FILES: &str = "FILES";


### PR DESCRIPTION
#4368 

`link -h` outputs the following.

```
$ ./target/debug/coreutils link -h
Call the link function to create a link named FILE2 to an existing FILE1.

Usage: ./target/debug/coreutils link FILE1 FILE2

Options:
  -h, --help     Print help information
  -V, --version  Print version information
```