### PR TITLE
everywhere: cleanup unused/unnecessary spellcheck-disabling

### DIFF
--- a/src/uu/tail/src/parse.rs
+++ b/src/uu/tail/src/parse.rs
@@ -32,7 +32,7 @@ pub enum ParseError {
     InvalidEncoding,
 }
 /// Parses obsolete syntax
-/// tail -\[NUM\]\[bcl\]\[f\] and tail +\[NUM\]\[bcl\]\[f\] // spell-checker:disable-line
+/// tail -\[NUM\]\[bcl\]\[f\] and tail +\[NUM\]\[bcl\]\[f\]
 pub fn parse_obsolete(src: &OsString) -> Option<Result<ObsoleteArgs, ParseError>> {
     let mut rest = match src.to_str() {
         Some(src) => src,

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -359,7 +359,7 @@ use libc::c_int;
 ))]
 extern "C" {
     #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
-    #[link_name = "getmntinfo$INODE64"] // spell-checker:disable-line
+    #[link_name = "getmntinfo$INODE64"]
     fn get_mount_info(mount_buffer_p: *mut *mut StatFs, flags: c_int) -> c_int;
 
     #[cfg(any(
@@ -367,14 +367,14 @@ extern "C" {
         target_os = "openbsd",
         all(target_vendor = "apple", target_arch = "aarch64")
     ))]
-    #[link_name = "getmntinfo"] // spell-checker:disable-line
+    #[link_name = "getmntinfo"]
     fn get_mount_info(mount_buffer_p: *mut *mut StatFs, flags: c_int) -> c_int;
 
     // Rust on FreeBSD uses 11.x ABI for filesystem metadata syscalls.
     // Call the right version of the symbol for getmntinfo() result to
     // match libc StatFS layout.
     #[cfg(target_os = "freebsd")]
-    #[link_name = "getmntinfo@FBSD_1.0"] // spell-checker:disable-line
+    #[link_name = "getmntinfo@FBSD_1.0"]
     fn get_mount_info(mount_buffer_p: *mut *mut StatFs, flags: c_int) -> c_int;
 }
 

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -70,7 +70,7 @@ fn test_multiple_param() {
         new_ucmd!()
             .args(&[multiple_param, path, path])
             .succeeds()
-            .stdout_only("baz\nbaz\n"); // spell-checker:disable-line
+            .stdout_only("baz\nbaz\n");
     }
 }
 
@@ -81,7 +81,7 @@ fn test_suffix_param() {
         new_ucmd!()
             .args(&[suffix_param, ".exe", path, path])
             .succeeds()
-            .stdout_only("baz\nbaz\n"); // spell-checker:disable-line
+            .stdout_only("baz\nbaz\n");
     }
 }
 

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -41,14 +41,14 @@ fn test_base64() {
         .pipe_in("to>be?")
         .succeeds()
         .no_stderr()
-        .stdout_only("dG8+YmU/\n"); // spell-checker:disable-line
+        .stdout_only("dG8+YmU/\n");
 }
 
 #[test]
 fn test_base64_decode() {
     new_ucmd!()
         .args(&["--base64", "-d"])
-        .pipe_in("dG8+YmU/") // spell-checker:disable-line
+        .pipe_in("dG8+YmU/")
         .succeeds()
         .no_stderr()
         .stdout_only("to>be?");
@@ -61,14 +61,14 @@ fn test_base64url() {
         .pipe_in("to>be?")
         .succeeds()
         .no_stderr()
-        .stdout_only("dG8-YmU_\n"); // spell-checker:disable-line
+        .stdout_only("dG8-YmU_\n");
 }
 
 #[test]
 fn test_base64url_decode() {
     new_ucmd!()
         .args(&["--base64url", "-d"])
-        .pipe_in("dG8-YmU_") // spell-checker:disable-line
+        .pipe_in("dG8-YmU_")
         .succeeds()
         .no_stderr()
         .stdout_only("to>be?");

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore NOFILE
+// spell-checker:ignore NOFILE nonewline
 
 #[cfg(not(windows))]
 use crate::common::util::vec_of_size;
@@ -23,7 +23,6 @@ fn test_output_simple() {
 
 #[test]
 fn test_no_options() {
-    // spell-checker:disable-next-line
     for fixture in ["empty.txt", "alpha.txt", "nonewline.txt"] {
         // Give fixture through command line file argument
         new_ucmd!()
@@ -196,7 +195,6 @@ fn test_directory() {
 fn test_directory_and_file() {
     let s = TestScenario::new(util_name!());
     s.fixtures.mkdir("test_directory2");
-    // spell-checker:disable-next-line
     for fixture in ["empty.txt", "alpha.txt", "nonewline.txt"] {
         s.ucmd()
             .args(&["test_directory2", fixture])
@@ -219,7 +217,7 @@ fn test_three_directories_and_file_and_stdin() {
             "alpha.txt",
             "-",
             "file_which_does_not_exist.txt",
-            "nonewline.txt", // spell-checker:disable-line
+            "nonewline.txt",
             "test_directory3/test_directory5",
             "test_directory3/../test_directory3/test_directory5",
             "test_directory3",

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -130,9 +130,9 @@ fn test_kill_list_one_signal_ignore_case() {
 fn test_kill_list_unknown_must_match_input_case() {
     new_ucmd!()
         .arg("-l")
-        .arg("IaMnOtAsIgNaL") // spell-checker:disable-line
+        .arg("IaMnOtAsIgNaL")
         .fails()
-        .stderr_contains("IaMnOtAsIgNaL"); // spell-checker:disable-line
+        .stderr_contains("IaMnOtAsIgNaL");
 }
 
 #[test]
@@ -169,7 +169,6 @@ fn test_kill_list_three_signal_first_unknown() {
 
 #[test]
 fn test_kill_set_bad_signal_name() {
-    // spell-checker:disable-line
     new_ucmd!()
         .arg("-s")
         .arg("IAMNOTASIGNAL") // spell-checker:disable-line
@@ -274,16 +273,15 @@ fn test_kill_with_signal_name_new_form_unknown_must_match_input_case() {
     let target = Target::new();
     new_ucmd!()
         .arg("-s")
-        .arg("IaMnOtAsIgNaL") // spell-checker:disable-line
+        .arg("IaMnOtAsIgNaL")
         .arg(format!("{}", target.pid()))
         .fails()
         .stderr_contains("unknown signal")
-        .stderr_contains("IaMnOtAsIgNaL"); // spell-checker:disable-line
+        .stderr_contains("IaMnOtAsIgNaL");
 }
 
 #[test]
 fn test_kill_no_pid_provided() {
-    // spell-checker:disable-line
     new_ucmd!()
         .fails()
         .stderr_contains("no process ID specified");

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2283,7 +2283,7 @@ fn test_ls_indicator_style() {
         "--ind=slash",
         "--classify",
         "--classify=always",
-        "--classify=alway", // spell-checker:disable-line
+        "--classify=alway",
         "--classify=al",
         "--classify=yes",
         "--classify=force",
@@ -4327,7 +4327,7 @@ fn test_ls_hyperlink() {
     for argument in [
         "--hyperlink=never",
         "--hyperlink=neve", // spell-checker:disable-line
-        "--hyperlink=ne",   // spell-checker:disable-line
+        "--hyperlink=ne",
         "--hyperlink=n",
     ] {
         scene

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -21,8 +21,8 @@ static TEST_TEMPLATE2: &str = "temp";
 static TEST_TEMPLATE3: &str = "tempX";
 static TEST_TEMPLATE4: &str = "tempXX";
 static TEST_TEMPLATE5: &str = "tempXXX";
-static TEST_TEMPLATE6: &str = "tempXXXlate"; // spell-checker:disable-line
-static TEST_TEMPLATE7: &str = "XXXtemplate"; // spell-checker:disable-line
+static TEST_TEMPLATE6: &str = "tempXXXlate";
+static TEST_TEMPLATE7: &str = "XXXtemplate";
 #[cfg(unix)]
 static TEST_TEMPLATE8: &str = "tempXXXl/ate";
 #[cfg(windows)]

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -550,7 +550,7 @@ fn test_delimiter_with_padding_and_fields() {
 fn test_round() {
     for (method, exp) in [
         ("from-zero", ["9.1K", "-9.1K", "9.1K", "-9.1K"]),
-        ("from-zer", ["9.1K", "-9.1K", "9.1K", "-9.1K"]), // spell-checker:disable-line
+        ("from-zer", ["9.1K", "-9.1K", "9.1K", "-9.1K"]),
         ("f", ["9.1K", "-9.1K", "9.1K", "-9.1K"]),
         ("towards-zero", ["9.0K", "-9.0K", "9.0K", "-9.0K"]),
         ("up", ["9.1K", "-9.0K", "9.1K", "-9.0K"]),

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -60,7 +60,7 @@ fn test_file() {
 #[test]
 fn test_2files() {
     let (at, mut ucmd) = at_and_ucmd!();
-    at.write("test1", "abcdefghijklmnop"); // spell-checker:disable-line
+    at.write("test1", "abcdefghijklmnop");
     at.write("test2", "qrstuvwxyz\n"); // spell-checker:disable-line
     ucmd.arg("--endian=little")
         .arg("test1")
@@ -74,13 +74,13 @@ fn test_2files() {
 #[test]
 fn test_no_file() {
     let (_at, mut ucmd) = at_and_ucmd!();
-    ucmd.arg("}surely'none'would'thus'a'file'name").fails(); // spell-checker:disable-line
+    ucmd.arg("}surely'none'would'thus'a'file'name").fails();
 }
 
 // Test that od reads from stdin instead of a file
 #[test]
 fn test_from_stdin() {
-    let input = "abcdefghijklmnopqrstuvwxyz\n"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopqrstuvwxyz\n";
     new_ucmd!()
         .arg("--endian=little")
         .run_piped_stdin(input.as_bytes())
@@ -110,7 +110,7 @@ fn test_from_mixed() {
 
 #[test]
 fn test_multiple_formats() {
-    let input = "abcdefghijklmnopqrstuvwxyz\n"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopqrstuvwxyz\n";
     new_ucmd!()
         .arg("-c")
         .arg("-b")
@@ -581,7 +581,7 @@ fn test_invalid_offset() {
 
 #[test]
 fn test_skip_bytes() {
-    let input = "abcdefghijklmnopq"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopq";
     new_ucmd!()
         .arg("-c")
         .arg("--skip-bytes=5")
@@ -598,7 +598,7 @@ fn test_skip_bytes() {
 
 #[test]
 fn test_skip_bytes_hex() {
-    let input = "abcdefghijklmnopq"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopq";
     new_ucmd!()
         .arg("-c")
         .arg("--skip-bytes=0xB")
@@ -636,7 +636,7 @@ fn test_skip_bytes_error() {
 
 #[test]
 fn test_read_bytes() {
-    let input = "abcdefghijklmnopqrstuvwxyz\n12345678"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopqrstuvwxyz\n12345678";
     new_ucmd!()
         .arg("--endian=little")
         .arg("--read-bytes=27")
@@ -695,7 +695,7 @@ fn test_filename_parsing() {
 
 #[test]
 fn test_stdin_offset() {
-    let input = "abcdefghijklmnopq"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopq";
     new_ucmd!()
         .arg("-c")
         .arg("+5")
@@ -730,7 +730,7 @@ fn test_file_offset() {
 #[test]
 fn test_traditional() {
     // note gnu od does not align both lines
-    let input = "abcdefghijklmnopq"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopq";
     new_ucmd!()
         .arg("--traditional")
         .arg("-a")
@@ -753,7 +753,7 @@ fn test_traditional() {
 #[test]
 fn test_traditional_with_skip_bytes_override() {
     // --skip-bytes is ignored in this case
-    let input = "abcdefghijklmnop"; // spell-checker:disable-line
+    let input = "abcdefghijklmnop";
     new_ucmd!()
         .arg("--traditional")
         .arg("--skip-bytes=10")
@@ -773,7 +773,7 @@ fn test_traditional_with_skip_bytes_override() {
 #[test]
 fn test_traditional_with_skip_bytes_non_override() {
     // no offset specified in the traditional way, so --skip-bytes is used
-    let input = "abcdefghijklmnop"; // spell-checker:disable-line
+    let input = "abcdefghijklmnop";
     new_ucmd!()
         .arg("--traditional")
         .arg("--skip-bytes=10")
@@ -803,7 +803,7 @@ fn test_traditional_error() {
 
 #[test]
 fn test_traditional_only_label() {
-    let input = "abcdefghijklmnopqrstuvwxyz"; // spell-checker:disable-line
+    let input = "abcdefghijklmnopqrstuvwxyz";
     new_ucmd!()
         .arg("-An")
         .arg("--traditional")

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -521,10 +521,7 @@ fn sub_any_specifiers_after_period() {
 
 #[test]
 fn unspecified_left_justify_is_1_width() {
-    new_ucmd!()
-        .args(&["%-o"]) //spell-checker:disable-line
-        .succeeds()
-        .stdout_only("0");
+    new_ucmd!().args(&["%-o"]).succeeds().stdout_only("0");
 }
 
 #[test]
@@ -538,7 +535,7 @@ fn sub_any_specifiers_after_second_param() {
 #[test]
 fn stop_after_additional_escape() {
     new_ucmd!()
-        .args(&["A%sC\\cD%sF", "B", "E"]) //spell-checker:disable-line
+        .args(&["A%sC\\cD%sF", "B", "E"])
         .succeeds()
         .stdout_only("ABC");
 }

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -353,7 +353,7 @@ fn test_relative() {
     new_ucmd!()
         .args(&["-sm", "--relative-base=/", "--relative-to=/", "/", "/usr"])
         .succeeds()
-        .stdout_is(".\nusr\n"); // spell-checker:disable-line
+        .stdout_is(".\nusr\n");
 
     let result = new_ucmd!()
         .args(&["-sm", "--relative-base=/usr", "/tmp", "/usr"])
@@ -366,7 +366,7 @@ fn test_relative() {
     new_ucmd!()
         .args(&["-sm", "--relative-base=/", "/", "/usr"])
         .succeeds()
-        .stdout_is(".\nusr\n"); // spell-checker:disable-line
+        .stdout_is(".\nusr\n");
 }
 
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -132,7 +132,7 @@ fn test_months_whitespace() {
             "-M",
             "--month-sort",
             "--sort=month",
-            "--sort=mont", // spell-checker:disable-line
+            "--sort=mont",
             "--sort=m",
         ],
     );

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -124,10 +124,10 @@ fn test_complement2() {
 #[test]
 fn test_complement3() {
     new_ucmd!()
-        .args(&["-c", "abcdefgh", "123"]) // spell-checker:disable-line
+        .args(&["-c", "abcdefgh", "123"])
         .pipe_in("the cat and the bat")
         .run()
-        .stdout_is("3he3ca33a3d33he3ba3"); // spell-checker:disable-line
+        .stdout_is("3he3ca33a3d33he3ba3");
 }
 
 #[test]
@@ -291,7 +291,7 @@ fn test_set1_shorter_than_set2() {
         .args(&["ab", "xyz"])
         .pipe_in("abcde")
         .run()
-        .stdout_is("xycde"); // spell-checker:disable-line
+        .stdout_is("xycde");
 }
 
 #[test]
@@ -301,7 +301,7 @@ fn test_truncate() {
         .args(&["-t", "abc", "xy"])
         .pipe_in("abcde")
         .succeeds()
-        .stdout_is("xycde"); // spell-checker:disable-line
+        .stdout_is("xycde");
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn test_truncate_multi() {
         .args(&["-tt", "-t", "abc", "xy"])
         .pipe_in("abcde")
         .succeeds()
-        .stdout_is("xycde"); // spell-checker:disable-line
+        .stdout_is("xycde");
 }
 
 #[test]
@@ -319,7 +319,7 @@ fn test_truncate_with_set1_shorter_than_set2() {
         .args(&["-t", "ab", "xyz"])
         .pipe_in("abcde")
         .run()
-        .stdout_is("xycde"); // spell-checker:disable-line
+        .stdout_is("xycde");
 }
 
 #[test]


### PR DESCRIPTION
We have lots of unnecessary `spell-checker:disable-THING` all over the place, 44 in fact. That means we wouldn't notice typos in those lines, so let's remove unnecessary stuff like that.

I found this when watching @jadijadi's video about #6225, because he copy-pastes a non-sensical `spell-checker:disable-line` on an empty line.

Code to find the unnecessary spellcheck-statements: https://gist.github.com/BenWiederhake/f43c386c957825b6109325c39a351cac

In the process, I also found that `tests/by-util/test_cat.rs` could be simplified a little bit. Not sure if it's worth it, but now it's done.