### PR TITLE
echo: handle multibyte escape sequences

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -87,6 +87,7 @@ fn print_escaped(input: &str, output: &mut StdoutLock) -> io::Result<ControlFlow
         if let Some(next) = iter.next() {
             // For extending lifetime
             let sl: [u8; 1_usize];
+            let sli: [u8; 1_usize];
 
             let unescaped: &[u8] = match next {
                 '\\' => br"\",
@@ -108,7 +109,11 @@ fn print_escaped(input: &str, output: &mut StdoutLock) -> io::Result<ControlFlow
                         br"\x"
                     }
                 }
-                '0' => &[parse_code(&mut iter, Base::Oct).unwrap_or(b'\0')],
+                '0' => {
+                    sli = [parse_code(&mut iter, Base::Oct).unwrap_or(b'\0')];
+
+                    &sli
+                }
                 c => {
                     write!(output, "\\{c}")?;
 

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -211,6 +211,7 @@ fn print_escaped(input: &[u8], output: &mut StdoutLock) -> io::Result<ControlFlo
             // For extending lifetime
             // Unnecessary when using Rust >= 1.79.0
             // https://github.com/rust-lang/rust/pull/121346
+            // TODO: when we have a MSRV >= 1.79.0, delete these "hold" bindings
             let hold_one_byte_outside_of_match: [u8; 1_usize];
             let hold_two_bytes_outside_of_match: [u8; 2_usize];
 
@@ -229,8 +230,11 @@ fn print_escaped(input: &[u8], output: &mut StdoutLock) -> io::Result<ControlFlo
                     if let Some(parsed_hexadecimal_number) =
                         parse_backslash_number(&mut iter, BackslashNumberType::Hexadecimal)
                     {
+                        // TODO: remove when we have a MSRV >= 1.79.0
                         hold_one_byte_outside_of_match = [parsed_hexadecimal_number];
 
+                        // TODO: when we have a MSRV >= 1.79.0, return reference to a temporary array:
+                        // &[parsed_hexadecimal_number]
                         &hold_one_byte_outside_of_match
                     } else {
                         // "\x" with any non-hexadecimal digit after means "\x" is treated literally
@@ -242,8 +246,11 @@ fn print_escaped(input: &[u8], output: &mut StdoutLock) -> io::Result<ControlFlo
                         &mut iter,
                         BackslashNumberType::OctalStartingWithZero,
                     ) {
+                        // TODO: remove when we have a MSRV >= 1.79.0
                         hold_one_byte_outside_of_match = [parsed_octal_number];
 
+                        // TODO: when we have a MSRV >= 1.79.0, return reference to a temporary array:
+                        // &[parsed_octal_number]
                         &hold_one_byte_outside_of_match
                     } else {
                         // "\0" with any non-octal digit after it means "\0" is treated as ASCII '\0' (NUL), 0x00

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -279,10 +279,8 @@ fn bytes_from_os_string(input: &OsStr) -> Option<&[u8]> {
         #[cfg(not(target_family = "unix"))]
         {
             // TODO
-            match input.to_str() {
-                Some(st) => Some(st.as_bytes()),
-                None => None,
-            }
+            // Verify that this works correctly on these platforms
+            input.to_str().map(|st| st.as_bytes())
         }
     };
 

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 use clap::{crate_version, Arg, ArgAction, Command};
-use std::io::{self, Write};
+use std::io::{self, StdoutLock, Write};
 use std::iter::Peekable;
 use std::ops::ControlFlow;
 use std::str::Chars;
@@ -63,7 +63,7 @@ fn parse_code(input: &mut Peekable<Chars>, base: Base) -> Option<u8> {
     Some(ret)
 }
 
-fn print_escaped(input: &str, mut output: impl Write) -> io::Result<ControlFlow<()>> {
+fn print_escaped(input: &str, output: &mut StdoutLock) -> io::Result<ControlFlow<()>> {
     let mut iter = input.chars().peekable();
 
     while let Some(c) = iter.next() {

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -303,3 +303,38 @@ fn partial_version_argument() {
 fn partial_help_argument() {
     new_ucmd!().arg("--he").succeeds().stdout_is("--he\n");
 }
+
+#[test]
+fn multibyte_escape_unicode() {
+    // spell-checker:disable-next-line
+    // Tests suggested by kkew3
+    // https://github.com/uutils/coreutils/issues/6741
+
+    // \u{1F602} is:
+    //
+    // "Face with Tears of Joy"
+    // U+1F602
+    // "😂"
+
+    new_ucmd!()
+        .args(&["-e", r"\xf0\x9f\x98\x82"])
+        .succeeds()
+        .stdout_only("\u{1F602}\n");
+
+    new_ucmd!()
+        .args(&["-e", r"\x41\xf0\x9f\x98\x82\x42"])
+        .succeeds()
+        .stdout_only("A\u{1F602}B\n");
+
+    new_ucmd!()
+        .args(&["-e", r"\xf0\x41\x9f\x98\x82"])
+        .succeeds()
+        .stdout_is_bytes(b"\xF0A\x9F\x98\x82\n")
+        .no_stderr();
+
+    new_ucmd!()
+        .args(&["-e", r"\x41\xf0\c\x9f\x98\x82"])
+        .succeeds()
+        .stdout_is_bytes(b"A\xF0")
+        .no_stderr();
+}

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -5,7 +5,6 @@
 // spell-checker:ignore (words) araba merci
 
 use crate::common::util::TestScenario;
-use std::ffi::OsStr;
 
 #[test]
 fn test_default() {
@@ -369,6 +368,7 @@ fn nine_bit_octal() {
 #[test]
 #[cfg(target_family = "unix")]
 fn non_utf_8() {
+    use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt;
 
     // ISO-8859-1 encoded text

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -329,14 +329,12 @@ fn multibyte_escape_unicode() {
     new_ucmd!()
         .args(&["-e", r"\xf0\x41\x9f\x98\x82"])
         .succeeds()
-        .stdout_is_bytes(b"\xF0A\x9F\x98\x82\n")
-        .no_stderr();
+        .stdout_only_bytes(b"\xF0A\x9F\x98\x82\n");
 
     new_ucmd!()
         .args(&["-e", r"\x41\xf0\c\x9f\x98\x82"])
         .succeeds()
-        .stdout_is_bytes(b"A\xF0")
-        .no_stderr();
+        .stdout_only_bytes(b"A\xF0");
 }
 
 #[test]
@@ -344,8 +342,7 @@ fn non_utf_8_hex_round_trip() {
     new_ucmd!()
         .args(&["-e", r"\xFF"])
         .succeeds()
-        .stdout_is_bytes(b"\xFF\n")
-        .no_stderr();
+        .stdout_only_bytes(b"\xFF\n");
 }
 
 #[test]
@@ -355,14 +352,12 @@ fn nine_bit_octal() {
     new_ucmd!()
         .args(&["-e", r"\0777"])
         .succeeds()
-        .stdout_is_bytes(RESULT)
-        .no_stderr();
+        .stdout_only_bytes(RESULT);
 
     new_ucmd!()
         .args(&["-e", r"\777"])
         .succeeds()
-        .stdout_is_bytes(RESULT)
-        .no_stderr();
+        .stdout_only_bytes(RESULT);
 }
 
 #[test]

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -383,6 +383,13 @@ fn non_utf_8() {
         .arg("-n")
         .arg(os_str)
         .succeeds()
-        .stdout_is_bytes(INPUT_AND_OUTPUT)
-        .no_stderr();
+        .stdout_only_bytes(INPUT_AND_OUTPUT);
+}
+
+#[test]
+fn slash_eight_off_by_one() {
+    new_ucmd!()
+        .args(&["-e", "-n", r"\8"])
+        .succeeds()
+        .stdout_only(r"\8");
 }


### PR DESCRIPTION
Bug was reported, with root cause analysis, by kkew3 Added tests were derived from test cases provided by kkew3 See https://github.com/uutils/coreutils/issues/6741