### PR TITLE
fold: move move help strings to markdown file

### DIFF
--- a/src/uu/fold/fold.md
+++ b/src/uu/fold/fold.md
@@ -1,0 +1,8 @@
+# fold
+
+```
+fold [OPTION]... [FILE]...
+```
+
+Writes each file (or standard input if no files are given)
+to standard output whilst breaking long lines

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -13,13 +13,12 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 const TAB_WIDTH: usize = 8;
 
-static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = "Writes each file (or standard input if no files are given)
- to standard output whilst breaking long lines";
+const USAGE: &str = help_usage!("fold.md");
+const ABOUT: &str = help_about!("fold.md");
 
 mod options {
     pub const BYTES: &str = "bytes";


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`fold -h` outputs the following:

```
./target/debug/fold -h
Writes each file (or standard input if no files are given)
to standard output whilst breaking long lines

Usage: ./target/debug/fold [OPTION]... [FILE]...

Options:
  -b, --bytes          count using bytes rather than columns (meaning control characters such as newline are not treated specially)
  -s, --spaces         break lines at word boundaries rather than a hard cut-off
  -w, --width <WIDTH>  set WIDTH as the maximum line width rather than 80
  -h, --help           Print help
  -V, --version        Print version
```