### PR TITLE
pwd: move help strings to markdown file

### DIFF
--- a/src/uu/pwd/pwd.md
+++ b/src/uu/pwd/pwd.md
@@ -1,6 +1,6 @@
 # pwd
 
-```sh
+```
 pwd [OPTION]... [FILE]...
 ```
 

--- a/src/uu/pwd/pwd.md
+++ b/src/uu/pwd/pwd.md
@@ -1,8 +1,6 @@
 # pwd
 
-## Usage
-
-```
+```sh
 pwd [OPTION]... [FILE]...
 ```
 

--- a/src/uu/pwd/pwd.md
+++ b/src/uu/pwd/pwd.md
@@ -1,0 +1,9 @@
+# pwd
+
+## Usage
+
+```
+pwd [OPTION]... [FILE]...
+```
+
+Display the full filename of the current working directory.

--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -10,13 +10,13 @@ use clap::{crate_version, Arg, Command};
 use std::env;
 use std::io;
 use std::path::PathBuf;
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
 
-static ABOUT: &str = "Display the full filename of the current working directory.";
-const USAGE: &str = "{} [OPTION]... FILE...";
+static ABOUT: &str = help_about!("pwd.md");
+const USAGE: &str = help_usage!("pwd.md");
 static OPT_LOGICAL: &str = "logical";
 static OPT_PHYSICAL: &str = "physical";
 


### PR DESCRIPTION
#4368 

`pwd --help` now outputs the following:

```
./target/debug/coreutils pwd --help
Display the full filename of the current working directory.

Usage: ./target/debug/coreutils pwd [OPTION]... [FILE]...

Options:
  -L, --logical   use PWD from environment, even if it contains symlinks
  -P, --physical  avoid all symlinks
  -h, --help      Print help information
  -V, --version   Print version information```