### PR TITLE
csplit: adjust the error message to match GNU's

### DIFF
--- a/src/uu/csplit/src/csplit_error.rs
+++ b/src/uu/csplit/src/csplit_error.rs
@@ -21,7 +21,7 @@ pub enum CsplitError {
     MatchNotFound(String),
     #[error("{}: match not found on repetition {}", ._0.quote(), _1)]
     MatchNotFoundOnRepetition(String, usize),
-    #[error("line number must be greater than zero")]
+    #[error("0: line number must be greater than zero")]
     LineNumberIsZero,
     #[error("line number '{}' is smaller than preceding line number, {}", _0, _1)]
     LineNumberSmallerThanPrevious(usize, usize),

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -1359,3 +1359,11 @@ fn precision_format() {
         assert_eq!(at.read("xx 0x001"), generate(10, 51));
     }
 }
+
+#[test]
+fn zero_error() {
+    let (_, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["in", "0"])
+        .fails()
+        .stderr_contains("0: line number must be greater");
+}


### PR DESCRIPTION
Should fix tests/csplit/csplit