### PR TITLE
ci: fix warnings from "cargo tree"

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -208,7 +208,7 @@ jobs:
         echo "## dependency list"
         ## * using the 'stable' toolchain is necessary to avoid "unexpected '--filter-platform'" errors
         RUSTUP_TOOLCHAIN=stable cargo fetch --locked --quiet
-        RUSTUP_TOOLCHAIN=stable cargo tree --all --locked --no-dev-dependencies --no-indent ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} | grep -vE "$PWD" | sort --unique
+        RUSTUP_TOOLCHAIN=stable cargo tree --no-dedupe --locked -e=no-dev --prefix=none ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} | grep -vE "$PWD" | sort --unique
     - name: Test
       run: cargo nextest run --hide-progress-bar --profile ci ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
       env:
@@ -670,7 +670,7 @@ jobs:
         # dependencies
         echo "## dependency list"
         cargo fetch --locked --quiet
-        cargo tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --all --no-dev-dependencies --no-indent | grep -vE "$PWD" | sort --unique
+        cargo tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-dedupe -e=no-dev --prefix=none | grep -vE "$PWD" | sort --unique
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -63,7 +63,7 @@ jobs:
         echo "## dependency list"
         cargo fetch --locked --quiet
         ## * using the 'stable' toolchain is necessary to avoid "unexpected '--filter-platform'" errors
-        RUSTUP_TOOLCHAIN=stable cargo tree --locked --all --no-dev-dependencies --no-indent --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
+        RUSTUP_TOOLCHAIN=stable cargo tree --locked --no-dedupe -e=no-dev --prefix=none --features ${{ matrix.job.features }} | grep -vE "$PWD" | sort --unique
     - name: Commit any changes (to '${{ env.BRANCH_TARGET }}')
       uses: EndBug/add-and-commit@v9
       with:


### PR DESCRIPTION
This PR fixes three warnings shown by `cargo tree` (for example in https://github.com/uutils/coreutils/actions/runs/7244626153/job/19733242456?pr=5668, in the "Info" section):
```
warning: the --no-indent flag has been changed to --prefix=none
warning: The `cargo tree` --all flag has been changed to --no-dedupe, and may be removed in a future version.
If you are looking to display all workspace members, use the --workspace flag.
warning: the --no-dev-dependencies flag has changed to -e=no-dev
```