### PR TITLE
CICD: remove "continue on error" in fuzz_date step

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -145,8 +145,6 @@ jobs:
     - name: Install `cargo-fuzz`
       run: cargo install cargo-fuzz
     - name: Run fuzz_date for XX seconds
-      # TODO: fix https://github.com/uutils/coreutils/issues/4494
-      continue-on-error: true
       shell: bash
       run: |
         ## Run it


### PR DESCRIPTION
This PR removes the `continue-on-error: true` setting in the `fuzz_date` step because the issue mentioned in the todo has been fixed in https://github.com/uutils/coreutils/pull/4499.