### PR TITLE
dd: fix flaky test_null_stats

### DIFF
--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -396,7 +396,7 @@ fn test_null_stats() {
         .arg("if=null.txt")
         .run()
         .stderr_contains("0+0 records in\n0+0 records out\n0 bytes copied, ")
-        .stderr_matches(&Regex::new(r"\d\.\d+(e-\d\d)? s, ").unwrap())
+        .stderr_matches(&Regex::new(r"\d(\.\d+)?(e-\d\d)? s, ").unwrap())
         .stderr_contains("0.0 B/s")
         .success();
 }


### PR DESCRIPTION
If the first four decimal digits are zero, GNU dd elides them altogether. Therefore, this test just contained an overly-strict regex.

See also ede944e1f856cc0011852a25d6826b9eac6f2f11.

This flake causes [real problems](https://github.com/uutils/coreutils/pull/6201#issuecomment-2041559555).