### PR TITLE
nl: handle line number overflow

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -344,7 +344,10 @@ fn nl<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UResult<()> {
                     line
                 );
                 // update line number for the potential next line
-                line_no += settings.line_increment;
+                match line_no.checked_add(settings.line_increment) {
+                    Some(new_line_no) => line_no = new_line_no,
+                    None => return Err(USimpleError::new(1, "line number overflow")),
+                }
             } else {
                 let spaces = " ".repeat(settings.number_width + 1);
                 println!("{spaces}{line}");

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -464,3 +464,21 @@ fn test_invalid_regex_numbering() {
             .stderr_contains("invalid regular expression");
     }
 }
+
+#[test]
+fn test_line_number_overflow() {
+    new_ucmd!()
+        .arg(format!("--starting-line-number={}", i64::MAX))
+        .pipe_in("a\nb")
+        .fails()
+        .stdout_is(format!("{}\ta\n", i64::MAX))
+        .stderr_is("nl: line number overflow\n");
+
+    new_ucmd!()
+        .arg(format!("--starting-line-number={}", i64::MIN))
+        .arg("--line-increment=-1")
+        .pipe_in("a\nb")
+        .fails()
+        .stdout_is(format!("{}\ta\n", i64::MIN))
+        .stderr_is("nl: line number overflow\n");
+}


### PR DESCRIPTION
This PR shows an error message if the line number gets too high or too low.