### PR TITLE
pwd: Allow -P flag precedence over POSIXLY_CORRECT

### DIFF
--- a/src/uu/pwd/src/pwd.rs
+++ b/src/uu/pwd/src/pwd.rs
@@ -115,7 +115,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // if POSIXLY_CORRECT is set, we want to a logical resolution.
     // This produces a different output when doing mkdir -p a/b && ln -s a/b c && cd c && pwd
     // We should get c in this case instead of a/b at the end of the path
-    let cwd = if matches.get_flag(OPT_LOGICAL) || env::var("POSIXLY_CORRECT").is_ok() {
+    let cwd = if matches.get_flag(OPT_PHYSICAL) {
+        physical_path()
+    } else if matches.get_flag(OPT_LOGICAL) || env::var("POSIXLY_CORRECT").is_ok() {
         logical_path()
     } else {
         physical_path()

--- a/tests/by-util/test_pwd.rs
+++ b/tests/by-util/test_pwd.rs
@@ -116,7 +116,7 @@ fn test_symlinked_default_posix_p() {
         .env("POSIXLY_CORRECT", "1")
         .arg("-P")
         .succeeds()
-        .stdout_is(env.symdir + "\n");
+        .stdout_is(env.subdir + "\n");
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
pwd: Fix #4855

Based on testing with GNU's pwd, it seems like the -P flag should take precedence over the use of the POSIXLY_CORRECT flag.