### PR TITLE
shuf: Refuse repeating zero lines

### DIFF
--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -435,11 +435,10 @@ fn shuf_exec(input: &mut impl Shufable, opts: Options) -> UResult<()> {
         None => WrappedRng::RngDefault(rand::thread_rng()),
     };
 
-    if input.is_empty() {
-        return Ok(());
-    }
-
     if opts.repeat {
+        if input.is_empty() {
+            return Err(USimpleError::new(1, "no lines to repeat"));
+        }
         for _ in 0..opts.head_count {
             let r = input.choose(&mut rng);
 

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -624,3 +624,32 @@ fn test_shuf_multiple_input_line_count() {
         .count();
     assert_eq!(result_count, 5, "Output should have 5 items");
 }
+
+#[test]
+#[ignore = "known issue"]
+fn test_shuf_repeat_empty_range() {
+    new_ucmd!()
+        .arg("-ri4-3")
+        .fails()
+        .no_stdout()
+        .stderr_only("shuf: no lines to repeat\n");
+}
+
+#[test]
+fn test_shuf_repeat_empty_echo() {
+    new_ucmd!()
+        .arg("-re")
+        .fails()
+        .no_stdout()
+        .stderr_only("shuf: no lines to repeat\n");
+}
+
+#[test]
+fn test_shuf_repeat_empty_input() {
+    new_ucmd!()
+        .arg("-r")
+        .pipe_in("")
+        .fails()
+        .no_stdout()
+        .stderr_only("shuf: no lines to repeat\n");
+}


### PR DESCRIPTION
This was a GNU behavior bug:

```console
$ LC_ALL=C shuf -er
shuf: no lines to repeat
[$? = 1]
$ cargo run shuf -er  # old, bad (unexpected success)
$ cargo run shuf -er  # new
shuf: no lines to repeat
[$? = 1]
```

Note that this bug already existed *before* #5980 and my other shuf-related PRs.

This should also fix the last testcase of the GNU shuf test.