### PR TITLE
mv: move help strings to markdown file

### DIFF
--- a/src/uu/mv/mv.md
+++ b/src/uu/mv/mv.md
@@ -1,0 +1,10 @@
+# mv
+
+```
+
+mv [OPTION]... [-T] SOURCE DEST
+mv [OPTION]... SOURCE... DIRECTORY
+mv [OPTION]... -t DIRECTORY SOURCE...
+```
+
+Move `SOURCE` to `DEST`, or multiple `SOURCE`(s) to `DIRECTORY`.

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 use uucore::backup_control::{self, BackupMode};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, prompt_yes, show};
+use uucore::{format_usage, help_about, help_usage, prompt_yes, show};
 
 use fs_extra::dir::{
     get_size as dir_get_size, move_dir, move_dir_with_progress, CopyOptions as DirCopyOptions,
@@ -53,12 +53,9 @@ pub enum OverwriteMode {
     Force,
 }
 
-static ABOUT: &str = "Move SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.";
+static ABOUT: &str = help_about!("mv.md");
 static LONG_HELP: &str = "";
-const USAGE: &str = "\
-    {} [OPTION]... [-T] SOURCE DEST
-    {} [OPTION]... SOURCE... DIRECTORY
-    {} [OPTION]... -t DIRECTORY SOURCE...";
+const USAGE: &str = help_usage!("mv.md");
 
 static OPT_FORCE: &str = "force";
 static OPT_INTERACTIVE: &str = "interactive";


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`mv --help` outputs the following:

```
target/debug/mv --help
Move `SOURCE` to `DEST`, or multiple `SOURCE`(s) to `DIRECTORY`.

Usage: target/debug/mv
target/debug/mv [OPTION]... [-T] SOURCE DEST
target/debug/mv [OPTION]... SOURCE... DIRECTORY
target/debug/mv [OPTION]... -t DIRECTORY SOURCE...

Arguments:
  <files>...  

Options:
      --backup[=<CONTROL>]            make a backup of each existing destination file
  -b                                  like --backup but does not accept an argument
  -f, --force                         do not prompt before overwriting
  -i, --interactive                   prompt before override
  -n, --no-clobber                    do not overwrite an existing file
      --strip-trailing-slashes        remove any trailing slashes from each SOURCE argument
  -S, --suffix <SUFFIX>               override the usual backup suffix
  -t, --target-directory <DIRECTORY>  move all SOURCE arguments into DIRECTORY
  -T, --no-target-directory           treat DEST as a normal file
  -u, --update                        move only when the SOURCE file is newer than the destination file or when the destination file is missing
  -v, --verbose                       explain what is being done
  -g, --progress                      Display a progress bar. 
                                      Note: this feature is not supported by GNU coreutils.
  -h, --help                          Print help
  -V, --version                       Print version


The backup suffix is '~', unless set with --suffix or SIMPLE_BACKUP_SUFFIX.
The version control method may be selected via the --backup option or through
the VERSION_CONTROL environment variable.  Here are the values:

  none, off       never make backups (even if --backup is given)
  numbered, t     make numbered backups
  existing, nil   numbered if numbered backups exist, simple otherwise
  simple, never   always make simple backups

```