### PR TITLE
Remove some replacements of touch in build script

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -176,7 +176,7 @@ grep -rl 'path_prepend_' tests/* | xargs sed -i 's| path_prepend_ ./src||'
 # Use the system coreutils where the test fails due to error in a util that is not the one being tested
 sed -i "s|grep '^#define HAVE_CAP 1' \$CONFIG_HEADER > /dev/null|true|"  tests/ls/capability.sh
 # tests/ls/abmon-align.sh - https://github.com/uutils/coreutils/issues/3505
-sed -i 's|touch |/usr/bin/touch |' tests/mv/update.sh tests/ls/ls-time.sh tests/misc/time-style.sh tests/test/test-N.sh tests/ls/abmon-align.sh
+sed -i 's|touch |/usr/bin/touch |' tests/test/test-N.sh tests/ls/abmon-align.sh
 
 # our messages are better
 sed -i "s|cannot stat 'symlink': Permission denied|not writing through dangling symlink 'symlink'|" tests/cp/fail-perm.sh


### PR DESCRIPTION
Remove some replacements of uutils `touch` for GNU `touch` in the `util/build-gnu.sh` script, since recent improvements to the `parse_datetime` have made these replacements unnecessary.