### PR TITLE
ci: undo part of #5825

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -612,15 +612,15 @@ jobs:
       run: |
         ## Install/setup prerequisites
         case '${{ matrix.job.target }}' in
-          arm-unknown-linux-gnueabihf) 
+          arm-unknown-linux-gnueabihf)
             sudo apt-get -y update
             sudo apt-get -y install gcc-arm-linux-gnueabihf
           ;;
-          aarch64-unknown-linux-*) 
+          aarch64-unknown-linux-*)
             sudo apt-get -y update
             sudo apt-get -y install gcc-aarch64-linux-gnu
           ;;
-          *-redox*) 
+          *-redox*)
             sudo apt-get -y update
             sudo apt-get -y install fuse3 libfuse-dev
           ;;
@@ -1013,7 +1013,7 @@ jobs:
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo -n "-puu_${u} "; done;)"
         outputs CARGO_UTILITY_LIST_OPTIONS
     - name: Test
-      run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
+      run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p coreutils
       env:
         RUSTC_WRAPPER: ""
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"


### PR DESCRIPTION
This PR undoes a part of #5825 in an attempt to get the CI back to green and to get rid of the `unknown package ID: uucore 0.0.23 (path+file:///home/runner/work/coreutils/coreutils/src/uucore)` errors.