### PR TITLE
ls: when facing an invalid utf-8, don't panic

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1997,7 +1997,15 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
         require_literal_separator: false,
         case_sensitive: true,
     };
-    let file_name = entry.file_name().into_string().unwrap();
+    let file_name = entry.file_name();
+    // If the decoding fails, still show an incorrect rendering
+    let file_name = match file_name.to_str() {
+        Some(s) => s.to_string(),
+        None => {
+            let file_name_bytes = file_name.to_string_lossy();
+            file_name_bytes.into_owned()
+        }
+    };
     !config
         .ignore_patterns
         .iter()

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2001,10 +2001,7 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
     // If the decoding fails, still show an incorrect rendering
     let file_name = match file_name.to_str() {
         Some(s) => s.to_string(),
-        None => {
-            let file_name_bytes = file_name.to_string_lossy();
-            file_name_bytes.into_owned()
-        }
+        None => file_name.to_string_lossy().into_owned(),
     };
     !config
         .ignore_patterns

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7,6 +7,10 @@ use crate::common::util::TestScenario;
 use nix::unistd::{close, dup};
 use regex::Regex;
 use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::ffi::OsStr;
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStrExt;
 #[cfg(all(unix, feature = "chmod"))]
 use std::os::unix::io::IntoRawFd;
 use std::path::Path;
@@ -3433,4 +3437,14 @@ fn test_device_number() {
         .arg(blk_dev_path.to_str().expect("should be UTF-8 encoded"))
         .succeeds()
         .stdout_contains(major_minor_str);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_invalid_utf8() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let filename = OsStr::from_bytes(b"-\xE0-foo");
+    at.touch(filename);
+    ucmd.succeeds();
 }


### PR DESCRIPTION
Before, it failed with
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "-\xE0-foo"', src/uu/ls/src/ls.rs:1932:53
```