### PR TITLE
mv: allow destination with slash when using --update

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -341,7 +341,11 @@ fn handle_two_paths(source: &Path, target: &Path, opts: &Options) -> UResult<()>
 
     let target_is_dir = target.is_dir();
 
-    if path_ends_with_terminator(target) && !target_is_dir && !opts.no_target_dir {
+    if path_ends_with_terminator(target)
+        && !target_is_dir
+        && !opts.no_target_dir
+        && opts.update != UpdateMode::ReplaceIfOlder
+    {
         return Err(MvError::FailedToAccessNotADirectory(target.quote().to_string()).into());
     }
 

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -906,6 +906,20 @@ fn test_mv_update_option() {
 }
 
 #[test]
+fn test_mv_update_with_dest_ending_with_slash() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = "source";
+    let dest = "destination/";
+
+    at.mkdir("source");
+
+    ucmd.arg("--update").arg(source).arg(dest).succeeds();
+
+    assert!(!at.dir_exists(source));
+    assert!(at.dir_exists(dest));
+}
+
+#[test]
 fn test_mv_arg_update_none() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
With GNU `mv`, `mv --update source/ dest/` renames `source` to `dest`. uutils `mv`, on the other hand, shows a "Not a directory" error message. This PR fixes this issue.