### PR TITLE
Add darwin arm64 builds

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -461,14 +461,15 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          # { os , target , cargo-options , features , use-cross , toolchain }
+          # - { os , target , cargo-options , features , use-cross , toolchain, skip-tests }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf, features: feat_os_unix_gnueabihf, use-cross: use-cross, }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf , use-cross: use-cross }
           # - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
-          - { os: ubuntu-latest   , target: i686-unknown-linux-gnu      , features: feat_os_unix           , use-cross: use-cross }
-          - { os: ubuntu-latest   , target: i686-unknown-linux-musl     , features: feat_os_unix_musl      , use-cross: use-cross }
-          - { os: ubuntu-latest   , target: x86_64-unknown-linux-gnu    , features: feat_os_unix           , use-cross: use-cross }
-          - { os: ubuntu-latest   , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl      , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: feat_os_unix           , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl      , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_os_unix           , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl      , use-cross: use-cross }
+          - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos          , use-cross: use-cross, skip-tests: true} # Hopefully github provides free M1 runners soon...
           - { os: macos-latest   , target: x86_64-apple-darwin         , features: feat_os_macos }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows } ## note: requires rust >= 1.43.0 to link correctly
@@ -575,7 +576,7 @@ jobs:
     - uses: taiki-e/install-action@v2
       if: steps.vars.outputs.CARGO_CMD == 'cross'
       with:
-        tool: cross@0.2.1
+        tool: cross@0.2.5
     - name: Create all needed build/work directories
       shell: bash
       run: |
@@ -650,6 +651,7 @@ jobs:
         ${{ steps.vars.outputs.CARGO_CMD }} +${{ env.RUST_MIN_SRV }} build --release \
         --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
     - name: Test
+      if: matrix.job.skip-tests != true
       shell: bash
       run: |
         ## Test
@@ -658,6 +660,7 @@ jobs:
       env:
         RUST_BACKTRACE: "1"
     - name: Test individual utilities
+      if: matrix.job.skip-tests != true
       shell: bash
       run: |
         ## Test individual utilities


### PR DESCRIPTION
Github claims they have arm64 runners but doesn't seem like they enabled them for free plans. So for now, we cross-compile from intel and skip tests. I verified that some basic smoketests passed on my M1.