### PR TITLE
cp/mv/ln: add support for the "will not overwrite just-created"

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1203,7 +1203,9 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
             if fs::metadata(&dest).is_ok() && !fs::symlink_metadata(&dest)?.file_type().is_symlink()
             {
                 // There is already a file and it isn't a symlink (managed in a different place)
-                if copied_destinations.contains(&dest) {
+                if copied_destinations.contains(&dest)
+                    && options.backup != BackupMode::NumberedBackup
+                {
                     // If the target file was already created in this cp call, do not overwrite
                     return Err(Error::Error(format!(
                         "will not overwrite just-created '{}' with '{}'",

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1171,6 +1171,9 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
     //
     // key is the source file's information and the value is the destination filepath.
     let mut copied_files: HashMap<FileInformation, PathBuf> = HashMap::with_capacity(sources.len());
+    // remember the copied destinations for further usage.
+    // we can't use copied_files as it is because the key is the source file's information.
+    let mut copied_destinations: HashSet<PathBuf> = HashSet::with_capacity(sources.len());
 
     let progress_bar = if options.progress_bar {
         let pb = ProgressBar::new(disk_usage(sources, options.recursive)?)
@@ -1191,17 +1194,38 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
         if seen_sources.contains(source) {
             // FIXME: compare sources by the actual file they point to, not their path. (e.g. dir/file == dir/../dir/file in most cases)
             show_warning!("source {} specified more than once", source.quote());
-        } else if let Err(error) = copy_source(
-            &progress_bar,
-            source,
-            target,
-            target_type,
-            options,
-            &mut symlinked_files,
-            &mut copied_files,
-        ) {
-            show_error_if_needed(&error);
-            non_fatal_errors = true;
+        } else {
+            // We need to compute the destination path
+
+            let dest = construct_dest_path(source, target, target_type, options)
+                .unwrap_or_else(|_| target.to_path_buf());
+
+            if fs::metadata(&dest).is_ok() && !fs::symlink_metadata(&dest)?.file_type().is_symlink()
+            {
+                // There is already a file and it isn't a symlink (managed in a different place)
+                if copied_destinations.contains(&dest) {
+                    // If the target file was already created in this cp call, do not overwrite
+                    return Err(Error::Error(format!(
+                        "will not overwrite just-created '{}' with '{}'",
+                        dest.display(),
+                        source.display()
+                    )));
+                }
+            }
+
+            if let Err(error) = copy_source(
+                &progress_bar,
+                source,
+                target,
+                target_type,
+                options,
+                &mut symlinked_files,
+                &mut copied_files,
+            ) {
+                show_error_if_needed(&error);
+                non_fatal_errors = true;
+            }
+            copied_destinations.insert(dest.clone());
         }
         seen_sources.insert(source);
     }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1195,8 +1195,6 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
             // FIXME: compare sources by the actual file they point to, not their path. (e.g. dir/file == dir/../dir/file in most cases)
             show_warning!("source {} specified more than once", source.quote());
         } else {
-            // We need to compute the destination path
-
             let dest = construct_dest_path(source, target, target_type, options)
                 .unwrap_or_else(|_| target.to_path_buf());
 

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -342,7 +342,7 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
             };
 
         if linked_destinations.contains(&targetpath) {
-            // If the target file was already created in this linked call, do not overwrite
+            // If the target file was already created in this ln call, do not overwrite
             show_error!(
                 "will not overwrite just-created '{}' with '{}'",
                 targetpath.display(),

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -434,7 +434,7 @@ pub fn mv(files: &[OsString], opts: &Options) -> UResult<()> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, opts: &Options) -> UResult<()> {
+fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, options: &Options) -> UResult<()> {
     // remember the moved destinations for further usage
     let mut moved_destinations: HashSet<PathBuf> = HashSet::with_capacity(files.len());
 
@@ -446,7 +446,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, opts: &Options) -> 
         .canonicalize()
         .unwrap_or_else(|_| target_dir.to_path_buf());
 
-    let multi_progress = opts.progress_bar.then(MultiProgress::new);
+    let multi_progress = options.progress_bar.then(MultiProgress::new);
 
     let count_progress = if let Some(ref multi_progress) = multi_progress {
         if files.len() > 1 {
@@ -475,7 +475,8 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, opts: &Options) -> 
             }
         };
 
-        if moved_destinations.contains(&targetpath) && opts.backup != BackupMode::NumberedBackup {
+        if moved_destinations.contains(&targetpath) && options.backup != BackupMode::NumberedBackup
+        {
             // If the target file was already created in this mv call, do not overwrite
             return Err(USimpleError::new(
                 1,
@@ -509,7 +510,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, opts: &Options) -> 
             }
         }
 
-        match rename(sourcepath, &targetpath, opts, multi_progress.as_ref()) {
+        match rename(sourcepath, &targetpath, options, multi_progress.as_ref()) {
             Err(e) if e.to_string().is_empty() => set_exit_code(1),
             Err(e) => {
                 let e = e.map_err_context(|| {

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -478,7 +478,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, options: &Options) 
         if moved_destinations.contains(&targetpath) && options.backup != BackupMode::NumberedBackup
         {
             // If the target file was already created in this mv call, do not overwrite
-            return Err(USimpleError::new(
+            show!(USimpleError::new(
                 1,
                 format!(
                     "will not overwrite just-created '{}' with '{}'",
@@ -486,6 +486,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, options: &Options) 
                     sourcepath.display()
                 ),
             ));
+            continue;
         }
 
         // Check if we have mv dir1 dir2 dir2

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3562,7 +3562,8 @@ fn test_cp_attributes_only() {
 
 #[test]
 fn test_cp_seen_file() {
-    let (at, mut ucmd) = at_and_ucmd!();
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
 
     at.mkdir("a");
     at.mkdir("b");
@@ -3570,11 +3571,21 @@ fn test_cp_seen_file() {
     at.write("a/f", "a");
     at.write("b/f", "b");
 
-    ucmd.arg("a/f")
+    ts.ucmd()
+        .arg("a/f")
         .arg("b/f")
         .arg("c")
         .fails()
         .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
 
     assert!(at.plus("c").join("f").exists());
+
+    ts.ucmd()
+        .arg("--backup=numbered")
+        .arg("a/f")
+        .arg("b/f")
+        .arg("c")
+        .succeeds();
+    assert!(at.plus("c").join("f").exists());
+    assert!(at.plus("c").join("f.~1~").exists());
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3559,3 +3559,22 @@ fn test_cp_attributes_only() {
     assert_eq!(mode_a, at.metadata(a).mode());
     assert_eq!(mode_b, at.metadata(b).mode());
 }
+
+#[test]
+fn test_cp_seen_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("a");
+    at.mkdir("b");
+    at.mkdir("c");
+    at.write("a/f", "a");
+    at.write("b/f", "b");
+
+    ucmd.arg("a/f")
+        .arg("b/f")
+        .arg("c")
+        .fails()
+        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+
+    assert!(at.plus("c").join("f").exists());
+}

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3571,12 +3571,15 @@ fn test_cp_seen_file() {
     at.write("a/f", "a");
     at.write("b/f", "b");
 
-    ts.ucmd()
-        .arg("a/f")
-        .arg("b/f")
-        .arg("c")
-        .fails()
-        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+    let result = ts.ucmd().arg("a/f").arg("b/f").arg("c").fails();
+    #[cfg(not(unix))]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c\\f' with 'b/f'"));
+    #[cfg(unix)]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c/f' with 'b/f'"));
 
     assert!(at.plus("c").join("f").exists());
 

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -747,7 +747,7 @@ fn test_ln_seen_file() {
     assert!(at.plus("c").join("f").exists());
     // b/f still exists
     assert!(at.plus("b").join("f").exists());
-    // a/f no longer exists
+    // a/f still exists
     assert!(at.plus("a").join("f").exists());
     #[cfg(unix)]
     {

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -723,6 +723,7 @@ fn test_symlink_remove_existing_same_src_and_dest() {
 }
 
 #[test]
+#[cfg(not(target_os = "android"))]
 fn test_ln_seen_file() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -733,12 +733,16 @@ fn test_ln_seen_file() {
     at.write("a/f", "a");
     at.write("b/f", "b");
 
-    ts.ucmd()
-        .arg("a/f")
-        .arg("b/f")
-        .arg("c")
-        .fails()
-        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+    let result = ts.ucmd().arg("a/f").arg("b/f").arg("c").fails();
+
+    #[cfg(not(unix))]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c\\f' with 'b/f'"));
+    #[cfg(unix)]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c/f' with 'b/f'"));
 
     assert!(at.plus("c").join("f").exists());
     // b/f still exists

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -3,6 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use crate::common::util::TestScenario;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 
 #[test]
@@ -718,4 +720,45 @@ fn test_symlink_remove_existing_same_src_and_dest() {
         .stderr_contains("'a' and 'a' are the same file");
     assert!(at.file_exists("a") && !at.symlink_exists("a"));
     assert_eq!(at.read("a"), "sample");
+}
+
+#[test]
+fn test_ln_seen_file() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.mkdir("a");
+    at.mkdir("b");
+    at.mkdir("c");
+    at.write("a/f", "a");
+    at.write("b/f", "b");
+
+    ts.ucmd()
+        .arg("a/f")
+        .arg("b/f")
+        .arg("c")
+        .fails()
+        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+
+    assert!(at.plus("c").join("f").exists());
+    // b/f still exists
+    assert!(at.plus("b").join("f").exists());
+    // a/f no longer exists
+    assert!(at.plus("a").join("f").exists());
+    #[cfg(unix)]
+    {
+        // Check inode numbers
+        let inode_a_f = at.plus("a").join("f").metadata().unwrap().ino();
+        let inode_b_f = at.plus("b").join("f").metadata().unwrap().ino();
+        let inode_c_f = at.plus("c").join("f").metadata().unwrap().ino();
+
+        assert_eq!(
+            inode_a_f, inode_c_f,
+            "Inode numbers of a/f and c/f should be equal"
+        );
+        assert_ne!(
+            inode_b_f, inode_c_f,
+            "Inode numbers of b/f and c/f should not be equal"
+        );
+    }
 }

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1470,6 +1470,32 @@ fn test_mv_file_into_dir_where_both_are_files() {
 }
 
 #[test]
+fn test_mv_seen_file() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.mkdir("a");
+    at.mkdir("b");
+    at.mkdir("c");
+    at.write("a/f", "a");
+    at.write("b/f", "b");
+
+    ts.ucmd()
+        .arg("a/f")
+        .arg("b/f")
+        .arg("c")
+        .fails()
+        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+
+    // a/f has been moved into c/f
+    assert!(at.plus("c").join("f").exists());
+    // b/f still exists
+    assert!(at.plus("b").join("f").exists());
+    // a/f no longer exists
+    assert!(!at.plus("a").join("f").exists());
+}
+
+#[test]
 fn test_mv_dir_into_file_where_both_are_files() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1496,6 +1496,32 @@ fn test_mv_seen_file() {
 }
 
 #[test]
+fn test_mv_seen_multiple_files_to_directory() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.mkdir("a");
+    at.mkdir("b");
+    at.mkdir("c");
+    at.write("a/f", "a");
+    at.write("b/f", "b");
+    at.write("b/g", "g");
+
+    ts.ucmd()
+        .arg("a/f")
+        .arg("b/f")
+        .arg("b/g")
+        .arg("c")
+        .fails()
+        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+    assert!(!at.plus("a").join("f").exists());
+    assert!(at.plus("b").join("f").exists());
+    assert!(!at.plus("b").join("g").exists());
+    assert!(at.plus("c").join("f").exists());
+    assert!(at.plus("c").join("g").exists());
+}
+
+#[test]
 fn test_mv_dir_into_file_where_both_are_files() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1480,12 +1480,16 @@ fn test_mv_seen_file() {
     at.write("a/f", "a");
     at.write("b/f", "b");
 
-    ts.ucmd()
-        .arg("a/f")
-        .arg("b/f")
-        .arg("c")
-        .fails()
-        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+    let result = ts.ucmd().arg("a/f").arg("b/f").arg("c").fails();
+
+    #[cfg(not(unix))]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c\\f' with 'b/f'"));
+    #[cfg(unix)]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c/f' with 'b/f'"));
 
     // a/f has been moved into c/f
     assert!(at.plus("c").join("f").exists());
@@ -1507,13 +1511,16 @@ fn test_mv_seen_multiple_files_to_directory() {
     at.write("b/f", "b");
     at.write("b/g", "g");
 
-    ts.ucmd()
-        .arg("a/f")
-        .arg("b/f")
-        .arg("b/g")
-        .arg("c")
-        .fails()
-        .stderr_contains("will not overwrite just-created 'c/f' with 'b/f'");
+    let result = ts.ucmd().arg("a/f").arg("b/f").arg("b/g").arg("c").fails();
+    #[cfg(not(unix))]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c\\f' with 'b/f'"));
+    #[cfg(unix)]
+    assert!(result
+        .stderr_str()
+        .contains("will not overwrite just-created 'c/f' with 'b/f'"));
+
     assert!(!at.plus("a").join("f").exists());
     assert!(at.plus("b").join("f").exists());
     assert!(!at.plus("b").join("g").exists());


### PR DESCRIPTION
Should fix: tests/mv/childproof.sh