### PR TITLE
Bump MSRV to `1.77`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.70.0"
+msrv = "1.77.0"
 cognitive-complexity-threshold = 24
 missing-docs-in-crate-items = true
 check-private-items = true

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -11,7 +11,7 @@ env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"
   PROJECT_AUTH: "uutils"
-  RUST_MIN_SRV: "1.70.0"
+  RUST_MIN_SRV: "1.77.0"
   # * style job configuration
   STYLE_FAIL_ON_FAULT: true ## (bool) fail the build if a style job contains a fault (error or warning); may be overridden on a per-job basis
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/uutils/coreutils"
 readme = "README.md"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-rust-version = "1.70.0"
+rust-version = "1.77.0"
 edition = "2021"
 
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![dependency status](https://deps.rs/repo/github/uutils/coreutils/status.svg)](https://deps.rs/repo/github/uutils/coreutils)
 
 [![CodeCov](https://codecov.io/gh/uutils/coreutils/branch/master/graph/badge.svg)](https://codecov.io/gh/uutils/coreutils)
-![MSRV](https://img.shields.io/badge/MSRV-1.70.0-brightgreen)
+![MSRV](https://img.shields.io/badge/MSRV-1.77.0-brightgreen)
 
 </div>
 
@@ -70,7 +70,7 @@ the [coreutils docs](https://github.com/uutils/uutils.github.io) repository.
 ### Rust Version
 
 uutils follows Rust's release channels and is tested against stable, beta and
-nightly. The current Minimum Supported Rust Version (MSRV) is `1.70.0`.
+nightly. The current Minimum Supported Rust Version (MSRV) is `1.77.0`.
 
 ## Building
 

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -172,7 +172,7 @@ mod linux_only {
 
         let mut fds: [c_int; 2] = [0, 0];
         assert!(
-            (unsafe { libc::pipe(&mut fds as *mut c_int) } == 0),
+            (unsafe { libc::pipe(std::ptr::from_mut::<c_int>(&mut fds[0])) } == 0),
             "Failed to create pipe"
         );
 


### PR DESCRIPTION
This PR bumps the MSRV from `1.70` to `1.77`. I used `1.77` because of #6755. It also fixes a clippy error from the [ref_as_ptr](https://rust-lang.github.io/rust-clippy/master/index.html#ref_as_ptr) lint.