### PR TITLE
runcon: move help strings to markdown file

### DIFF
--- a/src/uu/runcon/runcon.md
+++ b/src/uu/runcon/runcon.md
@@ -1,0 +1,18 @@
+# runcon
+
+```
+runcon [CONTEXT COMMAND [ARG...]]
+runcon [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]";
+```
+
+Run command with specified security context.
+
+## After Help
+
+Run COMMAND with completely-specified CONTEXT, or with current or transitioned security context modified by one or more of LEVEL, ROLE, TYPE, and USER.
+
+If none of --compute, --type, --user, --role or --range is specified, then the first argument is used as the complete context.
+
+Note that only carefully-chosen contexts are likely to successfully run.
+
+With neither CONTEXT nor COMMAND are specified, then this prints the current security context.

--- a/src/uu/runcon/runcon.md
+++ b/src/uu/runcon/runcon.md
@@ -5,7 +5,7 @@ runcon [CONTEXT COMMAND [ARG...]]
 runcon [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]";
 ```
 
-Run command with specified security context.
+Run command with specified security context under SELinux enabled systems.
 
 ## After Help
 

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -5,7 +5,7 @@ use uucore::error::{UResult, UUsageError};
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use selinux::{OpaqueSecurityContext, SecurityClass, SecurityContext};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage, help_section};
 
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
@@ -18,18 +18,9 @@ mod errors;
 use errors::error_exit_status;
 use errors::{Error, Result, RunconError};
 
-const ABOUT: &str = "Run command with specified security context.";
-const USAGE: &str = "\
-    {} [CONTEXT COMMAND [ARG...]]
-    {} [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]";
-const DESCRIPTION: &str = "Run COMMAND with completely-specified CONTEXT, or with current or \
-                      transitioned security context modified by one or more of \
-                      LEVEL, ROLE, TYPE, and USER.\n\n\
-                      If none of --compute, --type, --user, --role or --range is specified, \
-                      then the first argument is used as the complete context.\n\n\
-                      Note that only carefully-chosen contexts are likely to successfully run.\n\n\
-                      With neither CONTEXT nor COMMAND are specified, \
-                      then this prints the current security context.";
+const ABOUT: &str = help_about!("runcon.md");
+const USAGE: &str = help_usage!("runcon.md");
+const DESCRIPTION: &str = help_section!("after help", "runcon.md");
 
 pub mod options {
     pub const COMPUTE: &str = "compute";

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -5,7 +5,7 @@ use uucore::error::{UResult, UUsageError};
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use selinux::{OpaqueSecurityContext, SecurityClass, SecurityContext};
-use uucore::{format_usage, help_about, help_usage, help_section};
+use uucore::{format_usage, help_about, help_section, help_usage};
 
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};


### PR DESCRIPTION
`runcon --help` outputs follow.

```
$ ./target/debug/runcon --help
Run command with specified security context.

Usage: ./target/debug/runcon [CONTEXT COMMAND [ARG...]]
       ./target/debug/runcon [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]";

Arguments:
  [ARG]...  

Options:
  -c, --compute        Compute process transition context before modifying.
  -u, --user <USER>    Set user USER in the target security context.
  -r, --role <ROLE>    Set role ROLE in the target security context.
  -t, --type <TYPE>    Set type TYPE in the target security context.
  -l, --range <RANGE>  Set range RANGE in the target security context.
  -h, --help           Print help
  -V, --version        Print version

Run COMMAND with completely-specified CONTEXT, or with current or transitioned security context modified by one or more
of LEVEL, ROLE, TYPE, and USER.

If none of --compute, --type, --user, --role or --range is specified, then the first argument is used as the complete
context.

Note that only carefully-chosen contexts are likely to successfully run.

With neither CONTEXT nor COMMAND are specified, then this prints the current security context.
```