### PR TITLE
cat: remove --t

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -290,7 +290,6 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::SHOW_NONPRINTING_TABS)
                 .short('t')
-                .long(options::SHOW_NONPRINTING_TABS)
                 .help("equivalent to -vT")
                 .action(ArgAction::SetTrue),
         )


### PR DESCRIPTION
This PR removes `--t`, the long version of `-t`, because GNU `cat` doesn't have a long version of `-t`.