### PR TITLE
Bump chrono to 0.4.35 & replace usage of deprecated functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ binary-heap-plus = "0.5.0"
 bstr = "1.9"
 bytecount = "0.6.7"
 byteorder = "1.5.0"
-chrono = { version = "^0.4.34", default-features = false, features = [
+chrono = { version = "^0.4.35", default-features = false, features = [
   "std",
   "alloc",
   "clock",

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2981,7 +2981,8 @@ fn display_date(metadata: &Metadata, config: &Config) -> String {
         Some(time) => {
             //Date is recent if from past 6 months
             //According to GNU a Gregorian year has 365.2425 * 24 * 60 * 60 == 31556952 seconds on the average.
-            let recent = time + chrono::TimeDelta::seconds(31_556_952 / 2) > chrono::Local::now();
+            let recent = time + chrono::TimeDelta::try_seconds(31_556_952 / 2).unwrap()
+                > chrono::Local::now();
 
             match &config.time_style {
                 TimeStyle::FullIso => time.format("%Y-%m-%d %H:%M:%S.%f %z"),

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -433,7 +433,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
     // only care about the timestamp anyway.
     // Tested in gnu/tests/touch/60-seconds
     if local.second() == 59 && ts.ends_with(".60") {
-        local += Duration::seconds(1);
+        local += Duration::try_seconds(1).unwrap();
     }
 
     // Due to daylight saving time switch, local time can jump from 1:59 AM to
@@ -441,7 +441,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
     // valid. If we are within this jump, chrono takes the offset from before
     // the jump. If we then jump forward an hour, we get the new corrected
     // offset. Jumping back will then now correctly take the jump into account.
-    let local2 = local + Duration::hours(1) - Duration::hours(1);
+    let local2 = local + Duration::try_hours(1).unwrap() - Duration::try_hours(1).unwrap();
     if local.hour() != local2.hour() {
         return Err(USimpleError::new(
             1,

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -32,7 +32,7 @@ fn set_file_times(at: &AtPath, path: &str, atime: FileTime, mtime: FileTime) {
 
 fn str_to_filetime(format: &str, s: &str) -> FileTime {
     let tm = chrono::NaiveDateTime::parse_from_str(s, format).unwrap();
-    FileTime::from_unix_time(tm.timestamp(), tm.timestamp_subsec_nanos())
+    FileTime::from_unix_time(tm.and_utc().timestamp(), tm.timestamp_subsec_nanos())
 }
 
 #[test]


### PR DESCRIPTION
This PR bumps `chrono` from `0.4.34` to `0.4.35` and replaces the usage of deprecated functions.