### PR TITLE
move lints from rustflags to Cargo.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,2 @@
 [target.x86_64-unknown-redox]
 linker = "x86_64-unknown-redox-gcc"
-
-[target.'cfg(clippy)']
-rustflags = [
-    "-Wclippy::use_self",
-    "-Wclippy::needless_pass_by_value",
-    "-Wclippy::semicolon_if_nothing_returned",
-    "-Wclippy::single_char_pattern",
-    "-Wclippy::explicit_iter_loop",
-    "-Wclippy::if_not_else",
-]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,10 +559,17 @@ panic = "abort"
 strip = true
 
 [lints.clippy]
-multiple_crate_versions = { level = "allow", priority = 1 }
-cargo_common_metadata = { level = "allow", priority = 1 }
-uninlined_format_args = { level = "allow", priority = 1 }
-missing_panics_doc = { level = "allow", priority = 1 }
-all = "deny"
-cargo = "warn"
-pedantic = "deny"
+multiple_crate_versions = "allow"
+cargo_common_metadata = "allow"
+uninlined_format_args = "allow"
+missing_panics_doc = "allow"
+
+needless_pass_by_value = "warn"
+semicolon_if_nothing_returned = "warn"
+single_char_pattern = "warn"
+explicit_iter_loop = "warn"
+if_not_else = "warn"
+
+all = { level = "deny", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+pedantic = { level = "deny", priority = -1 }


### PR DESCRIPTION
This prevents unnecessary rebuilds when mixing runs of `cargo clippy` and other cargo commands (e.g., `cargo c && cargo clippy && cargo c` no longer rebuilds).