### PR TITLE
mkdir: remove TEST_DIR<x> consts in tests

### DIFF
--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -12,20 +12,6 @@ use std::sync::Mutex;
 // when writing a test case, acquire this mutex before proceeding with the main logic of the test
 static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
-static TEST_DIR1: &str = "mkdir_test1";
-static TEST_DIR2: &str = "mkdir_test2";
-static TEST_DIR3: &str = "mkdir_test3";
-static TEST_DIR4: &str = "mkdir_test4/mkdir_test4_1";
-static TEST_DIR5: &str = "mkdir_test5/mkdir_test5_1";
-static TEST_DIR6: &str = "mkdir_test6";
-static TEST_FILE7: &str = "mkdir_test7";
-static TEST_DIR8: &str = "mkdir_test8/mkdir_test8_1/mkdir_test8_2";
-static TEST_DIR9: &str = "mkdir_test9/../mkdir_test9_1/../mkdir_test9_2";
-static TEST_DIR10: &str = "mkdir_test10/.";
-static TEST_DIR11: &str = "mkdir_test11/..";
-#[cfg(not(windows))]
-static TEST_DIR12: &str = "mkdir_test12";
-
 #[test]
 fn test_invalid_arg() {
     let _guard = TEST_MUTEX.lock();
@@ -35,15 +21,15 @@ fn test_invalid_arg() {
 #[test]
 fn test_mkdir_mkdir() {
     let _guard = TEST_MUTEX.lock();
-    new_ucmd!().arg(TEST_DIR1).succeeds();
+    new_ucmd!().arg("test_dir").succeeds();
 }
 
 #[test]
 fn test_mkdir_verbose() {
     let _guard = TEST_MUTEX.lock();
-    let expected = "mkdir: created directory 'mkdir_test1'\n";
+    let expected = "mkdir: created directory 'test_dir'\n";
     new_ucmd!()
-        .arg(TEST_DIR1)
+        .arg("test_dir")
         .arg("-v")
         .run()
         .stdout_is(expected);
@@ -52,39 +38,47 @@ fn test_mkdir_verbose() {
 #[test]
 fn test_mkdir_dup_dir() {
     let _guard = TEST_MUTEX.lock();
+
     let scene = TestScenario::new(util_name!());
-    scene.ucmd().arg(TEST_DIR2).succeeds();
-    scene.ucmd().arg(TEST_DIR2).fails();
+    let test_dir = "test_dir";
+
+    scene.ucmd().arg(test_dir).succeeds();
+    scene.ucmd().arg(test_dir).fails();
 }
 
 #[test]
 fn test_mkdir_mode() {
     let _guard = TEST_MUTEX.lock();
-    new_ucmd!().arg("-m").arg("755").arg(TEST_DIR3).succeeds();
+    new_ucmd!().arg("-m").arg("755").arg("test_dir").succeeds();
 }
 
 #[test]
 fn test_mkdir_parent() {
     let _guard = TEST_MUTEX.lock();
     let scene = TestScenario::new(util_name!());
-    scene.ucmd().arg("-p").arg(TEST_DIR4).succeeds();
-    scene.ucmd().arg("-p").arg(TEST_DIR4).succeeds();
-    scene.ucmd().arg("--parent").arg(TEST_DIR4).succeeds();
-    scene.ucmd().arg("--parents").arg(TEST_DIR4).succeeds();
+    let test_dir = "parent_dir/child_dir";
+
+    scene.ucmd().arg("-p").arg(test_dir).succeeds();
+    scene.ucmd().arg("-p").arg(test_dir).succeeds();
+    scene.ucmd().arg("--parent").arg(test_dir).succeeds();
+    scene.ucmd().arg("--parents").arg(test_dir).succeeds();
 }
 
 #[test]
 fn test_mkdir_no_parent() {
     let _guard = TEST_MUTEX.lock();
-    new_ucmd!().arg(TEST_DIR5).fails();
+    new_ucmd!().arg("parent_dir/child_dir").fails();
 }
 
 #[test]
 fn test_mkdir_dup_dir_parent() {
     let _guard = TEST_MUTEX.lock();
+
     let scene = TestScenario::new(util_name!());
-    scene.ucmd().arg(TEST_DIR6).succeeds();
-    scene.ucmd().arg("-p").arg(TEST_DIR6).succeeds();
+    let test_dir = "test_dir";
+
+    scene.ucmd().arg(test_dir).succeeds();
+    scene.ucmd().arg("-p").arg(test_dir).succeeds();
 }
 
 #[cfg(not(windows))]
@@ -158,12 +152,16 @@ fn test_mkdir_parent_mode_check_existing_parent() {
 #[test]
 fn test_mkdir_dup_file() {
     let _guard = TEST_MUTEX.lock();
+
     let scene = TestScenario::new(util_name!());
-    scene.fixtures.touch(TEST_FILE7);
-    scene.ucmd().arg(TEST_FILE7).fails();
+    let test_file = "test_file.txt";
+
+    scene.fixtures.touch(test_file);
+
+    scene.ucmd().arg(test_file).fails();
 
     // mkdir should fail for a file even if -p is specified.
-    scene.ucmd().arg("-p").arg(TEST_FILE7).fails();
+    scene.ucmd().arg("-p").arg(test_file).fails();
 }
 
 #[test]
@@ -171,9 +169,10 @@ fn test_mkdir_dup_file() {
 fn test_symbolic_mode() {
     let _guard = TEST_MUTEX.lock();
     let (at, mut ucmd) = at_and_ucmd!();
+    let test_dir = "test_dir";
 
-    ucmd.arg("-m").arg("a=rwx").arg(TEST_DIR1).succeeds();
-    let perms = at.metadata(TEST_DIR1).permissions().mode();
+    ucmd.arg("-m").arg("a=rwx").arg(test_dir).succeeds();
+    let perms = at.metadata(test_dir).permissions().mode();
     assert_eq!(perms, 0o40777);
 }
 
@@ -182,12 +181,13 @@ fn test_symbolic_mode() {
 fn test_symbolic_alteration() {
     let _guard = TEST_MUTEX.lock();
     let (at, mut ucmd) = at_and_ucmd!();
+    let test_dir = "test_dir";
 
     let default_umask = 0o022;
     let original_umask = unsafe { umask(default_umask) };
 
-    ucmd.arg("-m").arg("-w").arg(TEST_DIR1).succeeds();
-    let perms = at.metadata(TEST_DIR1).permissions().mode();
+    ucmd.arg("-m").arg("-w").arg(test_dir).succeeds();
+    let perms = at.metadata(test_dir).permissions().mode();
     assert_eq!(perms, 0o40577);
 
     unsafe { umask(original_umask) };
@@ -198,60 +198,60 @@ fn test_symbolic_alteration() {
 fn test_multi_symbolic() {
     let _guard = TEST_MUTEX.lock();
     let (at, mut ucmd) = at_and_ucmd!();
+    let test_dir = "test_dir";
 
-    ucmd.arg("-m")
-        .arg("u=rwx,g=rx,o=")
-        .arg(TEST_DIR1)
-        .succeeds();
-    let perms = at.metadata(TEST_DIR1).permissions().mode();
+    ucmd.arg("-m").arg("u=rwx,g=rx,o=").arg(test_dir).succeeds();
+    let perms = at.metadata(test_dir).permissions().mode();
     assert_eq!(perms, 0o40750);
 }
 
 #[test]
 fn test_recursive_reporting() {
     let _guard = TEST_MUTEX.lock();
+    let test_dir = "test_dir/test_dir_a/test_dir_b";
+
     new_ucmd!()
         .arg("-p")
         .arg("-v")
-        .arg(TEST_DIR8)
+        .arg(test_dir)
         .succeeds()
-        .stdout_contains("created directory 'mkdir_test8'")
-        .stdout_contains("created directory 'mkdir_test8/mkdir_test8_1'")
-        .stdout_contains("created directory 'mkdir_test8/mkdir_test8_1/mkdir_test8_2'");
-    new_ucmd!().arg("-v").arg(TEST_DIR8).fails().no_stdout();
+        .stdout_contains("created directory 'test_dir'")
+        .stdout_contains("created directory 'test_dir/test_dir_a'")
+        .stdout_contains("created directory 'test_dir/test_dir_a/test_dir_b'");
+    new_ucmd!().arg("-v").arg(test_dir).fails().no_stdout();
+
+    let test_dir = "test_dir/../test_dir_a/../test_dir_b";
+
     new_ucmd!()
         .arg("-p")
         .arg("-v")
-        .arg(TEST_DIR9)
+        .arg(test_dir)
         .succeeds()
-        .stdout_contains("created directory 'mkdir_test9'")
-        .stdout_contains("created directory 'mkdir_test9/../mkdir_test9_1'")
-        .stdout_contains("created directory 'mkdir_test9/../mkdir_test9_1/../mkdir_test9_2'");
+        .stdout_contains("created directory 'test_dir'")
+        .stdout_contains("created directory 'test_dir/../test_dir_a'")
+        .stdout_contains("created directory 'test_dir/../test_dir_a/../test_dir_b'");
 }
 
 #[test]
 fn test_mkdir_trailing_dot() {
     let _guard = TEST_MUTEX.lock();
     let scene2 = TestScenario::new("ls");
-    new_ucmd!()
-        .arg("-p")
-        .arg("-v")
-        .arg("mkdir_test10-2")
-        .succeeds();
+
+    new_ucmd!().arg("-p").arg("-v").arg("test_dir").succeeds();
 
     new_ucmd!()
         .arg("-p")
         .arg("-v")
-        .arg(TEST_DIR10)
+        .arg("test_dir_a/.")
         .succeeds()
-        .stdout_contains("created directory 'mkdir_test10'");
+        .stdout_contains("created directory 'test_dir_a'");
 
     new_ucmd!()
         .arg("-p")
         .arg("-v")
-        .arg(TEST_DIR11)
+        .arg("test_dir_b/..")
         .succeeds()
-        .stdout_contains("created directory 'mkdir_test11'");
+        .stdout_contains("created directory 'test_dir_b'");
     let result = scene2.ucmd().arg("-al").run();
     println!("ls dest {}", result.stdout_str());
 }
@@ -261,12 +261,14 @@ fn test_mkdir_trailing_dot() {
 fn test_umask_compliance() {
     fn test_single_case(umask_set: mode_t) {
         let _guard = TEST_MUTEX.lock();
+
+        let test_dir = "test_dir";
         let (at, mut ucmd) = at_and_ucmd!();
 
         let original_umask = unsafe { umask(umask_set) };
 
-        ucmd.arg(TEST_DIR12).succeeds();
-        let perms = at.metadata(TEST_DIR12).permissions().mode() as mode_t;
+        ucmd.arg(test_dir).succeeds();
+        let perms = at.metadata(test_dir).permissions().mode() as mode_t;
 
         assert_eq!(perms, (!umask_set & 0o0777) + 0o40000); // before compare, add the set GUID, UID bits
         unsafe {

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -235,7 +235,6 @@ fn test_recursive_reporting() {
 #[test]
 fn test_mkdir_trailing_dot() {
     let _guard = TEST_MUTEX.lock();
-    let scene2 = TestScenario::new("ls");
 
     new_ucmd!().arg("-p").arg("-v").arg("test_dir").succeeds();
 
@@ -252,7 +251,9 @@ fn test_mkdir_trailing_dot() {
         .arg("test_dir_b/..")
         .succeeds()
         .stdout_contains("created directory 'test_dir_b'");
-    let result = scene2.ucmd().arg("-al").run();
+
+    let scene = TestScenario::new("ls");
+    let result = scene.ucmd().arg("-al").run();
     println!("ls dest {}", result.stdout_str());
 }
 


### PR DESCRIPTION
This PR removes all `TEST_DIR<x>` consts to improve the readability of the tests.