### PR TITLE
ls: use show_dir_name to output dir name

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1961,7 +1961,8 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
                 if config.dired {
                     dired::indent(&mut out)?;
                 }
-                writeln!(out, "{}:", path_data.p_buf.display())?;
+                show_dir_name(&path_data.p_buf, &mut out);
+                writeln!(out)?;
                 if config.dired {
                     // First directory displayed
                     let dir_len = path_data.display_name.len();


### PR DESCRIPTION
This PR uses the `show_dir_name` function to output the directory name instead of using `writeln!`. It's done for consistency reasons because a few lines below the same function is used.