### PR TITLE
ls: Limit value of --width to maximum value if overflowing

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -670,6 +670,23 @@ fn test_ls_width() {
             .stdout_only("test-width-1  test-width-3\ntest-width-2  test-width-4\n");
     }
 
+    for option in [
+        "-w 100000000000000",
+        "-w=100000000000000",
+        "--width=100000000000000",
+        "--width 100000000000000",
+        "-w 07777777777777777777",
+        "-w=07777777777777777777",
+        "--width=07777777777777777777",
+        "--width 07777777777777777777",
+    ] {
+        scene
+            .ucmd()
+            .args(&option.split(' ').collect::<Vec<_>>())
+            .arg("-C")
+            .succeeds()
+            .stdout_only("test-width-1  test-width-2  test-width-3  test-width-4\n");
+    }
     scene
         .ucmd()
         .arg("-w=bad")


### PR DESCRIPTION
This change will clamp --width value to u16::MAX if the number passed is too large. The present behaviour results in invalid line width error. This lets gnu/tests/ls/w-option.sh progress a bit further till the last test.

The actual correct behaviour would have been to set the limit to u64::MAX as per the GNU test but all the logic related to formatting seems to be heavily reliant on u16 values, including one crate terminal_size and that would probably take a while for me to sift through. In all practical cases, this should be indistinguishable unless you are printing on a billboard maybe.