### PR TITLE
chroot: fix unused import on Android

### DIFF
--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -1,6 +1,8 @@
 // spell-checker:ignore (words) araba newroot userspec chdir pwd's isroot
 
-use crate::common::util::{is_ci, run_ucmd_as_root, TestScenario};
+#[cfg(not(target_os = "android"))]
+use crate::common::util::is_ci;
+use crate::common::util::{run_ucmd_as_root, TestScenario};
 
 #[test]
 fn test_invalid_arg() {


### PR DESCRIPTION
See https://github.com/uutils/coreutils/actions/runs/4486101640/jobs/7888344087

```
warning: unused import: `is_ci`
 --> tests/by-util/test_chroot.rs:3:27
  |
3 | use crate::common::util::{is_ci, run_ucmd_as_root, TestScenario};
  |                           ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `coreutils` (test "tests") generated 1 warning
    Finished test [unoptimized + debuginfo] target(s) in 5m 12s
     Running unittests src/bin/coreutils.rs (target/debug/deps/coreutils-c1c95fca0b7a1e35)
```