### PR TITLE
Change the git pre-commit actions to work on stable.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@ repos:
     -   id: rust-linting
         name: Rust linting
         description: Run cargo fmt on files included in the commit.
-        entry: cargo +nightly fmt --
+        entry: cargo fmt --
         pass_filenames: true
         types: [file, rust]
         language: system
     -   id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit.
-        entry: cargo +nightly clippy --workspace --all-targets --all-features --
+        entry: cargo clippy --workspace --all-targets --all-features --
         pass_filenames: false
         types: [file, rust]
         language: system


### PR DESCRIPTION
These are not being fixed, so it does not make sense to constantly take on new lints. The fmts may never be stabilized. Currently, you can not even commit, because it errors out. At least switch to lints that make it to stable when they are released.