### PR TITLE
Bump `itertools` from `0.13.0` to `0.14.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1241,6 +1241,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3061,7 +3070,7 @@ version = "0.0.28"
 dependencies = [
  "chrono",
  "clap",
- "itertools",
+ "itertools 0.14.0",
  "quick-error",
  "regex",
  "uucore",
@@ -3197,7 +3206,7 @@ dependencies = [
  "compare",
  "ctrlc",
  "fnv",
- "itertools",
+ "itertools 0.14.0",
  "memchr",
  "nix",
  "rand",
@@ -3481,7 +3490,7 @@ name = "uu_yes"
 version = "0.0.28"
 dependencies = [
  "clap",
- "itertools",
+ "itertools 0.14.0",
  "nix",
  "uucore",
 ]
@@ -3500,7 +3509,7 @@ dependencies = [
  "dunce",
  "glob",
  "hex",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
  "libc",
  "md-5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ glob = "0.3.1"
 half = "2.4.1"
 hostname = "0.4"
 indicatif = "0.17.8"
-itertools = "0.13.0"
+itertools = "0.14.0"
 libc = "0.2.153"
 lscolors = { version = "0.20.0", default-features = false, features = [
   "gnu_legacy",

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,8 @@ skip = [
   { name = "thiserror", version = "1.0.69" },
   # thiserror
   { name = "thiserror-impl", version = "1.0.69" },
+  # bindgen
+  { name = "itertools", version = "0.13.0" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR bumps `itertools` from `0.13.0` to `0.14.0` and adds it to the skip list in `deny.toml`.