### PR TITLE
`stdbuf`: get profile from the end of the path

### DIFF
--- a/src/uu/stdbuf/build.rs
+++ b/src/uu/stdbuf/build.rs
@@ -37,15 +37,20 @@ fn main() {
     // var for the profile can only be "debug" or "release", not a custom
     // profile name, so we have to use the name of the directory within target
     // as the profile name.
+    //
+    // Adapted from https://stackoverflow.com/questions/73595435/how-to-get-profile-from-cargo-toml-in-build-rs-or-at-runtime
+    let profile_name = out_dir
+        .split(std::path::MAIN_SEPARATOR)
+        .nth_back(3)
+        .unwrap();
+
     let mut name = target_dir.file_name().unwrap().to_string_lossy();
-    let mut profile_name = name.clone();
     while name != "target" && !name.starts_with("cargo-install") {
         target_dir = target_dir.parent().unwrap();
-        profile_name = name.clone();
         name = target_dir.file_name().unwrap().to_string_lossy();
     }
     let mut dir = target_dir.to_path_buf();
-    dir.push(profile_name.as_ref());
+    dir.push(profile_name);
     dir.push("deps");
     let mut path = None;
 


### PR DESCRIPTION
The path is not always `/target/{PROFILE}`, because cross uses `/target/{TARGET_TRIPLE}/{PROFILE}`, so we have to get the name of the profile in another way. StackOverflow recommended the getting the third component from the back of the path.

Closes https://github.com/uutils/coreutils/issues/4634 (hopefully)

Maybe some time soon https://github.com/rust-lang/cargo/issues/11054 will get fixed and we can remove this again.