### PR TITLE
cat: use error code 62 for ELOOP on FreeBSD

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -409,9 +409,9 @@ fn get_input_type(path: &str) -> CatResult<InputType> {
             if let Some(raw_error) = e.raw_os_error() {
                 // On Unix-like systems, the error code for "Too many levels of symbolic links" is 40 (ELOOP).
                 // we want to provide a proper error message in this case.
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
                 let too_many_symlink_code = 40;
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "freebsd"))]
                 let too_many_symlink_code = 62;
                 if raw_error == too_many_symlink_code {
                     return Err(CatError::TooManySymlinks);


### PR DESCRIPTION
The error code for `ELOOP` (Too many levels of symbolic links) is `62`, and not `40`, on FreeBSD according to https://man.freebsd.org/cgi/man.cgi?query=errno&apropos=0&sektion=2&manpath=FreeBSD+15.0-CURRENT&arch=default&format=html