### PR TITLE
runcon: generate the same error as GNUs

### DIFF
--- a/src/uu/runcon/src/errors.rs
+++ b/src/uu/runcon/src/errors.rs
@@ -26,7 +26,7 @@ pub(crate) enum Error {
     #[error("No command is specified")]
     MissingCommand,
 
-    #[error("SELinux is not enabled")]
+    #[error("runcon may be used only on a SELinux kernel")]
     SELinuxNotEnabled,
 
     #[error(transparent)]


### PR DESCRIPTION
tested in tests/runcon/runcon-no-reorder.sh