### PR TITLE
Bump `nom` and adapt `tr` to API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1276,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1421,6 +1421,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1620,7 +1629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae130e79b384861c193d6016a46baa2733a6f8f17486eb36a5c098c577ce01e8"
 dependencies = [
  "chrono",
- "nom",
+ "nom 7.1.3",
  "regex",
 ]
 
@@ -1996,7 +2005,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2241,7 +2250,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix 0.38.43",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3325,7 +3334,7 @@ name = "uu_tr"
 version = "0.0.29"
 dependencies = [
  "clap",
- "nom",
+ "nom 8.0.0",
  "uucore",
 ]
 
@@ -3660,7 +3669,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ lscolors = { version = "0.20.0", default-features = false, features = [
 memchr = "2.7.2"
 memmap2 = "0.9.4"
 nix = { version = "0.29", default-features = false }
-nom = "7.1.3"
+nom = "8.0.0"
 notify = { version = "=8.0.0", features = ["macos_kqueue"] }
 num-bigint = "0.4.4"
 num-prime = "0.4.4"

--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,8 @@ skip = [
   { name = "itertools", version = "0.13.0" },
   # indexmap
   { name = "hashbrown", version = "0.14.5" },
+  # parse_datetime, cexpr (via bindgen)
+  { name = "nom", version = "7.1.3" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR does three things:
* bumps `nom` from `7.1.3` to `8.0.0`
* adds `nom` to the skip list in `deny.toml`
* adapts `tr` to API changes in `nom`