### PR TITLE
sort: needs support for human-readable block size suffixes R and Q

### DIFF
--- a/src/uu/sort/BENCHMARKING.md
+++ b/src/uu/sort/BENCHMARKING.md
@@ -48,7 +48,7 @@ rand = "0.8.3"
 ```rust
 use rand::prelude::*;
 fn main() {
-    let suffixes = ['k', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+    let suffixes = ['k', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'];
     let mut rng = thread_rng();
     for _ in 0..100000 {
         println!(

--- a/src/uu/sort/src/numeric_str_cmp.rs
+++ b/src/uu/sort/src/numeric_str_cmp.rs
@@ -82,7 +82,10 @@ impl NumInfo {
             if Self::is_invalid_char(char, &mut had_decimal_pt, parse_settings) {
                 return if let Some(start) = start {
                     let has_si_unit = parse_settings.accept_si_units
-                        && matches!(char, 'K' | 'k' | 'M' | 'G' | 'T' | 'P' | 'E' | 'Z' | 'Y');
+                        && matches!(
+                            char,
+                            'K' | 'k' | 'M' | 'G' | 'T' | 'P' | 'E' | 'Z' | 'Y' | 'R' | 'Q'
+                        );
                     (
                         Self { exponent, sign },
                         start..if has_si_unit { idx + 1 } else { idx },
@@ -176,6 +179,8 @@ fn get_unit(unit: Option<char>) -> u8 {
             'E' => 6,
             'Z' => 7,
             'Y' => 8,
+            'R' => 9,
+            'Q' => 10,
             _ => 0,
         }
     } else {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -289,7 +289,7 @@ impl GlobalSettings {
         // GNU sort (8.32) invalid:  b, B, 1B,                         p, e, z, y
         let size = Parser::default()
             .with_allow_list(&[
-                "b", "k", "K", "m", "M", "g", "G", "t", "T", "P", "E", "Z", "Y",
+                "b", "k", "K", "m", "M", "g", "G", "t", "T", "P", "E", "Z", "Y", "R", "Q",
             ])
             .with_default_unit("K")
             .with_b_byte_count(true)
@@ -535,8 +535,9 @@ impl<'a> Line<'a> {
                     } else {
                         // include a trailing si unit
                         if selector.settings.mode == SortMode::HumanNumeric
-                            && self.line[selection.end..initial_selection.end]
-                                .starts_with(&['k', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'][..])
+                            && self.line[selection.end..initial_selection.end].starts_with(
+                                &['k', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'][..],
+                            )
                         {
                             selection.end += 1;
                         }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1313,3 +1313,14 @@ fn test_k_overflow() {
         .succeeds()
         .stdout_is(output);
 }
+
+#[test]
+fn test_human_blocks_r_and_q() {
+    let input = "1Q\n1R\n";
+    let output = "1R\n1Q\n";
+    new_ucmd!()
+        .args(&["-h"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(output);
+}


### PR DESCRIPTION
Fixes #7182 

```bash

$ printf "1Q\n1R\n" | cargo run sort -h
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/coreutils sort -h`
1R
1Q
```

```bash
$ printf "1Q\n1R\n" | sort -h
1R
1Q
```