### PR TITLE
nl: fix output order if stdin and files are mixed

### DIFF
--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -350,6 +350,19 @@ fn test_default_body_numbering_multiple_files() {
 }
 
 #[test]
+fn test_default_body_numbering_multiple_files_and_stdin() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("a.txt", "a");
+    at.write("c.txt", "c");
+
+    ucmd.args(&["a.txt", "-", "c.txt"])
+        .pipe_in("b")
+        .succeeds()
+        .stdout_is("     1\ta\n     2\tb\n     3\tc\n");
+}
+
+#[test]
 fn test_body_numbering_all_lines_without_delimiter() {
     for arg in ["-ba", "--body-numbering=a"] {
         new_ucmd!()


### PR DESCRIPTION
This PR changes the output order from "files first, stdin last" to "input order = output order" to match the behavior of GNU nl.