### PR TITLE
mv: fix the output of an error message

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -488,7 +488,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, options: &Options) 
                     format!(
                         "cannot move '{}' to a subdirectory of itself, '{}/{}'",
                         sourcepath.display(),
-                        target_dir.display(),
+                        uucore::fs::normalize_path(target_dir).display(),
                         canonicalized_target_dir.components().last().map_or_else(
                             || target_dir.display().to_string(),
                             |dir| { PathBuf::from(dir.as_os_str()).display().to_string() }

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1732,3 +1732,23 @@ fn test_mv_error_msg_with_multiple_sources_that_does_not_exist() {
         .stderr_contains("mv: cannot stat 'a': No such file or directory")
         .stderr_contains("mv: cannot stat 'b/': No such file or directory");
 }
+
+#[test]
+fn test_mv_error_cant_move_itself() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("b");
+    scene
+        .ucmd()
+        .arg("b")
+        .arg("b/")
+        .fails()
+        .stderr_contains("mv: cannot move 'b' to a subdirectory of itself, 'b/b'");
+    scene
+        .ucmd()
+        .arg("./b")
+        .arg("b")
+        .arg("b/")
+        .fails()
+        .stderr_contains("mv: cannot move 'b' to a subdirectory of itself, 'b/b'");
+}

--- a/util/gnu-patches/tests_dup_source.patch
+++ b/util/gnu-patches/tests_dup_source.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/mv/dup-source.sh b/tests/mv/dup-source.sh
+index 7bcd82fc3..0f9005296 100755
+--- a/tests/mv/dup-source.sh
++++ b/tests/mv/dup-source.sh
+@@ -83,7 +83,7 @@ $i: cannot stat 'a': No such file or directory
+ $i: cannot stat 'a': No such file or directory
+ $i: cannot stat 'b': No such file or directory
+ $i: cannot move './b' to a subdirectory of itself, 'b/b'
+-$i: warning: source directory 'b' specified more than once
++$i: cannot move 'b' to a subdirectory of itself, 'b/b'
+ EOF
+   compare exp out || fail=1
+ done


### PR DESCRIPTION
+ adjust a GNU test

Should make tests/mv/dup-source.sh pass