### PR TITLE
cut-huge-range.sh: make cut fails on usize::MAX

### DIFF
--- a/src/uucore/src/lib/features/ranges.rs
+++ b/src/uucore/src/lib/features/ranges.rs
@@ -161,6 +161,7 @@ pub fn contain(ranges: &[Range], n: usize) -> bool {
 #[cfg(test)]
 mod test {
     use super::{complement, Range};
+    use std::str::FromStr;
 
     fn m(a: Vec<Range>, b: &[Range]) {
         assert_eq!(Range::merge(a), b);
@@ -230,5 +231,34 @@ mod test {
 
         // With start and end
         assert_eq!(complement(&[r(1, 4), r(6, usize::MAX - 1)]), vec![r(5, 5)]);
+    }
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(Range::from_str("5"), Ok(Range { low: 5, high: 5 }));
+        assert_eq!(Range::from_str("3-5"), Ok(Range { low: 3, high: 5 }));
+        assert_eq!(
+            Range::from_str("5-3"),
+            Err("high end of range less than low end")
+        );
+        assert_eq!(Range::from_str("-"), Err("invalid range with no endpoint"));
+        assert_eq!(
+            Range::from_str("3-"),
+            Ok(Range {
+                low: 3,
+                high: usize::MAX - 1
+            })
+        );
+        assert_eq!(Range::from_str("-5"), Ok(Range { low: 1, high: 5 }));
+        assert_eq!(
+            Range::from_str("0"),
+            Err("fields and positions are numbered from 1")
+        );
+
+        let max_value = format!("{}", usize::MAX);
+        assert_eq!(
+            Range::from_str(&max_value),
+            Err("byte/character offset is too large")
+        );
     }
 }

--- a/src/uucore/src/lib/features/ranges.rs
+++ b/src/uucore/src/lib/features/ranges.rs
@@ -38,6 +38,8 @@ impl FromStr for Range {
         fn parse(s: &str) -> Result<usize, &'static str> {
             match s.parse::<usize>() {
                 Ok(0) => Err("fields and positions are numbered from 1"),
+                // GNU fails when we are at the limit. Match their behavior
+                Ok(n) if n == usize::MAX => Err("byte/character offset is too large"),
                 Ok(n) => Ok(n),
                 Err(_) => Err("failed to parse range"),
             }

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -118,6 +118,14 @@ fn test_whitespace_with_char() {
 }
 
 #[test]
+fn test_too_large() {
+    new_ucmd!()
+        .args(&["-b1-18446744073709551615", "/dev/null"])
+        .fails()
+        .code_is(1);
+}
+
+#[test]
 fn test_specify_delimiter() {
     for param in ["-d", "--delimiter", "--del"] {
         new_ucmd!()


### PR DESCRIPTION
GNU fails with
$ cut -b18446744073709551615 /dev/null
but we are able to support this value

we both fail with
$ cut -b18446744073709551616 /dev/null