### PR TITLE
Remove crash! macro

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -16,7 +16,7 @@ use clap::{crate_version, Arg, ArgAction, ArgMatches, Command};
 use regex::Regex;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult};
-use uucore::{crash_if_err, format_usage, help_about, help_section, help_usage};
+use uucore::{format_usage, help_about, help_section, help_usage};
 
 mod csplit_error;
 mod patterns;
@@ -51,26 +51,23 @@ pub struct CsplitOptions {
 }
 
 impl CsplitOptions {
-    fn new(matches: &ArgMatches) -> Self {
+    fn new(matches: &ArgMatches) -> Result<Self, CsplitError> {
         let keep_files = matches.get_flag(options::KEEP_FILES);
         let quiet = matches.get_flag(options::QUIET);
         let elide_empty_files = matches.get_flag(options::ELIDE_EMPTY_FILES);
         let suppress_matched = matches.get_flag(options::SUPPRESS_MATCHED);
 
-        Self {
-            split_name: crash_if_err!(
-                1,
-                SplitName::new(
-                    matches.get_one::<String>(options::PREFIX).cloned(),
-                    matches.get_one::<String>(options::SUFFIX_FORMAT).cloned(),
-                    matches.get_one::<String>(options::DIGITS).cloned()
-                )
-            ),
+        Ok(Self {
+            split_name: SplitName::new(
+                matches.get_one::<String>(options::PREFIX).cloned(),
+                matches.get_one::<String>(options::SUFFIX_FORMAT).cloned(),
+                matches.get_one::<String>(options::DIGITS).cloned(),
+            )?,
             keep_files,
             quiet,
             elide_empty_files,
             suppress_matched,
-        }
+        })
     }
 }
 
@@ -561,7 +558,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .unwrap()
         .map(|s| s.to_string())
         .collect();
-    let options = CsplitOptions::new(&matches);
+    let options = CsplitOptions::new(&matches)?;
     if file_name == "-" {
         let stdin = io::stdin();
         Ok(csplit(&options, &patterns, stdin.lock())?)

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -587,7 +587,7 @@ impl FsUsage {
         let mut number_of_free_clusters = 0;
         let mut total_number_of_clusters = 0;
 
-        let success = unsafe {
+        unsafe {
             let path = to_nul_terminated_wide_string(path);
             GetDiskFreeSpaceW(
                 path.as_ptr(),
@@ -595,15 +595,7 @@ impl FsUsage {
                 &mut bytes_per_sector,
                 &mut number_of_free_clusters,
                 &mut total_number_of_clusters,
-            )
-        };
-        if 0 == success {
-            // Fails in case of CD for example
-            // crash!(
-            //     EXIT_ERR,
-            //     "GetDiskFreeSpaceW failed: {}",
-            //     IOError::last_os_error()
-            // );
+            );
         }
 
         let bytes_per_cluster = sectors_per_cluster as u64 * bytes_per_sector as u64;

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -380,7 +380,10 @@ macro_rules! prompt_yes(
         eprint!("{}: ", uucore::util_name());
         eprint!($($args)+);
         eprint!(" ");
-        uucore::crash_if_err!(1, std::io::stderr().flush());
+        let res = std::io::stderr().flush().map_err(|err| {
+            $crate::error::USimpleError::new(1, err.to_string())
+        });
+        uucore::show_if_err!(res);
         uucore::read_yes()
     })
 );

--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -30,8 +30,6 @@
 //!     [`crate::show_if_err!`]
 //!   - From custom messages: [`crate::show_error!`]
 //! - Print warnings: [`crate::show_warning!`]
-//! - Terminate util execution
-//!   - Crash program: [`crate::crash!`], [`crate::crash_if_err!`]
 
 // spell-checker:ignore sourcepath targetpath rustdoc
 
@@ -188,58 +186,4 @@ macro_rules! show_warning_caps(
         eprint!("{}: WARNING: ", $crate::util_name());
         eprintln!($($args)+);
     })
-);
-
-/// Display an error and [`std::process::exit`]
-///
-/// Displays the provided error message using [`show_error!`], then invokes
-/// [`std::process::exit`] with the provided exit code.
-///
-/// # Examples
-///
-/// ```should_panic
-/// # #[macro_use]
-/// # extern crate uucore;
-/// # fn main() {
-/// // outputs <name>: Couldn't apply foo to bar
-/// // and terminates execution
-/// crash!(1, "Couldn't apply {} to {}", "foo", "bar");
-/// # }
-/// ```
-#[macro_export]
-macro_rules! crash(
-    ($exit_code:expr, $($args:tt)+) => ({
-        $crate::show_error!($($args)+);
-        std::process::exit($exit_code);
-    })
-);
-
-/// Unwrap a [`std::result::Result`], crashing instead of panicking.
-///
-/// If the result is an `Ok`-variant, returns the value contained inside. If it
-/// is an `Err`-variant, invokes [`crash!`] with the formatted error instead.
-///
-/// # Examples
-///
-/// ```should_panic
-/// # #[macro_use]
-/// # extern crate uucore;
-/// # fn main() {
-/// let is_ok: Result<u32, &str> = Ok(1);
-/// // Does nothing
-/// crash_if_err!(1, is_ok);
-///
-/// let is_err: Result<u32, &str> = Err("This didn't work...");
-/// // Calls `crash!`
-/// crash_if_err!(1, is_err);
-/// # }
-/// ```
-#[macro_export]
-macro_rules! crash_if_err(
-    ($exit_code:expr, $exp:expr) => (
-        match $exp {
-            Ok(m) => m,
-            Err(f) => $crate::crash!($exit_code, "{}", f),
-        }
-    )
 );


### PR DESCRIPTION
Remove the crash! and crash_if_error! macros, as discussed in #5487 .

I've replaced all crash_if_err! macro calls, by changing the return type of the functions it was called on. Instead of returning T, they return UResult\<T\>.
This way, instead of crashing, we can propagate the error.

The prompt_yes! macro also used crash_if_err!. In this case, I've replaced that with a call to show_if_err!.

All test pass, except test_df::test_type_option_with_file, which already failed before the changes.

NOTE: This is my first time contributing. Hope I've done everything alright.