### PR TITLE
fix uucore/fsext/MountInfo::new don't support spaces/backslashs/tabs in mount_dir

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -1115,4 +1115,18 @@ mod tests {
         assert_eq!(info.fs_type, "xfs");
         assert_eq!(info.dev_name, "/dev/fs0");
     }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn test_mountinfo_dir_special_chars() {
+        let info = MountInfo::new(
+            LINUX_MOUNTINFO,
+            &r#"317 61 7:0 / /mnt/f\134\040\011oo rw,relatime shared:641 - ext4 /dev/loop0 rw,seclabel"#
+                .split_ascii_whitespace()
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+
+        assert_eq!(info.mount_dir, r#"/mnt/f\ 	oo"#);
+    }
 }

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -1125,7 +1125,7 @@ mod tests {
     fn test_mountinfo_dir_special_chars() {
         let info = MountInfo::new(
             LINUX_MOUNTINFO,
-            &r#"317 61 7:0 / /mnt/f\134\040\011oo rw,relatime shared:641 - ext4 /dev/loop0 rw,seclabel"#
+            &r#"317 61 7:0 / /mnt/f\134\040\011oo rw,relatime shared:641 - ext4 /dev/loop0 rw"#
                 .split_ascii_whitespace()
                 .collect::<Vec<_>>(),
         )
@@ -1135,7 +1135,7 @@ mod tests {
 
         let info = MountInfo::new(
             LINUX_MTAB,
-            &r#"/dev/loop0 /mnt/f\134\040\011oo ext4 rw,seclabel,relatime 0 0"#
+            &r#"/dev/loop0 /mnt/f\134\040\011oo ext4 rw,relatime 0 0"#
                 .split_ascii_whitespace()
                 .collect::<Vec<_>>(),
         )

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -1132,5 +1132,15 @@ mod tests {
         .unwrap();
 
         assert_eq!(info.mount_dir, r#"/mnt/f\ 	oo"#);
+
+        let info = MountInfo::new(
+            LINUX_MTAB,
+            &r#"/dev/loop0 /mnt/f\134\040\011oo ext4 rw,seclabel,relatime 0 0"#
+                .split_ascii_whitespace()
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+
+        assert_eq!(info.mount_dir, r#"/mnt/f\ 	oo"#);
     }
 }

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -216,7 +216,11 @@ impl MountInfo {
                     dev_name: raw[after_fields + 1].to_string(),
                     fs_type: raw[after_fields].to_string(),
                     mount_root: raw[3].to_string(),
-                    mount_dir: raw[4].to_string(),
+                    mount_dir: raw[4]
+                        .to_string()
+                        .replace(r#"\040"#, " ")
+                        .replace(r#"\011"#, "	")
+                        .replace(r#"\134"#, r#"\"#),
                     mount_option: raw[5].to_string(),
                     remote: false,
                     dummy: false,

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -234,7 +234,11 @@ impl MountInfo {
                     dev_name: raw[0].to_string(),
                     fs_type: raw[2].to_string(),
                     mount_root: String::new(),
-                    mount_dir: raw[1].to_string(),
+                    mount_dir: raw[1]
+                        .to_string()
+                        .replace(r#"\040"#, " ")
+                        .replace(r#"\011"#, "	")
+                        .replace(r#"\134"#, r#"\"#),
                     mount_option: raw[3].to_string(),
                     remote: false,
                     dummy: false,


### PR DESCRIPTION
This PR addresses an issue where the method fails to consider spaces, backslashes, and tabs in a `mount_dir` field, as they are replaced by `\040`, `\134`, `\011`, respectively.
This issue was observed for both `/etc/mtab` and `/proc/self/mountinfo`.
Additionally, it introduces a new test to verify this correction.

It addresses #5678
```
$ ./target/release/coreutils df
Filesystem     1K-blocks      Used Available Use% Mounted on
/dev/sda3      233379840  49180744 181577576  22% /
devtmpfs            4096         0      4096   0% /dev
tmpfs            8166380     16356   8150024   1% /dev/shm
tmpfs            3266556      1820   3264736   1% /run
tmpfs            8166384     15144   8151240   1% /tmp
/dev/sda3      233379840  49180744 181577576  22% /home
/dev/sda2         996780    333408    594560  36% /boot
tmpfs            1633276       156   1633120   1% /run/user/1000
/dev/loop0         90333        46     83119   1% /mnt/f\oo
```