### PR TITLE
cut: allow the same option to be passed multiple times

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -510,6 +510,7 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .after_help(AFTER_HELP)
         .infer_long_args(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::BYTES)
                 .short('b')

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -255,3 +255,13 @@ fn test_equal_as_delimiter3() {
         .succeeds()
         .stdout_only_bytes("abZcd\n");
 }
+
+#[test]
+fn test_multiple() {
+    let result = new_ucmd!()
+        .args(&["-f2", "-d:", "-d="])
+        .pipe_in("a=b\n")
+        .succeeds();
+    assert_eq!(result.stdout_str(), "b\n");
+    assert_eq!(result.stderr_str(), "");
+}


### PR DESCRIPTION
found with fuzzing