### PR TITLE
Bump `tempfile` from `3.10.1` to `3.11.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,12 +2274,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4.7"
 libc = "0.2.153"
-tempfile = "3.10.1"
+tempfile = "3.11.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 similar = "2.5.0"
 


### PR DESCRIPTION
renovate has a problem with updating `tempfile`, so doing it manually.