### PR TITLE
echo: don't output "\n" if "\c" is encountered

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -175,7 +175,7 @@ fn execute(no_newline: bool, escaped: bool, free: &[String]) -> io::Result<()> {
         }
         if escaped {
             if print_escaped(input, &mut output)?.is_break() {
-                break;
+                return Ok(());
             }
         } else {
             write!(output, "{input}")?;

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -122,7 +122,7 @@ fn test_escape_no_further_output() {
     new_ucmd!()
         .args(&["-e", "a\\cb", "c"])
         .succeeds()
-        .stdout_only("a\n");
+        .stdout_only("a");
 }
 
 #[test]


### PR DESCRIPTION
When running `env echo -e "a\cb"` GNU echo simply outputs "a" whereas uutils echo outputs "a\n". This PR fixes this bug.