### PR TITLE
dd: open stdout from file descriptor when possible

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1566,3 +1566,17 @@ fn test_nocache_file() {
         .succeeds()
         .stderr_only("2048+0 records in\n2048+0 records out\n");
 }
+
+/// Test for writing part of stdout from each of two child processes.
+#[cfg(all(not(windows), feature = "printf"))]
+#[test]
+fn test_multiple_processes_writing_stdout() {
+    let printf = format!("{TESTS_BINARY} printf 'abcde\n'");
+    let dd_skip = format!("{TESTS_BINARY} dd bs=1 skip=1 count=1");
+    let dd = format!("{TESTS_BINARY} dd bs=1 skip=1");
+    UCommand::new()
+        .arg(format!("{printf} | ( {dd_skip}; {dd} ) 2> /dev/null"))
+        .succeeds()
+        .stdout_only("bde\n");
+}
+


### PR DESCRIPTION
(Complements pull request #4189.)

Open stdout using its file descriptor so that a `dd skip=N` command in a subprocess does not close stdout.

For example, before this commit, multiple instances of `dd` writing to stdout and appearing in a single command line could incorrectly result in an empty stdout for each instance of `dd` after the first:

    $ printf "abcde\n" | (dd bs=1 skip=1 count=1 && dd bs=1 skip=1)  2> /dev/null
    b

After this commit, each `dd` process writes to the file descriptor referring to stdout:

    $ printf "abcde\n" | (dd bs=1 skip=1 count=1 && dd bs=1 skip=1)  2> /dev/null
    bde