### PR TITLE
``ls``: Changed unwrap_or and ``or`` option handling to lazy evaluated ``unwrap_or_else`` and ``or_else``

### DIFF
--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -174,7 +174,7 @@ pub(crate) fn color_name(
     } else {
         let md_option = path.get_metadata(out);
         let symlink_metadata = path.p_buf.symlink_metadata().ok();
-        let md = md_option.or_else(|| symlink_metadata.as_ref());
+        let md = md_option.or(symlink_metadata.as_ref());
         style_manager.apply_style_based_on_metadata(path, md, name, wrap)
     }
 }

--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -169,12 +169,12 @@ pub(crate) fn color_name(
         // Use fn get_metadata_with_deref_opt instead of get_metadata() here because ls
         // should not exit with an err, if we are unable to obtain the target_metadata
         let md_res = get_metadata_with_deref_opt(&target.p_buf, path.must_dereference);
-        let md = md_res.or(path.p_buf.symlink_metadata());
+        let md = md_res.or_else(|_| path.p_buf.symlink_metadata());
         style_manager.apply_style_based_on_metadata(path, md.ok().as_ref(), name, wrap)
     } else {
         let md_option = path.get_metadata(out);
         let symlink_metadata = path.p_buf.symlink_metadata().ok();
-        let md = md_option.or(symlink_metadata.as_ref());
+        let md = md_option.or_else(|| symlink_metadata.as_ref());
         style_manager.apply_style_based_on_metadata(path, md, name, wrap)
     }
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -697,7 +697,7 @@ fn extract_quoting_style(options: &clap::ArgMatches, show_control: bool) -> Quot
                 Some(qs) => return qs,
                 None => eprintln!(
                     "{}: Ignoring invalid value of environment variable QUOTING_STYLE: '{}'",
-                    std::env::args().next().unwrap_or("ls".to_string()),
+                    std::env::args().next().unwrap_or_else(|| "ls".to_string()),
                     style
                 ),
             }
@@ -3332,7 +3332,7 @@ fn display_item_name(
 }
 
 fn create_hyperlink(name: &str, path: &PathData) -> String {
-    let hostname = hostname::get().unwrap_or(OsString::from(""));
+    let hostname = hostname::get().unwrap_or_else(|_| OsString::from(""));
     let hostname = hostname.to_string_lossy();
 
     let absolute_path = fs::canonicalize(&path.p_buf).unwrap_or_default();


### PR DESCRIPTION
This would help us reduce a lstat() call on ``ls/colors.rs``