### PR TITLE
docs: fix URL for FreeBSD port

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -119,7 +119,7 @@ port install coreutils-uutils
 
 ## FreeBSD
 
-[![FreeBSD port](https://repology.org/badge/version-for-repo/freebsd/uutils-coreutils.svg)](https://repology.org/project/uutils-coreutils/versions)
+[![FreeBSD port](https://repology.org/badge/version-for-repo/freebsd/rust-coreutils.svg)](https://repology.org/project/rust-coreutils/versions)
 
 ```sh
 pkg install rust-coreutils


### PR DESCRIPTION
FreeBSD port name is `rust-coreutils`, fix URL for repology.org