### PR TITLE
split: make flaky test more verbose

### DIFF
--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -1644,6 +1644,7 @@ fn test_round_robin_limited_file_descriptors() {
     new_ucmd!()
         .args(&["-n", "r/40", "onehundredlines.txt"])
         .limit(Resource::NOFILE, 9, 9)
+        .env("RUST_BACKTRACE", "1")
         .succeeds();
 }
 


### PR DESCRIPTION
`test_round_robin_limited_file_descriptors` is flaky and [causes real problems](https://github.com/uutils/coreutils/pull/6012#issuecomment-1962974453).

The test imposes `.limit(Resource::NOFILE, 9, 9)`, that's the point of the test. On my machine, this number can be lowered to 5; it always works with 5 or above, and never works below that. So I would assume that the "real" limit is 5 (plus minus a bit wiggle room for version differences).
On CI, it *usually* works with 9, but sometimes fails in the middle of the run (`xaz`, the 26th file), so it seems like there is a real issue, like an fd leak. (So we should not just raise the number.)

So let's at least make this test more verbose. This way, the next time it fails, we can see where *exactly* in `<OutFiles as ManageOutFiles>::get_writer` it fails. (At least that's where I think it fails.)

I have a bit of a bad feeling that it might be the line `out_file.maybe_writer.as_mut().unwrap().flush()?;`, i.e. flushing old files *while* there are no free descriptors left.

I would also love to run `lsof` at the time of crash, but since I cannot reproduce this issue locally, there's no way for me to do so. (And trying to do it automatically seems extremely difficult.)