### PR TITLE
chown: remove some duplication in tests

### DIFF
--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -744,7 +744,7 @@ fn test_chown_file_notexisting() {
 }
 
 #[test]
-fn test_chown_no_change_to_user_from_user() {
+fn test_chown_no_change_to_user() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
@@ -755,99 +755,22 @@ fn test_chown_no_change_to_user_from_user() {
     let user_name = String::from(result.stdout_str().trim());
     assert!(!user_name.is_empty());
 
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=42")
-        .arg("43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!("ownership of '{file}' retained as {user_name}\n"));
+    for (i, from) in ["42", ":42", "42:42"].iter().enumerate() {
+        let file = i.to_string();
+        at.touch(&file);
+        scene
+            .ucmd()
+            .arg("-v")
+            .arg(format!("--from={from}"))
+            .arg("43")
+            .arg(&file)
+            .succeeds()
+            .stdout_only(format!("ownership of '{file}' retained as {user_name}\n"));
+    }
 }
 
 #[test]
-fn test_chown_no_change_to_user_from_group() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    let result = scene.cmd("whoami").run();
-    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
-        return;
-    }
-    let user_name = String::from(result.stdout_str().trim());
-    assert!(!user_name.is_empty());
-
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=:42")
-        .arg("43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!("ownership of '{file}' retained as {user_name}\n"));
-}
-
-#[test]
-fn test_chown_no_change_to_user_from_user_group() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    let result = scene.cmd("whoami").run();
-    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
-        return;
-    }
-    let user_name = String::from(result.stdout_str().trim());
-    assert!(!user_name.is_empty());
-
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=42:42")
-        .arg("43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!("ownership of '{file}' retained as {user_name}\n"));
-}
-
-#[test]
-fn test_chown_no_change_to_group_from_user() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    let result = scene.cmd("whoami").run();
-    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
-        return;
-    }
-    let user_name = String::from(result.stdout_str().trim());
-    assert!(!user_name.is_empty());
-
-    let result = scene.cmd("id").arg("-ng").run();
-    if skipping_test_is_okay(&result, "id: cannot find name for group ID") {
-        return;
-    }
-    let group_name = String::from(result.stdout_str().trim());
-    assert!(!group_name.is_empty());
-
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=42")
-        .arg(":43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!("ownership of '{file}' retained as {group_name}\n"));
-}
-
-#[test]
-fn test_chown_no_change_to_group_from_group() {
+fn test_chown_no_change_to_group() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
@@ -864,20 +787,22 @@ fn test_chown_no_change_to_group_from_group() {
     let group_name = String::from(result.stdout_str().trim());
     assert!(!group_name.is_empty());
 
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=:42")
-        .arg(":43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!("ownership of '{file}' retained as {group_name}\n"));
+    for (i, from) in ["42", ":42", "42:42"].iter().enumerate() {
+        let file = i.to_string();
+        at.touch(&file);
+        scene
+            .ucmd()
+            .arg("-v")
+            .arg(format!("--from={from}"))
+            .arg(":43")
+            .arg(&file)
+            .succeeds()
+            .stdout_only(format!("ownership of '{file}' retained as {group_name}\n"));
+    }
 }
 
 #[test]
-fn test_chown_no_change_to_group_from_user_group() {
+fn test_chown_no_change_to_user_group() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
@@ -894,111 +819,18 @@ fn test_chown_no_change_to_group_from_user_group() {
     let group_name = String::from(result.stdout_str().trim());
     assert!(!group_name.is_empty());
 
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=42:42")
-        .arg(":43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!("ownership of '{file}' retained as {group_name}\n"));
-}
-
-#[test]
-fn test_chown_no_change_to_user_group_from_user() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    let result = scene.cmd("whoami").run();
-    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
-        return;
+    for (i, from) in ["42", ":42", "42:42"].iter().enumerate() {
+        let file = i.to_string();
+        at.touch(&file);
+        scene
+            .ucmd()
+            .arg("-v")
+            .arg(format!("--from={from}"))
+            .arg("43:43")
+            .arg(&file)
+            .succeeds()
+            .stdout_only(format!(
+                "ownership of '{file}' retained as {user_name}:{group_name}\n"
+            ));
     }
-    let user_name = String::from(result.stdout_str().trim());
-    assert!(!user_name.is_empty());
-
-    let result = scene.cmd("id").arg("-ng").run();
-    if skipping_test_is_okay(&result, "id: cannot find name for group ID") {
-        return;
-    }
-    let group_name = String::from(result.stdout_str().trim());
-    assert!(!group_name.is_empty());
-
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=42")
-        .arg("43:43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!(
-            "ownership of '{file}' retained as {user_name}:{group_name}\n"
-        ));
-}
-
-#[test]
-fn test_chown_no_change_to_user_group_from_group() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    let result = scene.cmd("whoami").run();
-    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
-        return;
-    }
-    let user_name = String::from(result.stdout_str().trim());
-    assert!(!user_name.is_empty());
-    let result = scene.cmd("id").arg("-ng").run();
-    if skipping_test_is_okay(&result, "id: cannot find name for group ID") {
-        return;
-    }
-    let group_name = String::from(result.stdout_str().trim());
-    assert!(!group_name.is_empty());
-
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=:42")
-        .arg("43:43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!(
-            "ownership of '{file}' retained as {user_name}:{group_name}\n"
-        ));
-}
-
-#[test]
-fn test_chown_no_change_to_user_group_from_user_group() {
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    let result = scene.cmd("whoami").run();
-    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
-        return;
-    }
-    let user_name = String::from(result.stdout_str().trim());
-    assert!(!user_name.is_empty());
-    let result = scene.cmd("id").arg("-ng").run();
-    if skipping_test_is_okay(&result, "id: cannot find name for group ID") {
-        return;
-    }
-    let group_name = String::from(result.stdout_str().trim());
-    assert!(!group_name.is_empty());
-
-    let file = "f";
-    at.touch(file);
-    scene
-        .ucmd()
-        .arg("-v")
-        .arg("--from=42:42")
-        .arg("43:43")
-        .arg(file)
-        .succeeds()
-        .stdout_only(format!(
-            "ownership of '{file}' retained as {user_name}:{group_name}\n"
-        ));
 }


### PR DESCRIPTION
This PR removes some duplication by turning nine functions into three functions.