### PR TITLE
tests: remove all `#[cfg(not(target_pointer_width = "128"))]`

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1987,7 +1987,6 @@ mod tests {
         // SizeTooBig
         let invalid_input = ["500E", "1Y"];
         for input in &invalid_input {
-            #[cfg(not(target_pointer_width = "128"))]
             assert!(GlobalSettings::parse_byte_count(input).is_err());
         }
 

--- a/src/uucore/src/lib/parser/parse_size.rs
+++ b/src/uucore/src/lib/parser/parse_size.rs
@@ -451,7 +451,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_pointer_width = "128"))]
     fn overflow_x64() {
         assert!(parse_size_u64("10000000000000000000000").is_err());
         assert!(parse_size_u64("1000000000T").is_err());
@@ -482,7 +481,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_pointer_width = "128"))]
     fn overflow_to_max_u64() {
         assert_eq!(Ok(1_099_511_627_776), parse_size_u64_max("1T"));
         assert_eq!(Ok(1_125_899_906_842_624), parse_size_u64_max("1P"));
@@ -494,7 +492,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_pointer_width = "128"))]
     fn overflow_to_max_u128() {
         assert_eq!(
             Ok(12_379_400_392_853_802_748_991_242_240),

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -136,7 +136,6 @@ fn test_du_invalid_size() {
             .fails()
             .code_is(1)
             .stderr_only(format!("du: invalid --{s} argument 'x'\n"));
-        #[cfg(not(target_pointer_width = "128"))]
         ts.ucmd()
             .arg(format!("--{s}=1Y"))
             .arg("/tmp")

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -304,12 +304,10 @@ fn test_head_invalid_num() {
         .stderr_is(
             "head: invalid number of lines: '1024R': Value too large for defined data type\n",
         );
-    #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-c", "1Y", "emptyfile.txt"])
         .fails()
         .stderr_is("head: invalid number of bytes: '1Y': Value too large for defined data type\n");
-    #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-n", "1Y", "emptyfile.txt"])
         .fails()

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -860,7 +860,6 @@ fn test_od_invalid_bytes() {
                 "od: invalid suffix in {option} argument '{INVALID_SUFFIX}'\n"
             ));
 
-        #[cfg(not(target_pointer_width = "128"))]
         new_ucmd!()
             .arg(format!("{option}={BIG_SIZE}"))
             .arg("file")

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -72,7 +72,6 @@ fn test_invalid_buffer_size() {
         .code_is(2)
         .stderr_only("sort: invalid suffix in --buffer-size argument '100f'\n");
 
-    #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .arg("-n")
         .arg("-S")

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -705,7 +705,6 @@ fn test_split_invalid_bytes_size() {
 
 #[test]
 fn test_split_overflow_bytes_size() {
-    #[cfg(not(target_pointer_width = "128"))]
     let (at, mut ucmd) = at_and_ucmd!();
     let name = "test_split_overflow_bytes_size";
     RandomFile::new(&at, name).add_bytes(1000);

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -66,7 +66,6 @@ fn test_stdbuf_invalid_mode_fails() {
             .fails()
             .code_is(125)
             .usage_error("invalid mode '1024R': Value too large for defined data type");
-        #[cfg(not(target_pointer_width = "128"))]
         new_ucmd!()
             .args(&[*option, "1Y", "head"])
             .fails()

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1110,13 +1110,11 @@ fn test_invalid_num() {
         .fails()
         .stderr_str()
         .starts_with("tail: invalid number of lines: '1024R'");
-    #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-c", "1Y", "emptyfile.txt"])
         .fails()
         .stderr_str()
         .starts_with("tail: invalid number of bytes: '1Y': Value too large for defined data type");
-    #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["-n", "1Y", "emptyfile.txt"])
         .fails()

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -245,7 +245,6 @@ fn test_truncate_bytes_size() {
         .fails()
         .code_is(1)
         .stderr_only("truncate: Invalid number: '1024R': Value too large for defined data type\n");
-    #[cfg(not(target_pointer_width = "128"))]
     new_ucmd!()
         .args(&["--size", "1Y", "file"])
         .fails()


### PR DESCRIPTION
This PR removes all `#[cfg(not(target_pointer_width = "128"))]` to fix several "unexpected `cfg` condition value: `128`" warnings in the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/9151519099/job/25157662399#step:11:377).