### PR TITLE
simple custom log macro to avoid additional dependencies

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -64,7 +64,7 @@ use uucore::{
     shortcut_value_parser::ShortcutValueParser,
     version_cmp::version_cmp,
 };
-use uucore::{error::USimpleError, uu_log, uu_log_file};
+use uucore::{error::USimpleError, uu_log};
 use uucore::{help_about, help_section, help_usage, parse_glob, show, show_error, show_warning};
 mod dired;
 use dired::DiredOutput;

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -35,7 +35,6 @@ use std::{
     time::Duration,
 };
 use term_grid::{Direction, Filling, Grid, GridOptions};
-use uucore::error::USimpleError;
 use uucore::format::human::{human_readable, SizeFormat};
 #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
 use uucore::fsxattr::has_acl;
@@ -65,6 +64,7 @@ use uucore::{
     shortcut_value_parser::ShortcutValueParser,
     version_cmp::version_cmp,
 };
+use uucore::{error::USimpleError, uu_log, uu_log_file};
 use uucore::{help_about, help_section, help_usage, parse_glob, show, show_error, show_warning};
 mod dired;
 use dired::DiredOutput;
@@ -2384,6 +2384,7 @@ fn display_dir_entry_size(
             ),
             SizeOrDeviceId::Size(size) => (size.len(), 0usize, 0usize),
         };
+        uu_log!("success metadata from entry: size_len: {size_len}, major_len: {major_len}, minor_len: {minor_len}");
         (
             display_symlink_count(md).len(),
             display_uname(md, config).len(),
@@ -2393,6 +2394,7 @@ fn display_dir_entry_size(
             minor_len,
         )
     } else {
+        uu_log!("failed to get metadata from entry: {:?}", entry);
         (0, 0, 0, 0, 0, 0)
     }
 }
@@ -2412,14 +2414,23 @@ fn return_total(
 ) -> UResult<String> {
     let mut total_size = 0;
     for item in items {
-        total_size += item
-            .get_metadata(out)
-            .as_ref()
-            .map_or(0, |md| get_block_size(md, config));
+        let md = item.get_metadata(out);
+        uu_log!("item md {}: {:?}", item.display_name.to_string_lossy(), md);
+        if let Some(md) = md {
+            let gbs = get_block_size(md, config);
+            uu_log!(
+                "item gbs {:?}, blocks: {}, size: {}",
+                gbs,
+                md.blocks(),
+                md.size()
+            );
+        }
+        total_size += md.as_ref().map_or(0, |md| get_block_size(md, config));
     }
     if config.dired {
         dired::indent(out)?;
     }
+    uu_log!("total {total_size} of {} items", items.len());
     Ok(format!(
         "total {}{}",
         display_size(total_size, config),

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -71,7 +71,9 @@ windows-sys = { workspace = true, optional = true, default-features = false, fea
 ] }
 
 [features]
-default = ["uu_log"] # add "uu_log" here to activate logging during tests
+default = [] # Add "uu_log" here to activate logging during tests.
+             # When disabled, it will not compile with `uu_log!` statments.
+             # This is intented to avoid accidential left overs afer debugging is finished.
 # * non-default features
 uu_log = []
 backup-control = []

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -71,7 +71,7 @@ windows-sys = { workspace = true, optional = true, default-features = false, fea
 ] }
 
 [features]
-default = [] # add "uu_log" here to activate logging during tests
+default = ["uu_log"] # add "uu_log" here to activate logging during tests
 # * non-default features
 uu_log = []
 backup-control = []

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -71,8 +71,9 @@ windows-sys = { workspace = true, optional = true, default-features = false, fea
 ] }
 
 [features]
-default = []
+default = [] # add "uu_log" here to activate logging during tests
 # * non-default features
+uu_log = []
 backup-control = []
 colors = []
 encoding = ["data-encoding", "data-encoding-macro", "z85", "thiserror"]

--- a/src/uucore/src/lib/features/format/human.rs
+++ b/src/uucore/src/lib/features/format/human.rs
@@ -11,7 +11,7 @@
 
 use number_prefix::NumberPrefix;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum SizeFormat {
     Bytes,
     Binary,  // Powers of 1024, --human-readable, -h

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -180,6 +180,7 @@ pub fn execution_phrase() -> &'static str {
     &EXECUTION_PHRASE
 }
 
+#[cfg(feature = "uu_log")]
 pub mod uu_logging {
     use once_cell::sync::Lazy;
     use std::{cell::Cell, fs::File, io::Write};
@@ -230,6 +231,7 @@ pub mod uu_logging {
     }
 }
 
+#[cfg(feature = "uu_log")]
 #[macro_export]
 macro_rules! uu_log {
     ($($arg:tt)*) => {
@@ -237,6 +239,14 @@ macro_rules! uu_log {
             uucore::uu_logging::uu_log_to_file(format!($($arg)*));
         }
     };
+}
+
+#[cfg(not(feature = "uu_log"))]
+#[macro_export]
+macro_rules! uu_log {
+    ($($arg:tt)*) => { if cfg!(feature = "uu_log") {
+        let _ /* avoid warning about unused variable at caller side */ = ($($arg)*);
+    }};
 }
 
 pub trait Args: Iterator<Item = OsString> + Sized {

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -241,18 +241,6 @@ macro_rules! uu_log {
     };
 }
 
-#[cfg(not(feature = "uu_log"))]
-#[macro_export]
-macro_rules! uu_log {
-    ($($arg:tt)*) => { if cfg!(feature = "uu_log") {
-        let _ /* avoid warning about unused variable at caller side */ = ($($arg)*);
-    }};
-}
-
-pub fn get_uu_log_enabled() -> bool {
-    cfg!(feature = "uu_log")
-}
-
 pub trait Args: Iterator<Item = OsString> + Sized {
     /// Collects the iterator into a `Vec<String>`, lossily converting the `OsString`s to `Strings`.
     fn collect_lossy(self) -> Vec<String> {

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -249,6 +249,10 @@ macro_rules! uu_log {
     }};
 }
 
+pub fn get_uu_log_enabled() -> bool {
+    cfg!(feature = "uu_log")
+}
+
 pub trait Args: Iterator<Item = OsString> + Sized {
     /// Collects the iterator into a `Vec<String>`, lossily converting the `OsString`s to `Strings`.
     fn collect_lossy(self) -> Vec<String> {

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -42,6 +42,7 @@ use std::thread::{sleep, JoinHandle};
 use std::time::{Duration, Instant};
 use std::{env, hint, mem, thread};
 use tempfile::{Builder, TempDir};
+use uucore::UUTILS_LOG_FILE_ENV_NAME;
 
 static TESTS_DIR: &str = "tests";
 static FIXTURES_DIR: &str = "fixtures";
@@ -1158,7 +1159,50 @@ pub struct TestScenario {
     pub bin_path: PathBuf,
     pub util_name: String,
     pub fixtures: AtPath,
+    log_guard: LogPrintGuard,
     tmpd: Rc<TempDir>,
+}
+
+struct LogPrintGuard {
+    log_file: PathBuf,
+}
+
+// In the context of test execution, writing to std::io::stderr() is
+// apparently handled differently than writing using eprint!-macro
+// To still be able to use the std::io::copy, this PrintSink is needed.
+struct PrintSink {}
+
+impl std::io::Write for PrintSink {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        eprint!("{}", String::from_utf8_lossy(buf));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for LogPrintGuard {
+    fn drop(&mut self) {
+        let Ok(f) = File::open(&self.log_file) else {
+            return;
+        };
+        eprintln!("=============== collected logs: ===============");
+
+        std::io::stderr().flush().unwrap();
+        let mut reader = std::io::BufReader::new(f);
+        let result = std::io::copy(&mut reader, &mut PrintSink {}).unwrap_or_else(|e| {
+            eprintln!(
+                "Failed to read contents of log-file: {}, Err: {:?}",
+                self.log_file.display(),
+                e
+            );
+            0
+        });
+        std::io::stderr().flush().unwrap();
+        eprintln!("=============== log-size: {result} bytes =============");
+    }
 }
 
 impl TestScenario {
@@ -1167,10 +1211,15 @@ impl TestScenario {
         T: AsRef<str>,
     {
         let tmpd = Rc::new(TempDir::new().unwrap());
+        let fixtures = AtPath::new(tmpd.as_ref().path());
+        let log_guard = LogPrintGuard {
+            log_file: fixtures.plus("uu_logs.txt"),
+        };
         let ts = Self {
             bin_path: PathBuf::from(TESTS_BINARY),
             util_name: util_name.as_ref().into(),
-            fixtures: AtPath::new(tmpd.as_ref().path()),
+            fixtures,
+            log_guard,
             tmpd,
         };
         let mut fixture_path_builder = env::current_dir().unwrap();
@@ -1185,10 +1234,16 @@ impl TestScenario {
         ts
     }
 
+    fn activate_uu_logs_on_command(&self, cmd: &mut UCommand) {
+        cmd.env(UUTILS_LOG_FILE_ENV_NAME, &self.log_guard.log_file);
+    }
+
     /// Returns builder for invoking the target uutils binary. Paths given are
     /// treated relative to the environment's unique temporary test directory.
     pub fn ucmd(&self) -> UCommand {
-        UCommand::from_test_scenario(self)
+        let mut cmd = UCommand::from_test_scenario(self);
+        self.activate_uu_logs_on_command(&mut cmd);
+        cmd
     }
 
     /// Returns builder for invoking any system command. Paths given are treated
@@ -1197,13 +1252,16 @@ impl TestScenario {
         let mut command = UCommand::new();
         command.bin_path(bin_path);
         command.temp_dir(self.tmpd.clone());
+        self.activate_uu_logs_on_command(&mut command);
         command
     }
 
     /// Returns builder for invoking any uutils command. Paths given are treated
     /// relative to the environment's unique temporary test directory.
     pub fn ccmd<S: AsRef<str>>(&self, util_name: S) -> UCommand {
-        UCommand::with_util(util_name, self.tmpd.clone())
+        let mut cmd = UCommand::with_util(util_name, self.tmpd.clone());
+        self.activate_uu_logs_on_command(&mut cmd);
+        cmd
     }
 }
 

--- a/tests/test_uu_log_disabled.rs
+++ b/tests/test_uu_log_disabled.rs
@@ -1,0 +1,6 @@
+use uucore::get_uu_log_enabled;
+
+#[test]
+fn test_uu_log_disabled() {
+    assert_eq!(get_uu_log_enabled(), false);
+}


### PR DESCRIPTION
draft 3 for #6284, alternative for #6313 and #6314 

The main idea here is that we have a own log macro to avoid additional dependencies.

Same as with #6314, the idea is that the logs are not part of the stable code-base.
They would always be removed when debuggin is done.
This way, there is no explicit activation mechanism needed and the test-framework
can always specify the logfile-path via environmental variable.
It will check after execution if the logfile was written to and then dumps the content.