### PR TITLE
seq: improve format_float_shortest to match GNU

### DIFF
--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -383,7 +383,11 @@ fn format_float_shortest(
     }
 
     let mut exponent = f.log10().floor() as i32;
-    if f != 0.0 && exponent <= -4 || exponent > precision as i32 {
+
+    // Special handling for precision zero
+    if precision == 0 {
+        format!("d{:0>24}", f as i64)
+    } else if f != 0.0 && (exponent <= -4 || exponent > precision as i32) {
         // Scientific-ish notation (with a few differences)
         let mut normalized = f / 10.0_f64.powi(exponent);
 

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -766,3 +766,13 @@ fn test_invalid_zero_increment_value() {
         .no_stdout()
         .usage_error("invalid Zero increment value: '0'");
 }
+
+#[test]
+fn test_width_no_decimal_scientific() {
+    new_ucmd!()
+        .args(&["--format=d%030g", "11"])
+        .succeeds()
+        .stdout_contains("d00000d000000000000000000000011\n")
+        .stderr_does_not_contain("d00000000000000000000000001e+01")
+        .no_stderr();
+}


### PR DESCRIPTION
Should help with tests/cp/link-heap

Closes: #5766
