### PR TITLE
cp: adapt error message if destination directory doesn't exist

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -105,6 +105,22 @@ fn test_cp_existing_target() {
 }
 
 #[test]
+fn test_cp_non_existing_target_dir() {
+    #[cfg(not(windows))]
+    let non_existing_dir = "non-existing-dir/";
+    #[cfg(windows)]
+    let non_existing_dir = "non-existing-dir\\";
+
+    new_ucmd!()
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(non_existing_dir)
+        .fails()
+        .stderr_is(format!(
+            "cp: cannot create regular file '{non_existing_dir}': Not a directory\n"
+        ));
+}
+
+#[test]
 fn test_cp_duplicate_files() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.arg(TEST_HELLO_WORLD_SOURCE)


### PR DESCRIPTION
When trying to copy a file to a non-existing directory, uutils `cp` currently shows the following error:
```
$ cargo run cp a.txt no-such/
cp: 'a.txt' -> 'no-such/': Is a directory (os error 21)
```
GNU `cp`, on the other hand, shows the following error:
```
$ cp a.txt no-such/
cp: cannot create regular file 'no-such/': Not a directory
```
This PR adapts the error message to match the one from GNU `cp`.