### PR TITLE
cp: gnu "same-file" test case compatibility

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -770,6 +770,25 @@ pub mod sane_blksize {
     }
 }
 
+/// Extracts the filename component from the given `file` path and returns it as an `Option<&str>`.
+///
+/// If the `file` path contains a filename, this function returns `Some(filename)` where `filename` is
+/// the extracted filename as a string slice (`&str`). If the `file` path does not have a filename
+/// component or if the filename is not valid UTF-8, it returns `None`.
+///
+/// # Arguments
+///
+/// * `file`: A reference to a `Path` representing the file path from which to extract the filename.
+///
+/// # Returns
+///
+/// * `Some(filename)`: If a valid filename exists in the `file` path, where `filename` is the
+///   extracted filename as a string slice (`&str`).
+/// * `None`: If the `file` path does not contain a valid filename or if the filename is not valid UTF-8.
+pub fn get_filename(file: &Path) -> Option<&str> {
+    file.file_name().and_then(|filename| filename.to_str())
+}
+
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
@@ -1005,5 +1024,10 @@ mod tests {
         assert_eq!(4096, sane_blksize::sane_blksize(4096));
         assert_eq!(0x2000_0000, sane_blksize::sane_blksize(0x2000_0000));
         assert_eq!(512, sane_blksize::sane_blksize(0x2000_0001));
+    }
+    #[test]
+    fn test_get_file_name() {
+        let file_path = PathBuf::from("~/foo.txt");
+        assert!(matches!(get_filename(&file_path), Some("foo.txt")));
     }
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore (flags) reflink (fs) tmpfs (linux) rlimit Rlim NOFILE clob btrfs neve ROOTDIR USERDIR procfs outfile uufs xattrs
-
+// spell-checker:ignore bdfl hlsl
 use crate::common::util::TestScenario;
 #[cfg(not(windows))]
 use std::fs::set_permissions;
@@ -3885,4 +3885,928 @@ fn test_cp_no_dereference_attributes_only_with_symlink() {
         at.read("file2.exp"),
         "file2 content does not match expected"
     );
+}
+#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(test)]
+/// contains the test for cp when the source and destination points to the same file
+mod same_file {
+
+    use crate::common::util::TestScenario;
+
+    const FILE_NAME: &str = "foo";
+    const SYMLINK_NAME: &str = "symlink";
+    const CONTENTS: &str = "abcd";
+
+    // the following tests tries to copy a file to the symlink of the same file with
+    // various options
+    #[test]
+    fn test_same_file_from_file_to_symlink() {
+        for option in ["-d", "-f", "-df"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, SYMLINK_NAME])
+                .fails()
+                .stderr_contains("'foo' and 'symlink' are the same file");
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_symlink_with_rem_option() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        scene
+            .ucmd()
+            .args(&["--rem", FILE_NAME, SYMLINK_NAME])
+            .succeeds();
+        assert!(at.file_exists(SYMLINK_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert!(at.file_exists(FILE_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_symlink_with_backup_option() {
+        for option in ["-b", "-bd", "-bf", "-bdf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "symlink~";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.symlink_exists(backup));
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+            assert!(at.file_exists(SYMLINK_NAME));
+            assert_eq!(at.read(SYMLINK_NAME), CONTENTS,);
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_symlink_with_link_option() {
+        for option in ["-l", "-dl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, SYMLINK_NAME])
+                .fails()
+                .stderr_contains("cp: cannot create hard link 'symlink' to 'foo'");
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_symlink_with_options_link_and_force() {
+        for option in ["-fl", "-dfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(SYMLINK_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_symlink_with_options_backup_and_link() {
+        for option in ["-bl", "-bdl", "-bfl", "-bdfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "symlink~";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(SYMLINK_NAME));
+            assert!(at.symlink_exists(backup));
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_symlink_with_options_symlink() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        scene
+            .ucmd()
+            .args(&["-s", FILE_NAME, SYMLINK_NAME])
+            .fails()
+            .stderr_contains("cp: cannot create symlink 'symlink' to 'foo'");
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.symlink_exists(SYMLINK_NAME));
+        assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_symlink_with_options_symlink_and_force() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        scene
+            .ucmd()
+            .args(&["-sf", FILE_NAME, SYMLINK_NAME])
+            .succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.symlink_exists(SYMLINK_NAME));
+        assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+    // the following tests tries to copy a symlink to the file that symlink points to with
+    // various options
+    #[test]
+    fn test_same_file_from_symlink_to_file() {
+        for option in ["-d", "-f", "-df", "--rem"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, SYMLINK_NAME, FILE_NAME])
+                .fails()
+                .stderr_contains("'symlink' and 'foo' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_file_with_option_backup() {
+        for option in ["-b", "-bf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, SYMLINK_NAME, FILE_NAME])
+                .fails()
+                .stderr_contains("'symlink' and 'foo' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+    #[test]
+    fn test_same_file_from_symlink_to_file_with_option_backup_without_deref() {
+        for option in ["-bd", "-bdf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "foo~";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, SYMLINK_NAME, FILE_NAME])
+                .succeeds();
+            assert!(at.file_exists(backup));
+            assert!(at.symlink_exists(FILE_NAME));
+            // this doesn't makes sense but this is how gnu does it
+            assert_eq!(FILE_NAME, at.resolve_link(FILE_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(at.read(backup), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_file_with_options_link() {
+        for option in ["-l", "-dl", "-fl", "-bl", "-bfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, SYMLINK_NAME, FILE_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_file_with_option_symlink() {
+        for option in ["-s", "-sf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            scene
+                .ucmd()
+                .args(&[option, SYMLINK_NAME, FILE_NAME])
+                .fails()
+                .stderr_contains("'symlink' and 'foo' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    // the following tests tries to copy a file to the same file with various options
+    #[test]
+    fn test_same_file_from_file_to_file() {
+        for option in ["-d", "-f", "-df", "--rem"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, FILE_NAME])
+                .fails()
+                .stderr_contains("'foo' and 'foo' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+    #[test]
+    fn test_same_file_from_file_to_file_with_backup() {
+        for option in ["-b", "-bd"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, FILE_NAME])
+                .fails()
+                .stderr_contains("'foo' and 'foo' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_file_with_options_backup_and_no_deref() {
+        for option in ["-bf", "-bdf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "foo~";
+            at.write(FILE_NAME, CONTENTS);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, FILE_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+            assert_eq!(at.read(backup), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_file_with_options_link() {
+        for option in ["-l", "-dl", "-fl", "-dfl", "-bl", "-bdl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "foo~";
+            at.write(FILE_NAME, CONTENTS);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, FILE_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(!at.file_exists(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_file_with_options_link_and_backup_and_force() {
+        for option in ["-bfl", "-bdfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "foo~";
+            at.write(FILE_NAME, CONTENTS);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, FILE_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+            assert_eq!(at.read(backup), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_file_with_options_symlink() {
+        for option in ["-s", "-sf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            at.write(FILE_NAME, CONTENTS);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, FILE_NAME])
+                .fails()
+                .stderr_contains("'foo' and 'foo' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    // the following tests tries to copy a symlink that points to a file to a symlink
+    // that points to the same file with various options
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_no_deref() {
+        for option in ["-d", "-df"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let symlink1 = "sl1";
+            let symlink2 = "sl2";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, symlink1);
+            at.symlink_file(FILE_NAME, symlink2);
+            scene.ucmd().args(&[option, symlink1, symlink2]).succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+            assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+            assert_eq!(FILE_NAME, at.resolve_link(symlink2));
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_force() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let symlink1 = "sl1";
+        let symlink2 = "sl2";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, symlink1);
+        at.symlink_file(FILE_NAME, symlink2);
+        scene
+            .ucmd()
+            .args(&["-f", symlink1, symlink2])
+            .fails()
+            .stderr_contains("'sl1' and 'sl2' are the same file");
+        assert!(at.file_exists(FILE_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+        assert_eq!(FILE_NAME, at.resolve_link(symlink2));
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_rem() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let symlink1 = "sl1";
+        let symlink2 = "sl2";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, symlink1);
+        at.symlink_file(FILE_NAME, symlink2);
+        scene.ucmd().args(&["--rem", symlink1, symlink2]).succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+        assert!(at.file_exists(symlink2));
+        assert_eq!(at.read(symlink2), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_backup() {
+        for option in ["-b", "-bf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let symlink1 = "sl1";
+            let symlink2 = "sl2";
+            let backup = "sl2~";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, symlink1);
+            at.symlink_file(FILE_NAME, symlink2);
+            scene.ucmd().args(&[option, symlink1, symlink2]).succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+            assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+            assert!(at.file_exists(symlink2));
+            assert_eq!(at.read(symlink2), CONTENTS,);
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_backup_and_no_deref() {
+        for option in ["-bd", "-bdf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let symlink1 = "sl1";
+            let symlink2 = "sl2";
+            let backup = "sl2~";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, symlink1);
+            at.symlink_file(FILE_NAME, symlink2);
+            scene.ucmd().args(&[option, symlink1, symlink2]).succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+            assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+            assert_eq!(FILE_NAME, at.resolve_link(symlink2));
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+        }
+    }
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_link() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let symlink1 = "sl1";
+        let symlink2 = "sl2";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, symlink1);
+        at.symlink_file(FILE_NAME, symlink2);
+        scene
+            .ucmd()
+            .args(&["-l", symlink1, symlink2])
+            .fails()
+            .stderr_contains("cannot create hard link 'sl2' to 'sl1'");
+        assert!(at.file_exists(FILE_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+        assert_eq!(FILE_NAME, at.resolve_link(symlink2));
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_force_link() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let symlink1 = "sl1";
+        let symlink2 = "sl2";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, symlink1);
+        at.symlink_file(FILE_NAME, symlink2);
+        scene.ucmd().args(&["-fl", symlink1, symlink2]).succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+        assert!(at.file_exists(symlink2));
+        assert_eq!(at.read(symlink2), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_backup_and_link() {
+        for option in ["-bl", "-bfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let symlink1 = "sl1";
+            let symlink2 = "sl2";
+            let backup = "sl2~";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, symlink1);
+            at.symlink_file(FILE_NAME, symlink2);
+            scene.ucmd().args(&[option, symlink1, symlink2]).succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+            assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+            assert!(at.file_exists(symlink2));
+            assert_eq!(at.read(symlink2), CONTENTS,);
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_symlink() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let symlink1 = "sl1";
+        let symlink2 = "sl2";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, symlink1);
+        at.symlink_file(FILE_NAME, symlink2);
+        scene
+            .ucmd()
+            .args(&["-s", symlink1, symlink2])
+            .fails()
+            .stderr_contains("cannot create symlink 'sl2' to 'sl1'");
+        assert!(at.file_exists(FILE_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+        assert_eq!(FILE_NAME, at.resolve_link(symlink2));
+    }
+
+    #[test]
+    fn test_same_file_from_symlink_to_symlink_with_option_symlink_and_force() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let symlink1 = "sl1";
+        let symlink2 = "sl2";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, symlink1);
+        at.symlink_file(FILE_NAME, symlink2);
+        scene.ucmd().args(&["-sf", symlink1, symlink2]).succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert_eq!(FILE_NAME, at.resolve_link(symlink1));
+        assert_eq!(symlink1, at.resolve_link(symlink2));
+    }
+
+    // the following tests tries to copy file to a hardlink of the same file with
+    // various options
+    #[test]
+    fn test_same_file_from_file_to_hardlink() {
+        for option in ["-d", "-f", "-df"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let hardlink = "hardlink";
+            at.write(FILE_NAME, CONTENTS);
+            at.hard_link(FILE_NAME, hardlink);
+
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, hardlink])
+                .fails()
+                .stderr_contains("'foo' and 'hardlink' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(hardlink));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_hardlink_with_option_rem() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink = "hardlink";
+        at.write(FILE_NAME, CONTENTS);
+        at.hard_link(FILE_NAME, hardlink);
+        scene
+            .ucmd()
+            .args(&["--rem", FILE_NAME, hardlink])
+            .succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.file_exists(hardlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_hardlink_with_option_backup() {
+        for option in ["-b", "-bd", "-bf", "-bdf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let hardlink = "hardlink";
+            let backup = "hardlink~";
+            at.write(FILE_NAME, CONTENTS);
+            at.hard_link(FILE_NAME, hardlink);
+            scene.ucmd().args(&[option, FILE_NAME, hardlink]).succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(hardlink));
+            assert!(at.file_exists(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_hardlink_with_option_link() {
+        for option in ["-l", "-dl", "-fl", "-dfl", "-bl", "-bdl", "-bfl", "-bdfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let hardlink = "hardlink";
+            at.write(FILE_NAME, CONTENTS);
+            at.hard_link(FILE_NAME, hardlink);
+            scene.ucmd().args(&[option, FILE_NAME, hardlink]).succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(hardlink));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_file_to_hardlink_with_option_symlink() {
+        for option in ["-s", "-sf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let hardlink = "hardlink";
+            at.write(FILE_NAME, CONTENTS);
+            at.hard_link(FILE_NAME, hardlink);
+            scene
+                .ucmd()
+                .args(&[option, FILE_NAME, hardlink])
+                .fails()
+                .stderr_contains("'foo' and 'hardlink' are the same file");
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(hardlink));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    // the following tests tries to copy symlink to a hardlink of the same symlink with
+    // various options
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink_to_symlink = "hlsl";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+        scene
+            .ucmd()
+            .args(&[hardlink_to_symlink, SYMLINK_NAME])
+            .fails()
+            .stderr_contains("cp: 'hlsl' and 'symlink' are the same file");
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.symlink_exists(SYMLINK_NAME));
+        assert!(at.symlink_exists(hardlink_to_symlink));
+        assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+        assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_force() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink_to_symlink = "hlsl";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+        scene
+            .ucmd()
+            .args(&["-f", hardlink_to_symlink, SYMLINK_NAME])
+            .fails()
+            .stderr_contains("cp: 'hlsl' and 'symlink' are the same file");
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.symlink_exists(SYMLINK_NAME));
+        assert!(at.symlink_exists(hardlink_to_symlink));
+        assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+        assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_no_deref() {
+        for option in ["-d", "-df"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let hardlink_to_symlink = "hlsl";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+            scene
+                .ucmd()
+                .args(&[option, hardlink_to_symlink, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert!(at.symlink_exists(hardlink_to_symlink));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_rem() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink_to_symlink = "hlsl";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+        scene
+            .ucmd()
+            .args(&["--rem", hardlink_to_symlink, SYMLINK_NAME])
+            .succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.file_exists(SYMLINK_NAME));
+        assert!(!at.symlink_exists(SYMLINK_NAME));
+        assert!(at.symlink_exists(hardlink_to_symlink));
+        assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        assert_eq!(at.read(SYMLINK_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_backup() {
+        for option in ["-b", "-bf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "symlink~";
+            let hardlink_to_symlink = "hlsl";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+            scene
+                .ucmd()
+                .args(&[option, hardlink_to_symlink, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(SYMLINK_NAME));
+            assert!(!at.symlink_exists(SYMLINK_NAME));
+            assert!(at.symlink_exists(hardlink_to_symlink));
+            assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+            assert!(at.symlink_exists(backup));
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+            assert_eq!(at.read(SYMLINK_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_backup_and_no_deref() {
+        for option in ["-bd", "-bdf"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "symlink~";
+            let hardlink_to_symlink = "hlsl";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+            scene
+                .ucmd()
+                .args(&[option, hardlink_to_symlink, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert!(at.symlink_exists(hardlink_to_symlink));
+            assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+            assert!(at.symlink_exists(backup));
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_link() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink_to_symlink = "hlsl";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+        scene
+            .ucmd()
+            .args(&["-l", hardlink_to_symlink, SYMLINK_NAME])
+            .fails()
+            .stderr_contains("cannot create hard link 'symlink' to 'hlsl'");
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.symlink_exists(SYMLINK_NAME));
+        assert!(at.symlink_exists(hardlink_to_symlink));
+        assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+        assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_link_and_no_deref() {
+        for option in ["-dl", "-dfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let hardlink_to_symlink = "hlsl";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+            scene
+                .ucmd()
+                .args(&[option, hardlink_to_symlink, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert!(at.symlink_exists(hardlink_to_symlink));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_link_and_force() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink_to_symlink = "hlsl";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+        scene
+            .ucmd()
+            .args(&["-fl", hardlink_to_symlink, SYMLINK_NAME])
+            .succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.file_exists(SYMLINK_NAME));
+        assert!(!at.symlink_exists(SYMLINK_NAME));
+        assert!(at.symlink_exists(hardlink_to_symlink));
+        assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_link_and_backup() {
+        for option in ["-bl", "-bfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let backup = "symlink~";
+            let hardlink_to_symlink = "hlsl";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+            scene
+                .ucmd()
+                .args(&[option, hardlink_to_symlink, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.file_exists(SYMLINK_NAME));
+            assert!(!at.symlink_exists(SYMLINK_NAME));
+            assert!(at.symlink_exists(hardlink_to_symlink));
+            assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+            assert!(at.symlink_exists(backup));
+            assert_eq!(FILE_NAME, at.resolve_link(backup));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_options_backup_link_no_deref() {
+        for option in ["-bdl", "-bdfl"] {
+            let scene = TestScenario::new(util_name!());
+            let at = &scene.fixtures;
+            let hardlink_to_symlink = "hlsl";
+            at.write(FILE_NAME, CONTENTS);
+            at.symlink_file(FILE_NAME, SYMLINK_NAME);
+            at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+            scene
+                .ucmd()
+                .args(&[option, hardlink_to_symlink, SYMLINK_NAME])
+                .succeeds();
+            assert!(at.file_exists(FILE_NAME));
+            assert!(at.symlink_exists(SYMLINK_NAME));
+            assert!(at.symlink_exists(hardlink_to_symlink));
+            assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+            assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+            assert_eq!(at.read(FILE_NAME), CONTENTS,);
+        }
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_symlink() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink_to_symlink = "hlsl";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+        scene
+            .ucmd()
+            .args(&["-s", hardlink_to_symlink, SYMLINK_NAME])
+            .fails()
+            .stderr_contains("cannot create symlink 'symlink' to 'hlsl'");
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.symlink_exists(SYMLINK_NAME));
+        assert!(at.symlink_exists(hardlink_to_symlink));
+        assert_eq!(FILE_NAME, at.resolve_link(SYMLINK_NAME));
+        assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
+
+    #[test]
+    fn test_same_file_from_hard_link_of_symlink_to_symlink_with_option_symlink_and_force() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let hardlink_to_symlink = "hlsl";
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        at.hard_link(SYMLINK_NAME, hardlink_to_symlink);
+        scene
+            .ucmd()
+            .args(&["-sf", hardlink_to_symlink, SYMLINK_NAME])
+            .succeeds();
+        assert!(at.file_exists(FILE_NAME));
+        assert!(at.symlink_exists(SYMLINK_NAME));
+        assert!(at.symlink_exists(hardlink_to_symlink));
+        assert_eq!(hardlink_to_symlink, at.resolve_link(SYMLINK_NAME));
+        assert_eq!(FILE_NAME, at.resolve_link(hardlink_to_symlink));
+        assert_eq!(at.read(FILE_NAME), CONTENTS,);
+    }
 }


### PR DESCRIPTION
This pr tries to fix #6158 

- changed the behavior of how `-b` worked. Now, `VERSION_CONTROL` env is considered before resorting to  `--backup=existing`
- added more checks to `is_forbidden_to_copy_to_same_file` 
- added some more cases in `copy_file` so that it's okay to return without an error in some cases
- fixes the issue of cp not dereferencing the destination symlink when -d is given without -b, by only removing destination files that are only part of a hard link
- fixed the error caused by trying to remove a file that's already been removed