### PR TITLE
shuf: include all echo args, not just the last

### DIFF
--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -120,7 +120,6 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
-        .args_override_self(true)
         .arg(
             Arg::new(options::ECHO)
                 .short('e')
@@ -168,14 +167,16 @@ pub fn uu_app() -> Command {
                 .short('r')
                 .long(options::REPEAT)
                 .help("output lines can be repeated")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::REPEAT),
         )
         .arg(
             Arg::new(options::ZERO_TERMINATED)
                 .short('z')
                 .long(options::ZERO_TERMINATED)
                 .help("line delimiter is NUL, not newline")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::ZERO_TERMINATED),
         )
         .arg(Arg::new(options::FILE).value_hint(clap::ValueHint::FilePath))
 }

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -129,6 +129,7 @@ pub fn uu_app() -> Command {
                 .help("treat each ARG as an input line")
                 .use_value_delimiter(false)
                 .num_args(0..)
+                .action(clap::ArgAction::Append)
                 .conflicts_with(options::INPUT_RANGE),
         )
         .arg(

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -145,6 +145,7 @@ pub fn uu_app() -> Command {
                 .short('n')
                 .long(options::HEAD_COUNT)
                 .value_name("COUNT")
+                .action(clap::ArgAction::Append)
                 .help("output at most COUNT lines"),
         )
         .arg(

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -132,6 +132,72 @@ fn test_head_count() {
 }
 
 #[test]
+fn test_head_count_multi_big_then_small() {
+    let repeat_limit = 5;
+    let input_seq = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let input = input_seq
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    let result = new_ucmd!()
+        .arg("-n")
+        .arg(&(repeat_limit + 1).to_string())
+        .arg("-n")
+        .arg(&repeat_limit.to_string())
+        .pipe_in(input.as_bytes())
+        .succeeds();
+    result.no_stderr();
+
+    let result_seq: Vec<i32> = result
+        .stdout_str()
+        .split('\n')
+        .filter(|x| !x.is_empty())
+        .map(|x| x.parse().unwrap())
+        .collect();
+    assert_eq!(result_seq.len(), repeat_limit, "Output is not limited");
+    assert!(
+        result_seq.iter().all(|x| input_seq.contains(x)),
+        "Output includes element not from input: {}",
+        result.stdout_str()
+    );
+}
+
+#[test]
+fn test_head_count_multi_small_then_big() {
+    let repeat_limit = 5;
+    let input_seq = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let input = input_seq
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    let result = new_ucmd!()
+        .arg("-n")
+        .arg(&repeat_limit.to_string())
+        .arg("-n")
+        .arg(&(repeat_limit + 1).to_string())
+        .pipe_in(input.as_bytes())
+        .succeeds();
+    result.no_stderr();
+
+    let result_seq: Vec<i32> = result
+        .stdout_str()
+        .split('\n')
+        .filter(|x| !x.is_empty())
+        .map(|x| x.parse().unwrap())
+        .collect();
+    assert_eq!(result_seq.len(), repeat_limit, "Output is not limited");
+    assert!(
+        result_seq.iter().all(|x| input_seq.contains(x)),
+        "Output includes element not from input: {}",
+        result.stdout_str()
+    );
+}
+
+#[test]
 fn test_repeat() {
     let repeat_limit = 15000;
     let input_seq = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -80,6 +80,27 @@ fn test_echo() {
 }
 
 #[test]
+fn test_echo_multi() {
+    let result = new_ucmd!()
+        .arg("-e")
+        .arg("a")
+        .arg("b")
+        .arg("-e")
+        .arg("c")
+        .succeeds();
+    result.no_stderr();
+
+    let mut result_seq: Vec<String> = result
+        .stdout_str()
+        .split('\n')
+        .filter(|x| !x.is_empty())
+        .map(|x| x.into())
+        .collect();
+    result_seq.sort_unstable();
+    assert_eq!(result_seq, ["a", "b", "c"], "Output is not a permutation");
+}
+
+#[test]
 fn test_head_count() {
     let repeat_limit = 5;
     let input_seq = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];


### PR DESCRIPTION
This PR fixes all `shuf` bugs around repeated arguments:
- GNU shuf considers all arguments to `--echo`.  uutils `shuf` currently only considers the very last `--echo`, and ignores all the others.
- GNU shuf accepts multiple head-counts (`-n`), effectively only considering the *lowest*. uutils `shuf` currently only considers the very last `--head-count`, and ignores all the others.
- GNU shuf rejects repeated input ranges and output files with a clear error message. uutils `shuf` currently only considers the very last element each, silently ignoring all the others.

This is clearly buggy, since command-line arguments should be ignored only in exceptional cases. This appears to be a regression after #3329.

In this PR I'm fixing these and adopt the behavior of GNU, which is in my eyes the only sane reaction to those scenarios. Of course, this PR also adds tests for that.

I'm entirely new to uutils, so please do point out any resources that might help me. (I've already read {DEVELOPMENT,CONTRIBUTING,CODE_OF_CONDUCT}.md.)

<details><summary>Multiple echos example</summary>

```
$ shuf -e a b -e c
c
b
a
$ shuf -e a b -e c
a
b
c
```

The following demonstrations are run with this diff applied, to see what's going on:

```diff
diff --git a/src/uu/shuf/src/shuf.rs b/src/uu/shuf/src/shuf.rs
--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -48,9 +48,10 @@ mod options {
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
+    println!("**>{:?}<**", matches);
 
     let mode = if let Some(args) = matches.get_many::<String>(options::ECHO) {
-        Mode::Echo(args.map(String::from).collect())
+        Mode::Echo(args.map(String::from).inspect(|x| println!(">{x}<")).collect())
     } else if let Some(range) = matches.get_one::<String>(options::INPUT_RANGE) {
         match parse_range(range) {
             Ok(m) => Mode::InputRange(m),
```

Behavior *before* this PR:
```console
$ cargo run -- shuf -e a b -e c
**>ArgMatches { valid_args: ["echo", "input-range", "head-count", "output", "random-source", "repeat", "zero-terminated", "file", "help", "version"], valid_subcommands: [], args: FlatMap { keys: ["echo", "repeat", "zero-terminated"], values: [MatchedArg { source: Some(CommandLine), indices: [5], type_id: Some(alloc::string::String), vals: [[AnyValue { inner: alloc::string::String }]], raw_vals: [["c"]], ignore_case: false }, MatchedArg { source: Some(DefaultValue), indices: [6], type_id: Some(bool), vals: [[AnyValue { inner: bool }]], raw_vals: [["false"]], ignore_case: false }, MatchedArg { source: Some(DefaultValue), indices: [7], type_id: Some(bool), vals: [[AnyValue { inner: bool }]], raw_vals: [["false"]], ignore_case: false }] }, subcommand: None }<**
>c<
c
```

Note that `shuf` isn't even aware that `a` and `b` were passed in.

Behavior *after* this PR:
```console
$ cargo run -- shuf -e a b -e c
**>ArgMatches { valid_args: ["echo", "input-range", "head-count", "output", "random-source", "repeat", "zero-terminated", "file", "help", "version"], valid_subcommands: [], args: FlatMap { keys: ["echo", "repeat", "zero-terminated"], values: [MatchedArg { source: Some(CommandLine), indices: [2, 3, 5], type_id: Some(alloc::string::String), vals: [[AnyValue { inner: alloc::string::String }, AnyValue { inner: alloc::string::String }], [AnyValue { inner: alloc::string::String }]], raw_vals: [["a", "b"], ["c"]], ignore_case: false }, MatchedArg { source: Some(DefaultValue), indices: [6], type_id: Some(bool), vals: [[AnyValue { inner: bool }]], raw_vals: [["false"]], ignore_case: false }, MatchedArg { source: Some(DefaultValue), indices: [7], type_id: Some(bool), vals: [[AnyValue { inner: bool }]], raw_vals: [["false"]], ignore_case: false }] }, subcommand: None }<**
>a<
>b<
>c<
b
c
a
```

</details>