### PR TITLE
Adjust -i behavior for ln, cp & mv 

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -78,6 +78,7 @@ quick_error! {
         StripPrefixError(err: StripPrefixError) { from() }
 
         /// Result of a skipped file
+        /// Currently happens when "no" is selected in interactive mode
         Skipped { }
 
         /// Result of a skipped file
@@ -1018,7 +1019,11 @@ fn show_error_if_needed(error: &Error) -> bool {
         // When using --no-clobber, we don't want to show
         // an error message
         Error::NotAllFilesCopied => (),
-        Error::Skipped => (),
+        Error::Skipped => {
+            // touch a b && echo "n"|cp -i a b && echo $?
+            // should return an error from GNU 9.2
+            return true;
+        }
         _ => {
             show_error!("{}", error);
             return true;

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -391,7 +391,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
         match settings.overwrite {
             OverwriteMode::NoClobber => {}
             OverwriteMode::Interactive => {
-                if !prompt_yes!("overwrite {}?", dst.quote()) {
+                if !prompt_yes!("replace {}?", dst.quote()) {
                     return Err(LnError::SomeLinksFailed.into());
                 }
 

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -392,7 +392,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
             OverwriteMode::NoClobber => {}
             OverwriteMode::Interactive => {
                 if !prompt_yes!("overwrite {}?", dst.quote()) {
-                    return Ok(());
+                    return Err(LnError::SomeLinksFailed.into());
                 }
 
                 if fs::remove_file(dst).is_ok() {};

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -420,7 +420,7 @@ fn rename(
             OverwriteMode::NoClobber => return Ok(()),
             OverwriteMode::Interactive => {
                 if !prompt_yes!("overwrite {}?", to.quote()) {
-                    return Ok(());
+                    return Err(io::Error::new(io::ErrorKind::Other, ""));
                 }
             }
             OverwriteMode::Force => {}

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -235,15 +235,38 @@ fn test_cp_arg_update_interactive() {
 }
 
 #[test]
+fn test_cp_arg_update_interactive_error() {
+    new_ucmd!()
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .arg("-i")
+        .fails()
+        .no_stdout();
+}
+
+#[test]
 fn test_cp_arg_interactive() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("a");
     at.touch("b");
     ucmd.args(&["-i", "a", "b"])
         .pipe_in("N\n")
-        .succeeds()
+        .fails()
         .no_stdout()
         .stderr_is("cp: overwrite 'b'? ");
+}
+
+#[test]
+fn test_cp_arg_interactive_update() {
+    // -u -i won't show the prompt to validate the override or not
+    // Therefore, the error code will be 0
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("a");
+    at.touch("b");
+    ucmd.args(&["-i", "-u", "a", "b"])
+        .pipe_in("N\n")
+        .succeeds()
+        .no_stdout();
 }
 
 #[test]

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -116,7 +116,7 @@ fn test_symlink_interactive() {
         .ucmd()
         .args(&["-i", "-s", file, link])
         .pipe_in("n")
-        .succeeds()
+        .fails()
         .no_stdout();
 
     assert!(at.file_exists(file));

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -165,7 +165,7 @@ fn test_mv_interactive() {
         .arg(file_a)
         .arg(file_b)
         .pipe_in("n")
-        .succeeds()
+        .fails()
         .no_stdout();
 
     assert!(at.file_exists(file_a));


### PR DESCRIPTION
Mentioned in issue #4627
touch a b && echo "n"|./target/debug/coreutils ln -i a b; echo $?

was 0, it is now 1
See: 
https://github.com/coreutils/coreutils/commit/7a69df88999bedd8e9fccf9f3dfa9ac6907fab66

(no problem reading the code here as there isn't much)

