### PR TITLE
cp,tail: fix warnings in tests on Android

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2120,7 +2120,7 @@ fn test_cp_reflink_insufficient_permission() {
         .stderr_only("cp: 'unreadable' -> 'existing_file.txt': Permission denied (os error 13)\n");
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn test_closes_file_descriptors() {
     use procfs::process::Process;
@@ -3436,7 +3436,7 @@ fn test_cp_debug_sparse_auto() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn test_cp_debug_reflink_auto() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -23,6 +23,7 @@ use std::io::Write;
 use std::io::{Seek, SeekFrom};
 #[cfg(all(
     not(target_vendor = "apple"),
+    not(target_os = "android"),
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))]
@@ -31,6 +32,7 @@ use std::process::Stdio;
 use tail::chunks::BUFFER_SIZE as CHUNK_BUFFER_SIZE;
 #[cfg(all(
     not(target_vendor = "apple"),
+    not(target_os = "android"),
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))]


### PR DESCRIPTION
This PR fixes some "unused import" and "unused variable" warnings in tests on Android as shown in https://github.com/uutils/coreutils/actions/runs/6756912757/job/18366894422?pr=5494#step:8:2114:
```
warning: unused import: `rlimit::Resource`
  --> tests/by-util/test_cp.rs:28:5
   |
28 | use rlimit::Resource;
   |     ^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::path::Path`
  --> tests/by-util/test_tail.rs:29:5
   |
29 | use std::path::Path;
   |     ^^^^^^^^^^^^^^^

warning: unused import: `tail::text`
  --> tests/by-util/test_tail.rs:37:5
   |
37 | use tail::text;
   |     ^^^^^^^^^^

warning: unused import: `std::fmt::Write`
 --> tests/by-util/test_tee.rs:6:5
  |
6 | use std::fmt::Write;
  |     ^^^^^^^^^^^^^^^


Waiting for /sdcard/tests.probe: /sdcard/tests.log: 1 file pulled, 0 skipped. 1.4 MB/s (20059 bytes in 0.014s)

warning: unused variable: `result`
    --> tests/by-util/test_cp.rs:3444:9
     |
3444 |     let result = ts
     |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_result`
     |
     = note: `#[warn(unused_variables)]` on by default
```
The warning for `tee` should be fixed in https://github.com/uutils/coreutils/pull/5473