### PR TITLE
stdbuf: move help strings to markdown file

### DIFF
--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -17,23 +17,11 @@ use tempfile::tempdir;
 use tempfile::TempDir;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::parse_size::parse_size;
-use uucore::{crash, format_usage};
+use uucore::{crash, format_usage, help_about, help_section, help_usage};
 
-static ABOUT: &str =
-    "Run COMMAND, with modified buffering operations for its standard streams.\n\n\
-     Mandatory arguments to long options are mandatory for short options too.";
-const USAGE: &str = "{} OPTION... COMMAND";
-static LONG_HELP: &str = "If MODE is 'L' the corresponding stream will be line buffered.\n\
-     This option is invalid with standard input.\n\n\
-     If MODE is '0' the corresponding stream will be unbuffered.\n\n\
-     Otherwise MODE is a number which may be followed by one of the following:\n\n\
-     KB 1000, K 1024, MB 1000*1000, M 1024*1024, and so on for G, T, P, E, Z, Y.\n\
-     In this case the corresponding stream will be fully buffered with the buffer size set to \
-     MODE bytes.\n\n\
-     NOTE: If COMMAND adjusts the buffering of its standard streams ('tee' does for e.g.) then \
-     that will override corresponding settings changed by 'stdbuf'.\n\
-     Also some filters (like 'dd' and 'cat' etc.) don't use streams for I/O, \
-     and are thus unaffected by 'stdbuf' settings.\n";
+const ABOUT: &str = help_about!("stdbuf.md");
+const USAGE: &str = help_usage!("stdbuf.md");
+const LONG_HELP: &str = help_section!("after help", "stdbuf.md");
 
 mod options {
     pub const INPUT: &str = "input";

--- a/src/uu/stdbuf/stdbuf.md
+++ b/src/uu/stdbuf/stdbuf.md
@@ -1,7 +1,7 @@
 # stdbuf
 
 ```
-stdbuf [OPTION]... [COMMAND]...
+stdbuf [OPTION]... COMMAND
 ```
 
 Run COMMAND, with modified buffering operations for its standard streams.

--- a/src/uu/stdbuf/stdbuf.md
+++ b/src/uu/stdbuf/stdbuf.md
@@ -1,0 +1,24 @@
+# stdbuf
+
+```
+stdbuf [OPTION]... [COMMAND]...
+```
+
+Run COMMAND, with modified buffering operations for its standard streams.
+
+Mandatory arguments to long options are mandatory for short options too.
+
+## After Help
+
+If MODE is 'L' the corresponding stream will be line buffered.
+This option is invalid with standard input.
+
+If MODE is '0' the corresponding stream will be unbuffered.
+
+Otherwise, MODE is a number which may be followed by one of the following:
+
+KB 1000, K 1024, MB 1000*1000, M 1024*1024, and so on for G, T, P, E, Z, Y.
+In this case the corresponding stream will be fully buffered with the buffer size set to MODE bytes.
+
+NOTE: If COMMAND adjusts the buffering of its standard streams ('tee' does for e.g.) then that will override corresponding settings changed by 'stdbuf'.
+Also some filters (like 'dd' and 'cat' etc.) don't use streams for I/O, and are thus unaffected by 'stdbuf' settings.


### PR DESCRIPTION
issue: #4368 

`stdbuf --help` outputs follow.

```
$ ./target/debug/stdbuf --help
Run COMMAND, with modified buffering operations for its standard streams.

Mandatory arguments to long options are mandatory for short options too.

Usage: ./target/debug/stdbuf [OPTION]... COMMAND

Options:
  -i, --input <MODE>   adjust standard input stream buffering
  -o, --output <MODE>  adjust standard output stream buffering
  -e, --error <MODE>   adjust standard error stream buffering
  -h, --help           Print help
  -V, --version        Print version

If MODE is 'L' the corresponding stream will be line buffered.
This option is invalid with standard input.

If MODE is '0' the corresponding stream will be unbuffered.

Otherwise, MODE is a number which may be followed by one of the following:

KB 1000, K 1024, MB 1000*1000, M 1024*1024, and so on for G, T, P, E, Z, Y.
In this case the corresponding stream will be fully buffered with the buffer size set to MODE bytes.

NOTE: If COMMAND adjusts the buffering of its standard streams ('tee' does for e.g.) then that will override corresponding settings changed by 'stdbuf'.
Also some filters (like 'dd' and 'cat' etc.) don't use streams for I/O, and are thus unaffected by 'stdbuf' settings.
```