### PR TITLE
ls + vdir: move help strings to markdown file

### DIFF
--- a/src/uu/ls/ls.md
+++ b/src/uu/ls/ls.md
@@ -1,8 +1,6 @@
 # ls
 
-## Usage
-
-```
+```sh
 ls [OPTION]... [FILE]...
 ```
 

--- a/src/uu/ls/ls.md
+++ b/src/uu/ls/ls.md
@@ -1,6 +1,4 @@
 # ls
-
-ls [OPTION]... [FILE]...
 ```
 
 List directory contents.

--- a/src/uu/ls/ls.md
+++ b/src/uu/ls/ls.md
@@ -1,0 +1,13 @@
+# ls
+
+## Usage
+```
+ls [OPTION]... [FILE]...
+```
+
+List directory contents.
+Ignore files and directories starting with a '.' by default
+
+## After help
+
+The TIME_STYLE argument can be full-iso, long-iso, iso, locale or +FORMAT. FORMAT is interpreted like in date. Also the TIME_STYLE environment variable sets the default style to use.

--- a/src/uu/ls/ls.md
+++ b/src/uu/ls/ls.md
@@ -1,4 +1,7 @@
 # ls
+
+```
+ls [OPTION]... [FILE]...
 ```
 
 List directory contents.

--- a/src/uu/ls/ls.md
+++ b/src/uu/ls/ls.md
@@ -1,6 +1,7 @@
 # ls
 
 ## Usage
+
 ```
 ls [OPTION]... [FILE]...
 ```

--- a/src/uu/ls/ls.md
+++ b/src/uu/ls/ls.md
@@ -1,6 +1,5 @@
 # ls
 
-```sh
 ls [OPTION]... [FILE]...
 ```
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -55,7 +55,7 @@ use uucore::{
     parse_size::parse_size,
     version_cmp::version_cmp,
 };
-use uucore::{parse_glob, show, show_error, show_warning, help_about, help_section, help_usage};
+use uucore::{help_about, help_section, help_usage, parse_glob, show, show_error, show_warning};
 
 #[cfg(not(feature = "selinux"))]
 static CONTEXT_HELP_TEXT: &str = "print any security context of each file (not enabled)";

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -55,17 +55,16 @@ use uucore::{
     parse_size::parse_size,
     version_cmp::version_cmp,
 };
-use uucore::{parse_glob, show, show_error, show_warning};
+use uucore::{parse_glob, show, show_error, show_warning, help_about, help_section, help_usage};
 
 #[cfg(not(feature = "selinux"))]
 static CONTEXT_HELP_TEXT: &str = "print any security context of each file (not enabled)";
 #[cfg(feature = "selinux")]
 static CONTEXT_HELP_TEXT: &str = "print any security context of each file";
 
-const ABOUT: &str = r#"List directory contents.
-Ignore files and directories starting with a '.' by default"#;
-
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+const ABOUT: &str = help_about!("ls.md");
+const AFTER_HELP: &str = help_section!("after help", "ls.md");
+const USAGE: &str = help_usage!("ls.md");
 
 pub mod options {
     pub mod format {
@@ -1621,10 +1620,7 @@ pub fn uu_app() -> Command {
                 .value_hint(clap::ValueHint::AnyPath)
                 .value_parser(ValueParser::os_string()),
         )
-        .after_help(
-            "The TIME_STYLE argument can be full-iso, long-iso, iso, locale or +FORMAT. FORMAT is interpreted like in date. \
-            Also the TIME_STYLE environment variable sets the default style to use.",
-        )
+        .after_help(AFTER_HELP)
 }
 
 /// Represents a Path along with it's associated data.


### PR DESCRIPTION
#4368 

`vdir` is a wrapper for `ls` and does not have it's own help text. It will output what `ls` has configured.

`ls --help` and `vdir --help` now output the following:

```
target/debug/vdir --help
List directory contents.
Ignore files and directories starting with a '.' by default

Usage: target/debug/vdir [OPTION]... [FILE]...

Arguments:
  [paths]...

Options:
      --help                                     Print help information.
      --format=<format>                          Set the display format.
  -C                                             Display the files in columns.
  -l, --long                                     Display detailed information.
  -x                                             List entries in rows instead of in columns.
  -T, --tabsize <COLS>                           Assume tab stops at each COLS instead of 8 (unimplemented) [env: TABSIZE=]
  -m                                             List entries separated by commas.
      --zero                                     List entries separated by ASCII NUL characters.
  -1                                             List one file per line.
  -o                                             Long format without group information. Identical to --format=long with --no-group.
  -g                                             Long format without owner information.
  -n, --numeric-uid-gid                          -l with numeric UIDs and GIDs.
      --quoting-style <quoting-style>            Set quoting style. [possible values: literal, shell, shell-always, shell-escape, shell-escape-always, c, escape]
  -N, --literal                                  Use literal quoting style. Equivalent to `--quoting-style=literal`
  -b, --escape                                   Use escape quoting style. Equivalent to `--quoting-style=escape`
  -Q, --quote-name                               Use C quoting style. Equivalent to `--quoting-style=c`
  -q, --hide-control-chars                       Replace control characters with '?' if they are not escaped.
      --show-control-chars                       Show control characters 'as is' if they are not escaped.
      --time=<field>                             Show time in <field>:
                                                        access time (-u): atime, access, use;
                                                        change time (-t): ctime, status.
                                                        birth time: birth, creation;
  -c                                             If the long listing format (e.g., -l, -o) is being used, print the status change time (the 'ctime' in the inode) instead of the modification time. When
                                                 explicitly sorting by time (--sort=time or -t) or when not using a long listing format, sort according to the status change time.
  -u                                             If the long listing format (e.g., -l, -o) is being used, print the status access time instead of the modification time. When explicitly sorting by time
                                                 (--sort=time or -t) or when not using a long listing format, sort according to the access time.
      --hide <PATTERN>                           do not list implied entries matching shell PATTERN (overridden by -a or -A)
  -I, --ignore <PATTERN>                         do not list implied entries matching shell PATTERN
  -B, --ignore-backups                           Ignore entries which end with ~.
      --sort=<field>                             Sort by <field>: name, none (-U), time (-t), size (-S) or extension (-X) [possible values: name, none, time, size, version, extension]
  -S                                             Sort by file size, largest first.
  -t                                             Sort by modification time (the 'mtime' in the inode), newest first.
  -v                                             Natural sort of (version) numbers in the filenames.
  -X                                             Sort alphabetically by entry extension.
  -U                                             Do not sort; list the files in whatever order they are stored in the directory.  This is especially useful when listing very large directories, since not doing
                                                 any sorting can be noticeably faster.
  -L, --dereference                              When showing file information for a symbolic link, show information for the file the link references rather than the link itself.
      --dereference-command-line-symlink-to-dir  Do not dereference symlinks except when they link to directories and are given as command line arguments.
  -H, --dereference-command-line                 Do not dereference symlinks except when given as command line arguments.
  -G, --no-group                                 Do not show group in long format.
      --author                                   Show author in long format. On the supported platforms, the author always matches the file owner.
  -a, --all                                      Do not ignore hidden files (files with names that start with '.').
  -A, --almost-all                               In a directory, do not ignore all file names that start with '.', only ignore '.' and '..'.
  -d, --directory                                Only list the names of directories, rather than listing directory contents. This will not follow symbolic links unless one of `--dereference-command-line (-H)`,
                                                 `--dereference (-L)`, or `--dereference-command-line-symlink-to-dir` is specified.
  -h, --human-readable                           Print human readable file sizes (e.g. 1K 234M 56G).
  -k, --kibibytes                                default to 1024-byte blocks for file system usage; used only with -s and per directory totals
      --si                                       Print human readable file sizes using powers of 1000 instead of 1024.
      --block-size=<BLOCK_SIZE>                  scale sizes by BLOCK_SIZE when printing them
  -i, --inode                                    print the index number of each file
  -r, --reverse                                  Reverse whatever the sorting method is e.g., list files in reverse alphabetical order, youngest first, smallest first, or whatever.
  -R, --recursive                                List the contents of all directories recursively.
  -w, --width <COLS>                             Assume that the terminal is COLS columns wide.
  -s, --size                                     print the allocated size of each file, in blocks
      --color[=<color>]                          Color output based on file type. [possible values: always, yes, force, auto, tty, if-tty, never, no, none]
      --indicator-style <indicator-style>        Append indicator with style WORD to entry names: none (default),  slash (-p), file-type (--file-type), classify (-F) [possible values: none, slash, file-type,
                                                 classify]
  -F, --classify[=<when>]                        Append a character to each file name indicating the file type. Also, for regular files that are executable, append '*'. The file type indicators are '/' for
                                                 directories, '@' for symbolic links, '|' for FIFOs, '=' for sockets, '>' for doors, and nothing for regular files. when may be omitted, or one of:
                                                        none - Do not classify. This is the default.
                                                        auto - Only classify if standard output is a terminal.
                                                        always - Always classify.
                                                 Specifying --classify and no when is equivalent to --classify=always. This will not follow symbolic links listed on the command line unless the
                                                 --dereference-command-line (-H), --dereference (-L), or --dereference-command-line-symlink-to-dir options are specified. [possible values: always, yes, force,
                                                 auto, tty, if-tty, never, no, none]
      --file-type                                Same as --classify, but do not append '*'
  -p                                             Append / indicator to directories.
      --time-style <TIME_STYLE>                  time/date format with -l; see TIME_STYLE below [env: TIME_STYLE=]
      --full-time                                like -l --time-style=full-iso
  -Z, --context                                  print any security context of each file (not enabled)
      --group-directories-first                  group directories before files; can be augmented with a --sort option, but any use of --sort=none (-U) disables grouping
  -V, --version                                  Print version information

The TIME_STYLE argument can be full-iso, long-iso, iso, locale or +FORMAT. FORMAT is interpreted like in date. Also the TIME_STYLE environment variable sets the default style to use.
```

```
 target/debug/ls --help
List directory contents.
Ignore files and directories starting with a '.' by default

Usage: target/debug/ls [OPTION]... [FILE]...

Arguments:
  [paths]...

Options:
      --help                                     Print help information.
      --format=<format>                          Set the display format.
  -C                                             Display the files in columns.
  -l, --long                                     Display detailed information.
  -x                                             List entries in rows instead of in columns.
  -T, --tabsize <COLS>                           Assume tab stops at each COLS instead of 8 (unimplemented) [env: TABSIZE=]
  -m                                             List entries separated by commas.
      --zero                                     List entries separated by ASCII NUL characters.
  -1                                             List one file per line.
  -o                                             Long format without group information. Identical to --format=long with --no-group.
  -g                                             Long format without owner information.
  -n, --numeric-uid-gid                          -l with numeric UIDs and GIDs.
      --quoting-style <quoting-style>            Set quoting style. [possible values: literal, shell, shell-always, shell-escape, shell-escape-always, c, escape]
  -N, --literal                                  Use literal quoting style. Equivalent to `--quoting-style=literal`
  -b, --escape                                   Use escape quoting style. Equivalent to `--quoting-style=escape`
  -Q, --quote-name                               Use C quoting style. Equivalent to `--quoting-style=c`
  -q, --hide-control-chars                       Replace control characters with '?' if they are not escaped.
      --show-control-chars                       Show control characters 'as is' if they are not escaped.
      --time=<field>                             Show time in <field>:
                                                        access time (-u): atime, access, use;
                                                        change time (-t): ctime, status.
                                                        birth time: birth, creation;
  -c                                             If the long listing format (e.g., -l, -o) is being used, print the status change time (the 'ctime' in the inode) instead of the modification time. When
                                                 explicitly sorting by time (--sort=time or -t) or when not using a long listing format, sort according to the status change time.
  -u                                             If the long listing format (e.g., -l, -o) is being used, print the status access time instead of the modification time. When explicitly sorting by time
                                                 (--sort=time or -t) or when not using a long listing format, sort according to the access time.
      --hide <PATTERN>                           do not list implied entries matching shell PATTERN (overridden by -a or -A)
  -I, --ignore <PATTERN>                         do not list implied entries matching shell PATTERN
  -B, --ignore-backups                           Ignore entries which end with ~.
      --sort=<field>                             Sort by <field>: name, none (-U), time (-t), size (-S) or extension (-X) [possible values: name, none, time, size, version, extension]
  -S                                             Sort by file size, largest first.
  -t                                             Sort by modification time (the 'mtime' in the inode), newest first.
  -v                                             Natural sort of (version) numbers in the filenames.
  -X                                             Sort alphabetically by entry extension.
  -U                                             Do not sort; list the files in whatever order they are stored in the directory.  This is especially useful when listing very large directories, since not doing
                                                 any sorting can be noticeably faster.
  -L, --dereference                              When showing file information for a symbolic link, show information for the file the link references rather than the link itself.
      --dereference-command-line-symlink-to-dir  Do not dereference symlinks except when they link to directories and are given as command line arguments.
  -H, --dereference-command-line                 Do not dereference symlinks except when given as command line arguments.
  -G, --no-group                                 Do not show group in long format.
      --author                                   Show author in long format. On the supported platforms, the author always matches the file owner.
  -a, --all                                      Do not ignore hidden files (files with names that start with '.').
  -A, --almost-all                               In a directory, do not ignore all file names that start with '.', only ignore '.' and '..'.
  -d, --directory                                Only list the names of directories, rather than listing directory contents. This will not follow symbolic links unless one of `--dereference-command-line (-H)`,
                                                 `--dereference (-L)`, or `--dereference-command-line-symlink-to-dir` is specified.
  -h, --human-readable                           Print human readable file sizes (e.g. 1K 234M 56G).
  -k, --kibibytes                                default to 1024-byte blocks for file system usage; used only with -s and per directory totals
      --si                                       Print human readable file sizes using powers of 1000 instead of 1024.
      --block-size=<BLOCK_SIZE>                  scale sizes by BLOCK_SIZE when printing them
  -i, --inode                                    print the index number of each file
  -r, --reverse                                  Reverse whatever the sorting method is e.g., list files in reverse alphabetical order, youngest first, smallest first, or whatever.
  -R, --recursive                                List the contents of all directories recursively.
  -w, --width <COLS>                             Assume that the terminal is COLS columns wide.
  -s, --size                                     print the allocated size of each file, in blocks
      --color[=<color>]                          Color output based on file type. [possible values: always, yes, force, auto, tty, if-tty, never, no, none]
      --indicator-style <indicator-style>        Append indicator with style WORD to entry names: none (default),  slash (-p), file-type (--file-type), classify (-F) [possible values: none, slash, file-type,
                                                 classify]
  -F, --classify[=<when>]                        Append a character to each file name indicating the file type. Also, for regular files that are executable, append '*'. The file type indicators are '/' for
                                                 directories, '@' for symbolic links, '|' for FIFOs, '=' for sockets, '>' for doors, and nothing for regular files. when may be omitted, or one of:
                                                        none - Do not classify. This is the default.
                                                        auto - Only classify if standard output is a terminal.
                                                        always - Always classify.
                                                 Specifying --classify and no when is equivalent to --classify=always. This will not follow symbolic links listed on the command line unless the
                                                 --dereference-command-line (-H), --dereference (-L), or --dereference-command-line-symlink-to-dir options are specified. [possible values: always, yes, force,
                                                 auto, tty, if-tty, never, no, none]
      --file-type                                Same as --classify, but do not append '*'
  -p                                             Append / indicator to directories.
      --time-style <TIME_STYLE>                  time/date format with -l; see TIME_STYLE below [env: TIME_STYLE=]
      --full-time                                like -l --time-style=full-iso
  -Z, --context                                  print any security context of each file (not enabled)
      --group-directories-first                  group directories before files; can be augmented with a --sort option, but any use of --sort=none (-U) disables grouping
  -V, --version                                  Print version information

The TIME_STYLE argument can be full-iso, long-iso, iso, locale or +FORMAT. FORMAT is interpreted like in date. Also the TIME_STYLE environment variable sets the default style to use.
```