### PR TITLE
base32/base64/basenc: implement and test proper flag parsing

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -102,23 +102,24 @@ pub fn base_app(about: &'static str, usage: &str) -> Command {
                 .short('d')
                 .long(options::DECODE)
                 .help("decode data")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::DECODE),
         )
         .arg(
             Arg::new(options::IGNORE_GARBAGE)
                 .short('i')
                 .long(options::IGNORE_GARBAGE)
                 .help("when decoding, ignore non-alphabetic characters")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::IGNORE_GARBAGE),
         )
         .arg(
             Arg::new(options::WRAP)
                 .short('w')
                 .long(options::WRAP)
                 .value_name("COLS")
-                .help(
-                    "wrap encoded lines after COLS character (default 76, 0 to disable wrapping)",
-                ),
+                .help("wrap encoded lines after COLS character (default 76, 0 to disable wrapping)")
+                .overrides_with(options::WRAP),
         )
         // "multiple" arguments are used to check whether there is more than one
         // file passed in.

--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -53,12 +53,14 @@ const ENCODINGS: &[(&str, Format, &str)] = &[
 pub fn uu_app() -> Command {
     let mut command = base_common::base_app(ABOUT, USAGE);
     for encoding in ENCODINGS {
-        command = command.arg(
-            Arg::new(encoding.0)
-                .long(encoding.0)
-                .help(encoding.2)
-                .action(ArgAction::SetTrue),
-        );
+        let raw_arg = Arg::new(encoding.0)
+            .long(encoding.0)
+            .help(encoding.2)
+            .action(ArgAction::SetTrue);
+        let overriding_arg = ENCODINGS
+            .iter()
+            .fold(raw_arg, |arg, enc| arg.overrides_with(enc.0));
+        command = command.arg(overriding_arg);
     }
     command
 }

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -23,6 +23,26 @@ fn test_encode() {
 }
 
 #[test]
+fn test_encode_repeat_flags_later_wrap_10() {
+    let input = "Hello, World!\n";
+    new_ucmd!()
+        .args(&["-ii", "-w17", "-w10"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("JBSWY3DPFQ\nQFO33SNRSC\nCCQ=\n"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_encode_repeat_flags_later_wrap_17() {
+    let input = "Hello, World!\n";
+    new_ucmd!()
+        .args(&["-ii", "-w10", "-w17"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("JBSWY3DPFQQFO33SN\nRSCCCQ=\n"); // spell-checker:disable-line
+}
+
+#[test]
 fn test_base32_encode_file() {
     new_ucmd!()
         .arg("input-simple.txt")
@@ -40,6 +60,16 @@ fn test_decode() {
             .succeeds()
             .stdout_only("Hello, World!");
     }
+}
+
+#[test]
+fn test_decode_repeat_flags() {
+    let input = "JBSWY3DPFQQFO33SNRSCC===\n"; // spell-checker:disable-line
+    new_ucmd!()
+        .args(&["-didiw80", "--wrap=17", "--wrap", "8"]) // spell-checker:disable-line
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("Hello, World!");
 }
 
 #[test]

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -21,6 +21,26 @@ fn test_encode() {
 }
 
 #[test]
+fn test_encode_repeat_flags_later_wrap_10() {
+    let input = "hello, world!";
+    new_ucmd!()
+        .args(&["-ii", "-w15", "-w10"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("aGVsbG8sIH\ndvcmxkIQ==\n"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_encode_repeat_flags_later_wrap_15() {
+    let input = "hello, world!";
+    new_ucmd!()
+        .args(&["-ii", "-w10", "-w15"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("aGVsbG8sIHdvcmx\nkIQ==\n"); // spell-checker:disable-line
+}
+
+#[test]
 fn test_base64_encode_file() {
     new_ucmd!()
         .arg("input-simple.txt")
@@ -38,6 +58,16 @@ fn test_decode() {
             .succeeds()
             .stdout_only("hello, world!");
     }
+}
+
+#[test]
+fn test_decode_repeat_flags() {
+    let input = "aGVsbG8sIHdvcmxkIQ==\n"; // spell-checker:disable-line
+    new_ucmd!()
+        .args(&["-didiw80", "--wrap=17", "--wrap", "8"]) // spell-checker:disable-line
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("hello, world!");
 }
 
 #[test]

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -173,3 +173,60 @@ fn test_base2lsbf_decode() {
         .no_stderr()
         .stdout_only("lsbf");
 }
+
+#[test]
+fn test_choose_last_encoding_z85() {
+    new_ucmd!()
+        .args(&[
+            "--base2lsbf",
+            "--base2msbf",
+            "--base16",
+            "--base32hex",
+            "--base64url",
+            "--base32",
+            "--base64",
+            "--z85",
+        ])
+        .pipe_in("Hello, World")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("nm=QNz.92jz/PV8\n");
+}
+
+#[test]
+fn test_choose_last_encoding_base64() {
+    new_ucmd!()
+        .args(&[
+            "--base2msbf",
+            "--base2lsbf",
+            "--base64url",
+            "--base32hex",
+            "--base32",
+            "--base16",
+            "--z85",
+            "--base64",
+        ])
+        .pipe_in("Hello, World!")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("SGVsbG8sIFdvcmxkIQ==\n"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_choose_last_encoding_base2lsbf() {
+    new_ucmd!()
+        .args(&[
+            "--base64url",
+            "--base16",
+            "--base2msbf",
+            "--base32",
+            "--base64",
+            "--z85",
+            "--base32hex",
+            "--base2lsbf",
+        ])
+        .pipe_in("lsbf")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("00110110110011100100011001100110\n");
+}

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -230,3 +230,24 @@ fn test_choose_last_encoding_base2lsbf() {
         .no_stderr()
         .stdout_only("00110110110011100100011001100110\n");
 }
+
+#[test]
+fn test_base32_decode_repeated() {
+    new_ucmd!()
+        .args(&[
+            "--ignore",
+            "--wrap=80",
+            "--base32hex",
+            "--z85",
+            "--ignore",
+            "--decode",
+            "--z85",
+            "--base32",
+            "-w",
+            "10",
+        ])
+        .pipe_in("NZUWGZJ6MJQXGZJ7") // spell-checker:disable-line
+        .succeeds()
+        .no_stderr()
+        .stdout_only("nice>base?");
+}

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -2,6 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
+//spell-checker: ignore (encodings) lsbf msbf
 use crate::common::util::TestScenario;
 
 #[test]
@@ -30,4 +32,144 @@ fn test_invalid_input() {
         .args(&["--base32", "."])
         .fails()
         .stderr_only(error_message);
+}
+
+#[test]
+fn test_base64() {
+    new_ucmd!()
+        .arg("--base64")
+        .pipe_in("to>be?")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("dG8+YmU/\n"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_base64_decode() {
+    new_ucmd!()
+        .args(&["--base64", "-d"])
+        .pipe_in("dG8+YmU/") // spell-checker:disable-line
+        .succeeds()
+        .no_stderr()
+        .stdout_only("to>be?");
+}
+
+#[test]
+fn test_base64url() {
+    new_ucmd!()
+        .arg("--base64url")
+        .pipe_in("to>be?")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("dG8-YmU_\n"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_base64url_decode() {
+    new_ucmd!()
+        .args(&["--base64url", "-d"])
+        .pipe_in("dG8-YmU_") // spell-checker:disable-line
+        .succeeds()
+        .no_stderr()
+        .stdout_only("to>be?");
+}
+
+#[test]
+fn test_base32() {
+    new_ucmd!()
+        .arg("--base32")
+        .pipe_in("nice>base?")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("NZUWGZJ6MJQXGZJ7\n"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_base32_decode() {
+    new_ucmd!()
+        .args(&["--base32", "-d"])
+        .pipe_in("NZUWGZJ6MJQXGZJ7") // spell-checker:disable-line
+        .succeeds()
+        .no_stderr()
+        .stdout_only("nice>base?");
+}
+
+#[test]
+fn test_base32hex() {
+    new_ucmd!()
+        .arg("--base32hex")
+        .pipe_in("nice>base?")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("DPKM6P9UC9GN6P9V\n"); // spell-checker:disable-line
+}
+
+#[test]
+fn test_base32hex_decode() {
+    new_ucmd!()
+        .args(&["--base32hex", "-d"])
+        .pipe_in("DPKM6P9UC9GN6P9V") // spell-checker:disable-line
+        .succeeds()
+        .no_stderr()
+        .stdout_only("nice>base?");
+}
+
+#[test]
+fn test_base16() {
+    new_ucmd!()
+        .arg("--base16")
+        .pipe_in("Hello, World!")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("48656C6C6F2C20576F726C6421\n");
+}
+
+#[test]
+fn test_base16_decode() {
+    new_ucmd!()
+        .args(&["--base16", "-d"])
+        .pipe_in("48656C6C6F2C20576F726C6421")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("Hello, World!");
+}
+
+#[test]
+fn test_base2msbf() {
+    new_ucmd!()
+        .arg("--base2msbf")
+        .pipe_in("msbf")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("01101101011100110110001001100110\n");
+}
+
+#[test]
+fn test_base2msbf_decode() {
+    new_ucmd!()
+        .args(&["--base2msbf", "-d"])
+        .pipe_in("01101101011100110110001001100110")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("msbf");
+}
+
+#[test]
+fn test_base2lsbf() {
+    new_ucmd!()
+        .arg("--base2lsbf")
+        .pipe_in("lsbf")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("00110110110011100100011001100110\n");
+}
+
+#[test]
+fn test_base2lsbf_decode() {
+    new_ucmd!()
+        .args(&["--base2lsbf", "-d"])
+        .pipe_in("00110110110011100100011001100110")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("lsbf");
 }


### PR DESCRIPTION
This PR fixes several issues:
- Basic functionality of `basenc` was not tested – it already works, yes, but let's make sure it doesn't regress.
- `basenc` should not decide according to some arbitrary built-in priority list (`ENCODINGS`), but rather let the last encoding on the command-line override any earlier ones. (This fixes a GNU behavior bug.)
- Permit repeated flags on the command-line; i.e. the flags `-d`, `-i`, and `-w`. (This fixes a GNU behavior bug.)

This fixes #5998 for the special case of `base32`, `base64`, and `basenc`.