### PR TITLE
Fix ls: panicking on dangling symlink with ``--color=auto -l``

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3353,10 +3353,9 @@ fn color_name(
         // use the optional target_symlink
         // Use fn get_metadata_with_deref_opt instead of get_metadata() here because ls
         // should not exit with an err, if we are unable to obtain the target_metadata
-        let md = get_metadata_with_deref_opt(target.p_buf.as_path(), path.must_dereference)
-            .unwrap_or_else(|_| target.get_metadata(out).unwrap().clone());
-
-        apply_style_based_on_metadata(path, Some(&md), ls_colors, style_manager, &name)
+        let md_res = get_metadata_with_deref_opt(target.p_buf.as_path(), path.must_dereference);
+        let md = md_res.or(path.p_buf.symlink_metadata());
+        apply_style_based_on_metadata(path, md.ok().as_ref(), ls_colors, style_manager, &name)
     } else {
         let md_option = path.get_metadata(out);
         let symlink_metadata = path.p_buf.symlink_metadata().ok();

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1379,7 +1379,7 @@ fn test_ls_long_symlink_color() {
 /// This test is for "ls -l --color=auto|--color=always"
 /// We use "--color=always" as the colors are the same regardless of the color option being "auto" or "always"
 /// tests whether the specific color of the target and the dangling_symlink are equal and checks
-/// whether checks whether ls outputs the corrent path for the symlink and the file it points to and applies the color code to it.
+/// whether checks whether ls outputs the correct path for the symlink and the file it points to and applies the color code to it.
 #[test]
 fn test_ls_long_dangling_symlink_color() {
     let ts = TestScenario::new(util_name!());

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1387,7 +1387,6 @@ fn test_ls_long_dangling_symlink_color() {
     let at = &ts.fixtures;
 
     at.mkdir("dir1");
-    at.mkdir("dir2");
     at.symlink_dir("foo", "dir1/dangling_symlink");
     let result = ts
         .ucmd()

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1378,9 +1378,8 @@ fn test_ls_long_symlink_color() {
 
 /// This test is for "ls -l --color=auto|--color=always"
 /// We use "--color=always" as the colors are the same regardless of the color option being "auto" or "always"
-/// using 'ln' to create a dangling symlink
-/// Only tests whether the specific color of the target and the dangling_symlink are equal
-/// Modified version of the "test_ls_long_symlink_color" test. Please see that for more details
+/// tests whether the specific color of the target and the dangling_symlink are equal and checks
+/// whether checks whether ls outputs the corrent path for the symlink and the file it points to and applies the color code to it.
 #[test]
 fn test_ls_long_dangling_symlink_color() {
     let ts = TestScenario::new(util_name!());
@@ -1405,6 +1404,8 @@ fn test_ls_long_dangling_symlink_color() {
         .find_iter(stdout)
         .map(|color| color.as_str())
         .collect();
+
+    assert_eq!(colors_vec[0], colors_vec[1]);
     // constructs the string of file path with the color code
     let symlink_color_name = colors_vec[0].to_owned() + "dir1/dangling_symlink\x1b";
     let target_color_name = colors_vec[1].to_owned() + at.plus_as_string("foo\x1b").as_str();


### PR DESCRIPTION
fixes #6227 

The ``get_metadata()`` function seemed to try to deference to the non existent file. We change it to directly get the metadata of the symlink itself incase the deference fails.