### PR TITLE
install: move help strings to markdown file

### DIFF
--- a/src/uu/install/install.md
+++ b/src/uu/install/install.md
@@ -1,0 +1,8 @@
+# install
+
+```
+install [OPTION]... [FILE]...
+```
+
+Copy SOURCE to DEST or multiple SOURCE(s) to the existing
+DIRECTORY, while setting permission modes and owner/group

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -19,7 +19,7 @@ use uucore::error::{FromIo, UError, UIoError, UResult, UUsageError};
 use uucore::fs::dir_strip_dot_for_creation;
 use uucore::mode::get_umask;
 use uucore::perms::{wrap_chown, Verbosity, VerbosityLevel};
-use uucore::{format_usage, show, show_error, show_if_err, uio_error};
+use uucore::{format_usage, show, show_error, show_if_err, uio_error, help_about, help_usage};
 
 use libc::{getegid, geteuid};
 use std::error::Error;
@@ -144,9 +144,8 @@ impl Behavior {
     }
 }
 
-static ABOUT: &str = "Copy SOURCE to DEST or multiple SOURCE(s) to the existing
- DIRECTORY, while setting permission modes and owner/group";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+const ABOUT: &str = help_about!("install.md");
+const USAGE: &str = help_usage!("install.md");
 
 static OPT_COMPARE: &str = "compare";
 static OPT_DIRECTORY: &str = "directory";

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -19,7 +19,7 @@ use uucore::error::{FromIo, UError, UIoError, UResult, UUsageError};
 use uucore::fs::dir_strip_dot_for_creation;
 use uucore::mode::get_umask;
 use uucore::perms::{wrap_chown, Verbosity, VerbosityLevel};
-use uucore::{format_usage, show, show_error, show_if_err, uio_error, help_about, help_usage};
+use uucore::{format_usage, help_about, help_usage, show, show_error, show_if_err, uio_error};
 
 use libc::{getegid, geteuid};
 use std::error::Error;


### PR DESCRIPTION
#4368 

`install -h` now outputs the following.

```shell
$ ./target/debug/coreutils install -h
Copy SOURCE to DEST or multiple SOURCE(s) to the existing
DIRECTORY, while setting permission modes and owner/group

Usage: ./target/debug/coreutils install [OPTION]... [FILE]...

Arguments:
  [files]...  

Options:
      --backup[=<CONTROL>]            make a backup of each existing destination file
  -b                                  like --backup but does not accept an argument
  -c                                  ignored
  -C, --compare                       compare each pair of source and destination files, and in some cases, do not modify the destination at all
  -d, --directory                     treat all arguments as directory names. create all components of the specified directories
  -D                                  create all leading components of DEST except the last, then copy SOURCE to DEST
  -g, --group <GROUP>                 set group ownership, instead of process's current group
  -m, --mode <MODE>                   set permission mode (as in chmod), instead of rwxr-xr-x
  -o, --owner <OWNER>                 set ownership (super-user only)
  -p, --preserve-timestamps           apply access/modification times of SOURCE files to corresponding destination files
  -s, --strip                         strip symbol tables (no action Windows)
      --strip-program <PROGRAM>       program used to strip binaries (no action Windows)
  -S, --suffix <SUFFIX>               override the usual backup suffix
  -t, --target-directory <DIRECTORY>  move all SOURCE arguments into DIRECTORY
  -T, --no-target-directory           (unimplemented) treat DEST as a normal file
  -v, --verbose                       explain what is being done
  -P, --preserve-context              (unimplemented) preserve security context
  -Z, --context                       (unimplemented) set security context of files and directories
  -h, --help                          Print help information
  -V, --version                       Print version information
```