### PR TITLE
tests/cp, tests/test: Don't attempt to set sticky file bit on FreeBSD

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -13,7 +13,7 @@ use std::os::unix::fs;
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
-#[cfg(all(unix, not(target_os = "freebsd")))]
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_file;
@@ -2381,13 +2381,18 @@ fn test_copy_symlink_force() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "freebsd")))]
+#[cfg(unix)]
 fn test_no_preserve_mode() {
     use std::os::unix::prelude::MetadataExt;
 
     use uucore::mode::get_umask;
 
-    const PERMS_ALL: u32 = 0o7777;
+    const PERMS_ALL: u32 = if cfg!(target_os = "freebsd") {
+        // Only the superuser can set the sticky bit on a file.
+        0o6777
+    } else {
+        0o7777
+    };
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("file");
@@ -2407,11 +2412,16 @@ fn test_no_preserve_mode() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "freebsd")))]
+#[cfg(unix)]
 fn test_preserve_mode() {
     use std::os::unix::prelude::MetadataExt;
 
-    const PERMS_ALL: u32 = 0o7777;
+    const PERMS_ALL: u32 = if cfg!(target_os = "freebsd") {
+        // Only the superuser can set the sticky bit on a file.
+        0o6777
+    } else {
+        0o7777
+    };
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("file");

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -553,7 +553,7 @@ fn test_nonexistent_file_is_not_symlink() {
 }
 
 #[test]
-// FixME: freebsd fails with 'chmod: sticky_file: Inappropriate file type or format'
+// Only the superuser is allowed to set the sticky bit on files on FreeBSD.
 // Windows has no concept of sticky bit
 #[cfg(not(any(windows, target_os = "freebsd")))]
 fn test_file_is_sticky() {


### PR DESCRIPTION
Avoid trying to set the file sticky bit on FreeBSD, since only the superuser has permissions to set the file sticky bit.