### PR TITLE
sort: add retry logic on file-descriptor exhaustion

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -225,8 +225,8 @@ impl Output {
         Ok(Self { file })
     }
 
-    fn into_write(self) -> BufWriter<Box<dyn Write>> {
-        BufWriter::new(match self.file {
+    fn writer<'a>(&'a self) -> BufWriter<Box<dyn Write + 'a>> {
+        BufWriter::new(match &self.file {
             Some((_name, file)) => {
                 // truncate the file
                 let _ = file.set_len(0);
@@ -1823,7 +1823,7 @@ fn print_sorted<'a, T: Iterator<Item = &'a Line<'a>>>(
     settings: &GlobalSettings,
     output: Output,
 ) {
-    let mut writer = output.into_write();
+    let mut writer = output.writer();
     for line in iter {
         line.print(&mut writer, settings);
     }


### PR DESCRIPTION
Partial fix for bug #5714
Rework the merging logic to continue if we error-out due to file descriptor exhaustion. Merging will only stop if no progress can be made.
Also minor tweek to code handling output-is-an-input scenario to prevent a double-open of the generated temp-file.
Updated appropriate test case.