### PR TITLE
seq: add a lower bound for exponents

### DIFF
--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -878,6 +878,16 @@ fn test_parse_float_gnu_coreutils() {
         .stdout_only("0.000000\n0.000001\n0.000002\n0.000003\n");
 }
 
+#[test]
+fn test_parse_out_of_bounds_exponents() {
+    // The value 1e-9223372036854775808 is used in GNU Coreutils and BigDecimal tests to verify
+    // overflows and undefined behavior. Let's test the value too.
+    new_ucmd!()
+        .args(&["1e-9223372036854775808"])
+        .succeeds()
+        .stdout_only("");
+}
+
 #[ignore]
 #[test]
 fn test_parse_valid_hexadecimal_float_format_issues() {


### PR DESCRIPTION
### About
This PR adds a lower bound for the minimum exponent value to prevent [overflow](https://github.com/akubera/bigdecimal-rs/blob/466b291b12654520592af217f73030358e96a2f5/src/impl_num.rs#L101) when [parsing](https://github.com/akubera/bigdecimal-rs/blob/466b291b12654520592af217f73030358e96a2f5/src/impl_num.rs#L36) BigDecimal numbers.


### Before

```
cargo run -- seq 1e-9223372036854775808
seq: invalid floating point argument: '1e-9223372036854775808'
```

### After
```
cargo run -- seq 1e-9223372036854775808
```

### Expected

```
seq 1e-9223372036854775808
```

Thank you