### PR TITLE
Use https in link & fix quote in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,24 +240,30 @@ To improve the GNU compatibility, the following process is recommended:
 To help the project maintainers review pull requests from contributors across
 numerous utilities, the team has settled on conventions for commit messages.
 
-From <http://git-scm.com/book/ch5-2.html>:
+From <https://git-scm.com/book/ch5-2.html>:
 
 ```
-Short (50 chars or less) summary of changes
+Capitalized, short (50 chars or less) summary
 
 More detailed explanatory text, if necessary.  Wrap it to about 72
 characters or so.  In some contexts, the first line is treated as the
 subject of an email and the rest of the text as the body.  The blank
 line separating the summary from the body is critical (unless you omit
-the body entirely); tools like rebase can get confused if you run the
+the body entirely); tools like rebase will confuse you if you run the
 two together.
+
+Write your commit message in the imperative: "Fix bug" and not "Fixed bug"
+or "Fixes bug."  This convention matches up with commit messages generated
+by commands like git merge and git revert.
 
 Further paragraphs come after blank lines.
 
   - Bullet points are okay, too
 
-  - Typically a hyphen or asterisk is used for the bullet, preceded by a
+  - Typically a hyphen or asterisk is used for the bullet, followed by a
     single space, with blank lines in between, but conventions vary here
+
+  - Use a hanging indent
 ```
 
 Furthermore, here are a few examples for a summary line:


### PR DESCRIPTION
This PR changes a link to https and fixes the quoted text in the `Commit messages` section to match the original (https://git-scm.com/book/ch5-2.html).