### PR TITLE
deny.toml: remove hashbrown, update comment

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -93,7 +93,7 @@ skip = [
   { name = "windows_x86_64_gnullvm", version = "0.48.0" },
   # windows-targets
   { name = "windows_x86_64_msvc", version = "0.48.0" },
-  # various crates
+  # data-encoding-macro-internal
   { name = "syn", version = "1.0.109" },
   # various crates
   { name = "bitflags", version = "1.3.2" },
@@ -101,8 +101,6 @@ skip = [
   { name = "terminal_size", version = "0.2.6" },
   # filetime, parking_lot_core
   { name = "redox_syscall", version = "0.4.1" },
-  # num-prime, rust-ini
-  { name = "hashbrown", version = "0.12.3" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR removes `hashbrown` from the skip list because we no longer use two versions of this crate. It also updates a comment.