### PR TITLE
Bump redox_syscall to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,14 +813,14 @@ checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
 
 [[package]]
 name = "filetime"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
- "windows-sys 0.48.0",
+ "redox_syscall",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1455,13 +1455,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.0",
 ]
@@ -1689,18 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded0bce2d41cc3c57aefa284708ced249a64acb01745dbbe72bd78610bfd644c"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -2051,7 +2042,7 @@ checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.4.0",
+ "redox_syscall",
  "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
@@ -3014,7 +3005,7 @@ version = "0.0.23"
 dependencies = [
  "clap",
  "libc",
- "redox_syscall 0.4.0",
+ "redox_syscall",
  "uucore",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -102,8 +102,6 @@ skip = [
   { name = "syn", version = "1.0.109" },
   # various crates
   { name = "bitflags", version = "1.3.2" },
-  # various crates
-  { name = "redox_syscall", version = "0.3.5" },
   # clap_builder, textwrap
   { name = "terminal_size", version = "0.2.6" },
 ]


### PR DESCRIPTION
This PR bumps `redox_syscall` from `0.3.5` & `0.4.0` to `0.4.1`, `filetime` from `0.2.22` to `0.2.23`, and 
`parking_lot_core` from `0.9.8` to `0.9.9`.