### PR TITLE
cp: remove lint exceptions

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -3,8 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore (ToDO) copydir ficlone fiemap ftruncate linkgs lstat nlink nlinks pathbuf pwrite reflink strs xattrs symlinked deduplicated advcpmv nushell IRWXG IRWXO IRWXU IRWXUGO IRWXU IRWXG IRWXO IRWXUGO
-#![allow(clippy::missing_safety_doc)]
-#![allow(clippy::extra_unused_lifetimes)]
 
 use quick_error::quick_error;
 use std::cmp::Ordering;


### PR DESCRIPTION
Could not even reproduce what they would complain for. Closes: #5885

I went back to the commit introducing these, but with today's carg/clippy, warning did not show up