### PR TITLE
kill: print --table as vertical

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -134,8 +134,8 @@ fn handle_obsolete(args: &mut Vec<String>) -> Option<usize> {
 }
 
 fn table() {
-    for (idx, signal) in ALL_SIGNALS.iter().enumerate() {
-        println!("{0: >#2} {1}", idx + 1, signal);
+    for (idx, signal) in ALL_SIGNALS.iter().enumerate().skip(1) {
+        println!("{0: >#2} {1}", idx, signal);
     }
 }
 

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -134,7 +134,12 @@ fn handle_obsolete(args: &mut Vec<String>) -> Option<usize> {
 }
 
 fn table() {
-    for (idx, signal) in ALL_SIGNALS.iter().enumerate().skip(1) {
+    // GNU kill doesn't list the EXIT signal with --table, so we ignore it, too
+    for (idx, signal) in ALL_SIGNALS
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| **s != "EXIT")
+    {
         println!("{0: >#2} {1}", idx, signal);
     }
 }

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -137,12 +137,8 @@ fn table() {
     let name_width = ALL_SIGNALS.iter().map(|n| n.len()).max().unwrap();
 
     for (idx, signal) in ALL_SIGNALS.iter().enumerate() {
-        print!("{0: >#2} {1: <#2$}", idx, signal, name_width + 2);
-        if (idx + 1) % 7 == 0 {
-            println!();
-        }
+        println!("{0: >#2} {1: <#2$}", idx + 1, signal, name_width + 2);
     }
-    println!();
 }
 
 fn print_signal(signal_name_or_value: &str) -> UResult<()> {

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -134,10 +134,8 @@ fn handle_obsolete(args: &mut Vec<String>) -> Option<usize> {
 }
 
 fn table() {
-    let name_width = ALL_SIGNALS.iter().map(|n| n.len()).max().unwrap();
-
     for (idx, signal) in ALL_SIGNALS.iter().enumerate() {
-        println!("{0: >#2} {1: <#2$}", idx + 1, signal, name_width + 2);
+        println!("{0: >#2} {1}", idx + 1, signal);
     }
 }
 

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -87,7 +87,7 @@ fn test_kill_table_starts_at_1() {
     new_ucmd!()
         .arg("-t")
         .succeeds()
-        .stdout_matches(&Regex::new("^\\s?1").unwrap());
+        .stdout_matches(&Regex::new("^\\s?1\\sHUP").unwrap());
 }
 
 #[test]

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -83,6 +83,29 @@ fn test_kill_list_all_signals_as_table() {
 }
 
 #[test]
+fn test_kill_table_starts_at_1() {
+    new_ucmd!()
+        .arg("-t")
+        .succeeds()
+        .stdout_matches(&Regex::new("^\\s?1").unwrap());
+}
+
+#[test]
+fn test_kill_table_lists_all_vertically() {
+    // Check for a few signals.  Do not try to be comprehensive.
+    let command = new_ucmd!().arg("-t").succeeds();
+    let signals = command
+        .stdout_str()
+        .split('\n')
+        .flat_map(|line| line.trim().split(" ").nth(1))
+        .collect::<Vec<&str>>();
+
+    assert!(signals.contains(&"KILL"));
+    assert!(signals.contains(&"TERM"));
+    assert!(signals.contains(&"HUP"));
+}
+
+#[test]
 fn test_kill_list_one_signal_from_name() {
     // Use SIGKILL because it is 9 on all unixes.
     new_ucmd!()


### PR DESCRIPTION
### Issue #6202 

> ### Table (-L) format is wrong
> 
> Should be an actual table, not a grid
> 
> ```
> --- STDOUT_GNU	2024-04-07 19:12:25.820911283 +0200
> +++ STDOUT_UUTILS	2024-04-07 19:12:25.824911280 +0200
> @@ -1,62 +1,5 @@
> - 1 HUP      Hangup
> - 2 INT      Interrupt
> - 3 QUIT     Quit
> - 4 ILL      Illegal instruction
> - 5 TRAP     Trace/breakpoint trap
> - 6 ABRT     Aborted
> - 7 BUS      Bus error
> - 8 FPE      Floating point exception
> - 9 KILL     Killed
> -10 USR1     User defined signal 1
> -11 SEGV     Segmentation fault
> -12 USR2     User defined signal 2
> -13 PIPE     Broken pipe
> -14 ALRM     Alarm clock
> -15 TERM     Terminated
> -16 STKFLT   Stack fault
> -17 CHLD     Child exited
> -18 CONT     Continued
> -19 STOP     Stopped (signal)
> -20 TSTP     Stopped
> -21 TTIN     Stopped (tty input)
> -22 TTOU     Stopped (tty output)
> -23 URG      Urgent I/O condition
> -24 XCPU     CPU time limit exceeded
> -25 XFSZ     File size limit exceeded
> -26 VTALRM   Virtual timer expired
> -27 PROF     Profiling timer expired
> -28 WINCH    Window changed
> -29 POLL     I/O possible
> -30 PWR      Power failure
> -31 SYS      Bad system call
> -34 RTMIN    Real-time signal 0
> -35 RTMIN+1  Real-time signal 1
> -36 RTMIN+2  Real-time signal 2
> -37 RTMIN+3  Real-time signal 3
> -38 RTMIN+4  Real-time signal 4
> -39 RTMIN+5  Real-time signal 5
> -40 RTMIN+6  Real-time signal 6
> -41 RTMIN+7  Real-time signal 7
> -42 RTMIN+8  Real-time signal 8
> -43 RTMIN+9  Real-time signal 9
> -44 RTMIN+10 Real-time signal 10
> -45 RTMIN+11 Real-time signal 11
> -46 RTMIN+12 Real-time signal 12
> -47 RTMIN+13 Real-time signal 13
> -48 RTMIN+14 Real-time signal 14
> -49 RTMIN+15 Real-time signal 15
> -50 RTMAX-14 Real-time signal 16
> -51 RTMAX-13 Real-time signal 17
> -52 RTMAX-12 Real-time signal 18
> -53 RTMAX-11 Real-time signal 19
> -54 RTMAX-10 Real-time signal 20
> -55 RTMAX-9  Real-time signal 21
> -56 RTMAX-8  Real-time signal 22
> -57 RTMAX-7  Real-time signal 23
> -58 RTMAX-6  Real-time signal 24
> -59 RTMAX-5  Real-time signal 25
> -60 RTMAX-4  Real-time signal 26
> -61 RTMAX-3  Real-time signal 27
> -62 RTMAX-2  Real-time signal 28
> -63 RTMAX-1  Real-time signal 29
> -64 RTMAX    Real-time signal 30
> + 0 EXIT     1 HUP      2 INT      3 QUIT     4 ILL      5 TRAP     6 ABRT    
> + 7 BUS      8 FPE      9 KILL    10 USR1    11 SEGV    12 USR2    13 PIPE    
> +14 ALRM    15 TERM    16 STKFLT  17 CHLD    18 CONT    19 STOP    20 TSTP    
> +21 TTIN    22 TTOU    23 URG     24 XCPU    25 XFSZ    26 VTALRM  27 PROF    
> +28 WINCH   29 POLL    30 PWR     31 SYS     
> ```

This PR changes the --table output to be vertical but does not add the signal descriptions.