### PR TITLE
fix `ls`:  test_ls_allocation_size fails on filesystem `f2fs` (android)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   TERMUX: v0.118.0
-  KEY_POSTFIX: nextest+rustc-hash+adb+sshd+upgrade+XGB+inc17
+  KEY_POSTFIX: nextest+rustc-hash+adb+sshd+upgrade+XGB+inc18
   COMMON_EMULATOR_OPTIONS: -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect
   EMULATOR_DISK_SIZE: 12GB
   EMULATOR_HEAP_SIZE: 2048M

--- a/util/android-commands.sh
+++ b/util/android-commands.sh
@@ -371,7 +371,6 @@ run_command_via_ssh() {
 
 test_ssh_connection() {
     run_command_via_ssh echo ssh connection is working
-    run_command_via_ssh free -mh
 }
 
 # takes a local (on runner side) script file and runs it via ssh on the virtual android device. forwards return code.
@@ -509,7 +508,7 @@ snapshot() {
 
     apt_upgrade_all_packages
 
-    install_packages_via_ssh_using_apt "rust binutils openssl tar"
+    install_packages_via_ssh_using_apt "rust binutils openssl tar mount-utils"
 
     echo "Read /proc/cpuinfo"
     run_command_via_ssh "cat /proc/cpuinfo"
@@ -573,8 +572,7 @@ build() {
 
     reinit_ssh_connection
 
-    echo "Read /proc/cpuinfo"
-    run_command_via_ssh "cat /proc/cpuinfo"
+    run_script_file_via_ssh "$this_repo/util/android-scripts/collect-info.sh"
 
     command="export CARGO_TERM_COLOR=always;
              export CARGO_INCREMENTAL=0; \
@@ -589,8 +587,7 @@ tests() {
 
     reinit_ssh_connection
 
-    echo "Read /proc/cpuinfo"
-    run_command_via_ssh "cat /proc/cpuinfo"
+    run_script_file_via_ssh "$this_repo/util/android-scripts/collect-info.sh"
 
     run_script_file_via_ssh "$this_repo/util/android-scripts/run-tests.sh" || return
 

--- a/util/android-scripts/collect-info.sh
+++ b/util/android-scripts/collect-info.sh
@@ -2,6 +2,13 @@
 
 # spell-checker:ignore nextest watchplus PIPESTATUS
 
+echo "system resources - RAM:"
+free -hm
+echo "system resources - CPU:"
+lscpu
+echo "system resources - file systems:"
+mount
+
 echo "$HOME"
 PATH=$HOME/.cargo/bin:$PATH
 export PATH


### PR DESCRIPTION
addresses #6075 

changes:
- improve logging in CI
- detect filesystem type at runtime during test
- apply different set of reference values for case `f2fs`