### PR TITLE
deny.toml: add terminal_size to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -89,6 +89,8 @@ skip = [
   { name = "bitflags", version = "1.3.2" },
   # various crates
   { name = "redox_syscall", version = "0.3.5" },
+  # clap_builder, textwrap
+  { name = "terminal_size", version = "0.2.6" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR adds `terminal_size` to the skip list in `deny.toml` to be able to merge https://github.com/uutils/coreutils/pull/5275