### PR TITLE
tsort: returns error when input is dir - same as GNU tsort

### DIFF
--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -36,7 +36,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         if path.is_dir() {
             return Err(USimpleError::new(
                 1,
-                format!("tsort: `{}`: read error: Is a directory", input),
+                format!("{}: read error: Is a directory", input),
             ));
         }
         file_buf = File::open(path).map_err_context(|| input.to_string())?;

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -32,7 +32,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         stdin_buf = stdin();
         &mut stdin_buf as &mut dyn Read
     } else {
-        file_buf = File::open(Path::new(&input)).map_err_context(|| input.to_string())?;
+        let path = Path::new(&input);
+        if path.is_dir() {
+            return Err(USimpleError::new(
+                1,
+                format!("tsort: `{}`: read error: Is a directory", input),
+            ));
+        }
+        file_buf = File::open(path).map_err_context(|| input.to_string())?;
         &mut file_buf as &mut dyn Read
     });
 

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -70,5 +70,5 @@ fn test_error_on_dir() {
     new_ucmd!()
         .arg(".")
         .fails()
-        .stderr_contains("tsort: tsort: `.`: read error: Is a directory");
+        .stderr_contains("tsort: `.`: read error: Is a directory");
 }

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -64,3 +64,11 @@ fn test_multiple_arguments() {
         .fails()
         .stderr_contains("unexpected argument 'invalid_file' found");
 }
+
+#[test]
+fn test_error_on_dir() {
+    new_ucmd!()
+        .arg(".")
+        .fails()
+        .stderr_contains("tsort: tsort: `.`: read error: Is a directory");
+}

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -69,8 +69,7 @@ fn test_multiple_arguments() {
 fn test_error_on_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("tsort_test_dir");
-    ucmd
-        .arg("tsort_test_dir")
+    ucmd.arg("tsort_test_dir")
         .fails()
         .stderr_contains("tsort: tsort_test_dir: read error: Is a directory");
 }

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -67,8 +67,10 @@ fn test_multiple_arguments() {
 
 #[test]
 fn test_error_on_dir() {
-    new_ucmd!()
-        .arg(".")
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("tsort_test_dir");
+    ucmd
+        .arg("tsort_test_dir")
         .fails()
-        .stderr_contains("tsort: `.`: read error: Is a directory");
+        .stderr_contains("tsort: tsort_test_dir: read error: Is a directory");
 }


### PR DESCRIPTION
fix: #5853