### PR TITLE
Refuse to translate if set2 contains more than one unique characters and set1 contains a character class

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -265,10 +265,14 @@ impl Sequence {
             .flat_map(Self::flatten_all)
             .filter_map(to_u8)
             .collect();
+
+        // Calculate the set of unique characters in set2
         let mut set2_uniques = set2_solved.clone();
         set2_uniques.sort();
         set2_uniques.dedup();
 
+        //If the complement flag is used in translate mode, only one unique character may appear in
+        //set2. Validate this with the set of uniques in set2 that we just generated.
         if set1.iter().any(|x| matches!(x, Self::Class(_)))
             && translating
             && complement_flag

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1386,3 +1386,23 @@ fn check_set1_longer_set2_ends_in_class_with_trunc() {
         .args(&["-t", "[:lower:]a", "[:upper:]"])
         .succeeds();
 }
+
+#[test]
+fn check_complement_2_unique_in_set2() {
+    let x226 = "x".repeat(226);
+
+    // [y*] is expanded tp "y" here
+    let arg = x226 + "[y*]xxx";
+    new_ucmd!().args(&["-c", "[:upper:]", arg.as_str()]).fails();
+}
+
+#[test]
+fn check_complement_1_unique_in_set2() {
+    let x226 = "x".repeat(226);
+
+    // [y*] is expanded to "" here
+    let arg = x226 + "[y*]xxxx";
+    new_ucmd!()
+        .args(&["-c", "[:upper:]", arg.as_str()])
+        .succeeds();
+}


### PR DESCRIPTION
If complementing and translating with a character class, there can only be one unique character in set2.

The underlying issue, [y*] not being expanded to "" was fixed "accidentally" in a previous restructuring of tr. I have simply added the error check here.