### PR TITLE
unlink: move help strings to markdown file

### DIFF
--- a/src/uu/unlink/src/unlink.rs
+++ b/src/uu/unlink/src/unlink.rs
@@ -16,8 +16,10 @@ use clap::{crate_version, Arg, Command};
 
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
+use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Unlink the file at FILE.";
+const ABOUT: &str = help_about!("unlink.md");
+const USAGE: &str = help_usage!("unlink.md");
 static OPT_PATH: &str = "FILE";
 
 #[uucore::main]
@@ -33,6 +35,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .arg(
             Arg::new(OPT_PATH)

--- a/src/uu/unlink/unlink.md
+++ b/src/uu/unlink/unlink.md
@@ -1,0 +1,7 @@
+# unlink
+
+```
+unlink [FILE]
+```
+
+Unlink the file at `FILE`.


### PR DESCRIPTION
#4368

```sh
$ cargo run -- unlink --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/coreutils unlink --help`
Unlink the file at FILE.

Usage: target/debug/coreutils unlink [FILE]

Options:
  -h, --help     Print help
  -V, --version  Print version
```