### PR TITLE
unexpand: move help strings to markdown file

### DIFF
--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -19,11 +19,10 @@ use std::str::from_utf8;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult};
-use uucore::{crash, crash_if_err, format_usage};
+use uucore::{crash, crash_if_err, format_usage, help_about, help_usage};
 
-static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = "Convert blanks in each FILE to tabs, writing to standard output.\n\n\
-                      With no FILE, or when FILE is -, read standard input.";
+const USAGE: &str = help_usage!("unexpand.md");
+const ABOUT: &str = help_about!("unexpand.md");
 
 const DEFAULT_TABSTOP: usize = 8;
 

--- a/src/uu/unexpand/unexpand.md
+++ b/src/uu/unexpand/unexpand.md
@@ -1,0 +1,8 @@
+# unexpand
+
+```
+unexpand [OPTION]... [FILE]...
+```
+
+Convert blanks in each `FILE` to tabs, writing to standard output.
+With no `FILE`, or when `FILE` is `-`, read standard input.


### PR DESCRIPTION
https://github.com/uutils/coreutils/issues/4368

`unexpand --help` outputs the following:

```
target/debug/unexpand --help
Convert blanks in each `FILE` to tabs, writing to standard output.
With no `FILE`, or when `FILE` is `-`, read standard input.

Usage: target/debug/unexpand [OPTION]... [FILE]...

Options:
  -a, --all             convert all blanks, instead of just initial blanks
      --first-only      convert only leading sequences of blanks (overrides -a)
  -t, --tabs <N, LIST>  use comma separated LIST of tab positions or have tabs N characters
                        apart instead of 8 (enables -a)
  -U, --no-utf8         interpret input file as 8-bit ASCII rather than UTF-8
  -h, --help            Print help
  -V, --version         Print version
```