### PR TITLE
uucore:format:fix floating-point representation

### DIFF
--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -916,3 +916,50 @@ fn float_flag_position_space_padding() {
         .succeeds()
         .stdout_only(" +1.0");
 }
+
+#[test]
+fn float_abs_value_less_than_one() {
+    new_ucmd!()
+        .args(&["%g", "0.1171875"])
+        .succeeds()
+        .stdout_only("0.117188");
+
+    // The original value from #7031 issue
+    new_ucmd!()
+        .args(&["%g", "-0.1171875"])
+        .succeeds()
+        .stdout_only("-0.117188");
+
+    new_ucmd!()
+        .args(&["%g", "0.01171875"])
+        .succeeds()
+        .stdout_only("0.0117188");
+
+    new_ucmd!()
+        .args(&["%g", "-0.01171875"])
+        .succeeds()
+        .stdout_only("-0.0117188");
+
+    new_ucmd!()
+        .args(&["%g", "0.001171875001"])
+        .succeeds()
+        .stdout_only("0.00117188");
+
+    new_ucmd!()
+        .args(&["%g", "-0.001171875001"])
+        .succeeds()
+        .stdout_only("-0.00117188");
+}
+
+#[test]
+fn float_switch_switch_decimal_scientific() {
+    new_ucmd!()
+        .args(&["%g", "0.0001"])
+        .succeeds()
+        .stdout_only("0.0001");
+
+    new_ucmd!()
+        .args(&["%g", "0.00001"])
+        .succeeds()
+        .stdout_only("1e-05");
+}


### PR DESCRIPTION
This PR resolves issues with exponent calculation and usage, ensuring more accurate formatting:

- Exponent for negative values can differ from 0
- Switching to decimal mode now follows the P > X ≥ −4 rule

Fixes #7031

### Before

```
cargo run -- printf "%g" -0.1171875
-0.11719          
 
cargo run -- printf "%g"  -0.00001
-0.00001              
```

### After

```
cargo run -- printf "%g" -0.1171875
-0.117188        
          
cargo run -- printf "%g"  -0.00001
-1e-05                                
```

### Expected

```
printf "%g" -0.1171875
-0.117188  

printf "%g" -0.00001
-1e-05                               
```
