### PR TITLE
cp: improve error msg if -r is not specified

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -324,7 +324,7 @@ pub(crate) fn copy_directory(
     source_in_command_line: bool,
 ) -> CopyResult<()> {
     if !options.recursive {
-        return Err(format!("omitting directory {}", root.quote()).into());
+        return Err(format!("-r not specified; omitting directory {}", root.quote()).into());
     }
 
     // if no-dereference is enabled and this is a symlink, copy it as a file

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -131,7 +131,9 @@ fn test_cp_directory_not_recursive() {
         .arg(TEST_COPY_TO_FOLDER)
         .arg(TEST_HELLO_WORLD_DEST)
         .fails()
-        .stderr_contains("omitting directory");
+        .stderr_is(format!(
+            "cp: -r not specified; omitting directory '{TEST_COPY_TO_FOLDER}'\n"
+        ));
 }
 
 #[test]


### PR DESCRIPTION
This PR improves the error message when trying to call `cp source_dir target_dir` from `omitting directory 'source_dir'` to `-r not specified; omitting directory 'source_dir'` (the same message shown by GNU `cp`).