### PR TITLE
mv: gnu test case `to-symlink` fix

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -661,6 +661,9 @@ fn rename_with_fallback(
                 };
             }
         } else {
+            if to.is_symlink() {
+                fs::remove_file(to)?;
+            }
             #[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
             fs::copy(from, to)
                 .and_then(|_| fsxattr::copy_xattrs(&from, &to))


### PR DESCRIPTION
tries to fix #6577

**Behaviors changed**
- mv would remove the destination file first, if we are trying to move the file between different partitions and the destination is a symlink