### PR TITLE
pinky: move help strings to markdown file

### DIFF
--- a/src/uu/pinky/pinky.md
+++ b/src/uu/pinky/pinky.md
@@ -1,0 +1,7 @@
+# pinky
+
+```
+pinky [OPTION]... [USER]...
+```
+
+Lightweight finger

--- a/src/uu/pinky/pinky.md
+++ b/src/uu/pinky/pinky.md
@@ -4,4 +4,4 @@
 pinky [OPTION]... [USER]...
 ```
 
-Lightweight finger
+Displays brief user information on Unix-based systems

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -22,7 +22,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use std::path::PathBuf;
 use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = help_about!("pinky.md");
+const ABOUT: &str = help_about!("pinky.md");
 const USAGE: &str = help_usage!("pinky.md");
 
 mod options {

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -20,10 +20,10 @@ use std::os::unix::fs::MetadataExt;
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::path::PathBuf;
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Lightweight finger";
-const USAGE: &str = "{} [OPTION]... [USER]...";
+static ABOUT: &str = help_about!("pinky.md");
+const USAGE: &str = help_usage!("pinky.md");
 
 mod options {
     pub const LONG_FORMAT: &str = "long_format";


### PR DESCRIPTION
issue: #4368 

`pinky --help` outputs the following.

```
./target/debug/pinky --help
Lightweight finger

Usage: ./target/debug/pinky [OPTION]... [USER]...

Arguments:
  [user]...  

Options:
  -l             produce long format output for the specified USERs
  -b             omit the user's home directory and shell in long format
  -h             omit the user's project file in long format
  -p             omit the user's plan file in long format
  -s             do short format output, this is the default
  -f             omit the line of column headings in short format
  -w             omit the user's full name in short format
  -i             omit the user's full name and remote host in short format
  -q             omit the user's full name, remote host and idle time in short format
      --help     Print help information
  -V, --version  Print version

A lightweight 'finger' program;  print user information.
The utmp file will be /var/run/utmpx.

```