### PR TITLE
mv: Change confusing error msg

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -485,7 +485,7 @@ fn rename(
             if is_empty_dir(to) {
                 fs::remove_dir(to)?;
             } else {
-                return Err(io::Error::new(io::ErrorKind::Other, "Directory not empty"));
+                return Err(io::Error::new(io::ErrorKind::Other, "Directory with the same name already exists at destination"));
             }
         }
     }


### PR DESCRIPTION
Issue: mv: error message "Directory not empty" is confusing https://github.com/uutils/coreutils/issues/5102

Previously confusing error message changed to: "Directory with the same name exists at destination"