### PR TITLE
pr: move help strings to markdown file

### DIFF
--- a/src/uu/pr/pr.md
+++ b/src/uu/pr/pr.md
@@ -1,0 +1,33 @@
+# pr
+
+```
+pr [OPTIONS] [files]...
+```
+
+Write content of given file or standard input to standard output with pagination filter
+
+## After help
+
+`+PAGE`           Begin output at page number page of the formatted input.
+`-COLUMN`         Produce multi-column output. See `--column`
+
+The pr utility is a printing and pagination filter
+for text files.  When multiple input files are specified,
+each is read, formatted, and written to standard
+output.  By default, the input is separated
+into 66-line pages, each with
+
+o   A 5-line header with the page number, date,
+time, and the pathname of the file.
+
+o   A 5-line trailer consisting of blank lines.
+
+If standard output is associated with a terminal,
+diagnostic messages are suppressed until the pr
+utility has completed processing.
+
+When multiple column output is specified, text columns
+are of equal width. By default, text columns
+are separated by at least one `<blank>`.  Input lines
+that do not fit into a text column are truncated.
+Lines are not truncated under single column output.

--- a/src/uu/pr/pr.md
+++ b/src/uu/pr/pr.md
@@ -11,23 +11,17 @@ Write content of given file or standard input to standard output with pagination
 `+PAGE`           Begin output at page number page of the formatted input.
 `-COLUMN`         Produce multi-column output. See `--column`
 
-The pr utility is a printing and pagination filter
-for text files.  When multiple input files are specified,
-each is read, formatted, and written to standard
-output.  By default, the input is separated
-into 66-line pages, each with
+The pr utility is a printing and pagination filter for text files.
+When multiple input files are specified, each is read, formatted, and written to standard output.
+By default, the input is separated into 66-line pages, each with
 
-o   A 5-line header with the page number, date,
-time, and the pathname of the file.
+* A 5-line header with the page number, date, time, and the pathname of the file.
+* A 5-line trailer consisting of blank lines.
 
-o   A 5-line trailer consisting of blank lines.
-
-If standard output is associated with a terminal,
-diagnostic messages are suppressed until the pr
+If standard output is associated with a terminal, diagnostic messages are suppressed until the pr
 utility has completed processing.
 
-When multiple column output is specified, text columns
-are of equal width. By default, text columns
-are separated by at least one `<blank>`.  Input lines
-that do not fit into a text column are truncated.
+When multiple column output is specified, text columns are of equal width.
+By default, text columns are separated by at least one `<blank>`.
+Input lines that do not fit into a text column are truncated.
 Lines are not truncated under single column output.

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -21,33 +21,11 @@ use time::OffsetDateTime;
 use quick_error::quick_error;
 use uucore::display::Quotable;
 use uucore::error::UResult;
+use uucore::{format_usage, help_about, help_section, help_usage};
 
-const ABOUT: &str =
-    "Write content of given file or standard input to standard output with pagination filter";
-const AFTER_HELP: &str =
-    "    +PAGE\n            Begin output at page number page of the formatted input.
-    -COLUMN\n            Produce multi-column output. See --column
-
-The pr utility is a printing and pagination filter
-for text files.  When multiple input files are specified,
-each is read, formatted, and written to standard
-output.  By default, the input is separated
-into 66-line pages, each with
-
-o   A 5-line header with the page number, date,
-    time, and the pathname of the file.
-
-o   A 5-line trailer consisting of blank lines.
-
-If standard output is associated with a terminal,
-diagnostic messages are suppressed until the pr
-utility has completed processing.
-
-When multiple column output is specified, text columns
-are of equal width.  By default text columns
-are separated by at least one <blank>.  Input lines
-that do not fit into a text column are truncated.
-Lines are not truncated under single column output.";
+const ABOUT: &str = help_about!("pr.md");
+const USAGE: &str = help_usage!("pr.md");
+const AFTER_HELP: &str = help_section!("after help", "pr.md");
 const TAB: char = '\t';
 const LINES_PER_PAGE: usize = 66;
 const LINES_PER_PAGE_FOR_FORM_FEED: usize = 63;
@@ -195,6 +173,7 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .about(ABOUT)
         .after_help(AFTER_HELP)
+        .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .args_override_self(true)
         .disable_help_flag(true)


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`pr --help` outputs the following:

```
target/debug/pr --help
Write content of given file or standard input to standard output with pagination filter

Usage: target/debug/pr [OPTIONS] [files]...

Arguments:
  [files]...  

Options:
      --pages <FIRST_PAGE[:LAST_PAGE]>
          Begin and stop printing with page FIRST_PAGE[:LAST_PAGE]
  -h, --header <STRING>
          Use the string header to replace the file name in the header line.
  -d, --double-space
          Produce output that is double spaced. An extra <newline> character is output
          following every <newline> found in the input.
  -n, --number-lines <[char][width]>
          Provide width digit line numbering.  The default for width, if not specified, is
          5.  The number occupies the first width column positions of each text column or
          each line of -m output.  If char (any non-digit character) is given, it is
          appended to the line number to separate it from whatever follows.  The default
          for char is a <tab>. Line numbers longer than width columns are truncated.
  -N, --first-line-number <NUMBER>
          start counting with NUMBER at 1st line of first page printed
  -t, --omit-header
          Write neither the five-line identifying header nor the five-line trailer usually
          supplied for each page. Quit writing after the last line of each file without
          spacing to the end of the page.
  -l, --length <PAGE_LENGTH>
          Override the 66-line default (default number of lines of text 56, and with -F 63)
          and reset the page length to lines.  If lines is not greater than the sum  of
          both the  header  and trailer depths (in lines), the pr utility shall suppress
          both the header and trailer, as if the -t option were in effect.
  -r, --no-file-warnings
          omit warning when a file cannot be opened
  -F, --form-feed
          Use a <form-feed> for new pages, instead of the default behavior that uses a
          sequence of <newline>s.
  -w, --width <width>
          Set the width of the line to width column positions for multiple text-column
          output only. If the -w option is not specified and the -s option is not
          specified, the default width shall be 72. If the -w option is not specified and
          the -s option is specified, the default width shall be 512.
  -W, --page-width <width>
          set page width to PAGE_WIDTH (72) characters always, truncate lines, except -J
          option is set, no interference with -S or -s
  -a, --across
          Modify the effect of the - column option so that the columns are filled across
          the page in a  round-robin  order (for example, when column is 2, the first input
          line heads column 1, the second heads column 2, the third is the second line in
          column 1, and so on).
      --column <column>
          Produce multi-column output that is arranged in column columns (the default shall
          be 1) and is written down each column  in  the order in which the text is
          received from the input file. This option should not be used with -m. The options
          -e and -i shall be assumed for multiple text-column output.  Whether or not text
          columns are produced with identical vertical lengths is unspecified, but a text
          column shall never exceed the length of the page (see the -l option). When used
          with -t, use the minimum number of lines to write the output.
  -s, --separator <char>
          Separate text columns by the single character char instead of by the appropriate
          number of <space>s (default for char is the <tab> character).
  -S, --sep-string <string>
          separate columns by STRING, without -S: Default separator <TAB> with -J and
          <space> otherwise (same as -S" "), no effect on column options
  -m, --merge
          Merge files. Standard output shall be formatted so the pr utility writes one line
          from each file specified by a file operand, side by side into text columns of
          equal fixed widths, in terms of the number of column positions. Implementations
          shall support merging of at least nine file operands.
  -o, --indent <margin>
          Each line of output shall be preceded by offset <space>s. If the -o option is not
          specified, the default offset shall be zero. The space taken is in addition to
          the output line width (see the -w option below).
  -J
          merge full lines, turns off -W line truncation, no column alignment,
          --sep-string[=STRING] sets separators
      --help
          Print help information
  -V, --version
          Print version

+PAGE           Begin output at page number page of the formatted input.
-COLUMN         Produce multi-column output. See --column

The pr utility is a printing and pagination filter
for text files.  When multiple input files are specified,
each is read, formatted, and written to standard
output.  By default, the input is separated
into 66-line pages, each with

o   A 5-line header with the page number, date,
time, and the pathname of the file.

o   A 5-line trailer consisting of blank lines.

If standard output is associated with a terminal,
diagnostic messages are suppressed until the pr
utility has completed processing.

When multiple column output is specified, text columns
are of equal width. By default, text columns
are separated by at least one <blank>.  Input lines
that do not fit into a text column are truncated.
Lines are not truncated under single column output.
```