### PR TITLE
wc: disable part of test on Android

### DIFF
--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -428,13 +428,17 @@ fn test_files_from_pseudo_filesystem() {
     let result = new_ucmd!().arg("-c").arg("/proc/cpuinfo").succeeds();
     assert_ne!(result.stdout_str(), "0 /proc/cpuinfo\n");
 
-    let (at, mut ucmd) = at_and_ucmd!();
-    let result = ucmd.arg("-c").arg("/sys/kernel/profiling").succeeds();
-    let actual = at.read("/sys/kernel/profiling").len();
-    assert_eq!(
-        result.stdout_str(),
-        format!("{} /sys/kernel/profiling\n", actual)
-    );
+    // the following block fails on Android with a "Permission denied" error
+    #[cfg(target_os = "linux")]
+    {
+        let (at, mut ucmd) = at_and_ucmd!();
+        let result = ucmd.arg("-c").arg("/sys/kernel/profiling").succeeds();
+        let actual = at.read("/sys/kernel/profiling").len();
+        assert_eq!(
+            result.stdout_str(),
+            format!("{} /sys/kernel/profiling\n", actual)
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR disables a part of `test_files_from_pseudo_filesystems` on Android because it fails with a "Permission denied" error when accessing `/sys/kernel/profiling`. I noticed this issue in https://github.com/uutils/coreutils/actions/runs/7309434867/job/19917041320?pr=5701 