### PR TITLE
ls: return exit code 2 for invalid time-style

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -183,7 +183,7 @@ impl UError for LsError {
             Self::BlockSizeParseError(_) => 1,
             Self::ConflictingArgumentDired() => 1,
             Self::AlreadyListedError(_) => 2,
-            Self::TimeStyleParseError(_, _) => 1,
+            Self::TimeStyleParseError(_, _) => 2,
         }
     }
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1737,7 +1737,12 @@ fn test_ls_styles() {
         .stdout_matches(&re_custom_format);
 
     // Also fails due to not having full clap support for time_styles
-    scene.ucmd().arg("-l").arg("-time-style=invalid").fails();
+    scene
+        .ucmd()
+        .arg("-l")
+        .arg("--time-style=invalid")
+        .fails()
+        .code_is(2);
 
     //Overwrite options tests
     scene


### PR DESCRIPTION
This PR returns an exit code `2` if the value for `--time-style` is invalid. It makes https://github.com/coreutils/coreutils/blob/master/tests/ls/time-style-diag.sh pass.