### PR TITLE
tests: Harden two tests, prevent 4 flaky tests (cat, numfmt, sort, split, tee)

### DIFF
--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -175,6 +175,7 @@ fn test_piped_to_dev_full() {
             s.ucmd()
                 .set_stdout(dev_full)
                 .pipe_in_fixture("alpha.txt")
+                .ignore_stdin_write_error()
                 .fails()
                 .stderr_contains("No space left on device");
         }
@@ -224,6 +225,7 @@ fn test_three_directories_and_file_and_stdin() {
             "test_directory3",
         ])
         .pipe_in("stdout bytes")
+        .ignore_stdin_write_error()
         .fails()
         .stderr_is_fixture("three_directories_and_file_and_stdin.stderr.expected")
         .stdout_is(

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -666,7 +666,12 @@ fn test_invalid_stdin_number_returns_status_2() {
 
 #[test]
 fn test_invalid_stdin_number_in_middle_of_input() {
-    new_ucmd!().pipe_in("100\nhello\n200").fails().code_is(2);
+    new_ucmd!()
+        .pipe_in("100\nhello\n200")
+        .ignore_stdin_write_error()
+        .fails()
+        .stdout_is("100\n")
+        .code_is(2);
 }
 
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -813,10 +813,18 @@ fn test_check_silent() {
 
 #[test]
 fn test_check_unique() {
-    // Due to a clap bug the combination "-cu" does not work. "-c -u" works.
-    // See https://github.com/clap-rs/clap/issues/2624
     new_ucmd!()
         .args(&["-c", "-u"])
+        .pipe_in("A\nA\n")
+        .fails()
+        .code_is(1)
+        .stderr_only("sort: -:2: disorder: A\n");
+}
+
+#[test]
+fn test_check_unique_combined() {
+    new_ucmd!()
+        .args(&["-cu"])
         .pipe_in("A\nA\n")
         .fails()
         .code_is(1)

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -1068,6 +1068,7 @@ fn test_split_number_oversized_stdin() {
     new_ucmd!()
         .args(&["--number=3", "---io-blksize=600"])
         .pipe_in_fixture("sixhundredfiftyonebytes.txt")
+        .ignore_stdin_write_error()
         .fails()
         .stderr_only("split: -: cannot determine input size\n");
 }

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -77,7 +77,7 @@ fn test_tee_no_more_writeable_1() {
     // equals to 'tee /dev/full out2 <multi_read' call
     let (at, mut ucmd) = at_and_ucmd!();
     let content = (1..=10).fold(String::new(), |mut output, x| {
-        let _ = writeln!(output, "{x}");
+        writeln!(output, "{x}").unwrap();
         output
     });
     let file_out = "tee_file_out";


### PR DESCRIPTION
This PR improves the tests:
- Two tests were unnecessarily lax (`test_tee_no_more_writeable_1` ignored memory problems, the new `test_check_unique_combined` exercises an input that wasn't possible before clap#2624)
- Four tests had the potential to flake: They were writing to the stdin of a process that might have already terminated.

My goal was to find any flaky tests like 9995c637aa5de190ddce0abc4be36d773797f1bc: When we write a large buffer to the stdin of a process that will fail at some point, then a race happens:
- Perhaps the write happens first, and the kernel buffer is large enough to accept it entirely. In that case, the write is successful, and the writer thread terminates normally. This is likely to happen on a developer machine.
- Perhaps the write happens later, and the child process executes first. This will close the pipe. If we then try to write to it, the write will fail. This is unlikely to happen, but not impossible on a busy CI machine.

Arguably, these tests are unlikely to be the cause of any flakiness, but let's fix them anyway: Either it improves the situation, or makes no difference.