### PR TITLE
kill: list signal `0` with `-l` and `-t`

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -154,12 +154,7 @@ fn handle_obsolete(args: &mut Vec<String>) -> Option<usize> {
 }
 
 fn table() {
-    // GNU kill doesn't list the EXIT signal with --table, so we ignore it, too
-    for (idx, signal) in ALL_SIGNALS
-        .iter()
-        .enumerate()
-        .filter(|(_, s)| **s != "EXIT")
-    {
+    for (idx, signal) in ALL_SIGNALS.iter().enumerate() {
         println!("{idx: >#2} {signal}");
     }
 }
@@ -183,8 +178,7 @@ fn print_signal(signal_name_or_value: &str) -> UResult<()> {
 }
 
 fn print_signals() {
-    // GNU kill doesn't list the EXIT signal with --list, so we ignore it, too
-    for signal in ALL_SIGNALS.iter().filter(|x| **x != "EXIT") {
+    for signal in ALL_SIGNALS {
         println!("{signal}");
     }
 }

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -63,7 +63,7 @@ fn test_kill_list_all_signals() {
         .stdout_contains("KILL")
         .stdout_contains("TERM")
         .stdout_contains("HUP")
-        .stdout_does_not_contain("EXIT");
+        .stdout_contains("EXIT");
 }
 
 #[test]
@@ -80,15 +80,16 @@ fn test_kill_list_all_signals_as_table() {
         .succeeds()
         .stdout_contains("KILL")
         .stdout_contains("TERM")
-        .stdout_contains("HUP");
+        .stdout_contains("HUP")
+        .stdout_contains("EXIT");
 }
 
 #[test]
-fn test_kill_table_starts_at_1() {
+fn test_kill_table_starts_at_0() {
     new_ucmd!()
         .arg("-t")
         .succeeds()
-        .stdout_matches(&Regex::new("^\\s?1\\sHUP").unwrap());
+        .stdout_matches(&Regex::new("^\\s?0\\sEXIT").unwrap());
 }
 
 #[test]
@@ -104,6 +105,7 @@ fn test_kill_table_lists_all_vertically() {
     assert!(signals.contains(&"KILL"));
     assert!(signals.contains(&"TERM"));
     assert!(signals.contains(&"HUP"));
+    assert!(signals.contains(&"EXIT"));
 }
 
 #[test]
@@ -143,6 +145,7 @@ fn test_kill_list_all_vertically() {
     assert!(signals.contains(&"KILL"));
     assert!(signals.contains(&"TERM"));
     assert!(signals.contains(&"HUP"));
+    assert!(signals.contains(&"EXIT"));
 }
 
 #[test]


### PR DESCRIPTION
This PR shows signal `0` (`EXIT`) in the output of `-l`/`--list` and `-t`/`--table`. It's a [change](https://github.com/coreutils/coreutils/blob/master/NEWS) made in GNU `coreutils 9.6`:

> kill -l and -t now list signal 0, as it's a valid signal to send.
