### PR TITLE
dircolors: move help strings to markdown file

### DIFF
--- a/src/uu/dircolors/dircolors.md
+++ b/src/uu/dircolors/dircolors.md
@@ -1,0 +1,13 @@
+# dircolors
+
+```
+dircolors [OPTION]... [FILE]
+```
+
+Output commands to set the LS_COLORS environment variable.
+
+## After Help
+
+If FILE is specified, read it to determine which colors to use for which
+file types and extensions.  Otherwise, a precompiled database is used.
+For details on the format of these files, run 'dircolors --print-database'

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -16,6 +16,7 @@ use std::io::{BufRead, BufReader};
 use clap::{crate_version, Arg, ArgAction, Command};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::{help_about, help_section, help_usage};
 
 mod options {
     pub const BOURNE_SHELL: &str = "bourne-shell";
@@ -25,13 +26,9 @@ mod options {
     pub const FILE: &str = "FILE";
 }
 
-static USAGE: &str = "{} [OPTION]... [FILE]";
-static ABOUT: &str = "Output commands to set the LS_COLORS environment variable.";
-static LONG_HELP: &str = "
- If FILE is specified, read it to determine which colors to use for which
- file types and extensions.  Otherwise, a precompiled database is used.
- For details on the format of these files, run 'dircolors --print-database'
-";
+const USAGE: &str = help_usage!("dircolors.md");
+const ABOUT: &str = help_about!("dircolors.md");
+const AFTER_HELP: &str = help_section!("after help", "dircolors.md");
 
 mod colors;
 use self::colors::INTERNAL_DB;
@@ -170,7 +167,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .after_help(LONG_HELP)
+        .after_help(AFTER_HELP)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .arg(


### PR DESCRIPTION
#4368 

`dircolors -h ` shows the following.

```shell
$ ./target/debug/coreutils dircolors -h   
Output commands to set the LS_COLORS environment variable.

Usage: ./target/debug/coreutils dircolors [OPTION]... [FILE]

Options:
  -b, --sh               output Bourne shell code to set LS_COLORS [aliases: bourne-shell]
  -c, --csh              output C shell code to set LS_COLORS [aliases: c-shell]
  -p, --print-database   print the byte counts
      --print-ls-colors  output fully escaped colors for display
  -h, --help             Print help information
  -V, --version          Print version information

If FILE is specified, read it to determine which colors to use for which
file types and extensions.  Otherwise, a precompiled database is used.
For details on the format of these files, run 'dircolors --print-database'
```