### PR TITLE
ls: fix padding of size column when using `-l`

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3228,7 +3228,7 @@ fn calculate_padding_collection(
                 padding_collections.minor = minor_len.max(padding_collections.minor);
                 padding_collections.size = size_len
                     .max(padding_collections.size)
-                    .max(padding_collections.major + padding_collections.minor + 2usize);
+                    .max(padding_collections.major);
             }
         }
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1023,6 +1023,21 @@ fn test_ls_long_format() {
     ).unwrap());
 }
 
+#[test]
+fn test_ls_long_padding_of_size_column_with_multiple_files() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("dir");
+    at.touch("dir/a");
+    at.touch("dir/b");
+
+    ucmd.arg("-l")
+        .arg("dir")
+        .succeeds()
+        .stdout_contains(" 0 ")
+        .stdout_does_not_contain("  0 ");
+}
+
 /// This test tests `ls -laR --color`.
 /// This test is mainly about coloring, but, the recursion, symlink `->` processing,
 /// and `.` and `..` being present in `-a` all need to work for the test to pass.


### PR DESCRIPTION
This PR fixes an issue with the padding of the size column when using `-l` and the folder contains more than one file. The output of `ls -l` before the change:
```
total 0
-rw-r--r-- 1 dho dho    0 Nov 30 15:29 c.txt
-rw-r--r-- 1 dho dho    0 Nov 30 15:51 d.txt
```
And after the change:
```
total 0
-rw-r--r-- 1 dho dho 0 Nov 30 15:29 c.txt
-rw-r--r-- 1 dho dho 0 Nov 30 15:51 d.txt
```
This is the same output as GNU `ls` produces.