### PR TITLE
ls: fix quoting alignment, add tests for default quoting style in TTY and quoting alignment

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2616,12 +2616,24 @@ fn display_grid(
         }
     } else {
         let names = if quoted {
+            // In case some names are quoted, GNU adds a space before each
+            // entry that does not start with a quote to make it prettier
+            // on multiline.
+            //
+            // Example:
+            // ```
+            // $ ls
+            // 'a\nb'   bar
+            //  foo     baz
+            // ^       ^
+            // These spaces is added
+            // ```
             names
                 .map(|n| {
-                    if n.starts_with('\'') {
-                        format!(" {n}")
-                    } else {
+                    if n.starts_with('\'') || n.starts_with('"') {
                         n
+                    } else {
+                        format!(" {n}")
                     }
                 })
                 .collect()

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2961,6 +2961,7 @@ fn test_ls_align_unquoted() {
     at.touch("'quoted'");
 
     // In TTY
+    #[cfg(unix)]
     scene
         .ucmd()
         .arg("--color")

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2686,16 +2686,24 @@ fn test_ls_quoting_style() {
     {
         at.touch("one\ntwo");
         at.touch("one\\two");
-        // Default is literal, when stdout is not a TTY.
-        // Otherwise, it is shell-escape
+
+        // Default is literal, when stdout is not a TTY...
         scene
             .ucmd()
             .arg("--hide-control-chars")
             .arg("one\ntwo")
             .succeeds()
             .stdout_only("one?two\n");
-        // TODO: TTY-expected output, find a way to check this as well
-        // .stdout_only("'one'$'\\n''two'\n");
+
+        // ... Otherwise, it is shell-escape
+        #[cfg(unix)]
+        scene
+            .ucmd()
+            .arg("--hide-control-chars")
+            .arg("one\ntwo")
+            .terminal_simulation(true)
+            .succeeds()
+            .stdout_only("'one'$'\\n''two'\r\n");
 
         for (arg, correct) in [
             ("--quoting-style=literal", "one?two"),
@@ -2786,13 +2794,21 @@ fn test_ls_quoting_style() {
         }
     }
 
+    // No-TTY
     scene
         .ucmd()
         .arg("one two")
         .succeeds()
         .stdout_only("one two\n");
-    // TODO: TTY-expected output
-    // .stdout_only("'one two'\n");
+
+    // TTY
+    #[cfg(unix)]
+    scene
+        .ucmd()
+        .arg("one two")
+        .terminal_simulation(true)
+        .succeeds()
+        .stdout_only("'one two'\r\n");
 
     for (arg, correct) in [
         ("--quoting-style=literal", "one two"),
@@ -2914,14 +2930,24 @@ fn test_ls_quoting_and_color() {
     let at = &scene.fixtures;
 
     at.touch("one two");
+
+    // No-TTY
     scene
         .ucmd()
         .arg("--color")
         .arg("one two")
         .succeeds()
         .stdout_only("one two\n");
-    // TODO: TTY-expected output
-    // .stdout_only("'one two'\n");
+
+    // TTY
+    #[cfg(unix)]
+    scene
+        .ucmd()
+        .arg("--color")
+        .arg("one two")
+        .terminal_simulation(true)
+        .succeeds()
+        .stdout_only("'one two'\r\n");
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2951,6 +2951,41 @@ fn test_ls_quoting_and_color() {
 }
 
 #[test]
+fn test_ls_align_unquoted() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.touch("elf two");
+    at.touch("foobar");
+    at.touch("CAPS");
+    at.touch("'quoted'");
+
+    // In TTY
+    scene
+        .ucmd()
+        .arg("--color")
+        .terminal_simulation(true)
+        .succeeds()
+        .stdout_only("\"'quoted'\"   CAPS  'elf two'   foobar\r\n");
+    //                              ^      ^          ^
+    //                              space  no-space   space
+
+    // The same should happen with format columns/across
+    // and shell quoting style, except for the `\r` at the end.
+    for format in &["--format=column", "--format=across"] {
+        scene
+            .ucmd()
+            .arg("--color")
+            .arg(format)
+            .arg("--quoting-style=shell")
+            .succeeds()
+            .stdout_only("\"'quoted'\"   CAPS  'elf two'   foobar\n");
+        //                              ^      ^          ^
+        //                              space  no-space   space
+    }
+}
+
+#[test]
 fn test_ls_ignore_hide() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
Fixes #6386 