### PR TITLE
mkdir: allow --parent to be provided more than once

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -114,6 +114,7 @@ pub fn uu_app() -> Command {
                 .short('p')
                 .long(options::PARENTS)
                 .help("make parent directories as needed")
+                .overrides_with(options::PARENTS)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -61,9 +61,21 @@ fn test_mkdir_parent() {
     let test_dir = "parent_dir/child_dir";
 
     scene.ucmd().arg("-p").arg(test_dir).succeeds();
-    scene.ucmd().arg("-p").arg(test_dir).succeeds();
+    scene.ucmd().arg("-p").arg("-p").arg(test_dir).succeeds();
     scene.ucmd().arg("--parent").arg(test_dir).succeeds();
+    scene
+        .ucmd()
+        .arg("--parent")
+        .arg("--parent")
+        .arg(test_dir)
+        .succeeds();
     scene.ucmd().arg("--parents").arg(test_dir).succeeds();
+    scene
+        .ucmd()
+        .arg("--parents")
+        .arg("--parents")
+        .arg(test_dir)
+        .succeeds();
 }
 
 #[test]


### PR DESCRIPTION
Make `--parent` overrides itself when provided more than once. Fixes #6828