### PR TITLE
show-utils.sh: fix jq query to get coreutils deps

### DIFF
--- a/util/show-utils.sh
+++ b/util/show-utils.sh
@@ -33,5 +33,8 @@ cd "${project_main_dir}" &&
         echo "WARN: missing \`jq\` (install with \`sudo apt install jq\`); falling back to default (only fully cross-platform) utility list" 1>&2
         echo "$default_utils"
     else
-        cargo metadata "$@" --format-version 1 | jq -r '[.resolve.nodes[] | select(.id|match(".*coreutils#\\d+\\.\\d+\\.\\d+")) | .deps[] | select(.pkg|match("uu_")) | .name | sub("^uu_"; "")] | sort | join(" ")'
+    # Find 'coreutils' id with regex
+    # with cargo v1.76.0, id = "coreutils 0.0.26 (path+file://<coreutils local directory>)"
+    # with cargo v1.77.0, id = "path+file://<coreutils local directory>#coreutils@0.0.26"
+        cargo metadata "$@" --format-version 1 | jq -r '[.resolve.nodes[] | select(.id|match(".*coreutils[ |@]\\d+\\.\\d+\\.\\d+")) | .deps[] | select(.pkg|match("uu_")) | .name | sub("^uu_"; "")] | sort | join(" ")'
     fi


### PR DESCRIPTION
In jq query, the correct regex to select .id is ".*coreutils[ |@]\\d+\\.\\d+\\.\\d+"


- with cargo v1.76.0, id = `"coreutils 0.0.26 (path+file://<coreutils local directory>)"`
- with cargo v1.77.0, id = `"path+file://<coreutils local directory>#coreutils@0.0.26"`

Fix uutils/coreutils#6242

---

Tests OK on OpenBSD with cargo v1.76 and FreeBSD with cargo v1.77
```
$ ./util/show-utils.sh
base32 base64 basename basenc cat cksum comm cp csplit cut date dd df dir dircolors dirname du echo env expand expr factor false fmt fold hashsum head join link ln ls mkdir mktemp more mv nl numfmt od paste pr printenv printf ptx pwd readlink realpath rm rmdir seq shred shuf sleep sort split sum tac tail tee test touch tr true truncate tsort unexpand uniq unlink vdir wc yes

$ ./util/show-utils.sh --no-default-features --features "unix"
arch base32 base64 basename basenc cat chgrp chmod chown chroot cksum comm cp csplit cut date dd df dir dircolors dirname du echo env expand expr factor false fmt fold groups hashsum head hostid hostname id install join kill link ln logname ls mkdir mkfifo mknod mktemp more mv nice nl nohup nproc numfmt od paste pathchk pinky pr printenv printf ptx pwd readlink realpath rm rmdir seq shred shuf sleep sort split stat stdbuf stty sum sync tac tail tee test timeout touch tr true truncate tsort tty uname unexpand uniq unlink uptime users vdir wc who whoami yes
```