### PR TITLE
nl: make line number and --join-blank-lines work over multiple files

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -303,15 +303,14 @@ pub fn uu_app() -> Command {
 // nl implements the main functionality for an individual buffer.
 fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings) -> UResult<()> {
     let mut current_numbering_style = &settings.body_numbering;
-    let mut consecutive_empty_lines = stats.consecutive_empty_lines;
 
     for line in reader.lines() {
         let line = line.map_err_context(|| "could not read line".to_string())?;
 
         if line.is_empty() {
-            consecutive_empty_lines += 1;
+            stats.consecutive_empty_lines += 1;
         } else {
-            consecutive_empty_lines = 0;
+            stats.consecutive_empty_lines = 0;
         };
 
         // FIXME section delimiters are hardcoded and settings.section_delimiter is ignored
@@ -336,7 +335,7 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
                 // for numbering, and only number the last one
                 NumberingStyle::All
                     if line.is_empty()
-                        && consecutive_empty_lines % settings.join_blank_lines != 0 =>
+                        && stats.consecutive_empty_lines % settings.join_blank_lines != 0 =>
                 {
                     false
                 }

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -285,6 +285,31 @@ fn test_join_blank_lines() {
 }
 
 #[test]
+fn test_join_blank_lines_multiple_files() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("a.txt", "\n\n");
+    at.write("b.txt", "\n\n");
+    at.write("c.txt", "\n\n");
+
+    for arg in ["-l3", "--join-blank-lines=3"] {
+        scene
+            .ucmd()
+            .args(&[arg, "--body-numbering=a", "a.txt", "b.txt", "c.txt"])
+            .succeeds()
+            .stdout_is(concat!(
+                "       \n",
+                "       \n",
+                "     1\t\n",
+                "       \n",
+                "       \n",
+                "     2\t\n",
+            ));
+    }
+}
+
+#[test]
 fn test_join_blank_lines_zero() {
     for arg in ["-l0", "--join-blank-lines=0"] {
         new_ucmd!().arg(arg).fails().stderr_contains(

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -312,6 +312,19 @@ fn test_default_body_numbering() {
 }
 
 #[test]
+fn test_default_body_numbering_multiple_files() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("a.txt", "a");
+    at.write("b.txt", "b");
+    at.write("c.txt", "c");
+
+    ucmd.args(&["a.txt", "b.txt", "c.txt"])
+        .succeeds()
+        .stdout_is("     1\ta\n     2\tb\n     3\tc\n");
+}
+
+#[test]
 fn test_body_numbering_all_lines_without_delimiter() {
     for arg in ["-ba", "--body-numbering=a"] {
         new_ucmd!()


### PR DESCRIPTION
So far the line number and `consecutive_empty_lines` (used for `--join-blank-lines`) got reset for each file. This PR removes this reset and makes them work over multiple files.