### PR TITLE
Bump `itertools` and fix use of deprecated function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1241,6 +1241,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2990,7 +2999,7 @@ version = "0.0.26"
 dependencies = [
  "chrono",
  "clap",
- "itertools",
+ "itertools 0.13.0",
  "quick-error",
  "regex",
  "uucore",
@@ -3126,7 +3135,7 @@ dependencies = [
  "compare",
  "ctrlc",
  "fnv",
- "itertools",
+ "itertools 0.13.0",
  "memchr",
  "rand",
  "rayon",
@@ -3407,7 +3416,7 @@ name = "uu_yes"
 version = "0.0.26"
 dependencies = [
  "clap",
- "itertools",
+ "itertools 0.13.0",
  "nix",
  "uucore",
 ]
@@ -3426,7 +3435,7 @@ dependencies = [
  "dunce",
  "glob",
  "hex",
- "itertools",
+ "itertools 0.13.0",
  "libc",
  "md-5",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ glob = "0.3.1"
 half = "2.4.1"
 hostname = "0.4"
 indicatif = "0.17.8"
-itertools = "0.12.1"
+itertools = "0.13.0"
 libc = "0.2.153"
 lscolors = { version = "0.16.0", default-features = false, features = [
   "gnu_legacy",

--- a/deny.toml
+++ b/deny.toml
@@ -102,6 +102,8 @@ skip = [
   { name = "terminal_size", version = "0.2.6" },
   # filetime, parking_lot_core
   { name = "redox_syscall", version = "0.4.1" },
+  # bindgen
+  { name = "itertools", version = "0.12.1" },
 ]
 # spell-checker: enable
 

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -956,7 +956,7 @@ fn mpr(paths: &[&str], options: &OutputOptions) -> Result<i32, PrError> {
                 a.group_key < b.group_key
             }
         })
-        .group_by(|file_line| file_line.group_key);
+        .chunk_by(|file_line| file_line.group_key);
 
     let start_page = options.start_page;
     let mut lines = Vec::new();


### PR DESCRIPTION
This PR bumps `itertools` from `0.12.1` to `0.13.0` and adds it to the skip list in `deny.toml`. And in `pr` it uses `chunk_by()` from `itertools` instead of the deprecated `group_by()`.