### PR TITLE
seq: rename "--widths" to "--equal-width"

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -31,7 +31,7 @@ const USAGE: &str = help_usage!("seq.md");
 
 const OPT_SEPARATOR: &str = "separator";
 const OPT_TERMINATOR: &str = "terminator";
-const OPT_WIDTHS: &str = "widths";
+const OPT_EQUAL_WIDTH: &str = "equal-width";
 const OPT_FORMAT: &str = "format";
 
 const ARG_NUMBERS: &str = "numbers";
@@ -40,7 +40,7 @@ const ARG_NUMBERS: &str = "numbers";
 struct SeqOptions<'a> {
     separator: String,
     terminator: String,
-    widths: bool,
+    equal_width: bool,
     format: Option<&'a str>,
 }
 
@@ -74,7 +74,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .map(|s| s.as_str())
             .unwrap_or("\n")
             .to_string(),
-        widths: matches.get_flag(OPT_WIDTHS),
+        equal_width: matches.get_flag(OPT_EQUAL_WIDTH),
         format: matches.get_one::<String>(OPT_FORMAT).map(|s| s.as_str()),
     };
 
@@ -123,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 (first, increment, last),
                 &options.separator,
                 &options.terminator,
-                options.widths,
+                options.equal_width,
                 padding,
                 options.format,
             )
@@ -137,7 +137,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             largest_dec,
             &options.separator,
             &options.terminator,
-            options.widths,
+            options.equal_width,
             padding,
             options.format,
         ),
@@ -170,9 +170,9 @@ pub fn uu_app() -> Command {
                 .help("Terminator character (defaults to \\n)"),
         )
         .arg(
-            Arg::new(OPT_WIDTHS)
+            Arg::new(OPT_EQUAL_WIDTH)
                 .short('w')
-                .long("widths")
+                .long("equal-width")
                 .help("Equalize widths of all numbers by padding with zeros")
                 .action(ArgAction::SetTrue),
         )

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -208,10 +208,13 @@ fn test_separator_and_terminator() {
 
 #[test]
 fn test_equalize_widths() {
-    new_ucmd!()
-        .args(&["-w", "5", "10"])
-        .run()
-        .stdout_is("05\n06\n07\n08\n09\n10\n");
+    let args = ["-w", "--equal-width"];
+    for arg in args {
+        new_ucmd!()
+            .args(&[arg, "5", "10"])
+            .run()
+            .stdout_is("05\n06\n07\n08\n09\n10\n");
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR renames the long version of the `-w` argument from `--widths` to `--equal-width` to be compatible with GNU seq.