### PR TITLE
hashsum: use file_stem() instead of file_name()

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -306,7 +306,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     // if there is no program name for some reason, default to "hashsum"
     let program = args.next().unwrap_or_else(|| OsString::from(NAME));
     let binary_name = Path::new(&program)
-        .file_name()
+        .file_stem()
         .unwrap_or_else(|| OsStr::new(NAME))
         .to_string_lossy();
 


### PR DESCRIPTION
This program matches the binary name to determine which algorithm to use. On Windows, `file_name()` was matching against a string with `.exe`, causing binaries like `sha256sum.exe` to not properly detect the algorithm.

By using `file_stem()`, we exclude the `.exe` from matching, achieving similar and correct behavior on Windows.