### PR TITLE
cp: make --backup and --no-clobber are mutually exclusive

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -932,6 +932,16 @@ impl Options {
         };
         let update_mode = update_control::determine_update_mode(matches);
 
+        if backup_mode != BackupMode::NoBackup
+            && matches
+                .get_one::<String>(update_control::arguments::OPT_UPDATE)
+                .map_or(false, |v| v == "none" || v == "none-fail")
+        {
+            return Err(Error::InvalidArgument(
+                "--backup is mutually exclusive with -n or --update=none-fail".to_string(),
+            ));
+        }
+
         let backup_suffix = backup_control::determine_backup_suffix(matches);
 
         let overwrite = OverwriteMode::from_matches(matches);

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2424,8 +2424,7 @@ fn test_cp_reflink_bad() {
 
 #[test]
 fn test_cp_conflicting_update() {
-    let (_, mut ucmd) = at_and_ucmd!();
-    let _result = ucmd
+    new_ucmd!()
         .arg("-b")
         .arg("--update=none")
         .arg("a")

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2423,6 +2423,18 @@ fn test_cp_reflink_bad() {
 }
 
 #[test]
+fn test_cp_conflicting_update() {
+    let (_, mut ucmd) = at_and_ucmd!();
+    let _result = ucmd
+        .arg("-b")
+        .arg("--update=none")
+        .arg("a")
+        .arg("b")
+        .fails()
+        .stderr_contains("--backup is mutually exclusive with -n or --update=none-fail");
+}
+
+#[test]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn test_cp_reflink_insufficient_permission() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Should fix tests/cp/cp-i.sh