### PR TITLE
fix #4767: `chown -v 0 nf` isn't showing a message 

### DIFF
--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -10,7 +10,7 @@
 use uucore::display::Quotable;
 pub use uucore::entries;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::perms::{chown_base, options, IfFrom};
+use uucore::perms::{chown_base, options, GidUidOwnerFilter, IfFrom};
 use uucore::{format_usage, help_about, help_usage};
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
@@ -21,7 +21,7 @@ use std::os::unix::fs::MetadataExt;
 static ABOUT: &str = help_about!("chgrp.md");
 const USAGE: &str = help_usage!("chgrp.md");
 
-fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>, String, IfFrom)> {
+fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<GidUidOwnerFilter> {
     let mut raw_group: String = String::new();
     let dest_gid = if let Some(file) = matches.get_one::<String>(options::REFERENCE) {
         fs::metadata(file)
@@ -51,7 +51,12 @@ fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<(Option<u32>, Option<u32>,
             }
         }
     };
-    Ok((dest_gid, None, raw_group, IfFrom::All))
+    Ok(GidUidOwnerFilter {
+        dest_gid,
+        dest_uid: None,
+        raw_owner: raw_group,
+        filter: IfFrom::All,
+    })
 }
 
 #[uucore::main]

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -9,7 +9,7 @@
 
 use uucore::display::Quotable;
 pub use uucore::entries::{self, Group, Locate, Passwd};
-use uucore::perms::{chown_base, options, IfFrom};
+use uucore::perms::{chown_base, options, GidUidOwnerFilter, IfFrom};
 use uucore::{format_usage, help_about, help_usage};
 
 use uucore::error::{FromIo, UResult, USimpleError};
@@ -23,9 +23,7 @@ static ABOUT: &str = help_about!("chown.md");
 
 const USAGE: &str = help_usage!("chown.md");
 
-fn parse_gid_uid_and_filter(
-    matches: &ArgMatches,
-) -> UResult<(Option<u32>, Option<u32>, String, IfFrom)> {
+fn parse_gid_uid_and_filter(matches: &ArgMatches) -> UResult<GidUidOwnerFilter> {
     let filter = if let Some(spec) = matches.get_one::<String>(options::FROM) {
         match parse_spec(spec, ':')? {
             (Some(uid), None) => IfFrom::User(uid),
@@ -61,7 +59,12 @@ fn parse_gid_uid_and_filter(
         dest_uid = u;
         dest_gid = g;
     }
-    Ok((dest_gid, dest_uid, raw_owner, filter))
+    Ok(GidUidOwnerFilter {
+        dest_gid,
+        dest_uid,
+        raw_owner,
+        filter,
+    })
 }
 
 #[uucore::main]

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -422,7 +422,13 @@ pub mod options {
     pub const ARG_FILES: &str = "FILE";
 }
 
-type GidUidFilterParser = fn(&ArgMatches) -> UResult<(Option<u32>, Option<u32>, String, IfFrom)>;
+pub struct GidUidOwnerFilter {
+    pub dest_gid: Option<u32>,
+    pub dest_uid: Option<u32>,
+    pub raw_owner: String,
+    pub filter: IfFrom,
+}
+type GidUidFilterOwnerParser = fn(&ArgMatches) -> UResult<GidUidOwnerFilter>;
 
 /// Base implementation for `chgrp` and `chown`.
 ///
@@ -435,7 +441,7 @@ pub fn chown_base(
     mut command: Command,
     args: impl crate::Args,
     add_arg_if_not_reference: &'static str,
-    parse_gid_uid_and_filter: GidUidFilterParser,
+    parse_gid_uid_and_filter: GidUidFilterOwnerParser,
     groups_only: bool,
 ) -> UResult<()> {
     let args: Vec<_> = args.collect();
@@ -518,7 +524,12 @@ pub fn chown_base(
     } else {
         VerbosityLevel::Normal
     };
-    let (dest_gid, dest_uid, raw_owner, filter) = parse_gid_uid_and_filter(&matches)?;
+    let GidUidOwnerFilter {
+        dest_gid,
+        dest_uid,
+        raw_owner,
+        filter,
+    } = parse_gid_uid_and_filter(&matches)?;
 
     let executor = ChownExecutor {
         traverse_symlinks,

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -182,6 +182,7 @@ pub enum TraverseSymlinks {
 pub struct ChownExecutor {
     pub dest_uid: Option<u32>,
     pub dest_gid: Option<u32>,
+    pub raw_owner: String, // The owner of the file as input by the user in the command line.
     pub traverse_symlinks: TraverseSymlinks,
     pub verbosity: Verbosity,
     pub filter: IfFrom,
@@ -207,7 +208,16 @@ impl ChownExecutor {
         let path = root.as_ref();
         let meta = match self.obtain_meta(path, self.dereference) {
             Some(m) => m,
-            _ => return 1,
+            _ => {
+                if self.verbosity.level == VerbosityLevel::Verbose {
+                    println!(
+                        "failed to change ownership of {} to {}",
+                        path.quote(),
+                        self.raw_owner
+                    );
+                }
+                return 1;
+            }
         };
 
         // Prohibit only if:
@@ -412,7 +422,7 @@ pub mod options {
     pub const ARG_FILES: &str = "FILE";
 }
 
-type GidUidFilterParser = fn(&ArgMatches) -> UResult<(Option<u32>, Option<u32>, IfFrom)>;
+type GidUidFilterParser = fn(&ArgMatches) -> UResult<(Option<u32>, Option<u32>, String, IfFrom)>;
 
 /// Base implementation for `chgrp` and `chown`.
 ///
@@ -508,12 +518,13 @@ pub fn chown_base(
     } else {
         VerbosityLevel::Normal
     };
-    let (dest_gid, dest_uid, filter) = parse_gid_uid_and_filter(&matches)?;
+    let (dest_gid, dest_uid, raw_owner, filter) = parse_gid_uid_and_filter(&matches)?;
 
     let executor = ChownExecutor {
         traverse_symlinks,
         dest_gid,
         dest_uid,
+        raw_owner,
         verbosity: Verbosity {
             groups_only,
             level: verbosity_level,

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -735,11 +735,10 @@ fn test_chown_file_notexisting() {
         .arg(&user_name)
         .arg("--verbose")
         .arg("not_existing")
-        .fails();
-
-    result.stdout_contains(format!(
-        "failed to change ownership of 'not_existing' to {user_name}"
-    ));
+        .fails()
+        .stdout_contains(format!(
+            "failed to change ownership of 'not_existing' to {user_name}"
+        ));
     // TODO: uncomment once message changed from "cannot dereference" to "cannot access"
     // result.stderr_contains("cannot access 'not_existing': No such file or directory");
 }

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -730,15 +730,16 @@ fn test_chown_file_notexisting() {
     let user_name = String::from(result.stdout_str().trim());
     assert!(!user_name.is_empty());
 
-    let _result = scene
+    let result = scene
         .ucmd()
-        .arg(user_name)
+        .arg(&user_name)
         .arg("--verbose")
         .arg("not_existing")
         .fails();
 
-    // TODO: uncomment once "failed to change ownership of '{}' to {}" added to stdout
-    // result.stderr_contains("retained as");
+    result.stdout_contains(format!(
+        "failed to change ownership of 'not_existing' to {user_name}"
+    ));
     // TODO: uncomment once message changed from "cannot dereference" to "cannot access"
     // result.stderr_contains("cannot access 'not_existing': No such file or directory");
 }

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -730,7 +730,7 @@ fn test_chown_file_notexisting() {
     let user_name = String::from(result.stdout_str().trim());
     assert!(!user_name.is_empty());
 
-    let result = scene
+    scene
         .ucmd()
         .arg(&user_name)
         .arg("--verbose")


### PR DESCRIPTION

This PR modify `chown` to print a message to stdout when the file doesn't exist.
It's a fix for #4767 .

The following cases are implemented:
```
chown -v 0 nf 2> /dev/null
failed to change ownership of 'nf' to 0

$ chown -v user nf
failed to change ownership of 'nf' to user

$ chown -v user:group nf
failed to change ownership of 'nf' to user:group

$ touch f
$ chown -v --reference=f nf
failed to change ownership of 'nf' to user:group
```

To access the owner as specified by the user in the command, I had to modify the signature of the tuple returns by `parse_gid_uid_and_filter` and add a field in the struct `ChownExecutor`.

Note: the first part of the GNU tests/chown/basic is expected to fail (_ownership of 'f' retained as root_) but the rest is not.