### PR TITLE
Add benchmarking for `rm`

### DIFF
--- a/.vscode/cspell.dictionaries/shell.wordlist.txt
+++ b/.vscode/cspell.dictionaries/shell.wordlist.txt
@@ -83,6 +83,8 @@ codespell
 commitlint
 dprint
 dtrace
+flamegraph
+flamegraphs
 gcov
 gmake
 grcov
@@ -90,6 +92,7 @@ grep
 markdownlint
 rerast
 rollup
+samply
 sed
 selinuxenabled
 sestatus

--- a/src/uu/rm/BENCHMARKING.md
+++ b/src/uu/rm/BENCHMARKING.md
@@ -1,3 +1,4 @@
+<!-- spell-checker:ignore samply flamegraph flamegraphs -->
 # Benchmarking rm
 
 Run `cargo build --release` before benchmarking after you make a change!

--- a/src/uu/rm/BENCHMARKING.md
+++ b/src/uu/rm/BENCHMARKING.md
@@ -35,9 +35,9 @@ hyperfine --prepare "cp -r $test_dir tmp_d"  "rm -rf tmp_d" "target/release/core
 
 ## Flamegraphs
 
-### Samply
+### samply
 
-Samply is one option for simply creating flamegraphs. It isues the Firefox profiler as a UI.
+[samply](https://github.com/mstange/samply) is one option for simply creating flamegraphs. It isues the Firefox profiler as a UI.
 
 To install:
 ```bash

--- a/src/uu/rm/BENCHMARKING.md
+++ b/src/uu/rm/BENCHMARKING.md
@@ -33,20 +33,28 @@ hyperfine --prepare "cp -r $test_dir tmp_d"  "rm -rf tmp_d" "target/release/core
 - Another thing to look at would be system calls count using strace (on linux) or equivalent on other operating systems.
 - Example: `strace -c target/release/coreutils rm -rf tree`
 
-## Cargo Flamegraph
+## Flamegraphs
+
+### Samply
+
+Samply is one option for simply creating flamegraphs. It isues the Firefox profiler as a UI.
+
+To install:
+```bash
+cargo install samply
+```
+
+To run:
+
+```bash
+samply record target/release/coreutils rm -rf ../linux
+```
+
+### Cargo Flamegraph
 
 With Cargo Flamegraph you can easily make a flamegraph of `rm`:
 
 ```shell
 cargo flamegraph --cmd coreutils -- rm [additional parameters]
-```
-
-However, if the `-r` option is given, the output becomes pretty much useless due to recursion. We can fix this by merging all the direct recursive calls with `uniq`, below is a `bash` script that does this.
-
-```shell
-#!/bin/bash
-cargo build --release --no-default-features --features rm
-perf record target/release/coreutils rm "$@"
-perf script | uniq | inferno-collapse-perf | inferno-flamegraph > flamegraph.svg
 ```
 

--- a/src/uu/rm/BENCHMARKING.md
+++ b/src/uu/rm/BENCHMARKING.md
@@ -1,0 +1,52 @@
+# Benchmarking rm
+
+Run `cargo build --release` before benchmarking after you make a change!
+
+## Simple recursive rm
+
+- Get a large tree, for example linux kernel source tree.
+- We'll need to pass a `--prepare` argument, since `rm` deletes the dir each time.
+- Benchmark simple recursive rm with hyperfine: `hyperfine --prepare "cp -r tree tree-tmp" "target/release/coreutils rm -r tree-tmp"`.
+
+## Comparing with GNU rm
+
+Hyperfine accepts multiple commands to run and will compare them. To compare performance with GNU rm
+duplicate the string you passed to hyperfine but remove the `target/release/coreutils` bit from it.
+
+Example: `hyperfine --prepare "cp -r tree tree-tmp" "target/release/coreutils rm -rf tree-tmp"` becomes
+`hyperfine --prepare "cp -r tree tree-tmp" "target/release/coreutils rm -rf tree-tmp" "rm -rf tree-tmp"`
+(This assumes GNU rm is installed as `rm`)
+
+This can also be used to compare with version of rm built before your changes to ensure your change does not regress this.
+
+Here is a `bash` script for doing this comparison:
+
+```shell
+#!/bin/bash
+cargo build --no-default-features --features rm --release
+test_dir="$1"
+hyperfine --prepare "cp -r $test_dir tmp_d"  "rm -rf tmp_d" "target/release/coreutils rm -rf tmp_d"
+```
+
+## Checking system call count
+
+- Another thing to look at would be system calls count using strace (on linux) or equivalent on other operating systems.
+- Example: `strace -c target/release/coreutils rm -rf tree`
+
+## Cargo Flamegraph
+
+With Cargo Flamegraph you can easily make a flamegraph of `rm`:
+
+```shell
+cargo flamegraph --cmd coreutils -- rm [additional parameters]
+```
+
+However, if the `-r` option is given, the output becomes pretty much useless due to recursion. We can fix this by merging all the direct recursive calls with `uniq`, below is a `bash` script that does this.
+
+```shell
+#!/bin/bash
+cargo build --release --no-default-features --features rm
+perf record target/release/coreutils rm "$@"
+perf script | uniq | inferno-collapse-perf | inferno-flamegraph > flamegraph.svg
+```
+

--- a/src/uu/rm/BENCHMARKING.md
+++ b/src/uu/rm/BENCHMARKING.md
@@ -33,11 +33,11 @@ hyperfine --prepare "cp -r $test_dir tmp_d"  "rm -rf tmp_d" "target/release/core
 - Another thing to look at would be system calls count using strace (on linux) or equivalent on other operating systems.
 - Example: `strace -c target/release/coreutils rm -rf tree`
 
-## Flamegraphs
+## Flamegraph
 
 ### samply
 
-[samply](https://github.com/mstange/samply) is one option for simply creating flamegraphs. It isues the Firefox profiler as a UI.
+[samply](https://github.com/mstange/samply) is one option for simply creating flamegraphs. It uses the Firefox profiler as a UI.
 
 To install:
 ```bash

--- a/src/uu/rm/benchmark.sh
+++ b/src/uu/rm/benchmark.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Exit on any failures
+set +x
+
+cargo build --no-default-features --features rm --release
+test_dir="$1"
+hyperfine --prepare "cp -r $test_dir tmp_d"  "rm -rf tmp_d" "target/release/coreutils rm -rf tmp_d"


### PR DESCRIPTION
Add benchmarking script and guide for `rm`, mostly copied from `ls` benchmarking guide. Tested `rm` using `jwalk` instead of `walkdir`, and saw a slight performance regression, if any change.