### PR TITLE
printenv: move help strings to markdown file

### DIFF
--- a/src/uu/printenv/printenv.md
+++ b/src/uu/printenv/printenv.md
@@ -1,0 +1,7 @@
+# printenv
+
+```
+printenv [VARIABLE]... [OPTION]...
+```
+
+Display the values of the specified environment VARIABLE(s), or (with no VARIABLE) display name and value pairs for them all.

--- a/src/uu/printenv/src/printenv.rs
+++ b/src/uu/printenv/src/printenv.rs
@@ -9,10 +9,10 @@
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::env;
-use uucore::{error::UResult, format_usage};
+use uucore::{error::UResult, format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Display the values of the specified environment VARIABLE(s), or (with no VARIABLE) display name and value pairs for them all.";
-const USAGE: &str = "{} [VARIABLE]... [OPTION]...";
+const ABOUT: &str = help_about!("printenv.md");
+const USAGE: &str = help_usage!("printenv.md");
 
 static OPT_NULL: &str = "null";
 


### PR DESCRIPTION
#4368 

`printenv -h` outputs the following.

```shell
$ ./target/debug/coreutils printenv -h
Display the values of the specified environment VARIABLE(s), or (with no VARIABLE) display name and value pairs for them all.

Usage: ./target/debug/coreutils printenv [VARIABLE]... [OPTION]...

Arguments:
  [variables]...  

Options:
  -0, --null     end each output line with 0 byte rather than newline
  -h, --help     Print help information
  -V, --version  Print version information
```