### PR TITLE
date: fix `date -f dates.txt is failing`

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -404,9 +404,8 @@ fn make_format_string(settings: &Settings) -> &str {
 /// If it fails, return a tuple of the `String` along with its `ParseError`.
 fn parse_date<S: AsRef<str> + Clone>(
     s: S,
-) -> Result<DateTime<FixedOffset>, (String, chrono::format::ParseError)> {
-    // TODO: The GNU date command can parse a wide variety of inputs.
-    s.as_ref().parse().map_err(|e| (s.as_ref().into(), e))
+) -> Result<DateTime<FixedOffset>, (String, parse_datetime::ParseDateTimeError)> {
+    parse_datetime::parse_datetime(s.as_ref()).map_err(|e| (s.as_ref().into(), e))
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -409,3 +409,21 @@ fn test_date_overflow() {
         .no_stdout()
         .stderr_contains("invalid date");
 }
+
+#[test]
+fn test_date_parse_from_format() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    const FILE: &str = "file-with-dates";
+
+    std::fs::write(
+        at.plus(FILE),
+        "2023-03-27 08:30:00\n\
+         2023-04-01 12:00:00\n\
+         2023-04-15 18:30:00",
+    )
+    .unwrap();
+    ucmd.arg("-f")
+        .arg(at.plus(FILE))
+        .arg("+%Y-%m-%d %H:%M:%S")
+        .succeeds();
+}

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -415,13 +415,12 @@ fn test_date_parse_from_format() {
     let (at, mut ucmd) = at_and_ucmd!();
     const FILE: &str = "file-with-dates";
 
-    std::fs::write(
-        at.plus(FILE),
+    at.write(
+        FILE,
         "2023-03-27 08:30:00\n\
          2023-04-01 12:00:00\n\
          2023-04-15 18:30:00",
-    )
-    .unwrap();
+    );
     ucmd.arg("-f")
         .arg(at.plus(FILE))
         .arg("+%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
This commit is a trivial followup for:
https://github.com/uutils/coreutils/pull/4917
and
https://github.com/uutils/parse_datetime/pull/12

The functionality to parse the datetime was moved into the parse_datetime crate and the only (tiny) piece left is to call it from `date`.

It also adds the test-case from the original issue. I did not include the two tests from PR#4917 because they appear to work even without this change. I am happy to include them of course if prefered.

Closes: #4657

Thanks to Ben Schofield