### PR TITLE
dircolors: accept repeated flags

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -258,6 +258,7 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .after_help(AFTER_HELP)
         .override_usage(format_usage(USAGE))
+        .args_override_self(true)
         .infer_long_args(true)
         .arg(
             Arg::new(options::BOURNE_SHELL)

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -246,3 +246,10 @@ fn test_dircolors_for_dir_as_file() {
         "dircolors: expected file, got directory '/'",
     );
 }
+
+#[test]
+fn test_repeated() {
+    for arg in ["-b", "-c", "--print-database", "--print-ls-colors"] {
+        new_ucmd!().arg(arg).arg(arg).succeeds().no_stderr();
+    }
+}


### PR DESCRIPTION
This is work towards #5998. Turns out, it's pleasantly simple to fix `dircolors`.