### PR TITLE
chroot: fix parsing of --userspec argument

### DIFF
--- a/src/uu/chroot/src/error.rs
+++ b/src/uu/chroot/src/error.rs
@@ -28,10 +28,10 @@ pub enum ChrootError {
     MissingNewRoot,
 
     /// Failed to find the specified user.
-    NoSuchUser(String),
+    NoSuchUser,
 
     /// Failed to find the specified group.
-    NoSuchGroup(String),
+    NoSuchGroup,
 
     /// The given directory does not exist.
     NoSuchDirectory(String),
@@ -74,8 +74,8 @@ impl Display for ChrootError {
                 "Missing operand: NEWROOT\nTry '{} --help' for more information.",
                 uucore::execution_phrase(),
             ),
-            Self::NoSuchUser(s) => write!(f, "no such user: {}", s.maybe_quote(),),
-            Self::NoSuchGroup(s) => write!(f, "no such group: {}", s.maybe_quote(),),
+            Self::NoSuchUser => write!(f, "invalid user"),
+            Self::NoSuchGroup => write!(f, "invalid group"),
             Self::NoSuchDirectory(s) => write!(
                 f,
                 "cannot change root directory to {}: no such directory",


### PR DESCRIPTION
Fix the parsing of the `--userspec=USER:GROUP` argument so that the both the user and the group are optional, and update the error message to match that of GNU `chroot`. This commit also removes the incorrect `clap` arguments for `--user` and `--group`. In `chroot --user=USER`, the `--user` is an abbreviation of `--userspec`, and in `chroot --group=GROUP`, the `--group` is an abbreviation of `--groups`.

Closes #7040.