### PR TITLE
users: move help strings to markdown file

### DIFF
--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -14,11 +14,11 @@ use std::path::Path;
 use clap::builder::ValueParser;
 use clap::{crate_version, Arg, Command};
 use uucore::error::UResult;
-use uucore::format_usage;
 use uucore::utmpx::{self, Utmpx};
+use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Print the user names of users currently logged in to the current host";
-const USAGE: &str = "{} [FILE]";
+const ABOUT: &str = help_about!("users.md");
+const USAGE: &str = help_usage!("users.md");
 
 static ARG_FILES: &str = "files";
 

--- a/src/uu/users/users.md
+++ b/src/uu/users/users.md
@@ -1,0 +1,7 @@
+# users
+
+```
+users [FILE]
+```
+
+Print the user names of users currently logged in to the current host.


### PR DESCRIPTION
#4368 

```sh
$ cargo run -puu_users -- users -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.51s
     Running `target/debug/users users -h`
Print the user names of users currently logged in to the current host.

Usage: target/debug/users [FILE]

Arguments:
  [files]

Options:
  -h, --help     Print help
  -V, --version  Print version

Output who is currently logged in according to FILE.
If FILE is not specified, use /var/run/utmp.  /var/log/wtmp as FILE is common.
```