### PR TITLE
Refuse to translate if set1 is longer than set2 and set2 ends in a character class

### DIFF
--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1374,3 +1374,15 @@ fn check_disallow_blank_in_set2_when_translating() {
 fn check_class_in_set2_must_be_matched_in_set1() {
     new_ucmd!().args(&["-t", "1[:upper:]", "[:upper:]"]).fails();
 }
+
+#[test]
+fn check_set1_longer_set2_ends_in_class() {
+    new_ucmd!().args(&["[:lower:]a", "[:upper:]"]).fails();
+}
+
+#[test]
+fn check_set1_longer_set2_ends_in_class_with_trunc() {
+    new_ucmd!()
+        .args(&["-t", "[:lower:]a", "[:upper:]"])
+        .succeeds();
+}


### PR DESCRIPTION
I think we should fall in line with GNU behaviour here.

If you really think you need to do this: 

```
tr [:lower:]123 [:upper:]
```

you can already do this:

```
tr [:lower:]123 [:upper:]Z
```

which does the same thing and is more explicit about which character is repeated to fill set2.

(Although generally, I think that if you are at that point you are already using the wrong tool).

However, I do not have strong opinions on this and would happily implement this the other way  if someone is clearly in favour of  that.