### PR TITLE
tests/hostname: disable failing test_hostname::test_hostname_ip on OpenBSD

### DIFF
--- a/tests/by-util/test_hostname.rs
+++ b/tests/by-util/test_hostname.rs
@@ -14,8 +14,8 @@ fn test_hostname() {
     assert!(ls_default_res.stdout().len() >= ls_domain_res.stdout().len());
 }
 
-// FixME: fails for "MacOS" and "freebsd" "failed to lookup address information: Name does not resolve"
-#[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
+// FixME: fails for "MacOS", "freebsd" and "openbsd" "failed to lookup address information: Name does not resolve"
+#[cfg(not(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")))]
 #[test]
 fn test_hostname_ip() {
     let result = new_ucmd!().arg("-i").succeeds();


### PR DESCRIPTION
On OpenBSD, test_hostname::test_hostname_ip fails with "failed to lookup address information: Name does not resolve" error