### PR TITLE
pinky: use UTC if offset can't be determined

### DIFF
--- a/src/uu/pinky/src/platform/unix.rs
+++ b/src/uu/pinky/src/platform/unix.rs
@@ -115,7 +115,7 @@ struct Pinky {
 
 fn idle_string(when: i64) -> String {
     thread_local! {
-        static NOW: time::OffsetDateTime = time::OffsetDateTime::now_local().unwrap();
+        static NOW: time::OffsetDateTime = time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
     }
     NOW.with(|n| {
         let duration = n.unix_timestamp() - when;


### PR DESCRIPTION
This PR fixes the same issue as https://github.com/uutils/coreutils/pull/6413 but in a different place. It should fix the remaining `pinky` tests in the failing `Build (macos-latest, x86_64-apple-darwin, feat_os_macos)` job in the CI.