### PR TITLE
ls: display %Z alphabetic time zone abbreviation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,9 +2871,11 @@ version = "0.0.29"
 dependencies = [
  "ansi-width",
  "chrono",
+ "chrono-tz",
  "clap",
  "glob",
  "hostname",
+ "iana-time-zone",
  "lscolors",
  "number_prefix",
  "once_cell",

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -18,13 +18,17 @@ path = "src/ls.rs"
 
 [dependencies]
 ansi-width = { workspace = true }
-clap = { workspace = true, features = ["env"] }
 chrono = { workspace = true }
-number_prefix = { workspace = true }
-uutils_term_grid = { workspace = true }
-terminal_size = { workspace = true }
+chrono-tz = { workspace = true }
+clap = { workspace = true, features = ["env"] }
 glob = { workspace = true }
+hostname = { workspace = true }
+iana-time-zone = { workspace = true }
 lscolors = { workspace = true }
+number_prefix = { workspace = true }
+once_cell = { workspace = true }
+selinux = { workspace = true, optional = true }
+terminal_size = { workspace = true }
 uucore = { workspace = true, features = [
   "colors",
   "entries",
@@ -34,9 +38,7 @@ uucore = { workspace = true, features = [
   "quoting-style",
   "version-cmp",
 ] }
-once_cell = { workspace = true }
-selinux = { workspace = true, optional = true }
-hostname = { workspace = true }
+uutils_term_grid = { workspace = true }
 
 [[bin]]
 name = "ls"

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5628,3 +5628,14 @@ fn test_non_unicode_names() {
         .succeeds()
         .stdout_is_bytes(b"\xC0.dir\n\xC0.file\n");
 }
+
+#[test]
+fn test_time_style_timezone_name() {
+    let re_custom_format = Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d* UTC f\n").unwrap();
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("f");
+    ucmd.env("TZ", "UTC0")
+        .args(&["-l", "--time-style=+%Z"])
+        .succeeds()
+        .stdout_matches(&re_custom_format);
+}


### PR DESCRIPTION
Display the alphabetic timezone abbreviation (like "UTC" or "CET") when
the `--time-style` argument includes a `%Z` directive. This matches the
behavior of `date`.

This uses basically the same code as in pull request #7134. The common code in `date` and `ls` could be refactored later.

Fixes #7035