### PR TITLE
cksum: fix error message when the flags length and an algorithm different from blake2b are present 

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -276,10 +276,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     };
 
-    if ["bsd", "crc", "sysv"].contains(&algo_name) && check {
-        return Err(ChecksumError::AlgorithmNotSupportedWithCheck.into());
-    }
-
     let input_length = matches.get_one::<usize>(options::LENGTH);
 
     let length = match input_length {
@@ -292,6 +288,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
         None => None,
     };
+
+    if ["bsd", "crc", "sysv"].contains(&algo_name) && check {
+        return Err(ChecksumError::AlgorithmNotSupportedWithCheck.into());
+    }
 
     if check {
         let text_flag = matches.get_flag(options::TEXT);

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -352,6 +352,18 @@ fn test_length_not_supported() {
         .no_stdout()
         .stderr_contains("--length is only supported with --algorithm=blake2b")
         .code_is(1);
+
+    new_ucmd!()
+        .arg("-l")
+        .arg("158")
+        .arg("-c")
+        .arg("-a")
+        .arg("crc")
+        .arg("/tmp/xxx")
+        .fails()
+        .no_stdout()
+        .stderr_contains("--length is only supported with --algorithm=blake2b")
+        .code_is(1);
 }
 
 #[test]


### PR DESCRIPTION
The code fix the error message: first the code controls if the flags length and algorithm blake2b are present, if not the error `cksum: --length is only supported with --algorithm=blake2b`.
I added a new test to cover this case.
Fix #7050 