### PR TITLE
uucore/buf-copy: delete redundant functions

### DIFF
--- a/src/uucore/src/lib/features/buf_copy/other.rs
+++ b/src/uucore/src/lib/features/buf_copy/other.rs
@@ -2,6 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+//!
+//! Buffer-based copying implementation for other platforms.
 
 use std::io::{Read, Write};
 


### PR DESCRIPTION
Follow-up of #6980. Delete several functions adopted from `yes` in the `buf_copy` module from uucore as the functions there are too specific to `yes`'s use.