### PR TITLE
printf: %c prints the first byte of its argument

### DIFF
--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -45,7 +45,7 @@ impl<'a, T: Iterator<Item = &'a FormatArgument>> ArgumentIter<'a> for T {
         };
         match next {
             FormatArgument::Char(c) => *c,
-            FormatArgument::Unparsed(s) => s.chars().next().unwrap_or('\0'),
+            FormatArgument::Unparsed(s) => s.bytes().next().map_or('\0', char::from),
             _ => '\0',
         }
     }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -639,3 +639,8 @@ fn partial_char() {
             "printf: warning: bc: character(s) following character constant have been ignored\n",
         );
 }
+
+#[test]
+fn char_as_byte() {
+    new_ucmd!().args(&["%c", "🙃"]).succeeds().stdout_only("ð");
+}


### PR DESCRIPTION
Fix #5826