### PR TITLE
ci: Add a new workflow to check and format shell scripts in `util` dir

### DIFF
--- a/.github/workflows/CheckScripts.yml
+++ b/.github/workflows/CheckScripts.yml
@@ -1,0 +1,74 @@
+name: CheckScripts
+
+# spell-checker:ignore ludeeus mfinelli
+
+env:
+  SCRIPT_DIR: 'util'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'util/**/*.sh'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'util/**/*.sh'
+
+# End the current execution if there is a new changeset in the PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  shell_check:
+    name: ShellScript/Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -s bash
+        with:
+          severity: warning
+          scandir: ${{ env.SCRIPT_DIR }}
+          format: tty
+
+  shell_fmt:
+    name: ShellScript/Format
+    # no need to run in pr events
+    # shfmt will be performed on main branch when the PR is merged
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [ shell_check ]
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup shfmt
+        uses: mfinelli/setup-shfmt@v2
+      - name: Run shfmt
+        shell: bash
+        run: |
+          # show differs first for every files that need to be formatted
+          # fmt options: bash syntax, 4 spaces indent, indent for switch-case
+          echo "## show the differences between formatted and original scripts..."
+          find ${{ env.SCRIPT_DIR }} -name "*.sh" -print0 | xargs -0 shfmt -ln=bash -i 4 -ci -d || true
+          # perform a shell format
+          echo "## perform a shell format..."
+          # ignore the error code because `-d` will always return false when the file has difference
+          find ${{ env.SCRIPT_DIR }} -name "*.sh" -print0 | xargs -0 shfmt -ln=bash -i 4 -ci -w
+      - name: Commit any changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: "style: auto format by CI (shfmt)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          


### PR DESCRIPTION
Hi,
I've added a new GitHub action workflow to resolve https://github.com/uutils/coreutils/issues/4752. It utilizes `shellcheck` and `shfmt` tools to perform checks and formatting on our shell scripts during a push to the main branch or the creation of a PR.

As it stands, I would appreciate some input on the following aspects that may require further discussion or decision: 

1. Unification of Shell Interpreters: It appears that some of our scripts utilize #!/bin/sh shebang, yet contain certain statements that do not adhere to the POSIX sh standard, as pointed out by shellcheck. I have attached an example of such an occurrence in the CI output from my forked repo here:  [ShellScript/Check](https://github.com/starccy/coreutils/actions/runs/5539084094/jobs/10109672892). As a temporary measure, I've configured `shellcheck` to scrutinize all scripts against the `bash` rules. Would this be acceptable or should we strictly adhere to the $shebang rules?
2. Inclusion of Specific `shellcheck` Rules: Currently, I've left the `shellcheck` rules to their default settings, which still yield a number of warnings: [ShellScript/Check](https://github.com/starccy/coreutils/actions/runs/5539511763/jobs/10110527777). My plan is to address these in an additional commit, but before proceeding, it would be beneficial to determine which rules we should strictly enforce.
3. Auto Commit Post `shfmt` Execution: Once `shfmt` completes successfully, an automatic commit will be added to the main branch. I was wondering if this practice aligns with our workflow expectations.

