### PR TITLE
ls: Implement new sort option --sort=width 

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -294,6 +294,7 @@ enum Sort {
     Time,
     Version,
     Extension,
+    Width,
 }
 
 #[derive(PartialEq)]
@@ -496,6 +497,7 @@ fn extract_sort(options: &clap::ArgMatches) -> Sort {
             "size" => Sort::Size,
             "version" => Sort::Version,
             "extension" => Sort::Extension,
+            "width" => Sort::Width,
             // below should never happen as clap already restricts the values.
             _ => unreachable!("Invalid field for --sort"),
         }
@@ -1322,9 +1324,9 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::SORT)
                 .long(options::SORT)
-                .help("Sort by <field>: name, none (-U), time (-t), size (-S) or extension (-X)")
+                .help("Sort by <field>: name, none (-U), time (-t), size (-S), extension (-X) or width")
                 .value_name("field")
-                .value_parser(["name", "none", "time", "size", "version", "extension"])
+                .value_parser(["name", "none", "time", "size", "version", "extension", "width"])
                 .require_equals(true)
                 .overrides_with_all([
                     options::SORT,
@@ -1936,6 +1938,12 @@ fn sort_entries(entries: &mut [PathData], config: &Config, out: &mut BufWriter<S
                 .extension()
                 .cmp(&b.p_buf.extension())
                 .then(a.p_buf.file_stem().cmp(&b.p_buf.file_stem()))
+        }),
+        Sort::Width => entries.sort_by(|a, b| {
+            a.display_name
+                .len()
+                .cmp(&b.display_name.len())
+                .then(a.display_name.cmp(&b.display_name))
         }),
         Sort::None => {}
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc
+// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff
 
 #[cfg(any(unix, feature = "feat_selinux"))]
 use crate::common::util::expected_result;

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1565,6 +1565,28 @@ fn test_ls_sort_name() {
 }
 
 #[test]
+fn test_ls_sort_width() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.touch("aaaaa");
+    at.touch("bbb");
+    at.touch("cccc");
+    at.touch("eee");
+    at.touch("d");
+    at.touch("fffff");
+    at.touch("abc");
+    at.touch("zz");
+    at.touch("bcdef");
+
+    scene
+        .ucmd()
+        .arg("--sort=width")
+        .succeeds()
+        .stdout_is("d\nzz\nabc\nbbb\neee\ncccc\naaaaa\nbcdef\nfffff\n");
+}
+
+#[test]
 fn test_ls_order_size() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
This option was introduced in some more recent versions of GNU coreutils (around 2021-4-11) which lets you sort by filename widths .

One oddity of this particular option in GNU coreutils is that unlike other sort options, this one does not have a shorthand form flag so I have implemented it similarly as such here.