### PR TITLE
df: move help strings to markdown file

### DIFF
--- a/src/uu/df/df.md
+++ b/src/uu/df/df.md
@@ -1,0 +1,18 @@
+# df
+
+```
+df [OPTION]... [FILE]...
+```
+
+Show information about the file system on which each FILE resides,
+or all file systems by default.
+
+## After Help
+
+Display values are in units of the first available SIZE from --block-size,
+and the DF_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.
+Otherwise, units default to 1024 bytes (or 512 if POSIXLY_CORRECT is set).
+
+SIZE is an integer and optional unit (example: 10M is 10*1024*1024).
+Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB,... (powers
+of 1000).

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -19,7 +19,7 @@ use uucore::error::FromIo;
 use uucore::error::{UError, UResult, USimpleError};
 use uucore::fsext::{read_fs_list, MountInfo};
 use uucore::parse_size::ParseSizeError;
-use uucore::{format_usage, show};
+use uucore::{format_usage, help_about, help_section, help_usage, show};
 
 use clap::{crate_version, parser::ValueSource, Arg, ArgAction, ArgMatches, Command};
 
@@ -33,16 +33,9 @@ use crate::columns::{Column, ColumnError};
 use crate::filesystem::Filesystem;
 use crate::table::Table;
 
-static ABOUT: &str = "Show information about the file system on which each FILE resides,\n\
-                      or all file systems by default.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
-const LONG_HELP: &str = "Display values are in units of the first available SIZE from --block-size,
-and the DF_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.
-Otherwise, units default to 1024 bytes (or 512 if POSIXLY_CORRECT is set).
-
-SIZE is an integer and optional unit (example: 10M is 10*1024*1024).
-Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB,... (powers
-of 1000).";
+const ABOUT: &str = help_about!("df.md");
+const USAGE: &str = help_usage!("df.md");
+const AFTER_HELP: &str = help_section!("after help", "df.md");
 
 static OPT_HELP: &str = "help";
 static OPT_ALL: &str = "all";
@@ -487,7 +480,7 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
-        .after_help(LONG_HELP)
+        .after_help(AFTER_HELP)
         .infer_long_args(true)
         .disable_help_flag(true)
         .arg(


### PR DESCRIPTION
#4368 

`df --help` outputs the following.

```shell
$ ./target/debug/coreutils df --help
Show information about the file system on which each FILE resides,
or all file systems by default.

Usage: ./target/debug/coreutils df [OPTION]... [FILE]...

Arguments:
  [paths]...  

Options:
      --help                      Print help information.
  -a, --all                       include dummy file systems
  -B, --block-size <SIZE>         scale sizes by SIZE before printing them; e.g.'-BM' prints sizes in units of 1,048,576 bytes
      --total                     produce a grand total
  -h, --human-readable            print sizes in human readable format (e.g., 1K 234M 2G)
  -H, --si                        likewise, but use powers of 1000 not 1024
  -i, --inodes                    list inode information instead of block usage
  -k                              like --block-size=1K
  -l, --local                     limit listing to local file systems
      --no-sync                   do not invoke sync before getting usage info (default)
      --output[=<FIELD_LIST>...]  use the output format defined by FIELD_LIST, or print all fields if FIELD_LIST is omitted. [default: source size used avail pcent target] [possible
                                  values: source, fstype, itotal, iused, iavail, ipcent, size, used, avail, pcent, file, target]
  -P, --portability               use the POSIX output format
      --sync                      invoke sync before getting usage info (non-windows only)
  -t, --type <TYPE>               limit listing to file systems of type TYPE
  -T, --print-type                print file system type
  -x, --exclude-type <TYPE>       limit listing to file systems not of type TYPE
  -V, --version                   Print version information

Display values are in units of the first available SIZE from --block-size,
and the DF_BLOCK_SIZE, BLOCK_SIZE and BLOCKSIZE environment variables.
Otherwise, units default to 1024 bytes (or 512 if POSIXLY_CORRECT is set).

SIZE is an integer and optional unit (example: 10M is 10*1024*1024).
Units are K, M, G, T, P, E, Z, Y (powers of 1024) or KB, MB,... (powers
of 1000).
```