### PR TITLE
csplit: remove explicit "into_iter()"

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -127,7 +127,7 @@ where
     I: Iterator<Item = (usize, io::Result<String>)>,
 {
     // split the file based on patterns
-    for pattern in patterns.into_iter() {
+    for pattern in patterns {
         let pattern_as_str = pattern.to_string();
         let is_skip = matches!(pattern, patterns::Pattern::SkipToMatch(_, _, _));
         match pattern {


### PR DESCRIPTION
This PR fixes a warning from the pedantic [explicit_into_iter_loop](https://rust-lang.github.io/rust-clippy/master/index.html#/explicit_into_iter_loop) lint.