### PR TITLE
android: use cargo test instead of nextest

### DIFF
--- a/util/android-commands.sh
+++ b/util/android-commands.sh
@@ -209,7 +209,7 @@ snapshot() {
     # We need to install nextest via cargo currently, since there is no pre-built binary for android x86
     command="'\
 export CARGO_TERM_COLOR=always; \
-cargo install cargo-nextest; \
+#cargo install cargo-nextest; \
 echo \$? > $probe'"
     run_termux_command "$command" "$probe"
     return_code=$?
@@ -224,7 +224,7 @@ pwd; \
 command -v rustc && rustc -Vv; \
 ls -la ~/.cargo/bin; \
 cargo --list; \
-cargo nextest --version; \
+#cargo nextest --version; \
 touch $probe'"
     run_termux_command "$command" "$probe"
 
@@ -330,7 +330,8 @@ export CARGO_TERM_COLOR=always; \
 export CARGO_INCREMENTAL=0; \
 cd ~/coreutils; \
 timeout --preserve-status --verbose -k 1m 60m \
-    cargo nextest run --profile ci --hide-progress-bar --features feat_os_unix_android; \
+    cargo test --features feat_os_unix_android; \
+#    cargo nextest run --profile ci --hide-progress-bar --features feat_os_unix_android; \
 echo \$? >$probe'"
     run_termux_command "$command" "$probe" || return
 


### PR DESCRIPTION
nextest does build because of:

2023-04-29T08:03:36.5411530Z Compiling log v0.4.17 2023-04-29T08:03:36.5412100Z error[E0432]: unresolved import linux_raw_sys::ioctl 2023-04-29T08:03:36.5412710Z --> /data/data/com.termux/files/home/.cargo/registry/src/github.com-1285ae84e5963aae/rustix-0.37.17/src/backend/libc/io/syscalls.rs:384:24 2023-04-29T08:03:36.5413150Z |
2023-04-29T08:03:36.5413830Z 384 | use linux_raw_sys::ioctl::EXT4_IOC_RESIZE_FS; 2023-04-29T08:03:36.5414380Z | could not find ioctl in linux_raw_sys 2023-04-29T08:03:36.5414590Z
2023-04-29T08:03:36.5414840Z For more information about this error, try rustc --explain E0432. 2023-04-29T08:03:36.5415280Z error: could not compile rustix due to previous error 2023-04-29T08:03:36.5415730Z warning: build failed, waiting for other jobs to finish...

https://github.com/nextest-rs/nextest/issues/862