### PR TITLE
pathchk: simplify and rename test

### DIFF
--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -19,8 +19,6 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_default_mode() {
-    // test the default mode
-
     // accept some reasonable default
     new_ucmd!().args(&["dir/file"]).succeeds().no_stdout();
 
@@ -56,8 +54,6 @@ fn test_default_mode() {
 
 #[test]
 fn test_posix_mode() {
-    // test the posix mode
-
     // accept some reasonable default
     new_ucmd!().args(&["-p", "dir/file"]).succeeds().no_stdout();
 
@@ -82,8 +78,6 @@ fn test_posix_mode() {
 
 #[test]
 fn test_posix_special() {
-    // test the posix special mode
-
     // accept some reasonable default
     new_ucmd!().args(&["-P", "dir/file"]).succeeds().no_stdout();
 
@@ -123,8 +117,6 @@ fn test_posix_special() {
 
 #[test]
 fn test_posix_all() {
-    // test the posix special mode
-
     // accept some reasonable default
     new_ucmd!()
         .args(&["-p", "-P", "dir/file"])

--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -5,6 +5,14 @@
 use crate::common::util::TestScenario;
 
 #[test]
+fn test_no_args() {
+    new_ucmd!()
+        .fails()
+        .no_stdout()
+        .stderr_contains("pathchk: missing operand");
+}
+
+#[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }
@@ -163,11 +171,4 @@ fn test_posix_all() {
 
     // fail on empty path
     new_ucmd!().args(&["-p", "-P", ""]).fails().no_stdout();
-}
-
-#[test]
-fn test_args_parsing() {
-    // fail on no args
-    let empty_args: [String; 0] = [];
-    new_ucmd!().args(&empty_args).fails().no_stdout();
 }


### PR DESCRIPTION
This PR renames `test_args_parsing` to `test_no_args` and simplifies the test. And it removes some useless comments.