### PR TITLE
fix tr with any flag with more than 2 operands 

### DIFF
--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -75,11 +75,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     "\nOnly one string may be given when deleting without squeezing repeats.",
                 );
             }
-            return Err(UUsageError::new(1, format!("{}", msg)));
+            return Err(UUsageError::new(1, format!("{}", msg.to_string())));
         }
         if sets_len > 2 {
             msg.push_str(&sets[2].quote().to_string());
-            return Err(UUsageError::new(1, format!("{}", msg)));
+            return Err(UUsageError::new(1, format!("{}", msg.to_string())));
         }
     }
 

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -75,11 +75,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     "\nOnly one string may be given when deleting without squeezing repeats.",
                 );
             }
-            return Err(UUsageError::new(1, format!("{}", msg.to_string())));
+            return Err(UUsageError::new(1, msg.to_string()));
         }
         if sets_len > 2 {
             msg.push_str(&sets[2].quote().to_string());
-            return Err(UUsageError::new(1, format!("{}", msg.to_string())));
+            return Err(UUsageError::new(1, msg.to_string()));
         }
     }
 

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -64,22 +64,21 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    // all operation error on more than 2 but messages change sometimes depending on operand
-    // except delete also errors with 2
-    let mut msg: String = "extra operand ".into();
+    let mut msg: String = "extra operand".into();
     if sets_len > 1 {
         if delete_flag && !squeeze_flag {
-            msg.push_str(&sets[1].quote().to_string());
+            msg = format!("{} {}", msg, sets[1].quote());
             if sets_len == 2 {
-                msg.push_str(
-                    "\nOnly one string may be given when deleting without squeezing repeats.",
+                msg = format!(
+                    "{}\n{}",
+                    msg, "Only one string may be given when deleting without squeezing repeats."
                 );
             }
-            return Err(UUsageError::new(1, msg.to_string()));
+            return Err(UUsageError::new(1, msg));
         }
         if sets_len > 2 {
-            msg.push_str(&sets[2].quote().to_string());
-            return Err(UUsageError::new(1, msg.to_string()));
+            msg = format!("{} {}", msg, sets[2].quote());
+            return Err(UUsageError::new(1, msg));
         }
     }
 
@@ -185,5 +184,5 @@ pub fn uu_app() -> Command {
                 .help("first truncate SET1 to length of SET2")
                 .action(ArgAction::SetTrue),
         )
-        .arg(Arg::new(options::SETS).num_args(1..=32))
+        .arg(Arg::new(options::SETS).num_args(1..))
 }

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -64,8 +64,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    let start: &str = "extra operand";
     if sets_len > 1 {
+        let start = "extra operand";
         if delete_flag && !squeeze_flag {
             let op = sets[1].quote();
             let msg = if sets_len == 2 {

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -64,20 +64,23 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    let mut msg: String = "extra operand".into();
+    let start: &str = "extra operand";
     if sets_len > 1 {
         if delete_flag && !squeeze_flag {
-            msg = format!("{} {}", msg, sets[1].quote());
-            if sets_len == 2 {
-                msg = format!(
-                    "{}\n{}",
-                    msg, "Only one string may be given when deleting without squeezing repeats."
-                );
-            }
+            let op = sets[1].quote();
+            let msg = if sets_len == 2 {
+                format!(
+                    "{} {}\nOnly one string may be given when deleting without squeezing repeats.",
+                    start, op,
+                )
+            } else {
+                format!("{} {}", start, op,)
+            };
             return Err(UUsageError::new(1, msg));
         }
         if sets_len > 2 {
-            msg = format!("{} {}", msg, sets[2].quote());
+            let op = sets[2].quote();
+            let msg = format!("{} {}", start, op);
             return Err(UUsageError::new(1, msg));
         }
     }

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -57,15 +57,30 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if !(delete_flag || squeeze_flag) && sets_len < 2 {
         return Err(UUsageError::new(
             1,
-            format!("missing operand after {}", sets[0].quote()),
+            format!(
+                "missing operand after {}\nTwo strings must be given when translating.",
+                sets[0].quote()
+            ),
         ));
     }
 
-    if delete_flag && !squeeze_flag && sets_len > 1 {
-        return Err(UUsageError::new(
-            1,
-            format!("extra operand {}\nOnly one string may be given when deleting without squeezing repeats.", sets[1].quote()),
-        ));
+    // all operation error on more than 2 but messages change sometimes depending on operand
+    // except delete also errors with 2
+    let mut msg: String = "extra operand ".into();
+    if sets_len > 1 {
+        if delete_flag && !squeeze_flag {
+            msg.push_str(&sets[1].quote().to_string());
+            if sets_len == 2 {
+                msg.push_str(
+                    "\nOnly one string may be given when deleting without squeezing repeats.",
+                );
+            }
+            return Err(UUsageError::new(1, format!("{}", msg)));
+        }
+        if sets_len > 2 {
+            msg.push_str(&sets[2].quote().to_string());
+            return Err(UUsageError::new(1, format!("{}", msg)));
+        }
     }
 
     if let Some(first) = sets.first() {
@@ -170,5 +185,5 @@ pub fn uu_app() -> Command {
                 .help("first truncate SET1 to length of SET2")
                 .action(ArgAction::SetTrue),
         )
-        .arg(Arg::new(options::SETS).num_args(1..=2))
+        .arg(Arg::new(options::SETS).num_args(1..=32))
 }

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1161,7 +1161,7 @@ fn test_delete_flag_takes_only_one_operand() {
 }
 
 #[test]
-fn test_translate_flag_fails_with_more_than_two_operand() {
+fn test_truncate_flag_fails_with_more_than_two_operand() {
     new_ucmd!()
         .args(&["-t", "a", "b", "c"])
         .fails()

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1159,3 +1159,33 @@ fn test_delete_flag_takes_only_one_operand() {
         "extra operand 'p'\nOnly one string may be given when deleting without squeezing repeats.",
     );
 }
+
+#[test]
+fn test_translate_flag_fails_with_more_than_two_operand() {
+    // gnu tr -d fails with more than 1 argument
+    new_ucmd!()
+        .args(&["-t", "a", "b", "c"])
+        .pipe_in("abc")
+        .fails()
+        .stderr_contains("extra operand 'c'");
+}
+
+#[test]
+fn test_squeeze_flag_fails_with_more_than_two_operand() {
+    // gnu tr -d fails with more than 1 argument
+    new_ucmd!()
+        .args(&["-s", "a", "b", "c"])
+        .pipe_in("abc")
+        .fails()
+        .stderr_contains("extra operand 'c'");
+}
+
+#[test]
+fn test_complement_flag_fails_with_more_than_two_operand() {
+    // gnu tr -d fails with more than 1 argument
+    new_ucmd!()
+        .args(&["-s", "a", "b", "c"])
+        .pipe_in("abc")
+        .fails()
+        .stderr_contains("extra operand 'c'");
+}

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1162,30 +1162,24 @@ fn test_delete_flag_takes_only_one_operand() {
 
 #[test]
 fn test_translate_flag_fails_with_more_than_two_operand() {
-    // gnu tr -d fails with more than 1 argument
     new_ucmd!()
         .args(&["-t", "a", "b", "c"])
-        .pipe_in("abc")
         .fails()
         .stderr_contains("extra operand 'c'");
 }
 
 #[test]
 fn test_squeeze_flag_fails_with_more_than_two_operand() {
-    // gnu tr -d fails with more than 1 argument
     new_ucmd!()
         .args(&["-s", "a", "b", "c"])
-        .pipe_in("abc")
         .fails()
         .stderr_contains("extra operand 'c'");
 }
 
 #[test]
 fn test_complement_flag_fails_with_more_than_two_operand() {
-    // gnu tr -d fails with more than 1 argument
     new_ucmd!()
-        .args(&["-s", "a", "b", "c"])
-        .pipe_in("abc")
+        .args(&["-c", "a", "b", "c"])
         .fails()
         .stderr_contains("extra operand 'c'");
 }


### PR DESCRIPTION
turns out all tr flags should fail with the same massage not just delete flag if the number of operands is more than 2 so i rewrote the part i did write so all the flags fails with more than 2 operand 
so now 
```
gnu tr:
>tr -s a b c
tr: extra operand ‘c’
Try 'tr --help' for more information.
[ble: exit 1]
~
>tr -d a b c
tr: extra operand ‘b’
Try 'tr --help' for more information.
[ble: exit 1]

and uutils tr 
>cargo run tr -s a b c
   Compiling coreutils v0.0.24 (/home/broly/sad/coreutils)
   Finished dev [unoptimized + debuginfo] target(s) in 2.68s
   Running `target/debug/coreutils tr -s a b c`
tr: extra operand 'c'
Try 'target/debug/coreutils tr --help' for more information.
[ble: exit 1]

>cargo run tr -d a b c
  Finished dev [unoptimized + debuginfo] target(s) in 0.10s
  Running `target/debug/coreutils tr -d a b c`
tr: extra operand 'b'
Try 'target/debug/coreutils tr --help' for more information.
[ble: exit 1]
```
this fixes #5950
but i have 2 questions 
1. in gnu tr it takes any number of arguments even if more than 3 (which works here) but where to stop? so i choose to make the maximum number 32 is this right?
2. is there a better way to add strings together the way i did it looks ugly 🥹
