### PR TITLE
test: use mtime for -ot and fix direction of comparison

### DIFF
--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -218,7 +218,7 @@ fn files(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
         #[cfg(not(unix))]
         Some("-ef") => unimplemented!(),
         Some("-nt") => f_a.modified().unwrap() > f_b.modified().unwrap(),
-        Some("-ot") => f_a.created().unwrap() > f_b.created().unwrap(),
+        Some("-ot") => f_a.modified().unwrap() < f_b.modified().unwrap(),
         _ => return Err(ParseError::UnknownOperator(op.quote().to_string())),
     })
 }

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -317,7 +317,7 @@ fn test_file_is_itself() {
 }
 
 #[test]
-#[cfg(not(any(target_env = "musl", target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_file_is_newer_than_and_older_than_itself() {
     // odd but matches GNU
     new_ucmd!()
@@ -364,8 +364,7 @@ fn test_same_device_inode() {
 }
 
 #[test]
-#[cfg(not(any(target_env = "musl", target_os = "android")))]
-// musl: creation time is not available on this platform currently
+#[cfg(not(target_os = "android"))]
 fn test_newer_file() {
     let scenario = TestScenario::new(util_name!());
 
@@ -377,10 +376,21 @@ fn test_newer_file() {
         .ucmd()
         .args(&["newer_file", "-nt", "regular_file"])
         .succeeds();
+
+    scenario
+        .ucmd()
+        .args(&["regular_file", "-nt", "newer_file"])
+        .fails();
+
+    scenario
+        .ucmd()
+        .args(&["regular_file", "-ot", "newer_file"])
+        .succeeds();
+
     scenario
         .ucmd()
         .args(&["newer_file", "-ot", "regular_file"])
-        .succeeds();
+        .fails();
 }
 
 #[test]


### PR DESCRIPTION
- Use the file modification time instead of the creation time (matches GNU coreutils documentation)

- Fix direction of comparison (a < b instead of a > b)

- Extend test case to cover both the 0 and 1 exit code cases