### PR TITLE
quoting_style: Add support for non-UTF-8 bytes

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.77.0"
+msrv = "1.79.0"
 cognitive-complexity-threshold = 24
 missing-docs-in-crate-items = true
 check-private-items = true

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -11,7 +11,7 @@ env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"
   PROJECT_AUTH: "uutils"
-  RUST_MIN_SRV: "1.77.0"
+  RUST_MIN_SRV: "1.79.0"
   # * style job configuration
   STYLE_FAIL_ON_FAULT: true ## (bool) fail the build if a style job contains a fault (error or warning); may be overridden on a per-job basis
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/uutils/coreutils"
 readme = "README.md"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-rust-version = "1.77.0"
+rust-version = "1.79.0"
 edition = "2021"
 
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![dependency status](https://deps.rs/repo/github/uutils/coreutils/status.svg)](https://deps.rs/repo/github/uutils/coreutils)
 
 [![CodeCov](https://codecov.io/gh/uutils/coreutils/branch/master/graph/badge.svg)](https://codecov.io/gh/uutils/coreutils)
-![MSRV](https://img.shields.io/badge/MSRV-1.77.0-brightgreen)
+![MSRV](https://img.shields.io/badge/MSRV-1.79.0-brightgreen)
 
 </div>
 
@@ -70,7 +70,7 @@ the [coreutils docs](https://github.com/uutils/uutils.github.io) repository.
 ### Rust Version
 
 uutils follows Rust's release channels and is tested against stable, beta and
-nightly. The current Minimum Supported Rust Version (MSRV) is `1.77.0`.
+nightly. The current Minimum Supported Rust Version (MSRV) is `1.79.0`.
 
 ## Building
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -13,7 +13,7 @@ mod word_count;
 use std::{
     borrow::{Borrow, Cow},
     cmp::max,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     fs::{self, File},
     io::{self, Write},
     iter,
@@ -28,7 +28,7 @@ use utf8::{BufReadDecoder, BufReadDecoderError};
 use uucore::{
     error::{FromIo, UError, UResult},
     format_usage, help_about, help_usage,
-    quoting_style::{escape_name, QuotingStyle},
+    quoting_style::{self, QuotingStyle},
     shortcut_value_parser::ShortcutValueParser,
     show,
 };
@@ -259,7 +259,7 @@ impl<'a> Input<'a> {
         match self {
             Self::Path(path) => Some(match path.to_str() {
                 Some(s) if !s.contains('\n') => Cow::Borrowed(s),
-                _ => Cow::Owned(escape_name(path.as_os_str(), QS_ESCAPE)),
+                _ => Cow::Owned(escape_name_wrapper(path.as_os_str())),
             }),
             Self::Stdin(StdinKind::Explicit) => Some(Cow::Borrowed(STDIN_REPR)),
             Self::Stdin(StdinKind::Implicit) => None,
@@ -269,7 +269,7 @@ impl<'a> Input<'a> {
     /// Converts input into the form that appears in errors.
     fn path_display(&self) -> String {
         match self {
-            Self::Path(path) => escape_name(path.as_os_str(), QS_ESCAPE),
+            Self::Path(path) => escape_name_wrapper(path.as_os_str()),
             Self::Stdin(_) => String::from("standard input"),
         }
     }
@@ -361,7 +361,7 @@ impl WcError {
             Some((input, idx)) => {
                 let path = match input {
                     Input::Stdin(_) => STDIN_REPR.into(),
-                    Input::Path(path) => escape_name(path.as_os_str(), QS_ESCAPE).into(),
+                    Input::Path(path) => escape_name_wrapper(path.as_os_str()).into(),
                 };
                 Self::ZeroLengthFileNameCtx { path, idx }
             }
@@ -761,7 +761,9 @@ fn files0_iter_file<'a>(path: &Path) -> UResult<impl Iterator<Item = InputIterIt
         Err(e) => Err(e.map_err_context(|| {
             format!(
                 "cannot open {} for reading",
-                escape_name(path.as_os_str(), QS_QUOTE_ESCAPE)
+                quoting_style::escape_name(path.as_os_str(), QS_QUOTE_ESCAPE)
+                    .into_string()
+                    .expect("All escaped names with the escaping option return valid strings.")
             )
         })),
     }
@@ -793,9 +795,9 @@ fn files0_iter<'a>(
                         Ok(Input::Path(PathBuf::from(s).into()))
                     }
                 }
-                Err(e) => Err(e.map_err_context(|| {
-                    format!("{}: read error", escape_name(&err_path, QS_ESCAPE))
-                }) as Box<dyn UError>),
+                Err(e) => Err(e
+                    .map_err_context(|| format!("{}: read error", escape_name_wrapper(&err_path)))
+                    as Box<dyn UError>),
             }),
     );
     // Loop until there is an error; yield that error and then nothing else.
@@ -806,6 +808,12 @@ fn files0_iter<'a>(
         }
         next
     })
+}
+
+fn escape_name_wrapper(name: &OsStr) -> String {
+    quoting_style::escape_name(name, QS_ESCAPE)
+        .into_string()
+        .expect("All escaped names with the escaping option return valid strings.")
 }
 
 fn wc(inputs: &Inputs, settings: &Settings) -> UResult<()> {

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -112,7 +112,8 @@ fn extract_value<T: Default>(p: Result<T, ParseError<'_, T>>, input: &str) -> T 
                     Default::default()
                 }
                 ParseError::PartialMatch(v, rest) => {
-                    if input.starts_with('\'') {
+                    let bytes = input.as_encoded_bytes();
+                    if !bytes.is_empty() && bytes[0] == b'\'' {
                         show_warning!(
                             "{}: character(s) following character constant have been ignored",
                             &rest,

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -353,20 +353,20 @@ impl Spec {
                 writer.write_all(&parsed).map_err(FormatError::IoError)
             }
             Self::QuotedString => {
-                let s = args.get_str();
-                writer
-                    .write_all(
-                        escape_name(
-                            s.as_ref(),
-                            &QuotingStyle::Shell {
-                                escape: true,
-                                always_quote: false,
-                                show_control: false,
-                            },
-                        )
-                        .as_bytes(),
-                    )
-                    .map_err(FormatError::IoError)
+                let s = escape_name(
+                    args.get_str().as_ref(),
+                    &QuotingStyle::Shell {
+                        escape: true,
+                        always_quote: false,
+                        show_control: false,
+                    },
+                );
+                #[cfg(unix)]
+                let bytes = std::os::unix::ffi::OsStringExt::into_vec(s);
+                #[cfg(not(unix))]
+                let bytes = s.to_string_lossy().as_bytes().to_owned();
+
+                writer.write_all(&bytes).map_err(FormatError::IoError)
             }
             Self::SignedInt {
                 width,

--- a/src/uucore/src/lib/features/quoting_style.rs
+++ b/src/uucore/src/lib/features/quoting_style.rs
@@ -11,34 +11,38 @@ use std::fmt;
 
 // These are characters with special meaning in the shell (e.g. bash).
 // The first const contains characters that only have a special meaning when they appear at the beginning of a name.
-const SPECIAL_SHELL_CHARS_START: &[char] = &['~', '#'];
+const SPECIAL_SHELL_CHARS_START: &[u8] = b"~#";
 // PR#6559 : Remove `]{}` from special shell chars.
 const SPECIAL_SHELL_CHARS: &str = "`$&*()|[;\\'\"<>?! ";
 
 /// The quoting style to use when escaping a name.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum QuotingStyle {
-    /// Escape the name as a literal string.
+    /// Escape the name as a shell string.
+    /// Used in, e.g., `ls --quoting-style=shell`.
     Shell {
         /// Whether to escape characters in the name.
+        /// True in, e.g., `ls --quoting-style=shell-escape`.
         escape: bool,
 
         /// Whether to always quote the name.
         always_quote: bool,
 
-        /// Whether to show control characters.
+        /// Whether to show control and non-unicode characters, or replace them with `?`.
         show_control: bool,
     },
 
     /// Escape the name as a C string.
+    /// Used in, e.g., `ls --quote-name`.
     C {
         /// The type of quotes to use.
         quotes: Quotes,
     },
 
-    /// Escape the name as a literal string.
+    /// Do not escape the string.
+    /// Used in, e.g., `ls --literal`.
     Literal {
-        /// Whether to show control characters.
+        /// Whether to show control and non-unicode characters, or replace them with `?`.
         show_control: bool,
     },
 }
@@ -72,8 +76,9 @@ enum EscapeState {
     Octal(EscapeOctal),
 }
 
+/// Byte we need to present as escaped octal, in the form of `\nnn`
 struct EscapeOctal {
-    c: char,
+    c: u8,
     state: EscapeOctalState,
     idx: usize,
 }
@@ -95,20 +100,20 @@ impl Iterator for EscapeOctal {
                 Some('\\')
             }
             EscapeOctalState::Value => {
-                let octal_digit = ((self.c as u32) >> (self.idx * 3)) & 0o7;
+                let octal_digit = ((self.c) >> (self.idx * 3)) & 0o7;
                 if self.idx == 0 {
                     self.state = EscapeOctalState::Done;
                 } else {
                     self.idx -= 1;
                 }
-                Some(from_digit(octal_digit, 8).unwrap())
+                Some(from_digit(octal_digit.into(), 8).unwrap())
             }
         }
     }
 }
 
 impl EscapeOctal {
-    fn from(c: char) -> Self {
+    fn from(c: u8) -> Self {
         Self {
             c,
             idx: 2,
@@ -121,6 +126,12 @@ impl EscapedChar {
     fn new_literal(c: char) -> Self {
         Self {
             state: EscapeState::Char(c),
+        }
+    }
+
+    fn new_octal(b: u8) -> Self {
+        Self {
+            state: EscapeState::Octal(EscapeOctal::from(b)),
         }
     }
 
@@ -148,7 +159,7 @@ impl EscapedChar {
                 _ => Char(' '),
             },
             ':' if dirname => Backslash(':'),
-            _ if c.is_ascii_control() => Octal(EscapeOctal::from(c)),
+            _ if c.is_ascii_control() => Octal(EscapeOctal::from(c as u8)),
             _ => Char(c),
         };
         Self { state: init_state }
@@ -165,7 +176,7 @@ impl EscapedChar {
             '\x0B' => Backslash('v'),
             '\x0C' => Backslash('f'),
             '\r' => Backslash('r'),
-            '\x00'..='\x1F' | '\x7F' => Octal(EscapeOctal::from(c)),
+            '\x00'..='\x1F' | '\x7F' => Octal(EscapeOctal::from(c as u8)),
             '\'' => match quotes {
                 Quotes::Single => Backslash('\''),
                 _ => Char('\''),
@@ -205,102 +216,124 @@ impl Iterator for EscapedChar {
     }
 }
 
-fn shell_without_escape(name: &str, quotes: Quotes, show_control_chars: bool) -> (String, bool) {
+/// Check whether `bytes` starts with any byte in `pattern`.
+fn bytes_start_with(bytes: &[u8], pattern: &[u8]) -> bool {
+    !bytes.is_empty() && pattern.contains(&bytes[0])
+}
+
+fn shell_without_escape(name: &[u8], quotes: Quotes, show_control_chars: bool) -> (Vec<u8>, bool) {
     let mut must_quote = false;
-    let mut escaped_str = String::with_capacity(name.len());
+    let mut escaped_str = Vec::with_capacity(name.len());
+    let mut utf8_buf = vec![0; 4];
 
-    for c in name.chars() {
-        let escaped = {
-            let ec = EscapedChar::new_shell(c, false, quotes);
-            if show_control_chars {
-                ec
-            } else {
-                ec.hide_control()
-            }
-        };
+    for s in name.utf8_chunks() {
+        for c in s.valid().chars() {
+            let escaped = {
+                let ec = EscapedChar::new_shell(c, false, quotes);
+                if show_control_chars {
+                    ec
+                } else {
+                    ec.hide_control()
+                }
+            };
 
-        match escaped.state {
-            EscapeState::Backslash('\'') => escaped_str.push_str("'\\''"),
-            EscapeState::ForceQuote(x) => {
-                must_quote = true;
-                escaped_str.push(x);
-            }
-            _ => {
-                for char in escaped {
-                    escaped_str.push(char);
+            match escaped.state {
+                EscapeState::Backslash('\'') => escaped_str.extend_from_slice(b"'\\''"),
+                EscapeState::ForceQuote(x) => {
+                    must_quote = true;
+                    escaped_str.extend_from_slice(x.encode_utf8(&mut utf8_buf).as_bytes());
+                }
+                _ => {
+                    for c in escaped {
+                        escaped_str.extend_from_slice(c.encode_utf8(&mut utf8_buf).as_bytes());
+                    }
                 }
             }
         }
+
+        if show_control_chars {
+            escaped_str.extend_from_slice(s.invalid());
+        } else {
+            escaped_str.resize(escaped_str.len() + s.invalid().len(), b'?');
+        }
     }
 
-    must_quote = must_quote || name.starts_with(SPECIAL_SHELL_CHARS_START);
+    must_quote = must_quote || bytes_start_with(name, SPECIAL_SHELL_CHARS_START);
     (escaped_str, must_quote)
 }
 
-fn shell_with_escape(name: &str, quotes: Quotes) -> (String, bool) {
+fn shell_with_escape(name: &[u8], quotes: Quotes) -> (Vec<u8>, bool) {
     // We need to keep track of whether we are in a dollar expression
     // because e.g. \b\n is escaped as $'\b\n' and not like $'b'$'n'
     let mut in_dollar = false;
     let mut must_quote = false;
     let mut escaped_str = String::with_capacity(name.len());
 
-    for c in name.chars() {
-        let escaped = EscapedChar::new_shell(c, true, quotes);
-        match escaped.state {
-            EscapeState::Char(x) => {
-                if in_dollar {
-                    escaped_str.push_str("''");
+    for s in name.utf8_chunks() {
+        for c in s.valid().chars() {
+            let escaped = EscapedChar::new_shell(c, true, quotes);
+            match escaped.state {
+                EscapeState::Char(x) => {
+                    if in_dollar {
+                        escaped_str.push_str("''");
+                        in_dollar = false;
+                    }
+                    escaped_str.push(x);
+                }
+                EscapeState::ForceQuote(x) => {
+                    if in_dollar {
+                        escaped_str.push_str("''");
+                        in_dollar = false;
+                    }
+                    must_quote = true;
+                    escaped_str.push(x);
+                }
+                // Single quotes are not put in dollar expressions, but are escaped
+                // if the string also contains double quotes. In that case, they must
+                // be handled separately.
+                EscapeState::Backslash('\'') => {
+                    must_quote = true;
                     in_dollar = false;
+                    escaped_str.push_str("'\\''");
                 }
-                escaped_str.push(x);
-            }
-            EscapeState::ForceQuote(x) => {
-                if in_dollar {
-                    escaped_str.push_str("''");
-                    in_dollar = false;
-                }
-                must_quote = true;
-                escaped_str.push(x);
-            }
-            // Single quotes are not put in dollar expressions, but are escaped
-            // if the string also contains double quotes. In that case, they must
-            // be handled separately.
-            EscapeState::Backslash('\'') => {
-                must_quote = true;
-                in_dollar = false;
-                escaped_str.push_str("'\\''");
-            }
-            _ => {
-                if !in_dollar {
-                    escaped_str.push_str("'$'");
-                    in_dollar = true;
-                }
-                must_quote = true;
-                for char in escaped {
-                    escaped_str.push(char);
+                _ => {
+                    if !in_dollar {
+                        escaped_str.push_str("'$'");
+                        in_dollar = true;
+                    }
+                    must_quote = true;
+                    for char in escaped {
+                        escaped_str.push(char);
+                    }
                 }
             }
         }
+        if !s.invalid().is_empty() {
+            if !in_dollar {
+                escaped_str.push_str("'$'");
+                in_dollar = true;
+            }
+            must_quote = true;
+            let escaped_bytes: String = s
+                .invalid()
+                .iter()
+                .flat_map(|b| EscapedChar::new_octal(*b))
+                .collect();
+            escaped_str.push_str(&escaped_bytes);
+        }
     }
-    must_quote = must_quote || name.starts_with(SPECIAL_SHELL_CHARS_START);
-    (escaped_str, must_quote)
+    must_quote = must_quote || bytes_start_with(name, SPECIAL_SHELL_CHARS_START);
+    (escaped_str.into(), must_quote)
 }
 
 /// Return a set of characters that implies quoting of the word in
 /// shell-quoting mode.
-fn shell_escaped_char_set(is_dirname: bool) -> &'static [char] {
-    const ESCAPED_CHARS: &[char] = &[
-        // the ':' colon character only induce quoting in the
-        // context of ls displaying a directory name before listing its content.
-        // (e.g. with the recursive flag -R)
-        ':',
-        // Under this line are the control characters that should be
-        // quoted in shell mode in all cases.
-        '"', '`', '$', '\\', '^', '\n', '\t', '\r', '=',
-    ];
-
+fn shell_escaped_char_set(is_dirname: bool) -> &'static [u8] {
+    const ESCAPED_CHARS: &[u8] = b":\"`$\\^\n\t\r=";
+    // the ':' colon character only induce quoting in the
+    // context of ls displaying a directory name before listing its content.
+    // (e.g. with the recursive flag -R)
     let start_index = if is_dirname { 0 } else { 1 };
-
     &ESCAPED_CHARS[start_index..]
 }
 
@@ -308,41 +341,57 @@ fn shell_escaped_char_set(is_dirname: bool) -> &'static [char] {
 ///
 /// This inner function provides an additional flag `dirname` which
 /// is meant for ls' directory name display.
-fn escape_name_inner(name: &OsStr, style: &QuotingStyle, dirname: bool) -> String {
+fn escape_name_inner(name: &[u8], style: &QuotingStyle, dirname: bool) -> Vec<u8> {
     match style {
         QuotingStyle::Literal { show_control } => {
             if *show_control {
-                name.to_string_lossy().into_owned()
+                name.to_owned()
             } else {
-                name.to_string_lossy()
-                    .chars()
-                    .flat_map(|c| EscapedChar::new_literal(c).hide_control())
-                    .collect()
+                name.utf8_chunks()
+                    .map(|s| {
+                        let valid: String = s
+                            .valid()
+                            .chars()
+                            .flat_map(|c| EscapedChar::new_literal(c).hide_control())
+                            .collect();
+                        let invalid = "?".repeat(s.invalid().len());
+                        valid + &invalid
+                    })
+                    .collect::<String>()
+                    .into()
             }
         }
         QuotingStyle::C { quotes } => {
             let escaped_str: String = name
-                .to_string_lossy()
-                .chars()
-                .flat_map(|c| EscapedChar::new_c(c, *quotes, dirname))
-                .collect();
+                .utf8_chunks()
+                .flat_map(|s| {
+                    let valid = s
+                        .valid()
+                        .chars()
+                        .flat_map(|c| EscapedChar::new_c(c, *quotes, dirname));
+                    let invalid = s.invalid().iter().flat_map(|b| EscapedChar::new_octal(*b));
+                    valid.chain(invalid)
+                })
+                .collect::<String>();
 
             match quotes {
                 Quotes::Single => format!("'{escaped_str}'"),
                 Quotes::Double => format!("\"{escaped_str}\""),
                 Quotes::None => escaped_str,
             }
+            .into()
         }
         QuotingStyle::Shell {
             escape,
             always_quote,
             show_control,
         } => {
-            let name = name.to_string_lossy();
-
-            let (quotes, must_quote) = if name.contains(shell_escaped_char_set(dirname)) {
+            let (quotes, must_quote) = if name
+                .iter()
+                .any(|c| shell_escaped_char_set(dirname).contains(c))
+            {
                 (Quotes::Single, true)
-            } else if name.contains('\'') {
+            } else if name.contains(&b'\'') {
                 (Quotes::Double, true)
             } else if *always_quote {
                 (Quotes::Single, true)
@@ -351,15 +400,24 @@ fn escape_name_inner(name: &OsStr, style: &QuotingStyle, dirname: bool) -> Strin
             };
 
             let (escaped_str, contains_quote_chars) = if *escape {
-                shell_with_escape(&name, quotes)
+                shell_with_escape(name, quotes)
             } else {
-                shell_without_escape(&name, quotes, *show_control)
+                shell_without_escape(name, quotes, *show_control)
             };
 
-            match (must_quote | contains_quote_chars, quotes) {
-                (true, Quotes::Single) => format!("'{escaped_str}'"),
-                (true, Quotes::Double) => format!("\"{escaped_str}\""),
-                _ => escaped_str,
+            if must_quote | contains_quote_chars && quotes != Quotes::None {
+                let mut quoted_str = Vec::<u8>::with_capacity(escaped_str.len() + 2);
+                let quote = if quotes == Quotes::Single {
+                    b'\''
+                } else {
+                    b'"'
+                };
+                quoted_str.push(quote);
+                quoted_str.extend(escaped_str);
+                quoted_str.push(quote);
+                quoted_str
+            } else {
+                escaped_str
             }
         }
     }
@@ -367,14 +425,16 @@ fn escape_name_inner(name: &OsStr, style: &QuotingStyle, dirname: bool) -> Strin
 
 /// Escape a filename with respect to the given style.
 pub fn escape_name(name: &OsStr, style: &QuotingStyle) -> String {
-    escape_name_inner(name, style, false)
+    let name = name.to_string_lossy();
+    String::from_utf8_lossy(&escape_name_inner(name.as_bytes(), style, false)).to_string()
 }
 
 /// Escape a directory name with respect to the given style.
 /// This is mainly meant to be used for ls' directory name printing and is not
 /// likely to be used elsewhere.
 pub fn escape_dir_name(dir_name: &OsStr, style: &QuotingStyle) -> String {
-    escape_name_inner(dir_name, style, true)
+    let dir_name = dir_name.to_string_lossy();
+    String::from_utf8_lossy(&escape_name_inner(dir_name.as_bytes(), style, true)).to_string()
 }
 
 impl fmt::Display for QuotingStyle {
@@ -415,7 +475,7 @@ impl fmt::Display for Quotes {
 
 #[cfg(test)]
 mod tests {
-    use crate::quoting_style::{escape_name, Quotes, QuotingStyle};
+    use crate::quoting_style::{escape_name_inner, Quotes, QuotingStyle};
 
     // spell-checker:ignore (tests/words) one\'two one'two
 
@@ -465,14 +525,31 @@ mod tests {
         }
     }
 
+    fn check_names_inner<T>(name: &[u8], map: &[(T, &str)]) -> Vec<Vec<u8>> {
+        map.iter()
+            .map(|(_, style)| escape_name_inner(name, &get_style(style), false))
+            .collect()
+    }
+
     fn check_names(name: &str, map: &[(&str, &str)]) {
         assert_eq!(
             map.iter()
-                .map(|(_, style)| escape_name(name.as_ref(), &get_style(style)))
-                .collect::<Vec<String>>(),
+                .map(|(correct, _)| *correct)
+                .collect::<Vec<&str>>(),
+            check_names_inner(name.as_bytes(), map)
+                .iter()
+                .map(|bytes| std::str::from_utf8(bytes)
+                    .expect("valid str goes in, valid str comes out"))
+                .collect::<Vec<&str>>()
+        );
+    }
+
+    fn check_names_raw(name: &[u8], map: &[(&[u8], &str)]) {
+        assert_eq!(
             map.iter()
-                .map(|(correct, _)| correct.to_string())
-                .collect::<Vec<String>>()
+                .map(|(correct, _)| *correct)
+                .collect::<Vec<&[u8]>>(),
+            check_names_inner(name, map)
         );
     }
 
@@ -728,6 +805,229 @@ mod tests {
                 ("'\x7F'", "shell-always-show"),
                 ("''$'\\177'", "shell-escape"),
                 ("''$'\\177'", "shell-escape-always"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_non_unicode_bytes() {
+        let ascii = b'_';
+        let continuation = b'\xA7';
+        let first2byte = b'\xC2';
+        let first3byte = b'\xE0';
+        let first4byte = b'\xF0';
+        let invalid = b'\xC0';
+
+        // a single byte value invalid outside of additional context in UTF-8
+        check_names_raw(
+            &[continuation],
+            &[
+                (b"?", "literal"),
+                (b"\xA7", "literal-show"),
+                (b"\\247", "escape"),
+                (b"\"\\247\"", "c"),
+                (b"?", "shell"),
+                (b"\xA7", "shell-show"),
+                (b"'?'", "shell-always"),
+                (b"'\xA7'", "shell-always-show"),
+                (b"''$'\\247'", "shell-escape"),
+                (b"''$'\\247'", "shell-escape-always"),
+            ],
+        );
+
+        // ...but the byte becomes valid with appropriate context
+        // (this is just the § character in UTF-8, written as bytes)
+        check_names_raw(
+            &[first2byte, continuation],
+            &[
+                (b"\xC2\xA7", "literal"),
+                (b"\xC2\xA7", "literal-show"),
+                (b"\xC2\xA7", "escape"),
+                (b"\"\xC2\xA7\"", "c"),
+                (b"\xC2\xA7", "shell"),
+                (b"\xC2\xA7", "shell-show"),
+                (b"'\xC2\xA7'", "shell-always"),
+                (b"'\xC2\xA7'", "shell-always-show"),
+                (b"\xC2\xA7", "shell-escape"),
+                (b"'\xC2\xA7'", "shell-escape-always"),
+            ],
+        );
+
+        // mixed with valid characters
+        check_names_raw(
+            &[continuation, ascii],
+            &[
+                (b"?_", "literal"),
+                (b"\xA7_", "literal-show"),
+                (b"\\247_", "escape"),
+                (b"\"\\247_\"", "c"),
+                (b"?_", "shell"),
+                (b"\xA7_", "shell-show"),
+                (b"'?_'", "shell-always"),
+                (b"'\xA7_'", "shell-always-show"),
+                (b"''$'\\247''_'", "shell-escape"),
+                (b"''$'\\247''_'", "shell-escape-always"),
+            ],
+        );
+        check_names_raw(
+            &[ascii, continuation],
+            &[
+                (b"_?", "literal"),
+                (b"_\xA7", "literal-show"),
+                (b"_\\247", "escape"),
+                (b"\"_\\247\"", "c"),
+                (b"_?", "shell"),
+                (b"_\xA7", "shell-show"),
+                (b"'_?'", "shell-always"),
+                (b"'_\xA7'", "shell-always-show"),
+                (b"'_'$'\\247'", "shell-escape"),
+                (b"'_'$'\\247'", "shell-escape-always"),
+            ],
+        );
+        check_names_raw(
+            &[ascii, continuation, ascii],
+            &[
+                (b"_?_", "literal"),
+                (b"_\xA7_", "literal-show"),
+                (b"_\\247_", "escape"),
+                (b"\"_\\247_\"", "c"),
+                (b"_?_", "shell"),
+                (b"_\xA7_", "shell-show"),
+                (b"'_?_'", "shell-always"),
+                (b"'_\xA7_'", "shell-always-show"),
+                (b"'_'$'\\247''_'", "shell-escape"),
+                (b"'_'$'\\247''_'", "shell-escape-always"),
+            ],
+        );
+        check_names_raw(
+            &[continuation, ascii, continuation],
+            &[
+                (b"?_?", "literal"),
+                (b"\xA7_\xA7", "literal-show"),
+                (b"\\247_\\247", "escape"),
+                (b"\"\\247_\\247\"", "c"),
+                (b"?_?", "shell"),
+                (b"\xA7_\xA7", "shell-show"),
+                (b"'?_?'", "shell-always"),
+                (b"'\xA7_\xA7'", "shell-always-show"),
+                (b"''$'\\247''_'$'\\247'", "shell-escape"),
+                (b"''$'\\247''_'$'\\247'", "shell-escape-always"),
+            ],
+        );
+
+        // contiguous invalid bytes
+        check_names_raw(
+            &[
+                ascii,
+                invalid,
+                ascii,
+                continuation,
+                continuation,
+                ascii,
+                continuation,
+                continuation,
+                continuation,
+                ascii,
+                continuation,
+                continuation,
+                continuation,
+                continuation,
+                ascii,
+            ],
+            &[
+                (b"_?_??_???_????_", "literal"),
+                (
+                    b"_\xC0_\xA7\xA7_\xA7\xA7\xA7_\xA7\xA7\xA7\xA7_",
+                    "literal-show",
+                ),
+                (
+                    b"_\\300_\\247\\247_\\247\\247\\247_\\247\\247\\247\\247_",
+                    "escape",
+                ),
+                (
+                    b"\"_\\300_\\247\\247_\\247\\247\\247_\\247\\247\\247\\247_\"",
+                    "c",
+                ),
+                (b"_?_??_???_????_", "shell"),
+                (
+                    b"_\xC0_\xA7\xA7_\xA7\xA7\xA7_\xA7\xA7\xA7\xA7_",
+                    "shell-show",
+                ),
+                (b"'_?_??_???_????_'", "shell-always"),
+                (
+                    b"'_\xC0_\xA7\xA7_\xA7\xA7\xA7_\xA7\xA7\xA7\xA7_'",
+                    "shell-always-show",
+                ),
+                (
+                    b"'_'$'\\300''_'$'\\247\\247''_'$'\\247\\247\\247''_'$'\\247\\247\\247\\247''_'",
+                    "shell-escape",
+                ),
+                (
+                    b"'_'$'\\300''_'$'\\247\\247''_'$'\\247\\247\\247''_'$'\\247\\247\\247\\247''_'",
+                    "shell-escape-always",
+                ),
+            ],
+        );
+
+        // invalid multi-byte sequences that start valid
+        check_names_raw(
+            &[first2byte, ascii],
+            &[
+                (b"?_", "literal"),
+                (b"\xC2_", "literal-show"),
+                (b"\\302_", "escape"),
+                (b"\"\\302_\"", "c"),
+                (b"?_", "shell"),
+                (b"\xC2_", "shell-show"),
+                (b"'?_'", "shell-always"),
+                (b"'\xC2_'", "shell-always-show"),
+                (b"''$'\\302''_'", "shell-escape"),
+                (b"''$'\\302''_'", "shell-escape-always"),
+            ],
+        );
+        check_names_raw(
+            &[first2byte, first2byte, continuation],
+            &[
+                (b"?\xC2\xA7", "literal"),
+                (b"\xC2\xC2\xA7", "literal-show"),
+                (b"\\302\xC2\xA7", "escape"),
+                (b"\"\\302\xC2\xA7\"", "c"),
+                (b"?\xC2\xA7", "shell"),
+                (b"\xC2\xC2\xA7", "shell-show"),
+                (b"'?\xC2\xA7'", "shell-always"),
+                (b"'\xC2\xC2\xA7'", "shell-always-show"),
+                (b"''$'\\302''\xC2\xA7'", "shell-escape"),
+                (b"''$'\\302''\xC2\xA7'", "shell-escape-always"),
+            ],
+        );
+        check_names_raw(
+            &[first3byte, continuation, ascii],
+            &[
+                (b"??_", "literal"),
+                (b"\xE0\xA7_", "literal-show"),
+                (b"\\340\\247_", "escape"),
+                (b"\"\\340\\247_\"", "c"),
+                (b"??_", "shell"),
+                (b"\xE0\xA7_", "shell-show"),
+                (b"'??_'", "shell-always"),
+                (b"'\xE0\xA7_'", "shell-always-show"),
+                (b"''$'\\340\\247''_'", "shell-escape"),
+                (b"''$'\\340\\247''_'", "shell-escape-always"),
+            ],
+        );
+        check_names_raw(
+            &[first4byte, continuation, continuation, ascii],
+            &[
+                (b"???_", "literal"),
+                (b"\xF0\xA7\xA7_", "literal-show"),
+                (b"\\360\\247\\247_", "escape"),
+                (b"\"\\360\\247\\247_\"", "c"),
+                (b"???_", "shell"),
+                (b"\xF0\xA7\xA7_", "shell-show"),
+                (b"'???_'", "shell-always"),
+                (b"'\xF0\xA7\xA7_'", "shell-always-show"),
+                (b"''$'\\360\\247\\247''_'", "shell-escape"),
+                (b"''$'\\360\\247\\247''_'", "shell-escape-always"),
             ],
         );
     }

--- a/src/uucore/src/lib/features/quoting_style.rs
+++ b/src/uucore/src/lib/features/quoting_style.rs
@@ -8,8 +8,6 @@
 use std::char::from_digit;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
-#[cfg(unix)]
-use std::os::unix::ffi::{OsStrExt, OsStringExt};
 
 // These are characters with special meaning in the shell (e.g. bash).
 // The first const contains characters that only have a special meaning when they appear at the beginning of a name.
@@ -462,36 +460,18 @@ fn escape_name_inner(name: &[u8], style: &QuotingStyle, dirname: bool) -> Vec<u8
 
 /// Escape a filename with respect to the given style.
 pub fn escape_name(name: &OsStr, style: &QuotingStyle) -> OsString {
-    #[cfg(unix)]
-    {
-        let name = name.as_bytes();
-        OsStringExt::from_vec(escape_name_inner(name, style, false))
-    }
-    #[cfg(not(unix))]
-    {
-        let name = name.to_string_lossy();
-        String::from_utf8_lossy(&escape_name_inner(name.as_bytes(), style, false))
-            .to_string()
-            .into()
-    }
+    let name = crate::os_str_as_bytes_lossy(name);
+    crate::os_string_from_vec(escape_name_inner(&name, style, false))
+        .expect("all byte sequences should be valid for platform, or already replaced in name")
 }
 
 /// Escape a directory name with respect to the given style.
 /// This is mainly meant to be used for ls' directory name printing and is not
 /// likely to be used elsewhere.
 pub fn escape_dir_name(dir_name: &OsStr, style: &QuotingStyle) -> OsString {
-    #[cfg(unix)]
-    {
-        let name = dir_name.as_bytes();
-        OsStringExt::from_vec(escape_name_inner(name, style, true))
-    }
-    #[cfg(not(unix))]
-    {
-        let name = dir_name.to_string_lossy();
-        String::from_utf8_lossy(&escape_name_inner(name.as_bytes(), style, true))
-            .to_string()
-            .into()
-    }
+    let name = crate::os_str_as_bytes_lossy(dir_name);
+    crate::os_string_from_vec(escape_name_inner(&name, style, true))
+        .expect("all byte sequences should be valid for platform, or already replaced in name")
 }
 
 impl fmt::Display for QuotingStyle {

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -253,9 +253,10 @@ pub fn read_yes() -> bool {
     }
 }
 
-/// Helper function for processing delimiter values (which could be non UTF-8)
-/// It converts OsString to &[u8] for unix targets only
-/// On non-unix (i.e. Windows) it will just return an error if delimiter value is not UTF-8
+/// Converts an `OsStr` to a UTF-8 `&[u8]`.
+///
+/// This always succeeds on unix platforms,
+/// and fails on other platforms if the string can't be coerced to UTF-8.
 pub fn os_str_as_bytes(os_string: &OsStr) -> mods::error::UResult<&[u8]> {
     #[cfg(unix)]
     let bytes = os_string.as_bytes();
@@ -271,13 +272,28 @@ pub fn os_str_as_bytes(os_string: &OsStr) -> mods::error::UResult<&[u8]> {
     Ok(bytes)
 }
 
-/// Helper function for converting a slice of bytes into an &OsStr
-/// or OsString in non-unix targets.
+/// Performs a potentially lossy conversion from `OsStr` to UTF-8 bytes.
 ///
-/// It converts `&[u8]` to `Cow<OsStr>` for unix targets only.
-/// On non-unix (i.e. Windows), the conversion goes through the String type
-/// and thus undergo UTF-8 validation, making it fail if the stream contains
-/// non-UTF-8 characters.
+/// This is always lossless on unix platforms,
+/// and wraps [`OsStr::to_string_lossy`] on non-unix platforms.
+pub fn os_str_as_bytes_lossy(os_string: &OsStr) -> Cow<[u8]> {
+    #[cfg(unix)]
+    let bytes = Cow::from(os_string.as_bytes());
+
+    #[cfg(not(unix))]
+    let bytes = match os_string.to_string_lossy() {
+        Cow::Borrowed(slice) => Cow::from(slice.as_bytes()),
+        Cow::Owned(owned) => Cow::from(owned.into_bytes()),
+    };
+
+    bytes
+}
+
+/// Converts a `&[u8]` to an `&OsStr`,
+/// or parses it as UTF-8 into an [`OsString`] on non-unix platforms.
+///
+/// This always succeeds on unix platforms,
+/// and fails on other platforms if the bytes can't be parsed as UTF-8.
 pub fn os_str_from_bytes(bytes: &[u8]) -> mods::error::UResult<Cow<'_, OsStr>> {
     #[cfg(unix)]
     let os_str = Cow::Borrowed(OsStr::from_bytes(bytes));
@@ -289,9 +305,10 @@ pub fn os_str_from_bytes(bytes: &[u8]) -> mods::error::UResult<Cow<'_, OsStr>> {
     Ok(os_str)
 }
 
-/// Helper function for making an `OsString` from a byte field
-/// It converts `Vec<u8>` to `OsString` for unix targets only.
-/// On non-unix (i.e. Windows) it may fail if the bytes are not valid UTF-8
+/// Converts a `Vec<u8>` into an `OsString`, parsing as UTF-8 on non-unix platforms.
+///
+/// This always succeeds on unix platforms,
+/// and fails on other platforms if the bytes can't be parsed as UTF-8.
 pub fn os_string_from_vec(vec: Vec<u8>) -> mods::error::UResult<OsString> {
     #[cfg(unix)]
     let s = OsString::from_vec(vec);


### PR DESCRIPTION
This adds support for non-UTF-8 bytes in the quoting_style library on Unix platforms. This is necessary for proper support of non-unicode inputs in a few utilities, including `wc`, `ls`, and `printf` (as of this PR, `wc` should be good, `ls` is in a much better state but will need some work to close the final gaps, and `printf` needs @andrewliebenow's #6812, which might conflict this this, but if so, should be a quick fix).

The first commit bumps the MSRV, because we need access to [Utf8Chunks](https://doc.rust-lang.org/std/str/struct.Utf8Chunks.html), since we need to operate on strings and non-unicode bytes in the same OsString (namely, we need to be able to tell if something is invalid unicode, or valid unicode but a control character, and apply the appropriate escaping). Avoiding that would require implementing or using another UTF-8 parser.

The third commit fixes a preexisting bug that was in some sense independent of this patch set (multi-byte control characters weren't being handled properly), but it touches the same code so I'm including it.