### PR TITLE
touch: remove unnecessary "extern crate"s

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -7,11 +7,10 @@
 // that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) filetime strptime utcoff strs datetime MMDDhhmm clapv PWSTR lpszfilepath hresult mktime YYYYMMDDHHMM YYMMDDHHMM DATETIME YYYYMMDDHHMMS subsecond
-pub extern crate filetime;
 
 use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgAction, ArgGroup, Command};
-use filetime::*;
+use filetime::{set_symlink_file_times, FileTime};
 use std::ffi::OsString;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
@@ -23,6 +22,7 @@ use uucore::{format_usage, help_about, help_usage, show};
 
 const ABOUT: &str = help_about!("touch.md");
 const USAGE: &str = help_usage!("touch.md");
+
 pub mod options {
     // Both SOURCES and sources are needed as we need to be able to refer to the ArgGroup.
     pub static SOURCES: &str = "sources";

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -6,10 +6,8 @@
 // See https://github.com/time-rs/time/issues/293#issuecomment-946382614=
 // Defined in .cargo/config
 
-extern crate touch;
-use self::touch::filetime::{self, FileTime};
+use filetime::FileTime;
 
-extern crate time;
 use time::macros::format_description;
 
 use crate::common::util::{AtPath, TestScenario};


### PR DESCRIPTION
This PR removes a few "extern crate"s and expands a glob import.