### PR TITLE
fix(#4886) more: panics if file is not readable

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -104,7 +104,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             if length > 1 {
                 buff.push_str(&MULTI_FILE_TOP_PROMPT.replace("{}", file.to_str().unwrap()));
             }
-            let mut reader = BufReader::new(File::open(file).unwrap());
+            let opened_file = match File::open(file) {
+                Err(why) => {
+                    return Err(UUsageError::new(
+                        1,
+                        format!("cannot open {}: {}", file.quote(), why.kind()),
+                    ))
+                }
+                Ok(opened_file) => opened_file,
+            };
+            let mut reader = BufReader::new(opened_file);
             reader.read_to_string(&mut buff).unwrap();
             more(&buff, &mut stdout, next_file.copied(), &options)?;
             buff.clear();


### PR DESCRIPTION
fix for https://github.com/uutils/coreutils/issues/4886#issue-1719861294
i just changed the unwrap to a match and i hope it actually is a UUsageError i am supposed to return here. I chose UsageError since the code above mine chose UsageError for a similar case

output of the preinstalled more on my linux: `more: cannot open foo: Permission denied`
output of this more: `./more: cannot open 'foo': permission denied 
Try './more --help' for more information.`