### PR TITLE
sum: move help strings to markdown file

### DIFF
--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -13,11 +13,10 @@ use std::io::{stdin, Read};
 use std::path::Path;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, show};
+use uucore::{format_usage, help_about, help_usage, show};
 
-static USAGE: &str = "{} [OPTION]... [FILE]...";
-static ABOUT: &str = "Checksum and count the blocks in a file.\n\n\
-                      With no FILE, or when FILE is -, read standard input.";
+const USAGE: &str = help_usage!("sum.md");
+const ABOUT: &str = help_about!("sum.md");
 
 // This can be replaced with usize::div_ceil once it is stabilized.
 // This implementation approach is optimized for when `b` is a constant,

--- a/src/uu/sum/sum.md
+++ b/src/uu/sum/sum.md
@@ -1,0 +1,9 @@
+# sum
+
+```
+sum [OPTION]... [FILE]..."
+```
+
+Checksum and count the blocks in a file.
+
+With no FILE, or when FILE is -, read standard input.


### PR DESCRIPTION
issue: #4368 

`sum --help` outputs follow.

```
$ ./target/debug/sum --help
Checksum and count the blocks in a file.

With no FILE, or when FILE is -, read standard input.

Usage: ./target/debug/sum [OPTION]... [FILE]..."

Options:
  -r             use the BSD sum algorithm, use 1K blocks (default)
  -s, --sysv     use System V sum algorithm, use 512 bytes blocks
  -h, --help     Print help
  -V, --version  Print version
```