### PR TITLE
paste: move help strings to markdown file

### DIFF
--- a/src/uu/paste/paste.md
+++ b/src/uu/paste/paste.md
@@ -5,4 +5,4 @@ paste [OPTIONS] [FILE]...
 ```
 
 Write lines consisting of the sequentially corresponding lines from each
-`FILE`, separated by `TABs`, to standard output.
+`FILE`, separated by `TAB`s, to standard output.

--- a/src/uu/paste/paste.md
+++ b/src/uu/paste/paste.md
@@ -1,0 +1,8 @@
+# paste
+
+```
+paste [OPTIONS] [FILE]...
+```
+
+Write lines consisting of the sequentially corresponding lines from each
+`FILE`, separated by `TABs`, to standard output.

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -13,9 +13,10 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufRead, BufReader, Read, Write};
 use std::path::Path;
 use uucore::error::{FromIo, UResult};
+use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Write lines consisting of the sequentially corresponding lines from each
-FILE, separated by TABs, to standard output.";
+const ABOUT: &str = help_about!("paste.md");
+const USAGE: &str = help_usage!("paste.md");
 
 mod options {
     pub const DELIMITER: &str = "delimiters";
@@ -76,6 +77,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .arg(
             Arg::new(options::SERIAL)


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`paste --help` outputs the following:

```
target/debug/paste --help
Write lines consisting of the sequentially corresponding lines from each
`FILE`, separated by `TABs`, to standard output.

Usage: ./target/debug/paste [OPTIONS] [FILE]...

Arguments:
  [FILE]...  [default: -]

Options:
  -s, --serial             paste one file at a time instead of in parallel
  -d, --delimiters <LIST>  reuse characters from LIST instead of TABs
  -z, --zero-terminated    line delimiter is NUL, not newline
  -h, --help               Print help
  -V, --version            Print version
```