### PR TITLE
uucore: fix style in tests

### DIFF
--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -662,7 +662,7 @@ mod tests {
         let target = Path::new("data.txt");
         let suffix = String::from(".bak");
 
-        assert!(source_is_target_backup(&source, &target, &suffix));
+        assert!(source_is_target_backup(source, target, &suffix));
     }
 
     #[test]
@@ -671,7 +671,7 @@ mod tests {
         let target = Path::new("backup.txt");
         let suffix = String::from(".bak");
 
-        assert!(!source_is_target_backup(&source, &target, &suffix));
+        assert!(!source_is_target_backup(source, target, &suffix));
     }
 
     #[test]
@@ -680,6 +680,6 @@ mod tests {
         let target = Path::new("example");
         let suffix = String::from("~");
 
-        assert!(source_is_target_backup(&source, &target, &suffix));
+        assert!(source_is_target_backup(source, target, &suffix));
     }
 }

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -878,7 +878,7 @@ mod tests {
         let path1 = temp_file.path();
         let path2 = temp_file.path();
 
-        assert!(are_hardlinks_to_same_file(&path1, &path2));
+        assert!(are_hardlinks_to_same_file(path1, path2));
     }
 
     #[cfg(unix)]
@@ -893,7 +893,7 @@ mod tests {
         let path1 = temp_file1.path();
         let path2 = temp_file2.path();
 
-        assert!(!are_hardlinks_to_same_file(&path1, &path2));
+        assert!(!are_hardlinks_to_same_file(path1, path2));
     }
 
     #[cfg(unix)]
@@ -904,9 +904,9 @@ mod tests {
         let path1 = temp_file.path();
 
         let path2 = temp_file.path().with_extension("hardlink");
-        fs::hard_link(&path1, &path2).unwrap();
+        fs::hard_link(path1, &path2).unwrap();
 
-        assert!(are_hardlinks_to_same_file(&path1, &path2));
+        assert!(are_hardlinks_to_same_file(path1, &path2));
     }
 
     #[cfg(unix)]

--- a/src/uucore/src/lib/parser/parse_size.rs
+++ b/src/uucore/src/lib/parser/parse_size.rs
@@ -424,23 +424,23 @@ mod tests {
 
         for &(c, exp) in &suffixes {
             let s = format!("2{c}B"); // KB
-            assert_eq!(Ok((2 * (1000_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok(2 * (1000_u128).pow(exp)), parse_size_u128(&s));
             let s = format!("2{c}"); // K
-            assert_eq!(Ok((2 * (1024_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok(2 * (1024_u128).pow(exp)), parse_size_u128(&s));
             let s = format!("2{c}iB"); // KiB
-            assert_eq!(Ok((2 * (1024_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok(2 * (1024_u128).pow(exp)), parse_size_u128(&s));
             let s = format!("2{}iB", c.to_lowercase()); // kiB
-            assert_eq!(Ok((2 * (1024_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok(2 * (1024_u128).pow(exp)), parse_size_u128(&s));
 
             // suffix only
             let s = format!("{c}B"); // KB
-            assert_eq!(Ok(((1000_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok((1000_u128).pow(exp)), parse_size_u128(&s));
             let s = format!("{c}"); // K
-            assert_eq!(Ok(((1024_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok((1024_u128).pow(exp)), parse_size_u128(&s));
             let s = format!("{c}iB"); // KiB
-            assert_eq!(Ok(((1024_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok((1024_u128).pow(exp)), parse_size_u128(&s));
             let s = format!("{}iB", c.to_lowercase()); // kiB
-            assert_eq!(Ok(((1024_u128).pow(exp)) as u128), parse_size_u128(&s));
+            assert_eq!(Ok((1024_u128).pow(exp)), parse_size_u128(&s));
         }
     }
 

--- a/src/uucore/src/lib/parser/shortcut_value_parser.rs
+++ b/src/uucore/src/lib/parser/shortcut_value_parser.rs
@@ -163,7 +163,7 @@ mod tests {
         let parser = ShortcutValueParser::new(["abcd"]);
         let cmd = Command::new("cmd");
 
-        let result = parser.parse_ref(&cmd, None, OsStr::from_bytes(&[0xc3 as u8, 0x28 as u8]));
+        let result = parser.parse_ref(&cmd, None, OsStr::from_bytes(&[0xc3, 0x28]));
         assert_eq!(ErrorKind::InvalidUtf8, result.unwrap_err().kind());
     }
 }


### PR DESCRIPTION
- `Path::new()` returns a `&Path` and does not need to be dereferenced
- Some types can be deduced from the context and are well visible already (`parse_size_u128()` or `from_bytes()`)
