### PR TITLE
`ci/gnu tests`: fix Swatinem/rust-cache to use correct workspace

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -65,6 +65,8 @@ jobs:
         rustup toolchain install stable -c rustfmt --profile minimal
         rustup default stable
     - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: "./${{ steps.vars.outputs.path_UUTILS }} -> target"
     - name: Checkout code (GNU coreutils)
       uses: actions/checkout@v3
       with:
@@ -324,6 +326,8 @@ jobs:
         rustup toolchain install nightly -c rustfmt --profile minimal
         rustup default nightly
     - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: "./uutils -> target"
     - name: Install dependencies
       run: |
         ## Install dependencies


### PR DESCRIPTION
This pr fixes the location of the coreutils workspace in the `Swatinem/rust-cache` action, so it can cache the correct target directoy in all jobs of the gnu tests workflow.