### PR TITLE
For `date`, move help strings to `.md` file

### DIFF
--- a/src/uu/date/date.md
+++ b/src/uu/date/date.md
@@ -1,0 +1,8 @@
+# date
+
+```
+date [OPTION]... [+FORMAT]...
+date [OPTION]... [MMDDhhmm[[CC]YY][.ss]]
+```
+
+Print or set the system date and time

--- a/src/uu/date/date.md
+++ b/src/uu/date/date.md
@@ -1,3 +1,5 @@
+<!-- spell-checker:ignore Dhhmm -->
+
 # date
 
 ```

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -22,7 +22,7 @@ use uucore::display::Quotable;
 #[cfg(not(any(target_os = "macos", target_os = "redox")))]
 use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
-use uucore::{format_usage, show_error};
+use uucore::{format_usage, help_about, help_usage, show_error};
 #[cfg(windows)]
 use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};
 
@@ -36,10 +36,8 @@ const MINUTE: &str = "minute";
 const SECOND: &str = "second";
 const NS: &str = "ns";
 
-const ABOUT: &str = "Print or set the system date and time";
-const USAGE: &str = "\
-    {} [OPTION]... [+FORMAT]...
-    {} [OPTION]... [MMDDhhmm[[CC]YY][.ss]]";
+const ABOUT: &str = help_about!("date.md");
+const USAGE: &str = help_usage!("date.md");
 
 const OPT_DATE: &str = "date";
 const OPT_FORMAT: &str = "format";


### PR DESCRIPTION
## Description

https://github.com/uutils/coreutils/issues/4368

## Testing

Existing tests still pass

```bash
cargo test
...
test result: ok. 2139 passed; 0 failed; 25 ignored; 0 measured; 0 filtered out; finished in 23.66s
```

Manual debug build shows same as `main` branch

```bash
@ coreutils [stevenchu]$ ./target/debug/coreutils date -h
Print or set the system date and time

Usage: ./target/debug/coreutils date [OPTION]... [+FORMAT]...
./target/debug/coreutils date [OPTION]... [MMDDhhmm[[CC]YY][.ss]]

Arguments:
  [format]

Options:
  -d, --date <STRING>     display time described by STRING, not 'now'
  -f, --file <DATEFILE>   like --date; once for each line of DATEFILE
  -I, --iso-8601 <FMT>    output date/time in ISO 8601 format.
                           FMT='date' for date only (the default),
                           'hours', 'minutes', 'seconds', or 'ns'
                           for date and time to the indicated precision.
                           Example: 2006-08-14T02:34:56-06:00
  -R, --rfc-email         output date and time in RFC 5322 format.
                           Example: Mon, 14 Aug 2006 02:34:56 -0600
      --rfc-3339 <FMT>    output date/time in RFC 3339 format.
                           FMT='date', 'seconds', or 'ns'
                           for date and time to the indicated precision.
                           Example: 2006-08-14 02:34:56-06:00
      --debug             annotate the parsed date, and warn about questionable usage to stderr
  -r, --reference <FILE>  display the last modification time of FILE
  -s, --set <STRING>      set time described by STRING (not available on mac yet)
  -u, --universal         print or set Coordinated Universal Time (UTC)
  -h, --help              Print help information
  -V, --version           Print version information
```