### PR TITLE
Fix clippy::redundant_closure_for_method_calls

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         ## `cargo clippy` lint testing
         unset fault
-        CLIPPY_FLAGS="-W clippy::default_trait_access -W clippy::manual_string_new -W clippy::cognitive_complexity -W clippy::implicit_clone"
+        CLIPPY_FLAGS="-W clippy::default_trait_access -W clippy::manual_string_new -W clippy::cognitive_complexity -W clippy::implicit_clone -W clippy::redundant_closure_for_method_calls"
         fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
         fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
         # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -32,7 +32,7 @@ fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<GidUidOwnerFilter> {
     } else {
         let group = matches
             .get_one::<String>(options::ARG_GROUP)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             .unwrap_or_default();
         raw_group = group.to_string();
         if group.is_empty() {

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -65,7 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let commands = match matches.get_many::<String>(options::COMMAND) {
-        Some(v) => v.map(|s| s.as_str()).collect(),
+        Some(v) => v.map(String::as_str).collect(),
         None => vec![],
     };
 
@@ -181,15 +181,15 @@ fn set_context(root: &Path, options: &clap::ArgMatches) -> UResult<()> {
     let userspec_str = options.get_one::<String>(options::USERSPEC);
     let user_str = options
         .get_one::<String>(options::USER)
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .unwrap_or_default();
     let group_str = options
         .get_one::<String>(options::GROUP)
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .unwrap_or_default();
     let groups_str = options
         .get_one::<String>(options::GROUPS)
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .unwrap_or_default();
     let skip_chdir = options.contains_id(options::SKIP_CHDIR);
     let userspec = match userspec_str {

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -97,7 +97,7 @@ impl<'a> Context<'a> {
         let current_dir = env::current_dir()?;
         let root_path = current_dir.join(root);
         let root_parent = if target.exists() && !root.to_str().unwrap().ends_with("/.") {
-            root_path.parent().map(|p| p.to_path_buf())
+            root_path.parent().map(Path::to_path_buf)
         } else {
             Some(root_path)
         };

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -725,7 +725,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
         let paths: Vec<PathBuf> = matches
             .remove_many::<PathBuf>(options::PATHS)
-            .map(|v| v.collect())
+            .map(Iterator::collect)
             .unwrap_or_default();
 
         let (sources, target) = parse_path_args(paths, &options)?;

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -563,7 +563,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let patterns: Vec<String> = matches
         .get_many::<String>(options::PATTERN)
         .unwrap()
-        .map(|s| s.to_string())
+        .map(String::to_string)
         .collect();
     let patterns = patterns::get_patterns(&patterns[..])?;
     let options = CsplitOptions::new(&matches);

--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -192,7 +192,7 @@ mod tests {
     fn up_to_line_pattern() {
         let input: Vec<String> = vec!["24", "42", "{*}", "50", "{4}"]
             .into_iter()
-            .map(|v| v.to_string())
+            .map(String::to_string)
             .collect();
         let patterns = get_patterns(input.as_slice()).unwrap();
         assert_eq!(patterns.len(), 3);
@@ -223,7 +223,7 @@ mod tests {
             "/test5.*end$/-3",
         ]
         .into_iter()
-        .map(|v| v.to_string())
+        .map(String::to_string)
         .collect();
         let patterns = get_patterns(input.as_slice()).unwrap();
         assert_eq!(patterns.len(), 5);
@@ -277,7 +277,7 @@ mod tests {
             "%test5.*end$%-3",
         ]
         .into_iter()
-        .map(|v| v.to_string())
+        .map(String::to_string)
         .collect();
         let patterns = get_patterns(input.as_slice()).unwrap();
         assert_eq!(patterns.len(), 5);

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -370,7 +370,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     out_delim: Some(
                         matches
                             .get_one::<String>(options::OUTPUT_DELIMITER)
-                            .map(|s| s.as_str())
+                            .map(String::as_str)
                             .unwrap_or_default()
                             .to_owned(),
                     ),
@@ -385,7 +385,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     out_delim: Some(
                         matches
                             .get_one::<String>(options::OUTPUT_DELIMITER)
-                            .map(|s| s.as_str())
+                            .map(String::as_str)
                             .unwrap_or_default()
                             .to_owned(),
                     ),
@@ -411,7 +411,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 let zero_terminated = matches.get_flag(options::ZERO_TERMINATED);
                 let line_ending = LineEnding::from_zero_flag(zero_terminated);
 
-                match matches.get_one::<String>(options::DELIMITER).map(|s| s.as_str()) {
+                match matches.get_one::<String>(options::DELIMITER).map(String::as_str) {
                     Some(_) if whitespace_delimited => {
                             Err("invalid input: Only one of --delimiter (-d) or -w option can be specified".into())
                         }

--- a/src/uu/dd/src/blocks.rs
+++ b/src/uu/dd/src/blocks.rs
@@ -23,10 +23,9 @@ const SPACE: u8 = b' ';
 /// all-spaces block at the end. Otherwise, remove the last block if
 /// it is all spaces.
 fn block(buf: &[u8], cbs: usize, sync: bool, rstat: &mut ReadStat) -> Vec<Vec<u8>> {
-    let mut blocks = buf
-        .split(|&e| e == NEWLINE)
-        .map(|split| split.to_vec())
-        .fold(Vec::new(), |mut blocks, mut split| {
+    let mut blocks = buf.split(|&e| e == NEWLINE).map(<[u8]>::to_vec).fold(
+        Vec::new(),
+        |mut blocks, mut split| {
             if split.len() > cbs {
                 rstat.records_truncated += 1;
             }
@@ -34,7 +33,8 @@ fn block(buf: &[u8], cbs: usize, sync: bool, rstat: &mut ReadStat) -> Vec<Vec<u8
             blocks.push(split);
 
             blocks
-        });
+        },
+    );
 
     // If `sync` is true and there has been at least one partial
     // record read from the input, then leave the all-spaces block at

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1193,7 +1193,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         &matches
             .get_many::<String>(options::OPERANDS)
             .unwrap_or_default()
-            .map(|s| s.as_ref())
+            .map(AsRef::as_ref)
             .collect::<Vec<_>>()[..],
     )?;
 

--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -96,7 +96,7 @@ impl Column {
                 let names = matches
                     .get_many::<String>(OPT_OUTPUT)
                     .unwrap()
-                    .map(|s| s.as_str());
+                    .map(String::as_str);
                 let mut seen: Vec<&str> = vec![];
                 let mut columns = vec![];
                 for name in names {

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -65,7 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let files = matches
         .get_many::<String>(options::FILE)
-        .map_or(vec![], |file_values| file_values.collect());
+        .map_or(vec![], Iterator::collect);
 
     // clap provides .conflicts_with / .conflicts_with_all, but we want to
     // manually handle conflicts so we can match the output of GNU coreutils

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -533,7 +533,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let max_depth = parse_depth(
         matches
             .get_one::<String>(options::MAX_DEPTH)
-            .map(|s| s.as_str()),
+            .map(String::as_str),
         summarize,
     )?;
 
@@ -573,7 +573,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let block_size = read_block_size(
         matches
             .get_one::<String>(options::BLOCK_SIZE)
-            .map(|s| s.as_str()),
+            .map(String::as_str),
     );
 
     let threshold = matches.get_one::<String>(options::THRESHOLD).map(|s| {
@@ -598,7 +598,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let time_format_str =
-        parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?;
+        parse_time_style(matches.get_one::<String>("time-style").map(String::as_str))?;
 
     let line_ending = LineEnding::from_zero_flag(matches.get_flag(options::NULL));
 

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -124,7 +124,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let no_newline = matches.get_flag(options::NO_NEWLINE);
     let escaped = matches.get_flag(options::ENABLE_BACKSLASH_ESCAPE);
     let values: Vec<String> = match matches.get_many::<String>(options::STRING) {
-        Some(s) => s.map(|s| s.to_string()).collect(),
+        Some(s) => s.map(String::to_string).collect(),
         None => vec![String::new()],
     };
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -178,13 +178,13 @@ fn run_env(args: impl uucore::Args) -> UResult<()> {
 
     let ignore_env = matches.get_flag("ignore-environment");
     let line_ending = LineEnding::from_zero_flag(matches.get_flag("null"));
-    let running_directory = matches.get_one::<String>("chdir").map(|s| s.as_str());
+    let running_directory = matches.get_one::<String>("chdir").map(String::as_str);
     let files = match matches.get_many::<String>("file") {
-        Some(v) => v.map(|s| s.as_str()).collect(),
+        Some(v) => v.map(String::as_str).collect(),
         None => Vec::with_capacity(0),
     };
     let unsets = match matches.get_many::<String>("unset") {
-        Some(v) => v.map(|s| s.as_str()).collect(),
+        Some(v) => v.map(String::as_str).collect(),
         None => Vec::with_capacity(0),
     };
 

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -204,7 +204,7 @@ struct Options {
 impl Options {
     fn new(matches: &ArgMatches) -> Result<Self, ParseError> {
         let (remaining_mode, tabstops) = match matches.get_many::<String>(options::TABS) {
-            Some(s) => tabstops_parse(&s.map(|s| s.as_str()).collect::<Vec<_>>().join(","))?,
+            Some(s) => tabstops_parse(&s.map(String::as_str).collect::<Vec<_>>().join(","))?,
             None => (RemainingMode::None, vec![DEFAULT_TABSTOP]),
         };
 
@@ -225,7 +225,7 @@ impl Options {
         let tspaces = " ".repeat(nspaces);
 
         let files: Vec<String> = match matches.get_many::<String>(options::FILES) {
-            Some(s) => s.map(|v| v.to_string()).collect(),
+            Some(s) => s.map(String::to_string).collect(),
             None => vec!["-".to_owned()],
         };
 

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -55,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
     let token_strings = matches
         .get_many::<String>(options::EXPRESSION)
-        .map(|v| v.into_iter().map(|s| s.as_ref()).collect::<Vec<_>>())
+        .map(|v| v.into_iter().map(AsRef::as_ref).collect::<Vec<_>>())
         .unwrap_or_default();
 
     match process_expr(&token_strings[..]) {

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -356,7 +356,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
     };
 
     match matches.get_many::<OsString>("FILE") {
-        Some(files) => hashsum(opts, files.map(|f| f.as_os_str())),
+        Some(files) => hashsum(opts, files.map(OsString::as_os_str)),
         None => hashsum(opts, iter::once(OsStr::new("-"))),
     }
 }

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -273,7 +273,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
         let groups = entries::get_groups_gnu(Some(gid)).unwrap();
         let groups = if state.user_specified {
-            possible_pw.as_ref().map(|p| p.belongs_to()).unwrap()
+            possible_pw
+                .as_ref()
+                .map(uucore::entries::Passwd::belongs_to)
+                .unwrap()
         } else {
             groups.clone()
         };

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -391,7 +391,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
 
     let owner = matches
         .get_one::<String>(OPT_OWNER)
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .unwrap_or("")
         .to_string();
 
@@ -406,7 +406,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
 
     let group = matches
         .get_one::<String>(OPT_GROUP)
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .unwrap_or("")
         .to_string();
 
@@ -433,7 +433,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
         strip_program: String::from(
             matches
                 .get_one::<String>(OPT_STRIP_PROGRAM)
-                .map(|s| s.as_str())
+                .map(String::as_str)
                 .unwrap_or(DEFAULT_STRIP_PROGRAM),
         ),
         create_leading: matches.get_flag(OPT_CREATE_LEADING),

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -639,7 +639,7 @@ fn parse_print_settings(matches: &clap::ArgMatches) -> UResult<(bool, bool, bool
 }
 
 fn get_and_parse_field_number(matches: &clap::ArgMatches, key: &str) -> UResult<Option<usize>> {
-    let value = matches.get_one::<String>(key).map(|s| s.as_str());
+    let value = matches.get_one::<String>(key).map(String::as_str);
     parse_field_number_option(value)
 }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1853,7 +1853,7 @@ impl PathData {
 
     fn file_type(&self, out: &mut BufWriter<Stdout>) -> Option<&FileType> {
         self.ft
-            .get_or_init(|| self.md(out).map(|md| md.file_type()))
+            .get_or_init(|| self.md(out).map(Metadata::file_type))
             .as_ref()
     }
 }
@@ -1970,7 +1970,7 @@ fn sort_entries(entries: &mut [PathData], config: &Config, out: &mut BufWriter<S
                     .unwrap_or(UNIX_EPOCH),
             )
         }),
-        Sort::Size => entries.sort_by_key(|k| Reverse(k.md(out).map(|md| md.len()).unwrap_or(0))),
+        Sort::Size => entries.sort_by_key(|k| Reverse(k.md(out).map(Metadata::len).unwrap_or(0))),
         // The default sort in GNU ls is case insensitive
         Sort::Name => entries.sort_by(|a, b| a.display_name.cmp(&b.display_name)),
         Sort::Version => entries.sort_by(|a, b| {

--- a/src/uu/mknod/src/parsemode.rs
+++ b/src/uu/mknod/src/parsemode.rs
@@ -11,7 +11,7 @@ use uucore::mode;
 pub const MODE_RW_UGO: mode_t = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
 
 pub fn parse_mode(mode: &str) -> Result<mode_t, String> {
-    let result = if mode.chars().any(|c| c.is_ascii_digit()) {
+    let result = if mode.chars().any(char::is_ascii_digit) {
         mode::parse_numeric(MODE_RW_UGO as u32, mode)
     } else {
         mode::parse_symbolic(MODE_RW_UGO as u32, mode, true)

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -155,7 +155,7 @@ impl Options {
             }
             Some(template) => {
                 let tmpdir = if env::var(TMPDIR_ENV_VAR).is_ok() && matches.get_flag(OPT_T) {
-                    env::var_os(TMPDIR_ENV_VAR).map(|t| t.into())
+                    env::var_os(TMPDIR_ENV_VAR).map(Into::into)
                 } else if tmpdir.is_some() {
                     tmpdir
                 } else if matches.get_flag(OPT_T) || matches.contains_id(OPT_TMPDIR) {

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -101,7 +101,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let mut stdout = setup_term();
         let length = files.len();
 
-        let mut files_iter = files.map(|s| s.as_str()).peekable();
+        let mut files_iter = files.map(String::as_str).peekable();
         while let (Some(file), next_file) = (files_iter.next(), files_iter.peek()) {
             let file = Path::new(file);
             if file.is_dir() {

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -299,7 +299,7 @@ fn parse_paths(files: &[OsString], opts: &Options) -> Vec<PathBuf> {
             .map(|p| p.components().as_path().to_owned())
             .collect::<Vec<PathBuf>>()
     } else {
-        paths.map(|p| p.to_owned()).collect::<Vec<PathBuf>>()
+        paths.map(ToOwned::to_owned).collect::<Vec<PathBuf>>()
     }
 }
 

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -107,7 +107,7 @@ fn parse_implicit_precision(s: &str) -> usize {
     match s.split_once('.') {
         Some((_, decimal_part)) => decimal_part
             .chars()
-            .take_while(|c| c.is_ascii_digit())
+            .take_while(char::is_ascii_digit)
             .count(),
         None => 0,
     }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -256,7 +256,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let options = parse_options(&matches).map_err(NumfmtError::IllegalArgument)?;
 
     let result = match matches.get_many::<String>(options::NUMBER) {
-        Some(values) => handle_args(values.map(|s| s.as_str()), &options),
+        Some(values) => handle_args(values.map(String::as_str), &options),
         None => {
             let stdin = std::io::stdin();
             let mut locked_stdin = stdin.lock();

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -322,7 +322,7 @@ fn parse_type_string(params: &str) -> Result<Vec<ParsedFormatterItemInfo>, Strin
 
 #[cfg(test)]
 pub fn parse_format_flags_str(args_str: &[&'static str]) -> Result<Vec<FormatterItemInfo>, String> {
-    let args: Vec<String> = args_str.iter().map(|s| s.to_string()).collect();
+    let args: Vec<String> = args_str.iter().map(String::to_string).collect();
     parse_format_flags(&args).map(|v| {
         // tests using this function assume add_ascii_dump is not set
         v.into_iter()

--- a/src/uu/od/src/parse_inputs.rs
+++ b/src/uu/od/src/parse_inputs.rs
@@ -17,7 +17,7 @@ pub trait CommandLineOpts {
 impl CommandLineOpts for ArgMatches {
     fn inputs(&self) -> Vec<&str> {
         self.get_many::<String>(options::FILENAME)
-            .map(|values| values.map(|s| s.as_str()).collect())
+            .map(|values| values.map(String::as_str).collect())
             .unwrap_or_default()
     }
 

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -397,7 +397,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mut files = matches
         .get_many::<String>(options::FILES)
-        .map(|v| v.map(|s| s.as_str()).collect::<Vec<_>>())
+        .map(|v| v.map(String::as_str).collect::<Vec<_>>())
         .unwrap_or_default()
         .clone();
     if files.is_empty() {
@@ -514,7 +514,7 @@ fn build_options(
 
     let header = matches
         .get_one::<String>(options::HEADER)
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .unwrap_or(if is_merge_mode || paths[0] == FILE_STDIN {
             ""
         } else {

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -31,7 +31,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .get_one::<String>(options::FORMATSTRING)
         .ok_or_else(|| UUsageError::new(1, "missing operand"))?;
     let values: Vec<String> = match matches.get_many::<String>(options::ARGUMENT) {
-        Some(s) => s.map(|s| s.to_string()).collect(),
+        Some(s) => s.map(String::to_string).collect(),
         None => vec![],
     };
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -69,16 +69,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let options = SeqOptions {
         separator: matches
             .get_one::<String>(OPT_SEPARATOR)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             .unwrap_or("\n")
             .to_string(),
         terminator: matches
             .get_one::<String>(OPT_TERMINATOR)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             .unwrap_or("\n")
             .to_string(),
         equal_width: matches.get_flag(OPT_EQUAL_WIDTH),
-        format: matches.get_one::<String>(OPT_FORMAT).map(|s| s.as_str()),
+        format: matches.get_one::<String>(OPT_FORMAT).map(String::as_str),
     };
 
     let first = if numbers.len() > 1 {

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -234,7 +234,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let remove = matches.get_flag(options::REMOVE);
     let size_arg = matches
         .get_one::<String>(options::SIZE)
-        .map(|s| s.to_string());
+        .map(String::to_string);
     let size = get_size(size_arg);
     let exact = matches.get_flag(options::EXACT) || size.is_some();
     let zero = matches.get_flag(options::ZERO);

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -64,7 +64,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         Mode::Default(
             matches
                 .get_one::<String>(options::FILE)
-                .map(|s| s.as_str())
+                .map(String::as_str)
                 .unwrap_or("-")
                 .to_string(),
         )

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -37,7 +37,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 ),
             )
         })?
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .collect::<Vec<_>>();
 
     sleep(&numbers)

--- a/src/uu/sort/src/ext_sort.rs
+++ b/src/uu/sort/src/ext_sort.rs
@@ -99,7 +99,7 @@ fn reader_writer<
     match read_result {
         ReadResult::WroteChunksToFile { tmp_files } => {
             let merger = merge::merge_with_file_limit::<_, _, Tmp>(
-                tmp_files.into_iter().map(|c| c.reopen()),
+                tmp_files.into_iter().map(ClosedTmpFile::reopen),
                 settings,
                 tmp_dir,
             )?;

--- a/src/uu/sort/src/numeric_str_cmp.rs
+++ b/src/uu/sort/src/numeric_str_cmp.rs
@@ -221,8 +221,8 @@ pub fn numeric_str_cmp((a, a_info): (&str, &NumInfo), (b, b_info): (&str, &NumIn
         a_info.exponent.cmp(&b_info.exponent)
     } else {
         // walk the characters from the front until we find a difference
-        let mut a_chars = a.chars().filter(|c| c.is_ascii_digit());
-        let mut b_chars = b.chars().filter(|c| c.is_ascii_digit());
+        let mut a_chars = a.chars().filter(char::is_ascii_digit);
+        let mut b_chars = b.chars().filter(char::is_ascii_digit);
         loop {
             let a_next = a_chars.next();
             let b_next = b_chars.next();

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -985,7 +985,7 @@ impl FieldSelector {
                 let mut range = match to {
                     Some(Resolution::StartOfChar(mut to)) => {
                         // We need to include the character at `to`.
-                        to += line[to..].chars().next().map_or(1, |c| c.len_utf8());
+                        to += line[to..].chars().next().map_or(1, char::len_utf8);
                         from..to
                     }
                     Some(Resolution::EndOfChar(to)) => from..to,
@@ -1079,42 +1079,42 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     settings.mode = if matches.get_flag(options::modes::HUMAN_NUMERIC)
         || matches
             .get_one::<String>(options::modes::SORT)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             == Some("human-numeric")
     {
         SortMode::HumanNumeric
     } else if matches.get_flag(options::modes::MONTH)
         || matches
             .get_one::<String>(options::modes::SORT)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             == Some("month")
     {
         SortMode::Month
     } else if matches.get_flag(options::modes::GENERAL_NUMERIC)
         || matches
             .get_one::<String>(options::modes::SORT)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             == Some("general-numeric")
     {
         SortMode::GeneralNumeric
     } else if matches.get_flag(options::modes::NUMERIC)
         || matches
             .get_one::<String>(options::modes::SORT)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             == Some("numeric")
     {
         SortMode::Numeric
     } else if matches.get_flag(options::modes::VERSION)
         || matches
             .get_one::<String>(options::modes::SORT)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             == Some("version")
     {
         SortMode::Version
     } else if matches.get_flag(options::modes::RANDOM)
         || matches
             .get_one::<String>(options::modes::SORT)
-            .map(|s| s.as_str())
+            .map(String::as_str)
             == Some("random")
     {
         settings.salt = Some(get_rand_string());
@@ -1171,7 +1171,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         || matches!(
             matches
                 .get_one::<String>(options::check::CHECK)
-                .map(|s| s.as_str()),
+                .map(String::as_str),
             Some(options::check::SILENT | options::check::QUIET)
         )
     {
@@ -1260,7 +1260,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let output = Output::new(
         matches
             .get_one::<String>(options::OUTPUT)
-            .map(|s| s.as_str()),
+            .map(String::as_str),
     )?;
 
     settings.init_precomputed();

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -542,7 +542,7 @@ impl Stater {
         } else {
             matches
                 .get_one::<String>(options::FORMAT)
-                .map(|s| s.as_str())
+                .map(String::as_str)
                 .unwrap_or("")
         };
 

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -148,7 +148,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mut command_values = matches.get_many::<String>(options::COMMAND).unwrap();
     let mut command = process::Command::new(command_values.next().unwrap());
-    let command_params: Vec<&str> = command_values.map(|s| s.as_ref()).collect();
+    let command_params: Vec<&str> = command_values.map(AsRef::as_ref).collect();
 
     let tmp_dir = tempdir().unwrap();
     let (preload_env, libstdbuf) = get_preload_env(&tmp_dir).map_err_context(String::new)?;

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -145,7 +145,7 @@ impl<'a> Options<'a> {
             },
             settings: matches
                 .get_many::<String>(options::SETTINGS)
-                .map(|v| v.map(|s| s.as_ref()).collect()),
+                .map(|v| v.map(AsRef::as_ref).collect()),
         })
     }
 }

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -41,7 +41,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let regex = matches.get_flag(options::REGEX);
     let raw_separator = matches
         .get_one::<String>(options::SEPARATOR)
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .unwrap_or("\n");
     let separator = if raw_separator.is_empty() {
         "\0"
@@ -50,7 +50,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let files: Vec<&str> = match matches.get_many::<String>(options::FILE) {
-        Some(v) => v.map(|s| s.as_str()).collect(),
+        Some(v) => v.map(String::as_str).collect(),
         None => vec!["-"],
     };
 

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -194,7 +194,7 @@ impl Settings {
             follow_retry,
             matches
                 .get_one::<String>(options::FOLLOW)
-                .map(|s| s.as_str()),
+                .map(String::as_str),
         ) {
             // -F and --follow if -F is specified after --follow. We don't need to care about the
             // value of --follow.
@@ -297,11 +297,11 @@ impl Settings {
     }
 
     pub fn has_only_stdin(&self) -> bool {
-        self.inputs.iter().all(|input| input.is_stdin())
+        self.inputs.iter().all(Input::is_stdin)
     }
 
     pub fn has_stdin(&self) -> bool {
-        self.inputs.iter().any(|input| input.is_stdin())
+        self.inputs.iter().any(Input::is_stdin)
     }
 
     pub fn num_inputs(&self) -> usize {
@@ -354,7 +354,7 @@ impl Settings {
     /// process.
     pub fn verify(&self) -> VerificationResult {
         // Mimic GNU's tail for `tail -F`
-        if self.inputs.iter().any(|i| i.is_stdin()) && self.follow == Some(FollowMode::Name) {
+        if self.inputs.iter().any(Input::is_stdin) && self.follow == Some(FollowMode::Name) {
             return VerificationResult::CannotFollowStdinByName;
         }
 

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -174,7 +174,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let st = stat(path, !matches.get_flag(options::NO_DEREF))?;
             let time = matches
                 .get_one::<String>(options::TIME)
-                .map(|s| s.as_str())
+                .map(String::as_str)
                 .unwrap_or("");
 
             if !(matches.get_flag(options::ACCESS)

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -78,7 +78,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let locked_stdout = stdout.lock();
     let mut buffered_stdout = BufWriter::new(locked_stdout);
 
-    let mut sets_iter = sets.iter().map(|c| c.as_str());
+    let mut sets_iter = sets.iter().map(String::as_str);
     let (set1, set2) = Sequence::solve_set_characters(
         sets_iter.next().unwrap_or_default(),
         sets_iter.next().unwrap_or_default(),

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -43,7 +43,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let mut line = String::new();
         match reader.read_line(&mut line) {
             Ok(_) => {
-                let tokens: Vec<String> = line.split_whitespace().map(|s| s.to_owned()).collect();
+                let tokens: Vec<String> = line.split_whitespace().map(ToOwned::to_owned).collect();
                 if tokens.is_empty() {
                     break;
                 }
@@ -169,6 +169,6 @@ impl Graph {
     }
 
     fn is_acyclic(&self) -> bool {
-        self.out_edges.values().all(|edge| edge.is_empty())
+        self.out_edges.values().all(Vec::is_empty)
     }
 }

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -98,7 +98,7 @@ impl Options {
     fn new(matches: &clap::ArgMatches) -> Result<Self, ParseError> {
         let tabstops = match matches.get_many::<String>(options::TABS) {
             None => vec![DEFAULT_TABSTOP],
-            Some(s) => tabstops_parse(&s.map(|s| s.as_str()).collect::<Vec<_>>().join(","))?,
+            Some(s) => tabstops_parse(&s.map(String::as_str).collect::<Vec<_>>().join(","))?,
         };
 
         let aflag = (matches.get_flag(options::ALL) || matches.contains_id(options::TABS))

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -160,7 +160,7 @@ impl Uniq {
 
             // fast path: avoid skipping
             if self.ignore_case && slice_start == 0 && slice_stop == len {
-                return closure(&mut fields_to_check.chars().flat_map(|c| c.to_uppercase()));
+                return closure(&mut fields_to_check.chars().flat_map(char::to_uppercase));
             }
 
             // fast path: we can avoid mapping chars to upper-case, if we don't want to ignore the case
@@ -173,7 +173,7 @@ impl Uniq {
                     .chars()
                     .skip(slice_start)
                     .take(slice_stop)
-                    .flat_map(|c| c.to_uppercase()),
+                    .flat_map(char::to_uppercase),
             )
         } else {
             closure(&mut fields_to_check.chars())

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -188,7 +188,7 @@ impl<'a> Inputs<'a> {
 
         // The 1-based index of each yielded item must be tracked for error reporting.
         let mut with_idx = base.enumerate().map(|(i, v)| (i + 1, v));
-        let files0_from_path = settings.files0_from.as_ref().map(|p| p.as_borrowed());
+        let files0_from_path = settings.files0_from.as_ref().map(Input::as_borrowed);
 
         let iter = iter::from_fn(move || {
             let (idx, next) = with_idx.next()?;

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -363,7 +363,7 @@ pub fn canonicalize<P: AsRef<Path>>(
     } else {
         original
     };
-    let mut parts: VecDeque<OwningComponent> = path.components().map(|part| part.into()).collect();
+    let mut parts: VecDeque<OwningComponent> = path.components().map(Into::into).collect();
     let mut result = PathBuf::new();
     let mut followed_symlinks = 0;
     let mut visited_files = HashSet::new();
@@ -605,7 +605,7 @@ pub fn make_path_relative_to<P1: AsRef<Path>, P2: AsRef<Path>>(path: P1, to: P2)
     let path_suffix = path
         .components()
         .skip(common_prefix_size)
-        .map(|x| x.as_os_str());
+        .map(Component::as_os_str);
     let mut components: Vec<_> = to
         .components()
         .skip(common_prefix_size)

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -37,7 +37,7 @@ use std::marker::PhantomData;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::ptr;
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 pub use self::ut::*;
 pub use libc::endutxent;
@@ -317,7 +317,7 @@ pub struct UtmpxIter {
 impl UtmpxIter {
     fn new() -> Self {
         // PoisonErrors can safely be ignored
-        let guard = LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let guard = LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         Self {
             guard,
             phantom: PhantomData,

--- a/src/uucore/src/lib/parser/parse_size.rs
+++ b/src/uucore/src/lib/parser/parse_size.rs
@@ -90,9 +90,9 @@ impl<'parser> Parser<'parser> {
             NumberSystem::Hexadecimal => size
                 .chars()
                 .take(2)
-                .chain(size.chars().skip(2).take_while(|c| c.is_ascii_hexdigit()))
+                .chain(size.chars().skip(2).take_while(char::is_ascii_hexdigit))
                 .collect(),
-            _ => size.chars().take_while(|c| c.is_ascii_digit()).collect(),
+            _ => size.chars().take_while(char::is_ascii_digit).collect(),
         };
         let mut unit: &str = &size[numeric_string.len()..];
 
@@ -243,7 +243,7 @@ impl<'parser> Parser<'parser> {
 
         let num_digits: usize = size
             .chars()
-            .take_while(|c| c.is_ascii_digit())
+            .take_while(char::is_ascii_digit)
             .collect::<String>()
             .len();
         let all_zeros = size.chars().all(|c| c == '0');

--- a/src/uucore/src/lib/parser/shortcut_value_parser.rs
+++ b/src/uucore/src/lib/parser/shortcut_value_parser.rs
@@ -93,7 +93,7 @@ where
     T: Into<PossibleValue>,
 {
     fn from(values: I) -> Self {
-        Self(values.into_iter().map(|t| t.into()).collect())
+        Self(values.into_iter().map(Into::into).collect())
     }
 }
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3507,7 +3507,7 @@ fn test_device_number() {
     let dev_dir = read_dir("/dev").unwrap();
     // let's use the first device for test
     let blk_dev = dev_dir
-        .map(|res_entry| res_entry.unwrap())
+        .map(Result::unwrap)
         .find(|entry| {
             entry.file_type().unwrap().is_block_device()
                 || entry.file_type().unwrap().is_char_device()


### PR DESCRIPTION
Enabled [clippy::redundant_closure_for_method_calls](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_closure_for_method_calls) and fixed all warnings