### PR TITLE
ls: --l should output the same as --literal

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1202,6 +1202,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::quoting::LITERAL)
                 .short('N')
                 .long(options::quoting::LITERAL)
+                .alias("l")
                 .help("Use literal quoting style. Equivalent to `--quoting-style=literal`")
                 .overrides_with_all([
                     options::QUOTING_STYLE,

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -22,7 +22,6 @@ use std::time::Duration;
 const LONG_ARGS: &[&str] = &[
     "-l",
     "--long",
-    "--l",
     "--format=long",
     "--for=long",
     "--format=verbose",
@@ -2411,6 +2410,7 @@ fn test_ls_quoting_style() {
             ("--quoting-style=literal", "one?two"),
             ("-N", "one?two"),
             ("--literal", "one?two"),
+            ("--l", "one?two"),
             ("--quoting-style=c", "\"one\\ntwo\""),
             ("-Q", "\"one\\ntwo\""),
             ("--quote-name", "\"one\\ntwo\""),
@@ -2435,6 +2435,7 @@ fn test_ls_quoting_style() {
             ("--quoting-style=literal", "one\ntwo"),
             ("-N", "one\ntwo"),
             ("--literal", "one\ntwo"),
+            ("--l", "one\ntwo"),
             ("--quoting-style=shell", "one\ntwo"), // FIXME: GNU ls quotes this case
             ("--quoting-style=shell-always", "'one\ntwo'"),
         ] {
@@ -2496,6 +2497,7 @@ fn test_ls_quoting_style() {
         ("--quoting-style=literal", "one two"),
         ("-N", "one two"),
         ("--literal", "one two"),
+        ("--l", "one two"),
         ("--quoting-style=c", "\"one two\""),
         ("-Q", "\"one two\""),
         ("--quote-name", "\"one two\""),


### PR DESCRIPTION
#5025
I've fixed `--l` option to be a short cut for `--literal`.
