### PR TITLE
csplit: suppress lines matched with line numbers even if they have already passed

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -317,15 +317,7 @@ impl<'a> SplitWriter<'a> {
         while let Some((ln, line)) = input_iter.next() {
             let l = line?;
             match n.cmp(&(&ln + 1)) {
-                Ordering::Less => {
-                    assert!(
-                        input_iter.add_line_to_buffer(ln, l).is_none(),
-                        "the buffer is big enough to contain 1 line"
-                    );
-                    ret = Ok(());
-                    break;
-                }
-                Ordering::Equal => {
+                Ordering::Less | Ordering::Equal => {
                     assert!(
                         self.options.suppress_matched
                             || input_iter.add_line_to_buffer(ln, l).is_none(),

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -468,6 +468,43 @@ fn test_up_to_match_offset_option_suppress_matched() {
 }
 
 #[test]
+fn test_line_number_after_match_suppressed() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "--suppress-matched", "/10/", "9"])
+        .succeeds()
+        .stdout_only("18\n0\n117\n");
+
+    let count = glob(&at.plus_as_string("xx*"))
+        .expect("there should be splits created")
+        .count();
+    assert_eq!(count, 3);
+    assert_eq!(at.read("xx00"), generate(1, 10));
+    assert_eq!(at.read("xx01"), "");
+
+    // The 9 has suppressed line 11
+    assert_eq!(at.read("xx02"), generate(12, 51));
+}
+
+#[test]
+fn test_same_number_suppressed() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "--suppress-matched", "5", "5", "5"])
+        .succeeds()
+        .stdout_only("8\n0\n0\n127\n");
+
+    let count = glob(&at.plus_as_string("xx*"))
+        .expect("there should be splits created")
+        .count();
+    assert_eq!(count, 3);
+    assert_eq!(at.read("xx00"), generate(1, 5));
+    assert_eq!(at.read("xx01"), "");
+    assert_eq!(at.read("xx02"), "");
+
+    // The fives suppress lines 5, 6 and 7.
+    assert_eq!(at.read("xx02"), generate(8, 51));
+}
+
+#[test]
 fn test_up_to_match_negative_offset_option_suppress_matched() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "--suppress-matched", "/10/-4"])


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/6126