### PR TITLE
ls,date: rename `chrono::Duration` to `chrono::TimeDelta`

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -6,7 +6,7 @@
 // spell-checker:ignore (chrono) Datelike Timelike ; (format) DATEFILE MMDDhhmm ; (vars) datetime datetimes
 
 use chrono::format::{Item, StrftimeItems};
-use chrono::{DateTime, Duration, FixedOffset, Local, Offset, Utc};
+use chrono::{DateTime, FixedOffset, Local, Offset, TimeDelta, Utc};
 #[cfg(windows)]
 use chrono::{Datelike, Timelike};
 use clap::{crate_version, Arg, ArgAction, Command};
@@ -91,7 +91,7 @@ enum DateSource {
     Now,
     Custom(String),
     File(PathBuf),
-    Human(Duration),
+    Human(TimeDelta),
 }
 
 enum Iso8601Format {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2981,7 +2981,7 @@ fn display_date(metadata: &Metadata, config: &Config) -> String {
         Some(time) => {
             //Date is recent if from past 6 months
             //According to GNU a Gregorian year has 365.2425 * 24 * 60 * 60 == 31556952 seconds on the average.
-            let recent = time + chrono::Duration::seconds(31_556_952 / 2) > chrono::Local::now();
+            let recent = time + chrono::TimeDelta::seconds(31_556_952 / 2) > chrono::Local::now();
 
             match &config.time_style {
                 TimeStyle::FullIso => time.format("%Y-%m-%d %H:%M:%S.%f %z"),


### PR DESCRIPTION
This PR renames `chrono::Duration` to `chrono::TimeDelta` because in the latest [chrono release](https://github.com/uutils/coreutils/pull/5967) they did the same. While `chrono::Duration` still works for the time being, I think it makes sense to use the "official" name.