### PR TITLE
join: remove crash! macro

### DIFF
--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -335,7 +335,7 @@ impl<'a> State<'a> {
         line_ending: LineEnding,
         print_unpaired: bool,
     ) -> Result<State<'a>, JoinError> {
-        let f = if name == "-" {
+        let file_buf = if name == "-" {
             Box::new(stdin.lock()) as Box<dyn BufRead>
         } else {
             match File::open(name) {
@@ -355,7 +355,7 @@ impl<'a> State<'a> {
             file_name: name,
             file_num,
             print_unpaired,
-            lines: f.split(line_ending as u8),
+            lines: file_buf.split(line_ending as u8),
             max_len: 1,
             seq: Vec::new(),
             line_num: 0,

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -701,10 +701,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Err(USimpleError::new(1, "both files cannot be standard input"));
     }
 
-    match exec(file1, file2, settings) {
-        Ok(_) => Ok(()),
-        Err(e) => Err(USimpleError::new(1, format!("{e}"))),
-    }
+    exec(file1, file2, settings)
 }
 
 pub fn uu_app() -> Command {


### PR DESCRIPTION
This is related to issue https://github.com/uutils/coreutils/issues/5487. Removes the `crash!` macro from join.