### PR TITLE
src: Fixing typos in signatures for the argument parser

### DIFF
--- a/src/uu/basenc/basenc.md
+++ b/src/uu/basenc/basenc.md
@@ -1,7 +1,7 @@
 # basenc
 
 ```
-basenc [OPTION]... [FILE]"
+basenc [OPTION]... [FILE]
 ```
 
 Encode/decode data and print to standard output

--- a/src/uu/cut/cut.md
+++ b/src/uu/cut/cut.md
@@ -3,7 +3,7 @@
 <!-- spell-checker:ignore sourcefile sourcefiles -->
 
 ```
-cut [-d|-w] [-s] [-z] [--output-delimiter] ((-f|-b|-c) {{sequence}}) {{sourcefile}}+
+cut OPTION... [FILE]...
 ```
 
 Prints specified byte or field columns from each line of stdin or the input files

--- a/src/uu/join/join.md
+++ b/src/uu/join/join.md
@@ -1,7 +1,7 @@
 # join
 
 ```
-join [OPTIONS] <FILE1> <FILE2>
+join [OPTION]... FILE1 FILE2
 ```
 
 For each pair of input lines with identical join fields, write a line to

--- a/src/uu/mkdir/mkdir.md
+++ b/src/uu/mkdir/mkdir.md
@@ -3,7 +3,7 @@
 <!-- spell-checker:ignore ugoa -->
 
 ```
-mkdir [OPTION]... [USER]
+mkdir [OPTION]... DIRECTORY...
 ```
 
 Create the given DIRECTORY(ies) if they do not exist

--- a/src/uu/nohup/nohup.md
+++ b/src/uu/nohup/nohup.md
@@ -2,7 +2,7 @@
 
 ```
 nohup COMMAND [ARG]...
-nohup FLAG
+nohup OPTION
 ```
 
 Run COMMAND ignoring hangup signals.

--- a/src/uu/pr/pr.md
+++ b/src/uu/pr/pr.md
@@ -1,7 +1,7 @@
 # pr
 
 ```
-pr [OPTIONS] [files]...
+pr [OPTION]... [FILE]...
 ```
 
 Write content of given file or standard input to standard output with pagination filter

--- a/src/uu/printenv/printenv.md
+++ b/src/uu/printenv/printenv.md
@@ -1,7 +1,7 @@
 # printenv
 
 ```
-printenv [VARIABLE]... [OPTION]...
+printenv [OPTION]... [VARIABLE]...
 ```
 
 Display the values of the specified environment VARIABLE(s), or (with no VARIABLE) display name and value pairs for them all.

--- a/src/uu/printf/printf.md
+++ b/src/uu/printf/printf.md
@@ -4,6 +4,8 @@
 
 ```
 printf FORMATSTRING [ARGUMENT]...
+printf FORMAT [ARGUMENT]...
+printf OPTION
 ```
 
 Print output based off of the format string and proceeding arguments.

--- a/src/uu/runcon/runcon.md
+++ b/src/uu/runcon/runcon.md
@@ -2,7 +2,7 @@
 
 ```
 runcon [CONTEXT COMMAND [ARG...]]
-runcon [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]";
+runcon [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]
 ```
 
 Run command with specified security context under SELinux enabled systems.

--- a/src/uu/shuf/shuf.md
+++ b/src/uu/shuf/shuf.md
@@ -3,7 +3,7 @@
 ```
 shuf [OPTION]... [FILE]
 shuf -e [OPTION]... [ARG]...
-shuf -i LO-HI [OPTION]...;
+shuf -i LO-HI [OPTION]...
 ```
 
 Shuffle the input by outputting a random permutation of input lines.

--- a/src/uu/sum/sum.md
+++ b/src/uu/sum/sum.md
@@ -1,7 +1,7 @@
 # sum
 
 ```
-sum [OPTION]... [FILE]..."
+sum [OPTION]... [FILE]...
 ```
 
 Checksum and count the blocks in a file.

--- a/src/uu/uniq/uniq.md
+++ b/src/uu/uniq/uniq.md
@@ -1,7 +1,7 @@
 # uniq
 
 ```
-uniq [OPTION]... [INPUT [OUTPUT]]...
+uniq [OPTION]... [INPUT [OUTPUT]]
 ```
 
 Report or omit repeated lines.

--- a/src/uu/unlink/unlink.md
+++ b/src/uu/unlink/unlink.md
@@ -2,6 +2,7 @@
 
 ```
 unlink [FILE]
+unlink OPTION
 ```
 
 Unlink the file at `FILE`.


### PR DESCRIPTION
join: fixed parameter
basenc: fixed parameter
cut: fixed parameter
mkdir: fixed parameter
nohup: fixed parameter
pr: fixed parameter
printenv: fixed parameter
printf: added parameters
runcon: fixed typo
shuf: fixed typo
sum: fixed typo
uniq: fixed parameter
unlink: fixed parameter
issue #5692