### PR TITLE
ci: add aarch64-unknown-linux-musl release artifact

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -468,6 +468,7 @@ jobs:
           # - { os , target , cargo-options , features , use-cross , toolchain, skip-tests }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf, features: feat_os_unix_gnueabihf, use-cross: use-cross, }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl      , use-cross: use-cross }
           # - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: feat_os_unix           , use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl      , use-cross: use-cross }
@@ -590,7 +591,7 @@ jobs:
         # * executable for `strip`?
         STRIP="strip"
         case ${{ matrix.job.target }} in
-          aarch64-*-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;;
+          aarch64-*-linux-*) STRIP="aarch64-linux-gnu-strip" ;;
           arm-*-linux-gnueabihf) STRIP="arm-linux-gnueabihf-strip" ;;
           *-pc-windows-msvc) STRIP="" ;;
         esac;
@@ -612,7 +613,7 @@ jobs:
         ## Install/setup prerequisites
         case '${{ matrix.job.target }}' in
           arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
-          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+          aarch64-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
           *-redox*) sudo apt-get -y update ; sudo apt-get -y install fuse3 libfuse-dev ;;
         esac
         case '${{ matrix.job.os }}' in


### PR DESCRIPTION
Fixes #5690.

I tested the workflow on my fork:

- [CI run](https://github.com/malt3/coreutils/actions/runs/7298905395/job/19890810745)
- [test release](https://github.com/malt3/coreutils/releases/tag/0.0.24-malt3-rc1)

The resulting artifact works as expected:

```shell-session
$ file coreutils
coreutils: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped

$ ./coreutils
coreutils 0.0.23 (multi-call binary)

Usage: coreutils [function [arguments...]]

Currently defined functions:

    [, arch, b2sum, b3sum, base32, base64, basename, basenc, cat, chgrp, chmod, chown, chroot,
    cksum, comm, cp, csplit, cut, date, dd, df, dir, dircolors, dirname, du, echo, env, expand,
    expr, factor, false, fmt, fold, groups, hashsum, head, hostid, hostname, id, install,
    join, kill, link, ln, logname, ls, md5sum, mkdir, mkfifo, mknod, mktemp, more, mv, nice,
    nl, nohup, nproc, numfmt, od, paste, pathchk, pr, printenv, printf, ptx, pwd, readlink,
    realpath, rm, rmdir, seq, sha1sum, sha224sum, sha256sum, sha3-224sum, sha3-256sum, sha3-
    384sum, sha3-512sum, sha384sum, sha3sum, sha512sum, shake128sum, shake256sum, shred, shuf,
    sleep, sort, split, stat, stty, sum, sync, tac, tail, tee, test, timeout, touch, tr, true,
    truncate, tsort, tty, uname, unexpand, uniq, unlink, vdir, wc, whoami, yes
```