### PR TITLE
nl: make -p/--no-renumber a flag

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -29,7 +29,7 @@ fn parse_style(chars: &[char]) -> Result<crate::NumberingStyle, String> {
 pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) -> Vec<String> {
     // This vector holds error messages encountered.
     let mut errs: Vec<String> = vec![];
-    settings.renumber = !opts.contains_id(options::NO_RENUMBER);
+    settings.renumber = opts.get_flag(options::NO_RENUMBER);
     match opts.get_one::<String>(options::NUMBER_SEPARATOR) {
         None => {}
         Some(val) => {

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -213,7 +213,8 @@ pub fn uu_app() -> Command {
             Arg::new(options::NO_RENUMBER)
                 .short('p')
                 .long(options::NO_RENUMBER)
-                .help("do not reset line numbers at logical pages"),
+                .help("do not reset line numbers at logical pages")
+                .action(ArgAction::SetFalse),
         )
         .arg(
             Arg::new(options::NUMBER_SEPARATOR)

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -71,3 +71,10 @@ fn test_sections_and_styles() {
     }
     // spell-checker:enable
 }
+
+#[test]
+fn test_no_renumber() {
+    for arg in ["-p", "--no-renumber"] {
+        new_ucmd!().arg(arg).succeeds();
+    }
+}


### PR DESCRIPTION
This PR turns `-p`/`--no-renumber` into a flag to be compatible with GNU `nl`.