### PR TITLE
Cargo.toml: enable uucore's `mode` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,7 +490,12 @@ sha1 = { version = "0.10.6", features = ["std"] }
 tempfile = { workspace = true }
 time = { workspace = true, features = ["local-offset"] }
 unindent = "0.2.3"
-uucore = { workspace = true, features = ["entries", "process", "signals"] }
+uucore = { workspace = true, features = [
+  "entries",
+  "mode",
+  "process",
+  "signals",
+] }
 walkdir = { workspace = true }
 hex-literal = "0.4.1"
 rstest = { workspace = true }


### PR DESCRIPTION
This PR fixes an "unresolved import `uucore::mode`" error when running tests with `cargo test --features="<util name>" --no-default-features`.