### PR TITLE
du: disable test on Android

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -441,6 +441,7 @@ fn test_du_inodes() {
     }
 }
 
+#[cfg(not(target_os = "android"))]
 #[test]
 fn test_du_inodes_with_count_links() {
     let ts = TestScenario::new(util_name!());


### PR DESCRIPTION
This PR disables `test_du_inodes_with_count_links` on Android because its file system doesn't seem to support hard links.