### PR TITLE
csplit: add support for `-q`

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -621,8 +621,9 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::QUIET)
-                .short('s')
+                .short('q')
                 .long(options::QUIET)
+                .visible_short_alias('s')
                 .visible_alias("silent")
                 .help("do not print counts of output file sizes")
                 .action(ArgAction::SetTrue),

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -387,18 +387,23 @@ fn test_option_keep() {
 
 #[test]
 fn test_option_quiet() {
-    let (at, mut ucmd) = at_and_ucmd!();
-    ucmd.args(&["--quiet", "numbers50.txt", "13", "%25%", "/0$/"])
-        .succeeds()
-        .no_stdout();
+    for arg in ["-q", "--quiet", "-s", "--silent"] {
+        let (at, mut ucmd) = at_and_ucmd!();
+        ucmd.args(&[arg, "numbers50.txt", "13", "%25%", "/0$/"])
+            .succeeds()
+            .no_stdout();
 
-    let count = glob(&at.plus_as_string("xx*"))
-        .expect("there should be splits created")
-        .count();
-    assert_eq!(count, 3);
-    assert_eq!(at.read("xx00"), generate(1, 13));
-    assert_eq!(at.read("xx01"), generate(25, 30));
-    assert_eq!(at.read("xx02"), generate(30, 51));
+        let count = glob(&at.plus_as_string("xx*"))
+            .expect("there should be splits created")
+            .count();
+        assert_eq!(count, 3);
+        assert_eq!(at.read("xx00"), generate(1, 13));
+        assert_eq!(at.read("xx01"), generate(25, 30));
+        assert_eq!(at.read("xx02"), generate(30, 51));
+        at.remove("xx00");
+        at.remove("xx01");
+        at.remove("xx02");
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR adds `-q`, a short for `--quiet`. It makes some of the tests in [csplit-suppress-matched.pl](https://github.com/coreutils/coreutils/blob/master/tests/csplit/csplit-suppress-matched.pl) pass.