### PR TITLE
checksum: prepare further behavior fix with a rework

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -13,8 +13,8 @@ use std::iter;
 use std::path::Path;
 use uucore::checksum::{
     calculate_blake2b_length, detect_algo, digest_reader, perform_checksum_validation,
-    ChecksumError, ALGORITHM_OPTIONS_BLAKE2B, ALGORITHM_OPTIONS_BSD, ALGORITHM_OPTIONS_CRC,
-    ALGORITHM_OPTIONS_SYSV, SUPPORTED_ALGORITHMS,
+    ChecksumError, ChecksumOptions, ALGORITHM_OPTIONS_BLAKE2B, ALGORITHM_OPTIONS_BSD,
+    ALGORITHM_OPTIONS_CRC, ALGORITHM_OPTIONS_SYSV, SUPPORTED_ALGORITHMS,
 };
 use uucore::{
     encoding,
@@ -318,17 +318,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             || iter::once(OsStr::new("-")).collect::<Vec<_>>(),
             |files| files.map(OsStr::new).collect::<Vec<_>>(),
         );
-        return perform_checksum_validation(
-            files.iter().copied(),
-            strict,
-            status,
-            warn,
-            binary_flag,
+        let opts = ChecksumOptions {
+            binary: binary_flag,
             ignore_missing,
             quiet,
-            algo_option,
-            length,
-        );
+            status,
+            strict,
+            warn,
+        };
+
+        return perform_checksum_validation(files.iter().copied(), algo_option, length, opts);
     }
 
     let (tag, asterisk) = handle_tag_text_binary_flags(&matches)?;

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -23,6 +23,7 @@ use uucore::checksum::digest_reader;
 use uucore::checksum::escape_filename;
 use uucore::checksum::perform_checksum_validation;
 use uucore::checksum::ChecksumError;
+use uucore::checksum::ChecksumOptions;
 use uucore::checksum::HashAlgorithm;
 use uucore::error::{FromIo, UResult};
 use uucore::sum::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shake256};
@@ -239,18 +240,21 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
             || iter::once(OsStr::new("-")).collect::<Vec<_>>(),
             |files| files.map(OsStr::new).collect::<Vec<_>>(),
         );
+        let opts = ChecksumOptions {
+            binary,
+            ignore_missing,
+            quiet,
+            status,
+            strict,
+            warn,
+        };
 
         // Execute the checksum validation
         return perform_checksum_validation(
             input.iter().copied(),
-            strict,
-            status,
-            warn,
-            binary,
-            ignore_missing,
-            quiet,
             Some(algo.name),
             Some(algo.bits),
+            opts,
         );
     } else if quiet {
         return Err(ChecksumError::QuietNotCheck.into());

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -75,13 +75,22 @@ struct ChecksumResult {
     pub failed_open_file: i32,
 }
 
+/// Represents a reason for which the processing of a checksum line
+/// could not proceed to digest comparison.
 enum LineCheckError {
+    /// a generic UError was encountered in sub-functions
     UError(Box<dyn UError>),
+    /// the computed checksum digest differs from the expected one
     DigestMismatch,
+    /// the line is empty or is a comment
     Skipped,
+    /// the line has a formatting error
     ImproperlyFormatted,
+    /// file exists but is impossible to read
     CantOpenFile,
+    /// there is nothing at the given path
     FileNotFound,
+    /// the given path leads to a directory
     FileIsDirectory,
 }
 
@@ -97,10 +106,14 @@ impl From<ChecksumError> for LineCheckError {
     }
 }
 
+/// Represents an error that was encountered when processing a checksum file.
 #[allow(clippy::enum_variant_names)]
 enum FileCheckError {
+    /// a generic UError was encountered in sub-functions
     UError(Box<dyn UError>),
+    /// the error does not stop the processing of next files
     NonCriticalError,
+    /// the error must stop the run of the program
     CriticalError,
 }
 
@@ -226,6 +239,8 @@ fn cksum_output(res: &ChecksumResult, status: bool) {
     }
 }
 
+/// Represents the different outcomes that can happen to a file
+/// that is being checked.
 #[derive(Debug, Clone, Copy)]
 enum FileChecksumResult {
     Ok,
@@ -234,6 +249,8 @@ enum FileChecksumResult {
 }
 
 impl FileChecksumResult {
+    /// Creates a `FileChecksumResult` from a digest comparison that
+    /// either succeeded or failed.
     fn from_bool(checksum_correct: bool) -> Self {
         if checksum_correct {
             FileChecksumResult::Ok
@@ -242,6 +259,8 @@ impl FileChecksumResult {
         }
     }
 
+    /// The cli options might prevent to display on the outcome of the
+    /// comparison on STDOUT.
     fn can_display(&self, opts: ChecksumOptions) -> bool {
         match self {
             FileChecksumResult::Ok => !opts.status && !opts.quiet,

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -92,6 +92,25 @@ impl From<ChecksumError> for LineCheckError {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
+enum FileCheckError {
+    UError(Box<dyn UError>),
+    NonCriticalError,
+    CriticalError,
+}
+
+impl From<Box<dyn UError>> for FileCheckError {
+    fn from(value: Box<dyn UError>) -> Self {
+        Self::UError(value)
+    }
+}
+
+impl From<ChecksumError> for FileCheckError {
+    fn from(value: ChecksumError) -> Self {
+        Self::UError(Box::new(value))
+    }
+}
+
 /// This struct regroups CLI flags.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ChecksumOptions {
@@ -656,6 +675,104 @@ fn process_checksum_line(
     Ok(())
 }
 
+fn process_checksum_file(
+    filename_input: &OsStr,
+    cli_algo_name: Option<&str>,
+    cli_algo_length: Option<usize>,
+    opts: ChecksumOptions,
+) -> Result<(), FileCheckError> {
+    let mut correct_format = 0;
+    let mut properly_formatted = false;
+    let mut res = ChecksumResult::default();
+    let input_is_stdin = filename_input == OsStr::new("-");
+
+    let file: Box<dyn Read> = if input_is_stdin {
+        // Use stdin if "-" is specified
+        Box::new(stdin())
+    } else {
+        match get_input_file(filename_input) {
+            Ok(f) => f,
+            Err(e) => {
+                // Could not read the file, show the error and continue to the next file
+                show_error!("{e}");
+                set_exit_code(1);
+                return Err(FileCheckError::NonCriticalError);
+            }
+        }
+    };
+
+    let reader = BufReader::new(file);
+    let lines = read_os_string_lines(reader).collect::<Vec<_>>();
+
+    let Some((chosen_regex, is_algo_based_format)) = determine_regex(&lines) else {
+        let e = ChecksumError::NoProperlyFormattedChecksumLinesFound {
+            filename: get_filename_for_output(filename_input, input_is_stdin),
+        };
+        show_error!("{e}");
+        set_exit_code(1);
+        return Err(FileCheckError::NonCriticalError);
+    };
+
+    for (i, line) in lines.iter().enumerate() {
+        match process_checksum_line(
+            filename_input,
+            line,
+            i,
+            &chosen_regex,
+            is_algo_based_format,
+            &mut res,
+            cli_algo_name,
+            cli_algo_length,
+            &mut properly_formatted,
+            &mut correct_format,
+            opts,
+        ) {
+            Ok(_) => (),
+            Err(LineCheckError::UError(e)) => return Err(e.into()),
+        };
+    }
+
+    // not a single line correctly formatted found
+    // return an error
+    if !properly_formatted {
+        if !opts.status {
+            return Err(ChecksumError::NoProperlyFormattedChecksumLinesFound {
+                filename: get_filename_for_output(filename_input, input_is_stdin),
+            }
+            .into());
+        }
+        set_exit_code(1);
+        return Err(FileCheckError::CriticalError);
+    }
+
+    // if any incorrectly formatted line, show it
+    cksum_output(&res, opts.status);
+
+    if opts.ignore_missing && correct_format == 0 {
+        // we have only bad format
+        // and we had ignore-missing
+        eprintln!(
+            "{}: {}: no file was verified",
+            util_name(),
+            filename_input.maybe_quote(),
+        );
+        set_exit_code(1);
+    }
+
+    // strict means that we should have an exit code.
+    if opts.strict && res.bad_format > 0 {
+        set_exit_code(1);
+    }
+
+    // if we have any failed checksum verification, we set an exit code
+    // except if we have ignore_missing
+    if (res.failed_cksum > 0 || res.failed_open_file > 0) && !opts.ignore_missing {
+        set_exit_code(1);
+    }
+
+    Ok(())
+}
+
 /***
  * Do the checksum validation (can be strict or not)
 */
@@ -670,94 +787,11 @@ where
 {
     // if cksum has several input files, it will print the result for each file
     for filename_input in files {
-        let mut correct_format = 0;
-        let mut properly_formatted = false;
-        let mut res = ChecksumResult::default();
-        let input_is_stdin = filename_input == OsStr::new("-");
-
-        let file: Box<dyn Read> = if input_is_stdin {
-            // Use stdin if "-" is specified
-            Box::new(stdin())
-        } else {
-            match get_input_file(filename_input) {
-                Ok(f) => f,
-                Err(e) => {
-                    // Could not read the file, show the error and continue to the next file
-                    show_error!("{e}");
-                    set_exit_code(1);
-                    continue;
-                }
-            }
-        };
-
-        let reader = BufReader::new(file);
-        let lines = read_os_string_lines(reader).collect::<Vec<_>>();
-
-        let Some((chosen_regex, is_algo_based_format)) = determine_regex(&lines) else {
-            let e = ChecksumError::NoProperlyFormattedChecksumLinesFound {
-                filename: get_filename_for_output(filename_input, input_is_stdin),
-            };
-            show_error!("{e}");
-            set_exit_code(1);
-            continue;
-        };
-
-        for (i, line) in lines.iter().enumerate() {
-            match process_checksum_line(
-                filename_input,
-                line,
-                i,
-                &chosen_regex,
-                is_algo_based_format,
-                &mut res,
-                algo_name_input,
-                length_input,
-                &mut properly_formatted,
-                &mut correct_format,
-                opts,
-            ) {
-                Ok(_) => (),
-                Err(LineCheckError::UError(e)) => return Err(e),
-            };
-        }
-
-        // not a single line correctly formatted found
-        // return an error
-        if !properly_formatted {
-            if !opts.status {
-                return Err(ChecksumError::NoProperlyFormattedChecksumLinesFound {
-                    filename: get_filename_for_output(filename_input, input_is_stdin),
-                }
-                .into());
-            }
-            set_exit_code(1);
-
-            return Ok(());
-        }
-
-        // if any incorrectly formatted line, show it
-        cksum_output(&res, opts.status);
-
-        if opts.ignore_missing && correct_format == 0 {
-            // we have only bad format
-            // and we had ignore-missing
-            eprintln!(
-                "{}: {}: no file was verified",
-                util_name(),
-                filename_input.maybe_quote(),
-            );
-            set_exit_code(1);
-        }
-
-        // strict means that we should have an exit code.
-        if opts.strict && res.bad_format > 0 {
-            set_exit_code(1);
-        }
-
-        // if we have any failed checksum verification, we set an exit code
-        // except if we have ignore_missing
-        if (res.failed_cksum > 0 || res.failed_open_file > 0) && !opts.ignore_missing {
-            set_exit_code(1);
+        use FileCheckError::*;
+        match process_checksum_file(filename_input, algo_name_input, length_input, opts) {
+            Err(UError(e)) => return Err(e),
+            Err(CriticalError) => break,
+            Err(NonCriticalError) | Ok(_) => continue,
         }
     }
 

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -75,6 +75,23 @@ struct ChecksumResult {
     pub failed_open_file: i32,
 }
 
+enum LineCheckError {
+    UError(Box<dyn UError>),
+    // ImproperlyFormatted,
+}
+
+impl From<Box<dyn UError>> for LineCheckError {
+    fn from(value: Box<dyn UError>) -> Self {
+        Self::UError(value)
+    }
+}
+
+impl From<ChecksumError> for LineCheckError {
+    fn from(value: ChecksumError) -> Self {
+        Self::UError(Box::new(value))
+    }
+}
+
 /// This struct regroups CLI flags.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ChecksumOptions {
@@ -513,6 +530,132 @@ fn identify_algo_name_and_length(
     Some((algorithm, bits))
 }
 
+#[allow(clippy::too_many_arguments)]
+fn process_checksum_line(
+    filename_input: &OsStr,
+    line: &OsStr,
+    i: usize,
+    chosen_regex: &Regex,
+    is_algo_based_format: bool,
+    res: &mut ChecksumResult,
+    cli_algo_name: Option<&str>,
+    cli_algo_length: Option<usize>,
+    properly_formatted: &mut bool,
+    correct_format: &mut usize,
+    opts: ChecksumOptions,
+) -> Result<(), LineCheckError> {
+    let line_bytes = os_str_as_bytes(line)?;
+    if let Some(caps) = chosen_regex.captures(line_bytes) {
+        *properly_formatted = true;
+
+        let mut filename_to_check = caps.name("filename").unwrap().as_bytes();
+
+        if filename_to_check.starts_with(b"*")
+            && i == 0
+            && chosen_regex.as_str() == SINGLE_SPACE_REGEX
+        {
+            // Remove the leading asterisk if present - only for the first line
+            filename_to_check = &filename_to_check[1..];
+        }
+
+        let expected_checksum = get_expected_checksum(filename_to_check, &caps, chosen_regex)?;
+
+        // If the algo_name is provided, we use it, otherwise we try to detect it
+        let (algo_name, length) = if is_algo_based_format {
+            identify_algo_name_and_length(&caps, cli_algo_name, res, properly_formatted)
+                .unwrap_or((String::new(), None))
+        } else if let Some(a) = cli_algo_name {
+            // When a specific algorithm name is input, use it and use the provided bits
+            // except when dealing with blake2b, where we will detect the length
+            if cli_algo_name == Some(ALGORITHM_OPTIONS_BLAKE2B) {
+                // division by 2 converts the length of the Blake2b checksum from hexadecimal
+                // characters to bytes, as each byte is represented by two hexadecimal characters.
+                let length = Some(expected_checksum.len() / 2);
+                (ALGORITHM_OPTIONS_BLAKE2B.to_string(), length)
+            } else {
+                (a.to_lowercase(), cli_algo_length)
+            }
+        } else {
+            // Default case if no algorithm is specified and non-algo based format is matched
+            (String::new(), None)
+        };
+
+        if algo_name.is_empty() {
+            // we haven't been able to detect the algo name. No point to continue
+            *properly_formatted = false;
+
+            // TODO: return error?
+            return Ok(());
+        }
+        let mut algo = detect_algo(&algo_name, length)?;
+
+        let (filename_to_check_unescaped, prefix) = unescape_filename(filename_to_check);
+
+        let real_filename_to_check = os_str_from_bytes(&filename_to_check_unescaped)?;
+
+        // manage the input file
+        let file_to_check =
+            match get_file_to_check(&real_filename_to_check, opts.ignore_missing, res) {
+                Some(file) => file,
+                // TODO: return error?
+                None => return Ok(()),
+            };
+        let mut file_reader = BufReader::new(file_to_check);
+        // Read the file and calculate the checksum
+        let create_fn = &mut algo.create_fn;
+        let mut digest = create_fn();
+        let (calculated_checksum, _) =
+            digest_reader(&mut digest, &mut file_reader, opts.binary, algo.bits).unwrap();
+
+        // Do the checksum validation
+        if expected_checksum == calculated_checksum {
+            if !opts.quiet && !opts.status {
+                print_file_report(
+                    std::io::stdout(),
+                    filename_to_check,
+                    FileChecksumResult::Ok,
+                    prefix,
+                );
+            }
+            *correct_format += 1;
+        } else {
+            if !opts.status {
+                print_file_report(
+                    std::io::stdout(),
+                    filename_to_check,
+                    FileChecksumResult::Failed,
+                    prefix,
+                );
+            }
+            res.failed_cksum += 1;
+        }
+    } else {
+        if line.is_empty() || line_bytes.starts_with(b"#") {
+            // Don't show any warning for empty or commented lines.
+
+            // TODO: return error?
+            return Ok(());
+        }
+        if opts.warn {
+            let algo = if let Some(algo_name_input) = cli_algo_name {
+                algo_name_input.to_uppercase()
+            } else {
+                "Unknown algorithm".to_string()
+            };
+            eprintln!(
+                "{}: {}: {}: improperly formatted {} checksum line",
+                util_name(),
+                &filename_input.maybe_quote(),
+                i + 1,
+                algo
+            );
+        }
+
+        res.bad_format += 1;
+    }
+    Ok(())
+}
+
 /***
  * Do the checksum validation (can be strict or not)
 */
@@ -560,117 +703,22 @@ where
         };
 
         for (i, line) in lines.iter().enumerate() {
-            let line_bytes = os_str_as_bytes(line)?;
-            if let Some(caps) = chosen_regex.captures(line_bytes) {
-                properly_formatted = true;
-
-                let mut filename_to_check = caps.name("filename").unwrap().as_bytes();
-
-                if filename_to_check.starts_with(b"*")
-                    && i == 0
-                    && chosen_regex.as_str() == SINGLE_SPACE_REGEX
-                {
-                    // Remove the leading asterisk if present - only for the first line
-                    filename_to_check = &filename_to_check[1..];
-                }
-
-                let expected_checksum =
-                    get_expected_checksum(filename_to_check, &caps, &chosen_regex)?;
-
-                // If the algo_name is provided, we use it, otherwise we try to detect it
-                let (algo_name, length) = if is_algo_based_format {
-                    identify_algo_name_and_length(
-                        &caps,
-                        algo_name_input,
-                        &mut res,
-                        &mut properly_formatted,
-                    )
-                    .unwrap_or((String::new(), None))
-                } else if let Some(a) = algo_name_input {
-                    // When a specific algorithm name is input, use it and use the provided bits
-                    // except when dealing with blake2b, where we will detect the length
-                    if algo_name_input == Some(ALGORITHM_OPTIONS_BLAKE2B) {
-                        // division by 2 converts the length of the Blake2b checksum from hexadecimal
-                        // characters to bytes, as each byte is represented by two hexadecimal characters.
-                        let length = Some(expected_checksum.len() / 2);
-                        (ALGORITHM_OPTIONS_BLAKE2B.to_string(), length)
-                    } else {
-                        (a.to_lowercase(), length_input)
-                    }
-                } else {
-                    // Default case if no algorithm is specified and non-algo based format is matched
-                    (String::new(), None)
-                };
-
-                if algo_name.is_empty() {
-                    // we haven't been able to detect the algo name. No point to continue
-                    properly_formatted = false;
-                    continue;
-                }
-                let mut algo = detect_algo(&algo_name, length)?;
-
-                let (filename_to_check_unescaped, prefix) = unescape_filename(filename_to_check);
-
-                let real_filename_to_check = os_str_from_bytes(&filename_to_check_unescaped)?;
-
-                // manage the input file
-                let file_to_check =
-                    match get_file_to_check(&real_filename_to_check, opts.ignore_missing, &mut res)
-                    {
-                        Some(file) => file,
-                        None => continue,
-                    };
-                let mut file_reader = BufReader::new(file_to_check);
-                // Read the file and calculate the checksum
-                let create_fn = &mut algo.create_fn;
-                let mut digest = create_fn();
-                let (calculated_checksum, _) =
-                    digest_reader(&mut digest, &mut file_reader, opts.binary, algo.bits).unwrap();
-
-                // Do the checksum validation
-                if expected_checksum == calculated_checksum {
-                    if !opts.quiet && !opts.status {
-                        print_file_report(
-                            std::io::stdout(),
-                            filename_to_check,
-                            FileChecksumResult::Ok,
-                            prefix,
-                        );
-                    }
-                    correct_format += 1;
-                } else {
-                    if !opts.status {
-                        print_file_report(
-                            std::io::stdout(),
-                            filename_to_check,
-                            FileChecksumResult::Failed,
-                            prefix,
-                        );
-                    }
-                    res.failed_cksum += 1;
-                }
-            } else {
-                if line.is_empty() || line_bytes.starts_with(b"#") {
-                    // Don't show any warning for empty or commented lines.
-                    continue;
-                }
-                if opts.warn {
-                    let algo = if let Some(algo_name_input) = algo_name_input {
-                        algo_name_input.to_uppercase()
-                    } else {
-                        "Unknown algorithm".to_string()
-                    };
-                    eprintln!(
-                        "{}: {}: {}: improperly formatted {} checksum line",
-                        util_name(),
-                        &filename_input.maybe_quote(),
-                        i + 1,
-                        algo
-                    );
-                }
-
-                res.bad_format += 1;
-            }
+            match process_checksum_line(
+                filename_input,
+                line,
+                i,
+                &chosen_regex,
+                is_algo_based_format,
+                &mut res,
+                algo_name_input,
+                length_input,
+                &mut properly_formatted,
+                &mut correct_format,
+                opts,
+            ) {
+                Ok(_) => (),
+                Err(LineCheckError::UError(e)) => return Err(e),
+            };
         }
 
         // not a single line correctly formatted found


### PR DESCRIPTION
Now that #6782, #6793 and #6815 have landed, it is time to achieve the rework of `checksum.rs` started in #6654.

This will allow us to fix #6572, #6614 and #6653.

This PR mainly tries to split the massive `perform_checksum_verification` in smaller functions, and to get rid of the `&mut ChecksumResult` that is passed everywhere, which makes it very difficult to understand where the global state of the program is modified.

Also, it adds ignored tests for future features (it will prevent too many conflicts when rebasing future PRs on each other).

Next PRs will focus on reworking the algorithm detection behavior, in particular for blake2b size guessing,
Regex detection behavior which for now prevents us from encountering both hexa and base64 digits in the same file.