### PR TITLE
fix/CI ~ re-enable artifact deployment for version tagged commits

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
   push:
     tags:
+      - '*'
     branches:
       - main
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -541,6 +541,9 @@ jobs:
         PKG_BASENAME=${PROJECT_NAME}-${REF_TAG:-$REF_SHAS}-${{ matrix.job.target }}
         PKG_NAME=${PKG_BASENAME}${PKG_suffix}
         outputs PKG_suffix PKG_BASENAME PKG_NAME
+        # deployable tag? (ie, leading "vM" or "M"; M == version number)
+        unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
+        outputs DEPLOY
         # DPKG architecture?
         unset DPKG_ARCH
         case ${{ matrix.job.target }} in
@@ -746,7 +749,7 @@ jobs:
         fi
     - name: Publish
       uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
+      if: steps.vars.outputs.DEPLOY
       with:
         files: |
           ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}


### PR DESCRIPTION
This is a simple one-line fix of *CICD.yaml* to re-enable artifact creation for version tagged commits.
It does include a revert of https://github.com/uutils/coreutils/issues/6181 so that only version-type tags trigger deployment.

I've done testing on [a repo clone](https://github.com/rivy-t/rs.coreutils), so I'm 90% confident. 😄

If it doesn't work on the next release, ping me and I'll further debug it.

@sylvestre , the deployment does always create a release even if there's a draft release with the same title/version, so you'll have to copy any draft release text over to the actual release. Has that been your release practice in the past?

Fixes https://github.com/uutils/coreutils/issues/5929.