### PR TITLE
tr: enable ignored test on unix

### DIFF
--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1027,7 +1027,8 @@ fn check_against_gnu_tr_tests_bs_055() {
 }
 
 #[test]
-#[ignore = "Failing in Windows because it will not separate '\' and 'x' as separate arguments"]
+// Fails on Windows because it will not separate '\' and 'x' as separate arguments
+#[cfg(unix)]
 fn check_against_gnu_tr_tests_bs_at_end() {
     // ['bs-at-end', qw('\\' x), {IN=>"\\"}, {OUT=>'x'},
     //  {ERR=>"$prog: warning: an unescaped backslash at end of "


### PR DESCRIPTION
I noticed that there is a test marked as "ignore" because it fails on Windows. This PR enables this test on unix.