### PR TITLE
deny.toml: remove redox_syscall from skip list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "windows-sys 0.48.0",
 ]
 
@@ -1522,15 +1522,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1750,15 +1750,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2130,7 +2121,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix 0.37.19",
  "windows-sys 0.48.0",
 ]
@@ -3106,7 +3097,7 @@ version = "0.0.20"
 dependencies = [
  "clap",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "uucore",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,14 +841,14 @@ checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
 
 [[package]]
 name = "filetime"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
- "windows-sys 0.45.0",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -80,8 +80,6 @@ skip = [
   { name = "windows_x86_64_gnullvm", version = "0.42.2" },
   # windows-targets
   { name = "windows_x86_64_msvc", version = "0.42.2" },
-  # tempfile
-  { name = "redox_syscall", version = "0.3.5" },
   # cpp_macros
   { name = "aho-corasick", version = "0.7.19" },
   # various crates


### PR DESCRIPTION
This PR bumps `filetime` from `0.2.20` to `0.2.22` and `parking_lot_core` from `0.9.7` to `0.9.8` in order to remove `redox_syscall` from the skip list in `deny.toml`.