### PR TITLE
mv: reusing copy code from cp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,12 +940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,8 +2948,8 @@ name = "uu_mv"
 version = "0.0.27"
 dependencies = [
  "clap",
- "fs_extra",
  "indicatif",
+ "uu_cp",
  "uucore",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,6 +358,7 @@ digest = "0.10.7"
 uucore = { version = ">=0.0.19", package = "uucore", path = "src/uucore" }
 uucore_procs = { version = ">=0.0.19", package = "uucore_procs", path = "src/uucore_procs" }
 uu_ls = { version = ">=0.0.18", path = "src/uu/ls" }
+uu_cp = { version = ">=0.0.27", path = "src/uu/cp" }
 uu_base32 = { version = ">=0.0.18", path = "src/uu/base32" }
 
 [dependencies]

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -322,7 +322,7 @@ fn copy_direntry(
 /// Any errors encountered copying files in the tree will be logged but
 /// will not cause a short-circuit.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn copy_directory(
+pub fn copy_directory(
     progress_bar: &Option<ProgressBar>,
     root: &Path,
     target: &Path,

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -41,7 +41,7 @@ use uucore::{
     shortcut_value_parser::ShortcutValueParser, show_error, show_warning, util_name,
 };
 
-use crate::copydir::copy_directory;
+pub use crate::copydir::copy_directory;
 
 mod copydir;
 mod platform;
@@ -1987,7 +1987,7 @@ fn calculate_dest_permissions(
 /// The original permissions of `source` will be copied to `dest`
 /// after a successful copy.
 #[allow(clippy::cognitive_complexity, clippy::too_many_arguments)]
-fn copy_file(
+pub fn copy_file(
     progress_bar: &Option<ProgressBar>,
     source: &Path,
     dest: &Path,
@@ -2349,7 +2349,7 @@ pub fn localize_to_target(root: &Path, source: &Path, target: &Path) -> CopyResu
 /// This function is much like the `du` utility, by recursively getting the sizes of files in directories.
 /// Files are not deduplicated when appearing in multiple sources. If `recursive` is set to `false`, the
 /// directories in `paths` will be ignored.
-fn disk_usage(paths: &[PathBuf], recursive: bool) -> io::Result<u64> {
+pub fn disk_usage(paths: &[PathBuf], recursive: bool) -> io::Result<u64> {
     let mut total = 0;
     for p in paths {
         let md = fs::metadata(p)?;

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/mv.rs"
 
 [dependencies]
 clap = { workspace = true }
-fs_extra = { workspace = true }
 indicatif = { workspace = true }
 uucore = { workspace = true, features = [
   "backup-control",
@@ -26,6 +25,7 @@ uucore = { workspace = true, features = [
   "fsxattr",
   "update-control",
 ] }
+uu_cp = { workspace = true }
 
 [[bin]]
 name = "mv"

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -530,7 +530,7 @@ fn rename(
 ) -> io::Result<()> {
     let mut backup_path = None;
     //use path_ends_with_terminator
-    let to = if path_ends_with_terminator(to) {
+    let to = if path_ends_with_terminator(to) && opts.no_target_dir {
         Path::new(to.to_str().unwrap().trim_end_matches('/'))
     } else {
         to


### PR DESCRIPTION
Reusing the copy code from cp allows mv to leverage the functionalities that have already been implemented in cp. For example:
- When performing inter-device copying, mv could preserve links
- The progress bar would work better.