### PR TITLE
stat: Output error when - and -f are used together.

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -614,6 +614,10 @@ impl Stater {
     fn do_stat(&self, file: &OsStr, stdin_is_fifo: bool) -> i32 {
         let display_name = file.to_string_lossy();
         let file = if cfg!(unix) && display_name == "-" {
+            if self.show_fs {
+                show_error!("using '-' to denote standard input does not work in file system mode");
+                return 1;
+            }
             if let Ok(p) = Path::new("/dev/stdin").canonicalize() {
                 p.into_os_string()
             } else {
@@ -622,7 +626,6 @@ impl Stater {
         } else {
             OsString::from(file)
         };
-
         if self.show_fs {
             #[cfg(unix)]
             let p = file.as_bytes();

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -305,6 +305,19 @@ fn test_stdin_pipe_fifo2() {
 }
 
 #[test]
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_stdin_with_fs_option() {
+    // $ stat -f -
+    new_ucmd!()
+        .arg("-f")
+        .arg("-")
+        .set_stdin(std::process::Stdio::null())
+        .fails()
+        .code_is(1)
+        .stderr_contains("using '-' to denote standard input does not work in file system mode");
+}
+
+#[test]
 #[cfg(all(
     unix,
     not(any(target_os = "android", target_os = "macos", target_os = "freebsd"))


### PR DESCRIPTION
Currently, stat does not complain about it but GNU stat does not allow this.

This PR also fixes the test case tests/misc/stat-hyphen.sh which tests exactly this usage.