### PR TITLE
Un-Ignore two tests that fail for nonsense reasons

### DIFF
--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -99,10 +99,8 @@ fn test_verbose() {
 }
 
 #[test]
-#[ignore]
 fn test_spams_newline() {
-    //this test is does not mirror what GNU does
-    new_ucmd!().pipe_in("a").succeeds().stdout_is("a\n");
+    new_ucmd!().pipe_in("a").succeeds().stdout_is("a");
 }
 
 #[test]

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -846,13 +846,11 @@ fn test_touch_dash() {
 }
 
 #[test]
-// Chrono panics for now
-#[ignore]
 fn test_touch_invalid_date_format() {
     let (_at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_invalid_date_format";
 
     ucmd.args(&["-m", "-t", "+1000000000000 years", file])
         .fails()
-        .stderr_contains("touch: invalid date format ‘+1000000000000 years’");
+        .stderr_contains("touch: invalid date format '+1000000000000 years'");
 }


### PR DESCRIPTION
This PR un-ignores two tests:
- `test_head::test_spams_newline` set a wrong expectation. A simple comparison with GNU head and busybox head reveals that the test was flawed, and plugging in the correct output passes the test.
- `test_touch::test_touch_invalid_date_format` had a simple typo: Apparently someone accidentally copy-pasted typographic quotation marks instead of the usual "ASCII" quotation marks. Changing this passes the test.