### PR TITLE
Cargo.toml: fix incorrect lint name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -575,7 +575,7 @@ semicolon_if_nothing_returned = "warn"
 single_char_pattern = "warn"
 explicit_iter_loop = "warn"
 if_not_else = "warn"
-manual_if_else = "warn"
+manual_let_else = "warn"
 
 all = { level = "deny", priority = -1 }
 cargo = { level = "warn", priority = -1 }


### PR DESCRIPTION
This PR fixes a "warning[E0602]: unknown lint: `clippy::manual_if_else`" warning from clippy (see, for example, https://github.com/uutils/coreutils/actions/runs/13132290196/job/36639841764#step:7:36) caused by an incorrect lint name in `Cargo.toml`.