### PR TITLE
chmod: Fix chmod -c --reference reporting when no change is made

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -101,7 +101,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let recursive = matches.get_flag(options::RECURSIVE);
     let fmode = match matches.get_one::<String>(options::REFERENCE) {
         Some(fref) => match fs::metadata(fref) {
-            Ok(meta) => Some(meta.mode()),
+            Ok(meta) => Some(meta.mode() & 0o7777),
             Err(err) => {
                 return Err(USimpleError::new(
                     1,
@@ -306,7 +306,7 @@ impl Chmoder {
         use uucore::mode::get_umask;
 
         let fperm = match fs::metadata(file) {
-            Ok(meta) => meta.mode(),
+            Ok(meta) => meta.mode() & 0o7777,
             Err(err) => {
                 if file.is_symlink() {
                     if self.verbose {
@@ -392,7 +392,7 @@ impl Chmoder {
                 println!(
                     "mode of {} retained as {:04o} ({})",
                     file.quote(),
-                    fperm & 0o7777,
+                    fperm,
                     display_permissions_unix(fperm as mode_t, false),
                 );
             }
@@ -405,9 +405,9 @@ impl Chmoder {
                 println!(
                     "failed to change mode of file {} from {:04o} ({}) to {:04o} ({})",
                     file.quote(),
-                    fperm & 0o7777,
+                    fperm,
                     display_permissions_unix(fperm as mode_t, false),
-                    mode & 0o7777,
+                    mode,
                     display_permissions_unix(mode as mode_t, false)
                 );
             }
@@ -417,9 +417,9 @@ impl Chmoder {
                 println!(
                     "mode of {} changed from {:04o} ({}) to {:04o} ({})",
                     file.quote(),
-                    fperm & 0o7777,
+                    fperm,
                     display_permissions_unix(fperm as mode_t, false),
-                    mode & 0o7777,
+                    mode,
                     display_permissions_unix(mode as mode_t, false)
                 );
             }

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -306,7 +306,7 @@ impl Chmoder {
         use uucore::mode::get_umask;
 
         let fperm = match fs::metadata(file) {
-            Ok(meta) => meta.mode() & 0o7777,
+            Ok(meta) => meta.mode(),
             Err(err) => {
                 if file.is_symlink() {
                     if self.verbose {
@@ -392,7 +392,7 @@ impl Chmoder {
                 println!(
                     "mode of {} retained as {:04o} ({})",
                     file.quote(),
-                    fperm,
+                    fperm & 0o7777,
                     display_permissions_unix(fperm as mode_t, false),
                 );
             }
@@ -405,9 +405,9 @@ impl Chmoder {
                 println!(
                     "failed to change mode of file {} from {:04o} ({}) to {:04o} ({})",
                     file.quote(),
-                    fperm,
+                    fperm & 0o7777,
                     display_permissions_unix(fperm as mode_t, false),
-                    mode,
+                    mode & 0o7777,
                     display_permissions_unix(mode as mode_t, false)
                 );
             }
@@ -417,9 +417,9 @@ impl Chmoder {
                 println!(
                     "mode of {} changed from {:04o} ({}) to {:04o} ({})",
                     file.quote(),
-                    fperm,
+                    fperm & 0o7777,
                     display_permissions_unix(fperm as mode_t, false),
-                    mode,
+                    mode & 0o7777,
                     display_permissions_unix(mode as mode_t, false)
                 );
             }

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -653,8 +653,7 @@ fn test_changes_from_identical_reference() {
     scene
         .ucmd()
         .arg("-c")
-        .arg("--reference")
-        .arg("file")
+        .arg("--reference=file")
         .arg("file")
         .succeeds()
         .no_stdout();

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -646,6 +646,21 @@ fn test_quiet_n_verbose_used_multiple_times() {
 }
 
 #[test]
+fn test_changes_from_reference() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("file");
+    scene
+        .ucmd()
+        .arg("-c")
+        .arg("--reference")
+        .arg("file")
+        .arg("file")
+        .succeeds()
+        .no_stdout();
+}
+
+#[test]
 fn test_gnu_invalid_mode() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -646,7 +646,7 @@ fn test_quiet_n_verbose_used_multiple_times() {
 }
 
 #[test]
-fn test_changes_from_reference() {
+fn test_changes_from_identical_reference() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     at.touch("file");


### PR DESCRIPTION
Fix for issue #6009.
I changed the code so that the old permission octal is retrieved in "full form" (6 octal digits). It is afterwards set to 4 digits when displayed.

Beforehand, 2 identical permissions were marked as different because of the different formats, resulting in incorrect displays for `-c`.