### PR TITLE
seq: handle scientific notation with uppercase 'E'

### DIFF
--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -392,6 +392,7 @@ mod tests {
     fn test_parse_big_int() {
         assert_eq!(parse("0"), ExtendedBigDecimal::zero());
         assert_eq!(parse("0.1e1"), ExtendedBigDecimal::one());
+        assert_eq!(parse("0.1E1"), ExtendedBigDecimal::one());
         assert_eq!(
             parse("1.0e1"),
             ExtendedBigDecimal::BigDecimal("10".parse::<BigDecimal>().unwrap())

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -333,7 +333,7 @@ impl FromStr for PreciseNumber {
         // number differently depending on its form. This is important
         // because the form of the input dictates how the output will be
         // presented.
-        match (s.find('.'), s.find('e')) {
+        match (s.find('.'), s.find(['e', 'E'])) {
             // For example, "123456" or "inf".
             (None, None) => parse_no_decimal_no_exponent(s),
             // For example, "123e456" or "1e-2".

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -333,6 +333,11 @@ fn test_width_scientific_notation() {
         .succeeds()
         .stdout_is("0999\n1000\n")
         .no_stderr();
+    new_ucmd!()
+        .args(&["-w", "999", "1E3"])
+        .succeeds()
+        .stdout_is("0999\n1000\n")
+        .no_stderr();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #6925.