### PR TITLE
env: fix only long options are allowed to contain '='

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -370,6 +370,18 @@ impl EnvAppData {
                     self.had_string_argument = true;
                 }
                 _ => {
+                    let arg_str = arg.to_string_lossy();
+
+                    // Only long option is allowed to contain '='
+                    if arg_str.contains('=')
+                        && arg_str.starts_with('-')
+                        && !arg_str.starts_with("--")
+                    {
+                        return Err(USimpleError::new(
+                            125,
+                            format!("cannot unset '{}': Invalid argument", &arg_str[2..]),
+                        ));
+                    }
                     all_args.push(arg.clone());
                 }
             }

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -372,9 +372,9 @@ impl EnvAppData {
                 _ => {
                     let arg_str = arg.to_string_lossy();
 
-                    // Only long option is allowed to contain '='
+                    // Short unset option (-u) is not allowed to contain '='
                     if arg_str.contains('=')
-                        && arg_str.starts_with('-')
+                        && arg_str.starts_with("-u")
                         && !arg_str.starts_with("--")
                     {
                         return Err(USimpleError::new(
@@ -382,6 +382,7 @@ impl EnvAppData {
                             format!("cannot unset '{}': Invalid argument", &arg_str[2..]),
                         ));
                     }
+
                     all_args.push(arg.clone());
                 }
             }

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -882,6 +882,33 @@ fn test_env_arg_ignore_signal_empty() {
         .no_stderr()
         .stdout_contains("hello");
 }
+
+#[test]
+fn disallow_equals_sign_on_short_options() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .arg("-u=")
+        .fails()
+        .code_is(125)
+        .stderr_contains("env: cannot unset '=': Invalid argument");
+    ts.ucmd()
+        .arg("-u=A1B2C3")
+        .fails()
+        .code_is(125)
+        .stderr_contains("env: cannot unset '=A1B2C3': Invalid argument");
+    ts.ucmd().arg("--split-string=A1B=2C3=").succeeds();
+    ts.ucmd()
+        .arg("--unset=")
+        .fails()
+        .code_is(125)
+        .stderr_contains("env: cannot unset '': Invalid argument");
+    ts.ucmd().arg("A1B=2C3").succeeds();
+    ts.ucmd().arg("--unset=A1B2C3").succeeds();
+    ts.ucmd().arg("--unset=A1B23C").succeeds();
+    ts.ucmd().arg("-u A1B23C").succeeds();
+}
+
 #[cfg(test)]
 mod tests_split_iterator {
 

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -884,7 +884,7 @@ fn test_env_arg_ignore_signal_empty() {
 }
 
 #[test]
-fn disallow_equals_sign_on_short_options() {
+fn disallow_equals_sign_on_short_unset_option() {
     let ts = TestScenario::new(util_name!());
 
     ts.ucmd()
@@ -903,10 +903,6 @@ fn disallow_equals_sign_on_short_options() {
         .fails()
         .code_is(125)
         .stderr_contains("env: cannot unset '': Invalid argument");
-    ts.ucmd().arg("A1B=2C3").succeeds();
-    ts.ucmd().arg("--unset=A1B2C3").succeeds();
-    ts.ucmd().arg("--unset=A1B23C").succeeds();
-    ts.ucmd().arg("-u A1B23C").succeeds();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fixes #6165 and was adapted from #6711.

This PR contains changes that ensure short options (-u) do not have '=' as their arguments' first character in accordance with GNU/POSIX standards.

Tests were added to ensure this change does not regress.