### PR TITLE
multicall: add --list to list all utils

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -90,13 +90,20 @@ fn main() {
             None => not_found(&util_os),
         };
 
-        if util == "completion" {
-            gen_completions(args, &utils);
-        }
-
-        if util == "manpage" {
-            gen_manpage(args, &utils);
-        }
+        match util {
+            "completion" => gen_completions(args, &utils),
+            "manpage" => gen_manpage(args, &utils),
+            "--list" => {
+                let mut utils: Vec<_> = utils.keys().collect();
+                utils.sort();
+                for util in utils {
+                    println!("{util}");
+                }
+                process::exit(0);
+            }
+            // Not a special command: fallthrough to calling a util
+            _ => {}
+        };
 
         match utils.get(util) {
             Some(&(uumain, _)) => {


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/6250

I've implemented it more or less like the busybox version now, by just matching on the string `--list`. Ultimately, we might want to go for more sophisticated argument parsing in the multicall binary.

It is a bit strange though, because all the other things that the multicall binary can do are implemented as subcommands. In other words, one of these is not like the others:
```
coreutils completion
coreutils manpage
coreutils --list
```
I think using `--` makes sense to clearly separate it from the utils. Maybe `completion` and `manpage` should be prefixed with `--` too?