### PR TITLE
uuhelp_parser: add links to homepage and repo

### DIFF
--- a/src/uuhelp_parser/Cargo.toml
+++ b/src/uuhelp_parser/Cargo.toml
@@ -5,3 +5,6 @@ version = "0.0.23"
 edition = "2021"
 license = "MIT"
 description = "A collection of functions to parse the markdown code of help files"
+
+homepage = "https://github.com/uutils/coreutils"
+repository = "https://github.com/uutils/coreutils/tree/main/src/uuhelp_parser"


### PR DESCRIPTION
When viewing the crate right now, apart from via looking at the dependencies it's hard to find the associated project and repository.

Add the missing info.