### PR TITLE
add back use_self clippy warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -564,6 +564,7 @@ cargo_common_metadata = "allow"
 uninlined_format_args = "allow"
 missing_panics_doc = "allow"
 
+use_self = "warn"
 needless_pass_by_value = "warn"
 semicolon_if_nothing_returned = "warn"
 single_char_pattern = "warn"


### PR DESCRIPTION
Accidentally lost this in #6751, thankfully it looks like no merged PRs triggered it in the meantime.