### PR TITLE
nl: shorten variants of NumberingStyle enum

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -5,17 +5,15 @@ use crate::options;
 // parse_style parses a style string into a NumberingStyle.
 fn parse_style(chars: &[char]) -> Result<crate::NumberingStyle, String> {
     if chars.len() == 1 && chars[0] == 'a' {
-        Ok(crate::NumberingStyle::NumberForAll)
+        Ok(crate::NumberingStyle::All)
     } else if chars.len() == 1 && chars[0] == 't' {
-        Ok(crate::NumberingStyle::NumberForNonEmpty)
+        Ok(crate::NumberingStyle::NonEmpty)
     } else if chars.len() == 1 && chars[0] == 'n' {
-        Ok(crate::NumberingStyle::NumberForNone)
+        Ok(crate::NumberingStyle::None)
     } else if chars.len() > 1 && chars[0] == 'p' {
         let s: String = chars[1..].iter().cloned().collect();
         match regex::Regex::new(&s) {
-            Ok(re) => Ok(crate::NumberingStyle::NumberForRegularExpression(Box::new(
-                re,
-            ))),
+            Ok(re) => Ok(crate::NumberingStyle::Regex(Box::new(re))),
             Err(_) => Err(String::from("Illegal regular expression")),
         }
     } else {

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -44,9 +44,9 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            header_numbering: NumberingStyle::NumberForNone,
-            body_numbering: NumberingStyle::NumberForAll,
-            footer_numbering: NumberingStyle::NumberForNone,
+            header_numbering: NumberingStyle::None,
+            body_numbering: NumberingStyle::All,
+            footer_numbering: NumberingStyle::None,
             section_delimiter: ['\\', ':'],
             starting_line_number: 1,
             line_increment: 1,
@@ -65,12 +65,11 @@ impl Default for Settings {
 // 2. Number only nonempty lines
 // 3. Don't number any lines at all
 // 4. Number all lines that match a basic regular expression.
-#[allow(clippy::enum_variant_names)]
 enum NumberingStyle {
-    NumberForAll,
-    NumberForNonEmpty,
-    NumberForNone,
-    NumberForRegularExpression(Box<regex::Regex>),
+    All,
+    NonEmpty,
+    None,
+    Regex(Box<regex::Regex>),
 }
 
 // NumberFormat specifies how line numbers are output within their allocated
@@ -272,7 +271,7 @@ fn nl<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UResult<()> {
     };
     // Initially, we use the body's line counting settings
     let mut regex_filter = match settings.body_numbering {
-        NumberingStyle::NumberForRegularExpression(ref re) => re,
+        NumberingStyle::Regex(ref re) => re,
         _ => &regexp,
     };
     let mut line_filter: fn(&str, &regex::Regex) -> bool = pass_regex;
@@ -334,16 +333,16 @@ fn nl<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UResult<()> {
                 // a catch-all here.
                 _ => &settings.body_numbering,
             } {
-                NumberingStyle::NumberForAll => {
+                NumberingStyle::All => {
                     line_filter = pass_all;
                 }
-                NumberingStyle::NumberForNonEmpty => {
+                NumberingStyle::NonEmpty => {
                     line_filter = pass_nonempty;
                 }
-                NumberingStyle::NumberForNone => {
+                NumberingStyle::None => {
                     line_filter = pass_none;
                 }
-                NumberingStyle::NumberForRegularExpression(ref re) => {
+                NumberingStyle::Regex(ref re) => {
                     line_filter = pass_regex;
                     regex_filter = re;
                 }


### PR DESCRIPTION
This PR shortens the variants of the `NumberingStyle` enum by removing the `NumberFor` prefix and replacing `RegularExpression` with `Regex`.