### PR TITLE
uptime: remove duplicate test

### DIFF
--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -273,8 +273,3 @@ fn test_uptime_since() {
 
     new_ucmd!().arg("--since").succeeds().stdout_matches(&re);
 }
-
-#[test]
-fn test_failed() {
-    new_ucmd!().arg("will-fail").fails();
-}


### PR DESCRIPTION
This PR removes a test that does the same as `test_uptime_with_non_existent_file()`.