### PR TITLE
 unexpand: remove crash! macro

### DIFF
--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -402,8 +402,7 @@ fn unexpand(options: &Options) -> UResult<()> {
         let mut fh = match open(file) {
             Ok(reader) => reader,
             Err(err) => {
-                let err = format!("{}", err);
-                return Err(USimpleError::new(1, err));
+                return Err(USimpleError::new(1, err.to_string()));
             }
         };
 
@@ -411,8 +410,7 @@ fn unexpand(options: &Options) -> UResult<()> {
             Ok(s) => s > 0,
             Err(_) => !buf.is_empty(),
         } {
-            unexpand_line(&mut buf, &mut output, options, lastcol, ts)
-                .map_err_context(|| "failed to write output".to_string())?;
+            unexpand_line(&mut buf, &mut output, options, lastcol, ts)?;
         }
     }
     Ok(())

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -391,7 +391,6 @@ fn unexpand_line(
     Ok(())
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn unexpand(options: &Options) -> UResult<()> {
     let mut output = BufWriter::new(stdout());
     let ts = &options.tabstops[..];

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -161,7 +161,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().try_get_matches_from(expand_shortcuts(&args))?;
 
-    unexpand(&Options::new(&matches)?)?.map_err_context(String::new)
+    unexpand(&Options::new(&matches)?).map_err_context(String::new)
 }
 
 pub fn uu_app() -> Command {
@@ -318,26 +318,65 @@ fn next_char_info(uflag: bool, buf: &[u8], byte: usize) -> (CharType, usize, usi
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn unexpand(options: &Options) -> UResult<std::io::Result<()>> {
+fn unexpand(options: &Options) -> std::io::Result<()> {
     let mut output = BufWriter::new(stdout());
     let ts = &options.tabstops[..];
     let mut buf = Vec::new();
     let lastcol = if ts.len() > 1 { *ts.last().unwrap() } else { 0 };
 
     for file in &options.files {
-        let mut fh = open(file);
+        let fh = open(file);
 
-        while let Ok(s) = fh.as_mut().unwrap().read_until(b'\n', &mut buf) {
-            if s > 0 {
-                let mut byte = 0; // offset into the buffer
-                let mut col = 0; // the current column
-                let mut scol = 0; // the start col for the current span, i.e., the already-printed width
-                let mut init = true; // are we at the start of the line?
-                let mut pctype = CharType::Other;
+        let mut fh = fh.unwrap();
 
-                while byte < buf.len() {
-                    // when we have a finite number of columns, never convert past the last column
-                    if lastcol > 0 && col >= lastcol {
+        while match fh.read_until(b'\n', &mut buf) {
+            Ok(s) => s > 0,
+            Err(_) => !buf.is_empty(),
+        } {
+            let mut byte = 0; // offset into the buffer
+            let mut col = 0; // the current column
+            let mut scol = 0; // the start col for the current span, i.e., the already-printed width
+            let mut init = true; // are we at the start of the line?
+            let mut pctype = CharType::Other;
+
+            while byte < buf.len() {
+                // when we have a finite number of columns, never convert past the last column
+                if lastcol > 0 && col >= lastcol {
+                    write_tabs(
+                        &mut output,
+                        ts,
+                        scol,
+                        col,
+                        pctype == CharType::Tab,
+                        init,
+                        true,
+                    );
+                    output.write_all(&buf[byte..])?;
+                    scol = col;
+                    break;
+                }
+
+                // figure out how big the next char is, if it's UTF-8
+                let (ctype, cwidth, nbytes) = next_char_info(options.uflag, &buf, byte);
+
+                // now figure out how many columns this char takes up, and maybe print it
+                let tabs_buffered = init || options.aflag;
+                match ctype {
+                    CharType::Space | CharType::Tab => {
+                        // compute next col, but only write space or tab chars if not buffering
+                        col += if ctype == CharType::Space {
+                            1
+                        } else {
+                            next_tabstop(ts, col).unwrap_or(1)
+                        };
+
+                        if !tabs_buffered {
+                            output.write_all(&buf[byte..byte + nbytes])?;
+                            scol = col; // now printed up to this column
+                        }
+                    }
+                    CharType::Other | CharType::Backspace => {
+                        // always
                         write_tabs(
                             &mut output,
                             ts,
@@ -345,81 +384,42 @@ fn unexpand(options: &Options) -> UResult<std::io::Result<()>> {
                             col,
                             pctype == CharType::Tab,
                             init,
-                            true,
+                            options.aflag,
                         );
-                        output.write_all(&buf[byte..])?;
-                        scol = col;
-                        break;
+                        init = false; // no longer at the start of a line
+                        col = if ctype == CharType::Other {
+                            // use computed width
+                            col + cwidth
+                        } else if col > 0 {
+                            // Backspace case, but only if col > 0
+                            col - 1
+                        } else {
+                            0
+                        };
+                        output.write_all(&buf[byte..byte + nbytes])?;
+                        scol = col; // we've now printed up to this column
                     }
-
-                    // figure out how big the next char is, if it's UTF-8
-                    let (ctype, cwidth, nbytes) = next_char_info(options.uflag, &buf, byte);
-
-                    // now figure out how many columns this char takes up, and maybe print it
-                    let tabs_buffered = init || options.aflag;
-                    match ctype {
-                        CharType::Space | CharType::Tab => {
-                            // compute next col, but only write space or tab chars if not buffering
-                            col += if ctype == CharType::Space {
-                                1
-                            } else {
-                                next_tabstop(ts, col).unwrap_or(1)
-                            };
-
-                            if !tabs_buffered {
-                                output.write_all(&buf[byte..byte + nbytes])?;
-                                scol = col; // now printed up to this column
-                            }
-                        }
-                        CharType::Other | CharType::Backspace => {
-                            // always
-                            write_tabs(
-                                &mut output,
-                                ts,
-                                scol,
-                                col,
-                                pctype == CharType::Tab,
-                                init,
-                                options.aflag,
-                            );
-                            init = false; // no longer at the start of a line
-                            col = if ctype == CharType::Other {
-                                // use computed width
-                                col + cwidth
-                            } else if col > 0 {
-                                // Backspace case, but only if col > 0
-                                col - 1
-                            } else {
-                                0
-                            };
-                            output.write_all(&buf[byte..byte + nbytes])?;
-                            scol = col; // we've now printed up to this column
-                        }
-                    }
-
-                    byte += nbytes; // move on to the next char
-                    pctype = ctype; // save the previous type
                 }
 
-                // write out anything remaining
-                write_tabs(
-                    &mut output,
-                    ts,
-                    scol,
-                    col,
-                    pctype == CharType::Tab,
-                    init,
-                    true,
-                );
-                output.flush()?;
-                buf.clear(); // clear out the buffer for the next iteration
-            } else {
-                // handle case where read_until returns 0 (end of file or empty line)
-                break;
+                byte += nbytes; // move on to next char
+                pctype = ctype; // save the previous type
             }
+
+            // write out anything remaining
+            write_tabs(
+                &mut output,
+                ts,
+                scol,
+                col,
+                pctype == CharType::Tab,
+                init,
+                true,
+            );
+            output.flush()?;
+            buf.truncate(0); // clear out the buffer
         }
     }
-    Ok(output.flush())
+    output.flush()
 }
 
 #[cfg(test)]

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -161,7 +161,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let matches = uu_app().try_get_matches_from(expand_shortcuts(&args))?;
 
-    unexpand(&Options::new(&matches)?).map_err_context(String::new)
+    unexpand(&Options::new(&matches)?)
 }
 
 pub fn uu_app() -> Command {
@@ -214,13 +214,7 @@ fn open(path: &str) -> UResult<BufReader<Box<dyn Read + 'static>>> {
     if path == "-" {
         Ok(BufReader::new(Box::new(stdin()) as Box<dyn Read>))
     } else {
-        file_buf = match File::open(path) {
-            Ok(a) => a,
-            Err(e) => {
-                let err = format!("{}: {}", path.maybe_quote(), e);
-                return Err(USimpleError::new(1, err));
-            }
-        };
+        file_buf = File::open(path).map_err_context(|| path.to_string())?;
         Ok(BufReader::new(Box::new(file_buf) as Box<dyn Read>))
     }
 }
@@ -318,108 +312,110 @@ fn next_char_info(uflag: bool, buf: &[u8], byte: usize) -> (CharType, usize, usi
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn unexpand(options: &Options) -> std::io::Result<()> {
+fn unexpand_line(
+    buf: &mut Vec<u8>,
+    output: &mut BufWriter<std::io::Stdout>,
+    options: &Options,
+    lastcol: usize,
+    ts: &[usize],
+) -> std::io::Result<()> {
+    let mut byte = 0; // offset into the buffer
+    let mut col = 0; // the current column
+    let mut scol = 0; // the start col for the current span, i.e., the already-printed width
+    let mut init = true; // are we at the start of the line?
+    let mut pctype = CharType::Other;
+
+    while byte < buf.len() {
+        // when we have a finite number of columns, never convert past the last column
+        if lastcol > 0 && col >= lastcol {
+            write_tabs(output, ts, scol, col, pctype == CharType::Tab, init, true);
+            output.write_all(&buf[byte..])?;
+            scol = col;
+            break;
+        }
+
+        // figure out how big the next char is, if it's UTF-8
+        let (ctype, cwidth, nbytes) = next_char_info(options.uflag, buf, byte);
+
+        // now figure out how many columns this char takes up, and maybe print it
+        let tabs_buffered = init || options.aflag;
+        match ctype {
+            CharType::Space | CharType::Tab => {
+                // compute next col, but only write space or tab chars if not buffering
+                col += if ctype == CharType::Space {
+                    1
+                } else {
+                    next_tabstop(ts, col).unwrap_or(1)
+                };
+
+                if !tabs_buffered {
+                    output.write_all(&buf[byte..byte + nbytes])?;
+                    scol = col; // now printed up to this column
+                }
+            }
+            CharType::Other | CharType::Backspace => {
+                // always
+                write_tabs(
+                    output,
+                    ts,
+                    scol,
+                    col,
+                    pctype == CharType::Tab,
+                    init,
+                    options.aflag,
+                );
+                init = false; // no longer at the start of a line
+                col = if ctype == CharType::Other {
+                    // use computed width
+                    col + cwidth
+                } else if col > 0 {
+                    // Backspace case, but only if col > 0
+                    col - 1
+                } else {
+                    0
+                };
+                output.write_all(&buf[byte..byte + nbytes])?;
+                scol = col; // we've now printed up to this column
+            }
+        }
+
+        byte += nbytes; // move on to next char
+        pctype = ctype; // save the previous type
+    }
+
+    // write out anything remaining
+    write_tabs(output, ts, scol, col, pctype == CharType::Tab, init, true);
+    output.flush()?;
+    buf.truncate(0); // clear out the buffer
+
+    Ok(())
+}
+
+#[allow(clippy::cognitive_complexity)]
+fn unexpand(options: &Options) -> UResult<()> {
     let mut output = BufWriter::new(stdout());
     let ts = &options.tabstops[..];
     let mut buf = Vec::new();
     let lastcol = if ts.len() > 1 { *ts.last().unwrap() } else { 0 };
 
     for file in &options.files {
-        let fh = open(file);
-
-        let mut fh = fh.unwrap();
+        let mut fh = match open(file) {
+            Ok(reader) => reader,
+            Err(err) => {
+                let err = format!("{}", err);
+                return Err(USimpleError::new(1, err));
+            }
+        };
 
         while match fh.read_until(b'\n', &mut buf) {
             Ok(s) => s > 0,
             Err(_) => !buf.is_empty(),
         } {
-            let mut byte = 0; // offset into the buffer
-            let mut col = 0; // the current column
-            let mut scol = 0; // the start col for the current span, i.e., the already-printed width
-            let mut init = true; // are we at the start of the line?
-            let mut pctype = CharType::Other;
-
-            while byte < buf.len() {
-                // when we have a finite number of columns, never convert past the last column
-                if lastcol > 0 && col >= lastcol {
-                    write_tabs(
-                        &mut output,
-                        ts,
-                        scol,
-                        col,
-                        pctype == CharType::Tab,
-                        init,
-                        true,
-                    );
-                    output.write_all(&buf[byte..])?;
-                    scol = col;
-                    break;
-                }
-
-                // figure out how big the next char is, if it's UTF-8
-                let (ctype, cwidth, nbytes) = next_char_info(options.uflag, &buf, byte);
-
-                // now figure out how many columns this char takes up, and maybe print it
-                let tabs_buffered = init || options.aflag;
-                match ctype {
-                    CharType::Space | CharType::Tab => {
-                        // compute next col, but only write space or tab chars if not buffering
-                        col += if ctype == CharType::Space {
-                            1
-                        } else {
-                            next_tabstop(ts, col).unwrap_or(1)
-                        };
-
-                        if !tabs_buffered {
-                            output.write_all(&buf[byte..byte + nbytes])?;
-                            scol = col; // now printed up to this column
-                        }
-                    }
-                    CharType::Other | CharType::Backspace => {
-                        // always
-                        write_tabs(
-                            &mut output,
-                            ts,
-                            scol,
-                            col,
-                            pctype == CharType::Tab,
-                            init,
-                            options.aflag,
-                        );
-                        init = false; // no longer at the start of a line
-                        col = if ctype == CharType::Other {
-                            // use computed width
-                            col + cwidth
-                        } else if col > 0 {
-                            // Backspace case, but only if col > 0
-                            col - 1
-                        } else {
-                            0
-                        };
-                        output.write_all(&buf[byte..byte + nbytes])?;
-                        scol = col; // we've now printed up to this column
-                    }
-                }
-
-                byte += nbytes; // move on to next char
-                pctype = ctype; // save the previous type
-            }
-
-            // write out anything remaining
-            write_tabs(
-                &mut output,
-                ts,
-                scol,
-                col,
-                pctype == CharType::Tab,
-                init,
-                true,
-            );
-            output.flush()?;
-            buf.truncate(0); // clear out the buffer
+            unexpand_line(&mut buf, &mut output, options, lastcol, ts)
+                .map_err_context(|| "failed to write output".to_string())?;
         }
     }
-    output.flush()
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -218,7 +218,7 @@ fn open(path: &str) -> UResult<BufReader<Box<dyn Read + 'static>>> {
             Ok(a) => a,
             Err(e) => {
                 let err = format!("{}: {}", path.maybe_quote(), e);
-                return Err(USimpleError::new(1,err));
+                return Err(USimpleError::new(1, err));
             }
         };
         Ok(BufReader::new(Box::new(file_buf) as Box<dyn Read>))


### PR DESCRIPTION
This PR is related to https://github.com/uutils/coreutils/issues/5487.
It removes the `crash!` macro from `unexpand`.