### PR TITLE
ls: gnu test case `color-ext` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -1383,9 +1383,11 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.18.0"
-source = "git+https://github.com/matrixhead/lscolors#73fb17b72154d47f04f5b42d43f1e8fc8bc3e2fa"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f5f3bc18b481c70c416920f4bb02f7df64b99dbee36d8445027042a273ab84"
 dependencies = [
+ "aho-corasick",
  "nu-ansi-term",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,8 +1384,7 @@ dependencies = [
 [[package]]
 name = "lscolors"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a5d67fc8a616f260ee9a36868547da09ac24178a4b84708cd8ea781372fbe4"
+source = "git+https://github.com/matrixhead/lscolors#73fb17b72154d47f04f5b42d43f1e8fc8bc3e2fa"
 dependencies = [
  "nu-ansi-term",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,8 +298,7 @@ hostname = "0.4"
 indicatif = "0.17.8"
 itertools = "0.13.0"
 libc = "0.2.153"
-# this is just for a draft pr
-lscolors = { git = "https://github.com/matrixhead/lscolors", default-features = false, features = [
+lscolors = { version = "0.19.0", default-features = false, features = [
   "gnu_legacy",
 ] }
 memchr = "2.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,8 @@ hostname = "0.4"
 indicatif = "0.17.8"
 itertools = "0.13.0"
 libc = "0.2.153"
-lscolors = { version = "0.18.0", default-features = false, features = [
+# this is just for a draft pr
+lscolors = { git = "https://github.com/matrixhead/lscolors", default-features = false, features = [
   "gnu_legacy",
 ] }
 memchr = "2.7.2"


### PR DESCRIPTION
This pr tries to fix #6536 
#### Behaviors changed
- when one suffix is specified more than once with different cases and with different styles, then ls would only do a case-sensitive matching.


This is marked as draft because it's dependent on this ~~[pr](https://github.com/sharkdp/lscolors/pull/86)~~ [pr](https://github.com/sharkdp/lscolors/pull/87)