### PR TITLE
ci: use `-pcoreutils` when running clippy

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -49,11 +49,6 @@ jobs:
           *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
         esac;
         outputs FAIL_ON_FAULT FAULT_TYPE
-        # target-specific options
-        # * CARGO_FEATURES_OPTION
-        CARGO_FEATURES_OPTION='' ;
-        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
-        outputs CARGO_FEATURES_OPTION
     - name: "`cargo fmt` testing"
       shell: bash
       run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -99,23 +99,6 @@ jobs:
           *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
         esac;
         outputs FAIL_ON_FAULT FAULT_TYPE
-        # target-specific options
-        # * CARGO_FEATURES_OPTION
-        CARGO_FEATURES_OPTION='--all-features' ;
-        if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features ${{ matrix.job.features }}' ; fi
-        outputs CARGO_FEATURES_OPTION
-        # * determine sub-crate utility list
-        UTILITY_LIST="$(./util/show-utils.sh ${CARGO_FEATURES_OPTION})"
-        echo UTILITY_LIST=${UTILITY_LIST}
-        CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo -n "-puu_${u} "; done;)"
-        outputs CARGO_UTILITY_LIST_OPTIONS
-    - name: Install/setup prerequisites
-      shell: bash
-      run: |
-        ## Install/setup prerequisites
-        case '${{ matrix.job.os }}' in
-          macos-latest) brew install coreutils ;; # needed for show-utils.sh
-        esac
     - name: "`cargo clippy` lint testing"
       uses: nick-fields/retry@v3
       with:
@@ -130,7 +113,7 @@ jobs:
           fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
           fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
           # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-          S=$(cargo clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_UTILITY_LIST_OPTIONS }} -- ${CLIPPY_FLAGS} -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
+          S=$(cargo clippy --all-targets --features ${{ matrix.job.features }} -pcoreutils -- ${CLIPPY_FLAGS} -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
           if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
   style_spellcheck:

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -606,3 +606,39 @@ fn apply_specified_env_vars(opts: &Options<'_>) {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     EnvAppData::default().run_env(args)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_string_environment_vars_test() {
+        std::env::set_var("FOO", "BAR");
+        assert_eq!(
+            NCvt::convert(vec!["FOO=bar", "sh", "-c", "echo xBARx =$FOO="]),
+            parse_args_from_str(&NCvt::convert(r#"FOO=bar sh -c "echo x${FOO}x =\$FOO=""#))
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_split_string_misc() {
+        assert_eq!(
+            NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
+            parse_args_from_str(&NCvt::convert(r#"A=B FOO=AR  sh -c "echo \$A\$FOO""#)).unwrap(),
+        );
+        assert_eq!(
+            NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
+            parse_args_from_str(&NCvt::convert(r#"A=B FOO=AR  sh -c 'echo $A$FOO'"#)).unwrap()
+        );
+        assert_eq!(
+            NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
+            parse_args_from_str(&NCvt::convert(r#"A=B FOO=AR  sh -c 'echo $A$FOO'"#)).unwrap()
+        );
+
+        assert_eq!(
+            NCvt::convert(vec!["-i", "A=B ' C"]),
+            parse_args_from_str(&NCvt::convert(r#"-i A='B \' C'"#)).unwrap()
+        );
+    }
+}

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -471,7 +471,7 @@ fn test_chown_fail_id() {
 #[test]
 fn test_chown_only_user_id_nonexistent_user() {
     let ts = TestScenario::new(util_name!());
-    let at = ts.fixtures.clone();
+    let at = &ts.fixtures;
     at.touch("f");
     if let Ok(result) = run_ucmd_as_root(&ts, &["12345", "f"]) {
         result.success().no_stdout().no_stderr();
@@ -537,7 +537,7 @@ fn test_chown_only_group_id() {
 #[test]
 fn test_chown_only_group_id_nonexistent_group() {
     let ts = TestScenario::new(util_name!());
-    let at = ts.fixtures.clone();
+    let at = &ts.fixtures;
     at.touch("f");
     if let Ok(result) = run_ucmd_as_root(&ts, &[":12345", "f"]) {
         result.success().no_stdout().no_stderr();

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -165,7 +165,7 @@ fn test_chroot_skip_chdir_not_root() {
 #[test]
 fn test_chroot_skip_chdir() {
     let ts = TestScenario::new(util_name!());
-    let at = ts.fixtures.clone();
+    let at = &ts.fixtures;
     let dirs = ["/", "/.", "/..", "isroot"];
     at.symlink_file("/", "isroot");
     for dir in dirs {

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -7,7 +7,6 @@
 #[cfg(target_os = "linux")]
 use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
-use env::native_int_str::{Convert, NCvt};
 use regex::Regex;
 use std::env;
 use std::path::Path;
@@ -471,40 +470,6 @@ fn test_gnu_e20() {
 
     let out = scene.ucmd().args(&input).succeeds();
     assert_eq!(out.stdout_str(), output);
-}
-
-#[test]
-fn test_split_string_misc() {
-    use env::native_int_str::NCvt;
-    use env::parse_args_from_str;
-
-    assert_eq!(
-        NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
-        parse_args_from_str(&NCvt::convert(r#"A=B FOO=AR  sh -c "echo \$A\$FOO""#)).unwrap(),
-    );
-    assert_eq!(
-        NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
-        parse_args_from_str(&NCvt::convert(r#"A=B FOO=AR  sh -c 'echo $A$FOO'"#)).unwrap()
-    );
-    assert_eq!(
-        NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
-        parse_args_from_str(&NCvt::convert(r#"A=B FOO=AR  sh -c 'echo $A$FOO'"#)).unwrap()
-    );
-
-    assert_eq!(
-        NCvt::convert(vec!["-i", "A=B ' C"]),
-        parse_args_from_str(&NCvt::convert(r#"-i A='B \' C'"#)).unwrap()
-    );
-}
-
-#[test]
-fn test_split_string_environment_vars_test() {
-    std::env::set_var("FOO", "BAR");
-    assert_eq!(
-        NCvt::convert(vec!["FOO=bar", "sh", "-c", "echo xBARx =$FOO="]),
-        ::env::parse_args_from_str(&NCvt::convert(r#"FOO=bar sh -c "echo x${FOO}x =\$FOO=""#))
-            .unwrap(),
-    );
 }
 
 #[macro_export]

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -7,7 +7,7 @@
 #[cfg(target_os = "linux")]
 use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
-use ::env::native_int_str::{Convert, NCvt};
+use env::native_int_str::{Convert, NCvt};
 use regex::Regex;
 use std::env;
 use std::path::Path;
@@ -475,8 +475,8 @@ fn test_gnu_e20() {
 
 #[test]
 fn test_split_string_misc() {
-    use ::env::native_int_str::NCvt;
-    use ::env::parse_args_from_str;
+    use env::native_int_str::NCvt;
+    use env::parse_args_from_str;
 
     assert_eq!(
         NCvt::convert(vec!["A=B", "FOO=AR", "sh", "-c", "echo $A$FOO"]),
@@ -692,13 +692,13 @@ fn test_env_overwrite_arg0() {
 fn test_env_arg_argv0_overwrite() {
     let ts = TestScenario::new(util_name!());
 
-    let bin = ts.bin_path.clone();
+    let bin = &ts.bin_path;
 
     // overwrite --argv0 by --argv0
     ts.ucmd()
         .args(&["--argv0", "dirname"])
         .args(&["--argv0", "echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -708,7 +708,7 @@ fn test_env_arg_argv0_overwrite() {
     ts.ucmd()
         .args(&["-a", "dirname"])
         .args(&["-a", "echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -718,7 +718,7 @@ fn test_env_arg_argv0_overwrite() {
     ts.ucmd()
         .args(&["--argv0", "dirname"])
         .args(&["-a", "echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -728,7 +728,7 @@ fn test_env_arg_argv0_overwrite() {
     ts.ucmd()
         .args(&["-a", "dirname"])
         .args(&["--argv0", "echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -740,13 +740,13 @@ fn test_env_arg_argv0_overwrite() {
 fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
     let ts = TestScenario::new(util_name!());
 
-    let bin = ts.bin_path.clone();
+    let bin = &ts.bin_path;
 
     // string arg following normal
     ts.ucmd()
         .args(&["-S--argv0 dirname"])
         .args(&["--argv0", "echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -756,7 +756,7 @@ fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
     ts.ucmd()
         .args(&["-a", "dirname"])
         .args(&["-S-a echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -765,7 +765,7 @@ fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
     // one large string arg
     ts.ucmd()
         .args(&["-S--argv0 dirname -a echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -775,7 +775,7 @@ fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
     ts.ucmd()
         .args(&["-S-a dirname"])
         .args(&["-S--argv0 echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -786,7 +786,7 @@ fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
         .args(&["-a", "sleep"])
         .args(&["-S-a dirname"])
         .args(&["-a", "echo"])
-        .arg(&bin)
+        .arg(bin)
         .args(&["aa/bb/cc"])
         .succeeds()
         .stdout_is("aa/bb/cc\n")
@@ -916,8 +916,8 @@ mod tests_split_iterator {
 
     use std::ffi::OsString;
 
-    use ::env::parse_error::ParseError;
     use env::native_int_str::{from_native_int_representation_owned, Convert, NCvt};
+    use env::parse_error::ParseError;
 
     fn split(input: &str) -> Result<Vec<OsString>, ParseError> {
         ::env::split_iterator::split(&NCvt::convert(input)).map(|vec| {

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -1689,7 +1689,7 @@ fn test_target_file_ends_with_slash() {
 #[test]
 fn test_install_root_combined() {
     let ts = TestScenario::new(util_name!());
-    let at = ts.fixtures.clone();
+    let at = &ts.fixtures;
     at.touch("a");
     at.touch("c");
 


### PR DESCRIPTION
While looking at https://github.com/uutils/coreutils/pull/6246 I wondered why those clippy warnings were not caught by our CI. <del>The reason is probably that `${{ matrix.job.cargo-options }}` is never defined and so I replaced it with `${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}`.</del> <del>I couldn't figure out the reason and my two attempts to make the CI fail on those warnings failed. And so this PR is just about removing the undefined `${{ matrix.job.cargo-options }}`.</del> It looks like the reason is that we select the utils for the specific platform and then run clippy on those  packages (which don't contain the tests). By running clippy on the `coreutils` package with the `--features` flag, the tests are also checked by clippy.