### PR TITLE
Sort: Fixing opens too many files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,6 +2902,7 @@ dependencies = [
  "memchr",
  "rand",
  "rayon",
+ "rlimit",
  "self_cell",
  "tempfile",
  "unicode-width",

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -28,6 +28,7 @@ self_cell = { workspace = true }
 tempfile = { workspace = true }
 unicode-width = { workspace = true }
 uucore = { workspace = true, features = ["fs", "version-cmp"] }
+rlimit = "0.10.1"
 
 [[bin]]
 name = "sort"

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -26,6 +26,7 @@ use std::{
 
 use compare::Compare;
 use itertools::Itertools;
+use rlimit::{setrlimit, Resource};
 use uucore::error::UResult;
 
 use crate::{
@@ -42,6 +43,9 @@ fn replace_output_file_in_input_files(
     output: Option<&str>,
     tmp_dir: &mut TmpDirWrapper,
 ) -> UResult<()> {
+    // Increase the limit
+    setrlimit(Resource::NOFILE, 16, 16).unwrap();
+
     let mut copy: Option<PathBuf> = None;
     if let Some(Ok(output_path)) = output.map(|path| Path::new(path).canonicalize()) {
         for file in files {


### PR DESCRIPTION
Issue [#5714](https://github.com/uutils/coreutils/issues/5714) is addressed in this pull request.

Reference:
- [RustScan/issues/25](https://github.com/RustScan/RustScan/issues/25)
- [lychee/issues/1248](https://github.com/lycheeverse/lychee/issues/1248)

The same problem can be found in:
- [coreutils/issues/2312](https://github.com/uutils/coreutils/issues/2312)
- [coreutils/pull/2591](https://github.com/uutils/coreutils/pull/2591)

To be honest, I am not sure what the exact solution is to this problem. Increasing `ulimit`, for example, can resolve this issue, as can removing the `-m` flag from `sort -n -m`.

This pull request currently requires the user to run the target bash script in sudo mode. Hopefully, the maintainers can incorporate some hints into this PR.:)