### PR TITLE
fix(deps): crates import compatible uucore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -354,10 +354,10 @@ blake3 = "1.5.1"
 sm3 = "0.4.2"
 digest = "0.10.7"
 
-uucore = { version = ">=0.0.19", package = "uucore", path = "src/uucore" }
-uucore_procs = { version = ">=0.0.19", package = "uucore_procs", path = "src/uucore_procs" }
-uu_ls = { version = ">=0.0.18", path = "src/uu/ls" }
-uu_base32 = { version = ">=0.0.18", path = "src/uu/base32" }
+uucore = { version = "0.0.28", package = "uucore", path = "src/uucore" }
+uucore_procs = { version = "0.0.28", package = "uucore_procs", path = "src/uucore_procs" }
+uu_ls = { version = "0.0.28", path = "src/uu/ls" }
+uu_base32 = { version = "0.0.28", path = "src/uu/base32" }
 
 [dependencies]
 clap = { workspace = true }


### PR DESCRIPTION
solving https://github.com/uutils/coreutils/issues/6867.

I have test-run the `util/update-version.sh` from 0.0.28 to 0.0.29 and it correctly identifies the four version strings and the resulting workspace passes all the `cargo test` cases.
