### PR TITLE
dd: fix GNU test 'dd/skip-seek-past-dev'

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -4,6 +4,8 @@
 // file that was distributed with this source code.
 // spell-checker:ignore fname, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, availible, behaviour, bmax, bremain, btotal, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rposition, rremain, rsofar, rstat, sigusr, sigval, wlen, wstat abcdefghijklm abcdefghi nabcde nabcdefg abcdefg
 
+#[cfg(unix)]
+use crate::common::util::run_ucmd_as_root_with_stdin_stdout;
 use crate::common::util::TestScenario;
 #[cfg(all(not(windows), feature = "printf"))]
 use crate::common::util::{UCommand, TESTS_BINARY};
@@ -1565,4 +1567,46 @@ fn test_nocache_file() {
     ucmd.args(&["if=f", "of=/dev/null", "iflag=nocache", "status=noxfer"])
         .succeeds()
         .stderr_only("2048+0 records in\n2048+0 records out\n");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_skip_past_dev() {
+    // NOTE: This test intends to trigger code which can only be reached with root permissions.
+    let ts = TestScenario::new(util_name!());
+
+    if let Ok(result) = run_ucmd_as_root_with_stdin_stdout(
+        &ts,
+        &["bs=1", "skip=10000000000000000", "count=0", "status=noxfer"],
+        Some("/dev/sda1"),
+        None,
+    ) {
+        result.stderr_contains("dd: 'standard input': cannot skip: Invalid argument");
+        result.stderr_contains("0+0 records in");
+        result.stderr_contains("0+0 records out");
+        result.code_is(1);
+    } else {
+        print!("TEST SKIPPED");
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn test_seek_past_dev() {
+    // NOTE: This test intends to trigger code which can only be reached with root permissions.
+    let ts = TestScenario::new(util_name!());
+
+    if let Ok(result) = run_ucmd_as_root_with_stdin_stdout(
+        &ts,
+        &["bs=1", "seek=10000000000000000", "count=0", "status=noxfer"],
+        None,
+        Some("/dev/sda1"),
+    ) {
+        result.stderr_contains("dd: 'standard output': cannot seek: Invalid argument");
+        result.stderr_contains("0+0 records in");
+        result.stderr_contains("0+0 records out");
+        result.code_is(1);
+    } else {
+        print!("TEST SKIPPED");
+    }
 }


### PR DESCRIPTION
The GNU test suggests that GNU's variant is trying to seek stdin/stdout s.t. it can abort early if the respective fd is seekable and does not have enough length to do the requested skip/seek.

Draft for now to signalize that I am working on it.
There are some small open points, e.g. recognize this better:

```
# dd bs=1 skip=10000000000000000 count=0 status=noxfer < /dev/sda1
dd: 'standard input': cannot skip: Invalid argument
0+0 records in
0+0 records out
# echo $?
1
```
vs
```
# echo "abcd" | dd bs=1 skip=5 count=0 status=noxfer
0+0 records in
0+0 records out
# echo $?
0
```

and obviously add tests :)