### PR TITLE
cp: adapt warning if source is used more than once

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1193,7 +1193,7 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
     for source in sources {
         if seen_sources.contains(source) {
             // FIXME: compare sources by the actual file they point to, not their path. (e.g. dir/file == dir/../dir/file in most cases)
-            show_warning!("source {} specified more than once", source.quote());
+            show_warning!("source file {} specified more than once", source.quote());
         } else {
             let dest = construct_dest_path(source, target, target_type, options)
                 .unwrap_or_else(|_| target.to_path_buf());

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -111,7 +111,9 @@ fn test_cp_duplicate_files() {
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
         .succeeds()
-        .stderr_contains("specified more than once");
+        .stderr_contains(format!(
+            "source file '{TEST_HELLO_WORLD_SOURCE}' specified more than once"
+        ));
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 }
 


### PR DESCRIPTION
This PR adapts the warning shown when using `cp a a b/` to match the one shown by GNU `cp`.