### PR TITLE
Fix overflow error on WSL. Default to 0 when the values are non-sense.

### DIFF
--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore tmpfs Pcent Itotal Iused Iavail Ipcent
+// spell-checker:ignore tmpfs Pcent Itotal Iused Iavail Ipcent nosuid nodev
 //! The filesystem usage data table.
 //!
 //! A table ([`Table`]) comprises a header row ([`Header`]) and a


### PR DESCRIPTION
Hit crash like this:
```
thread 'main' panicked at src/uu/df/src/table.rs:156:21:
attempt to subtract with overflow
stack backtrace:
   0: rust_begin_unwind
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/panicking.rs:595:5
   1: core::panicking::panic_fmt
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:67:14
   2: core::panicking::panic
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:117:5
   3: <uu_df::table::Row as core::convert::From<uu_df::filesystem::Filesystem>>::from
             at ./src/uu/df/src/table.rs:156:21
   4: uu_df::table::Table::new
             at ./src/uu/df/src/table.rs:392:27
   5: uu_df::uumain::uumain
             at ./src/uu/df/src/df.rs:470:20
   6: uu_df::uumain
             at ./src/uu/df/src/df.rs:430:1
   7: coreutils::main
             at ./src/bin/coreutils.rs:103:31
   8: core::ops::function::FnOnce::call_once
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

After the fix, manual validated the df output with native df on WSL Debian. It works as expected. Native df also default to 0.