### PR TITLE
kill: support multiple signals for --list

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -71,7 +71,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             table();
             Ok(())
         }
-        Mode::List => list(pids_or_signals.first()),
+        Mode::List => {
+            list(&pids_or_signals);
+            Ok(())
+        }
     }
 }
 
@@ -164,12 +167,14 @@ fn print_signals() {
     }
 }
 
-fn list(arg: Option<&String>) -> UResult<()> {
-    match arg {
-        Some(x) => print_signal(x),
-        None => {
-            print_signals();
-            Ok(())
+fn list(signals: &Vec<String>) {
+    if signals.is_empty() {
+        print_signals();
+    } else {
+        for signal in signals {
+            if let Err(e) = print_signal(signal) {
+                uucore::show!(e)
+            }
         }
     }
 }

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -93,6 +93,16 @@ fn test_kill_list_one_signal_from_name() {
 }
 
 #[test]
+fn test_kill_list_all_vertically() {
+    // Check for a few signals.  Do not try to be comprehensive.
+    let command = new_ucmd!().arg("-l").succeeds();
+    let signals = command.stdout_str().split('\n').collect::<Vec<&str>>();
+    assert!(signals.contains(&"KILL"));
+    assert!(signals.contains(&"TERM"));
+    assert!(signals.contains(&"HUP"));
+}
+
+#[test]
 fn test_kill_list_two_signal_from_name() {
     new_ucmd!()
         .arg("-l")

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -93,6 +93,28 @@ fn test_kill_list_one_signal_from_name() {
 }
 
 #[test]
+fn test_kill_list_two_signal_from_name() {
+    new_ucmd!()
+        .arg("-l")
+        .arg("INT")
+        .arg("KILL")
+        .succeeds()
+        .stdout_matches(&Regex::new("\\d\n\\d").unwrap());
+}
+
+#[test]
+fn test_kill_list_three_signal_first_unknown() {
+    new_ucmd!()
+        .arg("-l")
+        .arg("IAMNOTASIGNAL") // spell-checker:disable-line
+        .arg("INT")
+        .arg("KILL")
+        .fails()
+        .stderr_contains("unknown signal")
+        .stdout_matches(&Regex::new("\\d\n\\d").unwrap());
+}
+
+#[test]
 fn test_kill_set_bad_signal_name() {
     // spell-checker:disable-line
     new_ucmd!()


### PR DESCRIPTION
### Issue #6202

> ### Broken support for querying multiple signal names
> 
> ```
> $ ../gnu/src/kill --version | head -n1
> kill (GNU coreutils) 9.5
> $ ../gnu/src/kill -l SIGUSR1 SIGUSR2
> 10
> 12
> $ cargo run --all-features kill -l SIGUSR1 SIGUSR2
> 10
> $
> ```

### Changes

Multiple signal input support for --list command

```
$ cargo run --all-features kill -l SIGUSR1 SIGUSR2
10
12
```

Don't terminate and display error inline when signal is not recognized

```
$ cargo run --all-features kill -l SIGUSR3 SIGUSR2
kill: unknown signal name 'SIGUSR3'
12
```