### PR TITLE
`ci`: Improve and speed up setup steps using github actions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -396,7 +396,6 @@ jobs:
       env:
         RUSTFLAGS: "-Awarnings"
         RUST_BACKTRACE: "1"
-        CARGO_TERM_COLOR: always
 
   deps:
     name: Dependencies
@@ -445,7 +444,6 @@ jobs:
       run: make nextest CARGOFLAGS="--profile ci --hide-progress-bar"
       env:
         RUST_BACKTRACE: "1"
-        CARGO_TERM_COLOR: "always"
     - name: "`make install`"
       shell: bash
       run: |
@@ -483,7 +481,6 @@ jobs:
       run: cargo nextest run --hide-progress-bar --profile ci ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
       env:
         RUST_BACKTRACE: "1"
-        CARGO_TERM_COLOR: "always"
 
   build_rust_nightly:
     name: Build/nightly
@@ -511,7 +508,6 @@ jobs:
       run: cargo nextest run --hide-progress-bar --profile ci ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
       env:
         RUST_BACKTRACE: "1"
-        CARGO_TERM_COLOR: "always"
 
   compute_size:
     name: Binary sizes
@@ -1138,7 +1134,6 @@ jobs:
     - name: Test uucore
       run: cargo nextest run --profile ci --hide-progress-bar -p uucore
       env:
-        CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
@@ -1147,7 +1142,6 @@ jobs:
     - name: Test
       run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
       env:
-        CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
@@ -1156,7 +1150,6 @@ jobs:
     - name: Test individual utilities
       run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
       env:
-        CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -3,7 +3,7 @@ name: CICD
 # spell-checker:ignore (abbrev/names) CICD CodeCOV MacOS MinGW MSVC musl taiki
 # spell-checker:ignore (env/flags) Awarnings Ccodegen Coverflow Cpanic Dwarnings RUSTDOCFLAGS RUSTFLAGS Zpanic CARGOFLAGS
 # spell-checker:ignore (jargon) SHAs deps dequote softprops subshell toolchain fuzzers
-# spell-checker:ignore (people) Peltoche rivy
+# spell-checker:ignore (people) Peltoche rivy dtolnay
 # spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot fdesc fdescfs gmake grcov halium lcov libssl mkdir popd printf pushd rsync rustc rustfmt rustup shopt utmpdump xargs
 # spell-checker:ignore (misc) aarch alnum armhf bindir busytest coreutils defconfig DESTDIR gecos gnueabihf issuecomment maint multisize nullglob onexitbegin onexitend pell runtest Swatinem tempfile testsuite toybox uutils
 
@@ -48,10 +48,7 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        rustup toolchain install nightly --no-self-update --profile minimal
-        rustup default nightly
+    - uses: dtolnay/rust-toolchain@nightly
     ## note: requires 'nightly' toolchain b/c `cargo-udeps` uses the `rustc` '-Z save-analysis' option
     ## * ... ref: <https://github.com/est31/cargo-udeps/issues/73>
     - uses: taiki-e/install-action@cargo-udeps
@@ -95,11 +92,10 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update -c rustfmt --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
@@ -136,10 +132,7 @@ jobs:
       RUN_FOR: 60
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        rustup toolchain install nightly --no-self-update --profile minimal
-        rustup default nightly
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Install `cargo-fuzz`
       run: cargo install cargo-fuzz
     - uses: Swatinem/rust-cache@v2
@@ -183,11 +176,10 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update -c clippy --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: clippy
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -294,11 +286,10 @@ jobs:
 #          - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update -c clippy --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: clippy
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -348,11 +339,10 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
-      run: |
-        ## Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
-        rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} --profile minimal
-        rustup default ${{ env.RUST_MIN_SRV }}
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_MIN_SRV }}
+        components: rustfmt
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
@@ -418,11 +408,7 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: "`cargo update` testing"
       shell: bash
@@ -445,11 +431,7 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
@@ -492,11 +474,7 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
@@ -524,11 +502,7 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install nightly --no-self-update --profile minimal
-        rustup default nightly
+    - uses: dtolnay/rust-toolchain@nightly
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
@@ -553,11 +527,7 @@ jobs:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v3
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rustup toolchain install stable --no-self-update --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -677,11 +647,10 @@ jobs:
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
     steps:
     - uses: actions/checkout@v3
-    - name: rust toolchain ~ install
-      run: |
-        ## rust toolchain ~ install
-        rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} -t ${{ matrix.job.target }} --profile minimal
-        rustup default ${{ env.RUST_MIN_SRV }}
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_MIN_SRV }}
+        targets: ${{ matrix.job.target }}
     - uses: Swatinem/rust-cache@v2
       with:
         key: "${{ matrix.job.os }}_${{ matrix.job.target }}"
@@ -762,7 +731,7 @@ jobs:
         outputs CARGO_CMD
         # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
         if [ "${CARGO_CMD}" = 'cross' ] && [ ! -e "Cross.toml" ] ; then
-          printf "[build.env]\npassthrough = [\"CI\", \"RUST_BACKTRACE\"]\n" > Cross.toml
+          printf "[build.env]\npassthrough = [\"CI\", \"RUST_BACKTRACE\", \"CARGO_TERM_COLOR\"]\n" > Cross.toml
         fi
         # * test only library and/or binaries for arm-type targets
         unset CARGO_TEST_OPTIONS ; case '${{ matrix.job.target }}' in aarch64-* | arm-*) CARGO_TEST_OPTIONS="--bins" ;; esac;
@@ -778,7 +747,7 @@ jobs:
     - uses: taiki-e/install-action@v2
       if: steps.vars.outputs.CARGO_CMD == 'cross'
       with:
-        tool: cross@v0.2.1
+        tool: cross@0.2.1
     - name: Create all needed build/work directories
       shell: bash
       run: |
@@ -1017,11 +986,10 @@ jobs:
         TEST_SUMMARY_FILE="toybox-result.json"
         outputs TEST_SUMMARY_FILE
     - uses: actions/checkout@v3
-    - name: rust toolchain ~ install
-      run: |
-        ## rust toolchain ~ install
-        rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} --profile minimal
-        rustup default ${{ env.RUST_MIN_SRV }}
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_MIN_SRV }}
+        components: rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -1100,11 +1068,10 @@ jobs:
           - { os: windows-latest , features: windows, toolchain: nightly-x86_64-pc-windows-gnu }
     steps:
     - uses: actions/checkout@v3
-    - name: rust toolchain ~ install
-      run: |
-        ## rust toolchain ~ install
-        rustup toolchain install ${{ matrix.job.toolchain }} --no-self-update --profile minimal
-        rustup default ${{ matrix.job.toolchain }}
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.job.toolchain }}
+        components: rustfmt
     - uses: taiki-e/install-action@nextest
     - uses: taiki-e/install-action@grcov
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -52,6 +52,9 @@ jobs:
       run: |
         rustup toolchain install nightly --no-self-update --profile minimal
         rustup default nightly
+    ## note: requires 'nightly' toolchain b/c `cargo-udeps` uses the `rustc` '-Z save-analysis' option
+    ## * ... ref: <https://github.com/est31/cargo-udeps/issues/73>
+    - uses: taiki-e/install-action@cargo-udeps
     - uses: Swatinem/rust-cache@v2
     - name: Initialize workflow variables
       id: vars
@@ -70,12 +73,6 @@ jobs:
         CARGO_FEATURES_OPTION='' ;
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
         outputs CARGO_FEATURES_OPTION
-    ## note: requires 'nightly' toolchain b/c `cargo-udeps` uses the `rustc` '-Z save-analysis' option
-    ## * ... ref: <https://github.com/est31/cargo-udeps/issues/73>
-    - name: Install `cargo-udeps`
-      run: cargo install cargo-udeps
-      env:
-        RUSTUP_TOOLCHAIN: stable
     - name: Detect unused dependencies
       shell: bash
       run: |
@@ -356,8 +353,8 @@ jobs:
         ## Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
         rustup toolchain install --no-self-update ${{ env.RUST_MIN_SRV }} --profile minimal
         rustup default ${{ env.RUST_MIN_SRV }}
-    - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@nextest
+    - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
     - name: Initialize workflow variables
@@ -765,7 +762,6 @@ jobs:
         outputs CARGO_CMD
         # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
         if [ "${CARGO_CMD}" = 'cross' ] && [ ! -e "Cross.toml" ] ; then
-          cargo install --version 0.2.1 cross
           printf "[build.env]\npassthrough = [\"CI\", \"RUST_BACKTRACE\"]\n" > Cross.toml
         fi
         # * test only library and/or binaries for arm-type targets
@@ -779,6 +775,10 @@ jobs:
           *-pc-windows-msvc) STRIP="" ;;
         esac;
         outputs STRIP
+    - uses: taiki-e/install-action@v2
+      if: steps.vars.outputs.CARGO_CMD == 'cross'
+      with:
+        tool: cross@v0.2.1
     - name: Create all needed build/work directories
       shell: bash
       run: |
@@ -1106,6 +1106,7 @@ jobs:
         rustup toolchain install ${{ matrix.job.toolchain }} --no-self-update --profile minimal
         rustup default ${{ matrix.job.toolchain }}
     - uses: taiki-e/install-action@nextest
+    - uses: taiki-e/install-action@grcov
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
@@ -1194,9 +1195,6 @@ jobs:
         RUSTDOCFLAGS: "-Cpanic=abort"
         RUST_BACKTRACE: "1"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
-    - name: "`grcov` ~ install"
-      id: build_grcov
-      run: cargo install grcov
     - name: Generate coverage data (via `grcov`)
       id: coverage
       shell: bash

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -1,6 +1,6 @@
 name: FixPR
 
-# spell-checker:ignore Swatinem
+# spell-checker:ignore Swatinem dtolnay
 
 # Trigger automated fixes for PRs being merged (with associated commits)
 
@@ -36,11 +36,7 @@ jobs:
         # surface MSRV from CICD workflow
         RUST_MIN_SRV=$(grep -P "^\s+RUST_MIN_SRV:" .github/workflows/CICD.yml | grep -Po "(?<=\x22)\d+[.]\d+(?:[.]\d+)?(?=\x22)" )
         outputs RUST_MIN_SRV
-    - name: Install `rust` toolchain (v${{ steps.vars.outputs.RUST_MIN_SRV }})
-      run: |
-        ## Install `rust` toolchain (v${{ steps.vars.outputs.RUST_MIN_SRV }})
-        rustup toolchain install ${{ steps.vars.outputs.RUST_MIN_SRV }} --profile minimal
-        rustup default ${{ steps.vars.outputs.RUST_MIN_SRV }}
+    - uses: dtolnay/rust-toolchain@${{ steps.vars.outputs.RUST_MIN_SRV }}
     - uses: Swatinem/rust-cache@v2
     - name: Ensure updated 'Cargo.lock'
       shell: bash
@@ -101,12 +97,10 @@ jobs:
         CARGO_FEATURES_OPTION='' ;
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
         outputs CARGO_FEATURES_OPTION
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
-        rustup toolchain install stable -c rustfmt --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: "`cargo fmt`"
       shell: bash

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -2,7 +2,7 @@ name: GnuTests
 
 # spell-checker:ignore (abbrev/names) CodeCov gnulib GnuTests Swatinem
 # spell-checker:ignore (jargon) submodules
-# spell-checker:ignore (libs/utils) autopoint chksum gperf lcov libexpect pyinotify shopt texinfo valgrind libattr libcap
+# spell-checker:ignore (libs/utils) autopoint chksum gperf lcov libexpect pyinotify shopt texinfo valgrind libattr libcap taiki-e
 # spell-checker:ignore (options) Ccodegen Coverflow Cpanic Zpanic
 # spell-checker:ignore (people) Dawid Dziurla * dawidd
 # spell-checker:ignore (vars) FILESET SUBDIRS XPASS
@@ -323,6 +323,7 @@ jobs:
         rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
         rustup toolchain install nightly -c rustfmt --profile minimal
         rustup default nightly
+    - uses: taiki-e/install-action@grcov
     - uses: Swatinem/rust-cache@v2
     - name: Install dependencies
       run: |
@@ -353,8 +354,6 @@ jobs:
         UU_MAKE_PROFILE=debug bash util/build-gnu.sh
     - name: Run GNU tests
       run: bash uutils/util/run-gnu-test.sh
-    - name: "`grcov` ~ install"
-      run: cargo install grcov
     - name: Generate coverage data (via `grcov`)
       id: coverage
       run: |

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -341,7 +341,6 @@ jobs:
         locale -a
     - name: Build binaries
       env:
-        CARGO_INCREMENTAL: "0"
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
       run: |

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -4,7 +4,7 @@ name: GnuTests
 # spell-checker:ignore (jargon) submodules
 # spell-checker:ignore (libs/utils) autopoint chksum gperf lcov libexpect pyinotify shopt texinfo valgrind libattr libcap taiki-e
 # spell-checker:ignore (options) Ccodegen Coverflow Cpanic Zpanic
-# spell-checker:ignore (people) Dawid Dziurla * dawidd
+# spell-checker:ignore (people) Dawid Dziurla * dawidd dtolnay
 # spell-checker:ignore (vars) FILESET SUBDIRS XPASS
 
 # * note: to run a single test => `REPO/util/run-gnu-test.sh PATH/TO/TEST/SCRIPT`
@@ -58,12 +58,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: '${{ steps.vars.outputs.path_UUTILS }}'
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
-        rustup toolchain install stable -c rustfmt --profile minimal
-        rustup default stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: Checkout code (GNU coreutils)
       uses: actions/checkout@v3
@@ -317,12 +315,10 @@ jobs:
         path: 'gnu'
         ref: 'v9.3'
         submodules: recursive
-    - name: Install `rust` toolchain
-      run: |
-        ## Install `rust` toolchain
-        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
-        rustup toolchain install nightly -c rustfmt --profile minimal
-        rustup default nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly
+        components: rustfmt
     - uses: taiki-e/install-action@grcov
     - uses: Swatinem/rust-cache@v2
     - name: Install dependencies


### PR DESCRIPTION
This pr speeds up installation of cargo tools in the ci by installing pre-built binaries with `taiki-e/install-action` where possible instead of building them from source with `cargo install`.

Setting up the rust toolchain with `dtolnay/rust-toolchain` simplifies and shortens the installation of the rust toolchain. This action is just used to outsource this setup step, so we don't have to care about it.

Some explicitly set environment variables which are already set by github actions are removed.