### PR TITLE
Add support in uucore for OpenBSD

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -115,6 +115,7 @@ impl FileInformation {
             not(target_os = "android"),
             not(target_os = "freebsd"),
             not(target_os = "netbsd"),
+            not(target_os = "openbsd"),
             not(target_os = "illumos"),
             not(target_os = "solaris"),
             not(target_arch = "aarch64"),
@@ -130,6 +131,7 @@ impl FileInformation {
                 target_os = "android",
                 target_os = "freebsd",
                 target_os = "netbsd",
+                target_os = "openbsd",
                 target_os = "illumos",
                 target_os = "solaris",
                 target_arch = "aarch64",
@@ -146,13 +148,14 @@ impl FileInformation {
     #[cfg(unix)]
     pub fn inode(&self) -> u64 {
         #[cfg(all(
-            not(any(target_os = "freebsd", target_os = "netbsd")),
+            not(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")),
             target_pointer_width = "64"
         ))]
         return self.0.st_ino;
         #[cfg(any(
             target_os = "freebsd",
             target_os = "netbsd",
+            target_os = "openbsd",
             not(target_pointer_width = "64")
         ))]
         return self.0.st_ino.into();


### PR DESCRIPTION
  - uucore/src/lib/features/fs.rs: add target_os = OpenBSD when needed
  - uucore/src/lib/features/fsext.rs: implement FsUsage::new for OpenBSD

  - fixes uutils/coreutils#5448

  - initial code by n1000 https://github.com/n1000/coreutils/tree/openbsd_compile_fixes

---

Build OK with `cargo build --release` on OpenBSD-current/amd64 and Rust 1.74.0
```
$ target/release/coreutils
coreutils 0.0.23 (multi-call binary)

Usage: coreutils [function [arguments...]]

Currently defined functions:

    [, b2sum, b3sum, base32, base64, basename, basenc, cat, cksum, comm, cp, csplit, cut, date,
    dd, df, dir, dircolors, dirname, du, echo, env, expand, expr, factor, false, fmt, fold,
    hashsum, head, join, link, ln, ls, md5sum, mkdir, mktemp, more, mv, nl, numfmt, od, paste,
    pr, printenv, printf, ptx, pwd, readlink, realpath, rm, rmdir, seq, sha1sum, sha224sum,
    sha256sum, sha3-224sum, sha3-256sum, sha3-384sum, sha3-512sum, sha384sum, sha3sum,
    sha512sum, shake128sum, shake256sum, shred, shuf, sleep, sort, split, sum, tac, tail, tee,
    test, touch, tr, true, truncate, tsort, unexpand, uniq, unlink, vdir, wc, yes
```

Tests results with `cargo --test`
```
(...)
failures:
    test_cat::test_error_loop
    test_cp::test_copy_contents_fifo
    test_cp::test_cp_parents_2_dirs
    test_cp::test_cp_preserve_xattr
    test_cp::test_no_preserve_mode
    test_cp::test_preserve_hardlink_attributes_in_directory
    test_cp::test_preserve_mode
    test_du::test_du_basics_subdir
    test_du::test_du_d_flag
    test_du::test_du_dereference
    test_du::test_du_hard_link
    test_du::test_du_no_dereference
    test_du::test_du_one_file_system
    test_du::test_du_soft_link
    test_du::test_du_symlink_multiple_fail
    test_du::test_du_threshold
    test_ls::test_ls_allocation_size
    test_ls::test_ls_human_si
    test_ls::test_ls_long_total_size
    test_split::test_dev_zero
    test_split::test_filter_broken_pipe
    test_split::test_number_by_bytes_dev_zero
    test_tail::test_follow_descriptor_vs_rename1
    test_tail::test_follow_descriptor_vs_rename2
    test_tail::test_follow_name_move1
    test_tail::test_follow_name_move2
    test_tail::test_follow_name_move_create1
    test_tail::test_follow_name_move_create2
    test_tail::test_follow_name_move_retry1
    test_tail::test_follow_name_move_retry2
    test_tail::test_follow_name_retry_headers
    test_tail::test_follow_when_files_are_pointing_to_same_relative_file_and_file_stays_same_size
    test_tail::test_retry3
    test_tail::test_retry4
    test_tail::test_retry5
    test_tail::test_retry7
    test_tail::test_retry8
    test_tail::test_retry9
    test_tail::test_stdin_redirect_dir
    test_test::test_file_is_sticky
    test_test::test_file_owned_by_egid
    test_touch::test_touch_changes_time_of_file_in_stdout
    test_touch::test_touch_dash

test result: FAILED. 2429 passed; 43 failed; 30 ignored; 0 measured; 0 filtered out; finished in 236.55s
```