### PR TITLE
`date`: make sure 'invalid date' message also returns exit code 1

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -22,7 +22,7 @@ use uucore::display::Quotable;
 #[cfg(not(any(target_os = "macos", target_os = "redox")))]
 use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
-use uucore::{format_usage, help_about, help_usage, show_error};
+use uucore::{format_usage, help_about, help_usage, show};
 #[cfg(windows)]
 use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};
 
@@ -257,7 +257,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         .replace("%f", "%N");
                     println!("{formatted}");
                 }
-                Err((input, _err)) => show_error!("invalid date {}", input.quote()),
+                Err((input, _err)) => show!(USimpleError::new(
+                    1,
+                    format!("invalid date {}", input.quote())
+                )),
             }
         }
     }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -232,3 +232,13 @@ fn test_invalid_format_string() {
     result.no_stdout();
     assert!(result.stderr_str().starts_with("date: invalid format "));
 }
+
+#[test]
+fn test_invalid_date_string() {
+    new_ucmd!()
+        .arg("-d")
+        .arg("foo")
+        .fails()
+        .no_stdout()
+        .stderr_contains("invalid date");
+}


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/4525