### PR TITLE
tee: move help strings to markdown file

### DIFF
--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -11,15 +11,16 @@ use std::io::{copy, sink, stdin, stdout, Error, ErrorKind, Read, Result, Write};
 use std::path::PathBuf;
 use uucore::display::Quotable;
 use uucore::error::UResult;
-use uucore::{format_usage, show_error};
+use uucore::{format_usage, help_about, help_section, help_usage, show_error};
 
 // spell-checker:ignore nopipe
 
 #[cfg(unix)]
 use uucore::libc;
 
-static ABOUT: &str = "Copy standard input to each FILE, and also to standard output.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+const ABOUT: &str = help_about!("tee.md");
+const USAGE: &str = help_usage!("tee.md");
+const AFTER_HELP: &str = help_section!("after help", "tee.md");
 
 mod options {
     pub const APPEND: &str = "append";
@@ -88,7 +89,7 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
-        .after_help("If a FILE is -, it refers to a file named - .")
+        .after_help(AFTER_HELP)
         .infer_long_args(true)
         .arg(
             Arg::new(options::APPEND)

--- a/src/uu/tee/tee.md
+++ b/src/uu/tee/tee.md
@@ -1,0 +1,11 @@
+# tee
+
+```
+tee [OPTION]... [FILE]...
+```
+
+Copy standard input to each FILE, and also to standard output.
+
+## After Help
+
+If a FILE is -, it refers to a file named - .


### PR DESCRIPTION
#4368 

`tee --help` shows the following

```shell
$ ./target/debug/coreutils tee --help
Copy standard input to each FILE, and also to standard output.

Usage: ./target/debug/coreutils tee [OPTION]... [FILE]...

Arguments:
  [file]...
          

Options:
  -a, --append
          append to the given FILEs, do not overwrite

  -i, --ignore-interrupts
          ignore interrupt signals (ignored on non-Unix platforms)

  -p
          set write error behavior (ignored on non-Unix platforms)

      --output-error[=<output-error>]
          set write error behavior

          Possible values:
          - warn:        produce warnings for errors writing to any output
          - warn-nopipe: produce warnings for errors that are not pipe errors (ignored on non-unix platforms)
          - exit:        exit on write errors to any output
          - exit-nopipe: exit on write errors to any output that are not pipe errors (equivalent to exit on non-unix platforms)

  -h, --help
          Print help information (use `-h` for a summary)

  -V, --version
          Print version information

If a FILE is -, it refers to a file named - .
```