### PR TITLE
fmt: Make sure goal is always positive

### DIFF
--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -95,7 +95,8 @@ impl FmtOptions {
                 (w, g)
             }
             (Some(&w), None) => {
-                let g = (w * DEFAULT_GOAL_TO_WIDTH_RATIO / 100).min(w - 3);
+                // Only allow a goal of zero if the width is set to be zero
+                let g = (w * DEFAULT_GOAL_TO_WIDTH_RATIO / 100).max(if w == 0 { 0 } else { 1 });
                 (w, g)
             }
             (None, Some(&g)) => {
@@ -104,6 +105,7 @@ impl FmtOptions {
             }
             (None, None) => (75, 70),
         };
+        debug_assert!(width >= goal, "GOAL {goal} should not be greater than WIDTH {width} when given {width_opt:?} and {goal_opt:?}.");
 
         if width > MAX_WIDTH {
             return Err(USimpleError::new(
@@ -331,7 +333,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::GOAL)
                 .short('g')
                 .long("goal")
-                .help("Goal width, default of 93% of WIDTH. Must be less than WIDTH.")
+                .help("Goal width, default of 93% of WIDTH. Must be less than or equal to WIDTH.")
                 .value_name("GOAL")
                 .value_parser(clap::value_parser!(usize)),
         )

--- a/src/uu/fmt/src/linebreak.rs
+++ b/src/uu/fmt/src/linebreak.rs
@@ -6,7 +6,7 @@
 // spell-checker:ignore (ToDO) INFTY MULT accum breakwords linebreak linebreaking linebreaks linelen maxlength minlength nchars ostream overlen parasplit plass posn powf punct signum slen sstart tabwidth tlen underlen winfo wlen wordlen
 
 use std::io::{BufWriter, Stdout, Write};
-use std::{cmp, i64, mem};
+use std::{cmp, mem};
 
 use crate::parasplit::{ParaWords, Paragraph, WordInfo};
 use crate::FmtOptions;
@@ -238,8 +238,8 @@ fn find_kp_breakpoints<'a, T: Iterator<Item = &'a WordInfo<'a>>>(
     let mut active_breaks = vec![0];
     let mut next_active_breaks = vec![];
 
-    let stretch = (args.opts.width - args.opts.goal) as isize;
-    let minlength = args.opts.goal - stretch as usize;
+    let stretch = args.opts.width - args.opts.goal;
+    let minlength = args.opts.goal - stretch;
     let mut new_linebreaks = vec![];
     let mut is_sentence_start = false;
     let mut least_demerits = 0;
@@ -300,7 +300,7 @@ fn find_kp_breakpoints<'a, T: Iterator<Item = &'a WordInfo<'a>>>(
                         compute_demerits(
                             args.opts.goal as isize - tlen as isize,
                             stretch,
-                            w.word_nchars as isize,
+                            w.word_nchars,
                             active.prev_rat,
                         )
                     };
@@ -393,7 +393,7 @@ const DR_MULT: f32 = 600.0;
 // DL_MULT is penalty multiplier for short words at end of line
 const DL_MULT: f32 = 300.0;
 
-fn compute_demerits(delta_len: isize, stretch: isize, wlen: isize, prev_rat: f32) -> (i64, f32) {
+fn compute_demerits(delta_len: isize, stretch: usize, wlen: usize, prev_rat: f32) -> (i64, f32) {
     // how much stretch are we using?
     let ratio = if delta_len == 0 {
         0.0f32
@@ -419,7 +419,7 @@ fn compute_demerits(delta_len: isize, stretch: isize, wlen: isize, prev_rat: f32
     };
 
     // we penalize lines that have very different ratios from previous lines
-    let bad_delta_r = (DR_MULT * (((ratio - prev_rat) / 2.0).powi(3)).abs()) as i64;
+    let bad_delta_r = (DR_MULT * ((ratio - prev_rat) / 2.0).powi(3).abs()) as i64;
 
     let demerits = i64::pow(1 + bad_linelen + bad_wordlen + bad_delta_r, 2);
 
@@ -440,8 +440,8 @@ fn restart_active_breaks<'a>(
     } else {
         // choose the lesser evil: breaking too early, or breaking too late
         let wlen = w.word_nchars + args.compute_width(w, active.length, active.fresh);
-        let underlen = (min - active.length) as isize;
-        let overlen = ((wlen + slen + active.length) - args.opts.width) as isize;
+        let underlen = min as isize - active.length as isize;
+        let overlen = (wlen + slen + active.length) as isize - args.opts.width as isize;
         if overlen > underlen {
             // break early, put this word on the next line
             (true, args.indent_len + w.word_nchars)

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -33,7 +33,19 @@ fn test_fmt_width() {
         new_ucmd!()
             .args(&["one-word-per-line.txt", param, "10"])
             .succeeds()
-            .stdout_is("this is\na file\nwith one\nword per\nline\n");
+            .stdout_is("this is a\nfile with\none word\nper line\n");
+    }
+}
+
+#[test]
+fn test_small_width() {
+    for width in ["0", "1", "2", "3"] {
+        for param in ["-w", "--width"] {
+            new_ucmd!()
+                .args(&[param, width, "one-word-per-line.txt"])
+                .succeeds()
+                .stdout_is("this\nis\na\nfile\nwith\none\nword\nper\nline\n");
+        }
     }
 }
 


### PR DESCRIPTION
Currently, the `fmt` utility will panic with an integer overflow when given a small enough width:
```shell
$ cargo run -q -- fmt -w3 Cargo.toml
thread 'main' panicked at src/uu/fmt/src/linebreak.rs:242:21:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
#%
```
GNU coreutil's fmt doesn't have a problem with this:
```shell
$ fmt -w3 Cargo.toml|head -n 3
#
coreutils
(uutils)
```

This PR adds a test to tests/by-util/test_fmt.rs reproducing this panic. The root cause is this calculation:
```
    let g = (w * DEFAULT_GOAL_TO_WIDTH_RATIO / 100).min(w - 3);
```
This sets the goal `g` to be zero when the width `w` is three, or negative for smaller widths. This also contradicts the behavior in the argument help and in the GNU fmt info page, both of which just say the goal will be 93% of the width.

This PR makes the goal set when only specifying the width be the value expected by the documentation. This avoids the overflow later on in `linebreak.rs`, which comes about from essentially calculating `2*goal - width` as a minimum length to consider breakpoints (this can't be correct if, for example, the goal is 2 and the width is 12, but I'm leaving addressing that issue out of this PR).

A simple `.max(1)` is added to ensure the goal is 1 if the width is 1.

There are a few other things in this PR:
- A few warnings about unneeded parenthesis and the use of an almost deprecated std::i64 module were fixed.
- A debug assertion was added to enforce "width >= goal" to catch that case before a panic in linebreak.rs. This is mainly relevant for the codepaths where the user has specified the width _or_ the goal and we calculate the unspecified one.
-  A few warnings in linebreak.rs were addressed as well, and some isize's that should always be positive (if there's no width/goal bugs) were changed to usizes to catch bugs earlier. In some of these cases the math was being done with usizes and then converted to isize (making it impossible for them to store negative values, they would have panicked during the usize operations).
- test_fmt_width tests the output with a set width, but the expected result differs from what I get on my system running `fmt -10 tests/fixtures/fmt/one-word-per-line.txt`. With this PR, I get the same as the `fmt` command, so I've updated the test.
