### PR TITLE
readme: advise using --locked with cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ make UTILS='UTILITY_1 UTILITY_2'
 Likewise, installing can simply be done using:
 
 ```shell
-cargo install --path .
+cargo install --path . --locked
 ```
 
 This command will install uutils into Cargo's *bin* folder (*e.g.* `$HOME/.cargo/bin`).


### PR DESCRIPTION
`cargo install --path . --locked` will honor the existing `Cargo.lock`. This will use version `0.3.17` of the time crate instead of the non-compatible `0.3.18`.