### PR TITLE
clippy: fix warnings introduced with Rust 1.78

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1120,6 +1120,7 @@ fn parse_path_args(
     };
 
     if options.strip_trailing_slashes {
+        #[allow(clippy::assigning_clones)]
         for source in &mut paths {
             *source = source.components().as_path().to_owned();
         }
@@ -1617,8 +1618,8 @@ fn handle_existing_dest(
             // linking.
 
             if options.preserve_hard_links()
-            // only try to remove dest file only if the current source 
-            // is hardlink to a file that is already copied  
+            // only try to remove dest file only if the current source
+            // is hardlink to a file that is already copied
                 && copied_files.contains_key(
                     &FileInformation::from_path(
                         source,
@@ -1734,7 +1735,7 @@ fn handle_copy_mode(
     dest: &Path,
     options: &Options,
     context: &str,
-    source_metadata: Metadata,
+    source_metadata: &Metadata,
     symlinked_files: &mut HashSet<FileInformation>,
     source_in_command_line: bool,
 ) -> CopyResult<()> {
@@ -2053,7 +2054,7 @@ fn copy_file(
         dest,
         options,
         context,
-        source_metadata,
+        &source_metadata,
         symlinked_files,
         source_in_command_line,
     )?;

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -86,17 +86,13 @@ impl CsplitOptions {
 /// - [`CsplitError::MatchNotFound`] if no line matched a regular expression.
 /// - [`CsplitError::MatchNotFoundOnRepetition`], like previous but after applying the pattern
 ///   more than once.
-pub fn csplit<T>(
-    options: &CsplitOptions,
-    patterns: Vec<String>,
-    input: T,
-) -> Result<(), CsplitError>
+pub fn csplit<T>(options: &CsplitOptions, patterns: &[String], input: T) -> Result<(), CsplitError>
 where
     T: BufRead,
 {
     let mut input_iter = InputSplitter::new(input.lines().enumerate());
     let mut split_writer = SplitWriter::new(options);
-    let patterns: Vec<patterns::Pattern> = patterns::get_patterns(&patterns[..])?;
+    let patterns: Vec<patterns::Pattern> = patterns::get_patterns(patterns)?;
     let ret = do_csplit(&mut split_writer, patterns, &mut input_iter);
 
     // consume the rest, unless there was an error
@@ -568,7 +564,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let options = CsplitOptions::new(&matches);
     if file_name == "-" {
         let stdin = io::stdin();
-        Ok(csplit(&options, patterns, stdin.lock())?)
+        Ok(csplit(&options, &patterns, stdin.lock())?)
     } else {
         let file = File::open(file_name)
             .map_err_context(|| format!("cannot access {}", file_name.quote()))?;
@@ -578,7 +574,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         if !file_metadata.is_file() {
             return Err(CsplitError::NotRegularFile(file_name.to_string()).into());
         }
-        Ok(csplit(&options, patterns, BufReader::new(file))?)
+        Ok(csplit(&options, &patterns, BufReader::new(file))?)
     }
 }
 

--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -25,14 +25,14 @@ pub enum Pattern {
     SkipToMatch(Regex, i32, ExecutePattern),
 }
 
-impl ToString for Pattern {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Pattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::UpToLine(n, _) => n.to_string(),
-            Self::UpToMatch(regex, 0, _) => format!("/{}/", regex.as_str()),
-            Self::UpToMatch(regex, offset, _) => format!("/{}/{:+}", regex.as_str(), offset),
-            Self::SkipToMatch(regex, 0, _) => format!("%{}%", regex.as_str()),
-            Self::SkipToMatch(regex, offset, _) => format!("%{}%{:+}", regex.as_str(), offset),
+            Self::UpToLine(n, _) => write!(f, "{n}"),
+            Self::UpToMatch(regex, 0, _) => write!(f, "/{}/", regex.as_str()),
+            Self::UpToMatch(regex, offset, _) => write!(f, "/{}/{:+}", regex.as_str(), offset),
+            Self::SkipToMatch(regex, 0, _) => write!(f, "%{}%", regex.as_str()),
+            Self::SkipToMatch(regex, offset, _) => write!(f, "%{}%{:+}", regex.as_str(), offset),
         }
     }
 }

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -220,6 +220,7 @@ mod tests {
         }
 
         #[test]
+        #[allow(clippy::assigning_clones)]
         fn test_dev_name_match() {
             let tmp = tempfile::TempDir::new().expect("Failed to create temp dir");
             let dev_name = std::fs::canonicalize(tmp.path())

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -104,7 +104,7 @@ fn load_config_file(opts: &mut Options) -> UResult<()> {
 
         for (_, prop) in &conf {
             // ignore all INI section lines (treat them as comments)
-            for (key, value) in prop.iter() {
+            for (key, value) in prop {
                 env::set_var(key, value);
             }
         }
@@ -371,7 +371,7 @@ impl EnvAppData {
             // no program provided, so just dump all env vars to stdout
             print_env(opts.line_ending);
         } else {
-            return self.run_program(opts, self.do_debug_printing);
+            return self.run_program(&opts, self.do_debug_printing);
         }
 
         Ok(())
@@ -379,7 +379,7 @@ impl EnvAppData {
 
     fn run_program(
         &mut self,
-        opts: Options<'_>,
+        opts: &Options<'_>,
         do_debug_printing: bool,
     ) -> Result<(), Box<dyn UError>> {
         let prog = Cow::from(opts.program[0]);

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -51,14 +51,14 @@ fn print_factors_str(
         ));
     }
 
-    write_result(w, x, factorization, print_exponents).map_err_context(|| "write error".into())?;
+    write_result(w, &x, factorization, print_exponents).map_err_context(|| "write error".into())?;
 
     Ok(())
 }
 
 fn write_result(
     w: &mut io::BufWriter<impl Write>,
-    x: BigUint,
+    x: &BigUint,
     factorization: BTreeMap<BigUint, usize>,
     print_exponents: bool,
 ) -> io::Result<()> {

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -831,27 +831,27 @@ where
     if !options.status && !skip_summary {
         match bad_format.cmp(&1) {
             Ordering::Equal => {
-                show_warning_caps!("{} line is improperly formatted", bad_format)
+                show_warning_caps!("{} line is improperly formatted", bad_format);
             }
             Ordering::Greater => {
-                show_warning_caps!("{} lines are improperly formatted", bad_format)
+                show_warning_caps!("{} lines are improperly formatted", bad_format);
             }
             Ordering::Less => {}
         };
 
         match failed_cksum.cmp(&1) {
             Ordering::Equal => {
-                show_warning_caps!("{} computed checksum did NOT match", failed_cksum)
+                show_warning_caps!("{} computed checksum did NOT match", failed_cksum);
             }
             Ordering::Greater => {
-                show_warning_caps!("{} computed checksums did NOT match", failed_cksum)
+                show_warning_caps!("{} computed checksums did NOT match", failed_cksum);
             }
             Ordering::Less => {}
         };
 
         match failed_open_file.cmp(&1) {
             Ordering::Equal => {
-                show_warning_caps!("{} listed file could not be read", failed_open_file)
+                show_warning_caps!("{} listed file could not be read", failed_open_file);
             }
             Ordering::Greater => {
                 show_warning_caps!("{} listed files could not be read", failed_open_file);

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -193,7 +193,7 @@ fn list(signals: &Vec<String>) {
     } else {
         for signal in signals {
             if let Err(e) = print_signal(signal) {
-                uucore::show!(e)
+                uucore::show!(e);
             }
         }
     }

--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -23,7 +23,7 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
         };
     }
     if let Some(val) = opts.get_one::<String>(options::NUMBER_SEPARATOR) {
-        settings.number_separator = val.clone();
+        settings.number_separator.clone_from(val);
     }
     settings.number_format = opts
         .get_one::<String>(options::NUMBER_FORMAT)

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -223,7 +223,7 @@ fn get_config(matches: &clap::ArgMatches) -> UResult<Config> {
     if matches.get_flag(options::TRADITIONAL) {
         config.gnu_ext = false;
         config.format = OutFormat::Roff;
-        config.context_regex = "[^ \t\n]+".to_owned();
+        "[^ \t\n]+".clone_into(&mut config.context_regex);
     } else {
         return Err(PtxError::NotImplemented("GNU extensions").into());
     }

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -45,6 +45,7 @@ impl WatcherRx {
             Tested for notify::InotifyWatcher and for notify::PollWatcher.
             */
             if let Some(parent) = path.parent() {
+                #[allow(clippy::assigning_clones)]
                 if parent.is_dir() {
                     path = parent.to_owned();
                 } else {


### PR DESCRIPTION
This PR fixes the clippy warnings introduced with Rust 1.78. In two cases I used `#[allow(clippy::assigning_clones)]` because the suggested changes didn't work.