### PR TITLE
checksum: rework for improving checkum checking GNU behavior match

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -11,6 +11,7 @@ use std::fs::File;
 use std::io::{self, stdin, stdout, BufReader, Read, Write};
 use std::iter;
 use std::path::Path;
+use uucore::checksum::ChecksumOptions;
 use uucore::checksum::{
     algo::detect_algo, calculate_blake2b_length, digest_reader, perform_checksum_validation,
     ChecksumError, ALGORITHM_OPTIONS_BLAKE2B, ALGORITHM_OPTIONS_BSD, ALGORITHM_OPTIONS_CRC,
@@ -309,17 +310,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             || iter::once(OsStr::new("-")).collect::<Vec<_>>(),
             |files| files.map(OsStr::new).collect::<Vec<_>>(),
         );
-        return perform_checksum_validation(
-            files.iter().copied(),
-            strict,
-            status,
-            warn,
-            binary_flag,
+
+        let opts = ChecksumOptions {
+            binary: binary_flag,
             ignore_missing,
             quiet,
-            algo_option,
-            length,
-        );
+            status,
+            strict,
+            warn,
+        };
+
+        return perform_checksum_validation(files.iter().copied(), opts, algo_option, length);
     }
 
     let (tag, asterisk) = handle_tag_text_binary_flags(&matches)?;

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -12,7 +12,7 @@ use std::io::{self, stdin, stdout, BufReader, Read, Write};
 use std::iter;
 use std::path::Path;
 use uucore::checksum::{
-    calculate_blake2b_length, detect_algo, digest_reader, perform_checksum_validation,
+    algo::detect_algo, calculate_blake2b_length, digest_reader, perform_checksum_validation,
     ChecksumError, ALGORITHM_OPTIONS_BLAKE2B, ALGORITHM_OPTIONS_BSD, ALGORITHM_OPTIONS_CRC,
     ALGORITHM_OPTIONS_SYSV, SUPPORTED_ALGORITHMS,
 };

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -262,14 +262,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let algo_name: &str = match matches.get_one::<String>(options::ALGORITHM) {
         Some(v) => v,
-        None => {
-            if check {
-                // if we are doing a --check, we should not default to crc
-                ""
-            } else {
-                ALGORITHM_OPTIONS_CRC
-            }
-        }
+        // if we are doing a --check, we should not default to crc
+        None if check => "",
+        None => ALGORITHM_OPTIONS_CRC,
     };
 
     if ["bsd", "crc", "sysv"].contains(&algo_name) && check {

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -16,6 +16,7 @@ use std::io::{stdin, BufReader, Read};
 use std::iter;
 use std::num::ParseIntError;
 use std::path::Path;
+use uucore::checksum::ChecksumOptions;
 use uucore::checksum::{
     algo::{create_sha3, detect_algo},
     calculate_blake2b_length, digest_reader, escape_filename, perform_checksum_validation,
@@ -233,15 +234,19 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
             |files| files.map(OsStr::new).collect::<Vec<_>>(),
         );
 
+        let opts = ChecksumOptions {
+            binary: binary_flag,
+            ignore_missing,
+            quiet,
+            status,
+            strict,
+            warn,
+        };
+
         // Execute the checksum validation
         return perform_checksum_validation(
             input.iter().copied(),
-            strict,
-            status,
-            warn,
-            binary_flag,
-            ignore_missing,
-            quiet,
+            opts,
             Some(algo.name),
             Some(algo.bits),
         );

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -16,16 +16,16 @@ use std::io::{stdin, BufReader, Read};
 use std::iter;
 use std::num::ParseIntError;
 use std::path::Path;
-use uucore::checksum::calculate_blake2b_length;
-use uucore::checksum::create_sha3;
-use uucore::checksum::detect_algo;
-use uucore::checksum::digest_reader;
-use uucore::checksum::escape_filename;
-use uucore::checksum::perform_checksum_validation;
-use uucore::checksum::ChecksumError;
-use uucore::checksum::HashAlgorithm;
-use uucore::error::{FromIo, UResult};
+use uucore::checksum::{
+    algo::{create_sha3, detect_algo},
+    calculate_blake2b_length, digest_reader, escape_filename, perform_checksum_validation,
+    ChecksumError,
+};
 use uucore::sum::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shake256};
+use uucore::{
+    checksum::HashAlgorithm,
+    error::{FromIo, UResult},
+};
 use uucore::{format_usage, help_about, help_usage};
 
 const NAME: &str = "hashsum";

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -6,17 +6,20 @@
 
 use data_encoding::BASE64;
 use os_display::Quotable;
-use regex::Regex;
+use regex::bytes::{Captures, Regex};
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::{
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
     fs::File,
     io::{self, BufReader, Read},
+    iter,
     path::Path,
 };
 
 use crate::{
     error::{set_exit_code, FromIo, UError, UResult, USimpleError},
-    show, show_error, show_warning_caps,
+    os_str_as_bytes, show, show_error, show_warning_caps,
     sum::{
         Blake2b, Blake3, Digest, DigestWriter, Md5, Sha1, Sha224, Sha256, Sha384, Sha3_224,
         Sha3_256, Sha3_384, Sha3_512, Sha512, Shake128, Shake256, Sm3, BSD, CRC, SYSV,
@@ -300,7 +303,7 @@ fn get_filename_for_output(filename: &OsStr, input_is_stdin: bool) -> String {
 }
 
 /// Determines the appropriate regular expression to use based on the provided lines.
-fn determine_regex(lines: &[String]) -> Option<(Regex, bool)> {
+fn determine_regex(lines: &[OsString]) -> Option<(Regex, bool)> {
     let regexes = [
         (Regex::new(ALGO_BASED_REGEX).unwrap(), true),
         (Regex::new(DOUBLE_SPACE_REGEX).unwrap(), false),
@@ -309,7 +312,21 @@ fn determine_regex(lines: &[String]) -> Option<(Regex, bool)> {
     ];
 
     for line in lines {
-        let line_trim = line.trim();
+        let mut line_trim = os_str_as_bytes(line).expect("UTF-8 decoding failed");
+        // FIXME: Replace this with `.trim_ascii()` when MSRV is 1.80
+        while let Some(first) = line_trim.first() {
+            if !first.is_ascii_whitespace() {
+                break;
+            }
+            line_trim = &line_trim[1..];
+        }
+        while let Some(last) = line_trim.last() {
+            if !last.is_ascii_whitespace() {
+                break;
+            }
+            line_trim = &line_trim[..line_trim.len() - 1];
+        }
+
         for (regex, is_algo_based) in &regexes {
             if regex.is_match(line_trim) {
                 return Some((regex.clone(), *is_algo_based));
@@ -330,14 +347,10 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
         })
 }
 
-fn get_expected_checksum(
-    filename: &str,
-    caps: &regex::Captures,
-    chosen_regex: &Regex,
-) -> UResult<String> {
+fn get_expected_checksum(filename: &str, caps: &Captures, chosen_regex: &Regex) -> UResult<String> {
     if chosen_regex.as_str() == ALGO_BASED_REGEX_BASE64 {
-        let ck = caps.name("checksum").unwrap().as_str();
-        match BASE64.decode(ck.as_bytes()) {
+        let ck = caps.name("checksum").unwrap().as_bytes();
+        match BASE64.decode(ck) {
             Ok(decoded_bytes) => {
                 match std::str::from_utf8(&decoded_bytes) {
                     Ok(decoded_str) => Ok(decoded_str.to_string()),
@@ -351,23 +364,31 @@ fn get_expected_checksum(
             )),
         }
     } else {
-        Ok(caps.name("checksum").unwrap().as_str().to_string())
+        Ok(
+            std::str::from_utf8(caps.name("checksum").unwrap().as_bytes())
+                .unwrap()
+                .to_string(),
+        )
     }
 }
 
 /// Returns a reader that reads from the specified file, or from stdin if `filename_to_check` is "-".
 fn get_file_to_check(
-    filename: &str,
+    filename: &OsStr,
     ignore_missing: bool,
     res: &mut ChecksumResult,
 ) -> Option<Box<dyn Read>> {
+    let filename_lossy = String::from_utf8_lossy(os_str_as_bytes(filename).expect("UTF-8 error"));
     if filename == "-" {
         Some(Box::new(stdin())) // Use stdin if "-" is specified in the checksum file
     } else {
         match File::open(filename) {
             Ok(f) => {
                 if f.metadata().ok()?.is_dir() {
-                    show!(USimpleError::new(1, format!("{filename}: Is a directory")));
+                    show!(USimpleError::new(
+                        1,
+                        format!("{filename_lossy}: Is a directory")
+                    ));
                     None
                 } else {
                     Some(Box::new(f))
@@ -376,8 +397,8 @@ fn get_file_to_check(
             Err(err) => {
                 if !ignore_missing {
                     // yes, we have both stderr and stdout here
-                    show!(err.map_err_context(|| filename.to_string()));
-                    println!("{filename}: FAILED open or read");
+                    show!(err.map_err_context(|| filename_lossy.to_string()));
+                    println!("{filename_lossy}: FAILED open or read");
                 }
                 res.failed_open_file += 1;
                 // we could not open the file but we want to continue
@@ -411,13 +432,18 @@ fn get_input_file(filename: &OsStr) -> UResult<Box<dyn Read>> {
 
 /// Extracts the algorithm name and length from the regex captures if the algo-based format is matched.
 fn identify_algo_name_and_length(
-    caps: &regex::Captures,
+    caps: &Captures,
     algo_name_input: Option<&str>,
     res: &mut ChecksumResult,
     properly_formatted: &mut bool,
 ) -> Option<(String, Option<usize>)> {
     // When the algo-based format is matched, extract details from regex captures
-    let algorithm = caps.name("algo").map_or("", |m| m.as_str()).to_lowercase();
+    let algorithm = caps
+        .name("algo")
+        .map_or(String::new(), |m| {
+            String::from_utf8(m.as_bytes().into()).unwrap()
+        })
+        .to_lowercase();
 
     // check if we are called with XXXsum (example: md5sum) but we detected a different algo parsing the file
     // (for example SHA1 (f) = d...)
@@ -435,7 +461,10 @@ fn identify_algo_name_and_length(
     }
 
     let bits = caps.name("bits").map_or(Some(None), |m| {
-        let bits_value = m.as_str().parse::<usize>().unwrap();
+        let bits_value = String::from_utf8(m.as_bytes().into())
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
         if bits_value % 8 == 0 {
             Some(Some(bits_value / 8))
         } else {
@@ -487,8 +516,32 @@ where
             }
         };
 
-        let reader = BufReader::new(file);
-        let lines: Vec<String> = reader.lines().collect::<Result<_, _>>()?;
+        let mut reader = BufReader::new(file);
+        let lines = iter::from_fn(|| {
+            let mut buf = Vec::with_capacity(256);
+            let size = reader.read_until(b'\n', &mut buf).ok()?;
+
+            if size == 0 {
+                return None;
+            }
+
+            // Trim (\r)\n
+            if buf.ends_with(b"\n") {
+                buf.pop();
+                if buf.ends_with(b"\r") {
+                    buf.pop();
+                }
+            }
+
+            #[cfg(unix)]
+            let s = OsString::from_vec(buf);
+            #[cfg(not(unix))]
+            let s = OsString::from(String::from_utf8(buf).expect("UTF-8 error"));
+
+            Some(s)
+        })
+        .collect::<Vec<_>>();
+
         let Some((chosen_regex, is_algo_based_format)) = determine_regex(&lines) else {
             let e = ChecksumError::NoProperlyFormattedChecksumLinesFound {
                 filename: get_filename_for_output(filename_input, input_is_stdin),
@@ -499,11 +552,14 @@ where
         };
 
         for (i, line) in lines.iter().enumerate() {
-            if let Some(caps) = chosen_regex.captures(line) {
+            if let Some(caps) =
+                chosen_regex.captures(os_str_as_bytes(line).expect("UTF-8 decoding failure"))
+            {
                 properly_formatted = true;
 
-                let mut filename_to_check = caps.name("filename").unwrap().as_str();
-                if filename_to_check.starts_with('*')
+                let mut filename_to_check = caps.name("filename").unwrap().as_bytes();
+
+                if filename_to_check.starts_with(b"*")
                     && i == 0
                     && chosen_regex.as_str() == SINGLE_SPACE_REGEX
                 {
@@ -511,8 +567,9 @@ where
                     filename_to_check = &filename_to_check[1..];
                 }
 
+                let filename_lossy = String::from_utf8_lossy(filename_to_check);
                 let expected_checksum =
-                    get_expected_checksum(filename_to_check, &caps, &chosen_regex)?;
+                    get_expected_checksum(&filename_lossy, &caps, &chosen_regex)?;
 
                 // If the algo_name is provided, we use it, otherwise we try to detect it
                 let (algo_name, length) = if is_algo_based_format {
@@ -548,10 +605,15 @@ where
 
                 let (filename_to_check_unescaped, prefix) = unescape_filename(filename_to_check);
 
+                #[cfg(unix)]
+                let real_filename_to_check = OsStr::from_bytes(&filename_to_check_unescaped);
+                #[cfg(not(unix))]
+                let real_filename_to_check =
+                    &OsString::from(String::from_utf8(filename_to_check_unescaped).unwrap());
+
                 // manage the input file
                 let file_to_check =
-                    match get_file_to_check(&filename_to_check_unescaped, ignore_missing, &mut res)
-                    {
+                    match get_file_to_check(real_filename_to_check, ignore_missing, &mut res) {
                         Some(file) => file,
                         None => continue,
                     };
@@ -565,12 +627,12 @@ where
                 // Do the checksum validation
                 if expected_checksum == calculated_checksum {
                     if !quiet && !status {
-                        println!("{prefix}{filename_to_check}: OK");
+                        println!("{prefix}{filename_lossy}: OK");
                     }
                     correct_format += 1;
                 } else {
                     if !status {
-                        println!("{prefix}{filename_to_check}: FAILED");
+                        println!("{prefix}{filename_lossy}: FAILED");
                     }
                     res.failed_cksum += 1;
                 }
@@ -704,11 +766,28 @@ pub fn calculate_blake2b_length(length: usize) -> UResult<Option<usize>> {
     }
 }
 
-pub fn unescape_filename(filename: &str) -> (String, &'static str) {
-    let unescaped = filename
-        .replace("\\\\", "\\")
-        .replace("\\n", "\n")
-        .replace("\\r", "\r");
+pub fn unescape_filename(filename: &[u8]) -> (Vec<u8>, &'static str) {
+    let mut unescaped = Vec::with_capacity(filename.len());
+    let mut byte_iter = filename.iter().peekable();
+    loop {
+        let Some(byte) = byte_iter.next() else {
+            break;
+        };
+        if *byte == b'\\' {
+            match byte_iter.next() {
+                Some(b'\\') => unescaped.push(b'\\'),
+                Some(b'n') => unescaped.push(b'\n'),
+                Some(b'r') => unescaped.push(b'\r'),
+                Some(x) => {
+                    unescaped.push(b'\\');
+                    unescaped.push(*x);
+                }
+                _ => {}
+            }
+        } else {
+            unescaped.push(*byte);
+        }
+    }
     let prefix = if unescaped == filename { "" } else { "\\" };
     (unescaped, prefix)
 }
@@ -729,19 +808,19 @@ mod tests {
 
     #[test]
     fn test_unescape_filename() {
-        let (unescaped, prefix) = unescape_filename("test\\nfile.txt");
-        assert_eq!(unescaped, "test\nfile.txt");
+        let (unescaped, prefix) = unescape_filename(b"test\\nfile.txt");
+        assert_eq!(unescaped, b"test\nfile.txt");
         assert_eq!(prefix, "\\");
-        let (unescaped, prefix) = unescape_filename("test\\nfile.txt");
-        assert_eq!(unescaped, "test\nfile.txt");
-        assert_eq!(prefix, "\\");
-
-        let (unescaped, prefix) = unescape_filename("test\\rfile.txt");
-        assert_eq!(unescaped, "test\rfile.txt");
+        let (unescaped, prefix) = unescape_filename(b"test\\nfile.txt");
+        assert_eq!(unescaped, b"test\nfile.txt");
         assert_eq!(prefix, "\\");
 
-        let (unescaped, prefix) = unescape_filename("test\\\\file.txt");
-        assert_eq!(unescaped, "test\\file.txt");
+        let (unescaped, prefix) = unescape_filename(b"test\\rfile.txt");
+        assert_eq!(unescaped, b"test\rfile.txt");
+        assert_eq!(prefix, "\\");
+
+        let (unescaped, prefix) = unescape_filename(b"test\\\\file.txt");
+        assert_eq!(unescaped, b"test\\file.txt");
         assert_eq!(prefix, "\\");
     }
 
@@ -846,24 +925,25 @@ mod tests {
     #[test]
     fn test_algo_based_regex() {
         let algo_based_regex = Regex::new(ALGO_BASED_REGEX).unwrap();
-        let test_cases = vec![
-            ("SHA256 (example.txt) = d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2", Some(("SHA256", None, "example.txt", "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"))),
+        #[allow(clippy::type_complexity)]
+        let test_cases: &[(&[u8], Option<(&[u8], Option<&[u8]>, &[u8], &[u8])>)] = &[
+            (b"SHA256 (example.txt) = d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2", Some((b"SHA256", None, b"example.txt", b"d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"))),
             // cspell:disable-next-line
-            ("BLAKE2b-512 (file) = abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef", Some(("BLAKE2b", Some("512"), "file", "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef"))),
-            (" MD5 (test) = 9e107d9d372bb6826bd81d3542a419d6", Some(("MD5", None, "test", "9e107d9d372bb6826bd81d3542a419d6"))),
-            ("SHA-1 (anotherfile) = a9993e364706816aba3e25717850c26c9cd0d89d", Some(("SHA", Some("1"), "anotherfile", "a9993e364706816aba3e25717850c26c9cd0d89d"))),
+            (b"BLAKE2b-512 (file) = abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef", Some((b"BLAKE2b", Some(b"512"), b"file", b"abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef"))),
+            (b" MD5 (test) = 9e107d9d372bb6826bd81d3542a419d6", Some((b"MD5", None, b"test", b"9e107d9d372bb6826bd81d3542a419d6"))),
+            (b"SHA-1 (anotherfile) = a9993e364706816aba3e25717850c26c9cd0d89d", Some((b"SHA", Some(b"1"), b"anotherfile", b"a9993e364706816aba3e25717850c26c9cd0d89d"))),
         ];
 
         for (input, expected) in test_cases {
-            let captures = algo_based_regex.captures(input);
+            let captures = algo_based_regex.captures(*input);
             match expected {
                 Some((algo, bits, filename, checksum)) => {
                     assert!(captures.is_some());
                     let captures = captures.unwrap();
-                    assert_eq!(captures.name("algo").unwrap().as_str(), algo);
-                    assert_eq!(captures.name("bits").map(|m| m.as_str()), bits);
-                    assert_eq!(captures.name("filename").unwrap().as_str(), filename);
-                    assert_eq!(captures.name("checksum").unwrap().as_str(), checksum);
+                    assert_eq!(&captures.name("algo").unwrap().as_bytes(), algo);
+                    assert_eq!(&captures.name("bits").map(|m| m.as_bytes()), bits);
+                    assert_eq!(&captures.name("filename").unwrap().as_bytes(), filename);
+                    assert_eq!(&captures.name("checksum").unwrap().as_bytes(), checksum);
                 }
                 None => {
                     assert!(captures.is_none());
@@ -876,28 +956,29 @@ mod tests {
     fn test_double_space_regex() {
         let double_space_regex = Regex::new(DOUBLE_SPACE_REGEX).unwrap();
 
-        let test_cases = vec![
+        #[allow(clippy::type_complexity)]
+        let test_cases: &[(&[u8], Option<(&[u8], &[u8])>)] = &[
             (
-                "60b725f10c9c85c70d97880dfe8191b3  a",
-                Some(("60b725f10c9c85c70d97880dfe8191b3", "a")),
+                b"60b725f10c9c85c70d97880dfe8191b3  a",
+                Some((b"60b725f10c9c85c70d97880dfe8191b3", b"a")),
             ),
             (
-                "bf35d7536c785cf06730d5a40301eba2   b",
-                Some(("bf35d7536c785cf06730d5a40301eba2", " b")),
+                b"bf35d7536c785cf06730d5a40301eba2   b",
+                Some((b"bf35d7536c785cf06730d5a40301eba2", b" b")),
             ),
             (
-                "f5b61709718c1ecf8db1aea8547d4698  *c",
-                Some(("f5b61709718c1ecf8db1aea8547d4698", "*c")),
+                b"f5b61709718c1ecf8db1aea8547d4698  *c",
+                Some((b"f5b61709718c1ecf8db1aea8547d4698", b"*c")),
             ),
             (
-                "b064a020db8018f18ff5ae367d01b212  dd",
-                Some(("b064a020db8018f18ff5ae367d01b212", "dd")),
+                b"b064a020db8018f18ff5ae367d01b212  dd",
+                Some((b"b064a020db8018f18ff5ae367d01b212", b"dd")),
             ),
             (
-                "b064a020db8018f18ff5ae367d01b212   ",
-                Some(("b064a020db8018f18ff5ae367d01b212", " ")),
+                b"b064a020db8018f18ff5ae367d01b212   ",
+                Some((b"b064a020db8018f18ff5ae367d01b212", b" ")),
             ),
-            ("invalidchecksum  test", None),
+            (b"invalidchecksum  test", None),
         ];
 
         for (input, expected) in test_cases {
@@ -906,8 +987,8 @@ mod tests {
                 Some((checksum, filename)) => {
                     assert!(captures.is_some());
                     let captures = captures.unwrap();
-                    assert_eq!(captures.name("checksum").unwrap().as_str(), checksum);
-                    assert_eq!(captures.name("filename").unwrap().as_str(), filename);
+                    assert_eq!(&captures.name("checksum").unwrap().as_bytes(), checksum);
+                    assert_eq!(&captures.name("filename").unwrap().as_bytes(), filename);
                 }
                 None => {
                     assert!(captures.is_none());
@@ -919,24 +1000,25 @@ mod tests {
     #[test]
     fn test_single_space_regex() {
         let single_space_regex = Regex::new(SINGLE_SPACE_REGEX).unwrap();
-        let test_cases = vec![
+        #[allow(clippy::type_complexity)]
+        let test_cases: &[(&[u8], Option<(&[u8], &[u8])>)] = &[
             (
-                "60b725f10c9c85c70d97880dfe8191b3 a",
-                Some(("60b725f10c9c85c70d97880dfe8191b3", "a")),
+                b"60b725f10c9c85c70d97880dfe8191b3 a",
+                Some((b"60b725f10c9c85c70d97880dfe8191b3", b"a")),
             ),
             (
-                "bf35d7536c785cf06730d5a40301eba2 b",
-                Some(("bf35d7536c785cf06730d5a40301eba2", "b")),
+                b"bf35d7536c785cf06730d5a40301eba2 b",
+                Some((b"bf35d7536c785cf06730d5a40301eba2", b"b")),
             ),
             (
-                "f5b61709718c1ecf8db1aea8547d4698 *c",
-                Some(("f5b61709718c1ecf8db1aea8547d4698", "*c")),
+                b"f5b61709718c1ecf8db1aea8547d4698 *c",
+                Some((b"f5b61709718c1ecf8db1aea8547d4698", b"*c")),
             ),
             (
-                "b064a020db8018f18ff5ae367d01b212 dd",
-                Some(("b064a020db8018f18ff5ae367d01b212", "dd")),
+                b"b064a020db8018f18ff5ae367d01b212 dd",
+                Some((b"b064a020db8018f18ff5ae367d01b212", b"dd")),
             ),
-            ("invalidchecksum test", None),
+            (b"invalidchecksum test", None),
         ];
 
         for (input, expected) in test_cases {
@@ -945,8 +1027,8 @@ mod tests {
                 Some((checksum, filename)) => {
                     assert!(captures.is_some());
                     let captures = captures.unwrap();
-                    assert_eq!(captures.name("checksum").unwrap().as_str(), checksum);
-                    assert_eq!(captures.name("filename").unwrap().as_str(), filename);
+                    assert_eq!(&captures.name("checksum").unwrap().as_bytes(), checksum);
+                    assert_eq!(&captures.name("filename").unwrap().as_bytes(), filename);
                 }
                 None => {
                     assert!(captures.is_none());
@@ -958,36 +1040,47 @@ mod tests {
     #[test]
     fn test_determine_regex() {
         // Test algo-based regex
-        let lines_algo_based =
-            vec!["MD5 (example.txt) = d41d8cd98f00b204e9800998ecf8427e".to_string()];
+        let lines_algo_based = ["MD5 (example.txt) = d41d8cd98f00b204e9800998ecf8427e"]
+            .iter()
+            .map(|s| OsString::from(s.to_string()))
+            .collect::<Vec<_>>();
         let (regex, algo_based) = determine_regex(&lines_algo_based).unwrap();
         assert!(algo_based);
-        assert!(regex.is_match(&lines_algo_based[0]));
+        assert!(regex.is_match(os_str_as_bytes(&lines_algo_based[0]).unwrap()));
 
         // Test double-space regex
-        let lines_double_space = vec!["d41d8cd98f00b204e9800998ecf8427e  example.txt".to_string()];
+        let lines_double_space = ["d41d8cd98f00b204e9800998ecf8427e  example.txt"]
+            .iter()
+            .map(|s| OsString::from(s.to_string()))
+            .collect::<Vec<_>>();
         let (regex, algo_based) = determine_regex(&lines_double_space).unwrap();
         assert!(!algo_based);
-        assert!(regex.is_match(&lines_double_space[0]));
+        assert!(regex.is_match(os_str_as_bytes(&lines_double_space[0]).unwrap()));
 
         // Test single-space regex
-        let lines_single_space = vec!["d41d8cd98f00b204e9800998ecf8427e example.txt".to_string()];
+        let lines_single_space = ["d41d8cd98f00b204e9800998ecf8427e example.txt"]
+            .iter()
+            .map(|s| OsString::from(s.to_string()))
+            .collect::<Vec<_>>();
         let (regex, algo_based) = determine_regex(&lines_single_space).unwrap();
         assert!(!algo_based);
-        assert!(regex.is_match(&lines_single_space[0]));
+        assert!(regex.is_match(os_str_as_bytes(&lines_single_space[0]).unwrap()));
 
         // Test double-space regex start with invalid
-        let lines_double_space = vec![
-            "ERR".to_string(),
-            "d41d8cd98f00b204e9800998ecf8427e  example.txt".to_string(),
-        ];
+        let lines_double_space = ["ERR", "d41d8cd98f00b204e9800998ecf8427e  example.txt"]
+            .iter()
+            .map(|s| OsString::from(s.to_string()))
+            .collect::<Vec<_>>();
         let (regex, algo_based) = determine_regex(&lines_double_space).unwrap();
         assert!(!algo_based);
-        assert!(!regex.is_match(&lines_double_space[0]));
-        assert!(regex.is_match(&lines_double_space[1]));
+        assert!(!regex.is_match(os_str_as_bytes(&lines_double_space[0]).unwrap()));
+        assert!(regex.is_match(os_str_as_bytes(&lines_double_space[1]).unwrap()));
 
         // Test invalid checksum line
-        let lines_invalid = vec!["invalid checksum line".to_string()];
+        let lines_invalid = ["invalid checksum line"]
+            .iter()
+            .map(|s| OsString::from(s.to_string()))
+            .collect::<Vec<_>>();
         assert!(determine_regex(&lines_invalid).is_none());
     }
 
@@ -995,7 +1088,7 @@ mod tests {
     fn test_get_expected_checksum() {
         let re = Regex::new(ALGO_BASED_REGEX_BASE64).unwrap();
         let caps = re
-            .captures("SHA256 (empty) = 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")
+            .captures(b"SHA256 (empty) = 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")
             .unwrap();
 
         let result = get_expected_checksum("filename", &caps, &re);
@@ -1010,7 +1103,7 @@ mod tests {
     fn test_get_expected_checksum_invalid() {
         let re = Regex::new(ALGO_BASED_REGEX_BASE64).unwrap();
         let caps = re
-            .captures("SHA256 (empty) = 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU")
+            .captures(b"SHA256 (empty) = 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU")
             .unwrap();
 
         let result = get_expected_checksum("filename", &caps, &re);

--- a/src/uucore/src/lib/features/checksum/algo.rs
+++ b/src/uucore/src/lib/features/checksum/algo.rs
@@ -1,0 +1,317 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use super::{
+    ChecksumError, HashAlgorithm, ALGORITHM_OPTIONS_BLAKE2B, ALGORITHM_OPTIONS_BLAKE3,
+    ALGORITHM_OPTIONS_BSD, ALGORITHM_OPTIONS_CRC, ALGORITHM_OPTIONS_MD5, ALGORITHM_OPTIONS_SHA1,
+    ALGORITHM_OPTIONS_SHA224, ALGORITHM_OPTIONS_SHA256, ALGORITHM_OPTIONS_SHA384,
+    ALGORITHM_OPTIONS_SHA512, ALGORITHM_OPTIONS_SHAKE128, ALGORITHM_OPTIONS_SHAKE256,
+    ALGORITHM_OPTIONS_SM3, ALGORITHM_OPTIONS_SYSV,
+};
+use crate::{
+    error::{UResult, USimpleError},
+    sum::{
+        Blake2b, Blake3, Digest, Md5, Sha1, Sha224, Sha256, Sha384, Sha3_224, Sha3_256, Sha3_384,
+        Sha3_512, Sha512, Shake128, Shake256, Sm3, BSD, CRC, SYSV,
+    },
+};
+
+#[derive(Debug, Default)]
+pub struct ChecksumAlgoBuilder {
+    /// Name of the CLI `--algo` if provided
+    cli_algo_argument: Option<String>,
+    /// Algorithm decoded from algo-based regex
+    algo: Option<String>,
+    /// CLI-given or guessed bit-length for the algorithm
+    length: Option<usize>,
+}
+
+impl ChecksumAlgoBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn maybe_cli_algo_name<S: Into<String>>(mut self, algo: Option<S>) -> Self {
+        self.cli_algo_argument = algo.map(S::into);
+        self
+    }
+
+    pub fn maybe_algo_name<S: Into<String>>(mut self, algo: Option<S>) -> Self {
+        self.algo = algo.map(S::into);
+        self
+    }
+
+    pub fn algo_name<S: Into<String>>(mut self, algo: S) -> Self {
+        self.algo = Some(algo.into());
+        self
+    }
+
+    pub fn maybe_algo_length(mut self, length: Option<usize>) -> Self {
+        self.length = length;
+        self
+    }
+
+    pub fn algo_length(mut self, length: usize) -> Self {
+        self.length = Some(length);
+        self
+    }
+
+    pub fn try_build(&self) -> UResult<HashAlgorithm> {
+        let Some(name) = self.algo.clone() else {
+            // No algo name was found.
+            return Err(ChecksumError::NeedAlgorithmToHash.into());
+        };
+        if self
+            .cli_algo_argument
+            .as_ref()
+            .is_some_and(|cli| *cli != name)
+        {
+            // Provided algorithm conflicts with the algorithm given in CLI.
+            // FIXME(dprn): Rework error handling
+            return Err(ChecksumError::UnknownAlgorithm.into());
+        }
+
+        match name.as_str() {
+            ALGORITHM_OPTIONS_SYSV => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_SYSV,
+                create_fn: Box::new(|| Box::new(SYSV::new())),
+                bits: 512,
+            }),
+            ALGORITHM_OPTIONS_BSD => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_BSD,
+                create_fn: Box::new(|| Box::new(BSD::new())),
+                bits: 1024,
+            }),
+            ALGORITHM_OPTIONS_CRC => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_CRC,
+                create_fn: Box::new(|| Box::new(CRC::new())),
+                bits: 256,
+            }),
+            ALGORITHM_OPTIONS_MD5 | "md5sum" => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_MD5,
+                create_fn: Box::new(|| Box::new(Md5::new())),
+                bits: 128,
+            }),
+            ALGORITHM_OPTIONS_SHA1 | "sha1sum" => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_SHA1,
+                create_fn: Box::new(|| Box::new(Sha1::new())),
+                bits: 160,
+            }),
+            ALGORITHM_OPTIONS_SHA224 | "sha224sum" => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_SHA224,
+                create_fn: Box::new(|| Box::new(Sha224::new())),
+                bits: 224,
+            }),
+            ALGORITHM_OPTIONS_SHA256 | "sha256sum" => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_SHA256,
+                create_fn: Box::new(|| Box::new(Sha256::new())),
+                bits: 256,
+            }),
+            ALGORITHM_OPTIONS_SHA384 | "sha384sum" => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_SHA384,
+                create_fn: Box::new(|| Box::new(Sha384::new())),
+                bits: 384,
+            }),
+            ALGORITHM_OPTIONS_SHA512 | "sha512sum" => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_SHA512,
+                create_fn: Box::new(|| Box::new(Sha512::new())),
+                bits: 512,
+            }),
+            ALGORITHM_OPTIONS_BLAKE2B | "b2sum" => {
+                // Set default length to 512 if None
+                let bits = self.length.unwrap_or(512);
+                if bits == 512 {
+                    Ok(HashAlgorithm {
+                        name: ALGORITHM_OPTIONS_BLAKE2B,
+                        create_fn: Box::new(move || Box::new(Blake2b::new())),
+                        bits: 512,
+                    })
+                } else {
+                    Ok(HashAlgorithm {
+                        name: ALGORITHM_OPTIONS_BLAKE2B,
+                        create_fn: Box::new(move || Box::new(Blake2b::with_output_bytes(bits))),
+                        bits,
+                    })
+                }
+            }
+            ALGORITHM_OPTIONS_BLAKE3 | "b3sum" => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_BLAKE3,
+                create_fn: Box::new(|| Box::new(Blake3::new())),
+                bits: 256,
+            }),
+            ALGORITHM_OPTIONS_SM3 => Ok(HashAlgorithm {
+                name: ALGORITHM_OPTIONS_SM3,
+                create_fn: Box::new(|| Box::new(Sm3::new())),
+                bits: 512,
+            }),
+            ALGORITHM_OPTIONS_SHAKE128 | "shake128sum" => {
+                let bits = self
+                    .length
+                    .ok_or_else(|| USimpleError::new(1, "--bits required for SHAKE128"))?;
+                Ok(HashAlgorithm {
+                    name: ALGORITHM_OPTIONS_SHAKE128,
+                    create_fn: Box::new(|| Box::new(Shake128::new())),
+                    bits,
+                })
+            }
+            ALGORITHM_OPTIONS_SHAKE256 | "shake256sum" => {
+                let bits = self
+                    .length
+                    .ok_or_else(|| USimpleError::new(1, "--bits required for SHAKE256"))?;
+                Ok(HashAlgorithm {
+                    name: ALGORITHM_OPTIONS_SHAKE256,
+                    create_fn: Box::new(|| Box::new(Shake256::new())),
+                    bits,
+                })
+            }
+            //ALGORITHM_OPTIONS_SHA3 | "sha3" => (
+            _ if name.starts_with("sha3") => create_sha3(self.length),
+
+            _ => Err(ChecksumError::UnknownAlgorithm.into()),
+        }
+    }
+}
+
+pub fn detect_algo(algo: &str, length: Option<usize>) -> UResult<HashAlgorithm> {
+    ChecksumAlgoBuilder::new()
+        .algo_name(algo)
+        .maybe_algo_length(length)
+        .try_build()
+}
+
+/// Creates a SHA3 hasher instance based on the specified bits argument.
+///
+/// # Returns
+///
+/// Returns a UResult of a tuple containing the algorithm name, the hasher instance, and
+/// the output length in bits or an Err if an unsupported output size is provided, or if
+/// the `--bits` flag is missing.
+pub fn create_sha3(bits: Option<usize>) -> UResult<HashAlgorithm> {
+    match bits {
+        Some(224) => Ok(HashAlgorithm {
+            name: "SHA3_224",
+            create_fn: Box::new(|| Box::new(Sha3_224::new())),
+            bits: 224,
+        }),
+        Some(256) => Ok(HashAlgorithm {
+            name: "SHA3_256",
+            create_fn: Box::new(|| Box::new(Sha3_256::new())),
+            bits: 256,
+        }),
+        Some(384) => Ok(HashAlgorithm {
+            name: "SHA3_384",
+            create_fn: Box::new(|| Box::new(Sha3_384::new())),
+            bits: 384,
+        }),
+        Some(512) => Ok(HashAlgorithm {
+            name: "SHA3_512",
+            create_fn: Box::new(|| Box::new(Sha3_512::new())),
+            bits: 512,
+        }),
+
+        Some(_) => Err(ChecksumError::InvalidOutputSizeForSha3.into()),
+        None => Err(ChecksumError::BitsRequiredForSha3.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_checksum_algo_builder() {
+        let algo_with_name = |name: &str| {
+            ChecksumAlgoBuilder::new()
+                .algo_name(name.to_string())
+                .try_build()
+                .unwrap()
+        };
+        let algo_with_name_and_len = |name: &str, len| {
+            ChecksumAlgoBuilder::new()
+                .algo_name(name.to_string())
+                .maybe_algo_length(len)
+                .try_build()
+                .unwrap()
+        };
+
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_SYSV).name,
+            ALGORITHM_OPTIONS_SYSV
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_BSD).name,
+            ALGORITHM_OPTIONS_BSD
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_CRC).name,
+            ALGORITHM_OPTIONS_CRC
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_MD5).name,
+            ALGORITHM_OPTIONS_MD5
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_SHA1).name,
+            ALGORITHM_OPTIONS_SHA1
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_SHA224).name,
+            ALGORITHM_OPTIONS_SHA224
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_SHA256).name,
+            ALGORITHM_OPTIONS_SHA256
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_SHA384).name,
+            ALGORITHM_OPTIONS_SHA384
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_SHA512).name,
+            ALGORITHM_OPTIONS_SHA512
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_BLAKE2B).name,
+            ALGORITHM_OPTIONS_BLAKE2B
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_BLAKE3).name,
+            ALGORITHM_OPTIONS_BLAKE3
+        );
+        assert_eq!(
+            algo_with_name(ALGORITHM_OPTIONS_SM3).name,
+            ALGORITHM_OPTIONS_SM3
+        );
+        assert_eq!(
+            algo_with_name_and_len(ALGORITHM_OPTIONS_SHAKE128, Some(128)).name,
+            ALGORITHM_OPTIONS_SHAKE128
+        );
+        assert_eq!(
+            algo_with_name_and_len(ALGORITHM_OPTIONS_SHAKE256, Some(256)).name,
+            ALGORITHM_OPTIONS_SHAKE256
+        );
+        assert_eq!(
+            algo_with_name_and_len("sha3_224", Some(224)).name,
+            "SHA3_224"
+        );
+        assert_eq!(
+            algo_with_name_and_len("sha3_256", Some(256)).name,
+            "SHA3_256"
+        );
+        assert_eq!(
+            algo_with_name_and_len("sha3_384", Some(384)).name,
+            "SHA3_384"
+        );
+        assert_eq!(
+            algo_with_name_and_len("sha3_512", Some(512)).name,
+            "SHA3_512"
+        );
+
+        assert!(ChecksumAlgoBuilder::new()
+            .algo_name("sha3_512".to_string())
+            .try_build()
+            .is_err());
+    }
+}

--- a/src/uucore/src/lib/features/checksum/mod.rs
+++ b/src/uucore/src/lib/features/checksum/mod.rs
@@ -17,7 +17,6 @@ use std::{
 };
 
 use crate::{
-    bytes_trim_ascii,
     error::{set_exit_code, FromIo, UError, UResult, USimpleError},
     os_str_as_bytes, read_os_string_lines, show, show_error, show_warning_caps,
     sum::{Digest, DigestWriter},
@@ -176,9 +175,7 @@ fn determine_regex(lines: &[OsString]) -> Option<(Regex, bool)> {
     ];
 
     for line in lines {
-        let mut line_trim = os_str_as_bytes(line).expect("UTF-8 decoding failed");
-        // FIXME: Replace this with `.trim_ascii()` when MSRV is 1.80
-        line_trim = bytes_trim_ascii(line_trim);
+        let line_trim = os_str_as_bytes(line.as_ref()).expect("UTF-8 decoding failed");
 
         for (regex, is_algo_based) in &regexes {
             if regex.is_match(line_trim) {

--- a/src/uucore/src/lib/features/checksum/mod.rs
+++ b/src/uucore/src/lib/features/checksum/mod.rs
@@ -13,8 +13,8 @@ use std::{
     ffi::{OsStr, OsString},
     fs::File,
     io::{self, BufReader, Read},
-    path::Path,
 };
+use utils::{get_filename_for_output, unescape_filename};
 
 use crate::{
     error::{set_exit_code, FromIo, UError, UResult, USimpleError},
@@ -27,6 +27,8 @@ use std::io::stdin;
 use thiserror::Error;
 
 pub mod algo;
+mod utils;
+pub use utils::escape_filename; // Used in hashsum.rs
 
 pub const ALGORITHM_OPTIONS_SYSV: &str = "sysv";
 pub const ALGORITHM_OPTIONS_BSD: &str = "bsd";
@@ -87,6 +89,33 @@ struct ChecksumResult {
     pub failed_open_file: i32,
 }
 
+impl ChecksumResult {
+    /// Print diagnostic lines at the end of the processing of a checksum file.
+    #[allow(clippy::comparison_chain)]
+    fn print_output(&self, ignore_missing: bool, status: bool) {
+        if self.bad_format == 1 {
+            show_warning_caps!("{} line is improperly formatted", self.bad_format);
+        } else if self.bad_format > 1 {
+            show_warning_caps!("{} lines are improperly formatted", self.bad_format);
+        }
+
+        if !status {
+            if self.failed_cksum == 1 {
+                show_warning_caps!("{} computed checksum did NOT match", self.failed_cksum);
+            } else if self.failed_cksum > 1 {
+                show_warning_caps!("{} computed checksums did NOT match", self.failed_cksum);
+            }
+        }
+        if !ignore_missing {
+            if self.failed_open_file == 1 {
+                show_warning_caps!("{} listed file could not be read", self.failed_open_file);
+            } else if self.failed_open_file > 1 {
+                show_warning_caps!("{} listed files could not be read", self.failed_open_file);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ChecksumError {
     #[error("the --raw option is not supported with multiple files")]
@@ -129,30 +158,6 @@ impl UError for ChecksumError {
     }
 }
 
-#[allow(clippy::comparison_chain)]
-fn cksum_output(res: &ChecksumResult, ignore_missing: bool, status: bool) {
-    if res.bad_format == 1 {
-        show_warning_caps!("{} line is improperly formatted", res.bad_format);
-    } else if res.bad_format > 1 {
-        show_warning_caps!("{} lines are improperly formatted", res.bad_format);
-    }
-
-    if !status {
-        if res.failed_cksum == 1 {
-            show_warning_caps!("{} computed checksum did NOT match", res.failed_cksum);
-        } else if res.failed_cksum > 1 {
-            show_warning_caps!("{} computed checksums did NOT match", res.failed_cksum);
-        }
-    }
-    if !ignore_missing {
-        if res.failed_open_file == 1 {
-            show_warning_caps!("{} listed file could not be read", res.failed_open_file);
-        } else if res.failed_open_file > 1 {
-            show_warning_caps!("{} listed files could not be read", res.failed_open_file);
-        }
-    }
-}
-
 // Regexp to handle the three input formats:
 // 1. <algo>[-<bits>] (<filename>) = <checksum>
 //    algo must be uppercase or b (for blake2b)
@@ -165,16 +170,6 @@ const DOUBLE_SPACE_REGEX: &str = r"^(?P<checksum>[a-fA-F0-9]+)\s{2}(?P<filename>
 
 // In this case, we ignore the *
 const SINGLE_SPACE_REGEX: &str = r"^(?P<checksum>[a-fA-F0-9]+)\s(?P<filename>\*?.*)$";
-
-fn get_filename_for_output(filename: &OsStr, input_is_stdin: bool) -> String {
-    if input_is_stdin {
-        "standard input"
-    } else {
-        filename.to_str().unwrap()
-    }
-    .maybe_quote()
-    .to_string()
-}
 
 /// Determines the appropriate regular expression to use based on the provided lines.
 fn determine_regex(lines: &[OsString]) -> Option<(Regex, bool)> {
@@ -559,7 +554,7 @@ where
         }
 
         // if any incorrectly formatted line, show it
-        cksum_output(&res, opts.ignore_missing, opts.status);
+        res.print_output(opts.ignore_missing, opts.status);
     }
 
     Ok(())
@@ -628,84 +623,11 @@ pub fn calculate_blake2b_length(length: usize) -> UResult<Option<usize>> {
     }
 }
 
-pub fn unescape_filename(filename: &[u8]) -> (Vec<u8>, &'static str) {
-    let mut unescaped = Vec::with_capacity(filename.len());
-    let mut byte_iter = filename.iter().peekable();
-    loop {
-        let Some(byte) = byte_iter.next() else {
-            break;
-        };
-        if *byte == b'\\' {
-            match byte_iter.next() {
-                Some(b'\\') => unescaped.push(b'\\'),
-                Some(b'n') => unescaped.push(b'\n'),
-                Some(b'r') => unescaped.push(b'\r'),
-                Some(x) => {
-                    unescaped.push(b'\\');
-                    unescaped.push(*x);
-                }
-                _ => {}
-            }
-        } else {
-            unescaped.push(*byte);
-        }
-    }
-    let prefix = if unescaped == filename { "" } else { "\\" };
-    (unescaped, prefix)
-}
-
-pub fn escape_filename(filename: &Path) -> (String, &'static str) {
-    let original = filename.as_os_str().to_string_lossy();
-    let escaped = original
-        .replace('\\', "\\\\")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r");
-    let prefix = if escaped == original { "" } else { "\\" };
-    (escaped, prefix)
-}
-
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
 
     use super::*;
-
-    #[test]
-    fn test_unescape_filename() {
-        let (unescaped, prefix) = unescape_filename(b"test\\nfile.txt");
-        assert_eq!(unescaped, b"test\nfile.txt");
-        assert_eq!(prefix, "\\");
-        let (unescaped, prefix) = unescape_filename(b"test\\nfile.txt");
-        assert_eq!(unescaped, b"test\nfile.txt");
-        assert_eq!(prefix, "\\");
-
-        let (unescaped, prefix) = unescape_filename(b"test\\rfile.txt");
-        assert_eq!(unescaped, b"test\rfile.txt");
-        assert_eq!(prefix, "\\");
-
-        let (unescaped, prefix) = unescape_filename(b"test\\\\file.txt");
-        assert_eq!(unescaped, b"test\\file.txt");
-        assert_eq!(prefix, "\\");
-    }
-
-    #[test]
-    fn test_escape_filename() {
-        let (escaped, prefix) = escape_filename(Path::new("testfile.txt"));
-        assert_eq!(escaped, "testfile.txt");
-        assert_eq!(prefix, "");
-
-        let (escaped, prefix) = escape_filename(Path::new("test\nfile.txt"));
-        assert_eq!(escaped, "test\\nfile.txt");
-        assert_eq!(prefix, "\\");
-
-        let (escaped, prefix) = escape_filename(Path::new("test\rfile.txt"));
-        assert_eq!(escaped, "test\\rfile.txt");
-        assert_eq!(prefix, "\\");
-
-        let (escaped, prefix) = escape_filename(Path::new("test\\file.txt"));
-        assert_eq!(escaped, "test\\\\file.txt");
-        assert_eq!(prefix, "\\");
-    }
 
     #[test]
     fn test_calculate_blake2b_length() {

--- a/src/uucore/src/lib/features/checksum/mod.rs
+++ b/src/uucore/src/lib/features/checksum/mod.rs
@@ -572,6 +572,10 @@ fn process_checksum_file(
             opts,
         ) {
             Err(UError(e)) => return Err(e.into()),
+            Err(ImproperlyFormatted) => {
+                res.bad_format += 1;
+                continue;
+            }
             Err(Skipped) => continue,
             Ok(_) => (),
         }

--- a/src/uucore/src/lib/features/checksum/utils.rs
+++ b/src/uucore/src/lib/features/checksum/utils.rs
@@ -1,0 +1,99 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use os_display::Quotable;
+use std::{ffi::OsStr, path::Path};
+
+/// Create a string version of the OsStr for display.
+pub fn get_filename_for_output(filename: &OsStr, input_is_stdin: bool) -> String {
+    if input_is_stdin {
+        "standard input"
+    } else {
+        filename.to_str().unwrap()
+    }
+    .maybe_quote()
+    .to_string()
+}
+
+/// Given a Path, create an escaped string version of it, where control chars
+/// are preceded with `\` backslashes.
+pub fn escape_filename(filename: &Path) -> (String, &'static str) {
+    let original = filename.as_os_str().to_string_lossy();
+    let escaped = original
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r");
+    let prefix = if escaped == original { "" } else { "\\" };
+    (escaped, prefix)
+}
+
+/// Revert the effect of `escape_filename`, takes a byte array in argument.
+pub fn unescape_filename(filename: &[u8]) -> (Vec<u8>, &'static str) {
+    let mut unescaped = Vec::with_capacity(filename.len());
+    let mut byte_iter = filename.iter().peekable();
+    loop {
+        let Some(byte) = byte_iter.next() else {
+            break;
+        };
+        if *byte == b'\\' {
+            match byte_iter.next() {
+                Some(b'\\') => unescaped.push(b'\\'),
+                Some(b'n') => unescaped.push(b'\n'),
+                Some(b'r') => unescaped.push(b'\r'),
+                Some(x) => {
+                    unescaped.push(b'\\');
+                    unescaped.push(*x);
+                }
+                _ => {}
+            }
+        } else {
+            unescaped.push(*byte);
+        }
+    }
+    let prefix = if unescaped == filename { "" } else { "\\" };
+    (unescaped, prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_filename() {
+        let (escaped, prefix) = escape_filename(Path::new("testfile.txt"));
+        assert_eq!(escaped, "testfile.txt");
+        assert_eq!(prefix, "");
+
+        let (escaped, prefix) = escape_filename(Path::new("test\nfile.txt"));
+        assert_eq!(escaped, "test\\nfile.txt");
+        assert_eq!(prefix, "\\");
+
+        let (escaped, prefix) = escape_filename(Path::new("test\rfile.txt"));
+        assert_eq!(escaped, "test\\rfile.txt");
+        assert_eq!(prefix, "\\");
+
+        let (escaped, prefix) = escape_filename(Path::new("test\\file.txt"));
+        assert_eq!(escaped, "test\\\\file.txt");
+        assert_eq!(prefix, "\\");
+    }
+
+    #[test]
+    fn test_unescape_filename() {
+        let (unescaped, prefix) = unescape_filename(b"test\\nfile.txt");
+        assert_eq!(unescaped, b"test\nfile.txt");
+        assert_eq!(prefix, "\\");
+        let (unescaped, prefix) = unescape_filename(b"test\\nfile.txt");
+        assert_eq!(unescaped, b"test\nfile.txt");
+        assert_eq!(prefix, "\\");
+
+        let (unescaped, prefix) = unescape_filename(b"test\\rfile.txt");
+        assert_eq!(unescaped, b"test\rfile.txt");
+        assert_eq!(prefix, "\\");
+
+        let (unescaped, prefix) = unescape_filename(b"test\\\\file.txt");
+        assert_eq!(unescaped, b"test\\file.txt");
+        assert_eq!(prefix, "\\");
+    }
+}

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -818,6 +818,29 @@ fn test_cksum_check_space() {
 }
 
 #[test]
+fn test_cksum_check_trailing_space() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.touch("f");
+    at.write("CHECKSUM",
+        &[
+            "SHA384 (f) = 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b\n",
+            "BLAKE2b (f) = 786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce\n",
+            "BLAKE2b-384 (f) = b32811423377f52d7862286ee1a72ee540524380fda1724a6f25d7978c6fd3244a6caf0498812673c5e05ef583825100\n",
+            // This line is improperly formatted because it has trailing spaces
+            "SM3 (f) = 1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b  \n"
+        ].join(""));
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg("CHECKSUM")
+        .succeeds()
+        .stdout_contains("f: OK\nf: OK\nf: OK\n")
+        .stderr_contains("line is improperly formatted");
+}
+
+#[test]
 fn test_cksum_check_leading_info() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -1300,4 +1323,265 @@ fn test_non_utf8_comment() {
         .arg(at.subdir.join("check"))
         .succeeds()
         .stdout_is("empty: OK\nempty: OK\nempty: OK\n");
+}
+
+#[test]
+fn test_check_blake_length_guess() {
+    let correct_lines = [
+        // Correct: The length is not explicit, but the checksum's size
+        // matches the default parameter.
+        "BLAKE2b (foo.dat) = ca002330e69d3e6b84a46a56a6533fd79d51d97a3bb7cad6c2ff43b354185d6dc1e723fb3db4ae0737e120378424c714bb982d9dc5bbd7a0ab318240ddd18f8d",
+        // Correct: The length is explicitly given, and the checksum's size
+        // matches the length.
+        "BLAKE2b-512 (foo.dat) = ca002330e69d3e6b84a46a56a6533fd79d51d97a3bb7cad6c2ff43b354185d6dc1e723fb3db4ae0737e120378424c714bb982d9dc5bbd7a0ab318240ddd18f8d",
+        // Correct: the checksum size is not default but
+        // the length is explicitly given.
+        "BLAKE2b-48 (foo.dat) = 171cdfdf84ed",
+    ];
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("foo.dat", "foo");
+
+    for line in correct_lines {
+        at.write("foo.sums", line);
+        scene
+            .ucmd()
+            .arg("--check")
+            .arg(at.subdir.join("foo.sums"))
+            .succeeds()
+            .stdout_is("foo.dat: OK\n");
+    }
+
+    // Incorrect lines
+
+    // This is incorrect because the algorithm provides no length,
+    // and the checksum length is not default.
+    let incorrect = "BLAKE2b (foo.dat) = 171cdfdf84ed";
+    at.write("foo.sums", incorrect);
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg(at.subdir.join("foo.sums"))
+        .fails()
+        .stderr_contains("foo.sums: no properly formatted checksum lines found");
+}
+
+#[test]
+fn test_check_confusing_base64() {
+    let cksum = "BLAKE2b-48 (foo.dat) = fc1f97C4";
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("foo.dat", "esq");
+    at.write("foo.sums", cksum);
+
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg(at.subdir.join("foo.sums"))
+        .succeeds()
+        .stdout_is("foo.dat: OK\n");
+}
+
+/// This test checks that when a file contains several checksum lines
+/// with different encoding, the decoding still works.
+#[test]
+fn test_check_mix_hexa_base64() {
+    let b64 = "BLAKE2b-128 (foo1.dat) = BBNuJPhdRwRlw9tm5Y7VbA==";
+    let hex = "BLAKE2b-128 (foo2.dat) = 04136e24f85d470465c3db66e58ed56c";
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("foo1.dat", "foo");
+    at.write("foo2.dat", "foo");
+
+    at.write("hex_b64", &format!("{}\n{}", hex, b64));
+    at.write("b64_hex", &format!("{}\n{}", b64, hex));
+
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg(at.subdir.join("hex_b64"))
+        .succeeds()
+        .stdout_is("foo2.dat: OK\nfoo1.dat: OK\n")
+        .no_stderr();
+
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg(at.subdir.join("b64_hex"))
+        .succeeds()
+        .stdout_is("foo1.dat: OK\nfoo2.dat: OK\n")
+        .no_stderr();
+}
+
+#[test]
+fn test_check_incorrectly_formatted_checksum_does_not_stop_processing() {
+    // The first line contains an incorrectly formatted checksum that can't be
+    // correctly decoded. This must not prevent the program from looking at the
+    // rest of the file.
+    let lines = [
+        "BLAKE2b-56 (foo1) = GFYEQ7HhAw=",    // Should be 2 '=' at the end
+        "BLAKE2b-56 (foo2) = 18560443b1e103", // OK
+    ];
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("foo1", "foo");
+    at.write("foo2", "foo");
+    at.write("sum", &lines.join("\n"));
+
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg(at.subdir.join("sum"))
+        .succeeds()
+        .stderr_contains("1 line is improperly formatted")
+        .stdout_contains("foo2: OK");
+}
+
+/// This module reimplements the cksum-base64.pl GNU test.
+mod cksum_base64 {
+    use super::*;
+    use crate::common::util::log_info;
+
+    const PAIRS: [(&str, &str); 11] = [
+        ("sysv", "0 0 f"),
+        ("bsd", "00000     0 f"),
+        ("crc", "4294967295 0 f"),
+        ("md5", "1B2M2Y8AsgTpgAmY7PhCfg=="),
+        ("sha1", "2jmj7l5rSw0yVb/vlWAYkK/YBwk="),
+        ("sha224", "0UoCjCo6K8lHYQK7KII0xBWisB+CjqYqxbPkLw=="),
+        ("sha256", "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="),
+        (
+            "sha384",
+            "OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb",
+        ),
+        (
+            "sha512",
+            "z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg=="
+        ),
+        (
+            "blake2b",
+            "eGoC90IBWQPGxv2FJVLScpEvR0DhWEdhiobiF/cfVBnSXhAxr+5YUxOJZESTTrBLkDpoWxRIt1XVb3Aa/pvizg=="
+        ),
+        ("sm3", "GrIdg1XPoX+OYRlIMegajyK+yMco/vt0ftA161CCqis="),
+    ];
+
+    fn make_scene() -> TestScenario {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.touch("f");
+
+        scene
+    }
+
+    fn output_format(algo: &str, digest: &str) -> String {
+        if ["sysv", "bsd", "crc"].contains(&algo) {
+            digest.to_string()
+        } else {
+            format!("{} (f) = {}", algo.to_uppercase(), digest).replace("BLAKE2B", "BLAKE2b")
+        }
+    }
+
+    #[test]
+    fn test_generating() {
+        // Ensure that each algorithm works with `--base64`.
+        let scene = make_scene();
+
+        for (algo, digest) in PAIRS {
+            scene
+                .ucmd()
+                .arg("--base64")
+                .arg("-a")
+                .arg(algo)
+                .arg("f")
+                .succeeds()
+                .stdout_is(format!("{}\n", output_format(algo, digest)))
+                .no_stderr();
+        }
+    }
+
+    #[test]
+    fn test_chk() {
+        // For each algorithm that accepts `--check`,
+        // ensure that it works with base64 digests.
+        let scene = make_scene();
+
+        for (algo, digest) in PAIRS {
+            if ["sysv", "bsd", "crc"].contains(&algo) {
+                // These algorithms do not accept `--check`
+                continue;
+            }
+
+            let line = output_format(algo, digest);
+            scene
+                .ucmd()
+                .arg("--check")
+                .arg("--strict")
+                .pipe_in(line)
+                .succeeds()
+                .stdout_is("f: OK\n")
+                .no_stderr();
+        }
+    }
+
+    #[test]
+    fn test_chk_eq1() {
+        // For digests ending with '=', ensure `--check` fails if '=' is removed.
+        let scene = make_scene();
+
+        for (algo, digest) in PAIRS {
+            if !digest.ends_with('=') {
+                continue;
+            }
+
+            let mut line = output_format(algo, digest);
+            if line.ends_with("==") {
+                line = line.replace("==", "=");
+            } else if line.ends_with('=') {
+                line = line.replace('=', "");
+            }
+
+            log_info(format!("ALGORITHM: {algo}, STDIN: '{line}'"), "");
+            scene
+                .ucmd()
+                .arg("--check")
+                .pipe_in(line)
+                .fails()
+                .no_stdout()
+                .stderr_contains("no properly formatted checksum lines found");
+        }
+    }
+
+    #[test]
+    fn test_chk_eq2() {
+        // For digests ending with '==',
+        // ensure `--check` fails if '==' is removed.
+        let scene = make_scene();
+
+        for (algo, digest) in PAIRS {
+            if !digest.ends_with("==") {
+                continue;
+            }
+
+            let mut line = output_format(algo, digest);
+            if line.ends_with("==") {
+                line = line.replace("==", "");
+            }
+
+            log_info(format!("ALGORITHM: {algo}, STDIN: '{line}'"), "");
+            scene
+                .ucmd()
+                .arg("--check")
+                .pipe_in(line)
+                .fails()
+                .no_stdout()
+                .stderr_contains("no properly formatted checksum lines found");
+        }
+    }
 }

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1277,3 +1277,27 @@ fn test_non_utf8_filename() {
         .stdout_is_bytes(b"SHA256 (funky\xffname) = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n")
         .no_stderr();
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_non_utf8_comment() {
+    let hashes =
+        b"MD5 (empty) = 1B2M2Y8AsgTpgAmY7PhCfg==\n\
+        # Comment with a non utf8 char: >>\xff<<\n\
+        SHA256 (empty) = 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n\
+        BLAKE2b (empty) = eGoC90IBWQPGxv2FJVLScpEvR0DhWEdhiobiF/cfVBnSXhAxr+5YUxOJZESTTrBLkDpoWxRIt1XVb3Aa/pvizg==\n"
+    ;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.touch("empty");
+    at.write_bytes("check", hashes);
+
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg(at.subdir.join("check"))
+        .succeeds()
+        .stdout_is("empty: OK\nempty: OK\nempty: OK\n");
+}


### PR DESCRIPTION
This PR makes a significant refactor of the checksum checking code.

The current architecture prevents us to fix #6572, #6614 and #6653.

For #6614, we will need to implement a "retry" step in case we matched the hexa regex and we wish to try again considering the checksum as base64.

The refactor mainly consists in decomposing and extracting functionalities, and improving error management.

It adds several tests, for #6653 and #6572.

Its merge is gated by #6603, as it depends on its commits.