### PR TITLE
df: fix rounding issue in test

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -422,7 +422,11 @@ fn test_total_label_in_correct_column() {
 #[test]
 fn test_use_percentage() {
     let output = new_ucmd!()
-        .args(&["--total", "--output=used,avail,pcent"])
+        // set block size = 1, otherwise the returned values for
+        // "used" and "avail" will be rounded. And using them to calculate
+        // the "percentage" values might lead to a mismatch with the returned
+        // "percentage" values.
+        .args(&["--total", "--output=used,avail,pcent", "--block-size=1"])
         .succeeds()
         .stdout_move_str();
 


### PR DESCRIPTION
This PR fixes a rounding issue in `test_use_percentage`. Because the test used the default block size of `1024`, the returned values for the columns `Used` and `Avail` were rounded. However, the test used them to calculate the percentage values to compare them with the values returned in the `Use%` column. In some cases, the rounding led to a mismatch between those values and that caused the test to fail. By setting the block size to `1`, the returned values for `Used` and `Avail` are no longer rounded.

Fixes https://github.com/uutils/coreutils/issues/5531