### PR TITLE
date: switch to parse_datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,16 +1155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime_to_duration"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80a233096ddccb74e62145f3a49cacea6a2669ee90f6e144e15fe28f4037c4"
-dependencies = [
- "chrono",
- "regex",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +1642,16 @@ dependencies = [
  "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "parse_datetime"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecceaede7767a9a98058687a321bc91742eff7670167a34104afb30fc8757df"
+dependencies = [
+ "chrono",
+ "regex",
 ]
 
 [[package]]
@@ -2539,8 +2539,8 @@ version = "0.0.19"
 dependencies = [
  "chrono",
  "clap",
- "humantime_to_duration 0.3.1",
  "libc",
+ "parse_datetime",
  "uucore",
  "windows-sys 0.48.0",
 ]
@@ -3235,7 +3235,7 @@ version = "0.0.19"
 dependencies = [
  "clap",
  "filetime",
- "humantime_to_duration 0.2.1",
+ "humantime_to_duration",
  "time",
  "uucore",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) libselinux gethostid procfs bigdecimal kqueue fundu mangen humantime uuhelp
+# spell-checker:ignore (libs) libselinux gethostid procfs bigdecimal kqueue fundu mangen datetime uuhelp
 
 [package]
 name = "coreutils"
@@ -284,7 +284,6 @@ fundu = "1.0.0"
 gcd = "2.3"
 glob = "0.3.1"
 half = "2.2"
-humantime_to_duration = "0.3.1"
 indicatif = "0.17"
 is-terminal = "0.4.7"
 itertools = "0.10.5"
@@ -302,6 +301,7 @@ number_prefix = "0.4"
 once_cell = "1.18.0"
 onig = { version = "~6.4", default-features = false }
 ouroboros = "0.15.6"
+parse_datetime = "0.4.0"
 phf = "0.11.1"
 phf_codegen = "0.11.1"
 platform-info = "2.0.1"

--- a/deny.toml
+++ b/deny.toml
@@ -87,8 +87,6 @@ skip = [
   { name = "redox_syscall", version = "0.3.5" },
   # cpp_macros
   { name = "aho-corasick", version = "0.7.19" },
-  # touch, can be remove when touch switches from time to chrono
-  { name = "humantime_to_duration", version = "0.2.1" },
 ]
 # spell-checker: enable
 

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -1,4 +1,4 @@
-# spell-checker:ignore humantime
+# spell-checker:ignore datetime
 [package]
 name = "uu_date"
 version = "0.0.19"
@@ -19,7 +19,7 @@ path = "src/date.rs"
 chrono = { workspace = true }
 clap = { workspace = true }
 uucore = { workspace = true }
-humantime_to_duration = { workspace = true }
+parse_datetime = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -6,7 +6,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (chrono) Datelike Timelike ; (format) DATEFILE MMDDhhmm ; (vars) datetime datetimes humantime
+// spell-checker:ignore (chrono) Datelike Timelike ; (format) DATEFILE MMDDhhmm ; (vars) datetime datetimes
 
 use chrono::format::{Item, StrftimeItems};
 use chrono::{DateTime, Duration, FixedOffset, Local, Offset, Utc};
@@ -170,7 +170,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let date_source = if let Some(date) = matches.get_one::<String>(OPT_DATE) {
-        if let Ok(duration) = humantime_to_duration::from_str(date.as_str()) {
+        if let Ok(duration) = parse_datetime::from_str(date.as_str()) {
             DateSource::Human(duration)
         } else {
             DateSource::Custom(date.into())


### PR DESCRIPTION
This PR replaces `humantime_to_duration` with its successor `parse_datetime`. It also removes `humantime_to_duration` from the skip list in `deny.toml` because with this update we no longer use two versions of `humantime_to_duration`.