### PR TITLE
kill: print signals vertically when using --list flag

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -161,7 +161,7 @@ fn print_signal(signal_name_or_value: &str) -> UResult<()> {
 fn print_signals() {
     for (idx, signal) in ALL_SIGNALS.iter().enumerate() {
         if idx > 0 {
-            print!(" ");
+            println!();
         }
         print!("{signal}");
     }

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -159,13 +159,9 @@ fn print_signal(signal_name_or_value: &str) -> UResult<()> {
 }
 
 fn print_signals() {
-    for (idx, signal) in ALL_SIGNALS.iter().enumerate() {
-        if idx > 0 {
-            println!();
-        }
-        print!("{signal}");
+    for signal in ALL_SIGNALS.iter() {
+        println!("{signal}");
     }
-    println!();
 }
 
 fn list(arg: Option<&String>) -> UResult<()> {


### PR DESCRIPTION
> Environment: Ubuntu 20.04, uutils main branch (git commit https://github.com/uutils/coreutils/commit/415de28fedcd66ae3482f22d4ba274fe77c9d3d8), GNU coreutils version 9.5.3-8f39 (from git commit https://github.com/coreutils/coreutils/commit/8f3989d586a88d182700050b435d2f6c393ec27b).

See #6197 for more details.