### PR TITLE
nl: add "after help"

### DIFF
--- a/src/uu/nl/nl.md
+++ b/src/uu/nl/nl.md
@@ -5,3 +5,19 @@ nl [OPTION]... [FILE]...
 ```
 
 Number lines of files
+
+## After Help
+
+`STYLE` is one of:
+
+* `a`     number all lines
+* `t`     number only nonempty lines
+* `n`     number no lines
+* `pBRE`  number only lines that contain a match for the basic regular
+        expression, `BRE`
+
+`FORMAT` is one of:
+
+* `ln`    left justified, no leading zeros
+* `rn`    right justified, no leading zeros
+* `rz`    right justified, leading zeros

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -12,11 +12,12 @@ use std::io::{stdin, BufRead, BufReader, Read};
 use std::iter::repeat;
 use std::path::Path;
 use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, help_about, help_usage};
+use uucore::{format_usage, help_about, help_section, help_usage};
 
 mod helper;
 
 const ABOUT: &str = help_about!("nl.md");
+const AFTER_HELP: &str = help_section!("after help", "nl.md");
 const USAGE: &str = help_usage!("nl.md");
 
 // Settings store options used by nl to produce its output.
@@ -146,6 +147,7 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
+        .after_help(AFTER_HELP)
         .infer_long_args(true)
         .disable_help_flag(true)
         .arg(


### PR DESCRIPTION
This PR adds an "after help" section to the markdown file and describes the possible values for `STYLE` and `FORMAT`.