### PR TITLE
touch: move help strings to markdown file

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -19,10 +19,10 @@ use time::macros::{format_description, offset, time};
 use time::Duration;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
-use uucore::{format_usage, show};
+use uucore::{format_usage, help_about, help_usage, show};
 
-static ABOUT: &str = "Update the access and modification times of each FILE to the current time.";
-const USAGE: &str = "{} [OPTION]... [USER]";
+const ABOUT: &str = help_about!("touch.md");
+const USAGE: &str = help_usage!("touch.md");
 pub mod options {
     // Both SOURCES and sources are needed as we need to be able to refer to the ArgGroup.
     pub static SOURCES: &str = "sources";

--- a/src/uu/touch/touch.md
+++ b/src/uu/touch/touch.md
@@ -1,0 +1,7 @@
+# touch
+
+```
+touch [OPTION]... [USER]
+```
+
+Update the access and modification times of each `FILE` to the current time.


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`touch --help` outputs the following:

```
target/debug/touch --help
Update the access and modification times of each `FILE` to the current time.

Usage: target/debug/touch [OPTION]... [USER]

Arguments:
  [files]...  

Options:
      --help              Print help information.
  -a                      change only the access time
  -t <STAMP>              use [[CC]YY]MMDDhhmm[.ss] instead of the current time
  -d, --date <STRING>     parse argument and use it instead of current time
  -m                      change only the modification time
  -c, --no-create         do not create any files
  -h, --no-dereference    affect each symbolic link instead of any referenced file (only for systems that can change the timestamps of a symlink)
  -r, --reference <FILE>  use this file's times instead of the current time
      --time <WORD>       change only the specified time: "access", "atime", or "use" are equivalent to -a; "modify" or "mtime" are equivalent to -m [possible values: access, atime, use]
  -V, --version           Print version
```