### PR TITLE
cp: fix preserved hardlinks are not reported in --verbose

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2108,6 +2108,10 @@ fn copy_file(
         .into());
     }
 
+    if options.verbose {
+        print_verbose_output(options.parents, progress_bar, source, dest);
+    }
+
     if options.preserve_hard_links() {
         // if we encounter a matching device/inode pair in the source tree
         // we can arrange to create a hard link between the corresponding names
@@ -2119,10 +2123,6 @@ fn copy_file(
             std::fs::hard_link(new_source, dest)?;
             return Ok(());
         };
-    }
-
-    if options.verbose {
-        print_verbose_output(options.parents, progress_bar, source, dest);
     }
 
     // Calculate the context upfront before canonicalizing the path


### PR DESCRIPTION
This PR reports preserved hardlinks.

Before this PR, the reporting occured after the hardlink creation.
The PR calls the verbose output before the preserved harlink processing.

Fixes #6267