### PR TITLE
printf: output of double-quote should not be escaped

### DIFF
--- a/src/uucore/src/lib/features/format/escape.rs
+++ b/src/uucore/src/lib/features/format/escape.rs
@@ -108,6 +108,7 @@ pub fn parse_escape_code(rest: &mut &[u8]) -> EscapedChar {
         *rest = new_rest;
         match c {
             b'\\' => EscapedChar::Byte(b'\\'),
+            b'"' => EscapedChar::Byte(b'"'),
             b'a' => EscapedChar::Byte(b'\x07'),
             b'b' => EscapedChar::Byte(b'\x08'),
             b'c' => EscapedChar::End,

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -37,6 +37,11 @@ fn escaped_slash() {
 }
 
 #[test]
+fn unescaped_double_quote() {
+    new_ucmd!().args(&["\\\""]).succeeds().stdout_only("\"");
+}
+
+#[test]
 fn escaped_hex() {
     new_ucmd!().args(&["\\x41"]).succeeds().stdout_only("A");
 }


### PR DESCRIPTION
``` bash
$ printf '\#\"\$'
\#"\$
```