### PR TITLE
chroot: move help strings to markdown file

### DIFF
--- a/src/uu/chroot/chroot.md
+++ b/src/uu/chroot/chroot.md
@@ -1,0 +1,7 @@
+# chroot
+
+```
+chroot [OPTION]... NEWROOT [COMMAND [ARG]...]
+```
+
+Run COMMAND with root directory set to NEWROOT.

--- a/src/uu/chroot/chroot.md
+++ b/src/uu/chroot/chroot.md
@@ -1,3 +1,4 @@
+<!-- spell-checker:ignore NEWROOT -->
 # chroot
 
 ```

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -19,10 +19,10 @@ use std::process;
 use uucore::error::{set_exit_code, UClapError, UResult, UUsageError};
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
 use uucore::libc::{self, chroot, setgid, setgroups, setuid};
-use uucore::{entries, format_usage};
+use uucore::{entries, format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Run COMMAND with root directory set to NEWROOT.";
-static USAGE: &str = "{} [OPTION]... NEWROOT [COMMAND [ARG]...]";
+static ABOUT: &str = help_about!("chroot.md");
+static USAGE: &str = help_usage!("chroot.md");
 
 mod options {
     pub const NEWROOT: &str = "newroot";


### PR DESCRIPTION
#4368 

`chroot -h` outputs the following.

```shell
$ ./target/debug/coreutils chroot -h
Run COMMAND with root directory set to NEWROOT.

Usage: ./target/debug/coreutils chroot [OPTION]... NEWROOT [COMMAND [ARG]...]

Options:
  -u, --user <USER>                User (ID or name) to switch before running the program
  -g, --group <GROUP>              Group (ID or name) to switch to
  -G, --groups <GROUP1,GROUP2...>  Comma-separated list of groups to switch to
      --userspec <USER:GROUP>      Colon-separated user and group to switch to. Same as -u USER -g GROUP. Userspec has higher preference than -u and/or -g
      --skip-chdir                 Use this option to not change the working directory to / after changing the root directory to newroot, i.e., inside the chroot.
  -h, --help                       Print help information
  -V, --version                    Print version information
```