### PR TITLE
Bump smallvec from 1.13.0 to 1.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smawk"


### PR DESCRIPTION
This PR bumps `smallvec` from `1.13.0` to `1.13.1` to fix a "yanked crate" warning from `cargo deny`.