### PR TITLE
kill: add `-n` hidden option for compatibility with bash

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -122,6 +122,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::SIGNAL)
                 .short('s')
+                .short_alias('n') // For bash compatibility, like in GNU coreutils
                 .long(options::SIGNAL)
                 .value_name("signal")
                 .help("Sends given signal instead of SIGTERM"),

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -296,3 +296,14 @@ fn test_kill_with_signal_exit_new_form() {
         .arg(format!("{}", target.pid()))
         .succeeds();
 }
+
+#[test]
+fn test_kill_with_signal_number_hidden_compatibility_option() {
+    let mut target = Target::new();
+    new_ucmd!()
+        .arg("-n")
+        .arg("9")
+        .arg(format!("{}", target.pid()))
+        .succeeds();
+    assert_eq!(target.wait_for_signal(), Some(9));
+}


### PR DESCRIPTION
GNU coreutils also implements it this way.

Close #7067 