### PR TITLE
fix: to show the name of utility instead of 'manpages'

### DIFF
--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -119,21 +119,11 @@ pub fn set_utility_is_second_arg() {
 static ARGV: Lazy<Vec<OsString>> = Lazy::new(|| wild::args_os().collect());
 
 static UTIL_NAME: Lazy<String> = Lazy::new(|| {
-    if get_utility_is_second_arg() {
-        let i = match ARGV[1].eq("manpage") {
-            true => 1,
-            false => 0,
-        };
-        &ARGV[1 + i]
-    } else {
-        let i = match ARGV[0].eq("manpage") {
-            true => 1,
-            false => 0,
-        };
-        &ARGV[i]
-    }
-    .to_string_lossy()
-    .into_owned()
+    let base_index = if get_utility_is_second_arg() { 1 } else { 0 };
+    let is_man = if ARGV[base_index].eq("manpage") { 1 } else { 0 };
+    let argv_index = base_index + is_man;
+
+    ARGV[argv_index].to_string_lossy().into_owned()
 });
 
 /// Derive the utility name.

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -120,9 +120,17 @@ static ARGV: Lazy<Vec<OsString>> = Lazy::new(|| wild::args_os().collect());
 
 static UTIL_NAME: Lazy<String> = Lazy::new(|| {
     if get_utility_is_second_arg() {
-        &ARGV[1]
+        let i = match ARGV[1].eq("manpage") {
+            true => 1,
+            false => 0,
+        };
+        &ARGV[1 + i]
     } else {
-        &ARGV[0]
+        let i = match ARGV[0].eq("manpage") {
+            true => 1,
+            false => 0,
+        };
+        &ARGV[i]
     }
     .to_string_lossy()
     .into_owned()


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/4543

I noticed it just got the name from command line. I added a condition to get the next argument instead when you use man.
There may be a better solution than this.