### PR TITLE
Bump wild from 2.2.0 to 2.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "wild"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d01931a94d5a115a53f95292f51d316856b68a035618eb831bbba593a30b67"
+checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
 dependencies = [
  "glob",
 ]

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -227,6 +227,19 @@ fn test_rm_directory_without_flag() {
 }
 
 #[test]
+#[cfg(windows)]
+// https://github.com/uutils/coreutils/issues/3200
+fn test_rm_directory_with_trailing_backslash() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir = "dir";
+
+    at.mkdir(dir);
+
+    ucmd.arg(".\\dir\\").arg("-rf").succeeds();
+    assert!(!at.dir_exists(dir));
+}
+
+#[test]
 fn test_rm_verbose() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_rm_verbose_file_a";


### PR DESCRIPTION
This PR bumps `wild` from `2.2.0` to `2.2.1` which fixes https://github.com/uutils/coreutils/issues/3200