### PR TITLE
`cp`: finish progress bar to make it always show up

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1242,6 +1242,11 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
             seen_sources.insert(source);
         }
     }
+
+    if let Some(pb) = progress_bar {
+        pb.finish();
+    }
+
     if non_fatal_errors {
         Err(Error::NotAllFilesCopied)
     } else {


### PR DESCRIPTION
Small break from my break to fix an issue for nushell :)

The progress bar sometimes does not show up if the `cp` itself is too fast for it to draw, or something like that. The `finish` method draws the progress bar one last time before exiting, so we get a full error bar at the end.

Context: https://github.com/nushell/nushell/pull/10097#issuecomment-1703865381