### PR TITLE
cp: Error out if cp only contains source

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1073,6 +1073,9 @@ fn parse_path_args(
     if paths.is_empty() {
         // No files specified
         return Err("missing file operand".into());
+    } else if paths.len() == 1 && options.target_dir.is_none() {
+        // Only one file specified
+        return Err(format!("missing destination file operand after {:?}", paths[0]).into());
     }
 
     // Return an error if the user requested to copy more than one

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3231,3 +3231,15 @@ fn test_cp_debug_sparse_always_reflink_auto() {
         panic!("Failure: stdout was \n{stdout_str}");
     }
 }
+
+#[test]
+fn test_cp_only_source_no_target() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.touch("a");
+    let result = ts.ucmd().arg("a").fails();
+    let stderr_str = result.stderr_str();
+    if !stderr_str.contains("missing destination file operand after \"a\"") {
+        panic!("Failure: stderr was \n{stderr_str}");
+    }
+}


### PR DESCRIPTION
Hi
Currently,
GNU :
```

>cp a:
`missing destination file operand after a

# uutils

>cp a
#nothing
```
With this fix, we match the  behavior

```
# uutils
>cp a
missing destination file operand after a