### PR TITLE
factor: remove unused method `zero`

### DIFF
--- a/src/uu/factor/src/numeric/montgomery.rs
+++ b/src/uu/factor/src/numeric/montgomery.rs
@@ -43,11 +43,9 @@ pub(crate) trait Arithmetic: Copy + Sized {
     fn one(&self) -> Self::ModInt {
         self.to_mod(1)
     }
+
     fn minus_one(&self) -> Self::ModInt {
         self.to_mod(self.modulus() - 1)
-    }
-    fn zero(&self) -> Self::ModInt {
-        self.to_mod(0)
     }
 }
 


### PR DESCRIPTION
This PR removes the unused method `zero` from the `Arithmetic` trait and thus fixes the "method is never used" warning in the nightly builds (see, for example, https://github.com/uutils/coreutils/actions/runs/8688432442/job/23824154227#step:7:111)