### PR TITLE
cp: fix cp -rT dir dir2 leads to different result than with GNU cp

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -87,6 +87,9 @@ struct Context<'a> {
 
     /// The target path to which the directory will be copied.
     target: &'a Path,
+
+    /// The source path to which the directory will be copied from.
+    root: &'a Path,
 }
 
 impl<'a> Context<'a> {
@@ -102,6 +105,7 @@ impl<'a> Context<'a> {
             current_dir,
             root_parent,
             target,
+            root,
         })
     }
 }
@@ -156,11 +160,19 @@ struct Entry {
 }
 
 impl Entry {
-    fn new(context: &Context, direntry: &DirEntry) -> Result<Self, StripPrefixError> {
+    fn new(
+        context: &Context,
+        direntry: &DirEntry,
+        no_target_dir: bool,
+    ) -> Result<Self, StripPrefixError> {
         let source_relative = direntry.path().to_path_buf();
         let source_absolute = context.current_dir.join(&source_relative);
-        let descendant =
+        let mut descendant =
             get_local_to_root_parent(&source_absolute, context.root_parent.as_deref())?;
+        if no_target_dir {
+            descendant = descendant.strip_prefix(context.root)?.to_path_buf();
+        }
+
         let local_to_target = context.target.join(descendant);
         let target_is_file = context.target.is_file();
         Ok(Self {
@@ -389,7 +401,7 @@ pub(crate) fn copy_directory(
     {
         match direntry_result {
             Ok(direntry) => {
-                let entry = Entry::new(&context, &direntry)?;
+                let entry = Entry::new(&context, &direntry, options.no_target_dir)?;
                 copy_direntry(
                     progress_bar,
                     entry,

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -88,7 +88,7 @@ struct Context<'a> {
     /// The target path to which the directory will be copied.
     target: &'a Path,
 
-    /// The source path to which the directory will be copied from.
+    /// The source path from which the directory will be copied.
     root: &'a Path,
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3499,3 +3499,18 @@ fn test_cp_dest_no_permissions() {
         .stderr_contains("invalid_perms.txt")
         .stderr_contains("denied");
 }
+
+#[test]
+fn test_cp_treat_dest_as_a_normal_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("dir");
+    at.mkdir("dir2");
+    at.touch("dir/a");
+    at.touch("dir/b");
+
+    ucmd.arg("-rT").arg("dir").arg("dir2").succeeds();
+
+    let metadata = at.metadata("dir2");
+    assert_eq!(metadata.len(), 0);
+}

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -231,6 +231,22 @@ fn test_cp_arg_no_target_directory() {
 }
 
 #[test]
+fn test_cp_arg_no_target_directory_with_recursive() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("dir");
+    at.mkdir("dir2");
+    at.touch("dir/a");
+    at.touch("dir/b");
+
+    ucmd.arg("-rT").arg("dir").arg("dir2").succeeds();
+
+    assert!(at.plus("dir2").join("a").exists());
+    assert!(at.plus("dir2").join("b").exists());
+    assert!(!at.plus("dir2").join("dir").exists());
+}
+
+#[test]
 fn test_cp_target_directory_is_file() {
     new_ucmd!()
         .arg("-t")
@@ -3498,19 +3514,4 @@ fn test_cp_dest_no_permissions() {
         .fails()
         .stderr_contains("invalid_perms.txt")
         .stderr_contains("denied");
-}
-
-#[test]
-fn test_cp_treat_dest_as_a_normal_file() {
-    let (at, mut ucmd) = at_and_ucmd!();
-
-    at.mkdir("dir");
-    at.mkdir("dir2");
-    at.touch("dir/a");
-    at.touch("dir/b");
-
-    ucmd.arg("-rT").arg("dir").arg("dir2").succeeds();
-
-    let metadata = at.metadata("dir2");
-    assert_eq!(metadata.len(), 0);
 }


### PR DESCRIPTION
fix #5457
by letting the cp respect the -T option