### PR TITLE
stty: Support more options: size speed drain

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -148,6 +148,12 @@ ioctl_write_ptr_bad!(
     TermSize
 );
 
+fn get_term_size(fd: RawFd) -> nix::Result<TermSize> {
+    let mut size = TermSize::default();
+    unsafe { tiocgwinsz(fd, &mut size as *mut _)? };
+    Ok(size)
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_lossy();
@@ -227,8 +233,7 @@ fn print_terminal_size(termios: &Termios, opts: &Options) -> nix::Result<()> {
     }
 
     if opts.all {
-        let mut size = TermSize::default();
-        unsafe { tiocgwinsz(opts.file, &mut size as *mut _)? };
+        let size = get_term_size(opts.file)?;
         print!("rows {}; columns {}; ", size.rows, size.columns);
     }
 

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -235,7 +235,7 @@ fn get_baud_rate_string(termios: &Termios) -> String {
     }
 }
 
-fn print_terminal_size(termios: &Termios, opts: &Options) -> nix::Result<()> {
+fn print_speed_size_and_line_discipline(termios: &Termios, opts: &Options) -> nix::Result<()> {
     let baud_rate = get_baud_rate_string(termios);
     print!("speed {baud_rate} baud; ");
 
@@ -321,7 +321,7 @@ fn print_settings(termios: &Termios, opts: &Options) -> nix::Result<()> {
     if opts.save {
         print_in_save_format(termios);
     } else {
-        print_terminal_size(termios, opts)?;
+        print_speed_size_and_line_discipline(termios, opts)?;
         print_control_chars(termios, opts)?;
         print_flags(termios, opts, CONTROL_FLAGS);
         print_flags(termios, opts, INPUT_FLAGS);


### PR DESCRIPTION
Also changes default of 'drain' to be on to match GNU.