### PR TITLE
tr: disallow classes besides [:upper:]/[:lower:] in set2 when translating

### DIFF
--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -120,6 +120,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         complement_flag,
         // if we are not translating then we don't truncate set1
         truncate_set1_flag && translating,
+        translating,
     )?;
 
     // '*_op' are the operations that need to be applied, in order.

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1364,3 +1364,8 @@ fn check_ignore_truncate_when_squeezing() {
         .no_stderr()
         .stdout_only("asdfqwer\n");
 }
+
+#[test]
+fn check_disallow_blank_in_set2_when_translating() {
+    new_ucmd!().args(&["-t", "1234", "[:blank:]"]).fails();
+}


### PR DESCRIPTION
To simplify the checks for [:upper:] and  [:lower:], I have separated the character classes into a sub-enum.

Additionally, I have implemented the divergent tr behaviour from the issue into a testcase.

Fixes issue #6342