### PR TITLE
Fix/flaky timeout kill subprocess

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -202,14 +202,15 @@ fn send_signal(process: &mut Child, signal: usize, foreground: bool) {
     // NOTE: GNU timeout doesn't check for errors of signal.
     // The subprocess might have exited just after the timeout.
     // Sending a signal now would return "No such process", but we should still try to kill the children.
-    _ = process.send_signal(signal);
-    if !foreground {
-        _ = process.send_signal_group(signal);
-        let kill_signal = signal_by_name_or_value("KILL").unwrap();
-        let continued_signal = signal_by_name_or_value("CONT").unwrap();
-        if signal != kill_signal && signal != continued_signal {
-            _ = process.send_signal(continued_signal);
-            _ = process.send_signal_group(continued_signal);
+    match foreground {
+        true => _ = process.send_signal(signal),
+        false => {
+            _ = process.send_signal_group(signal);
+            let kill_signal = signal_by_name_or_value("KILL").unwrap();
+            let continued_signal = signal_by_name_or_value("CONT").unwrap();
+            if signal != kill_signal && signal != continued_signal {
+                _ = process.send_signal_group(continued_signal);
+            }
         }
     }
 }

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -94,6 +94,18 @@ fn test_preserve_status() {
 }
 
 #[test]
+fn test_preserve_status_even_when_send_signal() {
+    // When sending CONT signal, process doesn't get killed or stopped.
+    // So, expected result is success and code 0.
+    new_ucmd!()
+        .args(&["-s", "CONT", "--preserve-status", ".1", "sleep", "5"])
+        .succeeds()
+        .code_is(0)
+        .no_stderr()
+        .no_stdout();
+}
+
+#[test]
 fn test_dont_overflow() {
     new_ucmd!()
         .args(&["9223372036854775808d", "sleep", "0"])

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -163,10 +163,10 @@ fn test_kill_subprocess() {
             "10",
             "sh",
             "-c",
-            "sh -c \"trap 'echo xyz' TERM; sleep 30\"",
+            "trap 'echo inside_trap' TERM; sleep 30",
         ])
         .fails()
         .code_is(124)
-        .stdout_contains("xyz")
+        .stdout_contains("inside_trap")
         .stderr_contains("Terminated");
 }


### PR DESCRIPTION
Addresses #5459

Stability improved by:

- sending only one signal
- waiting for child to stop
- adapt test such that the immediate child is the one to wait for