### PR TITLE
uptime: relax error message due to different errno on MacOS

### DIFF
--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -74,7 +74,7 @@ fn test_uptime_with_fifo() {
     ts.ucmd()
         .arg("fifo1")
         .fails()
-        .stderr_contains("uptime: couldn't get boot time: Illegal seek")
+        .stderr_contains("uptime: couldn't get boot time")
         .stdout_contains("up ???? days ??:??")
         .stdout_contains("load average");
 


### PR DESCRIPTION
Fixes #6569 by relaxing the test. Apparently, the entire stderr generated on MacOS is merely `uptime: couldn't get boot time\n`. It is unclear to my why `uptime: couldn't get boot time: Illegal seek` was expected, but this still seems like good behavior to me, so let's make the test green.

My best guess is that the error message changed slightly in #6514, but that PR had a green test. I don't understand.