### PR TITLE
head: fix clippy warnings in tests

### DIFF
--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -391,7 +391,7 @@ fn test_read_backwards_bytes_proc_fs_version() {
 
     let args = ["-c", "-1", "/proc/version"];
     let result = ts.ucmd().args(&args).succeeds();
-    assert!(result.stdout().len() > 0);
+    assert!(!result.stdout().is_empty());
 }
 
 #[cfg(all(
@@ -406,7 +406,7 @@ fn test_read_backwards_bytes_proc_fs_modules() {
 
     let args = ["-c", "-1", "/proc/modules"];
     let result = ts.ucmd().args(&args).succeeds();
-    assert!(result.stdout().len() > 0);
+    assert!(!result.stdout().is_empty());
 }
 
 #[cfg(all(
@@ -421,7 +421,7 @@ fn test_read_backwards_lines_proc_fs_modules() {
 
     let args = ["--lines", "-1", "/proc/modules"];
     let result = ts.ucmd().args(&args).succeeds();
-    assert!(result.stdout().len() > 0);
+    assert!(!result.stdout().is_empty());
 }
 
 #[cfg(all(


### PR DESCRIPTION
This PR fixes some clippy warnings from the [len_zero](https://rust-lang.github.io/rust-clippy/master/index.html#/len_zero) lint in the tests.