### PR TITLE
Bump bigdecimal from 0.4.0 to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,10 +120,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5274a6b6e0ee020148397245b973e30163b7bffbc6d473613f850cb99888581e"
+checksum = "c06619be423ea5bb86c95f087d5707942791a08a85530df0db2209a3ecfb8bc9"
 dependencies = [
+ "autocfg",
  "libm",
  "num-bigint",
  "num-integer",


### PR DESCRIPTION
This PR bumps `bigdecimal` from `0.4.0` to `0.4.2` as a (partial?) solution for https://github.com/uutils/coreutils/issues/6281. I didn't upgrade to `0.4.3` because it breaks a lot of `seq` tests and according to https://github.com/akubera/bigdecimal-rs/issues/127#issuecomment-2053739584 they will revert some of its changes in `0.4.4`:

> Version 0.4.3 changed the formatting in a way many people didn't like, so I'm changing formatting again for 0.4.4.