### PR TITLE
Fix nightly clippy

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -623,10 +623,10 @@ fn write_nonprint_to_end<W: Write>(in_buf: &[u8], writer: &mut W, tab: &[u8]) ->
             9 => writer.write_all(tab),
             0..=8 | 10..=31 => writer.write_all(&[b'^', byte + 64]),
             32..=126 => writer.write_all(&[byte]),
-            127 => writer.write_all(&[b'^', b'?']),
+            127 => writer.write_all(b"^?"),
             128..=159 => writer.write_all(&[b'M', b'-', b'^', byte - 64]),
             160..=254 => writer.write_all(&[b'M', b'-', byte - 128]),
-            _ => writer.write_all(&[b'M', b'-', b'^', b'?']),
+            _ => writer.write_all(b"M-^?"),
         }
         .unwrap();
         count += 1;

--- a/src/uucore/src/lib/features/encoding.rs
+++ b/src/uucore/src/lib/features/encoding.rs
@@ -86,7 +86,7 @@ pub fn decode(f: Format, input: &[u8]) -> DecodeResult {
         Z85 => {
             // The z85 crate implements a padded encoding by using a leading '#' which is otherwise not allowed.
             // We manually check for a leading '#' and return an error ourselves.
-            if input.starts_with(&[b'#']) {
+            if input.starts_with(b"#") {
                 return Err(z85::DecodeError::InvalidByte(0, b'#').into());
             } else {
                 z85::decode(input)?

--- a/src/uucore/src/lib/features/proc_info.rs
+++ b/src/uucore/src/lib/features/proc_info.rs
@@ -22,7 +22,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Display, Formatter},
-    fs,
+    fs, io,
     path::PathBuf,
     rc::Rc,
 };

--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -402,7 +402,7 @@ impl<'a> DigestWriter<'a> {
 
     pub fn finalize(&mut self) -> bool {
         if self.was_last_character_carriage_return {
-            self.digest.hash_update(&[b'\r']);
+            self.digest.hash_update(b"\r");
             true
         } else {
             false
@@ -433,7 +433,7 @@ impl<'a> Write for DigestWriter<'a> {
         // call to `write()`.
         let n = buf.len();
         if self.was_last_character_carriage_return && n > 0 && buf[0] != b'\n' {
-            self.digest.hash_update(&[b'\r']);
+            self.digest.hash_update(b"\r");
         }
 
         // Next, find all occurrences of "\r\n", inputting the slice
@@ -491,15 +491,15 @@ mod tests {
         // Writing "\r" in one call to `write()`, and then "\n" in another.
         let mut digest = Box::new(Md5::new()) as Box<dyn Digest>;
         let mut writer_crlf = DigestWriter::new(&mut digest, false);
-        writer_crlf.write_all(&[b'\r']).unwrap();
-        writer_crlf.write_all(&[b'\n']).unwrap();
+        writer_crlf.write_all(b"\r").unwrap();
+        writer_crlf.write_all(b"\n").unwrap();
         writer_crlf.finalize();
         let result_crlf = digest.result_str();
 
         // We expect "\r\n" to be replaced with "\n" in text mode on Windows.
         let mut digest = Box::new(Md5::new()) as Box<dyn Digest>;
         let mut writer_lf = DigestWriter::new(&mut digest, false);
-        writer_lf.write_all(&[b'\n']).unwrap();
+        writer_lf.write_all(b"\n").unwrap();
         writer_lf.finalize();
         let result_lf = digest.result_str();
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2028,7 +2028,7 @@ fn test_cp_archive_recursive() {
     let result = scene2
         .cmd("ls")
         .arg("-al")
-        .arg(&at.subdir.join(TEST_COPY_TO_FOLDER))
+        .arg(at.subdir.join(TEST_COPY_TO_FOLDER))
         .run();
 
     println!("ls dest {}", result.stdout_str());
@@ -2036,7 +2036,7 @@ fn test_cp_archive_recursive() {
     let result = scene2
         .cmd("ls")
         .arg("-al")
-        .arg(&at.subdir.join(TEST_COPY_TO_FOLDER_NEW))
+        .arg(at.subdir.join(TEST_COPY_TO_FOLDER_NEW))
         .run();
 
     println!("ls dest {}", result.stdout_str());

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -83,7 +83,7 @@ macro_rules! test_digest {
             // The asterisk indicates that the digest was computed in
             // binary mode.
             let n = expected.len();
-            let expected = [&expected[..n - 3], &[b' ', b'-', b'\n']].concat();
+            let expected = [&expected[..n - 3], b" -\n"].concat();
             new_ucmd!()
                 .args(&[DIGEST_ARG, BITS_ARG, "-t"])
                 .pipe_in("a\r\nb\r\nc\r\n")

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -962,7 +962,7 @@ fn test_install_dir() {
     at.mkdir(dir);
     ucmd.arg(file1)
         .arg(file2)
-        .arg(&format!("--target-directory={dir}"))
+        .arg(format!("--target-directory={dir}"))
         .succeeds()
         .no_stderr();
 

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -335,7 +335,7 @@ fn wrong_line_order() {
         .arg("fields_4.txt")
         .fails()
         .stdout_contains("7 g f 4 fg")
-        .stderr_is(&format!(
+        .stderr_is(format!(
             "{0} {1}: fields_4.txt:5: is not sorted: 11 g 5 gh\n{0} {1}: input is not in sorted order\n",
             ts.bin_path.to_string_lossy(),
             ts.util_name
@@ -347,7 +347,7 @@ fn wrong_line_order() {
         .arg("fields_4.txt")
         .fails()
         .stdout_does_not_contain("7 g f 4 fg")
-        .stderr_is(&format!(
+        .stderr_is(format!(
             "{0}: fields_4.txt:5: is not sorted: 11 g 5 gh\n",
             ts.util_name
         ));
@@ -361,7 +361,7 @@ fn both_files_wrong_line_order() {
         .arg("fields_5.txt")
         .fails()
         .stdout_contains("5 e 3 ef")
-        .stderr_is(&format!(
+        .stderr_is(format!(
             "{0} {1}: fields_5.txt:4: is not sorted: 3\n{0} {1}: fields_4.txt:5: is not sorted: 11 g 5 gh\n{0} {1}: input is not in sorted order\n",
             ts.bin_path.to_string_lossy(),
             ts.util_name
@@ -373,7 +373,7 @@ fn both_files_wrong_line_order() {
         .arg("fields_5.txt")
         .fails()
         .stdout_does_not_contain("5 e 3 ef")
-        .stderr_is(&format!(
+        .stderr_is(format!(
             "{0}: fields_5.txt:4: is not sorted: 3\n",
             ts.util_name
         ));

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -75,7 +75,7 @@ fn test_invalid_value_returns_1() {
         "--time",
     ] {
         new_ucmd!()
-            .arg(&format!("{flag}=definitely_invalid_value"))
+            .arg(format!("{flag}=definitely_invalid_value"))
             .fails()
             .no_stdout()
             .code_is(1);
@@ -87,7 +87,7 @@ fn test_invalid_value_returns_2() {
     // Invalid values to flags *sometimes* result in error code 2:
     for flag in ["--block-size", "--width", "--tab-size"] {
         new_ucmd!()
-            .arg(&format!("{flag}=definitely_invalid_value"))
+            .arg(format!("{flag}=definitely_invalid_value"))
             .fails()
             .no_stdout()
             .code_is(2);

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -133,7 +133,7 @@ fn test_mv_move_file_between_dirs() {
 
     assert!(at.file_exists(format!("{dir1}/{file}")));
 
-    ucmd.arg(&format!("{dir1}/{file}"))
+    ucmd.arg(format!("{dir1}/{file}"))
         .arg(dir2)
         .succeeds()
         .no_stderr();

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -54,10 +54,7 @@ fn test_long_format_multiple_users() {
     // multiple instances of one account we know exists,
     // the account of the test runner,
     // and an account that (probably) doesn't exist
-    let runner = match std::env::var("USER") {
-        Ok(user) => user,
-        Err(_) => String::new(),
-    };
+    let runner = std::env::var("USER").unwrap_or_default();
     let args = ["-l", "root", "root", "root", &runner, "no_such_user"];
     let ts = TestScenario::new(util_name!());
     let expect = unwrap_or_return!(expected_result(&ts, &args));

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -30,9 +30,9 @@ fn test_rm_failed() {
     let (_at, mut ucmd) = at_and_ucmd!();
     let file = "test_rm_one_file"; // Doesn't exist
 
-    ucmd.arg(file).fails().stderr_contains(&format!(
-        "cannot remove '{file}': No such file or directory"
-    ));
+    ucmd.arg(file)
+        .fails()
+        .stderr_contains(format!("cannot remove '{file}': No such file or directory"));
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn test_rm_non_empty_directory() {
     ucmd.arg("-d")
         .arg(dir)
         .fails()
-        .stderr_contains(&format!("cannot remove '{dir}': Directory not empty"));
+        .stderr_contains(format!("cannot remove '{dir}': Directory not empty"));
     assert!(at.file_exists(file_a));
     assert!(at.dir_exists(dir));
 }
@@ -225,7 +225,7 @@ fn test_rm_directory_without_flag() {
 
     ucmd.arg(dir)
         .fails()
-        .stderr_contains(&format!("cannot remove '{dir}': Is a directory"));
+        .stderr_contains(format!("cannot remove '{dir}': Is a directory"));
 }
 
 #[test]
@@ -289,7 +289,7 @@ fn test_rm_symlink_dir() {
         .ucmd()
         .arg(link)
         .fails()
-        .stderr_contains(&format!("cannot remove '{link}': Is a directory"));
+        .stderr_contains(format!("cannot remove '{link}': Is a directory"));
 
     assert!(at.dir_exists(link));
 
@@ -337,7 +337,7 @@ fn test_rm_verbose_slash() {
     ucmd.arg("-r")
         .arg("-f")
         .arg("-v")
-        .arg(&format!("{dir}///"))
+        .arg(format!("{dir}///"))
         .succeeds()
         .stdout_only(format!(
             "removed '{file_a_normalized}'\nremoved directory '{dir}'\n"

--- a/tests/by-util/test_shuf.rs
+++ b/tests/by-util/test_shuf.rs
@@ -143,7 +143,7 @@ fn test_range_repeat_no_overflow_1_max() {
     let upper_bound = usize::MAX;
     let result = new_ucmd!()
         .arg("-rn1")
-        .arg(&format!("-i1-{upper_bound}"))
+        .arg(format!("-i1-{upper_bound}"))
         .succeeds();
     result.no_stderr();
 
@@ -161,7 +161,7 @@ fn test_range_repeat_no_overflow_0_max_minus_1() {
     let upper_bound = usize::MAX - 1;
     let result = new_ucmd!()
         .arg("-rn1")
-        .arg(&format!("-i0-{upper_bound}"))
+        .arg(format!("-i0-{upper_bound}"))
         .succeeds();
     result.no_stderr();
 
@@ -179,7 +179,7 @@ fn test_range_permute_no_overflow_1_max() {
     let upper_bound = usize::MAX;
     let result = new_ucmd!()
         .arg("-n1")
-        .arg(&format!("-i1-{upper_bound}"))
+        .arg(format!("-i1-{upper_bound}"))
         .succeeds();
     result.no_stderr();
 
@@ -197,7 +197,7 @@ fn test_range_permute_no_overflow_0_max_minus_1() {
     let upper_bound = usize::MAX - 1;
     let result = new_ucmd!()
         .arg("-n1")
-        .arg(&format!("-i0-{upper_bound}"))
+        .arg(format!("-i0-{upper_bound}"))
         .succeeds();
     result.no_stderr();
 
@@ -218,7 +218,7 @@ fn test_range_permute_no_overflow_0_max() {
     let upper_bound = usize::MAX;
     let result = new_ucmd!()
         .arg("-n1")
-        .arg(&format!("-i0-{upper_bound}"))
+        .arg(format!("-i0-{upper_bound}"))
         .succeeds();
     result.no_stderr();
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -889,7 +889,7 @@ fn test_dictionary_and_nonprinting_conflicts() {
     for restricted_arg in ["d", "i"] {
         for conflicting_arg in &conflicting_args {
             new_ucmd!()
-                .arg(&format!("-{restricted_arg}{conflicting_arg}"))
+                .arg(format!("-{restricted_arg}{conflicting_arg}"))
                 .fails();
         }
         for conflicting_arg in &conflicting_args {
@@ -897,7 +897,7 @@ fn test_dictionary_and_nonprinting_conflicts() {
                 .args(&[
                     format!("-{restricted_arg}").as_str(),
                     "-k",
-                    &format!("1,1{conflicting_arg}"),
+                    format!("1,1{conflicting_arg}").as_str(),
                 ])
                 .succeeds();
         }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -4560,7 +4560,7 @@ fn test_gnu_args_c() {
         .arg("-12c")
         .pipe_in(format!("x{}z", "y".repeat(12)))
         .succeeds()
-        .stdout_only(&format!("{}z", "y".repeat(11)));
+        .stdout_only(format!("{}z", "y".repeat(11)));
 }
 
 #[test]
@@ -4594,7 +4594,7 @@ fn test_gnu_args_l() {
         .arg("-l")
         .pipe_in(format!("x{}z", "y\n".repeat(10)))
         .succeeds()
-        .stdout_only(&format!("{}z", "y\n".repeat(9)));
+        .stdout_only(format!("{}z", "y\n".repeat(9)));
 }
 
 #[test]
@@ -4681,7 +4681,7 @@ fn test_gnu_args_b() {
         .arg("-b")
         .pipe_in("x\n".repeat(512 * 10 / 2 + 1))
         .succeeds()
-        .stdout_only(&"x\n".repeat(512 * 10 / 2));
+        .stdout_only("x\n".repeat(512 * 10 / 2));
 }
 
 #[test]

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1434,8 +1434,8 @@ fn check_complement_set2_too_big() {
 #[test]
 #[cfg(unix)]
 fn test_truncate_non_utf8_set() {
-    let stdin = &[b'\x01', b'a', b'm', b'p', 0xfe_u8, 0xff_u8];
-    let set1 = OsStr::from_bytes(&[b'a', 0xfe_u8, 0xff_u8, b'z']);
+    let stdin = b"\x01amp\xfe\xff";
+    let set1 = OsStr::from_bytes(b"a\xfe\xffz"); // spell-checker:disable-line
     let set2 = OsStr::from_bytes(b"01234");
 
     new_ucmd!()

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1522,12 +1522,12 @@ impl UCommand {
     ///
     /// These __defaults__ are:
     /// * `bin_path`: Depending on the platform and os, the native shell (unix -> `/bin/sh` etc.).
-    /// This default also requires to set the first argument to `-c` on unix (`/C` on windows) if
-    /// this argument wasn't specified explicitly by the user.
+    ///   This default also requires to set the first argument to `-c` on unix (`/C` on windows) if
+    ///   this argument wasn't specified explicitly by the user.
     /// * `util_name`: `None`. If neither `bin_path` nor `util_name` were given the arguments are
-    /// run in a shell (See `bin_path` above).
+    ///   run in a shell (See `bin_path` above).
     /// * `temp_dir`: If `current_dir` was not set, a new temporary directory will be created in
-    /// which this command will be run and `current_dir` will be set to this `temp_dir`.
+    ///   which this command will be run and `current_dir` will be set to this `temp_dir`.
     /// * `current_dir`: The temporary directory given by `temp_dir`.
     /// * `timeout`: `30 seconds`
     /// * `stdin`: `Stdio::null()`

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -59,7 +59,7 @@ static ALREADY_RUN: &str = " you have already run this UCommand, if you want to 
 static MULTIPLE_STDIN_MEANINGLESS: &str = "Ucommand is designed around a typical use case of: provide args and input stream -> spawn process -> block until completion -> return output streams. For verifying that a particular section of the input stream is what causes a particular behavior, use the Command type directly.";
 
 static NO_STDIN_MEANINGLESS: &str = "Setting this flag has no effect if there is no stdin";
-static END_OF_TRANSMISSION_SEQUENCE: &[u8] = &[b'\n', 0x04];
+static END_OF_TRANSMISSION_SEQUENCE: &[u8] = b"\n\x04";
 
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_coreutils");
 pub const PATH: &str = env!("PATH");
@@ -3081,7 +3081,7 @@ mod tests {
         let result = TestScenario::new("echo").ucmd().arg("Hello world").run();
 
         result.stdout_str_check(|stdout| stdout.ends_with("world\n"));
-        result.stdout_check(|stdout| stdout.get(0..2).unwrap().eq(&[b'H', b'e']));
+        result.stdout_check(|stdout| stdout.get(0..2).unwrap().eq(b"He"));
         result.no_stderr();
     }
 
@@ -3096,7 +3096,7 @@ mod tests {
         ));
 
         result.stderr_str_check(|stderr| stderr.ends_with("world\n"));
-        result.stderr_check(|stderr| stderr.get(0..2).unwrap().eq(&[b'H', b'e']));
+        result.stderr_check(|stdout| stdout.get(0..2).unwrap().eq(b"He"));
         result.no_stdout();
     }
 


### PR DESCRIPTION
Currently, the pre-commit hook that runs nightly clippy fails for many reasons, all of which are things that we can and should improve.

This PR resolves all those issues: 4 clippy lints, and one missing import that somehow wasn't detected until now. (That is a hint that something is wrong with our CI, but I don't know how to fix that.)