### PR TITLE
`uniq`: remove `strum` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,12 +1031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,12 +1918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,25 +2101,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "subtle"
@@ -3237,8 +3206,6 @@ name = "uu_uniq"
 version = "0.0.17"
 dependencies = [
  "clap",
- "strum",
- "strum_macros",
  "uucore",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,8 +316,6 @@ same-file = "1.0.6"
 selinux = "0.4"
 signal-hook = "0.3.14"
 smallvec = { version = "1.10", features = ["union"] }
-strum = "0.24.1"
-strum_macros = "0.24.2"
 tempfile = "3.4.0"
 term_grid = "0.1.5"
 terminal_size = "0.2.5"

--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -16,8 +16,6 @@ path = "src/uniq.rs"
 
 [dependencies]
 clap = { workspace=true }
-strum = { workspace=true }
-strum_macros = { workspace=true }
 uucore = { workspace=true }
 
 [[bin]]

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -10,7 +10,6 @@ use std::fs::File;
 use std::io::{self, stdin, stdout, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 use std::str::FromStr;
-use strum_macros::{AsRefStr, EnumString};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::format_usage;
@@ -38,8 +37,7 @@ pub mod options {
 
 static ARG_FILES: &str = "files";
 
-#[derive(PartialEq, Clone, Copy, AsRefStr, EnumString)]
-#[strum(serialize_all = "snake_case")]
+#[derive(PartialEq, Clone, Copy)]
 enum Delimiters {
     Append,
     Prepend,
@@ -403,7 +401,14 @@ fn get_delimiter(matches: &ArgMatches) -> Delimiters {
         .get_one::<String>(options::ALL_REPEATED)
         .or_else(|| matches.get_one::<String>(options::GROUP));
     if let Some(delimiter_arg) = value {
-        Delimiters::from_str(delimiter_arg).unwrap() // All possible values for ALL_REPEATED are Delimiters (of type `&str`)
+        match delimiter_arg.as_ref() {
+            "append" => Delimiters::Append,
+            "prepend" => Delimiters::Prepend,
+            "separate" => Delimiters::Separate,
+            "both" => Delimiters::Both,
+            "none" => Delimiters::None,
+            _ => unreachable!("Should have been caught by possible values in clap"),
+        }
     } else if matches.contains_id(options::GROUP) {
         Delimiters::Separate
     } else {


### PR DESCRIPTION
The `strum` dependency was only used here and it wasn't doing a lot. It also pulled in two transitive dependencies.