### PR TITLE
deny.toml: remove two entries from skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -58,10 +58,7 @@ highlight = "all"
 # introduces it.
 # spell-checker: disable
 skip = [
-  # procfs
-  { name = "rustix", version = "0.36.16" },
   # rustix
-  { name = "linux-raw-sys", version = "0.1.4" },
   { name = "linux-raw-sys", version = "0.3.8" },
   # terminal_size
   { name = "rustix", version = "0.37.26" },


### PR DESCRIPTION
This PR removes entries for `rustix` and `linux-raw-sys` from the skip list in `deny.toml`. They are no longer needed due to https://github.com/uutils/coreutils/pull/5474