### PR TITLE
mkdir: set correct permissions on dirs created by -p

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -179,6 +179,7 @@ fn chmod(_path: &Path, _mode: u32) -> UResult<()> {
     Ok(())
 }
 
+// `is_parent` argument is not used on windows
 #[allow(unused_variables)]
 fn create_dir(path: &Path, recursive: bool, verbose: bool, is_parent: bool) -> UResult<()> {
     if path.exists() && !recursive {

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -179,6 +179,7 @@ fn chmod(_path: &Path, _mode: u32) -> UResult<()> {
     Ok(())
 }
 
+#[allow(unused_variables)]
 fn create_dir(path: &Path, recursive: bool, verbose: bool, is_parent: bool) -> UResult<()> {
     if path.exists() && !recursive {
         return Err(USimpleError::new(
@@ -207,6 +208,7 @@ fn create_dir(path: &Path, recursive: bool, verbose: bool, is_parent: bool) -> U
                     path.quote()
                 );
             }
+            #[cfg(not(windows))]
             if is_parent {
                 // directories created by -p have permission bits set to '=rwx,u+wx',
                 // which is umask modified by 'u+wx'

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -76,7 +76,7 @@ fn test_mkdir_dup_dir_parent() {
 fn test_mkdir_parent_mode() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    let default_umask: mode_t = 0o022;
+    let default_umask: mode_t = 0o160;
     let original_umask = unsafe { umask(default_umask) };
 
     ucmd.arg("-p").arg("a/b").succeeds().no_stderr().no_stdout();
@@ -104,10 +104,10 @@ fn test_mkdir_parent_mode() {
 fn test_mkdir_parent_mode_check_existing_parent() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    let default_umask: mode_t = 0o022;
-    let original_umask = unsafe { umask(default_umask) };
-
     at.mkdir("a");
+
+    let default_umask: mode_t = 0o160;
+    let original_umask = unsafe { umask(default_umask) };
 
     ucmd.arg("-p")
         .arg("a/b/c")
@@ -119,7 +119,7 @@ fn test_mkdir_parent_mode_check_existing_parent() {
     // parent dirs that already exist do not get their permissions modified
     assert_eq!(
         at.metadata("a").permissions().mode() as mode_t,
-        (!default_umask & 0o777) + 0o40000
+        (!original_umask & 0o777) + 0o40000
     );
     assert!(at.dir_exists("a/b"));
     assert_eq!(

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -84,13 +84,13 @@ fn test_mkdir_parent_mode() {
     assert!(at.dir_exists("a"));
     // parents created by -p have permissions set to "=rwx,u+wx"
     assert_eq!(
-        at.metadata("a").permissions().mode(),
+        at.metadata("a").permissions().mode() as mode_t,
         ((!default_umask & 0o777) | 0o300) + 0o40000
     );
     assert!(at.dir_exists("a/b"));
     // sub directory's permission is determined only by the umask
     assert_eq!(
-        at.metadata("a/b").permissions().mode(),
+        at.metadata("a/b").permissions().mode() as mode_t,
         (!default_umask & 0o777) + 0o40000
     );
 
@@ -118,17 +118,17 @@ fn test_mkdir_parent_mode_check_existing_parent() {
     assert!(at.dir_exists("a"));
     // parent dirs that already exist do not get their permissions modified
     assert_eq!(
-        at.metadata("a").permissions().mode(),
+        at.metadata("a").permissions().mode() as mode_t,
         (!default_umask & 0o777) + 0o40000
     );
     assert!(at.dir_exists("a/b"));
     assert_eq!(
-        at.metadata("a/b").permissions().mode(),
+        at.metadata("a/b").permissions().mode() as mode_t,
         ((!default_umask & 0o777) | 0o300) + 0o40000
     );
     assert!(at.dir_exists("a/b/c"));
     assert_eq!(
-        at.metadata("a/b/c").permissions().mode(),
+        at.metadata("a/b/c").permissions().mode() as mode_t,
         (!default_umask & 0o777) + 0o40000
     );
 


### PR DESCRIPTION
should fix mkdir/perm.sh
1. default permission created by mkdir is `a=rwx` (0o0777)
2. permission of parent dirs created by -p argument is `=rwx,u+wx`, which is umask modified by `u+wx`