### PR TITLE
`pathchk`: check empty path by default

### DIFF
--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -193,6 +193,17 @@ fn check_default(path: &[String]) -> bool {
         );
         return false;
     }
+    if total_len == 0 {
+        // Check whether a file name component is in a directory that is not searchable,
+        // or has some other serious problem. POSIX does not allow "" as a file name,
+        // but some non-POSIX hosts do (as an alias for "."),
+        // so allow "" if `symlink_metadata` (corresponds to `lstat`) does.
+        if fs::symlink_metadata(&joined_path).is_err() {
+            writeln!(std::io::stderr(), "pathchk: '': No such file or directory",);
+            return false;
+        }
+    }
+
     // components: length
     for p in path {
         let component_len = p.len();

--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -20,9 +20,15 @@ fn test_default_mode() {
     new_ucmd!().args(&["dir#/$file"]).succeeds().no_stdout();
 
     // fail on empty path
-    new_ucmd!().args(&[""]).fails().no_stdout();
+    new_ucmd!()
+        .args(&[""])
+        .fails()
+        .stderr_only("pathchk: '': No such file or directory\n");
 
-    new_ucmd!().args(&["", ""]).fails().no_stdout();
+    new_ucmd!().args(&["", ""]).fails().stderr_only(
+        "pathchk: '': No such file or directory\n\
+        pathchk: '': No such file or directory\n",
+    );
 
     // fail on long path
     new_ucmd!()

--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -19,8 +19,10 @@ fn test_default_mode() {
     // accept non-portable chars
     new_ucmd!().args(&["dir#/$file"]).succeeds().no_stdout();
 
-    // accept empty path
-    new_ucmd!().args(&[""]).succeeds().no_stdout();
+    // fail on empty path
+    new_ucmd!().args(&[""]).fails().no_stdout();
+
+    new_ucmd!().args(&["", ""]).fails().no_stdout();
 
     // fail on long path
     new_ucmd!()


### PR DESCRIPTION
fix #5314 
comment in GNU pathchk:
> Check whether a file name component is in a directory that is not searchable, or has some other serious problem. POSIX does not allow "" as a file name, but some non-POSIX hosts do (as an alias for "."), so allow "" if lstat does.

I use `std::fs::symlink_metadata`, which currently corresponds to the `lstat` function on Unix and the `GetFileInformationByHandle` function on Windows instead.

It looks good in my local, but I don't have a non-POSIX environment, so it may need some more tests.
In my local:
```
$ ./target/debug/pathchk ""         
pathchk: '': No such file or directory
```
```
$ ./target/debug/pathchk "" ""      
pathchk: '': No such file or directory
pathchk: '': No such file or directory
```
