### PR TITLE
groups: move help strings to markdown file

### DIFF
--- a/src/uu/groups/groups.md
+++ b/src/uu/groups/groups.md
@@ -1,0 +1,8 @@
+# groups
+
+```
+groups [OPTION]... [USERNAME]...
+```
+
+Print group memberships for each `USERNAME` or, if no `USERNAME` is specified, for
+the current process (which may differ if the groups data‐base has changed).

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -17,7 +17,12 @@
 
 use std::error::Error;
 use std::fmt::Display;
-use uucore::{display::Quotable, entries::{get_groups_gnu, gid2grp, Locate, Passwd}, error::{UError, UResult}, format_usage, help_about, help_usage, show};
+use uucore::{
+    display::Quotable,
+    entries::{get_groups_gnu, gid2grp, Locate, Passwd},
+    error::{UError, UResult},
+    format_usage, help_about, help_usage, show,
+};
 
 use clap::{crate_version, Arg, ArgAction, Command};
 

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -17,23 +17,15 @@
 
 use std::error::Error;
 use std::fmt::Display;
-use uucore::{
-    display::Quotable,
-    entries::{get_groups_gnu, gid2grp, Locate, Passwd},
-    error::{UError, UResult},
-    format_usage, show,
-};
+use uucore::{display::Quotable, entries::{get_groups_gnu, gid2grp, Locate, Passwd}, error::{UError, UResult}, format_usage, help_about, help_usage, show};
 
 use clap::{crate_version, Arg, ArgAction, Command};
 
 mod options {
     pub const USERS: &str = "USERNAME";
 }
-static ABOUT: &str = "Print group memberships for each USERNAME or, \
-                      if no USERNAME is specified, for\nthe current process \
-                      (which may differ if the groups data‐base has changed).";
-
-const USAGE: &str = "{} [OPTION]... [USERNAME]...";
+const ABOUT: &str = help_about!("groups.md");
+const USAGE: &str = help_usage!("groups.md");
 
 #[derive(Debug)]
 enum GroupsError {


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`groups --help` outputs the following:

```
./target/debug/groups --help
Print group memberships for each `USERNAME` or, if no `USERNAME` is specified, for
the current process (which may differ if the groups data‐base has changed).

Usage: ./target/debug/groups [OPTION]... [USERNAME]...

Arguments:
  [USERNAME]...  

Options:
  -h, --help     Print help
  -V, --version  Print version
```