### PR TITLE
Make `Spec` public

### DIFF
--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -38,7 +38,7 @@ pub mod num_parser;
 mod spec;
 
 pub use argument::*;
-use spec::Spec;
+pub use spec::Spec;
 use std::{
     error::Error,
     fmt::Display,


### PR DESCRIPTION
I would like to wrap `Spec` because I want to do some additional processing of a custom format string. I can't do so because this is private. It is marked pub in the `spec` mod but is not marked pub when imported in `format`. This exposes it.