### PR TITLE
docs: add conda installer

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,4 +1,4 @@
-<!-- spell-checker:ignore pacman pamac nixpkgs openmandriva -->
+<!-- spell-checker:ignore pacman pamac nixpkgs openmandriva conda -->
 
 # Installation
 
@@ -137,6 +137,16 @@ pkg install rust-coreutils
 
 ```shell
 scoop install uutils-coreutils
+```
+
+## Alternative installers
+
+### Conda
+
+[Conda package](https://anaconda.org/conda-forge/uutils-coreutils)
+
+```
+conda install -c conda-forge uutils-coreutils 
 ```
 
 ## Non-standard packages


### PR DESCRIPTION
I don't quite understand why people would want to install uutils with conda, but apparently it's possible 😄

See: https://anaconda.org/conda-forge/uutils-coreutils

I can't add a badge for it, because conda is not supported by repology, so I just added a simple link.