### PR TITLE
ls: when -CF is passed, use a tab. closes: #5396

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2650,7 +2650,7 @@ fn display_grid(
             writeln!(out)?;
         }
     } else {
-        let names = if quoted {
+        let names: Vec<String> = if quoted {
             // In case some names are quoted, GNU adds a space before each
             // entry that does not start with a quote to make it prettier
             // on multiline.
@@ -2675,12 +2675,21 @@ fn display_grid(
         } else {
             names.collect()
         };
+
+        // Determine whether to use tabs for separation based on whether any entry ends with '/'.
+        // If any entry ends with '/', it indicates that the -F flag is likely used to classify directories.
+        let use_tabs = names.iter().any(|name| name.ends_with('/'));
+
+        let filling = if use_tabs {
+            Filling::Text("\t".to_string())
+        } else {
+            Filling::Spaces(2)
+        };
+
         let grid = Grid::new(
             names,
             GridOptions {
-                // TODO: To match gnu/tests/ls/stat-dtype.sh
-                // we might want to have Filling::Text("\t".to_string());
-                filling: Filling::Spaces(2),
+                filling,
                 direction,
                 width: width as usize,
             },

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4259,7 +4259,6 @@ fn test_ls_subdired_complex() {
     assert_eq!(dirnames, vec!["dir1", "dir1\\c2", "dir1\\d"]);
 }
 
-#[ignore = "issue #5396"]
 #[test]
 fn test_ls_cf_output_should_be_delimited_by_tab() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Should fix gnu/tests/ls/stat-dtype.sh