### PR TITLE
cut: add test & improve error message if the delimiter is too long

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -426,7 +426,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                             delim = "";
                         }
                         if delim.chars().count() > 1 {
-                            Err("invalid input: The '--delimiter' ('-d') option expects empty or 1 character long, but was provided a value 2 characters or longer".into())
+                            Err("the delimiter must be a single character".into())
                         } else {
                             let delim = if delim.is_empty() {
                                 "\0".to_owned()

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -126,13 +126,22 @@ fn test_too_large() {
 }
 
 #[test]
-fn test_specify_delimiter() {
+fn test_delimiter() {
     for param in ["-d", "--delimiter", "--del"] {
         new_ucmd!()
             .args(&[param, ":", "-f", COMPLEX_SEQUENCE.sequence, INPUT])
             .succeeds()
             .stdout_only_fixture("delimiter_specified.expected");
     }
+}
+
+#[test]
+fn test_delimiter_with_more_than_one_char() {
+    new_ucmd!()
+        .args(&["-d", "ab", "-f1"])
+        .fails()
+        .stderr_contains("cut: the delimiter must be a single character")
+        .no_stdout();
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a test and improves the error message if the provided delimiter is longer than one char. Now it is the same message as GNU `cut` shows.