### PR TITLE
Bump `nix` & `ctrlc` and adapt code to API changes in `nix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,9 +297,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -730,12 +730,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
  "nix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -3657,7 +3657,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3708,6 +3708,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,7 +303,7 @@ lscolors = { version = "0.18.0", default-features = false, features = [
 ] }
 memchr = "2.7.2"
 memmap2 = "0.9.4"
-nix = { version = "0.28", default-features = false }
+nix = { version = "0.29", default-features = false }
 nom = "7.1.3"
 notify = { version = "=6.0.1", features = ["macos_kqueue"] }
 num-bigint = "0.4.4"

--- a/deny.toml
+++ b/deny.toml
@@ -62,6 +62,8 @@ skip = [
   { name = "windows-sys", version = "0.45.0" },
   # various crates
   { name = "windows-sys", version = "0.48.0" },
+  # various crates
+  { name = "windows-sys", version = "0.52.0" },
   # windows-sys
   { name = "windows-targets", version = "0.42.2" },
   # windows-sys

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -13,7 +13,7 @@ use uucore::error::UResult;
 use uucore::fs::FileInformation;
 
 #[cfg(unix)]
-use std::os::unix::io::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd};
 
 /// Linux splice support
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -125,12 +125,12 @@ struct OutputState {
 }
 
 #[cfg(unix)]
-trait FdReadable: Read + AsRawFd {}
+trait FdReadable: Read + AsFd + AsRawFd {}
 #[cfg(not(unix))]
 trait FdReadable: Read {}
 
 #[cfg(unix)]
-impl<T> FdReadable for T where T: Read + AsRawFd {}
+impl<T> FdReadable for T where T: Read + AsFd + AsRawFd {}
 #[cfg(not(unix))]
 impl<T> FdReadable for T where T: Read {}
 

--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -19,7 +19,7 @@ use nix::sys::stat;
 #[cfg(unix)]
 use std::io::{Seek, SeekFrom};
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use std::os::unix::io::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd};
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
 #[cfg(windows)]
@@ -43,7 +43,7 @@ const SPLICE_SIZE: usize = 128 * 1024;
 /// caller will fall back to a simpler method.
 #[inline]
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn count_bytes_using_splice(fd: &impl AsRawFd) -> Result<usize, usize> {
+fn count_bytes_using_splice(fd: &impl AsFd) -> Result<usize, usize> {
     let null_file = OpenOptions::new()
         .write(true)
         .open("/dev/null")

--- a/src/uu/wc/src/countable.rs
+++ b/src/uu/wc/src/countable.rs
@@ -11,10 +11,10 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, StdinLock};
 
 #[cfg(unix)]
-use std::os::unix::io::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd};
 
 #[cfg(unix)]
-pub trait WordCountable: AsRawFd + Read {
+pub trait WordCountable: AsFd + AsRawFd + Read {
     type Buffered: BufRead;
     fn buffered(self) -> Self::Buffered;
     fn inner_file(&mut self) -> Option<&mut File>;

--- a/src/uu/yes/src/splice.rs
+++ b/src/uu/yes/src/splice.rs
@@ -20,13 +20,19 @@
 //! make any effort to rescue data from the pipe if splice() fails, we can
 //! just fall back and start over from the beginning.
 
-use std::{io, os::unix::io::AsRawFd};
+use std::{
+    io,
+    os::fd::{AsFd, AsRawFd},
+};
 
 use nix::{errno::Errno, libc::S_IFIFO, sys::stat::fstat};
 
 use uucore::pipes::{pipe, splice_exact, vmsplice};
 
-pub(crate) fn splice_data(bytes: &[u8], out: &impl AsRawFd) -> Result<()> {
+pub(crate) fn splice_data<T>(bytes: &[u8], out: &T) -> Result<()>
+where
+    T: AsRawFd + AsFd,
+{
     let is_pipe = fstat(out.as_raw_fd())?.st_mode as nix::libc::mode_t & S_IFIFO != 0;
 
     if is_pipe {

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -9,6 +9,8 @@ use clap::{builder::ValueParser, crate_version, Arg, ArgAction, Command};
 use std::error::Error;
 use std::ffi::OsString;
 use std::io::{self, Write};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::fd::AsFd;
 use uucore::error::{UResult, USimpleError};
 #[cfg(unix)]
 use uucore::signals::enable_pipe_errors;
@@ -118,7 +120,7 @@ pub fn exec(bytes: &[u8]) -> io::Result<()> {
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
-        match splice::splice_data(bytes, &stdout) {
+        match splice::splice_data(bytes, &stdout.as_fd()) {
             Ok(_) => return Ok(()),
             Err(splice::Error::Io(err)) => return Err(err),
             Err(splice::Error::Unsupported) => (),

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::io::IoSlice;
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use std::os::unix::io::AsRawFd;
+use std::os::fd::AsFd;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::fcntl::SpliceFFlags;
@@ -35,15 +35,8 @@ pub fn pipe() -> Result<(File, File)> {
 /// a [`pipe`] and then from the pipe into your target (with `splice_exact`):
 /// this is still very efficient.
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn splice(source: &impl AsRawFd, target: &impl AsRawFd, len: usize) -> Result<usize> {
-    nix::fcntl::splice(
-        source.as_raw_fd(),
-        None,
-        target.as_raw_fd(),
-        None,
-        len,
-        SpliceFFlags::empty(),
-    )
+pub fn splice(source: &impl AsFd, target: &impl AsFd, len: usize) -> Result<usize> {
+    nix::fcntl::splice(source, None, target, None, len, SpliceFFlags::empty())
 }
 
 /// Splice wrapper which fully finishes the write.
@@ -52,7 +45,7 @@ pub fn splice(source: &impl AsRawFd, target: &impl AsRawFd, len: usize) -> Resul
 ///
 /// Panics if `source` runs out of data before `len` bytes have been moved.
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn splice_exact(source: &impl AsRawFd, target: &impl AsRawFd, len: usize) -> Result<()> {
+pub fn splice_exact(source: &impl AsFd, target: &impl AsFd, len: usize) -> Result<()> {
     let mut left = len;
     while left != 0 {
         let written = splice(source, target, left)?;
@@ -66,10 +59,6 @@ pub fn splice_exact(source: &impl AsRawFd, target: &impl AsRawFd, len: usize) ->
 ///
 /// Returns the number of successfully copied bytes.
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn vmsplice(target: &impl AsRawFd, bytes: &[u8]) -> Result<usize> {
-    nix::fcntl::vmsplice(
-        target.as_raw_fd(),
-        &[IoSlice::new(bytes)],
-        SpliceFFlags::empty(),
-    )
+pub fn vmsplice(target: &impl AsFd, bytes: &[u8]) -> Result<usize> {
+    nix::fcntl::vmsplice(target, &[IoSlice::new(bytes)], SpliceFFlags::empty())
 }


### PR DESCRIPTION
This PR bumps `nix` from `0.28` to `0.29` and `ctrlc` from `3.4.4` to `3.4.5` and fixes compilation errors in our code due to API changes in `nix`. And it adds an additional version of `windows-sys` to the skip list in `deny.toml`.