### PR TITLE
tail: move help strings to markdown file

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -17,16 +17,10 @@ use std::ffi::OsString;
 use std::time::Duration;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::parse_size::{parse_size, ParseSizeError};
-use uucore::{format_usage, show_warning};
+use uucore::{format_usage, help_about, help_usage, show_warning};
 
-const ABOUT: &str = "\
-    Print the last 10 lines of each FILE to standard output.\n\
-    With more than one FILE, precede each with a header giving the file name.\n\
-    With no FILE, or when FILE is -, read standard input.\n\
-    \n\
-    Mandatory arguments to long flags are mandatory for short flags too.\
-    ";
-const USAGE: &str = "{} [FLAG]... [FILE]...";
+const ABOUT: &str = help_about!("tail.md");
+const USAGE: &str = help_usage!("tail.md");
 
 pub mod options {
     pub mod verbosity {

--- a/src/uu/tail/tail.md
+++ b/src/uu/tail/tail.md
@@ -1,0 +1,11 @@
+# tail
+
+```
+tail [FLAG]... [FILE]...
+```
+
+Print the last 10 lines of each FILE to standard output.
+With more than one FILE, precede each with a header giving the file name.
+With no FILE, or when FILE is -, read standard input.
+
+Mandatory arguments to long flags are mandatory for short flags too.


### PR DESCRIPTION
#4368 

`tail -h` outputs the following

```shell
$ ./target/debug/coreutils tail -h
Print the last 10 lines of each FILE to standard output.
With more than one FILE, precede each with a header giving the file name.
With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long flags are mandatory for short flags too.

Usage: ./target/debug/coreutils tail [FLAG]... [FILE]...

Arguments:
  [files]...  

Options:
  -c, --bytes <bytes>            Number of bytes to print
  -f, --follow[=<follow>]        Print the file as it grows [default: descriptor] [possible values: descriptor, name]
  -n, --lines <lines>            Number of lines to print
      --pid <PID>                With -f, terminate after process ID, PID dies
  -q, --quiet                    Never output headers giving file names [aliases: silent]
  -s, --sleep-interval <N>       Number of seconds to sleep between polling the file when running with -f
      --max-unchanged-stats <N>  Reopen a FILE which has not changed size after N (default 5) iterations to see if it has been unlinked or renamed (this is the usual case of
                                 rotated log files); This option is meaningful only when polling (i.e., with --use-polling) and when --follow=name
  -v, --verbose                  Always output headers giving file names
  -z, --zero-terminated          Line delimiter is NUL, not newline
      --use-polling              Disable 'inotify' support and use polling instead
      --retry                    Keep trying to open a file if it is inaccessible
  -F                             Same as --follow=name --retry
  -h, --help                     Print help information
  -V, --version                  Print version information
```