### PR TITLE
ls: unquoted names should be indented with a space if there is a quoted name

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2718,12 +2718,8 @@ fn display_item_long(
         let item_name =
             display_item_name(item, config, None, String::new(), out, style_manager).contents;
 
-        let displayed_item = if quoted {
-            if item_name.starts_with('\'') {
-                item_name
-            } else {
-                format!(" {}", item_name)
-            }
+        let displayed_item = if quoted && !item_name.starts_with('\'') {
+            format!(" {}", item_name)
         } else {
             item_name
         };

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2462,10 +2462,10 @@ fn display_items(
 
         match config.format {
             Format::Columns => {
-                display_grid(names, config.width, Direction::TopToBottom, quoted, out)?;
+                display_grid(names, config.width, Direction::TopToBottom, out, quoted)?;
             }
             Format::Across => {
-                display_grid(names, config.width, Direction::LeftToRight, quoted, out)?;
+                display_grid(names, config.width, Direction::LeftToRight, out, quoted)?;
             }
             Format::Commas => {
                 let mut current_col = 0;
@@ -2530,8 +2530,8 @@ fn display_grid(
     names: impl Iterator<Item = Cell>,
     width: u16,
     direction: Direction,
-    quoted: bool,
     out: &mut BufWriter<Stdout>,
+    quoted: bool,
 ) -> UResult<()> {
     if width == 0 {
         // If the width is 0 we print one single line


### PR DESCRIPTION
Issue #5632 fix.

In short, I added a boolean variable `quoted` which is true if at least one file name is displayed between quotes. If so, all unquoted filenames are formatted so that they have an extra leading space, as GNU's ls does.

Unfortunately I couldn't find a way to write unit tests for this functionality because ls formats output differently when it's not stdout. I tried using different flags ("-C", "--quoting-style", "-T") but couldn't find a way to make ls format properly.