### PR TITLE
mv: show no "skipped" msg with -vi/-vin

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -448,19 +448,11 @@ fn rename(
 
         match b.overwrite {
             OverwriteMode::NoClobber => {
-                let err_msg = if b.verbose {
-                    println!("skipped {}", to.quote());
-                    String::new()
-                } else {
-                    format!("not replacing {}", to.quote())
-                };
+                let err_msg = format!("not replacing {}", to.quote());
                 return Err(io::Error::new(io::ErrorKind::Other, err_msg));
             }
             OverwriteMode::Interactive => {
                 if !prompt_yes!("overwrite {}?", to.quote()) {
-                    if b.verbose {
-                        println!("skipped {}", to.quote());
-                    }
                     return Err(io::Error::new(io::ErrorKind::Other, ""));
                 }
             }

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1350,7 +1350,7 @@ fn test_mv_arg_interactive_skipped() {
         .ignore_stdin_write_error()
         .fails()
         .stderr_is("mv: overwrite 'b'? ")
-        .stdout_is("skipped 'b'\n");
+        .no_stdout();
 }
 
 #[test]
@@ -1360,7 +1360,8 @@ fn test_mv_arg_interactive_skipped_vin() {
     at.touch("b");
     ucmd.args(&["-vin", "a", "b"])
         .fails()
-        .stdout_is("skipped 'b'\n");
+        .stderr_is("mv: not replacing 'b'\n")
+        .no_stdout();
 }
 
 #[test]


### PR DESCRIPTION
This PR no longer shows a "skipped" message with `-vi`/`-vin` and makes https://github.com/coreutils/coreutils/blob/master/tests/mv/mv-n.sh pass.