### PR TITLE
Bump `selinux-sys` and `fts-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,16 +167,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -185,7 +183,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.60",
- "which",
 ]
 
 [[package]]
@@ -959,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "fts-sys"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e184d5f593d19793f26afb6f9a58d25f0bc755c4e48890ffcba6db416153ebb"
+checksum = "28ab6a6dfd9184fe8a5097924dea6e7648f499121b3e933bb8486a17f817122e"
 dependencies = [
  "bindgen",
  "libc",
@@ -1253,15 +1250,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1318,12 +1306,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -2085,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "selinux-sys"
-version = "0.6.9"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d45498373dc17ec8ebb72e1fd320c015647b0157fc81dddf678e2e00205fec"
+checksum = "8d557667087c5b4791e180b80979cd1a92fdb9bfd92cfd4b9ab199c4d7402423"
 dependencies = [
  "bindgen",
  "cc",
@@ -3052,7 +3034,7 @@ version = "0.0.27"
 dependencies = [
  "chrono",
  "clap",
- "itertools 0.13.0",
+ "itertools",
  "quick-error",
  "regex",
  "uucore",
@@ -3188,7 +3170,7 @@ dependencies = [
  "compare",
  "ctrlc",
  "fnv",
- "itertools 0.13.0",
+ "itertools",
  "memchr",
  "nix",
  "rand",
@@ -3473,7 +3455,7 @@ name = "uu_yes"
 version = "0.0.27"
 dependencies = [
  "clap",
- "itertools 0.13.0",
+ "itertools",
  "nix",
  "uucore",
 ]
@@ -3492,7 +3474,7 @@ dependencies = [
  "dunce",
  "glob",
  "hex",
- "itertools 0.13.0",
+ "itertools",
  "libc",
  "md-5",
  "memchr",
@@ -3622,17 +3604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
-name = "which"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
-
-[[package]]
 name = "wild"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,7 +3634,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -102,8 +102,6 @@ skip = [
   { name = "bitflags", version = "1.3.2" },
   # clap_builder, textwrap
   { name = "terminal_size", version = "0.2.6" },
-  # bindgen
-  { name = "itertools", version = "0.12.1" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR bumps `selinux-sys` from `0.6.9` to `0.6.12` and `fts-sys` from `0.2.9` to `0.2.11`, thus removing some dependencies. It also removes `itertools` from the skip list in `deny.toml`.