### PR TITLE
printf: accept non-UTF-8 input in FORMAT and

### DIFF
--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/echo.rs"
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true }
+uucore = { workspace = true, features = ["format"] }
 
 [[bin]]
 name = "echo"

--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/echo.rs"
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["format"] }
+uucore = { workspace = true }
 
 [[bin]]
 name = "echo"

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -12,7 +12,7 @@ use std::iter::Peekable;
 use std::ops::ControlFlow;
 use std::slice::Iter;
 use uucore::error::UResult;
-use uucore::{format_usage, help_about, help_section, help_usage};
+use uucore::{format_usage, help_about, help_section, help_usage, os_str_as_bytes_verbose};
 
 const ABOUT: &str = help_about!("echo.md");
 const USAGE: &str = help_usage!("echo.md");
@@ -355,8 +355,9 @@ fn execute(
     arguments_after_options: ValuesRef<'_, OsString>,
 ) -> UResult<()> {
     for (i, input) in arguments_after_options.enumerate() {
-        let bytes = uucore::format::try_get_bytes_from_os_str(input)?;
+        let bytes = os_str_as_bytes_verbose(input)?;
 
+        // Don't print a space before the first argument
         if i > 0 {
             stdout_lock.write_all(b" ")?;
         }

--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -355,7 +355,7 @@ fn execute(
     arguments_after_options: ValuesRef<'_, OsString>,
 ) -> UResult<()> {
     for (i, input) in arguments_after_options.enumerate() {
-        let bytes = uucore::format::bytes_from_os_str(input)?;
+        let bytes = uucore::format::try_get_bytes_from_os_str(input)?;
 
         if i > 0 {
             stdout_lock.write_all(b" ")?;

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -11,7 +11,9 @@ use std::ffi::OsString;
 use std::io::stdout;
 use std::ops::ControlFlow;
 use uucore::error::{UResult, UUsageError};
-use uucore::format::{bytes_from_os_str, parse_spec_and_escape, FormatArgument, FormatItem};
+use uucore::format::{
+    parse_spec_and_escape, try_get_bytes_from_os_str, FormatArgument, FormatItem,
+};
 use uucore::{format_usage, help_about, help_section, help_usage};
 
 const VERSION: &str = "version";
@@ -33,7 +35,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .get_one::<OsString>(options::FORMAT)
         .ok_or_else(|| UUsageError::new(1, "missing operand"))?;
 
-    let format_bytes = bytes_from_os_str(format)?;
+    let format_bytes = try_get_bytes_from_os_str(format)?;
 
     let values = match matches.get_many::<OsString>(options::ARGUMENT) {
         Some(os_string) => os_string

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -5,11 +5,13 @@
 
 #![allow(dead_code)]
 
+use clap::builder::ValueParser;
 use clap::{crate_version, Arg, ArgAction, Command};
+use std::ffi::OsString;
 use std::io::stdout;
 use std::ops::ControlFlow;
 use uucore::error::{UResult, UUsageError};
-use uucore::format::{parse_spec_and_escape, FormatArgument, FormatItem};
+use uucore::format::{bytes_from_os_str, parse_spec_and_escape, FormatArgument, FormatItem};
 use uucore::{format_usage, help_about, help_section, help_usage};
 
 const VERSION: &str = "version";
@@ -28,17 +30,22 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().get_matches_from(args);
 
     let format = matches
-        .get_one::<String>(options::FORMAT)
+        .get_one::<OsString>(options::FORMAT)
         .ok_or_else(|| UUsageError::new(1, "missing operand"))?;
 
-    let values: Vec<_> = match matches.get_many::<String>(options::ARGUMENT) {
-        Some(s) => s.map(|s| FormatArgument::Unparsed(s.to_string())).collect(),
-        None => vec![],
+    let format_bytes = bytes_from_os_str(format)?;
+
+    let values = match matches.get_many::<OsString>(options::ARGUMENT) {
+        Some(os_string) => os_string
+            .map(|os_string_ref| FormatArgument::Unparsed(os_string_ref.to_owned()))
+            .collect(),
+        None => Vec::<FormatArgument>::new(),
     };
 
     let mut format_seen = false;
     let mut args = values.iter().peekable();
-    for item in parse_spec_and_escape(format.as_ref()) {
+
+    for item in parse_spec_and_escape(format_bytes) {
         if let Ok(FormatItem::Spec(_)) = item {
             format_seen = true;
         }
@@ -55,7 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     while args.peek().is_some() {
-        for item in parse_spec_and_escape(format.as_ref()) {
+        for item in parse_spec_and_escape(format_bytes) {
             match item?.write(stdout(), &mut args)? {
                 ControlFlow::Continue(()) => {}
                 ControlFlow::Break(()) => return Ok(()),
@@ -86,6 +93,10 @@ pub fn uu_app() -> Command {
                 .help("Print version information")
                 .action(ArgAction::Version),
         )
-        .arg(Arg::new(options::FORMAT))
-        .arg(Arg::new(options::ARGUMENT).action(ArgAction::Append))
+        .arg(Arg::new(options::FORMAT).value_parser(ValueParser::os_string()))
+        .arg(
+            Arg::new(options::ARGUMENT)
+                .action(ArgAction::Append)
+                .value_parser(ValueParser::os_string()),
+        )
 }

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -11,10 +11,8 @@ use std::ffi::OsString;
 use std::io::stdout;
 use std::ops::ControlFlow;
 use uucore::error::{UResult, UUsageError};
-use uucore::format::{
-    parse_spec_and_escape, try_get_bytes_from_os_str, FormatArgument, FormatItem,
-};
-use uucore::{format_usage, help_about, help_section, help_usage};
+use uucore::format::{parse_spec_and_escape, FormatArgument, FormatError, FormatItem};
+use uucore::{format_usage, help_about, help_section, help_usage, os_str_as_bytes_verbose};
 
 const VERSION: &str = "version";
 const HELP: &str = "help";
@@ -35,7 +33,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .get_one::<OsString>(options::FORMAT)
         .ok_or_else(|| UUsageError::new(1, "missing operand"))?;
 
-    let format_bytes = try_get_bytes_from_os_str(format)?;
+    let format_bytes = os_str_as_bytes_verbose(format).map_err(FormatError::from)?;
 
     let values = match matches.get_many::<OsString>(options::ARGUMENT) {
         Some(os_string) => os_string

--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -38,6 +38,7 @@ pub mod num_parser;
 mod spec;
 
 pub use argument::*;
+use os_display::Quotable;
 use spec::Spec;
 use std::{
     error::Error,
@@ -63,6 +64,7 @@ pub enum FormatError {
     NeedAtLeastOneSpec(Vec<u8>),
     WrongSpecType,
     InvalidPrecision(String),
+    InvalidEncoding(NonUtf8OsStr),
 }
 
 impl Error for FormatError {}
@@ -71,6 +73,12 @@ impl UError for FormatError {}
 impl From<std::io::Error> for FormatError {
     fn from(value: std::io::Error) -> Self {
         Self::IoError(value)
+    }
+}
+
+impl From<NonUtf8OsStr> for FormatError {
+    fn from(value: NonUtf8OsStr) -> FormatError {
+        FormatError::InvalidEncoding(value)
     }
 }
 
@@ -98,6 +106,13 @@ impl Display for FormatError {
             Self::IoError(_) => write!(f, "io error"),
             Self::NoMoreArguments => write!(f, "no more arguments"),
             Self::InvalidArgument(_) => write!(f, "invalid argument"),
+            Self::InvalidEncoding(no) => {
+                write!(
+                    f,
+                    "invalid (non-UTF-8) argument like {} encountered",
+                    no.0.quote()
+                )
+            }
         }
     }
 }

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -6,13 +6,17 @@
 // spell-checker:ignore (vars) intmax ptrdiff padlen
 
 use super::{
+    argument::ArgumentIter,
     num_format::{
         self, Case, FloatVariant, ForceDecimal, Formatter, NumberAlignment, PositiveSign, Prefix,
         UnsignedIntVariant,
     },
-    parse_escape_only, try_get_bytes_from_os_str, ArgumentIter, FormatChar, FormatError,
+    parse_escape_only, FormatChar, FormatError,
 };
-use crate::quoting_style::{escape_name, QuotingStyle};
+use crate::{
+    os_str_as_bytes_verbose,
+    quoting_style::{escape_name, QuotingStyle},
+};
 use std::{io::Write, ops::ControlFlow};
 
 /// A parsed specification for formatting a value
@@ -333,7 +337,7 @@ impl Spec {
 
                 let os_str = args.get_str();
 
-                let bytes = try_get_bytes_from_os_str(os_str).unwrap();
+                let bytes = os_str_as_bytes_verbose(os_str)?;
 
                 let truncated = match precision {
                     Some(p) if p < os_str.len() => &bytes[..p],
@@ -345,7 +349,7 @@ impl Spec {
             Self::EscapedString => {
                 let os_str = args.get_str();
 
-                let bytes = try_get_bytes_from_os_str(os_str).unwrap();
+                let bytes = os_str_as_bytes_verbose(os_str)?;
 
                 let mut parsed = Vec::<u8>::new();
 

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -253,22 +253,82 @@ pub fn read_yes() -> bool {
     }
 }
 
+fn os_str_as_bytes_core(os_string: &OsStr) -> Option<&[u8]> {
+    // Using a block like this prevents accidental shadowing if the #[cfg] attributes are accidentally not mutually
+    // exclusive
+    let option = {
+        #[cfg(unix)]
+        {
+            Some(os_string.as_bytes())
+        }
+
+        #[cfg(not(unix))]
+        {
+            os_string.to_str().map(|op| op.as_bytes())
+        }
+    };
+
+    option
+}
+
 /// Helper function for processing delimiter values (which could be non UTF-8)
 /// It converts OsString to &[u8] for unix targets only
 /// On non-unix (i.e. Windows) it will just return an error if delimiter value is not UTF-8
 pub fn os_str_as_bytes(os_string: &OsStr) -> mods::error::UResult<&[u8]> {
-    #[cfg(unix)]
-    let bytes = os_string.as_bytes();
-
-    #[cfg(not(unix))]
-    let bytes = os_string
-        .to_str()
-        .ok_or_else(|| {
-            mods::error::UUsageError::new(1, "invalid UTF-8 was detected in one or more arguments")
-        })?
-        .as_bytes();
+    let bytes = os_str_as_bytes_core(os_string).ok_or_else(|| {
+        mods::error::UUsageError::new(1, "invalid UTF-8 was detected in one or more arguments")
+    })?;
 
     Ok(bytes)
+}
+
+#[derive(Debug)]
+enum OsStrConversionType {
+    ToBytes,
+    ToString,
+}
+
+#[derive(Debug)]
+pub struct NonUtf8OsStrError {
+    conversion_type: OsStrConversionType,
+    input_lossy_string: String,
+}
+
+impl std::fmt::Display for NonUtf8OsStrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use os_display::Quotable;
+
+        let quoted = self.input_lossy_string.quote();
+
+        match self.conversion_type {
+            OsStrConversionType::ToBytes => f.write_fmt(format_args!(
+                "invalid (non-UTF-8) input like {quoted} encountered when converting input to bytes on a platform that doesn't use UTF-8",
+            )),
+            OsStrConversionType::ToString => f.write_fmt(format_args!(
+                "invalid (non-UTF-8) string like {quoted} encountered",
+            )),
+        }
+    }
+}
+
+impl std::error::Error for NonUtf8OsStrError {}
+impl error::UError for NonUtf8OsStrError {}
+
+pub fn os_str_as_bytes_verbose(input: &OsStr) -> Result<&[u8], NonUtf8OsStrError> {
+    os_str_as_bytes_core(input).ok_or_else(|| NonUtf8OsStrError {
+        conversion_type: OsStrConversionType::ToBytes,
+        input_lossy_string: input.to_string_lossy().into_owned(),
+    })
+}
+
+pub fn os_str_as_str_verbose(os_str: &OsStr) -> Result<&str, NonUtf8OsStrError> {
+    match os_str.to_str() {
+        Some(st) => Ok(st),
+        None => Err(NonUtf8OsStrError {
+            conversion_type: OsStrConversionType::ToString,
+            input_lossy_string: os_str.to_string_lossy().into_owned(),
+        }),
+    }
 }
 
 /// Helper function for converting a slice of bytes into an &OsStr
@@ -279,12 +339,21 @@ pub fn os_str_as_bytes(os_string: &OsStr) -> mods::error::UResult<&[u8]> {
 /// and thus undergo UTF-8 validation, making it fail if the stream contains
 /// non-UTF-8 characters.
 pub fn os_str_from_bytes(bytes: &[u8]) -> mods::error::UResult<Cow<'_, OsStr>> {
-    #[cfg(unix)]
-    let os_str = Cow::Borrowed(OsStr::from_bytes(bytes));
-    #[cfg(not(unix))]
-    let os_str = Cow::Owned(OsString::from(str::from_utf8(bytes).map_err(|_| {
-        mods::error::UUsageError::new(1, "Unable to transform bytes into OsStr")
-    })?));
+    // Using a block like this prevents accidental shadowing if the #[cfg] attributes are accidentally not mutually
+    // exclusive
+    let os_str = {
+        #[cfg(unix)]
+        {
+            Cow::Borrowed(OsStr::from_bytes(bytes))
+        }
+
+        #[cfg(not(unix))]
+        {
+            Cow::Owned(OsString::from(str::from_utf8(bytes).map_err(|_| {
+                mods::error::UUsageError::new(1, "Unable to transform bytes into OsStr")
+            })?))
+        }
+    };
 
     Ok(os_str)
 }
@@ -293,12 +362,24 @@ pub fn os_str_from_bytes(bytes: &[u8]) -> mods::error::UResult<Cow<'_, OsStr>> {
 /// It converts `Vec<u8>` to `OsString` for unix targets only.
 /// On non-unix (i.e. Windows) it may fail if the bytes are not valid UTF-8
 pub fn os_string_from_vec(vec: Vec<u8>) -> mods::error::UResult<OsString> {
-    #[cfg(unix)]
-    let s = OsString::from_vec(vec);
-    #[cfg(not(unix))]
-    let s = OsString::from(String::from_utf8(vec).map_err(|_| {
-        mods::error::UUsageError::new(1, "invalid UTF-8 was detected in one or more arguments")
-    })?);
+    // Using a block like this prevents accidental shadowing if the #[cfg] attributes are accidentally not mutually
+    // exclusive
+    let s = {
+        #[cfg(unix)]
+        {
+            OsString::from_vec(vec)
+        }
+
+        #[cfg(not(unix))]
+        {
+            OsString::from(String::from_utf8(vec).map_err(|_| {
+                mods::error::UUsageError::new(
+                    1,
+                    "invalid UTF-8 was detected in one or more arguments",
+                )
+            })?)
+        }
+    };
 
     Ok(s)
 }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -916,3 +916,29 @@ fn float_flag_position_space_padding() {
         .succeeds()
         .stdout_only(" +1.0");
 }
+
+#[test]
+#[cfg(target_family = "unix")]
+fn non_utf_8_input() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    // ISO-8859-1 encoded text
+    // spell-checker:disable
+    const INPUT_AND_OUTPUT: &[u8] =
+        b"Swer an rehte g\xFCete wendet s\xEEn gem\xFCete, dem volget s\xE6lde und \xEAre.";
+    // spell-checker:enable
+
+    let os_str = OsStr::from_bytes(INPUT_AND_OUTPUT);
+
+    new_ucmd!()
+        .arg("%s")
+        .arg(os_str)
+        .succeeds()
+        .stdout_only_bytes(INPUT_AND_OUTPUT);
+
+    new_ucmd!()
+        .arg(os_str)
+        .succeeds()
+        .stdout_only_bytes(INPUT_AND_OUTPUT);
+}

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -946,6 +946,8 @@ fn non_utf_8_input() {
         .arg("%d")
         .arg(os_str)
         .fails()
+        // spell-checker:disable
         .stderr_only("printf: invalid (non-UTF-8) argument like 'Swer an rehte g�ete wendet s�n gem�ete, dem volget s�lde und �re.' encountered
 ");
+    // spell-checker:enable
 }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -941,4 +941,11 @@ fn non_utf_8_input() {
         .arg(os_str)
         .succeeds()
         .stdout_only_bytes(INPUT_AND_OUTPUT);
+
+    new_ucmd!()
+        .arg("%d")
+        .arg(os_str)
+        .fails()
+        .stderr_only("printf: invalid (non-UTF-8) argument like 'Swer an rehte g�ete wendet s�n gem�ete, dem volget s�lde und �re.' encountered
+");
 }


### PR DESCRIPTION
ARGUMENT arguments

Other implementations of `printf` permit arbitrary data to be passed to `printf`. The only restriction is that a null byte terminates FORMAT and ARGUMENT argument strings (since they are C strings).

The current implementation only accepts FORMAT and ARGUMENT arguments that are valid UTF-8 (this is being enforced by clap).

This commit removes the UTF-8 validation by switching to OsStr and OsString.

This allows users to use `printf` to transmit or reformat null-safe but not UTF-8-safe data, such as text encoded in an 8-bit text encoding. See the `non_utf_8_input` test for an example (ISO-8859-1 text).