### PR TITLE
chcon: Handle repeated flags and overrides between --no-XXX and --XXX

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -154,6 +154,7 @@ pub fn uu_app() -> Command {
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
         .disable_help_flag(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::HELP)
                 .long(options::HELP)
@@ -180,7 +181,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::preserve_root::PRESERVE_ROOT)
                 .long(options::preserve_root::PRESERVE_ROOT)
-                .conflicts_with(options::preserve_root::NO_PRESERVE_ROOT)
+                .overrides_with(options::preserve_root::NO_PRESERVE_ROOT)
                 .help("Fail to operate recursively on '/'.")
                 .action(ArgAction::SetTrue),
         )

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -163,7 +163,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::dereference::DEREFERENCE)
                 .long(options::dereference::DEREFERENCE)
-                .conflicts_with(options::dereference::NO_DEREFERENCE)
+                .overrides_with(options::dereference::NO_DEREFERENCE)
                 .help(
                     "Affect the referent of each symbolic link (this is the default), \
                      rather than the symbolic link itself.",


### PR DESCRIPTION
This PR changes and tests three things:
- Accept `--no-dereference` and `--dereference` in any order, use the last occurrence.
- Accept `--no-preserve-root` and `--preserve-root` in any order, use the last occurrence.
- Accept repetitions of everything, flags and arguments like `--user`.

All three of these are GNU behavior bugs, i.e. GNU does it differently, and uutils wants to handle it like GNU does.

This is work towards #5998.