### PR TITLE
mktemp: move help strings to markdown file

### DIFF
--- a/src/uu/mktemp/mktemp.md
+++ b/src/uu/mktemp/mktemp.md
@@ -1,0 +1,7 @@
+# mktemp
+
+```
+mktemp [OPTION]... [TEMPLATE]
+```
+
+Create a temporary file or directory.

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -11,7 +11,7 @@
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use uucore::display::{println_verbatim, Quotable};
 use uucore::error::{FromIo, UError, UResult, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 use std::env;
 use std::error::Error;
@@ -28,8 +28,8 @@ use std::os::unix::prelude::PermissionsExt;
 use rand::Rng;
 use tempfile::Builder;
 
-static ABOUT: &str = "Create a temporary file or directory.";
-const USAGE: &str = "{} [OPTION]... [TEMPLATE]";
+const ABOUT: &str = help_about!("mktemp.md");
+const USAGE: &str = help_usage!("mktemp.md");
 
 static DEFAULT_TEMPLATE: &str = "tmp.XXXXXXXXXX";
 


### PR DESCRIPTION
#4368 

`mktemp -h` shows the following.

```shell
$ ./target/debug/coreutils mktemp -h
Create a temporary file or directory.

Usage: ./target/debug/coreutils mktemp [OPTION]... [TEMPLATE]

Arguments:
  [template]  

Options:
  -d, --directory        Make a directory instead of a file
  -u, --dry-run          do not create anything; merely print a name (unsafe)
  -q, --quiet            Fail silently if an error occurs.
      --suffix <SUFFIX>  append SUFFIX to TEMPLATE; SUFFIX must not contain a path separator. This option is implied if TEMPLATE does not end with X.
  -p, --tmpdir [<DIR>]   interpret TEMPLATE relative to DIR; if DIR is not specified, use $TMPDIR ($TMP on windows) if set, else /tmp. With this option, TEMPLATE
                         must not be an absolute name; unlike with -t, TEMPLATE may contain slashes, but mktemp creates only the final component
  -t                     Generate a template (using the supplied prefix and TMPDIR (TMP on windows) if set) to create a filename template [deprecated]
  -h, --help             Print help
  -V, --version          Print version
```