### PR TITLE
Bump tempfile from 3.3.0 to 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,15 +1868,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rlimit"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,16 +2190,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix 0.36.8",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ signal-hook = "0.3.14"
 smallvec = { version = "1.10", features = ["union"] }
 strum = "0.24.1"
 strum_macros = "0.24.2"
-tempfile = "3.3.0"
+tempfile = "3.4.0"
 term_grid = "0.1.5"
 terminal_size = "0.2.2"
 textwrap = { version="0.16.0", features=["terminal_size"] }


### PR DESCRIPTION
This PR bumps `tempfile` to `3.4.0`. This version no longer has a dependency on `remove_dir_all` and hence resolves https://github.com/advisories/GHSA-mc8h-8q98-g5hr.