### PR TITLE
Expose touch for Nushell

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -285,6 +285,7 @@ fn determine_times(opts: &Options) -> UResult<(FileTime, FileTime)> {
     }
 }
 
+/// Execute the touch command.
 pub fn touch(files: &[OsString], opts: &Options) -> UResult<()> {
     let (atime, mtime) = determine_times(opts)?;
 
@@ -341,7 +342,8 @@ pub fn touch(files: &[OsString], opts: &Options) -> UResult<()> {
     Ok(())
 }
 
-/// If `--time` is given, returns whether or not it is equivalent to `-a` or `-m`. Otherwise `None`.
+/// If `--time` is given, returns whether it is equivalent to `-a` (change access time only) or
+/// `-m` (change modification time only). Otherwise, returns `None`.
 fn determine_atime_mtime_change(matches: &ArgMatches) -> Option<bool> {
     if matches.contains_id(options::TIME) {
         matches


### PR DESCRIPTION
Part of https://github.com/uutils/coreutils/issues/5088 (and https://github.com/nushell/nushell/issues/11549, over in the Nushell repo). This should allow Nushell (and possibly Rust applications) to use `uu_touch`. I'll be making a PR in Nushell based on this one soon.

Stuff that's public now:
- A `touch` function taking an `InputFile` object and an `Options` object
- An `InputFile` struct with a `Path(PathBuf)` variant (for normal files) and a `Stdout` variant (for `-`). It's essentially an `Option`, so maybe it would be a better idea for `touch` to accept an `Option<&Path>` so the caller doesn't have to make a `PathBuf`?
- An `Options` struct with the following fields:
  - `no_create: bool` - `-c`, `--no-create`
  - `no_deref: bool` - `-h`, `--no-dereference`
  - `atime: Option<FileTime>` - New access time, None if you don't want to change it
  - `mtime: Option<FileTime>` - New modification time, None if you don't want to change it
- The `datetime_to_filetime` function. Maybe this doesn't need to be exposed since it's somewhat trivial. Or maybe it could go somewhere it could be shared by other utilities (although it seems like `touch` is currently the only utility converting `DateTime`s to `FileTime`s).
- The `stat` function to get access and modification times. Again, maybe this doesn't need to be exposed since others can do it themselves pretty easily, given that `std::fs::metadata` exists.

I had to move a bunch of stuff around, so the diff is unfortunately a bit big and not easy to review. Summary of internal changes:
- `update_times` now accepts only the path, whether or not it's stdout, and an `Options` object. It decides whether to change `atime` or `mtime` based on whether the corresponding field in `Options` is a `Some` or `None`.
- `determine_times` previously determined the atime and mtime. It's been renamed to `determine_times_from_ref` and only determines the atime and mtime if a reference file was given. The rest of its behavior was moved to `uumain` since it was simpler. In retrospect, not an entirely necessary change, I could move the stuff back into `determine_times_from_ref` (and rename it `determine_times`) if wanted.
- The `-a`, `-m`, and `--time` flags are thrown away now, and the logic for determining whether to update the atime and mtime has changed. There's a few tests that test `-a` and `-m` and they do pass, but it's worth taking a closer look at (I'll try to think of more edge cases).

Other stuff:
- Currently, applications using `uu_touch` can't do what `--date` does unless `parse_date` is exposed. Nushell's `touch` command doesn't do that, so it may be fine for Nushell, but maybe not for anyone else using `uu_touch`.
- The doc comment on `stat` says that if `follow` is `false`, it'll return the metadata of the symlink and not the file it points to. But it seems like the actual implementation will always try to return the metadata of the file that the symlink points to, and it will only give the symlink's metadata if the symlink is broken.