### PR TITLE
nproc: move help strings to markdown file

### DIFF
--- a/src/uu/nproc/nproc.md
+++ b/src/uu/nproc/nproc.md
@@ -1,0 +1,9 @@
+# nproc
+
+```
+nproc [OPTIONS]...
+```
+
+Print the number of cores available to the current process.
+If the `OMP_NUM_THREADS` or `OMP_THREAD_LIMIT` environment variables are set, then
+they will determine the minimum and maximum returned value respectively.

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -11,7 +11,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use std::{env, thread};
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub const _SC_NPROCESSORS_CONF: libc::c_int = 83;
@@ -25,10 +25,8 @@ pub const _SC_NPROCESSORS_CONF: libc::c_int = 1001;
 static OPT_ALL: &str = "all";
 static OPT_IGNORE: &str = "ignore";
 
-static ABOUT: &str = r#"Print the number of cores available to the current process.
-If the OMP_NUM_THREADS or OMP_THREAD_LIMIT environment variables are set, then
-they will determine the minimum and maximum returned value respectively."#;
-const USAGE: &str = "{} [OPTIONS]...";
+const ABOUT: &str = help_about!("nproc.md");
+const USAGE: &str = help_usage!("nproc.md");
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`nproc` --help outputs the following:

```
target/debug/nproc --help
Print the number of cores available to the current process.
If the `OMP_NUM_THREADS` or `OMP_THREAD_LIMIT` environment variables are set, then
they will determine the minimum and maximum returned value respectively.

Usage: ./target/debug/nproc [OPTIONS]...

Options:
      --all         print the number of cores available to the system
      --ignore <N>  ignore up to N cores
  -h, --help        Print help
  -V, --version     Print version
```