### PR TITLE
cp --remove-destination: don't fail if destination is symlink to source

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1647,6 +1647,14 @@ fn copy_file(
                 dest.display()
             )));
         }
+        if paths_refer_to_same_file(source, dest, true)
+            && matches!(
+                options.overwrite,
+                OverwriteMode::Clobber(ClobberMode::RemoveDestination)
+            )
+        {
+            fs::remove_file(dest)?;
+        }
     }
 
     if file_or_link_exists(dest) {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2828,6 +2828,22 @@ fn test_cp_mode_hardlink_no_dereference() {
 }
 
 #[test]
+fn test_remove_destination_with_destination_being_a_symlink_to_source() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "file";
+    let symlink = "symlink";
+
+    at.touch(file);
+    at.symlink_file(file, symlink);
+
+    ucmd.args(&["--remove-destination", file, symlink])
+        .succeeds();
+    assert!(!at.symlink_exists(symlink));
+    assert!(at.file_exists(file));
+    assert!(at.file_exists(symlink));
+}
+
+#[test]
 fn test_remove_destination_symbolic_link_loop() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.symlink_file("loop", "loop");


### PR DESCRIPTION
With this PR, `cp --remove-destination` no longer shows an error if the destination is a symlink to the source and the destination is removed instead.

Fixes https://github.com/uutils/coreutils/issues/5420