### PR TITLE
Update timeout tests to check sub-shell commands are killed

### DIFF
--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore dont
+// spell-checker:ignore dont subshell
 use crate::common::util::TestScenario;
 
 #[test]


### PR DESCRIPTION
Renames and fixes failing test case `test_kill_subshell` in the `timeout` tests. Adds documentation comments, reduces test execution time (was unnecessarily long before) and removes second `sh -c` layer (previously, `sh -c "sh -c '<cmd>'"` was executed). See #3489.