### PR TITLE
nl: implement -d/--section-delimiter

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -13,6 +13,15 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
     // This vector holds error messages encountered.
     let mut errs: Vec<String> = vec![];
     settings.renumber = opts.get_flag(options::NO_RENUMBER);
+    if let Some(delimiter) = opts.get_one::<String>(options::SECTION_DELIMITER) {
+        // check whether the delimiter is a single ASCII char (1 byte)
+        // because GNU nl doesn't add a ':' to single non-ASCII chars
+        settings.section_delimiter = if delimiter.len() == 1 {
+            format!("{delimiter}:")
+        } else {
+            delimiter.to_owned()
+        };
+    }
     if let Some(val) = opts.get_one::<String>(options::NUMBER_SEPARATOR) {
         settings.number_separator = val.to_owned();
     }


### PR DESCRIPTION
This PR implements `-d`/`--section-delimiter` that allows you to define a section delimiter other than the default `\:`. If the specified delimiter is a single character, `:` is added to the delimiter.