### PR TITLE
comm: allow multiple occurrence of --zero-terminated

### DIFF
--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -236,6 +236,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::ZERO_TERMINATED)
                 .long(options::ZERO_TERMINATED)
                 .short('z')
+                .overrides_with(options::ZERO_TERMINATED)
                 .help("line delimiter is NUL, not newline")
                 .action(ArgAction::SetTrue),
         )

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -106,6 +106,16 @@ fn zero_terminated() {
 }
 
 #[test]
+fn zero_terminated_provided_multiple_times() {
+    for param in ["-z", "--zero-terminated"] {
+        new_ucmd!()
+            .args(&[param, param, param, "a_nul", "b_nul"])
+            .succeeds()
+            .stdout_only_fixture("ab_nul.expected");
+    }
+}
+
+#[test]
 fn zero_terminated_with_total() {
     for param in ["-z", "--zero-terminated"] {
         new_ucmd!()


### PR DESCRIPTION
This PR allows multiple occurrences of the `-z`/ `--zero-terminated` argument. It makes the test `zdelim-empty` in https://github.com/coreutils/coreutils/blob/master/tests/misc/comm.pl pass.