### PR TITLE
Cargo.lock: downgrade `log` from `0.4.24` to `0.4.22`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,9 +1304,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.24"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6ea2a48c204030ee31a7d7fc72c93294c92fe87ecb1789881c9543516e1a0d"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"


### PR DESCRIPTION
This PR downgrades `log` from `0.4.24` to `0.4.22` because the newer versions have been yanked.