### PR TITLE
Bump chrono and fix deprecation warnings in touch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ binary-heap-plus = "0.5.0"
 bstr = "1.6"
 bytecount = "0.6.3"
 byteorder = "1.4.3"
-chrono = { version = "^0.4.28", default-features = false, features = [
+chrono = { version = "^0.4.30", default-features = false, features = [
   "std",
   "alloc",
   "clock",

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -5,7 +5,6 @@
 // spell-checker:ignore (formats) cymdhm cymdhms mdhm mdhms ymdhm ymdhms datetime mktime
 
 use crate::common::util::{AtPath, TestScenario};
-use chrono::TimeZone;
 use filetime::{self, FileTime};
 use std::fs::remove_file;
 use std::path::PathBuf;
@@ -32,7 +31,7 @@ fn set_file_times(at: &AtPath, path: &str, atime: FileTime, mtime: FileTime) {
 }
 
 fn str_to_filetime(format: &str, s: &str) -> FileTime {
-    let tm = chrono::Utc.datetime_from_str(s, format).unwrap();
+    let tm = chrono::NaiveDateTime::parse_from_str(s, format).unwrap();
     FileTime::from_unix_time(tm.timestamp(), tm.timestamp_subsec_nanos())
 }
 


### PR DESCRIPTION
This PR bumps `chrono` from `0.4.28` to `0.4.30` and fixes in `touch` the warnings caused by the deprecation of `chrono::TimeZone::datetime_from_str`.