### PR TITLE
uucore: remove useless conversion for features/fs on OpenBSD

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -148,14 +148,13 @@ impl FileInformation {
     #[cfg(unix)]
     pub fn inode(&self) -> u64 {
         #[cfg(all(
-            not(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")),
+            not(any(target_os = "freebsd", target_os = "netbsd")),
             target_pointer_width = "64"
         ))]
         return self.0.st_ino;
         #[cfg(any(
             target_os = "freebsd",
             target_os = "netbsd",
-            target_os = "openbsd",
             not(target_pointer_width = "64")
         ))]
         return self.0.st_ino.into();


### PR DESCRIPTION
- src/uucore/src/lib/features/fs.rs: in inode function, remove useless conversion for target_OS = OpenBSD

Build and tests OK on OpenBSD/amd64 and Linux

Tests with inodes (via `ls`) on OpenBSD => same results with Rust and system coreutils
```
$ target/release/coreutils ls -li
total 192
363028 -rw-r--r-- 1 fox fox  5227 Nov 28 11:22 CODE_OF_CONDUCT.md
363029 -rw-r--r-- 1 fox fox 13320 Nov 28 11:22 CONTRIBUTING.md
362949 -rw-r--r-- 1 fox fox 77830 Dec 16 18:38 Cargo.lock
362956 -rw-r--r-- 1 fox fox 20970 Dec 16 18:38 Cargo.toml
363032 -rw-r--r-- 1 fox fox 10965 Dec 16 18:40 DEVELOPMENT.md
363033 -rw-r--r-- 1 fox fox  8667 Nov 28 11:22 GNUmakefile
363034 -rw-r--r-- 1 fox fox  1056 Nov 28 11:22 LICENSE
363035 -rw-r--r-- 1 fox fox    55 Nov 28 11:22 Makefile
363037 -rw-r--r-- 1 fox fox 10264 Nov 28 11:22 Makefile.toml
362950 -rw-r--r-- 1 fox fox  8044 Dec  3 18:53 README.md
363040 -rw-r--r-- 1 fox fox  4207 Dec  3 18:53 build.rs
363042 -rw-r--r-- 1 fox fox  3989 Dec 16 18:38 deny.toml
388888 drwxr-xr-x 4 fox fox   512 Nov 28 11:22 docs
388913 drwxr-xr-x 3 fox fox   512 Dec  8 16:56 fuzz
363045 -rw-r--r-- 1 fox fox   306 Nov 28 11:22 oranda.json
363047 -rw-r--r-- 1 fox fox    37 Nov 28 11:22 renovate.json
388929 drwxr-xr-x 7 fox fox   512 Dec  8 17:22 src
443033 drwxr-xr-x 3 fox fox   512 Dec 18 19:36 target
389992 drwxr-xr-x 6 fox fox   512 Nov 28 11:22 tests
415522 drwxr-xr-x 2 fox fox  1024 Dec 19 11:47 util

$ ls -li
total 384
363028 -rw-r--r--  1 fox  fox   5227 Nov 28 11:22 CODE_OF_CONDUCT.md
363029 -rw-r--r--  1 fox  fox  13320 Nov 28 11:22 CONTRIBUTING.md
362949 -rw-r--r--  1 fox  fox  77830 Dec 16 18:38 Cargo.lock
362956 -rw-r--r--  1 fox  fox  20970 Dec 16 18:38 Cargo.toml
363032 -rw-r--r--  1 fox  fox  10965 Dec 16 18:40 DEVELOPMENT.md
363033 -rw-r--r--  1 fox  fox   8667 Nov 28 11:22 GNUmakefile
363034 -rw-r--r--  1 fox  fox   1056 Nov 28 11:22 LICENSE
363035 -rw-r--r--  1 fox  fox     55 Nov 28 11:22 Makefile
363037 -rw-r--r--  1 fox  fox  10264 Nov 28 11:22 Makefile.toml
362950 -rw-r--r--  1 fox  fox   8044 Dec  3 18:53 README.md
363040 -rw-r--r--  1 fox  fox   4207 Dec  3 18:53 build.rs
363042 -rw-r--r--  1 fox  fox   3989 Dec 16 18:38 deny.toml
388888 drwxr-xr-x  4 fox  fox    512 Nov 28 11:22 docs
388913 drwxr-xr-x  3 fox  fox    512 Dec  8 16:56 fuzz
363045 -rw-r--r--  1 fox  fox    306 Nov 28 11:22 oranda.json
363047 -rw-r--r--  1 fox  fox     37 Nov 28 11:22 renovate.json
388929 drwxr-xr-x  7 fox  fox    512 Dec  8 17:22 src
443033 drwxr-xr-x  3 fox  fox    512 Dec 18 19:36 target
389992 drwxr-xr-x  6 fox  fox    512 Nov 28 11:22 tests
415522 drwxr-xr-x  2 fox  fox   1024 Dec 19 11:47 util
```
