### PR TITLE
rm: In some cases, remove_dir is doing a better job than remove_dir_all

### DIFF
--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (path) eacces
+// spell-checker:ignore (path) eacces inacc
 
 use clap::{builder::ValueParser, crate_version, parser::ValueSource, Arg, ArgAction, Command};
 use std::collections::VecDeque;

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -647,6 +647,21 @@ fn test_prompt_write_protected_no() {
     assert!(at.file_exists(file_2));
 }
 
+#[cfg(feature = "chmod")]
+#[test]
+fn test_remove_inaccessible_dir() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    let dir_1 = "test_rm_protected";
+
+    at.mkdir(dir_1);
+
+    scene.ccmd("chmod").arg("0").arg(dir_1).succeeds();
+
+    scene.ucmd().arg("-rf").arg(dir_1).succeeds();
+    assert!(!at.dir_exists(dir_1));
+}
+
 #[test]
 #[cfg(not(windows))]
 fn test_fifo_removal() {


### PR DESCRIPTION
use it when remove_dir_all failed

GNU compatibility (rm/empty-inacc.sh)