### PR TITLE
mv: remove unnecessary OR in condition

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -433,9 +433,7 @@ fn rename(
     let mut backup_path = None;
 
     if to.exists() {
-        if (b.update == UpdateMode::ReplaceIfOlder || b.update == UpdateMode::ReplaceNone)
-            && b.overwrite == OverwriteMode::Interactive
-        {
+        if b.update == UpdateMode::ReplaceIfOlder && b.overwrite == OverwriteMode::Interactive {
             // `mv -i --update old new` when `new` exists doesn't move anything
             // and exit with 0
             return Ok(());


### PR DESCRIPTION
This PR removes an unnecessary OR in a condition. It can be removed because the removed condition appears again a few lines below as a condition on its own, with the same return value.