### PR TITLE
gnu `cp-parents` test case

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -431,7 +431,8 @@ pub(crate) fn copy_directory(
         let dest = target.join(root.file_name().unwrap());
         copy_attributes(root, dest.as_path(), &options.attributes)?;
         for (x, y) in aligned_ancestors(root, dest.as_path()) {
-            copy_attributes(x, y, &options.attributes)?;
+            let src = x.canonicalize()?;
+            copy_attributes(&src, y, &options.attributes)?;
         }
     } else {
         copy_attributes(root, target, &options.attributes)?;

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -431,8 +431,9 @@ pub(crate) fn copy_directory(
         let dest = target.join(root.file_name().unwrap());
         copy_attributes(root, dest.as_path(), &options.attributes)?;
         for (x, y) in aligned_ancestors(root, dest.as_path()) {
-            let src = x.canonicalize()?;
-            copy_attributes(&src, y, &options.attributes)?;
+            if let Ok(src) = canonicalize(x, MissingHandling::Normal, ResolveMode::Physical) {
+                copy_attributes(&src, y, &options.attributes)?;
+            }
         }
     } else {
         copy_attributes(root, target, &options.attributes)?;

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1459,7 +1459,7 @@ pub(crate) fn copy_attributes(
                 groups_only: false,
                 level: VerbosityLevel::Silent,
             },
-        ); 
+        );
         Ok(())
     })?;
 
@@ -2165,14 +2165,13 @@ fn copy_file(
         // the user does not have permission to write to the file.
         fs::set_permissions(dest, dest_permissions).ok();
     }
-    
-    if options.dereference(source_in_command_line){
-        copy_attributes(&source.canonicalize()?, dest, &options.attributes)?;
-    }else {
-        copy_attributes(source, dest, &options.attributes)?;
 
+    if options.dereference(source_in_command_line) {
+        copy_attributes(&source.canonicalize()?, dest, &options.attributes)?;
+    } else {
+        copy_attributes(source, dest, &options.attributes)?;
     }
-    
+
     copied_files.insert(
         FileInformation::from_path(source, options.dereference(source_in_command_line))?,
         dest.to_path_buf(),

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1332,7 +1332,7 @@ fn construct_dest_path(
     Ok(match target_type {
         TargetType::Directory => {
             let root = if options.parents {
-                Path::new("")
+                    Path::new("")
             } else {
                 source_path.parent().unwrap_or(source_path)
             };
@@ -1380,7 +1380,8 @@ fn copy_source(
         );
         if options.parents {
             for (x, y) in aligned_ancestors(source, dest.as_path()) {
-                copy_attributes(x, y, &options.attributes)?;
+                let src = x.canonicalize()?;
+                copy_attributes(&src, y, &options.attributes)?;
             }
         }
         res
@@ -2162,9 +2163,14 @@ fn copy_file(
         // the user does not have permission to write to the file.
         fs::set_permissions(dest, dest_permissions).ok();
     }
+    
+    if options.dereference(source_in_command_line){
+        copy_attributes(&source.canonicalize()?, dest, &options.attributes)?;
+    }else {
+        copy_attributes(source, dest, &options.attributes)?;
 
-    copy_attributes(source, dest, &options.attributes)?;
-
+    }
+    
     copied_files.insert(
         FileInformation::from_path(source, options.dereference(source_in_command_line))?,
         dest.to_path_buf(),

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -5574,7 +5574,7 @@ fn test_preserve_attrs_overriding_2() {
     }
 }
 
- /// Test the behavior of preserving permissions when copying through a symlink
+/// Test the behavior of preserving permissions when copying through a symlink
 #[test]
 fn test_cp_symlink_permissions() {
     let scene = TestScenario::new(util_name!());
@@ -5595,7 +5595,7 @@ fn test_cp_symlink_permissions() {
     );
 }
 
- /// Test the behavior of preserving permissions of parents when copying through a symlink
+/// Test the behavior of preserving permissions of parents when copying through a symlink
 #[test]
 fn test_cp_parents_symlink_permissions_file() {
     let scene = TestScenario::new(util_name!());
@@ -5617,8 +5617,8 @@ fn test_cp_parents_symlink_permissions_file() {
     );
 }
 
- /// Test the behavior of preserving permissions of parents when copying through
- /// a symlink when source is a dir.
+/// Test the behavior of preserving permissions of parents when copying through
+/// a symlink when source is a dir.
 #[test]
 fn test_cp_parents_symlink_permissions_dir() {
     let scene = TestScenario::new(util_name!());
@@ -5637,4 +5637,21 @@ fn test_cp_parents_symlink_permissions_dir() {
         src_dir_metadata.permissions().mode(),
         dest_dir_metadata.permissions().mode()
     );
+}
+
+/// Test the behavior of copying a file to a destination with parents using absolute paths.
+#[test]
+fn test_cp_parents_absolute_path() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir_all("a/b");
+    at.touch("a/b/f");
+    at.mkdir("dest");
+    let src = format!("{}/a/b/f", at.root_dir_resolved());
+    scene
+        .ucmd()
+        .args(&["--parents", src.as_str(), "dest"])
+        .succeeds();
+    let res = format!("dest{}/a/b/f", at.root_dir_resolved());
+    at.file_exists(res);
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -5573,3 +5573,68 @@ fn test_preserve_attrs_overriding_2() {
         assert_ne!(dest_file1_metadata.ino(), dest_file2_metadata.ino());
     }
 }
+
+ /// Test the behavior of preserving permissions when copying through a symlink
+#[test]
+fn test_cp_symlink_permissions() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    at.set_mode("a", 0o700);
+    at.symlink_file("a", "symlink");
+    at.mkdir("dest");
+    scene
+        .ucmd()
+        .args(&["--preserve", "symlink", "dest"])
+        .succeeds();
+    let dest_dir_metadata = at.metadata("dest/symlink");
+    let src_dir_metadata = at.metadata("a");
+    assert_eq!(
+        src_dir_metadata.permissions().mode(),
+        dest_dir_metadata.permissions().mode()
+    );
+}
+
+ /// Test the behavior of preserving permissions of parents when copying through a symlink
+#[test]
+fn test_cp_parents_symlink_permissions_file() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("a");
+    at.touch("a/file");
+    at.set_mode("a", 0o700);
+    at.symlink_dir("a", "symlink");
+    at.mkdir("dest");
+    scene
+        .ucmd()
+        .args(&["--parents", "-a", "symlink/file", "dest"])
+        .succeeds();
+    let dest_dir_metadata = at.metadata("dest/symlink");
+    let src_dir_metadata = at.metadata("a");
+    assert_eq!(
+        src_dir_metadata.permissions().mode(),
+        dest_dir_metadata.permissions().mode()
+    );
+}
+
+ /// Test the behavior of preserving permissions of parents when copying through
+ /// a symlink when source is a dir.
+#[test]
+fn test_cp_parents_symlink_permissions_dir() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir_all("a/b");
+    at.set_mode("a", 0o755); // Set mode for the actual directory
+    at.symlink_dir("a", "symlink");
+    at.mkdir("dest");
+    scene
+        .ucmd()
+        .args(&["--parents", "-a", "symlink/b", "dest"])
+        .succeeds();
+    let dest_dir_metadata = at.metadata("dest/symlink");
+    let src_dir_metadata = at.metadata("a");
+    assert_eq!(
+        src_dir_metadata.permissions().mode(),
+        dest_dir_metadata.permissions().mode()
+    );
+}

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -5576,6 +5576,7 @@ fn test_preserve_attrs_overriding_2() {
 
 /// Test the behavior of preserving permissions when copying through a symlink
 #[test]
+#[cfg(unix)]
 fn test_cp_symlink_permissions() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -5597,6 +5598,7 @@ fn test_cp_symlink_permissions() {
 
 /// Test the behavior of preserving permissions of parents when copying through a symlink
 #[test]
+#[cfg(unix)]
 fn test_cp_parents_symlink_permissions_file() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -5620,6 +5622,7 @@ fn test_cp_parents_symlink_permissions_file() {
 /// Test the behavior of preserving permissions of parents when copying through
 /// a symlink when source is a dir.
 #[test]
+#[cfg(unix)]
 fn test_cp_parents_symlink_permissions_dir() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -5640,6 +5643,7 @@ fn test_cp_parents_symlink_permissions_dir() {
 }
 
 /// Test the behavior of copying a file to a destination with parents using absolute paths.
+#[cfg(unix)]
 #[test]
 fn test_cp_parents_absolute_path() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
This PR aims to fix the GNU cp-parents test case. The following behaviors have been changed in this PR:
- if dereference is enabled and --preserve attributes are specified, instead of copying the attributes of the symlink itself, cp will try to copy the attributes of the actual file the symlink points to.
- --parents will not fail if an absolute path is given (I couldn't make this work on Windows).
- For GNU compatibility, cp will not return an error if setting ownership fails.