### PR TITLE
Bump io-lifetimes and remove it from the skip list in deny.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,12 +1226,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -61,13 +61,10 @@ highlight = "all"
 skip = [
     # is-terminal
     { name = "hermit-abi", version = "0.3.1" },
-    # is-terminal
+    # procfs
     { name = "rustix", version = "0.36.14" },
-    # is-terminal (via rustix)
-    { name = "io-lifetimes", version = "1.0.5" },
-    # is-terminal
-    { name = "linux-raw-sys", version = "0.1.4" },
-    # is-terminal
+        { name = "linux-raw-sys", version = "0.1.4" },
+    # various crates
     { name = "windows-sys", version = "0.45.0" },
         { name = "windows-targets", version = "0.42.2" },
             { name = "windows_aarch64_gnullvm", version = "0.42.2" },
@@ -77,7 +74,6 @@ skip = [
             { name = "windows_x86_64_gnu", version = "0.42.2" },
             { name = "windows_x86_64_gnullvm", version = "0.42.2" },
             { name = "windows_x86_64_msvc", version = "0.42.2" },
-
     # tempfile
     { name = "redox_syscall", version = "0.3.5" },
     # cpp_macros


### PR DESCRIPTION
This PR bumps `io-lifetimes` from `1.0.5` to `1.0.11` and removes it from the skip list in `deny.toml`. It also fixes some outdated comments in that file.