### PR TITLE
cp: treat an empty file name as a non-existing file

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -9,6 +9,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 #[cfg(not(windows))]
 use std::ffi::CString;
+use std::ffi::OsString;
 use std::fs::{self, File, Metadata, OpenOptions, Permissions};
 use std::io;
 #[cfg(unix)]
@@ -677,7 +678,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::PATHS)
                 .action(ArgAction::Append)
                 .value_hint(clap::ValueHint::AnyPath)
-                .value_parser(ValueParser::path_buf()),
+                .value_parser(ValueParser::os_string()),
         )
 }
 
@@ -707,8 +708,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
 
         let paths: Vec<PathBuf> = matches
-            .remove_many::<PathBuf>(options::PATHS)
-            .map(|v| v.collect())
+            .remove_many::<OsString>(options::PATHS)
+            .map(|v| v.map(PathBuf::from).collect())
             .unwrap_or_default();
 
         let (sources, target) = parse_path_args(paths, &options)?;

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -54,7 +54,6 @@ static TEST_MOUNT_COPY_FROM_FOLDER: &str = "dir_with_mount";
 static TEST_MOUNT_MOUNTPOINT: &str = "mount";
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 static TEST_MOUNT_OTHER_FILESYSTEM_FILE: &str = "mount/DO_NOT_copy_me.txt";
-#[cfg(unix)]
 static TEST_NONEXISTENT_FILE: &str = "nonexistent_file.txt";
 #[cfg(all(
     unix,
@@ -164,6 +163,32 @@ fn test_cp_multiple_files() {
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
         .succeeds();
+
+    assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
+    assert_eq!(at.read(TEST_HOW_ARE_YOU_DEST), "How are you?\n");
+}
+
+#[test]
+fn test_cp_multiple_files_with_nonexistent_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_NONEXISTENT_FILE)
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .arg(TEST_COPY_TO_FOLDER)
+        .fails();
+
+    assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
+    assert_eq!(at.read(TEST_HOW_ARE_YOU_DEST), "How are you?\n");
+}
+
+#[test]
+fn test_cp_multiple_files_with_empty_file_name() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg("")
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .arg(TEST_COPY_TO_FOLDER)
+        .fails();
 
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
     assert_eq!(at.read(TEST_HOW_ARE_YOU_DEST), "How are you?\n");

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -170,12 +170,17 @@ fn test_cp_multiple_files() {
 
 #[test]
 fn test_cp_multiple_files_with_nonexistent_file() {
+    #[cfg(windows)]
+    let error_msg = "The system cannot find the file specified";
+    #[cfg(not(windows))]
+    let error_msg = format!("'{TEST_NONEXISTENT_FILE}': No such file or directory");
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_NONEXISTENT_FILE)
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
-        .fails();
+        .fails()
+        .stderr_contains(error_msg);
 
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
     assert_eq!(at.read(TEST_HOW_ARE_YOU_DEST), "How are you?\n");
@@ -183,12 +188,17 @@ fn test_cp_multiple_files_with_nonexistent_file() {
 
 #[test]
 fn test_cp_multiple_files_with_empty_file_name() {
+    #[cfg(windows)]
+    let error_msg = "The system cannot find the path specified";
+    #[cfg(not(windows))]
+    let error_msg = "'': No such file or directory";
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.arg(TEST_HELLO_WORLD_SOURCE)
         .arg("")
         .arg(TEST_HOW_ARE_YOU_SOURCE)
         .arg(TEST_COPY_TO_FOLDER)
-        .fails();
+        .fails()
+        .stderr_contains(error_msg);
 
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
     assert_eq!(at.read(TEST_HOW_ARE_YOU_DEST), "How are you?\n");


### PR DESCRIPTION
The `PathBuf` value parser from `clap` cannot be used directly as it does not (rightly) accept empty file names. 

Fix #6177 