### PR TITLE
tsort.pl: adjust error message

### DIFF
--- a/util/gnu-patches/tests_tsort.patch
+++ b/util/gnu-patches/tests_tsort.patch
@@ -1,0 +1,17 @@
+diff --git a/tests/misc/tsort.pl b/tests/misc/tsort.pl
+index 70bdc474c..4fd420a4e 100755
+--- a/tests/misc/tsort.pl
++++ b/tests/misc/tsort.pl
+@@ -54,8 +54,10 @@ my @Tests =
+ 
+    ['only-one', {IN => {f => ""}}, {IN => {g => ""}},
+     {EXIT => 1},
+-    {ERR => "tsort: extra operand 'g'\n"
+-     . "Try 'tsort --help' for more information.\n"}],
++    {ERR => "error: unexpected argument 'g' found\n\n"
++         . "Usage: tsort [OPTIONS] FILE\n\n"
++         . "For more information, try '--help'.\n"
++    }],
+   );
+ 
+ my $save_temps = $ENV{DEBUG};


### PR DESCRIPTION
but will still fail.

Currently:
```
2024-10-16T07:22:20.6275735Z --- only-one.1	2024-10-16 07:11:51.980024380 +0000
2024-10-16T07:22:20.6275907Z +++ only-one.E	2024-10-16 07:11:51.984024374 +0000
2024-10-16T07:22:20.6276011Z @@ -1,2 +1,5 @@
2024-10-16T07:22:20.6276133Z -tsort: extra operand 'g'
2024-10-16T07:22:20.6276299Z -Try 'tsort --help' for more information.
2024-10-16T07:22:20.6276445Z +error: unexpected argument 'g' found
2024-10-16T07:22:20.6276519Z +
2024-10-16T07:22:20.6276622Z +Usage: tsort [OPTIONS] FILE
2024-10-16T07:22:20.6276696Z +
2024-10-16T07:22:20.6276838Z +For more information, try '--help'.

```