### PR TITLE
ls: make --block-size and --human-readable/--si override each other

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1070,6 +1070,7 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .infer_long_args(true)
         .disable_help_flag(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::HELP)
                 .long(options::HELP)

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1552,7 +1552,7 @@ pub fn uu_app() -> Command {
                 .short('h')
                 .long(options::size::HUMAN_READABLE)
                 .help("Print human readable file sizes (e.g. 1K 234M 56G).")
-                .overrides_with(options::size::SI)
+                .overrides_with_all([options::size::BLOCK_SIZE, options::size::SI])
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -1569,6 +1569,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::size::SI)
                 .long(options::size::SI)
                 .help("Print human readable file sizes using powers of 1000 instead of 1024.")
+                .overrides_with_all([options::size::BLOCK_SIZE, options::size::HUMAN_READABLE])
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -1576,7 +1577,8 @@ pub fn uu_app() -> Command {
                 .long(options::size::BLOCK_SIZE)
                 .require_equals(true)
                 .value_name("BLOCK_SIZE")
-                .help("scale sizes by BLOCK_SIZE when printing them"),
+                .help("scale sizes by BLOCK_SIZE when printing them")
+                .overrides_with_all([options::size::SI, options::size::HUMAN_READABLE]),
         )
         .arg(
             Arg::new(options::INODE)

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3874,6 +3874,56 @@ fn test_ls_invalid_block_size() {
         .stderr_is("ls: invalid --block-size argument 'invalid'\n");
 }
 
+#[cfg(all(unix, feature = "dd"))]
+#[test]
+fn test_ls_block_size_override() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ccmd("dd")
+        .arg("if=/dev/zero")
+        .arg("of=file")
+        .arg("bs=1024")
+        .arg("count=1")
+        .succeeds();
+
+    // --si "wins"
+    scene
+        .ucmd()
+        .arg("-s")
+        .arg("--block-size=512")
+        .arg("--si")
+        .succeeds()
+        .stdout_contains_line("total 4.1k");
+
+    // --block-size "wins"
+    scene
+        .ucmd()
+        .arg("-s")
+        .arg("--si")
+        .arg("--block-size=512")
+        .succeeds()
+        .stdout_contains_line("total 8");
+
+    // --human-readable "wins"
+    scene
+        .ucmd()
+        .arg("-s")
+        .arg("--block-size=512")
+        .arg("--human-readable")
+        .succeeds()
+        .stdout_contains_line("total 4.0K");
+
+    // --block-size "wins"
+    scene
+        .ucmd()
+        .arg("-s")
+        .arg("--human-readable")
+        .arg("--block-size=512")
+        .succeeds()
+        .stdout_contains_line("total 8");
+}
+
 #[test]
 fn test_ls_hyperlink() {
     let scene = TestScenario::new(util_name!());

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3925,6 +3925,21 @@ fn test_ls_block_size_override() {
 }
 
 #[test]
+fn test_ls_block_size_override_self() {
+    new_ucmd!()
+        .arg("--block-size=512")
+        .arg("--block-size=512")
+        .succeeds();
+
+    new_ucmd!()
+        .arg("--human-readable")
+        .arg("--human-readable")
+        .succeeds();
+
+    new_ucmd!().arg("--si").arg("--si").succeeds();
+}
+
+#[test]
 fn test_ls_hyperlink() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
This PR makes `--block-size` and `--human-readable`/`--si` override each other to match the behavior of GNU `ls`.