### PR TITLE
sort: enable clippy::suspicious_open_options on OpenBSD

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -258,9 +258,7 @@ impl Output {
         let file = if let Some(name) = name {
             // This is different from `File::create()` because we don't truncate the output yet.
             // This allows using the output file as an input file.
-            // clippy::suspicious_open_options supported only for Rust >= 1.77.0
-            // Rust version = 1.76 on OpenBSD stable/7.5
-            #[cfg_attr(not(target_os = "openbsd"), allow(clippy::suspicious_open_options))]
+            #[allow(clippy::suspicious_open_options)]
             let file = OpenOptions::new()
                 .write(true)
                 .create(true)


### PR DESCRIPTION
On OpenBSD 7.6 (release October 2024), Rust version = 1.81.0 => we can now enable `clippy::suspicious_open_options` for lint with `clippy`.

Revert commit ee4392e30cfdcd4c464b0faa0af1ed79d8c0a752

---
Tests OK with clippy (Rust 1.81 on OpenBSD 7.6) for `sort`:
```bash
$ cargo clippy --all-targets -puu_sort -- -W clippy::manual_string_new -D warnings
(...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.61s
```