### PR TITLE
uucore: correctly truncate response if getgroups shrinks

### DIFF
--- a/src/uucore/src/lib/features/entries.rs
+++ b/src/uucore/src/lib/features/entries.rs
@@ -83,13 +83,14 @@ pub fn get_groups() -> IOResult<Vec<gid_t>> {
         if res == -1 {
             let err = IOError::last_os_error();
             if err.raw_os_error() == Some(libc::EINVAL) {
-                // Number of groups changed, retry
+                // Number of groups has increased, retry
                 continue;
             } else {
                 return Err(err);
             }
         } else {
-            groups.truncate(ngroups.try_into().unwrap());
+            // Number of groups may have decreased
+            groups.truncate(res.try_into().unwrap());
             return Ok(groups);
         }
     }


### PR DESCRIPTION
The code above the line with `truncate` handles the case if `res` is larger than `ngroups`, but `res < ngroups` is also a possibility, which this line attempts to address but actually does not.

The original code resizes to `ngroups` which is a no-op (given that `groups` is already `ngroups` size). The correct target for re-sizing the `groups` is the result from the last `getgroups`, i.e., `res`.