### PR TITLE
`expr`: short-circuit evaluation for `|`

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -161,7 +161,8 @@ impl AstNode {
         {
             let mut out = Vec::with_capacity(operands.len());
             let mut operands = operands.iter();
-
+            // check the first value before `|`, stop evaluate and return directly if it is true.
+            // push dummy to pass the check of `len() == 2`
             if op_type == "|" {
                 if let Some(value) = operands.next() {
                     let value = value.evaluate()?;

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -155,8 +155,24 @@ impl AstNode {
         }
     }
     pub fn operand_values(&self) -> Result<Vec<String>, String> {
-        if let Self::Node { operands, .. } = self {
+        if let Self::Node {
+            operands, op_type, ..
+        } = self
+        {
             let mut out = Vec::with_capacity(operands.len());
+            let mut operands = operands.iter();
+
+            if op_type == "|" {
+                if let Some(value) = operands.next() {
+                    let value = value.evaluate()?;
+                    out.push(value.clone());
+                    if value_as_bool(&value) {
+                        out.push(String::from("dummy"));
+                        return Ok(out);
+                    }
+                }
+            }
+
             for operand in operands {
                 let value = operand.evaluate()?;
                 out.push(value);

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -52,7 +52,7 @@ impl AstNode {
                 operands,
             } => {
                 println!(
-                    "Node( {} ) at #{} (evaluate -> {:?})",
+                    "Node( {} ) at #{} ( evaluate -> {:?} )",
                     op_type,
                     token_idx,
                     self.evaluate()

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -128,7 +128,7 @@ fn test_or() {
         .args(&["1", "|", "a", "/", "5"])
         .succeeds()
         .stdout_only("1\n");
-    
+
     new_ucmd!()
         .args(&["foo", "|", "a", "/", "5"])
         .succeeds()

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -128,6 +128,16 @@ fn test_or() {
         .args(&["1", "|", "a", "/", "5"])
         .succeeds()
         .stdout_only("1\n");
+    
+    new_ucmd!()
+        .args(&["foo", "|", "a", "/", "5"])
+        .succeeds()
+        .stdout_only("foo\n");
+
+    new_ucmd!()
+        .args(&["0", "|", "10", "/", "5"])
+        .succeeds()
+        .stdout_only("2\n");
 }
 
 #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -123,6 +123,11 @@ fn test_or() {
         .args(&["-14", "|", "1"])
         .succeeds()
         .stdout_only("-14\n");
+
+    new_ucmd!()
+        .args(&["1", "|", "a", "/", "5"])
+        .succeeds()
+        .stdout_only("1\n");
 }
 
 #[test]


### PR DESCRIPTION
fix #5326 
Implement short-circuit evaluation for `|`. And add the corresponding test.