### PR TITLE
cp: normalize path when checking for duplicate source

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1266,7 +1266,15 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
     for source in sources {
         let normalized_source = normalize_path(source);
         if options.backup == BackupMode::NoBackup && seen_sources.contains(&normalized_source) {
-            show_warning!("source file {} specified more than once", source.quote());
+            let file_type = if source.symlink_metadata()?.file_type().is_dir() {
+                "directory"
+            } else {
+                "file"
+            };
+            show_warning!(
+                "source {file_type} {} specified more than once",
+                source.quote()
+            );
         } else {
             let dest = construct_dest_path(source, target, target_type, options)
                 .unwrap_or_else(|_| target.to_path_buf());

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1265,7 +1265,7 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
 
     for source in sources {
         let normalized_source = normalize_path(source);
-        if seen_sources.contains(&normalized_source) {
+        if options.backup == BackupMode::NoBackup && seen_sources.contains(&normalized_source) {
             show_warning!("source file {} specified more than once", source.quote());
         } else {
             let dest = construct_dest_path(source, target, target_type, options)

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -120,6 +120,7 @@ fn test_cp_duplicate_files() {
         ));
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 }
+
 #[test]
 fn test_cp_duplicate_folder() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -133,6 +134,7 @@ fn test_cp_duplicate_folder() {
         ));
     assert!(at.dir_exists(format!("{TEST_COPY_TO_FOLDER}/{TEST_COPY_FROM_FOLDER}").as_str()));
 }
+
 #[test]
 fn test_cp_duplicate_files_normalized_path() {
     let (at, mut ucmd) = at_and_ucmd!();

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -120,7 +120,19 @@ fn test_cp_duplicate_files() {
         ));
     assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
 }
-
+#[test]
+fn test_cp_duplicate_folder() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.arg("-r")
+        .arg(TEST_COPY_FROM_FOLDER)
+        .arg(TEST_COPY_FROM_FOLDER)
+        .arg(TEST_COPY_TO_FOLDER)
+        .succeeds()
+        .stderr_contains(format!(
+            "source directory '{TEST_COPY_FROM_FOLDER}' specified more than once"
+        ));
+    assert!(at.dir_exists(format!("{TEST_COPY_TO_FOLDER}/{TEST_COPY_FROM_FOLDER}").as_str()));
+}
 #[test]
 fn test_cp_duplicate_files_normalized_path() {
     let (at, mut ucmd) = at_and_ucmd!();

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -135,6 +135,33 @@ fn test_cp_duplicate_files_normalized_path() {
 }
 
 #[test]
+fn test_cp_duplicate_files_with_plain_backup() {
+    let (_, mut ucmd) = at_and_ucmd!();
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_COPY_TO_FOLDER)
+        .arg("--backup")
+        .fails()
+        // cp would skip duplicate src check and fail when it tries to overwrite the "just-created" file.
+        .stderr_contains(
+            "will not overwrite just-created 'hello_dir/hello_world.txt' with 'hello_world.txt",
+        );
+}
+
+#[test]
+fn test_cp_duplicate_files_with_numbered_backup() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    // cp would skip duplicate src check and succeeds
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(TEST_COPY_TO_FOLDER)
+        .arg("--backup=numbered")
+        .succeeds();
+    at.file_exists(TEST_COPY_TO_FOLDER_FILE);
+    at.file_exists(format!("{TEST_COPY_TO_FOLDER}.~1~"));
+}
+
+#[test]
 fn test_cp_same_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "a";

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -122,6 +122,19 @@ fn test_cp_duplicate_files() {
 }
 
 #[test]
+fn test_cp_duplicate_files_normalized_path() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg(format!("./{TEST_HELLO_WORLD_SOURCE}"))
+        .arg(TEST_COPY_TO_FOLDER)
+        .succeeds()
+        .stderr_contains(format!(
+            "source file './{TEST_HELLO_WORLD_SOURCE}' specified more than once"
+        ));
+    assert_eq!(at.read(TEST_COPY_TO_FOLDER_FILE), "Hello, World!\n");
+}
+
+#[test]
 fn test_cp_same_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "a";


### PR DESCRIPTION
Fixes #6824, #6827, #6832
