### PR TITLE
mv: moving directory itself should fail

### DIFF
--- a/src/uu/mv/src/error.rs
+++ b/src/uu/mv/src/error.rs
@@ -12,6 +12,7 @@ pub enum MvError {
     NoSuchFile(String),
     SameFile(String, String),
     SelfSubdirectory(String),
+    SelfTargetSubdirectory(String, String),
     DirectoryToNonDirectory(String),
     NonDirectoryToDirectory(String, String),
     NotADirectory(String),
@@ -28,6 +29,10 @@ impl Display for MvError {
             Self::SelfSubdirectory(s) => write!(
                 f,
                 "cannot move '{s}' to a subdirectory of itself, '{s}/{s}'"
+            ),
+            Self::SelfTargetSubdirectory(s, t) => write!(
+                f,
+                "cannot move '{s}' to a subdirectory of itself, '{t}/{s}'"
             ),
             Self::DirectoryToNonDirectory(t) => {
                 write!(f, "cannot overwrite directory {t} with non-directory")

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -328,10 +328,20 @@ fn handle_two_paths(source: &Path, target: &Path, opts: &Options) -> UResult<()>
         } else {
             // Check that source & target  do not contain same subdir/dir when both exist
             // mkdir dir1/dir2; mv dir1 dir1/dir2
-            if target
-                .components()
-                .any(|c| c.as_os_str() == source.as_os_str())
-            {
+            let target_contains_itself = target
+                .as_os_str()
+                .to_str()
+                .ok_or("not a valid unicode string")
+                .and_then(|t| {
+                    source
+                        .as_os_str()
+                        .to_str()
+                        .ok_or("not a valid unicode string")
+                        .map(|s| t.contains(s))
+                })
+                .unwrap();
+
+            if target_contains_itself {
                 return Err(MvError::SelfTargetSubdirectory(
                     source.display().to_string(),
                     target.display().to_string(),

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -326,6 +326,18 @@ fn handle_two_paths(source: &Path, target: &Path, opts: &Options) -> UResult<()>
                 Err(MvError::DirectoryToNonDirectory(target.quote().to_string()).into())
             }
         } else {
+            // Check that source & target  do not contain same subdir/dir when both exist
+            // mkdir dir1/dir2; mv dir1 dir1/dir2
+            if target
+                .components()
+                .any(|c| c.as_os_str() == source.as_os_str())
+            {
+                return Err(MvError::SelfTargetSubdirectory(
+                    source.display().to_string(),
+                    target.display().to_string(),
+                )
+                .into());
+            }
             move_files_into_dir(&[source.to_path_buf()], target, opts)
         }
     } else if target.exists() && source.is_dir() {

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1401,6 +1401,16 @@ fn test_mv_directory_into_subdirectory_of_itself_fails() {
     scene.ucmd().arg(dir1).arg(dir2).fails().stderr_contains(
         "mv: cannot move 'mydir' to a subdirectory of itself, 'mydir/mydir_2/mydir'",
     );
+
+    // check that it also errors out with /
+    scene
+        .ucmd()
+        .arg(format!("{}/", dir1))
+        .arg(dir2)
+        .fails()
+        .stderr_contains(
+            "mv: cannot move 'mydir/' to a subdirectory of itself, 'mydir/mydir_2/mydir/'",
+        );
 }
 // Todo:
 

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1389,6 +1389,19 @@ fn test_mv_into_self_data() {
     assert!(at.file_exists(file2));
     assert!(!at.file_exists(file1));
 }
+
+#[test]
+fn test_mv_directory_into_subdirectory_of_itself_fails() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    let dir1 = "mydir";
+    let dir2 = "mydir/mydir_2";
+    at.mkdir(dir1);
+    at.mkdir(dir2);
+    scene.ucmd().arg(dir1).arg(dir2).fails().stderr_contains(
+        "mv: cannot move 'mydir' to a subdirectory of itself, 'mydir/mydir_2/mydir'",
+    );
+}
 // Todo:
 
 // $ at.touch a b

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -2,6 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+//
+// spell-checker:ignore mydir
 use crate::common::util::TestScenario;
 use filetime::FileTime;
 use std::thread::sleep;


### PR DESCRIPTION
Fixes #5426, where moving a directory into itself would remove the source directory and not fail

Previously:
`mkdir mydir/mydir_2`

```
uutils mv mydir mydir/mydir_2
# 
```
And it would make `mydir` disappear. 

Now:
`mkdir mydir/mydir_2`
```
uutils mv mydir mydir/mydir_2
mv: cannot move 'mydir' to a subdirectory of itself, 'mydir/mydir_2/mydir'
```
which matches the GNU behavior
