### PR TITLE
fix: seq panic on no arguments #4749

### DIFF
--- a/src/uu/seq/src/error.rs
+++ b/src/uu/seq/src/error.rs
@@ -2,7 +2,7 @@
 //  *
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
-// spell-checker:ignore numberparse argtype
+// spell-checker:ignore numberparse
 //! Errors returned by seq.
 use std::error::Error;
 use std::fmt::Display;
@@ -30,29 +30,6 @@ pub enum SeqError {
     NoArguments,
 }
 
-impl SeqError {
-    /// The [`String`] argument as read from the command-line.
-    fn arg(&self) -> &str {
-        match self {
-            Self::ParseError(s, _) => s,
-            Self::ZeroIncrement(s) => s,
-            Self::NoArguments => "",
-        }
-    }
-
-    /// The type of argument that is causing the error.
-    fn argtype(&self) -> &str {
-        match self {
-            Self::ParseError(_, e) => match e {
-                ParseNumberError::Float => "invalid floating point argument: ",
-                ParseNumberError::Nan => "invalid 'not-a-number' argument: ",
-                ParseNumberError::Hex => "invalid hexadecimal argument: ",
-            },
-            Self::ZeroIncrement(_) => "invalid Zero increment value: ",
-            Self::NoArguments => "missing operand",
-        }
-    }
-}
 impl UError for SeqError {
     /// Always return 1.
     fn code(&self) -> i32 {
@@ -68,15 +45,17 @@ impl Error for SeqError {}
 
 impl Display for SeqError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}{}",
-            self.argtype(),
-            if self.arg() == "" {
-                String::new()
-            } else {
-                self.arg().quote().to_string()
+        match self {
+            Self::ParseError(s, e) => {
+                let error_type = match e {
+                    ParseNumberError::Float => "floating point",
+                    ParseNumberError::Nan => "'not-a-number'",
+                    ParseNumberError::Hex => "hexadecimal",
+                };
+                write!(f, "invalid {error_type} argument: {}", s.quote())
             }
-        )
+            Self::ZeroIncrement(s) => write!(f, "invalid Zero increment value: {}", s.quote()),
+            Self::NoArguments => write!(f, "missing operand"),
+        }
     }
 }

--- a/src/uu/seq/src/error.rs
+++ b/src/uu/seq/src/error.rs
@@ -72,10 +72,10 @@ impl Display for SeqError {
             f,
             "{}{}",
             self.argtype(),
-            if self.arg() != "" {
-                self.arg().quote().to_string()
+            if self.arg() == "" {
+                String::new()
             } else {
-                "".to_string()
+                self.arg().quote().to_string()
             }
         )
     }

--- a/src/uu/seq/src/error.rs
+++ b/src/uu/seq/src/error.rs
@@ -25,6 +25,9 @@ pub enum SeqError {
     /// The parameter is the increment argument as a [`String`] as read
     /// from the command line.
     ZeroIncrement(String),
+
+    /// No arguments were passed to this function, 1 or more is required
+    NoArguments,
 }
 
 impl SeqError {
@@ -33,6 +36,7 @@ impl SeqError {
         match self {
             Self::ParseError(s, _) => s,
             Self::ZeroIncrement(s) => s,
+            Self::NoArguments => "",
         }
     }
 
@@ -40,11 +44,12 @@ impl SeqError {
     fn argtype(&self) -> &str {
         match self {
             Self::ParseError(_, e) => match e {
-                ParseNumberError::Float => "floating point argument",
-                ParseNumberError::Nan => "'not-a-number' argument",
-                ParseNumberError::Hex => "hexadecimal argument",
+                ParseNumberError::Float => "invalid floating point argument: ",
+                ParseNumberError::Nan => "invalid 'not-a-number' argument: ",
+                ParseNumberError::Hex => "invalid hexadecimal argument: ",
             },
-            Self::ZeroIncrement(_) => "Zero increment value",
+            Self::ZeroIncrement(_) => "invalid Zero increment value: ",
+            Self::NoArguments => "missing operand",
         }
     }
 }
@@ -63,6 +68,15 @@ impl Error for SeqError {}
 
 impl Display for SeqError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid {}: {}", self.argtype(), self.arg().quote())
+        write!(
+            f,
+            "{}{}",
+            self.argtype(),
+            if self.arg() != "" {
+                self.arg().quote().to_string()
+            } else {
+                "".to_string()
+            }
+        )
     }
 }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -58,10 +58,13 @@ type RangeFloat = (ExtendedBigDecimal, ExtendedBigDecimal, ExtendedBigDecimal);
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
-    let numbers = matches
-        .get_many::<String>(ARG_NUMBERS)
-        .unwrap()
-        .collect::<Vec<_>>();
+    let numbers_option = matches.get_many::<String>(ARG_NUMBERS);
+
+    if numbers_option.is_none() {
+        return Err(SeqError::NoArguments.into());
+    }
+
+    let numbers = numbers_option.unwrap().collect::<Vec<_>>();
 
     let options = SeqOptions {
         separator: matches

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -8,6 +8,14 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_no_args() {
+    new_ucmd!()
+        .fails()
+        .code_is(1)
+        .stderr_contains("missing operand");
+}
+
+#[test]
 fn test_hex_rejects_sign_after_identifier() {
     new_ucmd!()
         .args(&["0x-123ABC"])


### PR DESCRIPTION
This is in reference to issue #4749, where just running `seq` ends up panicking. I have added a new `NoArguments` error, and refactored the display formatting, in order to match GNU messages.