### PR TITLE
cksum: Update error and flags handling to improver GNU's match

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -24,6 +24,7 @@ use uucore::checksum::escape_filename;
 use uucore::checksum::perform_checksum_validation;
 use uucore::checksum::ChecksumError;
 use uucore::checksum::ChecksumOptions;
+use uucore::checksum::ChecksumVerbose;
 use uucore::checksum::HashAlgorithm;
 use uucore::error::{FromIo, UResult};
 use uucore::sum::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shake256};
@@ -240,13 +241,14 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
             || iter::once(OsStr::new("-")).collect::<Vec<_>>(),
             |files| files.map(OsStr::new).collect::<Vec<_>>(),
         );
+
+        let verbose = ChecksumVerbose::new(status, quiet, warn);
+
         let opts = ChecksumOptions {
             binary,
             ignore_missing,
-            quiet,
-            status,
             strict,
-            warn,
+            verbose,
         };
 
         // Execute the checksum validation
@@ -356,14 +358,16 @@ pub fn uu_app_common() -> Command {
                 .short('q')
                 .long(options::QUIET)
                 .help("don't print OK for each successfully verified file")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with_all([options::STATUS, options::WARN]),
         )
         .arg(
             Arg::new(options::STATUS)
                 .short('s')
                 .long("status")
                 .help("don't output anything, status code shows success")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with_all([options::QUIET, options::WARN]),
         )
         .arg(
             Arg::new(options::STRICT)
@@ -382,7 +386,8 @@ pub fn uu_app_common() -> Command {
                 .short('w')
                 .long("warn")
                 .help("warn about improperly formatted checksum lines")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with_all([options::QUIET, options::STATUS]),
         )
         .arg(
             Arg::new("zero")

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (words) asdf algo algos asha mgmt xffname hexa GFYEQ HYQK Yqxb
+// spell-checker:ignore (words) asdf algo algos asha mgmt xffname hexa GFYEQ HYQK Yqxb dont
 
 use crate::common::util::TestScenario;
 
@@ -1285,6 +1285,18 @@ fn test_several_files_error_mgmt() {
 }
 
 #[test]
+fn test_check_unknown_checksum_file() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ucmd()
+        .arg("--check")
+        .arg("missing")
+        .fails()
+        .stderr_only("cksum: missing: No such file or directory\n");
+}
+
+#[test]
 fn test_check_comment_line() {
     // A comment in a checksum file shall be discarded unnoticed.
 
@@ -1808,6 +1820,373 @@ mod gnu_cksum_base64 {
                 .no_stdout()
                 .stderr_contains("no properly formatted checksum lines found");
         }
+    }
+}
+
+/// This module reimplements the cksum-c.sh GNU test.
+mod gnu_cksum_c {
+    use super::*;
+
+    const INVALID_SUM: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaafdb57c725157cb40b5aee8d937b8351477e";
+
+    fn make_scene() -> TestScenario {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.write("input", "9\n7\n1\n4\n2\n6\n3\n5\n8\n10\n");
+
+        let algos: &[&[&str]] = &[
+            &["-a", "sha384"],
+            &["-a", "blake2b"],
+            &["-a", "blake2b", "-l", "384"],
+            &["-a", "sm3"],
+        ];
+
+        for args in algos {
+            let result = scene.ucmd().args(args).succeeds();
+            let stdout = result.stdout();
+            at.append_bytes("CHECKSUMS", stdout);
+        }
+
+        scene
+    }
+
+    #[test]
+    #[ignore]
+    fn test_signed_checksums() {
+        todo!()
+    }
+
+    #[test]
+    fn test_check_individual_digests_in_mixed_file() {
+        let scene = make_scene();
+
+        scene
+            .ucmd()
+            .arg("--check")
+            .arg("-a")
+            .arg("sm3")
+            .arg("CHECKSUMS")
+            .succeeds();
+    }
+
+    #[test]
+    fn test_check_against_older_non_hex_formats() {
+        let scene = make_scene();
+
+        scene
+            .ucmd()
+            .arg("-c")
+            .arg("-a")
+            .arg("crc")
+            .arg("CHECKSUMS")
+            .fails();
+
+        let crc_cmd = scene.ucmd().arg("-a").arg("crc").arg("input").succeeds();
+        let crc_cmd_out = crc_cmd.stdout();
+        scene.fixtures.write_bytes("CHECKSUMS.crc", crc_cmd_out);
+
+        scene.ucmd().arg("-c").arg("CHECKSUMS.crc").fails();
+    }
+
+    #[test]
+    fn test_status() {
+        let scene = make_scene();
+
+        scene
+            .ucmd()
+            .arg("--status")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .succeeds()
+            .no_output();
+    }
+
+    fn make_scene_with_comment() -> TestScenario {
+        let scene = make_scene();
+
+        scene
+            .fixtures
+            .append("CHECKSUMS", "# Very important comment\n");
+
+        scene
+    }
+
+    #[test]
+    fn test_status_with_comment() {
+        let scene = make_scene_with_comment();
+
+        scene
+            .ucmd()
+            .arg("--status")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .succeeds()
+            .no_output();
+    }
+
+    fn make_scene_with_invalid_line() -> TestScenario {
+        let scene = make_scene_with_comment();
+
+        scene.fixtures.append("CHECKSUMS", "invalid_line\n");
+
+        scene
+    }
+
+    #[test]
+    fn test_check_strict() {
+        let scene = make_scene_with_invalid_line();
+
+        // without strict, succeeds
+        scene
+            .ucmd()
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .succeeds()
+            .stderr_contains("1 line is improperly formatted");
+
+        // with strict, fails
+        scene
+            .ucmd()
+            .arg("--strict")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .stderr_contains("1 line is improperly formatted");
+    }
+
+    fn make_scene_with_two_invalid_lines() -> TestScenario {
+        let scene = make_scene_with_comment();
+
+        scene
+            .fixtures
+            .append("CHECKSUMS", "invalid_line\ninvalid_line\n");
+
+        scene
+    }
+
+    #[test]
+    fn test_check_strict_plural_checks() {
+        let scene = make_scene_with_two_invalid_lines();
+
+        scene
+            .ucmd()
+            .arg("--strict")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .stderr_contains("2 lines are improperly formatted");
+    }
+
+    fn make_scene_with_incorrect_checksum() -> TestScenario {
+        let scene = make_scene_with_two_invalid_lines();
+
+        scene
+            .fixtures
+            .append("CHECKSUMS", &format!("SM3 (input) = {INVALID_SUM}\n"));
+
+        scene
+    }
+
+    #[test]
+    fn test_check_with_incorrect_checksum() {
+        let scene = make_scene_with_incorrect_checksum();
+
+        scene
+            .ucmd()
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .stdout_contains("input: FAILED")
+            .stderr_contains("1 computed checksum did NOT match");
+
+        // also fails with strict
+        scene
+            .ucmd()
+            .arg("--strict")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .stdout_contains("input: FAILED")
+            .stderr_contains("1 computed checksum did NOT match");
+    }
+
+    #[test]
+    fn test_status_with_errors() {
+        let scene = make_scene_with_incorrect_checksum();
+
+        scene
+            .ucmd()
+            .arg("--status")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .no_output();
+    }
+
+    #[test]
+    fn test_check_with_non_existing_file() {
+        let scene = make_scene();
+        scene
+            .fixtures
+            .write("CHECKSUMS2", &format!("SM3 (input2) = {INVALID_SUM}\n"));
+
+        scene
+            .ucmd()
+            .arg("--check")
+            .arg("CHECKSUMS2")
+            .fails()
+            .stdout_contains("input2: FAILED open or read")
+            .stderr_contains("1 listed file could not be read");
+
+        // also fails with strict
+        scene
+            .ucmd()
+            .arg("--strict")
+            .arg("--check")
+            .arg("CHECKSUMS2")
+            .fails()
+            .stdout_contains("input2: FAILED open or read")
+            .stderr_contains("1 listed file could not be read");
+    }
+
+    fn make_scene_with_another_improperly_formatted() -> TestScenario {
+        let scene = make_scene_with_incorrect_checksum();
+
+        scene.fixtures.append(
+            "CHECKSUMS",
+            &format!("BLAKE2b (missing-file) = {INVALID_SUM}\n"),
+        );
+
+        scene
+    }
+
+    #[test]
+    fn test_warn() {
+        let scene = make_scene_with_another_improperly_formatted();
+
+        scene
+            .ucmd()
+            .arg("--warn")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .run()
+            .stderr_contains("CHECKSUMS: 6: improperly formatted SM3 checksum line")
+            .stderr_contains("CHECKSUMS: 9: improperly formatted BLAKE2b checksum line");
+    }
+
+    fn make_scene_with_checksum_missing() -> TestScenario {
+        let scene = make_scene_with_another_improperly_formatted();
+
+        scene.fixtures.write(
+            "CHECKSUMS-missing",
+            &format!("SM3 (nonexistent) = {INVALID_SUM}\n"),
+        );
+
+        scene
+    }
+
+    #[test]
+    fn test_ignore_missing() {
+        let scene = make_scene_with_checksum_missing();
+
+        scene
+            .ucmd()
+            .arg("--ignore-missing")
+            .arg("--check")
+            .arg("CHECKSUMS-missing")
+            .fails()
+            .stdout_does_not_contain("nonexistent: No such file or directory")
+            .stdout_does_not_contain("nonexistent: FAILED open or read")
+            .stderr_contains("CHECKSUMS-missing: no file was verified");
+    }
+
+    #[test]
+    fn test_status_and_warn() {
+        let scene = make_scene_with_checksum_missing();
+
+        // --status before --warn
+        scene
+            .ucmd()
+            .arg("--status")
+            .arg("--warn")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .stderr_contains("CHECKSUMS: 9: improperly formatted BLAKE2b checksum line")
+            .stderr_contains("WARNING: 3 lines are improperly formatted")
+            .stderr_contains("WARNING: 1 computed checksum did NOT match");
+
+        // --warn before --status (status hides the results)
+        scene
+            .ucmd()
+            .arg("--warn")
+            .arg("--status")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .stderr_does_not_contain("CHECKSUMS: 9: improperly formatted BLAKE2b checksum line")
+            .stderr_does_not_contain("WARNING: 3 lines are improperly formatted")
+            .stderr_does_not_contain("WARNING: 1 computed checksum did NOT match");
+    }
+
+    #[test]
+    fn test_status_and_ignore_missing() {
+        let scene = make_scene_with_checksum_missing();
+
+        scene
+            .ucmd()
+            .arg("--status")
+            .arg("--ignore-missing")
+            .arg("--check")
+            .arg("CHECKSUMS")
+            .fails()
+            .no_output();
+    }
+
+    #[test]
+    fn test_status_warn_and_ignore_missing() {
+        let scene = make_scene_with_checksum_missing();
+
+        scene
+            .ucmd()
+            .arg("--status")
+            .arg("--warn")
+            .arg("--ignore-missing")
+            .arg("--check")
+            .arg("CHECKSUMS-missing")
+            .fails()
+            .stderr_contains("CHECKSUMS-missing: no file was verified")
+            .stdout_does_not_contain("nonexistent: No such file or directory");
+    }
+
+    #[test]
+    fn test_check_several_files_dont_exist() {
+        let scene = make_scene();
+
+        scene
+            .ucmd()
+            .arg("--check")
+            .arg("non-existing-1")
+            .arg("non-existing-2")
+            .fails()
+            .stderr_contains("non-existing-1: No such file or directory")
+            .stderr_contains("non-existing-2: No such file or directory");
+    }
+
+    #[test]
+    fn test_check_several_files_empty() {
+        let scene = make_scene();
+        scene.fixtures.touch("empty-1");
+        scene.fixtures.touch("empty-2");
+
+        scene
+            .ucmd()
+            .arg("--check")
+            .arg("empty-1")
+            .arg("empty-2")
+            .fails()
+            .stderr_contains("empty-1: no properly formatted checksum lines found")
+            .stderr_contains("empty-2: no properly formatted checksum lines found");
     }
 }
 


### PR DESCRIPTION
This PR does 4 things:
- Move the printing of improperly formatted inline warning to the `process_checksum_line` loop instead of only printing in the case of a problem of algorithm parsing (necessary for passing tests for `--warn`)
- Introduce another rather shitty variable for "caching" the algorithm that was used in the previous checksum line, so we can use it to print a warning message for a potentially incorrect line after.

Example:
```
CHECKSUM.txt:
  SM3 (foo.txt) = xxxxxxxxxxx
  an invalid line
```
```
cksum -c CHECKSUM.txt --warn
foo.txt: OK
CHECKSUM.txt: 2: improperly formatted SM3 checksum line      <-- SM3 is from the previous line
```

- Change the way the `--status`, `--quiet` and `--warn` flags interact together. In GNU, these flags supersedes each other to set a specific verbose level, while our implementation was just setting flags. Now, our implementation is using a verbose logic as well (STATUS, QUIET, NORMAL, WARN), and the last flag passed on CLi will override the others.

- Fix a bug which prevented cksum to return with an error exit code upon a failing checksum in case `--ignore-missing` was passed.

In addition to this, I have ported the gnu test `cksum/cksum-c.sh` directly in the rust testsuite