### PR TITLE
tty: fix for Ctrl-D when stdin is a terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,7 +260,7 @@ test = ["uu_test"]
 [workspace.dependencies]
 bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"
-bstr = "1.9"
+bstr = "1.9.1"
 bytecount = "0.6.7"
 byteorder = "1.5.0"
 chrono = { version = "^0.4.35", default-features = false, features = [


### PR DESCRIPTION
This PR updates `bstr` crate version from 1.9 to 1.9.1 to fix an issue with handling `stdin` when it is a terminal, i.e. in `cut` it would not exit on Ctrl-D (EOF) input. This check is used in `tty-eof.pl` GNU test.
Reference: https://github.com/BurntSushi/bstr/issues/180
