### PR TITLE
GNU: try to remove the fail-2eperm.sh workaround

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -227,8 +227,6 @@ eval cat "$path_UUTILS/util/gnu-patches/*.patch" | patch -N -r - -d "$path_GNU" 
 
 sed -i -e "s|rm: cannot remove 'e/slink'|rm: cannot remove 'e'|g" tests/rm/fail-eacces.sh
 
-sed -i -e "s|rm: cannot remove 'a/b'|rm: cannot remove 'a'|g" tests/rm/fail-2eperm.sh
-
 sed -i -e "s|rm: cannot remove 'a/b/file'|rm: cannot remove 'a'|g" tests/rm/cycle.sh
 
 sed -i -e "s|rm: cannot remove directory 'b/a/p'|rm: cannot remove 'b'|g" tests/rm/rm1.sh


### PR DESCRIPTION
Now fails with:
```
2024-12-28T14:55:18.9355074Z -rm: cannot remove 'a': Operation not permitted 
2024-12-28T14:55:18.9355364Z +rm: cannot remove 'a/b': Operation not permitted
```