### PR TITLE
ls.rs: changed variable name dfn to display_file_content responding to #5282

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2482,13 +2482,13 @@ fn display_item_long(
             }
         };
 
-        let display_file_content = display_file_name(item, config, None, String::new(), out).contents;
+        let displayed_file = display_file_name(item, config, None, String::new(), out).contents;
 
         write!(
             out,
             " {} {}{}",
             display_date(md, config),
-            display_file_content,
+            displayed_file,
             config.line_ending
         )?;
     } else {
@@ -2561,7 +2561,7 @@ fn display_item_long(
             write!(out, " {}", pad_right("?", padding.uname))?;
         }
 
-        let display_file_content = display_file_name(item, config, None, String::new(), out).contents;
+        let displayed_file = display_file_name(item, config, None, String::new(), out).contents;
         let date_len = 12;
 
         writeln!(
@@ -2569,7 +2569,7 @@ fn display_item_long(
             " {} {} {}",
             pad_left("?", padding.size),
             pad_left("?", date_len),
-            display_file_content,
+            displayed_file,
         )?;
     }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2482,13 +2482,13 @@ fn display_item_long(
             }
         };
 
-        let dfn = display_file_name(item, config, None, String::new(), out).contents;
+        let display_file_content = display_file_name(item, config, None, String::new(), out).contents;
 
         write!(
             out,
             " {} {}{}",
             display_date(md, config),
-            dfn,
+            display_file_content,
             config.line_ending
         )?;
     } else {
@@ -2561,7 +2561,7 @@ fn display_item_long(
             write!(out, " {}", pad_right("?", padding.uname))?;
         }
 
-        let dfn = display_file_name(item, config, None, String::new(), out).contents;
+        let display_file_content = display_file_name(item, config, None, String::new(), out).contents;
         let date_len = 12;
 
         writeln!(
@@ -2569,7 +2569,7 @@ fn display_item_long(
             " {} {} {}",
             pad_left("?", padding.size),
             pad_left("?", date_len),
-            dfn,
+            display_file_content,
         )?;
     }
 


### PR DESCRIPTION
## Changed the variable "dfn" to display_file_content in ls.rs
This hopefully will make this cade a little les cryptic

reponding to issue #5282




