### PR TITLE
Disabling xattrs tests on OpenBSD

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -782,7 +782,7 @@ pub fn get_root_path() -> &'static str {
 /// # Returns
 ///
 /// `true` if both paths have the same set of extended attributes, `false` otherwise.
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "openbsd"))))]
 pub fn compare_xattrs<P: AsRef<std::path::Path>>(path1: P, path2: P) -> bool {
     let get_sorted_xattrs = |path: P| {
         xattr::list(path)
@@ -3611,7 +3611,7 @@ mod tests {
         assert!(command.tmpd.is_some());
     }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(all(unix, not(any(target_os = "macos", target_os = "openbsd"))))]
     #[test]
     fn test_compare_xattrs() {
         use tempfile::tempdir;


### PR DESCRIPTION
The test_compare_xattrs test fails on OpenBSD because OpenBSD does not support xattrs. Disabling this test for `target_os = openbsd` resolved the issue.

Fixes #6348