### PR TITLE
build-gnu.sh: fix for /usr/bin/timeout on MacOS

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -151,6 +151,9 @@ sed -i -e '/tests\/misc\/seq-precision.sh/ D' \
 sed -i '/INT_OFLOW/ D' tests/misc/printf.sh
 
 # Use the system coreutils where the test fails due to error in a util that is not the one being tested
+# TODO : tests/tail-2/ does not appear to exist 
+# and have been moved to just tests/tail/ location
+# Might need to update the section bvelow to reflect that
 sed -i 's|stat|/usr/bin/stat|' tests/touch/60-seconds.sh tests/misc/sort-compress-proc.sh
 sed -i 's|ls -|/usr/bin/ls -|' tests/cp/same-file.sh tests/misc/mknod.sh tests/mv/part-symlink.sh
 sed -i 's|chmod |/usr/bin/chmod |' tests/du/inacc-dir.sh tests/tail-2/tail-n0f.sh tests/cp/fail-perm.sh tests/mv/i-2.sh tests/misc/shuf.sh
@@ -175,6 +178,9 @@ fi
 
 
 # Add specific timeout to tests that currently hang to limit time spent waiting
+# TODO : tests/misc/seq-precision.sh tests/misc/seq-long-double.sh do not appear to exist 
+# and have been moved to tests/seq/ location
+# Might need to update the section bvelow to reflect that
 if [ -x /usr/bin/timeout ] ; then
     sed -i 's|\(^\s*\)seq \$|\1/usr/bin/timeout 0.1 seq \$|' tests/misc/seq-precision.sh tests/misc/seq-long-double.sh
 else
@@ -205,6 +211,9 @@ sed -i -e "s|rm: cannot remove 'rel': Permission denied|rm: cannot remove 'rel':
 
 # overlay-headers.sh test intends to check for inotify events,
 # however there's a bug because `---dis` is an alias for: `---disable-inotify`
+# TODO : tests/tail-2/ does not appear to exist 
+# and have been moved to just tests/tail/ location
+# Might need to update the section bvelow to reflect that
 sed -i -e "s|---dis ||g" tests/tail-2/overlay-headers.sh
 
 test -f "${UU_BUILD_DIR}/getlimits" || cp src/getlimits "${UU_BUILD_DIR}"


### PR DESCRIPTION
Set to /usr/local/timeout if /usr/bin/timeout is not found.
On MacOS there is no system `/usr/bin/timeout`  and trying to add it to /usr/bin (with symlink of copy binary) will fail unless system integrity protection is disabled (not ideal)
ref: https://support.apple.com/en-us/102149
On MacOS the Homebrew coreutils could be installed and then 
`sudo ln -s /opt/homebrew/bin/timeout /usr/local/bin/timeout`
