### PR TITLE
ci: Fix usages of rust-cache to produce more cache hits

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -48,6 +48,11 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
+    - name: Install `rust` toolchain
+      run: |
+        rustup toolchain install nightly --no-self-update --profile minimal
+        rustup default nightly
+    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -67,10 +72,6 @@ jobs:
         outputs CARGO_FEATURES_OPTION
     ## note: requires 'nightly' toolchain b/c `cargo-udeps` uses the `rustc` '-Z save-analysis' option
     ## * ... ref: <https://github.com/est31/cargo-udeps/issues/73>
-    - name: Install `rust` toolchain
-      run: |
-        rustup toolchain install nightly --no-self-update --profile minimal
-        rustup default nightly
     - name: Install `cargo-udeps`
       run: cargo install cargo-udeps
       env:
@@ -97,6 +98,12 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
+    - name: Install `rust` toolchain
+      run: |
+        ## Install `rust` toolchain
+        rustup toolchain install stable --no-self-update -c rustfmt --profile minimal
+        rustup default stable
+    - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -114,11 +121,6 @@ jobs:
         CARGO_FEATURES_OPTION='' ;
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
         outputs CARGO_FEATURES_OPTION
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update -c rustfmt --profile minimal
-        rustup default stable
     - name: "`cargo fmt` testing"
       shell: bash
       run: |
@@ -137,13 +139,13 @@ jobs:
       RUN_FOR: 60
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
     - name: Install `rust` toolchain
       run: |
         rustup toolchain install nightly --no-self-update --profile minimal
         rustup default nightly
     - name: Install `cargo-fuzz`
       run: cargo install cargo-fuzz
+    - uses: Swatinem/rust-cache@v2
     - name: Run fuzz_date for XX seconds
       shell: bash
       run: |
@@ -184,6 +186,11 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
+    - name: Install `rust` toolchain
+      run: |
+        ## Install `rust` toolchain
+        rustup toolchain install stable --no-self-update -c clippy --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -216,11 +223,6 @@ jobs:
         case '${{ matrix.job.os }}' in
           macos-latest) brew install coreutils ;; # needed for show-utils.sh
         esac
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update -c clippy --profile minimal
-        rustup default stable
     - name: "`cargo clippy` lint testing"
       shell: bash
       run: |
@@ -295,6 +297,11 @@ jobs:
 #          - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
+    - name: Install `rust` toolchain
+      run: |
+        ## Install `rust` toolchain
+        rustup toolchain install stable --no-self-update -c clippy --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -320,11 +327,6 @@ jobs:
         echo UTILITY_LIST=${UTILITY_LIST}
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo -n "-puu_${u} "; done;)"
         outputs CARGO_UTILITY_LIST_OPTIONS
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update -c clippy --profile minimal
-        rustup default stable
     - name: "`cargo doc` with warnings"
       shell: bash
       run: |
@@ -349,6 +351,11 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
+    - name: Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
+      run: |
+        ## Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
+        rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} --profile minimal
+        rustup default ${{ env.RUST_MIN_SRV }}
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -363,11 +370,6 @@ jobs:
         unset CARGO_FEATURES_OPTION
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
         outputs CARGO_FEATURES_OPTION
-    - name: Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
-      run: |
-        ## Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
-        rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} --profile minimal
-        rustup default ${{ env.RUST_MIN_SRV }}
     - name: Confirm MinSRV compatible 'Cargo.lock'
       shell: bash
       run: |
@@ -422,6 +424,7 @@ jobs:
         ## Install `rust` toolchain
         rustup toolchain install stable --no-self-update --profile minimal
         rustup default stable
+    - uses: Swatinem/rust-cache@v2
     - name: "`cargo update` testing"
       shell: bash
       run: |
@@ -443,14 +446,14 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
     - name: Install `rust` toolchain
       run: |
         ## Install `rust` toolchain
         rustup toolchain install stable --no-self-update --profile minimal
         rustup default stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
     - name: "`make build`"
       shell: bash
       run: |
@@ -489,14 +492,14 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
     - name: Install `rust` toolchain
       run: |
         ## Install `rust` toolchain
         rustup toolchain install stable --no-self-update --profile minimal
         rustup default stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
     - name: Test
       run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
       env:
@@ -519,14 +522,14 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
     - name: Install `rust` toolchain
       run: |
         ## Install `rust` toolchain
         rustup toolchain install nightly --no-self-update --profile minimal
         rustup default nightly
+    - uses: Swatinem/rust-cache@v2
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
     - name: Test
       run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
       env:
@@ -546,6 +549,11 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
+    - name: Install `rust` toolchain
+      run: |
+        ## Install `rust` toolchain
+        rustup toolchain install stable --no-self-update --profile minimal
+        rustup default stable
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -555,11 +563,6 @@ jobs:
         ## Install dependencies
         sudo apt-get update
         sudo apt-get install jq
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update --profile minimal
-        rustup default stable
     - name: "`make install`"
       shell: bash
       run: |
@@ -615,7 +618,14 @@ jobs:
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
+    - name: rust toolchain ~ install
+      run: |
+        ## rust toolchain ~ install
+        rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} -t ${{ matrix.job.target }} --profile minimal
+        rustup default ${{ env.RUST_MIN_SRV }}
     - uses: Swatinem/rust-cache@v2
+      with:
+        key: "${{ matrix.job.os }}_${{ matrix.job.target }}"
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
     - name: Initialize workflow variables
@@ -740,11 +750,6 @@ jobs:
             echo "foo" > /home/runner/.plan
             ;;
         esac
-    - name: rust toolchain ~ install
-      run: |
-        ## rust toolchain ~ install
-        rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} -t ${{ matrix.job.target }} --profile minimal
-        rustup default ${{ env.RUST_MIN_SRV }}
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars
       shell: bash
@@ -950,14 +955,14 @@ jobs:
         TEST_SUMMARY_FILE="toybox-result.json"
         outputs TEST_SUMMARY_FILE
     - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
     - name: rust toolchain ~ install
       run: |
         ## rust toolchain ~ install
         rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} --profile minimal
         rustup default ${{ env.RUST_MIN_SRV }}
+    - uses: Swatinem/rust-cache@v2
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
     - name: Build coreutils as multiple binaries
       shell: bash
       run: |
@@ -1028,11 +1033,16 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: unix }
-          - { os: macos-latest   , features: macos }
-          - { os: windows-latest , features: windows }
+          - { os: ubuntu-latest  , features: unix, toolchain: nightly }
+          - { os: macos-latest   , features: macos, toolchain: nightly }
+          - { os: windows-latest , features: windows, toolchain: nightly-x86_64-pc-windows-gnu }
     steps:
     - uses: actions/checkout@v3
+    - name: rust toolchain ~ install
+      run: |
+        ## rust toolchain ~ install
+        rustup toolchain install ${{ matrix.job.toolchain }} --no-self-update --profile minimal
+        rustup default ${{ matrix.job.toolchain }}
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -1084,11 +1094,6 @@ jobs:
             echo "foo" > /home/runner/.plan
             ;;
         esac
-    - name: rust toolchain ~ install
-      run: |
-        ## rust toolchain ~ install
-        rustup toolchain install ${{ steps.vars.outputs.TOOLCHAIN }} --no-self-update --profile minimal
-        rustup default ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars
       shell: bash

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -1,8 +1,8 @@
 name: GnuTests
 
-# spell-checker:ignore (abbrev/names) CodeCov gnulib GnuTests
+# spell-checker:ignore (abbrev/names) CodeCov gnulib GnuTests Swatinem
 # spell-checker:ignore (jargon) submodules
-# spell-checker:ignore (libs/utils) autopoint chksum gperf lcov libexpect pyinotify shopt texinfo valgrind
+# spell-checker:ignore (libs/utils) autopoint chksum gperf lcov libexpect pyinotify shopt texinfo valgrind libattr libcap
 # spell-checker:ignore (options) Ccodegen Coverflow Cpanic Zpanic
 # spell-checker:ignore (people) Dawid Dziurla * dawidd
 # spell-checker:ignore (vars) FILESET SUBDIRS XPASS
@@ -58,6 +58,13 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: '${{ steps.vars.outputs.path_UUTILS }}'
+    - name: Install `rust` toolchain
+      run: |
+        ## Install `rust` toolchain
+        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
+        rustup toolchain install stable -c rustfmt --profile minimal
+        rustup default stable
+    - uses: Swatinem/rust-cache@v2
     - name: Checkout code (GNU coreutils)
       uses: actions/checkout@v3
       with:
@@ -75,12 +82,6 @@ jobs:
         # workflow_conclusion: success ## (default); * but, if commit with failed GnuTests is merged into the default branch, future commits will all show regression errors in GnuTests CI until o/w fixed
         workflow_conclusion: completed ## continually recalibrates to last commit of default branch with a successful GnuTests (ie, "self-heals" from GnuTest regressions, but needs more supervision for/of regressions)
         path: "${{ steps.vars.outputs.path_reference }}"
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
-        rustup toolchain install stable -c rustfmt --profile minimal
-        rustup default stable
     - name: Install dependencies
       shell: bash
       run: |
@@ -322,6 +323,7 @@ jobs:
         rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
         rustup toolchain install nightly -c rustfmt --profile minimal
         rustup default nightly
+    - uses: Swatinem/rust-cache@v2
     - name: Install dependencies
       run: |
         ## Install dependencies


### PR DESCRIPTION
This fix places steps which influence the cache key of `Swatinem/rust-cache` before this `Swatinem/rust-cache` step to produce more cache hits and eventually speed up ci runs.

Note this pr also adds the `Swatinem/rust-cache` step to some jobs which haven't used caching, yet.

Closes #4741