### PR TITLE
`tail`: Refactor `paths::Input::from` and `Settings::inputs`

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -12,7 +12,6 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use fundu::DurationParser;
 use is_terminal::IsTerminal;
 use same_file::Handle;
-use std::collections::VecDeque;
 use std::ffi::OsString;
 use std::time::Duration;
 use uucore::error::{UResult, USimpleError, UUsageError};
@@ -141,7 +140,8 @@ pub struct Settings {
     pub use_polling: bool,
     pub verbose: bool,
     pub presume_input_pipe: bool,
-    pub inputs: VecDeque<Input>,
+    /// `FILE(s)` positional arguments
+    pub inputs: Vec<Input>,
 }
 
 impl Default for Settings {
@@ -173,11 +173,11 @@ impl Settings {
         }
         settings.mode = FilterMode::from_obsolete_args(args);
         let input = if let Some(name) = name {
-            Input::from(&name)
+            Input::from(name)
         } else {
             Input::default()
         };
-        settings.inputs.push_back(input);
+        settings.inputs.push(input);
         settings
     }
 
@@ -282,19 +282,13 @@ impl Settings {
             }
         }
 
-        let mut inputs: VecDeque<Input> = matches
-            .get_many::<String>(options::ARG_FILES)
-            .map(|v| v.map(|string| Input::from(&string)).collect())
-            .unwrap_or_default();
+        settings.inputs = matches
+            .get_raw(options::ARG_FILES)
+            .map(|v| v.map(Input::from).collect())
+            .unwrap_or_else(|| vec![Input::default()]);
 
-        // apply default and add '-' to inputs if none is present
-        if inputs.is_empty() {
-            inputs.push_front(Input::default());
-        }
-
-        settings.verbose = inputs.len() > 1 && !matches.get_flag(options::verbosity::QUIET);
-
-        settings.inputs = inputs;
+        settings.verbose =
+            settings.inputs.len() > 1 && !matches.get_flag(options::verbosity::QUIET);
 
         Ok(settings)
     }

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -7,7 +7,7 @@
 
 use crate::paths::Input;
 use crate::{parse, platform, Quotable};
-use clap::crate_version;
+use clap::{crate_version, value_parser};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use fundu::DurationParser;
 use is_terminal::IsTerminal;
@@ -283,7 +283,7 @@ impl Settings {
         }
 
         settings.inputs = matches
-            .get_raw(options::ARG_FILES)
+            .get_many::<OsString>(options::ARG_FILES)
             .map(|v| v.map(Input::from).collect())
             .unwrap_or_else(|| vec![Input::default()]);
 
@@ -584,6 +584,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::ARG_FILES)
                 .action(ArgAction::Append)
                 .num_args(1..)
+                .value_parser(value_parser!(OsString))
                 .value_hint(clap::ValueHint::FilePath),
         )
 }

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -10,7 +10,6 @@ use crate::follow::files::{FileHandling, PathData};
 use crate::paths::{Input, InputKind, MetadataExtTail, PathExtTail};
 use crate::{platform, text};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher, WatcherKind};
-use std::collections::VecDeque;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, channel, Receiver};
@@ -270,7 +269,7 @@ impl Observer {
         self.follow_name() && self.retry
     }
 
-    fn init_files(&mut self, inputs: &VecDeque<Input>) -> UResult<()> {
+    fn init_files(&mut self, inputs: &Vec<Input>) -> UResult<()> {
         if let Some(watcher_rx) = &mut self.watcher_rx {
             for input in inputs {
                 match input.kind() {

--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -27,20 +27,21 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn from<T: AsRef<OsStr>>(string: &T) -> Self {
-        let kind = if string.as_ref() == Path::new(text::DASH) {
+    pub fn from<T: AsRef<OsStr>>(string: T) -> Self {
+        let string = string.as_ref();
+        let kind = if string == OsStr::new(text::DASH) {
             InputKind::Stdin
         } else {
-            InputKind::File(PathBuf::from(string.as_ref()))
+            InputKind::File(PathBuf::from(string))
         };
 
         let display_name = match kind {
-            InputKind::File(_) => string.as_ref().to_string_lossy().to_string(),
+            InputKind::File(_) => string.to_string_lossy().to_string(),
             InputKind::Stdin => {
                 if cfg!(unix) {
                     text::STDIN_HEADER.to_string()
                 } else {
-                    string.as_ref().to_string_lossy().to_string()
+                    string.to_string_lossy().to_string()
                 }
             }
         };

--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -10,10 +10,7 @@ use std::ffi::OsStr;
 use std::fs::{File, Metadata};
 use std::io::{Seek, SeekFrom};
 #[cfg(unix)]
-use std::os::unix::{
-    fs::{FileTypeExt, MetadataExt},
-    prelude::OsStrExt,
-};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 use uucore::error::UResult;
 
@@ -26,9 +23,7 @@ pub enum InputKind {
 #[cfg(unix)]
 impl From<&OsStr> for InputKind {
     fn from(value: &OsStr) -> Self {
-        const DASH: [u8; 1] = [b'-'];
-
-        if value.as_bytes() == DASH {
+        if value == OsStr::new("-") {
             Self::Stdin
         } else {
             Self::File(PathBuf::from(value))

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -145,12 +145,8 @@ fn test_stdin_redirect_offset() {
 }
 
 #[test]
-#[cfg(all(not(target_vendor = "apple"), not(target_os = "windows")))] // FIXME: for currently not working platforms
+#[cfg(all(not(target_vendor = "apple")))] // FIXME: for currently not working platforms
 fn test_stdin_redirect_offset2() {
-    // FIXME: windows: Failed because of difference in printed header. See below.
-    // actual  : ==> - <==
-    // expected: ==> standard input <==
-
     // like test_stdin_redirect_offset but with multiple files
 
     let ts = TestScenario::new(util_name!());


### PR DESCRIPTION
This pr refactors mainly the `Input::from` method and changes inputs in `Settings` from a `VecDeque` to a `Vec`.

There is no need for `Settings::inputs` being a `VecDeque` anymore and `Vec` is a little bit more efficient. In `Input::from`, unpacking `AsRef<OsString>` with `.as_ref()` just once is also a bit more efficient. Same with the comparison of `OsStr` with another `OsStr` instead of `Path`. Parsing the input arguments to a `String` and then back to an `OsStr` is unnecessary, since we can get the inputs raw as `OsStr` from clap to pass them to `Input::from`.

Note this pr also includes a small fix. When file headers are printed in verbose mode, the output for stdin should be equal on all platforms: `==> standard input <==`. Before this change the output for non unix systems was `==> - <==`.