### PR TITLE
touch: improve support for dangling link

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -209,14 +209,24 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
         }
 
-        if matches.get_flag(options::NO_DEREF) {
-            set_symlink_file_times(path, atime, mtime)
-        } else {
+        // sets the file access and modification times for a file or a symbolic link.
+        // The filename, access time (atime), and modification time (mtime) are provided as inputs.
+
+        // If the filename is not "-", indicating a special case for touch -h -,
+        // the code checks if the NO_DEREF flag is set, which means the user wants to
+        // set the times for a symbolic link itself, rather than the file it points to.
+        if filename == "-" {
             filetime::set_file_times(path, atime, mtime)
+        } else {
+            let should_set_symlink_times = matches.get_flag(options::NO_DEREF);
+            if should_set_symlink_times {
+                set_symlink_file_times(path, atime, mtime)
+            } else {
+                filetime::set_file_times(path, atime, mtime)
+            }
         }
         .map_err_context(|| format!("setting times of {}", path.quote()))?;
     }
-
     Ok(())
 }
 

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -816,3 +816,12 @@ fn test_touch_trailing_slash_no_create() {
     at.relative_symlink_dir("dir2", "link2");
     ucmd.args(&["-c", "link2/"]).succeeds();
 }
+
+#[test]
+fn test_touch_no_dereference_ref_dangling() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("file");
+    at.relative_symlink_file("nowhere", "dangling");
+
+    ucmd.args(&["-h", "-r", "dangling", "file"]).succeeds();
+}

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -833,3 +833,10 @@ fn test_touch_no_dereference_dangling() {
 
     ucmd.args(&["-h", "dangling"]).succeeds();
 }
+
+#[test]
+fn test_touch_dash() {
+    let (_, mut ucmd) = at_and_ucmd!();
+
+    ucmd.args(&["-h", "-"]).succeeds().no_stderr().no_stdout();
+}

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -825,3 +825,11 @@ fn test_touch_no_dereference_ref_dangling() {
 
     ucmd.args(&["-h", "-r", "dangling", "file"]).succeeds();
 }
+
+#[test]
+fn test_touch_no_dereference_dangling() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.relative_symlink_file("nowhere", "dangling");
+
+    ucmd.args(&["-h", "dangling"]).succeeds();
+}

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -67,7 +67,7 @@ if test -f gnu-built; then
     echo "'rm -f $(pwd)/gnu-built' to force the build"
     echo "Note: the customization of the tests will still happen"
 else
-    ./bootstrap
+    ./bootstrap --skip-po
     ./configure --quiet --disable-gcc-warnings
     #Add timeout to to protect against hangs
     sed -i 's|^"\$@|/usr/bin/timeout 600 "\$@|' build-aux/test-driver


### PR DESCRIPTION
Basically fixing:
```
ln -s nowhere dangling
touch -h -r dangling file
touch -h dangling
touch -h -
```
For:
tests/touch/no-dereference.sh
