### PR TITLE
docs(bin,has): add docstrings for macros bin and has

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -31,6 +31,9 @@ use std::path::{Component, Path, PathBuf, MAIN_SEPARATOR};
 #[cfg(target_os = "windows")]
 use winapi_util::AsHandleRef;
 
+/// Used to check if the `mode` has its `perm` bit set.
+///
+/// This macro expands to `mode & perm != 0`.
 #[cfg(unix)]
 #[macro_export]
 macro_rules! has {

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -86,6 +86,10 @@ use std::sync::atomic::Ordering;
 
 use once_cell::sync::Lazy;
 
+/// Execute utility code for `util`.
+///
+/// This macro expands to a main function that invokes the `uumain` function in `util`
+/// Exits with code returned by `uumain`.
 #[macro_export]
 macro_rules! bin {
     ($util:ident) => {


### PR DESCRIPTION
This PR adds documentation for the following macros -
- `bin` in src/uucore/src/lib/lib.rs
- `has` in src/uucore/src/lib/features/fs.rs

Fixes #5067 