### PR TITLE
pathchk: move help strings to markdown file

### DIFF
--- a/src/uu/pathchk/pathchk.md
+++ b/src/uu/pathchk/pathchk.md
@@ -1,0 +1,7 @@
+# pathchk
+
+```
+pathchk [OPTION]... NAME...
+```
+
+Check whether file names are valid or portable

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::io::{ErrorKind, Write};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, UResult, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
 // operating mode
 enum Mode {
@@ -23,8 +23,8 @@ enum Mode {
     Both,    // a combination of `Basic` and `Extra`
 }
 
-static ABOUT: &str = "Check whether file names are valid or portable";
-const USAGE: &str = "{} [OPTION]... NAME...";
+const ABOUT: &str = help_about!("pathchk.md");
+const USAGE: &str = help_usage!("pathchk.md");
 
 mod options {
     pub const POSIX: &str = "posix";


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`pathchk` --help outputs the following:

```
target/debug/pathchk --help
Check whether file names are valid or portable

Usage: target/debug/pathchk [OPTION]... NAME...

Options:
  -p                 check for most POSIX systems
  -P                 check for empty names and leading "-"
      --portability  check for all POSIX systems (equivalent to -p -P)
  -h, --help         Print help
  -V, --version      Print version
```