### PR TITLE
cp: show error if source and destination are same file

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1713,6 +1713,7 @@ fn copy_file(
         if are_hardlinks_to_same_file(source, dest)
             && !options.force()
             && options.backup == BackupMode::NoBackup
+            && source != dest
         {
             return Ok(());
         }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -118,6 +118,20 @@ fn test_cp_duplicate_files() {
 }
 
 #[test]
+fn test_cp_same_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "a";
+
+    at.touch(file);
+
+    ucmd.arg(file)
+        .arg(file)
+        .fails()
+        .code_is(1)
+        .stderr_contains(format!("'{file}' and '{file}' are the same file"));
+}
+
+#[test]
 fn test_cp_multiple_files_target_is_file() {
     new_ucmd!()
         .arg(TEST_HELLO_WORLD_SOURCE)


### PR DESCRIPTION
When using `cp a a`, GNU `cp` shows a "same file" error whereas uutils `cp` doesn't fail. This PR fixes this issue.