### PR TITLE
split: catch broken pipe error for round robin strategy

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1293,7 +1293,8 @@ where
         settings.suffix_length,
         settings.suffix_type,
         settings.suffix_start,
-    ).map_err(|e| io::Error::new(ErrorKind::Other, format!("{e}")))?;
+    )
+    .map_err(|e| io::Error::new(ErrorKind::Other, format!("{e}")))?;
 
     // Create one writer for each chunk. This will create each
     // of the underlying files (if not in `--filter` mode).

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -306,8 +306,7 @@ fn test_filter_broken_pipe() {
     let name = "filter-big-input";
 
     RandomFile::new(&at, name).add_lines(1024 * 10);
-    ucmd
-        .args(&["--filter=head -c1 > /dev/null", "-n", "r/1", name])
+    ucmd.args(&["--filter=head -c1 > /dev/null", "-n", "r/1", name])
         .succeeds();
 }
 

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -300,6 +300,18 @@ fn test_filter_command_fails() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_filter_broken_pipe() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let name = "filter-big-input";
+
+    RandomFile::new(&at, name).add_lines(1024 * 10);
+    ucmd
+        .args(&["--filter=head -c1 > /dev/null", "-n", "r/1", name])
+        .succeeds();
+}
+
+#[test]
 fn test_split_lines_number() {
     // Test if stdout/stderr for '--lines' option is correct
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
The broken pipe error is not handled in the case of the round robin strategy (typically used with --filter).

Align to the other strategies to silence that error in that use case too.

fixes #5191