### PR TITLE
uucore: allow use of deprecated `PanicInfo`

### DIFF
--- a/src/uucore/src/lib/mods/panic.rs
+++ b/src/uucore/src/lib/mods/panic.rs
@@ -14,9 +14,13 @@
 //! ```
 //!
 use std::panic;
+// TODO: use PanicHookInfo when we have a MSRV of 1.81
+#[allow(deprecated)]
 use std::panic::PanicInfo;
 
 /// Decide whether a panic was caused by a broken pipe (SIGPIPE) error.
+// TODO: use PanicHookInfo when we have a MSRV of 1.81
+#[allow(deprecated)]
 fn is_broken_pipe(info: &PanicInfo) -> bool {
     if let Some(res) = info.payload().downcast_ref::<String>() {
         if res.contains("BrokenPipe") || res.contains("Broken pipe") {


### PR DESCRIPTION
This PR adds `#[allow(deprecated)]` to "fix" the warnings "use of deprecated type alias `std::panic::PanicInfo`: use `PanicHookInfo` instead" from the lint jobs in the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/11393908726/job/31703171797?pr=6789#step:7:350).