### PR TITLE
mv: show prompt for `-u --interactive`

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -576,13 +576,6 @@ fn rename(
     let mut backup_path = None;
 
     if to.exists() {
-        if opts.update == UpdateMode::ReplaceIfOlder && opts.overwrite == OverwriteMode::Interactive
-        {
-            // `mv -i --update old new` when `new` exists doesn't move anything
-            // and exit with 0
-            return Ok(());
-        }
-
         if opts.update == UpdateMode::ReplaceNone {
             if opts.debug {
                 println!("skipped {}", to.quote());

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -1120,6 +1120,30 @@ fn test_mv_arg_update_older_dest_older() {
 }
 
 #[test]
+fn test_mv_arg_update_older_dest_older_interactive() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let old = "old";
+    let new = "new";
+    let old_content = "file1 content\n";
+    let new_content = "file2 content\n";
+
+    let mut f = at.make_file(old);
+    f.write_all(old_content.as_bytes()).unwrap();
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
+
+    at.write(new, new_content);
+
+    ucmd.arg(new)
+        .arg(old)
+        .arg("--interactive")
+        .arg("--update=older")
+        .fails()
+        .stderr_contains("overwrite 'old'?")
+        .no_stdout();
+}
+
+#[test]
 fn test_mv_arg_update_short_overwrite() {
     // same as --update=older
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
This PR adapts the behavior of `-u --interactive` to the new behavior of GNU `coreutils 9.6` and shows a prompt. It should make [tests/mv/update.sh](https://github.com/coreutils/coreutils/blob/master/tests/mv/update.sh) pass.