### PR TITLE
tests: test multi-call logic

### DIFF
--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -92,3 +92,154 @@ fn util_name_single() {
         scenario.fixtures.plus("uu-sort").display()
     )));
 }
+
+#[test]
+#[cfg(any(unix, windows))]
+fn util_invalid_name_help() {
+    use std::{
+        io::Write,
+        process::{Command, Stdio},
+    };
+
+    let scenario = TestScenario::new("invalid_name");
+    symlink_file(scenario.bin_path, scenario.fixtures.plus("invalid_name")).unwrap();
+    let child = Command::new(scenario.fixtures.plus("invalid_name"))
+        .arg("--help")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stderr, b"");
+    let output_str = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        output_str.contains("(multi-call binary)"),
+        "{:?}",
+        output_str
+    );
+    assert!(
+        output_str.contains("Usage: invalid_name [function "),
+        "{:?}",
+        output_str
+    );
+}
+
+#[test]
+// The exact set of permitted filenames depends on many factors. Non-UTF-8 strings
+// work on very few platforms, but linux works, especially because it also increases
+// the likelihood that a filesystem is being used that supports non-UTF-8 filenames.
+#[cfg(target_os = "linux")]
+fn util_non_utf8_name_help() {
+    // Make sure we don't crash even if the util name is invalid UTF-8.
+    use std::{
+        ffi::OsStr,
+        io::Write,
+        os::unix::ffi::OsStrExt,
+        path::Path,
+        process::{Command, Stdio},
+    };
+
+    let scenario = TestScenario::new("invalid_name");
+    let non_utf8_path = scenario.fixtures.plus(OsStr::from_bytes(b"\xff"));
+    symlink_file(scenario.bin_path, &non_utf8_path).unwrap();
+    let child = Command::new(&non_utf8_path)
+        .arg("--help")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stderr, b"");
+    let output_str = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        output_str.contains("(multi-call binary)"),
+        "{:?}",
+        output_str
+    );
+    assert!(
+        output_str.contains("Usage: <unknown binary name> [function "),
+        "{:?}",
+        output_str
+    );
+}
+
+#[test]
+#[cfg(any(unix, windows))]
+fn util_invalid_name_invalid_command() {
+    use std::{
+        io::Write,
+        process::{Command, Stdio},
+    };
+
+    let scenario = TestScenario::new("invalid_name");
+    symlink_file(scenario.bin_path, scenario.fixtures.plus("invalid_name")).unwrap();
+    let child = Command::new(scenario.fixtures.plus("invalid_name"))
+        .arg("definitely_invalid")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.stderr, b"");
+    assert_eq!(
+        output.stdout,
+        b"definitely_invalid: function/utility not found\n"
+    );
+}
+
+#[test]
+fn util_completion() {
+    use std::{
+        io::Write,
+        process::{Command, Stdio},
+    };
+
+    let scenario = TestScenario::new("completion");
+    let child = Command::new(scenario.bin_path)
+        .arg("completion")
+        .arg("true")
+        .arg("powershell")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stderr, b"");
+    let output_str = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        output_str.contains("using namespace System.Management.Automation"),
+        "{:?}",
+        output_str
+    );
+}
+
+#[test]
+fn util_manpage() {
+    use std::{
+        io::Write,
+        process::{Command, Stdio},
+    };
+
+    let scenario = TestScenario::new("completion");
+    let child = Command::new(scenario.bin_path)
+        .arg("manpage")
+        .arg("true")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stderr, b"");
+    let output_str = String::from_utf8(output.stdout).unwrap();
+    assert!(output_str.contains("\n.TH true 1 "), "{:?}", output_str);
+}


### PR DESCRIPTION
I noticed that [`src/bin/coreutils.rs`](https://app.codecov.io/gh/uutils/coreutils/blob/main/src%2Fbin%2Fcoreutils.rs?flags%5B0%5D=ubuntu_latest) had abysmal coverage. Turns out, we don't have any tests for most features of our "multi-call binary" logic!

This PR fixes that by adding a few tests, namely:
- Calling with an unusual name
- Calling with a non-UTF8-name
- Calling with invalid arguments (thus exercising the top-level argument error handling)
- Generating a manpage
- Generating a completion

Thankfully, this revealed no bugs. Let's prevent regressions!

EDIT: From 19% to 68%: https://app.codecov.io/gh/uutils/coreutils/blob/BenWiederhake%2Fcoreutils-rs%3Adev-better-test-coverage/src%2Fbin%2Fcoreutils.rs