### PR TITLE
chroot: fix many issues with chroot

### DIFF
--- a/src/uu/chroot/src/error.rs
+++ b/src/uu/chroot/src/error.rs
@@ -8,6 +8,7 @@ use std::fmt::Display;
 use std::io::Error;
 use uucore::display::Quotable;
 use uucore::error::UError;
+use uucore::libc;
 
 /// Errors that can happen while executing chroot.
 #[derive(Debug)]
@@ -32,6 +33,8 @@ pub enum ChrootError {
 
     /// The new root directory was not given.
     MissingNewRoot,
+
+    NoGroupSpecified(libc::uid_t),
 
     /// Failed to find the specified user.
     NoSuchUser,
@@ -83,6 +86,7 @@ impl Display for ChrootError {
                 "Missing operand: NEWROOT\nTry '{} --help' for more information.",
                 uucore::execution_phrase(),
             ),
+            Self::NoGroupSpecified(uid) => write!(f, "no group specified for unknown uid: {}", uid),
             Self::NoSuchUser => write!(f, "invalid user"),
             Self::NoSuchGroup => write!(f, "invalid group"),
             Self::NoSuchDirectory(s) => write!(

--- a/src/uu/chroot/src/error.rs
+++ b/src/uu/chroot/src/error.rs
@@ -21,6 +21,12 @@ pub enum ChrootError {
     /// Failed to find the specified command.
     CommandNotFound(String, Error),
 
+    GroupsParsingFailed,
+
+    InvalidGroup(String),
+
+    InvalidGroupList(String),
+
     /// The given user and group specification was invalid.
     InvalidUserspec(String),
 
@@ -68,6 +74,9 @@ impl Display for ChrootError {
             Self::CommandFailed(s, e) | Self::CommandNotFound(s, e) => {
                 write!(f, "failed to run command {}: {}", s.to_string().quote(), e,)
             }
+            Self::GroupsParsingFailed => write!(f, "--groups parsing failed"),
+            Self::InvalidGroup(s) => write!(f, "invalid group: {}", s.quote()),
+            Self::InvalidGroupList(s) => write!(f, "invalid group list: {}", s.quote()),
             Self::InvalidUserspec(s) => write!(f, "invalid userspec: {}", s.quote(),),
             Self::MissingNewRoot => write!(
                 f,


### PR DESCRIPTION
This merge request fixes several issues in the behavior of `chroot`, mostly around setting
group IDs. It ensures that supplemental groups provided by `--groups` are properly handled with respect to the groups implied by `--userspec`. It ensures that we fall back to numeric parsing when attempting to lookup user and group IDs from their names.

It changes the type of `Options.groups` to be `Option<Vec<String>>` so that
the absence of the `--groups` option is meaningfully distinguished from
an empty list of groups. This is important because `chroot --groups=''`
is used specifically to disable supplementary group lookup.

It improves the parsing of the `--groups` parameter to `chroot` so that it
handles more error cases and better matches the behavior of GNU
`chroot`. For example, multiple adjacent commas are allowed:

    --groups=a,,,b

but spaces between commas are not allowed:

    --groups="a, , ,b"

This fixes all but one of the test cases in the GNU test file `tests/chroot/chroot-credentials.sh`.