### PR TITLE
bump min required rust version to 1.74.0

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.70.0"
+msrv = "1.74.0"
 cognitive-complexity-threshold = 10

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -11,7 +11,7 @@ env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"
   PROJECT_AUTH: "uutils"
-  RUST_MIN_SRV: "1.70.0"
+  RUST_MIN_SRV: "1.74.0"
   # * style job configuration
   STYLE_FAIL_ON_FAULT: true ## (bool) fail the build if a style job contains a fault (error or warning); may be overridden on a per-job basis
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/uutils/coreutils"
 readme = "README.md"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-rust-version = "1.70.0"
+rust-version = "1.74.0"
 edition = "2021"
 
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![dependency status](https://deps.rs/repo/github/uutils/coreutils/status.svg)](https://deps.rs/repo/github/uutils/coreutils)
 
 [![CodeCov](https://codecov.io/gh/uutils/coreutils/branch/master/graph/badge.svg)](https://codecov.io/gh/uutils/coreutils)
-![MSRV](https://img.shields.io/badge/MSRV-1.70.0-brightgreen)
+![MSRV](https://img.shields.io/badge/MSRV-1.74.0-brightgreen)
 
 </div>
 
@@ -71,7 +71,7 @@ the [coreutils docs](https://github.com/uutils/uutils.github.io) repository.
 ### Rust Version
 
 uutils follows Rust's release channels and is tested against stable, beta and
-nightly. The current Minimum Supported Rust Version (MSRV) is `1.70.0`.
+nightly. The current Minimum Supported Rust Version (MSRV) is `1.74.0`.
 
 ## Building
 


### PR DESCRIPTION
to use the crate `os_str_bytes = "7.0.0"` in its latest version, we need to bump our min. req. rustc version to 1.74.0
usecase: PR #5801 