### PR TITLE
Use time-style only if time is provided

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -721,7 +721,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         excludes: build_exclude_patterns(&matches)?,
     };
 
-    let time_format = if let Some(_time) = time {
+    let time_format = if time.is_some() {
         parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?.to_string()
     } else {
         "%Y-%m-%d %H:%M".to_string()

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -722,8 +722,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let time_format = if let Some(_time) = time {
-        parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?
-            .to_string()
+        parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?.to_string()
     } else {
         "%Y-%m-%d %H:%M".to_string()
     };

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -721,6 +721,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         excludes: build_exclude_patterns(&matches)?,
     };
 
+    let time_format = if let Some(_time) = time {
+        parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?
+            .to_string()
+    } else {
+        "%Y-%m-%d %H:%M".to_string()
+    };
+
     let stat_printer = StatPrinter {
         max_depth,
         size_format,
@@ -737,8 +744,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .transpose()?,
         apparent_size: matches.get_flag(options::APPARENT_SIZE) || matches.get_flag(options::BYTES),
         time,
-        time_format: parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?
-            .to_string(),
+        time_format,
         line_ending: LineEnding::from_zero_flag(matches.get_flag(options::NULL)),
     };
 

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -1116,3 +1116,13 @@ fn test_du_files0_from_combined() {
 
     assert!(stderr.contains("file operands cannot be combined with --files0-from"));
 }
+
+#[test]
+fn test_invalid_time_style() {
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd()
+        .arg("-s")
+        .arg("--time-style=banana")
+        .succeeds()
+        .stdout_does_not_contain("du: invalid argument 'banana' for 'time style'");
+}

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -7,7 +7,7 @@
 #[cfg(target_os = "linux")]
 use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
-use env::native_int_str::{Convert, NCvt};
+use ::env::native_int_str::{Convert, NCvt};
 use std::env;
 use std::path::Path;
 use tempfile::tempdir;
@@ -376,8 +376,8 @@ fn test_gnu_e20() {
 
 #[test]
 fn test_split_string_misc() {
-    use env::native_int_str::NCvt;
-    use env::parse_args_from_str;
+    use ::env::native_int_str::NCvt;
+    use ::env::parse_args_from_str;
 
     assert_eq!(
         NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
@@ -687,8 +687,8 @@ mod tests_split_iterator {
 
     use std::ffi::OsString;
 
+    use ::env::parse_error::ParseError;
     use env::native_int_str::{from_native_int_representation_owned, Convert, NCvt};
-    use env::parse_error::ParseError;
 
     fn split(input: &str) -> Result<Vec<OsString>, ParseError> {
         ::env::split_iterator::split(&NCvt::convert(input)).map(|vec| {

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -7,7 +7,7 @@
 #[cfg(target_os = "linux")]
 use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
-use ::env::native_int_str::{Convert, NCvt};
+use env::native_int_str::{Convert, NCvt};
 use std::env;
 use std::path::Path;
 use tempfile::tempdir;
@@ -376,8 +376,8 @@ fn test_gnu_e20() {
 
 #[test]
 fn test_split_string_misc() {
-    use ::env::native_int_str::NCvt;
-    use ::env::parse_args_from_str;
+    use env::native_int_str::NCvt;
+    use env::parse_args_from_str;
 
     assert_eq!(
         NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
@@ -687,8 +687,8 @@ mod tests_split_iterator {
 
     use std::ffi::OsString;
 
-    use ::env::parse_error::ParseError;
     use env::native_int_str::{from_native_int_representation_owned, Convert, NCvt};
+    use env::parse_error::ParseError;
 
     fn split(input: &str) -> Result<Vec<OsString>, ParseError> {
         ::env::split_iterator::split(&NCvt::convert(input)).map(|vec| {


### PR DESCRIPTION
Closes #6169 

This is the output as expected
```
└─$ target/debug/coreutils du -s --time-style=banana
2449284 .
```
```
└─$ target/debug/coreutils du -s --time --time-style=banana
du: invalid argument 'banana' for 'time style'
Valid arguments are:
- 'full-iso'
- 'long-iso'
- 'iso'
Try 'target/debug/coreutils du --help' for more information.
```
```
└─$ target/debug/coreutils du -s --time --time-style=iso   
2449476 2024-04-01      .
```