### PR TITLE
cp: copy attributes after making subdir

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -174,7 +174,7 @@ pub enum CopyMode {
 /// For full compatibility with GNU, these options should also combine. We
 /// currently only do a best effort imitation of that behavior, because it is
 /// difficult to achieve in clap, especially with `--no-preserve`.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Attributes {
     #[cfg(unix)]
     pub ownership: Preserve,


### PR DESCRIPTION
Closes #6875.

**TODO:**
- [x] : Fix [`test_dir_perm_race_with_preserve_mode_and_ownership`](https://github.com/uutils/coreutils/blob/4bc9e7b395b8de54501713770a0f2a1432d69ca4/tests/by-util/test_cp.rs#L5614-L5623).
- [x] : Add a test for the original issue described in #6875 
- [x] : Fix gnu heap test