### PR TITLE
csplit: move help strings to markdown file

### DIFF
--- a/src/uu/csplit/csplit.md
+++ b/src/uu/csplit/csplit.md
@@ -1,0 +1,11 @@
+# csplit
+
+```
+csplit [OPTION]... FILE PATTERN...
+```
+
+Split a file into sections determined by context lines
+
+## After Help
+
+Output pieces of FILE separated by PATTERN(s) to files 'xx00', 'xx01', ..., and output byte counts of each piece to standard output.

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -13,7 +13,7 @@ use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use regex::Regex;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::{crash_if_err, format_usage};
+use uucore::{crash_if_err, format_usage, help_about, help_section, help_usage};
 
 mod csplit_error;
 mod patterns;
@@ -22,9 +22,9 @@ mod split_name;
 use crate::csplit_error::CsplitError;
 use crate::split_name::SplitName;
 
-static ABOUT: &str = "Split a file into sections determined by context lines";
-static LONG_HELP: &str = "Output pieces of FILE separated by PATTERN(s) to files 'xx00', 'xx01', ..., and output byte counts of each piece to standard output.";
-const USAGE: &str = "{} [OPTION]... FILE PATTERN...";
+const ABOUT: &str = help_about!("csplit.md");
+const AFTER_HELP: &str = help_section!("after help", "csplit.md");
+const USAGE: &str = help_usage!("csplit.md");
 
 mod options {
     pub const SUFFIX_FORMAT: &str = "suffix-format";
@@ -814,5 +814,5 @@ pub fn uu_app() -> Command {
                 .action(clap::ArgAction::Append)
                 .required(true),
         )
-        .after_help(LONG_HELP)
+        .after_help(AFTER_HELP)
 }


### PR DESCRIPTION
#4368 

`csplit -h` outputs the following.

```shell
$ ./target/debug/coreutils csplit -h
Split a file into sections determined by context lines

Usage: ./target/debug/coreutils csplit [OPTION]... FILE PATTERN...

Options:
  -b, --suffix-format <FORMAT>  use sprintf FORMAT instead of %02d
  -f, --prefix <PREFIX>         use PREFIX instead of 'xx'
  -k, --keep-files              do not remove output files on errors
      --suppress-matched        suppress the lines matching PATTERN
  -n, --digits <DIGITS>         use specified number of digits instead of 2
  -s, --quiet                   do not print counts of output file sizes [aliases: silent]
  -z, --elide-empty-files       remove empty output files
  -h, --help                    Print help information
  -V, --version                 Print version information

Output pieces of FILE separated by PATTERN(s) to files 'xx00', 'xx01', ..., and output byte counts of each piece to standard output.
```