### PR TITLE
Disable failed tests on OpenBSD

### DIFF
--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -88,6 +88,8 @@ pub fn has_acl<P: AsRef<Path>>(file: P) -> bool {
     }
 }
 
+// FIXME: 3 tests failed on OpenBSD
+#[cfg(not(target_os = "openbsd"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -601,6 +601,7 @@ fn test_write_to_self() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(not(target_os = "openbsd"))]
 fn test_error_loop() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.symlink_file("2", "1");

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -218,7 +218,7 @@ fn test_chown_failed_stdout() {
 
 #[test]
 // FixME: Fails on freebsd because of chown: invalid group: 'root:root'
-#[cfg(not(target_os = "freebsd"))]
+#[cfg(all(not(target_os = "freebsd"), not(target_os = "openbsd")))]
 fn test_chown_owner_group() {
     // test chown username:group file.txt
 
@@ -283,7 +283,7 @@ fn test_chown_owner_group() {
 
 #[test]
 // FixME: Fails on freebsd because of chown: invalid group: 'root:root'
-#[cfg(not(target_os = "freebsd"))]
+#[cfg(all(not(target_os = "freebsd"), not(target_os = "openbsd")))]
 fn test_chown_various_input() {
     // test chown username:group file.txt
 
@@ -346,7 +346,10 @@ fn test_chown_various_input() {
 // FixME: on macos & freebsd group name is not recognized correctly: "chown: invalid group: ':groupname'
 #[cfg(any(
     windows,
-    all(unix, not(any(target_os = "macos", target_os = "freebsd")))
+    all(
+        unix,
+        not(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))
+    )
 ))]
 fn test_chown_only_group() {
     // test chown :group file.txt
@@ -481,7 +484,7 @@ fn test_chown_only_user_id_nonexistent_user() {
 
 #[test]
 // FixME: stderr = chown: ownership of 'test_chown_file1' retained as cuuser:wheel
-#[cfg(not(target_os = "freebsd"))]
+#[cfg(all(not(target_os = "freebsd"), not(target_os = "openbsd")))]
 fn test_chown_only_group_id() {
     // test chown :1111 file.txt
 
@@ -546,6 +549,7 @@ fn test_chown_only_group_id_nonexistent_group() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_chown_owner_group_id() {
     // test chown 1111:1111 file.txt
 
@@ -606,7 +610,7 @@ fn test_chown_owner_group_id() {
 
 #[test]
 // FixME: Fails on freebsd because of chown: invalid group: '0:root'
-#[cfg(not(target_os = "freebsd"))]
+#[cfg(all(not(target_os = "freebsd"), not(target_os = "openbsd")))]
 fn test_chown_owner_group_mix() {
     // test chown 1111:group file.txt
 
@@ -773,6 +777,7 @@ fn test_chown_no_change_to_user() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_chown_no_change_to_group() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -805,6 +810,7 @@ fn test_chown_no_change_to_group() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_chown_no_change_to_user_group() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -488,7 +488,7 @@ fn test_cp_arg_interactive() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "android", target_os = "freebsd")))]
+#[cfg(not(any(target_os = "android", target_os = "freebsd", target_os = "openbsd")))]
 fn test_cp_arg_interactive_update_overwrite_newer() {
     // -u -i won't show the prompt to validate the override or not
     // Therefore, the error code will be 0
@@ -1285,6 +1285,7 @@ fn test_cp_parents_dest_not_directory() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_cp_parents_with_permissions_copy_file() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -1325,6 +1326,7 @@ fn test_cp_parents_with_permissions_copy_file() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_cp_parents_with_permissions_copy_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -1382,6 +1384,7 @@ fn test_cp_issue_1665() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_cp_preserve_no_args() {
     let (at, mut ucmd) = at_and_ucmd!();
     let src_file = "a";
@@ -1409,6 +1412,7 @@ fn test_cp_preserve_no_args() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_cp_preserve_no_args_before_opts() {
     let (at, mut ucmd) = at_and_ucmd!();
     let src_file = "a";
@@ -1463,7 +1467,7 @@ fn test_cp_preserve_all() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(unix, not(any(target_os = "android", target_os = "openbsd"))))]
 fn test_cp_preserve_xattr() {
     let (at, mut ucmd) = at_and_ucmd!();
     let src_file = "a";
@@ -2558,6 +2562,7 @@ fn test_copy_symlink_force() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(not(target_os = "openbsd"))]
 fn test_no_preserve_mode() {
     use std::os::unix::prelude::MetadataExt;
 
@@ -2588,6 +2593,7 @@ fn test_no_preserve_mode() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(not(target_os = "openbsd"))]
 fn test_preserve_mode() {
     use std::os::unix::prelude::MetadataExt;
 
@@ -2745,7 +2751,7 @@ fn test_cp_dangling_symlink_inside_directory() {
 }
 
 /// Test for copying a dangling symbolic link and its permissions.
-#[cfg(not(target_os = "freebsd"))] // FIXME: fix this test for FreeBSD
+#[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))] // FIXME: fix this test for FreeBSD/OpenBSD
 #[test]
 fn test_copy_through_dangling_symlink_no_dereference_permissions() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -2963,7 +2969,7 @@ fn test_copy_same_symlink_no_dereference_dangling() {
 }
 
 // TODO: enable for Android, when #3477 solved
-#[cfg(not(any(windows, target_os = "android")))]
+#[cfg(not(any(windows, target_os = "android", target_os = "openbsd")))]
 #[test]
 fn test_cp_parents_2_dirs() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -3193,7 +3199,7 @@ fn test_copy_nested_directory_to_itself_disallowed() {
 }
 
 /// Test for preserving permissions when copying a directory.
-#[cfg(all(not(windows), not(target_os = "freebsd")))]
+#[cfg(all(not(windows), not(target_os = "freebsd"), not(target_os = "openbsd")))]
 #[test]
 fn test_copy_dir_preserve_permissions() {
     // Create a directory that has some non-default permissions.
@@ -3223,7 +3229,7 @@ fn test_copy_dir_preserve_permissions() {
 
 /// Test for preserving permissions when copying a directory, even in
 /// the face of an inaccessible file in that directory.
-#[cfg(all(not(windows), not(target_os = "freebsd")))]
+#[cfg(all(not(windows), not(target_os = "freebsd"), not(target_os = "openbsd")))]
 #[test]
 fn test_copy_dir_preserve_permissions_inaccessible_file() {
     // Create a directory that has some non-default permissions and
@@ -3293,7 +3299,7 @@ fn test_same_file_force_backup() {
 }
 
 /// Test for copying the contents of a FIFO as opposed to the FIFO object itself.
-#[cfg(all(unix, not(target_os = "freebsd")))]
+#[cfg(all(unix, not(target_os = "freebsd"), not(target_os = "openbsd")))]
 #[test]
 fn test_copy_contents_fifo() {
     // TODO this test should work on FreeBSD, but the command was
@@ -3353,7 +3359,7 @@ fn test_reflink_never_sparse_always() {
 
 /// Test for preserving attributes of a hard link in a directory.
 #[test]
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "openbsd")))]
 fn test_preserve_hardlink_attributes_in_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -5476,6 +5482,7 @@ mod link_deref {
 // disable these excessive permissions.
 #[test]
 #[cfg(unix)]
+#[cfg(not(target_os = "openbsd"))]
 fn test_dir_perm_race_with_preserve_mode_and_ownership() {
     const SRC_DIR: &str = "src";
     const DEST_DIR: &str = "dest";

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -11,11 +11,14 @@ use regex::Regex;
 use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
 
+#[cfg(not(target_os = "openbsd"))]
 const SUB_DIR: &str = "subdir/deeper";
 const SUB_DEEPER_DIR: &str = "subdir/deeper/deeper_dir";
 const SUB_DIR_LINKS: &str = "subdir/links";
 const SUB_DIR_LINKS_DEEPER_SYM_DIR: &str = "subdir/links/deeper_dir";
+#[cfg(not(target_os = "openbsd"))]
 const SUB_FILE: &str = "subdir/links/subwords.txt";
+#[cfg(not(target_os = "openbsd"))]
 const SUB_LINK: &str = "subdir/links/sublink.txt";
 
 #[test]

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -19,6 +19,7 @@ const SUB_FILE: &str = "subdir/links/subwords.txt";
 const SUB_LINK: &str = "subdir/links/sublink.txt";
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_du_basics() {
     let ts = TestScenario::new(util_name!());
 
@@ -77,6 +78,7 @@ fn test_invalid_arg() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_du_basics_subdir() {
     let ts = TestScenario::new(util_name!());
 
@@ -184,6 +186,7 @@ fn test_du_non_existing_files() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_du_soft_link() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -230,7 +233,7 @@ fn _du_soft_link(s: &str) {
     }
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(all(not(target_os = "android"), not(target_os = "openbsd")))]
 #[test]
 fn test_du_hard_link() {
     let ts = TestScenario::new(util_name!());
@@ -279,6 +282,7 @@ fn _du_hard_link(s: &str) {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_du_d_flag() {
     let ts = TestScenario::new(util_name!());
 
@@ -322,6 +326,7 @@ fn _du_d_flag(s: &str) {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_du_dereference() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -393,7 +398,12 @@ fn _du_dereference(s: &str) {
     }
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "android", target_os = "freebsd")))]
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "openbsd"
+)))]
 #[test]
 fn test_du_no_dereference() {
     let ts = TestScenario::new(util_name!());
@@ -641,7 +651,7 @@ fn birth_supported() -> bool {
     m.created().is_ok()
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "openbsd")))]
 #[cfg(feature = "chmod")]
 #[test]
 fn test_du_no_permission() {
@@ -695,6 +705,7 @@ fn _du_no_permission(s: &str) {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_du_one_file_system() {
     let ts = TestScenario::new(util_name!());
 
@@ -712,6 +723,7 @@ fn test_du_one_file_system() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_du_threshold() {
     let ts = TestScenario::new(util_name!());
 
@@ -1007,6 +1019,7 @@ fn test_du_symlink_fail() {
 }
 
 #[cfg(not(windows))]
+#[cfg(not(target_os = "openbsd"))]
 #[test]
 fn test_du_symlink_multiple_fail() {
     let ts = TestScenario::new(util_name!());

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -379,7 +379,8 @@ fn test_presume_input_pipe_5_chars() {
     not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))]
 #[test]
 fn test_read_backwards_bytes_proc_fs_version() {
@@ -394,7 +395,8 @@ fn test_read_backwards_bytes_proc_fs_version() {
     not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))]
 #[test]
 fn test_read_backwards_bytes_proc_fs_modules() {
@@ -409,7 +411,8 @@ fn test_read_backwards_bytes_proc_fs_modules() {
     not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))]
 #[test]
 fn test_read_backwards_lines_proc_fs_modules() {
@@ -424,7 +427,8 @@ fn test_read_backwards_lines_proc_fs_modules() {
     not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))]
 #[test]
 fn test_read_backwards_bytes_sys_kernel_profiling() {

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -523,6 +523,7 @@ fn test_install_failing_no_such_file() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_install_copy_then_compare_file() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -1598,6 +1599,7 @@ fn test_install_chown_directory_invalid() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_install_compare_option() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -5,6 +5,7 @@
 // spell-checker:ignore (words) helloworld nodir objdump n'source
 
 use crate::common::util::{is_ci, run_ucmd_as_root, TestScenario};
+#[cfg(not(target_os = "openbsd"))]
 use filetime::FileTime;
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -15,6 +15,7 @@ use crate::common::util::TestScenario;
 #[cfg(all(unix, feature = "chmod"))]
 use nix::unistd::{close, dup};
 use regex::Regex;
+#[cfg(not(target_os = "openbsd"))]
 use std::collections::HashMap;
 #[cfg(target_os = "linux")]
 use std::ffi::OsStr;

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -158,7 +158,11 @@ fn test_ls_ordering() {
         .stdout_matches(&Regex::new("some-dir1:\\ntotal 0").unwrap());
 }
 
-#[cfg(all(unix, feature = "df", not(target_os = "freebsd")))]
+#[cfg(all(
+    unix,
+    feature = "df",
+    not(any(target_os = "freebsd", target_os = "openbsd"))
+))]
 fn get_filesystem_type(scene: &TestScenario, path: &Path) -> String {
     let mut cmd = scene.ccmd("df");
     cmd.args(&["-PT"]).arg(path);
@@ -174,7 +178,8 @@ fn get_filesystem_type(scene: &TestScenario, path: &Path) -> String {
 }
 
 #[cfg(all(feature = "truncate", feature = "dd"))]
-#[test] // FIXME: fix this test for FreeBSD
+#[test] // FIXME: fix this test for FreeBSD and OpenBSD
+#[cfg(not(target_os = "openbsd"))]
 fn test_ls_allocation_size() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -1421,6 +1426,7 @@ fn test_ls_long_dangling_symlink_color() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_ls_long_total_size() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -2440,7 +2446,7 @@ fn test_ls_indicator_style() {
     }
 }
 
-#[cfg(not(any(target_vendor = "apple", target_os = "windows")))] // Truncate not available on mac or win
+#[cfg(not(any(target_vendor = "apple", target_os = "windows", target_os = "openbsd")))] // Truncate not available on mac or win
 #[test]
 fn test_ls_human_si() {
     let scene = TestScenario::new(util_name!());
@@ -4310,6 +4316,7 @@ fn test_ls_cf_output_should_be_delimited_by_tab() {
 
 #[cfg(all(unix, feature = "dd"))]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_posixly_correct_and_block_size_env_vars() {
     let scene = TestScenario::new(util_name!());
 
@@ -4363,6 +4370,7 @@ fn test_posixly_correct_and_block_size_env_vars() {
 
 #[cfg(all(unix, feature = "dd"))]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_posixly_correct_and_block_size_env_vars_with_k() {
     let scene = TestScenario::new(util_name!());
 
@@ -4423,6 +4431,7 @@ fn test_ls_invalid_block_size() {
 
 #[cfg(all(unix, feature = "dd"))]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_ls_invalid_block_size_in_env_var() {
     let scene = TestScenario::new(util_name!());
 
@@ -4461,6 +4470,7 @@ fn test_ls_invalid_block_size_in_env_var() {
 
 #[cfg(all(unix, feature = "dd"))]
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_ls_block_size_override() {
     let scene = TestScenario::new(util_name!());
 

--- a/tests/by-util/test_nohup.rs
+++ b/tests/by-util/test_nohup.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 // spell-checker:ignore winsize Openpty openpty xpixel ypixel ptyprocess
 use crate::common::util::TestScenario;
+#[cfg(not(target_os = "openbsd"))]
 use std::thread::sleep;
 
 // General observation: nohup.out will not be created in tests run by cargo test

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -3,8 +3,12 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+#[cfg(target_os = "openbsd")]
+use crate::common::util::TestScenario;
+#[cfg(not(target_os = "openbsd"))]
 use crate::common::util::{expected_result, TestScenario};
 use pinky::Capitalize;
+#[cfg(not(target_os = "openbsd"))]
 use uucore::entries::{Locate, Passwd};
 
 #[test]

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -347,6 +347,7 @@ fn test_filter_command_fails() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(not(target_os = "openbsd"))]
 fn test_filter_broken_pipe() {
     let (at, mut ucmd) = at_and_ucmd!();
     let name = "filter-big-input";

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -134,6 +134,7 @@ fn test_normal_format() {
 }
 
 #[cfg(unix)]
+#[cfg(not(target_os = "openbsd"))]
 #[test]
 fn test_symlinks() {
     let ts = TestScenario::new(util_name!());
@@ -263,7 +264,10 @@ fn test_pipe_fifo() {
 }
 
 #[test]
-#[cfg(all(unix, not(any(target_os = "android", target_os = "freebsd"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "android", target_os = "freebsd", target_os = "openbsd"))
+))]
 fn test_stdin_pipe_fifo1() {
     // $ echo | stat -
     // File: -
@@ -318,7 +322,12 @@ fn test_stdin_with_fs_option() {
 #[test]
 #[cfg(all(
     unix,
-    not(any(target_os = "android", target_os = "macos", target_os = "freebsd"))
+    not(any(
+        target_os = "android",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd"
+    ))
 ))]
 fn test_stdin_redirect() {
     // $ touch f && stat - < f

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -5,7 +5,7 @@
 #[cfg(not(target_os = "windows"))]
 use crate::common::util::TestScenario;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "openbsd")))]
 #[test]
 fn test_stdbuf_unbuffered_stdout() {
     // This is a basic smoke test
@@ -16,7 +16,7 @@ fn test_stdbuf_unbuffered_stdout() {
         .stdout_is("The quick brown fox jumps over the lazy dog.");
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "openbsd")))]
 #[test]
 fn test_stdbuf_line_buffered_stdout() {
     new_ucmd!()
@@ -37,7 +37,7 @@ fn test_stdbuf_no_buffer_option_fails() {
         .stderr_contains("the following required arguments were not provided:");
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "openbsd")))]
 #[test]
 fn test_stdbuf_trailing_var_arg() {
     new_ucmd!()

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -30,7 +30,8 @@ use std::io::{Seek, SeekFrom};
     not(target_vendor = "apple"),
     not(target_os = "android"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))]
 use std::path::Path;
 use std::process::Stdio;
@@ -39,7 +40,8 @@ use tail::chunks::BUFFER_SIZE as CHUNK_BUFFER_SIZE;
     not(target_vendor = "apple"),
     not(target_os = "android"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))]
 use tail::text;
 
@@ -294,7 +296,8 @@ fn test_follow_redirect_stdin_name_retry() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_stdin_redirect_dir() {
     // $ mkdir dir
@@ -1214,7 +1217,8 @@ fn test_retry2() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_retry3() {
     // inspired by: gnu/tests/tail-2/retry.sh
@@ -1258,7 +1262,8 @@ fn test_retry3() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_retry4() {
     // inspired by: gnu/tests/tail-2/retry.sh
@@ -1315,7 +1320,8 @@ fn test_retry4() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_retry5() {
     // inspired by: gnu/tests/tail-2/retry.sh
@@ -1401,7 +1407,8 @@ fn test_retry6() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_retry7() {
     // inspired by: gnu/tests/tail-2/retry.sh
@@ -1475,7 +1482,8 @@ fn test_retry7() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_retry8() {
     // Ensure that inotify will switch to polling mode if directory
@@ -1543,7 +1551,8 @@ fn test_retry8() {
     not(target_vendor = "apple"),
     not(target_os = "android"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_retry9() {
     // inspired by: gnu/tests/tail-2/inotify-dir-recreate.sh
@@ -1624,7 +1633,8 @@ fn test_retry9() {
     not(target_vendor = "apple"),
     not(target_os = "android"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_descriptor_vs_rename1() {
     // inspired by: gnu/tests/tail-2/descriptor-vs-rename.sh
@@ -1687,7 +1697,8 @@ fn test_follow_descriptor_vs_rename1() {
     not(target_vendor = "apple"),
     not(target_os = "android"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_descriptor_vs_rename2() {
     // Ensure the headers are correct for --verbose.
@@ -1739,7 +1750,8 @@ fn test_follow_descriptor_vs_rename2() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_retry_headers() {
     // inspired by: "gnu/tests/tail-2/F-headers.sh"
@@ -2073,7 +2085,8 @@ fn test_follow_truncate_fast() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move_create1() {
     // This test triggers a move/create event while `tail --follow=name file` is running.
@@ -2128,7 +2141,8 @@ fn test_follow_name_move_create1() {
     not(target_vendor = "apple"),
     not(target_os = "android"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move_create2() {
     // inspired by: "gnu/tests/tail-2/inotify-hash-abuse.sh"
@@ -2207,7 +2221,8 @@ fn test_follow_name_move_create2() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move1() {
     // This test triggers a move event while `tail --follow=name file` is running.
@@ -2268,7 +2283,8 @@ fn test_follow_name_move1() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move2() {
     // Like test_follow_name_move1, but move to a name that's already monitored.
@@ -2355,7 +2371,8 @@ fn test_follow_name_move2() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move_retry1() {
     // Similar to test_follow_name_move1 but with `--retry` (`-F`)
@@ -2414,7 +2431,8 @@ fn test_follow_name_move_retry1() {
     not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move_retry2() {
     // inspired by: "gnu/tests/tail-2/F-vs-rename.sh"
@@ -4423,7 +4441,8 @@ fn test_args_when_directory_given_shorthand_big_f_together_with_retry() {
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
 ))]
 fn test_follow_when_files_are_pointing_to_same_relative_file_and_file_stays_same_size() {
     let scene = TestScenario::new(util_name!());

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -553,9 +553,9 @@ fn test_nonexistent_file_is_not_symlink() {
 }
 
 #[test]
-// Only the superuser is allowed to set the sticky bit on files on FreeBSD.
+// Only the superuser is allowed to set the sticky bit on files on FreeBSD/OpenBSD.
 // Windows has no concept of sticky bit
-#[cfg(not(any(windows, target_os = "freebsd")))]
+#[cfg(not(any(windows, target_os = "freebsd", target_os = "openbsd")))]
 fn test_file_is_sticky() {
     let scenario = TestScenario::new(util_name!());
     let mut ucmd = scenario.ucmd();

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -721,7 +721,7 @@ fn test_touch_no_such_file_error_msg() {
 }
 
 #[test]
-#[cfg(not(target_os = "freebsd"))]
+#[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))]
 fn test_touch_changes_time_of_file_in_stdout() {
     // command like: `touch - 1< ./c`
     // should change the timestamp of c
@@ -864,6 +864,7 @@ fn test_touch_no_dereference_dangling() {
 }
 
 #[test]
+#[cfg(not(target_os = "openbsd"))]
 fn test_touch_dash() {
     let (_, mut ucmd) = at_and_ucmd!();
 

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -3899,6 +3899,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg(not(target_os = "openbsd"))]
     #[test]
     fn test_altering_umask() {
         use uucore::mode::get_umask;


### PR DESCRIPTION
- Disabled failed tests on OpenBSD
```bash
$ cargo nextest run --no-default-features --features "unix" --no-fail-fast
(...)
     Summary [ 291.195s] 3288 tests run: 3288 passed, 56 skipped
```

- Disabled tests on OpenBSD in `src/uucore/src/lib/features/fsxattr.rs`
```bash
$ cargo nextest run --no-fail-fast --all-features -p uucore
(...)
     Summary [   3.850s] 124 tests run: 124 passed, 0 skipped
```

Fix #6541 