### PR TITLE
chore(deps): drop conv dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,15 +364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
-name = "conv"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
-dependencies = [
- "custom_derive",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +377,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "conv",
  "filetime",
  "glob",
  "hex-literal",
@@ -686,12 +676,6 @@ dependencies = [
  "nix",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "custom_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "data-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -477,7 +477,6 @@ yes = { optional = true, version = "0.0.26", package = "uu_yes", path = "src/uu/
 
 [dev-dependencies]
 chrono = { workspace = true }
-conv = "0.3"
 filetime = { workspace = true }
 glob = { workspace = true }
 libc = { workspace = true }

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -154,9 +154,7 @@ fn test_cli_args() {
 
 #[test]
 fn test_random() {
-    use conv::prelude::ValueFrom;
-
-    let log_num_primes = f64::value_from(NUM_PRIMES).unwrap().log2().ceil();
+    let log_num_primes = f64::from(u32::try_from(NUM_PRIMES).unwrap()).log2().ceil();
     let primes = Sieve::primes().take(NUM_PRIMES).collect::<Vec<u64>>();
 
     let rng_seed = SystemTime::now()


### PR DESCRIPTION
Drops the `conv` dependency, which hasn't been updated in the last 8 years and was used in just one place.