### PR TITLE
gnu patches: adapt `tests_ls_no_cap.patch` to GNU `coreutils 9.6`

### DIFF
--- a/util/gnu-patches/tests_ls_no_cap.patch
+++ b/util/gnu-patches/tests_ls_no_cap.patch
@@ -1,17 +1,15 @@
 diff --git a/tests/ls/no-cap.sh b/tests/ls/no-cap.sh
-index 3d84c74ff..d1f60e70a 100755
+index 99f0563bc..f7b9e7885 100755
 --- a/tests/ls/no-cap.sh
 +++ b/tests/ls/no-cap.sh
-@@ -21,13 +21,13 @@ print_ver_ ls
- require_strace_ capget
+@@ -27,11 +27,11 @@ setcap 'cap_net_bind_service=ep' file ||
+   skip_ "setcap doesn't work"
  
  LS_COLORS=ca=1; export LS_COLORS
 -strace -e capget ls --color=always > /dev/null 2> out || fail=1
 -$EGREP 'capget\(' out || skip_ "your ls doesn't call capget"
 +strace -e llistxattr ls --color=always > /dev/null 2> out || fail=1
 +$EGREP 'llistxattr\(' out || skip_ "your ls doesn't call llistxattr"
- 
- rm -f out
  
  LS_COLORS=ca=:; export LS_COLORS
 -strace -e capget ls --color=always > /dev/null 2> out || fail=1


### PR DESCRIPTION
Currently, `util/build-gnu.sh` fails to apply `tests_ls_no_cap.patch` with GNU `coreutils 9.6`:
```
patching file tests/ls/no-cap.sh
Hunk #1 FAILED at 21.
1 out of 1 hunk FAILED
```
This PR adapts the patch to the changes made to `tests/ls/no-cap.sh` in https://github.com/coreutils/coreutils/commit/96100139fc9c05c0ad2236a240783543f0778b85