### PR TITLE
doc: Fix the markdown highlighting syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ check out these documents:
 
 Now follows a very important warning:
 
-> [!WARNING] uutils is original code and cannot contain any code from GNU or
+> [!WARNING]
+> uutils is original code and cannot contain any code from GNU or
 > other implementations. This means that **we cannot accept any changes based on
 > the GNU source code**. To make sure that cannot happen, **you cannot link to
 > the GNU source code** either.


### PR DESCRIPTION
There should be a new line after `[!WARNING]`, according to [community · Discussion #16925](https://github.com/orgs/community/discussions/16925).

Before:

![](https://github.com/uutils/coreutils/assets/73375426/4fdc8bb6-e0a7-429f-af20-fdd27a1a7c99)
