### PR TITLE
fix(seq): handle 0e... scientific notation without padding

### DIFF
--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -103,7 +103,9 @@ fn parse_exponent_no_decimal(s: &str, j: usize) -> Result<PreciseNumber, ParseNu
     // displayed as "0.01", but "1e2" will be displayed as "100",
     // without a decimal point.
     let x: BigDecimal = {
-        let parsed_decimal = s.parse::<BigDecimal>().map_err(|_| ParseNumberError::Float)?;
+        let parsed_decimal = s
+            .parse::<BigDecimal>()
+            .map_err(|_| ParseNumberError::Float)?;
         if parsed_decimal == BigDecimal::zero() {
             BigDecimal::zero()
         } else {
@@ -212,7 +214,9 @@ fn parse_decimal_and_exponent(
     let num_digits_between_decimal_point_and_e = (j - (i + 1)) as i64;
     let exponent: i64 = s[j + 1..].parse().map_err(|_| ParseNumberError::Float)?;
     let val: BigDecimal = {
-        let parsed_decimal = s.parse::<BigDecimal>().map_err(|_| ParseNumberError::Float)?;
+        let parsed_decimal = s
+            .parse::<BigDecimal>()
+            .map_err(|_| ParseNumberError::Float)?;
         if parsed_decimal == BigDecimal::zero() {
             BigDecimal::zero()
         } else {

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -102,10 +102,13 @@ fn parse_exponent_no_decimal(s: &str, j: usize) -> Result<PreciseNumber, ParseNu
     // displayed in decimal notation. For example, "1e-2" will be
     // displayed as "0.01", but "1e2" will be displayed as "100",
     // without a decimal point.
-    let x: BigDecimal = if s.starts_with('0') {
-        BigDecimal::zero()
-    } else {
-        s.parse().map_err(|_| ParseNumberError::Float)?
+    let x: BigDecimal = {
+        let parsed_decimal = s.parse::<BigDecimal>().map_err(|_| ParseNumberError::Float)?;
+        if parsed_decimal == BigDecimal::zero() {
+            BigDecimal::zero()
+        } else {
+            parsed_decimal
+        }
     };
 
     let num_integral_digits = if is_minus_zero_float(s, &x) {
@@ -208,10 +211,13 @@ fn parse_decimal_and_exponent(
     // Because of the match guard, this subtraction will not underflow.
     let num_digits_between_decimal_point_and_e = (j - (i + 1)) as i64;
     let exponent: i64 = s[j + 1..].parse().map_err(|_| ParseNumberError::Float)?;
-    let val: BigDecimal = if s.starts_with('0') {
-        BigDecimal::zero()
-    } else {
-        s.parse().map_err(|_| ParseNumberError::Float)?
+    let val: BigDecimal = {
+        let parsed_decimal = s.parse::<BigDecimal>().map_err(|_| ParseNumberError::Float)?;
+        if parsed_decimal == BigDecimal::zero() {
+            BigDecimal::zero()
+        } else {
+            parsed_decimal
+        }
     };
 
     let num_integral_digits = {

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -102,7 +102,11 @@ fn parse_exponent_no_decimal(s: &str, j: usize) -> Result<PreciseNumber, ParseNu
     // displayed in decimal notation. For example, "1e-2" will be
     // displayed as "0.01", but "1e2" will be displayed as "100",
     // without a decimal point.
-    let x: BigDecimal = s.parse().map_err(|_| ParseNumberError::Float)?;
+    let x: BigDecimal = if s.starts_with('0') {
+        BigDecimal::zero()
+    } else {
+        s.parse().map_err(|_| ParseNumberError::Float)?
+    };
 
     let num_integral_digits = if is_minus_zero_float(s, &x) {
         if exponent > 0 {
@@ -204,7 +208,11 @@ fn parse_decimal_and_exponent(
     // Because of the match guard, this subtraction will not underflow.
     let num_digits_between_decimal_point_and_e = (j - (i + 1)) as i64;
     let exponent: i64 = s[j + 1..].parse().map_err(|_| ParseNumberError::Float)?;
-    let val: BigDecimal = s.parse().map_err(|_| ParseNumberError::Float)?;
+    let val: BigDecimal = if s.starts_with('0') {
+        BigDecimal::zero()
+    } else {
+        s.parse().map_err(|_| ParseNumberError::Float)?
+    };
 
     let num_integral_digits = {
         let minimum: usize = {

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -837,3 +837,31 @@ fn test_invalid_format() {
         .no_stdout()
         .stderr_contains("format '%g%g' has too many % directives");
 }
+
+#[test]
+fn test_parse_scientific_zero() {
+    new_ucmd!()
+        .args(&["0e15", "1"])
+        .succeeds()
+        .stdout_only("0\n1\n");
+    new_ucmd!()
+        .args(&["0.0e15", "1"])
+        .succeeds()
+        .stdout_only("0\n1\n");
+    new_ucmd!()
+        .args(&["0", "1"])
+        .succeeds()
+        .stdout_only("0\n1\n");
+    new_ucmd!()
+        .args(&["-w", "0e15", "1"])
+        .succeeds()
+        .stdout_only("0000000000000000\n0000000000000001\n");
+    new_ucmd!()
+        .args(&["-w", "0.0e15", "1"])
+        .succeeds()
+        .stdout_only("0000000000000000\n0000000000000001\n");
+    new_ucmd!()
+        .args(&["-w", "0", "1"])
+        .succeeds()
+        .stdout_only("0\n1\n");
+}


### PR DESCRIPTION
Fix: #6926

This pull request fixes the issue where `seq` mishandles scientific notation in the form of `0e...` by treating it as zero. 

Note;
While testing with `bash util/run-gnu-test.sh`, I discovered another bug unrelated to this fix. I will file a new issue.

```bash
cargo run -q seq 0x1p-1 2
seq: invalid hexadecimal argument: '0x1p-1'
```