### PR TITLE
Downgrade `libc` to `0.2.153`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,9 +1303,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ half = "2.4.1"
 hostname = "0.4"
 indicatif = "0.17.8"
 itertools = "0.12.1"
-libc = "0.2.154"
+libc = "0.2.153"
 lscolors = { version = "0.16.0", default-features = false, features = [
   "gnu_legacy",
 ] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4.7"
-libc = "0.2.154"
+libc = "0.2.153"
 tempfile = "3.10.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 similar = "2.5.0"


### PR DESCRIPTION
This PR downgrades `libc` to `0.2.153` because `0.2.154` got yanked.