### PR TITLE
tr: lazily generate the character mapping as necessary

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -122,7 +122,6 @@ impl Sequence {
     }
 
     // Hide all the nasty sh*t in here
-    // TODO: Make the 2 set lazily generate the character mapping as necessary.
     pub fn solve_set_characters(
         set1_str: &[u8],
         set2_str: &[u8],

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -129,11 +129,11 @@ impl Sequence {
         truncate_set1_flag: bool,
     ) -> Result<(Vec<u8>, Vec<u8>), BadSequence> {
         let set1 = Self::from_str(set1_str)?;
-        let set2 = Self::from_str(set2_str)?;
 
         let is_char_star = |s: &&Self| -> bool { matches!(s, Self::CharStar(_)) };
         let set1_star_count = set1.iter().filter(is_char_star).count();
         if set1_star_count == 0 {
+            let set2 = Self::from_str(set2_str)?;
             let set2_star_count = set2.iter().filter(is_char_star).count();
             if set2_star_count < 2 {
                 let char_star = set2.iter().find_map(|s| match s {


### PR DESCRIPTION
I found a TODO that I think I can help with, I tried to complete this TODO in a very simple way, but I'm not sure if I can achieve the right result.

In my CI, GNU Tests instead has an extra failure, which as I understand should not be a problem, this just initializes the value when needed, could this value be modified? But I didn't find any other modifications.