### PR TITLE
fuzz: use parse_size_u64

### DIFF
--- a/fuzz/fuzz_targets/fuzz_parse_size.rs
+++ b/fuzz/fuzz_targets/fuzz_parse_size.rs
@@ -1,10 +1,10 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use uucore::parse_size::parse_size;
+use uucore::parse_size::parse_size_u64;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
-        _ = parse_size(s);
+        _ = parse_size_u64(s);
     }
 });


### PR DESCRIPTION
`parse_size` is deprecated