### PR TITLE
nl: implement Default for Settings

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -6,8 +6,6 @@
 //  * file that was distributed with this source code.
 //  *
 
-// spell-checker:ignore (ToDO) corasick memchr
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -18,8 +18,8 @@ use uucore::{format_usage, help_about, help_usage};
 
 mod helper;
 
-static ABOUT: &str = help_about!("nl.md");
-static USAGE: &str = help_usage!("nl.md");
+const ABOUT: &str = help_about!("nl.md");
+const USAGE: &str = help_usage!("nl.md");
 
 // Settings store options used by nl to produce its output.
 pub struct Settings {

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -42,6 +42,24 @@ pub struct Settings {
     number_separator: String,
 }
 
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            header_numbering: NumberingStyle::NumberForNone,
+            body_numbering: NumberingStyle::NumberForAll,
+            footer_numbering: NumberingStyle::NumberForNone,
+            section_delimiter: ['\\', ':'],
+            starting_line_number: 1,
+            line_increment: 1,
+            join_blank_lines: 1,
+            number_width: 6,
+            number_format: NumberFormat::Right,
+            renumber: true,
+            number_separator: String::from("\t"),
+        }
+    }
+}
+
 // NumberingStyle stores which lines are to be numbered.
 // The possible options are:
 // 1. Number all lines
@@ -87,20 +105,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().try_get_matches_from(args)?;
 
-    // A mutable settings object, initialized with the defaults.
-    let mut settings = Settings {
-        header_numbering: NumberingStyle::NumberForNone,
-        body_numbering: NumberingStyle::NumberForAll,
-        footer_numbering: NumberingStyle::NumberForNone,
-        section_delimiter: ['\\', ':'],
-        starting_line_number: 1,
-        line_increment: 1,
-        join_blank_lines: 1,
-        number_width: 6,
-        number_format: NumberFormat::Right,
-        renumber: true,
-        number_separator: String::from("\t"),
-    };
+    let mut settings = Settings::default();
 
     // Update the settings from the command line options, and terminate the
     // program if some options could not successfully be parsed.


### PR DESCRIPTION
This PR implements `Default` for `Settings`. It also replaces `static` with `const`, and removes the unnecessary `spell-checker:ignore` line.