### PR TITLE
ls: handle invalid block size as GNU does

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -182,7 +182,7 @@ impl UError for LsError {
             Self::IOError(_) => 1,
             Self::IOErrorContext(_, _, false) => 1,
             Self::IOErrorContext(_, _, true) => 2,
-            Self::BlockSizeParseError(_) => 1,
+            Self::BlockSizeParseError(_) => 2,
             Self::ConflictingArgumentDired => 1,
             Self::DiredAndZeroAreIncompatible => 2,
             Self::AlreadyListedError(_) => 2,
@@ -806,10 +806,9 @@ impl Config {
             match parse_size_u64(&raw_block_size.to_string_lossy()) {
                 Ok(size) => Some(size),
                 Err(_) => {
-                    show!(LsError::BlockSizeParseError(
-                        opt_block_size.unwrap().clone()
-                    ));
-                    None
+                    return Err(Box::new(LsError::BlockSizeParseError(
+                        opt_block_size.unwrap().clone(),
+                    )));
                 }
             }
         } else if env_var_posixly_correct.is_some() {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3857,6 +3857,16 @@ fn test_posixly_correct() {
 }
 
 #[test]
+fn test_ls_invalid_block_size() {
+    new_ucmd!()
+        .arg("--block-size=invalid")
+        .fails()
+        .code_is(2)
+        .no_stdout()
+        .stderr_is("ls: invalid --block-size argument 'invalid'\n");
+}
+
+#[test]
 fn test_ls_hyperlink() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
If you provide an invalid block size with `ls --block-size=invalid`, GNU `ls` shows an error message and exits with a status code of `2`. uutils `ls`, on the other hand, shows the same error message but also lists the content of the current folder. And the status code is `1`. This PR adapts the handling of an invalid block size to match GNU's handling.