### PR TITLE
shred: enable `test_shred_force` on FreeBSD

### DIFF
--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -25,7 +25,6 @@ fn test_shred_remove() {
     assert!(at.file_exists(file_b));
 }
 
-#[cfg(not(target_os = "freebsd"))]
 #[test]
 fn test_shred_force() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
Closes #2061.

The `test-shred-force` has currently passed on FreeBSD, but I'm not sure which commit made it start working properly.