### PR TITLE
 cksum: stops when one of given files doesn't exist #5809

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -135,7 +135,10 @@ where
             Box::new(BufReader::new(io::empty())) as Box<dyn Read>
         } else {
             file_buf =
-                File::open(filename).map_err_context(|| filename.to_str().unwrap().to_string())?;
+            match File::open(filename){
+                Ok(file) => file,
+                Err(err) => { println!("{:?} file dosen't exist",filename); continue;}
+            };
             Box::new(file_buf) as Box<dyn Read>
         });
         let (sum, sz) = digest_read(&mut options.digest, &mut file, options.output_bits)


### PR DESCRIPTION
i have added match so if it didn't found a file it will just continue the loop