### PR TITLE
CI: test `uucore` with `coreutils` in codecov to run it with the proper features

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -994,16 +994,8 @@ jobs:
         UTILITY_LIST="$(./util/show-utils.sh ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }})"
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo -n "-puu_${u} "; done;)"
         outputs CARGO_UTILITY_LIST_OPTIONS
-    - name: Test uucore
-      run: cargo nextest run --profile ci --hide-progress-bar -p uucore
-      env:
-        RUSTC_WRAPPER: ""
-        RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
-        RUSTDOCFLAGS: "-Cpanic=abort"
-        RUST_BACKTRACE: "1"
-        # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Test
-      run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
       env:
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"

--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -484,22 +484,23 @@ mod tests {
     fn test_crlf_across_blocks() {
         use std::io::Write;
 
-        use crate::digest::Digest;
-        use crate::digest::DigestWriter;
+        use super::Digest;
+        use super::DigestWriter;
+        use super::Md5;
 
         // Writing "\r" in one call to `write()`, and then "\n" in another.
-        let mut digest = Box::new(md5::Md5::new()) as Box<dyn Digest>;
+        let mut digest = Box::new(Md5::new()) as Box<dyn Digest>;
         let mut writer_crlf = DigestWriter::new(&mut digest, false);
         writer_crlf.write_all(&[b'\r']).unwrap();
         writer_crlf.write_all(&[b'\n']).unwrap();
-        writer_crlf.hash_finalize();
+        writer_crlf.finalize();
         let result_crlf = digest.result_str();
 
         // We expect "\r\n" to be replaced with "\n" in text mode on Windows.
-        let mut digest = Box::new(md5::Md5::new()) as Box<dyn Digest>;
+        let mut digest = Box::new(Md5::new()) as Box<dyn Digest>;
         let mut writer_lf = DigestWriter::new(&mut digest, false);
         writer_lf.write_all(&[b'\n']).unwrap();
-        writer_lf.hash_finalize();
+        writer_lf.finalize();
         let result_lf = digest.result_str();
 
         assert_eq!(result_crlf, result_lf);


### PR DESCRIPTION
I think this should fix https://github.com/uutils/coreutils/pull/5783/files#r1447343162

The problem is that we were testing uucore without any features enabled, which led to a lot of tests being ignored.

In general it might be time to refactor our workflows a bit and make them a bit more uniform. The MSRV, codecov and regular builds all seem to be doing slightly different things.