### PR TITLE
Add flush after calculating factor

### DIFF
--- a/src/uu/factor/src/cli.rs
+++ b/src/uu/factor/src/cli.rs
@@ -52,6 +52,7 @@ fn print_factors_str(
                 writeln!(factors_buffer, "{}:{}", x, factor(x))?;
             }
             w.write_all(factors_buffer.as_bytes())?;
+            w.flush()?;
             Ok(())
         })
 }


### PR DESCRIPTION
When running factor without an argument, results are never printed. In that case, the stdout writer is never flushed since it's flushed at the end of the handling. I added a flush after a write to the buffer, and now it works as expected.