### PR TITLE
true: move help strings to markdown file

### DIFF
--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -7,14 +7,9 @@
 use clap::{Arg, ArgAction, Command};
 use std::{ffi::OsString, io::Write};
 use uucore::error::{set_exit_code, UResult};
+use uucore::help_about;
 
-static ABOUT: &str = "\
-Returns true, a successful exit status.
-
-Immediately returns with the exit status `0`, except when invoked with one of the recognized
-options. In those cases it will try to write the help or version text. Any IO error during this
-operation causes the program to return `1` instead.
-";
+const ABOUT: &str = help_about!("true.md");
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {

--- a/src/uu/true/true.md
+++ b/src/uu/true/true.md
@@ -1,0 +1,11 @@
+# true
+
+```
+true
+```
+
+Returns true, a successful exit status.
+
+Immediately returns with the exit status `0`, except when invoked with one of the recognized
+options. In those cases it will try to write the help or version text. Any IO error during this
+operation causes the program to return `1` instead.


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`true --help` outputs the following:

```
target/debug/true --help
Returns true, a successful exit status.

Immediately returns with the exit status `0`, except when invoked with one of the
recognized
options. In those cases it will try to write the help or version text. Any IO error during
this
operation causes the program to return `1` instead.

Usage: true

Options:
      --help     Print help information
      --version  Print version information
```