### PR TITLE
uucore: add alacritty to the list of terminals that support colors

### DIFF
--- a/src/uucore/src/lib/features/colors.rs
+++ b/src/uucore/src/lib/features/colors.rs
@@ -13,6 +13,7 @@
 /// restrict following config to systems with matching environment variables.
 pub static TERMS: &[&str] = &[
     "Eterm",
+    "alacritty*",
     "ansi",
     "*color*",
     "con[0-9]*x[0-9]*",


### PR DESCRIPTION
Any value of `TERM` with glob pattern `alacritty*` will be matched.

Note that a more comprehensive approach may be needed to fix the problem in the general case, with a more faithful implementation with respect to the GNU coreutils `ls`. See [the discussion on the related issue](https://github.com/uutils/coreutils/issues/6722#issuecomment-2365195668) for more details.

Fixes #6722