### PR TITLE
env: move help strings to a markdown file

### DIFF
--- a/src/uu/env/env.md
+++ b/src/uu/env/env.md
@@ -1,0 +1,13 @@
+# env
+
+```
+{} [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]
+```
+
+
+Set each NAME to VALUE in the environment and run COMMAND
+
+
+## After Help
+
+A mere - implies -i. If no COMMAND, print the resulting environment.

--- a/src/uu/env/env.md
+++ b/src/uu/env/env.md
@@ -1,7 +1,7 @@
 # env
 
 ```
-{} [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]
+env [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]
 ```
 
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -23,7 +23,7 @@ use std::os::unix::process::ExitStatusExt;
 use std::process;
 use uucore::display::Quotable;
 use uucore::error::{UClapError, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, show_warning, help_about, help_section, help_usage};
+use uucore::{format_usage, help_about, help_section, help_usage, show_warning};
 
 const ABOUT: &str = help_about!("env.md");
 const USAGE: &str = help_usage!("env.md");

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -23,13 +23,11 @@ use std::os::unix::process::ExitStatusExt;
 use std::process;
 use uucore::display::Quotable;
 use uucore::error::{UClapError, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, show_warning};
+use uucore::{format_usage, show_warning, help_about, help_section, help_usage};
 
-const ABOUT: &str = "Set each NAME to VALUE in the environment and run COMMAND";
-const USAGE: &str = "{} [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]";
-const AFTER_HELP: &str = "\
-A mere - implies -i. If no COMMAND, print the resulting environment.
-";
+const ABOUT: &str = help_about!("env.md");
+const USAGE: &str = help_usage!("env.md");
+const AFTER_HELP: &str = help_section!("after help", "env.md");
 
 struct Options<'a> {
     ignore_env: bool,


### PR DESCRIPTION
#4368

After this PR, env -h gives the following output.
~~~
Set each NAME to VALUE in the environment and run COMMAND

Usage: ./target/debug/coreutils env [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]

Arguments:
  [vars]...

Options:
  -i, --ignore-environment  start with an empty environment
  -C, --chdir <DIR>         change working directory to DIR
  -0, --null                end each output line with a 0 byte rather than a newline (only valid when printing the environment)
  -f, --file <PATH>         read and set variables from a ".env"-style configuration file (prior to any unset and/or set)
  -u, --unset <NAME>        remove variable from the environment
  -h, --help                Print help information
  -V, --version             Print version information

A mere - implies -i. If no COMMAND, print the resulting environment.
~~~