### PR TITLE
Remove the author copyright notices

### DIFF
--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -4,9 +4,6 @@
 // file that was distributed with this source code.
 // library ~ (core/bundler file)
 
-// Copyright (C) ~ Alex Lyon <arcterus@mail.com>
-// Copyright (C) ~ Roy Ivy III <rivy.dev@gmail.com>; MIT license
-
 // * feature-gated external crates (re-shared as public internal modules)
 #[cfg(feature = "libc")]
 pub extern crate libc;

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// Copyright (C) ~ Roy Ivy III <rivy.dev@gmail.com>; MIT license
+//
 // spell-checker:ignore backticks uuhelp
 
 use std::{fs::File, io::Read, path::PathBuf};


### PR DESCRIPTION
This PR removes the author copyright notices from two files missed by https://github.com/uutils/coreutils/pull/5184 and https://github.com/uutils/coreutils/pull/5197