### PR TITLE
expr: fix unexpected argument error

### DIFF
--- a/src/uu/expr/src/tokens.rs
+++ b/src/uu/expr/src/tokens.rs
@@ -16,6 +16,8 @@
 
 // spell-checker:ignore (ToDO) paren
 
+use uucore::display::Quotable;
+
 #[derive(Debug, Clone)]
 pub enum Token {
     Value {
@@ -89,18 +91,36 @@ pub fn strings_to_tokens(strings: &[&str]) -> Result<Vec<(usize, Token)>, String
 
             "|" => Token::new_infix_op(s, true, 1),
 
-            "match" | "index" => Token::PrefixOp {
-                arity: 2,
-                value: s.to_string(),
-            },
-            "substr" => Token::PrefixOp {
-                arity: 3,
-                value: s.to_string(),
-            },
-            "length" => Token::PrefixOp {
-                arity: 1,
-                value: s.to_string(),
-            },
+            "match" | "index" => {
+                if tok_idx == 1 {
+                    Token::PrefixOp {
+                        arity: 2,
+                        value: s.to_string(),
+                    }
+                } else {
+                    return Err(format!("syntax error: unexpected argument {}", s.quote()));
+                }
+            }
+            "substr" => {
+                if tok_idx == 1 {
+                    Token::PrefixOp {
+                        arity: 3,
+                        value: s.to_string(),
+                    }
+                } else {
+                    return Err(format!("syntax error: unexpected argument {}", s.quote()));
+                }
+            }
+            "length" => {
+                if tok_idx == 1 {
+                    Token::PrefixOp {
+                        arity: 1,
+                        value: s.to_string(),
+                    }
+                } else {
+                    return Err(format!("syntax error: unexpected argument {}", s.quote()));
+                }
+            }
 
             _ => Token::new_value(s),
         };

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -238,7 +238,7 @@ fn test_index() {
     new_ucmd!()
         .args(&["αbcdef", "index", "α"])
         .fails()
-        .stderr_only("expr: syntax error (operation should be prefix)\n");
+        .stderr_only("expr: syntax error: unexpected argument 'index'\n");
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn test_length() {
     new_ucmd!()
         .args(&["abcdef", "length"])
         .fails()
-        .stderr_only("expr: syntax error (operation should be prefix)\n");
+        .stderr_only("expr: syntax error: unexpected argument 'length'\n");
 }
 
 #[test]
@@ -298,7 +298,7 @@ fn test_substr() {
     new_ucmd!()
         .args(&["abc", "substr", "1", "1"])
         .fails()
-        .stderr_only("expr: syntax error (operation should be prefix)\n");
+        .stderr_only("expr: syntax error: unexpected argument 'substr'\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixing error message for `Token::PrefixOp` tokens when they are not the first token in the command line - in line with GNU behavior.
And updated tests