### PR TITLE
cp: remove `target_os = "macos-12"`

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2114,7 +2114,6 @@ fn handle_no_preserve_mode(options: &Options, org_mode: u32) -> u32 {
         #[cfg(not(any(
             target_os = "android",
             target_os = "macos",
-            target_os = "macos-12",
             target_os = "freebsd",
             target_os = "redox",
         )))]
@@ -2131,7 +2130,6 @@ fn handle_no_preserve_mode(options: &Options, org_mode: u32) -> u32 {
         #[cfg(any(
             target_os = "android",
             target_os = "macos",
-            target_os = "macos-12",
             target_os = "freebsd",
             target_os = "redox",
         ))]


### PR DESCRIPTION
This PR removes two unnecessary `target_os = "macos-12"` entries to fix the corresponding "unexpected `cfg` condition value: `macos-12`" warnings (see, for example, https://github.com/uutils/coreutils/actions/runs/9108537605/job/25039512756#step:11:287).