### PR TITLE
deny.toml: remove aho-corasick from skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -69,8 +69,6 @@ skip = [
     { name = "linux-raw-sys", version = "0.1.4" },
     # is-terminal
     { name = "windows-sys", version = "0.45.0" },
-    # cpp_macros
-    { name = "aho-corasick", version = "0.7.19" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
When running `cargo deny check` I get an "warning[unmatched-skip]: skipped crate 'aho-corasick = ^0.7.19' was not encountered" warning, so it seems like this entry is no longer necessary.