### PR TITLE
chroot: remove `-G` short option

### DIFF
--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -199,11 +199,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::USERSPEC)
                 .long(options::USERSPEC)
-                .help(
-                    "Colon-separated user and group to switch to. \
-                     Same as -u USER -g GROUP. \
-                     Userspec has higher preference than -u and/or -g",
-                )
+                .help("Colon-separated user and group to switch to.")
                 .value_name("USER:GROUP"),
         )
         .arg(

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -192,7 +192,6 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::GROUPS)
-                .short('G')
                 .long(options::GROUPS)
                 .help("Comma-separated list of groups to switch to")
                 .value_name("GROUP1,GROUP2..."),

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -141,7 +141,7 @@ fn test_preference_of_userspec() {
         .arg("a")
         .arg("--user")
         .arg("fake")
-        .arg("-G")
+        .arg("--groups")
         .arg("ABC,DEF")
         .arg(format!("--userspec={username}:{group_name}"))
         .fails();


### PR DESCRIPTION
This PR removes the `-G` short option because GNU `chroot` doesn't have such a short option. I think it was overlooked in https://github.com/uutils/coreutils/pull/7043 when removing the other options not available in GNU `chroot`.

The PR also removes some outdated info from the help for `--userspec`.
 