### PR TITLE
expr: different stderr with `expr "56" "substr"`

### DIFF
--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -7,6 +7,14 @@
 use crate::common::util::TestScenario;
 
 #[test]
+fn test_no_arguments() {
+    new_ucmd!()
+        .fails()
+        .code_is(2)
+        .stderr_only("expr: missing operand\n");
+}
+
+#[test]
 fn test_simple_values() {
     // null or 0 => EXIT_VALUE == 1
     new_ucmd!().args(&[""]).fails().code_is(1).stdout_only("\n");
@@ -275,6 +283,12 @@ fn test_substr() {
 
 #[test]
 fn test_invalid_substr() {
+    new_ucmd!()
+        .args(&["56", "substr"])
+        .fails()
+        .code_is(2)
+        .stderr_only("expr: syntax error: unexpected argument 'substr'\n");
+
     new_ucmd!()
         .args(&["substr", "abc", "0", "1"])
         .fails()


### PR DESCRIPTION
As addressed in https://github.com/uutils/coreutils/issues/5558 , this PR aligns the error messages from this implementation of `expr` with the GNU one.

If there are no arguments, it returns `expr: missing operand`.

If one of the arguments introduced arity, but there are not enough arguments, it returns `expr: syntax error: unexpected argument 'substr'` with the name of that argument, like `substr`.

Added tests.