### PR TITLE
ci: use codecov token in CICD/GnuTests workflows

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1043,9 +1043,8 @@ jobs:
         echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v4
-      # if: steps.vars.outputs.HAS_CODECOV_TOKEN
       with:
-        # token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ${{ steps.coverage.outputs.report }}
         ## flags: IntegrationTests, UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
         flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -399,6 +399,7 @@ jobs:
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ${{ steps.coverage.outputs.report }}
         flags: gnutests
         name: gnutests


### PR DESCRIPTION
Since the recent update of the `codecov` GH action, the "Run GNU tests with coverage" job in `GnuTests.yml` (for example, https://github.com/uutils/coreutils/actions/runs/7766050082/job/21181432457, "Upload coverage results") shows the following error:
```
Error: Codecov token not found. Please provide Codecov token with -t flag.
Warning: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```
This PR sets the required codecov token.