### PR TITLE
du: start printing output immediately

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -291,8 +291,6 @@ fn choose_size(matches: &ArgMatches, stat: &Stat) -> u64 {
 }
 
 // this takes `my_stat` to avoid having to stat files multiple times.
-// XXX: this should use the impl Trait return type when it is stabilized
-#[allow(clippy::cognitive_complexity)]
 fn du(
     mut my_stat: Stat,
     options: &Options,
@@ -667,7 +665,6 @@ impl StatPrinter {
 }
 
 #[uucore::main]
-#[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 
@@ -716,10 +713,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         show_warning!("options --apparent-size and -b are ineffective with --inodes");
     }
 
-    let (print_tx, rx) = mpsc::channel::<UResult<StatPrintInfo>>();
-
+    // Use separate thread to print output, so we can print finished results while computation is still running
     let stat_printer = StatPrinter::new(matches.clone(), options.clone(), summarize)?;
-
+    let (print_tx, rx) = mpsc::channel::<UResult<StatPrintInfo>>();
     let printing_thread = thread::spawn(move || stat_printer.print_stats(&rx));
 
     let excludes = build_exclude_patterns(&matches)?;

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -732,8 +732,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let iter = du(stat, &options, 0, &mut inodes, &excludes, &stat_printer)?;
 
             // Sum up all the returned `Stat`s and display results
-            let size = choose_size(&matches, &iter.last().unwrap());
-            grand_total += size;
+            if let Some(last_stat) = iter.last() {
+                grand_total += choose_size(&matches, &last_stat);
+            }
         } else {
             show_error!(
                 "{}: {}",

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -291,6 +291,7 @@ fn choose_size(matches: &ArgMatches, stat: &Stat) -> u64 {
 }
 
 // this takes `my_stat` to avoid having to stat files multiple times.
+#[allow(clippy::cognitive_complexity)]
 fn du(
     mut my_stat: Stat,
     options: &Options,
@@ -665,6 +666,7 @@ impl StatPrinter {
 }
 
 #[uucore::main]
+#[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args = args.collect_ignore();
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -288,6 +288,75 @@ fn choose_size(matches: &ArgMatches, stat: &Stat) -> u64 {
     }
 }
 
+struct StatPrinter<'a> {
+    matches: &'a ArgMatches,
+    threshold: &'a Option<Threshold>,
+    summarize: bool,
+    time_format_str: &'a str,
+    line_ending: LineEnding,
+    options: &'a Options,
+    convert_size: &'a dyn Fn(u64) -> String,
+}
+
+impl StatPrinter<'_> {
+    fn new<'a>(
+        matches: &'a ArgMatches,
+        threshold: &'a Option<Threshold>,
+        summarize: bool,
+        time_format_str: &'a str,
+        line_ending: LineEnding,
+        options: &'a Options,
+        convert_size: &'a dyn Fn(u64) -> String,
+    ) -> StatPrinter<'a> {
+        StatPrinter {
+            matches,
+            threshold,
+            summarize,
+            time_format_str,
+            line_ending,
+            options,
+            convert_size,
+        }
+    }
+
+    fn print(&self, stat: &Stat, depth: usize) -> UResult<()> {
+        let size = choose_size(self.matches, &stat);
+
+        if !self
+            .threshold
+            .map_or(false, |threshold| threshold.should_exclude(size))
+            && self
+                .options
+                .max_depth
+                .map_or(true, |max_depth| depth <= max_depth)
+        {
+            if self.matches.contains_id(options::TIME) {
+                let tm = {
+                    let secs = self
+                        .matches
+                        .get_one::<String>(options::TIME)
+                        .map(|s| get_time_secs(s, &stat))
+                        .transpose()?
+                        .unwrap_or(stat.modified);
+                    DateTime::<Local>::from(UNIX_EPOCH + Duration::from_secs(secs))
+                };
+                if !self.summarize || depth == 0 {
+                    let time_str = tm.format(self.time_format_str).to_string();
+                    print!("{}\t{}\t", (self.convert_size)(size), time_str);
+                    print_verbatim(&stat.path).unwrap();
+                    print!("{}", self.line_ending);
+                }
+            } else if !self.summarize || depth == 0 {
+                print!("{}\t", (self.convert_size)(size));
+                print_verbatim(&stat.path).unwrap();
+                print!("{}", self.line_ending);
+            }
+        }
+
+        Ok(())
+    }
+}
+
 // this takes `my_stat` to avoid having to stat files multiple times.
 // XXX: this should use the impl Trait return type when it is stabilized
 #[allow(clippy::cognitive_complexity)]
@@ -297,13 +366,7 @@ fn du(
     depth: usize,
     inodes: &mut HashSet<FileInfo>,
     exclude: &[Pattern],
-    matches: &ArgMatches,
-    threshold: &Option<Threshold>,
-    summarize: bool,
-    time_format_str: &str,
-    block_size: u64,
-    multiplier: u64,
-    line_ending: LineEnding,
+    stat_printer: &StatPrinter,
 ) -> UResult<Box<dyn DoubleEndedIterator<Item = Stat>>> {
     let mut stats = vec![];
     let mut futures = vec![];
@@ -315,44 +378,7 @@ fn du(
                 show!(
                     e.map_err_context(|| format!("cannot read directory {}", my_stat.path.quote()))
                 );
-                let convert_size_fn = get_convert_size_fn(&matches);
-
-                let convert_size = |size: u64| {
-                    if options.inodes {
-                        size.to_string()
-                    } else {
-                        convert_size_fn(size, multiplier, block_size)
-                    }
-                };
-
-                let size = choose_size(&matches, &my_stat);
-
-                if !threshold.map_or(false, |threshold| threshold.should_exclude(size))
-                    && options
-                        .max_depth
-                        .map_or(true, |max_depth| depth < max_depth + 1)
-                {
-                    if matches.contains_id(options::TIME) {
-                        let tm = {
-                            let secs = matches
-                                .get_one::<String>(options::TIME)
-                                .map(|s| get_time_secs(s, &my_stat))
-                                .transpose()?
-                                .unwrap_or(my_stat.modified);
-                            DateTime::<Local>::from(UNIX_EPOCH + Duration::from_secs(secs))
-                        };
-                        if !summarize || depth == 0 {
-                            let time_str = tm.format(time_format_str).to_string();
-                            print!("{}\t{}\t", convert_size(size), time_str);
-                            print_verbatim(&my_stat.path).unwrap();
-                            print!("{line_ending}");
-                        }
-                    } else if !summarize || depth == 0 {
-                        print!("{}\t", convert_size(size));
-                        print_verbatim(&my_stat.path).unwrap();
-                        print!("{line_ending}");
-                    }
-                }
+                stat_printer.print(&my_stat, depth)?;
                 return Ok(Box::new(iter::once(my_stat)));
             }
         };
@@ -401,62 +427,14 @@ fn du(
                                     depth + 1,
                                     inodes,
                                     exclude,
-                                    matches,
-                                    threshold,
-                                    summarize,
-                                    time_format_str,
-                                    block_size,
-                                    multiplier,
-                                    line_ending,
+                                    stat_printer,
                                 )?);
                             } else {
                                 my_stat.size += this_stat.size;
                                 my_stat.blocks += this_stat.blocks;
                                 my_stat.inodes += 1;
                                 if options.all {
-                                    let convert_size_fn = get_convert_size_fn(&matches);
-
-                                    let convert_size = |size: u64| {
-                                        if options.inodes {
-                                            size.to_string()
-                                        } else {
-                                            convert_size_fn(size, multiplier, block_size)
-                                        }
-                                    };
-
-                                    let size = choose_size(&matches, &this_stat);
-
-                                    if !threshold
-                                        .map_or(false, |threshold| threshold.should_exclude(size))
-                                        && options
-                                            .max_depth
-                                            .map_or(true, |max_depth| depth < max_depth + 1)
-                                    {
-                                        if matches.contains_id(options::TIME) {
-                                            let tm = {
-                                                let secs = matches
-                                                    .get_one::<String>(options::TIME)
-                                                    .map(|s| get_time_secs(s, &this_stat))
-                                                    .transpose()?
-                                                    .unwrap_or(this_stat.modified);
-                                                DateTime::<Local>::from(
-                                                    UNIX_EPOCH + Duration::from_secs(secs),
-                                                )
-                                            };
-                                            if !summarize || depth == 0 {
-                                                let time_str =
-                                                    tm.format(time_format_str).to_string();
-                                                print!("{}\t{}\t", convert_size(size), time_str);
-                                                print_verbatim(&this_stat.path).unwrap();
-                                                print!("{line_ending}");
-                                            }
-                                        } else if !summarize || depth == 0 {
-                                            print!("{}\t", convert_size(size));
-                                            print_verbatim(&this_stat.path).unwrap();
-                                            print!("{line_ending}");
-                                        }
-                                    }
-
+                                    stat_printer.print(&this_stat, depth)?;
                                     stats.push(this_stat);
                                 }
                             }
@@ -482,44 +460,7 @@ fn du(
             .map_or(true, |max_depth| depth < max_depth)
     }));
 
-    let convert_size_fn = get_convert_size_fn(&matches);
-
-    let convert_size = |size: u64| {
-        if options.inodes {
-            size.to_string()
-        } else {
-            convert_size_fn(size, multiplier, block_size)
-        }
-    };
-
-    let size = choose_size(&matches, &my_stat);
-
-    if !threshold.map_or(false, |threshold| threshold.should_exclude(size))
-        && options
-            .max_depth
-            .map_or(true, |max_depth| depth < max_depth + 1)
-    {
-        if matches.contains_id(options::TIME) {
-            let tm = {
-                let secs = matches
-                    .get_one::<String>(options::TIME)
-                    .map(|s| get_time_secs(s, &my_stat))
-                    .transpose()?
-                    .unwrap_or(my_stat.modified);
-                DateTime::<Local>::from(UNIX_EPOCH + Duration::from_secs(secs))
-            };
-            if !summarize || depth == 0 {
-                let time_str = tm.format(time_format_str).to_string();
-                print!("{}\t{}\t", convert_size(size), time_str);
-                print_verbatim(&my_stat.path).unwrap();
-                print!("{line_ending}");
-            }
-        } else if !summarize || depth == 0 {
-            print!("{}\t", convert_size(size));
-            print_verbatim(&my_stat.path).unwrap();
-            print!("{line_ending}");
-        }
-    }
+    stat_printer.print(&my_stat, depth)?;
 
     stats.push(my_stat);
 
@@ -753,6 +694,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let line_ending = LineEnding::from_zero_flag(matches.get_flag(options::NULL));
 
+    let stat_printer = StatPrinter::new(
+        &matches,
+        &threshold,
+        summarize,
+        time_format_str,
+        line_ending,
+        &options,
+        &convert_size,
+    );
+
     let excludes = build_exclude_patterns(&matches)?;
 
     let mut grand_total = 0;
@@ -778,20 +729,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             if let Some(inode) = stat.inode {
                 inodes.insert(inode);
             }
-            let iter = du(
-                stat,
-                &options,
-                0,
-                &mut inodes,
-                &excludes,
-                &matches,
-                &threshold,
-                summarize,
-                time_format_str,
-                block_size,
-                multiplier,
-                line_ending,
-            )?;
+            let iter = du(stat, &options, 0, &mut inodes, &excludes, &stat_printer)?;
 
             // Sum up all the returned `Stat`s and display results
             let size = choose_size(&matches, &iter.last().unwrap());


### PR DESCRIPTION
This PR updates `du` so that it continuously prints output as it is running, as opposed to waiting until all of the data has been collected before printing anything. A separate thread has been added which handles printing data (and errors) as they are produced by the main thread.

Fixes #5516 