### PR TITLE
kill: adding support for handling SIGEXIT

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -60,7 +60,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             } else {
                 15_usize //SIGTERM
             };
+
             let sig_name = signal_name_by_value(sig);
+            // Signal does not support converting from SIGEXIT/0
+            // Instead, nix::signal::kill expects Option::None to properly handle SIGEXIT
             let sig: Option<Signal> = if sig_name.is_some_and(|name| name == "EXIT") {
                 None
             } else {

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -62,8 +62,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             };
 
             let sig_name = signal_name_by_value(sig);
-            // Signal does not support converting from SIGEXIT/0
-            // Instead, nix::signal::kill expects Option::None to properly handle SIGEXIT
+            // Signal does not support converting from EXIT
+            // Instead, nix::signal::kill expects Option::None to properly handle EXIT
             let sig: Option<Signal> = if sig_name.is_some_and(|name| name == "EXIT") {
                 None
             } else {

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -288,3 +288,13 @@ fn test_kill_no_pid_provided() {
         .fails()
         .stderr_contains("no process ID specified");
 }
+
+#[test]
+fn test_kill_with_signal_exit_new_form() {
+    let mut target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("EXIT")
+        .arg(format!("{}", target.pid()))
+        .succeeds();
+}

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -291,7 +291,7 @@ fn test_kill_no_pid_provided() {
 
 #[test]
 fn test_kill_with_signal_exit_new_form() {
-    let mut target = Target::new();
+    let target = Target::new();
     new_ucmd!()
         .arg("-s")
         .arg("EXIT")


### PR DESCRIPTION
Adding support for handling `SIGEXIT` as mentioned in [Issue-6628](https://github.com/uutils/coreutils/issues/6228).

Before this change the nix library would return an `EINVAL` when passing `SIGEXIT` / `EXIT` to uutils/coretutils kill.

After this change nix passes `0` to libc kill as shown [here](https://github.com/nix-rust/nix/blob/master/src/sys/signal.rs#L1068-L1073).