### PR TITLE
Remove `rand_pcg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,6 @@ dependencies = [
  "pretty_assertions",
  "procfs",
  "rand",
- "rand_pcg",
  "regex",
  "rlimit",
  "rstest",
@@ -1829,15 +1828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,7 +520,6 @@ procfs = { version = "0.17", default-features = false }
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true, features = ["process", "signal", "user", "term"] }
 rlimit = "0.10.1"
-rand_pcg = "0.3.1"
 xattr = { workspace = true }
 
 # Specifically used in test_uptime::test_uptime_with_file_containing_valid_boot_time_utmpx_record

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1263,6 +1263,7 @@ fn test_tmp_files_deleted_on_sigint() {
     use std::{fs::read_dir, time::Duration};
 
     use nix::{sys::signal, unistd::Pid};
+    use rand::rngs::SmallRng;
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("tmp_dir");
@@ -1273,7 +1274,7 @@ fn test_tmp_files_deleted_on_sigint() {
         let mut file = at.make_file(file_name);
         // approximately 20 MB
         for _ in 0..40 {
-            let lines = rand_pcg::Pcg32::seed_from_u64(123)
+            let lines = SmallRng::seed_from_u64(123)
                 .sample_iter(rand::distributions::uniform::Uniform::new(0, 10000))
                 .take(100_000)
                 .map(|x| x.to_string() + "\n")


### PR DESCRIPTION
I noticed that the `rand_pcg` crate is only used in one single place in a `sort` test. This PR removes the crate and uses `rand::rngs::SmallRng::seed_from_u64` instead of `rand_pcg::Pcg32::seed_from_u64`.

Edit: The crate was added in https://github.com/uutils/coreutils/pull/3927