### PR TITLE
Cargo.toml: add "expensive_tests" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ windows = ["feat_os_windows"]
 ## project-specific feature shortcodes
 nightly = []
 test_unimplemented = []
+expensive_tests = []
 # * only build `uudoc` when `--feature uudoc` is activated
 uudoc = ["zip", "dep:uuhelp_parser"]
 ## features


### PR DESCRIPTION
This PR adds a "expensive_tests" feature in order to fix "unexpected `cfg` condition value: `expensive_tests`" warnings in the nightly builds in the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/9673817439/job/26688539353?pr=6496#step:7:630).