### PR TITLE
More implement arguments plain and from line

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -312,7 +312,7 @@ fn more(
         pager.content_rows += 3;
     }
 
-    if pager.should_close() {
+    if pager.should_close() && next_file.is_none() {
         return Ok(());
     }
 
@@ -499,10 +499,10 @@ impl<'a> Pager<'a> {
     }
 
     fn draw(&mut self, stdout: &mut std::io::Stdout, wrong_key: Option<char>) {
+        self.draw_lines(stdout);
         let lower_mark = self
             .line_count
             .min(self.upper_mark.saturating_add(self.content_rows.into()));
-        self.draw_lines(stdout);
         self.draw_prompt(stdout, lower_mark, wrong_key);
         stdout.flush().unwrap();
     }

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -21,9 +21,15 @@ fn test_valid_arg() {
         new_ucmd!().arg("-s").succeeds();
         new_ucmd!().arg("--squeeze").succeeds();
 
+        new_ucmd!().arg("-u").succeeds();
+        new_ucmd!().arg("--plain").succeeds();
+
         new_ucmd!().arg("-n").arg("10").succeeds();
         new_ucmd!().arg("--lines").arg("0").succeeds();
         new_ucmd!().arg("--number").arg("0").succeeds();
+
+        new_ucmd!().arg("-F").arg("10").succeeds();
+        new_ucmd!().arg("--from-line").arg("0").succeeds();
     }
 }
 
@@ -34,6 +40,8 @@ fn test_invalid_arg() {
 
         new_ucmd!().arg("--lines").arg("-10").fails();
         new_ucmd!().arg("--number").arg("-10").fails();
+
+        new_ucmd!().arg("--from-line").arg("-10").fails();
     }
 }
 

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -46,6 +46,40 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_argument_from_file() {
+    if std::io::stdout().is_terminal() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+
+        let file = "test_file";
+
+        at.write(file, "1\n2");
+
+        // output all lines
+        scene
+            .ucmd()
+            .arg("-F")
+            .arg("0")
+            .arg(file)
+            .succeeds()
+            .no_stderr()
+            .stdout_contains("1")
+            .stdout_contains("2");
+
+        // output only the second line
+        scene
+            .ucmd()
+            .arg("-F")
+            .arg("2")
+            .arg(file)
+            .succeeds()
+            .no_stderr()
+            .stdout_contains("2")
+            .stdout_does_not_contain("1");
+    }
+}
+
+#[test]
 fn test_more_dir_arg() {
     // Run the test only if there's a valid terminal, else do nothing
     // Maybe we could capture the error, i.e. "Device not found" in that case


### PR DESCRIPTION
Related to #2320 

This implements the arguments `plain` and `from-line`.

The `plain` option does nothing because, according to the man page of `more`, it is written that this option is silently ignored as backwards compatibility.

This also fixes two bugs. 

The first one occurs when multiple files are given, and a file takes one display to output its content. Now, it displays the next file message if there is another file and only stops if there is none other.
The second one happens with the `squeeze` option. When multiple files are given and the end of the file takes less than a full terminal size to display, it should not start printing the next file.