### PR TITLE
tsort: Switch to BTreeMap and BTreeSet

### DIFF
--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -6,7 +6,7 @@
 //  * For the full copyright and license information, please view the LICENSE
 //  * file that was distributed with this source code.
 use clap::{crate_version, Arg, Command};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
@@ -103,8 +103,8 @@ pub fn uu_app() -> Command {
 // but using integer may improve performance.
 #[derive(Default)]
 struct Graph {
-    in_edges: HashMap<String, HashSet<String>>,
-    out_edges: HashMap<String, Vec<String>>,
+    in_edges: BTreeMap<String, BTreeSet<String>>,
+    out_edges: BTreeMap<String, Vec<String>>,
     result: Vec<String>,
 }
 
@@ -122,7 +122,7 @@ impl Graph {
     }
 
     fn init_node(&mut self, n: &str) {
-        self.in_edges.insert(n.to_string(), HashSet::new());
+        self.in_edges.insert(n.to_string(), BTreeSet::new());
         self.out_edges.insert(n.to_string(), vec![]);
     }
 

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -21,6 +21,14 @@ fn test_sort_self_loop() {
 }
 
 #[test]
+fn test_sort_floating_nodes() {
+    new_ucmd!()
+        .pipe_in("d d\nc c\na a\nb b")
+        .succeeds()
+        .stdout_only("a\nb\nc\nd\n");
+}
+
+#[test]
 fn test_no_such_file() {
     new_ucmd!()
         .arg("invalid_file_txt")


### PR DESCRIPTION
Using HashMap and HashSet give a valid topological sort, but the output will change randomly at each run.

BTree based structures will guarantee that the output is always ordered in the same way.

This also makes the ouptut similar to the output of the C version of the tools, on which some applications rely.

An example of application that rely on this is the `initramfs-update` program on Debian that uses `tsort` to create the order of hooks execution. The floating nodes still need to be executed alphabetically to avoid having the `busybox` version of some tools in `initramfs` instead of the full versions. See [this issue](https://gitlab.apertis.org/infrastructure/apertis-issues/-/issues/334#note_100371) on Apertis.

Although the issue could be fixed in `initramfs-update`, other tools/programs could rely on this ordered output and a stable output for a given input makes sense.