### PR TITLE
mkfifo: add missing "mode" feature for uucore dep

### DIFF
--- a/src/uu/mkfifo/Cargo.toml
+++ b/src/uu/mkfifo/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/mkfifo.rs"
 [dependencies]
 clap = { workspace = true }
 libc = { workspace = true }
-uucore = { workspace = true, features = ["fs"] }
+uucore = { workspace = true, features = ["fs", "mode"] }
 
 [[bin]]
 name = "mkfifo"


### PR DESCRIPTION
This fixes the following issue:
```
$ cargo build -p uu_mkfifo
   Compiling uu_mkfifo v0.0.28 (/home/jeffrey/src/coreutils/src/uu/mkfifo)
error[E0433]: failed to resolve: could not find `mode` in `uucore`
  --> src/uu/mkfifo/src/mkfifo.rs:43:35
   |
43 |         None => 0o666 & !(uucore::mode::get_umask() as usize),
   |                                   ^^^^ could not find `mode` in `uucore`
   |
note: found an item that was configured out
  --> /home/jeffrey/src/coreutils/src/uucore/src/lib/lib.rs:73:26
   |
73 | pub use crate::features::mode;
   |                          ^^^^
note: the item is gated here
  --> /home/jeffrey/src/coreutils/src/uucore/src/lib/lib.rs:72:1
   |
72 | #[cfg(all(not(windows), feature = "mode"))]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0433`.
error: could not compile `uu_mkfifo` (lib) due to 1 previous error
```