### PR TITLE
ls: device number for BSDs and solarishOS

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -41,7 +41,13 @@ use unicode_width::UnicodeWidthStr;
     target_os = "linux",
     target_os = "macos",
     target_os = "android",
-    target_os = "ios"
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "illumos",
+    target_os = "solaris"
 ))]
 use uucore::libc::{dev_t, major, minor};
 #[cfg(unix)]
@@ -2716,7 +2722,13 @@ fn display_len_or_rdev(metadata: &Metadata, config: &Config) -> SizeOrDeviceId {
         target_os = "linux",
         target_os = "macos",
         target_os = "android",
-        target_os = "ios"
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "illumos",
+        target_os = "solaris"
     ))]
     {
         let ft = metadata.file_type();

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3397,7 +3397,6 @@ fn test_tabsize_formatting() {
 #[cfg(any(
     target_os = "linux",
     target_os = "macos",
-    target_os = "android",
     target_os = "ios",
     target_os = "freebsd",
     target_os = "dragonfly",

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3416,8 +3416,8 @@ fn test_device_number() {
     // let's use the first device for test
     let blk_dev = dev_dir
         .map(|res_entry| res_entry.unwrap())
-        .find(|entry| entry.file_type().unwrap().is_block_device())
-        .expect("Expect a block device");
+        .find(|entry| entry.file_type().unwrap().is_block_device() || entry.file_type().unwrap().is_char_device())
+        .expect("Expect a block/char device");
     let blk_dev_path = blk_dev.path();
     let blk_dev_meta = metadata(blk_dev_path.as_path()).unwrap();
     let blk_dev_number = blk_dev_meta.rdev() as dev_t;

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3416,7 +3416,10 @@ fn test_device_number() {
     // let's use the first device for test
     let blk_dev = dev_dir
         .map(|res_entry| res_entry.unwrap())
-        .find(|entry| entry.file_type().unwrap().is_block_device() || entry.file_type().unwrap().is_char_device())
+        .find(|entry| {
+            entry.file_type().unwrap().is_block_device()
+                || entry.file_type().unwrap().is_char_device()
+        })
         .expect("Expect a block/char device");
     let blk_dev_path = blk_dev.path();
     let blk_dev_meta = metadata(blk_dev_path.as_path()).unwrap();


### PR DESCRIPTION
With [libc#2999](https://github.com/rust-lang/libc/pull/2999) merged, we can finally add device numbers support to other platforms:)

# What does this PR do
1. Add `ls -l` device number support for BSDs and SolarishOS
   1. FreeBSD
   2. DragonFlyBSD
   3. NetBSD
   4. OpenBSD
   5. Illumos
   6. Solaris

For the list in this [comment](https://github.com/uutils/coreutils/issues/2140#issuecomment-1312494378), `Redox` does not have these `major/minor` things(yet, I guess), other platforms are all supported, so we can close #2140.
