### PR TITLE
Android CICD: use posix style test

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -178,7 +178,7 @@ jobs:
           util/android-commands.sh sync_host
           util/android-commands.sh build
           util/android-commands.sh tests
-          if [[ "${{ steps.rust-cache.outputs.cache-hit }}" != 'true' ]]; then util/android-commands.sh sync_image; fi; exit 0
+          if [ "${{ steps.rust-cache.outputs.cache-hit }}" != 'true' ]; then util/android-commands.sh sync_image; fi; exit 0
     - name: Collect information about runner ressources
       if: always()
       continue-on-error: true


### PR DESCRIPTION
It looks like the runner must have switched from bash to some other shell (likely dash). This caching step is failing on recent runs (without failing the whole run, because of the `; exit 0`). This commit just switches from bash's fancy `[[` to the more standard `[` shell test, which is good enough for the existing one-liner.