### PR TITLE
B2sum: add -l/--length option

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -71,7 +71,7 @@ fn detect_algo(
                     crash!(1, "Invalid length (maximum digest length is 512 bits)")
                 }
 
-                // --length=0 falls back to default behaviour
+                // --length=0 falls back to default behavior
                 if *length_in_bits == 0 {
                     return ("BLAKE2", Box::new(Blake2b::new()) as Box<dyn Digest>, 512);
                 }
@@ -88,7 +88,7 @@ fn detect_algo(
                     crash!(1, "Invalid length (expected a multiple of 8)")
                 }
             }
-            // by default, blake2 uses 64bytes (512 bits)
+            // by default, blake2 uses 64 bytes (512 bits)
             None => ("BLAKE2", Box::new(Blake2b::new()) as Box<dyn Digest>, 512),
         },
         "b3sum" => ("BLAKE3", Box::new(Blake3::new()) as Box<dyn Digest>, 256),

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -66,14 +66,12 @@ fn detect_algo(
         "sha384sum" => ("SHA384", Box::new(Sha384::new()) as Box<dyn Digest>, 384),
         "sha512sum" => ("SHA512", Box::new(Sha512::new()) as Box<dyn Digest>, 512),
         "b2sum" => match matches.get_one::<usize>("length") {
+            // by default, blake2 uses 64 bytes (512 bits)
+            // --length=0 falls back to default behavior
+            Some(0) | None => ("BLAKE2", Box::new(Blake2b::new()) as Box<dyn Digest>, 512),
             Some(length_in_bits) => {
                 if *length_in_bits > 512 {
                     crash!(1, "Invalid length (maximum digest length is 512 bits)")
-                }
-
-                // --length=0 falls back to default behavior
-                if *length_in_bits == 0 {
-                    return ("BLAKE2", Box::new(Blake2b::new()) as Box<dyn Digest>, 512);
                 }
 
                 // blake2 output size must be a multiple of 8 bits
@@ -88,8 +86,6 @@ fn detect_algo(
                     crash!(1, "Invalid length (expected a multiple of 8)")
                 }
             }
-            // by default, blake2 uses 64 bytes (512 bits)
-            None => ("BLAKE2", Box::new(Blake2b::new()) as Box<dyn Digest>, 512),
         },
         "b3sum" => ("BLAKE3", Box::new(Blake3::new()) as Box<dyn Digest>, 256),
         "sha3sum" => match matches.get_one::<usize>("bits") {

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -126,6 +126,23 @@ fn test_check_sha1() {
 }
 
 #[test]
+fn test_check_b2sum_length_option() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("testf", "foobar\n");
+    at.write("testf.b2sum", "6a  testf\n");
+
+    scene
+        .ccmd("b2sum")
+        .arg("--length=8")
+        .arg("-c")
+        .arg(at.subdir.join("testf.b2sum"))
+        .succeeds()
+        .stdout_only("testf: OK\n");
+}
+
+#[test]
 fn test_check_file_not_found_warning() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -126,7 +126,24 @@ fn test_check_sha1() {
 }
 
 #[test]
-fn test_check_b2sum_length_option() {
+fn test_check_b2sum_length_option_0() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("testf", "foobar\n");
+    at.write("testf.b2sum", "9e2bf63e933e610efee4a8d6cd4a9387e80860edee97e27db3b37a828d226ab1eb92a9cdd8ca9ca67a753edaf8bd89a0558496f67a30af6f766943839acf0110  testf\n");
+
+    scene
+        .ccmd("b2sum")
+        .arg("--length=0")
+        .arg("-c")
+        .arg(at.subdir.join("testf.b2sum"))
+        .succeeds()
+        .stdout_only("testf: OK\n");
+}
+
+#[test]
+fn test_check_b2sum_length_option_8() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
@@ -140,6 +157,36 @@ fn test_check_b2sum_length_option() {
         .arg(at.subdir.join("testf.b2sum"))
         .succeeds()
         .stdout_only("testf: OK\n");
+}
+
+#[test]
+fn test_invalid_b2sum_length_option_not_multiple_of_8() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("testf", "foobar\n");
+
+    scene
+        .ccmd("b2sum")
+        .arg("--length=9")
+        .arg(at.subdir.join("testf"))
+        .fails()
+        .code_is(1);
+}
+
+#[test]
+fn test_invalid_b2sum_length_option_too_large() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("testf", "foobar\n");
+
+    scene
+        .ccmd("b2sum")
+        .arg("--length=513")
+        .arg(at.subdir.join("testf"))
+        .fails()
+        .code_is(1);
 }
 
 #[test]


### PR DESCRIPTION
# Summary
This pull request adds support for the -l/--length option to b2sum (hashsum).
B2sum supports variable output size if 
- length is a multiple of 8 bits
- length is less or equal than 512

## Related Issue
#4610 

## Remarks
This is my first attempt to contribute to this project, so I may have missed something. (same goes for naming conventions) !

I added a new function to allow creating a Blake2d instance with custom output size (`with_output_bytes`). I updated the reset function to use this new function instead of calling ::new().
Eventually, the Blake2d tuple has now a new parameter to keep track of the custom size. 

I had to create a new parsing step `uu_app_opt_length` that behaves more or less like `uu_app_opt_bits` but cannot share the same code due to different text / names.

## Tests
I added a simple test with the --length option enabled. I took example of the sha1 tests in the very same file.

related test:  `bash util/run-gnu-test.sh   tests/misc/b2sum-bsd.sh ` (-l flags)
Unfortunately, I only have Windows for now and I couldn't run the linux tests.
