### PR TITLE
`expr`: short-circuit evaluation for `|`

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -155,8 +155,24 @@ impl AstNode {
         }
     }
     pub fn operand_values(&self) -> Result<Vec<String>, String> {
-        if let Self::Node { operands, .. } = self {
+        if let Self::Node {
+            operands, op_type, ..
+        } = self
+        {
             let mut out = Vec::with_capacity(operands.len());
+            let mut operands = operands.into_iter();
+
+            if op_type == "|" {
+                if let Some(value) = operands.next() {
+                    let value = value.evaluate()?;
+                    out.push(value.clone());
+                    if value_as_bool(&value) {
+                        out.push(String::from("dummy"));
+                        return Ok(out);
+                    }
+                }
+            }
+
             for operand in operands {
                 let value = operand.evaluate()?;
                 out.push(value);

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -52,7 +52,7 @@ impl AstNode {
                 operands,
             } => {
                 println!(
-                    "Node( {} ) at #{} (evaluate -> {:?})",
+                    "Node( {} ) at #{} ( evaluate -> {:?} )",
                     op_type,
                     token_idx,
                     self.evaluate()

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -123,6 +123,11 @@ fn test_or() {
         .args(&["-14", "|", "1"])
         .succeeds()
         .stdout_only("-14\n");
+
+    new_ucmd!()
+        .args(&["1", "|", "a", "/", "5"])
+        .succeeds()
+        .stdout_only("1\n");
 }
 
 #[test]


### PR DESCRIPTION
fix #5326 
Implement short-circuit evaluation for `|`. And add the corresponding test.