### PR TITLE
Fix "item x imported redundantly" warnings

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -17,7 +17,6 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::{Path, PathBuf, StripPrefixError};
-use std::string::ToString;
 
 use clap::{builder::ValueParser, crate_version, Arg, ArgAction, ArgMatches, Command};
 use filetime::FileTime;

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -12,7 +12,6 @@ use nix::sys::signal::{raise, sigaction, SaFlags, SigAction, SigHandler, SigSet,
 use std::borrow::Cow;
 use std::env;
 use std::io::{self, Write};
-use std::iter::Iterator;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::process;

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -9,7 +9,6 @@ use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgAction, Command};
 use memchr::{memchr3_iter, memchr_iter};
 use std::cmp::Ordering;
-use std::convert::From;
 use std::error::Error;
 use std::ffi::OsString;
 use std::fmt::Display;

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -5,9 +5,7 @@
 // spell-checker:ignore (ToDO) multifile curr fnames fname xfrd fillloop mockstream
 
 use std::fs::File;
-use std::io;
-use std::io::BufReader;
-use std::vec::Vec;
+use std::io::{self, BufReader};
 
 use uucore::display::Quotable;
 use uucore::show_error;

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -11,7 +11,6 @@ use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use itertools::Itertools;
 use quick_error::ResultExt;
 use regex::Regex;
-use std::convert::From;
 use std::fs::{metadata, File};
 use std::io::{stdin, stdout, BufRead, BufReader, Lines, Read, Write};
 #[cfg(unix)]

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -9,7 +9,6 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use regex::Regex;
 use std::cmp;
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::default::Default;
 use std::error::Error;
 use std::fmt::{Display, Formatter, Write as FmtWrite};
 use std::fs::File;

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -12,7 +12,7 @@ use uucore::{
 };
 
 use clap::{crate_version, Arg, ArgAction, Command};
-use fundu::{self, DurationParser, ParseError, SaturatingInto};
+use fundu::{DurationParser, ParseError, SaturatingInto};
 
 static ABOUT: &str = help_about!("sleep.md");
 const USAGE: &str = help_usage!("sleep.md");

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -17,7 +17,6 @@ use uucore::{
 use chrono::{DateTime, Local};
 use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use std::borrow::Cow;
-use std::convert::AsRef;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};

--- a/src/uu/timeout/src/status.rs
+++ b/src/uu/timeout/src/status.rs
@@ -3,7 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //! Exit status codes produced by `timeout`.
-use std::convert::From;
 use uucore::error::UError;
 
 /// Enumerates the exit statuses produced by `timeout`.

--- a/src/uu/wc/src/utf8/read.rs
+++ b/src/uu/wc/src/utf8/read.rs
@@ -7,7 +7,6 @@ use super::*;
 use std::error::Error;
 use std::fmt;
 use std::io::{self, BufRead};
-use std::str;
 
 /// Wraps a `std::io::BufRead` buffered byte stream and decode it as UTF-8.
 pub struct BufReadDecoder<B: BufRead> {

--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -474,7 +474,6 @@ pub fn source_is_target_backup(source: &Path, target: &Path, suffix: &str) -> bo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
     // Required to instantiate mutex in shared context
     use clap::Command;
     use once_cell::sync::Lazy;

--- a/src/uucore/src/lib/features/encoding.rs
+++ b/src/uucore/src/lib/features/encoding.rs
@@ -6,11 +6,9 @@
 // spell-checker:ignore (strings) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUV
 // spell-checker:ignore (encodings) lsbf msbf hexupper
 
-use data_encoding::{self, BASE32, BASE64};
-
 use std::io::{self, Read, Write};
 
-use data_encoding::{Encoding, BASE32HEX, BASE64URL, HEXUPPER};
+use data_encoding::{Encoding, BASE32, BASE32HEX, BASE64, BASE64URL, HEXUPPER};
 use data_encoding_macro::new_encoding;
 #[cfg(feature = "thiserror")]
 use thiserror::Error;

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -63,8 +63,6 @@ use libc::{
     mode_t, strerror, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK,
 };
 use std::borrow::Cow;
-#[cfg(not(windows))]
-use std::convert::From;
 #[cfg(unix)]
 use std::ffi::CStr;
 #[cfg(unix)]

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -6,16 +6,12 @@
 //! Common functions to manage permissions
 
 use crate::display::Quotable;
-use crate::error::strip_errno;
-use crate::error::UResult;
-use crate::error::USimpleError;
+use crate::error::{strip_errno, UResult, USimpleError};
 pub use crate::features::entries;
 use crate::fs::resolve_relative_path;
 use crate::show_error;
-use clap::Arg;
-use clap::ArgMatches;
-use clap::Command;
-use libc::{self, gid_t, uid_t};
+use clap::{Arg, ArgMatches, Command};
+use libc::{gid_t, uid_t};
 use walkdir::WalkDir;
 
 use std::io::Error as IOError;

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -54,8 +54,6 @@ pub unsafe extern "C" fn utmpxname(_file: *const libc::c_char) -> libc::c_int {
     0
 }
 
-use once_cell::sync::Lazy;
-
 use crate::*; // import macros from `../../macros.rs`
 
 // In case the c_char array doesn't end with NULL

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -56,7 +56,6 @@
 
 // spell-checker:ignore uioerror rustdoc
 
-use clap;
 use std::{
     error::Error,
     fmt::{Display, Formatter},

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -5,7 +5,7 @@
 // spell-checker:ignore (formats) cymdhm cymdhms mdhm mdhms ymdhm ymdhms datetime mktime
 
 use crate::common::util::{AtPath, TestScenario};
-use filetime::{self, FileTime};
+use filetime::FileTime;
 use std::fs::remove_file;
 use std::path::PathBuf;
 


### PR DESCRIPTION
This PR fixes the "item x imported redundantly" warnings that show up in the CI using the nightly builds (see, for example, https://github.com/uutils/coreutils/actions/runs/7957254785/job/21719731331, "Test" step).