### PR TITLE
hostid: move help strings to markdown file

### DIFF
--- a/src/uu/hostid/hostid.md
+++ b/src/uu/hostid/hostid.md
@@ -1,0 +1,7 @@
+# hostid
+
+```
+hostid [options]
+```
+
+Print the numeric identifier (in hexadecimal) for the current host

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -9,10 +9,10 @@
 
 use clap::{crate_version, Command};
 use libc::c_long;
-use uucore::{error::UResult, format_usage};
+use uucore::{error::UResult, format_usage, help_about, help_usage};
 
-const USAGE: &str = "{} [options]";
-const ABOUT: &str = "Print the numeric identifier (in hexadecimal) for the current host";
+const USAGE: &str = help_usage!("hostid.md");
+const ABOUT: &str = help_about!("hostid.md");
 
 // currently rust libc interface doesn't include gethostid
 extern "C" {


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`hostid --help` outputs the following:

```
target/debug/hostid --help
Print the numeric identifier (in hexadecimal) for the current host

Usage: target/debug/hostid [options]

Options:
  -h, --help     Print help
  -V, --version  Print version
```
