### PR TITLE
tr: fix intermittent test caused by pipe_in()

### DIFF
--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1151,11 +1151,7 @@ fn check_against_gnu_tr_tests_no_abort_1() {
 #[test]
 fn test_delete_flag_takes_only_one_operand() {
     // gnu tr -d fails with more than 1 argument
-    new_ucmd!()
-        .args(&["-d", "a", "p"])
-        .pipe_in("abc")
-        .fails()
-        .stderr_contains(
+    new_ucmd!().args(&["-d", "a", "p"]).fails().stderr_contains(
         "extra operand 'p'\nOnly one string may be given when deleting without squeezing repeats.",
     );
 }


### PR DESCRIPTION
This PR fixes an intermittent test by removing an unnecessary call of `pipe_in()` which causes the following error from time to time:
```
thread 'test_tr::test_delete_flag_takes_only_one_operand' panicked at tests/common/util.rs:2033:18:
called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "failed to write to stdin of child: Broken pipe (os error 32)" }
```