### PR TITLE
test_ls: cannot find function `expected_result` in this scope

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7,6 +7,8 @@ extern crate regex;
 extern crate tempfile;
 
 use self::regex::Regex;
+#[cfg(feature = "feat_selinux")]
+use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
 #[cfg(all(unix, feature = "chmod"))]
 use nix::unistd::{close, dup};


### PR DESCRIPTION
Fix for:

```
error[E0425]: cannot find function `expected_result` in this scope
    --> tests/by-util/test_ls.rs:3167:44
     |
3167 |             .stdout_only(unwrap_or_return!(expected_result(&ts, &[c_flag, "/"])).stdout_str());
     |                                            ^^^^^^^^^^^^^^^ not found in this scope
     |
help: consider importing this function
     |
9    | use crate::common::util::expected_result;
     |

error[E0425]: cannot find function `expected_result` in this scope
    --> tests/by-util/test_ls.rs:3197:35
     |
3197 |                 unwrap_or_return!(expected_result(&ts, &["-Z", format.as_str(), "/"])).stdout_str(),
     |                                   ^^^^^^^^^^^^^^^ not found in this scope
     |
help: consider importing this function
     |
9    | use crate::common::util::expected_result;
```