### PR TITLE
`head`: use `OsStringExt::from_vec` instead of `std::from_utf8_unchecked`

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -622,12 +622,10 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_arg_iterate_bad_encoding() {
-        #[allow(clippy::invalid_utf8_in_unchecked)]
-        let invalid = unsafe { std::str::from_utf8_unchecked(b"\x80\x81") };
+        use std::os::unix::ffi::OsStringExt;
+        let invalid = OsString::from_vec(vec![b'\x80', b'\x81']);
         // this arises from a conversion from OsString to &str
-        assert!(
-            arg_iterate(vec![OsString::from("head"), OsString::from(invalid)].into_iter()).is_err()
-        );
+        assert!(arg_iterate(vec![OsString::from("head"), invalid].into_iter()).is_err());
     }
     #[test]
     fn read_early_exit() {


### PR DESCRIPTION
This no longer triggers the `invalid_from_utf8_unchecked` lint. It is also a bit cleaner and no longer requires `unsafe` because `OsString` is not guaranteed to be valid UTF-8.

I noticed the lint here: https://github.com/uutils/coreutils/actions/runs/5134271496/jobs/9238032149?pr=4747

cc @cakebaker 