### PR TITLE
du: make -l/--count-links work

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -88,6 +88,7 @@ struct Options {
     separate_dirs: bool,
     one_file_system: bool,
     dereference: Deref,
+    count_links: bool,
     inodes: bool,
     verbose: bool,
 }
@@ -336,6 +337,9 @@ fn du(
 
                             if let Some(inode) = this_stat.inode {
                                 if inodes.contains(&inode) {
+                                    if options.count_links {
+                                        my_stat.inodes += 1;
+                                    }
                                     continue;
                                 }
                                 inodes.insert(inode);
@@ -561,6 +565,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         } else {
             Deref::None
         },
+        count_links: matches.get_flag(options::COUNT_LINKS),
         inodes: matches.get_flag(options::INODES),
         verbose: matches.get_flag(options::VERBOSE),
     };

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -296,7 +296,7 @@ fn du(
     mut my_stat: Stat,
     options: &Options,
     depth: usize,
-    inodes: &mut HashSet<FileInfo>,
+    seen_inodes: &mut HashSet<FileInfo>,
     exclude: &[Pattern],
 ) -> Box<dyn DoubleEndedIterator<Item = Stat>> {
     let mut stats = vec![];
@@ -336,13 +336,13 @@ fn du(
                             }
 
                             if let Some(inode) = this_stat.inode {
-                                if inodes.contains(&inode) {
+                                if seen_inodes.contains(&inode) {
                                     if options.count_links {
                                         my_stat.inodes += 1;
                                     }
                                     continue;
                                 }
-                                inodes.insert(inode);
+                                seen_inodes.insert(inode);
                             }
                             if this_stat.is_dir {
                                 if options.one_file_system {
@@ -354,7 +354,13 @@ fn du(
                                         }
                                     }
                                 }
-                                futures.push(du(this_stat, options, depth + 1, inodes, exclude));
+                                futures.push(du(
+                                    this_stat,
+                                    options,
+                                    depth + 1,
+                                    seen_inodes,
+                                    exclude,
+                                ));
                             } else {
                                 my_stat.size += this_stat.size;
                                 my_stat.blocks += this_stat.blocks;
@@ -637,11 +643,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         // Check existence of path provided in argument
         if let Ok(stat) = Stat::new(&path, &options) {
             // Kick off the computation of disk usage from the initial path
-            let mut inodes: HashSet<FileInfo> = HashSet::new();
+            let mut seen_inodes: HashSet<FileInfo> = HashSet::new();
             if let Some(inode) = stat.inode {
-                inodes.insert(inode);
+                seen_inodes.insert(inode);
             }
-            let iter = du(stat, &options, 0, &mut inodes, &excludes);
+            let iter = du(stat, &options, 0, &mut seen_inodes, &excludes);
 
             // Sum up all the returned `Stat`s and display results
             let (_, len) = iter.size_hint();

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -442,6 +442,33 @@ fn test_du_inodes() {
 }
 
 #[test]
+fn test_du_inodes_with_count_links() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.mkdir("dir");
+    at.touch("dir/file");
+    at.hard_link("dir/file", "dir/hard_link_a");
+    at.hard_link("dir/file", "dir/hard_link_b");
+
+    // ensure the hard links are not counted without --count-links
+    ts.ucmd()
+        .arg("--inodes")
+        .arg("dir")
+        .succeeds()
+        .stdout_is("2\tdir\n");
+
+    for arg in ["-l", "--count-links"] {
+        ts.ucmd()
+            .arg("--inodes")
+            .arg(arg)
+            .arg("dir")
+            .succeeds()
+            .stdout_is("4\tdir\n");
+    }
+}
+
+#[test]
 fn test_du_h_flag_empty_file() {
     new_ucmd!()
         .arg("-h")


### PR DESCRIPTION
So far, `-l`/`--count-links` were accepted as options and then ignored. This PR makes them work.