### PR TITLE
only set SELINUX_ENABLED=1 on Linux

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -43,7 +43,14 @@ UU_BUILD_DIR="${path_UUTILS}/target/${UU_MAKE_PROFILE}"
 echo "UU_BUILD_DIR='${UU_BUILD_DIR}'"
 
 cd "${path_UUTILS}" && echo "[ pwd:'${PWD}' ]"
-SELINUX_ENABLED=1 make PROFILE="${UU_MAKE_PROFILE}"
+
+if [ "$(uname)" == "Linux" ]; then
+# only set on linux
+    export SELINUX_ENABLED=1
+fi
+
+make PROFILE="${UU_MAKE_PROFILE}"
+
 cp "${UU_BUILD_DIR}/install" "${UU_BUILD_DIR}/ginstall" # The GNU tests rename this script before running, to avoid confusion with the make target
 # Create *sum binaries
 for sum in b2sum b3sum md5sum sha1sum sha224sum sha256sum sha384sum sha512sum; do


### PR DESCRIPTION
Fails on Mac otherwise with:
```

   Compiling crossterm v0.25.0
error: couldn't read /Users/sylvestre/dev/debian/coreutils/target/release/build/fts-sys-5da7dc1e06092d06/out/fts-sys.rs: No such file or directory (os error 2)
  --> /Users/sylvestre/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fts-sys-0.2.2/src/lib.rs:30:1
   |
30 | include!(concat!(env!("OUT_DIR"), "/fts-sys.rs"));
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `fts-sys` (lib) due to previous error
```