### PR TITLE
Remove the author copyright notices

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Michael Gehring <mg@ebfe.org>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Smigle00 <smigle00@gmail.com>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/base32/src/base32.rs
+++ b/src/uu/base32/src/base32.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -1,9 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jordy Dickinson <jordy.dickinson@gmail.com>
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-// (c) Alex Lyon <arcterus@mail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/base64/src/base64.rs
+++ b/src/uu/base64/src/base64.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jordy Dickinson <jordy.dickinson@gmail.com>
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jimmy Lu <jimmy.lu.2011@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jordy Dickinson <jordy.dickinson@gmail.com>
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -1,10 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jordi Boggiano <j.boggiano@seld.be>
-// (c) Evgeniy Klyuchikov <evgeniy.klyuchikov@gmail.com>
-// (c) Joshua S. Miller <jsmiller@uchicago.edu>
-// (c) Árni Dagur <arni@dagur.eu>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Alex Lyon <arcterus@mail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Vsevolod Velichko <torkvemada@sorokdva.net>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Michael Gehring <mg@ebfe.org>
-//
 //  For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Michael Gehring <mg@ebfe.org>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -3,9 +3,6 @@
 
 // This file is part of the uutils coreutils package.
 //
-// (c) Jordy Dickinson <jordy.dickinson@gmail.com>
-// (c) Joshua S. Miller <jsmiller@uchicago.edu>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Rolf Morel <rolfmorel@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/cut/src/searcher.rs
+++ b/src/uu/cut/src/searcher.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Rolf Morel <rolfmorel@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Anthony Deschamps <anthony.j.deschamps@gmail.com>
-// (c) Sylvestre Ledru <sylvestre@debian.org>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/dd/src/conversion_tables.rs
+++ b/src/uu/dd/src/conversion_tables.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Tyler Steele <tyler.steele@protonmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/dd/src/datastructures.rs
+++ b/src/uu/dd/src/datastructures.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Tyler Steele <tyler.steele@protonmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore ctable, outfile, iseek, oseek

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Tyler Steele <tyler.steele@protonmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Tyler Steele <tyler.steele@protonmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore ctty, ctable, iseek, oseek, iconvflags, oconvflags parseargs outfile oconv

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Fangxu Hu <framlog@gmail.com>
-// (c) Sylvestre Ledru <sylvestre@debian.org>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 // spell-checker:ignore itotal iused iavail ipcent pcent tmpfs squashfs lofs

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-// (c) Mitchell Mebane <mitchell.mebane@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Derek Chiang <derekchiang93@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Derek Chiang <derekchiang93@gmail.com>
-// (c) Christopher Brown <ccbrown112@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jordi Boggiano <j.boggiano@seld.be>
-// (c) Thomas Queiroz <thomasqueirozb@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Virgile Andreani <virgile.andreani@anbuco.fr>
-// (c) kwantam <kwantam@gmail.com>
 //     * 2015-04-28 ~ updated to work with both UTF-8 and non-UTF-8 encodings
 //
 // For the full copyright and license information, please view the LICENSE

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -1,6 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-//     * 2015-04-28 ~ updated to work with both UTF-8 and non-UTF-8 encodings
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Alan Andrade <alan.andradec@gmail.com>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Alan Andrade <alan.andradec@gmail.com>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jeremiah Peschka <jeremiah.peschka@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -1,6 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Sunrin SHIMURA
 // Collaborator: Jian Zeng
 //
 // For the full copyright and license information, please view the LICENSE

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -1,6 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// Collaborator: Jian Zeng
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -1,6 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Orvar Segerström <orvarsegerstrom@gmail.com>
-// (c) Sokovikov Evgeniy  <skv-headless@yandex.ru>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/test/src/parser.rs
+++ b/src/uu/test/src/parser.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Daniel Rocco <drocco@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) mahkoh (ju.orth [at] gmail [dot] com)
-// (c) Daniel Rocco <drocco@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Nick Platt <platt.nicholas@gmail.com>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Joao Oliveira <joaoxsouls@gmail.com>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/encoding.rs
+++ b/src/uucore/src/lib/features/encoding.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/entries.rs
+++ b/src/uucore/src/lib/features/entries.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Joseph Crail <jbcrail@gmail.com>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -1,9 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-// (c) Fangxu Hu <framlog@gmail.com>
-// (c) Sylvestre Ledru <sylvestre@debian.org>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Alex Lyon <arcterus@mail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -1,8 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Maciej Dziardziel <fiedzia@gmail.com>
-// (c) Jian Zeng <anonymousknight96 AT gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/signals.rs
+++ b/src/uucore/src/lib/features/signals.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Maciej Dziardziel <fiedzia@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Yuan YangHao <yuanyanghau@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //

--- a/src/uucore/src/lib/features/wide.rs
+++ b/src/uucore/src/lib/features/wide.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Peter Atashian <retep998@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -36,8 +36,6 @@ use std::sync::atomic::AtomicBool;
 
 // This file is part of the uutils coreutils package.
 //
-// (c) Alex Lyon <arcterus@mail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/mods/ranges.rs
+++ b/src/uucore/src/lib/mods/ranges.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Rolf Morel <rolfmorel@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/mods/update_control.rs
+++ b/src/uucore/src/lib/mods/update_control.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) John Shin <shinhs0506@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/src/uucore/src/lib/parser/parse_time.rs
+++ b/src/uucore/src/lib/parser/parse_time.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Alex Lyon <arcterus@mail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) Jian Zeng <anonymousknight96@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 //

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -1,7 +1,5 @@
 // This file is part of the uutils coreutils package.
 //
-// (c) kwantam <kwantam@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE file
 // that was distributed with this source code.
 #![allow(clippy::unreadable_literal)]

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -1,9 +1,6 @@
 //
 // This file is part of the uutils coreutils package.
 //
-// (c) mahkoh (ju.orth [at] gmail [dot] com)
-// (c) Daniel Rocco <drocco@gmail.com>
-//
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //


### PR DESCRIPTION
Rational:
* not maintained
* does not reflect reality
* don't provide any value (the info can be found in the git log)
* we don't have rules to update them (ex: should you update it after one line, two lines, etc)