### PR TITLE
`expr`: remove onig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,28 +1414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "onig"
-version = "6.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "ordered-multimap"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,12 +1520,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "platform-info"
@@ -2459,7 +2431,7 @@ dependencies = [
  "clap",
  "num-bigint",
  "num-traits",
- "onig",
+ "regex",
  "uucore",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,6 @@ num-bigint = "0.4.4"
 num-traits = "0.2.17"
 number_prefix = "0.4"
 once_cell = "1.18.0"
-onig = { version = "~6.4", default-features = false }
 parse_datetime = "0.5.0"
 phf = "0.11.2"
 phf_codegen = "0.11.2"

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/expr.rs"
 clap = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
-onig = { workspace = true }
+regex = { workspace = true }
 uucore = { workspace = true }
 
 [[bin]]

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -12,7 +12,7 @@
 
 use num_bigint::BigInt;
 use num_traits::Zero;
-use onig::{Regex, RegexOptions, Syntax};
+use regex::Regex;
 
 use crate::tokens::Token;
 
@@ -482,16 +482,15 @@ fn infix_operator_and(values: &[String]) -> String {
 
 fn operator_match(values: &[String]) -> Result<String, String> {
     assert!(values.len() == 2);
-    let re = Regex::with_options(&values[1], RegexOptions::REGEX_OPTION_NONE, Syntax::grep())
-        .map_err(|err| err.description().to_string())?;
-    Ok(if re.captures_len() > 0 {
+    let re = Regex::new(&values[1]).map_err(|err| err.to_string())?;
+    Ok(if re.captures_len() > 1 {
         re.captures(&values[0])
-            .map(|captures| captures.at(1).unwrap())
+            .map(|captures| captures.get(1).unwrap().as_str())
             .unwrap_or("")
             .to_string()
     } else {
         re.find(&values[0])
-            .map_or("0".to_string(), |(start, end)| (end - start).to_string())
+            .map_or("0".to_string(), |m| m.len().to_string())
     })
 }
 

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -245,22 +245,48 @@ fn test_length_mb() {
 }
 
 #[test]
-fn test_regex() {
-    // FixME: [2022-12-19; rivy] test disabled as it currently fails due to 'oniguruma' bug (see GH:kkos/oniguruma/issues/279)
-    // new_ucmd!()
-    //     .args(&["a^b", ":", "a^b"])
-    //     .succeeds()
-    //     .stdout_only("3\n");
+#[ignore = "requires custom regex syntax"]
+fn test_regex_hat() {
+    new_ucmd!()
+        .args(&["a^b", ":", "a^b"])
+        .succeeds()
+        .stdout_only("3\n");
+}
+
+#[test]
+#[ignore = "requires custom regex syntax"]
+fn test_regex_hat2() {
     new_ucmd!()
         .args(&["a^b", ":", "a\\^b"])
         .succeeds()
         .stdout_only("3\n");
+}
+
+#[test]
+#[ignore = "requires custom regex syntax"]
+fn test_regex_dollar() {
     new_ucmd!()
         .args(&["a$b", ":", "a\\$b"])
         .succeeds()
         .stdout_only("3\n");
+}
+
+#[test]
+#[ignore = "requires custom regex syntax"]
+fn test_regex_number() {
     new_ucmd!()
         .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
+        .succeeds()
+        .stdout_only("2\n");
+}
+
+#[test]
+fn test_regex_temporary() {
+    // This test should fail, but currently passes, because our regex syntax is
+    // different from GNU. This is only here to check that regex is working
+    // even if it's the wrong syntax.
+    new_ucmd!()
+        .args(&["-5", ":", "-{0,1}[0-9]*$"])
         .succeeds()
         .stdout_only("2\n");
 }


### PR DESCRIPTION
Step towards: https://github.com/uutils/coreutils/issues/1145

Also relevant: https://github.com/uutils/coreutils/issues/5210

This is an intentional regression. I think we should remove `onig` in any case and we should either find or implement a pure Rust regex syntax.