### PR TITLE
mv: fix moving FIFO to a different filesystem

### DIFF
--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -21,13 +21,14 @@ path = "src/mv.rs"
 clap = { workspace = true }
 fs_extra = { workspace = true }
 indicatif = { workspace = true }
+libc = { workspace = true }
+thiserror = { workspace = true }
 uucore = { workspace = true, features = [
   "backup-control",
   "fs",
   "fsxattr",
   "update-control",
 ] }
-thiserror = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [


### PR DESCRIPTION
Fix a bug in `mv` where it would hang indefinitely while trying to copy
a FIFO across filesystems. The solution is to remove the old FIFO and
create a new one on the new filesystem.

~The first commit factors out helper functions from the `rename_with_fallback()` function
so that there is one fallback helper per file type (symlink, directory,
or file). This doesn't change the functionality of `mv`, it is just a
re-organization of the code.~ This was done in pull request https://github.com/uutils/coreutils/pull/7774

Fixes #7076