### PR TITLE
Bump syn and add it to skip list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,9 +2133,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -492,7 +492,7 @@ uucore = { workspace = true, features = ["entries", "process", "signals"] }
 walkdir = { workspace = true }
 is-terminal = { workspace = true }
 hex-literal = "0.4.1"
-rstest = "0.17.0"
+rstest = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 procfs = { version = "0.15", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -87,6 +87,8 @@ skip = [
   { name = "aho-corasick", version = "0.7.19" },
   # ordered-multimap (via rust-ini)
   { name = "hashbrown", version = "0.13.2" },
+  # various crates
+  { name = "syn", version = "1.0.109" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR bumps `syn` from `1.0.103` to `1.0.109` and adds it to the skip list in `deny.toml` to resolve the `cargo-deny` error in https://github.com/uutils/coreutils/pull/5039. And while looking at that PR, I noticed we can use `{ workspace = true }` for `rstest` in `Cargo.toml`.