### PR TITLE
Fix/flaky `split` round robin limited fds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -495,10 +495,10 @@ rstest = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 procfs = { version = "0.16", default-features = false }
-rlimit = "0.10.1"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true, features = ["process", "signal", "user", "term"] }
+rlimit = "0.10.1"
 rand_pcg = "0.3"
 xattr = { workspace = true }
 

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1130,6 +1130,11 @@ struct OutFile {
 /// and [`n_chunks_by_line_round_robin`] functions.
 type OutFiles = Vec<OutFile>;
 trait ManageOutFiles {
+    fn instantiate_writer(
+        &mut self,
+        idx: usize,
+        settings: &Settings,
+    ) -> UResult<&mut BufWriter<Box<dyn Write>>>;
     /// Initialize a new set of output files
     /// Each OutFile is generated with filename, while the writer for it could be
     /// optional, to be instantiated later by the calling function as needed.
@@ -1194,6 +1199,52 @@ impl ManageOutFiles for OutFiles {
         Ok(out_files)
     }
 
+    fn instantiate_writer(
+        &mut self,
+        idx: usize,
+        settings: &Settings,
+    ) -> UResult<&mut BufWriter<Box<dyn Write>>> {
+        let mut count = 0;
+        // Use-case for doing multiple tries of closing fds:
+        // E.g. split running in parallel to other processes (e.g. another split) doing similar stuff,
+        // sharing the same limits. In this scenario, after closing one fd, the other process
+        // might "steel" the freed fd and open a file on its side. Then it would be beneficial
+        // if split would be able to close another fd before cancellation.
+        'loop1: loop {
+            let filename_to_open = self[idx].filename.as_str();
+            let file_to_open_is_new = self[idx].is_new;
+            let maybe_writer =
+                settings.instantiate_current_writer(filename_to_open, file_to_open_is_new);
+            if let Ok(writer) = maybe_writer {
+                self[idx].maybe_writer = Some(writer);
+                return Ok(self[idx].maybe_writer.as_mut().unwrap());
+            }
+
+            if settings.filter.is_some() {
+                // Propagate error if in `--filter` mode
+                return Err(maybe_writer.err().unwrap().into());
+            }
+
+            // Could have hit system limit for open files.
+            // Try to close one previously instantiated writer first
+            for (i, out_file) in self.iter_mut().enumerate() {
+                if i != idx && out_file.maybe_writer.is_some() {
+                    out_file.maybe_writer.as_mut().unwrap().flush()?;
+                    out_file.maybe_writer = None;
+                    out_file.is_new = false;
+                    count += 1;
+
+                    // And then try to instantiate the writer again
+                    continue 'loop1;
+                }
+            }
+
+            // If this fails - give up and propagate the error
+            uucore::show_error!("at file descriptor limit, but no file descriptor left to close. Closed {count} writers before.");
+            return Err(maybe_writer.err().unwrap().into());
+        }
+    }
+
     fn get_writer(
         &mut self,
         idx: usize,
@@ -1204,43 +1255,7 @@ impl ManageOutFiles for OutFiles {
         } else {
             // Writer was not instantiated upfront or was temporarily closed due to system resources constraints.
             // Instantiate it and record for future use.
-            let maybe_writer =
-                settings.instantiate_current_writer(self[idx].filename.as_str(), self[idx].is_new);
-            if let Ok(writer) = maybe_writer {
-                self[idx].maybe_writer = Some(writer);
-                Ok(self[idx].maybe_writer.as_mut().unwrap())
-            } else if settings.filter.is_some() {
-                // Propagate error if in `--filter` mode
-                Err(maybe_writer.err().unwrap().into())
-            } else {
-                // Could have hit system limit for open files.
-                // Try to close one previously instantiated writer first
-                for (i, out_file) in self.iter_mut().enumerate() {
-                    if i != idx && out_file.maybe_writer.is_some() {
-                        out_file.maybe_writer.as_mut().unwrap().flush()?;
-                        out_file.maybe_writer = None;
-                        out_file.is_new = false;
-                        break;
-                    }
-                }
-                // And then try to instantiate the writer again
-                // If this fails - give up and propagate the error
-                let result = settings
-                    .instantiate_current_writer(self[idx].filename.as_str(), self[idx].is_new);
-                if let Err(e) = result {
-                    let mut count = 0;
-                    for out_file in self {
-                        if out_file.maybe_writer.is_some() {
-                            count += 1;
-                        }
-                    }
-
-                    return Err(USimpleError::new(e.raw_os_error().unwrap_or(1),
-                        format!("Instantiation of writer failed due to error: {e:?}. Existing writer number: {count}")));
-                }
-                self[idx].maybe_writer = Some(result?);
-                Ok(self[idx].maybe_writer.as_mut().unwrap())
-            }
+            self.instantiate_writer(idx, settings)
         }
     }
 }


### PR DESCRIPTION
Addresses #6031

- refactoring: split large function `get_writer` into two parts
- robutify closing of fds by retry until it works or no fds to close left. Previous implemenation did only one try and failed then.
- robustify test setup: add `sleep 0.5 &&` to ensure that the limits are applied before `split` application starts.

_update: I implemented the idea with pre_exec from @tertsdiepraam as replacement for the `sleep 0.5` test-setup fix.
the results of 15*2*54 (1620) runs can be seen here: https://github.com/cre4ture/coreutils/actions/runs/8155517787/job/22291219367?pr=10
There was no single case where the original implementation of split failed._

I proved that both changes on its own fix the flakiness of the test by running all tests on 22 runners, each ~50times:

![grafik](https://github.com/uutils/coreutils/assets/252806/ce6f1414-1140-49b2-8a3a-d464051b9dc3)

Evaluation:
the reference contained 12 out of 22 cases where the split test failed.
the other two tests didn't contain a single case each where this test was failing.


Test runs:
reference: https://github.com/cre4ture/coreutils/actions/runs/8123936859/job/22204882466?pr=9
split robustification: https://github.com/cre4ture/coreutils/actions/runs/8124460686/job/22205966825?pr=11
test robustification: https://github.com/cre4ture/coreutils/actions/runs/8124437301/job/22205913310?pr=10