### PR TITLE
dd: fail on missing number in count, fix #5904

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -509,6 +509,7 @@ fn parse_bytes_only(s: &str) -> Result<u64, ParseError> {
 fn parse_bytes_no_x(full: &str, s: &str) -> Result<u64, ParseError> {
     let parser = SizeParser {
         capital_b_bytes: true,
+        no_empty_numeric: true,
         ..Default::default()
     };
     let (num, multiplier) = match (s.find('c'), s.rfind('w'), s.rfind('b')) {

--- a/src/uucore/src/lib/parser/parse_size.rs
+++ b/src/uucore/src/lib/parser/parse_size.rs
@@ -16,6 +16,8 @@ use crate::display::Quotable;
 /// The [`Parser::parse`] function performs the parse.
 #[derive(Default)]
 pub struct Parser<'parser> {
+    /// Whether to allow empty numeric strings.
+    pub no_empty_numeric: bool,
     /// Whether to treat the suffix "B" as meaning "bytes".
     pub capital_b_bytes: bool,
     /// Whether to treat "b" as a "byte count" instead of "block"
@@ -48,6 +50,10 @@ impl<'parser> Parser<'parser> {
         self
     }
 
+    pub fn with_allow_empty_numeric(&mut self, value: bool) -> &mut Self {
+        self.no_empty_numeric = value;
+        self
+    }
     /// Parse a size string into a number of bytes.
     ///
     /// A size string comprises an integer and an optional unit. The unit
@@ -160,7 +166,7 @@ impl<'parser> Parser<'parser> {
         // parse string into u128
         let number: u128 = match number_system {
             NumberSystem::Decimal => {
-                if numeric_string.is_empty() {
+                if numeric_string.is_empty() && !self.no_empty_numeric {
                     1
                 } else {
                     Self::parse_number(&numeric_string, 10, size)?

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1537,6 +1537,16 @@ fn test_nocache_stdin_error() {
         .stderr_only(format!("dd: failed to discard cache for: 'standard input': {detail}\n0+0 records in\n0+0 records out\n"));
 }
 
+/// Test that dd fails when no number in count.
+#[test]
+fn test_empty_count_number() {
+    new_ucmd!()
+        .args(&["count=B"])
+        .fails()
+        .code_is(1)
+        .stderr_only("dd: invalid number: ‘B’\n");
+}
+
 /// Test for discarding system file cache.
 #[test]
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Simple fix that adds a flag for dd when empty string is not allowed for units of count in dd