### PR TITLE
kill: fix the fail to use only least significant bits to identify signal with -l

### DIFF
--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -164,13 +164,19 @@ fn table() {
 }
 
 fn print_signal(signal_name_or_value: &str) -> UResult<()> {
+    let lower_5_bits = |x: usize| x & 0b11111;
+    let option_num_parse = signal_name_or_value.parse::<usize>().ok();
+
     for (value, &signal) in ALL_SIGNALS.iter().enumerate() {
         if signal.eq_ignore_ascii_case(signal_name_or_value)
             || format!("SIG{signal}").eq_ignore_ascii_case(signal_name_or_value)
         {
             println!("{value}");
             return Ok(());
-        } else if signal_name_or_value == value.to_string() {
+        } else if signal_name_or_value == value.to_string()
+            || option_num_parse
+                .is_some_and(|signal_value| lower_5_bits(signal_value) == lower_5_bits(value))
+        {
             println!("{signal}");
             return Ok(());
         }

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -164,7 +164,10 @@ fn table() {
 }
 
 fn print_signal(signal_name_or_value: &str) -> UResult<()> {
-    let lower_5_bits = |x: usize| x & 0b11111;
+    // Closure used to track the last 7 bits of the signal value
+    // when the -l option is passed only the lower 7 bits are important
+    // Example: kill -l 143 => TERM because 143 = 15 + 128
+    let lower_7_bits = |x: usize| x & 0b1111111;
     let option_num_parse = signal_name_or_value.parse::<usize>().ok();
 
     for (value, &signal) in ALL_SIGNALS.iter().enumerate() {
@@ -174,8 +177,7 @@ fn print_signal(signal_name_or_value: &str) -> UResult<()> {
             println!("{value}");
             return Ok(());
         } else if signal_name_or_value == value.to_string()
-            || option_num_parse
-                .is_some_and(|signal_value| lower_5_bits(signal_value) == lower_5_bits(value))
+            || option_num_parse.is_some_and(|signal_value| lower_7_bits(signal_value) == value)
         {
             println!("{signal}");
             return Ok(());

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -338,15 +338,21 @@ fn test_kill_with_signal_and_list() {
 fn test_kill_with_list_lower_bits() {
     new_ucmd!()
         .arg("-l")
+        .arg("128")
+        .succeeds()
+        .stdout_contains("EXIT");
+
+    new_ucmd!()
+        .arg("-l")
         .arg("143")
         .succeeds()
         .stdout_contains("TERM");
 
     new_ucmd!()
         .arg("-l")
-        .arg("145")
+        .arg("256")
         .succeeds()
-        .stdout_contains("CHLD");
+        .stdout_contains("EXIT");
 
     new_ucmd!()
         .arg("-l")
@@ -358,6 +364,7 @@ fn test_kill_with_list_lower_bits() {
 #[test]
 fn test_kill_with_list_lower_bits_unrecognized() {
     new_ucmd!().arg("-l").arg("111").fails();
+    new_ucmd!().arg("-l").arg("384").fails();
 }
 
 #[test]

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -340,7 +340,24 @@ fn test_kill_with_list_lower_bits() {
         .arg("-l")
         .arg("143")
         .succeeds()
-        .stdout_matches(&Regex::new("TERM").unwrap());
+        .stdout_contains("TERM");
+
+    new_ucmd!()
+        .arg("-l")
+        .arg("145")
+        .succeeds()
+        .stdout_contains("CHLD");
+
+    new_ucmd!()
+        .arg("-l")
+        .arg("2304")
+        .succeeds()
+        .stdout_contains("EXIT");
+}
+
+#[test]
+fn test_kill_with_list_lower_bits_unrecognized() {
+    new_ucmd!().arg("-l").arg("111").fails();
 }
 
 #[test]

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -335,6 +335,15 @@ fn test_kill_with_signal_and_list() {
 }
 
 #[test]
+fn test_kill_with_list_lower_bits() {
+    new_ucmd!()
+        .arg("-l")
+        .arg("143")
+        .succeeds()
+        .stdout_matches(&Regex::new("TERM").unwrap());
+}
+
+#[test]
 fn test_kill_with_signal_and_table() {
     let target = Target::new();
     new_ucmd!()

--- a/util/why-error.md
+++ b/util/why-error.md
@@ -26,7 +26,6 @@ This file documents why some tests are failing:
 * gnu/tests/ls/stat-free-symlinks.sh
 * gnu/tests/misc/close-stdout.sh
 * gnu/tests/misc/comm.pl
-* gnu/tests/misc/kill.sh - https://github.com/uutils/coreutils/issues/7066 https://github.com/uutils/coreutils/issues/7067
 * gnu/tests/misc/nohup.sh
 * gnu/tests/misc/numfmt.pl
 * gnu/tests/misc/stdbuf.sh - https://github.com/uutils/coreutils/issues/7072


### PR DESCRIPTION
This pull request solves the issue number #7218.
Fixes #7218 