### PR TITLE
uucore: add support for sparc64

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -121,6 +121,7 @@ impl FileInformation {
             not(target_arch = "aarch64"),
             not(target_arch = "riscv64"),
             not(target_arch = "loongarch64"),
+            not(target_arch = "sparc64"),
             target_pointer_width = "64"
         ))]
         return self.0.st_nlink;
@@ -137,6 +138,7 @@ impl FileInformation {
                 target_arch = "aarch64",
                 target_arch = "riscv64",
                 target_arch = "loongarch64",
+                target_arch = "sparc64",
                 not(target_pointer_width = "64")
             )
         ))]


### PR DESCRIPTION
Add support for sparc64 in uucore to avoid the following build failure with nushell:

```
error[E0308]: mismatched types
   --> /home/autobuild/autobuild/instance-7/output-1/build/nushell-0.85.0/VENDOR/uucore/src/lib/features/fs.rs:121:16
    |
111 |     pub fn number_of_links(&self) -> u64 {
    |                                      --- expected `u64` because of return type
...
121 |         return self.0.st_nlink;
    |                ^^^^^^^^^^^^^^^ expected `u64`, found `u32`
    |
help: you can convert a `u32` to a `u64`
    |
121 |         return self.0.st_nlink.into();
    |                               +++++++

For more information about this error, try `rustc --explain E0308`. error: could not compile `uucore` (lib) due to previous error

```

Fixes:
 - http://autobuild.buildroot.org/results/f9f0287a8e39c65895014ca513ed25071f020add