### PR TITLE
hostname: move help strings to markdown file

### DIFF
--- a/src/uu/hostname/hostname.md
+++ b/src/uu/hostname/hostname.md
@@ -1,0 +1,7 @@
+# hostname
+
+```
+hostname [OPTION]... [HOSTNAME]
+```
+
+Display or set the system's host name.

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -16,11 +16,11 @@ use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 
 use uucore::{
     error::{FromIo, UResult},
-    format_usage,
+    format_usage, help_about, help_usage,
 };
 
-static ABOUT: &str = "Display or set the system's host name.";
-const USAGE: &str = "{} [OPTION]... [HOSTNAME]";
+const ABOUT: &str = help_about!("hostname.md");
+const USAGE: &str = help_usage!("hostname.md");
 
 static OPT_DOMAIN: &str = "domain";
 static OPT_IP_ADDRESS: &str = "ip-address";


### PR DESCRIPTION
#4368 

Now `hostname -h` displays the following.

```shell
$ ./target/debug/coreutils hostname -h
Display or set the system's host name.

Usage: ./target/debug/coreutils hostname [OPTION]... [HOSTNAME]

Arguments:
  [host]  

Options:
  -d, --domain      Display the name of the DNS domain if possible
  -i, --ip-address  Display the network address(es) of the host
  -f, --fqdn        Display the FQDN (Fully Qualified Domain Name) (default)
  -s, --short       Display the short hostname (the portion before the first dot) if possible
  -h, --help        Print help information
  -V, --version     Print version information
```