### PR TITLE
dd: skip two tests without "printf" feature

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -15,7 +15,12 @@ use regex::Regex;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "freebsd")))]
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "freebsd"),
+    feature = "printf"
+))]
 use std::process::{Command, Stdio};
 #[cfg(not(windows))]
 use std::thread::sleep;
@@ -1586,7 +1591,12 @@ fn test_seek_past_dev() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "freebsd")))]
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "freebsd"),
+    feature = "printf"
+))]
 fn test_reading_partial_blocks_from_fifo() {
     // Create the FIFO.
     let ts = TestScenario::new(util_name!());
@@ -1622,7 +1632,12 @@ fn test_reading_partial_blocks_from_fifo() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "freebsd")))]
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "freebsd"),
+    feature = "printf"
+))]
 fn test_reading_partial_blocks_from_fifo_unbuffered() {
     // Create the FIFO.
     let ts = TestScenario::new(util_name!());


### PR DESCRIPTION
When running `cargo test --features "dd" --no-default-features` the compiler shows two errors like:
```
error[E0425]: cannot find value `TESTS_BINARY` in this scope
    --> tests/by-util/test_dd.rs:1599:43
     |
1599 |     let mut reader_command = Command::new(TESTS_BINARY);
     |                                           ^^^^^^^^^^^^ not found in this scope
```
This PR fixes the errors by skipping the tests without the "printf" feature.