### PR TITLE
od:remove custom implementations of PartialEq and Eq

### DIFF
--- a/src/uu/od/src/formatteriteminfo.rs
+++ b/src/uu/od/src/formatteriteminfo.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Copy)]
+#[derive(Copy, PartialEq, Eq)]
 pub enum FormatWriter {
     IntWriter(fn(u64) -> String),
     FloatWriter(fn(f64) -> String),
@@ -20,21 +20,6 @@ impl Clone for FormatWriter {
         *self
     }
 }
-
-impl PartialEq for FormatWriter {
-    fn eq(&self, other: &Self) -> bool {
-        use crate::formatteriteminfo::FormatWriter::*;
-
-        match (self, other) {
-            (IntWriter(a), IntWriter(b)) => a == b,
-            (FloatWriter(a), FloatWriter(b)) => a == b,
-            (MultibyteWriter(a), MultibyteWriter(b)) => *a as usize == *b as usize,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for FormatWriter {}
 
 impl fmt::Debug for FormatWriter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
### About

Issue #7187

### Description

Removing custom ```PartialEq``` and ```Eq``` implementations helps avoid issues like:

```
warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
  --> src/uu/od/src/formatteriteminfo.rs:29:45
   |
29 |             (IntWriter(a), IntWriter(b)) => a == b,
   |                                             ^^^^^^
   |
   = note: the address of the same function can vary between different codegen units
   = note: furthermore, different functions could have the same address after being merged together
 
```
Observable on nightly 1.86


Thank you