### PR TITLE
Bump proc-macro2 from 1.0.47 to 1.0.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,9 +1763,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This PR bumps `proc-macro2` from `1.0.47` to `1.0.63`. This is an attempt to fix the following error that popped up in the CI with the most recent PRs:

```
error[E0635]: unknown feature `proc_macro_span_shrink`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.47/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^
```