### PR TITLE
Bump freebsd-vm action to v1.0.2 & use ubuntu

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: macos-12 , features: unix } ## GHA MacOS-11.0 VM won't have VirtualBox; refs: <https://github.com/actions/virtual-environments/issues/4060> , <https://github.com/actions/virtual-environments/pull/4010>
+          - { os: ubuntu-22.04 , features: feat_os_unix }
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
@@ -35,9 +35,11 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
     - name: Prepare, build and test
-      uses: vmactions/freebsd-vm@v0.3.1
+      uses: vmactions/freebsd-vm@v1.0.2
       with:
         usesh: true
+        sync: rsync
+        copyback: false
         # We need jq to run show-utils.sh and bash to use inline shell string replacement
         prepare: pkg install -y curl sudo jq bash
         run: |
@@ -114,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: macos-12 , features: unix } ## GHA MacOS-11.0 VM won't have VirtualBox; refs: <https://github.com/actions/virtual-environments/issues/4060> , <https://github.com/actions/virtual-environments/pull/4010>
+          - { os: ubuntu-22.04 , features: feat_os_unix }
     env:
       mem: 4096
       SCCACHE_GHA_ENABLED: "true"
@@ -125,10 +127,11 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
     - name: Prepare, build and test
-      uses: vmactions/freebsd-vm@v0.3.1
+      uses: vmactions/freebsd-vm@v1.0.2
       with:
         usesh: true
-        # sync: sshfs
+        sync: rsync
+        copyback: false
         prepare: pkg install -y curl gmake sudo
         run: |
           ## Prepare, build, and test


### PR DESCRIPTION
This PR bumps `vmactions/freebsd-vm` action from `0.3.1` to <del>`1.0.0`</del>`1.0.2` and uses ubuntu instead of macOS.