### PR TITLE
head: Update error string on disk-full error.

### DIFF
--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -533,7 +533,7 @@ fn test_write_to_dev_full() {
                 .pipe_in_fixture(INPUT)
                 .set_stdout(dev_full)
                 .run()
-                .stderr_contains("No space left on device");
+                .stderr_contains("error writing 'standard output': No space left on device");
         }
     }
 }


### PR DESCRIPTION
Fixes #7271.
Update head to print identical error to GNU-head on disk-full scenario. Fixes all issues with head-write-error.sh test.