### PR TITLE
build all features on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ edition = "2021"
 
 build = "build.rs"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["feat_common_core"]
 ## OS feature shortcodes


### PR DESCRIPTION
To build all the docs with features

```
[package.metadata.docs.rs]
all-features = true
```


Fix: https://github.com/uutils/coreutils/issues/6442



Documentation:
- https://docs.rs/about/metadata