### PR TITLE
cargo: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.x86_64-unknown-redox]
 linker = "x86_64-unknown-redox-gcc"
 
-[target.'cfg(feature = "cargo-clippy")']
+[target.'cfg(clippy)']
 rustflags = [
     "-Wclippy::use_self",
     "-Wclippy::needless_pass_by_value",


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html