### PR TITLE
cp: gnu test case preserve-mode fix

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -835,39 +835,24 @@ impl Attributes {
 
     /// Set the field to Preserve::NO { explicit: true } if the corresponding field
     /// in other is set to Preserve::Yes { .. }.
+        Self {
     pub fn diff(self, other: &Self) -> Self {
+        fn update_preserve_field(current: Preserve, other: Preserve) -> Preserve {
+            if matches!(other, Preserve::Yes { .. }) {
+                Preserve::No { explicit: true }
+            } else {
+                current
+            }
+        }
+
         Self {
             #[cfg(unix)]
-            ownership: if matches!(other.ownership, Preserve::Yes { .. }) {
-                Preserve::No { explicit: true }
-            } else {
-                self.ownership
-            },
-            mode: if matches!(other.mode, Preserve::Yes { .. }) {
-                Preserve::No { explicit: true }
-            } else {
-                self.mode
-            },
-            timestamps: if matches!(other.timestamps, Preserve::Yes { .. }) {
-                Preserve::No { explicit: true }
-            } else {
-                self.timestamps
-            },
-            context: if matches!(other.context, Preserve::Yes { .. }) {
-                Preserve::No { explicit: true }
-            } else {
-                self.context
-            },
-            links: if matches!(other.links, Preserve::Yes { .. }) {
-                Preserve::No { explicit: true }
-            } else {
-                self.links
-            },
-            xattr: if matches!(other.xattr, Preserve::Yes { .. }) {
-                Preserve::No { explicit: true }
-            } else {
-                self.xattr
-            },
+            ownership: update_preserve_field(self.ownership, other.ownership),
+            mode: update_preserve_field(self.mode, other.mode),
+            timestamps: update_preserve_field(self.timestamps, other.timestamps),
+            context: update_preserve_field(self.context, other.context),
+            links: update_preserve_field(self.links, other.links),
+            xattr: update_preserve_field(self.xattr, other.xattr),
         }
     }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -835,7 +835,6 @@ impl Attributes {
 
     /// Set the field to Preserve::NO { explicit: true } if the corresponding field
     /// in other is set to Preserve::Yes { .. }.
-        Self {
     pub fn diff(self, other: &Self) -> Self {
         fn update_preserve_field(current: Preserve, other: Preserve) -> Preserve {
             if matches!(other, Preserve::Yes { .. }) {
@@ -844,7 +843,6 @@ impl Attributes {
                 current
             }
         }
-
         Self {
             #[cfg(unix)]
             ownership: update_preserve_field(self.ownership, other.ownership),
@@ -2426,6 +2424,22 @@ mod tests {
                 context: Preserve::Yes { required: true },
                 xattr: Preserve::Yes { required: true },
                 ..Attributes::ALL
+            }
+        );
+        assert_eq!(
+            Attributes::NONE.diff(&Attributes {
+                context: Preserve::Yes { required: true },
+                xattr: Preserve::Yes { required: true },
+                ..Attributes::ALL
+            }),
+            Attributes {
+                #[cfg(unix)]
+                ownership: Preserve::No { explicit: true },
+                mode: Preserve::No { explicit: true },
+                timestamps: Preserve::No { explicit: true },
+                context: Preserve::No { explicit: true },
+                links: Preserve::No { explicit: true },
+                xattr: Preserve::No { explicit: true }
             }
         );
     }


### PR DESCRIPTION
This PR was initially intended to fix GNU test preserve-mode, but as it turns out, there was nothing wrong with how `uu-cp` preserved mode. The test was failing because overriding wasn't working properly. The test involved copying a FIFO with options `-a --preserve=mode`. The `-a` was supposed to disable copying contents, but it was getting overridden by `--preserve` wrongly. So, this PR now tries to fix the overriding of attributes.

**changes in behavior**

- when a flag like `-a` which expands to `-dR --preserve=all` is given and a --preserve is given after that, cp would only override the --preserve part.
- cp could handle `--preserve` and `--no-preserve` together in a single command, for example `cp --preserve=mode,ownership --no-preserve=ownership --preserve=link f f2` would preserve mode and link but not the ownership
