### PR TITLE
fix: macos-latest is now arm64

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -477,8 +477,8 @@ jobs:
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_os_unix           , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
-          - { os: macos-14       , target: aarch64-apple-darwin        , features: feat_os_macos } # M1 CPU
-          - { os: macos-latest   , target: x86_64-apple-darwin         , features: feat_os_macos }
+          - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos } # M1 CPU
+          - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }


### PR DESCRIPTION
macos-latest is now an arm64 runner, it used to an amd64 runner but with https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/ macos-latest is no longer an am64 runner. 

This PR fixes this. By changing;

-> macos-14 to macos-latest
-> macos-latest to macos-13

