### PR TITLE
uudoc,chcon: fix `needless_lifetimes` warnings

### DIFF
--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -172,7 +172,7 @@ struct MDWriter<'a, 'b> {
     markdown: Option<String>,
 }
 
-impl<'a, 'b> MDWriter<'a, 'b> {
+impl MDWriter<'_, '_> {
     /// # Errors
     /// Returns an error if the writer fails.
     fn markdown(&mut self) -> io::Result<()> {

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -777,7 +777,7 @@ enum SELinuxSecurityContext<'t> {
     String(Option<CString>),
 }
 
-impl<'t> SELinuxSecurityContext<'t> {
+impl SELinuxSecurityContext<'_> {
     fn to_c_string(&self) -> Result<Option<Cow<CStr>>> {
         match self {
             Self::File(context) => context


### PR DESCRIPTION
This PR fixes two additional warnings from the [needless_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes) lint. They show up when running `cargo clippy --all-features --all-targets`.