### PR TITLE
Bump console and mio

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -615,6 +615,8 @@ jobs:
           arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
           aarch64-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
           *-redox*) sudo apt-get -y update ; sudo apt-get -y install fuse3 libfuse-dev ;;
+          # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
+          x86_64-pc-windows-gnu) C:/msys64/usr/bin/pacman.exe -Syu --needed mingw-w64-x86_64-gcc --noconfirm ; echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH ;;
         esac
         case '${{ matrix.job.os }}' in
           macos-latest) brew install coreutils ;; # needed for testing
@@ -983,6 +985,10 @@ jobs:
             touch /home/runner/.project
             echo "foo" > /home/runner/.plan
             ;;
+        esac
+        case '${{ matrix.job.os }}' in
+          # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
+          windows-latest) C:/msys64/usr/bin/pacman.exe -Syu --needed mingw-w64-x86_64-gcc --noconfirm ; echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH ;;
         esac
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,15 +320,15 @@ checksum = "120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3"
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -62,7 +62,7 @@ skip = [
   { name = "linux-raw-sys", version = "0.3.8" },
   # terminal_size
   { name = "rustix", version = "0.37.26" },
-  # various crates
+  # notify
   { name = "windows-sys", version = "0.45.0" },
   # various crates
   { name = "windows-sys", version = "0.48.0" },


### PR DESCRIPTION
This PR bumps `console` from `0.15.7` to `0.15.8` and `mio` from `0.8.6` to `0.8.10` in order to reduce the number of crates that depend on `windows-sys 0.45.0` to one (`notify`).