### PR TITLE
install: fix strip program stdout and destination hyphen handling #5718

### DIFF
--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -25,6 +25,7 @@ uucore = { workspace = true, features = [
   "mode",
   "perms",
   "entries",
+  "process"
 ] }
 
 [[bin]]

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -25,7 +25,7 @@ uucore = { workspace = true, features = [
   "mode",
   "perms",
   "entries",
-  "process"
+  "process",
 ] }
 
 [[bin]]

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -789,15 +789,14 @@ fn strip_file(to: &Path, b: &Behavior) -> UResult<()> {
     } else {
         to.to_path_buf()
     };
-    match process::Command::new(&b.strip_program).arg(&to).output() {
-        Ok(o) => {
-            if !o.status.success() {
+    match process::Command::new(&b.strip_program).arg(&to).status() {
+        Ok(status) => {
+            if !status.success() {
                 // Follow GNU's behavior: if strip fails, removes the target
                 let _ = fs::remove_file(to);
                 return Err(InstallError::StripProgramFailed(
-                    String::from_utf8(o.stderr).unwrap_or_default(),
-                )
-                .into());
+                    format!("strip process terminated abnormally - exit code: {}", status.code().unwrap())
+                ).into());
             }
         }
         Err(e) => {

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -776,13 +776,8 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
 ///
 fn strip_file(to: &Path, b: &Behavior) -> UResult<()> {
     // Check if the filename starts with a hyphen and adjust the path
-    let to = if to
-        .file_name()
-        .unwrap_or_default()
-        .to_str()
-        .unwrap_or_default()
-        .starts_with('-')
-    {
+    let to_str = to.as_os_str().to_str().unwrap_or_default();
+    let to = if to_str.starts_with('-') {
         let mut new_path = PathBuf::from(".");
         new_path.push(to);
         new_path

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -789,9 +789,11 @@ fn strip_file(to: &Path, b: &Behavior) -> UResult<()> {
             if !status.success() {
                 // Follow GNU's behavior: if strip fails, removes the target
                 let _ = fs::remove_file(to);
-                return Err(InstallError::StripProgramFailed(
-                    format!("strip process terminated abnormally - exit code: {}", status.code().unwrap())
-                ).into());
+                return Err(InstallError::StripProgramFailed(format!(
+                    "strip process terminated abnormally - exit code: {}",
+                    status.code().unwrap()
+                ))
+                .into());
             }
         }
         Err(e) => {

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -701,6 +701,18 @@ fn test_install_and_strip_with_program_hyphen() {
         .succeeds()
         .no_stderr()
         .stdout_is("./-dest\n");
+
+    scene
+        .ucmd()
+        .arg("-s")
+        .arg("--strip-program")
+        .arg("./no-hyphen")
+        .arg("--")
+        .arg("src")
+        .arg("./-dest")
+        .succeeds()
+        .no_stderr()
+        .stdout_is("./-dest\n");
 }
 
 #[test]

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -699,7 +699,8 @@ fn test_install_and_strip_with_program_hyphen() {
         .arg("src")
         .arg("-dest")
         .succeeds()
-        .no_stderr();
+        .no_stderr()
+        .stdout_is("./-dest\n");
 }
 
 #[test]


### PR DESCRIPTION
adresses issue #5718

there where two issues:
1. stdout from strip program wasn't forwarded
2. "./" was applied redundantly (`././-dest`) as the check was on the filename (without path)

Tests are extented accordingly