### PR TITLE
df: fix size column padding

### DIFF
--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -201,6 +201,7 @@ impl Column {
             // 14 = length of "Filesystem" plus 4 spaces
             Self::Source => 14,
             Self::Used => 5,
+            Self::Size => 5,
             // the shortest headers have a length of 4 chars so we use that as the minimum width
             _ => 4,
         }


### PR DESCRIPTION
Similarly to the `Used` column, GNU df pads an extra space to the right of the `Size` column.
