### PR TITLE
kill: make `-s` conflict with `-l` and `-t`

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -125,7 +125,8 @@ pub fn uu_app() -> Command {
                 .short_alias('n') // For bash compatibility, like in GNU coreutils
                 .long(options::SIGNAL)
                 .value_name("signal")
-                .help("Sends given signal instead of SIGTERM"),
+                .help("Sends given signal instead of SIGTERM")
+                .conflicts_with_all([options::LIST, options::TABLE]),
         )
         .arg(
             Arg::new(options::PIDS_OR_SIGNALS)

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -307,3 +307,25 @@ fn test_kill_with_signal_number_hidden_compatibility_option() {
         .succeeds();
     assert_eq!(target.wait_for_signal(), Some(9));
 }
+
+#[test]
+fn test_kill_with_signal_and_list() {
+    let target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("EXIT")
+        .arg(format!("{}", target.pid()))
+        .arg("-l")
+        .fails();
+}
+
+#[test]
+fn test_kill_with_signal_and_table() {
+    let target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("EXIT")
+        .arg(format!("{}", target.pid()))
+        .arg("-t")
+        .fails();
+}


### PR DESCRIPTION
Fix #7066 