### PR TITLE
printf: Fixing incorrect exit code when passing invalid value to %x

### DIFF
--- a/src/uucore/src/lib/features/tokenize/num_format/formatters/intf.rs
+++ b/src/uucore/src/lib/features/tokenize/num_format/formatters/intf.rs
@@ -8,10 +8,11 @@
 //! formatter for unsigned and signed int subs
 //! unsigned int: %X %x (hex u64) %o (octal u64) %u (base ten u64)
 //! signed int: %i %d (both base ten i64)
+use crate::error::set_exit_code;
+use crate::features::tokenize::num_format::num_format::warn_expected_numeric;
+
 use super::super::format_field::FormatField;
-use super::super::formatter::{
-    get_it_at, warn_incomplete_conv, Base, FormatPrimitive, Formatter, InitialPrefix,
-};
+use super::super::formatter::{get_it_at, Base, FormatPrimitive, Formatter, InitialPrefix};
 use std::i64;
 use std::u64;
 
@@ -112,7 +113,8 @@ impl Intf {
                         }
                     }
                     _ => {
-                        warn_incomplete_conv(str_in);
+                        warn_expected_numeric(str_in);
+                        set_exit_code(1);
                         break;
                     }
                 }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -259,6 +259,14 @@ fn sub_num_hex_upper() {
 }
 
 #[test]
+fn sub_num_hex_non_numerical() {
+    new_ucmd!()
+        .args(&["parameters need to be numbers %X", "%194"])
+        .fails()
+        .code_is(1);
+}
+
+#[test]
 fn sub_num_float() {
     new_ucmd!()
         .args(&["twenty is %f", "20"])


### PR DESCRIPTION
Fixes #5536 by changing the warning called from the `intf` module and adding an appropriate exit code.

Created a test to confirm the behavior.

Before:

```
./target/debug/coreutils printf %x %194 > /dev/null
echo $? 
```
returns:
 ```
printf: '%194': value not completely converted
0
```

After:
```
printf: %194: expected a numeric value
1
```

