### PR TITLE
realpath: move help strings to markdown file

### DIFF
--- a/src/uu/realpath/realpath.md
+++ b/src/uu/realpath/realpath.md
@@ -1,0 +1,7 @@
+# realpath
+
+```
+realpath [OPTION]... FILE...
+```
+
+Print the resolved path

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -20,11 +20,12 @@ use uucore::{
     error::{FromIo, UResult},
     format_usage,
     fs::{canonicalize, MissingHandling, ResolveMode},
+    help_about, help_usage,
 };
 use uucore::{error::UClapError, show, show_if_err};
 
-static ABOUT: &str = "Print the resolved path";
-const USAGE: &str = "{} [OPTION]... FILE...";
+static ABOUT: &str = help_about!("realpath.md");
+const USAGE: &str = help_usage!("realpath.md");
 
 static OPT_QUIET: &str = "quiet";
 static OPT_STRIP: &str = "strip";


### PR DESCRIPTION
#4368 

`mkdir -h` outputs the following.

```
$ ./target/debug/coreutils realpath -h
Print the resolved path

Usage: ./target/debug/coreutils realpath [OPTION]... FILE...

Arguments:
  <files>...

Options:
  -q, --quiet                  Do not print warnings for invalid paths
  -s, --strip                  Only strip '.' and '..' components, but don't resolve symbolic links [aliases: no-symlinks]
  -z, --zero                   Separate output filenames with \0 rather than newline
  -L, --logical                resolve '..' components before symlinks
  -P, --physical               resolve symlinks as encountered (default)
  -e, --canonicalize-existing  canonicalize by following every symlink in every component of the given name recursively, all components must exist
  -m, --canonicalize-missing   canonicalize by following every symlink in every component of the given name recursively, without requirements on components existence
      --relative-to <DIR>      print the resolved path relative to DIR
      --relative-base <DIR>    print absolute paths unless paths below DIR
  -h, --help                   Print help information
  -V, --version                Print version information
```