### PR TITLE
touch: use parse_datetime instead of humantime_to_duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,16 +1173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime_to_duration"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714764645f21cc70c4c151d7798dd158409641f37ad820bed65224aae403cbed"
-dependencies = [
- "regex",
- "time",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,7 +3227,7 @@ version = "0.0.19"
 dependencies = [
  "clap",
  "filetime",
- "humantime_to_duration",
+ "parse_datetime",
  "time",
  "uucore",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) libselinux gethostid procfs bigdecimal kqueue fundu mangen datetime uuhelp memmap
+# spell-checker:ignore (libs) bigdecimal datetime fundu gethostid kqueue libselinux mangen memmap procfs uuhelp
 
 [package]
 name = "coreutils"

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -1,4 +1,4 @@
-# spell-checker:ignore humantime
+# spell-checker:ignore datetime
 [package]
 name = "uu_touch"
 version = "0.0.19"
@@ -18,8 +18,7 @@ path = "src/touch.rs"
 [dependencies]
 filetime = { workspace = true }
 clap = { workspace = true }
-# TODO: use workspace dependency (0.3) when switching from time to chrono
-humantime_to_duration = "0.2.1"
+parse_datetime = { workspace = true }
 time = { workspace = true, features = [
   "parsing",
   "formatting",

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -84,7 +84,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     ) {
         (Some(reference), Some(date)) => {
             let (atime, mtime) = stat(Path::new(reference), !matches.get_flag(options::NO_DEREF))?;
-            if let Ok(offset) = humantime_to_duration::from_str(date) {
+            if let Ok(offset) = parse_datetime::from_str(date) {
                 let mut seconds = offset.whole_seconds();
                 let mut nanos = offset.subsec_nanoseconds();
                 if nanos < 0 {
@@ -445,7 +445,7 @@ fn parse_date(s: &str) -> UResult<FileTime> {
         }
     }
 
-    if let Ok(duration) = humantime_to_duration::from_str(s) {
+    if let Ok(duration) = parse_datetime::from_str(s) {
         let now_local = time::OffsetDateTime::now_local().unwrap();
         let diff = now_local.checked_add(duration).unwrap();
         return Ok(local_dt_to_filetime(diff));


### PR DESCRIPTION
This PR cherry-picks the necessary commits from https://github.com/uutils/coreutils/pull/4974 to switch from `humantime_to_duration` to `parse_datetime`. This should fix the "dependencies: 1 of 14 outdated" badge.