### PR TITLE
clippy: fix warnings in tests

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1545,7 +1545,6 @@ fn test_cp_preserve_links_case_7() {
         .arg("dest")
         .fails()
         .stderr_contains("not replacing");
-    ();
 
     assert!(at.dir_exists("dest"));
     assert!(at.plus("dest").join("f").exists());

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -438,7 +438,7 @@ fn test_split_obs_lines_within_combined_shorts() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     let name = "obs-lines-within-shorts";
-    RandomFile::new(&at, name).add_lines(400);
+    RandomFile::new(at, name).add_lines(400);
 
     scene
         .ucmd()
@@ -446,9 +446,9 @@ fn test_split_obs_lines_within_combined_shorts() {
         .succeeds()
         .no_stderr()
         .no_stdout();
-    let glob = Glob::new(&at, ".", r"x\d\d$");
+    let glob = Glob::new(at, ".", r"x\d\d$");
     assert_eq!(glob.count(), 2);
-    assert_eq!(glob.collate(), at.read_bytes(name))
+    assert_eq!(glob.collate(), at.read_bytes(name));
 }
 
 /// Test for obsolete lines option as part of combined short options with tailing suffix length with value
@@ -470,7 +470,7 @@ fn test_split_obs_lines_starts_combined_shorts() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     let name = "obs-lines-starts-shorts";
-    RandomFile::new(&at, name).add_lines(400);
+    RandomFile::new(at, name).add_lines(400);
 
     scene
         .ucmd()
@@ -478,9 +478,9 @@ fn test_split_obs_lines_starts_combined_shorts() {
         .succeeds()
         .no_stderr()
         .no_stdout();
-    let glob = Glob::new(&at, ".", r"x\d\d$");
+    let glob = Glob::new(at, ".", r"x\d\d$");
     assert_eq!(glob.count(), 2);
-    assert_eq!(glob.collate(), at.read_bytes(name))
+    assert_eq!(glob.collate(), at.read_bytes(name));
 }
 
 /// Test for using both obsolete lines (standalone) option and short/long lines option simultaneously
@@ -585,7 +585,7 @@ fn test_split_multiple_obs_lines_standalone() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     let name = "multiple-obs-lines";
-    RandomFile::new(&at, name).add_lines(400);
+    RandomFile::new(at, name).add_lines(400);
 
     scene
         .ucmd()
@@ -593,9 +593,9 @@ fn test_split_multiple_obs_lines_standalone() {
         .succeeds()
         .no_stderr()
         .no_stdout();
-    let glob = Glob::new(&at, ".", r"x[[:alpha:]][[:alpha:]]$");
+    let glob = Glob::new(at, ".", r"x[[:alpha:]][[:alpha:]]$");
     assert_eq!(glob.count(), 2);
-    assert_eq!(glob.collate(), at.read_bytes(name))
+    assert_eq!(glob.collate(), at.read_bytes(name));
 }
 
 /// Test for using more than one obsolete lines option within combined shorts
@@ -605,7 +605,7 @@ fn test_split_multiple_obs_lines_within_combined() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     let name = "multiple-obs-lines";
-    RandomFile::new(&at, name).add_lines(400);
+    RandomFile::new(at, name).add_lines(400);
 
     scene
         .ucmd()
@@ -613,9 +613,9 @@ fn test_split_multiple_obs_lines_within_combined() {
         .succeeds()
         .no_stderr()
         .no_stdout();
-    let glob = Glob::new(&at, ".", r"x\d\d$");
+    let glob = Glob::new(at, ".", r"x\d\d$");
     assert_eq!(glob.count(), 2);
-    assert_eq!(glob.collate(), at.read_bytes(name))
+    assert_eq!(glob.collate(), at.read_bytes(name));
 }
 
 /// Test for using both obsolete lines option within combined shorts with conflicting -n option simultaneously
@@ -1543,8 +1543,8 @@ fn test_split_separator_nul_lines() {
     ucmd.args(&["--lines=2", "-t", "\\0", "separator_nul.txt"])
         .succeeds();
 
-    assert_eq!(file_read(&at, "xaa"), "1\02\0");
-    assert_eq!(file_read(&at, "xab"), "3\04\0");
+    assert_eq!(file_read(&at, "xaa"), "1\x002\0");
+    assert_eq!(file_read(&at, "xab"), "3\x004\0");
     assert_eq!(file_read(&at, "xac"), "5\0");
     assert!(!at.plus("xad").exists());
 }
@@ -1555,8 +1555,8 @@ fn test_split_separator_nul_line_bytes() {
     ucmd.args(&["--line-bytes=4", "-t", "\\0", "separator_nul.txt"])
         .succeeds();
 
-    assert_eq!(file_read(&at, "xaa"), "1\02\0");
-    assert_eq!(file_read(&at, "xab"), "3\04\0");
+    assert_eq!(file_read(&at, "xaa"), "1\x002\0");
+    assert_eq!(file_read(&at, "xab"), "3\x004\0");
     assert_eq!(file_read(&at, "xac"), "5\0");
     assert!(!at.plus("xad").exists());
 }
@@ -1567,8 +1567,8 @@ fn test_split_separator_nul_number_l() {
     ucmd.args(&["--number=l/3", "--separator=\\0", "separator_nul.txt"])
         .succeeds();
 
-    assert_eq!(file_read(&at, "xaa"), "1\02\0");
-    assert_eq!(file_read(&at, "xab"), "3\04\0");
+    assert_eq!(file_read(&at, "xaa"), "1\x002\0");
+    assert_eq!(file_read(&at, "xab"), "3\x004\0");
     assert_eq!(file_read(&at, "xac"), "5\0");
     assert!(!at.plus("xad").exists());
 }
@@ -1579,8 +1579,8 @@ fn test_split_separator_nul_number_r() {
     ucmd.args(&["--number=r/3", "--separator=\\0", "separator_nul.txt"])
         .succeeds();
 
-    assert_eq!(file_read(&at, "xaa"), "1\04\0");
-    assert_eq!(file_read(&at, "xab"), "2\05\0");
+    assert_eq!(file_read(&at, "xaa"), "1\x004\0");
+    assert_eq!(file_read(&at, "xab"), "2\x005\0");
     assert_eq!(file_read(&at, "xac"), "3\0");
     assert!(!at.plus("xad").exists());
 }

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -3,6 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use crate::common::util::TestScenario;
+use std::fmt::Write;
 
 // tests for basic tee functionality.
 // inspired by:
@@ -74,7 +75,10 @@ fn test_tee_append() {
 fn test_tee_no_more_writeable_1() {
     // equals to 'tee /dev/full out2 <multi_read' call
     let (at, mut ucmd) = at_and_ucmd!();
-    let content = (1..=10).map(|x| format!("{x}\n")).collect::<String>();
+    let content = (1..=10).fold(String::new(), |mut output, x| {
+        let _ = writeln!(output, "{x}");
+        output
+    });
     let file_out = "tee_file_out";
 
     ucmd.arg("/dev/full")
@@ -94,7 +98,10 @@ fn test_tee_no_more_writeable_2() {
     // but currently there is no way to redirect stdout to /dev/full
     // so this test is disabled
     let (_at, mut ucmd) = at_and_ucmd!();
-    let _content = (1..=10).map(|x| format!("{x}\n")).collect::<String>();
+    let _content = (1..=10).fold(String::new(), |mut output, x| {
+        let _ = writeln!(output, "{x}");
+        output
+    });
     let file_out_a = "tee_file_out_a";
     let file_out_b = "tee_file_out_b";
 
@@ -114,6 +121,7 @@ fn test_tee_no_more_writeable_2() {
 mod linux_only {
     use crate::common::util::{AtPath, TestScenario, UCommand};
 
+    use std::fmt::Write;
     use std::fs::File;
     use std::process::{Output, Stdio};
 
@@ -135,7 +143,10 @@ mod linux_only {
     }
 
     fn run_tee(proc: &mut UCommand) -> (String, Output) {
-        let content = (1..=100_000).map(|x| format!("{x}\n")).collect::<String>();
+        let content = (1..=100_000).fold(String::new(), |mut output, x| {
+            let _ = writeln!(output, "{x}");
+            output
+        });
 
         #[allow(deprecated)]
         let output = proc


### PR DESCRIPTION
This PR fixes clippy warnings in tests introduced by Rust 1.73, among them warnings from the [format_collect](https://rust-lang.github.io/rust-clippy/master/index.html#/format_collect) and [octal_escapes](https://rust-lang.github.io/rust-clippy/master/index.html#/octal_escapes) lints.