### PR TITLE
util/build-gnu.sh: Improve error message when missing GNU Coreutils repository

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -11,25 +11,28 @@ ME="${0}"
 ME_dir="$(dirname -- "$(readlink -fm -- "${ME}")")"
 REPO_main_dir="$(dirname -- "${ME_dir}")"
 
-echo "ME='${ME}'"
-echo "ME_dir='${ME_dir}'"
-echo "REPO_main_dir='${REPO_main_dir}'"
-
 ### * config (from environment with fallback defaults); note: GNU is expected to be a sibling repo directory
 
 path_UUTILS=${path_UUTILS:-${REPO_main_dir}}
 path_GNU="$(readlink -fm -- "${path_GNU:-${path_UUTILS}/../gnu}")"
 
-echo "path_UUTILS='${path_UUTILS}'"
-echo "path_GNU='${path_GNU}'"
-
 ###
 
 if test ! -d "${path_GNU}"; then
-    echo "Could not find GNU (expected at '${path_GNU}')"
+    echo "Could not find GNU coreutils (expected at '${path_GNU}')"
+    echo "Run the following to download into the expected path:"
     echo "git clone --recurse-submodules https://github.com/coreutils/coreutils.git \"${path_GNU}\""
     exit 1
 fi
+
+###
+
+echo "ME='${ME}'"
+echo "ME_dir='${ME_dir}'"
+echo "REPO_main_dir='${REPO_main_dir}'"
+
+echo "path_UUTILS='${path_UUTILS}'"
+echo "path_GNU='${path_GNU}'"
 
 ###
 


### PR DESCRIPTION
For a new contributor, the message given by `utils/build-gnu.sh` is
fairly confusing - it starts with several lines of noise (showing
variables that are set in the script) followed by an error about missing
"GNU" and a `git` command string.

This PR changes the script to explicitly instruct the user to run
the `git clone` command. Since the GNU coreutils repository is probably
missing for new developers, this error is shown if the repository is
missing without including any VARIABLE=value lines that are not actionable
yet.
