### PR TITLE
mv: adapt error message to pass dir2dir.sh

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -399,13 +399,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> UR
         match rename(sourcepath, &targetpath, b, multi_progress.as_ref()) {
             Err(e) if e.to_string().is_empty() => set_exit_code(1),
             Err(e) => {
-                let e = e.map_err_context(|| {
-                    format!(
-                        "cannot move {} to {}",
-                        sourcepath.quote(),
-                        targetpath.quote()
-                    )
-                });
+                let e = e.map_err_context(|| format!("cannot overwrite {}", targetpath.quote()));
                 match multi_progress {
                     Some(ref pb) => pb.suspend(|| show!(e)),
                     None => show!(e),

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1181,6 +1181,32 @@ fn test_mv_overwrite_nonempty_dir() {
 }
 
 #[test]
+fn test_mv_dir_to_nonempty_dir() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = "a/t";
+    let destination = "b";
+    let file = "b/t/file";
+
+    at.mkdir_all(source);
+    at.mkdir_all(&format!("{destination}/t"));
+    at.touch(file);
+
+    #[cfg(not(windows))]
+    let expected_msg = "mv: cannot overwrite 'b/t': Directory not empty\n";
+    #[cfg(windows)]
+    let expected_msg = "mv: cannot overwrite 'b\\t': Directory not empty\n";
+
+    ucmd.arg(source)
+        .arg(destination)
+        .fails()
+        .no_stdout()
+        .stderr_is(expected_msg);
+
+    assert!(at.dir_exists(source));
+    assert!(at.dir_exists(destination));
+}
+
+#[test]
 fn test_mv_backup_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     let dir_a = "test_mv_backup_dir_dir_a";


### PR DESCRIPTION
This PR adapts an error message to pass https://github.com/coreutils/coreutils/blob/master/tests/mv/dir2dir.sh and adds a corresponding test.