### PR TITLE
kill: don't show `EXIT` with `--list`

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -162,7 +162,8 @@ fn print_signal(signal_name_or_value: &str) -> UResult<()> {
 }
 
 fn print_signals() {
-    for signal in ALL_SIGNALS.iter() {
+    // GNU kill doesn't list the EXIT signal with --list, so we ignore it, too
+    for signal in ALL_SIGNALS.iter().filter(|x| **x != "EXIT") {
         println!("{signal}");
     }
 }

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -62,7 +62,8 @@ fn test_kill_list_all_signals() {
         .succeeds()
         .stdout_contains("KILL")
         .stdout_contains("TERM")
-        .stdout_contains("HUP");
+        .stdout_contains("HUP")
+        .stdout_does_not_contain("EXIT");
 }
 
 #[test]


### PR DESCRIPTION
GNU `kill` doesn't list the `EXIT` signal when using `--list` whereas uutils `kill` does. This PR removes `EXIT` from the output of `--list`.