### PR TITLE
uucore: enable `sum` feature for `checksum` feature

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -76,7 +76,7 @@ default = []
 # * non-default features
 backup-control = []
 colors = []
-checksum = ["regex"]
+checksum = ["regex", "sum"]
 encoding = ["data-encoding", "data-encoding-macro", "z85", "thiserror"]
 entries = ["libc"]
 fs = ["dunce", "libc", "winapi-util", "windows-sys"]


### PR DESCRIPTION
This PR enables the `sum` feature for the `checksum` feature in `Cargo.toml`. I noticed the missing feature when trying to run `cargo test --features=checksum`.