### PR TITLE
tsort: split edge data on any whitespace chars

### DIFF
--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -74,18 +74,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         std::fs::read_to_string(path)?
     };
 
+    // Create the directed graph from pairs of tokens in the input data.
     let mut g = Graph::default();
-
-    for line in data.lines() {
-        let tokens: Vec<_> = line.split_whitespace().collect();
-        if tokens.is_empty() {
-            break;
-        }
-        for ab in tokens.chunks(2) {
-            match ab.len() {
-                2 => g.add_edge(ab[0], ab[1]),
-                _ => return Err(TsortError::NumTokensOdd(input.to_string()).into()),
-            }
+    for ab in data.split_whitespace().collect::<Vec<&str>>().chunks(2) {
+        match ab {
+            [a, b] => g.add_edge(a, b),
+            _ => return Err(TsortError::NumTokensOdd(input.to_string()).into()),
         }
     }
 

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -75,3 +75,11 @@ fn test_error_on_dir() {
         .fails()
         .stderr_contains("tsort: tsort_test_dir: read error: Is a directory");
 }
+
+#[test]
+fn test_split_on_any_whitespace() {
+    new_ucmd!()
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_only("a\nb\n");
+}


### PR DESCRIPTION
Make `tsort` split on any whitespace character instead of just
whitespace within a single line. This allows edge information to be
split with the source node on one line and the target node on another.

For example, after this commit

    $ printf "a\nb\n" | tsort
    a
    b

whereas before this would print an error message.

This pull request also makes two other small changes. First, it introduces a `TsortError` enum implementing the `UError` trait to represent the various problems that `tsort` might encounter. Second, it uses the standard library `std::io::read_to_string` and `std::fs::read_to_string` in place of custom code that was ultimately doing the same thing.

Closes #7077