### PR TITLE
split: fix error message shown if file doesn't exist

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1635,12 +1635,8 @@ fn split(settings: &Settings) -> UResult<()> {
     let r_box = if settings.input == "-" {
         Box::new(stdin()) as Box<dyn Read>
     } else {
-        let r = File::open(Path::new(&settings.input)).map_err_context(|| {
-            format!(
-                "cannot open {} for reading: No such file or directory",
-                settings.input.quote()
-            )
-        })?;
+        let r = File::open(Path::new(&settings.input))
+            .map_err_context(|| format!("cannot open {} for reading", settings.input.quote()))?;
         Box::new(r) as Box<dyn Read>
     };
     let mut reader = if let Some(c) = settings.io_blksize {

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -124,6 +124,15 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_split_non_existing_file() {
+    new_ucmd!()
+        .arg("non-existing")
+        .fails()
+        .code_is(1)
+        .stderr_is("split: cannot open 'non-existing' for reading: No such file or directory\n");
+}
+
+#[test]
 fn test_split_default() {
     let (at, mut ucmd) = at_and_ucmd!();
     let name = "split_default";


### PR DESCRIPTION
Currently, uutils `split` shows "No such file or directory" twice if the specified file doesn't exist. This PR fixes the issue.