### PR TITLE
touch: add underscores to long number in test

### DIFF
--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -464,7 +464,7 @@ fn test_touch_set_date5() {
     // Slightly different result on Windows for nano seconds
     // TODO: investigate
     #[cfg(windows)]
-    let expected = FileTime::from_unix_time(67413, 23456700);
+    let expected = FileTime::from_unix_time(67413, 23_456_700);
     #[cfg(not(windows))]
     let expected = FileTime::from_unix_time(67413, 23_456_789);
 


### PR DESCRIPTION
This PR adds underscores to a long number in a test. The number was overlooked in https://github.com/uutils/coreutils/pull/4546