### PR TITLE
doc: Fix a broken link

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -6,7 +6,7 @@ This is a list of uutils packages in various distributions and package managers.
 Note that these are packaged by third-parties and the packages might contain
 patches.
 
-You can also [build uutils from source](/build.md).
+You can also [build uutils from source](build.md).
 
 <!-- toc -->
 


### PR DESCRIPTION
`/build.md` is absolute, so the link in https://uutils.github.io/coreutils/book/installation.html turns out to be https://uutils.github.io/build.html instead of https://uutils.github.io/coreutils/book/build.html.

Reference: [Links · Markdown - mdBook Documentation](https://rust-lang.github.io/mdBook/format/markdown.html#links)