### PR TITLE
cksum: even more fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3573,6 +3573,7 @@ dependencies = [
  "glob",
  "hex",
  "itertools",
+ "lazy_static",
  "libc",
  "md-5",
  "memchr",

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -25,6 +25,7 @@ dns-lookup = { workspace = true, optional = true }
 dunce = { version = "1.0.4", optional = true }
 wild = "2.2.1"
 glob = { workspace = true }
+lazy_static = "1.4.0"
 # * optional
 itertools = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -1337,8 +1337,7 @@ mod tests {
         // Test leading space before checksum line
         let line_algo_based_leading_space =
             OsString::from("   MD5 (example.txt) = d41d8cd98f00b204e9800998ecf8427e");
-        let res = LineInfo::parse(&line_algo_based_leading_space, &mut cached_regex);
-        assert!(res.is_some());
+        let line_info = LineInfo::parse(&line_algo_based_leading_space, &mut cached_regex).unwrap();
         assert_eq!(line_info.format, LineFormat::AlgoBased);
         assert!(cached_regex.is_none());
 

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1480,7 +1480,6 @@ mod check_utf8 {
     }
 }
 
-#[ignore = "not yet implemented"]
 #[test]
 fn test_check_blake_length_guess() {
     let correct_lines = [
@@ -1523,7 +1522,6 @@ fn test_check_blake_length_guess() {
         .stderr_contains("foo.sums: no properly formatted checksum lines found");
 }
 
-#[ignore = "not yet implemented"]
 #[test]
 fn test_check_confusing_base64() {
     let cksum = "BLAKE2b-48 (foo.dat) = fc1f97C4";


### PR DESCRIPTION
Fixes #6653

This PR changes the way the regex to parse a checksum line is chosen. Now, every line gets to choose the regex it matches with, instead of trying to match with the regex that matched the first line (except for non-algo based line which should follow the flavor of the first one).

While doing this, I've decided to get rid of the `regex::Capture` which was being carried around everywhere, and create a `LineInfo` struct that holds all the parsed data.

It adds `lazy_static` as a *direct* dependency to `uu_core` (it was an indirect dependency until now). I allows to not recompile the regexes again and again.

---
EDIT: I have added some code to rework the way the expected checksum is decoded, this PR now fixes #6576 and #6614 as well.