### PR TITLE
uniq: move help strings to markdown file

### DIFF
--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -12,15 +12,11 @@ use std::path::Path;
 use std::str::FromStr;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_section, help_usage};
 
-const ABOUT: &str = "Report or omit repeated lines.";
-const USAGE: &str = "{} [OPTION]... [INPUT [OUTPUT]]...";
-const LONG_USAGE: &str = "\
-    Filter adjacent matching lines from INPUT (or standard input),\n\
-    writing to OUTPUT (or standard output).\n\n\
-    Note: 'uniq' does not detect repeated lines unless they are adjacent.\n\
-    You may want to sort the input first, or use 'sort -u' without 'uniq'.";
+const ABOUT: &str = help_about!("uniq.md");
+const USAGE: &str = help_usage!("uniq.md");
+const AFTER_HELP: &str = help_section!("after help", "uniq.md");
 
 pub mod options {
     pub static ALL_REPEATED: &str = "all-repeated";
@@ -247,7 +243,7 @@ fn opt_parsed<T: FromStr>(opt_name: &str, matches: &ArgMatches) -> UResult<Optio
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().after_help(LONG_USAGE).try_get_matches_from(args)?;
+    let matches = uu_app().after_help(AFTER_HELP).try_get_matches_from(args)?;
 
     let files: Vec<String> = matches
         .get_many::<String>(ARG_FILES)

--- a/src/uu/uniq/uniq.md
+++ b/src/uu/uniq/uniq.md
@@ -1,0 +1,15 @@
+# uniq
+
+```
+uniq [OPTION]... [INPUT [OUTPUT]]...
+```
+
+Report or omit repeated lines.
+
+## After help
+
+Filter adjacent matching lines from `INPUT` (or standard input),
+writing to `OUTPUT` (or standard output).
+
+Note: `uniq` does not detect repeated lines unless they are adjacent.
+You may want to sort the input first, or use `sort -u` without `uniq`.


### PR DESCRIPTION
#4368 

```sh
$ cargo run -- uniq --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/coreutils uniq --help`
Report or omit repeated lines.

Usage: target/debug/coreutils uniq [OPTION]... [INPUT [OUTPUT]]...

Arguments:
  [files]...

Options:
  -D, --all-repeated[=<delimit-method>]  print all duplicate lines. Delimiting is done with blank lines. [default: none] [possible values: none, prepend, separate]
      --group[=<group-method>]           show all items, separating groups with an empty line. [default: separate] [possible values: separate, prepend, append, both]
  -w, --check-chars <N>                  compare no more than N characters in lines
  -c, --count                            prefix lines by the number of occurrences
  -i, --ignore-case                      ignore differences in case when comparing
  -d, --repeated                         only print duplicate lines
  -s, --skip-chars <N>                   avoid comparing the first N characters
  -f, --skip-fields <N>                  avoid comparing the first N fields
  -u, --unique                           only print unique lines
  -z, --zero-terminated                  end lines with 0 byte, not newline
  -h, --help                             Print help
  -V, --version                          Print version

Filter adjacent matching lines from INPUT (or standard input),
writing to OUTPUT (or standard output).

Note: 'uniq' does not detect repeated lines unless they are adjacent.
You may want to sort the input first, or use 'sort -u' without 'uniq'.
```