### PR TITLE
ci: remove `-Zprofile`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -945,7 +945,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.job.toolchain }}
-        components: rustfmt
+        components: rustfmt, llvm-tools-preview
     - uses: taiki-e/install-action@nextest
     - uses: taiki-e/install-action@grcov
     - uses: Swatinem/rust-cache@v2
@@ -1000,6 +1000,7 @@ jobs:
           # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
           windows-latest) C:/msys64/usr/bin/pacman.exe -Sy --needed mingw-w64-x86_64-gcc --noconfirm ; echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH ;;
         esac
+        mkdir -p ${{ vars.RUNNER_TEMP }}/target/debug
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars
       shell: bash
@@ -1014,17 +1015,19 @@ jobs:
       run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
       env:
         RUSTC_WRAPPER: ""
-        RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        RUSTFLAGS: "-Cprofile-generate=${{ vars.RUNNER_TEMP }}/target/debug -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
         RUST_BACKTRACE: "1"
+        LLVM_PROFILE_FILE: "coreutils-%p-%m.profraw"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Test individual utilities
       run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
       env:
         RUSTC_WRAPPER: ""
-        RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        RUSTFLAGS: "-Cprofile-generate=${{ vars.RUNNER_TEMP }}/target/debug -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
         RUST_BACKTRACE: "1"
+        LLVM_PROFILE_FILE: "coreutils-%p-%m.profraw"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
     - name: Generate coverage data (via `grcov`)
       id: coverage
@@ -1037,9 +1040,9 @@ jobs:
         # GRCOV_EXCLUDE_OPTION='--excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"' ## `grcov` ignores these params when passed as an environment variable (why?)
         mkdir -p "${COVERAGE_REPORT_DIR}"
         # display coverage files
-        grcov . --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+        grcov . --binary-path="${COVERAGE_REPORT_DIR}" --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
         # generate coverage report
-        grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+        grcov . --binary-path="${COVERAGE_REPORT_DIR}" --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
         echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v4

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -936,8 +936,10 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: unix, toolchain: nightly }
-          - { os: macos-latest   , features: macos, toolchain: nightly }
+          - { os: ubuntu-latest  , features: "feat_Tier1,feat_require_unix,feat_require_unix_utmpx", toolchain: nightly }
+          - { os: macos-latest  , features: "feat_Tier1,feat_require_unix,feat_require_unix_utmpx", toolchain: nightly }
+          #- { os: ubuntu-latest  , features: unix, toolchain: nightly }
+          #- { os: macos-latest   , features: macos, toolchain: nightly }
           # FIXME: Re-enable Code Coverage on windows, which currently fails due to "profiler_builtins". See #6686.
           # - { os: windows-latest , features: windows, toolchain: nightly-x86_64-pc-windows-gnu }
     steps:
@@ -945,9 +947,9 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.job.toolchain }}
-        components: rustfmt, llvm-tools-preview
+        components: rustfmt
     - uses: taiki-e/install-action@nextest
-    - uses: taiki-e/install-action@grcov
+    #    - uses: taiki-e/install-action@grcov
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.6
@@ -1000,7 +1002,6 @@ jobs:
           # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
           windows-latest) C:/msys64/usr/bin/pacman.exe -Sy --needed mingw-w64-x86_64-gcc --noconfirm ; echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH ;;
         esac
-        mkdir -p ${{ vars.RUNNER_TEMP }}/target/debug
     - name: Initialize toolchain-dependent workflow variables
       id: dep_vars
       shell: bash
@@ -1011,39 +1012,44 @@ jobs:
         UTILITY_LIST="$(./util/show-utils.sh ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }})"
         CARGO_UTILITY_LIST_OPTIONS="$(for u in ${UTILITY_LIST}; do echo -n "-puu_${u} "; done;)"
         outputs CARGO_UTILITY_LIST_OPTIONS
-    - name: Test
-      run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
-      env:
-        RUSTC_WRAPPER: ""
-        RUSTFLAGS: "-Cprofile-generate=${{ vars.RUNNER_TEMP }}/target/debug -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
-        RUSTDOCFLAGS: "-Cpanic=abort"
-        RUST_BACKTRACE: "1"
-        LLVM_PROFILE_FILE: "coreutils-%p-%m.profraw"
+        #    - name: Test
+        #run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -p uucore -p coreutils
+        #env:
+        #RUSTC_WRAPPER: ""
+        #RUSTFLAGS: "-Cprofile-generate=${{ vars.RUNNER_TEMP }}/target/debug -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        #RUSTDOCFLAGS: "-Cpanic=abort"
+        #RUST_BACKTRACE: "1"
+        #LLVM_PROFILE_FILE: "coreutils-%p-%m.profraw"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
-    - name: Test individual utilities
-      run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
-      env:
-        RUSTC_WRAPPER: ""
-        RUSTFLAGS: "-Cprofile-generate=${{ vars.RUNNER_TEMP }}/target/debug -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
-        RUSTDOCFLAGS: "-Cpanic=abort"
-        RUST_BACKTRACE: "1"
-        LLVM_PROFILE_FILE: "coreutils-%p-%m.profraw"
+        #- name: Test individual utilities
+        #run: cargo nextest run --profile ci --hide-progress-bar ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
+        #env:
+        #RUSTC_WRAPPER: ""
+        #RUSTFLAGS: "-Cprofile-generate=${{ vars.RUNNER_TEMP }}/target/debug -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        #RUSTDOCFLAGS: "-Cpanic=abort"
+        #RUST_BACKTRACE: "1"
+        #LLVM_PROFILE_FILE: "coreutils-%p-%m.profraw"
         # RUSTUP_TOOLCHAIN: ${{ steps.vars.outputs.TOOLCHAIN }}
-    - name: Generate coverage data (via `grcov`)
-      id: coverage
-      shell: bash
-      run: |
+        #- name: Generate coverage data (via `grcov`)
+        #id: coverage
+        #shell: bash
+        #run: |
         ## Generate coverage data
-        COVERAGE_REPORT_DIR="target/debug"
-        COVERAGE_REPORT_FILE="${COVERAGE_REPORT_DIR}/lcov.info"
+        #COVERAGE_REPORT_DIR="target/debug"
+        #COVERAGE_REPORT_FILE="${COVERAGE_REPORT_DIR}/lcov.info"
         # GRCOV_IGNORE_OPTION='--ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*"' ## `grcov` ignores these params when passed as an environment variable (why?)
         # GRCOV_EXCLUDE_OPTION='--excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"' ## `grcov` ignores these params when passed as an environment variable (why?)
-        mkdir -p "${COVERAGE_REPORT_DIR}"
+        # mkdir -p "${COVERAGE_REPORT_DIR}"
         # display coverage files
-        grcov . --binary-path="${COVERAGE_REPORT_DIR}" --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+        #grcov . --binary-path="${COVERAGE_REPORT_DIR}" --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
         # generate coverage report
-        grcov . --binary-path="${COVERAGE_REPORT_DIR}" --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
-        echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
+        #grcov . --binary-path="${COVERAGE_REPORT_DIR}" --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+        #echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Generate code coverage
+      run: cargo llvm-cov nextest ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --lcov --branch --output-path lcov.info -p uucore -p coreutils
+      #run: cargo llvm-cov --all-features --lcov --branch --output-path lcov.info --ignore-filename-regex build
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -383,7 +383,7 @@ jobs:
         locale -a
     - name: Build binaries
       env:
-        RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        RUSTFLAGS: "-Cprofile-generate=uutils/target/debug -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         RUSTDOCFLAGS: "-Cpanic=abort"
       run: |
         ## Build binaries
@@ -391,6 +391,8 @@ jobs:
         bash util/build-gnu.sh
     - name: Run GNU tests
       run: bash uutils/util/run-gnu-test.sh
+    - name: Install llvm-tools-preview
+      run: rustup component add llvm-tools-preview
     - name: Generate coverage data (via `grcov`)
       id: coverage
       run: |
@@ -401,9 +403,9 @@ jobs:
         mkdir -p "${COVERAGE_REPORT_DIR}"
         sudo chown -R "$(whoami)" "${COVERAGE_REPORT_DIR}"
         # display coverage files
-        grcov . --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+        grcov . --binary-path="${COVERAGE_REPORT_DIR}" --output-type files --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
         # generate coverage report
-        grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+        grcov . --binary-path="{COVERAGE_REPORT_DIR}" --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "vendor/*" --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
         echo "report=${COVERAGE_REPORT_FILE}" >> $GITHUB_OUTPUT
     - name: Upload coverage results (to Codecov.io)
       uses: codecov/codecov-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "dlv-list"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d529fd73d344663edfd598ccb3f344e46034db51ebd103518eae34338248ad73"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]


### PR DESCRIPTION
The code coverage jobs currently fail with the following error:
```
error: unknown unstable option: `profile`
```
The reason is that the support for `-Zprofile` has been removed in https://github.com/rust-lang/rust/pull/131829

This PR removes `-Zprofile`, though probably more work is necessary.