### PR TITLE
docs: date: Remove unimplemented example

### DIFF
--- a/src/uu/date/date-usage.md
+++ b/src/uu/date/date-usage.md
@@ -79,9 +79,3 @@ Show the time on the west coast of the US (use tzselect(1) to find TZ)
 ```
 TZ='America/Los_Angeles' date
 ```
-
-Show the local time for 9AM next Friday on the west coast of the US
-
-```
-date --date='TZ="America/Los_Angeles" 09:00 next Fri'
-```


### PR DESCRIPTION
Remove non-working example from documentation

```console
$ date --date='TZ="America/Los_Angeles" 09:00 next Fri'
date: invalid date 'TZ="America/Los_Angeles" 09:00 next Fri'

$ udate --date='TZ="America/Los_Angeles" 09:00 next Fri'
udate: invalid date 'TZ="America/Los_Angeles" 09:00 next Fri'
```

also treated in [#2685](https://github.com/uutils/coreutils/issues/2685) and [#3463](https://github.com/uutils/coreutils/issues/3463)