### PR TITLE
sort: errors on overflowing -k argument but shouldn't

### DIFF
--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1302,3 +1302,14 @@ fn test_same_sort_mode_twice() {
 fn test_args_override() {
     new_ucmd!().args(&["-f", "-f"]).pipe_in("foo").succeeds();
 }
+
+#[test]
+fn test_k_overflow() {
+    let input = "2\n1\n";
+    let output = "1\n2\n";
+    new_ucmd!()
+        .args(&["-k", "18446744073709551616"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(output);
+}


### PR DESCRIPTION
Fixes issue #7185 "sort: errors on overflowing -k argument but shouldn't"

```bash
$ printf "2\n1\n" | cargo run sort -k 18446744073709551616
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/coreutils sort -k 18446744073709551616`
1
2
```

I'm making the assumption based on the issue that we set to `usize::MAX`. 

As this is my first ever commit to a project and new to rust, please let me know what else would have to be done if needed to get this approved.