### PR TITLE
'tail': Change static global variables to const

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -24,22 +24,22 @@ const USAGE: &str = help_usage!("tail.md");
 
 pub mod options {
     pub mod verbosity {
-        pub static QUIET: &str = "quiet";
-        pub static VERBOSE: &str = "verbose";
+        pub const QUIET: &str = "quiet";
+        pub const VERBOSE: &str = "verbose";
     }
-    pub static BYTES: &str = "bytes";
-    pub static FOLLOW: &str = "follow";
-    pub static LINES: &str = "lines";
-    pub static PID: &str = "pid";
-    pub static SLEEP_INT: &str = "sleep-interval";
-    pub static ZERO_TERM: &str = "zero-terminated";
-    pub static DISABLE_INOTIFY_TERM: &str = "-disable-inotify"; // NOTE: three hyphens is correct
-    pub static USE_POLLING: &str = "use-polling";
-    pub static RETRY: &str = "retry";
-    pub static FOLLOW_RETRY: &str = "F";
-    pub static MAX_UNCHANGED_STATS: &str = "max-unchanged-stats";
-    pub static ARG_FILES: &str = "files";
-    pub static PRESUME_INPUT_PIPE: &str = "-presume-input-pipe"; // NOTE: three hyphens is correct
+    pub const BYTES: &str = "bytes";
+    pub const FOLLOW: &str = "follow";
+    pub const LINES: &str = "lines";
+    pub const PID: &str = "pid";
+    pub const SLEEP_INT: &str = "sleep-interval";
+    pub const ZERO_TERM: &str = "zero-terminated";
+    pub const DISABLE_INOTIFY_TERM: &str = "-disable-inotify"; // NOTE: three hyphens is correct
+    pub const USE_POLLING: &str = "use-polling";
+    pub const RETRY: &str = "retry";
+    pub const FOLLOW_RETRY: &str = "F";
+    pub const MAX_UNCHANGED_STATS: &str = "max-unchanged-stats";
+    pub const ARG_FILES: &str = "files";
+    pub const PRESUME_INPUT_PIPE: &str = "-presume-input-pipe"; // NOTE: three hyphens is correct
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -470,12 +470,11 @@ pub fn parse_args(args: impl uucore::Args) -> UResult<Settings> {
 
 pub fn uu_app() -> Command {
     #[cfg(target_os = "linux")]
-    pub static POLLING_HELP: &str = "Disable 'inotify' support and use polling instead";
+    const POLLING_HELP: &str = "Disable 'inotify' support and use polling instead";
     #[cfg(all(unix, not(target_os = "linux")))]
-    pub static POLLING_HELP: &str = "Disable 'kqueue' support and use polling instead";
+    const POLLING_HELP: &str = "Disable 'kqueue' support and use polling instead";
     #[cfg(target_os = "windows")]
-    pub static POLLING_HELP: &str =
-        "Disable 'ReadDirectoryChanges' support and use polling instead";
+    const POLLING_HELP: &str = "Disable 'ReadDirectoryChanges' support and use polling instead";
 
     Command::new(uucore::util_name())
         .version(crate_version!())

--- a/src/uu/tail/src/text.rs
+++ b/src/uu/tail/src/text.rs
@@ -5,20 +5,20 @@
 
 // spell-checker:ignore (ToDO) kqueue
 
-pub static DASH: &str = "-";
-pub static DEV_STDIN: &str = "/dev/stdin";
-pub static STDIN_HEADER: &str = "standard input";
-pub static NO_FILES_REMAINING: &str = "no files remaining";
-pub static NO_SUCH_FILE: &str = "No such file or directory";
-pub static BECOME_INACCESSIBLE: &str = "has become inaccessible";
-pub static BAD_FD: &str = "Bad file descriptor";
+pub const DASH: &str = "-";
+pub const DEV_STDIN: &str = "/dev/stdin";
+pub const STDIN_HEADER: &str = "standard input";
+pub const NO_FILES_REMAINING: &str = "no files remaining";
+pub const NO_SUCH_FILE: &str = "No such file or directory";
+pub const BECOME_INACCESSIBLE: &str = "has become inaccessible";
+pub const BAD_FD: &str = "Bad file descriptor";
 #[cfg(target_os = "linux")]
-pub static BACKEND: &str = "inotify";
+pub const BACKEND: &str = "inotify";
 #[cfg(all(unix, not(target_os = "linux")))]
-pub static BACKEND: &str = "kqueue";
+pub const BACKEND: &str = "kqueue";
 #[cfg(target_os = "windows")]
-pub static BACKEND: &str = "ReadDirectoryChanges";
-pub static FD0: &str = "/dev/fd/0";
-pub static IS_A_DIRECTORY: &str = "Is a directory";
-pub static DEV_TTY: &str = "/dev/tty";
-pub static DEV_PTMX: &str = "/dev/ptmx";
+pub const BACKEND: &str = "ReadDirectoryChanges";
+pub const FD0: &str = "/dev/fd/0";
+pub const IS_A_DIRECTORY: &str = "Is a directory";
+pub const DEV_TTY: &str = "/dev/tty";
+pub const DEV_PTMX: &str = "/dev/ptmx";

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -36,15 +36,15 @@ use tail::chunks::BUFFER_SIZE as CHUNK_BUFFER_SIZE;
 ))]
 use tail::text;
 
-static FOOBAR_TXT: &str = "foobar.txt";
-static FOOBAR_2_TXT: &str = "foobar2.txt";
-static FOOBAR_WITH_NULL_TXT: &str = "foobar_with_null.txt";
+const FOOBAR_TXT: &str = "foobar.txt";
+const FOOBAR_2_TXT: &str = "foobar2.txt";
+const FOOBAR_WITH_NULL_TXT: &str = "foobar_with_null.txt";
 #[allow(dead_code)]
-static FOLLOW_NAME_TXT: &str = "follow_name.txt";
+const FOLLOW_NAME_TXT: &str = "follow_name.txt";
 #[allow(dead_code)]
-static FOLLOW_NAME_SHORT_EXP: &str = "follow_name_short.expected";
+const FOLLOW_NAME_SHORT_EXP: &str = "follow_name_short.expected";
 #[allow(dead_code)]
-static FOLLOW_NAME_EXP: &str = "follow_name.expected";
+const FOLLOW_NAME_EXP: &str = "follow_name.expected";
 
 #[cfg(not(windows))]
 const DEFAULT_SLEEP_INTERVAL_MILLIS: u64 = 1000;


### PR DESCRIPTION
Like discussed in #4756 this pr changes usages of `static` global variables to `const` in `tail` and `test_tail`.