### PR TITLE
deny.toml: add hashbrown to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -87,6 +87,8 @@ skip = [
   { name = "redox_syscall", version = "0.3.5" },
   # cpp_macros
   { name = "aho-corasick", version = "0.7.19" },
+  # ordered-multimap (via rust-ini)
+  { name = "hashbrown", version = "0.13.2" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR adds `hashbrown` to the skip list in `deny.toml`. This is done to unblock https://github.com/uutils/coreutils/pull/4825, where `cargo-deny` currently fails with a "found 2 duplicate entries for crate 'hashbrown'" error.