### PR TITLE
 pr: use chrono instead of time in tests #5972

### DIFF
--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -5,13 +5,10 @@
 // spell-checker:ignore (ToDO) Sdivide
 
 use crate::common::util::{TestScenario, UCommand};
+use chrono::{DateTime, Duration, Utc};
 use std::fs::metadata;
-use time::macros::format_description;
-use time::Duration;
-use time::OffsetDateTime;
 
-const DATE_TIME_FORMAT: &[time::format_description::FormatItem] =
-    format_description!("[month repr:short] [day] [hour]:[minute] [year]");
+const DATE_TIME_FORMAT: &str = "%b %d %H:%M %Y";
 
 fn file_last_modified_time(ucmd: &UCommand, path: &str) -> String {
     let tmp_dir_path = ucmd.get_full_fixture_path(path);
@@ -20,28 +17,28 @@ fn file_last_modified_time(ucmd: &UCommand, path: &str) -> String {
         .map(|i| {
             i.modified()
                 .map(|x| {
-                    let date_time: OffsetDateTime = x.into();
-                    date_time.format(&DATE_TIME_FORMAT).unwrap()
+                    let date_time: DateTime<Utc> = x.into();
+                    date_time.format(DATE_TIME_FORMAT).to_string()
                 })
                 .unwrap_or_default()
         })
         .unwrap_or_default()
 }
 
-fn all_minutes(from: OffsetDateTime, to: OffsetDateTime) -> Vec<String> {
+fn all_minutes(from: DateTime<Utc>, to: DateTime<Utc>) -> Vec<String> {
     let to = to + Duration::minutes(1);
     // const FORMAT: &str = "%b %d %H:%M %Y";
     let mut vec = vec![];
     let mut current = from;
     while current < to {
-        vec.push(current.format(&DATE_TIME_FORMAT).unwrap());
+        vec.push(current.format(DATE_TIME_FORMAT).to_string());
         current += Duration::minutes(1);
     }
     vec
 }
 
-fn valid_last_modified_template_vars(from: OffsetDateTime) -> Vec<Vec<(String, String)>> {
-    all_minutes(from, OffsetDateTime::now_utc())
+fn valid_last_modified_template_vars(from: DateTime<Utc>) -> Vec<Vec<(String, String)>> {
+    all_minutes(from, Utc::now())
         .into_iter()
         .map(|time| vec![("{last_modified_time}".to_string(), time)])
         .collect()
@@ -257,7 +254,7 @@ fn test_with_suppress_error_option() {
 fn test_with_stdin() {
     let expected_file_path = "stdin.log.expected";
     let mut scenario = new_ucmd!();
-    let start = OffsetDateTime::now_utc();
+    let start = Utc::now();
     scenario
         .pipe_in_fixture("stdin.log")
         .args(&["--pages=1:2", "-n", "-"])
@@ -320,7 +317,7 @@ fn test_with_mpr() {
     let expected_test_file_path = "mpr.log.expected";
     let expected_test_file_path1 = "mpr1.log.expected";
     let expected_test_file_path2 = "mpr2.log.expected";
-    let start = OffsetDateTime::now_utc();
+    let start = Utc::now();
     new_ucmd!()
         .args(&["--pages=1:2", "-m", "-n", test_file_path, test_file_path1])
         .succeeds()
@@ -329,7 +326,7 @@ fn test_with_mpr() {
             &valid_last_modified_template_vars(start),
         );
 
-    let start = OffsetDateTime::now_utc();
+    let start = Utc::now();
     new_ucmd!()
         .args(&["--pages=2:4", "-m", "-n", test_file_path, test_file_path1])
         .succeeds()
@@ -338,7 +335,7 @@ fn test_with_mpr() {
             &valid_last_modified_template_vars(start),
         );
 
-    let start = OffsetDateTime::now_utc();
+    let start = Utc::now();
     new_ucmd!()
         .args(&[
             "--pages=1:2",
@@ -445,7 +442,7 @@ fn test_with_join_lines_option() {
     let test_file_2 = "test.log";
     let expected_file_path = "joined.log.expected";
     let mut scenario = new_ucmd!();
-    let start = OffsetDateTime::now_utc();
+    let start = Utc::now();
     scenario
         .args(&["+1:2", "-J", "-m", test_file_1, test_file_2])
         .run()


### PR DESCRIPTION
Replaced `time` with `crono` for pr test