### PR TITLE
Use `div_ceil()` from `std`

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -22,7 +22,7 @@ use uucore::{
     format_usage, help_about, help_section, help_usage,
     line_ending::LineEnding,
     os_str_as_bytes, show,
-    sum::{div_ceil, Digest},
+    sum::Digest,
 };
 
 const USAGE: &str = help_usage!("cksum.md");
@@ -124,7 +124,7 @@ where
                 format!(
                     "{} {}{}",
                     sum.parse::<u16>().unwrap(),
-                    div_ceil(sz, options.output_bits),
+                    sz.div_ceil(options.output_bits),
                     if not_file { "" } else { " " }
                 ),
                 !not_file,
@@ -134,7 +134,7 @@ where
                 format!(
                     "{:0bsd_width$} {:bsd_width$}{}",
                     sum.parse::<u16>().unwrap(),
-                    div_ceil(sz, options.output_bits),
+                    sz.div_ceil(options.output_bits),
                     if not_file { "" } else { " " }
                 ),
                 !not_file,

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -555,7 +555,7 @@ impl StatPrinter {
                 size,
                 uucore::format::human::SizeFormat::Binary,
             ),
-            SizeFormat::BlockSize(block_size) => div_ceil(size, block_size).to_string(),
+            SizeFormat::BlockSize(block_size) => size.div_ceil(block_size).to_string(),
         }
     }
 
@@ -574,13 +574,6 @@ impl StatPrinter {
 
         Ok(())
     }
-}
-
-// This can be replaced with u64::div_ceil once it is stabilized.
-// This implementation approach is optimized for when `b` is a constant,
-// particularly a power of two.
-pub fn div_ceil(a: u64, b: u64) -> u64 {
-    (a + b - 1) / b
 }
 
 // Read file paths from the specified file, separated by null characters

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -16,13 +16,6 @@ use uucore::{format_usage, help_about, help_usage, show};
 const USAGE: &str = help_usage!("sum.md");
 const ABOUT: &str = help_about!("sum.md");
 
-// This can be replaced with usize::div_ceil once it is stabilized.
-// This implementation approach is optimized for when `b` is a constant,
-// particularly a power of two.
-const fn div_ceil(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
-}
-
 fn bsd_sum(mut reader: Box<dyn Read>) -> (usize, u16) {
     let mut buf = [0; 4096];
     let mut bytes_read = 0;
@@ -41,7 +34,7 @@ fn bsd_sum(mut reader: Box<dyn Read>) -> (usize, u16) {
     }
 
     // Report blocks read in terms of 1024-byte blocks.
-    let blocks_read = div_ceil(bytes_read, 1024);
+    let blocks_read = bytes_read.div_ceil(1024);
     (blocks_read, checksum)
 }
 
@@ -66,7 +59,7 @@ fn sysv_sum(mut reader: Box<dyn Read>) -> (usize, u16) {
     ret = (ret & 0xffff) + (ret >> 16);
 
     // Report blocks read in terms of 512-byte blocks.
-    let blocks_read = div_ceil(bytes_read, 512);
+    let blocks_read = bytes_read.div_ceil(512);
     (blocks_read, ret as u16)
 }
 

--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -207,13 +207,6 @@ impl Digest for CRC {
     }
 }
 
-// This can be replaced with usize::div_ceil once it is stabilized.
-// This implementation approach is optimized for when `b` is a constant,
-// particularly a power of two.
-pub fn div_ceil(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
-}
-
 pub struct BSD {
     state: u16,
 }


### PR DESCRIPTION
With the recent bump of our MSRV to `1.77` we are able to use `div_ceil()` from `std`. And so this PR removes our implementations of `div_ceil()` and uses `div_ceil()` from `std` instead.