### PR TITLE
od: fix parsing of hex input ending with `E`

### DIFF
--- a/src/uu/od/src/parse_nrofbytes.rs
+++ b/src/uu/od/src/parse_nrofbytes.rs
@@ -43,7 +43,7 @@ pub fn parse_number_of_bytes(s: &str) -> Result<u64, ParseSizeError> {
             len -= 1;
         }
         #[cfg(target_pointer_width = "64")]
-        Some('E') => {
+        Some('E') if radix != 16 => {
             multiply = 1024 * 1024 * 1024 * 1024 * 1024 * 1024;
             len -= 1;
         }
@@ -84,6 +84,7 @@ fn test_parse_number_of_bytes() {
 
     // hex input
     assert_eq!(15, parse_number_of_bytes("0xf").unwrap());
+    assert_eq!(14, parse_number_of_bytes("0XE").unwrap());
     assert_eq!(15, parse_number_of_bytes("0XF").unwrap());
     assert_eq!(27, parse_number_of_bytes("0x1b").unwrap());
     assert_eq!(16 * 1024, parse_number_of_bytes("0x10k").unwrap());

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -628,6 +628,35 @@ fn test_skip_bytes() {
 }
 
 #[test]
+fn test_skip_bytes_hex() {
+    let input = "abcdefghijklmnopq"; // spell-checker:disable-line
+    new_ucmd!()
+        .arg("-c")
+        .arg("--skip-bytes=0xB")
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
+            "
+            0000013   l   m   n   o   p   q
+            0000021
+            ",
+        ));
+    new_ucmd!()
+        .arg("-c")
+        .arg("--skip-bytes=0xE")
+        .run_piped_stdin(input.as_bytes())
+        .no_stderr()
+        .success()
+        .stdout_is(unindent(
+            "
+            0000016   o   p   q
+            0000021
+            ",
+        ));
+}
+
+#[test]
 fn test_skip_bytes_error() {
     let input = "12345";
     new_ucmd!()


### PR DESCRIPTION
This should fix #4981.

This is my first contribution in Rust and I just started learning it today, so pardon me if I missed something, do let me know and I will fix it promptly!

Special thanks to @tertsdiepraam for finding the bug before I even started learning Rust, thus saving me a bunch of time :smile: