### PR TITLE
who: move help strings to markdown file

### DIFF
--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -18,7 +18,7 @@ use std::ffi::CStr;
 use std::fmt::Write;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 mod options {
     pub const ALL: &str = "all";
@@ -38,8 +38,8 @@ mod options {
     pub const FILE: &str = "FILE"; // if length=1: FILE, if length=2: ARG1 ARG2
 }
 
-static ABOUT: &str = "Print information about users who are currently logged in.";
-const USAGE: &str = "{} [OPTION]... [ FILE | ARG1 ARG2 ]";
+const ABOUT: &str = help_about!("who.md");
+const USAGE: &str = help_usage!("who.md");
 
 #[cfg(target_os = "linux")]
 static RUNLEVEL_HELP: &str = "print current runlevel";

--- a/src/uu/who/who.md
+++ b/src/uu/who/who.md
@@ -1,0 +1,8 @@
+# who
+
+```
+who [OPTION]... [ FILE | ARG1 ARG2 ]
+```
+
+Print information about users who are currently logged in.
+


### PR DESCRIPTION
#4368

`who -h` outputs the following:

```
./target/debug/who -h
Print information about users who are currently logged in.

Usage: ./target/debug/who [OPTION]... [ FILE | ARG1 ARG2 ]

Arguments:
  [FILE]...  

Options:
  -a, --all       same as -b -d --login -p -r -t -T -u
  -b, --boot      time of last system boot
  -d, --dead      print dead processes
  -H, --heading   print line of column headings
  -l, --login     print system login processes
      --lookup    attempt to canonicalize hostnames via DNS
  -m              only hostname and user associated with stdin
  -p, --process   print active processes spawned by init
  -q, --count     all login names and number of users logged on
  -r, --runlevel  print current runlevel
  -s, --short     print only name, line, and time (default)
  -t, --time      print last system clock change
  -u, --users     list users logged in
  -T, --mesg      add user's message status as +, - or ? [aliases: message, writable] [short aliases: w]
  -h, --help      Print help
  -V, --version   Print version

If FILE is not specified, use /var/run/utmp.  /var/log/wtmp as FILE is common.
If ARG1 ARG2 given, -m presumed: 'am i' or 'mom likes' are usual.
```