### PR TITLE
tail: allow multiple usage of --pid to match upstream (regression of …

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -510,7 +510,8 @@ pub fn uu_app() -> Command {
             Arg::new(options::PID)
                 .long(options::PID)
                 .value_name("PID")
-                .help("With -f, terminate after process ID, PID dies"),
+                .help("With -f, terminate after process ID, PID dies")
+                .overrides_with(options::PID),
         )
         .arg(
             Arg::new(options::verbosity::QUIET)

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -3908,6 +3908,13 @@ fn test_args_when_settings_check_warnings_then_shows_warnings() {
         .args(&["--pid=1000", "--retry", "data"])
         .stderr_to_stdout()
         .run()
+        .stdout_only(&expected_stdout)
+        .success();
+    scene
+        .ucmd()
+        .args(&["--pid=1000", "--pid=1000", "--retry", "data"])
+        .stderr_to_stdout()
+        .run()
         .stdout_only(expected_stdout)
         .success();
 }


### PR DESCRIPTION
…9.5)

tested by tests/tail/pid