### PR TITLE
cp --link: don't fail if destination is hardlink to source

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1682,6 +1682,12 @@ fn copy_file(
     }
 
     if file_or_link_exists(dest) {
+        if are_hardlinks_to_same_file(source, dest)
+            && !options.force()
+            && options.backup == BackupMode::NoBackup
+        {
+            return Ok(());
+        }
         handle_existing_dest(source, dest, options, source_in_command_line)?;
     }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -532,6 +532,25 @@ fn test_cp_arg_link() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_cp_arg_link_with_dest_hardlink_to_source() {
+    use std::os::linux::fs::MetadataExt;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "file";
+    let hardlink = "hardlink";
+
+    at.touch(file);
+    at.hard_link(file, hardlink);
+
+    ucmd.args(&["--link", file, hardlink]).succeeds();
+
+    assert_eq!(at.metadata(file).st_nlink(), 2);
+    assert!(at.file_exists(file));
+    assert!(at.file_exists(hardlink));
+}
+
+#[test]
 fn test_cp_arg_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.arg(TEST_HELLO_WORLD_SOURCE)


### PR DESCRIPTION
With this PR, `cp --link` no longer shows a "same file" error if the destination is a hardlink to the source.