### PR TITLE
ci: disable broken code coverage on windows

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -938,7 +938,8 @@ jobs:
         job:
           - { os: ubuntu-latest  , features: unix, toolchain: nightly }
           - { os: macos-latest   , features: macos, toolchain: nightly }
-          - { os: windows-latest , features: windows, toolchain: nightly-x86_64-pc-windows-gnu }
+          # FIXME: Re-enable Code Coverage on windows, which currently fails due to "profiler_builtins". See #6686.
+          # - { os: windows-latest , features: windows, toolchain: nightly-x86_64-pc-windows-gnu }
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
The `Code Coverage (windows-latest, windows, nightly-x86_64-pc-windows-gnu)` CI step seems to always fail for all PRs, and has been broken for several months now: #6534.

Instead of wasting even more CPU time (and perhaps money?) on a broken CI step that apparently noone wants to fix it, let's just deactivate it for now. If someone wants to fix it later, a FIXME points at the open issue #6686, which also serves as a good place to discuss potential fixes, should someone ever be interested.