### PR TITLE
cut: set exit code to 1 if directory is specified

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufReader, BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::error::{set_exit_code, FromIo, UResult, USimpleError};
 use uucore::line_ending::LineEnding;
 
 use self::searcher::Searcher;
@@ -319,6 +319,7 @@ fn cut_files(mut filenames: Vec<String>, mode: &Mode) {
 
             if path.is_dir() {
                 show_error!("{}: Is a directory", filename.maybe_quote());
+                set_exit_code(1);
                 continue;
             }
 

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -219,7 +219,8 @@ fn test_is_a_directory() {
 
     ucmd.arg("-b1")
         .arg("some")
-        .run()
+        .fails()
+        .code_is(1)
         .stderr_is("cut: some: Is a directory\n");
 }
 
@@ -228,7 +229,8 @@ fn test_no_such_file() {
     new_ucmd!()
         .arg("-b1")
         .arg("some")
-        .run()
+        .fails()
+        .code_is(1)
         .stderr_is("cut: some: No such file or directory\n");
 }
 

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -212,7 +212,7 @@ fn test_zero_terminated_only_delimited() {
 }
 
 #[test]
-fn test_directory_and_no_such_file() {
+fn test_is_a_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 
     at.mkdir("some");
@@ -221,7 +221,10 @@ fn test_directory_and_no_such_file() {
         .arg("some")
         .run()
         .stderr_is("cut: some: Is a directory\n");
+}
 
+#[test]
+fn test_no_such_file() {
     new_ucmd!()
         .arg("-b1")
         .arg("some")


### PR DESCRIPTION
This PR sets the exit code to `1` if a directory is specified and adapts the existing test accordingly. It also ensures there is an exit code of `1` if a non-existing file is specified (the corresponding functionality was already implemented).