### PR TITLE
truncate: move help strings to markdown file

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -14,7 +14,7 @@ use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_section, help_usage};
 use uucore::parse_size::{parse_size, ParseSizeError};
 
 #[derive(Debug, Eq, PartialEq)]
@@ -73,25 +73,9 @@ impl TruncateMode {
     }
 }
 
-const ABOUT: &str = "Shrink or extend the size of each file to the specified size.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
-const LONG_USAGE: &str = "\
-SIZE is an integer with an optional prefix and optional unit.
-The available units (K, M, G, T, P, E, Z, and Y) use the following format:
-    'KB' =>           1000 (kilobytes)
-    'K'  =>           1024 (kibibytes)
-    'MB' =>      1000*1000 (megabytes)
-    'M'  =>      1024*1024 (mebibytes)
-    'GB' => 1000*1000*1000 (gigabytes)
-    'G'  => 1024*1024*1024 (gibibytes)
-SIZE may also be prefixed by one of the following to adjust the size of each
-file based on its current size:
-    '+'  => extend by
-    '-'  => reduce by
-    '<'  => at most
-    '>'  => at least
-    '/'  => round down to multiple of
-    '%'  => round up to multiple of";
+const ABOUT: &str = help_about!("truncate.md");
+const AFTER_HELP: &str = help_section!("after help", "truncate.md");
+const USAGE: &str = help_usage!("truncate.md");
 
 pub mod options {
     pub static IO_BLOCKS: &str = "io-blocks";
@@ -104,7 +88,7 @@ pub mod options {
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app()
-        .after_help(LONG_USAGE)
+        .after_help(AFTER_HELP)
         .try_get_matches_from(args)
         .map_err(|e| {
             e.print().expect("Error writing clap::Error");

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -14,8 +14,8 @@ use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, help_about, help_section, help_usage};
 use uucore::parse_size::{parse_size, ParseSizeError};
+use uucore::{format_usage, help_about, help_section, help_usage};
 
 #[derive(Debug, Eq, PartialEq)]
 enum TruncateMode {

--- a/src/uu/truncate/truncate.md
+++ b/src/uu/truncate/truncate.md
@@ -1,7 +1,5 @@
 # truncate
 
-## Usage
-
 ```sh
 truncate [OPTION]... [FILE]...
 ```

--- a/src/uu/truncate/truncate.md
+++ b/src/uu/truncate/truncate.md
@@ -1,6 +1,5 @@
 # truncate
 
-```sh
 truncate [OPTION]... [FILE]...
 ```
 

--- a/src/uu/truncate/truncate.md
+++ b/src/uu/truncate/truncate.md
@@ -1,0 +1,28 @@
+# truncate
+
+## Usage
+
+```sh
+truncate [OPTION]... [FILE]...
+```
+
+Shrink or extend the size of each file to the specified size.
+
+## After help
+
+SIZE is an integer with an optional prefix and optional unit.
+The available units (K, M, G, T, P, E, Z, and Y) use the following format:
+    'KB' =>           1000 (kilobytes)
+    'K'  =>           1024 (kibibytes)
+    'MB' =>      1000*1000 (megabytes)
+    'M'  =>      1024*1024 (mebibytes)
+    'GB' => 1000*1000*1000 (gigabytes)
+    'G'  => 1024*1024*1024 (gibibytes)
+SIZE may also be prefixed by one of the following to adjust the size of each
+file based on its current size:
+    '+'  => extend by
+    '-'  => reduce by
+    '<'  => at most
+    '>'  => at least
+    '/'  => round down to multiple of
+    '%'  => round up to multiple of


### PR DESCRIPTION
#4368 

`truncate --help` now outputs the following:

```sh
./target/debug/truncate --help
Shrink or extend the size of each file to the specified size.

Usage: ./target/debug/truncate [OPTION]... [FILE]...

Arguments:
  <FILE>...

Options:
  -o, --io-blocks          treat SIZE as the number of I/O blocks of the file rather than bytes (NOT IMPLEMENTED)
  -c, --no-create          do not create files that do not exist
  -r, --reference <RFILE>  base the size of each file on the size of RFILE
  -s, --size <SIZE>        set or adjust the size of each file according to SIZE, which is in bytes unless --io-blocks is specified
  -h, --help               Print help information
  -V, --version            Print version information

SIZE is an integer with an optional prefix and optional unit.
The available units (K, M, G, T, P, E, Z, and Y) use the following format:
    'KB' =>           1000 (kilobytes)
    'K'  =>           1024 (kibibytes)
    'MB' =>      1000*1000 (megabytes)
    'M'  =>      1024*1024 (mebibytes)
    'GB' => 1000*1000*1000 (gigabytes)
    'G'  => 1024*1024*1024 (gibibytes)
SIZE may also be prefixed by one of the following to adjust the size of each
file based on its current size:
    '+'  => extend by
    '-'  => reduce by
    '<'  => at most
    '>'  => at least
    '/'  => round down to multiple of
    '%'  => round up to multiple of
```