### PR TITLE
`rm`: implement iterator interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,7 +2881,6 @@ dependencies = [
  "clap",
  "libc",
  "uucore",
- "walkdir",
  "windows-sys 0.48.0",
 ]
 

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/df.rs"
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["libc", "fsext"] }
+uucore = { workspace = true, features = ["fsext"] }
 unicode-width = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/rm.rs"
 
 [dependencies]
 clap = { workspace = true }
-walkdir = { workspace = true }
 uucore = { workspace = true, features = ["fs"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -6,6 +6,7 @@
 // spell-checker:ignore (path) eacces
 
 use clap::{builder::ValueParser, crate_version, parser::ValueSource, Arg, ArgAction, Command};
+use std::ffi::OsString;
 use std::fs::{self, File, Metadata, ReadDir};
 use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
@@ -85,8 +86,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().after_help(AFTER_HELP).try_get_matches_from(args)?;
 
     let files: Vec<&Path> = matches
-        .get_many::<PathBuf>(ARG_FILES)
-        .map(|v| v.map(PathBuf::as_path).collect())
+        .get_many::<OsString>(ARG_FILES)
+        .map(|v| v.map(|s| Path::new(s)).collect())
         .unwrap_or_default();
 
     let force_flag = matches.get_flag(OPT_FORCE);
@@ -266,7 +267,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(ARG_FILES)
                 .action(ArgAction::Append)
-                .value_parser(ValueParser::path_buf())
+                .value_parser(ValueParser::os_string())
                 .num_args(1..)
                 .value_hint(clap::ValueHint::AnyPath),
         )

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -405,12 +405,15 @@ impl RecursiveRemover {
                 remove_self: true,
             });
         } else {
-            // All parents of this directory shouldn't get removed
-            for s in &mut self.stack {
-                s.remove_self = false;
-            }
+            self.dont_remove_parents();
         }
         Ok(())
+    }
+
+    fn dont_remove_parents(&mut self) {
+        for s in &mut self.stack {
+            s.remove_self = false;
+        }
     }
 
     /// Only call when the stack is non-empty!
@@ -463,7 +466,11 @@ impl RecursiveRemover {
         if self.stack.is_empty() {
             None
         } else {
-            Some(self.remove_one_from_stack(options))
+            let res = self.remove_one_from_stack(options);
+            if res.is_err() {
+                self.dont_remove_parents();
+            }
+            Some(res)
         }
     }
 }

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -87,7 +87,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let files: Vec<&Path> = matches
         .get_many::<OsString>(ARG_FILES)
-        .map(|v| v.map(|s| Path::new(s)).collect())
+        .map(|v| v.map(Path::new).collect())
         .unwrap_or_default();
 
     let force_flag = matches.get_flag(OPT_FORCE);
@@ -405,12 +405,12 @@ impl RecursiveRemover {
                 remove_self: true,
             });
         } else {
-            self.dont_remove_parents();
+            self.do_not_remove_parents();
         }
         Ok(())
     }
 
-    fn dont_remove_parents(&mut self) {
+    fn do_not_remove_parents(&mut self) {
         for s in &mut self.stack {
             s.remove_self = false;
         }
@@ -468,7 +468,7 @@ impl RecursiveRemover {
         } else {
             let res = self.remove_one_from_stack(options);
             if res.is_err() {
-                self.dont_remove_parents();
+                self.do_not_remove_parents();
             }
             Some(res)
         }

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/stat.rs"
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["entries", "libc", "fs", "fsext"] }
+uucore = { workspace = true, features = ["entries", "fs", "fsext"] }
 
 [[bin]]
 name = "stat"

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/tee.rs"
 [dependencies]
 clap = { workspace = true }
 libc = { workspace = true }
-uucore = { workspace = true, features = ["libc", "signals"] }
+uucore = { workspace = true, features = ["signals"] }
 
 [[bin]]
 name = "tee"

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -20,7 +20,7 @@ filetime = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
 parse_datetime = { workspace = true }
-uucore = { workspace = true, features = ["libc"] }
+uucore = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/uptime.rs"
 [dependencies]
 chrono = { workspace = true }
 clap = { workspace = true }
-uucore = { workspace = true, features = ["libc", "utmpx"] }
+uucore = { workspace = true, features = ["utmpx"] }
 
 [[bin]]
 name = "uptime"

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -36,7 +36,7 @@ time = { workspace = true, optional = true, features = [
 data-encoding = { version = "2.4", optional = true }
 data-encoding-macro = { version = "0.1.13", optional = true }
 z85 = { version = "3.0.5", optional = true }
-libc = { workspace = true, optional = true }
+libc = { workspace = true }
 once_cell = { workspace = true }
 os_display = "0.1.3"
 
@@ -73,15 +73,15 @@ default = []
 # * non-default features
 backup-control = []
 encoding = ["data-encoding", "data-encoding-macro", "z85", "thiserror"]
-entries = ["libc"]
-fs = ["dunce", "libc", "winapi-util", "windows-sys"]
-fsext = ["libc", "time", "windows-sys"]
+entries = []
+fs = ["dunce", "winapi-util", "windows-sys"]
+fsext = ["time", "windows-sys"]
 lines = []
 memo = ["itertools"]
-mode = ["libc"]
-perms = ["libc", "walkdir"]
+mode = []
+perms = ["walkdir"]
 pipes = []
-process = ["libc"]
+process = []
 quoting-style = []
 ranges = []
 ringbuffer = []
@@ -100,6 +100,6 @@ sum = [
 ]
 update-control = []
 utf8 = []
-utmpx = ["time", "time/macros", "libc", "dns-lookup"]
+utmpx = ["time", "time/macros", "dns-lookup"]
 version-cmp = []
 wide = []

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -5,7 +5,6 @@
 // library ~ (core/bundler file)
 
 // * feature-gated external crates (re-shared as public internal modules)
-#[cfg(feature = "libc")]
 pub extern crate libc;
 #[cfg(all(feature = "windows-sys", target_os = "windows"))]
 pub extern crate windows_sys;

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -54,7 +54,7 @@
 //! * Using [`ExitCode`] is not recommended but can be useful for converting utils to use
 //!   [`UResult`].
 
-// spell-checker:ignore uioerror rustdoc
+// spell-checker:ignore uioerror rustdoc EISDIR ENOTDIR ENOTEMPTY
 
 use crate::libc;
 use clap;

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -58,6 +58,18 @@ fn test_rm_multiple_files() {
 }
 
 #[test]
+fn test_cycle() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir_all("a/b");
+    at.touch("a/b/file");
+    ucmd.arg("-rf")
+        .arg("a")
+        .arg("a")
+        .fails()
+        .stderr_contains("cannot remove");
+}
+
+#[test]
 fn test_rm_interactive() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -24,6 +24,15 @@ fn test_rm_one_file() {
 }
 
 #[test]
+fn test_rm_empty_name() {
+    new_ucmd!()
+        .arg("")
+        .fails()
+        .code_is(1)
+        .stderr_contains("cannot remove");
+}
+
+#[test]
 fn test_rm_failed() {
     let (_at, mut ucmd) = at_and_ucmd!();
     let file = "test_rm_one_file"; // Doesn't exist

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -187,18 +187,11 @@ grep -rlE '/usr/local/bin/\s?/usr/local/bin' init.cfg tests/* | xargs --no-run-i
 # we should not regress our project just to match what GNU is going.
 # So, do some changes on the fly
 
-sed -i -e "s|rm: cannot remove 'e/slink'|rm: cannot remove 'e'|g" tests/rm/fail-eacces.sh
-
-sed -i -e "s|rm: cannot remove 'a/b/file'|rm: cannot remove 'a'|g" tests/rm/cycle.sh
-
 sed -i -e "s|rm: cannot remove directory 'b/a/p'|rm: cannot remove 'b'|g" tests/rm/rm1.sh
 
 sed -i -e "s|rm: cannot remove 'a/1'|rm: cannot remove 'a'|g" tests/rm/rm2.sh
 
 sed -i -e "s|removed directory 'a/'|removed directory 'a'|g" tests/rm/v-slash.sh
-
-# 'rel' doesn't exist. Our implementation is giving a better message.
-sed -i -e "s|rm: cannot remove 'rel': Permission denied|rm: cannot remove 'rel': No such file or directory|g" tests/rm/inaccessible.sh
 
 # overlay-headers.sh test intends to check for inotify events,
 # however there's a bug because `---dis` is an alias for: `---disable-inotify`


### PR DESCRIPTION
Part of https://github.com/nushell/nushell/issues/10447#issuecomment-1741883171

This path makes an iterator interface for `rm`. The iterator is the `Remover` type, which yields an `UResult<()>` for every file. `nushell` can choose to how to print the errors.

To achieve that, I had to make every function return errors instead of printing them. This in turn lead to some big refactors for `remove_file` and `remove_dir`. I wish there was a better way to write an iterator like this, but I think it turned out alright. Maybe we can clean it up more in the future.

Oh and `walkdir` was only getting in the way. So I removed that too.