### PR TITLE
fix(mv): don't panic if apply_xattrs fails

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -679,7 +679,7 @@ fn rename_with_fallback(
             };
 
             #[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
-            fsxattr::apply_xattrs(to, xattrs).unwrap();
+            fsxattr::apply_xattrs(to, xattrs)?;
 
             if let Err(err) = result {
                 return match err.kind {


### PR DESCRIPTION
### About

This commit fixes #6727 by returning the error status instead of causing a panic. It aligns with the original GNU mv more closely

### Before
```
cargo run -q mv dummy /run/media/user/8EC5-8BC8
thread 'main' panicked at src/uu/mv/src/mv.rs:682:47:
called `Result::unwrap()` on an `Err` value: Os { code: 95, kind: Uncategorized, message: "Operation not supported" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### After
```
cargo run -q mv dummy /run/media/user/8EC5-8BC8
mv: cannot move 'dummy' to '/run/media/user/8EC5-8BC8/dummy': Operation not supported
```

### GNU mv 

```
mv dummy /run/media/user/8EC5-8BC8
mv: preserving permissions for ‘/run/media/user/8EC5-8BC8/dummy’: Operation not supported
```

### Testing environment

- ArchLinux
- rustc 1.83.0 (90b35a623 2024-11-26)
- Destination filesystem is FAT32

Commands for preparing a directory with xattrs

```
mkdir -p dummy/1
setfacl -m u:user:r dummy
```

Thank you
