### PR TITLE
cp/tail: use `#[ignore]` to disable tests

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1507,7 +1507,7 @@ fn test_cp_preserve_invalid_rejected() {
 
 #[test]
 #[cfg(target_os = "android")]
-#[cfg(disabled_until_fixed)] // FIXME: the test looks to .succeed on android
+#[ignore = "disabled until fixed"] // FIXME: the test looks to .succeed on android
 fn test_cp_preserve_xattr_fails_on_android() {
     // Because of the SELinux extended attributes used on Android, trying to copy extended
     // attributes has to fail in this case, since we specify `--preserve=xattr` and this puts it

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -3525,7 +3525,7 @@ fn test_when_argument_file_is_a_symlink_to_directory_then_error() {
 // TODO: make this work on windows
 #[test]
 #[cfg(unix)]
-#[cfg(disabled_until_fixed)]
+#[ignore = "disabled until fixed"]
 fn test_when_argument_file_is_a_faulty_symlink_then_error() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -3557,7 +3557,7 @@ fn test_when_argument_file_is_a_faulty_symlink_then_error() {
 
 #[test]
 #[cfg(unix)]
-#[cfg(disabled_until_fixed)]
+#[ignore = "disabled until fixed"]
 fn test_when_argument_file_is_non_existent_unix_socket_address_then_error() {
     use std::os::unix::net;
 
@@ -3616,7 +3616,7 @@ fn test_when_argument_file_is_non_existent_unix_socket_address_then_error() {
 }
 
 #[test]
-#[cfg(disabled_until_fixed)]
+#[ignore = "disabled until fixed"]
 fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -3718,7 +3718,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
 }
 
 #[test]
-#[cfg(disabled_until_fixed)]
+#[ignore = "disabled until fixed"]
 fn test_when_argument_files_are_triple_combinations_of_fifo_pipe_and_regular_file() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -3599,7 +3599,7 @@ fn test_when_argument_file_is_non_existent_unix_socket_address_then_error() {
     let result = file.write_all(random_string.as_bytes());
     assert!(result.is_ok());
 
-    let expected_stdout = vec![format!("==> {} <==", path), random_string].join("\n");
+    let expected_stdout = [format!("==> {} <==", path), random_string].join("\n");
     ts.ucmd()
         .args(&["-c", "+0", path, socket])
         .fails()


### PR DESCRIPTION
This PR uses `#[ignore]` instead of `#[cfg(disabled_until_fixed)]` to disable tests. I overlooked those cases in https://github.com/uutils/coreutils/pull/6388 because of the slightly different attribute name ("disable**d**_until_fixed" vs. "disable_until_fixed").