### PR TITLE
tty: move help strings to markdown file

### DIFF
--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -14,10 +14,10 @@ use is_terminal::IsTerminal;
 use std::io::Write;
 use std::os::unix::io::AsRawFd;
 use uucore::error::{set_exit_code, UResult};
-use uucore::format_usage;
+use uucore::{format_usage, help_about, help_usage};
 
-static ABOUT: &str = "Print the file name of the terminal connected to standard input.";
-const USAGE: &str = "{} [OPTION]...";
+const ABOUT: &str = help_about!("tty.md");
+const USAGE: &str = help_usage!("tty.md");
 
 mod options {
     pub const SILENT: &str = "silent";

--- a/src/uu/tty/tty.md
+++ b/src/uu/tty/tty.md
@@ -1,0 +1,7 @@
+# tty
+
+```
+tty [OPTION]...
+```
+
+Print the file name of the terminal connected to standard input.


### PR DESCRIPTION
issue: #4368 

`tty --help` outputs following.

```
$ ./target/debug/tty --help
Print the file name of the terminal connected to standard input.

Usage: ./target/debug/tty [OPTION]...

Options:
  -s, --silent   print nothing, only return an exit status [aliases: quiet]
  -h, --help     Print help
  -V, --version  Print version
```