### PR TITLE
seq: improve error handling for invalid -f values

### DIFF
--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -787,6 +787,16 @@ fn test_invalid_format() {
         .fails()
         .no_stdout()
         .stderr_contains("format '%g%g' has too many % directives");
+    new_ucmd!()
+        .args(&["-f", "%g%", "1"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("format '%g%' has too many % directives");
+    new_ucmd!()
+        .args(&["-f", "%", "1"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("format '%' ends in %");
 }
 
 #[test]


### PR DESCRIPTION
Improve the error message produced by `seq` when given invalid format specifiers for the `-f` option. Before this commit:

    $ seq -f "%" 1
    seq: %: invalid conversion specification
    $ seq -f "%g%" 1
    seq: %: invalid conversion specification

After this commit:

    $ seq -f "%" 1
    seq: format '%' ends in %
    $ seq -f "%g%" 1
    seq: format '%g%' has too many % directives

This matches the behavior of GNU `seq`.