### PR TITLE
Fixed Bugs When Not Using Default Target Directory

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,7 +41,11 @@ PROG_PREFIX ?=
 # This won't support any directory with spaces in its name, but you can just
 # make a symlink without spaces that points to the directory.
 BASEDIR       ?= $(shell pwd)
+ifdef CARGO_TARGET_DIR
+BUILDDIR 	  := $(CARGO_TARGET_DIR)/${PROFILE}
+else
 BUILDDIR      := $(BASEDIR)/target/${PROFILE}
+endif
 PKG_BUILDDIR  := $(BUILDDIR)/deps
 DOCSDIR       := $(BASEDIR)/docs
 

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -84,7 +84,11 @@ echo "path_GNU='${path_GNU}'"
 
 ###
 
+if [[ ! -z  "$CARGO_TARGET_DIR" ]]; then
+UU_BUILD_DIR="${CARGO_TARGET_DIR}/${UU_MAKE_PROFILE}"
+else
 UU_BUILD_DIR="${path_UUTILS}/target/${UU_MAKE_PROFILE}"
+fi
 echo "UU_BUILD_DIR='${UU_BUILD_DIR}'"
 
 cd "${path_UUTILS}" && echo "[ pwd:'${PWD}' ]"


### PR DESCRIPTION
- Changes stdbuf's build script to allow target directory to not require 'target' or 'cargo-install' in name
- Updates scripts to use "CARGO_TARGET_DIR" when supplied