### PR TITLE
Bump rayon from 1.6.0 to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,20 +1808,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ platform-info = "1.0.2"
 quick-error = "2.0.1"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_core = "0.6"
-rayon = "1.5"
+rayon = "1.7"
 redox_syscall = "0.2"
 regex = "1.7.1"
 rust-ini = "0.18.0"


### PR DESCRIPTION
This PR replaces outdated https://github.com/uutils/coreutils/pull/4173.