### PR TITLE
dd: fix "unused imports" warning in tests

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1,7 +1,7 @@
 // spell-checker:ignore fname, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, availible, behaviour, bmax, bremain, btotal, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rposition, rremain, rsofar, rstat, sigusr, sigval, wlen, wstat abcdefghijklm abcdefghi nabcde nabcdefg abcdefg
 
 use crate::common::util::TestScenario;
-#[cfg(not(windows))]
+#[cfg(all(not(windows), feature = "printf"))]
 use crate::common::util::{UCommand, TESTS_BINARY};
 
 use regex::Regex;


### PR DESCRIPTION
When running `cargo test --features "dd" --no-default-features`, a `unused imports: 'TESTS_BINARY', 'UCommand'` warning is shown because of a mismatch between the `cfg`-attributes of those imports and the function where they are used. This PR fixes this issue.