### PR TITLE
basename: Fix handling of repeated flags/arguments

### DIFF
--- a/src/uu/basename/basename.md
+++ b/src/uu/basename/basename.md
@@ -1,7 +1,7 @@
 # basename
 
 ```
-basename NAME [SUFFIX]
+basename [-z] NAME [SUFFIX]
 basename OPTION... NAME...
 ```
 

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -201,3 +201,19 @@ fn test_simple_format() {
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }
+
+#[test]
+fn test_zero_does_not_imply_multiple() {
+    new_ucmd!()
+        .args(&["-z", "foo.c", "c"])
+        .succeeds()
+        .stdout_is("foo.\0");
+}
+
+#[test]
+fn test_suffix_implies_multiple() {
+    new_ucmd!()
+        .args(&["-s", ".c", "foo.c", "o.c"])
+        .succeeds()
+        .stdout_is("foo\no\n");
+}

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -203,6 +203,54 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_repeated_multiple() {
+    new_ucmd!()
+        .args(&["-aa", "-a", "foo"])
+        .succeeds()
+        .stdout_is("foo\n");
+}
+
+#[test]
+fn test_repeated_multiple_many() {
+    new_ucmd!()
+        .args(&["-aa", "-a", "1/foo", "q/bar", "x/y/baz"])
+        .succeeds()
+        .stdout_is("foo\nbar\nbaz\n");
+}
+
+#[test]
+fn test_repeated_suffix_last() {
+    new_ucmd!()
+        .args(&["-s", ".h", "-s", ".c", "foo.c"])
+        .succeeds()
+        .stdout_is("foo\n");
+}
+
+#[test]
+fn test_repeated_suffix_not_first() {
+    new_ucmd!()
+        .args(&["-s", ".h", "-s", ".c", "foo.h"])
+        .succeeds()
+        .stdout_is("foo.h\n");
+}
+
+#[test]
+fn test_repeated_suffix_multiple() {
+    new_ucmd!()
+        .args(&["-as", ".h", "-a", "-s", ".c", "foo.c", "bar.c", "bar.h"])
+        .succeeds()
+        .stdout_is("foo\nbar\nbar.h\n");
+}
+
+#[test]
+fn test_repeated_zero() {
+    new_ucmd!()
+        .args(&["-zz", "-z", "foo/bar"])
+        .succeeds()
+        .stdout_is("bar\0");
+}
+
+#[test]
 fn test_zero_does_not_imply_multiple() {
     new_ucmd!()
         .args(&["-z", "foo.c", "c"])


### PR DESCRIPTION
This fixes several GNU behavior bugs around repeated arguments. In my eyes, the parsing code is now simpler, too.

Note in particular that `args_override_self` would *NOT* work here, since it would in all cases cause `options::NAME` to override itself, or interfere with `trailing_var_arg`.

This fixes #5998 for the special case of basename.

<details><summary>Notes on the GNU documentation bug</summary>

The GNU basename help suggests that `-z` immediately implies "multi-name mode", because it cannot appear in the first pattern:

```console
$ basename --help
Usage: basename NAME [SUFFIX]
  or:  basename OPTION... NAME...
```

However, that is evidently wrong:

```console
$ basename -z tool l  | hd
00000000  74 6f 6f 00                                       |too.|
00000004
```

If `-z` would imply multi-name mode, this should have interpreted `l` as a second file name, but it was obviously parsed as the suffix-to-be-removed.

Hence a bug in the `--help` string. And that's why I also changed our `basename.md`.

</details>