### PR TITLE
du: adapt error message to match GNU's

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -785,8 +785,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 .send(Err(USimpleError::new(
                     1,
                     format!(
-                        "{}: No such file or directory",
-                        path.to_string_lossy().maybe_quote()
+                        "cannot access {}: No such file or directory",
+                        path.to_string_lossy().quote()
                     ),
                 )))
                 .map_err(|e| USimpleError::new(1, e.to_string()))?;

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -173,11 +173,15 @@ fn test_du_with_posixly_correct() {
 }
 
 #[test]
-fn test_du_basics_bad_name() {
+fn test_du_non_existing_files() {
     new_ucmd!()
-        .arg("bad_name")
+        .arg("non_existing_a")
+        .arg("non_existing_b")
         .fails()
-        .stderr_only("du: bad_name: No such file or directory\n");
+        .stderr_only(concat!(
+            "du: cannot access 'non_existing_a': No such file or directory\n",
+            "du: cannot access 'non_existing_b': No such file or directory\n"
+        ));
 }
 
 #[test]


### PR DESCRIPTION
This PR adapts the error message shown if a specified doesn't exist to match GNU's message. It also modifies the corresponding test to ensure multiple errors are shown if there are multiple non-existing files specified.