### PR TITLE
`factor`: remove `paste` dev dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,12 +1571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,7 +2572,6 @@ dependencies = [
  "clap",
  "coz",
  "num-traits",
- "paste",
  "quickcheck",
  "rand",
  "smallvec",

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -23,7 +23,6 @@ smallvec = { workspace=true }
 uucore = { workspace=true }
 
 [dev-dependencies]
-paste = "1.0.6"
 quickcheck = "1.0.3"
 
 [[bin]]

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -112,7 +112,6 @@ pub(crate) fn is_prime(n: u64) -> bool {
 mod tests {
     use super::*;
     use crate::numeric::{traits::DoubleInt, Arithmetic, Montgomery};
-    use crate::parametrized_check;
     use quickcheck::quickcheck;
     use std::iter;
     const LARGEST_U64_PRIME: u64 = 0xFFFFFFFFFFFFFFC5;
@@ -157,7 +156,16 @@ mod tests {
             );
         }
     }
-    parametrized_check!(first_primes);
+
+    #[test]
+    fn first_primes_u32() {
+        first_primes::<u32>();
+    }
+
+    #[test]
+    fn first_primes_u64() {
+        first_primes::<u64>();
+    }
 
     #[test]
     fn one() {
@@ -195,7 +203,16 @@ mod tests {
             }
         }
     }
-    parametrized_check!(small_semiprimes);
+
+    #[test]
+    fn small_semiprimes_u32() {
+        small_semiprimes::<u32>();
+    }
+
+    #[test]
+    fn small_semiprimes_u64() {
+        small_semiprimes::<u64>();
+    }
 
     quickcheck! {
         fn composites(i: u64, j: u64) -> bool {

--- a/src/uu/factor/src/numeric/modular_inverse.rs
+++ b/src/uu/factor/src/numeric/modular_inverse.rs
@@ -46,7 +46,6 @@ pub(crate) fn modular_inverse<T: Int>(a: T) -> T {
 #[cfg(test)]
 mod tests {
     use super::{super::traits::Int, *};
-    use crate::parametrized_check;
     use quickcheck::quickcheck;
 
     fn small_values<T: Int>() {
@@ -59,7 +58,16 @@ mod tests {
 
         assert!(test_values.all(|x| x.wrapping_mul(&modular_inverse(x)) == one));
     }
-    parametrized_check!(small_values);
+
+    #[test]
+    fn small_values_u32() {
+        small_values::<u32>();
+    }
+
+    #[test]
+    fn small_values_u64() {
+        small_values::<u64>();
+    }
 
     quickcheck! {
         fn random_values_u32(n: u32) -> bool {

--- a/src/uu/factor/src/numeric/montgomery.rs
+++ b/src/uu/factor/src/numeric/montgomery.rs
@@ -182,8 +182,6 @@ impl<T: DoubleInt> Arithmetic for Montgomery<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parametrized_check;
-
     fn test_add<A: DoubleInt>() {
         for n in 0..100 {
             let n = 2 * n + 1;
@@ -198,7 +196,16 @@ mod tests {
             }
         }
     }
-    parametrized_check!(test_add);
+
+    #[test]
+    fn add_u32() {
+        test_add::<u32>();
+    }
+
+    #[test]
+    fn add_u64() {
+        test_add::<u64>();
+    }
 
     fn test_multiplication<A: DoubleInt>() {
         for n in 0..100 {
@@ -213,7 +220,16 @@ mod tests {
             }
         }
     }
-    parametrized_check!(test_multiplication);
+
+    #[test]
+    fn multiplication_u32() {
+        test_multiplication::<u32>();
+    }
+
+    #[test]
+    fn multiplication_u64() {
+        test_multiplication::<u64>();
+    }
 
     fn test_roundtrip<A: DoubleInt>() {
         for n in 0..100 {
@@ -225,5 +241,14 @@ mod tests {
             }
         }
     }
-    parametrized_check!(test_roundtrip);
+
+    #[test]
+    fn roundtrip_u32() {
+        test_roundtrip::<u32>();
+    }
+
+    #[test]
+    fn roundtrip_u64() {
+        test_roundtrip::<u64>();
+    }
 }


### PR DESCRIPTION
Another macro that's not really pulling its weight. I think being explicit here is easier to understand anyway.