### PR TITLE
csplit: remove `crate_name` attribute

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -2,7 +2,6 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-#![crate_name = "uu_csplit"]
 // spell-checker:ignore rustdoc
 #![allow(rustdoc::private_intra_doc_links)]
 


### PR DESCRIPTION
While reviewing https://github.com/uutils/coreutils/pull/6090 I noticed a `crate_name` attribute I think is unnecessary as no other util uses it. According to https://doc.rust-lang.org/rust-by-example/attribute/crate.html:

> it is important to note that both the `crate_type` and `crate_name` attributes have **no** effect whatsoever when using Cargo, the Rust package manager.

