### PR TITLE
kill: return 1 and gnu style stderr in case of no pid

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -68,7 +68,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 Err(USimpleError::new(
                     1,
                     "no process ID specified\n\
-                              Try --help for more information.",
+                     Try --help for more information.",
                 ))
             } else {
                 kill(sig, &pids);

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -64,8 +64,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 .try_into()
                 .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
             let pids = parse_pids(&pids_or_signals)?;
-            kill(sig, &pids);
-            Ok(())
+            if pids.is_empty() {
+                Err(USimpleError::new(
+                    1,
+                    "no process ID specified\n\
+                              Try --help for more information.",
+                ))
+            } else {
+                kill(sig, &pids);
+                Ok(())
+            }
         }
         Mode::Table => {
             table();

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -203,3 +203,11 @@ fn test_kill_with_signal_prefixed_name_new_form() {
         .succeeds();
     assert_eq!(target.wait_for_signal(), Some(libc::SIGKILL));
 }
+
+#[test]
+fn test_kill_no_pid_provided() {
+    // spell-checker:disable-line
+    new_ucmd!()
+        .fails()
+        .stderr_contains("no process ID specified");
+}


### PR DESCRIPTION
including a new test for "no pid provided" use case.

closes #6221