### PR TITLE
nl: move help strings to a markdown file

### DIFF
--- a/src/uu/nl/nl.md
+++ b/src/uu/nl/nl.md
@@ -4,5 +4,4 @@
 nl [OPTION]... [FILE]...
 ```
 
-
 Number lines of files

--- a/src/uu/nl/nl.md
+++ b/src/uu/nl/nl.md
@@ -6,5 +6,3 @@ nl [OPTION]... [FILE]...
 
 
 Number lines of files
-
-

--- a/src/uu/nl/nl.md
+++ b/src/uu/nl/nl.md
@@ -1,0 +1,10 @@
+#nl
+
+```
+nl [OPTION]... [FILE]...
+```
+
+
+Number lines of files
+
+

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -14,12 +14,12 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::iter::repeat;
 use std::path::Path;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 mod helper;
 
-static ABOUT: &str = "Number lines of files";
-static USAGE: &str = "{} [OPTION]... [FILE]...";
+static ABOUT: &str = help_about!("nl.md");
+static USAGE: &str = help_usage!("nl.md");
 
 // Settings store options used by nl to produce its output.
 pub struct Settings {


### PR DESCRIPTION
#4368

After this PR, nl --help gives the following output.

~~~
Number lines of files

Usage: ./target/debug/coreutils nl [OPTION]... [FILE]...

Options:
      --help                           Print help information.
  -b, --body-numbering <SYNTAX>        use STYLE for numbering body lines
  -d, --section-delimiter <CC>         use CC for separating logical pages
  -f, --footer-numbering <STYLE>       use STYLE for numbering footer lines
  -h, --header-numbering <STYLE>       use STYLE for numbering header lines
  -i, --line-increment <NUMBER>        line number increment at each line
  -l, --join-blank-lines <NUMBER>      group of NUMBER empty lines counted as one
  -n, --number-format <FORMAT>         insert line numbers according to FORMAT
  -p, --no-renumber <no-renumber>      do not reset line numbers at logical pages
  -s, --number-separator <STRING>      add STRING after (possible) line number
  -v, --starting-line-number <NUMBER>  first line number on each logical page
  -w, --number-width <NUMBER>          use NUMBER columns for line numbers
  -V, --version                        Print version information
~~~