### PR TITLE
cp: fix backup of destination symlink

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1496,7 +1496,11 @@ fn context_for(src: &Path, dest: &Path) -> String {
 /// Implements a simple backup copy for the destination file.
 /// TODO: for the backup, should this function be replaced by `copy_file(...)`?
 fn backup_dest(dest: &Path, backup_path: &Path) -> CopyResult<PathBuf> {
-    fs::copy(dest, backup_path)?;
+    if dest.is_symlink() {
+        fs::rename(dest, backup_path)?;
+    } else {
+        fs::copy(dest, backup_path)?;
+    }
     Ok(backup_path.into())
 }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -679,6 +679,27 @@ fn test_cp_arg_backup() {
 }
 
 #[test]
+fn test_cp_arg_backup_with_dest_a_symlink() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = "source";
+    let source_content = "content";
+    let symlink = "symlink";
+    let original = "original";
+    let backup = "symlink~";
+
+    at.write(source, source_content);
+    at.write(original, "original");
+    at.symlink_file(original, symlink);
+
+    ucmd.arg("-b").arg(source).arg(symlink).succeeds();
+
+    assert!(!at.symlink_exists(symlink));
+    assert_eq!(source_content, at.read(symlink));
+    assert!(at.symlink_exists(backup));
+    assert_eq!(original, at.resolve_link(backup));
+}
+
+#[test]
 fn test_cp_arg_backup_with_other_args() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
When using `cp -b a symlink`, GNU `cp` backups `symlink` as `symlink~` and then overwrites `symlink` with `a` (and thus `symlink` is no longer a symlink). uutils `cp`, on the other hand, backups the target of the symlink as `symlink~` and then overwrites the target of the symlink with `a` (and thus `symlink` remains a symlink). This PR fixes this behavior.