### PR TITLE
ci: install `libselinux1-dev`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -119,6 +119,10 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.7
+    - name: Install/setup prerequisites
+      shell: bash
+      run: |
+        sudo apt-get -y update ; sudo apt-get -y install libselinux1-dev
     - name: Initialize workflow variables
       id: vars
       shell: bash


### PR DESCRIPTION
This PR is an attempt to fix the failing "Documentation/warnings" job in the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/12742477783/job/35510671748). It currently fails with
```
thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/selinux-sys-0.6.13/build.rs:258:10:
  selinux-sys: Failed to find 'selinux/selinux.h'. Please make sure the C header files of libselinux are installed and accessible: Kind(NotFound)
```