### PR TITLE
uucore/proc_info: ignore spelling of some words

### DIFF
--- a/src/uucore/src/lib/features/proc_info.rs
+++ b/src/uucore/src/lib/features/proc_info.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore exitstatus cmdline kworker
+// spell-checker:ignore exitstatus cmdline kworker pgrep pwait snice
 
 //! Set of functions to manage IDs
 //!


### PR DESCRIPTION
This PR adds some words to `spell-checker:ignore` in order to fix the failing `Style/spelling` job in the CI.