### PR TITLE
relpath: show error if no argument provided

### DIFF
--- a/src/uu/relpath/src/relpath.rs
+++ b/src/uu/relpath/src/relpath.rs
@@ -82,6 +82,10 @@ pub fn uu_app() -> Command {
         .arg(Arg::new(options::DIR).short('d').help(
             "If any of FROM and TO is not subpath of DIR, output absolute path instead of relative",
         ))
-        .arg(Arg::new(options::TO).value_hint(clap::ValueHint::AnyPath))
+        .arg(
+            Arg::new(options::TO)
+                .value_hint(clap::ValueHint::AnyPath)
+                .required(true),
+        )
         .arg(Arg::new(options::FROM).value_hint(clap::ValueHint::AnyPath))
 }

--- a/tests/by-util/test_relpath.rs
+++ b/tests/by-util/test_relpath.rs
@@ -180,3 +180,10 @@ fn test_relpath_no_from_with_d() {
         assert!(Path::new(&result_stdout).is_absolute());
     }
 }
+
+#[test]
+fn test_relpath_no_to() {
+    new_ucmd!()
+        .fails()
+        .stderr_contains("required arguments were not provided");
+}


### PR DESCRIPTION
This PR shows a (clap) error message if no argument is provided.

Fixes #5300 