### PR TITLE
sort: allow `-f` to be pass multiple time

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1280,6 +1280,7 @@ pub fn uu_app() -> Command {
         .infer_long_args(true)
         .disable_help_flag(true)
         .disable_version_flag(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::HELP)
                 .long(options::HELP)

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1181,3 +1181,11 @@ fn test_tmp_files_deleted_on_sigint() {
 fn test_same_sort_mode_twice() {
     new_ucmd!().args(&["-k", "2n,2n", "empty.txt"]).succeeds();
 }
+
+#[test]
+fn test_args_override() {
+    new_ucmd!()
+        .args(&["-f", "-f"])
+        .pipe_in("foo")
+        .succeeds();
+}


### PR DESCRIPTION
Hello :wave: 

This small PR try to fix #5667.

I'm pretty new to rust, so if there's a better way to allow a flag to be pass multiple time, let me know.  :smile: 

```
echo "foo" | target/debug/sort -f -f
foo
```