### PR TITLE
runcon: remove trailing '.'

### DIFF
--- a/src/uu/runcon/src/errors.rs
+++ b/src/uu/runcon/src/errors.rs
@@ -87,7 +87,6 @@ where
         err = source;
         write!(writer, ": {err}")?;
     }
-    write!(writer, ".")?;
     Ok(())
 }
 


### PR DESCRIPTION
Upstream doesn't have in:
https://github.com/coreutils/coreutils/blob/master/tests/runcon/runcon-no-reorder.sh#L22