### PR TITLE
stty: move help strings to markdown file

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -18,7 +18,7 @@ use std::ops::ControlFlow;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use uucore::error::{UResult, USimpleError};
-use uucore::{format_usage, help_usage, help_about};
+use uucore::{format_usage, help_about, help_usage};
 
 #[cfg(not(any(
     target_os = "freebsd",

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -18,7 +18,7 @@ use std::ops::ControlFlow;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_usage, help_about};
 
 #[cfg(not(any(
     target_os = "freebsd",
@@ -31,11 +31,8 @@ use uucore::format_usage;
 use flags::BAUD_RATES;
 use flags::{CONTROL_FLAGS, INPUT_FLAGS, LOCAL_FLAGS, OUTPUT_FLAGS};
 
-const USAGE: &str = "\
-    {} [-F DEVICE | --file=DEVICE] [SETTING]...
-    {} [-F DEVICE | --file=DEVICE] [-a|--all]
-    {} [-F DEVICE | --file=DEVICE] [-g|--save]";
-const SUMMARY: &str = "Print or change terminal characteristics.";
+const USAGE: &str = help_usage!("stty.md");
+const SUMMARY: &str = help_about!("stty.md");
 
 #[derive(Clone, Copy, Debug)]
 pub struct Flag<T> {

--- a/src/uu/stty/stty.md
+++ b/src/uu/stty/stty.md
@@ -1,0 +1,9 @@
+# stty
+
+```
+stty [-F DEVICE | --file=DEVICE] [SETTING]...
+stty [-F DEVICE | --file=DEVICE] [-a|--all]
+stty [-F DEVICE | --file=DEVICE] [-g|--save]
+```
+
+Print or change terminal characteristics.


### PR DESCRIPTION
issue: #4368 

`stty --help` outputs follow.

```
./target/debug/stty
Print or change terminal characteristics.

Usage: ../../../target/debug/stty [-F DEVICE | --file=DEVICE] [SETTING]...
       ../../../target/debug/stty [-F DEVICE | --file=DEVICE] [-a|--all]
       ../../../target/debug/stty [-F DEVICE | --file=DEVICE] [-g|--save]

Arguments:
  [settings]...  settings to change

Options:
  -a, --all            print all current settings in human-readable form
  -g, --save           print all current settings in a stty-readable form
  -F, --file <DEVICE>  open and use the specified DEVICE instead of stdin
  -h, --help           Print help
  -V, --version        Print version
```