### PR TITLE
test/id: do not run gnu

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -29,6 +29,14 @@ variables accordingly. This feature is adopted from `dotenv` style packages.
 
 `cp` can display a progress bar when the `-g`/`--progress` flag is set.
 
+## `id`
+
+`id` has several flags that are not available in GNU `id`, but are instead inspired by FreeBSD's `id`:
+
+- `-A`: Display the process audit user ID and other process audit properties, which is only available on BSD's.
+- `-p`: Makes the output more human-readable.
+- `-P`: Display the id as a password file entry.
+
 ## `mv`
 
 `mv` can display a progress bar when the `-g`/`--progress` flag is set.


### PR DESCRIPTION
Running GNU to get the expected result for tests is a _terrible_ idea:

- It makes the test only work if GNU is present.
- It makes the test only work for platforms supported by GNU.
- The version of GNU must be right.
- It is unclear what the output of the test should actually be by just looking at the test.

I've removed all tests of `id` that use this method and made some best effort approximations for them using regex and other techniques. I do not cover all cases that were there because frankly I couldn't be bothered and I think this is still a clear improvement.

Bonus: I discovered that we have some extensions for `id`! I've documented them in another commit.