### PR TITLE
deny.toml: remove deprecated keys, opt-in to v2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,10 +6,8 @@
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "warn"
-unmaintained = "warn"
+version = 2
 yanked = "warn"
-notice = "warn"
 ignore = [
   #"RUSTSEC-0000-0000",
 ]
@@ -18,7 +16,7 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-unlicensed = "deny"
+version = 2
 allow = [
   "MIT",
   "Apache-2.0",
@@ -29,9 +27,6 @@ allow = [
   "CC0-1.0",
   "Unicode-DFS-2016",
 ]
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 
 [[licenses.clarify]]


### PR DESCRIPTION
I noticed that `cargo-deny` shows several "deprecated" warnings (see, for example:  https://github.com/uutils/coreutils/actions/runs/8260400412/job/22595846683). This PR removes the deprecated keys and  opts-in to the new behavior (see also https://github.com/EmbarkStudios/cargo-deny/pull/611).