### PR TITLE
cksum: adding -b as the short form of --base64

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -448,6 +448,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::BASE64)
             .long(options::BASE64)
+            .short('b')
             .help("emit a base64 digest, not hexadecimal")
             .action(ArgAction::SetTrue)
             // Even though this could easily just override an earlier '--raw',

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -379,13 +379,15 @@ fn test_base64_raw_conflicts() {
 #[test]
 fn test_base64_single_file() {
     for algo in ALGOS {
-        new_ucmd!()
-            .arg("--base64")
-            .arg("lorem_ipsum.txt")
-            .arg(format!("--algorithm={algo}"))
-            .succeeds()
-            .no_stderr()
-            .stdout_is_fixture_bytes(format!("base64/{algo}_single_file.expected"));
+        for base64_option in ["--base64", "-b"] {
+            new_ucmd!()
+                .arg(base64_option)
+                .arg("lorem_ipsum.txt")
+                .arg(format!("--algorithm={algo}"))
+                .succeeds()
+                .no_stderr()
+                .stdout_is_fixture_bytes(format!("base64/{algo}_single_file.expected"));
+        }
     }
 }
 #[test]


### PR DESCRIPTION
The base64 coding was present & only lacked the short option form (-b). Added.

closes #5706