### PR TITLE
tr: Add ambiguous octal escape warning

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -329,10 +329,7 @@ impl Sequence {
             recognize(many_m_n(1, 3, one_of("01234567"))),
             |out: &[u8]| {
                 let str_to_parse = std::str::from_utf8(out).unwrap();
-                match u8::from_str_radix(str_to_parse, 8) {
-                    Ok(ue) => Some(ue),
-                    Err(_pa) => None,
-                }
+                u8::from_str_radix(str_to_parse, 8).ok()
             },
         )(input)
     }
@@ -342,21 +339,19 @@ impl Sequence {
             recognize(many_m_n(1, 3, one_of("01234567"))),
             |out: &[u8]| {
                 let str_to_parse = std::str::from_utf8(out).unwrap();
-                match u8::from_str_radix(str_to_parse, 8) {
-                    Ok(ue) => Some(ue),
-                    Err(_pa) => {
-                        let origin_octal: &str = std::str::from_utf8(input).unwrap();
-                        let actual_octal_tail: &str = std::str::from_utf8(&input[0..2]).unwrap();
-                        let outstand_char: char = char::from_u32(input[2] as u32).unwrap();
-                        show_warning!(
-                            "the ambiguous octal escape \\{} is being\n        interpreted as the 2-byte sequence \\0{}, {}",
-                            origin_octal,
-                            actual_octal_tail,
-                            outstand_char
-                        );
-                        None
-                    }
+                let result = u8::from_str_radix(str_to_parse, 8).ok();
+                if result.is_none() {
+                    let origin_octal: &str = std::str::from_utf8(input).unwrap();
+                    let actual_octal_tail: &str = std::str::from_utf8(&input[0..2]).unwrap();
+                    let outstand_char: char = char::from_u32(input[2] as u32).unwrap();
+                    show_warning!(
+                        "the ambiguous octal escape \\{} is being\n        interpreted as the 2-byte sequence \\0{}, {}",
+                        origin_octal,
+                        actual_octal_tail,
+                        outstand_char
+                    );
                 }
+                result
             },
         )(input)
     }

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1494,9 +1494,7 @@ fn test_multibyte_octal_sequence() {
         .args(&["-d", r"\501"])
         .pipe_in("(1Ł)")
         .succeeds()
-        // TODO
-        // A warning needs to be printed here
-        // See https://github.com/uutils/coreutils/issues/6821
+        .stderr_is("tr: warning: the ambiguous octal escape \\501 is being\n        interpreted as the 2-byte sequence \\050, 1\n")
         .stdout_is("Ł)");
 }
 


### PR DESCRIPTION
This PR is to fix issue #6821. 

I add `parse_octal_up_to_three_digits_with_warning` which is similar to `parse_octal_up_to_three_digits` but can print warning. Becuase `parse_octal_up_to_three_digits` is alse used in other cases, and those cases should not output the warning. With two versions, we can avoid printing the same warning more than once. 

Some of the other functions are also added "with_warning" version.