### PR TITLE
use is_empty()

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -400,7 +400,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> UR
         }
 
         match rename(sourcepath, &targetpath, b, multi_progress.as_ref()) {
-            Err(e) if e.to_string() == "" => set_exit_code(1),
+            Err(e) if e.to_string().is_empty() => set_exit_code(1),
             Err(e) => {
                 let e = e.map_err_context(|| {
                     format!(

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -100,7 +100,7 @@ fn remove(mut path: &Path, opts: Opts) -> Result<(), Error<'_>> {
     if opts.parents {
         while let Some(new) = path.parent() {
             path = new;
-            if path.as_os_str() == "" {
+            if path.as_os_str().is_empty() {
                 break;
             }
             remove_single(path, opts)?;


### PR DESCRIPTION
not sure why clippy isn't showing any warnings for [comparison_to_empty](https://rust-lang.github.io/rust-clippy/master/index.html#/comparison_to_empty)