### PR TITLE
timeout: heavy system load might cause "timeout" to wait too long

### DIFF
--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -151,7 +151,7 @@ fn test_kill_subprocess() {
             "10",
             "sh",
             "-c",
-            "sh -c \"trap 'echo xyz' TERM; sleep 30\"",
+            "sh -c \"trap 'echo xyz' TERM; sleep 120\"",
         ])
         .fails()
         .code_is(124)


### PR DESCRIPTION
tries to address #5459

Increase sleep to ensure that a kill signal is send. 
In green case the execution time of unittest will stay the same.

This solution is just a guess. I was not able to reproduce the issue locally.