### PR TITLE
mv: remove `sleep` in tests

### DIFF
--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -6,8 +6,7 @@
 // spell-checker:ignore mydir
 use crate::common::util::TestScenario;
 use filetime::FileTime;
-use std::thread::sleep;
-use std::time::Duration;
+use std::io::Write;
 
 #[test]
 fn test_mv_invalid_arg() {
@@ -974,9 +973,9 @@ fn test_mv_arg_update_older_dest_not_older() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1001,9 +1000,9 @@ fn test_mv_arg_update_none_then_all() {
     let old_content = "old content\n";
     let new_content = "new content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1029,9 +1028,9 @@ fn test_mv_arg_update_all_then_none() {
     let old_content = "old content\n";
     let new_content = "new content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1055,9 +1054,9 @@ fn test_mv_arg_update_older_dest_older() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1081,9 +1080,9 @@ fn test_mv_arg_update_short_overwrite() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 
@@ -1107,9 +1106,9 @@ fn test_mv_arg_update_short_no_overwrite() {
     let old_content = "file1 content\n";
     let new_content = "file2 content\n";
 
-    at.write(old, old_content);
-
-    sleep(Duration::from_secs(1));
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
 
     at.write(new, new_content);
 


### PR DESCRIPTION
So far `std::thread::sleep` was used in the tests to ensure that `fileA` is older than `fileB`. With this PR, the same is done by calling `set_modified` on the "older" file, thus speeding up the tests.