### PR TITLE
deny.toml: add redox_syscall to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -99,6 +99,8 @@ skip = [
   { name = "bitflags", version = "1.3.2" },
   # clap_builder, textwrap
   { name = "terminal_size", version = "0.2.6" },
+  # filetime, parking_lot_core
+  { name = "redox_syscall", version = "0.4.1" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR adds `redox_syscall` to the skip list in `deny.toml` and should unblock https://github.com/uutils/coreutils/pull/6060.