### PR TITLE
cut: show error for multiple mode args (`-b`, `-c`, `-f`)

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -359,6 +359,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let complement = matches.get_flag(options::COMPLEMENT);
 
+    // Only one, and only one of cutting mode arguments, i.e. `-b`, `-c`, `-f`,
+    // is expected. The number of those arguments is used for parsing a cutting
+    // mode and handling the error cases.
     let mode_args_count = [
         matches.indices_of(options::BYTES),
         matches.indices_of(options::CHARACTERS),
@@ -521,6 +524,13 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .after_help(AFTER_HELP)
         .infer_long_args(true)
+        // While `args_override_self(true)` for some arguments, such as `-d`
+        // and `--output-delimiter`, is consistent to the behavior of GNU cut,
+        // arguments related to cutting mode, i.e. `-b`, `-c`, `-f`, should
+        // cause an error when there is more than one of them, as described in
+        // the manual of GNU cut: "Use one, and only one of -b, -c or -f".
+        // `ArgAction::Append` is used on `-b`, `-c`, `-f` arguments, so that
+        // the occurrences of those could be counted and be handled accordingly.
         .args_override_self(true)
         .arg(
             Arg::new(options::BYTES)

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -368,7 +368,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         matches.indices_of(options::FIELDS),
     ]
     .into_iter()
-    .filter_map(|mode| mode.map(|indices| indices.len()))
+    .map(|indices| indices.unwrap_or_default().count())
     .sum();
 
     let mode_parse = match (

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -270,3 +270,21 @@ fn test_multiple() {
     assert_eq!(result.stdout_str(), "b\n");
     assert_eq!(result.stderr_str(), "");
 }
+
+#[test]
+fn test_multiple_mode_args() {
+    for args in [
+        vec!["-b1", "-b2"],
+        vec!["-c1", "-c2"],
+        vec!["-f1", "-f2"],
+        vec!["-b1", "-c2"],
+        vec!["-b1", "-f2"],
+        vec!["-c1", "-f2"],
+        vec!["-b1", "-c2", "-f3"],
+    ] {
+        new_ucmd!()
+        .args(&args)
+        .fails()
+        .stderr_is("cut: invalid usage: expects no more than one of --fields (-f), --chars (-c) or --bytes (-b)\n");
+    }
+}


### PR DESCRIPTION
### Overview

`uutils-cut` runs without an error when there are multiple cutting mode arguments of one type, i.e. more than one `--bytes`, or `--characters`, or `--fields`, while GNU cut shows an error as described in GNU cut manual - _`"Use one, and only one of -b, -c or -f."`_

For example:

```bash
# uutils-cut
$ echo "12345" | cargo run cut -c1 -c5
5

# GNU cut
$ echo "12345" | cut -c1 -c5
cut: only one list may be specified
Try 'cut --help' for more information.
```

### Cause

Duplicated arguments were overriding the previous ones, therefore only the last cutting mode argument (`-b`, `-c`, `-f`) was handled, as you can see on the example above.

### Fix

Disable overriding of cutting mode arguments (`-b`, `-c`, `-f`) using `ArgAction::APPEND`. Count the number of the cutting mode arguments and show an error when there are more than one `-b`, `-c`, or `-f`.

fixes #5925