### PR TITLE
nl: re-add handling for -p/--no-renumber

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -297,7 +297,9 @@ fn nl<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UResult<()> {
 
         if let Some(new_style) = new_numbering_style {
             current_numbering_style = new_style;
-            line_no = settings.starting_line_number;
+            if settings.renumber {
+                line_no = settings.starting_line_number;
+            }
             println!();
         } else {
             let is_line_numbered = match current_numbering_style {

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -77,7 +77,11 @@ fn test_sections_and_styles() {
 #[test]
 fn test_no_renumber() {
     for arg in ["-p", "--no-renumber"] {
-        new_ucmd!().arg(arg).succeeds();
+        new_ucmd!()
+            .arg(arg)
+            .pipe_in("a\n\\:\\:\nb")
+            .succeeds()
+            .stdout_is("     1\ta\n\n     2\tb\n");
     }
 }
 


### PR DESCRIPTION
This PR re-adds the functionality of `-p`/`--no-renumber` I forgot to add in https://github.com/uutils/coreutils/pull/5131