### PR TITLE
fuzz: also generate the empty string sometimes

### DIFF
--- a/fuzz/fuzz_targets/fuzz_common.rs
+++ b/fuzz/fuzz_targets/fuzz_common.rs
@@ -374,7 +374,7 @@ pub fn generate_random_string(max_length: usize) -> String {
     let invalid_utf8 = [0xC3, 0x28]; // Invalid UTF-8 sequence
     let mut result = String::new();
 
-    for _ in 0..rng.gen_range(1..=max_length) {
+    for _ in 0..rng.gen_range(0..=max_length) {
         if rng.gen_bool(0.9) {
             let ch = valid_utf8.choose(&mut rng).unwrap();
             result.push(*ch);


### PR DESCRIPTION
Inspired by #6167: #6175 is a bug in uutils, caused by an unexpectedly empty string.

Note that the empty string regularly causes interesting behavior:

```
$ echo hello world | hd
00000000  68 65 6c 6c 6f 20 77 6f  72 6c 64 0a              |hello world.|
0000000c
$ echo hello "" world | hd # Additional space!
00000000  68 65 6c 6c 6f 20 20 77  6f 72 6c 64 0a           |hello  world.|
0000000d
```
(uutils already behaves correctly here.)

However, uutils sometimes doesn't behave correctly. To prove my point, I just found this bug merely by inserting the empty string in various places:

```console
$ rm -rf target/test/; mkdir target/test/; cp LICENSE "" README.md target/test/; echo "EXITCODE GNU: $?"; ls -l target/test/; echo "(end)"      
cp: cannot stat '': No such file or directory
EXITCODE GNU: 1
total 12
-rw-r--r-- 1 user user 1056 Apr  1 21:12 LICENSE
-rw-r--r-- 1 user user 7973 Apr  1 21:12 README.md
(end)
$ rm -rf target/test/; mkdir target/test/; cargo run cp LICENSE "" README.md target/test/; echo "EXITCODE uutils: $?"; ls -l target/test/; echo "(end)"
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/coreutils cp LICENSE '' README.md target/test/`
error: a value is required for '[paths]...' but none was supplied

For more information, try '--help'.
EXITCODE uutils: 1
total 0
(end)
```

I hope this is enough motivation that we should include the empty string during fuzzing.