### PR TITLE
chmod: add uucore's `perms` feature to `Cargo.toml`

### DIFF
--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/chmod.rs"
 [dependencies]
 clap = { workspace = true }
 libc = { workspace = true }
-uucore = { workspace = true, features = ["fs", "mode"] }
+uucore = { workspace = true, features = ["fs", "mode", "perms"] }
 
 [[bin]]
 name = "chmod"


### PR DESCRIPTION
This PR adds the missing `perms` feature from `uucore` to `Cargo.toml`. I noticed it when I tried to run the `chmod` tests:
```
$ cargo test --features=chmod --no-default-features
   Compiling uu_chmod v0.0.28 (/home/dho/projects/coreutils/src/uu/chmod)
error[E0433]: failed to resolve: could not find `perms` in `uucore`
   --> src/uu/chmod/src/chmod.rs:229:23
    |
229 |         .args(uucore::perms::common_args())
    |                       ^^^^^ could not find `perms` in `uucore`
    |
```