### PR TITLE
fmt: accept repeated arguments

### DIFF
--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -305,6 +305,7 @@ pub fn uu_app() -> Command {
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::CROWN_MARGIN)
                 .short('c')

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -185,3 +185,74 @@ fn test_fmt_set_goal_not_contain_width() {
             .stdout_is("this is a file with one word per line\n");
     }
 }
+
+#[test]
+fn split_does_not_reflow() {
+    for arg in ["-s", "-ss", "--split-only"] {
+        new_ucmd!()
+            .arg("one-word-per-line.txt")
+            .arg(arg)
+            .succeeds()
+            .stdout_is_fixture("one-word-per-line.txt");
+    }
+}
+
+#[test]
+fn prefix_minus() {
+    for prefix_args in [
+        vec!["-p-"],
+        vec!["-p", "-"],
+        vec!["--prefix=-"],
+        vec!["--prefix", "-"],
+        vec!["--pref=-"],
+        vec!["--pref", "-"],
+        // Test self-overriding:
+        vec!["--prefix==", "--prefix=-"],
+    ] {
+        new_ucmd!()
+            .args(&prefix_args)
+            .arg("prefixed-one-word-per-line.txt")
+            .succeeds()
+            .stdout_is_fixture("prefixed-one-word-per-line_p-.txt");
+    }
+}
+
+#[test]
+fn prefix_equal() {
+    for prefix_args in [
+        // FIXME: #6353 vec!["-p="],
+        vec!["-p", "="],
+        vec!["--prefix=="],
+        vec!["--prefix", "="],
+        vec!["--pref=="],
+        vec!["--pref", "="],
+        // Test self-overriding:
+        vec!["--prefix=-", "--prefix=="],
+    ] {
+        new_ucmd!()
+            .args(&prefix_args)
+            .arg("prefixed-one-word-per-line.txt")
+            .succeeds()
+            .stdout_is_fixture("prefixed-one-word-per-line_p=.txt");
+    }
+}
+
+#[test]
+fn prefix_equal_skip_prefix_equal_two() {
+    for prefix_args in [
+        // FIXME: #6353 vec!["--prefix==", "-P=2"],
+        vec!["--prefix==", "-P", "=2"],
+        vec!["--prefix==", "--skip-prefix==2"],
+        vec!["--prefix==", "--skip-prefix", "=2"],
+        vec!["--prefix==", "--skip-pref==2"],
+        vec!["--prefix==", "--skip-pref", "=2"],
+        // Test self-overriding:
+        vec!["--prefix==", "--skip-pref", "asdf", "-P", "=2"],
+    ] {
+        new_ucmd!()
+            .args(&prefix_args)
+            .arg("prefixed-one-word-per-line.txt")
+            .succeeds()
+            .stdout_is_fixture("prefixed-one-word-per-line_p=_P=2.txt");
+    }
+}

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -19,7 +19,7 @@ fn test_fmt() {
 
 #[test]
 fn test_fmt_quick() {
-    for param in ["-q", "--quick"] {
+    for param in ["-q", "--quick", "-qq"] {
         new_ucmd!()
             .args(&["one-word-per-line.txt", param])
             .succeeds()
@@ -35,6 +35,10 @@ fn test_fmt_width() {
             .succeeds()
             .stdout_is("this is a\nfile with\none word\nper line\n");
     }
+    new_ucmd!()
+        .args(&["one-word-per-line.txt", "-w50", "--width", "10"])
+        .succeeds()
+        .stdout_is("this is a\nfile with\none word\nper line\n");
 }
 
 #[test]
@@ -66,6 +70,11 @@ fn test_fmt_width_too_big() {
             .code_is(1)
             .stderr_is("fmt: invalid width: '2501': Numerical result out of range\n");
     }
+    // However, as a temporary value it is okay:
+    new_ucmd!()
+        .args(&["one-word-per-line.txt", "-w2501", "--width", "10"])
+        .succeeds()
+        .stdout_is("this is a\nfile with\none word\nper line\n");
 }
 
 #[test]
@@ -97,7 +106,7 @@ fn test_fmt_width_not_valid_number() {
         .stderr_contains("fmt: invalid width: '25x'");
 }
 
-#[ignore]
+#[ignore = "our 'goal' algorithm is very different from GNU; fix this!"]
 #[test]
 fn test_fmt_goal() {
     for param in ["-g", "--goal"] {
@@ -106,6 +115,10 @@ fn test_fmt_goal() {
             .succeeds()
             .stdout_is("this is a\nfile with one\nword per line\n");
     }
+    new_ucmd!()
+        .args(&["one-word-per-line.txt", "-g40", "-g7"])
+        .succeeds()
+        .stdout_is("this is a\nfile with one\nword per line\n");
 }
 
 #[test]
@@ -128,6 +141,19 @@ fn test_fmt_goal_bigger_than_default_width_of_75() {
             .code_is(1)
             .stderr_is("fmt: GOAL cannot be greater than WIDTH.\n");
     }
+}
+
+#[ignore = "our 'goal' algorithm is very different from GNU; fix this!"]
+#[test]
+fn test_fmt_too_big_goal_sometimes_okay() {
+    new_ucmd!()
+        .args(&["one-word-per-line.txt", "--width=75", "-g76", "-g10"])
+        .succeeds()
+        .stdout_is("this is a\nfile with one\nword per line\n");
+    new_ucmd!()
+        .args(&["one-word-per-line.txt", "-g76", "-g10"])
+        .succeeds()
+        .stdout_is("this is a\nfile with one\nword per line\n");
 }
 
 #[test]

--- a/tests/fixtures/fmt/prefixed-one-word-per-line.txt
+++ b/tests/fixtures/fmt/prefixed-one-word-per-line.txt
@@ -1,0 +1,19 @@
+- this
+- is
+- a
+- file
+- with
+- one
+- word
+- per
+- line
+
+=1this
+=1is
+=1a
+=2file
+=2with
+=2one
+=3word
+=3per
+=3line

--- a/tests/fixtures/fmt/prefixed-one-word-per-line_p-.txt
+++ b/tests/fixtures/fmt/prefixed-one-word-per-line_p-.txt
@@ -1,0 +1,11 @@
+- this is a file with one word per line
+
+=1this
+=1is
+=1a
+=2file
+=2with
+=2one
+=3word
+=3per
+=3line

--- a/tests/fixtures/fmt/prefixed-one-word-per-line_p=.txt
+++ b/tests/fixtures/fmt/prefixed-one-word-per-line_p=.txt
@@ -1,0 +1,11 @@
+- this
+- is
+- a
+- file
+- with
+- one
+- word
+- per
+- line
+
+=1this 1is 1a 2file 2with 2one 3word 3per 3line

--- a/tests/fixtures/fmt/prefixed-one-word-per-line_p=_P=2.txt
+++ b/tests/fixtures/fmt/prefixed-one-word-per-line_p=_P=2.txt
@@ -1,0 +1,15 @@
+- this
+- is
+- a
+- file
+- with
+- one
+- word
+- per
+- line
+
+=1this 1is 1a
+=2file
+=2with
+=2one
+=3word 3per 3line


### PR DESCRIPTION
Turns out, just a simple `args_override_self(true)` is precisely the correct behavior.

This is also correct with regard to `-p`, `-w`, `-g`; I checked (and found #6352, #6353, #6354 in the process of doing so).

This is work towards #5998.

Note that even though I added some basic tests, a huge chunk of the functionality is still untested, especially `-c`, `-x`/`-X`, `-t`, `-m`, `-q`, `-T`, and of course `-g`, which is broken (known issue).