### PR TITLE
deps: bump `time` from 0.3.17 to 0.3.20

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,11 +10,3 @@ rustflags = [
   "-Wclippy::explicit_iter_loop",
 ]
 
-[build]
-# See https://github.com/time-rs/time/issues/293#issuecomment-1005002386. The
-# unsoundness here is not in the `time` library, but in the Rust stdlib, and as
-# such it needs to be fixed there.
-rustflags = ["--cfg", "unsound_local_offset"]
-
-[target.'cfg(target_os = "linux")']
-rustflags = ["--cfg", "unsound_local_offset"]

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -406,7 +406,7 @@ jobs:
     - name: Test
       run: cargo test -v ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
       env:
-        RUSTFLAGS: "-Awarnings --cfg unsound_local_offset"
+        RUSTFLAGS: "-Awarnings"
         RUST_BACKTRACE: "1"
 
   deps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "libc",
@@ -2208,9 +2208,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1211,7 +1211,7 @@ fn test_cp_no_deref_folder_to_folder() {
 #[cfg(target_os = "linux")]
 fn test_cp_archive() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let ts = time::OffsetDateTime::now_local().unwrap();
+    let ts = time::OffsetDateTime::now_utc();
     let previous = FileTime::from_unix_time(ts.unix_timestamp() - 3600, ts.nanosecond());
     // set the file creation/modification an hour ago
     filetime::set_file_times(
@@ -1304,7 +1304,7 @@ fn test_cp_archive_recursive() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn test_cp_preserve_timestamps() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let ts = time::OffsetDateTime::now_local().unwrap();
+    let ts = time::OffsetDateTime::now_utc();
     let previous = FileTime::from_unix_time(ts.unix_timestamp() - 3600, ts.nanosecond());
     // set the file creation/modification an hour ago
     filetime::set_file_times(
@@ -1337,7 +1337,7 @@ fn test_cp_preserve_timestamps() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn test_cp_no_preserve_timestamps() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let ts = time::OffsetDateTime::now_local().unwrap();
+    let ts = time::OffsetDateTime::now_utc();
     let previous = FileTime::from_unix_time(ts.unix_timestamp() - 3600, ts.nanosecond());
     // set the file creation/modification an hour ago
     filetime::set_file_times(

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -618,7 +618,7 @@ fn test_mv_update_option() {
 
     at.touch(file_a);
     at.touch(file_b);
-    let ts = time::OffsetDateTime::now_local().unwrap();
+    let ts = time::OffsetDateTime::now_utc();
     let now = FileTime::from_unix_time(ts.unix_timestamp(), ts.nanosecond());
     let later = FileTime::from_unix_time(ts.unix_timestamp() + 3600, ts.nanosecond());
     filetime::set_file_times(at.plus_as_string(file_a), now, now).unwrap();

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -103,10 +103,7 @@ fn test_touch_set_mdhm_time() {
 
     let start_of_year = str_to_filetime(
         "%Y%m%d%H%M",
-        &format!(
-            "{}01010000",
-            time::OffsetDateTime::now_local().unwrap().year()
-        ),
+        &format!("{}01010000", time::OffsetDateTime::now_utc().year()),
     );
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);


### PR DESCRIPTION
Should fix the issues in https://github.com/uutils/coreutils/pull/4639

With https://github.com/uutils/coreutils/pull/4593, we no longer run `now_local` in a multithreaded environment, so we don't need to opt in to the unsound behaviour anymore. If we ever do need to do that, we should probably use `chrono` instead.