### PR TITLE
ci: rename test summary names for busybox & toybox

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -791,7 +791,7 @@ jobs:
     - name: Reserve test results summary
       uses: actions/upload-artifact@v4
       with:
-        name: test-summary
+        name: busybox-test-summary
         path: "${{ steps.vars.outputs.TEST_SUMMARY_FILE }}"
     - name: Upload json results
       uses: actions/upload-artifact@v4
@@ -879,7 +879,7 @@ jobs:
     - name: Reserve test results summary
       uses: actions/upload-artifact@v4
       with:
-        name: test-summary
+        name: toybox-test-summary
         path: "${{ steps.vars.outputs.TEST_SUMMARY_FILE }}"
     - name: Upload json results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR is an attempt to fix the failing `Tests/Toybox test suite`, probably caused by https://github.com/uutils/coreutils/pull/5646 and its breaking change:

> Uploading to the same named Artifact multiple times.
>
> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

