### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -197,7 +197,7 @@ struct SplitWriter<'a> {
     dev_null: bool,
 }
 
-impl<'a> Drop for SplitWriter<'a> {
+impl Drop for SplitWriter<'_> {
     fn drop(&mut self) {
         if self.options.elide_empty_files && self.size == 0 {
             let file_name = self.options.split_name.get(self.counter);
@@ -206,7 +206,7 @@ impl<'a> Drop for SplitWriter<'a> {
     }
 }
 
-impl<'a> SplitWriter<'a> {
+impl SplitWriter<'_> {
     fn new(options: &CsplitOptions) -> SplitWriter {
         SplitWriter {
             options,

--- a/src/uu/cut/src/matcher.rs
+++ b/src/uu/cut/src/matcher.rs
@@ -23,7 +23,7 @@ impl<'a> ExactMatcher<'a> {
     }
 }
 
-impl<'a> Matcher for ExactMatcher<'a> {
+impl Matcher for ExactMatcher<'_> {
     fn next_match(&self, haystack: &[u8]) -> Option<(usize, usize)> {
         let mut pos = 0usize;
         loop {

--- a/src/uu/cut/src/searcher.rs
+++ b/src/uu/cut/src/searcher.rs
@@ -27,7 +27,7 @@ impl<'a, 'b, M: Matcher> Searcher<'a, 'b, M> {
 // Iterate over field delimiters
 // Returns (first, last) positions of each sequence, where `haystack[first..last]`
 // corresponds to the delimiter.
-impl<'a, 'b, M: Matcher> Iterator for Searcher<'a, 'b, M> {
+impl<M: Matcher> Iterator for Searcher<'_, '_, M> {
     type Item = (usize, usize);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -103,7 +103,7 @@ enum Iso8601Format {
     Ns,
 }
 
-impl<'a> From<&'a str> for Iso8601Format {
+impl From<&str> for Iso8601Format {
     fn from(s: &str) -> Self {
         match s {
             HOURS => Self::Hours,
@@ -123,7 +123,7 @@ enum Rfc3339Format {
     Ns,
 }
 
-impl<'a> From<&'a str> for Rfc3339Format {
+impl From<&str> for Rfc3339Format {
     fn from(s: &str) -> Self {
         match s {
             DATE => Self::Date,

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -424,7 +424,7 @@ fn make_linux_iflags(iflags: &IFlags) -> Option<libc::c_int> {
     }
 }
 
-impl<'a> Read for Input<'a> {
+impl Read for Input<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut base_idx = 0;
         let target_len = buf.len();
@@ -447,7 +447,7 @@ impl<'a> Read for Input<'a> {
     }
 }
 
-impl<'a> Input<'a> {
+impl Input<'_> {
     /// Discard the system file cache for the given portion of the input.
     ///
     /// `offset` and `len` specify a contiguous portion of the input.
@@ -928,7 +928,7 @@ enum BlockWriter<'a> {
     Unbuffered(Output<'a>),
 }
 
-impl<'a> BlockWriter<'a> {
+impl BlockWriter<'_> {
     fn discard_cache(&self, offset: libc::off_t, len: libc::off_t) {
         match self {
             Self::Unbuffered(o) => o.discard_cache(offset, len),

--- a/src/uu/dd/src/numbers.rs
+++ b/src/uu/dd/src/numbers.rs
@@ -2,8 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-/// Functions for formatting a number as a magnitude and a unit suffix.
 
+/// Functions for formatting a number as a magnitude and a unit suffix.
 /// The first ten powers of 1024.
 const IEC_BASES: [u128; 10] = [
     1,

--- a/src/uu/dd/src/numbers.rs
+++ b/src/uu/dd/src/numbers.rs
@@ -3,7 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-/// Functions for formatting a number as a magnitude and a unit suffix.
+//! Functions for formatting a number as a magnitude and a unit suffix.
+
 /// The first ten powers of 1024.
 const IEC_BASES: [u128; 10] = [
     1,

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -311,7 +311,6 @@ fn is_best(previous: &[MountInfo], mi: &MountInfo) -> bool {
 ///
 /// Finally, if there are duplicate entries, the one with the shorter
 /// path is kept.
-
 fn filter_mount_list(vmi: Vec<MountInfo>, opt: &Options) -> Vec<MountInfo> {
     let mut result = vec![];
     for mi in vmi {
@@ -331,7 +330,6 @@ fn filter_mount_list(vmi: Vec<MountInfo>, opt: &Options) -> Vec<MountInfo> {
 ///
 /// `opt` excludes certain filesystems from consideration and allows for the synchronization of filesystems before running; see
 /// [`Options`] for more information.
-
 fn get_all_filesystems(opt: &Options) -> UResult<Vec<Filesystem>> {
     // Run a sync call before any operation if so instructed.
     if opt.sync {

--- a/src/uu/env/src/string_parser.rs
+++ b/src/uu/env/src/string_parser.rs
@@ -114,10 +114,9 @@ impl<'a> StringParser<'a> {
     }
 
     pub fn peek_chunk(&self) -> Option<Chunk<'a>> {
-        return self
-            .get_chunk_with_length_at(self.pointer)
+        self.get_chunk_with_length_at(self.pointer)
             .ok()
-            .map(|(chunk, _)| chunk);
+            .map(|(chunk, _)| chunk)
     }
 
     pub fn consume_chunk(&mut self) -> Result<Chunk<'a>, Error> {

--- a/src/uu/env/src/variable_parser.rs
+++ b/src/uu/env/src/variable_parser.rs
@@ -11,7 +11,7 @@ pub struct VariableParser<'a, 'b> {
     pub parser: &'b mut StringParser<'a>,
 }
 
-impl<'a, 'b> VariableParser<'a, 'b> {
+impl<'a> VariableParser<'a, '_> {
     fn get_current_char(&self) -> Option<char> {
         self.parser.peek().ok()
     }

--- a/src/uu/fmt/src/linebreak.rs
+++ b/src/uu/fmt/src/linebreak.rs
@@ -20,7 +20,7 @@ struct BreakArgs<'a> {
     ostream: &'a mut BufWriter<Stdout>,
 }
 
-impl<'a> BreakArgs<'a> {
+impl BreakArgs<'_> {
     fn compute_width(&self, winfo: &WordInfo, posn: usize, fresh: bool) -> usize {
         if fresh {
             0

--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -73,7 +73,7 @@ pub struct FileLines<'a> {
     lines: Lines<&'a mut FileOrStdReader>,
 }
 
-impl<'a> FileLines<'a> {
+impl FileLines<'_> {
     fn new<'b>(opts: &'b FmtOptions, lines: Lines<&'b mut FileOrStdReader>) -> FileLines<'b> {
         FileLines { opts, lines }
     }
@@ -144,7 +144,7 @@ impl<'a> FileLines<'a> {
     }
 }
 
-impl<'a> Iterator for FileLines<'a> {
+impl Iterator for FileLines<'_> {
     type Item = Line;
 
     fn next(&mut self) -> Option<Line> {
@@ -232,7 +232,7 @@ pub struct ParagraphStream<'a> {
     opts: &'a FmtOptions,
 }
 
-impl<'a> ParagraphStream<'a> {
+impl ParagraphStream<'_> {
     pub fn new<'b>(opts: &'b FmtOptions, reader: &'b mut FileOrStdReader) -> ParagraphStream<'b> {
         let lines = FileLines::new(opts, reader.lines()).peekable();
         // at the beginning of the file, we might find mail headers
@@ -273,7 +273,7 @@ impl<'a> ParagraphStream<'a> {
     }
 }
 
-impl<'a> Iterator for ParagraphStream<'a> {
+impl Iterator for ParagraphStream<'_> {
     type Item = Result<Paragraph, String>;
 
     #[allow(clippy::cognitive_complexity)]
@@ -491,7 +491,7 @@ struct WordSplit<'a> {
     prev_punct: bool,
 }
 
-impl<'a> WordSplit<'a> {
+impl WordSplit<'_> {
     fn analyze_tabs(&self, string: &str) -> (Option<usize>, usize, Option<usize>) {
         // given a string, determine (length before tab) and (printed length after first tab)
         // if there are no tabs, beforetab = -1 and aftertab is the printed length
@@ -517,7 +517,7 @@ impl<'a> WordSplit<'a> {
     }
 }
 
-impl<'a> WordSplit<'a> {
+impl WordSplit<'_> {
     fn new<'b>(opts: &'b FmtOptions, string: &'b str) -> WordSplit<'b> {
         // wordsplits *must* start at a non-whitespace character
         let trim_string = string.trim_start();

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -109,7 +109,7 @@ struct MultiByteSep<'a> {
     finder: Finder<'a>,
 }
 
-impl<'a> Separator for MultiByteSep<'a> {
+impl Separator for MultiByteSep<'_> {
     fn field_ranges(&self, haystack: &[u8], len_guess: usize) -> Vec<(usize, usize)> {
         let mut field_ranges = Vec::with_capacity(len_guess);
         let mut last_end = 0;

--- a/src/uu/od/src/inputdecoder.rs
+++ b/src/uu/od/src/inputdecoder.rs
@@ -33,7 +33,7 @@ where
     byte_order: ByteOrder,
 }
 
-impl<'a, I> InputDecoder<'a, I> {
+impl<I> InputDecoder<'_, I> {
     /// Creates a new `InputDecoder` with an allocated buffer of `normal_length` + `peek_length` bytes.
     /// `byte_order` determines how to read multibyte formats from the buffer.
     pub fn new(
@@ -55,7 +55,7 @@ impl<'a, I> InputDecoder<'a, I> {
     }
 }
 
-impl<'a, I> InputDecoder<'a, I>
+impl<I> InputDecoder<'_, I>
 where
     I: PeekRead,
 {
@@ -81,7 +81,7 @@ where
     }
 }
 
-impl<'a, I> HasError for InputDecoder<'a, I>
+impl<I> HasError for InputDecoder<'_, I>
 where
     I: HasError,
 {
@@ -103,7 +103,7 @@ pub struct MemoryDecoder<'a> {
     byte_order: ByteOrder,
 }
 
-impl<'a> MemoryDecoder<'a> {
+impl MemoryDecoder<'_> {
     /// Set a part of the internal buffer to zero.
     /// access to the whole buffer is possible, not just to the valid data.
     pub fn zero_out_buffer(&mut self, start: usize, end: usize) {

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -28,7 +28,7 @@ pub trait HasError {
     fn has_error(&self) -> bool;
 }
 
-impl<'b> MultifileReader<'b> {
+impl MultifileReader<'_> {
     pub fn new(fnames: Vec<InputSource>) -> MultifileReader {
         let mut mf = MultifileReader {
             ni: fnames,
@@ -76,7 +76,7 @@ impl<'b> MultifileReader<'b> {
     }
 }
 
-impl<'b> io::Read for MultifileReader<'b> {
+impl io::Read for MultifileReader<'_> {
     // Fill buf with bytes read from the list of files
     // Returns Ok(<number of bytes read>)
     // Handles io errors itself, thus always returns OK
@@ -113,7 +113,7 @@ impl<'b> io::Read for MultifileReader<'b> {
     }
 }
 
-impl<'b> HasError for MultifileReader<'b> {
+impl HasError for MultifileReader<'_> {
     fn has_error(&self) -> bool {
         self.any_err
     }

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -279,7 +279,10 @@ impl<'a> Shufable for Vec<&'a [u8]> {
         // this is safe.
         (**self).choose(rng).unwrap()
     }
-    type PartialShuffleIterator<'b> = std::iter::Copied<std::slice::Iter<'b, &'a [u8]>> where Self: 'b;
+    type PartialShuffleIterator<'b>
+        = std::iter::Copied<std::slice::Iter<'b, &'a [u8]>>
+    where
+        Self: 'b;
     fn partial_shuffle<'b>(
         &'b mut self,
         rng: &'b mut WrappedRng,
@@ -298,7 +301,10 @@ impl Shufable for RangeInclusive<usize> {
     fn choose(&self, rng: &mut WrappedRng) -> usize {
         rng.gen_range(self.clone())
     }
-    type PartialShuffleIterator<'b> = NonrepeatingIterator<'b> where Self: 'b;
+    type PartialShuffleIterator<'b>
+        = NonrepeatingIterator<'b>
+    where
+        Self: 'b;
     fn partial_shuffle<'b>(
         &'b mut self,
         rng: &'b mut WrappedRng,

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -380,7 +380,7 @@ impl<'a> NonrepeatingIterator<'a> {
     }
 }
 
-impl<'a> Iterator for NonrepeatingIterator<'a> {
+impl Iterator for NonrepeatingIterator<'_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<usize> {
@@ -407,7 +407,7 @@ trait Writable {
     fn write_all_to(&self, output: &mut impl Write) -> Result<(), Error>;
 }
 
-impl<'a> Writable for &'a [u8] {
+impl Writable for &[u8] {
     fn write_all_to(&self, output: &mut impl Write) -> Result<(), Error> {
         output.write_all(self)
     }

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -267,7 +267,7 @@ pub struct FileMerger<'a> {
     reader_join_handle: JoinHandle<UResult<()>>,
 }
 
-impl<'a> FileMerger<'a> {
+impl FileMerger<'_> {
     /// Write the merged contents to the output file.
     pub fn write_all(self, settings: &GlobalSettings, output: Output) -> UResult<()> {
         let mut out = output.into_write();
@@ -341,7 +341,7 @@ struct FileComparator<'a> {
     settings: &'a GlobalSettings,
 }
 
-impl<'a> Compare<MergeableFile> for FileComparator<'a> {
+impl Compare<MergeableFile> for FileComparator<'_> {
     fn compare(&self, a: &MergeableFile, b: &MergeableFile) -> Ordering {
         let mut cmp = compare_by(
             &a.current_chunk.lines()[a.line_idx],

--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -341,7 +341,7 @@ impl<'a> FilenameIterator<'a> {
     }
 }
 
-impl<'a> Iterator for FilenameIterator<'a> {
+impl Iterator for FilenameIterator<'_> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -748,7 +748,7 @@ impl<'a> ByteChunkWriter<'a> {
     }
 }
 
-impl<'a> Write for ByteChunkWriter<'a> {
+impl Write for ByteChunkWriter<'_> {
     /// Implements `--bytes=SIZE`
     fn write(&mut self, mut buf: &[u8]) -> std::io::Result<usize> {
         // If the length of `buf` exceeds the number of bytes remaining
@@ -872,7 +872,7 @@ impl<'a> LineChunkWriter<'a> {
     }
 }
 
-impl<'a> Write for LineChunkWriter<'a> {
+impl Write for LineChunkWriter<'_> {
     /// Implements `--lines=NUMBER`
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         // If the number of lines in `buf` exceeds the number of lines
@@ -978,7 +978,7 @@ impl<'a> LineBytesChunkWriter<'a> {
     }
 }
 
-impl<'a> Write for LineBytesChunkWriter<'a> {
+impl Write for LineBytesChunkWriter<'_> {
     /// Write as many lines to a chunk as possible without
     /// exceeding the byte limit. If a single line has more bytes
     /// than the limit, then fill an entire single chunk with those

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -64,7 +64,7 @@ impl<'a> ReverseChunks<'a> {
     }
 }
 
-impl<'a> Iterator for ReverseChunks<'a> {
+impl Iterator for ReverseChunks<'_> {
     type Item = Vec<u8>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -288,7 +288,6 @@ fn preserve_signal_info(signal: libc::c_int) -> libc::c_int {
 }
 
 /// TODO: Improve exit codes, and make them consistent with the GNU Coreutils exit codes.
-
 fn timeout(
     cmd: &[String],
     duration: Duration,

--- a/src/uu/wc/src/utf8/read.rs
+++ b/src/uu/wc/src/utf8/read.rs
@@ -27,7 +27,7 @@ pub enum BufReadDecoderError<'a> {
     Io(io::Error),
 }
 
-impl<'a> fmt::Display for BufReadDecoderError<'a> {
+impl fmt::Display for BufReadDecoderError<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             BufReadDecoderError::InvalidByteSequence(bytes) => {
@@ -38,7 +38,7 @@ impl<'a> fmt::Display for BufReadDecoderError<'a> {
     }
 }
 
-impl<'a> Error for BufReadDecoderError<'a> {
+impl Error for BufReadDecoderError<'_> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             BufReadDecoderError::InvalidByteSequence(_) => None,

--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -403,7 +403,7 @@ impl<'a> DigestWriter<'a> {
     }
 }
 
-impl<'a> Write for DigestWriter<'a> {
+impl Write for DigestWriter<'_> {
     #[cfg(not(windows))]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.digest.hash_update(buf);

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1658,13 +1658,14 @@ fn test_reading_partial_blocks_from_fifo() {
     // Start different processes to write to the FIFO, with a small
     // pause in between.
     let mut writer_command = Command::new("sh");
-    writer_command
+    let _ = writer_command
         .args([
             "-c",
             &format!("(printf \"ab\"; sleep 0.1; printf \"cd\") > {fifoname}"),
         ])
         .spawn()
-        .unwrap();
+        .unwrap()
+        .wait();
 
     let output = child.wait_with_output().unwrap();
     assert_eq!(output.stdout, b"abcd");
@@ -1701,13 +1702,14 @@ fn test_reading_partial_blocks_from_fifo_unbuffered() {
     // Start different processes to write to the FIFO, with a small
     // pause in between.
     let mut writer_command = Command::new("sh");
-    writer_command
+    let _ = writer_command
         .args([
             "-c",
             &format!("(printf \"ab\"; sleep 0.1; printf \"cd\") > {fifoname}"),
         ])
         .spawn()
-        .unwrap();
+        .unwrap()
+        .wait();
 
     let output = child.wait_with_output().unwrap();
     assert_eq!(output.stdout, b"abcd");

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -7,7 +7,7 @@
 #[cfg(not(windows))]
 use regex::Regex;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(not(target_os = "windows"))]
 use crate::common::util::expected_result;
 use crate::common::util::TestScenario;
 
@@ -36,11 +36,11 @@ fn test_du_basics() {
             return;
         }
     }
-    _du_basics(result.stdout_str());
+    du_basics(result.stdout_str());
 }
 
 #[cfg(target_vendor = "apple")]
-fn _du_basics(s: &str) {
+fn du_basics(s: &str) {
     let answer = concat!(
         "4\t./subdir/deeper/deeper_dir\n",
         "8\t./subdir/deeper\n",
@@ -52,7 +52,7 @@ fn _du_basics(s: &str) {
 }
 
 #[cfg(target_os = "windows")]
-fn _du_basics(s: &str) {
+fn du_basics(s: &str) {
     let answer = concat!(
         "0\t.\\subdir\\deeper\\deeper_dir\n",
         "0\t.\\subdir\\deeper\n",
@@ -64,7 +64,7 @@ fn _du_basics(s: &str) {
 }
 
 #[cfg(all(not(target_vendor = "apple"), not(target_os = "windows"),))]
-fn _du_basics(s: &str) {
+fn du_basics(s: &str) {
     let answer = concat!(
         "8\t./subdir/deeper/deeper_dir\n",
         "16\t./subdir/deeper\n",
@@ -95,19 +95,19 @@ fn test_du_basics_subdir() {
             return;
         }
     }
-    _du_basics_subdir(result.stdout_str());
+    du_basics_subdir(result.stdout_str());
 }
 
 #[cfg(target_vendor = "apple")]
-fn _du_basics_subdir(s: &str) {
+fn du_basics_subdir(s: &str) {
     assert_eq!(s, "4\tsubdir/deeper/deeper_dir\n8\tsubdir/deeper\n");
 }
 #[cfg(target_os = "windows")]
-fn _du_basics_subdir(s: &str) {
+fn du_basics_subdir(s: &str) {
     assert_eq!(s, "0\tsubdir/deeper\\deeper_dir\n0\tsubdir/deeper\n");
 }
 #[cfg(target_os = "freebsd")]
-fn _du_basics_subdir(s: &str) {
+fn du_basics_subdir(s: &str) {
     assert_eq!(s, "8\tsubdir/deeper/deeper_dir\n16\tsubdir/deeper\n");
 }
 #[cfg(all(
@@ -115,7 +115,7 @@ fn _du_basics_subdir(s: &str) {
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))]
-fn _du_basics_subdir(s: &str) {
+fn du_basics_subdir(s: &str) {
     // MS-WSL linux has altered expected output
     if uucore::os::is_wsl_1() {
         assert_eq!(s, "0\tsubdir/deeper\n");
@@ -206,20 +206,20 @@ fn test_du_soft_link() {
             return;
         }
     }
-    _du_soft_link(result.stdout_str());
+    du_soft_link(result.stdout_str());
 }
 
 #[cfg(target_vendor = "apple")]
-fn _du_soft_link(s: &str) {
+fn du_soft_link(s: &str) {
     // 'macos' host variants may have `du` output variation for soft links
     assert!((s == "12\tsubdir/links\n") || (s == "16\tsubdir/links\n"));
 }
 #[cfg(target_os = "windows")]
-fn _du_soft_link(s: &str) {
+fn du_soft_link(s: &str) {
     assert_eq!(s, "8\tsubdir/links\n");
 }
 #[cfg(target_os = "freebsd")]
-fn _du_soft_link(s: &str) {
+fn du_soft_link(s: &str) {
     assert_eq!(s, "16\tsubdir/links\n");
 }
 #[cfg(all(
@@ -227,7 +227,7 @@ fn _du_soft_link(s: &str) {
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))]
-fn _du_soft_link(s: &str) {
+fn du_soft_link(s: &str) {
     // MS-WSL linux has altered expected output
     if uucore::os::is_wsl_1() {
         assert_eq!(s, "8\tsubdir/links\n");
@@ -255,19 +255,19 @@ fn test_du_hard_link() {
         }
     }
     // We do not double count hard links as the inodes are identical
-    _du_hard_link(result.stdout_str());
+    du_hard_link(result.stdout_str());
 }
 
 #[cfg(target_vendor = "apple")]
-fn _du_hard_link(s: &str) {
+fn du_hard_link(s: &str) {
     assert_eq!(s, "12\tsubdir/links\n");
 }
 #[cfg(target_os = "windows")]
-fn _du_hard_link(s: &str) {
+fn du_hard_link(s: &str) {
     assert_eq!(s, "8\tsubdir/links\n");
 }
 #[cfg(target_os = "freebsd")]
-fn _du_hard_link(s: &str) {
+fn du_hard_link(s: &str) {
     assert_eq!(s, "16\tsubdir/links\n");
 }
 #[cfg(all(
@@ -275,7 +275,7 @@ fn _du_hard_link(s: &str) {
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))]
-fn _du_hard_link(s: &str) {
+fn du_hard_link(s: &str) {
     // MS-WSL linux has altered expected output
     if uucore::os::is_wsl_1() {
         assert_eq!(s, "8\tsubdir/links\n");
@@ -299,19 +299,19 @@ fn test_du_d_flag() {
             return;
         }
     }
-    _du_d_flag(result.stdout_str());
+    du_d_flag(result.stdout_str());
 }
 
 #[cfg(target_vendor = "apple")]
-fn _du_d_flag(s: &str) {
+fn du_d_flag(s: &str) {
     assert_eq!(s, "20\t./subdir\n24\t.\n");
 }
 #[cfg(target_os = "windows")]
-fn _du_d_flag(s: &str) {
+fn du_d_flag(s: &str) {
     assert_eq!(s, "8\t.\\subdir\n8\t.\n");
 }
 #[cfg(target_os = "freebsd")]
-fn _du_d_flag(s: &str) {
+fn du_d_flag(s: &str) {
     assert_eq!(s, "36\t./subdir\n44\t.\n");
 }
 #[cfg(all(
@@ -319,7 +319,7 @@ fn _du_d_flag(s: &str) {
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))]
-fn _du_d_flag(s: &str) {
+fn du_d_flag(s: &str) {
     // MS-WSL linux has altered expected output
     if uucore::os::is_wsl_1() {
         assert_eq!(s, "8\t./subdir\n8\t.\n");
@@ -348,7 +348,7 @@ fn test_du_dereference() {
         }
     }
 
-    _du_dereference(result.stdout_str());
+    du_dereference(result.stdout_str());
 }
 
 #[cfg(not(windows))]
@@ -376,15 +376,15 @@ fn test_du_dereference_args() {
 }
 
 #[cfg(target_vendor = "apple")]
-fn _du_dereference(s: &str) {
+fn du_dereference(s: &str) {
     assert_eq!(s, "4\tsubdir/links/deeper_dir\n16\tsubdir/links\n");
 }
 #[cfg(target_os = "windows")]
-fn _du_dereference(s: &str) {
+fn du_dereference(s: &str) {
     assert_eq!(s, "0\tsubdir/links\\deeper_dir\n8\tsubdir/links\n");
 }
 #[cfg(target_os = "freebsd")]
-fn _du_dereference(s: &str) {
+fn du_dereference(s: &str) {
     assert_eq!(s, "8\tsubdir/links/deeper_dir\n24\tsubdir/links\n");
 }
 #[cfg(all(
@@ -392,7 +392,7 @@ fn _du_dereference(s: &str) {
     not(target_os = "windows"),
     not(target_os = "freebsd")
 ))]
-fn _du_dereference(s: &str) {
+fn du_dereference(s: &str) {
     // MS-WSL linux has altered expected output
     if uucore::os::is_wsl_1() {
         assert_eq!(s, "0\tsubdir/links/deeper_dir\n8\tsubdir/links\n");
@@ -454,39 +454,20 @@ fn test_du_inodes_basic() {
     let ts = TestScenario::new(util_name!());
     let result = ts.ucmd().arg("--inodes").succeeds();
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(not(target_os = "windows"))]
     {
         let result_reference = unwrap_or_return!(expected_result(&ts, &["--inodes"]));
         assert_eq!(result.stdout_str(), result_reference.stdout_str());
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
-    _du_inodes_basic(result.stdout_str());
-}
-
-#[cfg(target_os = "windows")]
-fn _du_inodes_basic(s: &str) {
+    #[cfg(target_os = "windows")]
     assert_eq!(
-        s,
+        result.stdout_str(),
         concat!(
             "2\t.\\subdir\\deeper\\deeper_dir\n",
             "4\t.\\subdir\\deeper\n",
             "3\t.\\subdir\\links\n",
             "8\t.\\subdir\n",
-            "11\t.\n",
-        )
-    );
-}
-
-#[cfg(not(target_os = "windows"))]
-fn _du_inodes_basic(s: &str) {
-    assert_eq!(
-        s,
-        concat!(
-            "2\t./subdir/deeper/deeper_dir\n",
-            "4\t./subdir/deeper\n",
-            "3\t./subdir/links\n",
-            "8\t./subdir\n",
             "11\t.\n",
         )
     );
@@ -706,8 +687,10 @@ fn test_du_no_permission() {
             return;
         }
     }
-
-    _du_no_permission(result.stdout_str());
+    #[cfg(not(target_vendor = "apple"))]
+    assert_eq!(result.stdout_str(), "4\tsubdir/links\n");
+    #[cfg(target_vendor = "apple")]
+    assert_eq!(result.stdout_str(), "0\tsubdir/links\n");
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -725,15 +708,6 @@ fn test_du_no_exec_permission() {
     result.stderr_contains("du: cannot access 'd/no-x/y': Permission denied");
 }
 
-#[cfg(target_vendor = "apple")]
-fn _du_no_permission(s: &str) {
-    assert_eq!(s, "0\tsubdir/links\n");
-}
-#[cfg(all(not(target_vendor = "apple"), not(target_os = "windows")))]
-fn _du_no_permission(s: &str) {
-    assert_eq!(s, "4\tsubdir/links\n");
-}
-
 #[test]
 #[cfg(not(target_os = "openbsd"))]
 fn test_du_one_file_system() {
@@ -749,7 +723,7 @@ fn test_du_one_file_system() {
             return;
         }
     }
-    _du_basics_subdir(result.stdout_str());
+    du_basics_subdir(result.stdout_str());
 }
 
 #[test]

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -36,13 +36,14 @@ impl Target {
         Self { child }
     }
     fn send_signal(&mut self, signal: Signal) {
-        Command::new("kill")
+        let _ = Command::new("kill")
             .args(&[
                 format!("-{}", signal as i32),
                 format!("{}", self.child.id()),
             ])
             .spawn()
-            .expect("failed to send signal");
+            .expect("failed to send signal")
+            .wait();
         self.child.delay(100);
     }
     fn is_alive(&mut self) -> bool {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1329,10 +1329,10 @@ fn test_ls_long_symlink_color() {
             Some(captures) => {
                 dbg!(captures.get(1).unwrap().as_str().to_string());
                 dbg!(captures.get(2).unwrap().as_str().to_string());
-                return (
+                (
                     captures.get(1).unwrap().as_str().to_string(),
                     captures.get(2).unwrap().as_str().to_string(),
-                );
+                )
             }
             None => (String::new(), input.to_string()),
         }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -75,7 +75,7 @@ pub fn is_ci() -> bool {
 }
 
 /// Read a test scenario fixture, returning its bytes
-fn read_scenario_fixture<S: AsRef<OsStr>>(tmpd: &Option<Rc<TempDir>>, file_rel_path: S) -> Vec<u8> {
+fn read_scenario_fixture<S: AsRef<OsStr>>(tmpd: Option<&Rc<TempDir>>, file_rel_path: S) -> Vec<u8> {
     let tmpdir_path = tmpd.as_ref().unwrap().as_ref().path();
     AtPath::new(tmpdir_path).read_bytes(file_rel_path.as_ref().to_str().unwrap())
 }
@@ -517,7 +517,7 @@ impl CmdResult {
     /// like `stdout_is()`, but expects the contents of the file at the provided relative path
     #[track_caller]
     pub fn stdout_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &Self {
-        let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
+        let contents = read_scenario_fixture(self.tmpd.as_ref(), file_rel_path);
         self.stdout_is(String::from_utf8(contents).unwrap())
     }
 
@@ -539,7 +539,7 @@ impl CmdResult {
     /// ```
     #[track_caller]
     pub fn stdout_is_fixture_bytes<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &Self {
-        let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
+        let contents = read_scenario_fixture(self.tmpd.as_ref(), file_rel_path);
         self.stdout_is_bytes(contents)
     }
 
@@ -552,7 +552,7 @@ impl CmdResult {
         template_vars: &[(&str, &str)],
     ) -> &Self {
         let mut contents =
-            String::from_utf8(read_scenario_fixture(&self.tmpd, file_rel_path)).unwrap();
+            String::from_utf8(read_scenario_fixture(self.tmpd.as_ref(), file_rel_path)).unwrap();
         for kv in template_vars {
             contents = contents.replace(kv.0, kv.1);
         }
@@ -566,7 +566,8 @@ impl CmdResult {
         file_rel_path: T,
         template_vars: &[Vec<(String, String)>],
     ) {
-        let contents = String::from_utf8(read_scenario_fixture(&self.tmpd, file_rel_path)).unwrap();
+        let contents =
+            String::from_utf8(read_scenario_fixture(self.tmpd.as_ref(), file_rel_path)).unwrap();
         let possible_values = template_vars.iter().map(|vars| {
             let mut contents = contents.clone();
             for kv in vars {
@@ -604,7 +605,7 @@ impl CmdResult {
     /// Like `stdout_is_fixture`, but for stderr
     #[track_caller]
     pub fn stderr_is_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &Self {
-        let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
+        let contents = read_scenario_fixture(self.tmpd.as_ref(), file_rel_path);
         self.stderr_is(String::from_utf8(contents).unwrap())
     }
 
@@ -629,7 +630,7 @@ impl CmdResult {
     /// like `stdout_only()`, but expects the contents of the file at the provided relative path
     #[track_caller]
     pub fn stdout_only_fixture<T: AsRef<OsStr>>(&self, file_rel_path: T) -> &Self {
-        let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
+        let contents = read_scenario_fixture(self.tmpd.as_ref(), file_rel_path);
         self.stdout_only_bytes(contents)
     }
 
@@ -1384,7 +1385,7 @@ impl UCommand {
 
     /// like `pipe_in()`, but uses the contents of the file at the provided relative path as the piped in data
     pub fn pipe_in_fixture<S: AsRef<OsStr>>(&mut self, file_rel_path: S) -> &mut Self {
-        let contents = read_scenario_fixture(&self.tmpd, file_rel_path);
+        let contents = read_scenario_fixture(self.tmpd.as_ref(), file_rel_path);
         self.pipe_in(contents)
     }
 


### PR DESCRIPTION
`The following explicit lifetimes could be elided: 'a`