### PR TITLE
kill: accept all cases for signal names

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -154,7 +154,9 @@ fn table() {
 
 fn print_signal(signal_name_or_value: &str) -> UResult<()> {
     for (value, &signal) in ALL_SIGNALS.iter().enumerate() {
-        if signal == signal_name_or_value || (format!("SIG{signal}")) == signal_name_or_value {
+        if signal.eq_ignore_ascii_case(signal_name_or_value)
+            || format!("SIG{signal}").eq_ignore_ascii_case(signal_name_or_value)
+        {
             println!("{value}");
             return Ok(());
         } else if signal_name_or_value == value.to_string() {

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -190,7 +190,8 @@ fn list(signals: &Vec<String>) {
 }
 
 fn parse_signal_value(signal_name: &str) -> UResult<usize> {
-    let optional_signal_value = signal_by_name_or_value(signal_name);
+    let signal_name_upcase = signal_name.to_uppercase();
+    let optional_signal_value = signal_by_name_or_value(&signal_name_upcase);
     match optional_signal_value {
         Some(x) => Ok(x),
         None => Err(USimpleError::new(

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -117,6 +117,25 @@ fn test_kill_list_one_signal_from_name() {
 }
 
 #[test]
+fn test_kill_list_one_signal_ignore_case() {
+    // Use SIGKILL because it is 9 on all unixes.
+    new_ucmd!()
+        .arg("-l")
+        .arg("KiLl")
+        .succeeds()
+        .stdout_matches(&Regex::new("\\b9\\b").unwrap());
+}
+
+#[test]
+fn test_kill_list_unknown_must_match_input_case() {
+    new_ucmd!()
+        .arg("-l")
+        .arg("IaMnOtAsIgNaL") // spell-checker:disable-line
+        .fails()
+        .stderr_contains("IaMnOtAsIgNaL"); // spell-checker:disable-line
+}
+
+#[test]
 fn test_kill_list_all_vertically() {
     // Check for a few signals.  Do not try to be comprehensive.
     let command = new_ucmd!().arg("-l").succeeds();

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -237,6 +237,17 @@ fn test_kill_with_signal_name_new_form() {
 }
 
 #[test]
+fn test_kill_with_signal_name_new_form_ignore_case() {
+    let mut target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("KiLl")
+        .arg(format!("{}", target.pid()))
+        .succeeds();
+    assert_eq!(target.wait_for_signal(), Some(libc::SIGKILL));
+}
+
+#[test]
 fn test_kill_with_signal_prefixed_name_new_form() {
     let mut target = Target::new();
     new_ucmd!()
@@ -245,6 +256,29 @@ fn test_kill_with_signal_prefixed_name_new_form() {
         .arg(format!("{}", target.pid()))
         .succeeds();
     assert_eq!(target.wait_for_signal(), Some(libc::SIGKILL));
+}
+
+#[test]
+fn test_kill_with_signal_prefixed_name_new_form_ignore_case() {
+    let mut target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("SiGKiLl")
+        .arg(format!("{}", target.pid()))
+        .succeeds();
+    assert_eq!(target.wait_for_signal(), Some(libc::SIGKILL));
+}
+
+#[test]
+fn test_kill_with_signal_name_new_form_unknown_must_match_input_case() {
+    let target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("IaMnOtAsIgNaL") // spell-checker:disable-line
+        .arg(format!("{}", target.pid()))
+        .fails()
+        .stderr_contains("unknown signal")
+        .stderr_contains("IaMnOtAsIgNaL"); // spell-checker:disable-line
 }
 
 #[test]


### PR DESCRIPTION
This PR updates the signal name comparison to work with all cases. The changes are effective on `--list` and `--signal` commands.

```
$ cargo run --features kill kill -l sIgUsR2
12
[$? = 1]
$ kill -l sIgUsR2 # bash built-in
12
$ /usr/bin/kill -l sIgUsR2 # Debian procps-ng 4.0.4
12
```

Fixes #6217