### PR TITLE
df: fix incorrect test & add another test

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -179,13 +179,28 @@ fn test_default_headers() {
 }
 
 #[test]
-fn test_precedence_of_human_readable_header_over_output_header() {
+fn test_precedence_of_human_readable_and_si_header_over_output_header() {
+    let args = ["-h", "--human-readable", "-H", "--si"];
+
+    for arg in args {
+        let output = new_ucmd!()
+            .args(&[arg, "--output=size"])
+            .succeeds()
+            .stdout_move_str();
+        let header = output.lines().next().unwrap();
+        assert_eq!(header, " Size");
+    }
+}
+
+#[test]
+fn test_used_header_starts_with_space() {
     let output = new_ucmd!()
-        .args(&["-H", "--output=size"])
+        // using -h here to ensure the width of the column's content is <= 4
+        .args(&["-h", "--output=used"])
         .succeeds()
         .stdout_move_str();
-    let header = output.lines().next().unwrap().to_string();
-    assert_eq!(header.trim(), "Size");
+    let header = output.lines().next().unwrap();
+    assert_eq!(header, " Used");
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes an incorrect test related to https://github.com/uutils/coreutils/pull/6433 and adds an additional test to ensure the `Used` column is left-padded with a space.