### PR TITLE
tr: Stream output instead of buffering

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -339,6 +339,32 @@ impl Sequence {
 
 pub trait SymbolTranslator {
     fn translate(&mut self, current: u8) -> Option<u8>;
+
+    /// Takes two SymbolTranslators and creates a new SymbolTranslator over both in sequence.
+    ///
+    /// This behaves pretty much identical to [`Iterator::chain`].
+    fn chain<T>(self, other: T) -> ChainedSymbolTranslator<Self, T>
+    where
+        Self: Sized,
+    {
+        ChainedSymbolTranslator::<Self, T> {
+            stage_a: self,
+            stage_b: other,
+        }
+    }
+}
+
+pub struct ChainedSymbolTranslator<A, B> {
+    stage_a: A,
+    stage_b: B,
+}
+
+impl<A: SymbolTranslator, B: SymbolTranslator> SymbolTranslator for ChainedSymbolTranslator<A, B> {
+    fn translate(&mut self, current: u8) -> Option<u8> {
+        self.stage_a
+            .translate(current)
+            .and_then(|c| self.stage_b.translate(c))
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This should lower memory consumption, and fixes OOM in some scenarios.

Before, buggy behavior:

```console
$ yes | tr -ds a b | head -n5  # GNU
y
y
y
y
y
$ yes | cargo run -- -ds a b | head -n5  # WARNING: THIS CAUSES OOM!
^C
[$? = 130]
$ yes yes | tr -s ye s | head -n5  # GNU
s
s
s
s
s
$ yes yes | cargo run -- -s ye s | head -n5  # WARNING: THIS CAUSES OOM!
^C
[$? = 130]
```

After:

```console
$ yes | cargo run -- -ds a b | head -n5
y
y
y
y
y
$ yes yes | cargo run -- -s ye s | head -n5
s
s
s
s
s
$
```

It might be tempting to factor out the common line `translate_input(&mut locked_stdin, &mut buffered_stdout, op);` from all if-branches. However, note that `op` has distinct types in each case, and virtualizing it (e.g. `let op: Box<dyn SymbolTranslator>`) would incur additional runtime costs. That cost seems unnecessary just to gain a little bit of beauty.

I'm not really sure how to test this. Ideally we could pipe in some data, and *NOT* close the stdin pipe, and see whether the program produces any partial output. However, I didn't see any methods/functions for doing so, and it sounds like it's too hard to get right to be worth it.

Maybe I could write a `BENCHMARKING.md` file, like for `shuf`? What do you suggest?