### PR TITLE
echo: handle double hyphens

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -255,9 +255,26 @@ fn print_escaped(input: &[u8], output: &mut StdoutLock) -> io::Result<ControlFlo
     Ok(ControlFlow::Continue(()))
 }
 
+// A workaround because clap interprets the first '--' as a marker that a value
+// follows. In order to use '--' as a value, we have to inject an additional '--'
+fn handle_double_hyphens(args: impl uucore::Args) -> impl uucore::Args {
+    let mut result = Vec::new();
+    let mut is_first_double_hyphen = true;
+
+    for arg in args {
+        if arg == "--" && is_first_double_hyphen {
+            result.push(OsString::from("--"));
+            is_first_double_hyphen = false;
+        }
+        result.push(arg);
+    }
+
+    result.into_iter()
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().get_matches_from(args);
+    let matches = uu_app().get_matches_from(handle_double_hyphens(args));
 
     // TODO
     // "If the POSIXLY_CORRECT environment variable is set, then when echo’s first argument is not -n it outputs option-like arguments instead of treating them as options."

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -243,6 +243,16 @@ fn test_hyphen_values_between() {
 }
 
 #[test]
+fn test_double_hyphens() {
+    new_ucmd!().arg("--").succeeds().stdout_only("--\n");
+    new_ucmd!()
+        .arg("--")
+        .arg("--")
+        .succeeds()
+        .stdout_only("-- --\n");
+}
+
+#[test]
 fn wrapping_octal() {
     // Some odd behavior of GNU. Values of \0400 and greater do not fit in the
     // u8 that we write to stdout. So we test that it wraps:

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -219,8 +219,7 @@ fn test_hyphen_values_at_start() {
         .arg("-test")
         .arg("araba")
         .arg("-merci")
-        .run()
-        .success()
+        .succeeds()
         .stdout_does_not_contain("-E")
         .stdout_is("-test araba -merci\n");
 }
@@ -231,8 +230,7 @@ fn test_hyphen_values_between() {
         .arg("test")
         .arg("-E")
         .arg("araba")
-        .run()
-        .success()
+        .succeeds()
         .stdout_is("test -E araba\n");
 
     new_ucmd!()
@@ -240,8 +238,7 @@ fn test_hyphen_values_between() {
         .arg("dum dum dum")
         .arg("-e")
         .arg("dum")
-        .run()
-        .success()
+        .succeeds()
         .stdout_is("dumdum  dum dum dum -e dum\n");
 }
 


### PR DESCRIPTION
This PR fixes an issue with double hyphens:
```
$ cargo run -q echo -- --
--
$ env echo -- --
-- --
```
It also simplifies a few tests by replacing
```rust
.run()
.success()
```
with `.succeeds()`.
