### PR TITLE
expand: fix duplicate flags

### DIFF
--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -275,6 +275,7 @@ pub fn uu_app() -> Command {
         .after_help(LONG_HELP)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::INITIAL)
                 .long(options::INITIAL)

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -396,13 +396,16 @@ fn test_comma_with_plus_4() {
 #[test]
 fn test_args_override() {
     new_ucmd!()
-        .args(&["-i", "-i", "alice_in_wonderland.txt"])
+        .args(&["-i", "-i", "with-trailing-tab.txt"])
         .run()
         .stdout_is(
-            "Alice was beginning to get very tired of sitting by\n\
-        her sister on the bank, and of having nothing to do: once or twice\n\
-        she had peeped into the book her sister was reading, but it had no\n\
-        pictures or conversations in it, \"and what is the use of a book,\"\n\
-        thought Alice \"without pictures or conversation?\"\n",
+            "// !note: file contains significant whitespace
+// * indentation uses <TAB> characters
+int main() {
+        // * next line has both a leading & trailing tab
+        // with tabs=>	
+        return 0;
+}
+",
         );
 }

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -392,3 +392,17 @@ fn test_comma_with_plus_4() {
         //          01234567890
         .stdout_is("a  b    c");
 }
+
+#[test]
+fn test_args_override() {
+    new_ucmd!()
+        .args(&["-i", "-i", "alice_in_wonderland.txt"])
+        .run()
+        .stdout_is(
+            "Alice was beginning to get very tired of sitting by\n\
+        her sister on the bank, and of having nothing to do: once or twice\n\
+        she had peeped into the book her sister was reading, but it had no\n\
+        pictures or conversations in it, \"and what is the use of a book,\"\n\
+        thought Alice \"without pictures or conversation?\"\n",
+        );
+}

--- a/tests/fixtures/expand/alice_in_wonderland.txt
+++ b/tests/fixtures/expand/alice_in_wonderland.txt
@@ -1,0 +1,5 @@
+Alice was beginning to get very tired of sitting by
+her sister on the bank, and of having nothing to do: once or twice
+she had peeped into the book her sister was reading, but it had no
+pictures or conversations in it, "and what is the use of a book,"
+thought Alice "without pictures or conversation?"

--- a/tests/fixtures/expand/alice_in_wonderland.txt
+++ b/tests/fixtures/expand/alice_in_wonderland.txt
@@ -1,5 +1,0 @@
-Alice was beginning to get very tired of sitting by
-her sister on the bank, and of having nothing to do: once or twice
-she had peeped into the book her sister was reading, but it had no
-pictures or conversations in it, "and what is the use of a book,"
-thought Alice "without pictures or conversation?"


### PR DESCRIPTION
Fixed `expand` failed when executing multiple args. See [#5671](https://github.com/uutils/coreutils/pull/5671)

**GNU:**
```
$ echo -e "foo\tbar" | expand -i -i
foo	bar
```

**Current uutils/coreutils:**
```
$ echo -e "foo\tbar" | uuu expand -i -i
error: the argument '--initial' cannot be used multiple times

Usage: /home/nemesis/Documents/Github/Focus/util/coreutils/target/debug/coreutils expand [OPTION]... [FILE]...

For more information, try '--help'.
```


**Expected behavior for uutils/coreutils:**
```
$ echo -e "foo\tbar" | uuu expand -i -i
foo	bar
```