### PR TITLE
tests: remove all "extern crate" statements

### DIFF
--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -4,9 +4,7 @@ use std::fs::{metadata, set_permissions, OpenOptions, Permissions};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::sync::Mutex;
 
-extern crate chmod;
-extern crate libc;
-use self::libc::umask;
+use libc::umask;
 
 static TEST_FILE: &str = "file";
 static REFERENCE_FILE: &str = "reference";

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -4,8 +4,6 @@ use crate::common::util::{is_ci, run_ucmd_as_root, CmdResult, TestScenario};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use rust_users::get_effective_uid;
 
-extern crate chown;
-
 // Apparently some CI environments have configuration issues, e.g. with 'whoami' and 'id'.
 // If we are running inside the CI and "needle" is in "stderr" skipping this test is
 // considered okay. If we are not inside the CI this calls assert!(result.success).
@@ -36,7 +34,7 @@ fn skipping_test_is_okay(result: &CmdResult, needle: &str) -> bool {
 
 #[cfg(test)]
 mod test_passgrp {
-    use super::chown::entries::{gid2grp, grp2gid, uid2usr, usr2uid};
+    use chown::entries::{gid2grp, grp2gid, uid2usr, usr2uid};
 
     #[test]
     fn test_usr2uid() {

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1,7 +1,5 @@
-extern crate regex;
-
-use self::regex::Regex;
 use crate::common::util::TestScenario;
+use regex::Regex;
 #[cfg(all(unix, not(target_os = "macos")))]
 use rust_users::get_effective_uid;
 

--- a/tests/by-util/test_dir.rs
+++ b/tests/by-util/test_dir.rs
@@ -1,11 +1,5 @@
-#[cfg(not(windows))]
-extern crate libc;
-extern crate regex;
-#[cfg(not(windows))]
-extern crate tempfile;
-
-use self::regex::Regex;
 use crate::common::util::TestScenario;
+use regex::Regex;
 
 /*
  * As dir use the same functions than ls, we don't have to retest them here.

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -1,8 +1,7 @@
 // spell-checker:ignore overridable
 use crate::common::util::TestScenario;
 
-extern crate dircolors;
-use self::dircolors::{guess_syntax, OutputFmt, StrUtils};
+use dircolors::{guess_syntax, OutputFmt, StrUtils};
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_hostid.rs
+++ b/tests/by-util/test_hostid.rs
@@ -1,6 +1,5 @@
-use crate::common::util::*;
-extern crate regex;
-use self::regex::Regex;
+use crate::common::util::TestScenario;
+use regex::Regex;
 
 #[test]
 fn test_normal() {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1,17 +1,11 @@
 // spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc
 
-#[cfg(not(windows))]
-extern crate libc;
-extern crate regex;
-#[cfg(not(windows))]
-extern crate tempfile;
-
-use self::regex::Regex;
 #[cfg(feature = "feat_selinux")]
 use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
 #[cfg(all(unix, feature = "chmod"))]
 use nix::unistd::{close, dup};
+use regex::Regex;
 use std::collections::HashMap;
 #[cfg(all(unix, feature = "chmod"))]
 use std::os::unix::io::IntoRawFd;

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -1,10 +1,8 @@
 use crate::common::util::TestScenario;
 #[cfg(not(windows))]
+use libc::{mode_t, umask};
+#[cfg(not(windows))]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(not(windows))]
-extern crate libc;
-#[cfg(not(windows))]
-use self::libc::{mode_t, umask};
 
 static TEST_DIR1: &str = "mkdir_test1";
 static TEST_DIR2: &str = "mkdir_test2";

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1,8 +1,5 @@
-extern crate filetime;
-extern crate time;
-
-use self::filetime::FileTime;
 use crate::common::util::TestScenario;
+use filetime::FileTime;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -4,15 +4,13 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate unindent;
-
-use self::unindent::unindent;
 use crate::common::util::TestScenario;
 use std::env;
 use std::fs::remove_file;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use unindent::unindent;
 
 // octal dump of 'abcdefghijklmnopqrstuvwxyz\n'     // spell-checker:disable-line
 static ALPHA_OUT: &str = "

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -3,14 +3,9 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate uucore;
-
 use crate::common::util::{expected_result, TestScenario};
-
-use self::uucore::entries::{Locate, Passwd};
-
-extern crate pinky;
-pub use self::pinky::*;
+use pinky::Capitalize;
+use uucore::entries::{Locate, Passwd};
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1,5 +1,4 @@
 // spell-checker:ignore (ToDO) Sdivide
-extern crate time;
 
 use crate::common::util::{TestScenario, UCommand};
 use std::fs::metadata;

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -3,13 +3,10 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 // spell-checker:ignore xzaaa sixhundredfiftyonebytes ninetyonebytes threebytes asciilowercase fghij klmno pqrst uvwxyz fivelines twohundredfortyonebytes onehundredlines nbbbb
-extern crate rand;
-extern crate regex;
 
-use self::rand::{thread_rng, Rng};
-use self::regex::Regex;
 use crate::common::util::{AtPath, TestScenario};
-use rand::SeedableRng;
+use rand::{thread_rng, Rng, SeedableRng};
+use regex::Regex;
 #[cfg(not(windows))]
 use std::env;
 use std::path::Path;

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -3,8 +3,6 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-extern crate regex;
-
 use crate::common::util::{expected_result, TestScenario};
 
 #[test]

--- a/tests/by-util/test_sync.rs
+++ b/tests/by-util/test_sync.rs
@@ -1,5 +1,4 @@
 use crate::common::util::TestScenario;
-extern crate tempfile;
 use std::fs;
 use tempfile::tempdir;
 

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -7,8 +7,6 @@
 // spell-checker:ignore (libs) kqueue
 // spell-checker:ignore (jargon) tailable untailable datasame runneradmin tmpi
 
-extern crate tail;
-
 use crate::common::random::{AlphanumericNewline, RandomString};
 #[cfg(unix)]
 use crate::common::util::expected_result;

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -1,6 +1,5 @@
-extern crate regex;
-use self::regex::Regex;
 use crate::common::util::TestScenario;
+use regex::Regex;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_vdir.rs
+++ b/tests/by-util/test_vdir.rs
@@ -1,11 +1,5 @@
-#[cfg(not(windows))]
-extern crate libc;
-extern crate regex;
-#[cfg(not(windows))]
-extern crate tempfile;
-
-use self::regex::Regex;
 use crate::common::util::TestScenario;
+use regex::Regex;
 
 /*
  * As vdir use the same functions than ls, we don't have to retest them here.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,9 +1,6 @@
 #[macro_use]
 mod common;
 
-#[cfg(unix)]
-extern crate rust_users;
-
 #[cfg(feature = "arch")]
 #[path = "by-util/test_arch.rs"]
 mod test_arch;


### PR DESCRIPTION
The final PR to clean up unnecessary "extern crate" statements.