### PR TITLE
expand: make tab explicit in test

### DIFF
--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -403,7 +403,7 @@ fn test_args_override() {
 // * indentation uses <TAB> characters
 int main() {
         // * next line has both a leading & trailing tab
-        // with tabs=>	
+        // with tabs=>\t
         return 0;
 }
 ",


### PR DESCRIPTION
This PR replaces an invisible trailing tab in a test with `\t`.