### PR TITLE
dd: misc gnu test 

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -286,6 +286,15 @@ impl<'a> Input<'a> {
         let mut src = Source::Stdin(io::stdin());
         #[cfg(unix)]
         let mut src = Source::stdin_as_file();
+        #[cfg(unix)]
+        if let Source::StdinFile(f) = &src {
+            // GNU compatibility:
+            // this will check stdin point to a folder or not
+            if f.metadata()?.is_file() && settings.iflags.directory {
+                show_error!("standard input: not a directory");
+                return Err(1.into());
+            }
+        };
         if settings.skip > 0 {
             src.skip(settings.skip)?;
         }

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -313,7 +313,7 @@ impl<'a> Input<'a> {
         #[cfg(unix)]
         if let Source::StdinFile(f) = &src {
             // GNU compatibility:
-            // this will check stdin point to a folder or not
+            // this will check whether stdin points to a folder or not
             if f.metadata()?.is_file() && settings.iflags.directory {
                 show_error!("standard input: not a directory");
                 return Err(1.into());

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1713,3 +1713,16 @@ fn test_reading_partial_blocks_from_fifo_unbuffered() {
     let expected = b"0+2 records in\n0+2 records out\n4 bytes copied";
     assert!(output.stderr.starts_with(expected));
 }
+
+#[test]
+#[cfg(unix)]
+fn test_iflag_directory_fails_when_file_is_passed_via_std_in() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.make_file("input");
+    let filename = at.plus_as_string("input");
+    new_ucmd!()
+        .args(&["iflag=directory", "count=0"])
+        .set_stdin(std::process::Stdio::from(File::open(filename).unwrap()))
+        .fails();
+}

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1716,7 +1716,7 @@ fn test_reading_partial_blocks_from_fifo_unbuffered() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn test_iflag_directory_fails_when_file_is_passed_via_std_in() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -1725,7 +1725,8 @@ fn test_iflag_directory_fails_when_file_is_passed_via_std_in() {
     new_ucmd!()
         .args(&["iflag=directory", "count=0"])
         .set_stdin(std::process::Stdio::from(File::open(filename).unwrap()))
-        .fails();
+        .fails()
+        .stderr_contains("standard input: not a directory");
 }
 
 #[cfg(unix)]

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1729,7 +1729,7 @@ fn test_iflag_directory_fails_when_file_is_passed_via_std_in() {
         .stderr_contains("standard input: not a directory");
 }
 
-#[cfg(unix)]
+#[test]
 fn test_stdin_stdout_not_rewound_even_when_connected_to_seekable_file() {
     use std::process::Stdio;
 


### PR DESCRIPTION
this fixes the `misc` test case in dd, it was failing because there was this check in misc where dd should error when given the input via stdin is not a folder and `iflag=directory` is set. 