### PR TITLE
ls: use OnceCell from std instead of once_cell

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -12,8 +12,7 @@ use clap::{
 use glob::{MatchOptions, Pattern};
 use lscolors::LsColors;
 use number_prefix::NumberPrefix;
-use once_cell::unsync::OnceCell;
-use std::num::IntErrorKind;
+use std::{cell::OnceCell, num::IntErrorKind};
 use std::{collections::HashSet, io::IsTerminal};
 
 #[cfg(windows)]


### PR DESCRIPTION
This PR uses `std::cell::OnceCell` instead of `once_cell::unsync::OnceCell`.