### PR TITLE
`printf`: support %q

### DIFF
--- a/src/uu/printf/printf.md
+++ b/src/uu/printf/printf.md
@@ -186,7 +186,7 @@ All string fields have a 'max width' parameter
 
 * `%q`:  escaped string - the string in a format that can be reused as input by most shells.
       Non-printable characters are escaped with the POSIX proposed ‘$''’ syntax,
-      and shell metacharacters are quoted appropriately.
+      and shell meta-characters are quoted appropriately.
       This is an equivalent format to ls --quoting=shell-escape output.
 
 #### CHAR SUBSTITUTIONS

--- a/src/uu/printf/printf.md
+++ b/src/uu/printf/printf.md
@@ -78,6 +78,9 @@ Fields
             second parameter is min-width, integer
             output below that width is padded with leading zeroes
 
+* `%p`:       ARGUMENT is printed in a format that can be reused as shell input, escaping non-printable
+            characters with the proposed POSIX $'' syntax.
+
 * `%f` or `%F`: decimal floating point value
 * `%e` or `%E`: scientific notation floating point value
 * `%g` or `%G`: shorter of specially interpreted decimal or SciNote floating point value.
@@ -180,6 +183,11 @@ All string fields have a 'max width' parameter
       instead of `\\NNN`. (Although, for legacy reasons, octal literals in the form of `\\NNN` will
       still be interpreted and not throw a warning, you will have problems if you use this for a
       literal whose code begins with zero, as it will be viewed as in `\\0NNN` form.)
+
+* `%q`:  escaped string - the string in a format that can be reused as input by most shells.
+      Non-printable characters are escaped with the POSIX proposed ‘$''’ syntax,
+      and shell metacharacters are quoted appropriately.
+      This is an equivalent format to ls --quoting=shell-escape output.
 
 #### CHAR SUBSTITUTIONS
 

--- a/src/uucore/src/lib/features/tokenize/sub.rs
+++ b/src/uucore/src/lib/features/tokenize/sub.rs
@@ -406,11 +406,11 @@ impl Sub {
                                 None
                             }
                             'q' => {
-                                let mut non_printable_char = [
+                                let mut non_printable_chars = [
                                     '`', '#', '$', '^', '&', '*', '(', ')', '[', ']', '\\', '{',
-                                    '}', '|', ';', '\'', '"', '<', '>', '?',
+                                    '}', '|', ';', '\'', '"', '<', '>', '?', ' ',
                                 ];
-                                non_printable_char.sort_unstable();
+                                non_printable_chars.sort_unstable();
 
                                 let arg_string = match field.second_field {
                                     Some(max) => String::from(&arg_string[..max as usize]),
@@ -419,7 +419,7 @@ impl Sub {
 
                                 let mut new_arg_string = String::new();
                                 for c in arg_string.chars() {
-                                    if non_printable_char.binary_search(&c).is_ok() {
+                                    if non_printable_chars.binary_search(&c).is_ok() {
                                         new_arg_string.push('\\');
                                     }
                                     new_arg_string.push(c);

--- a/src/uucore/src/lib/features/tokenize/sub.rs
+++ b/src/uucore/src/lib/features/tokenize/sub.rs
@@ -261,7 +261,6 @@ impl SubParser {
                 }
                 x if legal_fields.binary_search(&x).is_ok() => {
                     self.field_char = Some(ch);
-                    self.text_so_far.push(ch);
                     break;
                 }
                 x if specifiers.binary_search(&x).is_ok() => {

--- a/src/uucore/src/lib/features/tokenize/sub.rs
+++ b/src/uucore/src/lib/features/tokenize/sub.rs
@@ -332,7 +332,7 @@ impl SubParser {
         if (field_char == 's' && self.min_width_tmp == Some(String::from("0")))
             || (field_char == 'c'
                 && (self.min_width_tmp == Some(String::from("0")) || self.past_decimal))
-            || (field_char == 'b'
+            || ((field_char == 'b' || field_char == 'q')
                 && (self.min_width_tmp.is_some()
                     || self.past_decimal
                     || self.second_field_tmp.is_some()))
@@ -406,20 +406,14 @@ impl Sub {
                                 UnescapedText::from_it_core(writer, &mut a_it, true);
                                 None
                             }
-                            'q' => {
-                                let arg_string = match field.second_field {
-                                    Some(max) => String::from(&arg_string[..max as usize]),
-                                    None => arg_string.clone(),
-                                };
-                                Some(escape_name(
-                                    arg_string.as_ref(),
-                                    &QuotingStyle::Shell {
-                                        escape: true,
-                                        always_quote: false,
-                                        show_control: false,
-                                    },
-                                ))
-                            }
+                            'q' => Some(escape_name(
+                                arg_string.as_ref(),
+                                &QuotingStyle::Shell {
+                                    escape: true,
+                                    always_quote: false,
+                                    show_control: false,
+                                },
+                            )),
                             // get opt<char> of first val
                             // and map it to opt<String>
                             'c' => arg_string.chars().next().map(|x| x.to_string()),

--- a/src/uucore/src/lib/features/tokenize/sub.rs
+++ b/src/uucore/src/lib/features/tokenize/sub.rs
@@ -418,6 +418,12 @@ impl Sub {
                                 };
 
                                 let mut new_arg_string = String::new();
+                                // `~` is non-printable only when being the first char.
+                                if let Some(first) = arg_string.chars().peekable().peek() {
+                                    if first == &'~' {
+                                        new_arg_string.push('\\');
+                                    }
+                                }
                                 for c in arg_string.chars() {
                                     if non_printable_chars.binary_search(&c).is_ok() {
                                         new_arg_string.push('\\');

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -125,23 +125,15 @@ fn sub_q_string_non_printable() {
     new_ucmd!()
         .args(&["non-printable: %q", "\"$test\""])
         .succeeds()
-        .stdout_only("non-printable: \\\"\\$test\\\"");
-}
-
-#[test]
-fn sub_q_string_more_non_printable() {
-    new_ucmd!()
-        .args(&["non-printable: %q", "[]{}<>"])
-        .succeeds()
-        .stdout_only("non-printable: \\[\\]\\{\\}\\<\\>");
+        .stdout_only("non-printable: '\"$test\"'");
 }
 
 #[test]
 fn sub_q_string_special_non_printable() {
     new_ucmd!()
-        .args(&["non-printable: %q", "~ ~"])
+        .args(&["non-printable: %q", "test~"])
         .succeeds()
-        .stdout_only("non-printable: \\~\\ ~");
+        .stdout_only("non-printable: test~");
 }
 
 #[test]

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -137,6 +137,14 @@ fn sub_q_string_more_non_printable() {
 }
 
 #[test]
+fn sub_q_string_special_non_printable() {
+    new_ucmd!()
+        .args(&["non-printable: %q", "~ ~"])
+        .succeeds()
+        .stdout_only("non-printable: \\~\\ ~");
+}
+
+#[test]
 fn sub_char() {
     new_ucmd!()
         .args(&["the letter %c", "A"])

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -113,6 +113,15 @@ fn sub_b_string_handle_escapes() {
 }
 
 #[test]
+fn sub_b_string_validate_field_params() {
+    new_ucmd!()
+        .args(&["hello %7b", "world"])
+        .run()
+        .stdout_is("hello ")
+        .stderr_is("printf: %7b: invalid conversion specification\n");
+}
+
+#[test]
 fn sub_b_string_ignore_subs() {
     new_ucmd!()
         .args(&["hello %b", "world %% %i"])
@@ -126,6 +135,15 @@ fn sub_q_string_non_printable() {
         .args(&["non-printable: %q", "\"$test\""])
         .succeeds()
         .stdout_only("non-printable: '\"$test\"'");
+}
+
+#[test]
+fn sub_q_string_validate_field_params() {
+    new_ucmd!()
+        .args(&["hello %7q", "world"])
+        .run()
+        .stdout_is("hello ")
+        .stderr_is("printf: %7q: invalid conversion specification\n");
 }
 
 #[test]

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -121,6 +121,22 @@ fn sub_b_string_ignore_subs() {
 }
 
 #[test]
+fn sub_q_string_non_printable() {
+    new_ucmd!()
+        .args(&["non-printable: %q", "\"$test\""])
+        .succeeds()
+        .stdout_only("non-printable: \\\"\\$test\\\"");
+}
+
+#[test]
+fn sub_q_string_more_non_printable() {
+    new_ucmd!()
+        .args(&["non-printable: %q", "[]{}<>"])
+        .succeeds()
+        .stdout_only("non-printable: \\[\\]\\{\\}\\<\\>");
+}
+
+#[test]
 fn sub_char() {
     new_ucmd!()
         .args(&["the letter %c", "A"])


### PR DESCRIPTION
fix #5468 
Now `printf %q '"$test"'` can produce the right result:
```
./target/debug/printf %q '"$test"'; echo
\"\$test\"
```
However I have a doubt about the description in [GNU manual](https://www.gnu.org/software/coreutils/manual/coreutils.html#printf-invocation):
> An additional directive `%q`, prints its argument string in a format that can be reused as input by most shells. Non-printable characters are escaped with the POSIX proposed `$''` syntax, and shell metacharacters are quoted appropriately. This is an equivalent format to ls --quoting=shell-escape output.

And in my local:
```
$ ls --quoting=shell-escape
'"$test"'
$ printf %q '"$test"'; echo
\"\$test\"
```
What does "equivalent format" mean?