### PR TITLE
ci: add Android x86_64

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         api-level: [28]
         target: [default]
-        arch: [x86] # , arm64-v8a
+        arch: [x86, x86_64] # , arm64-v8a
     env:
       TERMUX: v0.118.0
     steps:


### PR DESCRIPTION
This PR enables Android x86_64 in the CI/CD as suggested in https://github.com/uutils/coreutils/pull/5821 and should be merged after it.