### PR TITLE
GNUmakefile: remove `sleep` from `UNIX_PROGS` to avoid warning

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -147,7 +147,6 @@ UNIX_PROGS := \
 	nohup \
 	pathchk \
 	pinky \
-	sleep \
 	stat \
 	stdbuf \
 	timeout \


### PR DESCRIPTION
When running `./util/build-gnu.sh` I noticed the following two warnings:
```
GNUmakefile:288: warning: overriding recipe for target 'test_busybox_sleep'
GNUmakefile:288: warning: ignoring old recipe for target 'test_busybox_sleep'
```
They are shown because `sleep` is listed in both `PROGS` and `UNIX_PROGS` whereas all other utils are listed only in one of those two lists.

This PR removes `sleep` from `UNIX_PROGS`. I removed it from `UNIX_PROGS` and not from `PROGS` because there is no special handling of `sleep` in `Cargo.toml`.