### PR TITLE
nl: fix zero padding of negative line numbers

### DIFF
--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -115,6 +115,18 @@ fn test_number_format_rz() {
 }
 
 #[test]
+fn test_number_format_rz_with_negative_line_number() {
+    for arg in ["-nrz", "--number-format=rz"] {
+        new_ucmd!()
+            .arg(arg)
+            .arg("-v-12")
+            .pipe_in("test")
+            .succeeds()
+            .stdout_is("-00012\ttest\n");
+    }
+}
+
+#[test]
 fn test_invalid_number_format() {
     for arg in ["-ninvalid", "--number-format=invalid"] {
         new_ucmd!()


### PR DESCRIPTION
This PR fixes the zero padding of negative line numbers when using `-nrz`/`--number-format=rz`. It also moves the logic for formatting line numbers to its own function.

```
// before change
$ echo "test" | cargo run nl -v-10 --number-format=rz
000-10  test

// after change
$ echo "test" | cargo run nl -v-10 --number-format=rz
-00010  test
```
This PR probably conflicts with #5091.