### PR TITLE
always setup logging, dump whatever its logged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "glob",
  "hex-literal",
  "libc",
+ "log",
  "nix",
  "num-prime",
  "once_cell",
@@ -849,6 +850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fern"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "file_diff"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1130,12 @@ dependencies = [
  "libc",
  "windows",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -2751,6 +2767,7 @@ dependencies = [
  "clap",
  "glob",
  "hostname",
+ "log",
  "lscolors",
  "number_prefix",
  "once_cell",
@@ -3338,10 +3355,13 @@ dependencies = [
  "digest",
  "dns-lookup",
  "dunce",
+ "fern",
  "glob",
  "hex",
+ "humantime",
  "itertools",
  "libc",
+ "log",
  "md-5",
  "memchr",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,9 +287,12 @@ gcd = "2.3"
 glob = "0.3.1"
 half = "2.4.1"
 hostname = "0.4"
+humantime = "2.1.0"
 indicatif = "0.17.8"
 itertools = "0.12.1"
 libc = "0.2.154"
+log = "0.4"
+fern = { version = "0.6.2", default-features = false }
 lscolors = { version = "0.16.0", default-features = false, features = [
   "gnu_legacy",
 ] }
@@ -494,6 +497,7 @@ uucore = { workspace = true, features = ["entries", "process", "signals"] }
 walkdir = { workspace = true }
 hex-literal = "0.4.1"
 rstest = { workspace = true }
+log = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 procfs = { version = "0.16", default-features = false }

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -22,6 +22,7 @@ number_prefix = { workspace = true }
 uutils_term_grid = { workspace = true }
 terminal_size = { workspace = true }
 glob = { workspace = true }
+log = { workspace = true }
 lscolors = { workspace = true }
 uucore = { workspace = true, features = [
   "colors",

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -25,6 +25,9 @@ dns-lookup = { version = "2.0.4", optional = true }
 dunce = { version = "1.0.4", optional = true }
 wild = "2.2"
 glob = { workspace = true }
+log = { workspace = true }
+fern = { workspace = true }
+humantime = { workspace = true }
 # * optional
 itertools = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }

--- a/src/uucore/src/lib/features/format/human.rs
+++ b/src/uucore/src/lib/features/format/human.rs
@@ -11,7 +11,7 @@
 
 use number_prefix::NumberPrefix;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum SizeFormat {
     Bytes,
     Binary,  // Powers of 1024, --human-readable, -h

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -4,6 +4,8 @@
 // file that was distributed with this source code.
 // library ~ (core/bundler file)
 
+// spell-checker:ignore manpages mangen humantime
+
 // * feature-gated external crates (re-shared as public internal modules)
 #[cfg(feature = "libc")]
 pub extern crate libc;
@@ -17,6 +19,7 @@ mod macros; // crate macros (macro_rules-type; exported to `crate::...`)
 mod mods; // core cross-platform modules
 mod parser; // string parsing modules
 
+use log::LevelFilter;
 pub use uucore_procs::*;
 
 // * cross-platform modules
@@ -97,10 +100,16 @@ pub use crate::features::fsxattr;
 
 //## core functions
 
+use std::ffi::OsStr;
 use std::ffi::OsString;
+use std::str::FromStr;
 use std::sync::atomic::Ordering;
+use std::time::SystemTime;
 
 use once_cell::sync::Lazy;
+
+pub const UUTILS_LOG_FILE_ENV_NAME: &str = "UUTILS_LOG_FILE";
+pub const UUTILS_LOG_LEVEL_ENV_NAME: &str = "UUTILS_LOG_LEVEL";
 
 /// Execute utility code for `util`.
 ///
@@ -177,6 +186,40 @@ static EXECUTION_PHRASE: Lazy<String> = Lazy::new(|| {
 /// Derive the complete execution phrase for "usage".
 pub fn execution_phrase() -> &'static str {
     &EXECUTION_PHRASE
+}
+
+fn setup_logger(log_file: &OsStr, log_level: log::LevelFilter) -> Result<(), fern::InitError> {
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{} {} {}] {}",
+                humantime::format_rfc3339_seconds(SystemTime::now()),
+                record.level(),
+                record.target(),
+                message
+            ))
+        })
+        .level(log_level)
+        .chain(fern::log_file(log_file)?)
+        .apply()?;
+    Ok(())
+}
+
+/// Default initialization of global logging facade
+pub fn initialize_logging() {
+    let default_log_level = LevelFilter::Debug;
+    let logging_out_file = std::env::var_os(UUTILS_LOG_FILE_ENV_NAME);
+    if let Some(log_file) = logging_out_file {
+        let log_level = default_log_level;
+        let result = setup_logger(&log_file, log_level);
+        if let Err(e) = result {
+            eprintln!(
+                "Failed to setup logging to file {}. Error: {:?}",
+                log_file.to_string_lossy(),
+                e
+            );
+        }
+    }
 }
 
 pub trait Args: Iterator<Item = OsString> + Sized {

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -21,6 +21,7 @@ pub fn main(_args: TokenStream, stream: TokenStream) -> TokenStream {
     let new = quote!(
         pub fn uumain(args: impl uucore::Args) -> i32 {
             #stream
+            uucore::initialize_logging();
             let result = uumain(args);
             match result {
                 Ok(()) => uucore::error::get_exit_code(),


### PR DESCRIPTION
draft 2 for #6284, alternative for #6313

The main idea here is, that the logs are not part of the stable code-base.
They would always be removed when debuggin is done.
This way, there is no explicit activation mechanism needed and the test-framework
can always specify the logfile-path via environmental variable.
It will check after execution if the logfile was written to and then dumps the content.