### PR TITLE
`cp`: make more types public and add more documentation (for nushell)

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -25,7 +25,7 @@ use walkdir::{DirEntry, WalkDir};
 
 use crate::{
     aligned_ancestors, context_for, copy_attributes, copy_file, copy_link, preserve_hardlinks,
-    CopyResult, Error, Options, TargetSlice,
+    CopyResult, Error, Options,
 };
 
 /// Ensure a Windows path starts with a `\\?`.
@@ -307,7 +307,7 @@ fn copy_direntry(
 pub(crate) fn copy_directory(
     progress_bar: &Option<ProgressBar>,
     root: &Path,
-    target: &TargetSlice,
+    target: &Path,
     options: &Options,
     symlinked_files: &mut HashSet<FileInformation>,
     source_in_command_line: bool,


### PR DESCRIPTION
Part of https://github.com/uutils/coreutils/issues/5088.

I've removed the `Source`, `SourceSlice`, `Target` and `TargetSlice` type aliases, because I think those obfuscate the public API. I want to make it as easy as possible for the nushell people to understand how to use our types and functions, without having to dive into the source code. For the same reason, I've documented every field of the `Options` struct with the arguments that change the behavior. Various other docstrings are added or improved too.

~While the `Attributes` struct is `pub`, nu won't be able to construct it yet. We'll have to discuss whether they want to do their own parsing there or that we should do it (i.e. should we make all the fields `pub` or should we provide some functions to set the values).~

`Attributes` can now be constructed either:
 - directly with a struct literal,
 - using the `Attributes::parse_iter` method which takes an iterator of strings,
 - or with the constants `Attributes::{ALL, NONE, LINKS}`

This PR also cleans up attribute parsing in general. It should therefore receive additional attention in code review. Those changes are in a separate commit.

@dmatos2012 I figured you weren't actively working on this anymore, so I picked it up. If you have a branch with changes ready, let's discuss how we can get the best of both versions.

@fdncred Does this look like something you can work with? I'd be happy to help out with the PR on the nu side.

Some final notes:
- `cp` is particularly well-suited for this purpose with a clear single function, a good `Options` struct and `Error` type.
- It's nice that nu does not need to do with `UResult` yet. That might be something to tackle later.
- There are more public functions and types than necessary. To get better docs, we might need to restrict some of the things we currently expose.
- If nu starts using this, that puts a restriction on uutils to not change the API arbitrarily. That's something we haven't had to deal with up until now. At the moment, I don't really think we can guarantee real stability, but on the other hand, the current API makes sense, so I don't see any reason to change it in the near future.