### PR TITLE
docs: fix broken Arch package link

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -37,7 +37,7 @@ apk update uutils-coreutils
 
 ### Arch
 
-[![Arch package](https://repology.org/badge/version-for-repo/arch/uutils-coreutils.svg)](https://archlinux.org/packages/community/x86_64/uutils-coreutils/)
+[![Arch package](https://repology.org/badge/version-for-repo/arch/uutils-coreutils.svg)](https://archlinux.org/packages/extra/x86_64/uutils-coreutils/)
 
 ```shell
 pacman -S uutils-coreutils


### PR DESCRIPTION
This PR updates the Arch Package link in the documentation, because it is currently pointing to a 404 page. :smile: