### PR TITLE
printf : no infinite loop

### DIFF
--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -11,7 +11,7 @@ use std::ops::ControlFlow;
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use uucore::error::{UResult, UUsageError};
-use uucore::format::{parse_spec_and_escape, FormatArgument};
+use uucore::format::{parse_spec_and_escape, FormatArgument, FormatItem};
 use uucore::{format_usage, help_about, help_section, help_usage};
 
 const VERSION: &str = "version";
@@ -44,6 +44,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             ControlFlow::Continue(()) => {}
             ControlFlow::Break(()) => return Ok(()),
         };
+    }
+
+    // See #5815 - We don't need to iter on args if no format string seen
+    let format_seen = parse_spec_and_escape(format_string.as_ref())
+        .into_iter()
+        .any(|r| matches!(r, Ok(FormatItem::Spec(_))));
+    if !format_seen {
+        return Ok(());
     }
 
     while args.peek().is_some() {

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -47,9 +47,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     // See #5815 - We don't need to iter on args if no format string seen
-    let format_seen = parse_spec_and_escape(format_string.as_ref())
-        .into_iter()
-        .any(|r| matches!(r, Ok(FormatItem::Spec(_))));
+    let format_seen =
+        parse_spec_and_escape(format_string.as_ref()).any(|r| matches!(r, Ok(FormatItem::Spec(_))));
     if !format_seen {
         return Ok(());
     }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -649,3 +649,8 @@ fn partial_char() {
 fn char_as_byte() {
     new_ucmd!().args(&["%c", "🙃"]).succeeds().stdout_only("ð");
 }
+
+#[test]
+fn no_infinite_loop() {
+    new_ucmd!().args(&["a", "b"]).succeeds().stdout_only("a");
+}


### PR DESCRIPTION
Fixes #5815

```bash
$ printf a b
a
```
This PR adds a test for this behaviour. at this moment - the iter from `parse_spec_and_escape` function won't consume `args` if no format string is present and goes to an infinite loop.

https://github.com/uutils/coreutils/blob/edb77b8d591a1f0653a35f462923aaa7fb61b574/src/uu/printf/src/printf.rs#L49-L54
