### PR TITLE
readlink: move help strings to markdown file

### DIFF
--- a/src/uu/readlink/readlink.md
+++ b/src/uu/readlink/readlink.md
@@ -1,0 +1,7 @@
+# readlink
+
+```
+readlink [OPTION]... [FILE]... 
+```
+
+Print value of a symbolic link or canonical file name.

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
-use uucore::{format_usage, show_error, help_about, help_usage};
+use uucore::{format_usage, help_about, help_usage, show_error};
 
 const ABOUT: &str = help_about!("readlink.md");
 const USAGE: &str = help_usage!("readlink.md");

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -99,7 +99,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
-        .override_help(format_usage(USAGE))
+        .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .arg(
             Arg::new(OPT_CANONICALIZE)

--- a/src/uu/readlink/src/readlink.rs
+++ b/src/uu/readlink/src/readlink.rs
@@ -14,10 +14,10 @@ use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::fs::{canonicalize, MissingHandling, ResolveMode};
-use uucore::{format_usage, show_error};
+use uucore::{format_usage, show_error, help_about, help_usage};
 
-const ABOUT: &str = "Print value of a symbolic link or canonical file name.";
-const USAGE: &str = "{} [OPTION]... [FILE]...";
+const ABOUT: &str = help_about!("readlink.md");
+const USAGE: &str = help_usage!("readlink.md");
 const OPT_CANONICALIZE: &str = "canonicalize";
 const OPT_CANONICALIZE_MISSING: &str = "canonicalize-missing";
 const OPT_CANONICALIZE_EXISTING: &str = "canonicalize-existing";


### PR DESCRIPTION
issue: #4368 

This PR contains bellow contents.

- Move help strings to markdown file e82ba6e7073fa1ff0cd3c42005cb4cecf70f075b
- Use override_usage method instead of override_help method b84a94b8895137819f5eda95db74dc16febba69c

`readlink --help` outputs follow.

**before**

```
$ ./target/debug/readlink --help
./target/debug/readlink [OPTION]... [FILE]...
```

**after**

```
$ ./target/debugreadlink --help
Print value of a symbolic link or canonical file name.

Usage: ./target/debug/readlink [OPTION]... [FILE]...

Arguments:
  [files]...

Options:
  -f, --canonicalize           canonicalize by following every symlink in every component of the given name recursively; all but the last component must exist
  -e, --canonicalize-existing  canonicalize by following every symlink in every component of the given name recursively, all components must exist
  -m, --canonicalize-missing   canonicalize by following every symlink in every component of the given name recursively, without requirements on components existence
  -n, --no-newline             do not output the trailing delimiter
  -q, --quiet                  suppress most error messages
  -s, --silent                 suppress most error messages
  -v, --verbose                report error message
  -z, --zero                   separate output with NUL rather than newline
  -h, --help                   Print help
  -V, --version                Print version
```
