### PR TITLE
install: remove / from end of path if it exists so as not to mess with .exists()

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -570,7 +570,7 @@ fn standard(mut paths: Vec<String>, b: &Behavior) -> UResult<()> {
 
         if let Some(to_create) = to_create {
             // if the path ends in /, remove it
-            let to_create = if to_create.to_string_lossy().ends_with("/") {
+            let to_create = if to_create.to_string_lossy().ends_with('/') {
                 Path::new(to_create.to_str().unwrap().trim_end_matches('/'))
             } else {
                 to_create

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -569,6 +569,13 @@ fn standard(mut paths: Vec<String>, b: &Behavior) -> UResult<()> {
         };
 
         if let Some(to_create) = to_create {
+            // if path ends in /, remove the slash
+            let to_create = if to_create.as_os_str().as_bytes().last() == Some(&b'/') {
+                to_create.parent().unwrap()
+            } else {
+                to_create
+            };
+
             if !to_create.exists() {
                 if b.verbose {
                     let mut result = PathBuf::new();

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -569,9 +569,9 @@ fn standard(mut paths: Vec<String>, b: &Behavior) -> UResult<()> {
         };
 
         if let Some(to_create) = to_create {
-            // if path ends in /, remove the slash
-            let to_create = if to_create.as_os_str().as_bytes().last() == Some(&b'/') {
-                to_create.parent().unwrap()
+            // if the path ends in /, remove it
+            let to_create = if to_create.to_string_lossy().ends_with("/") {
+                Path::new(to_create.to_str().unwrap().trim_end_matches('/'))
             } else {
                 to_create
             };

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -1589,3 +1589,27 @@ fn test_t_exist_dir() {
         .fails()
         .stderr_contains("failed to access 'sub4/file_exists': Not a directory");
 }
+
+#[test]
+fn test_target_file_ends_with_slash() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let source = "source_file";
+    let target_dir = "dir";
+    let target_file = "dir/target_file";
+    let target_file_slash = format!("{}/", target_file);
+
+    at.touch(source);
+    at.mkdir(target_dir);
+    at.touch(target_file);
+
+    scene
+        .ucmd()
+        .arg("-t")
+        .arg(target_file_slash)
+        .arg("-D")
+        .arg(source)
+        .fails()
+        .stderr_contains("failed to access 'dir/target_file/': Not a directory");
+}


### PR DESCRIPTION
#5720 fix.
I figured paths ending in "/" make .exists() not work properly so I added a check as to remove the / if there is one.