### PR TITLE
`split` fix android memory kill in split

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -7,10 +7,7 @@
 
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::ffi::OsString;
-use std::fs::Metadata;
 use std::io::{self, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
-#[cfg(not(target_os = "windows"))]
-use std::os::unix::fs::MetadataExt;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::line_ending::LineEnding;
@@ -401,30 +398,10 @@ fn is_seekable(input: &mut std::fs::File) -> bool {
         && input.seek(SeekFrom::Start(current_pos.unwrap())).is_ok()
 }
 
-fn sanity_limited_blksize(_st: &Metadata) -> u64 {
-    #[cfg(not(target_os = "windows"))]
-    {
-        const DEFAULT: u64 = 512;
-        const MAX: u64 = usize::MAX as u64 / 8 + 1;
-
-        let st_blksize: u64 = _st.blksize();
-        match st_blksize {
-            0 => DEFAULT,
-            1..=MAX => st_blksize,
-            _ => DEFAULT,
-        }
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        512
-    }
-}
-
 fn head_backwards_file(input: &mut std::fs::File, options: &HeadOptions) -> std::io::Result<()> {
     let st = input.metadata()?;
     let seekable = is_seekable(input);
-    let blksize_limit = sanity_limited_blksize(&st);
+    let blksize_limit = uucore::fs::sane_blksize::sane_blksize_from_metadata(&st);
     if !seekable || st.len() <= blksize_limit {
         return head_backwards_without_seek_file(input, options);
     }


### PR DESCRIPTION
`split` allocates quite some memory when reading from "files" with no real end like `/dev/zero`.
On x86 its ~ 1GB and on x86_x64 its 2GB. This was cause frequent stability issues on android CI.
This change limits the initially read memory heavily to the `blksize` of the filesystem or 500MB at max if no blksize is specified. This is aligned with a solution used in `head`