### PR TITLE
seq: move help strings to markdown file

### DIFF
--- a/src/uu/seq/seq.md
+++ b/src/uu/seq/seq.md
@@ -1,0 +1,9 @@
+# seq
+
+Display numbers from FIRST to LAST, in steps of INCREMENT.
+
+```
+seq [OPTION]... LAST
+seq [OPTION]... FIRST LAST
+seq [OPTION]... FIRST INCREMENT LAST";
+```

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -30,12 +30,12 @@ use crate::number::PreciseNumber;
 const ABOUT: &str = help_about!("seq.md");
 const USAGE: &str = help_usage!("seq.md");
 
-static OPT_SEPARATOR: &str = "separator";
-static OPT_TERMINATOR: &str = "terminator";
-static OPT_WIDTHS: &str = "widths";
-static OPT_FORMAT: &str = "format";
+const OPT_SEPARATOR: &str = "separator";
+const OPT_TERMINATOR: &str = "terminator";
+const OPT_WIDTHS: &str = "widths";
+const OPT_FORMAT: &str = "format";
 
-static ARG_NUMBERS: &str = "numbers";
+const ARG_NUMBERS: &str = "numbers";
 
 #[derive(Clone)]
 struct SeqOptions<'a> {

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -2,7 +2,6 @@
 //  *
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
-// TODO: Support -f flag
 // spell-checker:ignore (ToDO) istr chiter argptr ilen extendedbigdecimal extendedbigint numberparse
 use std::io::{stdout, ErrorKind, Write};
 use std::process::exit;

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -12,9 +12,9 @@ use num_traits::Zero;
 
 use uucore::error::FromIo;
 use uucore::error::UResult;
-use uucore::format_usage;
 use uucore::memo::printf;
 use uucore::show;
+use uucore::{format_usage, help_about, help_usage};
 
 mod error;
 mod extendedbigdecimal;
@@ -27,11 +27,9 @@ use crate::extendedbigint::ExtendedBigInt;
 use crate::number::Number;
 use crate::number::PreciseNumber;
 
-static ABOUT: &str = "Display numbers from FIRST to LAST, in steps of INCREMENT.";
-const USAGE: &str = "\
-    {} [OPTION]... LAST
-    {} [OPTION]... FIRST LAST
-    {} [OPTION]... FIRST INCREMENT LAST";
+const ABOUT: &str = help_about!("seq.md");
+const USAGE: &str = help_usage!("seq.md");
+
 static OPT_SEPARATOR: &str = "separator";
 static OPT_TERMINATOR: &str = "terminator";
 static OPT_WIDTHS: &str = "widths";


### PR DESCRIPTION
`seq --help` outputs follow.

```
$ ./target/debug/seq --help
Usage: ./target/debug/seq [OPTION]... LAST
       ./target/debug/seq [OPTION]... FIRST LAST
       ./target/debug/seq [OPTION]... FIRST INCREMENT LAST";

Arguments:
  [numbers]...

Options:
  -s, --separator <separator>    Separator character (defaults to \n)
  -t, --terminator <terminator>  Terminator character (defaults to \n)
  -w, --widths                   Equalize widths of all numbers by padding with zeros
  -f, --format <format>          use printf style floating-point FORMAT
  -h, --help                     Print help
  -V, --version                  Print version
```