### PR TITLE
printf: error on missing hexadecial escape value

### DIFF
--- a/src/uucore/src/lib/features/format/escape.rs
+++ b/src/uucore/src/lib/features/format/escape.rs
@@ -94,43 +94,50 @@ fn parse_unicode(input: &mut &[u8], digits: u8) -> Option<char> {
     char::from_u32(ret)
 }
 
-pub fn parse_escape_code(rest: &mut &[u8]) -> EscapedChar {
+/// Represents an invalid escape sequence.
+#[derive(Debug)]
+pub struct EscapeError {}
+
+/// Parse an escape sequence, like `\n` or `\xff`, etc.
+pub fn parse_escape_code(rest: &mut &[u8]) -> Result<EscapedChar, EscapeError> {
     if let [c, new_rest @ ..] = rest {
         // This is for the \NNN syntax for octal sequences.
         // Note that '0' is intentionally omitted because that
         // would be the \0NNN syntax.
         if let b'1'..=b'7' = c {
             if let Some(parsed) = parse_code(rest, Base::Oct) {
-                return EscapedChar::Byte(parsed);
+                return Ok(EscapedChar::Byte(parsed));
             }
         }
 
         *rest = new_rest;
         match c {
-            b'\\' => EscapedChar::Byte(b'\\'),
-            b'"' => EscapedChar::Byte(b'"'),
-            b'a' => EscapedChar::Byte(b'\x07'),
-            b'b' => EscapedChar::Byte(b'\x08'),
-            b'c' => EscapedChar::End,
-            b'e' => EscapedChar::Byte(b'\x1b'),
-            b'f' => EscapedChar::Byte(b'\x0c'),
-            b'n' => EscapedChar::Byte(b'\n'),
-            b'r' => EscapedChar::Byte(b'\r'),
-            b't' => EscapedChar::Byte(b'\t'),
-            b'v' => EscapedChar::Byte(b'\x0b'),
+            b'\\' => Ok(EscapedChar::Byte(b'\\')),
+            b'"' => Ok(EscapedChar::Byte(b'"')),
+            b'a' => Ok(EscapedChar::Byte(b'\x07')),
+            b'b' => Ok(EscapedChar::Byte(b'\x08')),
+            b'c' => Ok(EscapedChar::End),
+            b'e' => Ok(EscapedChar::Byte(b'\x1b')),
+            b'f' => Ok(EscapedChar::Byte(b'\x0c')),
+            b'n' => Ok(EscapedChar::Byte(b'\n')),
+            b'r' => Ok(EscapedChar::Byte(b'\r')),
+            b't' => Ok(EscapedChar::Byte(b'\t')),
+            b'v' => Ok(EscapedChar::Byte(b'\x0b')),
             b'x' => {
                 if let Some(c) = parse_code(rest, Base::Hex) {
-                    EscapedChar::Byte(c)
+                    Ok(EscapedChar::Byte(c))
                 } else {
-                    EscapedChar::Backslash(b'x')
+                    Err(EscapeError {})
                 }
             }
-            b'0' => EscapedChar::Byte(parse_code(rest, Base::Oct).unwrap_or(b'\0')),
-            b'u' => EscapedChar::Char(parse_unicode(rest, 4).unwrap_or('\0')),
-            b'U' => EscapedChar::Char(parse_unicode(rest, 8).unwrap_or('\0')),
-            c => EscapedChar::Backslash(*c),
+            b'0' => Ok(EscapedChar::Byte(
+                parse_code(rest, Base::Oct).unwrap_or(b'\0'),
+            )),
+            b'u' => Ok(EscapedChar::Char(parse_unicode(rest, 4).unwrap_or('\0'))),
+            b'U' => Ok(EscapedChar::Char(parse_unicode(rest, 8).unwrap_or('\0'))),
+            c => Ok(EscapedChar::Backslash(*c)),
         }
     } else {
-        EscapedChar::Byte(b'\\')
+        Ok(EscapedChar::Byte(b'\\'))
     }
 }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -47,6 +47,15 @@ fn escaped_hex() {
 }
 
 #[test]
+fn test_missing_escaped_hex_value() {
+    new_ucmd!()
+        .arg(r"\x")
+        .fails()
+        .code_is(1)
+        .stderr_only("printf: missing hexadecimal number in escape\n");
+}
+
+#[test]
 fn escaped_octal() {
     new_ucmd!().args(&["\\101"]).succeeds().stdout_only("A");
 }


### PR DESCRIPTION
Change `printf` to correctly terminate with an error message when an escape sequence starts with `\x` but doesn't include a literal hexadecimal value after. For example, before this commit,

    printf '\x'

would output `\x`, but after this commit, it terminates with an error message,

    printf: missing hexadecimal number in escape

Fixes #7097