### PR TITLE
`split`: undocumented options aliases + help fix

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -311,6 +311,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(OPT_NUMERIC_SUFFIXES)
                 .long(OPT_NUMERIC_SUFFIXES)
+                .alias("numeric")
                 .require_equals(true)
                 .default_missing_value("0")
                 .num_args(0..=1)
@@ -338,6 +339,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(OPT_HEX_SUFFIXES)
                 .long(OPT_HEX_SUFFIXES)
+                .alias("hex")
                 .default_missing_value("0")
                 .require_equals(true)
                 .num_args(0..=1)
@@ -372,7 +374,7 @@ pub fn uu_app() -> Command {
                 .allow_hyphen_values(true)
                 .value_name("SEP")
                 .action(ArgAction::Append)
-                .help("use SEP instead of newline as the record separator; '\0' (zero) specifies the NUL character"),
+                .help("use SEP instead of newline as the record separator; '\\0' (zero) specifies the NUL character"),
         )
         .arg(
             Arg::new(OPT_IO)

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -1193,9 +1193,35 @@ fn test_numeric_suffix() {
 }
 
 #[test]
+fn test_numeric_suffix_alias() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-n", "4", "--numeric=9", "threebytes.txt"])
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert_eq!(at.read("x09"), "a");
+    assert_eq!(at.read("x10"), "b");
+    assert_eq!(at.read("x11"), "c");
+    assert_eq!(at.read("x12"), "");
+}
+
+#[test]
 fn test_hex_suffix() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["-n", "4", "--hex-suffixes=9", "threebytes.txt"])
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert_eq!(at.read("x09"), "a");
+    assert_eq!(at.read("x0a"), "b");
+    assert_eq!(at.read("x0b"), "c");
+    assert_eq!(at.read("x0c"), "");
+}
+
+#[test]
+fn test_hex_suffix_alias() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-n", "4", "--hex=9", "threebytes.txt"])
         .succeeds()
         .no_stdout()
         .no_stderr();


### PR DESCRIPTION
Implements undocumented `--numeric` and `--hex` aliases of the `--numeric-suffixes` and `--hex-suffixes` long options. At least one of them (`--numeric`) is used in GNU tests for `split`.
Minor fix for `--help` output.