### PR TITLE
Fix some simple clippy warnings

### DIFF
--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -10,7 +10,7 @@ fn test_output_is_random_permutation() {
     let input_seq = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let input = input_seq
         .iter()
-        .map(|x| x.to_string())
+        .map(ToString::to_string)
         .collect::<Vec<String>>()
         .join("\n");
 
@@ -52,7 +52,7 @@ fn test_echo() {
         .args(
             &input_seq
                 .iter()
-                .map(|x| x.to_string())
+                .map(ToString::to_string)
                 .collect::<Vec<String>>(),
         )
         .succeeds();
@@ -74,7 +74,7 @@ fn test_head_count() {
     let input_seq = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let input = input_seq
         .iter()
-        .map(|x| x.to_string())
+        .map(ToString::to_string)
         .collect::<Vec<String>>()
         .join("\n");
 
@@ -105,7 +105,7 @@ fn test_repeat() {
     let input_seq = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let input = input_seq
         .iter()
-        .map(|x| x.to_string())
+        .map(ToString::to_string)
         .collect::<Vec<String>>()
         .join("\n");
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -2812,7 +2812,7 @@ mod tests {
     #[should_panic]
     fn test_cmd_result_stdout_check_when_false_then_panics() {
         let result = TestScenario::new("echo").ucmd().arg("Hello world").run();
-        result.stdout_check(|s| s.is_empty());
+        result.stdout_check(<[u8]>::is_empty);
     }
 
     #[cfg(feature = "echo")]
@@ -3055,9 +3055,10 @@ mod tests {
         // check `child.is_alive()` and `child.delay()` is working
         let mut trials = 10;
         while child.is_alive() {
-            if trials <= 0 {
-                panic!("Assertion failed: child process is still alive.")
-            }
+            assert!(
+                trials > 0,
+                "Assertion failed: child process is still alive."
+            );
 
             child.delay(500);
             trials -= 1;


### PR DESCRIPTION
With:
`cargo +nightly clippy --features unix --allow-dirty --fix -- -W clippy::pedantic`