### PR TITLE
cp: fail when trying to copy to read only file on mac

### DIFF
--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -66,6 +66,9 @@ pub(crate) fn copy_on_write(
                 // first lets make sure the dest file is not read only
                 if fs::metadata(dest).map_or(false, |md| !md.permissions().readonly()) {
                     // remove and copy again
+                    // TODO: rewrite this to better match linux behavior
+                    // linux first opens the source file and destination file then uses the file
+                    // descriptiors to do the clone.
                     let _ = fs::remove_file(dest);
                     error = pfn(src.as_ptr(), dst.as_ptr(), 0);
                 }

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -64,21 +64,10 @@ pub(crate) fn copy_on_write(
                 // clonefile(2) fails if the destination exists.  Remove it and try again.  Do not
                 // bother to check if removal worked because we're going to try to clone again.
                 // first lets make sure the dest file is not read only
-                match fs::metadata(dest) {
-                    Ok(md) => {
-                        if md.permissions().readonly() {
-                            return Err(format!(
-                                "failed to clone {source:?} from {dest:?}: permission denied"
-                            )
-                            .into());
-                        } else {
-                            let _ = fs::remove_file(dest);
-                            error = pfn(src.as_ptr(), dst.as_ptr(), 0);
-                        }
-                    }
-                    Err(e) => {
-                        return Err(format!("failed to clone {source:?} from {dest:?}: {e}").into());
-                    }
+                if fs::metadata(dest).map_or(false, |md| !md.permissions().readonly()) {
+                    // remove and copy again
+                    let _ = fs::remove_file(dest);
+                    error = pfn(src.as_ptr(), dst.as_ptr(), 0);
                 }
             }
         }

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -63,7 +63,7 @@ pub(crate) fn copy_on_write(
             {
                 // clonefile(2) fails if the destination exists.  Remove it and try again.  Do not
                 // bother to check if removal worked because we're going to try to clone again.
-                // first lets make sure the dest file isnt read only
+                // first lets make sure the dest file is not read only
                 match fs::metadata(dest) {
                     Ok(md) => {
                         if md.permissions().readonly() {

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -68,7 +68,7 @@ pub(crate) fn copy_on_write(
                     // remove and copy again
                     // TODO: rewrite this to better match linux behavior
                     // linux first opens the source file and destination file then uses the file
-                    // descriptiors to do the clone.
+                    // descriptors to do the clone.
                     let _ = fs::remove_file(dest);
                     error = pfn(src.as_ptr(), dst.as_ptr(), 0);
                 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3243,3 +3243,19 @@ fn test_cp_only_source_no_target() {
         panic!("Failure: stderr was \n{stderr_str}");
     }
 }
+
+#[test]
+fn test_cp_dest_no_permissions() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.touch("valid.txt");
+    at.touch("invalid_perms.txt");
+    at.set_readonly("invalid_perms.txt");
+
+    ts.ucmd()
+        .args(&["valid.txt", "invalid_perms.txt"])
+        .fails()
+        .stderr_contains("invalid_perms.txt")
+        .stderr_contains("denied");
+}


### PR DESCRIPTION
Fixes issue #5257 by first checking if file is read only or not before removing file and trying clonefile again