### PR TITLE
ci: use latest version of `cspell`

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -152,10 +152,7 @@ jobs:
     - name: Install/setup prerequisites
       shell: bash
       run: |
-        ## Install/setup prerequisites
-        # * pin installed cspell to v4.2.8 (cspell v5+ is broken for NodeJS < v12)
-        ## maint: [2021-11-10; rivy] `cspell` version may be advanced to v5 when used with NodeJS >= v12
-        sudo apt-get -y update ; sudo apt-get -y install npm ; sudo npm install cspell@4.2.8 -g ;
+        sudo apt-get -y update ; sudo apt-get -y install npm ; sudo npm install cspell -g ;
     - name: Run `cspell`
       shell: bash
       run: |
@@ -167,10 +164,7 @@ jobs:
         cfg_files=($(shopt -s nullglob ; echo {.vscode,.}/{,.}c[sS]pell{.json,.config{.js,.cjs,.json,.yaml,.yml},.yaml,.yml} ;))
         cfg_file=${cfg_files[0]}
         unset CSPELL_CFG_OPTION ; if [ -n "$cfg_file" ]; then CSPELL_CFG_OPTION="--config $cfg_file" ; fi
-        # * `cspell`
-        ## maint: [2021-11-10; rivy] the `--no-progress` option for `cspell` is a `cspell` v5+ option
-        # S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress "**/*") && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
-        S=$(cspell ${CSPELL_CFG_OPTION} --no-summary "**/*") && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
+        S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress "**/*") && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
         if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
   toml_format:

--- a/docs/compiles_table.py
+++ b/docs/compiles_table.py
@@ -10,7 +10,7 @@ from pathlib import Path
 # third party dependencies
 from tqdm import tqdm
 
-# spell-checker:ignore (libs) tqdm imap ; (shell/mac) xcrun ; (vars) nargs
+# spell-checker:ignore (libs) tqdm imap ; (shell/mac) xcrun ; (vars) nargs retcode csvfile
 
 BINS_PATH = Path("../src/uu")
 CACHE_PATH = Path("compiles_table.csv")

--- a/src/uu/factor/src/numeric/montgomery.rs
+++ b/src/uu/factor/src/numeric/montgomery.rs
@@ -111,7 +111,7 @@ impl<T: DoubleInt> Arithmetic for Montgomery<T> {
     }
 
     fn to_mod(&self, x: u64) -> Self::ModInt {
-        // TODO: optimise!
+        // TODO: optimize!
         debug_assert!(x < self.n.as_u64());
         let r = T::from_double_width(
             ((T::DoubleWidth::from_u64(x)) << T::zero().count_zeros() as usize)

--- a/src/uucore/src/lib/parser/shortcut_value_parser.rs
+++ b/src/uucore/src/lib/parser/shortcut_value_parser.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore abcdefgh
+// spell-checker:ignore abcdefgh abef
 use clap::{
     builder::{PossibleValue, TypedValueParser},
     error::{ContextKind, ContextValue, ErrorKind},

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe
+// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe bcdef
 
 #[cfg(any(unix, feature = "feat_selinux"))]
 use crate::common::util::expected_result;

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
-// spell-checker:ignore binvalid finvalid hinvalid iinvalid linvalid nabcabc nabcabcabc ninvalid vinvalid winvalid
+// spell-checker:ignore binvalid finvalid hinvalid iinvalid linvalid nabcabc nabcabcabc ninvalid vinvalid winvalid dabc näää
 use crate::common::util::TestScenario;
 
 #[test]

--- a/util/size-experiment.py
+++ b/util/size-experiment.py
@@ -1,3 +1,4 @@
+# spell-checker:ignore debuginfo
 import subprocess
 from itertools import product
 import shutil


### PR DESCRIPTION
This PR uses the latest version of `cspell` in the `code-quality` workflow and fixes the spelling errors shown by it.