### PR TITLE
wc: use Rust's ilog10(), remove custom ilog10 fn

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -702,7 +702,7 @@ fn compute_number_width(inputs: &Inputs, settings: &Settings) -> usize {
             if total == 0 {
                 minimum_width
             } else {
-                let total_width = (1 + ilog10_u64(total))
+                let total_width = (1 + total.ilog10())
                     .try_into()
                     .expect("ilog of a u64 should fit into a usize");
                 max(total_width, minimum_width)
@@ -855,31 +855,5 @@ fn print_stats(
         writeln!(stdout, "{space}{title}")
     } else {
         writeln!(stdout)
-    }
-}
-
-// TODO: remove and just use usize::ilog10 once the MSRV is >= 1.67.
-fn ilog10_u64(mut u: u64) -> u32 {
-    if u == 0 {
-        panic!("cannot compute log of 0")
-    }
-    let mut log = 0;
-    if u >= 10_000_000_000 {
-        log += 10;
-        u /= 10_000_000_000;
-    }
-    if u >= 100_000 {
-        log += 5;
-        u /= 100_000;
-    }
-    // Rust's standard library in versions >= 1.67 does something even more clever than this, but
-    // this should work just fine for the time being.
-    log + match u {
-        1..=9 => 0,
-        10..=99 => 1,
-        100..=999 => 2,
-        1000..=9999 => 3,
-        10000..=99999 => 4,
-        _ => unreachable!(),
     }
 }


### PR DESCRIPTION
This PR fixes a todo by using Rust's `ilog10` function and removing our custom `ilog10` implementation.