### PR TITLE
expand: move help strings to markdown file

### DIFF
--- a/src/uu/expand/expand.md
+++ b/src/uu/expand/expand.md
@@ -1,0 +1,8 @@
+# expand
+
+```
+expand [OPTION]... [FILE]...
+```
+
+Convert tabs in each FILE to spaces, writing to standard output.
+With no FILE, or when FILE is -, read standard input.

--- a/src/uu/expand/expand.md
+++ b/src/uu/expand/expand.md
@@ -4,5 +4,5 @@
 expand [OPTION]... [FILE]...
 ```
 
-Convert tabs in each FILE to spaces, writing to standard output.
-With no FILE, or when FILE is -, read standard input.
+Convert tabs in each `FILE` to spaces, writing to standard output.
+With no `FILE`, or when `FILE` is `-`, read standard input.

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -19,11 +19,10 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{crash, format_usage};
+use uucore::{crash, format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Convert tabs in each FILE to spaces, writing to standard output.
- With no FILE, or when FILE is -, read standard input.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+const ABOUT: &str = help_about!("expand.md");
+const USAGE: &str = help_usage!("expand.md");
 
 pub mod options {
     pub static TABS: &str = "tabs";


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`expand -h` outputs the following:

```
./target/debug/expand -h
Convert tabs in each FILE to spaces, writing to standard output.
With no FILE, or when FILE is -, read standard input.

Usage: ./target/debug/expand [OPTION]... [FILE]...

Options:
  -i, --initial         do not convert tabs after non blanks
  -t, --tabs <N, LIST>  have tabs N characters apart, not 8 or use comma separated list of explicit tab positions
  -U, --no-utf8         interpret input file as 8-bit ASCII rather than UTF-8
  -h, --help            Print help
  -V, --version         Print version

```