### PR TITLE
`windows-sys` to `windows`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
  "libc",
  "parse_datetime",
  "uucore",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -2422,7 +2422,7 @@ dependencies = [
  "clap",
  "glob",
  "uucore",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -2545,7 +2545,7 @@ dependencies = [
  "clap",
  "hostname",
  "uucore",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -2836,7 +2836,7 @@ dependencies = [
  "libc",
  "uucore",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -2980,7 +2980,7 @@ dependencies = [
  "libc",
  "nix",
  "uucore",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -3007,7 +3007,7 @@ dependencies = [
  "same-file",
  "uucore",
  "winapi-util",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -3048,7 +3048,7 @@ dependencies = [
  "filetime",
  "parse_datetime",
  "uucore",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -3181,7 +3181,7 @@ dependencies = [
  "clap",
  "libc",
  "uucore",
- "windows-sys 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -3226,7 +3226,7 @@ dependencies = [
  "walkdir",
  "wild",
  "winapi-util",
- "windows-sys 0.48.0",
+ "windows",
  "z85",
 ]
 
@@ -3384,6 +3384,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,7 +330,7 @@ unicode-width = "0.1.11"
 utf-8 = "0.7.6"
 walkdir = "2.4"
 winapi-util = "0.1.6"
-windows-sys = { version = "0.48.0", default-features = false }
+windows = { version = "0.52.0", default-features = false }
 xattr = "1.1.3"
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -25,7 +25,7 @@ parse_datetime = { workspace = true }
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
   "Win32_Foundation",
   "Win32_System_SystemInformation",
 ] }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -20,7 +20,7 @@ use uucore::error::FromIo;
 use uucore::error::{UResult, USimpleError};
 use uucore::{format_usage, help_about, help_usage, show};
 #[cfg(windows)]
-use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};
+use windows::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};
 
 use uucore::shortcut_value_parser::ShortcutValueParser;
 
@@ -472,8 +472,9 @@ fn set_system_datetime(date: DateTime<Utc>) -> UResult<()> {
 
     let result = unsafe { SetSystemTime(&system_time) };
 
-    if result == 0 {
-        Err(std::io::Error::last_os_error().map_err_context(|| "cannot set date".to_string()))
+    if let Err(e) = result {
+        Err(std::io::Error::from_raw_os_error(e.code().0)
+            .map_err_context(|| "cannot set date".to_string()))
     } else {
         Ok(())
     }

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 uucore = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_Foundation",
 ] }

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -20,7 +20,7 @@ hostname = { workspace = true, features = ["set"] }
 uucore = { workspace = true, features = ["wide"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
   "Win32_Networking_WinSock",
   "Win32_Foundation",
 ] }

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -30,7 +30,7 @@ static OPT_HOST: &str = "host";
 mod wsa {
     use std::io;
 
-    use windows_sys::Win32::Networking::WinSock::{WSACleanup, WSAStartup, WSADATA};
+    use windows::Win32::Networking::WinSock::{WSACleanup, WSAStartup, WSADATA};
 
     pub(super) struct WsaHandle(());
 

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -23,7 +23,7 @@ uucore = { workspace = true, features = ["fs"] }
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
+windows = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [[bin]]
 name = "rm"

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -564,8 +564,8 @@ fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata
 #[cfg(windows)]
 fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata) -> bool {
     use std::os::windows::prelude::MetadataExt;
-    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_READONLY;
-    let not_user_writable = (metadata.file_attributes() & FILE_ATTRIBUTE_READONLY) != 0;
+    use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_READONLY;
+    let not_user_writable = (metadata.file_attributes() & FILE_ATTRIBUTE_READONLY.0) != 0;
     if not_user_writable {
         prompt_yes!("remove write-protected directory {}?", path.quote())
     } else if options.interactive == InteractiveMode::Always {
@@ -606,8 +606,8 @@ fn is_symlink_dir(_metadata: &Metadata) -> bool {
 #[cfg(windows)]
 fn is_symlink_dir(metadata: &Metadata) -> bool {
     use std::os::windows::prelude::MetadataExt;
-    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
+    use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
 
     metadata.file_type().is_symlink()
-        && ((metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY) != 0)
+        && ((metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY.0) != 0)
 }

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -23,7 +23,7 @@ uucore = { workspace = true, features = ["wide"] }
 nix = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_System_WindowsProgramming",
   "Win32_Foundation",

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -25,7 +25,7 @@ same-file = { workspace = true }
 fundu = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
   "Win32_System_Threading",
   "Win32_Foundation",
 ] }

--- a/src/uu/tail/src/platform/windows.rs
+++ b/src/uu/tail/src/platform/windows.rs
@@ -3,46 +3,50 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use windows_sys::Win32::Foundation::{CloseHandle, BOOL, HANDLE, WAIT_FAILED, WAIT_OBJECT_0};
-use windows_sys::Win32::System::Threading::{
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0};
+use windows::Win32::System::Threading::{
     OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
 };
 
 pub type Pid = u32;
 
-pub struct ProcessChecker {
-    dead: bool,
-    handle: HANDLE,
+pub enum ProcessChecker {
+    Alive(HANDLE),
+    Dead,
 }
 
 impl ProcessChecker {
     pub fn new(process_id: self::Pid) -> Self {
-        #[allow(non_snake_case)]
-        let FALSE: BOOL = 0;
-        let h = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, FALSE, process_id) };
-        Self {
-            dead: h == 0,
-            handle: h,
+        let h = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, process_id) };
+        match h {
+            Ok(h) => Self::Alive(h),
+            Err(_) => Self::Dead,
         }
     }
 
     #[allow(clippy::wrong_self_convention)]
     pub fn is_dead(&mut self) -> bool {
-        if !self.dead {
-            self.dead = unsafe {
-                let status = WaitForSingleObject(self.handle, 0);
-                status == WAIT_OBJECT_0 || status == WAIT_FAILED
+        match self {
+            Self::Alive(h) => {
+                let status = unsafe {  WaitForSingleObject(*h, 0) };
+                if status == WAIT_OBJECT_0 || status == WAIT_FAILED {
+                    *self = Self::Dead;
+                    true
+                } else {
+                    false
+                }
             }
+            Self::Dead => true,
         }
-
-        self.dead
     }
 }
 
 impl Drop for ProcessChecker {
     fn drop(&mut self) {
-        unsafe {
-            CloseHandle(self.handle);
+        if let Self::Alive(h) = self {
+            unsafe {
+                let _ = CloseHandle(*h);
+            }
         }
     }
 }

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -23,7 +23,7 @@ parse_datetime = { workspace = true }
 uucore = { workspace = true, features = ["libc"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_Foundation",
 ] }

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -19,7 +19,7 @@ clap = { workspace = true }
 uucore = { workspace = true, features = ["entries"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
   "Win32_NetworkManagement_NetManagement",
   "Win32_System_WindowsProgramming",
   "Win32_Foundation",

--- a/src/uu/whoami/src/platform/windows.rs
+++ b/src/uu/whoami/src/platform/windows.rs
@@ -6,16 +6,19 @@
 use std::ffi::OsString;
 use std::io;
 use std::os::windows::ffi::OsStringExt;
-use windows_sys::Win32::NetworkManagement::NetManagement::UNLEN;
-use windows_sys::Win32::System::WindowsProgramming::GetUserNameW;
+use windows::Win32::NetworkManagement::NetManagement::UNLEN;
+use windows::Win32::System::WindowsProgramming::GetUserNameW;
+use windows::core::PWSTR;
 
 pub fn get_username() -> io::Result<OsString> {
     const BUF_LEN: u32 = UNLEN + 1;
     let mut buffer = [0_u16; BUF_LEN as usize];
     let mut len = BUF_LEN;
     // SAFETY: buffer.len() == len
-    if unsafe { GetUserNameW(buffer.as_mut_ptr(), &mut len) } == 0 {
-        return Err(io::Error::last_os_error());
+    let result = unsafe { GetUserNameW(PWSTR::from_raw(buffer.as_mut_ptr()), &mut len) };
+    
+    match result {
+        Ok(_) => Ok(OsString::from_wide(&buffer[..len as usize - 1])),
+        Err(_) =>  Err(io::Error::last_os_error()),
     }
-    Ok(OsString::from_wide(&buffer[..len as usize - 1]))
 }

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -62,7 +62,7 @@ tempfile = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi-util = { workspace = true, optional = true }
-windows-sys = { workspace = true, optional = true, default-features = false, features = [
+windows = { workspace = true, optional = true, default-features = false, features = [
   "Win32_Storage_FileSystem",
   "Win32_Foundation",
   "Win32_System_WindowsProgramming",
@@ -75,8 +75,8 @@ backup-control = []
 colors = []
 encoding = ["data-encoding", "data-encoding-macro", "z85", "thiserror"]
 entries = ["libc"]
-fs = ["dunce", "libc", "winapi-util", "windows-sys"]
-fsext = ["libc", "time", "windows-sys"]
+fs = ["dunce", "libc", "winapi-util", "windows"]
+fsext = ["libc", "time", "windows"]
 lines = []
 format = ["itertools"]
 mode = ["libc"]

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -78,14 +78,16 @@ impl FileInformation {
         {
             use std::fs::OpenOptions;
             use std::os::windows::prelude::*;
+            use windows::Win32::Storage::FileSystem::{
+                FILE_FLAGS_AND_ATTRIBUTES, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+            };
             let mut open_options = OpenOptions::new();
-            let mut custom_flags = 0;
+            let mut custom_flags = FILE_FLAGS_AND_ATTRIBUTES(0);
             if !dereference {
-                custom_flags |=
-                    windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+                custom_flags |= FILE_FLAG_OPEN_REPARSE_POINT;
             }
-            custom_flags |= windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
-            open_options.custom_flags(custom_flags);
+            custom_flags |= FILE_FLAG_BACKUP_SEMANTICS;
+            open_options.custom_flags(custom_flags.0);
             let file = open_options.read(true).open(path.as_ref())?;
             Self::from_file(&file)
         }

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -25,11 +25,13 @@ use std::ffi::OsStr;
 #[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
 #[cfg(windows)]
-use windows_sys::Win32::Foundation::{ERROR_NO_MORE_FILES, INVALID_HANDLE_VALUE};
-#[cfg(windows)]
-use windows_sys::Win32::Storage::FileSystem::{
+use windows_sys::Win32::{
+    Foundation::{ERROR_NO_MORE_FILES, INVALID_HANDLE_VALUE},
+    Storage::FileSystem::{
     FindFirstVolumeW, FindNextVolumeW, FindVolumeClose, GetDiskFreeSpaceW, GetDriveTypeW,
     GetVolumeInformationW, GetVolumePathNamesForVolumeNameW, QueryDosDeviceW,
+    },
+    System::WindowsProgramming::DRIVE_REMOTE,
 };
 #[cfg(windows)]
 use windows_sys::Win32::System::WindowsProgramming::DRIVE_REMOTE;

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -7,8 +7,8 @@
 // * feature-gated external crates (re-shared as public internal modules)
 #[cfg(feature = "libc")]
 pub extern crate libc;
-#[cfg(all(feature = "windows-sys", target_os = "windows"))]
-pub extern crate windows_sys;
+#[cfg(all(feature = "windows", target_os = "windows"))]
+pub extern crate windows;
 
 //## internal modules
 


### PR DESCRIPTION
Builds on top of https://github.com/uutils/coreutils/pull/5680 (so should be merged afterwards).

The `windows` crate is a small layer over `windows-sys` that provides a much nicer and Rustier API, so we should use that instead of `windows-sys`.