### PR TITLE
dd: error if iflag=directory and input is stdin

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -54,7 +54,7 @@ use nix::{
 };
 use uucore::display::Quotable;
 #[cfg(unix)]
-use uucore::error::set_exit_code;
+use uucore::error::{set_exit_code, USimpleError};
 use uucore::error::{FromIo, UResult};
 #[cfg(target_os = "linux")]
 use uucore::show_if_err;
@@ -338,11 +338,11 @@ impl<'a> Input<'a> {
         let mut src = Source::stdin_as_file();
         #[cfg(unix)]
         if let Source::StdinFile(f) = &src {
-            // GNU compatibility:
-            // this will check whether stdin points to a folder or not
-            if f.metadata()?.is_file() && settings.iflags.directory {
-                show_error!("standard input: not a directory");
-                return Err(1.into());
+            if settings.iflags.directory && !f.metadata()?.is_dir() {
+                return Err(USimpleError::new(
+                    1,
+                    "setting flags for 'standard input': Not a directory",
+                ));
             }
         };
         if settings.skip > 0 {

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1728,7 +1728,26 @@ fn test_iflag_directory_fails_when_file_is_passed_via_std_in() {
         .args(&["iflag=directory", "count=0"])
         .set_stdin(std::process::Stdio::from(File::open(filename).unwrap()))
         .fails()
-        .stderr_contains("standard input: not a directory");
+        .stderr_only("dd: setting flags for 'standard input': Not a directory\n");
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_iflag_directory_passes_when_dir_is_redirected() {
+    new_ucmd!()
+        .args(&["iflag=directory", "count=0"])
+        .set_stdin(std::process::Stdio::from(File::open(".").unwrap()))
+        .succeeds();
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_iflag_directory_fails_when_file_is_piped_via_std_in() {
+    new_ucmd!()
+        .arg("iflag=directory")
+        .pipe_in("")
+        .fails()
+        .stderr_only("dd: setting flags for 'standard input': Not a directory\n");
 }
 
 #[test]


### PR DESCRIPTION
Make `dd` error if `iflag=directory` and the input file is not a
directory, as in

    : | dd iflag=directory

Fixes #5900