### PR TITLE
Add OpenMandriva Lx to the documentation

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,4 +1,4 @@
-<!-- spell-checker:ignore pacman pamac nixpkgs -->
+<!-- spell-checker:ignore pacman pamac nixpkgs openmandriva -->
 
 # Installation
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -79,6 +79,13 @@ pamac install uutils-coreutils
 nix-env -iA nixos.uutils-coreutils
 ```
 
+### OpenMandriva Lx
+[![openmandriva cooker package](https://repology.org/badge/version-for-repo/openmandriva_cooker/uutils-coreutils.svg)](https://repology.org/project/uutils-coreutils/versions)
+
+```bash
+dnf install uutils-coreutils
+```
+
 ### Ubuntu
 
 [![Ubuntu package](https://repology.org/badge/version-for-repo/ubuntu_23_04/uutils-coreutils.svg)](https://packages.ubuntu.com/source/lunar/rust-coreutils)


### PR DESCRIPTION
Hi,

just to let you know that uutils-coreutils is available for OpenMandriva to install it. 