### PR TITLE
parser: fix index out of bounds error

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,10 +11,10 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 
 [dependencies.uucore]
-uucore = { workspace = true }
+path = "../src/uucore/"
 
 [dependencies.uu_date]
-uu_date = { workspace = true }
+path = "../src/uu/date/"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/src/uucore/src/lib/parser/parse_glob.rs
+++ b/src/uucore/src/lib/parser/parse_glob.rs
@@ -10,8 +10,8 @@ fn fix_negation(glob: &str) -> String {
     let mut chars = glob.chars().collect::<Vec<_>>();
 
     let mut i = 0;
-    while i < chars.len() {
-        if chars[i] == '[' && i + 4 <= glob.len() && chars[i + 1] == '^' {
+    while i + 4 <= chars.len() {
+        if chars[i] == '[' && chars[i + 1] == '^' {
             match chars[i + 3..].iter().position(|x| *x == ']') {
                 None => (),
                 Some(j) => {

--- a/src/uucore/src/lib/parser/parse_glob.rs
+++ b/src/uucore/src/lib/parser/parse_glob.rs
@@ -10,7 +10,8 @@ fn fix_negation(glob: &str) -> String {
     let mut chars = glob.chars().collect::<Vec<_>>();
 
     let mut i = 0;
-    while i + 4 <= chars.len() {
+    // Add 3 to prevent out of bounds in loop
+    while i + 3 < chars.len() {
         if chars[i] == '[' && chars[i + 1] == '^' {
             match chars[i + 3..].iter().position(|x| *x == ']') {
                 None => (),
@@ -105,5 +106,8 @@ mod tests {
         assert_eq!(fix_negation("[^]"), "[^]");
         assert_eq!(fix_negation("[^"), "[^");
         assert_eq!(fix_negation("[][^]"), "[][^]");
+
+        // Issue #4479
+        assert_eq!(fix_negation("ààà[^"), "ààà[^");
     }
 }


### PR DESCRIPTION
Fixes #4479 

This PR fixes index out of bounds in `parse_glob::fix_negation`.