### PR TITLE
dd: fix flaky test_final_stats_unspec

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -277,7 +277,7 @@ fn test_final_stats_unspec() {
     new_ucmd!()
         .run()
         .stderr_contains("0+0 records in\n0+0 records out\n0 bytes copied, ")
-        .stderr_matches(&Regex::new(r"\d\.\d+(e-\d\d)? s, ").unwrap())
+        .stderr_matches(&Regex::new(r"\d(\.\d+)?(e-\d\d)? s, ").unwrap())
         .stderr_contains("0.0 B/s")
         .success();
 }


### PR DESCRIPTION
If the first four decimal digits are zero, GNU dd elides them altogether. Here's an execution on my PC:

```console
$ for i in $(seq 20000); do LC_ALL=C gnu_dd if=/dev/null of=/dev/null \
    2>&1; done | grep copied | grep -E ' [0-9]e'
0 bytes copied, 1e-05 s, 0 B/s
0 bytes copied, 9e-06 s, 0.0 kB/s
```

Our implementation conforms to this, resulting in the following CI flake:

```
---- test_dd::test_final_stats_unspec stdout ----
run: D:\a\coreutils\coreutils\target\x86_64-pc-windows-gnu\debug\coreutils.exe dd
thread 'test_dd::test_final_stats_unspec' panicked at 'Stderr does not match regex:
0+0 records in
0+0 records out
0 bytes copied, 8e-05 s, 0.0 B/s
', tests\by-util\test_dd.rs:280:10
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src/panicking.rs:578:5
```

Of course, this is just an overly strict regex in the test. This was a one-in-tenthousand flaky test.

EDIT: Fun fact, I discovered this because it flaked in https://github.com/uutils/coreutils/pull/5999#issuecomment-1960739822 .