### PR TITLE
ls: gnu `color-norm` test fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b209ec3976527806024406fe765474b9a1750a0ed4b8f0372364741f50e7b"
+checksum = "02a5d67fc8a616f260ee9a36868547da09ac24178a4b84708cd8ea781372fbe4"
 dependencies = [
  "nu-ansi-term",
 ]
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+checksum = "dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14"
 dependencies = [
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,9 +290,10 @@ hostname = "0.4"
 indicatif = "0.17.8"
 itertools = "0.13.0"
 libc = "0.2.153"
-lscolors = { version = "0.16.0", default-features = false, features = [
+# this is just for a draft pr
+lscolors = { default-features = false, features = [
   "gnu_legacy",
-] }
+], git = "https://github.com/matrixhead/lscolors" }
 memchr = "2.7.2"
 memmap2 = "0.9.4"
 nix = { version = "0.28", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,10 +290,10 @@ hostname = "0.4"
 indicatif = "0.17.8"
 itertools = "0.13.0"
 libc = "0.2.153"
-# this is just for a draft pr
+# this is just for a draft r
 lscolors = { default-features = false, features = [
   "gnu_legacy",
-], git = "https://github.com/matrixhead/lscolors" }
+], git = "https://github.com/tavianator/lscolors", branch = "fix-fi-no-fallback" }
 memchr = "2.7.2"
 memmap2 = "0.9.4"
 nix = { version = "0.28", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,10 +290,9 @@ hostname = "0.4"
 indicatif = "0.17.8"
 itertools = "0.13.0"
 libc = "0.2.153"
-# this is just for a draft r
-lscolors = { default-features = false, features = [
+lscolors = { version = "0.18.0", default-features = false, features = [
   "gnu_legacy",
-], git = "https://github.com/tavianator/lscolors", branch = "fix-fi-no-fallback" }
+] }
 memchr = "2.7.2"
 memmap2 = "0.9.4"
 nix = { version = "0.28", default-features = false }

--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -1,0 +1,165 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+use super::get_metadata_with_deref_opt;
+use super::PathData;
+use lscolors::{Indicator, LsColors, Style};
+use std::fs::{DirEntry, Metadata};
+use std::io::{BufWriter, Stdout};
+
+/// We need this struct to be able to store the previous style.
+/// This because we need to check the previous value in case we don't need
+/// the reset
+pub(crate) struct StyleManager<'a> {
+    /// last style that is applied, if `None` that means reset is applied.
+    pub(crate) current_style: Option<Style>,
+    /// `true` if the initial reset is applied
+    pub(crate) initial_reset_is_done: bool,
+    pub(crate) colors: &'a LsColors,
+}
+
+impl<'a> StyleManager<'a> {
+    pub(crate) fn new(colors: &'a LsColors) -> Self {
+        Self {
+            initial_reset_is_done: false,
+            current_style: None,
+            colors,
+        }
+    }
+
+    pub(crate) fn apply_style(&mut self, new_style: Option<&Style>, name: &str) -> String {
+        let mut style_code = String::new();
+        let mut force_suffix_reset: bool = false;
+        // if reset is done we need to apply normal style before applying new style
+        if self.is_reset() {
+            if let Some(norm_sty) = self.get_normal_style().copied() {
+                style_code.push_str(&self.get_style_code(&norm_sty));
+            }
+        }
+        // we only need to apply a new style if it's not the same as the current
+        // style for example if normal is the current style and a file with
+        // normal style is to be printed we could skip printing new color
+        // codes
+        if let Some(new_style) = new_style {
+            if !self.is_current_style(new_style) {
+                style_code.push_str(&self.reset(!self.initial_reset_is_done));
+                style_code.push_str(&self.get_style_code(new_style));
+            }
+        }
+        // lscolors might be set to zero value if it's set to zero value that
+        // means it should clear all style attributes including normal,so in the
+        // following code if it's not reset it means that it's running normal,
+        // then if zeroed is passed we should reset
+        else if !self.is_reset() {
+            if let Some(norm) = self.get_normal_style().copied() {
+                if self.is_current_style(&norm) {
+                    style_code.push_str(&self.reset(false));
+                    // even though this is an unnecessary reset for gnu compatibility we allow it here
+                    force_suffix_reset = true;
+                }
+            }
+        }
+        format!("{}{}{}", style_code, name, self.reset(force_suffix_reset))
+    }
+
+    /// Resets the current style and returns the default ANSI reset code to
+    /// reset all text formatting attributes. If `force` is true, the reset is
+    /// done even if the reset has been applied before.
+    pub(crate) fn reset(&mut self, force: bool) -> String {
+        // todo:
+        // We need to use style from `Indicator::Reset` but as of now ls colors
+        // uses a fallback mechanism and because of that if `Indicator::Reset`
+        // is not specified it would fallback to `Indicator::Normal` which seems
+        // to be non compatible with gnu
+        if self.current_style.is_some() || force {
+            self.initial_reset_is_done = true;
+            self.current_style = None;
+            return "\x1b[0m".to_string();
+        }
+        String::new()
+    }
+
+    pub(crate) fn get_style_code(&mut self, new_style: &Style) -> String {
+        self.current_style = Some(*new_style);
+        let mut nu_a_style = new_style.to_nu_ansi_term_style();
+        nu_a_style.prefix_with_reset = false;
+        let mut ret = nu_a_style.paint("").to_string();
+        // remove the suffix reset
+        ret.truncate(ret.len() - 4);
+        ret
+    }
+
+    pub(crate) fn is_current_style(&mut self, new_style: &Style) -> bool {
+        matches!(&self.current_style,Some(style) if style == new_style )
+    }
+
+    pub(crate) fn is_reset(&mut self) -> bool {
+        self.current_style.is_none()
+    }
+
+    pub(crate) fn get_normal_style(&self) -> Option<&Style> {
+        self.colors.style_for_indicator(Indicator::Normal)
+    }
+    pub(crate) fn apply_normal(&mut self) -> String {
+        if let Some(sty) = self.get_normal_style().copied() {
+            return self.get_style_code(&sty);
+        }
+        String::new()
+    }
+
+    pub(crate) fn apply_style_based_on_metadata(
+        &mut self,
+        path: &PathData,
+        md_option: Option<&Metadata>,
+        name: &str,
+    ) -> String {
+        let style = self
+            .colors
+            .style_for_path_with_metadata(&path.p_buf, md_option);
+        self.apply_style(style, name)
+    }
+
+    pub(crate) fn apply_style_based_on_dir_entry(
+        &mut self,
+        dir_entry: &DirEntry,
+        name: &str,
+    ) -> String {
+        let style = self.colors.style_for(dir_entry);
+        self.apply_style(style, name)
+    }
+}
+
+/// Colors the provided name based on the style determined for the given path
+/// This function is quite long because it tries to leverage DirEntry to avoid
+/// unnecessary calls to stat()
+/// and manages the symlink errors
+pub(crate) fn color_name(
+    name: &str,
+    path: &PathData,
+    style_manager: &mut StyleManager,
+    out: &mut BufWriter<Stdout>,
+    target_symlink: Option<&PathData>,
+) -> String {
+    if !path.must_dereference {
+        // If we need to dereference (follow) a symlink, we will need to get the metadata
+        if let Some(de) = &path.de {
+            // There is a DirEntry, we don't need to get the metadata for the color
+            return style_manager.apply_style_based_on_dir_entry(de, name);
+        }
+    }
+
+    if let Some(target) = target_symlink {
+        // use the optional target_symlink
+        // Use fn get_metadata_with_deref_opt instead of get_metadata() here because ls
+        // should not exit with an err, if we are unable to obtain the target_metadata
+        let md_res = get_metadata_with_deref_opt(&target.p_buf, path.must_dereference);
+        let md = md_res.or(path.p_buf.symlink_metadata());
+        style_manager.apply_style_based_on_metadata(path, md.ok().as_ref(), name)
+    } else {
+        let md_option = path.get_metadata(out);
+        let symlink_metadata = path.p_buf.symlink_metadata().ok();
+        let md = md_option.or(symlink_metadata.as_ref());
+        style_manager.apply_style_based_on_metadata(path, md, name)
+    }
+}

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3415,7 +3415,14 @@ fn apply_style_based_on_metadata(
 ) -> String {
     let path_indicator = ls_colors.indicator_for_path_with_metadata(&path.p_buf, md_option);
     let is_zeroed = ls_colors.zeroed_indicators.contains(&path_indicator);
-    match ls_colors.style_for_indicator(path_indicator) {
+    let style = if path_indicator == Indicator::RegularFile {
+        ls_colors
+            .style_for_str(&name)
+            .or_else(|| ls_colors.style_for_indicator(path_indicator))
+    } else {
+        ls_colors.style_for_indicator(path_indicator)
+    };
+    match style {
         Some(style) => style_manager.apply_style(style, name, ls_colors, is_zeroed),
         None => name.to_owned(),
     }
@@ -3439,7 +3446,14 @@ fn color_name(
             // There is a DirEntry, we don't need to get the metadata for the color
             let de_indicator = ls_colors.indicator_for(de);
             let is_zeroed = ls_colors.zeroed_indicators.contains(&de_indicator);
-            return match ls_colors.style_for_indicator(de_indicator) {
+            let style = if de_indicator == Indicator::RegularFile {
+                ls_colors
+                    .style_for_str(&name)
+                    .or_else(|| ls_colors.style_for_indicator(de_indicator))
+            } else {
+                ls_colors.style_for_indicator(de_indicator)
+            };
+            return match style {
                 Some(style) => style_manager.apply_style(style, &name, ls_colors, is_zeroed),
                 None => name,
             };

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -2,7 +2,7 @@
 # `build-gnu.bash` ~ builds GNU coreutils (from supplied sources)
 #
 
-# spell-checker:ignore (paths) abmon deref discrim eacces getlimits getopt ginstall inacc infloop inotify reflink ; (misc) INT_OFLOW OFLOW baddecode submodules xstrtol ; (vars/env) SRCDIR vdir rcexp xpart dired OSTYPE ; (utils) gnproc greadlink gsed
+# spell-checker:ignore (paths) abmon deref discrim eacces getlimits getopt ginstall inacc infloop inotify reflink ; (misc) INT_OFLOW OFLOW baddecode submodules xstrtol ; (vars/env) SRCDIR vdir rcexp xpart dired OSTYPE ; (utils) gnproc greadlink gsed multihardlink
 
 set -e
 

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -343,3 +343,11 @@ test \$n_stat1 -ge \$n_stat2 \\' tests/ls/stat-free-color.sh
 
 # no need to replicate this output with hashsum
 sed -i -e  "s|Try 'md5sum --help' for more information.\\\n||" tests/cksum/md5sum.pl
+
+# Our ls command always outputs ANSI color codes prepended with a zero. However,
+# in the case of GNU, it seems inconsistent. Nevertheless, it looks like it
+# doesn't matter whether we prepend a zero or not.
+sed -i -E '65,79{s/\^\[\[([1-9]m)/^[[0\1/g;  s/\^\[\[m/^[[0m/g}' tests/ls/color-norm.sh
+# It says in the test itself that having more than one reset is a bug, so we
+# don't need to replicate that behavior.
+sed -i -E '73,75{s/(\^\[\[0m)+/\^\[\[0m/g}' tests/ls/color-norm.sh

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -347,12 +347,12 @@ sed -i -e  "s|Try 'md5sum --help' for more information.\\\n||" tests/cksum/md5su
 # Our ls command always outputs ANSI color codes prepended with a zero. However,
 # in the case of GNU, it seems inconsistent. Nevertheless, it looks like it
 # doesn't matter whether we prepend a zero or not.
-sed -i -E '65,79{s/\^\[\[([1-9]m)/^[[0\1/g;  s/\^\[\[m/^[[0m/g}' tests/ls/color-norm.sh
+sed -i -E 's/\^\[\[([1-9]m)/^[[0\1/g;  s/\^\[\[m/^[[0m/g' tests/ls/color-norm.sh
 # It says in the test itself that having more than one reset is a bug, so we
 # don't need to replicate that behavior.
-sed -i -E '73,75{s/(\^\[\[0m)+/\^\[\[0m/g}' tests/ls/color-norm.sh
+sed -i -E 's/(\^\[\[0m)+/\^\[\[0m/g' tests/ls/color-norm.sh
 
 # GNU's ls seems to output color codes in the order given in the environment
 # variable, but our ls seems to output them in a predefined order. Nevertheless,
 # the order doesn't matter, so it's okay.
-sed -i  '25s/44;37/37;44/' tests/ls/multihardlink.sh
+sed -i  's/44;37/37;44/' tests/ls/multihardlink.sh

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -351,3 +351,8 @@ sed -i -E '65,79{s/\^\[\[([1-9]m)/^[[0\1/g;  s/\^\[\[m/^[[0m/g}' tests/ls/color-
 # It says in the test itself that having more than one reset is a bug, so we
 # don't need to replicate that behavior.
 sed -i -E '73,75{s/(\^\[\[0m)+/\^\[\[0m/g}' tests/ls/color-norm.sh
+
+# GNU's ls seems to output color codes in the order given in the environment
+# variable, but our ls seems to output them in a predefined order. Nevertheless,
+# the order doesn't matter, so it's okay.
+sed -i  '25s/44;37/37;44/' tests/ls/multihardlink.sh


### PR DESCRIPTION
This pr tries to fix gnu test case color-norm for ls util
these behaviors that are changed
- ls could now apply normal colour to non file names when --color is passed
thanks @tavianator for helping me with issue.