### PR TITLE
deny.toml: add bitflags to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -86,6 +86,8 @@ skip = [
   { name = "aho-corasick", version = "0.7.19" },
   # various crates
   { name = "syn", version = "1.0.109" },
+  # various crates
+  { name = "bitflags", version = "1.3.2" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR adds `bitflags` to the skip list in `deny.toml`. It's necessary for https://github.com/uutils/coreutils/pull/5133