### PR TITLE
uucore: Add `getsid` for `process.rs`

### DIFF
--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -137,13 +137,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_getpid() {
-        let libc_pid = getgid();
-
-        assert_ne!(libc_pid, 0);
-    }
-
-    #[test]
     #[cfg(not(target_os = "redox"))]
     fn test_getsid() {
         assert!(getsid(getpid()).is_ok());

--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -139,7 +139,15 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "redox"))]
     fn test_getsid() {
-        assert!(getsid(getpid()).is_ok());
+        assert_eq!(
+            getsid(getpid()).expect("getsid(getpid)"),
+            // zero is a special value for SID.
+            // https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsid.html
+            getsid(0).expect("getsid(0)")
+        );
+
+        // SID never be 0.
+        assert!(getsid(getpid()).expect("getsid(getpid)") > 0);
 
         // This might caused tests failure but the probability is low.
         assert!(getsid(999999).is_err());

--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 // spell-checker:ignore (vars) cvar exitstatus cmdline kworker getsid
-// spell-checker:ignore (sys/unix) WIFSIGNALED
+// spell-checker:ignore (sys/unix) WIFSIGNALED ESRCH
 // spell-checker:ignore pgrep pwait snice
 
 use libc::{gid_t, pid_t, uid_t};
@@ -45,6 +45,13 @@ pub fn getuid() -> uid_t {
 ///
 /// - [Errno::EPERM] A process with process ID pid exists, but it is not in the same session as the calling process, and the implementation considers this an error.
 /// - [Errno::ESRCH] No process with process ID pid was found.
+///
+///
+/// # Platform
+///
+/// This function only support standard POSIX implementation platform,
+/// so some system such as redox doesn't supported.
+#[cfg(not(target_os = "redox"))]
 pub fn getsid(pid: i32) -> Result<pid_t, Errno> {
     unsafe {
         let result = libc::getsid(pid);

--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -134,33 +134,19 @@ impl ChildExt for Child {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::PathBuf, str::FromStr};
-
     use super::*;
 
     #[test]
     fn test_getpid() {
         let libc_pid = getgid();
 
-        // Read `/proc/self` directly.
-        let proc_pid = fs::read_link(PathBuf::from_str("/proc/self").unwrap())
-            .unwrap()
-            .iter()
-            .last()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .parse::<usize>()
-            .unwrap() as u32;
-
-        assert_eq!(libc_pid, proc_pid);
+        assert_ne!(libc_pid, 0);
     }
 
     #[test]
     #[cfg(not(target_os = "redox"))]
     fn test_getsid() {
-        // This test assumes that the current allowed process is actually the session leader.
-        assert_eq!(getpid(), getsid(getpid()).unwrap());
+        assert!(getsid(getpid()).is_ok());
 
         // This might caused tests failure but the probability is low.
         assert!(getsid(999999).is_err());

--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -37,6 +37,11 @@ pub fn getuid() -> uid_t {
     unsafe { libc::getuid() }
 }
 
+/// `getpid()` returns the pid of the calling process.
+pub fn getpid() -> pid_t {
+    unsafe { libc::getpid() }
+}
+
 /// `getsid()` returns the session ID of the process with process ID pid.
 ///
 /// If pid is 0, getsid() returns the session ID of the calling process.

--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (vars) cvar exitstatus cmdline kworker
+// spell-checker:ignore (vars) cvar exitstatus cmdline kworker getsid
 // spell-checker:ignore (sys/unix) WIFSIGNALED
 // spell-checker:ignore pgrep pwait snice
 
@@ -34,6 +34,11 @@ pub fn getgid() -> gid_t {
 /// `getuid()` returns the real user ID of the calling process.
 pub fn getuid() -> uid_t {
     unsafe { libc::getuid() }
+}
+
+/// `getsid()` returns the session ID of the pid.
+pub fn getsid(pid: i32) -> pid_t {
+    unsafe { libc::getsid(pid) }
 }
 
 /// Missing methods for Child objects


### PR DESCRIPTION
Sorry, I closed pr by mistake :( #6590

This pr will add getsid function for process.rs to detect the session ID of pid.

The session ID plays a full role, and he usually plays the role of a process group identifier on Linux systems (or is it the POSIX standard?). The session ID plays a full role as a kind of process group identifier. In addition to that, this pr will also fulfill the role of getting the session leader.

However, because of the need to call libc, the pr involves unsafe code, so this pr will be ready for review after due consideration.
