### PR TITLE
more: fix two incorrect tests

### DIFF
--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -3,11 +3,9 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (methods) isnt
-
 use std::{
     fs::File,
-    io::{stdin, stdout, BufReader, IsTerminal, Read, Stdout, Write},
+    io::{stdin, stdout, BufReader, Read, Stdout, Write},
     panic::set_hook,
     path::Path,
     time::Duration,
@@ -159,13 +157,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             buff.clear();
         }
         reset_term(&mut stdout);
-    } else if !std::io::stdin().is_terminal() {
+    } else {
         stdin().read_to_string(&mut buff).unwrap();
+        if buff.is_empty() {
+            return Err(UUsageError::new(1, "bad usage"));
+        }
         let mut stdout = setup_term();
         more(&buff, &mut stdout, false, None, None, &mut options)?;
         reset_term(&mut stdout);
-    } else {
-        return Err(UUsageError::new(1, "bad usage"));
     }
     Ok(())
 }

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -7,36 +7,46 @@ use std::io::IsTerminal;
 
 #[test]
 fn test_more_no_arg() {
-    // Reading from stdin is now supported, so this must succeed
     if std::io::stdout().is_terminal() {
-        new_ucmd!().succeeds();
+        new_ucmd!().fails().stderr_contains("more: bad usage");
     }
 }
 
 #[test]
 fn test_valid_arg() {
     if std::io::stdout().is_terminal() {
-        new_ucmd!().arg("-c").succeeds();
-        new_ucmd!().arg("--print-over").succeeds();
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
 
-        new_ucmd!().arg("-p").succeeds();
-        new_ucmd!().arg("--clean-print").succeeds();
+        let file = "test_file";
+        at.touch(file);
 
-        new_ucmd!().arg("-s").succeeds();
-        new_ucmd!().arg("--squeeze").succeeds();
+        scene.ucmd().arg(file).arg("-c").succeeds();
+        scene.ucmd().arg(file).arg("--print-over").succeeds();
 
-        new_ucmd!().arg("-u").succeeds();
-        new_ucmd!().arg("--plain").succeeds();
+        scene.ucmd().arg(file).arg("-p").succeeds();
+        scene.ucmd().arg(file).arg("--clean-print").succeeds();
 
-        new_ucmd!().arg("-n").arg("10").succeeds();
-        new_ucmd!().arg("--lines").arg("0").succeeds();
-        new_ucmd!().arg("--number").arg("0").succeeds();
+        scene.ucmd().arg(file).arg("-s").succeeds();
+        scene.ucmd().arg(file).arg("--squeeze").succeeds();
 
-        new_ucmd!().arg("-F").arg("10").succeeds();
-        new_ucmd!().arg("--from-line").arg("0").succeeds();
+        scene.ucmd().arg(file).arg("-u").succeeds();
+        scene.ucmd().arg(file).arg("--plain").succeeds();
 
-        new_ucmd!().arg("-P").arg("something").succeeds();
-        new_ucmd!().arg("--pattern").arg("-1").succeeds();
+        scene.ucmd().arg(file).arg("-n").arg("10").succeeds();
+        scene.ucmd().arg(file).arg("--lines").arg("0").succeeds();
+        scene.ucmd().arg(file).arg("--number").arg("0").succeeds();
+
+        scene.ucmd().arg(file).arg("-F").arg("10").succeeds();
+        scene
+            .ucmd()
+            .arg(file)
+            .arg("--from-line")
+            .arg("0")
+            .succeeds();
+
+        scene.ucmd().arg(file).arg("-P").arg("something").succeeds();
+        scene.ucmd().arg(file).arg("--pattern").arg("-1").succeeds();
     }
 }
 


### PR DESCRIPTION
This PR fixes two tests I think are incorrect. It's possible I'm missing something as I don't understand why they test a different code branch than is used when running `more` manually. For example, running `cargo run more` fails as expected. However, the corresponding test, `test_more_no_arg`, ensures it doesn't fail with no arguments. For the fix, I merged the two code branches.