### PR TITLE
install: implement copying from streams

### DIFF
--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -23,6 +23,7 @@ file_diff = { workspace = true }
 libc = { workspace = true }
 uucore = { workspace = true, features = [
   "backup-control",
+  "buf-copy",
   "fs",
   "mode",
   "perms",

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -12,14 +12,12 @@ use file_diff::diff;
 use filetime::{set_file_times, FileTime};
 use std::error::Error;
 use std::fmt::{Debug, Display};
-use std::fs;
 use std::fs::File;
-use std::os::unix::fs::MetadataExt;
-#[cfg(unix)]
-use std::os::unix::prelude::OsStrExt;
+use std::fs::{self, metadata};
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::process;
 use uucore::backup_control::{self, BackupMode};
+use uucore::buf_copy::copy_stream;
 use uucore::display::Quotable;
 use uucore::entries::{grp2gid, usr2uid};
 use uucore::error::{FromIo, UError, UIoError, UResult, UUsageError};
@@ -28,6 +26,11 @@ use uucore::mode::get_umask;
 use uucore::perms::{wrap_chown, Verbosity, VerbosityLevel};
 use uucore::process::{getegid, geteuid};
 use uucore::{format_usage, help_about, help_usage, show, show_error, show_if_err, uio_error};
+
+#[cfg(unix)]
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+#[cfg(unix)]
+use std::os::unix::prelude::OsStrExt;
 
 const DEFAULT_MODE: u32 = 0o755;
 const DEFAULT_STRIP_PROGRAM: &str = "strip";
@@ -736,7 +739,24 @@ fn perform_backup(to: &Path, b: &Behavior) -> UResult<Option<PathBuf>> {
     }
 }
 
-/// Copy a file from one path to another.
+/// Copy a non-special file using std::fs::copy.
+///
+/// # Parameters
+/// * `from` - The source file path.
+/// * `to` - The destination file path.
+///
+/// # Returns
+///
+/// Returns an empty Result or an error in case of failure.
+fn copy_normal_file(from: &Path, to: &Path) -> UResult<()> {
+    if let Err(err) = fs::copy(from, to) {
+        return Err(InstallError::InstallFailed(from.to_path_buf(), to.to_path_buf(), err).into());
+    }
+    Ok(())
+}
+
+/// Copy a file from one path to another. Handles the certain cases of special
+/// files (e.g character specials).
 ///
 /// # Parameters
 ///
@@ -760,18 +780,26 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
         }
     }
 
-    if from.as_os_str() == "/dev/null" {
-        /* workaround a limitation of fs::copy
-         * https://github.com/rust-lang/rust/issues/79390
-         */
-        if let Err(err) = File::create(to) {
+    let ft = match metadata(from) {
+        Ok(ft) => ft.file_type(),
+        Err(err) => {
             return Err(
                 InstallError::InstallFailed(from.to_path_buf(), to.to_path_buf(), err).into(),
             );
         }
-    } else if let Err(err) = fs::copy(from, to) {
-        return Err(InstallError::InstallFailed(from.to_path_buf(), to.to_path_buf(), err).into());
+    };
+
+    // Stream-based copying to get around the limitations of std::fs::copy
+    #[cfg(unix)]
+    if ft.is_char_device() || ft.is_block_device() || ft.is_fifo() {
+        let mut handle = File::open(from)?;
+        let mut dest = File::create(to)?;
+        copy_stream(&mut handle, &mut dest)?;
+        return Ok(());
     }
+
+    copy_normal_file(from, to)?;
+
     Ok(())
 }
 

--- a/src/uucore/src/lib/features/buf_copy/linux.rs
+++ b/src/uucore/src/lib/features/buf_copy/linux.rs
@@ -58,8 +58,6 @@ impl From<nix::Error> for Error {
 ///
 /// Result of operation and bytes successfully written (as a `u64`) when
 /// operation is successful.
-///
-
 pub fn copy_stream<R, S>(src: &mut R, dest: &mut S) -> UResult<u64>
 where
     R: Read + AsFd + AsRawFd,


### PR DESCRIPTION
Resolves:
- #5080
- #4387

`install` now uses the `buf-copy` module from `uucore` to do quick data copy under Linux & Android and a buffer-based copy for other OS. FIFOs, character/block devices are considered as streams. Other files still use Rust's `fs::copy`.