### PR TITLE
cp: show "same file" error for `--remove-destination a a`

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1706,7 +1706,11 @@ fn copy_file(
             OverwriteMode::Clobber(ClobberMode::RemoveDestination)
         )
     {
-        fs::remove_file(dest)?;
+        if source == dest {
+            handle_existing_dest(source, dest, options, source_in_command_line)?;
+        } else {
+            fs::remove_file(dest)?;
+        }
     }
 
     if file_or_link_exists(dest) {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2937,6 +2937,19 @@ fn test_cp_mode_hardlink_no_dereference() {
     assert_eq!(at.read_symlink("z"), "slink");
 }
 
+#[test]
+fn test_remove_destination_with_destination_being_same_file_as_source() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "file";
+
+    at.touch(file);
+
+    ucmd.args(&["--remove-destination", file, file])
+        .fails()
+        .stderr_contains(format!("'{file}' and '{file}' are the same file"));
+    assert!(at.file_exists(file));
+}
+
 #[cfg(not(any(windows, target_os = "android")))]
 #[test]
 fn test_remove_destination_with_destination_being_a_hardlink_to_source() {


### PR DESCRIPTION
When running `cp --remove-destination a a`, GNU `cp` shows a "same file" error whereas uutils `cp` removes the file and then shows a "no such file" error. This PR fixes this issue.