### PR TITLE
sort: disable clippy::suspicious_open_options on OpenBSD

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -252,7 +252,9 @@ impl Output {
         let file = if let Some(name) = name {
             // This is different from `File::create()` because we don't truncate the output yet.
             // This allows using the output file as an input file.
-            #[allow(clippy::suspicious_open_options)]
+            // clippy::suspicious_open_options supported only for Rust >= 1.77.0
+            // Rust version = 1.76 on OpenBSD stable/7.5
+            #[cfg_attr(not(target_os = "openbsd"), allow(clippy::suspicious_open_options))]
             let file = OpenOptions::new()
                 .write(true)
                 .create(true)


### PR DESCRIPTION
- Avoid error on OpenBSD stable/7.5 with clippy (lint)
- suspicious_open_options added in Rust 1.77.0 (1.76 used on OpenBSD 7.5) https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options

Fix uutils/coreutils#6290

Lint with `clippy` and build OK on OpenBSD stable/7.5 and FreeBSD 14.0 (Rust version 1.77).