### PR TITLE
chmod: fix incorrect test

### DIFF
--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -238,7 +238,7 @@ fn test_chmod_ugoa() {
         .fails()
         .code_is(1)
         // spell-checker:disable-next-line
-        .stderr_is("chmod: file: new permissions are r-xrwxrwx, not r-xr-xr-x\n");
+        .stderr_is("chmod: file: new permissions are r-xr-xrwx, not r-xr-xr-x\n");
     assert_eq!(
         metadata(at.plus("file")).unwrap().permissions().mode(),
         0o100577


### PR DESCRIPTION
First of all, let's observe that uutils and GNU coreutils behave identically in a special edgecase, and emit exactly the same warning message:
```console
$ touch file
$ chmod =0777 file; ls -l file
-rwxrwxrwx 1 user user 0 Aug 12 00:02 file
$ chmod -w file # GNU says "r-xr-xrwx" in the error message
chmod: file: new permissions are r-xr-xrwx, not r-xr-xr-x
[$? = 1]
$ chmod =0777 file; ls -l file # (reset test setup)
-rwxrwxrwx 1 user user 0 Aug 12 00:02 file
$ cargo run -q --features chmod chmod -w file # uutils correctly says "r-xr-xrwx" in the error message, too
chmod: file: new permissions are r-xr-xrwx, not r-xr-xr-x
[$? = 1]
```

So uutils *is already correct*.

However, this test somehow fails:

```console
$ cargo test -q --features chmod -- test_chmod_ugoa
<SNIP irrelevant output>
Diff < left / right > :
<chmod: file: new permissions are r-xr-xrwx, not r-xr-xr-x
>chmod: file: new permissions are r-xrwxrwx, not r-xr-xr-x
<SNIP irrelevant output>
```

In other words, the test code itself is wrong, because it asserts the wrong output. Also, for the record, even uutils changes the permissions to `-r-xr-xrwx`, which is correct.

This PR fixes the incorrect test.

Note that this does NOT fix #6637, which is a bug in the way that `cargo test` is invoked.