### PR TITLE
  src/uucore/src/lib/features/fsext.rs: Add magic for bcachefs

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -899,6 +899,7 @@ pub fn pretty_fstype<'a>(fstype: i64) -> Cow<'a, str> {
         0x0187 => "autofs".into(),
         0x4246_5331 => "befs".into(),
         0x6264_6576 => "bdevfs".into(),
+        0xCA451A4E => "bcachefs".into(),
         0x1BAD_FACE => "bfs".into(),
         0xCAFE_4A11 => "bpf_fs".into(),
         0x4249_4E4D => "binfmt_misc".into(),


### PR DESCRIPTION
  Enables stat to recogise a BcacheFS filesystem - for example:

  $ ./target/debug/stat -f /
  File: "/"
    ID: 64b40636928f3ee7 Namelen: 512     Type: bcachefs
  Block size: 512        Fundamental block size: 512
  Blocks: Total: 2044464374 Free: 295830135  Available: 291278902
  Inodes: Total: 2375400624 Free: 2366641080