### PR TITLE
dircolors+join+sleep: optimize int and string ops as required by clippy nightly

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -469,7 +469,7 @@ fn escape(s: &str) -> String {
         match c {
             '\'' => result.push_str("'\\''"),
             ':' if previous != '\\' => result.push_str("\\:"),
-            _ => result.push_str(&c.to_string()),
+            _ => result.push(c),
         }
         previous = c;
     }

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -654,7 +654,7 @@ fn parse_settings(matches: &clap::ArgMatches) -> UResult<Settings> {
             settings.autoformat = true;
         } else {
             let mut specs = vec![];
-            for part in format.split(|c| c == ' ' || c == ',' || c == '\t') {
+            for part in format.split([' ', ',', '\t']) {
                 specs.push(Spec::parse(part)?);
             }
             settings.format = specs;

--- a/tests/by-util/test_sleep.rs
+++ b/tests/by-util/test_sleep.rs
@@ -138,7 +138,7 @@ fn test_sleep_wrong_time() {
 #[test]
 fn test_sleep_when_single_input_exceeds_max_duration_then_no_error() {
     let mut child = new_ucmd!()
-        .arg(format!("{}", u64::MAX as u128 + 1))
+        .arg(format!("{}", u128::from(u64::MAX) + 1))
         .timeout(Duration::from_secs(10))
         .run_no_wait();
 


### PR DESCRIPTION
The changes should be pretty self-explanatory: We used to do things in weird ways, clippy nightly caught it, this fixes it.