### PR TITLE
date: show error when reading dirs for -f arg

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use uucore::display::Quotable;
 #[cfg(not(any(target_os = "macos", target_os = "redox")))]
 use uucore::error::FromIo;
-use uucore::error::{UResult, USimpleError};
+use uucore::error::{UIoError, UResult, USimpleError};
 use uucore::{format_usage, help_about, help_usage, show};
 #[cfg(windows)]
 use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};
@@ -232,11 +232,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         let iter = lines.filter_map(Result::ok).map(parse_date);
                         Box::new(iter)
                     }
-                    Err(_err) => {
-                        return Err(USimpleError::new(
-                            2,
-                            format!("{}: No such file or directory", path.display()),
-                        ));
+                    Err(err) => {
+                        let uio_error: Box<UIoError> = err.map_err_context(|| format!("{}", path.quote()));
+                        return Err(uio_error);
                     }
                 }
             }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -226,19 +226,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         format!("expected file, got directory"),
                     ));
                 }
-                match File::open(path) {
-                    Ok(file) => {
-                        let lines = BufReader::new(file).lines();
-                        let iter = lines.map_while(Result::ok).map(parse_date);
-                        Box::new(iter)
-                    }
-                    Err(_err) => {
-                        return Err(USimpleError::new(
-                            2,
-                            String::new()
-                        ));
-                    }
-                }
+                let file = File::open(path).map_err_context(|| path.quote().to_string())?;
+                let lines = BufReader::new(file).lines();
+                let iter = lines.map_while(Result::ok).map(parse_date);
+                Box::new(iter)
+
             }
             DateSource::Now => {
                 let iter = std::iter::once(Ok(now));

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -226,11 +226,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         format!("expected file, got directory"),
                     ));
                 }
-                let file = File::open(path).map_err_context(|| path.quote().to_string())?;
+                let file = File::open(path)
+                    .map_err_context(|| path.as_os_str().to_string_lossy().to_string())?;
                 let lines = BufReader::new(file).lines();
                 let iter = lines.map_while(Result::ok).map(parse_date);
                 Box::new(iter)
-
             }
             DateSource::Now => {
                 let iter = std::iter::once(Ok(now));

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -232,10 +232,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         let iter = lines.map_while(Result::ok).map(parse_date);
                         Box::new(iter)
                     }
-                    Err(err) => {
-                        let uio_error: Box<UIoError> =
-                            err.map_err_context(|| format!("{}", path.quote()));
-                        return Err(uio_error);
+                    Err(_err) => {
+                        return Err(USimpleError::new(
+                            2,
+                            String::new()
+                        ));
                     }
                 }
             }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use uucore::display::Quotable;
 #[cfg(not(any(target_os = "macos", target_os = "redox")))]
 use uucore::error::FromIo;
-use uucore::error::{UIoError, UResult, USimpleError};
+use uucore::error::{UResult, USimpleError};
 use uucore::{format_usage, help_about, help_usage, show};
 #[cfg(windows)]
 use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -233,7 +233,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         Box::new(iter)
                     }
                     Err(err) => {
-                        let uio_error: Box<UIoError> = err.map_err_context(|| format!("{}", path.quote()));
+                        let uio_error: Box<UIoError> =
+                            err.map_err_context(|| format!("{}", path.quote()));
                         return Err(uio_error);
                     }
                 }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -229,7 +229,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 match File::open(path) {
                     Ok(file) => {
                         let lines = BufReader::new(file).lines();
-                        let iter = lines.filter_map(Result::ok).map(parse_date);
+                        let iter = lines.map_while(Result::ok).map(parse_date);
                         Box::new(iter)
                     }
                     Err(err) => {

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -219,19 +219,27 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 let iter = std::iter::once(date);
                 Box::new(iter)
             }
-            DateSource::File(ref path) => match File::open(path) {
-                Ok(file) => {
-                    let lines = BufReader::new(file).lines();
-                    let iter = lines.filter_map(Result::ok).map(parse_date);
-                    Box::new(iter)
-                }
-                Err(_err) => {
+            DateSource::File(ref path) => {
+                if path.is_dir() {
                     return Err(USimpleError::new(
                         2,
-                        format!("{}: No such file or directory", path.display()),
+                        format!("expected file, got directory"),
                     ));
                 }
-            },
+                match File::open(path) {
+                    Ok(file) => {
+                        let lines = BufReader::new(file).lines();
+                        let iter = lines.filter_map(Result::ok).map(parse_date);
+                        Box::new(iter)
+                    }
+                    Err(_err) => {
+                        return Err(USimpleError::new(
+                            2,
+                            format!("{}: No such file or directory", path.display()),
+                        ));
+                    }
+                }
+            }
             DateSource::Now => {
                 let iter = std::iter::once(Ok(now));
                 Box::new(iter)

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -19,7 +19,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use uucore::display::Quotable;
-#[cfg(not(any(target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(target_os = "redox")))]
 use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
 use uucore::{format_usage, help_about, help_usage, show};
@@ -223,7 +223,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 if path.is_dir() {
                     return Err(USimpleError::new(
                         2,
-                        format!("expected file, got directory"),
+                        format!("expected file, got directory {}", path.quote()),
                     ));
                 }
                 let file = File::open(path)

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -279,7 +279,7 @@ fn test_date_for_invalid_file() {
     result.no_stdout();
     assert_eq!(
         result.stderr_str().trim(),
-        "date: invalid_file: No such file or directory",
+        "date: 'invalid_file': No such file or directory",
     );
 }
 

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -284,6 +284,16 @@ fn test_date_for_invalid_file() {
 }
 
 #[test]
+fn test_date_for_dir_as_file() {
+    let result = new_ucmd!().arg("--file").arg("/").fails();
+    result.no_stdout();
+    assert_eq!(
+        result.stderr_str().trim(),
+        "date: expected file, got directory",
+    );
+}
+
+#[test]
 fn test_date_for_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_date_for_file";

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -279,7 +279,7 @@ fn test_date_for_invalid_file() {
     result.no_stdout();
     assert_eq!(
         result.stderr_str().trim(),
-        "date: 'invalid_file': No such file or directory",
+        "date: invalid_file: No such file or directory",
     );
 }
 

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -289,7 +289,7 @@ fn test_date_for_dir_as_file() {
     result.no_stdout();
     assert_eq!(
         result.stderr_str().trim(),
-        "date: expected file, got directory",
+        "date: expected file, got directory '/'",
     );
 }
 


### PR DESCRIPTION
Fixes #4539 


### GNU date implementation

GNU `date` runs `fopen` on input path ("/"). Later, we are at https://github.com/coreutils/coreutils/blob/master/src/date.c#L372 where `getline` fails and the `while(true)` loop breaks.

This error message gets returned as result for `batch_convert` which in the end calls `main_exit` where the process finally exits with error code 1.

### My PR

If a directory path is provided as argument for `-f`, we show the following error:

```sh
$ target/debug/coreutils date -f /
date: expected file, got directory
```
 