### PR TITLE
cat: return the same error message as GNU with loop symlink

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -405,8 +405,7 @@ fn get_input_type(path: &str) -> CatResult<InputType> {
         return Ok(InputType::StdIn);
     }
 
-    let metadata_result = metadata(path);
-    let ft = match metadata_result {
+    let ft = match metadata(path) {
         Ok(md) => md.file_type(),
         Err(e) => {
             if let Some(raw_error) = e.raw_os_error() {

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -540,3 +540,15 @@ fn test_write_to_self() {
         "first_file_content.second_file_content."
     );
 }
+
+#[test]
+#[cfg(unix)]
+fn test_error_loop() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.symlink_file("2", "1");
+    at.symlink_file("3", "2");
+    at.symlink_file("1", "3");
+    ucmd.arg("1")
+        .fails()
+        .stderr_is("cat: 1: Too many levels of symbolic links\n");
+}


### PR DESCRIPTION
Should fix tests/du/long-sloop.sh because it is using cat as a ref for error messages