### PR TITLE
mv: fix issue with -T and destination ending with "/"

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -341,7 +341,7 @@ fn handle_two_paths(source: &Path, target: &Path, opts: &Options) -> UResult<()>
 
     let target_is_dir = target.is_dir();
 
-    if path_ends_with_terminator(target) && !target_is_dir {
+    if path_ends_with_terminator(target) && !target_is_dir && !opts.no_target_dir {
         return Err(MvError::FailedToAccessNotADirectory(target.quote().to_string()).into());
     }
 

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1159,6 +1159,32 @@ fn test_mv_overwrite_dir() {
 }
 
 #[test]
+fn test_mv_no_target_dir_with_dest_not_existing() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir_a = "a";
+    let dir_b = "b";
+
+    at.mkdir(dir_a);
+    ucmd.arg("-T").arg(dir_a).arg(dir_b).succeeds().no_output();
+
+    assert!(!at.dir_exists(dir_a));
+    assert!(at.dir_exists(dir_b));
+}
+
+#[test]
+fn test_mv_no_target_dir_with_dest_not_existing_and_ending_with_slash() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir_a = "a";
+    let dir_b = "b/";
+
+    at.mkdir(dir_a);
+    ucmd.arg("-T").arg(dir_a).arg(dir_b).succeeds().no_output();
+
+    assert!(!at.dir_exists(dir_a));
+    assert!(at.dir_exists(dir_b));
+}
+
+#[test]
 fn test_mv_overwrite_nonempty_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     let dir_a = "test_mv_overwrite_nonempty_dir_a";


### PR DESCRIPTION
When using `mv -T source_dir dest_dir/` (note the trailing slash, it works fine without it), and `dest_dir` doesn't exist, uutils `mv` shows an error message whereas GNU `mv` renames `source_dir` to `dest_dir`. This PR fixes this issue.

