### PR TITLE
wc: use concat! to improve readability of tests

### DIFF
--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -475,9 +475,11 @@ fn test_total_auto() {
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=auto"])
         .run()
-        .stdout_is(
-            "  13  109  772 lorem_ipsum.txt\n  18  204 1115 moby_dick.txt\n  31  313 1887 total\n",
-        );
+        .stdout_is(concat!(
+            "  13  109  772 lorem_ipsum.txt\n",
+            "  18  204 1115 moby_dick.txt\n",
+            "  31  313 1887 total\n",
+        ));
 }
 
 #[test]
@@ -485,14 +487,19 @@ fn test_total_always() {
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "--total=always"])
         .run()
-        .stdout_is(" 13 109 772 lorem_ipsum.txt\n 13 109 772 total\n");
+        .stdout_is(concat!(
+            " 13 109 772 lorem_ipsum.txt\n",
+            " 13 109 772 total\n",
+        ));
 
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=always"])
         .run()
-        .stdout_is(
-            "  13  109  772 lorem_ipsum.txt\n  18  204 1115 moby_dick.txt\n  31  313 1887 total\n",
-        );
+        .stdout_is(concat!(
+            "  13  109  772 lorem_ipsum.txt\n",
+            "  18  204 1115 moby_dick.txt\n",
+            "  31  313 1887 total\n",
+        ));
 }
 
 #[test]
@@ -505,7 +512,10 @@ fn test_total_never() {
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=never"])
         .run()
-        .stdout_is("  13  109  772 lorem_ipsum.txt\n  18  204 1115 moby_dick.txt\n");
+        .stdout_is(concat!(
+            "  13  109  772 lorem_ipsum.txt\n",
+            "  18  204 1115 moby_dick.txt\n",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
This PR uses `concat!` to improve the readability of the tests from https://github.com/uutils/coreutils/pull/4695. Inspired by the tests in https://github.com/uutils/coreutils/pull/4696.