### PR TITLE
disable failing test_od::test_f16() for android CI

### DIFF
--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -229,6 +229,13 @@ fn test_hex32() {
         .stdout_is(expected_output);
 }
 
+// This test fails on Android CI on AVD on Ubuntu Github runners.
+// It was never reproducible locally and seems to be very hard to fix.
+// Thats why its disabled for android x86*. See uutils issue #5941.
+#[cfg(not(all(
+    target_os = "android",
+    any(target_arch = "x86", target_arch = "x86_64")
+)))]
 #[test]
 fn test_f16() {
     let input: [u8; 14] = [


### PR DESCRIPTION
As discussed and agreed in #5941, the test gets disabled for android CI.

I disabled it for android on x86 and x86_64.