### PR TITLE
Bump redox_syscall from 0.2.16 to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "windows-sys 0.42.0",
 ]
 
@@ -1565,7 +1565,7 @@ checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.42.0",
 ]
@@ -1810,6 +1810,15 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb02a9aee8e8c7ad8d86890f1e16b49e0bbbffc9961ff3788c31d57c98bcbf03"
 dependencies = [
  "bitflags",
 ]
@@ -2158,7 +2167,7 @@ checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "rustix",
  "windows-sys 0.42.0",
 ]
@@ -3145,7 +3154,7 @@ version = "0.0.17"
 dependencies = [
  "clap",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.4",
  "uucore",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ quick-error = "2.0.1"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_core = "0.6"
 rayon = "1.7"
-redox_syscall = "0.2"
+redox_syscall = "0.3"
 regex = "1.7.1"
 rust-ini = "0.18.0"
 same-file = "1.0.6"


### PR DESCRIPTION
This PR replaces https://github.com/uutils/coreutils/pull/3891