### PR TITLE
du: ignore duplicate names with `--files0-from`

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -629,7 +629,10 @@ fn read_files_from(file_name: &str) -> Result<Vec<PathBuf>, std::io::Error> {
             show_error!("{file_name}:{line_number}: invalid zero-length file name");
             set_exit_code(1);
         } else {
-            paths.push(PathBuf::from(String::from_utf8_lossy(&path).to_string()));
+            let p = PathBuf::from(String::from_utf8_lossy(&path).to_string());
+            if !paths.contains(&p) {
+                paths.push(p);
+            }
         }
     }
 

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -1011,6 +1011,21 @@ fn test_du_files0_from() {
 }
 
 #[test]
+fn test_du_files0_from_ignore_duplicate_file_names() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    let file = "testfile";
+
+    at.touch(file);
+    at.write("filelist", &format!("{file}\0{file}\0"));
+
+    ts.ucmd()
+        .arg("--files0-from=filelist")
+        .succeeds()
+        .stdout_is(format!("0\t{file}\n"));
+}
+
+#[test]
 fn test_du_files0_from_with_invalid_zero_length_file_names() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -1044,6 +1059,23 @@ fn test_du_files0_from_stdin() {
         .succeeds()
         .stdout_contains("testfile1")
         .stdout_contains("testfile2");
+}
+
+#[test]
+fn test_du_files0_from_stdin_ignore_duplicate_file_names() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    let file = "testfile";
+
+    at.touch(file);
+
+    let input = format!("{file}\0{file}");
+
+    ts.ucmd()
+        .arg("--files0-from=-")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(format!("0\t{file}\n"));
 }
 
 #[test]


### PR DESCRIPTION
This PR ignores duplicate file names, whether they are piped in or read from a file specified with `--files0-from=some-file`. It makes the [files0-from.pl](https://github.com/coreutils/coreutils/blob/master/tests/du/files0-from.pl) GNU test pass.