### PR TITLE
tests/common/util.rs: add `cfg(feature = "env")`

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -3583,6 +3583,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg(feature = "env")]
     #[test]
     fn test_simulation_of_terminal_false() {
         let scene = TestScenario::new("util");
@@ -3599,6 +3600,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg(feature = "env")]
     #[test]
     fn test_simulation_of_terminal_true() {
         let scene = TestScenario::new("util");
@@ -3620,6 +3622,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg(feature = "env")]
     #[test]
     fn test_simulation_of_terminal_size_information() {
         let scene = TestScenario::new("util");
@@ -3646,6 +3649,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg(feature = "env")]
     #[test]
     fn test_simulation_of_terminal_pty_sends_eot_automatically() {
         let scene = TestScenario::new("util");
@@ -3662,6 +3666,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg(feature = "env")]
     #[test]
     fn test_simulation_of_terminal_pty_pipes_into_data_and_sends_eot_automatically() {
         let scene = TestScenario::new("util");
@@ -3683,6 +3688,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg(feature = "env")]
     #[test]
     fn test_simulation_of_terminal_pty_write_in_data_and_sends_eot_automatically() {
         let scene = TestScenario::new("util");


### PR DESCRIPTION
The recent merge of https://github.com/uutils/coreutils/pull/5869 has an unwanted side effect: running the tests for a single tool shows some failures unrelated to the tool:
```
$ cargo test --features "nl" --no-default-features

[snipped]

failures:

---- common::util::tests::test_simulation_of_terminal_false stdout ----
run: /home/dho/projects/coreutils/target/debug/coreutils env sh is_atty.sh
thread 'common::util::tests::test_simulation_of_terminal_false' panicked at tests/common/util.rs:3590:65:
Command was expected to succeed. Exit code: 1.
stdout = env: function/utility not found

 stderr = 

[snipped]

failures:
    common::util::tests::test_simulation_of_terminal_false
    common::util::tests::test_simulation_of_terminal_pty_pipes_into_data_and_sends_eot_automatically
    common::util::tests::test_simulation_of_terminal_pty_sends_eot_automatically
    common::util::tests::test_simulation_of_terminal_pty_write_in_data_and_sends_eot_automatically
    common::util::tests::test_simulation_of_terminal_size_information
    common::util::tests::test_simulation_of_terminal_true
```
This PR fixes the issue by adding `#[cfg(feature = "env")]` to the failing tests.