### PR TITLE
Bump MSRV to 1.70

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.64.0"
+msrv = "1.70.0"
 cognitive-complexity-threshold = 10

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -11,7 +11,7 @@ env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"
   PROJECT_AUTH: "uutils"
-  RUST_MIN_SRV: "1.64.0"
+  RUST_MIN_SRV: "1.70.0"
   # * style job configuration
   STYLE_FAIL_ON_FAULT: true ## (bool) fail the build if a style job contains a fault (error or warning); may be overridden on a per-job basis
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/uutils/coreutils"
 readme = "README.md"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 edition = "2021"
 
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![dependency status](https://deps.rs/repo/github/uutils/coreutils/status.svg)](https://deps.rs/repo/github/uutils/coreutils)
 
 [![CodeCov](https://codecov.io/gh/uutils/coreutils/branch/master/graph/badge.svg)](https://codecov.io/gh/uutils/coreutils)
-![MSRV](https://img.shields.io/badge/MSRV-1.64.0-brightgreen)
+![MSRV](https://img.shields.io/badge/MSRV-1.70.0-brightgreen)
 
 </div>
 
@@ -71,7 +71,7 @@ the [coreutils docs](https://github.com/uutils/uutils.github.io) repository.
 ### Rust Version
 
 uutils follows Rust's release channels and is tested against stable, beta and
-nightly. The current Minimum Supported Rust Version (MSRV) is `1.64.0`.
+nightly. The current Minimum Supported Rust Version (MSRV) is `1.70.0`.
 
 ## Building
 

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -871,7 +871,7 @@ fn test_short_combination() {
     assert_eq!(at.read("x00"), "a");
     assert_eq!(at.read("x01"), "b");
     assert_eq!(at.read("x02"), "c");
-    assert_eq!(at.file_exists("x03"), false);
+    assert!(!at.file_exists("x03"));
 }
 
 /// Test for the last effective suffix, ignoring all others - numeric long last


### PR DESCRIPTION
This PR bumps the MSRV to `1.70` and fixes a Clippy warning in a test.