### PR TITLE
yes: use let/else to fix todo

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -58,10 +58,7 @@ fn args_into_buffer<'a>(
     buf: &mut Vec<u8>,
     i: Option<impl Iterator<Item = &'a OsString>>,
 ) -> Result<(), Box<dyn Error>> {
-    // TODO: this should be replaced with let/else once available in the MSRV.
-    let i = if let Some(i) = i {
-        i
-    } else {
+    let Some(i) = i else {
         buf.extend_from_slice(b"y\n");
         return Ok(());
     };


### PR DESCRIPTION
This PR fixes a todo by using `let`/`else` to simplify an expression.