### PR TITLE
yes: add --version option

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -9,7 +9,7 @@
 
 // cSpell:ignore strs
 
-use clap::{builder::ValueParser, Arg, ArgAction, Command};
+use clap::{builder::ValueParser, crate_version, Arg, ArgAction, Command};
 use std::error::Error;
 use std::ffi::OsString;
 use std::io::{self, Write};
@@ -44,6 +44,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
+        .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .arg(


### PR DESCRIPTION
`--version` option is not implemented in `yes`.
So I've fixed `src/uu/yes/src/yes.rs`.