### PR TITLE
docs: github repo link related to uutils/coreutils

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,7 +6,7 @@ src = "src"
 title = "uutils Documentation"
 
 [output.html]
-git-repository-url = "https://github.com/rust-lang/cargo/tree/master/src/doc/src"
+git-repository-url = "https://github.com/uutils/coreutils/tree/main/docs/src"
 
 [preprocessor.toc]
 command = "mdbook-toc"


### PR DESCRIPTION
There is a GitHub icon in the top right of the [documentation page](https://uutils.github.io/user).
This links to Cargo repository, which make it weird for contributors to the `uutils/coreutils` documentation, so this PR updates this link to point to this repository instead.