### PR TITLE
cp: show no "same file" error for `--link a a`

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -150,6 +150,7 @@ pub enum TargetType {
 }
 
 /// Copy action to perform
+#[derive(PartialEq)]
 pub enum CopyMode {
     Link,
     SymLink,
@@ -1714,6 +1715,7 @@ fn copy_file(
             && !options.force()
             && options.backup == BackupMode::NoBackup
             && source != dest
+            || (source == dest && options.copy_mode == CopyMode::Link)
         {
             return Ok(());
         }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -567,6 +567,22 @@ fn test_cp_arg_link_with_dest_hardlink_to_source() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_cp_arg_link_with_same_file() {
+    use std::os::linux::fs::MetadataExt;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "file";
+
+    at.touch(file);
+
+    ucmd.args(&["--link", file, file]).succeeds();
+
+    assert_eq!(at.metadata(file).st_nlink(), 1);
+    assert!(at.file_exists(file));
+}
+
+#[test]
 fn test_cp_arg_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.arg(TEST_HELLO_WORLD_SOURCE)


### PR DESCRIPTION
When running `cp --link a a`, GNU `cp` doesn't do anything whereas uutils `cp` shows a "same file" error. This PR adapts the behavior of uutils `cp` to match the one of GNU `cp`.