### PR TITLE
fmt: fail if goal is bigger than default width

### DIFF
--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -101,6 +101,9 @@ impl FmtOptions {
                 (w, g)
             }
             (None, Some(&g)) => {
+                if g > DEFAULT_WIDTH {
+                    return Err(USimpleError::new(1, "GOAL cannot be greater than WIDTH."));
+                }
                 let w = (g * 100 / DEFAULT_GOAL_TO_WIDTH_RATIO).max(g + 3);
                 (w, g)
             }

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -21,6 +21,10 @@ mod parasplit;
 const ABOUT: &str = help_about!("fmt.md");
 const USAGE: &str = help_usage!("fmt.md");
 const MAX_WIDTH: usize = 2500;
+const DEFAULT_GOAL: usize = 70;
+const DEFAULT_WIDTH: usize = 75;
+// by default, goal is 93% of width
+const DEFAULT_GOAL_TO_WIDTH_RATIO: usize = 93;
 
 mod options {
     pub const CROWN_MARGIN: &str = "crown-margin";
@@ -38,9 +42,6 @@ mod options {
     pub const TAB_WIDTH: &str = "tab-width";
     pub const FILES: &str = "files";
 }
-
-// by default, goal is 93% of width
-const DEFAULT_GOAL_TO_WIDTH_RATIO: usize = 93;
 
 pub type FileOrStdReader = BufReader<Box<dyn Read + 'static>>;
 pub struct FmtOptions {
@@ -103,7 +104,7 @@ impl FmtOptions {
                 let w = (g * 100 / DEFAULT_GOAL_TO_WIDTH_RATIO).max(g + 3);
                 (w, g)
             }
-            (None, None) => (75, 70),
+            (None, None) => (DEFAULT_WIDTH, DEFAULT_GOAL),
         };
         debug_assert!(width >= goal, "GOAL {goal} should not be greater than WIDTH {width} when given {width_opt:?} and {goal_opt:?}.");
 

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -94,6 +94,17 @@ fn test_fmt_goal_too_big() {
 }
 
 #[test]
+fn test_fmt_goal_bigger_than_default_width_of_75() {
+    for param in ["-g", "--goal"] {
+        new_ucmd!()
+            .args(&["one-word-per-line.txt", param, "76"])
+            .fails()
+            .code_is(1)
+            .stderr_is("fmt: GOAL cannot be greater than WIDTH.\n");
+    }
+}
+
+#[test]
 fn test_fmt_invalid_goal() {
     for param in ["-g", "--goal"] {
         new_ucmd!()


### PR DESCRIPTION
GNU `fmt` fails when using `fmt --goal=76 example.txt` because the provided goal value is bigger than `75`, the default width. uutils `fmt`, on the other hand, doesn't fail.

This PR fixes this issue and also replaces two magic numbers with constants.