### PR TITLE
seq:add floating point support

### DIFF
--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -7,7 +7,7 @@ use crate::extendedbigdecimal::ExtendedBigDecimal;
 use crate::number::PreciseNumber;
 use crate::numberparse::ParseNumberError;
 use bigdecimal::BigDecimal;
-use num_traits::{Float, FromPrimitive};
+use num_traits::FromPrimitive;
 
 /// The base of the hex number system
 const HEX_RADIX: u32 = 16;

--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -2,6 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+// spell-checker:ignore extendedbigdecimal bigdecimal hexdigit numberparse
 use crate::extendedbigdecimal::ExtendedBigDecimal;
 use crate::number::PreciseNumber;
 use crate::numberparse::ParseNumberError;

--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -117,23 +117,33 @@ fn parse_float(s: &str) -> Result<f64, ParseNumberError> {
 
 /// Parse the fractional part in hexadecimal notation.
 ///
+/// The function calculates the sum of the digits after the '.' (dot) sign. Each Nth digit is
+/// interpreted as digit / 16^n, where n represents the position after the dot starting from 1.
+///
+/// For example, the number 0x1.234p2 has a fractional part 234, which can be interpreted as
+/// 2/16^1 + 3/16^2 + 4/16^3, where 16 is the radix of the hexadecimal number system. This equals
+/// 0.125 + 0.01171875 + 0.0009765625 = 0.1376953125 in decimal. And this is exactly what the
+/// function does.
+///
 /// # Errors
 ///
-/// This function returns an error if the string is empty or contains characters that are not hex digits.
+/// This function returns an error if the string is empty or contains characters that are not hex
+/// digits.
 fn parse_fractional_part(s: &str) -> Result<f64, ParseNumberError> {
     if s.is_empty() {
         return Err(ParseNumberError::Float);
     }
 
-    let mut multiplier = 1.0 / 16.0;
+    const RADIX: u32 = 16;
+    let mut multiplier = 1.0 / RADIX as f64;
     let mut total = 0.0;
     for c in s.chars() {
         let digit = c
-            .to_digit(16)
+            .to_digit(RADIX)
             .map(|x| x as u8)
             .ok_or(ParseNumberError::Float)?;
         total += (digit as f64) * multiplier;
-        multiplier /= 16.0;
+        multiplier /= RADIX as f64;
     }
     Ok(total)
 }

--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -1,0 +1,197 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+use crate::extendedbigdecimal::ExtendedBigDecimal;
+use crate::number::PreciseNumber;
+use crate::numberparse::ParseNumberError;
+use bigdecimal::BigDecimal;
+use num_traits::FromPrimitive;
+
+pub fn parse_hexadecimal_float(s: &str) -> Result<PreciseNumber, ParseNumberError> {
+    let value = parse_float(s)?;
+    let number = BigDecimal::from_f64(value).ok_or(ParseNumberError::Float)?;
+    let fractional_digits = i64::max(number.fractional_digit_count(), 0) as usize;
+    Ok(PreciseNumber::new(
+        ExtendedBigDecimal::BigDecimal(number),
+        0,
+        fractional_digits,
+    ))
+}
+
+fn parse_float(s: &str) -> Result<f64, ParseNumberError> {
+    let mut s = s.trim();
+
+    // Detect a sign
+    let sign = if s.starts_with('-') {
+        s = &s[1..];
+        -1.0
+    } else if s.starts_with('+') {
+        s = &s[1..];
+        1.0
+    } else {
+        1.0
+    };
+
+    // Is HEX?
+    if s.starts_with("0x") || s.starts_with("0X") {
+        s = &s[2..];
+    } else {
+        return Err(ParseNumberError::Float);
+    }
+
+    // Read an integer part (if presented)
+    let length = s.chars().take_while(|c| c.is_ascii_hexdigit()).count();
+    let integer = u64::from_str_radix(&s[..length], 16).unwrap_or(0);
+    s = &s[length..];
+
+    // Read a fractional part (if presented)
+    let fractional = if s.starts_with('.') {
+        s = &s[1..];
+        let length = s.chars().take_while(|c| c.is_ascii_hexdigit()).count();
+        let value = parse_fractional_part(&s[..length])?;
+        s = &s[length..];
+        Some(value)
+    } else {
+        None
+    };
+
+    // Read a power (if presented)
+    let power = if s.starts_with('p') || s.starts_with('P') {
+        s = &s[1..];
+        let length = s
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '-' || *c == '+')
+            .count();
+        let value = s[..length].parse().map_err(|_| ParseNumberError::Float)?;
+        s = &s[length..];
+        Some(value)
+    } else {
+        None
+    };
+
+    // Post checks:
+    // - Both Fractions & Power values can't be none in the same time
+    // - string should be consumed. Otherwise, it's possible to have garbage symbols after the HEX
+    // float
+    if fractional.is_none() && power.is_none() {
+        return Err(ParseNumberError::Float);
+    }
+
+    if !s.is_empty() {
+        return Err(ParseNumberError::Float);
+    }
+
+    // Build the result
+    let total =
+        sign * (integer as f64 + fractional.unwrap_or(0.0)) * (2.0_f64).powi(power.unwrap_or(0));
+    Ok(total)
+}
+
+fn parse_fractional_part(s: &str) -> Result<f64, ParseNumberError> {
+    if s.is_empty() {
+        return Err(ParseNumberError::Float);
+    }
+
+    let mut multiplier = 1.0 / 16.0;
+    let mut total = 0.0;
+    for c in s.chars() {
+        let digit = c
+            .to_digit(16)
+            .map(|x| x as u8)
+            .ok_or(ParseNumberError::Float)?;
+        total += (digit as f64) * multiplier;
+        multiplier /= 16.0;
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_hexadecimal_float;
+    use crate::{numberparse::ParseNumberError, ExtendedBigDecimal};
+    use num_traits::ToPrimitive;
+
+    fn parse_f64(s: &str) -> Result<f64, ParseNumberError> {
+        match parse_hexadecimal_float(s)?.number {
+            ExtendedBigDecimal::BigDecimal(bd) => bd.to_f64().ok_or(ParseNumberError::Float),
+            _ => Err(ParseNumberError::Float),
+        }
+    }
+
+    #[test]
+    fn test_parse_precise_number_case_insensitive() {
+        assert_eq!(parse_f64("0x1P1").unwrap(), 2.0);
+        assert_eq!(parse_f64("0x1p1").unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_parse_precise_number_plus_minus_prefixes() {
+        assert_eq!(parse_f64("+0x1p1").unwrap(), 2.0);
+        assert_eq!(parse_f64("-0x1p1").unwrap(), -2.0);
+    }
+
+    #[test]
+    fn test_parse_precise_number_power_signs() {
+        assert_eq!(parse_f64("0x1p1").unwrap(), 2.0);
+        assert_eq!(parse_f64("0x1p+1").unwrap(), 2.0);
+        assert_eq!(parse_f64("0x1p-1").unwrap(), 0.5);
+    }
+
+    #[test]
+    fn test_parse_precise_number_hex() {
+        assert_eq!(parse_f64("0xd.dp-1").unwrap(), 6.90625);
+    }
+
+    #[test]
+    fn test_parse_precise_number_no_power() {
+        assert_eq!(parse_f64("0x123.a").unwrap(), 291.625);
+    }
+
+    #[test]
+    fn test_parse_precise_number_no_fractional() {
+        assert_eq!(parse_f64("0x333p-4").unwrap(), 51.1875);
+    }
+
+    #[test]
+    fn test_parse_precise_number_no_integral() {
+        assert_eq!(parse_f64("0x.9").unwrap(), 0.5625);
+        assert_eq!(parse_f64("0x.9p2").unwrap(), 2.25);
+    }
+
+    #[test]
+    fn test_parse_precise_number_from_valid_values() {
+        assert_eq!(parse_f64("0x1p1").unwrap(), 2.0);
+        assert_eq!(parse_f64("+0x1p1").unwrap(), 2.0);
+        assert_eq!(parse_f64("-0x1p1").unwrap(), -2.0);
+        assert_eq!(parse_f64("0x1p-1").unwrap(), 0.5);
+        assert_eq!(parse_f64("0x1.8").unwrap(), 1.5);
+        assert_eq!(parse_f64("-0x1.8").unwrap(), -1.5);
+        assert_eq!(parse_f64("0x1.8p2").unwrap(), 6.0);
+        assert_eq!(parse_f64("0x1.8p+2").unwrap(), 6.0);
+        assert_eq!(parse_f64("0x1.8p-2").unwrap(), 0.375);
+        assert_eq!(parse_f64("0x.8").unwrap(), 0.5);
+        assert_eq!(parse_f64("0x10p0").unwrap(), 16.0);
+        assert_eq!(parse_f64("0x0.0").unwrap(), 0.0);
+        assert_eq!(parse_f64("0x0p0").unwrap(), 0.0);
+        assert_eq!(parse_f64("0x0.0p0").unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_parse_float_from_invalid_values() {
+        let expected_error = ParseNumberError::Float;
+        assert_eq!(parse_f64("1").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("1p").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1.").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1p").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1p+").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("-0xx1p1").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1.k").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("-0x1pa").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1.1pk").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1.8p2z").unwrap_err(), expected_error);
+        assert_eq!(parse_f64("0x1p3.2").unwrap_err(), expected_error);
+    }
+}

--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -110,8 +110,7 @@ pub fn detect_precision(s: &str) -> Option<usize> {
                 .count();
 
             if length > 0 {
-                let exponent_value: i32 =
-                    s[exponent + 1..exponent + length + 1].parse().unwrap_or(0);
+                let exponent_value: i32 = s[exponent + 1..=exponent + length].parse().unwrap_or(0);
                 if exponent_value < 0 {
                     precision = precision.map(|x| x + exponent_value.abs());
                 } else {
@@ -253,8 +252,8 @@ fn parse_exponent_part(s: &str) -> Result<(Option<i32>, &str), ParseNumberError>
 #[cfg(test)]
 mod tests {
 
-    use super::parse_hexadecimal_float;
-    use crate::{floatparse::detect_precision, numberparse::ParseNumberError, ExtendedBigDecimal};
+    use super::{detect_precision, parse_hexadecimal_float};
+    use crate::{numberparse::ParseNumberError, ExtendedBigDecimal};
     use bigdecimal::BigDecimal;
     use num_traits::ToPrimitive;
 
@@ -380,13 +379,11 @@ mod tests {
         assert_eq!(detect_precision("0x1.1"), None);
         assert_eq!(detect_precision("0x1.1p2"), None);
         assert_eq!(detect_precision("0x1.1p-2"), None);
-        assert_eq!(detect_precision("0x1.1p-2"), None);
         assert_eq!(detect_precision(".1"), Some(1));
         assert_eq!(detect_precision("1.1"), Some(1));
         assert_eq!(detect_precision("1.12"), Some(2));
         assert_eq!(detect_precision("1.12345678"), Some(8));
         assert_eq!(detect_precision("1.1e-1"), Some(2));
-        assert_eq!(detect_precision("1.1e-3"), Some(4));
         assert_eq!(detect_precision("1.1e-3"), Some(4));
     }
 }

--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -55,9 +55,13 @@ pub fn parse_hexadecimal_float(s: &str) -> Result<PreciseNumber, ParseNumberErro
 
     // Build a PreciseNumber
     let number = BigDecimal::from_f64(value).ok_or(ParseNumberError::Float)?;
-    let fractional_digits = i64::max(number.fractional_digit_count(), 0);
-    let integral_digits =
-        number.digits() - fractional_digits as u64 + if sign < 0.0 { 1 } else { 0 };
+    let fractional_digits = i64::max(number.fractional_digit_count(), 0) as u64;
+    let integral_digits = if value.abs() < 1.0 {
+        0
+    } else {
+        number.digits() - fractional_digits
+    } + if sign < 0.0 { 1 } else { 0 };
+
     Ok(PreciseNumber::new(
         ExtendedBigDecimal::BigDecimal(number),
         integral_digits as usize,
@@ -269,6 +273,8 @@ mod tests {
         assert_eq!(parse_f64("0x0.0").unwrap(), 0.0);
         assert_eq!(parse_f64("0x0p0").unwrap(), 0.0);
         assert_eq!(parse_f64("0x0.0p0").unwrap(), 0.0);
+        assert_eq!(parse_f64("-0x.1p-3").unwrap(), -0.0078125);
+        assert_eq!(parse_f64("-0x.ep-3").unwrap(), -0.109375);
     }
 
     #[test]

--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -9,6 +9,9 @@ use crate::numberparse::ParseNumberError;
 use bigdecimal::BigDecimal;
 use num_traits::FromPrimitive;
 
+/// The base of the hex number system
+const HEX_RADIX: u32 = 16;
+
 ///  Parse a number from a floating-point hexadecimal exponent notation.
 ///
 /// # Errors
@@ -69,7 +72,7 @@ fn parse_float(s: &str) -> Result<f64, ParseNumberError> {
 
     // Read an integer part (if presented)
     let length = s.chars().take_while(|c| c.is_ascii_hexdigit()).count();
-    let integer = u64::from_str_radix(&s[..length], 16).unwrap_or(0);
+    let integer = u64::from_str_radix(&s[..length], HEX_RADIX).unwrap_or(0);
     s = &s[length..];
 
     // Read a fractional part (if presented)
@@ -134,16 +137,15 @@ fn parse_fractional_part(s: &str) -> Result<f64, ParseNumberError> {
         return Err(ParseNumberError::Float);
     }
 
-    const RADIX: u32 = 16;
-    let mut multiplier = 1.0 / RADIX as f64;
+    let mut multiplier = 1.0 / HEX_RADIX as f64;
     let mut total = 0.0;
     for c in s.chars() {
         let digit = c
-            .to_digit(RADIX)
+            .to_digit(HEX_RADIX)
             .map(|x| x as u8)
             .ok_or(ParseNumberError::Float)?;
         total += (digit as f64) * multiplier;
-        multiplier /= RADIX as f64;
+        multiplier /= HEX_RADIX as f64;
     }
     Ok(total)
 }

--- a/src/uu/seq/src/floatparse.rs
+++ b/src/uu/seq/src/floatparse.rs
@@ -55,17 +55,17 @@ pub fn parse_hexadecimal_float(s: &str) -> Result<PreciseNumber, ParseNumberErro
 
     // Build a PreciseNumber
     let number = BigDecimal::from_f64(value).ok_or(ParseNumberError::Float)?;
-    let fractional_digits = i64::max(number.fractional_digit_count(), 0) as u64;
-    let integral_digits = if value.abs() < 1.0 {
+    let num_fractional_digits = number.fractional_digit_count().max(0) as u64;
+    let num_integral_digits = if value.abs() < 1.0 {
         0
     } else {
-        number.digits() - fractional_digits
+        number.digits() - num_fractional_digits
     } + if sign < 0.0 { 1 } else { 0 };
 
     Ok(PreciseNumber::new(
         ExtendedBigDecimal::BigDecimal(number),
-        integral_digits as usize,
-        fractional_digits as usize,
+        num_integral_digits as usize,
+        num_fractional_digits as usize,
     ))
 }
 

--- a/src/uu/seq/src/number.rs
+++ b/src/uu/seq/src/number.rs
@@ -19,6 +19,8 @@ use crate::extendedbigdecimal::ExtendedBigDecimal;
 pub struct PreciseNumber {
     pub number: ExtendedBigDecimal,
     pub num_integral_digits: usize,
+
+    #[allow(dead_code)]
     pub num_fractional_digits: usize,
 }
 

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -16,6 +16,7 @@ use num_traits::Num;
 use num_traits::Zero;
 
 use crate::extendedbigdecimal::ExtendedBigDecimal;
+use crate::floatparse;
 use crate::number::PreciseNumber;
 
 /// An error returned when parsing a number fails.
@@ -296,6 +297,14 @@ fn parse_decimal_and_exponent(
 /// assert_eq!(actual, expected);
 /// ```
 fn parse_hexadecimal(s: &str) -> Result<PreciseNumber, ParseNumberError> {
+    if s.find(['.', 'p', 'P']).is_some() {
+        floatparse::parse_hexadecimal_float(s)
+    } else {
+        parse_hexadecimal_integer(s)
+    }
+}
+
+fn parse_hexadecimal_integer(s: &str) -> Result<PreciseNumber, ParseNumberError> {
     let (is_neg, s) = if s.starts_with('-') {
         (true, &s[3..])
     } else {

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore extendedbigdecimal bigdecimal numberparse
+// spell-checker:ignore extendedbigdecimal bigdecimal numberparse floatparse
 //! Parsing numbers for use in `seq`.
 //!
 //! This module provides an implementation of [`FromStr`] for the

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore extendedbigdecimal bigdecimal numberparse floatparse
+// spell-checker:ignore extendedbigdecimal bigdecimal numberparse hexadecimalfloat
 //! Parsing numbers for use in `seq`.
 //!
 //! This module provides an implementation of [`FromStr`] for the
@@ -16,7 +16,7 @@ use num_traits::Num;
 use num_traits::Zero;
 
 use crate::extendedbigdecimal::ExtendedBigDecimal;
-use crate::floatparse;
+use crate::hexadecimalfloat;
 use crate::number::PreciseNumber;
 
 /// An error returned when parsing a number fails.
@@ -298,7 +298,7 @@ fn parse_decimal_and_exponent(
 /// ```
 fn parse_hexadecimal(s: &str) -> Result<PreciseNumber, ParseNumberError> {
     if s.find(['.', 'p', 'P']).is_some() {
-        floatparse::parse_hexadecimal_float(s)
+        hexadecimalfloat::parse_number(s)
     } else {
         parse_hexadecimal_integer(s)
     }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -247,7 +247,7 @@ fn write_value_float(
         // format without precision: hexadecimal floats
         match value {
             ExtendedBigDecimal::BigDecimal(bd) => {
-                format_bigdecimal(&bd).unwrap_or("{value}".to_owned())
+                format_bigdecimal(bd).unwrap_or("{value}".to_owned())
             }
             _ => format!("{value:>0width$}"),
         }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -15,6 +15,7 @@ use uucore::{format_usage, help_about, help_usage};
 
 mod error;
 mod extendedbigdecimal;
+mod floatparse;
 // public to allow fuzzing
 #[cfg(fuzzing)]
 pub mod number;

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -10,7 +10,7 @@ use clap::{crate_version, Arg, ArgAction, Command};
 use num_traits::{ToPrimitive, Zero};
 
 use uucore::error::{FromIo, UResult};
-use uucore::format::{num_format, Format};
+use uucore::format::{num_format, sprintf, Format, FormatArgument};
 use uucore::{format_usage, help_about, help_usage};
 
 mod error;
@@ -73,6 +73,18 @@ fn split_short_args_with_value(args: impl uucore::Args) -> impl uucore::Args {
     v.into_iter()
 }
 
+fn select_precision(
+    first: Option<usize>,
+    increment: Option<usize>,
+    last: Option<usize>,
+) -> Option<usize> {
+    match (first, increment, last) {
+        (Some(0), Some(0), Some(0)) => Some(0),
+        (Some(f), Some(i), Some(_)) => Some(f.max(i)),
+        _ => None,
+    }
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(split_short_args_with_value(args))?;
@@ -100,32 +112,32 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         format: matches.get_one::<String>(OPT_FORMAT).map(|s| s.as_str()),
     };
 
-    let first = if numbers.len() > 1 {
+    let (first, first_precision) = if numbers.len() > 1 {
         match numbers[0].parse() {
-            Ok(num) => num,
+            Ok(num) => (num, floatparse::detect_precision(numbers[0])),
             Err(e) => return Err(SeqError::ParseError(numbers[0].to_string(), e).into()),
         }
     } else {
-        PreciseNumber::one()
+        (PreciseNumber::one(), Some(0))
     };
-    let increment = if numbers.len() > 2 {
+    let (increment, increment_precision) = if numbers.len() > 2 {
         match numbers[1].parse() {
-            Ok(num) => num,
+            Ok(num) => (num, floatparse::detect_precision(numbers[1])),
             Err(e) => return Err(SeqError::ParseError(numbers[1].to_string(), e).into()),
         }
     } else {
-        PreciseNumber::one()
+        (PreciseNumber::one(), Some(0))
     };
     if increment.is_zero() {
         return Err(SeqError::ZeroIncrement(numbers[1].to_string()).into());
     }
-    let last: PreciseNumber = {
+    let (last, last_precision): (PreciseNumber, Option<usize>) = {
         // We are guaranteed that `numbers.len()` is greater than zero
         // and at most three because of the argument specification in
         // `uu_app()`.
         let n: usize = numbers.len();
         match numbers[n - 1].parse() {
-            Ok(num) => num,
+            Ok(num) => (num, floatparse::detect_precision(numbers[n - 1])),
             Err(e) => return Err(SeqError::ParseError(numbers[n - 1].to_string(), e).into()),
         }
     };
@@ -134,9 +146,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .num_integral_digits
         .max(increment.num_integral_digits)
         .max(last.num_integral_digits);
-    let largest_dec = first
-        .num_fractional_digits
-        .max(increment.num_fractional_digits);
+
+    let precision = select_precision(first_precision, increment_precision, last_precision);
 
     let format = match options.format {
         Some(f) => {
@@ -147,7 +158,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
     let result = print_seq(
         (first.number, increment.number, last.number),
-        largest_dec,
+        precision,
         &options.separator,
         &options.terminator,
         options.equal_width,
@@ -211,26 +222,43 @@ fn done_printing<T: Zero + PartialOrd>(next: &T, increment: &T, last: &T) -> boo
     }
 }
 
+fn format_bigdecimal(value: &bigdecimal::BigDecimal) -> Option<String> {
+    let format_arguments = &[FormatArgument::Float(value.to_f64()?)];
+    let value_as_bytes = sprintf("%g", format_arguments).ok()?;
+    String::from_utf8(value_as_bytes).ok()
+}
+
 /// Write a big decimal formatted according to the given parameters.
 fn write_value_float(
     writer: &mut impl Write,
     value: &ExtendedBigDecimal,
     width: usize,
-    precision: usize,
+    precision: Option<usize>,
 ) -> std::io::Result<()> {
-    let value_as_str =
-        if *value == ExtendedBigDecimal::Infinity || *value == ExtendedBigDecimal::MinusInfinity {
-            format!("{value:>width$.precision$}")
-        } else {
-            format!("{value:>0width$.precision$}")
-        };
+    let value_as_str = if let Some(precision) = precision {
+        // format with precision: decimal floats and integers
+        match value {
+            ExtendedBigDecimal::Infinity | ExtendedBigDecimal::MinusInfinity => {
+                format!("{value:>width$.precision$}")
+            }
+            _ => format!("{value:>0width$.precision$}"),
+        }
+    } else {
+        // format without precision: hexadecimal floats
+        match value {
+            ExtendedBigDecimal::BigDecimal(bd) => {
+                format_bigdecimal(&bd).unwrap_or("{value}".to_owned())
+            }
+            _ => format!("{value:>0width$}"),
+        }
+    };
     write!(writer, "{value_as_str}")
 }
 
 /// Floating point based code path
 fn print_seq(
     range: RangeFloat,
-    largest_dec: usize,
+    precision: Option<usize>,
     separator: &str,
     terminator: &str,
     pad: bool,
@@ -242,7 +270,13 @@ fn print_seq(
     let (first, increment, last) = range;
     let mut value = first;
     let padding = if pad {
-        padding + if largest_dec > 0 { largest_dec + 1 } else { 0 }
+        let precision_value = precision.unwrap_or(0);
+        padding
+            + if precision_value > 0 {
+                precision_value + 1
+            } else {
+                0
+            }
     } else {
         0
     };
@@ -274,7 +308,7 @@ fn print_seq(
                 };
                 f.fmt(&mut stdout, float)?;
             }
-            None => write_value_float(&mut stdout, &value, padding, largest_dec)?,
+            None => write_value_float(&mut stdout, &value, padding, precision)?,
         }
         // TODO Implement augmenting addition.
         value = value + increment.clone();

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -235,22 +235,21 @@ fn write_value_float(
     width: usize,
     precision: Option<usize>,
 ) -> std::io::Result<()> {
-    let value_as_str = if let Some(precision) = precision {
+    let value_as_str = match precision {
         // format with precision: decimal floats and integers
-        match value {
+        Some(precision) => match value {
             ExtendedBigDecimal::Infinity | ExtendedBigDecimal::MinusInfinity => {
                 format!("{value:>width$.precision$}")
             }
             _ => format!("{value:>0width$.precision$}"),
-        }
-    } else {
+        },
         // format without precision: hexadecimal floats
-        match value {
+        None => match value {
             ExtendedBigDecimal::BigDecimal(bd) => {
-                format_bigdecimal(bd).unwrap_or("{value}".to_owned())
+                format_bigdecimal(bd).unwrap_or_else(|| "{value}".to_owned())
             }
             _ => format!("{value:>0width$}"),
-        }
+        },
     };
     write!(writer, "{value_as_str}")
 }

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (ToDO) extendedbigdecimal numberparse
+// spell-checker:ignore (ToDO) extendedbigdecimal numberparse floatparse
 use std::ffi::OsString;
 use std::io::{stdout, ErrorKind, Write};
 

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (ToDO) bigdecimal extendedbigdecimal numberparse floatparse
+// spell-checker:ignore (ToDO) bigdecimal extendedbigdecimal numberparse hexadecimalfloat
 use std::ffi::OsString;
 use std::io::{stdout, ErrorKind, Write};
 
@@ -15,8 +15,9 @@ use uucore::{format_usage, help_about, help_usage};
 
 mod error;
 mod extendedbigdecimal;
+mod hexadecimalfloat;
+
 // public to allow fuzzing
-mod floatparse;
 #[cfg(fuzzing)]
 pub mod number;
 #[cfg(not(fuzzing))]
@@ -114,7 +115,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let (first, first_precision) = if numbers.len() > 1 {
         match numbers[0].parse() {
-            Ok(num) => (num, floatparse::detect_precision(numbers[0])),
+            Ok(num) => (num, hexadecimalfloat::parse_precision(numbers[0])),
             Err(e) => return Err(SeqError::ParseError(numbers[0].to_string(), e).into()),
         }
     } else {
@@ -122,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
     let (increment, increment_precision) = if numbers.len() > 2 {
         match numbers[1].parse() {
-            Ok(num) => (num, floatparse::detect_precision(numbers[1])),
+            Ok(num) => (num, hexadecimalfloat::parse_precision(numbers[1])),
             Err(e) => return Err(SeqError::ParseError(numbers[1].to_string(), e).into()),
         }
     } else {
@@ -137,7 +138,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         // `uu_app()`.
         let n: usize = numbers.len();
         match numbers[n - 1].parse() {
-            Ok(num) => (num, floatparse::detect_precision(numbers[n - 1])),
+            Ok(num) => (num, hexadecimalfloat::parse_precision(numbers[n - 1])),
             Err(e) => return Err(SeqError::ParseError(numbers[n - 1].to_string(), e).into()),
         }
     };

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -698,7 +698,7 @@ fn test_parse_error_hex() {
     new_ucmd!()
         .arg("0xlmnop")
         .fails()
-        .usage_error("invalid hexadecimal argument: '0xlmnop'");
+        .usage_error("invalid floating point argument: '0xlmnop'");
 }
 
 #[test]

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -837,7 +837,7 @@ fn test_parse_valid_hexadecimal_float() {
     new_ucmd!()
         .args(&["1", "0x1p-1", "2"])
         .succeeds()
-        .stdout_only("1.0\n1.5\n2.0\n");
+        .stdout_only("1\n1.5\n2\n");
 
     new_ucmd!()
         .args(&["0x3.4p-1", "0x4p-1", "4"])

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -881,6 +881,20 @@ fn test_parse_valid_hexadecimal_float() {
         .stdout_only("1024\n");
 }
 
+#[test]
+fn test_parse_float_gnu_coreutils() {
+    // some values from GNU coreutils tests
+    new_ucmd!()
+        .args(&[".89999", "1e-7", ".8999901"])
+        .succeeds()
+        .stdout_only("0.8999900\n0.8999901\n");
+
+    new_ucmd!()
+        .args(&["0", "0.000001", "0.000003"])
+        .succeeds()
+        .stdout_only("0.000000\n0.000001\n0.000002\n0.000003\n");
+}
+
 #[ignore]
 #[test]
 fn test_parse_valid_hexadecimal_float_format_issues() {

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -850,9 +850,35 @@ fn test_parse_valid_hexadecimal_float() {
         .stdout_only("1.625\n3.625\n");
 
     new_ucmd!()
-        .args(&[" 0x.8p16", "32768"])
+        .args(&["0x.8p16", "32768"])
         .succeeds()
         .stdout_only("32768\n");
+
+    // from issue #2660
+    new_ucmd!()
+        .args(&["-0x.ep-3", "-0x.1p-3", "-0x.fp-3"])
+        .succeeds()
+        .stdout_only("-0.109375\n-0.117188\n");
+
+    new_ucmd!()
+        .args(&["0xffff.4p-4", "4096"])
+        .succeeds()
+        .stdout_only("4095.95\n");
+
+    new_ucmd!()
+        .args(&["0xA.A9p-1", "6"])
+        .succeeds()
+        .stdout_only("5.33008\n");
+
+    new_ucmd!()
+        .args(&["0xa.a9p-1", "6"])
+        .succeeds()
+        .stdout_only("5.33008\n");
+
+    new_ucmd!()
+        .args(&["0xffffffffffp-30", "1024"]) // spell-checker:disable-line
+        .succeeds()
+        .stdout_only("1024\n");
 }
 
 #[ignore]
@@ -875,36 +901,6 @@ fn test_parse_valid_hexadecimal_float_format_issues() {
     // It makes sense to begin by experimenting with formats and attempting to replicate
     // the printf("%Lg",...) behavior. Another area worth investigating is glibc, as reviewing its
     // code may help uncover additional corner cases or test data that could reveal more issues.
-
-    // Test output: 4095.953125
-    // In fact, the 4095.953125 is correct value.
-    // (65535 + 4/16)*2^(-4) = 4095.953125
-    // So, it looks like a formatting or output rounding differences
-    new_ucmd!()
-        .args(&["0xffff.4p-4", "4096"])
-        .succeeds()
-        .stdout_only("4095.95\n");
-
-    // Test output: 1023.999999999068677425384521484375
-    // 0xffffffffff = 1099511627775
-    // 2^(-30) = 1 / 1073741824
-    // 1099511627775 / 1073741824 = 1024
-    new_ucmd!()
-        .args(&["0xffffffffffp-30", "1024"]) // spell-checker:disable-line
-        .succeeds()
-        .stdout_only("1024\n");
-
-    // Test output: 5.330078125
-    new_ucmd!()
-        .args(&["0xa.a9p-1", "6"])
-        .succeeds()
-        .stdout_only("5.33008\n");
-
-    // Test output: 5.330078125
-    new_ucmd!()
-        .args(&["0xA.A9p-1", "6"])
-        .succeeds()
-        .stdout_only("5.33008\n");
 
     //Test output: 0.00000000992804416455328464508056640625
     new_ucmd!()

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -858,7 +858,23 @@ fn test_parse_valid_hexadecimal_float() {
 #[ignore]
 #[test]
 fn test_parse_valid_hexadecimal_float_format_issues() {
-    // Parsing is OK, but value representation conflicts with the GNU seq.
+    // These tests detect differences in the representation of floating-point values with GNU seq.
+    // There are two key areas to investigate:
+    //
+    // 1. GNU seq uses long double (80-bit) types for values, while the current implementation
+    // relies on f64 (64-bit). This can lead to differences due to varying precision. However, it's
+    // likely not the primary cause, as even double (64-bit) values can differ when compared to
+    // f64.
+    //
+    // 2. GNU seq uses the %Lg format specifier for printing (see the "get_default_format" function
+    // ). It appears that Rust lacks a direct equivalent for this format. Additionally, %Lg
+    // can use %f (floating) or %e (scientific) depending on the precision. There also seem to be
+    // some differences in the behavior of C and Rust when displaying floating-point or scientific
+    // notation, at least without additional configuration.
+    //
+    // It makes sense to begin by experimenting with formats and attempting to replicate
+    // the printf("%Lg",...) behavior. Another area worth investigating is glibc, as reviewing its
+    // code may help uncover additional corner cases or test data that could reveal more issues.
 
     // Test output: 4095.953125
     // In fact, the 4095.953125 is correct value.

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -826,3 +826,73 @@ fn test_parse_scientific_zero() {
         .succeeds()
         .stdout_only("0\n1\n");
 }
+
+#[test]
+fn test_parse_valid_hexadecimal_float() {
+    new_ucmd!()
+        .args(&["0x1p-1", "2"])
+        .succeeds()
+        .stdout_only("0.5\n1.5\n");
+
+    new_ucmd!()
+        .args(&["1", "0x1p-1", "2"])
+        .succeeds()
+        .stdout_only("1.0\n1.5\n2.0\n");
+
+    new_ucmd!()
+        .args(&["0x3.4p-1", "0x4p-1", "4"])
+        .succeeds()
+        .stdout_only("1.625\n3.625\n");
+
+    new_ucmd!()
+        .args(&["0x3.4p-1", "0x4p-1", "4"])
+        .succeeds()
+        .stdout_only("1.625\n3.625\n");
+
+    new_ucmd!()
+        .args(&[" 0x.8p16", "32768"])
+        .succeeds()
+        .stdout_only("32768\n");
+}
+
+#[ignore]
+#[test]
+fn test_parse_valid_hexadecimal_float_format_issues() {
+    // Parsing is OK, but value representation conflicts with the GNU seq.
+
+    // Test output: 4095.953125
+    // In fact, the 4095.953125 is correct value.
+    // (65535 + 4/16)*2^(-4) = 4095.953125
+    // So, it looks like a formatting or output rounding differences
+    new_ucmd!()
+        .args(&["0xffff.4p-4", "4096"])
+        .succeeds()
+        .stdout_only("4095.95\n");
+
+    // Test output: 1023.999999999068677425384521484375
+    // 0xffffffffff = 1099511627775
+    // 2^(-30) = 1 / 1073741824
+    // 1099511627775 / 1073741824 = 1024
+    new_ucmd!()
+        .args(&["0xffffffffffp-30", "1024"]) // spell-checker:disable-line
+        .succeeds()
+        .stdout_only("1024\n");
+
+    // Test output: 5.330078125
+    new_ucmd!()
+        .args(&["0xa.a9p-1", "6"])
+        .succeeds()
+        .stdout_only("5.33008\n");
+
+    // Test output: 5.330078125
+    new_ucmd!()
+        .args(&["0xA.A9p-1", "6"])
+        .succeeds()
+        .stdout_only("5.33008\n");
+
+    //Test output: 0.00000000992804416455328464508056640625
+    new_ucmd!()
+        .args(&["0xa.a9p-30", "1"])
+        .succeeds()
+        .stdout_only("9.92804e-09\n1\n");
+}

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -829,51 +829,27 @@ fn test_parse_scientific_zero() {
 
 #[test]
 fn test_parse_valid_hexadecimal_float() {
-    new_ucmd!()
-        .args(&["0x1p-1", "2"])
-        .succeeds()
-        .stdout_only("0.5\n1.5\n");
+    let test_cases = [
+        (vec!["0x1p-1", "2"], "0.5\n1.5\n"),
+        (vec!["1", "0x1p-1", "2"], "1\n1.5\n2\n"),
+        (vec!["0x3.4p-1", "0x4p-1", "4"], "1.625\n3.625\n"),
+        (vec!["0x.8p16", "32768"], "32768\n"),
+        (
+            vec!["-0x.ep-3", "-0x.1p-3", "-0x.fp-3"],
+            "-0.109375\n-0.117188\n",
+        ),
+        (vec!["0xffff.4p-4", "4096"], "4095.95\n"),
+        (vec!["0xA.A9p-1", "6"], "5.33008\n"),
+        (vec!["0xa.a9p-1", "6"], "5.33008\n"),
+        (vec!["0xffffffffffp-30", "1024"], "1024\n"),
+    ];
 
-    new_ucmd!()
-        .args(&["1", "0x1p-1", "2"])
-        .succeeds()
-        .stdout_only("1\n1.5\n2\n");
-
-    new_ucmd!()
-        .args(&["0x3.4p-1", "0x4p-1", "4"])
-        .succeeds()
-        .stdout_only("1.625\n3.625\n");
-
-    new_ucmd!()
-        .args(&["0x.8p16", "32768"])
-        .succeeds()
-        .stdout_only("32768\n");
-
-    // from issue #2660
-    new_ucmd!()
-        .args(&["-0x.ep-3", "-0x.1p-3", "-0x.fp-3"])
-        .succeeds()
-        .stdout_only("-0.109375\n-0.117188\n");
-
-    new_ucmd!()
-        .args(&["0xffff.4p-4", "4096"])
-        .succeeds()
-        .stdout_only("4095.95\n");
-
-    new_ucmd!()
-        .args(&["0xA.A9p-1", "6"])
-        .succeeds()
-        .stdout_only("5.33008\n");
-
-    new_ucmd!()
-        .args(&["0xa.a9p-1", "6"])
-        .succeeds()
-        .stdout_only("5.33008\n");
-
-    new_ucmd!()
-        .args(&["0xffffffffffp-30", "1024"]) // spell-checker:disable-line
-        .succeeds()
-        .stdout_only("1024\n");
+    for (input_arguments, expected_output) in &test_cases {
+        new_ucmd!()
+            .args(input_arguments)
+            .succeeds()
+            .stdout_only(expected_output);
+    }
 }
 
 #[test]

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -845,11 +845,6 @@ fn test_parse_valid_hexadecimal_float() {
         .stdout_only("1.625\n3.625\n");
 
     new_ucmd!()
-        .args(&["0x3.4p-1", "0x4p-1", "4"])
-        .succeeds()
-        .stdout_only("1.625\n3.625\n");
-
-    new_ucmd!()
         .args(&["0x.8p16", "32768"])
         .succeeds()
         .stdout_only("32768\n");

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -828,20 +828,32 @@ fn test_parse_scientific_zero() {
 }
 
 #[test]
-fn test_parse_valid_hexadecimal_float() {
+fn test_parse_valid_hexadecimal_float_two_args() {
     let test_cases = [
-        (vec!["0x1p-1", "2"], "0.5\n1.5\n"),
-        (vec!["1", "0x1p-1", "2"], "1\n1.5\n2\n"),
-        (vec!["0x3.4p-1", "0x4p-1", "4"], "1.625\n3.625\n"),
-        (vec!["0x.8p16", "32768"], "32768\n"),
+        (["0x1p-1", "2"], "0.5\n1.5\n"),
+        (["0x.8p16", "32768"], "32768\n"),
+        (["0xffff.4p-4", "4096"], "4095.95\n"),
+        (["0xA.A9p-1", "6"], "5.33008\n"),
+        (["0xa.a9p-1", "6"], "5.33008\n"),
+        (["0xffffffffffp-30", "1024"], "1024\n"), // spell-checker:disable-line
+    ];
+
+    for (input_arguments, expected_output) in &test_cases {
+        new_ucmd!()
+            .args(input_arguments)
+            .succeeds()
+            .stdout_only(expected_output);
+    }
+}
+
+#[test]
+fn test_parse_valid_hexadecimal_float_three_args() {
+    let test_cases = [
+        (["0x3.4p-1", "0x4p-1", "4"], "1.625\n3.625\n"),
         (
-            vec!["-0x.ep-3", "-0x.1p-3", "-0x.fp-3"],
+            ["-0x.ep-3", "-0x.1p-3", "-0x.fp-3"],
             "-0.109375\n-0.117188\n",
         ),
-        (vec!["0xffff.4p-4", "4096"], "4095.95\n"),
-        (vec!["0xA.A9p-1", "6"], "5.33008\n"),
-        (vec!["0xa.a9p-1", "6"], "5.33008\n"),
-        (vec!["0xffffffffffp-30", "1024"], "1024\n"),
     ];
 
     for (input_arguments, expected_output) in &test_cases {


### PR DESCRIPTION
# About

Hello,

This is the initial implementation of hexadecimal floating-point arguments in seq. It started as an attempt to add parsing for hexadecimal floats (issue #6935), but quickly grew into bigger changes.

### Before
```
cargo run -q seq 0x1p-1 2
seq: invalid hexadecimal argument: '0x1p-1'
```
### After
```
cargo run -q seq 0x1p-1 2
0.5
1.5
```

### Expected
```
seq 0x1p-1 2
0.5
1.5
```

# Changes 

- Added the``hexdecimalfloat`` module for parsing hex-floats and detecting the precision of numbers closer to GNU seq. I tried to keep the new functionality separate and minimize changes to the existing code to make changes more observable. I'm sure it’s possible unify number parsing to handle all types of values in one place. However, this seems like a big change and (IMHO) deserves a separate refactor-like PR.

- Changed the method for detecting and using precision for numbers. The initial approach of using the number of fractional digits from a ``BigDecimal`` didn’t match the GNU behavior and led to different representations. For now the precision is detected separately and this is not a part of the ``PreciseNumber`` (to avoid changing too much of the existing code).

- Added decimal/exponent notations for hexadecimal floats to match the ``%Lg`` format in GNU seq. The ``sprintf`` function from ``uucore`` is used for this.

- Added tests. During development, I found some additional mismatches with GNU seq. However, they are not directly related to hexadecimal floating points and could be addressed in future PRs.

Thank you