### PR TITLE
who: suppress cognitive_complexity lint

### DIFF
--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -326,6 +326,7 @@ fn current_tty() -> String {
 }
 
 impl Who {
+    #[allow(clippy::cognitive_complexity)]
     fn exec(&mut self) -> UResult<()> {
         let run_level_chk = |_record: i16| {
             #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
This PR suppresses the `cognitive_complexity` lint for the `exec` function. Discovered thanks to https://github.com/uutils/coreutils/pull/5399