### PR TITLE
`timeout`: Make use of fundu in timeout to parse the KILL_AFTER and DURATION arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ name = "uu_timeout"
 version = "0.0.19"
 dependencies = [
  "clap",
+ "fundu",
  "libc",
  "nix",
  "uucore",

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["signal"] }
 uucore = { workspace = true, features = ["process", "signals"] }
+fundu = { workspace = true }
 
 [[bin]]
 name = "timeout"

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -22,7 +22,7 @@ fn test_invalid_time_interval() {
         .args(&["xyz", "sleep", "0"])
         .fails()
         .code_is(125)
-        .usage_error("invalid time interval 'xyz'");
+        .usage_error("invalid time interval 'xyz': Invalid input: 'xyz' at position 1");
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn test_invalid_kill_after() {
         .args(&["-k", "xyz", "1", "sleep", "0"])
         .fails()
         .code_is(125)
-        .usage_error("invalid time interval 'xyz'");
+        .usage_error("invalid time interval 'xyz': Invalid input: 'xyz' at position 1");
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_command_empty_args() {
     new_ucmd!()
         .args(&["", ""])
         .fails()
-        .stderr_contains("timeout: empty string");
+        .usage_error("invalid time interval '': Empty input");
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn test_negative_interval() {
     new_ucmd!()
         .args(&["--", "-1", "sleep", "0"])
         .fails()
-        .usage_error("invalid time interval '-1'");
+        .usage_error("invalid time interval '-1': Number was negative");
 }
 
 #[test]
@@ -126,7 +126,7 @@ fn test_invalid_multi_byte_characters() {
     new_ucmd!()
         .args(&["10€", "sleep", "0"])
         .fails()
-        .usage_error("invalid time interval '10€'");
+        .usage_error("invalid time interval '10€': Invalid time unit: '€' at position 3");
 }
 
 /// Test that the long form of the `--kill-after` argument is recognized.


### PR DESCRIPTION
As the title describes, make use of fundu which is faster by maintaining full precision of the input arguments and has nicer error messages if something goes wrong during the parsing.