### PR TITLE
users: fix lint error manual_unwrap_or_default on OpenBSD

### DIFF
--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -51,7 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     #[cfg(target_os = "openbsd")]
     {
         let filename = maybe_file.unwrap_or(Path::new(OPENBSD_UTMP_FILE));
-        let entries = parse_from_path(filename).unwrap_or(Vec::new());
+        let entries = parse_from_path(filename).unwrap_or_default();
         users = Vec::new();
         for entry in entries {
             if let UtmpEntry::UTMP {


### PR DESCRIPTION
Fix uutils/coreutils#6771

---
No error for `users` tool on OpenBSD with clippy
```bash
$ cargo clippy --all-targets -puu_users -- -W clippy::manual_string_new -D warnings
(...)
    Checking uucore v0.0.27 (/home/fox/dev/rust-coreutils.git/src/uucore)
    Checking uu_users v0.0.27 (/home/fox/dev/rust-coreutils.git/src/uu/users)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.90s
```