### PR TITLE
du: show hard links with --inodes --all --count-links

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -339,7 +339,9 @@ fn du(
                             }
 
                             if let Some(inode) = this_stat.inode {
-                                if seen_inodes.contains(&inode) {
+                                if seen_inodes.contains(&inode)
+                                    && !(options.all && options.count_links)
+                                {
                                     if options.count_links {
                                         my_stat.inodes += 1;
                                     }
@@ -347,6 +349,7 @@ fn du(
                                 }
                                 seen_inodes.insert(inode);
                             }
+
                             if this_stat.is_dir {
                                 if options.one_file_system {
                                     if let (Some(this_inode), Some(my_inode)) =

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -470,6 +470,35 @@ fn test_du_inodes_with_count_links() {
 }
 
 #[test]
+fn test_du_inodes_with_all_and_count_links() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    let sep = std::path::MAIN_SEPARATOR_STR;
+
+    at.mkdir("dir");
+    at.touch("dir/file");
+    at.hard_link("dir/file", "dir/hard_link");
+
+    // ensure the hard link is not shown without --count-links
+    ts.ucmd()
+        .arg("--inodes")
+        .arg("--all")
+        .arg("dir")
+        .succeeds()
+        .stdout_is(format!("1\tdir{sep}file\n2\tdir\n"));
+
+    ts.ucmd()
+        .arg("--inodes")
+        .arg("--count-links")
+        .arg("--all")
+        .arg("dir")
+        .succeeds()
+        .stdout_contains_line(format!("1\tdir{sep}file"))
+        .stdout_contains_line(format!("1\tdir{sep}hard_link"))
+        .stdout_contains_line("3\tdir");
+}
+
+#[test]
 fn test_du_h_flag_empty_file() {
     new_ucmd!()
         .arg("-h")


### PR DESCRIPTION
GNU `du` lists hard links when running `du --inodes --all --count-links` whereas uutils `du` doesn't. This PR fixes it.