### PR TITLE
cp: handle update prompt with and without interactive mode enabled

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -275,20 +275,6 @@ fn test_cp_target_directory_is_file() {
 }
 
 #[test]
-// FixMe: for FreeBSD, flaky test; track repair progress at GH:uutils/coreutils/issue/4725
-#[cfg(not(target_os = "freebsd"))]
-fn test_cp_arg_update_interactive() {
-    new_ucmd!()
-        .arg(TEST_HELLO_WORLD_SOURCE)
-        .arg(TEST_HOW_ARE_YOU_SOURCE)
-        .arg("-i")
-        .arg("--update")
-        .succeeds()
-        .no_stdout()
-        .no_stderr();
-}
-
-#[test]
 fn test_cp_arg_update_interactive_error() {
     new_ucmd!()
         .arg(TEST_HELLO_WORLD_SOURCE)
@@ -498,7 +484,7 @@ fn test_cp_arg_interactive() {
 
 #[test]
 #[cfg(not(any(target_os = "android", target_os = "freebsd")))]
-fn test_cp_arg_interactive_update() {
+fn test_cp_arg_interactive_update_overwrite_newer() {
     // -u -i won't show the prompt to validate the override or not
     // Therefore, the error code will be 0
     let (at, mut ucmd) = at_and_ucmd!();
@@ -517,12 +503,13 @@ fn test_cp_arg_interactive_update() {
 
 #[test]
 #[cfg(not(any(target_os = "android", target_os = "freebsd")))]
-#[ignore = "known issue #6019"]
-fn test_cp_arg_interactive_update_newer() {
+fn test_cp_arg_interactive_update_overwrite_older() {
     // -u -i *WILL* show the prompt to validate the override.
     // Therefore, the error code depends on the prompt response.
+    // Option N
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("b");
+    std::thread::sleep(Duration::from_secs(1));
     at.touch("a");
     ucmd.args(&["-i", "-u", "a", "b"])
         .pipe_in("N\n")
@@ -530,6 +517,16 @@ fn test_cp_arg_interactive_update_newer() {
         .code_is(1)
         .no_stdout()
         .stderr_is("cp: overwrite 'b'? ");
+
+    // Option Y
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("b");
+    std::thread::sleep(Duration::from_secs(1));
+    at.touch("a");
+    ucmd.args(&["-i", "-u", "a", "b"])
+        .pipe_in("Y\n")
+        .succeeds()
+        .no_stdout();
 }
 
 #[test]


### PR DESCRIPTION
This is #6069.

To recap what this PR does: If `-u` is given, don't consider overwriting. If not considering overwriting, don't ask even if `-i` is given.

Reason: While trying to rebase and push his PR, I accidentally overwrite Vikrant's `main` branch, which caused his original PR to be closed, which caused me no longer having implicit write permission to his branch. I guess I'll just never use that GitHub feature again.

@Vikrant2691 Please sanity-check whether this looks correct. `git diff` says there is no difference in content between c94809b490d5ae83b4c69e9b97bb8e52d249bc1a (your original final commit) and 9b9c0cc237e3eb6f9855cab3a40b0f6bf6a0b456 (this commit).