### PR TITLE
dd: parse big numbers and return u64::MAX

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -490,6 +490,8 @@ fn parse_bytes_only(s: &str) -> Result<u64, ParseError> {
 /// 512. You can also use standard block size suffixes like `'k'` for
 /// 1024.
 ///
+/// If the number would be too large, return [`std::u64::MAX`] instead.
+///
 /// # Errors
 ///
 /// If a number cannot be parsed or if the multiplication would cause
@@ -512,11 +514,9 @@ fn parse_bytes_no_x(full: &str, s: &str) -> Result<u64, ParseError> {
     let (num, multiplier) = match (s.find('c'), s.rfind('w'), s.rfind('b')) {
         (None, None, None) => match parser.parse_u64(s) {
             Ok(n) => (n, 1),
+            Err(ParseSizeError::SizeTooBig(_)) => (u64::MAX, 1),
             Err(ParseSizeError::InvalidSuffix(_) | ParseSizeError::ParseFailure(_)) => {
                 return Err(ParseError::InvalidNumber(full.to_string()))
-            }
-            Err(ParseSizeError::SizeTooBig(_)) => {
-                return Err(ParseError::MultiplierStringOverflow(full.to_string()))
             }
         },
         (Some(i), None, None) => (parse_bytes_only(&s[..i])?, 1),
@@ -632,20 +632,30 @@ mod tests {
 
     use crate::parseargs::parse_bytes_with_opt_multiplier;
 
+    const BIG: &str = "9999999999999999999999999999999999999999999999999999999999999";
+
     #[test]
-    fn test_parse_bytes_with_opt_multiplier() {
+    fn test_parse_bytes_with_opt_multiplier_invalid() {
+        assert!(parse_bytes_with_opt_multiplier("123asdf").is_err());
+    }
+
+    #[test]
+    fn test_parse_bytes_with_opt_multiplier_without_x() {
         assert_eq!(parse_bytes_with_opt_multiplier("123").unwrap(), 123);
         assert_eq!(parse_bytes_with_opt_multiplier("123c").unwrap(), 123); // 123 * 1
         assert_eq!(parse_bytes_with_opt_multiplier("123w").unwrap(), 123 * 2);
         assert_eq!(parse_bytes_with_opt_multiplier("123b").unwrap(), 123 * 512);
-        assert_eq!(parse_bytes_with_opt_multiplier("123x3").unwrap(), 123 * 3);
         assert_eq!(parse_bytes_with_opt_multiplier("123k").unwrap(), 123 * 1024);
-        assert_eq!(parse_bytes_with_opt_multiplier("1x2x3").unwrap(), 6); // 1 * 2 * 3
+        assert_eq!(parse_bytes_with_opt_multiplier(BIG).unwrap(), u64::MAX);
+    }
 
+    #[test]
+    fn test_parse_bytes_with_opt_multiplier_with_x() {
+        assert_eq!(parse_bytes_with_opt_multiplier("123x3").unwrap(), 123 * 3);
+        assert_eq!(parse_bytes_with_opt_multiplier("1x2x3").unwrap(), 6); // 1 * 2 * 3
         assert_eq!(
             parse_bytes_with_opt_multiplier("1wx2cx3w").unwrap(),
             2 * 2 * (3 * 2) // (1 * 2) * (2 * 1) * (3 * 2)
         );
-        assert!(parse_bytes_with_opt_multiplier("123asdf").is_err());
     }
 }

--- a/src/uu/dd/src/parseargs/unit_tests.rs
+++ b/src/uu/dd/src/parseargs/unit_tests.rs
@@ -508,14 +508,6 @@ mod test_64bit_arch {
 
 #[test]
 #[should_panic]
-fn test_overflow_panic() {
-    let bs_str = format!("{}KiB", u64::MAX);
-
-    parse_bytes_with_opt_multiplier(&bs_str).unwrap();
-}
-
-#[test]
-#[should_panic]
 fn test_neg_panic() {
     let bs_str = format!("{}", -1);
 


### PR DESCRIPTION
Change the behavior of `dd` so that it parses numbers that would be too big and instead treats them as `u64::MAX`. This allows `dd` to run without error on

    dd count=00x9999999999999999999999999999999999999999999999999999999999999

This matches the behavior of GNU `dd`. This test case appears in GNU test suite `tests/dd/misc.sh`.