### PR TITLE
Bump notify to 5.2.0 and disable tests on android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
+checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -1473,7 +1473,7 @@ dependencies = [
  "libc",
  "mio",
  "walkdir",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ lscolors = { version = "0.14.0", default-features=false, features = ["nu-ansi-te
 memchr = "2"
 nix = { version="0.26", default-features=false }
 nom = "7.1.3"
-notify = { version = "=5.1.0", features=["macos_kqueue"]}
+notify = { version = "=5.2.0", features=["macos_kqueue"]}
 num-bigint = "0.4.3"
 num-traits = "0.2.15"
 number_prefix = "0.4"

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1536,6 +1536,7 @@ fn test_retry8() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
+    not(target_os = "android"),
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))] // FIXME: for currently not working platforms
@@ -1616,6 +1617,7 @@ fn test_retry9() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
+    not(target_os = "android"),
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))] // FIXME: for currently not working platforms
@@ -1678,6 +1680,7 @@ fn test_follow_descriptor_vs_rename1() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
+    not(target_os = "android"),
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))] // FIXME: for currently not working platforms
@@ -2118,6 +2121,7 @@ fn test_follow_name_move_create1() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
+    not(target_os = "android"),
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))] // FIXME: for currently not working platforms


### PR DESCRIPTION
This PR bumps `notify` from `5.1.0` to `5.2.0`, and disables some failing tests on Android.