### PR TITLE
timeout: move help strings to markdown file

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -22,12 +22,12 @@ use uucore::process::ChildExt;
 use uucore::signals::enable_pipe_errors;
 
 use uucore::{
-    format_usage, show_error,
+    format_usage, help_about, help_usage, show_error,
     signals::{signal_by_name_or_value, signal_name_by_value},
 };
 
-static ABOUT: &str = "Start COMMAND, and kill it if still running after DURATION.";
-const USAGE: &str = "{} [OPTION] DURATION COMMAND...";
+const ABOUT: &str = help_about!("timeout.md");
+const USAGE: &str = help_usage!("timeout.md");
 
 pub mod options {
     pub static FOREGROUND: &str = "foreground";

--- a/src/uu/timeout/timeout.md
+++ b/src/uu/timeout/timeout.md
@@ -4,4 +4,4 @@
 timeout [OPTION] DURATION COMMAND...
 ```
 
-Start COMMAND, and kill it if still running after DURATION.
+Start `COMMAND`, and kill it if still running after `DURATION`.

--- a/src/uu/timeout/timeout.md
+++ b/src/uu/timeout/timeout.md
@@ -1,0 +1,7 @@
+# timeout
+
+```
+timeout [OPTION] DURATION COMMAND...
+```
+
+Start COMMAND, and kill it if still running after DURATION.


### PR DESCRIPTION
issue: #4368 

`timeout --help` outputs follow.

```
$ ./target/debug/timeout --help
Start COMMAND, and kill it if still running after DURATION.

Usage: ./target/debug/timeout [OPTION] DURATION COMMAND...

Arguments:
  <duration>
  <command>...

Options:
      --foreground               when not running timeout directly from a shell prompt, allow COMMAND to read from the TTY and get TTY signals; in this mode, children of COMMAND will not be timed out
  -k, --kill-after <kill-after>  also send a KILL signal if COMMAND is still running this long after the initial signal was sent
      --preserve-status          exit with the same status as COMMAND, even when the command times out
  -s, --signal <SIGNAL>          specify the signal to be sent on timeout; SIGNAL may be a name like 'HUP' or a number; see 'kill -l' for a list of signals
  -v, --verbose                  diagnose to stderr any signal sent upon timeout
  -h, --help                     Print help
  -V, --version                  Print version
```