### PR TITLE
fuzz: reset the exit code global variable after every test

### DIFF
--- a/fuzz/fuzz_targets/fuzz_common.rs
+++ b/fuzz/fuzz_targets/fuzz_common.rs
@@ -125,6 +125,9 @@ where
         let out = s.spawn(|| read_from_fd(pipe_stdout_fds[0]));
         let err = s.spawn(|| read_from_fd(pipe_stderr_fds[0]));
         let status = uumain_function(args.to_owned().into_iter());
+        // Reset the exit code global variable in case we run another test after this one
+        // See https://github.com/uutils/coreutils/issues/5777
+        uucore::error::set_exit_code(0);
         io::stdout().flush().unwrap();
         io::stderr().flush().unwrap();
         unsafe {


### PR DESCRIPTION
Fix #5777
