### PR TITLE
cut: move help strings to markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Crates.io](https://img.shields.io/crates/v/coreutils.svg)](https://crates.io/crates/coreutils)
 [![Discord](https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat)](https://discord.gg/wQVJbvJ)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/uutils/coreutils/blob/main/LICENSE)
-[![LOC](https://tokei.rs/b1/github/uutils/coreutils?category=code)](https://github.com/Aaronepower/tokei)
 [![dependency status](https://deps.rs/repo/github/uutils/coreutils/status.svg)](https://deps.rs/repo/github/uutils/coreutils)
 
 [![CodeCov](https://codecov.io/gh/uutils/coreutils/branch/master/graph/badge.svg)](https://codecov.io/gh/uutils/coreutils)

--- a/src/uu/cut/cut.md
+++ b/src/uu/cut/cut.md
@@ -1,5 +1,7 @@
 # cut
 
+<!-- spell-checker:ignore sourcefile -->
+
 ```
 cut [-d|-w] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+
 ```
@@ -13,76 +15,85 @@ a sequence (which columns to print), and provide a data source
 
 Specifying a mode
 
-    Use --bytes (-b) or --characters (-c) to specify byte mode
+```
+Use --bytes (-b) or --characters (-c) to specify byte mode
 
-    Use --fields (-f) to specify field mode, where each line is broken into
-    fields identified by a delimiter character. For example for a typical CSV
-    you could use this in combination with setting comma as the delimiter
+Use --fields (-f) to specify field mode, where each line is broken into
+fields identified by a delimiter character. For example for a typical CSV
+you could use this in combination with setting comma as the delimiter
+```
 
 Specifying a sequence
 
-    A sequence is a group of 1 or more numbers or inclusive ranges separated
-    by a commas.
+```
+A sequence is a group of 1 or more numbers or inclusive ranges separated
+by a commas.
 
-    cut -f 2,5-7 some_file.txt
-    will display the 2nd, 5th, 6th, and 7th field for each source line
+cut -f 2,5-7 some_file.txt
+will display the 2nd, 5th, 6th, and 7th field for each source line
 
-    Ranges can extend to the end of the row by excluding the the second number
+Ranges can extend to the end of the row by excluding the the second number
 
-    cut -f 3- some_file.txt
-    will display the 3rd field and all fields after for each source line
+cut -f 3- some_file.txt
+will display the 3rd field and all fields after for each source line
 
-    The first number of a range can be excluded, and this is effectively the
-    same as using 1 as the first number: it causes the range to begin at the
-    first column. Ranges can also display a single column
+The first number of a range can be excluded, and this is effectively the
+same as using 1 as the first number: it causes the range to begin at the
+first column. Ranges can also display a single column
 
-    cut -f 1,3-5 some_file.txt
-    will display the 1st, 3rd, 4th, and 5th field for each source line
+cut -f 1,3-5 some_file.txt
+will display the 1st, 3rd, 4th, and 5th field for each source line
 
-    The --complement option, when used, inverts the effect of the sequence
+The --complement option, when used, inverts the effect of the sequence
 
-    cut --complement -f 4-6 some_file.txt
-    will display the every field but the 4th, 5th, and 6th
+cut --complement -f 4-6 some_file.txt
+will display the every field but the 4th, 5th, and 6th
+```
 
 Specifying a data source
 
-    If no sourcefile arguments are specified, stdin is used as the source of
-    lines to print
+```
+If no sourcefile arguments are specified, stdin is used as the source of
+lines to print
 
-    If sourcefile arguments are specified, stdin is ignored and all files are
-    read in consecutively if a sourcefile is not successfully read, a warning
-    will print to stderr, and the eventual status code will be 1, but cut
-    will continue to read through proceeding sourcefiles
+If sourcefile arguments are specified, stdin is ignored and all files are
+read in consecutively if a sourcefile is not successfully read, a warning
+will print to stderr, and the eventual status code will be 1, but cut
+will continue to read through proceeding sourcefiles
 
-    To print columns from both STDIN and a file argument, use - (dash) as a
-    sourcefile argument to represent stdin.
+To print columns from both STDIN and a file argument, use - (dash) as a
+sourcefile argument to represent stdin.
+```
 
 Field Mode options
 
-    The fields in each line are identified by a delimiter (separator)
+```
+The fields in each line are identified by a delimiter (separator)
 
-    Set the delimiter
-        Set the delimiter which separates fields in the file using the
-        --delimiter (-d) option. Setting the delimiter is optional.
-        If not set, a default delimiter of Tab will be used.
+Set the delimiter
+    Set the delimiter which separates fields in the file using the
+    --delimiter (-d) option. Setting the delimiter is optional.
+    If not set, a default delimiter of Tab will be used.
 
-        If the -w option is provided, fields will be separated by any number
-        of whitespace characters (Space and Tab). The output delimiter will
-        be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
-        This is an extension adopted from FreeBSD.
+    If the -w option is provided, fields will be separated by any number
+    of whitespace characters (Space and Tab). The output delimiter will
+    be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
+    This is an extension adopted from FreeBSD.
 
-    Optionally Filter based on delimiter
-        If the --only-delimited (-s) flag is provided, only lines which
-        contain the delimiter will be printed
+Optionally Filter based on delimiter
+    If the --only-delimited (-s) flag is provided, only lines which
+    contain the delimiter will be printed
 
-    Replace the delimiter
-        If the --output-delimiter option is provided, the argument used for
-        it will replace the delimiter character in each line printed. This is
-        useful for transforming tabular data - e.g. to convert a CSV to a
-        TSV (tab-separated file)
+Replace the delimiter
+    If the --output-delimiter option is provided, the argument used for
+    it will replace the delimiter character in each line printed. This is
+    useful for transforming tabular data - e.g. to convert a CSV to a
+    TSV (tab-separated file)
+```
 
 Line endings
 
+```
     When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
     'line ending' character (both for the purposes of reading lines and
     separating printed lines) instead of \\n (newline). This is useful for
@@ -90,3 +101,4 @@ Line endings
 
     echo 'ab\\0cd' | cut -z -c 1
     will result in 'a\\0c\\0'
+```

--- a/src/uu/cut/cut.md
+++ b/src/uu/cut/cut.md
@@ -1,0 +1,92 @@
+# cut
+
+```
+cut [-d|-w] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+
+```
+
+Prints specified byte or field columns from each line of stdin or the input files
+
+## After Help
+
+Each call must specify a mode (what to use for columns),
+a sequence (which columns to print), and provide a data source
+
+Specifying a mode
+
+    Use --bytes (-b) or --characters (-c) to specify byte mode
+
+    Use --fields (-f) to specify field mode, where each line is broken into
+    fields identified by a delimiter character. For example for a typical CSV
+    you could use this in combination with setting comma as the delimiter
+
+Specifying a sequence
+
+    A sequence is a group of 1 or more numbers or inclusive ranges separated
+    by a commas.
+
+    cut -f 2,5-7 some_file.txt
+    will display the 2nd, 5th, 6th, and 7th field for each source line
+
+    Ranges can extend to the end of the row by excluding the the second number
+
+    cut -f 3- some_file.txt
+    will display the 3rd field and all fields after for each source line
+
+    The first number of a range can be excluded, and this is effectively the
+    same as using 1 as the first number: it causes the range to begin at the
+    first column. Ranges can also display a single column
+
+    cut -f 1,3-5 some_file.txt
+    will display the 1st, 3rd, 4th, and 5th field for each source line
+
+    The --complement option, when used, inverts the effect of the sequence
+
+    cut --complement -f 4-6 some_file.txt
+    will display the every field but the 4th, 5th, and 6th
+
+Specifying a data source
+
+    If no sourcefile arguments are specified, stdin is used as the source of
+    lines to print
+
+    If sourcefile arguments are specified, stdin is ignored and all files are
+    read in consecutively if a sourcefile is not successfully read, a warning
+    will print to stderr, and the eventual status code will be 1, but cut
+    will continue to read through proceeding sourcefiles
+
+    To print columns from both STDIN and a file argument, use - (dash) as a
+    sourcefile argument to represent stdin.
+
+Field Mode options
+
+    The fields in each line are identified by a delimiter (separator)
+
+    Set the delimiter
+        Set the delimiter which separates fields in the file using the
+        --delimiter (-d) option. Setting the delimiter is optional.
+        If not set, a default delimiter of Tab will be used.
+
+        If the -w option is provided, fields will be separated by any number
+        of whitespace characters (Space and Tab). The output delimiter will
+        be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
+        This is an extension adopted from FreeBSD.
+
+    Optionally Filter based on delimiter
+        If the --only-delimited (-s) flag is provided, only lines which
+        contain the delimiter will be printed
+
+    Replace the delimiter
+        If the --output-delimiter option is provided, the argument used for
+        it will replace the delimiter character in each line printed. This is
+        useful for transforming tabular data - e.g. to convert a CSV to a
+        TSV (tab-separated file)
+
+Line endings
+
+    When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
+    'line ending' character (both for the purposes of reading lines and
+    separating printed lines) instead of \\n (newline). This is useful for
+    tabular data where some of the cells may contain newlines
+
+    echo 'ab\\0cd' | cut -z -c 1
+    will result in 'a\\0c\\0'

--- a/src/uu/cut/cut.md
+++ b/src/uu/cut/cut.md
@@ -13,92 +13,100 @@ Prints specified byte or field columns from each line of stdin or the input file
 Each call must specify a mode (what to use for columns),
 a sequence (which columns to print), and provide a data source
 
-Specifying a mode
+### Specifying a mode
 
-```
-Use --bytes (-b) or --characters (-c) to specify byte mode
+Use `--bytes` (`-b`) or `--characters` (`-c`) to specify byte mode
 
 Use --fields (-f) to specify field mode, where each line is broken into
 fields identified by a delimiter character. For example for a typical CSV
 you could use this in combination with setting comma as the delimiter
-```
 
-Specifying a sequence
+### Specifying a sequence
 
-```
 A sequence is a group of 1 or more numbers or inclusive ranges separated
 by a commas.
 
+```
 cut -f 2,5-7 some_file.txt
+```
+
 will display the 2nd, 5th, 6th, and 7th field for each source line
 
-Ranges can extend to the end of the row by excluding the the second number
+Ranges can extend to the end of the row by excluding the second number
 
+```
 cut -f 3- some_file.txt
+```
+
 will display the 3rd field and all fields after for each source line
 
 The first number of a range can be excluded, and this is effectively the
 same as using 1 as the first number: it causes the range to begin at the
 first column. Ranges can also display a single column
 
+```
 cut -f 1,3-5 some_file.txt
+```
+
 will display the 1st, 3rd, 4th, and 5th field for each source line
 
-The --complement option, when used, inverts the effect of the sequence
+The `--complement` option, when used, inverts the effect of the sequence
 
+```
 cut --complement -f 4-6 some_file.txt
+```
+
 will display the every field but the 4th, 5th, and 6th
-```
 
-Specifying a data source
+### Specifying a data source
 
-```
-If no sourcefile arguments are specified, stdin is used as the source of
+If no `sourcefile` arguments are specified, stdin is used as the source of
 lines to print
 
-If sourcefile arguments are specified, stdin is ignored and all files are
-read in consecutively if a sourcefile is not successfully read, a warning
+If `sourcefile` arguments are specified, stdin is ignored and all files are
+read in consecutively if a `sourcefile` is not successfully read, a warning
 will print to stderr, and the eventual status code will be 1, but cut
-will continue to read through proceeding sourcefiles
+will continue to read through proceeding `sourcefiles`
 
-To print columns from both STDIN and a file argument, use - (dash) as a
-sourcefile argument to represent stdin.
-```
+To print columns from both STDIN and a file argument, use `-` (dash) as a
+`sourcefile` argument to represent stdin.
 
-Field Mode options
+### Field Mode options
 
-```
 The fields in each line are identified by a delimiter (separator)
 
-Set the delimiter
-    Set the delimiter which separates fields in the file using the
-    --delimiter (-d) option. Setting the delimiter is optional.
-    If not set, a default delimiter of Tab will be used.
+#### Set the delimiter
 
-    If the -w option is provided, fields will be separated by any number
-    of whitespace characters (Space and Tab). The output delimiter will
-    be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
-    This is an extension adopted from FreeBSD.
+Set the delimiter which separates fields in the file using the
+`--delimiter` (`-d`) option. Setting the delimiter is optional.
+If not set, a default delimiter of Tab will be used.
 
-Optionally Filter based on delimiter
-    If the --only-delimited (-s) flag is provided, only lines which
-    contain the delimiter will be printed
+If the -w option is provided, fields will be separated by any number
+of whitespace characters (Space and Tab). The output delimiter will
+be a Tab unless explicitly specified. Only one of `-d` or `-w` option can be specified.
+This is an extension adopted from FreeBSD.
 
-Replace the delimiter
-    If the --output-delimiter option is provided, the argument used for
-    it will replace the delimiter character in each line printed. This is
-    useful for transforming tabular data - e.g. to convert a CSV to a
-    TSV (tab-separated file)
+#### Optionally Filter based on delimiter
+
+If the `--only-delimited` (`-s`) flag is provided, only lines which
+contain the delimiter will be printed
+
+#### Replace the delimiter
+
+If the `--output-delimiter` option is provided, the argument used for
+it will replace the delimiter character in each line printed. This is
+useful for transforming tabular data - e.g. to convert a CSV to a
+TSV (tab-separated file)
+
+### Line endings
+
+When the `--zero-terminated` (`-z`) option is used, cut sees \\0 (null) as the
+'line ending' character (both for the purposes of reading lines and
+separating printed lines) instead of \\n (newline). This is useful for
+tabular data where some of the cells may contain newlines
+
+```
+echo 'ab\\0cd' | cut -z -c 1
 ```
 
-Line endings
-
-```
-    When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
-    'line ending' character (both for the purposes of reading lines and
-    separating printed lines) instead of \\n (newline). This is useful for
-    tabular data where some of the cells may contain newlines
-
-    echo 'ab\\0cd' | cut -z -c 1
-    will result in 'a\\0c\\0'
-```
+will result in 'a\\0c\\0'

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -19,99 +19,14 @@ use uucore::error::{FromIo, UResult, USimpleError};
 use self::searcher::Searcher;
 use matcher::{ExactMatcher, Matcher, WhitespaceMatcher};
 use uucore::ranges::Range;
-use uucore::{format_usage, show, show_error, show_if_err};
+use uucore::{format_usage, help_about, help_section, help_usage, show, show_error, show_if_err};
 
 mod matcher;
 mod searcher;
 
-static USAGE: &str =
-    "{} [-d|-w] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+";
-static ABOUT: &str =
-    "Prints specified byte or field columns from each line of stdin or the input files";
-static LONG_HELP: &str = "
- Each call must specify a mode (what to use for columns),
- a sequence (which columns to print), and provide a data source
-
- Specifying a mode
-
-    Use --bytes (-b) or --characters (-c) to specify byte mode
-
-    Use --fields (-f) to specify field mode, where each line is broken into
-    fields identified by a delimiter character. For example for a typical CSV
-    you could use this in combination with setting comma as the delimiter
-
- Specifying a sequence
-
-    A sequence is a group of 1 or more numbers or inclusive ranges separated
-    by a commas.
-
-    cut -f 2,5-7 some_file.txt
-    will display the 2nd, 5th, 6th, and 7th field for each source line
-
-    Ranges can extend to the end of the row by excluding the the second number
-
-    cut -f 3- some_file.txt
-    will display the 3rd field and all fields after for each source line
-
-    The first number of a range can be excluded, and this is effectively the
-    same as using 1 as the first number: it causes the range to begin at the
-    first column. Ranges can also display a single column
-
-    cut -f 1,3-5 some_file.txt
-    will display the 1st, 3rd, 4th, and 5th field for each source line
-
-    The --complement option, when used, inverts the effect of the sequence
-
-    cut --complement -f 4-6 some_file.txt
-    will display the every field but the 4th, 5th, and 6th
-
- Specifying a data source
-
-    If no sourcefile arguments are specified, stdin is used as the source of
-    lines to print
-
-    If sourcefile arguments are specified, stdin is ignored and all files are
-    read in consecutively if a sourcefile is not successfully read, a warning
-    will print to stderr, and the eventual status code will be 1, but cut
-    will continue to read through proceeding sourcefiles
-
-    To print columns from both STDIN and a file argument, use - (dash) as a
-    sourcefile argument to represent stdin.
-
- Field Mode options
-
-    The fields in each line are identified by a delimiter (separator)
-
-    Set the delimiter
-        Set the delimiter which separates fields in the file using the
-        --delimiter (-d) option. Setting the delimiter is optional.
-        If not set, a default delimiter of Tab will be used.
-
-        If the -w option is provided, fields will be separated by any number
-        of whitespace characters (Space and Tab). The output delimiter will
-        be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
-        This is an extension adopted from FreeBSD.
-
-    Optionally Filter based on delimiter
-        If the --only-delimited (-s) flag is provided, only lines which
-        contain the delimiter will be printed
-
-    Replace the delimiter
-        If the --output-delimiter option is provided, the argument used for
-        it will replace the delimiter character in each line printed. This is
-        useful for transforming tabular data - e.g. to convert a CSV to a
-        TSV (tab-separated file)
-
- Line endings
-
-    When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
-    'line ending' character (both for the purposes of reading lines and
-    separating printed lines) instead of \\n (newline). This is useful for
-    tabular data where some of the cells may contain newlines
-
-    echo 'ab\\0cd' | cut -z -c 1
-    will result in 'a\\0c\\0'
-";
+const USAGE: &str = help_usage!("cut.md");
+const ABOUT: &str = help_about!("cut.md");
+const AFTER_HELP: &str = help_section!("after help", "cut.md");
 
 struct Options {
     out_delim: Option<String>,
@@ -594,7 +509,7 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .about(ABOUT)
-        .after_help(LONG_HELP)
+        .after_help(AFTER_HELP)
         .infer_long_args(true)
         .arg(
             Arg::new(options::BYTES)

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/dd.rs"
 clap = { workspace=true }
 gcd = { workspace=true }
 libc = { workspace=true }
-uucore = { workspace=true }
+uucore = { workspace=true, features=["memo"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 signal-hook = { workspace=true }

--- a/src/uu/expand/expand.md
+++ b/src/uu/expand/expand.md
@@ -1,0 +1,8 @@
+# expand
+
+```
+expand [OPTION]... [FILE]...
+```
+
+Convert tabs in each FILE to spaces, writing to standard output.
+With no FILE, or when FILE is -, read standard input.

--- a/src/uu/expand/expand.md
+++ b/src/uu/expand/expand.md
@@ -4,5 +4,5 @@
 expand [OPTION]... [FILE]...
 ```
 
-Convert tabs in each FILE to spaces, writing to standard output.
-With no FILE, or when FILE is -, read standard input.
+Convert tabs in each `FILE` to spaces, writing to standard output.
+With no `FILE`, or when `FILE` is `-`, read standard input.

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -19,11 +19,10 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{crash, format_usage};
+use uucore::{crash, format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Convert tabs in each FILE to spaces, writing to standard output.
- With no FILE, or when FILE is -, read standard input.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+const ABOUT: &str = help_about!("expand.md");
+const USAGE: &str = help_usage!("expand.md");
 
 pub mod options {
     pub static TABS: &str = "tabs";

--- a/src/uu/false/false.md
+++ b/src/uu/false/false.md
@@ -1,0 +1,11 @@
+# false
+
+```
+false
+```
+
+Returns false, an unsuccessful exit status.
+
+Immediately returns with the exit status `1`. When invoked with one of the recognized options it
+will try to write the help or version text. Any IO error during this operation is diagnosed, yet
+the program will also return `1`.

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -7,14 +7,9 @@
 use clap::{Arg, ArgAction, Command};
 use std::{ffi::OsString, io::Write};
 use uucore::error::{set_exit_code, UResult};
+use uucore::help_about;
 
-static ABOUT: &str = "\
-Returns false, an unsuccessful exit status.
-
-Immediately returns with the exit status `1`. When invoked with one of the recognized options it
-will try to write the help or version text. Any IO error during this operation is diagnosed, yet
-the program will also return `1`.
-";
+const ABOUT: &str = help_about!("false.md");
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {

--- a/src/uu/fold/fold.md
+++ b/src/uu/fold/fold.md
@@ -1,0 +1,8 @@
+# fold
+
+```
+fold [OPTION]... [FILE]...
+```
+
+Writes each file (or standard input if no files are given)
+to standard output whilst breaking long lines

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -13,13 +13,12 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 const TAB_WIDTH: usize = 8;
 
-static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = "Writes each file (or standard input if no files are given)
- to standard output whilst breaking long lines";
+const USAGE: &str = help_usage!("fold.md");
+const ABOUT: &str = help_about!("fold.md");
 
 mod options {
     pub const BYTES: &str = "bytes";

--- a/src/uu/groups/groups.md
+++ b/src/uu/groups/groups.md
@@ -1,0 +1,8 @@
+# groups
+
+```
+groups [OPTION]... [USERNAME]...
+```
+
+Print group memberships for each `USERNAME` or, if no `USERNAME` is specified, for
+the current process (which may differ if the groups data‐base has changed).

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -17,7 +17,12 @@
 
 use std::error::Error;
 use std::fmt::Display;
-use uucore::{display::Quotable, entries::{get_groups_gnu, gid2grp, Locate, Passwd}, error::{UError, UResult}, format_usage, help_about, help_usage, show};
+use uucore::{
+    display::Quotable,
+    entries::{get_groups_gnu, gid2grp, Locate, Passwd},
+    error::{UError, UResult},
+    format_usage, help_about, help_usage, show,
+};
 
 use clap::{crate_version, Arg, ArgAction, Command};
 

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -17,23 +17,15 @@
 
 use std::error::Error;
 use std::fmt::Display;
-use uucore::{
-    display::Quotable,
-    entries::{get_groups_gnu, gid2grp, Locate, Passwd},
-    error::{UError, UResult},
-    format_usage, show,
-};
+use uucore::{display::Quotable, entries::{get_groups_gnu, gid2grp, Locate, Passwd}, error::{UError, UResult}, format_usage, help_about, help_usage, show};
 
 use clap::{crate_version, Arg, ArgAction, Command};
 
 mod options {
     pub const USERS: &str = "USERNAME";
 }
-static ABOUT: &str = "Print group memberships for each USERNAME or, \
-                      if no USERNAME is specified, for\nthe current process \
-                      (which may differ if the groups data‐base has changed).";
-
-const USAGE: &str = "{} [OPTION]... [USERNAME]...";
+const ABOUT: &str = help_about!("groups.md");
+const USAGE: &str = help_usage!("groups.md");
 
 #[derive(Debug)]
 enum GroupsError {

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -18,7 +18,7 @@ use std::ffi::CStr;
 use std::fmt::Write;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 mod options {
     pub const ALL: &str = "all";
@@ -38,8 +38,8 @@ mod options {
     pub const FILE: &str = "FILE"; // if length=1: FILE, if length=2: ARG1 ARG2
 }
 
-static ABOUT: &str = "Print information about users who are currently logged in.";
-const USAGE: &str = "{} [OPTION]... [ FILE | ARG1 ARG2 ]";
+const ABOUT: &str = help_about!("who.md");
+const USAGE: &str = help_usage!("who.md");
 
 #[cfg(target_os = "linux")]
 static RUNLEVEL_HELP: &str = "print current runlevel";

--- a/src/uu/who/who.md
+++ b/src/uu/who/who.md
@@ -1,0 +1,8 @@
+# who
+
+```
+who [OPTION]... [ FILE | ARG1 ARG2 ]
+```
+
+Print information about users who are currently logged in.
+

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -545,8 +545,8 @@ fn test_mode_after_dash_dash() {
     run_single_test(
         &TestCase {
             args: vec!["--", "-r", TEST_FILE],
-            before: 0o100777,
-            after: 0o100333,
+            before: 0o100_777,
+            after: 0o100_333,
         },
         &at,
         ucmd,
@@ -570,7 +570,7 @@ fn test_chmod_file_after_non_existing_file() {
         .stderr_contains("chmod: cannot access 'does-not-exist': No such file or directory")
         .code_is(1);
 
-    assert_eq!(at.metadata(TEST_FILE).permissions().mode(), 0o100764);
+    assert_eq!(at.metadata(TEST_FILE).permissions().mode(), 0o100_764);
 
     scene
         .ucmd()
@@ -581,7 +581,7 @@ fn test_chmod_file_after_non_existing_file() {
         .fails()
         .no_stderr()
         .code_is(1);
-    assert_eq!(at.metadata("file2").permissions().mode(), 0o100764);
+    assert_eq!(at.metadata("file2").permissions().mode(), 0o100_764);
 }
 
 #[test]
@@ -617,7 +617,7 @@ fn test_chmod_file_symlink_after_non_existing_file() {
         .stderr_contains(expected_stderr);
     assert_eq!(
         at.metadata(test_existing_symlink).permissions().mode(),
-        0o100764
+        0o100_764
     );
 }
 
@@ -679,8 +679,8 @@ fn test_gnu_repeating_options() {
 fn test_gnu_special_filenames() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
-    let perms_before = Permissions::from_mode(0o100640);
-    let perms_after = Permissions::from_mode(0o100440);
+    let perms_before = Permissions::from_mode(0o100_640);
+    let perms_after = Permissions::from_mode(0o100_440);
 
     make_file(&at.plus_as_string("--"), perms_before.mode());
     scene.ucmd().arg("-w").arg("--").arg("--").succeeds();

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -2,6 +2,8 @@
 
 use crate::common::util::*;
 
+use regex::Regex;
+
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
@@ -261,7 +263,9 @@ fn test_final_stats_noxfer() {
 fn test_final_stats_unspec() {
     new_ucmd!()
         .run()
-        .stderr_only("0+0 records in\n0+0 records out\n0 bytes copied, 0.0 s, 0.0 B/s\n")
+        .stderr_contains("0+0 records in\n0+0 records out\n0 bytes copied, ")
+        .stderr_matches(&Regex::new(r"\d\.\d+(e-\d\d)? s, ").unwrap())
+        .stderr_contains("0.0 B/s")
         .success();
 }
 
@@ -375,9 +379,11 @@ fn test_existing_file_truncated() {
 #[test]
 fn test_null_stats() {
     new_ucmd!()
-        .args(&["if=null.txt"])
+        .arg("if=null.txt")
         .run()
-        .stderr_only("0+0 records in\n0+0 records out\n0 bytes copied, 0.0 s, 0.0 B/s\n")
+        .stderr_contains("0+0 records in\n0+0 records out\n0 bytes copied, ")
+        .stderr_matches(&Regex::new(r"\d\.\d+(e-\d\d)? s, ").unwrap())
+        .stderr_contains("0.0 B/s")
         .success();
 }
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1133,7 +1133,7 @@ fn test_tmp_files_deleted_on_sigint() {
         for _ in 0..40 {
             let lines = rand_pcg::Pcg32::seed_from_u64(123)
                 .sample_iter(rand::distributions::uniform::Uniform::new(0, 10000))
-                .take(100000)
+                .take(100_000)
                 .map(|x| x.to_string() + "\n")
                 .collect::<String>();
             file.write_all(lines.as_bytes()).unwrap();

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -130,7 +130,7 @@ mod linux_only {
     }
 
     fn run_tee(proc: &mut UCommand) -> (String, Output) {
-        let content = (1..=100000).map(|x| format!("{x}\n")).collect::<String>();
+        let content = (1..=100_000).map(|x| format!("{x}\n")).collect::<String>();
 
         #[allow(deprecated)]
         let output = proc

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -425,7 +425,7 @@ fn test_touch_set_date3() {
 
     assert!(at.file_exists(file));
 
-    let expected = FileTime::from_unix_time(1623786360, 0);
+    let expected = FileTime::from_unix_time(1_623_786_360, 0);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, expected);
@@ -466,7 +466,7 @@ fn test_touch_set_date5() {
     #[cfg(windows)]
     let expected = FileTime::from_unix_time(67413, 23456700);
     #[cfg(not(windows))]
-    let expected = FileTime::from_unix_time(67413, 23456789);
+    let expected = FileTime::from_unix_time(67413, 23_456_789);
 
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
@@ -485,7 +485,7 @@ fn test_touch_set_date6() {
 
     assert!(at.file_exists(file));
 
-    let expected = FileTime::from_unix_time(946684800, 0);
+    let expected = FileTime::from_unix_time(946_684_800, 0);
 
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
@@ -504,7 +504,7 @@ fn test_touch_set_date7() {
 
     assert!(at.file_exists(file));
 
-    let expected = FileTime::from_unix_time(1074254400, 0);
+    let expected = FileTime::from_unix_time(1_074_254_400, 0);
 
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -693,6 +693,16 @@ impl CmdResult {
     }
 
     #[track_caller]
+    pub fn stderr_matches(&self, regex: &regex::Regex) -> &Self {
+        assert!(
+            regex.is_match(self.stderr_str()),
+            "Stderr does not match regex:\n{}",
+            self.stderr_str()
+        );
+        self
+    }
+
+    #[track_caller]
     pub fn stdout_does_not_match(&self, regex: &regex::Regex) -> &Self {
         assert!(
             !regex.is_match(self.stdout_str()),


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`cut -h` outputs the following:

```
./target/debug/cut -h
Prints specified byte or field columns from each line of stdin or the input files

Usage: ./target/debug/cut [-d|-w] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+

Options:
  -b, --bytes <LIST>                  filter byte columns from the input source
  -c, --characters <LIST>             alias for character mode
  -d, --delimiter <DELIM>             specify the delimiter character that separates fields in the input source. Defaults to Tab.
  -w                                  Use any number of whitespace (Space, Tab) to separate fields in the input source (FreeBSD extension).
  -f, --fields <LIST>                 filter field columns from the input source
      --complement                    invert the filter - instead of displaying only the filtered columns, display all but those columns
  -s, --only-delimited                in field mode, only print lines which contain the delimiter
  -z, --zero-terminated               instead of filtering columns based on line, filter columns based on \0 (NULL character)
      --output-delimiter <NEW_DELIM>  in field mode, replace the delimiter in output lines with this option's argument
  -h, --help                          Print help
  -V, --version                       Print version

Each call must specify a mode (what to use for columns),
a sequence (which columns to print), and provide a data source

Specifying a mode

    Use --bytes (-b) or --characters (-c) to specify byte mode

    Use --fields (-f) to specify field mode, where each line is broken into
    fields identified by a delimiter character. For example for a typical CSV
    you could use this in combination with setting comma as the delimiter

Specifying a sequence

    A sequence is a group of 1 or more numbers or inclusive ranges separated
    by a commas.

    cut -f 2,5-7 some_file.txt
    will display the 2nd, 5th, 6th, and 7th field for each source line

    Ranges can extend to the end of the row by excluding the the second number

    cut -f 3- some_file.txt
    will display the 3rd field and all fields after for each source line

    The first number of a range can be excluded, and this is effectively the
    same as using 1 as the first number: it causes the range to begin at the
    first column. Ranges can also display a single column

    cut -f 1,3-5 some_file.txt
    will display the 1st, 3rd, 4th, and 5th field for each source line

    The --complement option, when used, inverts the effect of the sequence

    cut --complement -f 4-6 some_file.txt
    will display the every field but the 4th, 5th, and 6th

Specifying a data source

    If no sourcefile arguments are specified, stdin is used as the source of
    lines to print

    If sourcefile arguments are specified, stdin is ignored and all files are
    read in consecutively if a sourcefile is not successfully read, a warning
    will print to stderr, and the eventual status code will be 1, but cut
    will continue to read through proceeding sourcefiles

    To print columns from both STDIN and a file argument, use - (dash) as a
    sourcefile argument to represent stdin.

Field Mode options

    The fields in each line are identified by a delimiter (separator)

    Set the delimiter
        Set the delimiter which separates fields in the file using the
        --delimiter (-d) option. Setting the delimiter is optional.
        If not set, a default delimiter of Tab will be used.

        If the -w option is provided, fields will be separated by any number
        of whitespace characters (Space and Tab). The output delimiter will
        be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
        This is an extension adopted from FreeBSD.

    Optionally Filter based on delimiter
        If the --only-delimited (-s) flag is provided, only lines which
        contain the delimiter will be printed

    Replace the delimiter
        If the --output-delimiter option is provided, the argument used for
        it will replace the delimiter character in each line printed. This is
        useful for transforming tabular data - e.g. to convert a CSV to a
        TSV (tab-separated file)

Line endings

    When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
    'line ending' character (both for the purposes of reading lines and
    separating printed lines) instead of \\n (newline). This is useful for
    tabular data where some of the cells may contain newlines

    echo 'ab\\0cd' | cut -z -c 1
    will result in 'a\\0c\\0'

```