### PR TITLE
Fix/findings for env string args

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -388,21 +388,7 @@ impl EnvAppData {
         // load .env-style config file prior to those given on the command-line
         load_config_file(&mut opts)?;
 
-        // unset specified env vars
-        for name in &opts.unsets {
-            let native_name = NativeStr::new(name);
-            if name.is_empty()
-                || native_name.contains(&'\0').unwrap()
-                || native_name.contains(&'=').unwrap()
-            {
-                return Err(USimpleError::new(
-                    125,
-                    format!("cannot unset {}: Invalid argument", name.quote()),
-                ));
-            }
-
-            env::remove_var(name);
-        }
+        apply_unset_env_vars(&opts)?;
 
         apply_specified_env_vars(&opts);
 
@@ -481,6 +467,24 @@ impl EnvAppData {
         }
         Ok(())
     }
+}
+
+fn apply_unset_env_vars(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
+    for name in &opts.unsets {
+        let native_name = NativeStr::new(name);
+        if name.is_empty()
+            || native_name.contains(&'\0').unwrap()
+            || native_name.contains(&'=').unwrap()
+        {
+            return Err(USimpleError::new(
+                125,
+                format!("cannot unset {}: Invalid argument", name.quote()),
+            ));
+        }
+
+        env::remove_var(name);
+    }
+    Ok(())
 }
 
 fn apply_change_directory(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -344,18 +344,7 @@ impl EnvAppData {
             program: vec![],
         };
 
-        // change directory
-        if let Some(d) = opts.running_directory {
-            match env::set_current_dir(d) {
-                Ok(()) => d,
-                Err(error) => {
-                    return Err(USimpleError::new(
-                        125,
-                        format!("cannot change directory to {}: {error}", d.quote()),
-                    ));
-                }
-            };
-        }
+        apply_change_directory(&opts)?;
 
         let mut begin_prog_opts = false;
         if let Some(mut iter) = matches.get_many::<OsString>("vars") {
@@ -492,6 +481,21 @@ impl EnvAppData {
         }
         Ok(())
     }
+}
+
+fn apply_change_directory(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
+    if let Some(d) = opts.running_directory {
+        match env::set_current_dir(d) {
+            Ok(()) => d,
+            Err(error) => {
+                return Err(USimpleError::new(
+                    125,
+                    format!("cannot change directory to {}: {error}", d.quote()),
+                ));
+            }
+        };
+    }
+    Ok(())
 }
 
 fn apply_specified_env_vars(opts: &Options<'_>) {


### PR DESCRIPTION
this addresses remaining findings from  #5801  (env: support string args by "-S", "-vS" or "--split-strings" )

it consists of purely refactorings. More specifically: many pure extract to function refactorings.