### PR TITLE
relpath: move help strings to markdown file

### DIFF
--- a/src/uu/relpath/relpath.md
+++ b/src/uu/relpath/relpath.md
@@ -1,0 +1,8 @@
+# relpath
+
+```
+relpath [-d DIR] TO [FROM]
+```
+
+Convert TO destination to the relative path from the FROM dir.
+If FROM path is omitted, current working dir will be used.

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -12,9 +12,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
-use uucore::{help_about, help_usage};
 
 const USAGE: &str = help_usage!("relpath.md");
 const ABOUT: &str = help_about!("relpath.md");

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -12,8 +12,8 @@ use std::env;
 use std::path::{Path, PathBuf};
 use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
-use uucore::{format_usage, help_about, help_usage};
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
+use uucore::{format_usage, help_about, help_usage};
 
 const USAGE: &str = help_usage!("relpath.md");
 const ABOUT: &str = help_about!("relpath.md");

--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -14,10 +14,10 @@ use uucore::display::println_verbatim;
 use uucore::error::{FromIo, UResult};
 use uucore::format_usage;
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
+use uucore::{help_about, help_usage};
 
-static ABOUT: &str = "Convert TO destination to the relative path from the FROM dir.
-If FROM path is omitted, current working dir will be used.";
-const USAGE: &str = "{} [-d DIR] TO [FROM]";
+const USAGE: &str = help_usage!("relpath.md");
+const ABOUT: &str = help_about!("relpath.md");
 
 mod options {
     pub const DIR: &str = "DIR";


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368
Now relpath -h shows the following:

```
$ ./target/debug/coreutils relpath -h
Convert TO destination to the relative path from the FROM dir.
If FROM path is omitted, current working dir will be used.

Usage: ./target/debug/coreutils relpath [-d DIR] TO [FROM]

Arguments:
  [TO]    
  [FROM]  

Options:
  -d <DIR>       If any of FROM and TO is not subpath of DIR, output absolute path instead of relative
  -h, --help     Print help information
  -V, --version  Print version information
```
