### PR TITLE
du: threshold error message fix

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -913,6 +913,9 @@ impl FromStr for Threshold {
         let size = parse_size(&s[offset..])?;
 
         if s.starts_with('-') {
+            if size == 0 {
+                return Err(ParseSizeError::ParseFailure(s.to_string()));
+            }
             Ok(Self::Upper(size))
         } else {
             Ok(Self::Lower(size))

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -912,9 +912,9 @@ impl FromStr for Threshold {
 
         let size = parse_size(&s[offset..])?;
 
-        if s.starts_with('-') {
-				// Threshold of '-0' excludes everything besides 0 sized entries
-				// GNU's du threats '-0' as an invalid argument
+        if s.starts_with('-') {	
+            // Threshold of '-0' excludes everything besides 0 sized entries
+			// GNU's du threats '-0' as an invalid argument
             if size == 0 {
                 return Err(ParseSizeError::ParseFailure(s.to_string()));
             }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -913,6 +913,8 @@ impl FromStr for Threshold {
         let size = parse_size(&s[offset..])?;
 
         if s.starts_with('-') {
+				// Threshold of '-0' excludes everything besides 0 sized entries
+				// GNU's du threats '-0' as an invalid argument
             if size == 0 {
                 return Err(ParseSizeError::ParseFailure(s.to_string()));
             }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -912,9 +912,9 @@ impl FromStr for Threshold {
 
         let size = parse_size(&s[offset..])?;
 
-        if s.starts_with('-') {	
+        if s.starts_with('-') {
             // Threshold of '-0' excludes everything besides 0 sized entries
-			// GNU's du threats '-0' as an invalid argument
+            // GNU's du threats '-0' as an invalid argument
             if size == 0 {
                 return Err(ParseSizeError::ParseFailure(s.to_string()));
             }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -914,7 +914,7 @@ impl FromStr for Threshold {
 
         if s.starts_with('-') {
             // Threshold of '-0' excludes everything besides 0 sized entries
-            // GNU's du threats '-0' as an invalid argument
+            // GNU's du treats '-0' as an invalid argument
             if size == 0 {
                 return Err(ParseSizeError::ParseFailure(s.to_string()));
             }

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -547,6 +547,17 @@ fn test_du_threshold() {
 }
 
 #[test]
+fn test_du_invalid_threshold() {
+    let ts = TestScenario::new(util_name!());
+
+    let threshold = "-0";
+
+    ts.ucmd()
+        .arg(format!("--threshold={threshold}"))
+        .fails();
+}
+
+#[test]
 fn test_du_apparent_size() {
     let ts = TestScenario::new(util_name!());
     let result = ts.ucmd().arg("--apparent-size").succeeds();

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -552,9 +552,7 @@ fn test_du_invalid_threshold() {
 
     let threshold = "-0";
 
-    ts.ucmd()
-        .arg(format!("--threshold={threshold}"))
-        .fails();
+    ts.ucmd().arg(format!("--threshold={threshold}")).fails();
 }
 
 #[test]


### PR DESCRIPTION
This pull requests adds an error message to the `--threshold` option inline with the GNU version of du.

Previous behavior:
```sh
$ du --threshold -0 file
0	file
```

Current behavior:
```sh
$ du --threshold -0 file
du: invalid --threshold argument '-0'
```