### PR TITLE
Initial oranda setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 /busybox/
 /.vscode/
 /.vs/
+/public/
 *~
 .*.swp
 .*.swo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD033 MD041 MD002 -->
 <!-- markdownlint-disable commands-show-output no-duplicate-heading -->
-<!-- spell-checker:ignore markdownlint ; (options) DESTDIR UTILNAME manpages reimplementation -->
+<!-- spell-checker:ignore markdownlint ; (options) DESTDIR UTILNAME manpages reimplementation oranda -->
 <div class="oranda-hide">
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- markdownlint-disable MD033 MD041 MD002 -->
 <!-- markdownlint-disable commands-show-output no-duplicate-heading -->
 <!-- spell-checker:ignore markdownlint ; (options) DESTDIR UTILNAME manpages reimplementation -->
+<div class="oranda-hide">
 <div align="center">
 
 ![uutils logo](docs/src/logo.svg)
@@ -19,10 +20,13 @@
 
 ---
 
+</div>
 
 uutils coreutils is a cross-platform reimplementation of the GNU coreutils in
 [Rust](http://www.rust-lang.org). While all programs have been implemented, some
 options might be missing or different behavior might be experienced.
+
+<div class="oranda-hide">
 
 To install it:
 
@@ -30,6 +34,8 @@ To install it:
 cargo install coreutils
 ~/.cargo/bin/coreutils
 ```
+
+</div>
 
 <!-- markdownlint-disable-next-line MD026 -->
 
@@ -42,6 +48,8 @@ uutils aims to work on as many platforms as possible, to be able to use the same
 utils on Linux, Mac, Windows and other platforms. This ensures, for example,
 that scripts can be easily transferred between platforms.
 
+<div class="oranda-hide">
+
 ## Documentation
 
 uutils has both user and developer documentation available:
@@ -51,6 +59,7 @@ uutils has both user and developer documentation available:
 
 Both can also be generated locally, the instructions for that can be found in
 the [coreutils docs](https://github.com/uutils/uutils.github.io) repository.
+
 
 <!-- ANCHOR: build (this mark is needed for mdbook) -->
 
@@ -300,6 +309,8 @@ See <https://github.com/uutils/coreutils/issues/3336> for the main meta bugs
 (many are missing).
 
 ![Evolution over time](https://github.com/uutils/coreutils-tracking/blob/main/gnu-results.png?raw=true)
+
+</div> <!-- close oranda-hide div -->
 
 ## Contributing
 

--- a/docs/src/oranda.css
+++ b/docs/src/oranda.css
@@ -1,0 +1,4 @@
+.logo {
+  display: block;
+  height: 170px;
+}

--- a/oranda.json
+++ b/oranda.json
@@ -1,0 +1,13 @@
+{
+  "project": {
+    "name": "uutils coreutils"
+  },
+  "components": {
+    "changelog": true
+  },
+  "styles": {
+    "theme": "light",
+    "logo": "docs/src/logo.svg",
+    "additional_css": ["docs/src/oranda.css"]
+  }
+}


### PR DESCRIPTION
[oranda](https://opensource.axo.dev/oranda/) is a new tool by [axo](https://axo.dev/), which can generate pretty websites for projects, based on info from `Cargo.toml` and GitHub. Here is the blog post where they explain it: https://blog.axo.dev/2023/06/oranda.

I think it would be nice to replace [this page](https://uutils.github.io/) with the generated website. It contains a link to the docs, funding and changelog. It also renders the mdbook documentation with the same style as the rest of the website. It can also show installation options, but currently, that feature is not yet flexible enough for us. We could open some issues on their repo to discuss what we would need (they're really friendly).

We might need to either clean up the README or make a separate markdown document as landing page to make this even more useful, but I think this is a nice start.

I chose the light theme to start with, but we can customize the CSS any way we want.

You can test the website yourself by installing `oranda`:
```
cargo install oranda --locked --profile=dist
```
and then running it in `dev` mode in the root of the project:
```
oranda dev
```

<details>
<summary>Click here to see screenshots of the generated website</summary>

![image](https://github.com/uutils/coreutils/assets/11643477/654cf16d-27c0-4e00-a64c-d50fc2dbf04a)
![image](https://github.com/uutils/coreutils/assets/11643477/0611143e-8af8-459c-b559-a9fbb2877511)
![image](https://github.com/uutils/coreutils/assets/11643477/074366f9-5796-4130-bcdc-e4d86002ad3a)
![image](https://github.com/uutils/coreutils/assets/11643477/275a4f3a-e7d4-486b-9b6a-aa6e9bb3fb73)

</details>