### PR TITLE
mkfifo: move help strings to markdown file

### DIFF
--- a/src/uu/mkfifo/mkfifo.md
+++ b/src/uu/mkfifo/mkfifo.md
@@ -1,0 +1,7 @@
+# mkfifo
+
+```
+mkfifo [OPTION]... NAME...
+```
+
+Create a FIFO with the given name.

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -10,10 +10,10 @@ use libc::mkfifo;
 use std::ffi::CString;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
-use uucore::{format_usage, show};
+use uucore::{format_usage, help_about, help_usage, show};
 
-static USAGE: &str = "{} [OPTION]... NAME...";
-static ABOUT: &str = "Create a FIFO with the given name.";
+static USAGE: &str = help_usage!("mkfifo.md");
+static ABOUT: &str = help_about!("mkfifo.md");
 
 mod options {
     pub static MODE: &str = "mode";


### PR DESCRIPTION
#4368 

`mkfifo -h` outputs the following.

```shell
$ ./target/debug/coreutils mkfifo -h
Create a FIFO with the given name.

Usage: ./target/debug/coreutils mkfifo [OPTION]... NAME...

Options:
  -m, --mode <MODE>    file permissions for the fifo [default: 0666]
  -Z                   set the SELinux security context to default type
      --context <CTX>  like -Z, or if CTX is specified then set the SELinux or SMACK security context to CTX
  -h, --help           Print help
  -V, --version        Print version
```