### PR TITLE
basenc: ignore case with "--base16 --decode"

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -11,7 +11,7 @@ use std::io::{self, ErrorKind, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::encoding::{
-    for_base_common::{BASE32, BASE32HEX, BASE64, BASE64URL, BASE64_NOPAD, HEXUPPER},
+    for_base_common::{BASE32, BASE32HEX, BASE64, BASE64URL, BASE64_NOPAD, HEXUPPER_PERMISSIVE},
     Format, Z85Wrapper, BASE2LSBF, BASE2MSBF,
 };
 use uucore::encoding::{EncodingWrapper, SupportsFastDecodeAndEncode};
@@ -226,11 +226,11 @@ pub fn get_supports_fast_decode_and_encode(
 
     match format {
         Format::Base16 => Box::from(EncodingWrapper::new(
-            HEXUPPER,
+            HEXUPPER_PERMISSIVE,
             BASE16_VALID_DECODING_MULTIPLE,
             BASE16_UNPADDED_MULTIPLE,
             // spell-checker:disable-next-line
-            b"0123456789ABCDEF",
+            b"0123456789ABCDEFabcdef",
         )),
         Format::Base2Lsbf => Box::from(EncodingWrapper::new(
             BASE2LSBF,

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -131,6 +131,24 @@ fn test_base16_decode() {
 }
 
 #[test]
+fn test_base16_decode_lowercase() {
+    new_ucmd!()
+        .args(&["--base16", "-d"])
+        .pipe_in("48656c6c6f2c20576f726c6421")
+        .succeeds()
+        .stdout_only("Hello, World!");
+}
+
+#[test]
+fn test_base16_decode_and_ignore_garbage_lowercase() {
+    new_ucmd!()
+        .args(&["--base16", "-d", "-i"])
+        .pipe_in("48656c6c6f2c20576f726c6421")
+        .succeeds()
+        .stdout_only("Hello, World!");
+}
+
+#[test]
 fn test_base2msbf() {
     new_ucmd!()
         .arg("--base2msbf")


### PR DESCRIPTION
Currently, an error is shown if the input provided to `basenc --base16 --decode` contains lowercase characters. This PR fixes this issue and allows lowercase characters. It also makes the tests `b16_9` and `b16_10` in [basenc.pl](https://github.com/coreutils/coreutils/blob/master/tests/basenc/basenc.pl) pass.
```
// before change
$ printf "48656c6c6f2c20576f726c6421" | cargo run basenc --base16 -d
basenc: error: invalid input

// after change
$ printf "48656c6c6f2c20576f726c6421" | cargo run basenc --base16 -d
Hello, World!
```