### PR TITLE
pr: Check the correct timestamp in test_with_pr_core_utils_tests

### DIFF
--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -410,7 +410,7 @@ fn test_with_pr_core_utils_tests() {
         let mut scenario = new_ucmd!();
         let input_file_path = input_file.first().unwrap();
         let test_file_path = expected_file.first().unwrap();
-        let value = file_last_modified_time(&scenario, test_file_path);
+        let value = file_last_modified_time(&scenario, input_file_path);
         let mut arguments: Vec<&str> = flags
             .split(' ')
             .filter(|i| i.trim() != "")


### PR DESCRIPTION
The test `test_pr::test_with_pr_core_utils_tests` is flaky, and causes [real problems](https://github.com/uutils/coreutils/pull/5980#issuecomment-1962726133).

Here's a branch that makes the bug 100% reproducible, by injecting "lag" at critical moments: https://github.com/BenWiederhake/coreutils-rs/tree/historic/demo-pr-test-race

The bug is best explained by the fix:

```diff
     let input_file_path = input_file.first().unwrap();
     let test_file_path = expected_file.first().unwrap();
-    let value = file_last_modified_time(&scenario, test_file_path);
+    let value = file_last_modified_time(&scenario, input_file_path);
     let mut arguments: Vec<&str> = …;
     arguments.extend(input_file.clone());
     // "value" is then used to construct the expected output.
```

In other words: `value` is the last modified time of the wrong file.

All other tests in `test_pr` seem to use the correct file, so this should fix this issue for good.