### PR TITLE
docs: fix tr.pl and stat-printf.pl don't show up in gnu-full-result

### DIFF
--- a/util/gnu-json-result.py
+++ b/util/gnu-json-result.py
@@ -18,7 +18,7 @@ for filepath in test_dir.glob("**/*.log"):
             current[key] = {}
         current = current[key]
     try:
-        with open(path) as f:
+        with open(path, errors="ignore") as f:
             content = f.read()
             result = re.search(
                 r"(PASS|FAIL|SKIP|ERROR) [^ ]+ \(exit status: \d+\)$", content


### PR DESCRIPTION
Closes #4341 

Ignore decoding error with the `open()` function in `gnu-json-result.py`

```bash
$ python3 /coreutils/util/gnu-json-result.py /gnu/tests
/gnu/tests/test-suite.log 'utf-8' codec can't decode byte 0xc0 in position 940: invalid start byte
/gnu/tests/misc/stat-printf.log 'utf-8' codec can't decode byte 0xff in position 297: invalid start byte                                                           
/gnu/tests/misc/tr.log 'utf-8' codec can't decode byte 0xc0 in position 627: invalid start byte
```