### PR TITLE
factor: add -h/--exponents option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,9 +1125,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcb5b3e439c92a7191df2f9bbe733de8de55c3f86368cdb1c63f8be7e9e328e"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hostname"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,7 @@ unindent = "0.2"
 uucore = { workspace=true, features=["entries", "process", "signals"] }
 walkdir = { workspace=true }
 is-terminal = { workspace=true }
-hex-literal = "0.4.0"
+hex-literal = "0.4.1"
 rstest = "0.17.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]

--- a/src/uu/factor/factor.md
+++ b/src/uu/factor/factor.md
@@ -1,7 +1,7 @@
 # factor
 
 ```
-factor [NUMBER]...
+factor [OPTION]... [NUMBER]...
 ```
 
 Print the prime factors of the given NUMBER(s).

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -9,6 +9,7 @@ use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::fmt;
 
+use crate::exponent_options::PRINT_EXPONENTS;
 use crate::numeric::{Arithmetic, Montgomery};
 use crate::{miller_rabin, rho, table};
 
@@ -98,8 +99,17 @@ impl fmt::Display for Factors {
         v.sort_unstable();
 
         for (p, exp) in v.iter() {
-            for _ in 0..*exp {
-                write!(f, " {p}")?;
+            // Safety
+            //
+            // Using PRINT_EXPONENTS here is safe because it is only ever set to
+            // true in the uumain function, and the uumain function is the only
+            // function that calls this function.
+            if unsafe { PRINT_EXPONENTS } && *exp > 1 {
+                write!(f, " {p}^{exp}")?;
+            } else {
+                for _ in 0..*exp {
+                    write!(f, " {p}")?;
+                }
             }
         }
 

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -9,7 +9,6 @@ use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::fmt;
 
-use crate::exponent_options::PRINT_EXPONENTS;
 use crate::numeric::{Arithmetic, Montgomery};
 use crate::{miller_rabin, rho, table};
 
@@ -98,13 +97,9 @@ impl fmt::Display for Factors {
         let v = &mut (self.0).borrow_mut().0;
         v.sort_unstable();
 
+        let include_exponents = f.alternate();
         for (p, exp) in v.iter() {
-            // Safety
-            //
-            // Using PRINT_EXPONENTS here is safe because it is only ever set to
-            // true in the uumain function, and the uumain function is the only
-            // function that calls this function.
-            if unsafe { PRINT_EXPONENTS } && *exp > 1 {
+            if include_exponents && *exp > 1 {
                 write!(f, " {p}^{exp}")?;
             } else {
                 for _ in 0..*exp {

--- a/tests/benches/factor/Cargo.toml
+++ b/tests/benches/factor/Cargo.toml
@@ -7,6 +7,8 @@ description = "Benchmarks for the uu_factor integer factorization tool"
 homepage = "https://github.com/uutils/coreutils"
 edition = "2021"
 
+[workspace]
+
 [dependencies]
 uu_factor = { path = "../../../src/uu/factor" }
 
@@ -14,7 +16,7 @@ uu_factor = { path = "../../../src/uu/factor" }
 array-init = "2.0.0"
 criterion = "0.3"
 rand = "0.8"
-rand_chacha = "0.2.2"
+rand_chacha = "0.3.1"
 
 [[bench]]
 name = "gcd"

--- a/tests/benches/factor/benches/gcd.rs
+++ b/tests/benches/factor/benches/gcd.rs
@@ -6,7 +6,7 @@ fn gcd(c: &mut Criterion) {
         // Deterministic RNG; use an explicitly-named RNG to guarantee stability
         use rand::{RngCore, SeedableRng};
         use rand_chacha::ChaCha8Rng;
-        const SEED: u64 = 0xa_b4d_1dea_dead_cafe;
+        const SEED: u64 = 0xab4d_1dea_dead_cafe;
         let mut rng = ChaCha8Rng::seed_from_u64(SEED);
 
         std::iter::repeat_with(move || (rng.next_u64(), rng.next_u64()))
@@ -22,7 +22,7 @@ fn gcd(c: &mut Criterion) {
             },
         );
     }
-    group.finish()
+    group.finish();
 }
 
 criterion_group!(benches, gcd);

--- a/tests/benches/factor/benches/table.rs
+++ b/tests/benches/factor/benches/table.rs
@@ -7,12 +7,7 @@ fn table(c: &mut Criterion) {
     check_personality();
 
     const INPUT_SIZE: usize = 128;
-    assert!(
-        INPUT_SIZE % CHUNK_SIZE == 0,
-        "INPUT_SIZE ({}) is not divisible by CHUNK_SIZE ({})",
-        INPUT_SIZE,
-        CHUNK_SIZE
-    );
+
     let inputs = {
         // Deterministic RNG; use an explicitly-named RNG to guarantee stability
         use rand::{RngCore, SeedableRng};
@@ -29,42 +24,40 @@ fn table(c: &mut Criterion) {
         let a_str = format!("{:?}", a);
         group.bench_with_input(BenchmarkId::new("factor_chunk", &a_str), &a, |b, &a| {
             b.iter(|| {
-                let mut n_s = a.clone();
+                let mut n_s = a;
                 let mut f_s: [_; INPUT_SIZE] = array_init(|_| Factors::one());
                 for (n_s, f_s) in n_s.chunks_mut(CHUNK_SIZE).zip(f_s.chunks_mut(CHUNK_SIZE)) {
-                    factor_chunk(n_s.try_into().unwrap(), f_s.try_into().unwrap())
+                    factor_chunk(n_s.try_into().unwrap(), f_s.try_into().unwrap());
                 }
-            })
+            });
         });
         group.bench_with_input(BenchmarkId::new("factor", &a_str), &a, |b, &a| {
             b.iter(|| {
-                let mut n_s = a.clone();
+                let mut n_s = a;
                 let mut f_s: [_; INPUT_SIZE] = array_init(|_| Factors::one());
                 for (n, f) in n_s.iter_mut().zip(f_s.iter_mut()) {
-                    factor(n, f)
+                    factor(n, f);
                 }
-            })
+            });
         });
     }
-    group.finish()
+    group.finish();
 }
 
 #[cfg(target_os = "linux")]
 fn check_personality() {
     use std::fs;
     const ADDR_NO_RANDOMIZE: u64 = 0x0040000;
-    const PERSONALITY_PATH: &'static str = "/proc/self/personality";
+    const PERSONALITY_PATH: &str = "/proc/self/personality";
 
     let p_string = fs::read_to_string(PERSONALITY_PATH)
-        .expect(&format!("Couldn't read '{}'", PERSONALITY_PATH))
-        .strip_suffix("\n")
+        .unwrap_or_else(|_| panic!("Couldn't read '{}'", PERSONALITY_PATH))
+        .strip_suffix('\n')
         .unwrap()
         .to_owned();
 
-    let personality = u64::from_str_radix(&p_string, 16).expect(&format!(
-        "Expected a hex value for personality, got '{:?}'",
-        p_string
-    ));
+    let personality = u64::from_str_radix(&p_string, 16)
+        .unwrap_or_else(|_| panic!("Expected a hex value for personality, got '{:?}'", p_string));
     if personality & ADDR_NO_RANDOMIZE == 0 {
         eprintln!(
             "WARNING: Benchmarking with ASLR enabled (personality is {:x}), results might not be reproducible.",

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -8,19 +8,16 @@
 
 // spell-checker:ignore (methods) hexdigest
 
-use crate::common::util::{AtPath, TestScenario};
+use crate::common::util::TestScenario;
 
 use std::time::{Duration, SystemTime};
 
 #[path = "../../src/uu/factor/sieve.rs"]
 mod sieve;
 
-extern crate conv;
-extern crate rand;
-
-use self::rand::distributions::{Distribution, Uniform};
-use self::rand::{rngs::SmallRng, Rng, SeedableRng};
 use self::sieve::Sieve;
+use rand::distributions::{Distribution, Uniform};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 const NUM_PRIMES: usize = 10000;
 const NUM_TESTS: usize = 100;
@@ -39,6 +36,7 @@ fn test_valid_arg_exponents() {
 #[test]
 #[cfg(feature = "sort")]
 fn test_parallel() {
+    use crate::common::util::AtPath;
     use hex_literal::hex;
     use sha1::{Digest, Sha1};
     use std::{fs::OpenOptions, time::Duration};
@@ -86,7 +84,6 @@ fn test_parallel() {
 
 #[test]
 fn test_first_1000_integers() {
-    extern crate sha1;
     use hex_literal::hex;
     use sha1::{Digest, Sha1};
 
@@ -111,7 +108,6 @@ fn test_first_1000_integers() {
 
 #[test]
 fn test_first_1000_integers_with_exponents() {
-    extern crate sha1;
     use hex_literal::hex;
     use sha1::{Digest, Sha1};
 
@@ -128,7 +124,7 @@ fn test_first_1000_integers_with_exponents() {
         .succeeds();
 
     // Using factor from GNU Coreutils 9.2
-    // `seq 0 1000 | factor | sha1sum` => "45f5f758a9319870770bd1fec2de23d54331944d"
+    // `seq 0 1000 | factor -h | sha1sum` => "45f5f758a9319870770bd1fec2de23d54331944d"
     let mut hasher = Sha1::new();
     hasher.update(result.stdout());
     let hash_check = hasher.finalize();
@@ -151,7 +147,7 @@ fn test_cli_args() {
 
 #[test]
 fn test_random() {
-    use conv::prelude::*;
+    use conv::prelude::ValueFrom;
 
     let log_num_primes = f64::value_from(NUM_PRIMES).unwrap().log2().ceil();
     let primes = Sieve::primes().take(NUM_PRIMES).collect::<Vec<u64>>();

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -31,6 +31,12 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_valid_arg_exponents() {
+    new_ucmd!().arg("-h").succeeds().code_is(0);
+    new_ucmd!().arg("--exponents").succeeds().code_is(0);
+}
+
+#[test]
 #[cfg(feature = "sort")]
 fn test_parallel() {
     use hex_literal::hex;
@@ -103,6 +109,34 @@ fn test_first_1000_integers() {
     );
 }
 
+#[test]
+fn test_first_1000_integers_with_exponents() {
+    extern crate sha1;
+    use hex_literal::hex;
+    use sha1::{Digest, Sha1};
+
+    let n_integers = 1000;
+    let mut input_string = String::new();
+    for i in 0..=n_integers {
+        input_string.push_str(&(format!("{i} "))[..]);
+    }
+
+    println!("STDIN='{input_string}'");
+    let result = new_ucmd!()
+        .arg("-h")
+        .pipe_in(input_string.as_bytes())
+        .succeeds();
+
+    // Using factor from GNU Coreutils 9.2
+    // `seq 0 1000 | factor | sha1sum` => "45f5f758a9319870770bd1fec2de23d54331944d"
+    let mut hasher = Sha1::new();
+    hasher.update(result.stdout());
+    let hash_check = hasher.finalize();
+    assert_eq!(
+        hash_check[..],
+        hex!("45f5f758a9319870770bd1fec2de23d54331944d")
+    );
+}
 #[test]
 fn test_cli_args() {
     // Make sure that factor works with CLI arguments as well.
@@ -280,6 +314,35 @@ fn run(input_string: &[u8], output_string: &[u8]) {
         .pipe_in(input_string)
         .run()
         .stdout_is(String::from_utf8(output_string.to_owned()).unwrap());
+}
+
+#[test]
+fn test_primes_with_exponents() {
+    let mut input_string = String::new();
+    let mut output_string = String::new();
+    for primes in PRIMES_BY_BITS.iter() {
+        for &prime in *primes {
+            input_string.push_str(&(format!("{prime} "))[..]);
+            output_string.push_str(&(format!("{prime}: {prime}\n"))[..]);
+        }
+    }
+
+    println!(
+        "STDIN='{}'",
+        String::from_utf8_lossy(input_string.as_bytes())
+    );
+    println!(
+        "STDOUT(expected)='{}'",
+        String::from_utf8_lossy(output_string.as_bytes())
+    );
+
+    // run factor with --exponents
+    new_ucmd!()
+        .timeout(Duration::from_secs(240))
+        .arg("--exponents")
+        .pipe_in(input_string)
+        .run()
+        .stdout_is(String::from_utf8(output_string.as_bytes().to_owned()).unwrap());
 }
 
 const PRIMES_BY_BITS: &[&[u64]] = &[


### PR DESCRIPTION
This pull request adds support for the -h/--exponents option to the factor function, which was recently introduced in GNU coreutils 9.2. 

With this option, the factors are printed in the form p^e, rather than repeating the prime p, e times.

For example : 
```
$ ./factor -h 3000
3000: 2^3 3 5^3
```

This is implemented with a new module that sets a mutable global variable when the option is provided. The Display implementation for Factors has been updated to use this global variable when printing factors. Tests have been added to cover the new option.

This pull request Fixes #4682 