### PR TITLE
nl: use value parser for "--number-format"

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -36,23 +36,10 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             settings.number_separator = val.to_owned();
         }
     }
-    match opts.get_one::<String>(options::NUMBER_FORMAT) {
-        None => {}
-        Some(val) => match val.as_str() {
-            "ln" => {
-                settings.number_format = crate::NumberFormat::Left;
-            }
-            "rn" => {
-                settings.number_format = crate::NumberFormat::Right;
-            }
-            "rz" => {
-                settings.number_format = crate::NumberFormat::RightZero;
-            }
-            _ => {
-                errs.push(String::from("Illegal value for -n"));
-            }
-        },
-    }
+    settings.number_format = opts
+        .get_one::<String>(options::NUMBER_FORMAT)
+        .map(Into::into)
+        .unwrap_or_default();
     match opts.get_one::<String>(options::BODY_NUMBERING) {
         None => {}
         Some(val) => {

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -75,10 +75,23 @@ enum NumberingStyle {
 // NumberFormat specifies how line numbers are output within their allocated
 // space. They are justified to the left or right, in the latter case with
 // the option of having all unused space to its left turned into leading zeroes.
+#[derive(Default)]
 enum NumberFormat {
     Left,
+    #[default]
     Right,
     RightZero,
+}
+
+impl<T: AsRef<str>> From<T> for NumberFormat {
+    fn from(s: T) -> Self {
+        match s.as_ref() {
+            "ln" => Self::Left,
+            "rn" => Self::Right,
+            "rz" => Self::RightZero,
+            _ => unreachable!("Should have been caught by clap"),
+        }
+    }
 }
 
 pub mod options {
@@ -207,7 +220,8 @@ pub fn uu_app() -> Command {
                 .short('n')
                 .long(options::NUMBER_FORMAT)
                 .help("insert line numbers according to FORMAT")
-                .value_name("FORMAT"),
+                .value_name("FORMAT")
+                .value_parser(["ln", "rn", "rz"]),
         )
         .arg(
             Arg::new(options::NO_RENUMBER)

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -1,3 +1,4 @@
+// spell-checker:ignore ninvalid
 use crate::common::util::TestScenario;
 
 #[test]
@@ -76,5 +77,48 @@ fn test_sections_and_styles() {
 fn test_no_renumber() {
     for arg in ["-p", "--no-renumber"] {
         new_ucmd!().arg(arg).succeeds();
+    }
+}
+
+#[test]
+fn test_number_format_ln() {
+    for arg in ["-nln", "--number-format=ln"] {
+        new_ucmd!()
+            .arg(arg)
+            .pipe_in("test")
+            .succeeds()
+            .stdout_is("1     \ttest\n");
+    }
+}
+
+#[test]
+fn test_number_format_rn() {
+    for arg in ["-nrn", "--number-format=rn"] {
+        new_ucmd!()
+            .arg(arg)
+            .pipe_in("test")
+            .succeeds()
+            .stdout_is("     1\ttest\n");
+    }
+}
+
+#[test]
+fn test_number_format_rz() {
+    for arg in ["-nrz", "--number-format=rz"] {
+        new_ucmd!()
+            .arg(arg)
+            .pipe_in("test")
+            .succeeds()
+            .stdout_is("000001\ttest\n");
+    }
+}
+
+#[test]
+fn test_invalid_number_format() {
+    for arg in ["-ninvalid", "--number-format=invalid"] {
+        new_ucmd!()
+            .arg(arg)
+            .fails()
+            .stderr_contains("invalid value 'invalid'");
     }
 }


### PR DESCRIPTION
This PR uses `clap`'s value parser to handle `-n`/`--number-format`.