### PR TITLE
feat(github): add CICD job build_programs_individually

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1047,3 +1047,23 @@ jobs:
         flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
         name: codecov-umbrella
         fail_ci_if_error: false
+
+  test_separately:
+    name: Separate Builds
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - name: build and test all programs individually
+      shell: bash
+      run: |
+        for f in $(util/show-utils.sh)
+        do
+          echo "Building and testing $f"
+          cargo test -p "uu_$f" || exit 1
+        done


### PR DESCRIPTION
This adds a rudimentary CI job for building the different programs individually by basically looping over a subset of the `cargo feature` output.

Would look like this: https://github.com/gierens/coreutils/actions/runs/8638198438/job/23682121436

![Screenshot from 2024-04-11 00-20-35](https://github.com/uutils/coreutils/assets/49617392/d04723a6-2a25-41bb-9c70-b76c068aca77)

Not sure if this is what you're looking for or rather some static list, I just stumbled across this issue and did something similar before. A future alternative could be cargo-all-features (https://github.com/frewsxcv/cargo-all-features) but unfortunately this is more for feature combinations and still lacks a few features thus would require a fork at the moment.

Resolves: #6097