### PR TITLE
more: move help strings to markdown file

### DIFF
--- a/src/uu/more/more.md
+++ b/src/uu/more/more.md
@@ -1,0 +1,7 @@
+# more
+
+```
+more [OPTIONS] <FILE>...
+```
+
+A file perusal filter for CRT viewing.

--- a/src/uu/more/more.md
+++ b/src/uu/more/more.md
@@ -4,4 +4,5 @@
 more [OPTIONS] <FILE>...
 ```
 
-A file perusal filter for CRT viewing.
+Display the contents of a text file
+

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -28,8 +28,11 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::{format_usage, help_about, help_usage};
 
+const ABOUT: &str = help_about!("more.md");
 const BELL: &str = "\x07";
+const USAGE: &str = help_usage!("more.md");
 
 pub mod options {
     pub const SILENT: &str = "silent";
@@ -97,7 +100,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .about("A file perusal filter for CRT viewing.")
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .version(crate_version!())
         .infer_long_args(true)
         .arg(

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -31,8 +31,8 @@ use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::{format_usage, help_about, help_usage};
 
 const ABOUT: &str = help_about!("more.md");
-const BELL: &str = "\x07";
 const USAGE: &str = help_usage!("more.md");
+const BELL: &str = "\x07";
 
 pub mod options {
     pub const SILENT: &str = "silent";


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`more --help` outputs the following:

```
target/debug/more --help
A file perusal filter for CRT viewing.

Usage: target/debug/more [OPTIONS] <FILE>...

Arguments:
  [files]...  Path to the files to be read

Options:
  -d, --silent   Display help instead of ringing bell
  -h, --help     Print help
  -V, --version  Print version
```