### PR TITLE
tr: calculate complement set early

### DIFF
--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -121,26 +121,26 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // '*_op' are the operations that need to be applied, in order.
     if delete_flag {
         if squeeze_flag {
-            let delete_op = DeleteOperation::new(set1, complement_flag);
-            let squeeze_op = SqueezeOperation::new(set2, false);
+            let delete_op = DeleteOperation::new(set1);
+            let squeeze_op = SqueezeOperation::new(set2);
             let op = delete_op.chain(squeeze_op);
             translate_input(&mut locked_stdin, &mut buffered_stdout, op);
         } else {
-            let op = DeleteOperation::new(set1, complement_flag);
+            let op = DeleteOperation::new(set1);
             translate_input(&mut locked_stdin, &mut buffered_stdout, op);
         }
     } else if squeeze_flag {
         if sets_len < 2 {
-            let op = SqueezeOperation::new(set1, complement_flag);
+            let op = SqueezeOperation::new(set1);
             translate_input(&mut locked_stdin, &mut buffered_stdout, op);
         } else {
-            let translate_op = TranslateOperation::new(set1, set2.clone(), complement_flag)?;
-            let squeeze_op = SqueezeOperation::new(set2, false);
+            let translate_op = TranslateOperation::new(set1, set2.clone())?;
+            let squeeze_op = SqueezeOperation::new(set2);
             let op = translate_op.chain(squeeze_op);
             translate_input(&mut locked_stdin, &mut buffered_stdout, op);
         }
     } else {
-        let op = TranslateOperation::new(set1, set2, complement_flag)?;
+        let op = TranslateOperation::new(set1, set2)?;
         translate_input(&mut locked_stdin, &mut buffered_stdout, op);
     }
     Ok(())

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -111,11 +111,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let locked_stdout = stdout.lock();
     let mut buffered_stdout = BufWriter::new(locked_stdout);
 
+    // According to the man page: translating only happens if deleting or if a second set is given
+    let translating = !delete_flag && sets.len() > 1;
     let mut sets_iter = sets.iter().map(|c| c.as_str());
     let (set1, set2) = Sequence::solve_set_characters(
         sets_iter.next().unwrap_or_default().as_bytes(),
         sets_iter.next().unwrap_or_default().as_bytes(),
-        truncate_set1_flag,
+        complement_flag,
+        // if we are not translating then we don't truncate set1
+        truncate_set1_flag && translating,
     )?;
 
     // '*_op' are the operations that need to be applied, in order.

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1313,3 +1313,24 @@ fn check_regression_class_blank() {
         .no_stderr()
         .stdout_only("a12b");
 }
+
+// Check regression found in https://github.com/uutils/coreutils/issues/6163
+#[test]
+fn check_regression_issue_6163_no_match() {
+    new_ucmd!()
+        .args(&["-c", "-t", "Y", "Z"])
+        .pipe_in("X\n")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("X\n");
+}
+
+#[test]
+fn check_regression_issue_6163_match() {
+    new_ucmd!()
+        .args(&["-c", "-t", "Y", "Z"])
+        .pipe_in("\0\n")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("Z\n");
+}

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore aabbaa aabbcc aabc abbb abbbcddd abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit XXXYYY xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn
+// spell-checker:ignore aabbaa aabbcc aabc abbb abbbcddd abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit XXXYYY xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn asdfqqwweerr qwerr asdfqwer qwer aassddffqwer asdfqwer
 use crate::common::util::TestScenario;
 
 #[test]
@@ -1333,4 +1333,34 @@ fn check_regression_issue_6163_match() {
         .succeeds()
         .no_stderr()
         .stdout_only("Z\n");
+}
+
+#[test]
+fn check_ignore_truncate_when_deleting_and_squeezing() {
+    new_ucmd!()
+        .args(&["-dts", "asdf", "qwe"])
+        .pipe_in("asdfqqwweerr\n")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("qwerr\n");
+}
+
+#[test]
+fn check_ignore_truncate_when_deleting() {
+    new_ucmd!()
+        .args(&["-dt", "asdf"])
+        .pipe_in("asdfqwer\n")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("qwer\n");
+}
+
+#[test]
+fn check_ignore_truncate_when_squeezing() {
+    new_ucmd!()
+        .args(&["-ts", "asdf"])
+        .pipe_in("aassddffqwer\n")
+        .succeeds()
+        .no_stderr()
+        .stdout_only("asdfqwer\n");
 }


### PR DESCRIPTION
Fixes #6163 and adds a test to verify that a regression is not caused.

Instead of inverting the conditions to check (e.g. delete characters **not** present in set1) invert set1 when passed the complement flag (`-c`, `-C`, `--complement`). This is done by calculating set1 then "inverting" it by subtracting from the "full" (universe) set (0..=u8::MAX).

This fixes issue 6163 because it was caused by a combination of the `-c` and `-t` flag. `-c` is the abovementioned complement flag and `-t`/`--truncate-set1` truncates set1 to the length of set2. What happened in issue 6163 is that `set1={b'Y'}` and `set2={b'Z'}`, when truncated set1 stays the same and we proceed. The problem is GNU utils does not consider set1 to be `{b'Y'}`, but the complement of `{b'Y'}`, that is `U \ {b'Y'}={0, 1, ..., b'X', b'Z', ...}`, thus it is truncated to `{0}`.

We can verify this by doing: `printf '\0' | tr -c -t Y Z`, which prints `Z` to stdout as expected.

Additionally, by calculating the complement of set1 we no longer need to consider the complement flag when doing the translate operation, this allows us to delete a lot of code.