### PR TITLE
factor: remove clippy exceptions by reformatting "unreadable literals"

### DIFF
--- a/src/uu/factor/build.rs
+++ b/src/uu/factor/build.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-//! Generate a table of the multiplicative inverses of p_i mod 2^64
+//! Generate a table of the multiplicative inverses of `p_i` mod 2^64
 //! for the first 1027 odd primes (all 13 bit and smaller primes).
 //! You can supply a command line argument to override the default
 //! value of 1027 for the number of entries in the table.
@@ -87,7 +87,7 @@ fn test_generator_10001() {
 }
 
 const MAX_WIDTH: usize = 102;
-const PREAMBLE: &str = r##"/*
+const PREAMBLE: &str = r"/*
 * This file is part of the uutils coreutils package.
 *
 * For the full copyright and license information, please view the LICENSE file
@@ -100,4 +100,4 @@ const PREAMBLE: &str = r##"/*
 
 #[allow(clippy::unreadable_literal)]
 pub const PRIME_INVERSIONS_U64: &[(u64, u64, u64)] = &[
-   "##;
+   ";

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -217,7 +217,7 @@ mod tests {
         // This is a strong pseudoprime (wrt. miller_rabin::BASIS)
         //  and triggered a bug in rho::factor's code path handling
         //  miller_rabbin::Result::Composite
-        let pseudoprime = 17179869183;
+        let pseudoprime = 17_179_869_183;
         for _ in 0..20 {
             // Repeat the test 20 times, as it only fails some fraction
             // of the time.

--- a/src/uu/factor/src/miller_rabin.rs
+++ b/src/uu/factor/src/miller_rabin.rs
@@ -14,19 +14,17 @@ pub(crate) trait Basis {
 impl Basis for Montgomery<u64> {
     // Small set of bases for the Miller-Rabin prime test, valid for all 64b integers;
     //  discovered by Jim Sinclair on 2011-04-20, see miller-rabin.appspot.com
-    #[allow(clippy::unreadable_literal)]
-    const BASIS: &'static [u64] = &[2, 325, 9375, 28178, 450775, 9780504, 1795265022];
+    const BASIS: &'static [u64] = &[2, 325, 9375, 28178, 450_775, 9_780_504, 1_795_265_022];
 }
 
 impl Basis for Montgomery<u32> {
     // spell-checker:ignore (names) Steve Worley
     // Small set of bases for the Miller-Rabin prime test, valid for all 32b integers;
     //  discovered by Steve Worley on 2013-05-27, see miller-rabin.appspot.com
-    #[allow(clippy::unreadable_literal)]
     const BASIS: &'static [u64] = &[
-        4230279247111683200,
-        14694767155120705706,
-        16641139526367750375,
+        4_230_279_247_111_683_200,
+        14_694_767_155_120_705_706,
+        16_641_139_526_367_750_375,
     ];
 }
 
@@ -112,7 +110,7 @@ mod tests {
     use crate::numeric::{traits::DoubleInt, Arithmetic, Montgomery};
     use quickcheck::quickcheck;
     use std::iter;
-    const LARGEST_U64_PRIME: u64 = 0xFFFFFFFFFFFFFFC5;
+    const LARGEST_U64_PRIME: u64 = 0xFFFF_FFFF_FFFF_FFC5;
 
     fn primes() -> impl Iterator<Item = u64> {
         iter::once(2).chain(odd_primes())

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -2,7 +2,6 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-#![allow(clippy::unreadable_literal)]
 
 // spell-checker:ignore (methods) hexdigest
 


### PR DESCRIPTION
Closes: #5884

first dabbling with uutils. Trying to be helpful.