### PR TITLE
nl: add test for "--number-separator"

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -30,11 +30,8 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
     // This vector holds error messages encountered.
     let mut errs: Vec<String> = vec![];
     settings.renumber = opts.get_flag(options::NO_RENUMBER);
-    match opts.get_one::<String>(options::NUMBER_SEPARATOR) {
-        None => {}
-        Some(val) => {
-            settings.number_separator = val.to_owned();
-        }
+    if let Some(val) = opts.get_one::<String>(options::NUMBER_SEPARATOR) {
+        settings.number_separator = val.to_owned();
     }
     settings.number_format = opts
         .get_one::<String>(options::NUMBER_FORMAT)

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -156,3 +156,14 @@ fn test_invalid_number_width() {
             .stderr_contains("invalid value 'invalid'");
     }
 }
+
+#[test]
+fn test_number_separator() {
+    for arg in ["-s:-:", "--number-separator=:-:"] {
+        new_ucmd!()
+            .arg(arg)
+            .pipe_in("test")
+            .succeeds()
+            .stdout_is("     1:-:test\n");
+    }
+}


### PR DESCRIPTION
This PR adds a test for `-s`/`--number-separator` and replaces the `match` to handle the value of this argument with an `if let` for better readability.