### PR TITLE
hashsum: move help strings to markdown file

### DIFF
--- a/src/uu/hashsum/hashsum.md
+++ b/src/uu/hashsum/hashsum.md
@@ -1,0 +1,7 @@
+# hashsum
+
+```
+hashsum [OPTIONS] [FILE]...
+```
+
+Compute and check message digests.

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -24,12 +24,12 @@ use std::iter;
 use std::num::ParseIntError;
 use std::path::Path;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{format_usage, help_about, help_usage};
 use uucore::sum::{
     Blake2b, Blake3, Digest, DigestWriter, Md5, Sha1, Sha224, Sha256, Sha384, Sha3_224, Sha3_256,
     Sha3_384, Sha3_512, Sha512, Shake128, Shake256,
 };
 use uucore::{crash, display::Quotable, show_warning};
+use uucore::{format_usage, help_about, help_usage};
 
 const NAME: &str = "hashsum";
 const ABOUT: &str = help_about!("hashsum.md");

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -24,6 +24,9 @@ use std::iter;
 use std::num::ParseIntError;
 use std::path::Path;
 use uucore::error::{FromIo, UError, UResult};
+use uucore::format_usage;
+use uucore::help_about;
+use uucore::help_usage;
 use uucore::sum::{
     Blake2b, Blake3, Digest, DigestWriter, Md5, Sha1, Sha224, Sha256, Sha384, Sha3_224, Sha3_256,
     Sha3_384, Sha3_512, Sha512, Shake128, Shake256,
@@ -31,6 +34,8 @@ use uucore::sum::{
 use uucore::{crash, display::Quotable, show_warning};
 
 const NAME: &str = "hashsum";
+const ABOUT: &str = help_about!("hashsum.md");
+const USAGE: &str = help_usage!("hashsum.md");
 
 struct Options {
     algoname: &'static str,
@@ -298,7 +303,8 @@ pub fn uu_app_common() -> Command {
     const TEXT_HELP: &str = "read in text mode (default)";
     Command::new(uucore::util_name())
         .version(crate_version!())
-        .about("Compute and check message digests.")
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .arg(
             Arg::new("binary")

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -24,9 +24,7 @@ use std::iter;
 use std::num::ParseIntError;
 use std::path::Path;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::format_usage;
-use uucore::help_about;
-use uucore::help_usage;
+use uucore::{format_usage, help_about, help_usage};
 use uucore::sum::{
     Blake2b, Blake3, Digest, DigestWriter, Md5, Sha1, Sha224, Sha256, Sha384, Sha3_224, Sha3_256,
     Sha3_384, Sha3_512, Sha512, Shake128, Shake256,


### PR DESCRIPTION
#4368 

```sh
$ cargo run -- hashsum -h
    Finished dev [unoptimized + debuginfo] target(s) in 2.82s
     Running `target/debug/coreutils hashsum -h`
Compute and check message digests.

Usage: target/debug/coreutils hashsum [OPTIONS] [FILE]...

Arguments:
  [FILE]...

Options:
  -b, --binary       read in binary mode
  -c, --check        read hashsums from the FILEs and check them
      --tag          create a BSD-style checksum
  -t, --text         read in text mode (default)
  -q, --quiet        don't print OK for each successfully verified file
  -s, --status       don't output anything, status code shows success
      --strict       exit non-zero for improperly formatted checksum lines
  -w, --warn         warn about improperly formatted checksum lines
      --bits <BITS>  set the size of the output (only for SHAKE)
      --no-names     Omits filenames in the output (option not present in GNU/Coreutils)
      --md5          work with MD5
      --sha1         work with SHA1
      --sha224       work with SHA224
      --sha256       work with SHA256
      --sha384       work with SHA384
      --sha512       work with SHA512
      --sha3         work with SHA3
      --sha3-224     work with SHA3-224
      --sha3-256     work with SHA3-256
      --sha3-384     work with SHA3-384
      --sha3-512     work with SHA3-512
      --shake128     work with SHAKE128 using BITS for the output size
      --shake256     work with SHAKE256 using BITS for the output size
      --b2sum        work with BLAKE2
      --b3sum        work with BLAKE3
  -h, --help         Print help
  -V, --version      Print version
```