### PR TITLE
run-gnu-test.sh: accept "run-root" as first param

### DIFF
--- a/util/run-gnu-test.sh
+++ b/util/run-gnu-test.sh
@@ -29,25 +29,27 @@ cd "${path_GNU}" && echo "[ pwd:'${PWD}' ]"
 
 export RUST_BACKTRACE=1
 
-if test $# -ge 1; then
-    # if set, run only the tests passed
-    SPECIFIC_TESTS=""
-    for t in "$@"; do
+if test "$1" != "run-root"; then
+    if test $# -ge 1; then
+        # if set, run only the tests passed
+        SPECIFIC_TESTS=""
+        for t in "$@"; do
 
-        # Construct the full path
-        full_path="$path_GNU/$t"
+            # Construct the full path
+            full_path="$path_GNU/$t"
 
-        # Check if the file exists with .sh, .pl extension or without any extension in the $path_GNU directory
-        if [ -f "$full_path" ] || [ -f "$full_path.sh" ] || [ -f "$full_path.pl" ]; then
-            SPECIFIC_TESTS="$SPECIFIC_TESTS $t"
-        else
-            echo "Error: Test file $full_path, $full_path.sh, or $full_path.pl does not exist!"
-            exit 1
-        fi
-    done
-    # trim it
-    SPECIFIC_TESTS=$(echo $SPECIFIC_TESTS | xargs)
-    echo "Running specific tests: $SPECIFIC_TESTS"
+            # Check if the file exists with .sh, .pl extension or without any extension in the $path_GNU directory
+            if [ -f "$full_path" ] || [ -f "$full_path.sh" ] || [ -f "$full_path.pl" ]; then
+                SPECIFIC_TESTS="$SPECIFIC_TESTS $t"
+            else
+                echo "Error: Test file $full_path, $full_path.sh, or $full_path.pl does not exist!"
+                exit 1
+            fi
+        done
+        # trim it
+        SPECIFIC_TESTS=$(echo $SPECIFIC_TESTS | xargs)
+        echo "Running specific tests: $SPECIFIC_TESTS"
+    fi
 fi
 
 # * timeout used to kill occasionally errant/"stuck" processes (note: 'release' testing takes ~1 hour; 'debug' testing takes ~2.5 hours)


### PR DESCRIPTION
This PR fixes a "file not found" error if `run-root` is passed to `run-gnu-test.sh`.