### PR TITLE
A better handler for `./coreutils date -f aze`

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -230,7 +230,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         Box::new(iter)
                     }
                     Err(_) => {
-                        eprintln!("Error: File not found at path {:?}", path);
+                        eprintln!("date: {:?}: No such file or directory", path);
                         Box::new(std::iter::empty())
                     }
                 }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -203,9 +203,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
         return set_system_datetime(date);
     } else {
-        // Declare a file here because it needs to outlive the `dates` iterator.
-        let _file: File;
-
         // Get the current time, either in the local time zone or UTC.
         let now: DateTime<FixedOffset> = if settings.utc {
             let now = Utc::now();

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -204,7 +204,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return set_system_datetime(date);
     } else {
         // Declare a file here because it needs to outlive the `dates` iterator.
-        let file: File;
+        let _file: File;
 
         // Get the current time, either in the local time zone or UTC.
         let now: DateTime<FixedOffset> = if settings.utc {
@@ -229,9 +229,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         let iter = lines.filter_map(Result::ok).map(parse_date);
                         Box::new(iter)
                     }
-                    Err(_) => {
-                        eprintln!("date: {:?}: No such file or directory", path);
-                        Box::new(std::iter::empty())
+                    Err(_err) => {
+                        return Err(USimpleError::new(
+                            2,
+                            format!("date: {}: No such file or directory", path.display()),
+                        ));
                     }
                 }
             }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -232,7 +232,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     Err(_err) => {
                         return Err(USimpleError::new(
                             2,
-                            format!("date: {}: No such file or directory", path.display()),
+                            format!("{}: No such file or directory", path.display()),
                         ));
                     }
                 }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -222,21 +222,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 let iter = std::iter::once(date);
                 Box::new(iter)
             }
-            DateSource::File(ref path) => {
-                match File::open(path) {
-                    Ok(file) => {
-                        let lines = BufReader::new(file).lines();
-                        let iter = lines.filter_map(Result::ok).map(parse_date);
-                        Box::new(iter)
-                    }
-                    Err(_err) => {
-                        return Err(USimpleError::new(
-                            2,
-                            format!("{}: No such file or directory", path.display()),
-                        ));
-                    }
+            DateSource::File(ref path) => match File::open(path) {
+                Ok(file) => {
+                    let lines = BufReader::new(file).lines();
+                    let iter = lines.filter_map(Result::ok).map(parse_date);
+                    Box::new(iter)
                 }
-            }
+                Err(_err) => {
+                    return Err(USimpleError::new(
+                        2,
+                        format!("{}: No such file or directory", path.display()),
+                    ));
+                }
+            },
             DateSource::Now => {
                 let iter = std::iter::once(Ok(now));
                 Box::new(iter)

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -223,10 +223,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Box::new(iter)
             }
             DateSource::File(ref path) => {
-                file = File::open(path).unwrap();
-                let lines = BufReader::new(file).lines();
-                let iter = lines.filter_map(Result::ok).map(parse_date);
-                Box::new(iter)
+                match File::open(path) {
+                    Ok(file) => {
+                        let lines = BufReader::new(file).lines();
+                        let iter = lines.filter_map(Result::ok).map(parse_date);
+                        Box::new(iter)
+                    }
+                    Err(_) => {
+                        eprintln!("Error: File not found at path {:?}", path);
+                        Box::new(std::iter::empty())
+                    }
+                }
             }
             DateSource::Now => {
                 let iter = std::iter::once(Ok(now));

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -205,8 +205,10 @@ fn test_date_for_invalid_file() {
         .arg("invalid_file")
         .fails();
     result.no_stdout();
-    // should fail
-    assert!(result.stderr_str().starts_with("date: "));
+    assert_eq!(
+        result.stderr_str().trim(),
+        "date: invalid_file: No such file or directory",
+    );
 }
 
 #[test]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -205,7 +205,16 @@ fn test_date_for_invalid_file() {
         .arg("invalid_file")
         .fails();
     result.no_stdout();
-    assert!(result.stderr_str().starts_with("date: invalid_file: "));
+    // should fail
+    assert!(result.stderr_str().starts_with("date: "));
+}
+
+#[test]
+fn test_date_for_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_date_for_file";
+    at.touch(file);
+    ucmd.arg("--file").arg(file).succeeds();
 }
 
 #[test]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -199,6 +199,16 @@ fn test_date_set_valid_2() {
 }
 
 #[test]
+fn test_date_for_invalid_file() {
+    let result = new_ucmd!()
+        .arg("--file")
+        .arg("invalid_file")
+        .fails();
+    result.no_stdout();
+    assert!(result.stderr_str().starts_with("date: invalid_file: "));
+}
+
+#[test]
 #[cfg(all(unix, not(target_os = "macos")))]
 /// TODO: expected to fail currently; change to succeeds() when required.
 fn test_date_set_valid_3() {

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -200,10 +200,7 @@ fn test_date_set_valid_2() {
 
 #[test]
 fn test_date_for_invalid_file() {
-    let result = new_ucmd!()
-        .arg("--file")
-        .arg("invalid_file")
-        .fails();
+    let result = new_ucmd!().arg("--file").arg("invalid_file").fails();
     result.no_stdout();
     assert_eq!(
         result.stderr_str().trim(),


### PR DESCRIPTION
./target/release/coreutils date -f aze doesn't result in panic anymore, instead gives Error: File not found at path <PATH>. Fixes https://github.com/uutils/coreutils/issues/4480