### PR TITLE
Bump nix & ctrlc, adapt stty to nix API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix",
  "windows-sys 0.48.0",
@@ -1343,14 +1343,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -2075,12 +2074,6 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,7 +293,7 @@ lscolors = { version = "0.15.0", default-features = false, features = [
 ] }
 memchr = "2"
 memmap2 = "0.7"
-nix = { version = "0.26", default-features = false }
+nix = { version = "0.27", default-features = false }
 nom = "7.1.3"
 notify = { version = "=6.0.1", features = ["macos_kqueue"] }
 num-bigint = "0.4.4"

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -14,10 +14,12 @@ use nix::sys::termios::{
     OutputFlags, SpecialCharacterIndices, Termios,
 };
 use nix::{ioctl_read_bad, ioctl_write_ptr_bad};
-use std::io::{self, stdout};
+use std::fs::File;
+use std::io::{self, stdout, Stdout};
 use std::ops::ControlFlow;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::fs::OpenOptionsExt;
-use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, RawFd};
 use uucore::error::{UResult, USimpleError};
 use uucore::{format_usage, help_about, help_usage};
 
@@ -91,8 +93,31 @@ mod options {
 struct Options<'a> {
     all: bool,
     save: bool,
-    file: RawFd,
+    file: Device,
     settings: Option<Vec<&'a str>>,
+}
+
+enum Device {
+    File(File),
+    Stdout(Stdout),
+}
+
+impl AsFd for Device {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self {
+            Self::File(f) => f.as_fd(),
+            Self::Stdout(stdout) => stdout.as_fd(),
+        }
+    }
+}
+
+impl AsRawFd for Device {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            Self::File(f) => f.as_raw_fd(),
+            Self::Stdout(stdout) => stdout.as_raw_fd(),
+        }
+    }
 }
 
 impl<'a> Options<'a> {
@@ -110,12 +135,13 @@ impl<'a> Options<'a> {
                 //    will clean up the FD for us on exit, so it doesn't
                 //    matter. The alternative would be to have an enum of
                 //    BorrowedFd/OwnedFd to handle both cases.
-                Some(f) => std::fs::OpenOptions::new()
-                    .read(true)
-                    .custom_flags(O_NONBLOCK)
-                    .open(f)?
-                    .into_raw_fd(),
-                None => stdout().as_raw_fd(),
+                Some(f) => Device::File(
+                    std::fs::OpenOptions::new()
+                        .read(true)
+                        .custom_flags(O_NONBLOCK)
+                        .open(f)?,
+                ),
+                None => Device::Stdout(stdout()),
             },
             settings: matches
                 .get_many::<String>(options::SETTINGS)
@@ -175,7 +201,7 @@ fn stty(opts: &Options) -> UResult<()> {
     }
 
     // TODO: Figure out the right error message for when tcgetattr fails
-    let mut termios = tcgetattr(opts.file).expect("Could not get terminal attributes");
+    let mut termios = tcgetattr(opts.file.as_fd()).expect("Could not get terminal attributes");
 
     if let Some(settings) = &opts.settings {
         for setting in settings {
@@ -187,8 +213,12 @@ fn stty(opts: &Options) -> UResult<()> {
             }
         }
 
-        tcsetattr(opts.file, nix::sys::termios::SetArg::TCSANOW, &termios)
-            .expect("Could not write terminal attributes");
+        tcsetattr(
+            opts.file.as_fd(),
+            nix::sys::termios::SetArg::TCSANOW,
+            &termios,
+        )
+        .expect("Could not write terminal attributes");
     } else {
         print_settings(&termios, opts).expect("TODO: make proper error here from nix error");
     }
@@ -228,7 +258,7 @@ fn print_terminal_size(termios: &Termios, opts: &Options) -> nix::Result<()> {
 
     if opts.all {
         let mut size = TermSize::default();
-        unsafe { tiocgwinsz(opts.file, &mut size as *mut _)? };
+        unsafe { tiocgwinsz(opts.file.as_raw_fd(), &mut size as *mut _)? };
         print!("rows {}; columns {}; ", size.rows, size.columns);
     }
 


### PR DESCRIPTION
This PR bumps `nix` from `0.26.2` to `0.27.1` and `ctrlc` from `3.4.0` to `3.4.1`. And it fixes two compilation errors in `stty` because `nix` changed the function signatures of `tcgetattr` and `tcsetattr`.