### PR TITLE
Bump `crossterm` from `0.27.0` to `0.28.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,16 +703,16 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "filedescriptor",
- "libc",
- "mio",
+ "mio 1.0.2",
  "parking_lot",
+ "rustix 0.38.40",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1140,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1436,6 +1436,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,7 +1483,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -2215,12 +2228,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.0.2",
  "signal-hook",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ clap_complete = "4.4"
 clap_mangen = "0.2"
 compare = "0.1.0"
 coz = { version = "0.1.3" }
-crossterm = ">=0.27.0"
+crossterm = "0.28.1"
 ctrlc = { version = "3.4.4", features = ["termination"] }
 dns-lookup = { version = "2.0.4" }
 exacl = "0.12.0"

--- a/deny.toml
+++ b/deny.toml
@@ -104,6 +104,8 @@ skip = [
   { name = "terminal_size", version = "0.2.6" },
   # ansi-width, console, os_display
   { name = "unicode-width", version = "0.1.13" },
+  # notify
+  { name = "mio", version = "0.8.11" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR bumps `crossterm` from `0.27.0` to `0.28.1` and adds `mio` to the skip list in `deny.toml`. This is another crate that seems to cause a problem with `renovate`.