### PR TITLE
du: add -H (alias for --dereference-args)

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -821,6 +821,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::DEREFERENCE_ARGS)
                 .short('D')
+                .visible_short_alias('H')
                 .long(options::DEREFERENCE_ARGS)
                 .help("follow only symlinks that are listed on the command line")
                 .action(ArgAction::SetTrue)

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -299,11 +299,13 @@ fn test_du_dereference_args() {
     file2.write_all(b"amaz?ng").unwrap();
     at.symlink_dir("subdir", "sublink");
 
-    let result = ts.ucmd().arg("-D").arg("-s").arg("sublink").succeeds();
-    let stdout = result.stdout_str();
+    for arg in ["-D", "-H", "--dereference-args"] {
+        let result = ts.ucmd().arg(arg).arg("-s").arg("sublink").succeeds();
+        let stdout = result.stdout_str();
 
-    assert!(!stdout.starts_with('0'));
-    assert!(stdout.contains("sublink"));
+        assert!(!stdout.starts_with('0'));
+        assert!(stdout.contains("sublink"));
+    }
 
     // Without the option
     let result = ts.ucmd().arg("-s").arg("sublink").succeeds();


### PR DESCRIPTION
This PR adds `-H`, an alias for `-D`/`--dereference-args`.