### PR TITLE
split: move help strings to markdown file

### DIFF
--- a/src/uu/split/split.md
+++ b/src/uu/split/split.md
@@ -1,3 +1,5 @@
+<!-- spell-checker:ignore PREFI -->
+
 # split
 
 ```

--- a/src/uu/split/split.md
+++ b/src/uu/split/split.md
@@ -1,0 +1,11 @@
+# split
+
+```
+split [OPTION]... [INPUT [PREFIX]]
+```
+
+Create output files containing consecutive or interleaved sections of input
+
+## After Help
+
+Output fixed-size pieces of INPUT to PREFIXaa, PREFIXab, ...; default size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is -, read standard input.

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -5,7 +5,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) PREFIXaa PREFIXab nbbbb ncccc
+// spell-checker:ignore nbbbb ncccc
 
 mod filenames;
 mod number;

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -23,7 +23,7 @@ use std::io::{stdin, BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UIoError, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage, help_section};
 use uucore::parse_size::{parse_size, ParseSizeError};
 use uucore::uio_error;
 
@@ -47,11 +47,9 @@ static OPT_ELIDE_EMPTY_FILES: &str = "elide-empty-files";
 static ARG_INPUT: &str = "input";
 static ARG_PREFIX: &str = "prefix";
 
-const USAGE: &str = "{} [OPTION]... [INPUT [PREFIX]]";
-const AFTER_HELP: &str = "\
-    Output fixed-size pieces of INPUT to PREFIXaa, PREFIXab, ...; default \
-    size is 1000, and default PREFIX is 'x'. With no INPUT, or when INPUT is \
-    -, read standard input.";
+const ABOUT: &str = help_about!("split.md");
+const USAGE: &str = help_usage!("split.md");
+const AFTER_HELP: &str = help_section!("after help", "split.md");
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -66,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
-        .about("Create output files containing consecutive or interleaved sections of input")
+        .about(ABOUT)
         .after_help(AFTER_HELP)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -23,9 +23,9 @@ use std::io::{stdin, BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UIoError, UResult, USimpleError, UUsageError};
-use uucore::{format_usage, help_about, help_usage, help_section};
 use uucore::parse_size::{parse_size, ParseSizeError};
 use uucore::uio_error;
+use uucore::{format_usage, help_about, help_section, help_usage};
 
 static OPT_BYTES: &str = "bytes";
 static OPT_LINE_BYTES: &str = "line-bytes";


### PR DESCRIPTION
issue: #4368 

`split --help` outputs follow.

```
$ ./target/debug/split --help
Create output files containing consecutive or interleaved sections of input

Usage: ./target/debug/split [OPTION]... [INPUT [PREFIX]]

Arguments:
  [input]   [default: -]
  [prefix]  [default: x]

Options:
  -b, --bytes <SIZE>
          put SIZE bytes per output file
  -C, --line-bytes <SIZE>
          put at most SIZE bytes of lines per output file [default: 2]
  -l, --lines <NUMBER>
          put NUMBER lines/records per output file [default: 1000]
  -n, --number <CHUNKS>
          generate CHUNKS output files; see explanation below
      --additional-suffix <SUFFIX>
          additional SUFFIX to append to output file names [default: ]
      --filter <COMMAND>
          write to shell COMMAND; file name is $FILE (Currently not implemented for Windows)
  -e, --elide-empty-files
          do not generate empty output files with '-n'
  -d, --numeric-suffixes [<numeric-suffixes>]
          use numeric suffixes instead of alphabetic
  -a, --suffix-length <N>
          use suffixes of fixed length N. 0 implies dynamic length. [default: 0]
  -x, --hex-suffixes [<hex-suffixes>]
          use hex suffixes instead of alphabetic
      --verbose
          print a diagnostic just before each output file is opened
  -h, --help
          Print help
  -V, --version
          Print version

Output fixed-size pieces of INPUT to PREFIXaa, PREFIXab, ...; default size is 1000, and default PREFIX is
'x'. With no INPUT, or when INPUT is -, read standard input.
```