### PR TITLE
ln: move help strings to markdown file

### DIFF
--- a/src/uu/ln/ln.md
+++ b/src/uu/ln/ln.md
@@ -1,0 +1,21 @@
+# ln
+
+```
+ln [OPTION]... [-T] TARGET LINK_NAME
+ln [OPTION]... TARGET
+ln [OPTION]... TARGET... DIRECTORY
+ln [OPTION]... -t DIRECTORY TARGET...
+```
+
+Change file owner and group
+
+## After Help
+
+In the 1st form, create a link to TARGET with the name LINK_NAME.
+In the 2nd form, create a link to TARGET in the current directory.
+In the 3rd and 4th forms, create links to each TARGET in DIRECTORY.
+Create hard links by default, symbolic links with --symbolic.
+By default, each destination (name of new link) should not already exist.
+When creating hard links, each TARGET must exist.  Symbolic links
+can hold arbitrary text; if later resolved, a relative link is
+interpreted in relation to its parent directory.

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -11,7 +11,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
 use uucore::fs::{make_path_relative_to, paths_refer_to_same_file};
-use uucore::{format_usage, prompt_yes, show_error};
+use uucore::{format_usage, help_about, help_section, help_usage, prompt_yes, show_error};
 
 use std::borrow::Cow;
 use std::error::Error;
@@ -85,21 +85,9 @@ impl UError for LnError {
     }
 }
 
-const ABOUT: &str = "Change file owner and group";
-const USAGE: &str = "\
-       {} [OPTION]... [-T] TARGET LINK_NAME
-       {} [OPTION]... TARGET
-       {} [OPTION]... TARGET... DIRECTORY
-       {} [OPTION]... -t DIRECTORY TARGET...";
-const LONG_USAGE: &str = "\
-    In the 1st form, create a link to TARGET with the name LINK_NAME.\n\
-    In the 2nd form, create a link to TARGET in the current directory.\n\
-    In the 3rd and 4th forms, create links to each TARGET in DIRECTORY.\n\
-    Create hard links by default, symbolic links with --symbolic.\n\
-    By default, each destination (name of new link) should not already exist.\n\
-    When creating hard links, each TARGET must exist.  Symbolic links\n\
-    can hold arbitrary text; if later resolved, a relative link is\n\
-    interpreted in relation to its parent directory.";
+const ABOUT: &str = help_about!("ln.md");
+const USAGE: &str = help_usage!("ln.md");
+const AFTER_HELP: &str = help_section!("after help", "ln.md");
 
 mod options {
     pub const FORCE: &str = "force";
@@ -119,13 +107,13 @@ static ARG_FILES: &str = "files";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let long_usage = format!(
+    let after_help = format!(
         "{}\n\n{}",
-        LONG_USAGE,
+        AFTER_HELP,
         backup_control::BACKUP_CONTROL_LONG_HELP
     );
 
-    let matches = uu_app().after_help(long_usage).try_get_matches_from(args)?;
+    let matches = uu_app().after_help(after_help).try_get_matches_from(args)?;
 
     /* the list of files */
 


### PR DESCRIPTION
#4368 

`ln -h` outputs the following.

```
$ ./target/debug/coreutils ln -h
Change file owner and group

Usage: ./target/debug/coreutils ln [OPTION]... [-T] TARGET LINK_NAME
./target/debug/coreutils ln [OPTION]... TARGET
./target/debug/coreutils ln [OPTION]... TARGET... DIRECTORY
./target/debug/coreutils ln [OPTION]... -t DIRECTORY TARGET...

Arguments:
  <files>...  

Options:
      --backup[=<CONTROL>]            make a backup of each existing destination file
  -b                                  like --backup but does not accept an argument
  -f, --force                         remove existing destination files
  -i, --interactive                   prompt whether to remove existing destination files
  -n, --no-dereference                treat LINK_NAME as a normal file if it is a symbolic link to a directory
  -L, --logical                       dereference TARGETs that are symbolic links
  -P, --physical                      make hard links directly to symbolic links
  -s, --symbolic                      make symbolic links instead of hard links
  -S, --suffix <SUFFIX>               override the usual backup suffix
  -t, --target-directory <DIRECTORY>  specify the DIRECTORY in which to create the links
  -T, --no-target-directory           treat LINK_NAME as a normal file always
  -r, --relative                      create symbolic links relative to link location
  -v, --verbose                       print name of each linked file
  -h, --help                          Print help information
  -V, --version                       Print version information

In the 1st form, create a link to TARGET with the name LINK_NAME.
In the 2nd form, create a link to TARGET in the current directory.
In the 3rd and 4th forms, create links to each TARGET in DIRECTORY.
Create hard links by default, symbolic links with --symbolic.
By default, each destination (name of new link) should not already exist.
When creating hard links, each TARGET must exist.  Symbolic links
can hold arbitrary text; if later resolved, a relative link is
interpreted in relation to its parent directory.

The backup suffix is '~', unless set with --suffix or SIMPLE_BACKUP_SUFFIX.
The version control method may be selected via the --backup option or through
the VERSION_CONTROL environment variable.  Here are the values:

  none, off       never make backups (even if --backup is given)
  numbered, t     make numbered backups
  existing, nil   numbered if numbered backups exist, simple otherwise
  simple, never   always make simple backups
```