### PR TITLE
Re-enable integer overflow test case for printf

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -180,9 +180,6 @@ fi
 
 grep -rl 'path_prepend_' tests/* | xargs sed -i 's| path_prepend_ ./src||'
 
-# printf doesn't limit the values used in its arg, so this produced ~2GB of output
-sed -i '/INT_OFLOW/ D' tests/printf/printf.sh
-
 # Use the system coreutils where the test fails due to error in a util that is not the one being tested
 sed -i 's|stat|/usr/bin/stat|' tests/touch/60-seconds.sh tests/sort/sort-compress-proc.sh
 sed -i 's|ls -|/usr/bin/ls -|' tests/cp/same-file.sh tests/misc/mknod.sh tests/mv/part-symlink.sh


### PR DESCRIPTION
Re-enable the test case
```
returns_ 1 $prog '%.*dx\n' $INT_OFLOW 0 >>out 2> /dev/null || fail=1                                                     
```
in the GNU test file `tests/printf/printf.sh`. On my machine, the behavior of this command with uutils printf now matches the behavior of GNU printf:
```
$ printf '%.*dx\n' 2147483648 0
printf: invalid precision: '2147483648'
```