### PR TITLE
printf: remove allow(dead_code) directive

### DIFF
--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -2,9 +2,6 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-
-#![allow(dead_code)]
-
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::io::stdout;
 use std::ops::ControlFlow;


### PR DESCRIPTION
Remove an `allow(dead_code)` directive that seems unnecessary.