### PR TITLE
mktemp: prioritize TMPDIR over -p when using -t

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -42,6 +42,11 @@ static OPT_T: &str = "t";
 
 static ARG_TEMPLATE: &str = "template";
 
+#[cfg(not(windows))]
+const TMPDIR_ENV_VAR: &str = "TMPDIR";
+#[cfg(windows)]
+const TMPDIR_ENV_VAR: &str = "TMP";
+
 #[derive(Debug)]
 enum MkTempError {
     PersistError(PathBuf),
@@ -191,7 +196,9 @@ impl Options {
                     (tmpdir, template.to_string())
                 }
                 Some(template) => {
-                    let tmpdir = if matches.contains_id(OPT_TMPDIR) {
+                    let tmpdir = if env::var(TMPDIR_ENV_VAR).is_ok() && matches.get_flag(OPT_T) {
+                        env::var(TMPDIR_ENV_VAR).ok()
+                    } else if matches.contains_id(OPT_TMPDIR) {
                         matches.get_one::<String>(OPT_TMPDIR).map(String::from)
                     } else if matches.get_flag(OPT_T) {
                         // mktemp -t foo.xxx should export in TMPDIR

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -884,3 +884,20 @@ fn test_default_issue_4821_t_tmpdir_p() {
     println!("stdout = {stdout}");
     assert!(stdout.contains(&pathname));
 }
+
+#[test]
+fn test_t_ensure_tmpdir_has_higher_priority_than_p() {
+    let scene = TestScenario::new(util_name!());
+    let pathname = scene.fixtures.as_string();
+    let result = scene
+        .ucmd()
+        .env(TMPDIR, &pathname)
+        .arg("-t")
+        .arg("-p")
+        .arg("should_not_attempt_to_write_in_this_nonexisting_dir")
+        .arg("foo.XXXX")
+        .succeeds();
+    let stdout = result.stdout_str();
+    println!("stdout = {stdout}");
+    assert!(stdout.contains(&pathname));
+}


### PR DESCRIPTION
This PR ensures that the `TMPDIR` env variable has a higher priority than `-p` when using `-t`.

```
$ TMPDIR=dir_a cargo run mktemp -t -p dir_b foo.XXXX
dir_a/foo.DAXt
```

Closes #4874