### PR TITLE
ls: ignore capitalization while sorting

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1958,7 +1958,11 @@ fn sort_entries(entries: &mut [PathData], config: &Config, out: &mut BufWriter<S
         }),
         Sort::Size => entries.sort_by_key(|k| Reverse(k.md(out).map(|md| md.len()).unwrap_or(0))),
         // The default sort in GNU ls is case insensitive
-        Sort::Name => entries.sort_by(|a, b| a.display_name.cmp(&b.display_name)),
+        Sort::Name => entries.sort_by(|a, b| {
+            a.display_name
+                .to_ascii_lowercase()
+                .cmp(&b.display_name.to_ascii_lowercase())
+        }),
         Sort::Version => entries.sort_by(|a, b| {
             version_cmp(&a.p_buf.to_string_lossy(), &b.p_buf.to_string_lossy())
                 .then(a.p_buf.to_string_lossy().cmp(&b.p_buf.to_string_lossy()))

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1582,6 +1582,18 @@ fn test_ls_sort_name() {
         .arg("-A")
         .succeeds()
         .stdout_is(".a\n.b\na\nb\n");
+
+    let scene_capitalization = TestScenario::new(util_name!());
+    let at = &scene_capitalization.fixtures;
+    at.touch("ctest");
+    at.touch("atest");
+    at.touch("Btest");
+
+    scene_capitalization
+        .ucmd()
+        .arg("--sort=name")
+        .succeeds()
+        .stdout_is("atest\nBtest\nctest\n");
 }
 
 #[test]


### PR DESCRIPTION
- Ignore capitalization when sorting entries, just like the GNU version does.