### PR TITLE
seq:reduce memory allocation during prefix search

### DIFF
--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -341,7 +341,7 @@ impl FromStr for PreciseNumber {
         // Check if the string seems to be in hexadecimal format.
         //
         // May be 0x123 or -0x123, so the index `i` may be either 0 or 1.
-        if let Some(i) = s.to_lowercase().find("0x") {
+        if let Some(i) = s.find("0x").or_else(|| s.find("0X")) {
             if i <= 1 {
                 return parse_hexadecimal(s);
             }


### PR DESCRIPTION
Hello, 

I noticed that the code in the ```numberparse``` module tries to work without extra memory allocations. However, one place with ```to_lowercase``` breaks the general approach.

So, I slightly updated that part to match the common pattern. 

Please feel free just to close the PR if this change seems unimportant or a preliminary optimization.

Thank you