### PR TITLE
Fix warning when executing Clippy

### DIFF
--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -278,7 +278,7 @@ fn test_chmod_many_options() {
 #[test]
 #[allow(clippy::unreadable_literal)]
 fn test_chmod_reference_file() {
-    let tests = vec![
+    let tests = [
         TestCase {
             args: vec!["--reference", REFERENCE_FILE, TEST_FILE],
             before: 0o100070,

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -98,7 +98,7 @@ fn test_kill_table_lists_all_vertically() {
     let signals = command
         .stdout_str()
         .split('\n')
-        .flat_map(|line| line.trim().split(" ").nth(1))
+        .flat_map(|line| line.trim().split(' ').nth(1))
         .collect::<Vec<&str>>();
 
     assert!(signals.contains(&"KILL"));


### PR DESCRIPTION
Fix warning when executing Clippy