### PR TITLE
numfmt: remove duplicate info from help output

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -360,10 +360,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::ROUND)
                 .long(options::ROUND)
-                .help(
-                    "use METHOD for rounding when scaling; METHOD can be: up,\
-                    down, from-zero, towards-zero, nearest",
-                )
+                .help("use METHOD for rounding when scaling")
                 .value_name("METHOD")
                 .default_value("from-zero")
                 .value_parser(["up", "down", "from-zero", "towards-zero", "nearest"]),
@@ -380,10 +377,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::INVALID)
                 .long(options::INVALID)
-                .help(
-                    "set the failure mode for invalid input; \
-                    valid options are abort, fail, warn or ignore",
-                )
+                .help("set the failure mode for invalid input")
                 .default_value("abort")
                 .value_parser(["abort", "fail", "warn", "ignore"])
                 .value_name("INVALID"),


### PR DESCRIPTION
`clap` automatically shows a list of possible values for an option in the help output, so it is unnecessary that we list the same values again. This PR removes this duplicate information.

```
// before the change
--round <METHOD>     use METHOD for rounding when scaling; METHOD can be: up,down, from-zero, towards-zero, nearest [default: from-zero] [possible values:
                     up, down, from-zero, towards-zero, nearest]

// after the change
--round <METHOD>     use METHOD for rounding when scaling [default: from-zero] [possible values: up, down, from-zero, towards-zero, nearest]
```