### PR TITLE
Made cksum return an error if the algorithm blake2b is used on a directory.

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -169,6 +169,13 @@ where
             (ALGORITHM_OPTIONS_CRC, true) => println!("{sum} {sz}"),
             (ALGORITHM_OPTIONS_CRC, false) => println!("{sum} {sz} {}", filename.display()),
             (ALGORITHM_OPTIONS_BLAKE2B, _) if !options.untagged => {
+                if filename.is_dir() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("{}: Is a directory", filename.display()),
+                    )
+                    .into());
+                }
                 if let Some(length) = options.length {
                     // Multiply by 8 here, as we want to print the length in bits.
                     println!("BLAKE2b-{} ({}) = {sum}", length * 8, filename.display());

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -286,3 +286,17 @@ fn test_length_is_zero() {
         .no_stderr()
         .stdout_is_fixture("length_is_zero.expected");
 }
+
+#[test]
+fn test_blake2b_fail_on_directory() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let folder_name = "a_folder";
+    at.mkdir(folder_name);
+
+    ucmd.arg("--algorithm=blake2b")
+        .arg(folder_name)
+        .fails()
+        .no_stdout()
+        .stderr_contains(format!("cksum: {folder_name}: Is a directory"));
+}


### PR DESCRIPTION
This PR should fix https://github.com/uutils/coreutils/issues/5792. Now an error is generated if the blake2b algorithm is used on a directory.