### PR TITLE
cp: backup dest symlink linking to source

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1509,7 +1509,7 @@ fn backup_dest(dest: &Path, backup_path: &Path) -> CopyResult<PathBuf> {
 ///
 /// Copying to the same file is only allowed if both `--backup` and
 /// `--force` are specified and the file is a regular file.
-fn is_forbidden_copy_to_same_file(
+fn is_forbidden_to_copy_to_same_file(
     source: &Path,
     dest: &Path,
     options: &Options,
@@ -1533,7 +1533,7 @@ fn handle_existing_dest(
 ) -> CopyResult<()> {
     // Disallow copying a file to itself, unless `--force` and
     // `--backup` are both specified.
-    if is_forbidden_copy_to_same_file(source, dest, options, source_in_command_line) {
+    if is_forbidden_to_copy_to_same_file(source, dest, options, source_in_command_line) {
         return Err(format!("{} and {} are the same file", source.quote(), dest.quote()).into());
     }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1521,6 +1521,7 @@ fn is_forbidden_copy_to_same_file(
         options.dereference(source_in_command_line) || !source.is_symlink();
     paths_refer_to_same_file(source, dest, dereference_to_compare)
         && !(options.force() && options.backup != BackupMode::NoBackup)
+        && !(dest.is_symlink() && options.backup != BackupMode::NoBackup)
 }
 
 /// Back up, remove, or leave intact the destination file, depending on the options.

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -702,6 +702,25 @@ fn test_cp_arg_backup_with_dest_a_symlink() {
 }
 
 #[test]
+fn test_cp_arg_backup_with_dest_a_symlink_to_source() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = "source";
+    let source_content = "content";
+    let symlink = "symlink";
+    let backup = "symlink~";
+
+    at.write(source, source_content);
+    at.symlink_file(source, symlink);
+
+    ucmd.arg("-b").arg(source).arg(symlink).succeeds();
+
+    assert!(!at.symlink_exists(symlink));
+    assert_eq!(source_content, at.read(symlink));
+    assert!(at.symlink_exists(backup));
+    assert_eq!(source, at.resolve_link(backup));
+}
+
+#[test]
 fn test_cp_arg_backup_with_other_args() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
This PR covers a special case of https://github.com/uutils/coreutils/pull/5731, with the destination being a symlink to the source. So far this caused a "same file" error whereas it works fine with GNU `cp`.