### PR TITLE
df: Replace the error message by the one generated by clap

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -269,6 +269,8 @@ sed -i -E "s|^([^#]*2_31.*)$|#\1|g" tests/printf/printf-cov.pl
 
 sed -i -e "s/du: invalid -t argument/du: invalid --threshold argument/" -e "s/du: option requires an argument/error: a value is required for '--threshold <SIZE>' but none was supplied/" -e "/Try 'du --help' for more information./d" tests/du/threshold.sh
 
+awk 'BEGIN {count=0} /compare exp out2/ && count < 6 {sub(/compare exp out2/, "grep -q \"cannot be used with\" out2"); count++} 1' tests/df/df-output.sh > tests/df/df-output.sh.tmp && mv tests/df/df-output.sh.tmp tests/df/df-output.sh
+
 # with ls --dired, in case of error, we have a slightly different error position
 sed -i -e "s|44 45|48 49|" tests/ls/stat-failed.sh
 


### PR DESCRIPTION
Failed with:
```
-df: options OPT and --output are mutually exclusive 
-Try 'df --help' for more information.
+error: the argument '--inodes' cannot be used with '--output[=<FIELD_LIST>...]' 
+
+Usage: df [OPTION]... [FILE]...
```