### PR TITLE
cksum/hashsum: Support for commented lines in checksum files

### DIFF
--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -575,8 +575,8 @@ where
                     res.failed_cksum += 1;
                 }
             } else {
-                if line.is_empty() {
-                    // Don't show any warning for empty lines
+                if line.is_empty() || line.starts_with("#") {
+                    // Don't show any warning for empty or commented lines.
                     continue;
                 }
                 if warn {


### PR DESCRIPTION
As #6603 implicitly implemented commented line support, I moved it into its own PR, with proper testing.

**TL;DR**:
This change make the checksum verification system ignore lines starting with `#`, treating them as empty lines.

Example:
```
$ echo 'foo-content' > foo
$ cksum --algo=sha1 foo | tee CHECKSUM
SHA1 (foo) = 058ab38dd3603703b3a7063cf95dc51a4286b6fe 

$ echo '# Comment' >> CHECKSUM 
$ cat CHECKSUM
SHA1 (foo) = 058ab38dd3603703b3a7063cf95dc51a4286b6fe
# Comment

$ cksum --check CHECKSUM
foo: OK
```

The changes similarly apply to `hashsum` and its derivatives.