### PR TITLE
Add specific openbsd feature to disable use of utmpx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ build = "build.rs"
 default = ["feat_common_core"]
 ## OS feature shortcodes
 macos = ["feat_os_macos"]
+openbsd = ["feat_os_openbsd"]
 unix = ["feat_os_unix"]
 windows = ["feat_os_windows"]
 ## project-specific feature shortcodes
@@ -142,6 +143,15 @@ feat_Tier1 = [
 feat_os_macos = [
   "feat_os_unix", ## == a modern/usual *nix platform
   #
+  "feat_require_unix_hostid",
+]
+# "feat_os_openbsd" == set of utilities which can be built/run on OpenBSD
+# utmpx is not supported on OpenBSD, contrary to other modern *nix platforms
+feat_os_openbsd = [
+  "feat_Tier1",
+  #
+  "feat_require_crate_cpp",
+  "feat_require_unix",
   "feat_require_unix_hostid",
 ]
 # "feat_os_unix" == set of utilities which can be built/run on modern/usual *nix platforms

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ cargo build --release --features macos
 cargo build --release --features windows
 # or ...
 cargo build --release --features unix
+# or ...
+cargo build --release --features openbsd
 ```
 
 If you don't want to build every utility available on your platform into the

--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,9 @@ pub fn main() {
             // Allow this as we have a bunch of info in the comments
             #[allow(clippy::match_same_arms)]
             match krate.as_ref() {
-                "default" | "macos" | "unix" | "windows" | "selinux" | "zip" => continue, // common/standard feature names
+                "default" | "macos" | "openbsd" | "unix" | "windows" | "selinux" | "zip" => {
+                    continue
+                } // common/standard feature names
                 "nightly" | "test_unimplemented" => continue, // crate-local custom features
                 "uudoc" => continue,                          // is not a utility
                 "test" => continue, // over-ridden with 'uu_test' to avoid collision with rust core crate 'test'

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -253,7 +253,7 @@ fn set_main_group(group: &str) -> UResult<()> {
     Ok(())
 }
 
-#[cfg(any(target_vendor = "apple", target_os = "freebsd"))]
+#[cfg(any(target_vendor = "apple", target_os = "freebsd", target_os = "openbsd"))]
 fn set_groups(groups: &[libc::gid_t]) -> libc::c_int {
     unsafe { setgroups(groups.len() as libc::c_int, groups.as_ptr()) }
 }

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -507,7 +507,7 @@ fn pline(possible_uid: Option<uid_t>) {
     );
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd"))]
 fn pline(possible_uid: Option<uid_t>) {
     let uid = possible_uid.unwrap_or_else(getuid);
     let pw = Passwd::locate(uid).unwrap();
@@ -524,10 +524,10 @@ fn pline(possible_uid: Option<uid_t>) {
     );
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd"))]
 fn auditid() {}
 
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "openbsd")))]
 fn auditid() {
     use std::mem::MaybeUninit;
 
@@ -624,7 +624,7 @@ fn id_print(state: &State, groups: &[u32]) {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "openbsd")))]
 mod audit {
     use super::libc::{c_int, c_uint, dev_t, pid_t, uid_t};
 

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -200,7 +200,12 @@ extern "C" {
     fn _vprocmgr_detach_from_console(flags: u32) -> *const libc::c_int;
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "openbsd"
+))]
 unsafe fn _vprocmgr_detach_from_console(_: u32) -> *const libc::c_int {
     std::ptr::null()
 }


### PR DESCRIPTION
- build.rs: add openbsd in krate list
- Cargo.toml: add feature openbsd => no utmpx support
- Fixes uutils/coreutils#5596
- README: add cargo build with openbsd feature
- nohup: fix for OpenBSD with _vprocmgr_detach_from_console function
- id: fix support for OpenBSD
- chroot: add OpenBSD support for set_groups function

---
- Build OK on OpenBSD-current/amd64 with Rust v1.74.0
```
$ cargo build -v --release --features openbsd
(...)
    Finished release [optimized] target(s) in 5m 24s
$ target/release/coreutils
coreutils 0.0.23 (multi-call binary)

Usage: coreutils [function [arguments...]]

Currently defined functions:

    [, arch, b2sum, b3sum, base32, base64, basename, basenc, cat, chgrp, chmod, chown, chroot,
    cksum, comm, cp, csplit, cut, date, dd, df, dir, dircolors, dirname, du, echo, env, expand,
    expr, factor, false, fmt, fold, groups, hashsum, head, hostid, hostname, id, install,
    join, kill, link, ln, logname, ls, md5sum, mkdir, mkfifo, mknod, mktemp, more, mv, nice,
    nl, nohup, nproc, numfmt, od, paste, pathchk, pr, printenv, printf, ptx, pwd, readlink,
    realpath, rm, rmdir, seq, sha1sum, sha224sum, sha256sum, sha3-224sum, sha3-256sum, sha3-
    384sum, sha3-512sum, sha384sum, sha3sum, sha512sum, shake128sum, shake256sum, shred, shuf,
    sleep, sort, split, stat, stdbuf, stty, sum, sync, tac, tail, tee, test, timeout, touch, tr,
    true, truncate, tsort, tty, uname, unexpand, uniq, unlink, vdir, wc, whoami, yes

$ target/release/coreutils id
uid=1000(fox) gid=1000(fox) groups=1000(fox),0(wheel),9(wsrc),21(wobj)

$ target/release/coreutils uname -a
OpenBSD openbsd-dev.home.lan 7.4 GENERIC.MP#1471 amd64 OpenBSD
```

- Tests results for `openbsd` feature
```
$ cargo test --features openbsd
(...)
failures:
    test_cat::test_error_loop
    test_chown::test_chown_no_change_to_group
    test_chown::test_chown_no_change_to_user_group
    test_chown::test_chown_only_group
    test_chown::test_chown_only_group_id
    test_chown::test_chown_owner_group
    test_chown::test_chown_owner_group_id
    test_chown::test_chown_owner_group_mix
    test_chown::test_chown_various_input
    test_cp::test_copy_contents_fifo
    test_cp::test_cp_parents_2_dirs
    test_cp::test_cp_preserve_xattr
    test_cp::test_no_preserve_mode
    test_cp::test_preserve_hardlink_attributes_in_directory
    test_cp::test_preserve_mode
    test_du::test_du_basics_subdir
    test_du::test_du_d_flag
    test_du::test_du_dereference
    test_du::test_du_hard_link
    test_du::test_du_no_dereference
    test_du::test_du_no_permission
    test_du::test_du_one_file_system
    test_du::test_du_soft_link
    test_du::test_du_symlink_multiple_fail
    test_du::test_du_threshold
    test_hostname::test_hostname_ip
    test_install::test_install_compare_option
    test_install::test_install_copy_then_compare_file
    test_ls::test_ls_allocation_size
    test_ls::test_ls_human_si
    test_ls::test_ls_long_total_size
    test_split::test_dev_zero
    test_split::test_filter_broken_pipe
    test_split::test_number_by_bytes_dev_zero
    test_stat::test_format_created_time
    test_stat::test_multi_files
    test_stat::test_normal_format
    test_stat::test_pipe_fifo
    test_stat::test_stdin_pipe_fifo1
    test_stat::test_stdin_pipe_fifo2
    test_stat::test_stdin_redirect
    test_stat::test_symlinks
    test_stdbuf::test_stdbuf_line_buffered_stdout
    test_stdbuf::test_stdbuf_trailing_var_arg
    test_stdbuf::test_stdbuf_unbuffered_stdout
    test_tail::test_follow_descriptor_vs_rename1
    test_tail::test_follow_descriptor_vs_rename2
    test_tail::test_follow_name_move1
    test_tail::test_follow_name_move2
    test_tail::test_follow_name_move_create1
    test_tail::test_follow_name_move_create2
    test_tail::test_follow_name_move_retry1
    test_tail::test_follow_name_move_retry2
    test_tail::test_follow_name_retry_headers
    test_tail::test_follow_when_files_are_pointing_to_same_relative_file_and_file_stays_same_size
    test_tail::test_retry3
    test_tail::test_retry4
    test_tail::test_retry5
    test_tail::test_retry7
    test_tail::test_retry8
    test_tail::test_stdin_redirect_dir
    test_test::test_file_is_sticky
    test_test::test_file_owned_by_egid
    test_touch::test_touch_changes_time_of_file_in_stdout
    test_touch::test_touch_dash

test result: FAILED. 2707 passed; 65 failed; 32 ignored; 0 measured; 0 filtered out; finished in 229.37s
```