### PR TITLE
android CI: incremental install when retry

### DIFF
--- a/util/android-commands.sh
+++ b/util/android-commands.sh
@@ -515,7 +515,10 @@ snapshot() {
 
     echo "Installing cargo-nextest"
     # We need to install nextest via cargo currently, since there is no pre-built binary for android x86
-    command="export CARGO_TERM_COLOR=always && cargo install cargo-nextest"
+    # explicitly set CARGO_TARGET_DIR as otherwise a random generated tmp directory is used,
+    # which prevents incremental build for the retries.
+    command="export CARGO_TERM_COLOR=always && export CARGO_TARGET_DIR=\"cargo_install_target_dir\" && cargo install cargo-nextest"
+
     run_with_retry 3 run_command_via_ssh "$command"
     return_code=$?
 


### PR DESCRIPTION
I stumbled accross this by chance. When the install step was retried, it started from scratch again.
This PR enables the reuse of build artefacts from previous try.
This done by explicitly setting CARGO_TARGET_DIR env variable as otherwise a random generated tmp directory is used,
which prevents incremental build for the retries.