### PR TITLE
uptime: move help strings to markdown file

### DIFF
--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -11,17 +11,15 @@
 use chrono::{Local, TimeZone, Utc};
 use clap::{crate_version, Arg, ArgAction, Command};
 
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 // import crate time from utmpx
 pub use uucore::libc;
 use uucore::libc::time_t;
 
 use uucore::error::{UResult, USimpleError};
 
-static ABOUT: &str = "Display the current time, the length of time the system has been up,\n\
-                      the number of users on the system, and the average number of jobs\n\
-                      in the run queue over the last 1, 5 and 15 minutes.";
-const USAGE: &str = "{} [OPTION]...";
+const ABOUT: &str = help_about!("uptime.md");
+const USAGE: &str = help_usage!("uptime.md");
 pub mod options {
     pub static SINCE: &str = "since";
 }

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -11,10 +11,8 @@
 use chrono::{Local, TimeZone, Utc};
 use clap::{crate_version, Arg, ArgAction, Command};
 
-use uucore::{format_usage, help_about, help_usage};
-// import crate time from utmpx
-pub use uucore::libc;
 use uucore::libc::time_t;
+use uucore::{format_usage, help_about, help_usage};
 
 use uucore::error::{UResult, USimpleError};
 

--- a/src/uu/uptime/uptime.md
+++ b/src/uu/uptime/uptime.md
@@ -1,0 +1,9 @@
+# uptime
+
+```
+uptime [OPTION]...
+```
+
+Display the current time, the length of time the system has been up,
+the number of users on the system, and the average number of jobs
+in the run queue over the last 1, 5 and 15 minutes.


### PR DESCRIPTION
#4368 

```bash
$ cargo run --features 'uptime' -- uptime -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/coreutils uptime -h`
Display the current time, the length of time the system has been up,
the number of users on the system, and the average number of jobs
in the run queue over the last 1, 5 and 15 minutes.

Usage: target/debug/coreutils uptime [OPTION]...

Options:
  -s, --since    system up since
  -h, --help     Print help
  -V, --version  Print version
```