### PR TITLE
ls: gnu `color-clear-to-eol` fix

### DIFF
--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -70,11 +70,8 @@ impl<'a> StyleManager<'a> {
         let clear_to_eol = if wrap { "\x1b[K" } else { "" };
 
         format!(
-            "{}{}{}{}",
-            style_code,
-            name,
+            "{style_code}{name}{}{clear_to_eol}",
             self.reset(force_suffix_reset),
-            clear_to_eol
         )
     }
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4803,3 +4803,26 @@ fn test_ls_color_norm() {
         .succeeds()
         .stdout_contains(expected);
 }
+
+#[test]
+fn test_ls_color_clear_to_eol() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    // we create file with a long name
+    at.touch("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.foo");
+    let result = scene
+        .ucmd()
+        .env("TERM", "xterm")
+        // set the columns to something small so that the text would wrap around
+        .env("COLUMNS", "80")
+        // set the background to green and text to red
+        .env("LS_COLORS", "*.foo=0;31;42")
+        .env("TIME_STYLE", "+T")
+        .arg("-og")
+        .arg("--color")
+        .arg("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.foo")
+        .succeeds();
+    // check that the wrapped name contains clear to end of line code
+    // cspell:disable-next-line
+    result.stdout_contains("\x1b[0m\x1b[31;42mzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.foo\x1b[0m\x1b[K");
+}

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -356,3 +356,13 @@ sed -i -E 's/(\^\[\[0m)+/\^\[\[0m/g' tests/ls/color-norm.sh
 # variable, but our ls seems to output them in a predefined order. Nevertheless,
 # the order doesn't matter, so it's okay.
 sed -i  's/44;37/37;44/' tests/ls/multihardlink.sh
+
+# Just like mentioned in the previous patch, GNU's ls output color codes in the
+# same way it is specified in the environment variable, but our ls emits them
+# differently. In this case, the color code is set to 0;31;42, and our ls would
+# ignore the 0; part. This would have been a bug if we output color codes
+# individually, for example, ^[[31^[[42 instead of ^[[31;42, but we don't do
+# that anywhere in our implementation, and it looks like GNU's ls also doesn't
+# do that. So, it's okay to ignore the zero.
+sed -i  "s/color_code='0;31;42'/color_code='31;42'/" tests/ls/color-clear-to-eol.sh
+


### PR DESCRIPTION
This pr tries to fix gnu test case `color-clear-to-eol`.
This test tries to check when a colored file name that is too long is wrapped, it will append a clear-to-end-of-line ANSI code. GNU's ls does this because in some terminals, when ls tries to print at the last line of the terminal window and needs to scroll the text up in order to print the new lines, the background color would stretch up to the end of the line.
for example 
```shell
seq 200 # inorder to fill the terminal window
touch zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.foo # create a long named file so that it would wrap
env TERM=xterm  LS_COLORS="*.foo=0;31;42" TIME_STYLE=+T ls  --color=always zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.foo
``` 
without the patch, it would look like this
![without k](https://github.com/uutils/coreutils/assets/52113972/11ae6269-8ecf-4970-b0db-91a44be2a560)
with the patch 
![with k](https://github.com/uutils/coreutils/assets/52113972/957c0776-e689-43ab-ae9a-3b13ab75ced0)

Behaviors changed
- ls would append a clear-to-eol at the end of the colored name if it would wrap
- $COLUMNS has more priority than the calculated terminal width 

