### PR TITLE
factor: rename input parameter

### DIFF
--- a/src/uu/factor/src/rho.rs
+++ b/src/uu/factor/src/rho.rs
@@ -10,15 +10,14 @@ use std::cmp::{max, min};
 
 use crate::numeric::*;
 
-pub(crate) fn find_divisor<A: Arithmetic>(n: A) -> u64 {
-    #![allow(clippy::many_single_char_names)]
+pub(crate) fn find_divisor<A: Arithmetic>(input: A) -> u64 {
     let mut rand = {
-        let range = Uniform::new(1, n.modulus());
+        let range = Uniform::new(1, input.modulus());
         let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
-        move || n.to_mod(range.sample(&mut rng))
+        move || input.to_mod(range.sample(&mut rng))
     };
 
-    let quadratic = |a, b| move |x| n.add(n.mul(a, n.mul(x, x)), b);
+    let quadratic = |a, b| move |x| input.add(input.mul(a, input.mul(x, x)), b);
 
     loop {
         let f = quadratic(rand(), rand());
@@ -29,11 +28,11 @@ pub(crate) fn find_divisor<A: Arithmetic>(n: A) -> u64 {
             x = f(x);
             y = f(f(y));
             let d = {
-                let _x = n.to_u64(x);
-                let _y = n.to_u64(y);
-                gcd(n.modulus(), max(_x, _y) - min(_x, _y))
+                let _x = input.to_u64(x);
+                let _y = input.to_u64(y);
+                gcd(input.modulus(), max(_x, _y) - min(_x, _y))
             };
-            if d == n.modulus() {
+            if d == input.modulus() {
                 // Failure, retry with a different quadratic
                 break;
             } else if d > 1 {


### PR DESCRIPTION
Closes: #5883

Clippy warns if there are more than 4 single-character local variables.

I looked up the original papers for that algorithm and I don't see any sense renaming `x,y or d`.
I see the best solution in renaming the input parameter.