### PR TITLE
fmt: move help strings to markdown file

### DIFF
--- a/src/uu/fmt/fmt.md
+++ b/src/uu/fmt/fmt.md
@@ -1,0 +1,7 @@
+# fmt
+
+```
+fmt [OPTION]... [FILE]...
+```
+
+Reformat paragraphs from input files (or stdin) to stdout.

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -14,7 +14,7 @@ use std::io::{stdin, stdout, Write};
 use std::io::{BufReader, BufWriter, Read};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, show_warning};
+use uucore::{format_usage, help_about, help_usage, show_warning};
 
 use self::linebreak::break_lines;
 use self::parasplit::ParagraphStream;
@@ -22,8 +22,8 @@ use self::parasplit::ParagraphStream;
 mod linebreak;
 mod parasplit;
 
-static ABOUT: &str = "Reformat paragraphs from input files (or stdin) to stdout.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+static ABOUT: &str = help_about!("fmt.md");
+const USAGE: &str = help_usage!("fmt.md");
 static MAX_WIDTH: usize = 2500;
 
 static OPT_CROWN_MARGIN: &str = "crown-margin";


### PR DESCRIPTION
#4368 

`fmt -h` outputs the following.

```
$ ./target/debug/coreutils fmt -h
Reformat paragraphs from input files (or stdin) to stdout.

Usage: ./target/debug/coreutils fmt [OPTION]... [FILE]...

Arguments:
  [files]...  

Options:
  -c, --crown-margin          First and second line of paragraph may have different indentations, in which case the    
                              first line's indentation is preserved, and each subsequent line's indentation matches the
                              second line.
  -t, --tagged-paragraph      Like -c, except that the first and second line of a paragraph *must* have different      
                              indentation or they are treated as separate paragraphs.
  -m, --preserve-headers      Attempt to detect and preserve mail headers in the input. Be careful when combining this 
                              flag with -p.
  -s, --split-only            Split lines only, do not reflow.
  -u, --uniform-spacing       Insert exactly one space between words, and two between sentences. Sentence breaks in the
                              input are detected as [?!.] followed by two spaces or a newline; other punctuation is not
                              interpreted as a sentence break.
  -p, --prefix <PREFIX>       Reformat only lines beginning with PREFIX, reattaching PREFIX to reformatted lines.      
                              Unless -x is specified, leading whitespace will be ignored when matching PREFIX.
  -P, --skip-prefix <PSKIP>   Do not reformat lines beginning with PSKIP. Unless -X is specified, leading whitespace   
                              will be ignored when matching PSKIP
  -x, --exact-prefix          PREFIX must match at the beginning of the line with no preceding whitespace.
  -X, --exact-skip-prefix     PSKIP must match at the beginning of the line with no preceding whitespace.
  -w, --width <WIDTH>         Fill output lines up to a maximum of WIDTH columns, default 79.
  -g, --goal <GOAL>           Goal width, default ~0.94*WIDTH. Must be less than WIDTH.
  -q, --quick                 Break lines more quickly at the expense of a potentially more ragged appearance.
  -T, --tab-width <TABWIDTH>  Treat tabs as TABWIDTH spaces for determining line length, default 8. Note that this is  
                              used only for calculating line lengths; tabs are preserved in the output.
  -h, --help                  Print help information
  -V, --version               Print version information
```