### PR TITLE
Bump procfs from 0.14.1 to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,15 +1719,15 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
 dependencies = [
  "bitflags",
  "byteorder",
  "hex",
  "lazy_static",
- "rustix 0.35.13",
+ "rustix 0.36.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -493,7 +493,7 @@ hex-literal = "0.3.1"
 rstest = "0.16.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
-procfs = { version = "0.14", default-features = false }
+procfs = { version = "0.15", default-features = false }
 rlimit = "0.9.1"
 
 [target.'cfg(unix)'.dev-dependencies]


### PR DESCRIPTION
This PR replaces the outdated https://github.com/uutils/coreutils/pull/4310