### PR TITLE
checksum: Further rework

### DIFF
--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -1056,7 +1056,7 @@ mod tests {
         ];
 
         for (input, expected) in test_cases {
-            let captures = algo_based_regex.captures(*input);
+            let captures = algo_based_regex.captures(input);
             match expected {
                 Some((algo, bits, filename, checksum)) => {
                     assert!(captures.is_some());
@@ -1206,7 +1206,7 @@ mod tests {
 
         // Test leading space before checksum line
         let lines_algo_based_leading_space =
-            vec!["   MD5 (example.txt) = d41d8cd98f00b204e9800998ecf8427e"]
+            ["   MD5 (example.txt) = d41d8cd98f00b204e9800998ecf8427e"]
                 .iter()
                 .map(|s| OsString::from(s.to_string()))
                 .collect::<Vec<_>>();
@@ -1216,7 +1216,7 @@ mod tests {
 
         // Test trailing space after checksum line (should fail)
         let lines_algo_based_leading_space =
-            vec!["MD5 (example.txt) = d41d8cd98f00b204e9800998ecf8427e "]
+            ["MD5 (example.txt) = d41d8cd98f00b204e9800998ecf8427e "]
                 .iter()
                 .map(|s| OsString::from(s.to_string()))
                 .collect::<Vec<_>>();

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -468,8 +468,12 @@ fn get_expected_digest_as_hex_string(caps: &Captures, chosen_regex: &Regex) -> O
 
     if chosen_regex.as_str() == ALGO_BASED_REGEX_BASE64 {
         BASE64.decode(ck).map(hex::encode).ok()
-    } else {
+    } else if ck.len() % 2 == 0 {
         Some(str::from_utf8(ck).unwrap().to_string())
+    } else {
+        // If the length of the digest is not a multiple of 2, then it
+        // must be improperly formatted (1 hex digit is 2 characters)
+        None
     }
 }
 

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1251,33 +1251,6 @@ fn test_several_files_error_mgmt() {
         .stderr_contains("incorrect: no properly ");
 }
 
-#[cfg(target_os = "linux")]
-#[test]
-fn test_non_utf8_filename() {
-    use std::ffi::OsString;
-    use std::os::unix::ffi::OsStringExt;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-    let filename: OsString = OsStringExt::from_vec(b"funky\xffname".to_vec());
-
-    at.touch(&filename);
-
-    scene
-        .ucmd()
-        .arg(&filename)
-        .succeeds()
-        .stdout_is_bytes(b"4294967295 0 funky\xffname\n")
-        .no_stderr();
-    scene
-        .ucmd()
-        .arg("-asha256")
-        .arg(filename)
-        .succeeds()
-        .stdout_is_bytes(b"SHA256 (funky\xffname) = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n")
-        .no_stderr();
-}
-
 #[test]
 fn test_check_comment_line() {
     // A comment in a checksum file shall be discarded unnoticed.
@@ -1458,7 +1431,6 @@ mod check_utf8 {
             .no_stderr();
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
     fn test_check_non_utf8_filename() {
         use std::{ffi::OsString, os::unix::ffi::OsStringExt};


### PR DESCRIPTION
This PR further rework `checksum.rs` to get rid of entangled variable processing.

It also partly fixes #6576, for the case where the digest has an odd length (it may still fail in case the length is even but still wrong)