### PR TITLE
dd: buffer partial blocks in the output writer

### DIFF
--- a/src/uu/dd/src/bufferedoutput.rs
+++ b/src/uu/dd/src/bufferedoutput.rs
@@ -1,0 +1,201 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+//
+// spell-checker:ignore wstat towrite cdefg bufferedoutput
+//! Buffer partial output blocks until they are completed.
+//!
+//! Use the [`BufferedOutput`] struct to create a buffered form of the
+//! [`Output`] writer.
+use crate::{Output, WriteStat};
+
+/// Buffer partial output blocks until they are completed.
+///
+/// Complete blocks are written immediately to the inner [`Output`],
+/// but partial blocks are stored in an internal buffer until they are
+/// completed.
+pub(crate) struct BufferedOutput<'a> {
+    /// The unbuffered inner block writer.
+    inner: Output<'a>,
+
+    /// The internal buffer that stores a partial block.
+    ///
+    /// The size of this buffer is always less than the output block
+    /// size (that is, the value of the `obs` command-line option).
+    buf: Vec<u8>,
+}
+
+impl<'a> BufferedOutput<'a> {
+    /// Add partial block buffering to the given block writer.
+    ///
+    /// The internal buffer size is at most the value of `obs` as
+    /// defined in `inner`.
+    pub(crate) fn new(inner: Output<'a>) -> Self {
+        let obs = inner.settings.obs;
+        Self {
+            inner,
+            buf: Vec::with_capacity(obs),
+        }
+    }
+
+    pub(crate) fn discard_cache(&self, offset: libc::off_t, len: libc::off_t) {
+        self.inner.discard_cache(offset, len);
+    }
+
+    /// Flush the partial block stored in the internal buffer.
+    pub(crate) fn flush(&mut self) -> std::io::Result<WriteStat> {
+        let wstat = self.inner.write_blocks(&self.buf)?;
+        let n = wstat.bytes_total;
+        for _ in 0..n {
+            self.buf.remove(0);
+        }
+        Ok(wstat)
+    }
+
+    /// Synchronize the inner block writer.
+    pub(crate) fn sync(&mut self) -> std::io::Result<()> {
+        self.inner.sync()
+    }
+
+    /// Truncate the underlying file to the current stream position, if possible.
+    pub(crate) fn truncate(&mut self) -> std::io::Result<()> {
+        self.inner.dst.truncate()
+    }
+
+    /// Write the given bytes one block at a time.
+    ///
+    /// Only complete blocks will be written. Partial blocks will be
+    /// buffered until enough bytes have been provided to complete a
+    /// block. The returned [`WriteStat`] object will include the
+    /// number of blocks written during execution of this function.
+    pub(crate) fn write_blocks(&mut self, buf: &[u8]) -> std::io::Result<WriteStat> {
+        // Concatenate the old partial block with the new incoming bytes.
+        let towrite = [&self.buf, buf].concat();
+
+        // Write all complete blocks to the inner block writer.
+        //
+        // For example, if the output block size were 3, the buffered
+        // partial block were `b"ab"` and the new incoming bytes were
+        // `b"cdefg"`, then we would write blocks `b"abc"` and
+        // b`"def"` to the inner block writer.
+        let n = towrite.len();
+        let rem = n % self.inner.settings.obs;
+        let wstat = self.inner.write_blocks(&towrite[..n - rem])?;
+        self.buf.clear();
+
+        // Buffer any remaining bytes as a partial block.
+        //
+        // Continuing the example above, the last byte `b"g"` would be
+        // buffered as a partial block until the next call to
+        // `write_blocks()`.
+        for byte in &towrite[n - rem..] {
+            self.buf.push(*byte);
+        }
+
+        Ok(wstat)
+    }
+}
+
+#[cfg(unix)]
+#[cfg(test)]
+mod tests {
+    use crate::bufferedoutput::BufferedOutput;
+    use crate::{Dest, Output, Settings};
+
+    #[test]
+    fn test_buffered_output_write_blocks_empty() {
+        let settings = Settings {
+            obs: 3,
+            ..Default::default()
+        };
+        let inner = Output {
+            dst: Dest::Sink,
+            settings: &settings,
+        };
+        let mut output = BufferedOutput::new(inner);
+        let wstat = output.write_blocks(&[]).unwrap();
+        assert_eq!(wstat.writes_complete, 0);
+        assert_eq!(wstat.writes_partial, 0);
+        assert_eq!(wstat.bytes_total, 0);
+        assert_eq!(output.buf, vec![]);
+    }
+
+    #[test]
+    fn test_buffered_output_write_blocks_partial() {
+        let settings = Settings {
+            obs: 3,
+            ..Default::default()
+        };
+        let inner = Output {
+            dst: Dest::Sink,
+            settings: &settings,
+        };
+        let mut output = BufferedOutput::new(inner);
+        let wstat = output.write_blocks(b"ab").unwrap();
+        assert_eq!(wstat.writes_complete, 0);
+        assert_eq!(wstat.writes_partial, 0);
+        assert_eq!(wstat.bytes_total, 0);
+        assert_eq!(output.buf, b"ab");
+    }
+
+    #[test]
+    fn test_buffered_output_write_blocks_complete() {
+        let settings = Settings {
+            obs: 3,
+            ..Default::default()
+        };
+        let inner = Output {
+            dst: Dest::Sink,
+            settings: &settings,
+        };
+        let mut output = BufferedOutput::new(inner);
+        let wstat = output.write_blocks(b"abcd").unwrap();
+        assert_eq!(wstat.writes_complete, 1);
+        assert_eq!(wstat.writes_partial, 0);
+        assert_eq!(wstat.bytes_total, 3);
+        assert_eq!(output.buf, b"d");
+    }
+
+    #[test]
+    fn test_buffered_output_write_blocks_append() {
+        let settings = Settings {
+            obs: 3,
+            ..Default::default()
+        };
+        let inner = Output {
+            dst: Dest::Sink,
+            settings: &settings,
+        };
+        let mut output = BufferedOutput {
+            inner,
+            buf: b"ab".to_vec(),
+        };
+        let wstat = output.write_blocks(b"cdefg").unwrap();
+        assert_eq!(wstat.writes_complete, 2);
+        assert_eq!(wstat.writes_partial, 0);
+        assert_eq!(wstat.bytes_total, 6);
+        assert_eq!(output.buf, b"g");
+    }
+
+    #[test]
+    fn test_buffered_output_flush() {
+        let settings = Settings {
+            obs: 10,
+            ..Default::default()
+        };
+        let inner = Output {
+            dst: Dest::Sink,
+            settings: &settings,
+        };
+        let mut output = BufferedOutput {
+            inner,
+            buf: b"abc".to_vec(),
+        };
+        let wstat = output.flush().unwrap();
+        assert_eq!(wstat.writes_complete, 0);
+        assert_eq!(wstat.writes_partial, 1);
+        assert_eq!(wstat.bytes_total, 3);
+        assert_eq!(output.buf, vec![]);
+    }
+}

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -901,7 +901,7 @@ fn dd_copy(mut i: Input, mut o: Output) -> std::io::Result<()> {
     // blocks to this output. Read/write statistics are updated on
     // each iteration and cumulative statistics are reported to
     // the progress reporting thread.
-    while below_count_limit(&i.settings.count, &rstat, &wstat) {
+    while below_count_limit(&i.settings.count, &rstat) {
         // Read a block from the input then write the block to the output.
         //
         // As an optimization, make an educated guess about the
@@ -1108,16 +1108,10 @@ fn calc_loop_bsize(
 
 // Decide if the current progress is below a count=N limit or return
 // true if no such limit is set.
-fn below_count_limit(count: &Option<Num>, rstat: &ReadStat, wstat: &WriteStat) -> bool {
+fn below_count_limit(count: &Option<Num>, rstat: &ReadStat) -> bool {
     match count {
-        Some(Num::Blocks(n)) => {
-            let n = *n;
-            rstat.reads_complete + rstat.reads_partial <= n
-        }
-        Some(Num::Bytes(n)) => {
-            let n = (*n).try_into().unwrap();
-            wstat.bytes_total <= n
-        }
+        Some(Num::Blocks(n)) => rstat.reads_complete + rstat.reads_partial < *n,
+        Some(Num::Bytes(n)) => rstat.bytes_total < *n,
         None => true,
     }
 }

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -76,6 +76,8 @@ struct Settings {
     oconv: OConvFlags,
     oflags: OFlags,
     status: Option<StatusLevel>,
+    /// Whether the output writer should buffer partial blocks until complete.
+    buffered: bool,
 }
 
 /// A timer which triggers on a given interval
@@ -126,6 +128,12 @@ impl Alarm {
 enum Num {
     Blocks(u64),
     Bytes(u64),
+}
+
+impl Default for Num {
+    fn default() -> Self {
+        Self::Blocks(0)
+    }
 }
 
 impl Num {

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -3,23 +3,20 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore fname, ftype, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, behaviour, bmax, bremain, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rremain, rsofar, rstat, sigusr, wlen, wstat seekable oconv canonicalized fadvise Fadvise FADV DONTNEED ESPIPE
-
-mod datastructures;
-use datastructures::*;
-
-mod parseargs;
-use parseargs::Parser;
-
-mod conversion_tables;
-
-mod progress;
-use progress::{gen_prog_updater, ProgUpdate, ReadStat, StatusLevel, WriteStat};
+// spell-checker:ignore fname, ftype, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, behaviour, bmax, bremain, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rremain, rsofar, rstat, sigusr, wlen, wstat seekable oconv canonicalized fadvise Fadvise FADV DONTNEED ESPIPE bufferedoutput
 
 mod blocks;
-use blocks::conv_block_unblock_helper;
-
+mod bufferedoutput;
+mod conversion_tables;
+mod datastructures;
 mod numbers;
+mod parseargs;
+mod progress;
+
+use blocks::conv_block_unblock_helper;
+use datastructures::*;
+use parseargs::Parser;
+use progress::{gen_prog_updater, ProgUpdate, ReadStat, StatusLevel, WriteStat};
 
 use std::cmp;
 use std::env;

--- a/src/uu/dd/src/parseargs/unit_tests.rs
+++ b/src/uu/dd/src/parseargs/unit_tests.rs
@@ -358,6 +358,7 @@ fn parse_icf_tokens_remaining() {
                 fsync: true,
                 ..Default::default()
             },
+            is_conv_specified: true,
             ..Default::default()
         })
     );

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -379,6 +379,17 @@ impl std::ops::AddAssign for WriteStat {
     }
 }
 
+impl std::ops::Add for WriteStat {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        Self {
+            writes_complete: self.writes_complete + other.writes_complete,
+            writes_partial: self.writes_partial + other.writes_partial,
+            bytes_total: self.bytes_total + other.bytes_total,
+        }
+    }
+}
+
 /// How much detail to report when printing transfer statistics.
 ///
 /// This corresponds to the available settings of the `status`

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore fname, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, availible, behaviour, bmax, bremain, btotal, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rposition, rremain, rsofar, rstat, sigusr, sigval, wlen, wstat abcdefghijklm abcdefghi nabcde nabcdefg abcdefg
+// spell-checker:ignore fname, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, availible, behaviour, bmax, bremain, btotal, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rposition, rremain, rsofar, rstat, sigusr, sigval, wlen, wstat abcdefghijklm abcdefghi nabcde nabcdefg abcdefg fifoname
 
 #[cfg(unix)]
 use crate::common::util::run_ucmd_as_root_with_stdin_stdout;
@@ -15,6 +15,8 @@ use regex::Regex;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "freebsd")))]
+use std::process::{Command, Stdio};
 #[cfg(not(windows))]
 use std::thread::sleep;
 #[cfg(not(windows))]
@@ -1581,4 +1583,78 @@ fn test_seek_past_dev() {
     } else {
         print!("TEST SKIPPED");
     }
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "freebsd")))]
+fn test_reading_partial_blocks_from_fifo() {
+    // Create the FIFO.
+    let ts = TestScenario::new(util_name!());
+    let at = ts.fixtures.clone();
+    at.mkfifo("fifo");
+    let fifoname = at.plus_as_string("fifo");
+
+    // Start a `dd` process that reads from the fifo (so it will wait
+    // until the writer process starts).
+    let mut reader_command = Command::new(TESTS_BINARY);
+    let child = reader_command
+        .args(["dd", "ibs=3", "obs=3", &format!("if={}", fifoname)])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Start different processes to write to the FIFO, with a small
+    // pause in between.
+    let mut writer_command = Command::new("sh");
+    writer_command
+        .args([
+            "-c",
+            &format!("(printf \"ab\"; sleep 0.1; printf \"cd\") > {}", fifoname),
+        ])
+        .spawn()
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.stdout, b"abcd");
+    let expected = b"0+2 records in\n1+1 records out\n4 bytes copied";
+    assert!(output.stderr.starts_with(expected));
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "freebsd")))]
+fn test_reading_partial_blocks_from_fifo_unbuffered() {
+    // Create the FIFO.
+    let ts = TestScenario::new(util_name!());
+    let at = ts.fixtures.clone();
+    at.mkfifo("fifo");
+    let fifoname = at.plus_as_string("fifo");
+
+    // Start a `dd` process that reads from the fifo (so it will wait
+    // until the writer process starts).
+    //
+    // `bs=N` takes precedence over `ibs=N` and `obs=N`.
+    let mut reader_command = Command::new(TESTS_BINARY);
+    let child = reader_command
+        .args(["dd", "bs=3", "ibs=1", "obs=1", &format!("if={}", fifoname)])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Start different processes to write to the FIFO, with a small
+    // pause in between.
+    let mut writer_command = Command::new("sh");
+    writer_command
+        .args([
+            "-c",
+            &format!("(printf \"ab\"; sleep 0.1; printf \"cd\") > {}", fifoname),
+        ])
+        .spawn()
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.stdout, b"abcd");
+    let expected = b"0+2 records in\n0+2 records out\n4 bytes copied";
+    assert!(output.stderr.starts_with(expected));
 }


### PR DESCRIPTION
This pull request adds buffering of partial blocks in the output block writer until they are completed.

The test case that demonstrates this buffering behavior is
```
mkfifo fifo
dd ibs=3 obs=3 if=fifo &
(printf 'ab'; sleep 1; printf 'cd') > dd.fifo
```
The "ab" forms a partial block, which is buffered and not written immediately. Then when the "cd" comes in, the complete block "abc" is written, followed by the partial block "d".

To override the behavior set `bs=N`, like this:
```
dd bs=3 ibs=1 obs=1 if=fifo
```

Fixes GNU test case `tests/dd/reblock.sh`.