### PR TITLE
deny.toml: remove `syn` from skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,6 @@ allow = [
   "BSD-3-Clause",
   "BSL-1.0",
   "CC0-1.0",
-  "Unicode-DFS-2016",
   "Unicode-3.0",
   "Zlib",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -79,11 +79,9 @@ skip = [
   { name = "windows_x86_64_gnullvm", version = "0.48.0" },
   # windows-targets
   { name = "windows_x86_64_msvc", version = "0.48.0" },
-  # data-encoding-macro-internal
-  { name = "syn", version = "1.0.109" },
   # various crates
   { name = "bitflags", version = "1.3.2" },
-  # clap_builder, textwrap
+  # textwrap
   { name = "terminal_size", version = "0.2.6" },
   # ansi-width, console, os_display
   { name = "unicode-width", version = "0.1.13" },


### PR DESCRIPTION
This PR removes `syn` from the skip list in `deny.toml`. It also removes the `Unicode-DFS-2016` license from the allowed licenses to fix a "license not encountered" warning from `cargo deny`.