### PR TITLE
date: Adds support for datetime for parameter -d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "parse_datetime"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecceaede7767a9a98058687a321bc91742eff7670167a34104afb30fc8757df"
+checksum = "3bbf4e25b13841080e018a1e666358adfe5e39b6d353f986ca5091c210b586a1"
 dependencies = [
  "chrono",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ num-traits = "0.2.16"
 number_prefix = "0.4"
 once_cell = "1.18.0"
 onig = { version = "~6.4", default-features = false }
-parse_datetime = "0.4.0"
+parse_datetime = "0.5.0"
 phf = "0.11.2"
 phf_codegen = "0.11.2"
 platform-info = "2.0.2"

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -368,7 +368,7 @@ fn test_unsupported_format() {
 }
 
 #[test]
-fn test_date_string_human() {
+fn test_date_string_human_relative_time() {
     let date_formats = vec![
         "1 year ago",
         "1 year",
@@ -378,6 +378,43 @@ fn test_date_string_human() {
         "5 hours ago",
         "30 minutes ago",
         "10 seconds",
+    ];
+    let re = Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}\n$").unwrap();
+    for date_format in date_formats {
+        new_ucmd!()
+            .arg("-d")
+            .arg(date_format)
+            .arg("+%Y-%m-%d %S:%M")
+            .succeeds()
+            .stdout_matches(&re);
+    }
+}
+
+#[test]
+fn test_date_string_human_date_time() {
+    let date_formats = vec![
+        // unix timestamp format
+        "@0",
+        "@2",
+        "@10",
+        "@100",
+        "@2000",
+        "@1234400000",
+        "@1334400000",
+        "@1692582913",
+        "@2092582910",
+        // format YYYY-MM-DD
+        "2012-01-01",
+        "1999-01-12",
+        "2012-01-12",
+        // format YYYY-MM-DD HH:mm
+        "1970-01-01 00:00",
+        "2000-02-29 12:34",
+        "2100-02-28 23:59",
+        "2012-12-31 05:30",
+        "1800-01-01 18:45",
+        "9999-12-31 11:11",
+        "2023-08-21 14:55", //
     ];
     let re = Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}\n$").unwrap();
     for date_format in date_formats {


### PR DESCRIPTION
This resolves issue #5177.

The PR adds a new enum  HumanDuration(Duration), HumanDateTime(DateTime<FixedOffset>) and uses  parse_datetime::parse_datetime::from_str  to support datetime if relative time cannot be parsed.

For example we can now parse `date -d "@0"`, `date -d "1992-02-12"` and `date -d "2012-01-01 14:00"`.

Furthermore tests are added for tests/by-util/test_date.rs.