### PR TITLE
deny.toml: add redox_syscall to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -89,6 +89,8 @@ skip = [
   { name = "bitflags", version = "1.3.2" },
   # blake2b_simd
   { name = "constant_time_eq", version = "0.2.6" },
+  # various crates
+  { name = "redox_syscall", version = "0.3.5" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR adds `redox_syscall` to the skip list in `deny.toml` in order to be able to merge https://github.com/uutils/coreutils/pull/5262