### PR TITLE
ci: run CICD workflow on tag creation

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -18,6 +18,7 @@ env:
 on:
   pull_request:
   push:
+    tags:
     branches:
       - main
 


### PR DESCRIPTION
Fixes 4d2bdf4. For a release to be triggered, the workflow has to run with GITHUB_REF=refs/tags/X.Y.Z, which was disabled by limiting the push trigger to a branch.
Please note that the tag filter `v*.*.*` does not work since releases are tagged like `0.0.24`.
<strike>This will create extra runs in case branches are created in the uutls/coreutils repo.
I think this is an acceptable tradeoff.</strike>

See also: 

- https://github.com/uutils/coreutils/issues/5929
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create