### PR TITLE
Fix stderr output mv file into dir and dir into file where both are files

### DIFF
--- a/src/uu/mv/src/error.rs
+++ b/src/uu/mv/src/error.rs
@@ -4,7 +4,9 @@
 // file that was distributed with this source code.
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result};
+use std::path::PathBuf;
 
+use uucore::display::Quotable;
 use uucore::error::UError;
 
 #[derive(Debug)]
@@ -18,6 +20,7 @@ pub enum MvError {
     NonDirectoryToDirectory(String, String),
     NotADirectory(String),
     TargetNotADirectory(String),
+    FailedToAccessNotADirectory(PathBuf),
 }
 
 impl Error for MvError {}
@@ -44,6 +47,10 @@ impl Display for MvError {
             }
             Self::NotADirectory(t) => write!(f, "target {t}: Not a directory"),
             Self::TargetNotADirectory(t) => write!(f, "target directory {t}: Not a directory"),
+
+            Self::FailedToAccessNotADirectory(p) => {
+                write!(f, "failed to access {}: Not a directory", p.quote())
+            }
         }
     }
 }

--- a/src/uu/mv/src/error.rs
+++ b/src/uu/mv/src/error.rs
@@ -10,6 +10,7 @@ use uucore::error::UError;
 #[derive(Debug)]
 pub enum MvError {
     NoSuchFile(String),
+    CannotStatNotADirectory(String),
     SameFile(String, String),
     SelfSubdirectory(String),
     SelfTargetSubdirectory(String, String),
@@ -25,6 +26,7 @@ impl Display for MvError {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             Self::NoSuchFile(s) => write!(f, "cannot stat {s}: No such file or directory"),
+            Self::CannotStatNotADirectory(s) => write!(f, "cannot stat {s}: Not a directory"),
             Self::SameFile(s, t) => write!(f, "{s} and {t} are the same file"),
             Self::SelfSubdirectory(s) => write!(
                 f,

--- a/src/uu/mv/src/error.rs
+++ b/src/uu/mv/src/error.rs
@@ -4,9 +4,7 @@
 // file that was distributed with this source code.
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result};
-use std::path::PathBuf;
 
-use uucore::display::Quotable;
 use uucore::error::UError;
 
 #[derive(Debug)]
@@ -20,7 +18,7 @@ pub enum MvError {
     NonDirectoryToDirectory(String, String),
     NotADirectory(String),
     TargetNotADirectory(String),
-    FailedToAccessNotADirectory(PathBuf),
+    FailedToAccessNotADirectory(String),
 }
 
 impl Error for MvError {}
@@ -48,8 +46,8 @@ impl Display for MvError {
             Self::NotADirectory(t) => write!(f, "target {t}: Not a directory"),
             Self::TargetNotADirectory(t) => write!(f, "target directory {t}: Not a directory"),
 
-            Self::FailedToAccessNotADirectory(p) => {
-                write!(f, "failed to access {}: Not a directory", p.quote())
+            Self::FailedToAccessNotADirectory(t) => {
+                write!(f, "failed to access {t}: Not a directory")
             }
         }
     }

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -119,7 +119,7 @@ fn path_ends_with_terminator(path: &Path) -> bool {
     path.as_os_str()
         .encode_wide()
         .last()
-        .map_or(false, |&wide| wide == b'/'.into() || wide == b'\\'.into())
+        .map_or(false, |wide| wide == b'/'.into() || wide == b'\\'.into())
 }
 
 #[uucore::main]

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -332,7 +332,7 @@ fn handle_two_paths(source: &Path, target: &Path, opts: &Options) -> UResult<()>
     let target_is_dir = target.is_dir();
 
     if path_ends_with_terminator(target) && !target_is_dir {
-        return Err(MvError::FailedToAccessNotADirectory(target.to_owned()).into());
+        return Err(MvError::FailedToAccessNotADirectory(target.quote().to_string()).into());
     }
 
     if target_is_dir {

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -16,7 +16,6 @@ use std::fs;
 use std::io;
 #[cfg(unix)]
 use std::os::unix;
-use std::os::unix::prelude::OsStrExt;
 #[cfg(windows)]
 use std::os::windows;
 use std::path::{Path, PathBuf};
@@ -105,11 +104,22 @@ static OPT_PROGRESS: &str = "progress";
 static ARG_FILES: &str = "files";
 
 /// Returns true if the passed `path` ends with a path terminator.
+#[cfg(unix)]
 fn path_ends_with_terminator(path: &Path) -> bool {
+    use std::os::unix::prelude::OsStrExt;
     path.as_os_str()
         .as_bytes()
         .last()
-        .map_or(false, |&byte| std::path::is_separator(byte as char))
+        .map_or(false, |&byte| byte == b'/' || byte == b'\\')
+}
+
+#[cfg(windows)]
+fn path_ends_with_terminator(path: &Path) -> bool {
+    use std::os::windows::prelude::OsStrExt;
+    path.as_os_str()
+        .encode_wide()
+        .last()
+        .map_or(false, |&wide| wide == b'/'.into() || wide == b'\\'.into())
 }
 
 #[uucore::main]

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1414,6 +1414,35 @@ fn test_mv_directory_into_subdirectory_of_itself_fails() {
             "mv: cannot move 'mydir/' to a subdirectory of itself, 'mydir/mydir_2/mydir/'",
         );
 }
+
+#[test]
+fn test_mv_file_into_dir_where_both_are_files() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    at.touch("b");
+    scene
+        .ucmd()
+        .arg("a")
+        .arg("b/")
+        .fails()
+        .stderr_contains("mv: failed to access 'b/': Not a directory");
+}
+
+#[test]
+fn test_mv_dir_into_file_where_both_are_files() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    at.touch("b");
+    scene
+        .ucmd()
+        .arg("a/")
+        .arg("b")
+        .fails()
+        .stderr_contains("mv: cannot stat 'a/': Not a directory");
+}
+
 // Todo:
 
 // $ at.touch a b


### PR DESCRIPTION
Fixes #5463

The implementation of mv seems a bit messy, at least to a first time reader. My changes also feel a bit "band-aided" in. Glad we have a bunch of tests but the many repeated calls to `is_dir` and `symlink_metadata` and hard to understand flow may need to be addressed. 