### PR TITLE
android: update the repo before doing the install

### DIFF
--- a/util/android-commands.sh
+++ b/util/android-commands.sh
@@ -202,7 +202,7 @@ snapshot() {
 
     echo "Prepare and install system packages"
     probe='/sdcard/pkg.probe'
-    command="'mkdir -vp ~/.cargo/bin; yes | pkg install rust binutils openssl tar -y; echo \$? > $probe'"
+    command="'mkdir -vp ~/.cargo/bin; yes | pkg update; pkg install rust binutils openssl tar -y; echo \$? > $probe'"
     run_termux_command "$command" "$probe" || return
 
     echo "Installing cargo-nextest"


### PR DESCRIPTION
Not sure it will be enough

We are often failing on:

```
Get:1 https://deb.kcubeterm.me/termux-main stable InRelease [512 B]
Err:1 https://deb.kcubeterm.me/termux-main stable InRelease
  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
Reading package lists...
E: Failed to fetch https://deb.kcubeterm.me/termux-main/dists/stable/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
E: The repository 'https://deb.kcubeterm.me/termux-main stable InRelease' is not signed.
```

if it doesn't work, we could force use of one repo:

For example:
`https://termux.librehat.com/apt/termux-main: ok`
which seems to work:
```

2023-09-24T09:06:02.6362680Z Get:1 https://termux.librehat.com/apt/termux-main stable InRelease [14.0 kB]
2023-09-24T09:06:02.6464450Z Get:2 https://termux.librehat.com/apt/termux-main stable/main i686 Packages [486 kB]
```