### PR TITLE
clippy: fix warnings introduced by Rust 1.79

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -259,7 +259,7 @@ fn catch_too_large_numbers_in_backwards_bytes_or_lines(n: u64) -> Option<usize> 
 fn read_but_last_n_bytes(input: &mut impl std::io::BufRead, n: u64) -> std::io::Result<()> {
     if n == 0 {
         //prints everything
-        return read_n_bytes(input, std::u64::MAX);
+        return read_n_bytes(input, u64::MAX);
     }
 
     if let Some(n) = catch_too_large_numbers_in_backwards_bytes_or_lines(n) {

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -119,12 +119,7 @@ struct Repr<'a> {
 }
 
 impl<'a> Repr<'a> {
-    fn new(
-        line_ending: LineEnding,
-        separator: u8,
-        format: &'a [Spec],
-        empty: &'a [u8],
-    ) -> Repr<'a> {
+    fn new(line_ending: LineEnding, separator: u8, format: &'a [Spec], empty: &'a [u8]) -> Self {
         Repr {
             line_ending,
             separator,
@@ -333,7 +328,7 @@ impl<'a> State<'a> {
         key: usize,
         line_ending: LineEnding,
         print_unpaired: bool,
-    ) -> UResult<State<'a>> {
+    ) -> UResult<Self> {
         let file_buf = if name == "-" {
             Box::new(stdin.lock()) as Box<dyn BufRead>
         } else {

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -177,7 +177,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
     let fields = if fields.split(&[',', ' ']).any(|x| x == "-") {
         vec![Range {
             low: 1,
-            high: std::usize::MAX,
+            high: usize::MAX,
         }]
     } else {
         Range::from_list(fields)?

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -321,14 +321,10 @@ struct NonrepeatingIterator<'a> {
 }
 
 impl<'a> NonrepeatingIterator<'a> {
-    fn new(
-        range: RangeInclusive<usize>,
-        rng: &'a mut WrappedRng,
-        amount: usize,
-    ) -> NonrepeatingIterator {
+    fn new(range: RangeInclusive<usize>, rng: &'a mut WrappedRng, amount: usize) -> Self {
         let capped_amount = if range.start() > range.end() {
             0
-        } else if *range.start() == 0 && *range.end() == std::usize::MAX {
+        } else if *range.start() == 0 && *range.end() == usize::MAX {
             amount
         } else {
             amount.min(range.end() - range.start() + 1)
@@ -482,7 +478,7 @@ fn parse_range(input_range: &str) -> Result<RangeInclusive<usize>, String> {
 }
 
 fn parse_head_count(headcounts: Vec<String>) -> Result<usize, String> {
-    let mut result = std::usize::MAX;
+    let mut result = usize::MAX;
     for count in headcounts {
         match count.parse::<usize>() {
             Ok(pv) => result = std::cmp::min(result, pv),

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1728,8 +1728,8 @@ fn general_f64_parse(a: &str) -> GeneralF64ParseResult {
     // TODO: Once our minimum supported Rust version is 1.53 or above, we should add tests for those cases.
     match a.parse::<f64>() {
         Ok(a) if a.is_nan() => GeneralF64ParseResult::NaN,
-        Ok(a) if a == std::f64::NEG_INFINITY => GeneralF64ParseResult::NegInfinity,
-        Ok(a) if a == std::f64::INFINITY => GeneralF64ParseResult::Infinity,
+        Ok(a) if a == f64::NEG_INFINITY => GeneralF64ParseResult::NegInfinity,
+        Ok(a) if a == f64::INFINITY => GeneralF64ParseResult::Infinity,
         Ok(a) => GeneralF64ParseResult::Number(a),
         Err(_) => GeneralF64ParseResult::Invalid,
     }

--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -316,7 +316,7 @@ pub struct FilenameIterator<'a> {
 }
 
 impl<'a> FilenameIterator<'a> {
-    pub fn new(prefix: &'a str, suffix: &'a Suffix) -> UResult<FilenameIterator<'a>> {
+    pub fn new(prefix: &'a str, suffix: &'a Suffix) -> UResult<Self> {
         let radix = suffix.stype.radix();
         let number = if suffix.auto_widening {
             Number::DynamicWidth(DynamicWidthNumber::new(radix, suffix.start))

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -20,7 +20,6 @@ use std::fs::{metadata, File};
 use std::io;
 use std::io::{stdin, BufRead, BufReader, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::u64;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UIoError, UResult, USimpleError, UUsageError};
 use uucore::parse_size::parse_size_u64;
@@ -729,7 +728,7 @@ struct ByteChunkWriter<'a> {
 }
 
 impl<'a> ByteChunkWriter<'a> {
-    fn new(chunk_size: u64, settings: &'a Settings) -> UResult<ByteChunkWriter<'a>> {
+    fn new(chunk_size: u64, settings: &'a Settings) -> UResult<Self> {
         let mut filename_iterator = FilenameIterator::new(&settings.prefix, &settings.suffix)?;
         let filename = filename_iterator
             .next()
@@ -853,7 +852,7 @@ struct LineChunkWriter<'a> {
 }
 
 impl<'a> LineChunkWriter<'a> {
-    fn new(chunk_size: u64, settings: &'a Settings) -> UResult<LineChunkWriter<'a>> {
+    fn new(chunk_size: u64, settings: &'a Settings) -> UResult<Self> {
         let mut filename_iterator = FilenameIterator::new(&settings.prefix, &settings.suffix)?;
         let filename = filename_iterator
             .next()
@@ -959,7 +958,7 @@ struct LineBytesChunkWriter<'a> {
 }
 
 impl<'a> LineBytesChunkWriter<'a> {
-    fn new(chunk_size: u64, settings: &'a Settings) -> UResult<LineBytesChunkWriter<'a>> {
+    fn new(chunk_size: u64, settings: &'a Settings) -> UResult<Self> {
         let mut filename_iterator = FilenameIterator::new(&settings.prefix, &settings.suffix)?;
         let filename = filename_iterator
             .next()

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -46,7 +46,7 @@ pub struct ReverseChunks<'a> {
 }
 
 impl<'a> ReverseChunks<'a> {
-    pub fn new(file: &'a mut File) -> ReverseChunks<'a> {
+    pub fn new(file: &'a mut File) -> Self {
         let current = if cfg!(unix) {
             file.stream_position().unwrap()
         } else {

--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -391,7 +391,7 @@ pub struct DigestWriter<'a> {
 }
 
 impl<'a> DigestWriter<'a> {
-    pub fn new(digest: &'a mut Box<dyn Digest>, binary: bool) -> DigestWriter {
+    pub fn new(digest: &'a mut Box<dyn Digest>, binary: bool) -> Self {
         let was_last_character_carriage_return = false;
         DigestWriter {
             digest,

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -158,7 +158,7 @@ fn test_range_repeat_no_overflow_1_max() {
 
 #[test]
 fn test_range_repeat_no_overflow_0_max_minus_1() {
-    let upper_bound = std::usize::MAX - 1;
+    let upper_bound = usize::MAX - 1;
     let result = new_ucmd!()
         .arg("-rn1")
         .arg(&format!("-i0-{upper_bound}"))
@@ -176,7 +176,7 @@ fn test_range_repeat_no_overflow_0_max_minus_1() {
 
 #[test]
 fn test_range_permute_no_overflow_1_max() {
-    let upper_bound = std::usize::MAX;
+    let upper_bound = usize::MAX;
     let result = new_ucmd!()
         .arg("-n1")
         .arg(&format!("-i1-{upper_bound}"))
@@ -194,7 +194,7 @@ fn test_range_permute_no_overflow_1_max() {
 
 #[test]
 fn test_range_permute_no_overflow_0_max_minus_1() {
-    let upper_bound = std::usize::MAX - 1;
+    let upper_bound = usize::MAX - 1;
     let result = new_ucmd!()
         .arg("-n1")
         .arg(&format!("-i0-{upper_bound}"))
@@ -215,7 +215,7 @@ fn test_range_permute_no_overflow_0_max() {
     // NOTE: This is different from GNU shuf!
     // GNU shuf accepts -i0-MAX-1 and -i1-MAX, but not -i0-MAX.
     // This feels like a bug in GNU shuf.
-    let upper_bound = std::usize::MAX;
+    let upper_bound = usize::MAX;
     let result = new_ucmd!()
         .arg("-n1")
         .arg(&format!("-i0-{upper_bound}"))


### PR DESCRIPTION
This PR fixes clippy warnings introduced by Rust 1.79 from the [legacy_numeric_constants](https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants) and [use_self](https://rust-lang.github.io/rust-clippy/master/index.html#/use_self) lints.