### PR TITLE
ls: support hyperlinks for dir names

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1926,8 +1926,14 @@ impl PathData {
     }
 }
 
-fn show_dir_name(dir: &Path, out: &mut BufWriter<Stdout>) {
-    write!(out, "{}:", dir.display()).unwrap();
+fn show_dir_name(path_data: &PathData, out: &mut BufWriter<Stdout>, config: &Config) {
+    if config.hyperlink {
+        let name = escape_name(&path_data.display_name, &config.quoting_style);
+        let hyperlink = create_hyperlink(&name, path_data);
+        write!(out, "{}:", hyperlink).unwrap();
+    } else {
+        write!(out, "{}:", path_data.p_buf.display()).unwrap();
+    }
 }
 
 #[allow(clippy::cognitive_complexity)]
@@ -1995,7 +2001,7 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
                 if config.dired {
                     dired::indent(&mut out)?;
                 }
-                show_dir_name(&path_data.p_buf, &mut out);
+                show_dir_name(path_data, &mut out, config);
                 writeln!(out)?;
                 if config.dired {
                     // First directory displayed
@@ -2007,7 +2013,7 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
                 }
             } else {
                 writeln!(out)?;
-                show_dir_name(&path_data.p_buf, &mut out);
+                show_dir_name(path_data, &mut out, config);
                 writeln!(out)?;
             }
         }
@@ -2232,7 +2238,7 @@ fn enter_directory(
                             dired::add_dir_name(dired, dir_name_size);
                         }
 
-                        show_dir_name(&e.p_buf, out);
+                        show_dir_name(e, out, config);
                         writeln!(out)?;
                         enter_directory(
                             e,

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4002,6 +4002,42 @@ fn test_ls_hyperlink_encode_link() {
 // spell-checker: enable
 
 #[test]
+fn test_ls_hyperlink_dirs() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    let dir_a = "a";
+    let dir_b = "b";
+
+    at.mkdir(dir_a);
+    at.mkdir(dir_b);
+
+    let path = at.root_dir_resolved();
+    let separator = std::path::MAIN_SEPARATOR_STR;
+
+    let result = scene
+        .ucmd()
+        .arg("--hyperlink")
+        .arg(dir_a)
+        .arg(dir_b)
+        .succeeds();
+
+    assert!(result.stdout_str().contains("\x1b]8;;file://"));
+    assert!(result
+        .stdout_str()
+        .lines()
+        .nth(0)
+        .unwrap()
+        .contains(&format!("{path}{separator}{dir_a}\x07{dir_a}\x1b]8;;\x07:")));
+    assert_eq!(result.stdout_str().lines().nth(1).unwrap(), "");
+    assert!(result
+        .stdout_str()
+        .lines()
+        .nth(2)
+        .unwrap()
+        .contains(&format!("{path}{separator}{dir_b}\x07{dir_b}\x1b]8;;\x07:")));
+}
+
+#[test]
 fn test_ls_color_do_not_reset() {
     let scene: TestScenario = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
This PR adds `--hyperlink` support for dir names and makes the [hyperlink.sh GNU test](https://github.com/coreutils/coreutils/blob/master/tests/ls/hyperlink.sh) pass.