### PR TITLE
printf: delete unused file

### DIFF
--- a/src/uu/printf/src/mod.rs
+++ b/src/uu/printf/src/mod.rs
@@ -1,5 +1,0 @@
-// This file is part of the uutils coreutils package.
-//
-// For the full copyright and license information, please view the LICENSE
-// file that was distributed with this source code.
-mod cli;


### PR DESCRIPTION
The main file in directories like this is `main.rs` (in contrast to subdirectories, where it would be `src/foo/mod.rs`), and no other `src/mod.rs` exists, indicating that this was just an error all the way back in 0892ad3cdecb8ad38f1419f92d697f0fcb0a2058.

Found by #6721.

Fixes #6721.