### PR TITLE
stty: Finish '--save' support

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -244,12 +244,30 @@ fn print_terminal_size(termios: &Termios, opts: &Options) -> nix::Result<()> {
     Ok(())
 }
 
+fn print_in_save_format(termios: &Termios) {
+    print!(
+        "{:x}:{:x}:{:x}:{:x}",
+        termios.input_flags.bits(),
+        termios.output_flags.bits(),
+        termios.control_flags.bits(),
+        termios.local_flags.bits()
+    );
+    for cc in termios.control_chars {
+        print!(":{cc:x}");
+    }
+    println!();
+}
+
 fn print_settings(termios: &Termios, opts: &Options) -> nix::Result<()> {
-    print_terminal_size(termios, opts)?;
-    print_flags(termios, opts, CONTROL_FLAGS);
-    print_flags(termios, opts, INPUT_FLAGS);
-    print_flags(termios, opts, OUTPUT_FLAGS);
-    print_flags(termios, opts, LOCAL_FLAGS);
+    if opts.save {
+        print_in_save_format(termios);
+    } else {
+        print_terminal_size(termios, opts)?;
+        print_flags(termios, opts, CONTROL_FLAGS);
+        print_flags(termios, opts, INPUT_FLAGS);
+        print_flags(termios, opts, OUTPUT_FLAGS);
+        print_flags(termios, opts, LOCAL_FLAGS);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Argument parsing for this exists, but the option doesn't change output in any way. Finish the support.

Closes #3862.

I haven't found any documentation on the format of this or looked at any code, but it would appear to be simple hex printing of some (not all) struct termios fields:

````
$ cat termiostest.c
#include <stdio.h>
#include <termios.h>

int main() {
    struct termios t;
    tcgetattr(0, &t);
    while (1)
        ;
}
$ gcc -g termiostest.c
$ gdb ./a.out
(gdb) run
(gdb) p/x t
$1 = {c_iflag = 0x100, c_oflag = 0x5, c_cflag = 0xbf, c_lflag = 0x8a3b, c_line = 0x0, c_cc = {0x3, 0x1c, 0x7f, 0x15, 0x4, 0x0, 0x1, 0x0, 0x11, 0x13, 0x1a, 0x0, 0x12, 0xf, 0x17, 0x16, 0x0 <repeats 16 times>},
  c_ispeed = 0xf, c_ospeed = 0xf}
$ stty --save
100:5:bf:8a3b:3:1c:7f:15:4:0:1:0:11:13:1a:0:12:f:17:16:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0
````
