### PR TITLE
fsext: remove crash!

### DIFF
--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -109,7 +109,7 @@ impl Filesystem {
         #[cfg(unix)]
         let usage = FsUsage::new(statfs(_stat_path).ok()?);
         #[cfg(windows)]
-        let usage = FsUsage::new(Path::new(&_stat_path));
+        let usage = FsUsage::new(Path::new(&_stat_path)).ok()?;
         Some(Self {
             mount_info,
             usage,

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -4,9 +4,13 @@
 // file that was distributed with this source code.
 // spell-checker:ignore datetime
 
+#[cfg(target_os = "android")]
+use uucore::error::UResult;
+#[cfg(not(target_os = "android"))]
+use uucore::error::{UResult, USimpleError};
+
 use clap::builder::ValueParser;
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::fs::display_permissions;
 use uucore::fsext::{pretty_filetype, pretty_fstype, read_fs_list, statfs, BirthTime, FsMeta};
 use uucore::libc::mode_t;
@@ -583,7 +587,10 @@ impl Stater {
             None
         } else {
             let mut mount_list = read_fs_list()
-                .map_err_context(|| "cannot read table of mounted file systems".into())?
+                .map_err(|e| {
+                    let context = "cannot read table of mounted file systems";
+                    USimpleError::new(e.code(), format!("{}: {}", context, e))
+                })?
                 .iter()
                 .map(|mi| mi.mount_dir.clone())
                 .collect::<Vec<String>>();


### PR DESCRIPTION
remove all `crash!` in fsext and modify some related files. I think those were the final `crash!`s.
relating issue #5487

I also noticed that the cargo doc in CICD has been failing since commit fb48e7d.