### PR TITLE
`expr`: coerce to string before comparing values

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -70,6 +70,8 @@ impl RelationOp {
             }
         } else {
             // These comparisons should be using locale settings
+            let a = a.eval_as_string();
+            let b = b.eval_as_string();
             match self {
                 Self::Lt => a < b,
                 Self::Leq => a <= b,
@@ -195,7 +197,7 @@ const PRECEDENCE: &[&[(&str, BinOp)]] = &[
     &[(":", BinOp::String(StringOp::Match))],
 ];
 
-#[derive(Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug)]
 pub enum NumOrStr {
     Num(BigInt),
     Str(String),

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -362,3 +362,11 @@ fn test_invalid_syntax() {
             .stderr_contains("syntax error");
     }
 }
+
+#[test]
+fn test_num_str_comparison() {
+    new_ucmd!()
+        .args(&["1a", "<", "1", "+", "1"])
+        .succeeds()
+        .stdout_is("1\n");
+}


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/5647