### PR TITLE
uucore: remove mention of crash in docs

### DIFF
--- a/src/uucore/src/lib/macros.rs
+++ b/src/uucore/src/lib/macros.rs
@@ -20,7 +20,7 @@
 //! fully qualified name like this:
 //!
 //! ```no_run
-//! use uucore::{show, crash};
+//! use uucore::show;
 //! ```
 //!
 //! Here's an overview of the macros sorted by purpose


### PR DESCRIPTION
The `crash!` macro has been removed in https://github.com/uutils/coreutils/pull/7084