### PR TITLE
deny.toml: allow BSL-1.0 as license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-2-Clause-FreeBSD",
   "BSD-3-Clause",
+  "BSL-1.0",
   "CC0-1.0",
   "Unicode-DFS-2016",
 ]


### PR DESCRIPTION
This PR adds the "Boost Software License 1.0" (BSL-1.0) to the list of allowed licenses. It's added because it's used by `lockfree-object-pool`, a new dependency of `zip` (see https://github.com/uutils/coreutils/pull/6426).