### PR TITLE
cksum: the --tag is meaningless with --check

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -301,8 +301,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let warn = matches.get_flag(options::WARN);
         let ignore_missing = matches.get_flag(options::IGNORE_MISSING);
         let quiet = matches.get_flag(options::QUIET);
+        let tag = matches.get_flag(options::TAG);
 
-        if binary_flag || text_flag {
+        if tag || binary_flag || text_flag {
             return Err(ChecksumError::BinaryTextConflict.into());
         }
         // Determine the appropriate algorithm option to pass
@@ -426,8 +427,7 @@ pub fn uu_app() -> Command {
                 .short('c')
                 .long(options::CHECK)
                 .help("read hashsums from the FILEs and check them")
-                .action(ArgAction::SetTrue)
-                .conflicts_with("tag"),
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new(options::BASE64)

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -748,6 +748,19 @@ fn test_conflicting_options() {
             "cksum: the --binary and --text options are meaningless when verifying checksums",
         )
         .code_is(1);
+
+    scene
+        .ucmd()
+        .arg("--tag")
+        .arg("-c")
+        .arg("-a")
+        .arg("md5")
+        .fails()
+        .no_stdout()
+        .stderr_contains(
+            "cksum: the --binary and --text options are meaningless when verifying checksums",
+        )
+        .code_is(1);
 }
 
 #[test]


### PR DESCRIPTION
The code fix the error message: I deleted the clap code that output the wrong error message, then when the check flag is controlled, if the tag is set to true, the program outputs `the --binary and --text options are meaningless when verifying checksums` as the GNU implementation.
I added a new test to cover this case.
Fix #7055 