### PR TITLE
wc: fix escaping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ windows = ["feat_os_windows"]
 nightly = []
 test_unimplemented = []
 expensive_tests = []
+# "test_risky_names" == enable tests that create problematic file names (would make a network share inaccessible to Windows, breaks SVN on Mac OS, etc.)
+test_risky_names = []
 # * only build `uudoc` when `--feature uudoc` is activated
 uudoc = ["zip", "dep:uuhelp_parser"]
 ## features

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,9 @@ pub fn main() {
             #[allow(clippy::match_same_arms)]
             match krate.as_ref() {
                 "default" | "macos" | "unix" | "windows" | "selinux" | "zip" => continue, // common/standard feature names
-                "nightly" | "test_unimplemented" | "expensive_tests" => continue, // crate-local custom features
+                "nightly" | "test_unimplemented" | "expensive_tests" | "test_risky_names" => {
+                    continue
+                } // crate-local custom features
                 "uudoc" => continue, // is not a utility
                 "test" => continue, // over-ridden with 'uu_test' to avoid collision with rust core crate 'test'
                 s if s.starts_with(FEATURE_PREFIX) => continue, // crate feature sets


### PR DESCRIPTION
It turns out GNU wc only escapes file names with newlines in them. This was never working properly, but became more noticeable when we added non-unicode support. (I'll also just say this choice by GNU was questionable.)

This also adds one of the tests requested in #6882. I added a new flag to build these kinds of tests, since, as hinted in #6639, files with unusual file names can be problematic with file systems or tools not written with them in mind.