### PR TITLE
uucore: fix help section doesn't render 3+ level headers

### DIFF
--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -256,6 +256,31 @@ mod tests {
     }
 
     #[test]
+    fn section_parsing_with_additional_headers() {
+        let input = "\
+            # ls\n\
+            ## after section\n\
+            This is some section\n\
+            \n\
+            ### level 3 header\n\
+            \n\
+            Additional text under the section.\n\
+            \n\
+            #### level 4 header\n\
+            \n\
+            Yet another paragraph\n";
+
+        assert_eq!(
+            parse_help_section("after section", input),
+            "This is some section\n\n\
+            ### level 3 header\n\n\
+            Additional text under the section.\n\n\
+            #### level 4 header\n\n\
+            Yet another paragraph"
+        );
+    }
+
+    #[test]
     #[should_panic]
     fn section_parsing_panic() {
         let input = "\

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -170,11 +170,14 @@ fn parse_help_section(section: &str, content: &str) -> String {
         )
     }
 
+    // Prefix includes space to allow processing of section with level 3-6 headers
+    let section_header_prefix = "## ";
+
     content
         .lines()
         .skip_while(|&l| !is_section_header(l, section))
         .skip(1)
-        .take_while(|l| !l.starts_with("## "))
+        .take_while(|l| !l.starts_with(section_header_prefix))
         .collect::<Vec<_>>()
         .join("\n")
         .trim()

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -174,7 +174,7 @@ fn parse_help_section(section: &str, content: &str) -> String {
         .lines()
         .skip_while(|&l| !is_section_header(l, section))
         .skip(1)
-        .take_while(|l| !l.starts_with("##"))
+        .take_while(|l| !l.starts_with("## "))
         .collect::<Vec<_>>()
         .join("\n")
         .trim()


### PR DESCRIPTION
While working on help for cut I've noticed that headers for levels below 2 are not rendered.

This is due to the fact that every they start with `##`.

To reproduce check current help for `dd` command before and after the fix.

I'm not sure if it's the best solution.