### PR TITLE
Fix issue 5576 (regex matching bug in expr)

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -498,7 +498,8 @@ fn infix_operator_and(values: &[String]) -> String {
 
 fn operator_match(values: &[String]) -> Result<String, String> {
     assert!(values.len() == 2);
-    let re = Regex::with_options(&values[1], RegexOptions::REGEX_OPTION_NONE, Syntax::grep())
+    let re_string = format!("^{}", &values[1]);
+    let re = Regex::with_options(&re_string, RegexOptions::REGEX_OPTION_NONE, Syntax::grep())
         .map_err(|err| err.description().to_string())?;
     Ok(if re.captures_len() > 0 {
         re.captures(&values[0])

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -289,6 +289,10 @@ fn test_regex() {
         .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
         .succeeds()
         .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["abc", ":", "bc"])
+        .fails()
+        .stdout_only("0\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixes uutils/coreutils#5576

Issue 5576 reported a bug in expr, found by the fuzzer. The problem
turns out to be with the regex match operator `:`, which is defined in
POSIX and the GNU manual to match the pattern only when it occurs at
the beginning of the string, i.e., the regex has an implicit `^`
prepended to it. We hadn't been doing that.

References:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/expr.html
https://www.gnu.org/software/coreutils/manual/html_node/String-expressions.html
