### PR TITLE
wc: move help strings to markdown file

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -15,7 +15,7 @@ use count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast};
 use countable::WordCountable;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
-use uucore::{format_usage, show, help_about, help_usage};
+use uucore::{format_usage, help_about, help_usage, show};
 use word_count::{TitledWordCount, WordCount};
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -15,7 +15,7 @@ use count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast};
 use countable::WordCountable;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
-use uucore::{format_usage, show};
+use uucore::{format_usage, show, help_about, help_usage};
 use word_count::{TitledWordCount, WordCount};
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
@@ -98,9 +98,8 @@ impl Settings {
     }
 }
 
-static ABOUT: &str = "Display newline, word, and byte counts for each FILE, and a total line if
-more than one FILE is specified. With no FILE, or when FILE is -, read standard input.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+static ABOUT: &str = help_about!("wc.md");
+const USAGE: &str = help_usage!("wc.md");
 
 pub mod options {
     pub static BYTES: &str = "bytes";

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -98,7 +98,7 @@ impl Settings {
     }
 }
 
-static ABOUT: &str = help_about!("wc.md");
+const ABOUT: &str = help_about!("wc.md");
 const USAGE: &str = help_usage!("wc.md");
 
 pub mod options {

--- a/src/uu/wc/wc.md
+++ b/src/uu/wc/wc.md
@@ -1,0 +1,9 @@
+# wc
+
+## Usage
+```
+wc [OPTION]... [FILE]...
+```
+
+Display newline, word, and byte counts for each FILE, and a total line if
+more than one FILE is specified. With no FILE, or when FILE is -, read standard input.

--- a/src/uu/wc/wc.md
+++ b/src/uu/wc/wc.md
@@ -1,7 +1,6 @@
 # wc
 
-## Usage
-```
+```sh
 wc [OPTION]... [FILE]...
 ```
 

--- a/src/uu/wc/wc.md
+++ b/src/uu/wc/wc.md
@@ -1,6 +1,5 @@
 # wc
 
-```sh
 wc [OPTION]... [FILE]...
 ```
 


### PR DESCRIPTION
#4368 

`wc --help` now outputs the following:

```
./target/debug/coreutils wc --help
Display newline, word, and byte counts for each FILE, and a total line if
more than one FILE is specified. With no FILE, or when FILE is -, read standard input.

Usage: ./target/debug/coreutils wc [OPTION]... [FILE]...

Arguments:
  [files]...

Options:
  -c, --bytes            print the byte counts
  -m, --chars            print the character counts
      --files0-from <F>  read input from the files specified by
                             NUL-terminated names in file F;
                             If F is - then read names from standard input
  -l, --lines            print the newline counts
  -L, --max-line-length  print the length of the longest line
  -w, --words            print the word counts
  -h, --help             Print help information
  -V, --version          Print version information
```