### PR TITLE
head: move help strings to markdown file

### DIFF
--- a/src/uu/head/head.md
+++ b/src/uu/head/head.md
@@ -1,0 +1,11 @@
+# head
+
+```
+head [FLAG]... [FILE]...
+```
+
+Print the first 10 lines of each `FILE` to standard output.
+With more than one `FILE`, precede each with a header giving the file name.
+With no `FILE`, or when `FILE` is `-`, read standard input.
+
+Mandatory arguments to long flags are mandatory for short flags too.

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -11,21 +11,15 @@ use std::io::{self, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::lines::lines;
-use uucore::{format_usage, show};
+use uucore::{format_usage, help_about, help_usage, show};
 
 const BUF_SIZE: usize = 65536;
 
 /// The capacity in bytes for buffered writers.
 const BUFWRITER_CAPACITY: usize = 16_384; // 16 kilobytes
 
-const ABOUT: &str = "\
-                     Print the first 10 lines of each FILE to standard output.\n\
-                     With more than one FILE, precede each with a header giving the file name.\n\
-                     With no FILE, or when FILE is -, read standard input.\n\
-                     \n\
-                     Mandatory arguments to long flags are mandatory for short flags too.\
-                     ";
-const USAGE: &str = "{} [FLAG]... [FILE]...";
+const ABOUT: &str = help_about!("head.md");
+const USAGE: &str = help_usage!("head.md");
 
 mod options {
     pub const BYTES_NAME: &str = "BYTES";


### PR DESCRIPTION
#4368 

```sh
$ cargo run -puu_head -- head -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.59s
     Running `target/debug/head head -h`
Print the first 10 lines of each FILE to standard output.
With more than one FILE, precede each with a header giving the file name.
With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long flags are mandatory for short flags too.

Usage: target/debug/head [FLAG]... [FILE]...

Arguments:
  [FILE]...

Options:
  -c, --bytes <[-]NUM>   print the first NUM bytes of each file;
                         with the leading '-', print all but the last
                         NUM bytes of each file
  -n, --lines <[-]NUM>   print the first NUM lines instead of the first 10;
                         with the leading '-', print all but the last
                         NUM lines of each file
  -q, --quiet            never print headers giving file names [aliases: silent]
  -v, --verbose          always print headers giving file names
  -z, --zero-terminated  line delimiter is NUL, not newline
  -h, --help             Print help
  -V, --version          Print version
```