### PR TITLE
Bump `thiserror` from `1.0.69` to `2.0.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
 ]
 
@@ -2128,7 +2128,7 @@ dependencies = [
  "once_cell",
  "reference-counted-singleton",
  "selinux-sys",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2377,7 +2377,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -2385,6 +2394,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2524,7 +2544,7 @@ checksum = "e24c654e19afaa6b8f3877ece5d3bed849c2719c56f6752b18ca7da4fcc6e85a"
 dependencies = [
  "cfg-if",
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "utmp-classic-raw",
  "zerocopy",
@@ -2590,7 +2610,7 @@ version = "0.0.28"
 dependencies = [
  "clap",
  "nix",
- "thiserror",
+ "thiserror 2.0.3",
  "uucore",
 ]
 
@@ -2602,7 +2622,7 @@ dependencies = [
  "fts-sys",
  "libc",
  "selinux",
- "thiserror",
+ "thiserror 2.0.3",
  "uucore",
 ]
 
@@ -2679,7 +2699,7 @@ version = "0.0.28"
 dependencies = [
  "clap",
  "regex",
- "thiserror",
+ "thiserror 2.0.3",
  "uucore",
 ]
 
@@ -3195,7 +3215,7 @@ dependencies = [
  "clap",
  "libc",
  "selinux",
- "thiserror",
+ "thiserror 2.0.3",
  "uucore",
 ]
 
@@ -3474,7 +3494,7 @@ version = "0.0.28"
 dependencies = [
  "chrono",
  "clap",
- "thiserror",
+ "thiserror 2.0.3",
  "utmp-classic",
  "uucore",
 ]
@@ -3505,7 +3525,7 @@ dependencies = [
  "clap",
  "libc",
  "nix",
- "thiserror",
+ "thiserror 2.0.3",
  "unicode-width 0.1.13",
  "uucore",
 ]
@@ -3566,7 +3586,7 @@ dependencies = [
  "sha3",
  "sm3",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "time",
  "uucore_procs",
  "walkdir",
@@ -4048,5 +4068,5 @@ dependencies = [
  "flate2",
  "indexmap",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,7 +332,7 @@ tempfile = "3.10.1"
 uutils_term_grid = "0.6"
 terminal_size = "0.4.0"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
-thiserror = "1.0.59"
+thiserror = "2.0.3"
 time = { version = "0.3.36" }
 unicode-segmentation = "1.11.0"
 unicode-width = "0.1.12"

--- a/deny.toml
+++ b/deny.toml
@@ -106,6 +106,10 @@ skip = [
   { name = "unicode-width", version = "0.1.13" },
   # notify
   { name = "mio", version = "0.8.11" },
+  # various crates
+  { name = "thiserror", version = "1.0.69" },
+  # thiserror
+  { name = "thiserror-impl", version = "1.0.69" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR bumps `thiserror` from `1.0.69` to `2.0.3` and adds `thiserror` and `thiserror-impl` to the skip list in `deny.toml`.