### PR TITLE
Fix two "item x is imported redundantly" warnings

### DIFF
--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -650,7 +650,7 @@ mod tests {
     use super::*;
     #[cfg(unix)]
     use std::os::unix;
-    use std::path::{Component, Path, PathBuf};
+    use std::path::{Component, PathBuf};
     #[cfg(unix)]
     use tempfile::tempdir;
 

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -5,7 +5,7 @@
 // spell-checker:ignore (formats) cymdhm cymdhms mdhm mdhms ymdhm ymdhms datetime mktime
 
 use crate::common::util::{AtPath, TestScenario};
-use filetime::{self, set_symlink_file_times, FileTime};
+use filetime::{set_symlink_file_times, FileTime};
 use std::fs::remove_file;
 use std::path::PathBuf;
 


### PR DESCRIPTION
This PR fixes two "item x is imported redundantly" warnings I noticed in the CI output (see, for example: https://github.com/uutils/coreutils/actions/runs/8268396799/job/22621166258#step:11:55 and https://github.com/uutils/coreutils/actions/runs/8268396799/job/22621166258#step:11:178)