### PR TITLE
ls: use try_get_matches_from instead of get_matches_from

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1027,7 +1027,7 @@ impl Config {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let command = uu_app();
 
-    let matches = command.get_matches_from(args);
+    let matches = command.try_get_matches_from(args)?;
 
     let config = Config::from(&matches)?;
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3565,6 +3565,20 @@ fn test_ls_dired_incompatible() {
 }
 
 #[test]
+fn test_ls_dired_and_zero_are_incompatible() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ucmd()
+        .arg("--dired")
+        .arg("-l")
+        .arg("--zero")
+        .fails()
+        .code_is(2)
+        .stderr_contains("--dired and --zero are incompatible");
+}
+
+#[test]
 fn test_ls_dired_recursive() {
     let scene = TestScenario::new(util_name!());
 


### PR DESCRIPTION
This PR replaces `get_matches_from` with `try_get_matches_from` to adapt clap's exit code. It makes https://github.com/coreutils/coreutils/blob/master/tests/ls/classify.sh pass and replaces https://github.com/uutils/coreutils/pull/5437