### PR TITLE
tests: fix deprecation warning `timestamp_subsec_nanos()`

### DIFF
--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -34,7 +34,7 @@ fn set_file_times(at: &AtPath, path: &str, atime: FileTime, mtime: FileTime) {
 
 fn str_to_filetime(format: &str, s: &str) -> FileTime {
     let tm = chrono::NaiveDateTime::parse_from_str(s, format).unwrap();
-    FileTime::from_unix_time(tm.and_utc().timestamp(), tm.timestamp_subsec_nanos())
+    FileTime::from_unix_time(tm.and_utc().timestamp(), tm.and_utc().timestamp_subsec_nanos())
 }
 
 #[test]

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -34,7 +34,10 @@ fn set_file_times(at: &AtPath, path: &str, atime: FileTime, mtime: FileTime) {
 
 fn str_to_filetime(format: &str, s: &str) -> FileTime {
     let tm = chrono::NaiveDateTime::parse_from_str(s, format).unwrap();
-    FileTime::from_unix_time(tm.and_utc().timestamp(), tm.and_utc().timestamp_subsec_nanos())
+    FileTime::from_unix_time(
+        tm.and_utc().timestamp(),
+        tm.and_utc().timestamp_subsec_nanos(),
+    )
 }
 
 #[test]


### PR DESCRIPTION
When building coreutils I got the following deprecation warning:
```
warning: use of deprecated method `chrono::NaiveDateTime::timestamp_subsec_nanos`: use `.and_utc().timestamp_subsec_nanos()` instead
  --> tests/by-util/test_touch.rs:37:59
   |
37 | ..._utc().timestamp(), tm.timestamp_subsec_nanos())
   |                           ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: `coreutils` (test "tests") generated 1 warning
```
This commit fixes it.