### PR TITLE
nl: don't exit if input is directory

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -7,8 +7,8 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Read};
 use std::path::Path;
-use uucore::error::{FromIo, UResult, USimpleError};
-use uucore::{format_usage, help_about, help_section, help_usage};
+use uucore::error::{set_exit_code, FromIo, UResult, USimpleError};
+use uucore::{format_usage, help_about, help_section, help_usage, show_error};
 
 mod helper;
 
@@ -205,9 +205,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             nl(&mut buffer, &mut stats, &settings)?;
         } else {
             let path = Path::new(file);
-            let reader = File::open(path).map_err_context(|| file.to_string())?;
-            let mut buffer = BufReader::new(reader);
-            nl(&mut buffer, &mut stats, &settings)?;
+
+            if path.is_dir() {
+                show_error!("{}: Is a directory", path.display());
+                set_exit_code(1);
+            } else {
+                let reader = File::open(path).map_err_context(|| file.to_string())?;
+                let mut buffer = BufReader::new(reader);
+                nl(&mut buffer, &mut stats, &settings)?;
+            }
         }
     }
 

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -634,3 +634,20 @@ fn test_empty_section_delimiter() {
             .stdout_is("     1\ta\n       \n     2\tb\n");
     }
 }
+
+#[test]
+fn test_directory_as_input() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir = "dir";
+    let file = "file";
+    let content = "aaa";
+
+    at.mkdir(dir);
+    at.write(file, content);
+
+    ucmd.arg(dir)
+        .arg(file)
+        .fails()
+        .stderr_is(format!("nl: {dir}: Is a directory\n"))
+        .stdout_contains(content);
+}


### PR DESCRIPTION
When specifying a directory instead of a file, GNU `nl` shows an error but keeps printing the output of the next file(s):
```
$ nl dir file
nl: dir: Is a directory
     1  content
```
uutils `nl`, on the other hand, shows an error and exits:
```
$ cargo run nl dir file
nl: could not read line: Is a directory
```
This PR makes uutils `nl` skip directories and show the same error as GNU `nl`.