### PR TITLE
`Cargo.toml`: add `feat_require_unix_hostid` to `feat_os_unix`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ feat_os_unix = [
   "feat_require_crate_cpp",
   "feat_require_unix",
   "feat_require_unix_utmpx",
+  "feat_require_unix_hostid",
 ]
 # "feat_os_windows" == set of utilities which can be built/run on modern/usual windows platforms
 feat_os_windows = [


### PR DESCRIPTION
I noticed in https://uutils.github.io/coreutils/book/platforms.html that `hostid` was not included in `unix` by default. Therefore, many people will probably have coreutils installed without `hostid`. Since, `hostid` is at least supported on Linux, Mac and FreeBSD, I think it makes sense to include it by default.