### PR TITLE
Remove users crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,6 @@ dependencies = [
  "textwrap",
  "time",
  "unindent",
- "users",
  "uu_arch",
  "uu_base32",
  "uu_base64",
@@ -2368,16 +2367,6 @@ name = "unindent"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa30f5ea51ff7edfc797c6d3f9ec8cbd8cfedef5371766b7181d33977f4814f"
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -499,7 +499,6 @@ rlimit = "0.9.1"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace=true, features=["process", "signal", "user"] }
-rust-users = { version="0.11", package="users" }
 rand_pcg = "0.3"
 
 [build-dependencies]

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -1,7 +1,7 @@
 // spell-checker:ignore (words) nosuchgroup groupname
 
 use crate::common::util::TestScenario;
-use rust_users::get_effective_gid;
+use uucore::process::getegid;
 
 #[test]
 fn test_invalid_option() {
@@ -53,7 +53,7 @@ fn test_invalid_group() {
 
 #[test]
 fn test_1() {
-    if get_effective_gid() != 0 {
+    if getegid() != 0 {
         new_ucmd!().arg("bin").arg(DIR).fails().stderr_contains(
             // linux fails with "Operation not permitted (os error 1)"
             // because of insufficient permissions,
@@ -66,7 +66,7 @@ fn test_1() {
 
 #[test]
 fn test_fail_silently() {
-    if get_effective_gid() != 0 {
+    if getegid() != 0 {
         for opt in ["-f", "--silent", "--quiet", "--sil", "--qui"] {
             new_ucmd!()
                 .arg(opt)
@@ -137,7 +137,7 @@ fn test_reference() {
     // skip for root or MS-WSL
     // * MS-WSL is bugged (as of 2019-12-25), allowing non-root accounts su-level privileges for `chgrp`
     // * for MS-WSL, succeeds and stdout == 'group of /etc retained as root'
-    if !(get_effective_gid() == 0 || uucore::os::is_wsl_1()) {
+    if !(getegid() == 0 || uucore::os::is_wsl_1()) {
         new_ucmd!()
             .arg("-v")
             .arg("--reference=/etc/passwd")
@@ -203,7 +203,7 @@ fn test_missing_files() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_big_p() {
-    if get_effective_gid() != 0 {
+    if getegid() != 0 {
         new_ucmd!()
             .arg("-RP")
             .arg("bin")
@@ -218,7 +218,7 @@ fn test_big_p() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn test_big_h() {
-    if get_effective_gid() != 0 {
+    if getegid() != 0 {
         assert!(
             new_ucmd!()
                 .arg("-RH")

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -2,7 +2,7 @@
 
 use crate::common::util::{is_ci, run_ucmd_as_root, CmdResult, TestScenario};
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use rust_users::get_effective_uid;
+use uucore::process::geteuid;
 
 // Apparently some CI environments have configuration issues, e.g. with 'whoami' and 'id'.
 // If we are running inside the CI and "needle" is in "stderr" skipping this test is
@@ -701,7 +701,7 @@ fn test_root_preserve() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn test_big_p() {
-    if get_effective_uid() != 0 {
+    if geteuid() != 0 {
         new_ucmd!()
             .arg("-RP")
             .arg("bin")

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1,7 +1,7 @@
 use crate::common::util::TestScenario;
 use regex::Regex;
 #[cfg(all(unix, not(target_os = "macos")))]
-use rust_users::get_effective_uid;
+use uucore::process::geteuid;
 
 #[test]
 fn test_invalid_arg() {
@@ -213,7 +213,7 @@ fn test_date_format_literal() {
 #[test]
 #[cfg(all(unix, not(target_os = "macos")))]
 fn test_date_set_valid() {
-    if get_effective_uid() == 0 {
+    if geteuid() == 0 {
         new_ucmd!()
             .arg("--set")
             .arg("2020-03-12 13:30:00+08:00")
@@ -234,7 +234,7 @@ fn test_date_set_invalid() {
 #[test]
 #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
 fn test_date_set_permissions_error() {
-    if !(get_effective_uid() == 0 || uucore::os::is_wsl_1()) {
+    if !(geteuid() == 0 || uucore::os::is_wsl_1()) {
         let result = new_ucmd!()
             .arg("--set")
             .arg("2020-03-11 21:45:00+08:00")
@@ -261,7 +261,7 @@ fn test_date_set_mac_unavailable() {
 #[cfg(all(unix, not(target_os = "macos")))]
 /// TODO: expected to fail currently; change to succeeds() when required.
 fn test_date_set_valid_2() {
-    if get_effective_uid() == 0 {
+    if geteuid() == 0 {
         let result = new_ucmd!()
             .arg("--set")
             .arg("Sat 20 Mar 2021 14:53:01 AWST") // spell-checker:disable-line
@@ -325,7 +325,7 @@ fn test_date_for_file() {
 #[cfg(all(unix, not(target_os = "macos")))]
 /// TODO: expected to fail currently; change to succeeds() when required.
 fn test_date_set_valid_3() {
-    if get_effective_uid() == 0 {
+    if geteuid() == 0 {
         let result = new_ucmd!()
             .arg("--set")
             .arg("Sat 20 Mar 2021 14:53:01") // Local timezone
@@ -339,7 +339,7 @@ fn test_date_set_valid_3() {
 #[cfg(all(unix, not(target_os = "macos")))]
 /// TODO: expected to fail currently; change to succeeds() when required.
 fn test_date_set_valid_4() {
-    if get_effective_uid() == 0 {
+    if geteuid() == 0 {
         let result = new_ucmd!()
             .arg("--set")
             .arg("2020-03-11 21:45:00") // Local timezone

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2,12 +2,12 @@
 
 use crate::common::util::{is_ci, TestScenario};
 use filetime::FileTime;
-use rust_users::{get_effective_gid, get_effective_uid};
 use std::os::unix::fs::PermissionsExt;
 #[cfg(not(any(windows, target_os = "freebsd")))]
 use std::process::Command;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::thread::sleep;
+use uucore::process::{getegid, geteuid};
 
 #[test]
 fn test_invalid_arg() {
@@ -322,7 +322,7 @@ fn test_install_target_new_file_with_group() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "file";
     let dir = "target_dir";
-    let gid = get_effective_gid();
+    let gid = getegid();
 
     at.touch(file);
     at.mkdir(dir);
@@ -349,7 +349,7 @@ fn test_install_target_new_file_with_owner() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "file";
     let dir = "target_dir";
-    let uid = get_effective_uid();
+    let uid = geteuid();
 
     at.touch(file);
     at.mkdir(dir);


### PR DESCRIPTION
This PR removes the unmaintained `users` crate and uses the same functionality from `uucore::process` instead.

Closes #4941 