### PR TITLE
clippy: fix warnings introduced by Rust 1.76

### DIFF
--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -148,7 +148,6 @@ fn find_stdout() -> UResult<File> {
     };
 
     match OpenOptions::new()
-        .write(true)
         .create(true)
         .append(true)
         .open(Path::new(NOHUP_OUT))
@@ -168,12 +167,7 @@ fn find_stdout() -> UResult<File> {
             let mut homeout = PathBuf::from(home);
             homeout.push(NOHUP_OUT);
             let homeout_str = homeout.to_str().unwrap();
-            match OpenOptions::new()
-                .write(true)
-                .create(true)
-                .append(true)
-                .open(&homeout)
-            {
+            match OpenOptions::new().create(true).append(true).open(&homeout) {
                 Ok(t) => {
                     show_error!(
                         "ignoring input and appending output to {}",

--- a/src/uu/od/src/mockstream.rs
+++ b/src/uu/od/src/mockstream.rs
@@ -10,7 +10,7 @@ use std::io::{Cursor, Error, ErrorKind, Read, Result};
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use std::io::{Cursor, Read};
 ///
 /// struct CountIo {}

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -577,18 +577,19 @@ fn build_options(
 
     // +page option is less priority than --pages
     let page_plus_re = Regex::new(r"\s*\+(\d+:*\d*)\s*").unwrap();
-    let start_page_in_plus_option = match page_plus_re.captures(free_args).map(|i| {
+    let res = page_plus_re.captures(free_args).map(|i| {
         let unparsed_num = i.get(1).unwrap().as_str().trim();
         let x: Vec<_> = unparsed_num.split(':').collect();
         x[0].to_string().parse::<usize>().map_err(|_e| {
             PrError::EncounteredErrors(format!("invalid {} argument {}", "+", unparsed_num.quote()))
         })
-    }) {
+    });
+    let start_page_in_plus_option = match res {
         Some(res) => res?,
         None => 1,
     };
 
-    let end_page_in_plus_option = match page_plus_re
+    let res = page_plus_re
         .captures(free_args)
         .map(|i| i.get(1).unwrap().as_str().trim())
         .filter(|i| i.contains(':'))
@@ -601,7 +602,8 @@ fn build_options(
                     unparsed_num.quote()
                 ))
             })
-        }) {
+        });
+    let end_page_in_plus_option = match res {
         Some(res) => Some(res?),
         None => None,
     };
@@ -616,27 +618,27 @@ fn build_options(
         })
     };
 
-    let start_page = match matches
+    let res = matches
         .get_one::<String>(options::PAGES)
         .map(|i| {
             let x: Vec<_> = i.split(':').collect();
             x[0].to_string()
         })
-        .map(invalid_pages_map)
-    {
+        .map(invalid_pages_map);
+    let start_page = match res {
         Some(res) => res?,
         None => start_page_in_plus_option,
     };
 
-    let end_page = match matches
+    let res = matches
         .get_one::<String>(options::PAGES)
         .filter(|i| i.contains(':'))
         .map(|i| {
             let x: Vec<_> = i.split(':').collect();
             x[1].to_string()
         })
-        .map(invalid_pages_map)
-    {
+        .map(invalid_pages_map);
+    let end_page = match res {
         Some(res) => Some(res?),
         None => end_page_in_plus_option,
     };
@@ -707,12 +709,13 @@ fn build_options(
 
     let re_col = Regex::new(r"\s*-(\d+)\s*").unwrap();
 
-    let start_column_option = match re_col.captures(free_args).map(|i| {
+    let res = re_col.captures(free_args).map(|i| {
         let unparsed_num = i.get(1).unwrap().as_str().trim();
         unparsed_num.parse::<usize>().map_err(|_e| {
             PrError::EncounteredErrors(format!("invalid {} argument {}", "-", unparsed_num.quote()))
         })
-    }) {
+    });
+    let start_column_option = match res {
         Some(res) => Some(res?),
         None => None,
     };

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -503,7 +503,6 @@ fn test_write_to_self_empty() {
 
     let file = OpenOptions::new()
         .create_new(true)
-        .write(true)
         .append(true)
         .open(&file_path)
         .unwrap();
@@ -519,7 +518,6 @@ fn test_write_to_self() {
 
     let file = OpenOptions::new()
         .create_new(true)
-        .write(true)
         .append(true)
         .open(file_path)
         .unwrap();

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -864,7 +864,6 @@ impl AtPath {
     pub fn append(&self, name: &str, contents: &str) {
         log_info("write(append)", self.plus_as_string(name));
         let mut f = OpenOptions::new()
-            .write(true)
             .append(true)
             .create(true)
             .open(self.plus(name))
@@ -876,7 +875,6 @@ impl AtPath {
     pub fn append_bytes(&self, name: &str, contents: &[u8]) {
         log_info("write(append)", self.plus_as_string(name));
         let mut f = OpenOptions::new()
-            .write(true)
             .append(true)
             .create(true)
             .open(self.plus(name))


### PR DESCRIPTION
This PR fixes clippy warnings from the [blocks_in_conditions](https://rust-lang.github.io/rust-clippy/master/index.html#/blocks_in_conditions), [ineffective_open_options](https://rust-lang.github.io/rust-clippy/master/index.html#ineffective_open_options) and [test_attr_in_doctest](https://rust-lang.github.io/rust-clippy/master/index.html#/test_attr_in_doctest) lints.