### PR TITLE
`echo`: fix wrapping behavior of octal sequences

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -54,6 +54,16 @@ fn print_escaped(input: &str, mut output: impl Write) -> io::Result<bool> {
             continue;
         }
 
+        // This is for the \NNN syntax for octal sequences.
+        // Note that '0' is intentionally omitted because that
+        // would be the \0NNN syntax.
+        if let Some('1'..='8') = iter.peek() {
+            if let Some(parsed) = parse_code(&mut iter, 8, 3) {
+                write!(output, "{parsed}")?;
+                continue;
+            }
+        }
+
         if let Some(next) = iter.next() {
             let unescaped = match next {
                 '\\' => '\\',

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -236,3 +236,20 @@ fn test_hyphen_values_between() {
         .success()
         .stdout_is("dumdum  dum dum dum -e dum\n");
 }
+
+#[test]
+fn wrapping_octal() {
+    // Some odd behavior of GNU. Values of \0400 and greater do not fit in the
+    // u8 that we write to stdout. So we test that it wraps:
+    //
+    // We give it this input:
+    //     \o501 = 1_0100_0001 (yes, **9** bits)
+    // This should be wrapped into:
+    //     \o101 = 'A' = 0100_0001,
+    // because we only write a single character
+    new_ucmd!()
+        .arg("-e")
+        .arg("\\0501")
+        .succeeds()
+        .stdout_is("A\n");
+}

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -253,3 +253,30 @@ fn wrapping_octal() {
         .succeeds()
         .stdout_is("A\n");
 }
+
+#[test]
+fn old_octal_syntax() {
+    new_ucmd!()
+        .arg("-e")
+        .arg("\\1foo")
+        .succeeds()
+        .stdout_is("\x01foo\n");
+
+    new_ucmd!()
+        .arg("-e")
+        .arg("\\43foo")
+        .succeeds()
+        .stdout_is("#foo\n");
+
+    new_ucmd!()
+        .arg("-e")
+        .arg("\\101foo")
+        .succeeds()
+        .stdout_is("Afoo\n");
+
+    new_ucmd!()
+        .arg("-e")
+        .arg("\\1011")
+        .succeeds()
+        .stdout_is("A1\n");
+}

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -270,9 +270,9 @@ fn old_octal_syntax() {
 
     new_ucmd!()
         .arg("-e")
-        .arg("\\101foo")
+        .arg("\\101 foo")
         .succeeds()
-        .stdout_is("Afoo\n");
+        .stdout_is("A foo\n");
 
     new_ucmd!()
         .arg("-e")


### PR DESCRIPTION
Funny behaviour in GNU:
```
$ echo -e "\0501"
A
```
Even though the octal code for `A` is `\0101`. The reason that happens is because 3 octal digits is equivalent to a _9_ bit integer.

This is possibly a bug in GNU that nobody has fixed in 31 years or they just chose to ignore it since it is fairly minor. I was investigating this with @jdonszelmann and we found that GNU and the built-in `echo` for zsh and fish both also have this wrapping behaviour. Though it's not really a problem because it is all done using `unsigned` integers. In this PR, I've made sure to use the `wrapping_*` methods for arithmetic to further avoid any problems.

Some other utilities might need to be checked too. For instance `printf`:
```
$ env printf "\501"
A
```

I noticed this while I was refactoring `print_escaped`, which is why that function is changed too.