### PR TITLE
ls: recognize BLOCKSIZE env var

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -810,10 +810,6 @@ impl Config {
             || options.get_flag(options::size::HUMAN_READABLE);
         let opt_kb = options.get_flag(options::size::KIBIBYTES);
 
-        let env_var_block_size = std::env::var_os("BLOCK_SIZE");
-        let env_var_ls_block_size = std::env::var_os("LS_BLOCK_SIZE");
-        let env_var_posixly_correct = std::env::var_os("POSIXLY_CORRECT");
-
         let size_format = if opt_si {
             SizeFormat::Decimal
         } else if opt_hr {
@@ -822,6 +818,11 @@ impl Config {
             SizeFormat::Bytes
         };
 
+        let env_var_blocksize = std::env::var_os("BLOCKSIZE");
+        let env_var_block_size = std::env::var_os("BLOCK_SIZE");
+        let env_var_ls_block_size = std::env::var_os("LS_BLOCK_SIZE");
+        let env_var_posixly_correct = std::env::var_os("POSIXLY_CORRECT");
+
         let raw_block_size = if let Some(opt_block_size) = opt_block_size {
             OsString::from(opt_block_size)
         } else if !opt_kb {
@@ -829,6 +830,8 @@ impl Config {
                 env_var_ls_block_size
             } else if let Some(env_var_block_size) = env_var_block_size {
                 env_var_block_size
+            } else if let Some(env_var_blocksize) = env_var_blocksize {
+                env_var_blocksize
             } else {
                 OsString::from("")
             }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3839,7 +3839,7 @@ fn test_ls_cf_output_should_be_delimited_by_tab() {
 
 #[cfg(all(unix, feature = "dd"))]
 #[test]
-fn test_posixly_correct() {
+fn test_posixly_correct_and_block_size_env_vars() {
     let scene = TestScenario::new(util_name!());
 
     scene
@@ -3852,16 +3852,42 @@ fn test_posixly_correct() {
 
     scene
         .ucmd()
-        .arg("-s")
+        .arg("-l")
         .succeeds()
-        .stdout_contains_line("total 4");
+        .stdout_contains_line("total 4")
+        .stdout_contains(" 1024 ");
 
     scene
         .ucmd()
-        .arg("-s")
+        .arg("-l")
         .env("POSIXLY_CORRECT", "some_value")
         .succeeds()
         .stdout_contains_line("total 8");
+    //.stdout_contains(" 1024 "); // TODO needs second internal blocksize
+
+    scene
+        .ucmd()
+        .arg("-l")
+        .env("LS_BLOCK_SIZE", "512")
+        .succeeds()
+        .stdout_contains_line("total 8")
+        .stdout_contains(" 2 ");
+
+    scene
+        .ucmd()
+        .arg("-l")
+        .env("BLOCK_SIZE", "512")
+        .succeeds()
+        .stdout_contains_line("total 8")
+        .stdout_contains(" 2 ");
+
+    scene
+        .ucmd()
+        .arg("-l")
+        .env("BLOCKSIZE", "512")
+        .succeeds()
+        .stdout_contains_line("total 8");
+    //.stdout_contains(" 1024 "); // TODO needs second internal blocksize
 }
 
 #[test]
@@ -3880,6 +3906,7 @@ fn test_ls_invalid_block_size() {
 fn test_ls_invalid_block_size_in_env_var() {
     new_ucmd!().env("LS_BLOCK_SIZE", "invalid").succeeds();
     new_ucmd!().env("BLOCK_SIZE", "invalid").succeeds();
+    new_ucmd!().env("BLOCKSIZE", "invalid").succeeds();
 }
 
 #[cfg(all(unix, feature = "dd"))]


### PR DESCRIPTION
This PR adds initial support for the `BLOCKSIZE` env variable. The output of `ls -l` with `BLOCKSIZE` set needs more work, it is currently the same as with `BLOCK_SIZE` or `LS_BLOCK_SIZE`.