### PR TITLE
ls: fixed dired option (-D) not outputting datetime and parent dir byte offsets

### DIFF
--- a/src/uu/ls/src/dired.rs
+++ b/src/uu/ls/src/dired.rs
@@ -348,6 +348,4 @@ mod tests {
         );
         assert_eq!(dired.padding, 0);
     }
-
-
 }

--- a/src/uu/ls/src/dired.rs
+++ b/src/uu/ls/src/dired.rs
@@ -110,7 +110,7 @@ pub fn print_dired_output(
     out: &mut BufWriter<Stdout>,
 ) -> UResult<()> {
     out.flush()?;
-    if dired.padding == 0 && !dired.dired_positions.is_empty() {
+    if !dired.dired_positions.is_empty() {
         print_positions("//DIRED//", &dired.dired_positions);
     }
     if config.recursive {
@@ -348,4 +348,6 @@ mod tests {
         );
         assert_eq!(dired.padding, 0);
     }
+
+
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -971,7 +971,8 @@ impl Config {
         let mut quoting_style = extract_quoting_style(options, show_control);
         let indicator_style = extract_indicator_style(options);
         // Only parse the value to "--time-style" if it will become relevant.
-        let time_style = if format == Format::Long {
+        let dired = options.get_flag(options::DIRED);
+        let time_style = if format == Format::Long || dired {
             parse_time_style(options)?
         } else {
             TimeStyle::Iso
@@ -1092,7 +1093,6 @@ impl Config {
             None
         };
 
-        let dired = options.get_flag(options::DIRED);
         if dired || is_dired_arg_present() {
             // --dired implies --format=long
             // if we have --dired --hyperlink, we don't show dired but we still want to see the

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4059,6 +4059,42 @@ fn test_ls_dired_recursive() {
 }
 
 #[test]
+fn test_ls_dired_outputs_parent_offset() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("dir");
+    at.mkdir("dir/a");
+    scene
+        .ucmd()
+        .arg("--dired")
+        .arg("dir")
+        .arg("-R")
+        .succeeds()
+        .stdout_contains("//DIRED//");
+}
+
+#[test]
+fn test_ls_dired_outputs_same_date_time_format() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("dir");
+    at.mkdir("dir/a");
+    let binding = scene.ucmd().arg("-l").arg("dir").run();
+    let long_output_str = binding.stdout_str();
+    let split_lines: Vec<&str> = long_output_str.split('\n').collect();
+    // the second line should contain the long output which includes date
+    let list_line = split_lines.get(1).unwrap();
+    // should be same as the dired output
+    scene
+        .ucmd()
+        .arg("--dired")
+        .arg("dir")
+        .arg("-R")
+        .succeeds()
+        .stdout_contains(list_line);
+}
+
+#[test]
 fn test_ls_dired_recursive_multiple() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
Fix for #6522 