### PR TITLE
mv: Fix for tests/mv/symlink-onto-hardlink-to-self.sh

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 use uucore::backup_control::{self, BackupMode};
 use uucore::display::Quotable;
 use uucore::error::{set_exit_code, FromIo, UError, UResult, USimpleError, UUsageError};
-use uucore::fs::are_hardlinks_or_one_way_symlink_to_same_file;
+use uucore::fs::{are_hardlinks_or_one_way_symlink_to_same_file, are_hardlinks_to_same_file};
 use uucore::update_control::{self, UpdateMode};
 use uucore::{format_usage, help_about, help_section, help_usage, prompt_yes, show};
 
@@ -255,8 +255,10 @@ fn handle_two_paths(source: &Path, target: &Path, b: &Behavior) -> UResult<()> {
         return Err(MvError::NoSuchFile(source.quote().to_string()).into());
     }
 
-    if (source.eq(target) || are_hardlinks_or_one_way_symlink_to_same_file(source, target))
-        && b.backup != BackupMode::SimpleBackup
+    if (source.eq(target)
+        || are_hardlinks_to_same_file(source, target)
+        || are_hardlinks_or_one_way_symlink_to_same_file(source, target))
+        && b.backup == BackupMode::NoBackup
     {
         if source.eq(Path::new(".")) || source.ends_with("/.") || source.is_file() {
             return Err(

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -635,12 +635,12 @@ pub fn are_hardlinks_to_same_file(_source: &Path, _target: &Path) -> bool {
 /// * `bool` - Returns `true` if the paths are hard links to the same file, and `false` otherwise.
 #[cfg(unix)]
 pub fn are_hardlinks_to_same_file(source: &Path, target: &Path) -> bool {
-    let source_metadata = match fs::metadata(source) {
+    let source_metadata = match fs::symlink_metadata(source) {
         Ok(metadata) => metadata,
         Err(_) => return false,
     };
 
-    let target_metadata = match fs::metadata(target) {
+    let target_metadata = match fs::symlink_metadata(target) {
         Ok(metadata) => metadata,
         Err(_) => return false,
     };

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -467,6 +467,35 @@ fn test_mv_same_symlink() {
 
 #[test]
 #[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_hardlink_to_symlink() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "file";
+    let symlink_file = "symlink";
+    let hardlink_to_symlink_file = "hardlink_to_symlink";
+
+    at.touch(file);
+    at.symlink_file(file, symlink_file);
+    at.hard_link(symlink_file, hardlink_to_symlink_file);
+
+    ucmd.arg(symlink_file).arg(hardlink_to_symlink_file).fails();
+
+    let (at2, mut ucmd2) = at_and_ucmd!();
+
+    at2.touch(file);
+    at2.symlink_file(file, symlink_file);
+    at2.hard_link(symlink_file, hardlink_to_symlink_file);
+
+    ucmd2
+        .arg("--backup")
+        .arg(symlink_file)
+        .arg(hardlink_to_symlink_file)
+        .succeeds();
+    assert!(!at2.symlink_exists(symlink_file));
+    assert!(at2.symlink_exists(&format!("{hardlink_to_symlink_file}~")));
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
 fn test_mv_same_hardlink_backup_simple() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_same_file_a";


### PR DESCRIPTION
My previous PR missed an extremely special case of moving onto a hardlink to symbolic link. So, the correct way is to first check immediate metadata for hard link before checking for symbolic link. In short, the previous PR I put may have caused this test to regress silently, which was already not passing

Previously, the only reason this test was failing was due to the --backup option part of the test not passing, which I have fixed as well. 

This PR should fix tests/mv/symlink-onto-hardlink-to-self.sh keeping all else intact.