### PR TITLE
kill: don't allow lowercase signal names with '-'

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -141,6 +141,10 @@ fn handle_obsolete(args: &mut Vec<String>) -> Option<usize> {
         // Old signal can only be in the first argument position
         let slice = args[1].as_str();
         if let Some(signal) = slice.strip_prefix('-') {
+            // With '-', a signal name must start with an uppercase char
+            if signal.chars().next().is_some_and(|c| c.is_lowercase()) {
+                return None;
+            }
             // Check if it is a valid signal
             let opt_signal = signal_by_name_or_value(signal);
             if opt_signal.is_some() {

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -198,12 +198,24 @@ fn test_kill_with_signal_number_old_form() {
 
 #[test]
 fn test_kill_with_signal_name_old_form() {
-    let mut target = Target::new();
+    for arg in ["-Kill", "-KILL"] {
+        let mut target = Target::new();
+        new_ucmd!()
+            .arg(arg)
+            .arg(format!("{}", target.pid()))
+            .succeeds();
+        assert_eq!(target.wait_for_signal(), Some(libc::SIGKILL));
+    }
+}
+
+#[test]
+fn test_kill_with_lower_case_signal_name_old_form() {
+    let target = Target::new();
     new_ucmd!()
-        .arg("-KILL")
+        .arg("-kill")
         .arg(format!("{}", target.pid()))
-        .succeeds();
-    assert_eq!(target.wait_for_signal(), Some(libc::SIGKILL));
+        .fails()
+        .stderr_contains("unexpected argument");
 }
 
 #[test]


### PR DESCRIPTION
This PR no longer allows to use lowercase signal names with `-` and makes the `returns_ 1 env kill -cont $$ || fail=1` test in [tests/misc/kill.sh](https://github.com/coreutils/coreutils/blob/master/tests/misc/kill.sh#L39C1-L39C39) pass.