### PR TITLE
cp: restrict two test functions to linux/mac/win

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3216,6 +3216,7 @@ fn test_cp_archive_on_directory_ending_dot() {
 }
 
 #[test]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 fn test_cp_debug_default() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -3243,6 +3244,7 @@ fn test_cp_debug_default() {
 }
 
 #[test]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 fn test_cp_debug_multiple_default() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;


### PR DESCRIPTION
This PR restricts two test functions to avoid the following "unused variable" warnings on FreeBSD:
```
warning: unused variable: `stdout_str`
      --> tests/by-util/test_cp.rs:3225:9
       |
  3225 |     let stdout_str = result.stdout_str();
       |         ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_stdout_str`
       |
       = note: `#[warn(unused_variables)]` on by default
  
  warning: unused variable: `stdout_str`
      --> tests/by-util/test_cp.rs:3261:9
       |
  3261 |     let stdout_str = result.stdout_str();
       |         ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_stdout_str`
  
```