### PR TITLE
join: move help strings to markdown file

### DIFF
--- a/src/uu/join/join.md
+++ b/src/uu/join/join.md
@@ -1,7 +1,7 @@
 # join
 
 ```
-[OPTIONS] <FILE1> <FILE2>
+join [OPTIONS] <FILE1> <FILE2>
 ```
 
 For each pair of input lines with identical join fields, write a line to

--- a/src/uu/join/join.md
+++ b/src/uu/join/join.md
@@ -1,0 +1,10 @@
+# join
+
+```
+[OPTIONS] <FILE1> <FILE2>
+```
+
+For each pair of input lines with identical join fields, write a line to
+standard output. The default join field is the first, delimited by blanks.
+
+When `FILE1` or `FILE2` (not both) is `-`, read standard input.

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -22,7 +22,10 @@ use std::num::IntErrorKind;
 use std::os::unix::ffi::OsStrExt;
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UError, UResult, USimpleError};
-use uucore::{crash, crash_if_err};
+use uucore::{crash, crash_if_err, format_usage, help_about, help_usage};
+
+const ABOUT: &str = help_about!("join.md");
+const USAGE: &str = help_usage!("join.md");
 
 #[derive(Debug)]
 enum JoinError {
@@ -699,12 +702,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
-        .about(
-            "For each pair of input lines with identical join fields, write a line to
-standard output. The default join field is the first, delimited by blanks.
-
-When FILE1 or FILE2 (not both) is -, read standard input.",
-        )
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .arg(
             Arg::new("a")


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`join --help` outputs the following:

```
target/debug/join --help
For each pair of input lines with identical join fields, write a line to
standard output. The default join field is the first, delimited by blanks.

When `FILE1` or `FILE2` (not both) is `-`, read standard input.

Usage: target/debug/join <FILE1> <FILE2>

Options:
  -a <FILENUM>           also print unpairable lines from file FILENUM, where
                         FILENUM is 1 or 2, corresponding to FILE1 or FILE2 [possible values: 1, 2]
  -v <FILENUM>           like -a FILENUM, but suppress joined output lines [possible values: 1, 2]
  -e <EMPTY>             replace missing input fields with EMPTY
  -i, --ignore-case      ignore differences in case when comparing fields
  -j <FIELD>             equivalent to '-1 FIELD -2 FIELD'
  -o <FORMAT>            obey FORMAT while constructing output line
  -t <CHAR>              use CHAR as input and output field separator
  -1 <FIELD>             join on this FIELD of file 1
  -2 <FIELD>             join on this FIELD of file 2
      --check-order      check that the input is correctly sorted, even if all input lines are pairable
      --nocheck-order    do not check that the input is correctly sorted
      --header           treat the first line in each file as field headers, print them without trying to pair them
  -z, --zero-terminated  line delimiter is NUL, not newline
  -h, --help             Print help
  -V, --version          Print version
```