### PR TITLE
cksum: accept non-UTF-8 filenames

### DIFF
--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -222,9 +222,9 @@ pub fn read_yes() -> bool {
     }
 }
 
-// Helper function for processing delimiter values (which could be non UTF-8)
-// It converts OsString to &[u8] for unix targets only
-// On non-unix (i.e. Windows) it will just return an error if delimiter value is not UTF-8
+/// Helper function for processing delimiter values (which could be non UTF-8)
+/// It converts OsString to &[u8] for unix targets only
+/// On non-unix (i.e. Windows) it will just return an error if delimiter value is not UTF-8
 pub fn os_str_as_bytes(os_string: &OsStr) -> mods::error::UResult<&[u8]> {
     #[cfg(unix)]
     let bytes = os_string.as_bytes();


### PR DESCRIPTION
Fixes #6574.

Example:

```console
$ touch $'funky\xffname'
$ cargo run -q cksum $'funky\xffname'
4294967295 0 funky�name
$ cksum $'funky\xffname'
4294967295 0 funky�name
```