### PR TITLE
Do not rebuild the build script unless necessary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,10 @@ pub fn main() {
     const FEATURE_PREFIX: &str = "feat_";
     const OVERRIDE_PREFIX: &str = "uu_";
 
+    // Do not rebuild build script unless the script itself or the enabled features are modified
+    // See <https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection>
+    println!("cargo:rerun-if-changed=build.rs");
+
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=build={profile:?}");
     }


### PR DESCRIPTION
Without this guard, the build script is rebuilt as soon as any file within the package is changed. This includes files created by external tools such as IDE.

Fix #6640