### PR TITLE
stdbuf: remove crash macro

### DIFF
--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::process;
 use tempfile::tempdir;
 use tempfile::TempDir;
-use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
+use uucore::error::{set_exit_code, FromIo, UResult, USimpleError, UUsageError};
 use uucore::parse_size::parse_size_u64;
 use uucore::{format_usage, help_about, help_section, help_usage};
 
@@ -103,7 +103,10 @@ fn check_option(matches: &ArgMatches, name: &str) -> Result<BufferType, ProgramO
                 }
             }
             x => parse_size_u64(x).map_or_else(
-                |e| Err(ProgramOptionsError(format!("invalid mode {e}"))),
+                |e| {
+                    set_exit_code(125);
+                    Err(ProgramOptionsError(format!("invalid mode {e}")))
+                },
                 |m| {
                     Ok(BufferType::Size(m.try_into().map_err(|_| {
                         ProgramOptionsError(format!(

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::process;
 use tempfile::tempdir;
 use tempfile::TempDir;
-use uucore::error::{set_exit_code, FromIo, UResult, USimpleError, UUsageError};
+use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::parse_size::parse_size_u64;
 use uucore::{format_usage, help_about, help_section, help_usage};
 
@@ -103,10 +103,7 @@ fn check_option(matches: &ArgMatches, name: &str) -> Result<BufferType, ProgramO
                 }
             }
             x => parse_size_u64(x).map_or_else(
-                |e| {
-                    set_exit_code(125);
-                    Err(ProgramOptionsError(format!("invalid mode {e}")))
-                },
+                |e| Err(ProgramOptionsError(format!("invalid mode {e}"))),
                 |m| {
                     Ok(BufferType::Size(m.try_into().map_err(|_| {
                         ProgramOptionsError(format!(

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -7,7 +7,7 @@
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::Write;
 use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
 use std::process;
@@ -15,7 +15,7 @@ use tempfile::tempdir;
 use tempfile::TempDir;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::parse_size::parse_size_u64;
-use uucore::{crash, format_usage, help_about, help_section, help_usage};
+use uucore::{format_usage, help_about, help_section, help_usage};
 
 const ABOUT: &str = help_about!("stdbuf.md");
 const USAGE: &str = help_usage!("stdbuf.md");
@@ -66,13 +66,13 @@ struct ProgramOptionsError(String);
     target_os = "netbsd",
     target_os = "dragonflybsd"
 ))]
-fn preload_strings() -> (&'static str, &'static str) {
-    ("LD_PRELOAD", "so")
+fn preload_strings() -> UResult<(&'static str, &'static str)> {
+    Ok(("LD_PRELOAD", "so"))
 }
 
-#[cfg(target_vendor = "apple")]
-fn preload_strings() -> (&'static str, &'static str) {
-    ("DYLD_LIBRARY_PATH", "dylib")
+#[cfg(target_vendor = "linux")]
+fn preload_strings() -> UResult<(&'static str, &'static str)> {
+    Ok(("DYLD_LIBRARY_PATH", "dylib"))
 }
 
 #[cfg(not(any(
@@ -83,10 +83,11 @@ fn preload_strings() -> (&'static str, &'static str) {
     target_os = "dragonflybsd",
     target_vendor = "apple"
 )))]
-fn preload_strings() -> (&'static str, &'static str) {
-    use uucore::crash;
-
-    crash!(1, "Command not supported for this operating system!")
+fn preload_strings() -> UResult<(&'static str, &'static str)> {
+    Err(USimpleError::new(
+        1,
+        "Command not supported for this operating system!",
+    ))
 }
 
 fn check_option(matches: &ArgMatches, name: &str) -> Result<BufferType, ProgramOptionsError> {
@@ -102,7 +103,7 @@ fn check_option(matches: &ArgMatches, name: &str) -> Result<BufferType, ProgramO
                 }
             }
             x => parse_size_u64(x).map_or_else(
-                |e| crash!(125, "invalid mode {}", e),
+                |e| Err(ProgramOptionsError(format!("invalid mode {e}"))),
                 |m| {
                     Ok(BufferType::Size(m.try_into().map_err(|_| {
                         ProgramOptionsError(format!(
@@ -128,8 +129,8 @@ fn set_command_env(command: &mut process::Command, buffer_name: &str, buffer_typ
     }
 }
 
-fn get_preload_env(tmp_dir: &TempDir) -> io::Result<(String, PathBuf)> {
-    let (preload, extension) = preload_strings();
+fn get_preload_env(tmp_dir: &TempDir) -> UResult<(String, PathBuf)> {
+    let (preload, extension) = preload_strings()?;
     let inject_path = tmp_dir.path().join("libstdbuf").with_extension(extension);
 
     let mut file = File::create(&inject_path)?;
@@ -151,7 +152,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let command_params: Vec<&str> = command_values.map(|s| s.as_ref()).collect();
 
     let tmp_dir = tempdir().unwrap();
-    let (preload_env, libstdbuf) = get_preload_env(&tmp_dir).map_err_context(String::new)?;
+    let (preload_env, libstdbuf) = get_preload_env(&tmp_dir)?;
     command.env(preload_env, libstdbuf);
     set_command_env(&mut command, "_STDBUF_I", &options.stdin);
     set_command_env(&mut command, "_STDBUF_O", &options.stdout);

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -70,7 +70,7 @@ fn preload_strings() -> UResult<(&'static str, &'static str)> {
     Ok(("LD_PRELOAD", "so"))
 }
 
-#[cfg(target_vendor = "linux")]
+#[cfg(target_vendor = "apple")]
 fn preload_strings() -> UResult<(&'static str, &'static str)> {
     Ok(("DYLD_LIBRARY_PATH", "dylib"))
 }

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -65,7 +65,7 @@ fn test_stdbuf_invalid_mode_fails() {
             .args(&[*option, "1024R", "head"])
             .fails()
             .code_is(125)
-            .stderr_only("stdbuf: invalid mode '1024R': Value too large for defined data type\n");
+            .usage_error("invalid mode '1024R': Value too large for defined data type");
         #[cfg(not(target_pointer_width = "128"))]
         new_ucmd!()
             .args(&[*option, "1Y", "head"])


### PR DESCRIPTION
This is related to issue: https://github.com/uutils/coreutils/issues/5487
Removes the `crash!` macro from `stdbuf`.