### PR TITLE
ls: fix error sub dir output

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2038,7 +2038,7 @@ impl PathData {
 
 fn show_dir_name(path_data: &PathData, out: &mut BufWriter<Stdout>, config: &Config) {
     if config.hyperlink && !config.dired {
-        let name = escape_name(&path_data.display_name, &config.quoting_style);
+        let name = escape_name(path_data.p_buf.as_os_str(), &config.quoting_style);
         let hyperlink = create_hyperlink(&name, path_data);
         write!(out, "{}:", hyperlink).unwrap();
     } else {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4598,30 +4598,43 @@ fn test_ls_hyperlink_dirs() {
 fn test_ls_hyperlink_recursive_dirs() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
-    at.mkdir("example");
-    at.mkdir("example/a");
+    let path = at.root_dir_resolved();
+    let separator = std::path::MAIN_SEPARATOR_STR;
+
+    let dir_a = "a";
+    let dir_b = "b";
+    at.mkdir(dir_a);
+    at.mkdir(format!("{dir_a}/{dir_b}"));
 
     let result = scene
         .ucmd()
         .arg("--hyperlink")
         .arg("--recursive")
-        .arg("example")
+        .arg(dir_a)
         .succeeds();
 
+    macro_rules! assert_hyperlink {
+        ($line:expr, $expected:expr) => {
+            assert!(matches!($line, Some(l) if l.starts_with("\x1b]8;;file://") && l.ends_with($expected)));
+        };
+    }
+
     let mut lines = result.stdout_str().lines();
-    assert!(&lines
-        .next()
-        .unwrap()
-        .ends_with("/example\u{7}example\u{1b}]8;;\u{7}:"));
-    assert!(&lines
-        .next()
-        .unwrap()
-        .ends_with("/example/a\u{7}a\u{1b}]8;;\u{7}"));
-    assert!(&lines.next().unwrap().is_empty());
-    assert!(&lines
-        .next()
-        .unwrap()
-        .ends_with("/example/a\u{7}example/a\u{1b}]8;;\u{7}:"));
+    assert_hyperlink!(
+        lines.next(),
+        &format!("{path}{separator}{dir_a}\x07{dir_a}\x1b]8;;\x07:")
+    );
+    assert_hyperlink!(
+        lines.next(),
+        &format!("{path}{separator}{dir_a}{separator}{dir_b}\x07{dir_b}\x1b]8;;\x07")
+    );
+    assert!(matches!(lines.next(), Some(l) if l.is_empty()));
+    assert_hyperlink!(
+        lines.next(),
+        &format!(
+            "{path}{separator}{dir_a}{separator}{dir_b}\x07{dir_a}{separator}{dir_b}\x1b]8;;\x07:"
+        )
+    );
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4595,6 +4595,36 @@ fn test_ls_hyperlink_dirs() {
 }
 
 #[test]
+fn test_ls_hyperlink_recursive_dirs() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("example");
+    at.mkdir("example/a");
+
+    let result = scene
+        .ucmd()
+        .arg("--hyperlink")
+        .arg("--recursive")
+        .arg("example")
+        .succeeds();
+
+    let mut lines = result.stdout_str().lines();
+    assert!(&lines
+        .next()
+        .unwrap()
+        .ends_with("/example\u{7}example\u{1b}]8;;\u{7}:"));
+    assert!(&lines
+        .next()
+        .unwrap()
+        .ends_with("/example/a\u{7}a\u{1b}]8;;\u{7}"));
+    assert!(&lines.next().unwrap().is_empty());
+    assert!(&lines
+        .next()
+        .unwrap()
+        .ends_with("/example/a\u{7}example/a\u{1b}]8;;\u{7}:"));
+}
+
+#[test]
 fn test_ls_color_do_not_reset() {
     let scene: TestScenario = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
Close #6492
- Fix error output when hyperlink options combines with recursive
