### PR TITLE
chown: move help strings to markdown file

### DIFF
--- a/src/uu/chown/chown.md
+++ b/src/uu/chown/chown.md
@@ -1,3 +1,4 @@
+<!-- spell-checker:ignore RFILE -->
 # chown
 
 ```

--- a/src/uu/chown/chown.md
+++ b/src/uu/chown/chown.md
@@ -1,0 +1,8 @@
+# chown
+
+```
+chown [OPTION]... [OWNER][:[GROUP]] FILE...
+chown [OPTION]... --reference=RFILE FILE...
+```
+
+Change file owner and group

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -9,8 +9,8 @@
 
 use uucore::display::Quotable;
 pub use uucore::entries::{self, Group, Locate, Passwd};
-use uucore::format_usage;
 use uucore::perms::{chown_base, options, IfFrom};
+use uucore::{format_usage, help_about, help_usage};
 
 use uucore::error::{FromIo, UResult, USimpleError};
 
@@ -19,11 +19,9 @@ use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 
-static ABOUT: &str = "Change file owner and group";
+static ABOUT: &str = help_about!("chown.md");
 
-const USAGE: &str = "\
-    {} [OPTION]... [OWNER][:[GROUP]] FILE...
-    {} [OPTION]... --reference=RFILE FILE...";
+const USAGE: &str = help_usage!("chown.md");
 
 fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>, IfFrom)> {
     let filter = if let Some(spec) = matches.get_one::<String>(options::FROM) {


### PR DESCRIPTION
#4368 

Now `chown --help` outputs the following.

```shell
$ ./target/debug/coreutils chown --help
Change file owner and group

Usage: ./target/debug/coreutils chown [OPTION]... [OWNER][:[GROUP]] FILE...
./target/debug/coreutils chown [OPTION]... --reference=RFILE FILE...

Arguments:
  <OWNER>    
  <FILE>...  

Options:
      --help                                Print help information.
  -c, --changes                             like verbose but report only when a change is made
      --dereference                         affect the referent of each symbolic link (this is the default), rather than the symbolic link itself
  -h, --no-dereference                      affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)
      --from <CURRENT_OWNER:CURRENT_GROUP>  change the owner and/or group of each file only if its current owner and/or group match those specified here. Either may be
                                            omitted, in which case a match is not required for the omitted attribute
      --preserve-root                       fail to operate recursively on '/'
      --no-preserve-root                    do not treat '/' specially (the default)
      --quiet                               suppress most error messages
  -R, --recursive                           operate on files and directories recursively
      --reference <RFILE>...                use RFILE's owner and group rather than specifying OWNER:GROUP values
  -f, --silent                              
  -H                                        if a command line argument is a symbolic link to a directory, traverse it
  -L                                        traverse every symbolic link to a directory encountered
  -P                                        do not traverse any symbolic links (default)
  -v, --verbose                             output a diagnostic for every file processed
  -V, --version                             Print version information
```