### PR TITLE
uucore,comm: fix warnings from bool_to_int_with_if

### DIFF
--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -30,14 +30,6 @@ mod options {
     pub const ZERO_TERMINATED: &str = "zero-terminated";
 }
 
-fn column_width(col: &str, opts: &ArgMatches) -> usize {
-    if opts.get_flag(col) {
-        0
-    } else {
-        1
-    }
-}
-
 enum Input {
     Stdin(Stdin),
     FileIn(BufReader<File>),
@@ -75,8 +67,8 @@ fn comm(a: &mut LineReader, b: &mut LineReader, opts: &ArgMatches) {
         delim => delim,
     };
 
-    let width_col_1 = column_width(options::COLUMN_1, opts);
-    let width_col_2 = column_width(options::COLUMN_2, opts);
+    let width_col_1 = usize::from(!opts.get_flag(options::COLUMN_1));
+    let width_col_2 = usize::from(!opts.get_flag(options::COLUMN_2));
 
     let delim_col_2 = delim.repeat(width_col_1);
     let delim_col_3 = delim.repeat(width_col_1 + width_col_2);

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -133,8 +133,8 @@ pub fn set_utility_is_second_arg() {
 static ARGV: Lazy<Vec<OsString>> = Lazy::new(|| wild::args_os().collect());
 
 static UTIL_NAME: Lazy<String> = Lazy::new(|| {
-    let base_index = if get_utility_is_second_arg() { 1 } else { 0 };
-    let is_man = if ARGV[base_index].eq("manpage") { 1 } else { 0 };
+    let base_index = usize::from(get_utility_is_second_arg());
+    let is_man = usize::from(ARGV[base_index].eq("manpage"));
     let argv_index = base_index + is_man;
 
     ARGV[argv_index].to_string_lossy().into_owned()


### PR DESCRIPTION
This PR fixes some warnings from the pedantic [bool_to_int_with_if](https://rust-lang.github.io/rust-clippy/master/index.html#/bool_to_int_with_if) lint.