### PR TITLE
expr fuzz: add missing ops. found thanks to oss fuzz coverage

### DIFF
--- a/fuzz/fuzz_targets/fuzz_expr.rs
+++ b/fuzz/fuzz_targets/fuzz_expr.rs
@@ -22,7 +22,7 @@ static CMD_PATH: &str = "expr";
 fn generate_expr(max_depth: u32) -> String {
     let mut rng = rand::thread_rng();
     let ops = [
-        "+", "-", "*", "/", "%", "<", ">", "=", "&", "|", "!=", "<=", ">=", ":", "length", "substr",
+        "+", "-", "*", "/", "%", "<", ">", "=", "&", "|", "!=", "<=", ">=", ":", "index", "length", "substr",
     ];
 
     let mut expr = String::new();

--- a/fuzz/fuzz_targets/fuzz_expr.rs
+++ b/fuzz/fuzz_targets/fuzz_expr.rs
@@ -21,7 +21,9 @@ static CMD_PATH: &str = "expr";
 
 fn generate_expr(max_depth: u32) -> String {
     let mut rng = rand::thread_rng();
-    let ops = ["+", "-", "*", "/", "%", "<", ">", "=", "&", "|"];
+    let ops = [
+        "+", "-", "*", "/", "%", "<", ">", "=", "&", "|", "!=", "<=", ">=", ":", "length", "substr",
+    ];
 
     let mut expr = String::new();
     let mut depth = 0;


### PR DESCRIPTION
https://storage.googleapis.com/oss-fuzz-coverage/rust-coreutils/reports/20231118/linux/src/rust-coreutils/src/uu/expr/src/syntax_tree.rs.html