### PR TITLE
test,wc: use vars directly in format! strings

### DIFF
--- a/src/uu/test/src/error.rs
+++ b/src/uu/test/src/error.rs
@@ -16,12 +16,12 @@ pub type ParseResult<T> = Result<T, ParseError>;
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Expected(s) => write!(f, "expected {}", s),
+            Self::Expected(s) => write!(f, "expected {s}"),
             Self::ExpectedValue => write!(f, "expected value"),
-            Self::MissingArgument(s) => write!(f, "missing argument after {}", s),
-            Self::ExtraArgument(s) => write!(f, "extra argument {}", s),
-            Self::UnknownOperator(s) => write!(f, "unknown operator {}", s),
-            Self::InvalidInteger(s) => write!(f, "invalid integer {}", s),
+            Self::MissingArgument(s) => write!(f, "missing argument after {s}"),
+            Self::ExtraArgument(s) => write!(f, "extra argument {s}"),
+            Self::UnknownOperator(s) => write!(f, "unknown operator {s}"),
+            Self::InvalidInteger(s) => write!(f, "invalid integer {s}"),
         }
     }
 }

--- a/src/uu/wc/src/utf8/read.rs
+++ b/src/uu/wc/src/utf8/read.rs
@@ -28,9 +28,9 @@ impl<'a> fmt::Display for BufReadDecoderError<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             BufReadDecoderError::InvalidByteSequence(bytes) => {
-                write!(f, "invalid byte sequence: {:02x?}", bytes)
+                write!(f, "invalid byte sequence: {bytes:02x?}")
             }
-            BufReadDecoderError::Io(ref err) => write!(f, "underlying bytestream error: {}", err),
+            BufReadDecoderError::Io(ref err) => write!(f, "underlying bytestream error: {err}"),
         }
     }
 }


### PR DESCRIPTION
This PR fixes warnings from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lint (clippy::pedantic).