### PR TITLE
tests: disable tests for tools unsupported on OpenBSD

### DIFF
--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -21,6 +21,7 @@ fn test_capitalize() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_long_format() {
     let login = "root";
     let pw: Passwd = Passwd::locate(login).unwrap();
@@ -44,6 +45,7 @@ fn test_long_format() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_long_format_multiple_users() {
     // multiple instances of one account we know exists,
     // the account of the test runner,
@@ -71,6 +73,7 @@ fn test_long_format_wo_user() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_short_format_i() {
     // allow whitespace variation
     // * minor whitespace differences occur between platform built-in outputs; specifically, the number of trailing TABs may be variant
@@ -85,6 +88,7 @@ fn test_short_format_i() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_short_format_q() {
     // allow whitespace variation
     // * minor whitespace differences occur between platform built-in outputs; specifically, the number of trailing TABs may be variant
@@ -99,6 +103,7 @@ fn test_short_format_q() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_no_flag() {
     let ts = TestScenario::new(util_name!());
     let actual = ts.ucmd().succeeds().stdout_move_str();

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -11,6 +11,7 @@ fn test_invalid_arg() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_uptime() {
     TestScenario::new(util_name!())
         .ucmd()
@@ -22,6 +23,7 @@ fn test_uptime() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_uptime_since() {
     let re = Regex::new(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}").unwrap();
 

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -25,6 +25,7 @@ fn test_count() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_boot() {
     let ts = TestScenario::new(util_name!());
     for opt in ["-b", "--boot", "--b"] {
@@ -65,6 +66,7 @@ fn test_short() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_login() {
     let ts = TestScenario::new(util_name!());
     for opt in ["-l", "--login", "--log"] {
@@ -75,6 +77,7 @@ fn test_login() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_m() {
     let ts = TestScenario::new(util_name!());
     let expected_stdout = unwrap_or_return!(expected_result(&ts, &["-m"])).stdout_move_str();
@@ -83,6 +86,7 @@ fn test_m() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_process() {
     let ts = TestScenario::new(util_name!());
     for opt in ["-p", "--process", "--p"] {
@@ -93,6 +97,7 @@ fn test_process() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_runlevel() {
     let ts = TestScenario::new(util_name!());
     for opt in ["-r", "--runlevel", "--r"] {
@@ -106,6 +111,7 @@ fn test_runlevel() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_time() {
     let ts = TestScenario::new(util_name!());
     for opt in ["-t", "--time", "--t"] {
@@ -141,6 +147,7 @@ fn test_mesg() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_arg1_arg2() {
     let args = ["am", "i"];
     let ts = TestScenario::new(util_name!());
@@ -195,6 +202,7 @@ fn test_lookup() {
 
 #[cfg(unix)]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_dead() {
     let ts = TestScenario::new(util_name!());
     for opt in ["-d", "--dead", "--de"] {


### PR DESCRIPTION
pinky, uptime and who are not supported on OpenBSD (no support of utmpx feature, see PR uutils/coreutils#5620) => disable tests for these tools on OpenBSD with conditional compilation

No need to disable tests for users (tool not supported on OpenBSD)