### PR TITLE
Replace unordered list markers with an empty string

### DIFF
--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -48,6 +48,9 @@ pub fn main(_args: TokenStream, stream: TokenStream) -> TokenStream {
 /// - Printing tables in a nice format
 fn render_markdown(s: &str) -> String {
     s.replace('`', "")
+        .replace("* ", "") // replace unordered list markers
+        .replace("- ", "") // replace unordered list markers
+        .replace("+ ", "") // replace unordered list markers
 }
 
 /// Get the about text from the help file.


### PR DESCRIPTION
Closes: #4818 

When using --help and list keywords ( * ) are used in markdown, * is displayed in the terminal.
However, since it is originally unnecessary, we would like to replace it with an empty string.

So, In the render_markdown method used in `help_section!`, added replace chains to replace unordered list markers with an empty string.

For example, `mknod --help` outputs follow

### before 

```
Create the special file NAME of the given TYPE.

Usage: ./target/debug/mknod [OPTION]... NAME TYPE [MAJOR MINOR]

Arguments:
  <NAME>   name of the new file
  <TYPE>   type of the new file (b, c, u or p)
  [MAJOR]  major file type
  [MINOR]  minor file type

Options:
  -m, --mode <MODE>  set file permission bits to MODE, not a=rw - umask
  -h, --help         Print help
  -V, --version      Print version

Mandatory arguments to long options are mandatory for short options too.
-m, --mode=MODE    set file permission bits to MODE, not a=rw - umask

Both MAJOR and MINOR must be specified when TYPE is b, c, or u, and they
must be omitted when TYPE is p.  If MAJOR or MINOR begins with 0x or 0X,
it is interpreted as hexadecimal; otherwise, if it begins with 0, as octal;
otherwise, as decimal.  TYPE may be:

* b      create a block (buffered) special file
* c, u   create a character (unbuffered) special file
* p      create a FIFO

NOTE: your shell may have its own version of mknod, which usually supersedes
the version described here.  Please refer to your shell's documentation
for details about the options it supports.
```

### after

```
Create the special file NAME of the given TYPE.

Usage: ./target/debug/mknod [OPTION]... NAME TYPE [MAJOR MINOR]

Arguments:
  <NAME>   name of the new file
  <TYPE>   type of the new file (b, c, u or p)
  [MAJOR]  major file type
  [MINOR]  minor file type

Options:
  -m, --mode <MODE>  set file permission bits to MODE, not a=rw - umask
  -h, --help         Print help
  -V, --version      Print version

Mandatory arguments to long options are mandatory for short options too.
-m, --mode=MODE    set file permission bits to MODE, not a=rw - umask

Both MAJOR and MINOR must be specified when TYPE is b, c, or u, and they
must be omitted when TYPE is p.  If MAJOR or MINOR begins with 0x or 0X,
it is interpreted as hexadecimal; otherwise, if it begins with 0, as octal;
otherwise, as decimal.  TYPE may be:

b      create a block (buffered) special file
c, u   create a character (unbuffered) special file
p      create a FIFO

NOTE: your shell may have its own version of mknod, which usually supersedes
the version described here.  Please refer to your shell's documentation
for details about the options it supports.
```