### PR TITLE
Disable clippy::assigning_clones on OpenBSD

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1120,7 +1120,9 @@ fn parse_path_args(
     };
 
     if options.strip_trailing_slashes {
-        #[allow(clippy::assigning_clones)]
+        // clippy::assigning_clones added with Rust 1.78
+        // Rust version = 1.76 on OpenBSD stable/7.5
+        #[cfg_attr(not(target_os = "openbsd"), allow(clippy::assigning_clones))]
         for source in &mut paths {
             *source = source.components().as_path().to_owned();
         }

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -220,7 +220,9 @@ mod tests {
         }
 
         #[test]
-        #[allow(clippy::assigning_clones)]
+        // clippy::assigning_clones added with Rust 1.78
+        // Rust version = 1.76 on OpenBSD stable/7.5
+        #[cfg_attr(not(target_os = "openbsd"), allow(clippy::assigning_clones))]
         fn test_dev_name_match() {
             let tmp = tempfile::TempDir::new().expect("Failed to create temp dir");
             let dev_name = std::fs::canonicalize(tmp.path())

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -45,7 +45,9 @@ impl WatcherRx {
             Tested for notify::InotifyWatcher and for notify::PollWatcher.
             */
             if let Some(parent) = path.parent() {
-                #[allow(clippy::assigning_clones)]
+                // clippy::assigning_clones added with Rust 1.78
+                // Rust version = 1.76 on OpenBSD stable/7.5
+                #[cfg_attr(not(target_os = "openbsd"), allow(clippy::assigning_clones))]
                 if parent.is_dir() {
                     path = parent.to_owned();
                 } else {


### PR DESCRIPTION
- Avoid error on OpenBSD stable/7.5 with clippy (lint), Rust version 1.76 used on OpenBSD 7.5 and will be not updated before the next stable version 7.6, release ~October 2024
- assigning_clones added in Rust 1.78.0 https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones

- disable clippy::assigning_clones via `cfg_attr` for cp, df and tail utils