### PR TITLE
 tests/du: run test_du_time with TZ=UTC. 

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -391,7 +391,12 @@ fn test_du_h_flag_empty_file() {
 fn test_du_time() {
     let ts = TestScenario::new(util_name!());
 
+    // du --time formats the timestamp according to the local timezone. We set the TZ
+    // environment variable to UTC in the commands below to ensure consistent outputs
+    // and test results regardless of the timezone of the machine this test runs in.
+
     ts.ccmd("touch")
+        .env("TZ", "UTC")
         .arg("-a")
         .arg("-t")
         .arg("201505150000")
@@ -399,19 +404,35 @@ fn test_du_time() {
         .succeeds();
 
     ts.ccmd("touch")
+        .env("TZ", "UTC")
         .arg("-m")
         .arg("-t")
         .arg("201606160000")
         .arg("date_test")
         .succeeds();
 
-    let result = ts.ucmd().arg("--time").arg("date_test").succeeds();
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("date_test")
+        .succeeds();
     result.stdout_only("0\t2016-06-16 00:00\tdate_test\n");
 
-    let result = ts.ucmd().arg("--time=atime").arg("date_test").succeeds();
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time=atime")
+        .arg("date_test")
+        .succeeds();
     result.stdout_only("0\t2015-05-15 00:00\tdate_test\n");
 
-    let result = ts.ucmd().arg("--time=ctime").arg("date_test").succeeds();
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time=ctime")
+        .arg("date_test")
+        .succeeds();
     result.stdout_only("0\t2016-06-16 00:00\tdate_test\n");
 
     if birth_supported() {


### PR DESCRIPTION
Hi,

When running tests locally, I noticed that [`test_du_time`](https://github.com/uutils/coreutils/blob/f6b646e4e5aebb89defc24f8202ee41b947199ad/tests/by-util/test_du.rs#L391) fails because it expects the output to be 1h offset from what the tool produces:

```
$ cargo test --features "du touch" --no-default-features
...
---- test_du::test_du_time stdout ----
run: /Users/guilherme/src/coreutils/target/debug/coreutils touch -a -t 201505150000 date_test
run: /Users/guilherme/src/coreutils/target/debug/coreutils touch -m -t 201606160000 date_test
run: /Users/guilherme/src/coreutils/target/debug/coreutils du --time date_test
thread 'test_du::test_du_time' panicked at 'assertion failed: `(left == right)`

Diff < left / right > :
<0	2016-06-16 01:00	date_test
>0	2016-06-16 00:00	date_test


', tests/by-util/test_du.rs:409:12


failures:
    test_du::test_du_time

test result: FAILED. 85 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.82s
```

I believe the test assumes it is running on a machine with UTC timezone. I am in UTC + 1, which the tool output is correctly aware of. This PR changes the test to also expect local times.

Apologies if this is not very idiomatic, I am fairly new to Rust and obviously open to iterating on this 😄

Thanks in advance for the review!