### PR TITLE
website: fix changelog config

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -6,7 +6,9 @@
     "path_prefix": "coreutils"
   },
   "components": {
-    "changelog": true
+    "changelog": {
+      "read_changelog_file": false
+    }
   },
   "styles": {
     "theme": "light",


### PR DESCRIPTION
Our website doesn't have a changelog due to a misconfiguration in oranda. See https://github.com/axodotdev/oranda/issues/611

This fixes the config and brings back our beautiful and extensive changelog :)