### PR TITLE
refactor wc.rs to remove clippy's cognitive complexity lint

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -623,6 +623,7 @@ fn handle_error(error: BufReadDecoderError<'_>, total: &mut WordCount) -> Option
     }
     None
 }
+
 fn word_count_from_reader_specialized<
     T: WordCountable,
     const SHOW_CHARS: bool,

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -614,7 +614,7 @@ fn process_chunk<
     total.max_line_length = max(*current_len, total.max_line_length);
 }
 
-fn handle_error<'a>(error: BufReadDecoderError<'a>, total: &mut WordCount) -> Option<io::Error> {
+fn handle_error(error: BufReadDecoderError<'_>, total: &mut WordCount) -> Option<io::Error> {
     match error {
         BufReadDecoderError::InvalidByteSequence(bytes) => {
             total.bytes += bytes.len();


### PR DESCRIPTION
refactor wc.rs to remove clippy's cognitive complexity lint.
closes: [uutils#5882](https://github.com/uutils/coreutils/issues/5882)