### PR TITLE
deny.toml: remove constant_time_eq from skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -87,8 +87,6 @@ skip = [
   { name = "syn", version = "1.0.109" },
   # various crates
   { name = "bitflags", version = "1.3.2" },
-  # blake2b_simd
-  { name = "constant_time_eq", version = "0.2.6" },
   # various crates
   { name = "redox_syscall", version = "0.3.5" },
 ]


### PR DESCRIPTION
This PR removes `constant_time_eq` from the skip list in `deny.toml` because of https://github.com/uutils/coreutils/pull/5266