### PR TITLE
test_od - re-enable f16 test with newer AVD system image

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   TERMUX: v0.118.0
-  KEY_POSTFIX: nextest+rustc-hash+adb+sshd+upgrade+XGB+inc15
+  KEY_POSTFIX: nextest+rustc-hash+adb+sshd+upgrade+XGB+inc17
   COMMON_EMULATOR_OPTIONS: -no-window -noaudio -no-boot-anim -camera-back none -gpu swiftshader_indirect
   EMULATOR_DISK_SIZE: 12GB
   EMULATOR_HEAP_SIZE: 2048M
@@ -36,7 +36,7 @@ jobs:
         cores: [4] # , 6
         ram: [4096, 8192]
         api-level: [28]
-        target: [default]
+        target: [google_apis_playstore]
         arch: [x86, x86_64] # , arm64-v8a
         exclude:
           - ram: 8192

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -229,13 +229,6 @@ fn test_hex32() {
         .stdout_is(expected_output);
 }
 
-// This test fails on Android CI on AVD on Ubuntu Github runners.
-// It was never reproducible locally and seems to be very hard to fix.
-// Thats why its disabled for android x86*. See uutils issue #5941.
-#[cfg(not(all(
-    target_os = "android",
-    any(target_arch = "x86", target_arch = "x86_64")
-)))]
 #[test]
 fn test_f16() {
     let input: [u8; 14] = [


### PR DESCRIPTION
fixes issue  #5941

how?
- using the system image "google_apis_playstore" instead of "default" results in slightly newer OS version (2019 instead of 2018) that apparently fixed the issue with `f16c` instruction set

found by chance when investigateting different issue. Sadly the different issue (PR #6080) is not yet fixed by this version.

This brings me to the general question: Why are we using the old API level 28? Is there any specific reason why not switching to a even newer one?