### PR TITLE
basename,realpath: add words to `spell-checker:ignore`

### DIFF
--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (words) reallylongexecutable
+// spell-checker:ignore (words) reallylongexecutable nbaz
 
 use crate::common::util::TestScenario;
 #[cfg(any(unix, target_os = "redox"))]

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -2,6 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+// spell-checker:ignore nusr
 use crate::common::util::{get_root_path, TestScenario};
 
 #[cfg(windows)]


### PR DESCRIPTION
This PR adds two words to `spell-checker:ignore` that started to fail the "Style/spelling" job in the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/10318729989/job/28565689683?pr=6626#step:5:16). The failures are probably due to a new release of `cspell`.