### PR TITLE
id: move help strings to a markdown file

### DIFF
--- a/src/uu/id/id.md
+++ b/src/uu/id/id.md
@@ -1,0 +1,18 @@
+# id
+
+```
+id [OPTION]... [USER]...
+```
+
+Print user and group information for each specified `USER`,
+or (when `USER` omitted) for the current user.
+
+## After help
+
+The id utility displays the user and group names and numeric IDs, of the
+calling process, to the standard output. If the real and effective IDs are
+different, both are displayed, otherwise only the real ID is displayed.
+
+If a user (login name or user ID) is specified, the user and group IDs of
+that user are displayed. In this case, the real and effective IDs are
+assumed to be the same.

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -45,7 +45,7 @@ use uucore::error::{set_exit_code, USimpleError};
 pub use uucore::libc;
 use uucore::libc::{getlogin, uid_t};
 use uucore::process::{getegid, geteuid, getgid, getuid};
-use uucore::{format_usage, show_error};
+use uucore::{format_usage, help_about, help_section, help_usage, show_error};
 
 macro_rules! cstr2cow {
     ($v:expr) => {
@@ -53,9 +53,9 @@ macro_rules! cstr2cow {
     };
 }
 
-static ABOUT: &str = "Print user and group information for each specified USER,
-or (when USER omitted) for the current user.";
-const USAGE: &str = "{} [OPTION]... [USER]...";
+const ABOUT: &str = help_about!("id.md");
+const USAGE: &str = help_usage!("id.md");
+const AFTER_HELP: &str = help_section!("after help", "id.md");
 
 #[cfg(not(feature = "selinux"))]
 static CONTEXT_HELP_TEXT: &str = "print only the security context of the process (not enabled)";
@@ -74,15 +74,6 @@ mod options {
     pub const OPT_REAL_ID: &str = "real";
     pub const OPT_ZERO: &str = "zero"; // BSD's id does not have this
     pub const ARG_USERS: &str = "USER";
-}
-
-fn get_description() -> &'static str {
-    "The id utility displays the user and group names and numeric IDs, of the \
-    calling process, to the standard output. If the real and effective IDs are \
-    different, both are displayed, otherwise only the real ID is displayed.\n\n\
-    If a user (login name or user ID) is specified, the user and group IDs of \
-    that user are displayed. In this case, the real and effective IDs are \
-    assumed to be the same."
 }
 
 struct Ids {
@@ -121,9 +112,7 @@ struct State {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app()
-        .after_help(get_description())
-        .try_get_matches_from(args)?;
+    let matches = uu_app().after_help(AFTER_HELP).try_get_matches_from(args)?;
 
     let users: Vec<String> = matches
         .get_many::<String>(options::ARG_USERS)


### PR DESCRIPTION
#4368

`id --help` outputs the following:

```
target/debug/id --help
Print user and group information for each specified `USER`,
or (when `USER` omitted) for the current user.

Usage: target/debug/id [OPTION]... [USER]...

Arguments:
  [USER]...  

Options:
  -A             Display the process audit user ID and other process audit properties,
                 which requires privilege (not available on Linux).
  -u, --user     Display only the effective user ID as a number.
  -g, --group    Display only the effective group ID as a number
  -G, --groups   Display only the different group IDs as white-space separated numbers, in no particular order.
  -p             Make the output human-readable. Each display is on a separate line.
  -n, --name     Display the name of the user or group ID for the -G, -g and -u options instead of the number.
                 If any of the ID numbers cannot be mapped into names, the number will be displayed as usual.
  -P             Display the id as a password file entry.
  -r, --real     Display the real ID for the -G, -g and -u options instead of the effective ID.
  -z, --zero     delimit entries with NUL characters, not whitespace;
                 not permitted in default format
  -Z, --context  print only the security context of the process (not enabled)
  -h, --help     Print help
  -V, --version  Print version

The id utility displays the user and group names and numeric IDs, of the
calling process, to the standard output. If the real and effective IDs are
different, both are displayed, otherwise only the real ID is displayed.

If a user (login name or user ID) is specified, the user and group IDs of
that user are displayed. In this case, the real and effective IDs are
assumed to be the same.
```