### PR TITLE
CI fix: use features arg for stable and nightly build

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -309,7 +309,7 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.4
     - name: Test
-      run: cargo nextest run --hide-progress-bar --profile ci ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      run: cargo nextest run --hide-progress-bar --profile ci --features ${{ matrix.job.features }}
       env:
         RUST_BACKTRACE: "1"
 
@@ -336,7 +336,7 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.4
     - name: Test
-      run: cargo nextest run --hide-progress-bar --profile ci ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      run: cargo nextest run --hide-progress-bar --profile ci --features ${{ matrix.job.features }}
       env:
         RUST_BACKTRACE: "1"
 


### PR DESCRIPTION
I stumbled across the issue that the nightly and stable builds in CICD.yml where not properly providing the "--features" arg. I think it was probably an issue with copy-paste, as the code on a different place in the yml works.

![grafik](https://github.com/uutils/coreutils/assets/252806/bfc3fc45-5d95-4a0b-a93d-a0ca9beaeec2)

After change:

![grafik](https://github.com/uutils/coreutils/assets/252806/abdf869d-8b51-4bef-a13f-28495debb29b)

