### PR TITLE
seq: fix typo in benchmarking documentation file

### DIFF
--- a/src/uu/seq/BENCHMARKING.md
+++ b/src/uu/seq/BENCHMARKING.md
@@ -15,7 +15,7 @@ Next, build the `seq` binary under the release profile:
 cargo build --release -p uu_seq
 ```
 
-Finally, you can compare the performance of the two versions of `head`
+Finally, you can compare the performance of the two versions of `seq`
 by running, for example,
 
 ```shell


### PR DESCRIPTION
This MR fix a little type in the documentation of `seq` benchmarking documentation file.