### PR TITLE
tests: fix multi-call test precondition

### DIFF
--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -194,6 +194,7 @@ fn util_invalid_name_invalid_command() {
 }
 
 #[test]
+#[cfg(feature = "true")]
 fn util_completion() {
     use std::{
         io::Write,
@@ -222,6 +223,7 @@ fn util_completion() {
 }
 
 #[test]
+#[cfg(feature = "true")]
 fn util_manpage() {
     use std::{
         io::Write,


### PR DESCRIPTION
This bug was introduced in de37baaf839bb41e2d388d4eb42a3e486458df1c.

Fixes #6273.

The underlying cause was that I assumed in #6198 that "Surely, the `true` command is ALWAYS available, no exceptions!", and of course there's an exception. Hence the need for a `#[cfg(…)]` gate.

I checked with `cargo test --features "cp" --no-default-features` and `cargo test --features "cp,true" --no-default-features`, and the tests don't run / run as intended now.

CC @cakebaker, can you verify that this works?