### PR TITLE
ci: add default_trait_access lint and fix its warnings

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -220,7 +220,7 @@ jobs:
         fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
         fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
         # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-        S=$(cargo clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_UTILITY_LIST_OPTIONS }} -- -W clippy::manual_string_new -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
+        S=$(cargo clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_UTILITY_LIST_OPTIONS }} -- -W clippy::default_trait_access -W clippy::manual_string_new -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
         if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
   style_spellcheck:

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -498,7 +498,7 @@ mod tests {
 
     fn prog_update_write(n: u128) -> ProgUpdate {
         ProgUpdate {
-            read_stat: Default::default(),
+            read_stat: ReadStat::default(),
             write_stat: WriteStat {
                 bytes_total: n,
                 ..Default::default()
@@ -510,8 +510,8 @@ mod tests {
 
     fn prog_update_duration(duration: Duration) -> ProgUpdate {
         ProgUpdate {
-            read_stat: Default::default(),
-            write_stat: Default::default(),
+            read_stat: ReadStat::default(),
+            write_stat: WriteStat::default(),
             duration,
             complete: false,
         }
@@ -557,8 +557,8 @@ mod tests {
     #[test]
     fn test_prog_update_write_prog_line() {
         let prog_update = ProgUpdate {
-            read_stat: Default::default(),
-            write_stat: Default::default(),
+            read_stat: ReadStat::default(),
+            write_stat: WriteStat::default(),
             duration: Duration::new(1, 0), // one second
             complete: false,
         };
@@ -613,8 +613,8 @@ mod tests {
     #[test]
     fn write_transfer_stats() {
         let prog_update = ProgUpdate {
-            read_stat: Default::default(),
-            write_stat: Default::default(),
+            read_stat: ReadStat::default(),
+            write_stat: WriteStat::default(),
             duration: Duration::new(1, 0), // one second
             complete: false,
         };
@@ -634,8 +634,8 @@ mod tests {
     fn write_final_transfer_stats() {
         // Tests the formatting of the final statistics written after a progress line.
         let prog_update = ProgUpdate {
-            read_stat: Default::default(),
-            write_stat: Default::default(),
+            read_stat: ReadStat::default(),
+            write_stat: WriteStat::default(),
             duration: Duration::new(1, 0), // one second
             complete: false,
         };

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -746,7 +746,7 @@ mod tests {
 
         #[test]
         fn test_remote_included() {
-            let opt = Default::default();
+            let opt = Options::default();
             let m = mount_info("ext4", "/mnt/foo", true, false);
             assert!(is_included(&m, &opt));
         }
@@ -773,7 +773,7 @@ mod tests {
 
         #[test]
         fn test_dummy_excluded() {
-            let opt = Default::default();
+            let opt = Options::default();
             let m = mount_info("ext4", "/mnt/foo", false, true);
             assert!(!is_included(&m, &opt));
         }
@@ -864,11 +864,11 @@ mod tests {
 
     mod filter_mount_list {
 
-        use crate::filter_mount_list;
+        use crate::{filter_mount_list, Options};
 
         #[test]
         fn test_empty() {
-            let opt = Default::default();
+            let opt = Options::default();
             let mount_infos = vec![];
             assert!(filter_mount_list(mount_infos, &opt).is_empty());
         }

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -158,12 +158,12 @@ mod tests {
         // Create a fake `MountInfo` with the given directory name.
         fn mount_info(mount_dir: &str) -> MountInfo {
             MountInfo {
-                dev_id: Default::default(),
-                dev_name: Default::default(),
-                fs_type: Default::default(),
+                dev_id: String::default(),
+                dev_name: String::default(),
+                fs_type: String::default(),
                 mount_dir: String::from(mount_dir),
-                mount_option: Default::default(),
-                mount_root: Default::default(),
+                mount_option: String::default(),
+                mount_root: String::default(),
                 remote: Default::default(),
                 dummy: Default::default(),
             }

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_default_header() {
-        let options = Default::default();
+        let options = Options::default();
         assert_eq!(
             Header::get_headers(&options),
             vec!(

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -575,7 +575,7 @@ mod tests {
     }
     #[test]
     fn test_options_correct_defaults() {
-        let opts: HeadOptions = Default::default();
+        let opts = HeadOptions::default();
 
         assert!(!opts.verbose);
         assert!(!opts.quiet);

--- a/src/uu/sort/src/numeric_str_cmp.rs
+++ b/src/uu/sort/src/numeric_str_cmp.rs
@@ -269,7 +269,7 @@ mod tests {
     fn parses_exp() {
         let n = "1";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: 0,
@@ -280,7 +280,7 @@ mod tests {
         );
         let n = "100";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: 2,
@@ -308,7 +308,7 @@ mod tests {
         );
         let n = "1,000";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: 0,
@@ -319,7 +319,7 @@ mod tests {
         );
         let n = "1000.00";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: 3,
@@ -333,7 +333,7 @@ mod tests {
     fn parses_negative_exp() {
         let n = "0.00005";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: -5,
@@ -344,7 +344,7 @@ mod tests {
         );
         let n = "00000.00005";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: -5,
@@ -359,7 +359,7 @@ mod tests {
     fn parses_sign() {
         let n = "5";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: 0,
@@ -370,7 +370,7 @@ mod tests {
         );
         let n = "-5";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: 0,
@@ -381,7 +381,7 @@ mod tests {
         );
         let n = "    -5";
         assert_eq!(
-            NumInfo::parse(n, &Default::default()),
+            NumInfo::parse(n, &NumInfoParseSettings::default()),
             (
                 NumInfo {
                     exponent: 0,
@@ -393,8 +393,8 @@ mod tests {
     }
 
     fn test_helper(a: &str, b: &str, expected: Ordering) {
-        let (a_info, a_range) = NumInfo::parse(a, &Default::default());
-        let (b_info, b_range) = NumInfo::parse(b, &Default::default());
+        let (a_info, a_range) = NumInfo::parse(a, &NumInfoParseSettings::default());
+        let (b_info, b_range) = NumInfo::parse(b, &NumInfoParseSettings::default());
         let ordering = numeric_str_cmp(
             (&a[a_range.to_owned()], &a_info),
             (&b[b_range.to_owned()], &b_info),
@@ -469,7 +469,7 @@ mod tests {
     }
     #[test]
     fn single_minus() {
-        let info = NumInfo::parse("-", &Default::default());
+        let info = NumInfo::parse("-", &NumInfoParseSettings::default());
         assert_eq!(
             info,
             (

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -149,21 +149,21 @@ impl Default for Settings {
         Self {
             max_unchanged_stats: 5,
             sleep_sec: Duration::from_secs_f32(1.0),
-            follow: Default::default(),
-            mode: Default::default(),
+            follow: Option::default(),
+            mode: FilterMode::default(),
             pid: Default::default(),
             retry: Default::default(),
             use_polling: Default::default(),
             verbose: Default::default(),
             presume_input_pipe: Default::default(),
-            inputs: Default::default(),
+            inputs: Vec::default(),
         }
     }
 }
 
 impl Settings {
     pub fn from_obsolete_args(args: &parse::ObsoleteArgs, name: Option<&OsString>) -> Self {
-        let mut settings: Self = Default::default();
+        let mut settings = Self::default();
         if args.follow {
             settings.follow = if name.is_some() {
                 Some(FollowMode::Name)


### PR DESCRIPTION
This PR adds the pedantic [default_trait_access](https://rust-lang.github.io/rust-clippy/master/index.html#/default_trait_access) lint to the CICD and fixes its warnings.