### PR TITLE
Bump fts-sys to 0.2.4 & selinux-sys to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "fts-sys"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32bd98333d10742c0b048272ebf4cb05336d415423b853961c92ccb398966a03"
+checksum = "9a66c0a21e344f20c87b4ca12643cf4f40a7018f132c98d344e989b959f49dd1"
 dependencies = [
  "bindgen",
  "libc",
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "selinux-sys"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c02c5c6e2db8a78b3ffffc666f75fcda5bbd7068ba3c0f560e5504f4d88443"
+checksum = "806d381649bb85347189d2350728817418138d11d738e2482cb644ec7f3c755d"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
This PR bumps `fts-sys` from `0.2.3` to `0.2.4` and `selinux-sys` from `0.6.1` to `0.6.2`. It replaces https://github.com/uutils/coreutils/pull/4177 and should fix the error `found 2 duplicate entries for crate 'bindgen'` from `CICD / Style/cargo-deny`