### PR TITLE
replace VERSION string with clap::crate_version

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -5,7 +5,7 @@ use clap::builder::ValueParser;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::{display::Quotable, format_usage, help_about, help_usage, show_error, show_warning};
 
-use clap::{Arg, ArgAction, Command};
+use clap::{crate_version, Arg, ArgAction, Command};
 use selinux::{OpaqueSecurityContext, SecurityContext};
 
 use std::borrow::Cow;
@@ -19,7 +19,6 @@ mod fts;
 
 use errors::*;
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 const ABOUT: &str = help_about!("chcon.md");
 const USAGE: &str = help_usage!("chcon.md");
 
@@ -146,7 +145,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .version(VERSION)
+        .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -13,12 +13,11 @@ use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::perms::{chown_base, options, IfFrom};
 use uucore::{format_usage, help_about, help_usage};
 
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 
-static VERSION: &str = env!("CARGO_PKG_VERSION");
 static ABOUT: &str = help_about!("chgrp.md");
 const USAGE: &str = help_usage!("chgrp.md");
 
@@ -56,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .version(VERSION)
+        .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -3,7 +3,7 @@
 use clap::builder::ValueParser;
 use uucore::error::{UResult, UUsageError};
 
-use clap::{Arg, ArgAction, Command};
+use clap::{crate_version, Arg, ArgAction, Command};
 use selinux::{OpaqueSecurityContext, SecurityClass, SecurityContext};
 use uucore::format_usage;
 
@@ -18,7 +18,6 @@ mod errors;
 use errors::error_exit_status;
 use errors::{Error, Result, RunconError};
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 const ABOUT: &str = "Run command with specified security context.";
 const USAGE: &str = "\
     {} [CONTEXT COMMAND [ARG...]]
@@ -107,7 +106,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .version(VERSION)
+        .version(crate_version!())
         .about(ABOUT)
         .after_help(DESCRIPTION)
         .override_usage(format_usage(USAGE))


### PR DESCRIPTION
replace VERSION string with clap::crate_version in chcon, chgrp and runcon utilities

Ref: https://github.com/uutils/coreutils/pull/4461#discussion_r1125632433