### PR TITLE
fuzzing: use LC_ALL instead of LC_COLLATE

### DIFF
--- a/fuzz/fuzz_targets/fuzz_sort.rs
+++ b/fuzz/fuzz_targets/fuzz_sort.rs
@@ -60,7 +60,7 @@ fuzz_target!(|_data: &[u8]| {
     let rust_result = generate_and_run_uumain(&args, uumain, Some(&input_lines));
 
     // TODO remove once uutils sort supports localization
-    env::set_var("LC_COLLATE", "C");
+    env::set_var("LC_ALL", "C");
     let gnu_result = match run_gnu_cmd(CMD_PATH, &args[1..], false, Some(&input_lines)) {
         Ok(result) => result,
         Err(error_result) => {


### PR DESCRIPTION
The output of GNU `sort` in https://github.com/uutils/coreutils/issues/5849 doesn't seem to use the C locale, even though `LC_COLLATE=C` is set before running GNU `sort`. The help says to set `LC_ALL=C`:
```
The locale specified by the environment affects sort order.
Set LC_ALL=C to get the traditional sort order that uses
native byte values.
```
On my machine I don't see a difference, both `LC_COLLATE=C` and `LC_ALL=C` lead to the same `sort` output. So I'm not sure whether this PR will fix the issue.