### PR TITLE
ls: ignore invalid block size from env vars

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -840,9 +840,14 @@ impl Config {
             match parse_size_u64(&raw_block_size.to_string_lossy()) {
                 Ok(size) => Some(size),
                 Err(_) => {
-                    return Err(Box::new(LsError::BlockSizeParseError(
-                        opt_block_size.unwrap().clone(),
-                    )));
+                    // only fail if invalid block size was specified with --block-size,
+                    // ignore invalid block size from env vars
+                    if let Some(invalid_block_size) = opt_block_size {
+                        return Err(Box::new(LsError::BlockSizeParseError(
+                            invalid_block_size.clone(),
+                        )));
+                    }
+                    None
                 }
             }
         } else if env_var_posixly_correct.is_some() {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3874,6 +3874,14 @@ fn test_ls_invalid_block_size() {
         .stderr_is("ls: invalid --block-size argument 'invalid'\n");
 }
 
+// TODO ensure the correct block size is used when using -l because
+// the output of "ls -l" and "BLOCK_SIZE=invalid ls -l" is different
+#[test]
+fn test_ls_invalid_block_size_in_env_var() {
+    new_ucmd!().env("LS_BLOCK_SIZE", "invalid").succeeds();
+    new_ucmd!().env("BLOCK_SIZE", "invalid").succeeds();
+}
+
 #[cfg(all(unix, feature = "dd"))]
 #[test]
 fn test_ls_block_size_override() {


### PR DESCRIPTION
If the block size value specified by an env variable (e.g. `LS_BLOCK_SIZE`) is invalid, GNU `ls` "ignores" the value (it changes a block size value we currently don't have) whereas uutils `ls` panics while creating an error. This PR fixes this issue.