### PR TITLE
fuzz - use the local crates for fuzz

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,10 +11,10 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 
 [dependencies.uucore]
-uucore = { workspace = true }
+path = "../src/uucore/"
 
 [dependencies.uu_date]
-uu_date = { workspace = true }
+path = "../src/uu/date/"
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
otherwise, it uses the crate from crates.io
