### PR TITLE
shuf: Treat empty file as zero elements instead of one emptystring

### DIFF
--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -195,6 +195,13 @@ fn read_input_file(filename: &str) -> UResult<Vec<u8>> {
 }
 
 fn find_seps(data: &mut Vec<&[u8]>, sep: u8) {
+    // Special case: If data is empty (and does not even contain a single 'sep'
+    // to indicate the presence of the empty element), then behave as if the input contained no elements at all.
+    if data.len() == 1 && data[0].is_empty() {
+        data.clear();
+        return;
+    }
+
     // need to use for loop so we don't borrow the vector as we modify it in place
     // basic idea:
     // * We don't care about the order of the result. This lets us slice the slices

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -49,6 +49,13 @@ fn test_zero_termination() {
 }
 
 #[test]
+fn test_empty_input() {
+    let result = new_ucmd!().pipe_in(vec![]).succeeds();
+    result.no_stderr();
+    result.no_stdout();
+}
+
+#[test]
 fn test_echo() {
     let input_seq = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let result = new_ucmd!()


### PR DESCRIPTION
This PR makes shuf behave more like GNU shuf in the case of empty files (e.g. null stdin).

Old behavior:
```console
$ true | cargo run -- shuf | hd
00000000  0a                                                |.|
00000001
$
```

GNU behavior:
```console
$ true | shuf | hd
$
```

New behavior:
```console
$ true | cargo run -- shuf | hd
$
```

Note that this also makes `shuf-reservoir.sh` in the GNU shuf tests happy.

I'm [mostly](https://github.com/uutils/coreutils/pull/5978) new to uutils, so please do point out any resources that might help me. (I've already read {DEVELOPMENT,CONTRIBUTING,CODE_OF_CONDUCT}.md.)