### PR TITLE
pr/chgrp: fix warnings

### DIFF
--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -124,10 +124,8 @@ fn test_preserve_root_symlink() {
     ] {
         let (at, mut ucmd) = at_and_ucmd!();
         at.symlink_file(d, file);
-        let expected_error = format!(
-            "chgrp: it is dangerous to operate recursively on 'test_chgrp_symlink2root' (same as '/')\nchgrp: use --no-preserve-root to override this failsafe\n",
-            //d,
-        );
+        let expected_error =
+            "chgrp: it is dangerous to operate recursively on 'test_chgrp_symlink2root' (same as '/')\nchgrp: use --no-preserve-root to override this failsafe\n";
         ucmd.arg("--preserve-root")
             .arg("-HR")
             .arg("bin")

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -26,13 +26,12 @@ fn file_last_modified_time(ucmd: &UCommand, path: &str) -> String {
 }
 
 fn all_minutes(from: DateTime<Utc>, to: DateTime<Utc>) -> Vec<String> {
-    let to = to + Duration::minutes(1);
-    // const FORMAT: &str = "%b %d %H:%M %Y";
+    let to = to + Duration::try_minutes(1).unwrap();
     let mut vec = vec![];
     let mut current = from;
     while current < to {
         vec.push(current.format(DATE_TIME_FORMAT).to_string());
-        current += Duration::minutes(1);
+        current += Duration::try_minutes(1).unwrap();
     }
     vec
 }


### PR DESCRIPTION
This PR fixes three warnings in tests I noticed while reviewing https://github.com/uutils/coreutils/pull/6052 and removes a commented out constant.