### PR TITLE
printf: '%0c' and '%0s' should fail

### DIFF
--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -171,7 +171,7 @@ impl Spec {
         Ok(match type_spec {
             // GNU accepts minus, plus and space even though they are not used
             b'c' => {
-                if flags.hash || precision.is_some() {
+                if flags.zero || flags.hash || precision.is_some() {
                     return Err(&start[..index]);
                 }
                 Self::Char {
@@ -180,7 +180,7 @@ impl Spec {
                 }
             }
             b's' => {
-                if flags.hash {
+                if flags.zero || flags.hash {
                     return Err(&start[..index]);
                 }
                 Self::String {

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -765,3 +765,15 @@ fn pad_string() {
             .stdout_only(expected);
     }
 }
+
+#[test]
+fn format_spec_zero_char_fails() {
+    // It is invalid to have the format spec '%0c'
+    new_ucmd!().args(&["%0c", "3"]).fails().code_is(1);
+}
+
+#[test]
+fn format_spec_zero_string_fails() {
+    // It is invalid to have the format spec '%0s'
+    new_ucmd!().args(&["%0s", "3"]).fails().code_is(1);
+}


### PR DESCRIPTION
Fix #6030 

For now I just added tests to check that the error is raised, I will provide implementation later on