### PR TITLE
test: move help strings to markdown file

### DIFF
--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -20,80 +20,23 @@ use std::fs;
 use std::os::unix::fs::MetadataExt;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_section};
 
+const ABOUT: &str = help_about!("test.md");
+
+// The help_usage method replaces util name (assumed to be the first word) with {}.
+// And, The format_usage method replaces {} with execution_phase ( e.g. test or [ ).
+// However, This test command has two util names.
+// So, we use test or [ instead of {} so that the usage string is correct.
 const USAGE: &str = "\
-    {} EXPRESSION
-    {}
-    [ EXPRESSION ]
-    [ ]
-    [ OPTION";
+test EXPRESSION
+test
+[ EXPRESSION ]
+[ ]
+[ OPTION";
 
 // We use after_help so that this comes after the usage string (it would come before if we used about)
-const AFTER_HELP: &str = "
-Exit with the status determined by EXPRESSION.
-
-An omitted EXPRESSION defaults to false.  Otherwise,
-EXPRESSION is true or false and sets exit status.  It is one of:
-
-  ( EXPRESSION )               EXPRESSION is true
-  ! EXPRESSION                 EXPRESSION is false
-  EXPRESSION1 -a EXPRESSION2   both EXPRESSION1 and EXPRESSION2 are true
-  EXPRESSION1 -o EXPRESSION2   either EXPRESSION1 or EXPRESSION2 is true
-
-  -n STRING            the length of STRING is nonzero
-  STRING               equivalent to -n STRING
-  -z STRING            the length of STRING is zero
-  STRING1 = STRING2    the strings are equal
-  STRING1 != STRING2   the strings are not equal
-
-  INTEGER1 -eq INTEGER2   INTEGER1 is equal to INTEGER2
-  INTEGER1 -ge INTEGER2   INTEGER1 is greater than or equal to INTEGER2
-  INTEGER1 -gt INTEGER2   INTEGER1 is greater than INTEGER2
-  INTEGER1 -le INTEGER2   INTEGER1 is less than or equal to INTEGER2
-  INTEGER1 -lt INTEGER2   INTEGER1 is less than INTEGER2
-  INTEGER1 -ne INTEGER2   INTEGER1 is not equal to INTEGER2
-
-  FILE1 -ef FILE2   FILE1 and FILE2 have the same device and inode numbers
-  FILE1 -nt FILE2   FILE1 is newer (modification date) than FILE2
-  FILE1 -ot FILE2   FILE1 is older than FILE2
-
-  -b FILE     FILE exists and is block special
-  -c FILE     FILE exists and is character special
-  -d FILE     FILE exists and is a directory
-  -e FILE     FILE exists
-  -f FILE     FILE exists and is a regular file
-  -g FILE     FILE exists and is set-group-ID
-  -G FILE     FILE exists and is owned by the effective group ID
-  -h FILE     FILE exists and is a symbolic link (same as -L)
-  -k FILE     FILE exists and has its sticky bit set
-  -L FILE     FILE exists and is a symbolic link (same as -h)
-  -N FILE     FILE exists and has been modified since it was last read
-  -O FILE     FILE exists and is owned by the effective user ID
-  -p FILE     FILE exists and is a named pipe
-  -r FILE     FILE exists and read permission is granted
-  -s FILE     FILE exists and has a size greater than zero
-  -S FILE     FILE exists and is a socket
-  -t FD       file descriptor FD is opened on a terminal
-  -u FILE     FILE exists and its set-user-ID bit is set
-  -w FILE     FILE exists and write permission is granted
-  -x FILE     FILE exists and execute (or search) permission is granted
-
-Except for -h and -L, all FILE-related tests dereference symbolic links.
-Beware that parentheses need to be escaped (e.g., by backslashes) for shells.
-INTEGER may also be -l STRING, which evaluates to the length of STRING.
-
-NOTE: Binary -a and -o are inherently ambiguous.  Use 'test EXPR1 && test
-EXPR2' or 'test EXPR1 || test EXPR2' instead.
-
-NOTE: [ honors the --help and --version options, but test does not.
-test treats each of those as it treats any other nonempty STRING.
-
-NOTE: your shell may have its own version of test and/or [, which usually supersedes
-the version described here.  Please refer to your shell's documentation
-for details about the options it supports.";
-
-const ABOUT: &str = "Check file types and compare values.";
+const AFTER_HELP: &str = help_section!("after help", "test.md");
 
 pub fn uu_app() -> Command {
     // Disable printing of -h and -v as valid alternatives for --help and --version,

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -24,8 +24,8 @@ use uucore::{format_usage, help_about, help_section};
 
 const ABOUT: &str = help_about!("test.md");
 
-// The help_usage method replaces util name (assumed to be the first word) with {}.
-// And, The format_usage method replaces {} with execution_phase ( e.g. test or [ ).
+// The help_usage method replaces util name (the first word) with {}.
+// And, The format_usage method replaces {} with execution_phrase ( e.g. test or [ ).
 // However, This test command has two util names.
 // So, we use test or [ instead of {} so that the usage string is correct.
 const USAGE: &str = "\

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -96,6 +96,8 @@ for details about the options it supports.";
 const ABOUT: &str = "Check file types and compare values.";
 
 pub fn uu_app() -> Command {
+    // Disable printing of -h and -v as valid alternatives for --help and --version,
+    // since we don't recognize -h and -v as help/version flags.
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
@@ -112,15 +114,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     if binary_name.ends_with('[') {
         // If invoked as [ we should recognize --help and --version (but not -h or -v)
         if args.len() == 1 && (args[0] == "--help" || args[0] == "--version") {
-            // Let clap pretty-print help and version
-            Command::new(binary_name)
-                .version(crate_version!())
-                .about(ABOUT)
-                .override_usage(format_usage(USAGE))
-                .after_help(AFTER_HELP)
-                // Disable printing of -h and -v as valid alternatives for --help and --version,
-                // since we don't recognize -h and -v as help/version flags.
-                .get_matches_from(std::iter::once(program).chain(args.into_iter()));
+            uu_app().get_matches_from(std::iter::once(program).chain(args.into_iter()));
             return Ok(());
         }
         // If invoked via name '[', matching ']' must be in the last arg

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -30,37 +30,37 @@ It is one of:
 * STRING1 = STRING2    the strings are equal
 * STRING1 != STRING2   the strings are not equal
 
-INTEGER1 -eq INTEGER2   `INTEGER1` is equal to `INTEGER2`
-INTEGER1 -ge INTEGER2   `INTEGER1` is greater than or equal to `INTEGER2`
-INTEGER1 -gt INTEGER2   `INTEGER1` is greater than `INTEGER2`
-INTEGER1 -le INTEGER2   `INTEGER1` is less than or equal to `INTEGER2`
-INTEGER1 -lt INTEGER2   `INTEGER1` is less than `INTEGER2`
-INTEGER1 -ne INTEGER2   `INTEGER1` is not equal to `INTEGER2`
+* INTEGER1 -eq INTEGER2   `INTEGER1` is equal to `INTEGER2`
+* INTEGER1 -ge INTEGER2   `INTEGER1` is greater than or equal to `INTEGER2`
+* INTEGER1 -gt INTEGER2   `INTEGER1` is greater than `INTEGER2`
+* INTEGER1 -le INTEGER2   `INTEGER1` is less than or equal to `INTEGER2`
+* INTEGER1 -lt INTEGER2   `INTEGER1` is less than `INTEGER2`
+* INTEGER1 -ne INTEGER2   `INTEGER1` is not equal to `INTEGER2`
 
-FILE1 -ef FILE2   `FILE1` and `FILE2` have the same device and inode numbers
-FILE1 -nt FILE2   `FILE1` is newer (modification date) than `FILE2`
-FILE1 -ot FILE2   `FILE1` is older than `FILE2`
+* FILE1 -ef FILE2   `FILE1` and `FILE2` have the same device and inode numbers
+* FILE1 -nt FILE2   `FILE1` is newer (modification date) than `FILE2`
+* FILE1 -ot FILE2   `FILE1` is older than `FILE2`
 
--b FILE     `FILE` exists and is block special
--c FILE     `FILE` exists and is character special
--d FILE     `FILE` exists and is a directory
--e FILE     `FILE` exists
--f FILE     `FILE` exists and is a regular file
--g FILE     `FILE` exists and is set-group-ID
--G FILE     `FILE` exists and is owned by the effective group ID
--h FILE     `FILE` exists and is a symbolic link (same as -L)
--k FILE     `FILE` exists and has its sticky bit set
--L FILE     `FILE` exists and is a symbolic link (same as -h)
--N FILE     `FILE` exists and has been modified since it was last read
--O FILE     `FILE` exists and is owned by the effective user ID
--p FILE     `FILE` exists and is a named pipe
--r FILE     `FILE` exists and read permission is granted
--s FILE     `FILE` exists and has a size greater than zero
--S FILE     `FILE` exists and is a socket
--t FD       `file` descriptor `FD` is opened on a terminal
--u FILE     `FILE` exists and its set-user-ID bit is set
--w FILE     `FILE` exists and write permission is granted
--x FILE     `FILE` exists and execute (or search) permission is granted
+* -b FILE     `FILE` exists and is block special
+* -c FILE     `FILE` exists and is character special
+* -d FILE     `FILE` exists and is a directory
+* -e FILE     `FILE` exists
+* -f FILE     `FILE` exists and is a regular file
+* -g FILE     `FILE` exists and is set-group-ID
+* -G FILE     `FILE` exists and is owned by the effective group ID
+* -h FILE     `FILE` exists and is a symbolic link (same as -L)
+* -k FILE     `FILE` exists and has its sticky bit set
+* -L FILE     `FILE` exists and is a symbolic link (same as -h)
+* -N FILE     `FILE` exists and has been modified since it was last read
+* -O FILE     `FILE` exists and is owned by the effective user ID
+* -p FILE     `FILE` exists and is a named pipe
+* -r FILE     `FILE` exists and read permission is granted
+* -s FILE     `FILE` exists and has a size greater than zero
+* -S FILE     `FILE` exists and is a socket
+* -t FD       `file` descriptor `FD` is opened on a terminal
+* -u FILE     `FILE` exists and its set-user-ID bit is set
+* -w FILE     `FILE` exists and write permission is granted
+* -x FILE     `FILE` exists and execute (or search) permission is granted
 
 Except for `-h` and `-L`, all FILE-related tests dereference (follow) symbolic links.
 Beware that parentheses need to be escaped (e.g., by backslashes) for shells.

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -31,6 +31,7 @@ String operations:
 * STRING1 = STRING2    the strings are equal
 * STRING1 != STRING2   the strings are not equal
 
+Integer comparisons:
 * INTEGER1 -eq INTEGER2   `INTEGER1` is equal to `INTEGER2`
 * INTEGER1 -ge INTEGER2   `INTEGER1` is greater than or equal to `INTEGER2`
 * INTEGER1 -gt INTEGER2   `INTEGER1` is greater than `INTEGER2`

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -24,6 +24,7 @@ It is one of:
 * EXPRESSION1 -a EXPRESSION2   both `EXPRESSION1` and `EXPRESSION2` are true
 * EXPRESSION1 -o EXPRESSION2   either `EXPRESSION1` or `EXPRESSION2` is true
 
+String operations:
 * -n STRING            the length of `STRING` is nonzero
 * STRING               equivalent to -n `STRING`
 * -z STRING            the length of `STRING` is zero

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -19,10 +19,10 @@ Otherwise, `EXPRESSION` is true or false and sets exit status.
 
 It is one of:
 
-( EXPRESSION )               `EXPRESSION` is true
-! EXPRESSION                 `EXPRESSION` is false
-EXPRESSION1 -a EXPRESSION2   both `EXPRESSION1` and `EXPRESSION2` are true
-EXPRESSION1 -o EXPRESSION2   either `EXPRESSION1` or `EXPRESSION2` is true
+* ( EXPRESSION )               `EXPRESSION` is true
+* ! EXPRESSION                 `EXPRESSION` is false
+* EXPRESSION1 -a EXPRESSION2   both `EXPRESSION1` and `EXPRESSION2` are true
+* EXPRESSION1 -o EXPRESSION2   either `EXPRESSION1` or `EXPRESSION2` is true
 
 -n STRING            the length of `STRING` is nonzero
 STRING               equivalent to -n `STRING`

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -72,5 +72,5 @@ Use `test EXPR1 && test EXPR2` or `test EXPR1 || test EXPR2` instead.
 NOTE: `[` honors the `--help` and `--version` options, but test does not.
 test treats each of those as it treats any other nonempty `STRING`.
 
-NOTE: your shell may have its own version of test and/or [, which usually supersedes the version described here.
+NOTE: your shell may have its own version of `test` and/or `[`, which usually supersedes the version described here.
 Please refer to your shell's documentation for details about the options it supports.

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -62,7 +62,7 @@ FILE1 -ot FILE2   `FILE1` is older than `FILE2`
 -w FILE     `FILE` exists and write permission is granted
 -x FILE     `FILE` exists and execute (or search) permission is granted
 
-Except for -h and -L, all FILE-related tests dereference symbolic links.
+Except for `-h` and `-L`, all FILE-related tests dereference (follow) symbolic links.
 Beware that parentheses need to be escaped (e.g., by backslashes) for shells.
 `INTEGER` may also be -l `STRING`, which evaluates to the length of `STRING`.
 

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -69,7 +69,7 @@ Beware that parentheses need to be escaped (e.g., by backslashes) for shells.
 NOTE: Binary `-a` and `-o` are inherently ambiguous.
 Use `test EXPR1 && test EXPR2` or `test EXPR1 || test EXPR2` instead.
 
-NOTE: [ honors the --help and --version options, but test does not.
+NOTE: `[` honors the `--help` and `--version` options, but test does not.
 test treats each of those as it treats any other nonempty `STRING`.
 
 NOTE: your shell may have its own version of test and/or [, which usually supersedes the version described here.

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -24,11 +24,11 @@ It is one of:
 * EXPRESSION1 -a EXPRESSION2   both `EXPRESSION1` and `EXPRESSION2` are true
 * EXPRESSION1 -o EXPRESSION2   either `EXPRESSION1` or `EXPRESSION2` is true
 
--n STRING            the length of `STRING` is nonzero
-STRING               equivalent to -n `STRING`
--z STRING            the length of `STRING` is zero
-STRING1 = STRING2    the strings are equal
-STRING1 != STRING2   the strings are not equal
+* -n STRING            the length of `STRING` is nonzero
+* STRING               equivalent to -n `STRING`
+* -z STRING            the length of `STRING` is zero
+* STRING1 = STRING2    the strings are equal
+* STRING1 != STRING2   the strings are not equal
 
 INTEGER1 -eq INTEGER2   `INTEGER1` is equal to `INTEGER2`
 INTEGER1 -ge INTEGER2   `INTEGER1` is greater than or equal to `INTEGER2`

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -66,8 +66,8 @@ Except for -h and -L, all FILE-related tests dereference symbolic links.
 Beware that parentheses need to be escaped (e.g., by backslashes) for shells.
 `INTEGER` may also be -l `STRING`, which evaluates to the length of `STRING`.
 
-NOTE: Binary -a and -o are inherently ambiguous.
-Use 'test EXPR1 && test EXPR2' or 'test EXPR1 || test EXPR2' instead.
+NOTE: Binary `-a` and `-o` are inherently ambiguous.
+Use `test EXPR1 && test EXPR2` or `test EXPR1 || test EXPR2` instead.
 
 NOTE: [ honors the --help and --version options, but test does not.
 test treats each of those as it treats any other nonempty `STRING`.

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -37,6 +37,7 @@ It is one of:
 * INTEGER1 -lt INTEGER2   `INTEGER1` is less than `INTEGER2`
 * INTEGER1 -ne INTEGER2   `INTEGER1` is not equal to `INTEGER2`
 
+File operations:
 * FILE1 -ef FILE2   `FILE1` and `FILE2` have the same device and inode numbers
 * FILE1 -nt FILE2   `FILE1` is newer (modification date) than `FILE2`
 * FILE1 -ot FILE2   `FILE1` is older than `FILE2`

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -1,0 +1,76 @@
+# test
+
+```
+test EXPRESSION
+test
+[ EXPRESSION ]
+[ ]
+[ OPTION
+```
+
+Check file types and compare values.
+
+## After Help
+
+Exit with the status determined by `EXPRESSION`.
+
+An omitted `EXPRESSION` defaults to false.
+Otherwise, `EXPRESSION` is true or false and sets exit status. 
+
+It is one of:
+
+( EXPRESSION )               `EXPRESSION` is true
+! EXPRESSION                 `EXPRESSION` is false
+EXPRESSION1 -a EXPRESSION2   both `EXPRESSION1` and `EXPRESSION2` are true
+EXPRESSION1 -o EXPRESSION2   either `EXPRESSION1` or `EXPRESSION2` is true
+
+-n STRING            the length of `STRING` is nonzero
+STRING               equivalent to -n `STRING`
+-z STRING            the length of `STRING` is zero
+STRING1 = STRING2    the strings are equal
+STRING1 != STRING2   the strings are not equal
+
+INTEGER1 -eq INTEGER2   `INTEGER1` is equal to `INTEGER2`
+INTEGER1 -ge INTEGER2   `INTEGER1` is greater than or equal to `INTEGER2`
+INTEGER1 -gt INTEGER2   `INTEGER1` is greater than `INTEGER2`
+INTEGER1 -le INTEGER2   `INTEGER1` is less than or equal to `INTEGER2`
+INTEGER1 -lt INTEGER2   `INTEGER1` is less than `INTEGER2`
+INTEGER1 -ne INTEGER2   `INTEGER1` is not equal to `INTEGER2`
+
+FILE1 -ef FILE2   `FILE1` and `FILE2` have the same device and inode numbers
+FILE1 -nt FILE2   `FILE1` is newer (modification date) than `FILE2`
+FILE1 -ot FILE2   `FILE1` is older than `FILE2`
+
+-b FILE     `FILE` exists and is block special
+-c FILE     `FILE` exists and is character special
+-d FILE     `FILE` exists and is a directory
+-e FILE     `FILE` exists
+-f FILE     `FILE` exists and is a regular file
+-g FILE     `FILE` exists and is set-group-ID
+-G FILE     `FILE` exists and is owned by the effective group ID
+-h FILE     `FILE` exists and is a symbolic link (same as -L)
+-k FILE     `FILE` exists and has its sticky bit set
+-L FILE     `FILE` exists and is a symbolic link (same as -h)
+-N FILE     `FILE` exists and has been modified since it was last read
+-O FILE     `FILE` exists and is owned by the effective user ID
+-p FILE     `FILE` exists and is a named pipe
+-r FILE     `FILE` exists and read permission is granted
+-s FILE     `FILE` exists and has a size greater than zero
+-S FILE     `FILE` exists and is a socket
+-t FD       `file` descriptor `FD` is opened on a terminal
+-u FILE     `FILE` exists and its set-user-ID bit is set
+-w FILE     `FILE` exists and write permission is granted
+-x FILE     `FILE` exists and execute (or search) permission is granted
+
+Except for -h and -L, all FILE-related tests dereference symbolic links.
+Beware that parentheses need to be escaped (e.g., by backslashes) for shells.
+`INTEGER` may also be -l `STRING`, which evaluates to the length of `STRING`.
+
+NOTE: Binary -a and -o are inherently ambiguous.
+Use 'test EXPR1 && test EXPR2' or 'test EXPR1 || test EXPR2' instead.
+
+NOTE: [ honors the --help and --version options, but test does not.
+test treats each of those as it treats any other nonempty `STRING`.
+
+NOTE: your shell may have its own version of test and/or [, which usually supersedes the version described here.
+Please refer to your shell's documentation for details about the options it supports.


### PR DESCRIPTION
issue: #4368

This PR contains bellow contents.

- Remove duplicated expressions 22d1880e715ce6e224c19c2cc3e3c2aeaea92822
- Move help strings to markdown file d6366c41eda316cad6b1c1047d97bed9e2b4b078

This command has two util names ( `test` or `[` ). And, the format_usage method replaces {} with a util name. So, we changed `USAGE` as strings that do not contain `{}`.
If there are better ideas, please tell me.

## before


```
$ cargo run -- [ --help
Check file types and compare values.

Usage: target/debug/coreutils [ EXPRESSION
           target/debug/coreutils [
           [ EXPRESSION ]
           [ ]
           [ OPTION

Options:
  -h, --help     Print help
  -V, --version  Print version


Exit with the status determined by EXPRESSION.

An omitted EXPRESSION defaults to false.  Otherwise,
EXPRESSION is true or false and sets exit status.  It is one of:

  ( EXPRESSION )               EXPRESSION is true
  ! EXPRESSION                 EXPRESSION is false
  EXPRESSION1 -a EXPRESSION2   both EXPRESSION1 and EXPRESSION2 are true
  EXPRESSION1 -o EXPRESSION2   either EXPRESSION1 or EXPRESSION2 is true

  -n STRING            the length of STRING is nonzero
  STRING               equivalent to -n STRING
  -z STRING            the length of STRING is zero
  STRING1 = STRING2    the strings are equal
  STRING1 != STRING2   the strings are not equal

  INTEGER1 -eq INTEGER2   INTEGER1 is equal to INTEGER2
  INTEGER1 -ge INTEGER2   INTEGER1 is greater than or equal to INTEGER2
  INTEGER1 -gt INTEGER2   INTEGER1 is greater than INTEGER2
  INTEGER1 -le INTEGER2   INTEGER1 is less than or equal to INTEGER2
  INTEGER1 -lt INTEGER2   INTEGER1 is less than INTEGER2
  INTEGER1 -ne INTEGER2   INTEGER1 is not equal to INTEGER2

  FILE1 -ef FILE2   FILE1 and FILE2 have the same device and inode numbers
  FILE1 -nt FILE2   FILE1 is newer (modification date) than FILE2
  FILE1 -ot FILE2   FILE1 is older than FILE2

  -b FILE     FILE exists and is block special
  -c FILE     FILE exists and is character special
  -d FILE     FILE exists and is a directory
  -e FILE     FILE exists
  -f FILE     FILE exists and is a regular file
  -g FILE     FILE exists and is set-group-ID
  -G FILE     FILE exists and is owned by the effective group ID
  -h FILE     FILE exists and is a symbolic link (same as -L)
  -k FILE     FILE exists and has its sticky bit set
  -L FILE     FILE exists and is a symbolic link (same as -h)
  -N FILE     FILE exists and has been modified since it was last read
  -O FILE     FILE exists and is owned by the effective user ID
  -p FILE     FILE exists and is a named pipe
  -r FILE     FILE exists and read permission is granted
  -s FILE     FILE exists and has a size greater than zero
  -S FILE     FILE exists and is a socket
  -t FD       file descriptor FD is opened on a terminal
  -u FILE     FILE exists and its set-user-ID bit is set
  -w FILE     FILE exists and write permission is granted
  -x FILE     FILE exists and execute (or search) permission is granted

Except for -h and -L, all FILE-related tests dereference symbolic links.
Beware that parentheses need to be escaped (e.g., by backslashes) for shells.
INTEGER may also be -l STRING, which evaluates to the length of STRING.

NOTE: Binary -a and -o are inherently ambiguous.  Use 'test EXPR1 && test
EXPR2' or 'test EXPR1 || test EXPR2' instead.

NOTE: [ honors the --help and --version options, but test does not.
test treats each of those as it treats any other nonempty STRING.

NOTE: your shell may have its own version of test and/or [, which usually supersedes
the version described here.  Please refer to your shell's documentation
for details about the options it supports.
```

## after

```
$ cargo run -- [ --help
Check file types and compare values.

Usage: test EXPRESSION
       test
       [ EXPRESSION ]
       [ ]
       [ OPTION

Options:
  -h, --help     Print help
  -V, --version  Print version

Exit with the status determined by EXPRESSION.

An omitted EXPRESSION defaults to false.
Otherwise, EXPRESSION is true or false and sets exit status.

It is one of:

( EXPRESSION )               EXPRESSION is true
! EXPRESSION                 EXPRESSION is false
EXPRESSION1 -a EXPRESSION2   both EXPRESSION1 and EXPRESSION2 are true
EXPRESSION1 -o EXPRESSION2   either EXPRESSION1 or EXPRESSION2 is true

-n STRING            the length of STRING is nonzero
STRING               equivalent to -n STRING
-z STRING            the length of STRING is zero
STRING1 = STRING2    the strings are equal
STRING1 != STRING2   the strings are not equal

INTEGER1 -eq INTEGER2   INTEGER1 is equal to INTEGER2
INTEGER1 -ge INTEGER2   INTEGER1 is greater than or equal to INTEGER2
INTEGER1 -gt INTEGER2   INTEGER1 is greater than INTEGER2
INTEGER1 -le INTEGER2   INTEGER1 is less than or equal to INTEGER2
INTEGER1 -lt INTEGER2   INTEGER1 is less than INTEGER2
INTEGER1 -ne INTEGER2   INTEGER1 is not equal to INTEGER2

FILE1 -ef FILE2   FILE1 and FILE2 have the same device and inode numbers
FILE1 -nt FILE2   FILE1 is newer (modification date) than FILE2
FILE1 -ot FILE2   FILE1 is older than FILE2

-b FILE     FILE exists and is block special
-c FILE     FILE exists and is character special
-d FILE     FILE exists and is a directory
-e FILE     FILE exists
-f FILE     FILE exists and is a regular file
-g FILE     FILE exists and is set-group-ID
-G FILE     FILE exists and is owned by the effective group ID
-h FILE     FILE exists and is a symbolic link (same as -L)
-k FILE     FILE exists and has its sticky bit set
-L FILE     FILE exists and is a symbolic link (same as -h)
-N FILE     FILE exists and has been modified since it was last read
-O FILE     FILE exists and is owned by the effective user ID
-p FILE     FILE exists and is a named pipe
-r FILE     FILE exists and read permission is granted
-s FILE     FILE exists and has a size greater than zero
-S FILE     FILE exists and is a socket
-t FD       file descriptor FD is opened on a terminal
-u FILE     FILE exists and its set-user-ID bit is set
-w FILE     FILE exists and write permission is granted
-x FILE     FILE exists and execute (or search) permission is granted

Except for -h and -L, all FILE-related tests dereference symbolic links.
Beware that parentheses need to be escaped (e.g., by backslashes) for shells.
INTEGER may also be -l STRING, which evaluates to the length of STRING.

NOTE: Binary -a and -o are inherently ambiguous.
Use 'test EXPR1 && test EXPR2' or 'test EXPR1 || test EXPR2' instead.

NOTE: [ honors the --help and --version options, but test does not.
test treats each of those as it treats any other nonempty STRING.

NOTE: your shell may have its own version of test and/or [, which usually supersedes the version described here.
Please refer to your shell's documentation for details about the options it supports.
```