### PR TITLE
`env` argv0 overwrite possibility (unix only) - fixes new gnu test version

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -147,6 +147,7 @@ UNIX_PROGS := \
 	nohup \
 	pathchk \
 	pinky \
+	sleep \
 	stat \
 	stdbuf \
 	timeout \
@@ -221,6 +222,7 @@ TEST_PROGS  := \
 	rmdir \
 	runcon \
 	seq \
+	sleep \
 	sort \
 	split \
 	stat \


### PR DESCRIPTION
as discussed with @sylvestre here: #5801 

this makes the gnu-test `tests/env/env.sh` green again.

changes explained:
- accept new parameter and provide it at program start
- adapt debug logmessages to fit to gnu ones
- introduce a second debug-level (-vv) that allowes more detailed, non-gnu conform logs.
- add own test that uses --argv0 argument to `coreutils` executable to execute specific tools without placing seperate argument for tool-name
- UPDATE: patch gnu test to seperately test "-a" and "--argv0"