### PR TITLE
mv: remove "sleep" in tests

### DIFF
--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -6,8 +6,7 @@
 // spell-checker:ignore mydir
 use crate::common::util::TestScenario;
 use filetime::FileTime;
-use std::thread::sleep;
-use std::time::Duration;
+use std::io::Write;
 
 #[test]
 fn test_mv_invalid_arg() {
@@ -972,9 +971,9 @@ fn test_mv_arg_update_older_dest_not_older() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -999,9 +998,9 @@ fn test_mv_arg_update_none_then_all() {
     let old_content = "old content\n";
     let new_content = "new content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1027,9 +1026,9 @@ fn test_mv_arg_update_all_then_none() {
     let old_content = "old content\n";
     let new_content = "new content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1053,9 +1052,9 @@ fn test_mv_arg_update_older_dest_older() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1079,9 +1078,9 @@ fn test_mv_arg_update_short_overwrite() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1105,9 +1104,9 @@ fn test_mv_arg_update_short_no_overwrite() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 


### PR DESCRIPTION
So far `std::thread::sleep` was used in the tests to ensure that `fileA` is older than `fileB`. With this PR, the same is done by calling `set_modified` on the "older" file, thus speeding up the tests.