### PR TITLE
sync: move help strings to markdown file

### DIFF
--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -19,10 +19,11 @@ use uucore::display::Quotable;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Synchronize cached writes to persistent storage";
-const USAGE: &str = "{} [OPTION]... FILE...";
+const ABOUT: &str = help_about!("sync.md");
+const USAGE: &str = help_usage!("sync.md");
+
 pub mod options {
     pub static FILE_SYSTEM: &str = "file-system";
     pub static DATA: &str = "data";

--- a/src/uu/sync/sync.md
+++ b/src/uu/sync/sync.md
@@ -1,0 +1,7 @@
+# sync
+
+```
+sync [OPTION]... FILE...
+```
+
+Synchronize cached writes to persistent storage


### PR DESCRIPTION
issue #4368 

`sync --help` outputs follow.

```
$ ./target/debug/sync --help
Synchronize cached writes to persistent storage

Usage: ./target/debug/sync [OPTION]... FILE...

Arguments:
  [files]...

Options:
  -f, --file-system  sync the file systems that contain the files (Linux and Windows only)
  -d, --data         sync only file data, no unneeded metadata (Linux only)
  -h, --help         Print help
  -V, --version      Print version
```