### PR TITLE
rm: fix issue #6620 (refuse to remove '.' and '..')

### DIFF
--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -326,10 +326,7 @@ pub fn remove(files: &[&OsStr], options: &Options) -> bool {
 fn handle_dir(path: &Path, options: &Options) -> bool {
     let mut had_err = false;
 
-    #[cfg(unix)]
-    let del = "/";
-    #[cfg(windows)]
-    let del = "\\";
+    let del = std::path::MAIN_SEPARATOR;
 
     if path
         .to_str()

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -326,17 +326,20 @@ pub fn remove(files: &[&OsStr], options: &Options) -> bool {
 fn handle_dir(path: &Path, options: &Options) -> bool {
     let mut had_err = false;
 
-    let path_as_str = path.as_os_str().to_str().unwrap();
     #[cfg(unix)]
-    if path_as_str.ends_with("/.") || path_as_str.ends_with("/..") {
-        show_error!(
-            "refusing to remove '.' or '..' directory: skipping {}",
-            path.quote()
-        );
-        return true;
-    }
+    let del = "/";
     #[cfg(windows)]
-    if path_as_str.ends_with("\\.") || path_as_str.ends_with("\\..") {
+    let del = "\\";
+
+    if path
+        .to_str()
+        .unwrap()
+        .ends_with(format!("{}.", del).as_str())
+        || path
+            .to_str()
+            .unwrap()
+            .ends_with(format!("{}..", del).as_str())
+    {
         show_error!(
             "refusing to remove '.' or '..' directory: skipping {}",
             path.quote()

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -326,6 +326,24 @@ pub fn remove(files: &[&OsStr], options: &Options) -> bool {
 fn handle_dir(path: &Path, options: &Options) -> bool {
     let mut had_err = false;
 
+    let path_as_str = path.as_os_str().to_str().unwrap();
+    #[cfg(unix)]
+    if path_as_str.ends_with("/.") || path_as_str.ends_with("/..") {
+        show_error!(
+            "refusing to remove '.' or '..' directory: skipping {}",
+            path.quote()
+        );
+        return true;
+    }
+    #[cfg(windows)]
+    if path_as_str.ends_with("\\.") || path_as_str.ends_with("\\..") {
+        show_error!(
+            "refusing to remove '.' or '..' directory: skipping {}",
+            path.quote()
+        );
+        return true;
+    }
+
     let is_root = path.has_root() && path.parent().is_none();
     if options.recursive && (!is_root || !options.preserve_root) {
         if options.interactive != InteractiveMode::Always && !options.verbose {

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -718,10 +718,7 @@ fn test_non_utf8() {
 fn test_rm_no_del_parent() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    #[cfg(not(windows))]
-    let del = "/";
-    #[cfg(windows)]
-    let del = "\\";
+    let del = std::path::MAIN_SEPARATOR;
 
     at.mkdir("test");
     at.mkdir(&format!("test{del}dir"));
@@ -736,10 +733,7 @@ fn test_rm_no_del_parent() {
 fn test_rm_no_del_cur() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    #[cfg(not(windows))]
-    let del = "/";
-    #[cfg(windows)]
-    let del = "\\";
+    let del = std::path::MAIN_SEPARATOR;
 
     at.mkdir("test");
     at.touch(&format!("test{del}file"));

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -713,3 +713,37 @@ fn test_non_utf8() {
     ucmd.arg(file).succeeds();
     assert!(!at.file_exists(file));
 }
+
+#[test]
+fn test_rm_no_del_parent() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    #[cfg(not(windows))]
+    let del = "/";
+    #[cfg(windows)]
+    let del = "\\";
+
+    at.mkdir("test");
+    at.mkdir(&format!("test{del}dir"));
+    at.touch(&format!("test{del}dir{del}file"));
+    ucmd.arg("-rf").arg(format!("test{del}dir{del}..")).fails();
+    assert!(at.dir_exists("test"));
+    assert!(at.dir_exists(&format!("test{del}dir")));
+    assert!(at.file_exists(&format!("test{del}dir{del}file")));
+}
+
+#[test]
+fn test_rm_no_del_cur() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    #[cfg(not(windows))]
+    let del = "/";
+    #[cfg(windows)]
+    let del = "\\";
+
+    at.mkdir("test");
+    at.touch(&format!("test{del}file"));
+    ucmd.arg("-rf").arg(format!("test{del}.")).fails();
+    assert!(at.dir_exists("test"));
+    assert!(at.file_exists(&format!("test{del}file")));
+}


### PR DESCRIPTION
Before processing the directory, if it ends with "." or "..", it now immediately returns with the same error message as GNU
Should close #6620