### PR TITLE
Bump `chrono-tz` to `0.10.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "cd6dd8046d00723a59a2f8c5f295c515b9bb9a331ee4f8f3d4dd49e428acd3b6"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -315,12 +315,11 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
 dependencies = [
  "parse-zoneinfo",
- "phf",
  "phf_codegen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,10 +278,9 @@ chrono = { version = "0.4.38", default-features = false, features = [
   "alloc",
   "clock",
 ] }
+chrono-tz = "0.10.0"
 clap = { version = "4.5", features = ["wrap_help", "cargo"] }
 clap_complete = "4.4"
-chrono-tz = "0.8.3"
-iana-time-zone = "0.1.57"
 clap_mangen = "0.2"
 compare = "0.1.0"
 coz = { version = "0.1.3" }
@@ -299,6 +298,7 @@ gcd = "2.3"
 glob = "0.3.1"
 half = "2.4.1"
 hostname = "0.4"
+iana-time-zone = "0.1.57"
 indicatif = "0.17.8"
 itertools = "0.14.0"
 libc = "0.2.153"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "cd6dd8046d00723a59a2f8c5f295c515b9bb9a331ee4f8f3d4dd49e428acd3b6"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -243,12 +243,11 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
 dependencies = [
  "parse-zoneinfo",
- "phf",
  "phf_codegen",
 ]
 

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -288,7 +288,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     // GNU `date` uses `%N` for nano seconds, however crate::chrono uses `%f`
                     let format_string = &format_string
                         .replace("%N", "%f")
-                        .replace("%Z", tz_abbreviation);
+                        .replace("%Z", tz_abbreviation.unwrap_or("UTC"));
                     // Refuse to pass this string to chrono as it is crashing in this crate
                     if format_string.contains("%#z") {
                         return Err(USimpleError::new(

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -277,7 +277,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     // TODO - Revisit when chrono 0.5 is released. https://github.com/chronotope/chrono/issues/970
                     let tz = match std::env::var("TZ") {
                         // TODO Support other time zones...
-                        Ok(s) if s == "UTC0" => Tz::Etc__UTC,
+                        Ok(s) if s == "UTC0" || s.is_empty() => Tz::Etc__UTC,
                         _ => match get_timezone() {
                             Ok(tz_str) => tz_str.parse().unwrap(),
                             Err(_) => Tz::Etc__UTC,

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -482,3 +482,12 @@ fn test_date_from_stdin() {
              Sat Apr 15 18:30:00 UTC 2023\n",
         );
 }
+
+#[test]
+fn test_date_empty_tz() {
+    new_ucmd!()
+        .env("TZ", "")
+        .arg("+%Z")
+        .succeeds()
+        .stdout_only("UTC\n");
+}


### PR DESCRIPTION
This PR bumps `chrono-tz` from `0.8.6` to `0.10.0` and adapts the code to an API change.

It also fixes a small issue if the `TZ` environment variable is empty. In such a case, GNU `date` uses `UTC` whereas we used whatever the default was on the machine:
```
$ TZ= date +"%Z"
UTC
$ TZ= cargo run -q date +"%Z"
CET
```