### PR TITLE
Change the git pre-commit actions to *actually* use stable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@ repos:
     -   id: rust-linting
         name: Rust linting
         description: Run cargo fmt on files included in the commit.
-        entry: cargo fmt --
+        entry: cargo +stable fmt --
         pass_filenames: true
         types: [file, rust]
         language: system
     -   id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit.
-        entry: cargo clippy --workspace --all-targets --all-features --
+        entry: cargo +stable clippy --workspace --all-targets --all-features --
         pass_filenames: false
         types: [file, rust]
         language: system


### PR DESCRIPTION
This is in response to #6715: e8bb8dffa1b1af05b7be184c820f5c72a2b8c1da

The pre-commit actions have a higher MSRV than the overall project (1.70.0), so if 1.70.0 is the configured default, this lead to problems: #6730

This PR fixes the situation by specifying 'stable', whatever that means on the user's system.

Fixes #6730.