### PR TITLE
swap `cp`’s short `-r` and alias `-R` recursive options

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -475,8 +475,8 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::RECURSIVE)
-                .short('r')
-                .visible_short_alias('R')
+                .short('R')
+                .visible_short_alias('r')
                 .long(options::RECURSIVE)
                 // --archive sets this option
                 .help("copy directories recursively")


### PR DESCRIPTION
Replace `-r` with POSIX’s `-R` and vice versa in `cp`’s manpage to begin to fix  the only reparable part of [#6223](https://github.com/uutils/coreutils/issues/6223) pending changes to `clap` or to the adoption of `uutils-args`.