### PR TITLE
reduce the final binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -510,3 +510,10 @@ path = "src/bin/coreutils.rs"
 name = "uudoc"
 path = "src/bin/uudoc.rs"
 required-features = ["uudoc"]
+
+[profile.release]
+opt-level = "z"
+debug = false
+lto = "thin"
+incremental = false
+strip = true


### PR DESCRIPTION
Hi, looks like release binary can be a little bit smaller.

```
[tpg@omv-rockpro64 LOL]$ stat -c%s uu-coreutils
19810944
[tpg@omv-rockpro64 LOL]$ stat -c%s uu-coreutils-opt 
15533632
[tpg@omv-rockpro64 LOL]$ echo $(($(stat -c%s uu-coreutils) - $(stat -c%s uu-coreutils-opt) ))
4277312
[tpg@omv-rockpro64 LOL]$ echo $((($(stat -c%s uu-coreutils) - $(stat -c%s uu-coreutils-opt))/1024/1024 ))
4
```

Comapred to GNu coreutils compiled with corresponding CFLAGS/LDFLAGS and same LLVM toolchain 15.0.7
```
[tpg@omv-rockpro64 coreutils]$ stat -c%s /usr/bin/coreutils 
1067680
```