### PR TITLE
Bump `parking_lot_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1642,15 +1642,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1898,15 +1898,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3315,7 +3306,7 @@ version = "0.0.27"
 dependencies = [
  "clap",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "uucore",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -102,8 +102,6 @@ skip = [
   { name = "bitflags", version = "1.3.2" },
   # clap_builder, textwrap
   { name = "terminal_size", version = "0.2.6" },
-  # filetime, parking_lot_core
-  { name = "redox_syscall", version = "0.4.1" },
   # bindgen
   { name = "itertools", version = "0.12.1" },
 ]


### PR DESCRIPTION
This PR bumps `parking_lot_core` from `0.9.9` to `0.9.10` in order to get rid of an older version of `redox_syscall`. And removes `redox_syscall` from the skip list in `deny.toml`.