### PR TITLE
tr: Properly handle deleting and squeezing

### DIFF
--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -64,6 +64,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
+    if delete_flag & squeeze_flag && sets_len < 2 {
+        return Err(UUsageError::new(
+            1,
+            format!(
+                "missing operand after {}\nTwo strings must be given when deleting and squeezing.",
+                sets[0].quote()
+            ),
+        ));
+    }
+
     if sets_len > 1 {
         let start = "extra operand";
         if delete_flag && !squeeze_flag {

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -127,7 +127,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
             {
                 let mut squeeze_reader = BufReader::new(delete_buffer.as_bytes());
-                let op = SqueezeOperation::new(set2, complement_flag);
+                let op = SqueezeOperation::new(set2, false);
                 translate_input(&mut squeeze_reader, &mut buffered_stdout, op);
             }
         } else {

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore aabbaa aabbcc aabc abbb abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn
+// spell-checker:ignore aabbaa aabbcc aabc abbb abbbcddd abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit XXXYYY xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn
 use crate::common::util::TestScenario;
 
 #[test]
@@ -188,6 +188,15 @@ fn test_delete_and_squeeze_complement() {
         .pipe_in("abBcB")
         .run()
         .stdout_is("abc");
+}
+
+#[test]
+fn test_delete_and_squeeze_complement_squeeze_set2() {
+    new_ucmd!()
+        .args(&["-dsc", "abX", "XYZ"])
+        .pipe_in("abbbcdddXXXYYY")
+        .succeeds()
+        .stdout_is("abbbX");
 }
 
 #[test]

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -164,6 +164,15 @@ fn test_translate_and_squeeze_multiple_lines() {
 }
 
 #[test]
+fn test_delete_and_squeeze_one_set() {
+    new_ucmd!()
+        .args(&["-ds", "a-z"])
+        .fails()
+        .stderr_contains("missing operand after 'a-z'")
+        .stderr_contains("Two strings must be given when deleting and squeezing.");
+}
+
+#[test]
 fn test_delete_and_squeeze() {
     new_ucmd!()
         .args(&["-ds", "a-z", "A-Z"])


### PR DESCRIPTION
Found while playing around with multiple arguments, and comparing with GNU `tr` output:
- We used to accept invocations with only one string; note that this never makes sense with `tr -ds`, for example.
- We used to complement the second set in `tr -cds`, even though our `--help` text already correctly points out that `-c` only complements `SET1`, not `SET2`.