### PR TITLE
fix tr with delete flag if more than 1 operand given 

### DIFF
--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -60,7 +60,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             format!("missing operand after {}", sets[0].quote()),
         ));
     }
-
+    if delete_flag && !squeeze_flag && sets_len > 1 {
+        return Err(UUsageError::new(
+            1,
+            format!("extra operand {}\nOnly one string may be given when deleting without squeezing repeats.", sets[1].quote()),
+        ));
+    }
     if let Some(first) = sets.first() {
         if first.ends_with('\\') {
             show!(USimpleError::new(

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -60,12 +60,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             format!("missing operand after {}", sets[0].quote()),
         ));
     }
+
     if delete_flag && !squeeze_flag && sets_len > 1 {
         return Err(UUsageError::new(
             1,
             format!("extra operand {}\nOnly one string may be given when deleting without squeezing repeats.", sets[1].quote()),
         ));
     }
+
     if let Some(first) = sets.first() {
         if first.ends_with('\\') {
             show!(USimpleError::new(

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1147,3 +1147,15 @@ fn check_against_gnu_tr_tests_no_abort_1() {
         .succeeds()
         .stdout_is("abb");
 }
+
+#[test]
+fn check_against_gnu_tr_delete_flag_takes_only_one_operand() {
+    // gnu tr -d fails with more than 1 argument
+    new_ucmd!()
+        .args(&["-d", "a", "p"])
+        .pipe_in("abc")
+        .fails()
+        .stderr_contains(
+        "extra operand 'p'\nOnly one string may be given when deleting without squeezing repeats.",
+    );
+}

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1149,7 +1149,7 @@ fn check_against_gnu_tr_tests_no_abort_1() {
 }
 
 #[test]
-fn check_against_gnu_tr_delete_flag_takes_only_one_operand() {
+fn test_delete_flag_takes_only_one_operand() {
     // gnu tr -d fails with more than 1 argument
     new_ucmd!()
         .args(&["-d", "a", "p"])


### PR DESCRIPTION
fixes the issue #5944 where tr -d flag should not take more than one operand
so its like this now
```
❯ echo "acsd5c"| ./target/debug/tr -d "c"
asd5

~/sad/coreutils main
❯ echo "acsd5c"| ./target/debug/tr -d "c" "p"
./target/debug/tr: extra operand 'p'
Only one string may be given when deleting without squeezing repeats.
Try './target/debug/tr --help' for more information.
```
problem tho is that adding more arguments errors out tr when it should just display the same massage

where gnu tr
```
❯ echo "acsd5c"| tr -d "c" "p" "m"
tr: extra operand ‘p’
Try 'tr --help' for more information.
```
coreutils one 
```
❯ echo "acsd5c"| ./target/debug/tr -d "c" "p" "m"
error: unexpected value 'm' for '[sets]...' found; no more were expected

Usage: ./target/debug/tr [OPTION]... SET1 [SET2]

For more information, try '--help'.
```

not sure this is related to  #5944 since i could not grep for the error expect in whom test so don't know where to look for that