### PR TITLE
tr: A [:lower:]/[:upper:] in set2 must be matched in set1

### DIFF
--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1369,3 +1369,8 @@ fn check_ignore_truncate_when_squeezing() {
 fn check_disallow_blank_in_set2_when_translating() {
     new_ucmd!().args(&["-t", "1234", "[:blank:]"]).fails();
 }
+
+#[test]
+fn check_class_in_set2_must_be_matched_in_set1() {
+    new_ucmd!().args(&["-t", "1[:upper:]", "[:upper:]"]).fails();
+}


### PR DESCRIPTION
If there is a [:lower:] or [:upper:] in set2, then there must be a [:lower:] or [:upper:] at the same logical position in set1

So
```bash
$tr '[:upper:]' '[:lower:]' # works
$tr '1[:upper:]' '[:lower:]' # doesnt
```

To accomplish this change I have done the following things:

- flatten error checks (take early exits from  `solve_set_characters` instead of nesting `if`s)

- simplify CharStar (`[c*]`) handling code by simply replacing CharStar with a CharRepeat of appropriate length

- switch flatten() from `Sequence -> u8` to `Sequence -> Char`

The main idea here is that to correctly implement the tr behaviour, one has to flatten everything but [:upper:]/[:lower:] into the underlying string of chars and then check if  the character class in the one set is at the same position in the other set:

This apparent behavior is supported by these two GNU tr invocations:

```bash
$tr [:blank:][:lower:] 12[:upper:] # works
$abcs="abcdefghijklmnopqrstuvwxyz"
$tr [:lower:][:upper:]  "${abcs}[:upper:]" # misaligned error
```