### PR TITLE
mv: adapt -n behavior to GNU mv 9.3

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -419,7 +419,12 @@ fn rename(
         }
 
         match b.overwrite {
-            OverwriteMode::NoClobber => return Ok(()),
+            OverwriteMode::NoClobber => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("not replacing {}", to.quote()),
+                ));
+            }
             OverwriteMode::Interactive => {
                 if !prompt_yes!("overwrite {}?", to.quote()) {
                     return Err(io::Error::new(io::ErrorKind::Other, ""));

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -232,8 +232,9 @@ fn test_mv_no_clobber() {
     ucmd.arg("-n")
         .arg(file_a)
         .arg(file_b)
-        .succeeds()
-        .no_stderr();
+        .fails()
+        .code_is(1)
+        .stderr_only(format!("mv: not replacing '{file_b}'\n"));
 
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));


### PR DESCRIPTION
This PR adapts the behavior of `-n/--no-clobber` to the new behavior of GNU mv 9.3: it returns an exit code of `1` and shows a "not replacing" message if the target already exists.