### PR TITLE
Nix/Nixos development

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
+fi
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ lib*.a
 *.iml
 ### macOS ###
 .DS_Store
+
+### direnv ###
+/.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720633750,
+        "narHash": "sha256-N8apMO2pP/upWeH+JY5eM8VDp2qBAAzE+OY5LRW6qpw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "54bc082f5a7219d122e74fe52c021cf59fed9d6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      libselinuxPath = with pkgs;
+        lib.makeLibraryPath [
+          libselinux
+        ];
+      libaclPath = with pkgs;
+        lib.makeLibraryPath [
+          acl
+        ];
+
+      build_deps = with pkgs; [
+          clang
+          llvmPackages.bintools
+          rustup
+
+          pre-commit
+
+          # debugging
+          gdb
+        ];
+      gnu_testing_deps = with pkgs; [
+          autoconf
+          automake
+          bison
+          gnum4
+          gperf
+          gettext
+          texinfo
+        ];
+    in {
+      devShell = pkgs.mkShell {
+        buildInputs = build_deps ++ gnu_testing_deps;
+
+        RUSTC_VERSION = "1.75";
+        LIBCLANG_PATH = pkgs.lib.makeLibraryPath [pkgs.llvmPackages_latest.libclang.lib];
+        shellHook = ''
+          export PATH=$PATH:''${CARGO_HOME:-~/.cargo}/bin
+          export PATH=$PATH:''${RUSTUP_HOME:-~/.rustup}/toolchains/$RUSTC_VERSION-x86_64-unknown-linux-gnu/bin/
+        '';
+
+        SELINUX_INCLUDE_DIR = ''${pkgs.libselinux.dev}/include'';
+        SELINUX_LIB_DIR = libselinuxPath;
+        SELINUX_STATIC = "0";
+
+        # Necessary to build GNU.
+        LDFLAGS = ''-L ${libselinuxPath} -L ${libaclPath}'';
+
+        # Add precompiled library to rustc search path
+        RUSTFLAGS =
+          (builtins.map (a: ''-L ${a}/lib'') [
+            ])
+          ++ [
+            ''-L ${libselinuxPath}''
+            ''-L ${libaclPath}''
+          ];
+      };
+    });
+}

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -345,3 +345,8 @@ sed -i  "s/color_code='0;31;42'/color_code='31;42'/" tests/ls/quote-align.sh
 
 # Slightly different error message
 sed -i 's/not supported/unexpected argument/' tests/mv/mv-exchange.sh
+# Most tests check that `/usr/bin/tr` is working correctly before running.
+# However in NixOS/Nix-based distros, the tr coreutil is located somewhere in
+# /nix/store/xxxxxxxxxxxx...xxxx/bin/tr
+# We just replace the references to `/usr/bin/tr` with the result of `$(which tr)`
+sed -i  's/\/usr\/bin\/tr/$(which tr)/' tests/init.sh


### PR DESCRIPTION
I don't really know if this has its place here, but I've been using a nix flake to setup my dev environment for a while, and I thought I might share it here, and maybe integrate it to the main branch if it's coherent.

To make use of these scripts, you'll first need to install the Nix package manager ([instructions](https://nixos.org/download/))

Then, install the `direnv` package from your preferred distro ([instructions](https://direnv.net/docs/installation.html))

Once that's done, open a shell and type
```
$ direnv allow
```
in the repository. The initial setup will take 1-2min.
After that, your environment will be instantly loaded every time you `cd` to this folder !

I note that for rust-analyzer to work in VS Code, I installed the `direnv` extension, which allows VS Code to load the `.envrc`.