### PR TITLE
clippy: fix errors introduced with Rust `1.84`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -564,6 +564,8 @@ multiple_crate_versions = "allow"
 cargo_common_metadata = "allow"
 uninlined_format_args = "allow"
 missing_panics_doc = "allow"
+# TODO remove when https://github.com/rust-lang/rust-clippy/issues/13774 is fixed
+large_stack_arrays = "allow"
 
 use_self = "warn"
 needless_pass_by_value = "warn"

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -935,7 +935,7 @@ impl Options {
         if backup_mode != BackupMode::NoBackup
             && matches
                 .get_one::<String>(update_control::arguments::OPT_UPDATE)
-                .map_or(false, |v| v == "none" || v == "none-fail")
+                .is_some_and(|v| v == "none" || v == "none-fail")
         {
             return Err(Error::InvalidArgument(
                 "--backup is mutually exclusive with -n or --update=none-fail".to_string(),

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -64,7 +64,7 @@ pub(crate) fn copy_on_write(
                 // clonefile(2) fails if the destination exists.  Remove it and try again.  Do not
                 // bother to check if removal worked because we're going to try to clone again.
                 // first lets make sure the dest file is not read only
-                if fs::metadata(dest).map_or(false, |md| !md.permissions().readonly()) {
+                if fs::metadata(dest).is_ok_and(|md| !md.permissions().readonly()) {
                     // remove and copy again
                     // TODO: rewrite this to better match linux behavior
                     // linux first opens the source file and destination file then uses the file

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -719,7 +719,7 @@ pub fn path_ends_with_terminator(path: &Path) -> bool {
     path.as_os_str()
         .encode_wide()
         .last()
-        .map_or(false, |wide| wide == b'/'.into() || wide == b'\\'.into())
+        .is_some_and(|wide| wide == b'/'.into() || wide == b'\\'.into())
 }
 
 /// Checks if the standard input (stdin) is a directory.

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2524,7 +2524,7 @@ fn test_cp_sparse_always_non_empty() {
     const BUFFER_SIZE: usize = 4096 * 16 + 3;
     let (at, mut ucmd) = at_and_ucmd!();
 
-    let mut buf: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
+    let mut buf = vec![0; BUFFER_SIZE].into_boxed_slice();
     let blocks_to_touch = [buf.len() / 3, 2 * (buf.len() / 3)];
 
     for i in blocks_to_touch {
@@ -2540,7 +2540,7 @@ fn test_cp_sparse_always_non_empty() {
     let touched_block_count =
         blocks_to_touch.len() as u64 * at.metadata("dst_file_sparse").blksize() / 512;
 
-    assert_eq!(at.read_bytes("dst_file_sparse"), buf);
+    assert_eq!(at.read_bytes("dst_file_sparse").into_boxed_slice(), buf);
     assert_eq!(at.metadata("dst_file_sparse").blocks(), touched_block_count);
 }
 


### PR DESCRIPTION
This PR fixes a bunch of clippy errors introduced with Rust `1.84`:

- an error from [unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or) in `cp`
- two errors from [regex_creation_in_loops](https://rust-lang.github.io/rust-clippy/master/index.html#regex_creation_in_loops) in `ls` tests
- an error from [large_stack_arrays](https://rust-lang.github.io/rust-clippy/master/index.html#large_stack_arrays) in a `cp` test

It also allows the `large_stack_arrays` lint in `Cargo.toml` because the lint only partially works (see https://github.com/rust-lang/rust-clippy/issues/13774)