### PR TITLE
du: Reuse existing metadata instead of calling path.is_dir() again

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -171,7 +171,7 @@ impl Stat {
             Ok(Self {
                 path: path.to_path_buf(),
                 is_dir: metadata.is_dir(),
-                size: if path.is_dir() { 0 } else { metadata.len() },
+                size: if metadata.is_dir() { 0 } else { metadata.len() },
                 blocks: metadata.blocks(),
                 inodes: 1,
                 inode: Some(file_info),
@@ -189,7 +189,7 @@ impl Stat {
             Ok(Self {
                 path: path.to_path_buf(),
                 is_dir: metadata.is_dir(),
-                size: if path.is_dir() { 0 } else { metadata.len() },
+                size: if metadata.is_dir() { 0 } else { metadata.len() },
                 blocks: size_on_disk / 1024 * 2,
                 inodes: 1,
                 inode: file_info,


### PR DESCRIPTION
`Path::is_dir` does another call to `stat` but we can reuse the metadata we already have.

Also `Path::is_dir` traverses symbolic links which is only right if `-L` was passed.

~1.13x speedup on my test directory.

### Before

```
> cargo build --release
> measure-command { .\target\release\coreutils.exe du --apparent-size "test folder" }
TotalSeconds      : 11.0101422
```

### After

```
> cargo build --release
> measure-command { .\target\release\coreutils.exe du --apparent-size "test folder" }
TotalSeconds      : 9.7109226
```
