### PR TITLE
cksum: enable encoding feature

### DIFF
--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/cksum.rs"
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["sum"] }
+uucore = { workspace = true, features = ["encoding", "sum"] }
 hex = { workspace = true }
 
 [[bin]]


### PR DESCRIPTION
Running `cargo test --features "cksum" --no-default-features` currently leads to the following error:
```
error[E0432]: unresolved import `uucore::encoding`
  --> src/uu/cksum/src/cksum.rs:18:5
   |
18 |     encoding,
   |     ^^^^^^^^ no `encoding` in the root
   |
note: found an item that was configured out
  --> /home/dho/projects/coreutils/src/uucore/src/lib/lib.rs:43:26
   |
43 | pub use crate::features::encoding;
   |                          ^^^^^^^^
   = note: the item is gated behind the `encoding` feature
```
This PR fixes the issue by enabling the `encoding` feature.