### PR TITLE
Bump `windows-sys` & adapt `tail` to API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ dependencies = [
  "libc",
  "parse_datetime",
  "uucore",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2698,7 +2698,7 @@ dependencies = [
  "clap",
  "glob",
  "uucore",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2824,7 +2824,7 @@ dependencies = [
  "dns-lookup",
  "hostname",
  "uucore",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3115,7 +3115,7 @@ dependencies = [
  "libc",
  "uucore",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3261,7 +3261,7 @@ dependencies = [
  "libc",
  "nix",
  "uucore",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3288,7 +3288,7 @@ dependencies = [
  "same-file",
  "uucore",
  "winapi-util",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3329,7 +3329,7 @@ dependencies = [
  "filetime",
  "parse_datetime",
  "uucore",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3465,7 +3465,7 @@ dependencies = [
  "clap",
  "libc",
  "uucore",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3512,7 +3512,7 @@ dependencies = [
  "walkdir",
  "wild",
  "winapi-util",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
  "xattr",
  "z85",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,7 +341,7 @@ utf-8 = "0.7.6"
 utmp-classic = "0.1.6"
 walkdir = "2.5"
 winapi-util = "0.1.8"
-windows-sys = { version = "0.48.0", default-features = false }
+windows-sys = { version = "0.59.0", default-features = false }
 xattr = "1.3.1"
 zip = { version = "1.1.4", default-features = false, features = ["deflate"] }
 

--- a/src/uu/tail/src/platform/windows.rs
+++ b/src/uu/tail/src/platform/windows.rs
@@ -21,7 +21,7 @@ impl ProcessChecker {
         let FALSE: BOOL = 0;
         let h = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, FALSE, process_id) };
         Self {
-            dead: h == 0,
+            dead: h.is_null(),
             handle: h,
         }
     }


### PR DESCRIPTION
This PR bumps `windows-sys` from `0.48` to `0.59` and adapts `tail` to an API change.