### PR TITLE
ci: replace deprecated "command" with "fix"

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -328,7 +328,7 @@ jobs:
         RUSTDOCFLAGS="-Dwarnings" cargo doc  ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-deps --workspace --document-private-items
     - uses: DavidAnson/markdownlint-cli2-action@v12
       with:
-        command: fix
+        fix: "true"
         globs: |
           *.md
           docs/src/*.md


### PR DESCRIPTION
`markdownlint-cli2-action` deprecated the `command` input and so this PR replaces it with the `fix` input. See also https://github.com/marketplace/actions/markdownlint-cli2-action#command-optional