### PR TITLE
env: add missing `cfg` attributes to tests

### DIFF
--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -10,6 +10,7 @@ use crate::common::util::TestScenario;
 use crate::common::util::UChild;
 #[cfg(unix)]
 use nix::sys::signal::Signal;
+#[cfg(feature = "echo")]
 use regex::Regex;
 use std::env;
 use std::path::Path;
@@ -98,6 +99,7 @@ fn test_if_windows_batch_files_can_be_executed() {
     assert!(result.stdout_str().contains("Hello Windows World!"));
 }
 
+#[cfg(feature = "echo")]
 #[test]
 fn test_debug_1() {
     let ts = TestScenario::new(util_name!());
@@ -118,6 +120,7 @@ fn test_debug_1() {
     );
 }
 
+#[cfg(feature = "echo")]
 #[test]
 fn test_debug_2() {
     let ts = TestScenario::new(util_name!());
@@ -144,6 +147,7 @@ fn test_debug_2() {
     );
 }
 
+#[cfg(feature = "echo")]
 #[test]
 fn test_debug1_part_of_string_arg() {
     let ts = TestScenario::new(util_name!());
@@ -165,6 +169,7 @@ fn test_debug1_part_of_string_arg() {
     );
 }
 
+#[cfg(feature = "echo")]
 #[test]
 fn test_debug2_part_of_string_arg() {
     let ts = TestScenario::new(util_name!());
@@ -651,7 +656,7 @@ fn test_env_with_empty_executable_double_quotes() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(all(unix, feature = "dirname", feature = "echo"))]
 fn test_env_overwrite_arg0() {
     let ts = TestScenario::new(util_name!());
 
@@ -675,7 +680,7 @@ fn test_env_overwrite_arg0() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(all(unix, feature = "echo"))]
 fn test_env_arg_argv0_overwrite() {
     let ts = TestScenario::new(util_name!());
 
@@ -723,7 +728,7 @@ fn test_env_arg_argv0_overwrite() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(all(unix, feature = "echo"))]
 fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
     let ts = TestScenario::new(util_name!());
 


### PR DESCRIPTION
Currently, when running `cargo test --features=env --no-default-features` some tests fail because they depend on other features. This PR fixes this issue by adding the missing `cfg` attributes to the failing test functions.