### PR TITLE
timeout: add support for `-f` and `-p` short options

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -129,6 +129,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::FOREGROUND)
                 .long(options::FOREGROUND)
+                .short('f')
                 .help(
                     "when not running timeout directly from a shell prompt, allow \
                 COMMAND to read from the TTY and get TTY signals; in this mode, \
@@ -148,6 +149,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::PRESERVE_STATUS)
                 .long(options::PRESERVE_STATUS)
+                .short('p')
                 .help("exit with the same status as COMMAND, even when the command times out")
                 .action(ArgAction::SetTrue),
         )

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -65,13 +65,11 @@ fn test_zero_timeout() {
     new_ucmd!()
         .args(&["-v", "0", "sleep", ".1"])
         .succeeds()
-        .no_stderr()
-        .no_stdout();
+        .no_output();
     new_ucmd!()
         .args(&["-v", "0", "-s0", "-k0", "sleep", ".1"])
         .succeeds()
-        .no_stderr()
-        .no_stdout();
+        .no_output();
 }
 
 #[test]
@@ -101,8 +99,7 @@ fn test_preserve_status() {
             .fails()
             // 128 + SIGTERM = 128 + 15
             .code_is(128 + 15)
-            .no_stderr()
-            .no_stdout();
+            .no_output();
     }
 }
 
@@ -115,8 +112,7 @@ fn test_preserve_status_even_when_send_signal() {
             .args(&["-s", cont_spelling, "--preserve-status", ".1", "sleep", "2"])
             .succeeds()
             .code_is(0)
-            .no_stderr()
-            .no_stdout();
+            .no_output();
     }
 }
 
@@ -126,14 +122,12 @@ fn test_dont_overflow() {
         .args(&["9223372036854775808d", "sleep", "0"])
         .succeeds()
         .code_is(0)
-        .no_stderr()
-        .no_stdout();
+        .no_output();
     new_ucmd!()
         .args(&["-k", "9223372036854775808d", "10", "sleep", "0"])
         .succeeds()
         .code_is(0)
-        .no_stderr()
-        .no_stdout();
+        .no_output();
 }
 
 #[test]
@@ -166,8 +160,7 @@ fn test_kill_after_long() {
     new_ucmd!()
         .args(&["--kill-after=1", "1", "sleep", "0"])
         .succeeds()
-        .no_stdout()
-        .no_stderr();
+        .no_output();
 }
 
 #[test]

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -83,14 +83,27 @@ fn test_command_empty_args() {
 }
 
 #[test]
+fn test_foreground() {
+    for arg in ["-f", "--foreground"] {
+        new_ucmd!()
+            .args(&[arg, ".1", "sleep", "10"])
+            .fails()
+            .code_is(124)
+            .no_output();
+    }
+}
+
+#[test]
 fn test_preserve_status() {
-    new_ucmd!()
-        .args(&["--preserve-status", ".1", "sleep", "10"])
-        .fails()
-        // 128 + SIGTERM = 128 + 15
-        .code_is(128 + 15)
-        .no_stderr()
-        .no_stdout();
+    for arg in ["-p", "--preserve-status"] {
+        new_ucmd!()
+            .args(&[arg, ".1", "sleep", "10"])
+            .fails()
+            // 128 + SIGTERM = 128 + 15
+            .code_is(128 + 15)
+            .no_stderr()
+            .no_stdout();
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for `-f` and `-p`. These short options have been added in GNU `timeout 9.6`. From the [release notes](https://github.com/coreutils/coreutils/blob/master/NEWS):

> timeout now supports the POSIX:2024 specified -f, and -p short options,
  corresponding to --foreground, and --preserve-status respectively.

The PR also simplifies some tests by using `no_output()` instead of `no_stderr()` and `no_stdout()`.