### PR TITLE
Bump bstr and regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -1728,9 +1728,9 @@ checksum = "f1bfbf25d7eb88ddcbb1ec3d755d0634da8f7657b2cb8b74089121409ab8228f"
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1751,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
 
 [[package]]
 name = "relative-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,7 +259,7 @@ test = ["uu_test"]
 [workspace.dependencies]
 bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"
-bstr = "1.6"
+bstr = "1.7"
 bytecount = "0.6.4"
 byteorder = "1.5.0"
 chrono = { version = "^0.4.31", default-features = false, features = [
@@ -309,7 +309,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 rand_core = "0.6"
 rayon = "1.8"
 redox_syscall = "0.4"
-regex = "1.9.6"
+regex = "1.10.0"
 rstest = "0.18.2"
 rust-ini = "0.19.0"
 same-file = "1.0.6"


### PR DESCRIPTION
This PR bumps `bstr` from `1.6` to `1.7` and `regex` from `1.9.6` to `1.10.0`.