### PR TITLE
Fix a warning in upstream code on Rust nightly.

### DIFF
--- a/src/uucore/src/lib/features/entries.rs
+++ b/src/uucore/src/lib/features/entries.rs
@@ -321,7 +321,8 @@ macro_rules! f {
                 } else {
                     // SAFETY: We're holding PW_LOCK.
                     unsafe {
-                        let data = $fnam(CString::new(k).unwrap().as_ptr());
+                        let cstring = CString::new(k).unwrap();
+                        let data = $fnam(cstring.as_ptr());
                         if !data.is_null() {
                             Ok($st::from_raw(ptr::read(data as *const _)))
                         } else {


### PR DESCRIPTION
Rust nightly recently [started] issuing the following warning when compiling coreutils:

[started]: https://github.com/rust-lang/rust/pull/109944

```
warning: getting the inner pointer of a temporary `CString`
   --> src/uucore/src/lib/features/entries.rs:324:67
    |
324 |                         let data = $fnam(CString::new(k).unwrap().as_ptr());
    |                                          ------------------------ ^^^^^^ this pointer will be invalid
    |                                          |
    |                                          this `CString` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
...
340 | f!(getpwnam, getpwuid, uid_t, Passwd);
    | ------------------------------------- in this macro invocation
    |
    = note: pointers do not have a lifetime; when calling `as_ptr` the `CString` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
    = help: for more information, see https://doc.rust-lang.org/reference/destructors.html
    = note: `#[warn(temporary_cstring_as_ptr)]` on by default
    = note: this warning originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
```

There doesn't seem to be an actual problem in this case, as the pointer is only used within the statement.