### PR TITLE
ls: ignore value of `POSIXLY_CORRECT`

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -20,7 +20,7 @@ use std::os::windows::fs::MetadataExt;
 use std::{
     cmp::Reverse,
     error::Error,
-    ffi::{OsStr, OsString},
+    ffi::OsString,
     fmt::{Display, Write as FmtWrite},
     fs::{self, DirEntry, FileType, Metadata, ReadDir},
     io::{stdout, BufWriter, ErrorKind, Stdout, Write},
@@ -792,12 +792,8 @@ impl Config {
                     None
                 }
             }
-        } else if let Some(pc) = env_var_posixly_correct {
-            if pc.as_os_str() == OsStr::new("true") || pc == OsStr::new("1") {
-                Some(POSIXLY_CORRECT_BLOCK_SIZE)
-            } else {
-                None
-            }
+        } else if env_var_posixly_correct.is_some() {
+            Some(POSIXLY_CORRECT_BLOCK_SIZE)
         } else {
             None
         };

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) cpio svgz webm somegroup nlink rmvb xspf tabsize dired subdired dtype
+// spell-checker:ignore (ToDO) somegroup nlink tabsize dired subdired dtype
 
 use clap::{
     builder::{NonEmptyStringValueParser, ValueParser},

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3828,3 +3828,30 @@ fn test_ls_cf_output_should_be_delimited_by_tab() {
         .succeeds()
         .stdout_is("a2345/\tb/\n");
 }
+
+#[cfg(all(unix, feature = "dd"))]
+#[test]
+fn test_posixly_correct() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ccmd("dd")
+        .arg("if=/dev/zero")
+        .arg("of=file")
+        .arg("bs=1024")
+        .arg("count=1")
+        .succeeds();
+
+    scene
+        .ucmd()
+        .arg("-s")
+        .succeeds()
+        .stdout_contains_line("total 4");
+
+    scene
+        .ucmd()
+        .arg("-s")
+        .env("POSIXLY_CORRECT", "some_value")
+        .succeeds()
+        .stdout_contains_line("total 8");
+}


### PR DESCRIPTION
This PR ignores the value of `POSIXLY_CORRECT` to match the behavior of GNU `ls`. It also renames some vars related to block sizes for better readability and consistency.