### PR TITLE
dircolors: fix loop where filter_map ignores errors

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -136,12 +136,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     } else if files[0].eq("-") {
         let fin = BufReader::new(std::io::stdin());
-        result = parse(fin.lines().filter_map(Result::ok), &out_format, files[0]);
+        result = parse(fin.lines().map_while(Result::ok), &out_format, files[0]);
     } else {
         match File::open(files[0]) {
             Ok(f) => {
                 let fin = BufReader::new(f);
-                result = parse(fin.lines().filter_map(Result::ok), &out_format, files[0]);
+                result = parse(fin.lines().map_while(Result::ok), &out_format, files[0]);
             }
             Err(e) => {
                 return Err(USimpleError::new(

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -206,6 +206,17 @@ export LS_COLORS
     check("[^a]_negation", "b_negation", expectation_if_match);
 }
 
+#[test]
+fn test_dir() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir(DIR);
+    ucmd.env("SHELL", "/bin/bash")
+        .arg(DIR)
+        .succeeds()
+        .stdout_is("LS_COLORS='';\nexport LS_COLORS\n")
+        .no_stderr();
+}
+
 fn test_helper(file_name: &str, term: &str) {
     new_ucmd!()
         .env("TERM", term)

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -206,6 +206,17 @@ export LS_COLORS
     check("[^a]_negation", "b_negation", expectation_if_match);
 }
 
+#[test]
+fn test_dir() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir");
+    ucmd.env("SHELL", "/bin/bash")
+        .arg("dir")
+        .succeeds()
+        .stdout_is("LS_COLORS='';\nexport LS_COLORS\n")
+        .no_stderr();
+}
+
 fn test_helper(file_name: &str, term: &str) {
     new_ucmd!()
         .env("TERM", term)

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -206,17 +206,6 @@ export LS_COLORS
     check("[^a]_negation", "b_negation", expectation_if_match);
 }
 
-#[test]
-fn test_dir() {
-    let (at, mut ucmd) = at_and_ucmd!();
-    at.mkdir(DIR);
-    ucmd.env("SHELL", "/bin/bash")
-        .arg(DIR)
-        .succeeds()
-        .stdout_is("LS_COLORS='';\nexport LS_COLORS\n")
-        .no_stderr();
-}
-
 fn test_helper(file_name: &str, term: &str) {
     new_ucmd!()
         .env("TERM", term)


### PR DESCRIPTION
Fixes #4573 by using replacing filter_map with map_while to catch errors. Specifically, resolves an infinite loop when reading a directory.