### PR TITLE
id: Handle repeated flags, recognize conflict between pretty-print and passwd file-entry

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -397,6 +397,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::OPT_PASSWORD)
                 .short('P')
                 .help("Display the id as a password file entry.")
+                .conflicts_with(options::OPT_HUMAN_READABLE)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -324,6 +324,7 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::OPT_AUDIT)
                 .short('A')

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -461,3 +461,16 @@ fn test_id_no_specified_user_posixly() {
         }
     }
 }
+
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_id_pretty_print_password_record() {
+    // `-p` is BSD only and not supported on GNU's `id`.
+    // `-P` is our own extension, and not supported by either GNU nor BSD.
+    // These must conflict, because they both set the output format.
+    new_ucmd!()
+        .arg("-p")
+        .arg("-P")
+        .fails()
+        .stderr_contains("the argument '-p' cannot be used with '-P'");
+}

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -327,6 +327,11 @@ fn test_id_default_format() {
             .args(&args)
             .succeeds()
             .stdout_only(unwrap_or_return!(expected_result(&ts, &args)).stdout_str());
+        let args = [opt2, opt2];
+        ts.ucmd()
+            .args(&args)
+            .succeeds()
+            .stdout_only(unwrap_or_return!(expected_result(&ts, &args)).stdout_str());
     }
 }
 


### PR DESCRIPTION
This PR fixes argument-parsing for `id`, in particular:
- All arguments can now be repeated (this makes sense for all of them; I checked.)
- `-p` and `-P` both take control of the output format, so it does not make sense to specify both of them.

This is work toward #5998.