### PR TITLE
uucore/utmpx: use UTC if offset can't be resolved

### DIFF
--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -189,7 +189,8 @@ impl Utmpx {
         let ts_nanos: i128 = (1_000_000_000_i64 * self.inner.ut_tv.tv_sec as i64
             + 1_000_i64 * self.inner.ut_tv.tv_usec as i64)
             .into();
-        let local_offset = time::OffsetDateTime::now_local().unwrap().offset();
+        let local_offset =
+            time::OffsetDateTime::now_local().map_or_else(|_| time::UtcOffset::UTC, |v| v.offset());
         time::OffsetDateTime::from_unix_timestamp_nanos(ts_nanos)
             .unwrap()
             .to_offset(local_offset)


### PR DESCRIPTION
This PR is an attempt to fix some of the errors that make the `Build (macos-latest, x86_64-apple-darwin, feat_os_macos)` job fail in the CI. It should fix the tests of `pinky`, `uptime`, and `who`, which currently fail with:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: IndeterminateOffset', src/uucore/src/lib/features/utmpx.rs:192:62
```
For some unknown reason, `OffsetDateTime::now_local()` from `time` is unable to determine the offset and returns an error. The proposed fix simply removes the `unwrap` and sets a default offset in the error case. I don't know whether this is correct, as I develop "blind", without macOS.