### PR TITLE
ci: android delete AVD lockfile when running from cached image

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,6 +42,12 @@ jobs:
           ~/.android/adb*
           ~/__rustc_hash__
         key: avd-${{ matrix.api-level }}-${{ matrix.arch }}+termux-${{ env.TERMUX }}+nextest+rustc-hash
+    - name: Delete AVD Lockfile when run from cache
+      if: steps.avd-cache.outputs.cache-hit == 'true'
+      run: |
+        rm -f \
+          ~/.android/avd/*.avd/*.lock \
+          ~/.android/avd/*/*.lock              
     - name: Create and cache emulator image
       if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
working against 

```

  /bin/sh -c \/Users/runner/Library/Android/sdk/emulator/emulator -avd test -no-window -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -snapshot 28-x86+termux-v0.118.0 &
  INFO    | Android emulator version 33.1.24.0 (build_id 11237101) (CL:N/A)
  INFO    | Found systemPath /Users/runner/Library/Android/sdk/system-images/android-28/default/x86/
  ERROR   | Running multiple emulators with the same AVD 
  ERROR   | is an experimental feature.
  ERROR   | Please use -read-only flag to enable this feature.
  INFO    | Storing crashdata in: , detection is enabled for process: 1367
  INFO    | Duplicate loglines will be removed, if you wish to see each individual line launch with the -log-nofilter flag.
  INFO    | Increasing RAM size to 1536MB

```