### PR TITLE
tr: Correctly handle multiple appearances of flag-args

### DIFF
--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -179,7 +179,8 @@ pub fn uu_app() -> Command {
                 .short('d')
                 .long(options::DELETE)
                 .help("delete characters in SET1, do not translate")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::DELETE),
         )
         .arg(
             Arg::new(options::SQUEEZE)

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -164,6 +164,7 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
+        .trailing_var_arg(true)
         .arg(
             Arg::new(options::COMPLEMENT)
                 .visible_short_alias('C')

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -199,7 +199,8 @@ pub fn uu_app() -> Command {
                 .long(options::TRUNCATE_SET1)
                 .short('t')
                 .help("first truncate SET1 to length of SET2")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::TRUNCATE_SET1),
         )
         .arg(Arg::new(options::SETS).num_args(1..))
 }

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -170,7 +170,8 @@ pub fn uu_app() -> Command {
                 .short('c')
                 .long(options::COMPLEMENT)
                 .help("use the complement of SET1")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::COMPLEMENT),
         )
         .arg(
             Arg::new(options::DELETE)

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -191,7 +191,8 @@ pub fn uu_app() -> Command {
                      listed in the last specified SET, with a single occurrence \
                      of that character",
                 )
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::SQUEEZE),
         )
         .arg(
             Arg::new(options::TRUNCATE_SET1)

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -47,6 +47,32 @@ fn test_delete() {
 }
 
 #[test]
+fn test_delete_afterwards_is_not_flag() {
+    new_ucmd!()
+        .args(&["a-z", "-d"])
+        .pipe_in("aBcD")
+        .succeeds()
+        .stdout_is("-BdD");
+}
+
+#[test]
+fn test_delete_multi() {
+    new_ucmd!()
+        .args(&["-d", "-d", "a-z"])
+        .pipe_in("aBcD")
+        .succeeds()
+        .stdout_is("BD");
+}
+
+#[test]
+fn test_delete_late() {
+    new_ucmd!()
+        .args(&["-d", "a-z", "-d"])
+        .fails()
+        .stderr_contains("extra operand '-d'");
+}
+
+#[test]
 fn test_delete_complement() {
     new_ucmd!()
         .args(&["-d", "-c", "a-z"])

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -119,6 +119,15 @@ fn test_complement5() {
 }
 
 #[test]
+fn test_complement_multi_early() {
+    new_ucmd!()
+        .args(&["-c", "-c", "a", "X"])
+        .pipe_in("ab")
+        .succeeds()
+        .stdout_is("aX");
+}
+
+#[test]
 fn test_squeeze() {
     new_ucmd!()
         .args(&["-s", "a-z"])

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -300,7 +300,16 @@ fn test_truncate() {
     new_ucmd!()
         .args(&["-t", "abc", "xy"])
         .pipe_in("abcde")
-        .run()
+        .succeeds()
+        .stdout_is("xycde"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_truncate_multi() {
+    new_ucmd!()
+        .args(&["-tt", "-t", "abc", "xy"])
+        .pipe_in("abcde")
+        .succeeds()
         .stdout_is("xycde"); // spell-checker:disable-line
 }
 

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -79,6 +79,14 @@ fn test_complement1() {
 }
 
 #[test]
+fn test_complement_afterwards_is_not_flag() {
+    new_ucmd!()
+        .args(&["a", "X", "-c"])
+        .fails()
+        .stderr_contains("extra operand '-c'");
+}
+
+#[test]
 fn test_complement2() {
     new_ucmd!()
         .args(&["-c", "0-9", "x"])
@@ -125,6 +133,22 @@ fn test_complement_multi_early() {
         .pipe_in("ab")
         .succeeds()
         .stdout_is("aX");
+}
+
+#[test]
+fn test_complement_multi_middle() {
+    new_ucmd!()
+        .args(&["-c", "a", "-c", "X"])
+        .fails()
+        .stderr_contains("tr: extra operand 'X'");
+}
+
+#[test]
+fn test_complement_multi_late() {
+    new_ucmd!()
+        .args(&["-c", "a", "X", "-c"])
+        .fails()
+        .stderr_contains("tr: extra operand '-c'");
 }
 
 #[test]

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -182,7 +182,16 @@ fn test_squeeze() {
     new_ucmd!()
         .args(&["-s", "a-z"])
         .pipe_in("aaBBcDcc")
-        .run()
+        .succeeds()
+        .stdout_is("aBBcDc");
+}
+
+#[test]
+fn test_squeeze_multi() {
+    new_ucmd!()
+        .args(&["-ss", "-s", "a-z"])
+        .pipe_in("aaBBcDcc")
+        .succeeds()
         .stdout_is("aBBcDc");
 }
 
@@ -191,7 +200,16 @@ fn test_squeeze_complement() {
     new_ucmd!()
         .args(&["-sc", "a-z"])
         .pipe_in("aaBBcDcc")
-        .run()
+        .succeeds()
+        .stdout_is("aaBcDcc");
+}
+
+#[test]
+fn test_squeeze_complement_multi() {
+    new_ucmd!()
+        .args(&["-scsc", "a-z"]) // spell-checker:disable-line
+        .pipe_in("aaBBcDcc")
+        .succeeds()
         .stdout_is("aaBcDcc");
 }
 


### PR DESCRIPTION
Before:
```console
$ echo abbbcddd | tr -tt abc x  # GNU
xbbbcddd
$ echo abbbcddd | cargo run tr -tt abc x
error: the argument '--truncate-set1' cannot be used multiple times

Usage: target/debug/coreutils tr [OPTION]... SET1 [SET2]

For more information, try '--help'.
[$? = 1]
$
```

After:
```
$ echo abbbcddd | cargo run tr -tt abc x
xbbbcddd
```

This fixes #5998 for the special case of `tr`.