### PR TITLE
users: fix lint error needless_borrows_for_generic_args on OpenBSD

### DIFF
--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -59,7 +59,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         } else {
             files[0]
         };
-        let entries = parse_from_path(&filename).unwrap_or(Vec::new());
+        let entries = parse_from_path(filename).unwrap_or(Vec::new());
         users = Vec::new();
         for entry in entries {
             if let UtmpEntry::UTMP {


### PR DESCRIPTION
Fix uutils/coreutils#6508

---

Tests on OpenBSD: build and lint with `clippy` OK
```bash
$ target/debug/coreutils users
fox
$ target/debug/coreutils users tests/fixtures/users/openbsd_utmp
root test test user
```