### PR TITLE
clippy: fix warnings introduced by Rust 1.80

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1947,7 +1947,8 @@ fn handle_copy_mode(
 ///
 /// * `Ok(Permissions)` - The calculated permissions for the destination file.
 /// * `Err(CopyError)` - An error occurred while getting the metadata of the destination file.
-/// Allow unused variables for Windows (on options)
+///
+// Allow unused variables for Windows (on options)
 #[allow(unused_variables)]
 fn calculate_dest_permissions(
     dest: &Path,

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -351,7 +351,7 @@ impl<'a> SplitWriter<'a> {
     /// In addition to errors reading/writing from/to a file, the following errors may be returned:
     /// - if no line matched, an [`CsplitError::MatchNotFound`].
     /// - if there are not enough lines to accommodate the offset, an
-    /// [`CsplitError::LineOutOfRange`].
+    ///   [`CsplitError::LineOutOfRange`].
     #[allow(clippy::cognitive_complexity)]
     fn do_to_match<I>(
         &mut self,

--- a/src/uu/csplit/src/split_name.rs
+++ b/src/uu/csplit/src/split_name.rs
@@ -19,7 +19,7 @@ impl SplitName {
     /// Creates a new SplitName with the given user-defined options:
     /// - `prefix_opt` specifies a prefix for all splits.
     /// - `format_opt` specifies a custom format for the suffix part of the filename, using the
-    /// `sprintf` format notation.
+    ///   `sprintf` format notation.
     /// - `n_digits_opt` defines the width of the split number.
     ///
     /// # Caveats

--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -266,11 +266,11 @@ fn resolve_path(
 /// Conditionally converts an absolute path to a relative form,
 /// according to the rules:
 /// 1. if only `relative_to` is given, the result is relative to `relative_to`
-/// 1. if only `relative_base` is given, it checks whether given `path` is a descendant
-/// of `relative_base`, on success the result is relative to `relative_base`, otherwise
-/// the result is the given `path`
-/// 1. if both `relative_to` and `relative_base` are given, the result is relative to `relative_to`
-/// if `path` is a descendant of `relative_base`, otherwise the result is `path`
+/// 2. if only `relative_base` is given, it checks whether given `path` is a descendant
+///    of `relative_base`, on success the result is relative to `relative_base`, otherwise
+///    the result is the given `path`
+/// 3. if both `relative_to` and `relative_base` are given, the result is relative to `relative_to`
+///    if `path` is a descendant of `relative_base`, otherwise the result is `path`
 ///
 /// For more information see
 /// <https://www.gnu.org/software/coreutils/manual/html_node/Realpath-usage-examples.html>

--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -191,14 +191,11 @@ pub fn strip_minus_from_mode(args: &mut Vec<String>) -> bool {
             break;
         }
         if let Some(arg_stripped) = arg.strip_prefix('-') {
-            if let Some(second) = arg.chars().nth(1) {
-                match second {
-                    'r' | 'w' | 'x' | 'X' | 's' | 't' | 'u' | 'g' | 'o' | '0'..='7' => {
-                        *arg = arg_stripped.to_string();
-                        return true;
-                    }
-                    _ => {}
-                }
+            if let Some('r' | 'w' | 'x' | 'X' | 's' | 't' | 'u' | 'g' | 'o' | '0'..='7') =
+                arg.chars().nth(1)
+            {
+                *arg = arg_stripped.to_string();
+                return true;
             }
         }
     }

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -29,7 +29,7 @@
 //! * When `Ok` is returned, the code set with [`set_exit_code`] is used as exit code. If
 //!   [`set_exit_code`] was not used, then `0` is used.
 //! * When `Err` is returned, the code corresponding with the error is used as exit code and the
-//! error message is displayed.
+//!   error message is displayed.
 //!
 //! Additionally, the errors can be displayed manually with the [`crate::show`] and [`crate::show_if_err`] macros:
 //! ```ignore


### PR DESCRIPTION
This PR fixes the clippy warnings introduced by Rust 1.80.

Not included in this PR is a fix for the "unexpected `cfg` condition name: `fuzzing`" warnings because there is already a PR for it: https://github.com/uutils/coreutils/pull/6497