### PR TITLE
Bump clap from 4.0.26 to 4.1.8 & fix broken tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,17 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,13 +225,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.26"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "atty",
  "bitflags",
  "clap_lex",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ bstr = "1.0"
 bytecount = "0.6.3"
 byteorder = "1.3.2"
 chrono = { version="^0.4.23", default-features=false, features=["std", "alloc", "clock"]}
-clap = { version = "4.0", features = ["wrap_help", "cargo"] }
+clap = { version = "4.1", features = ["wrap_help", "cargo"] }
 clap_complete = "4.0"
 clap_mangen = "0.2"
 compare = "0.1.0"

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -86,7 +86,7 @@ fn test_wrap() {
 fn test_wrap_no_arg() {
     for wrap_param in ["-w", "--wrap"] {
         let ts = TestScenario::new(util_name!());
-        let expected_stderr = "The argument '--wrap <COLS>' requires a value but none was supplied";
+        let expected_stderr = "a value is required for '--wrap <COLS>' but none was supplied";
         ts.ucmd()
             .arg(wrap_param)
             .fails()

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -79,7 +79,7 @@ fn test_wrap_no_arg() {
         new_ucmd!()
             .arg(wrap_param)
             .fails()
-            .stderr_contains("The argument '--wrap <COLS>' requires a value but none was supplied")
+            .stderr_contains("a value is required for '--wrap <COLS>' but none was supplied")
             .no_stdout();
     }
 }

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -196,7 +196,7 @@ fn test_missing_files() {
         .arg("groupname")
         .fails()
         .stderr_contains(
-            "error: The following required arguments were not provided:\n  <FILE>...\n",
+            "error: the following required arguments were not provided:\n  <FILE>...\n",
         );
 }
 

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -15,7 +15,7 @@ fn test_missing_operand() {
 
     assert!(result
         .stderr_str()
-        .starts_with("error: The following required arguments were not provided"));
+        .starts_with("error: the following required arguments were not provided"));
 
     assert!(result.stderr_str().contains("<newroot>"));
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1495,7 +1495,7 @@ fn test_cp_reflink_bad() {
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_EXISTING_FILE)
         .fails()
-        .stderr_contains("error: 'bad' isn't a valid value for '--reflink[=<WHEN>]'");
+        .stderr_contains("error: invalid value 'bad' for '--reflink[=<WHEN>]'");
 }
 
 #[test]

--- a/tests/by-util/test_link.rs
+++ b/tests/by-util/test_link.rs
@@ -52,7 +52,7 @@ fn test_link_one_argument() {
     let file = "test_link_argument";
     ucmd.args(&[file])
         .fails()
-        .stderr_contains("requires 2 values");
+        .stderr_contains("2 values required");
 }
 
 #[test]
@@ -65,5 +65,5 @@ fn test_link_three_arguments() {
     ];
     ucmd.args(&arguments[..])
         .fails()
-        .stderr_contains("requires 2 values");
+        .stderr_contains("2 values required");
 }

--- a/tests/by-util/test_mknod.rs
+++ b/tests/by-util/test_mknod.rs
@@ -92,14 +92,14 @@ fn test_mknod_character_device_requires_major_and_minor() {
         .arg("1")
         .arg("c")
         .fails()
-        .stderr_contains("Invalid value 'c'");
+        .stderr_contains("invalid value 'c'");
     new_ucmd!()
         .arg("test_file")
         .arg("c")
         .arg("c")
         .arg("1")
         .fails()
-        .stderr_contains("Invalid value 'c'");
+        .stderr_contains("invalid value 'c'");
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn test_mknod_invalid_arg() {
         .arg("--foo")
         .fails()
         .no_stdout()
-        .stderr_contains("Found argument '--foo' which wasn't expected");
+        .stderr_contains("unexpected argument '--foo' found");
 }
 
 #[test]

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -36,18 +36,12 @@ fn test_hex_rejects_sign_after_identifier() {
         .args(&["-0x-123ABC"])
         .fails()
         .no_stdout()
-        .stderr_contains(
-            "Found argument '-0' which wasn't expected, or isn't valid in this context",
-        )
-        .stderr_contains("For more information try '--help'");
+        .stderr_contains("unexpected argument '-0' found");
     new_ucmd!()
         .args(&["-0x+123ABC"])
         .fails()
         .no_stdout()
-        .stderr_contains(
-            "Found argument '-0' which wasn't expected, or isn't valid in this context",
-        )
-        .stderr_contains("For more information try '--help'");
+        .stderr_contains("unexpected argument '-0' found");
 }
 
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -999,7 +999,7 @@ fn test_conflict_check_out() {
             .fails()
             .stderr_contains(
                 // the rest of the message might be subject to change
-                "error: The argument",
+                "error: the argument",
             );
     }
 }

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -30,7 +30,7 @@ fn test_stdbuf_no_buffer_option_fails() {
     ts.ucmd()
         .args(&["head"])
         .fails()
-        .stderr_contains("The following required arguments were not provided:");
+        .stderr_contains("the following required arguments were not provided:");
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -194,7 +194,7 @@ fn test_error_filename_only() {
         .args(&["file"])
         .fails()
         .code_is(1)
-        .stderr_contains("error: The following required arguments were not provided:");
+        .stderr_contains("error: the following required arguments were not provided:");
 }
 
 #[test]

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -50,7 +50,5 @@ fn test_multiple_arguments() {
         .arg("call_graph.txt")
         .arg("invalid_file")
         .fails()
-        .stderr_contains(
-            "Found argument 'invalid_file' which wasn't expected, or isn't valid in this context",
-        );
+        .stderr_contains("unexpected argument 'invalid_file' found");
 }

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -151,7 +151,7 @@ fn test_arg1_arg2() {
 #[test]
 fn test_too_many_args() {
     const EXPECTED: &str =
-        "error: The value 'u' was provided to '[FILE]...' but it wasn't expecting any more values";
+        "error: unexpected value 'u' for '[FILE]...' found; no more were expected";
 
     let args = ["am", "i", "u"];
     new_ucmd!().args(&args).fails().stderr_contains(EXPECTED);


### PR DESCRIPTION
This PR bumps clap to `4.1.8` and fixes some broken tests caused by changes in clap's error messages.