### PR TITLE
nl: show error if --number-width is zero

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -94,17 +94,12 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
             }
         }
     }
-    match opts.get_one::<String>(options::NUMBER_WIDTH) {
+    match opts.get_one::<usize>(options::NUMBER_WIDTH) {
         None => {}
-        Some(val) => {
-            let conv: Option<usize> = val.parse().ok();
-            match conv {
-                None => {
-                    errs.push(String::from("Illegal value for -w"));
-                }
-                Some(num) => settings.number_width = num,
-            }
-        }
+        Some(num) if *num > 0 => settings.number_width = *num,
+        Some(_) => errs.push(String::from(
+            "Invalid line number field width: ‘0’: Numerical result out of range",
+        )),
     }
     match opts.get_one::<String>(options::STARTING_LINE_NUMBER) {
         None => {}

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -251,7 +251,8 @@ pub fn uu_app() -> Command {
                 .short('w')
                 .long(options::NUMBER_WIDTH)
                 .help("use NUMBER columns for line numbers")
-                .value_name("NUMBER"),
+                .value_name("NUMBER")
+                .value_parser(clap::value_parser!(usize)),
         )
 }
 

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -1,4 +1,4 @@
-// spell-checker:ignore ninvalid
+// spell-checker:ignore ninvalid winvalid
 use crate::common::util::TestScenario;
 
 #[test]
@@ -116,6 +116,40 @@ fn test_number_format_rz() {
 #[test]
 fn test_invalid_number_format() {
     for arg in ["-ninvalid", "--number-format=invalid"] {
+        new_ucmd!()
+            .arg(arg)
+            .fails()
+            .stderr_contains("invalid value 'invalid'");
+    }
+}
+
+#[test]
+fn test_number_width() {
+    for width in 1..10 {
+        for arg in [format!("-w{width}"), format!("--number-width={width}")] {
+            let spaces = " ".repeat(width - 1);
+            new_ucmd!()
+                .arg(arg)
+                .pipe_in("test")
+                .succeeds()
+                .stdout_is(format!("{spaces}1\ttest\n"));
+        }
+    }
+}
+
+#[test]
+fn test_number_width_zero() {
+    for arg in ["-w0", "--number-width=0"] {
+        new_ucmd!()
+            .arg(arg)
+            .fails()
+            .stderr_contains("Invalid line number field width: ‘0’: Numerical result out of range");
+    }
+}
+
+#[test]
+fn test_invalid_number_width() {
+    for arg in ["-winvalid", "--number-width=invalid"] {
         new_ucmd!()
             .arg(arg)
             .fails()


### PR DESCRIPTION
GNU `nl` shows an "invalid line number field width" error if `-w`/`--number-width` is `0` whereas uutils `nl` doesn't fail. This PR fixes this issue.