### PR TITLE
Revert "chore(deps): update rust crate exacl to 0.10.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "exacl"
-version = "0.10.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfeb22a59deb24c3262c43ffcafd1eb807180f371f9fcc99098d181b5d639be"
+checksum = "129c7b60e19ea8393c47b2110f8e3cea800530fd962380ef110d1fef6591faee"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ compare = "0.1.0"
 coz = { version = "0.1.3" }
 crossterm = ">=0.26.1"
 ctrlc = { version = "3.2", features = ["termination"] }
-exacl = "0.10.0"
+exacl = "0.9.0"
 file_diff = "1.0.0"
 filetime = "0.2"
 fnv = "1.0.7"


### PR DESCRIPTION
Reverts uutils/coreutils#4662. Not sure whether it is necessary, but Github suddenly showed a different number of failures after merging.