### PR TITLE
Disabling compare_xattrs cp and mv related tests on OpenBSD

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -56,7 +56,10 @@ static TEST_MOUNT_MOUNTPOINT: &str = "mount";
 static TEST_MOUNT_OTHER_FILESYSTEM_FILE: &str = "mount/DO_NOT_copy_me.txt";
 #[cfg(unix)]
 static TEST_NONEXISTENT_FILE: &str = "nonexistent_file.txt";
-#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "android", target_os = "macos", target_os = "openbsd"))
+))]
 use crate::common::util::compare_xattrs;
 
 /// Assert that mode, ownership, and permissions of two metadata objects match.
@@ -3692,7 +3695,10 @@ fn test_cp_no_such() {
         .stderr_is("cp: 'no-such/' is not a directory\n");
 }
 
-#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "android", target_os = "macos", target_os = "openbsd"))
+))]
 #[test]
 fn test_acl_preserve() {
     use std::process::Command;

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1569,7 +1569,7 @@ fn test_mv_dir_into_path_slash() {
     assert!(at.dir_exists("f/b"));
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "openbsd"))))]
 #[test]
 fn test_acl() {
     use std::process::Command;


### PR DESCRIPTION
The test_cp and test_mv have xattr related tests. They should be disabled on OpenBSD after commit 19d42c033923e disabled the `compare_xattrs` function on OpenBSD.

Related to #6349
Fixes #6348