### PR TITLE
cut: don't merge adjacent ranges

### DIFF
--- a/src/uucore/src/lib/features/ranges.rs
+++ b/src/uucore/src/lib/features/ranges.rs
@@ -91,7 +91,7 @@ impl Range {
         Ok(Self::merge(ranges))
     }
 
-    /// Merge any overlapping ranges
+    /// Merge any overlapping ranges. Adjacent ranges are *NOT* merged.
     ///
     /// Is guaranteed to return only disjoint ranges in a sorted order.
     fn merge(mut ranges: Vec<Self>) -> Vec<Self> {
@@ -101,10 +101,7 @@ impl Range {
         for i in 0..ranges.len() {
             let j = i + 1;
 
-            // The +1 is a small optimization, because we can merge adjacent Ranges.
-            // For example (1,3) and (4,6), because in the integers, there are no
-            // possible values between 3 and 4, this is equivalent to (1,6).
-            while j < ranges.len() && ranges[j].low <= ranges[i].high + 1 {
+            while j < ranges.len() && ranges[j].low <= ranges[i].high {
                 let j_high = ranges.remove(j).high;
                 ranges[i].high = max(ranges[i].high, j_high);
             }
@@ -216,8 +213,8 @@ mod test {
             &[r(10, 40), r(50, 60)],
         );
 
-        // Merge adjacent ranges
-        m(vec![r(1, 3), r(4, 6)], &[r(1, 6)]);
+        // Don't merge adjacent ranges
+        m(vec![r(1, 3), r(4, 6)], &[r(1, 3), r(4, 6)]);
     }
 
     #[test]

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -350,7 +350,6 @@ fn test_newline_preservation_with_f1_option() {
     ucmd.args(&["-f1-", "1"]).succeeds().stdout_is(expected);
 }
 
-#[ignore = "Not yet implemented"]
 #[test]
 fn test_output_delimiter_with_character_ranges() {
     new_ucmd!()
@@ -360,7 +359,6 @@ fn test_output_delimiter_with_character_ranges() {
         .stdout_only("bc:defg\n");
 }
 
-#[ignore = "Not yet implemented"]
 #[test]
 fn test_output_delimiter_with_adjacent_ranges() {
     new_ucmd!()


### PR DESCRIPTION
This PR removes the merging of adjacent ranges. It should make the tests `out-delim4`, `out-delim5` and `od_abut` in [cut.pl](https://github.com/coreutils/coreutils/blob/master/tests/cut/cut.pl) pass.