### PR TITLE
deny.toml: remove MPL license from allow list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,7 +27,6 @@ allow = [
   "BSD-2-Clause-FreeBSD",
   "BSD-3-Clause",
   "CC0-1.0",
-  "MPL-2.0",              # XXX considered copyleft?
   "Unicode-DFS-2016",
 ]
 copyleft = "deny"


### PR DESCRIPTION
This PR removes the MPL license from the allow list in `deny.toml`. The change comes from https://github.com/uutils/coreutils/pull/4974 (which is unlikely to be merged in its current form), and I set that PR's author as the author.