### PR TITLE
date: Added default value for `date --i`.

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -292,6 +292,8 @@ pub fn uu_app() -> Command {
                 .long(OPT_ISO_8601)
                 .value_name("FMT")
                 .value_parser([DATE, HOUR, HOURS, MINUTE, MINUTES, SECOND, SECONDS, NS])
+                .num_args(0..=1)
+                .default_missing_value(OPT_DATE)
                 .help(ISO_8601_HELP_STRING),
         )
         .arg(

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -44,6 +44,14 @@ fn test_date_rfc_3339() {
 }
 
 #[test]
+fn test_date_rfc_8601_default() {
+    let re = Regex::new(r"^\d{4}-\d{2}-\d{2}\n$").unwrap();
+    for param in ["--iso-8601", "--i"] {
+        new_ucmd!().arg(param).succeeds().stdout_matches(&re);
+    }
+}
+
+#[test]
 fn test_date_rfc_8601() {
     let re = Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2},\d{9}[+-]\d{2}:\d{2}\n$").unwrap();
     for param in ["--iso-8601", "--i"] {


### PR DESCRIPTION
`default_missing_value` set to `OPT_DATE` (`"date"`) `num_args(0..=1)` required for `default_missing_value`.

Using function name `test_date_rfc_8601_default`.
The function name `test_date_rfc_8601` is left intact for compatibility.
 
Fixes: #4521