### PR TITLE
uname: move help strings to a markdown file

### DIFF
--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -14,12 +14,11 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use platform_info::*;
 use uucore::{
     error::{FromIo, UResult},
-    format_usage,
+    format_usage, help_about, help_usage,
 };
 
-const ABOUT: &str = r#"Print certain system information.
-With no OPTION, same as -s."#;
-const USAGE: &str = "{} [OPTION]...";
+const ABOUT: &str = help_about!("uname.md");
+const USAGE: &str = help_usage!("uname.md");
 
 pub mod options {
     pub static ALL: &str = "all";

--- a/src/uu/uname/uname.md
+++ b/src/uu/uname/uname.md
@@ -1,0 +1,9 @@
+# uname
+
+
+```
+uname [OPTION]...
+```
+
+Print certain system information. 
+With no OPTION, same as -s.


### PR DESCRIPTION
#4368
After this PR, `uname -h` gives the following output.

```
./target/debug/coreutils uname -h
Print certain system information.
With no OPTION, same as -s.

Usage: ./target/debug/coreutils uname [OPTION]...

Options:
  -a, --all               Behave as though all of the options -mnrsvo were specified.
  -s, --kernel-name       print the kernel name.
  -n, --nodename          print the nodename (the nodename may be a name that the system is known by to a communications
                          network).
  -r, --kernel-release    print the operating system release.
  -v, --kernel-version    print the operating system version.
  -m, --machine           print the machine hardware name.
  -o, --operating-system  print the operating system name.
  -h, --help              Print help information
  -V, --version           Print version information
```