### PR TITLE
expr: interpret numbers != 0 as true for | and &

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -8,10 +8,10 @@
 //! * `<https://en.wikipedia.org/wiki/Shunting-yard_algorithm>`
 //!
 
-// spell-checker:ignore (ToDO) binop binops ints paren prec multibytes
+// spell-checker:ignore (ToDO) ints paren prec multibytes
 
 use num_bigint::BigInt;
-use num_traits::{One, Zero};
+use num_traits::Zero;
 use onig::{Regex, RegexOptions, Syntax};
 
 use crate::tokens::Token;
@@ -515,7 +515,7 @@ fn value_as_bool(s: &str) -> bool {
         return false;
     }
     match s.parse::<BigInt>() {
-        Ok(n) => n.is_one(),
+        Ok(n) => n != Zero::zero(),
         Err(_) => true,
     }
 }

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -113,6 +113,16 @@ fn test_or() {
         .args(&["foo", "|", "bar"])
         .succeeds()
         .stdout_only("foo\n");
+
+    new_ucmd!()
+        .args(&["14", "|", "1"])
+        .succeeds()
+        .stdout_only("14\n");
+
+    new_ucmd!()
+        .args(&["-14", "|", "1"])
+        .succeeds()
+        .stdout_only("-14\n");
 }
 
 #[test]
@@ -123,6 +133,13 @@ fn test_and() {
         .stdout_only("foo\n");
 
     new_ucmd!().args(&["", "&", "1"]).run().stdout_is("0\n");
+
+    new_ucmd!().args(&["14", "&", "1"]).run().stdout_is("14\n");
+
+    new_ucmd!()
+        .args(&["-14", "&", "1"])
+        .run()
+        .stdout_is("-14\n");
 }
 
 #[test]


### PR DESCRIPTION
So far when using `|` or `&` numbers were only interpreted as `true` if they were `1`. This PR changes this behavior, now any number != 0 is interpreted as `true`.

Fixes https://github.com/uutils/coreutils/issues/5315 and https://github.com/uutils/coreutils/issues/5316