### PR TITLE
touch: support obsolete POSIX timestamp argument

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -161,20 +161,10 @@ fn is_first_filename_timestamp(
 ) -> bool {
     match std::env::var("_POSIX2_VERSION") {
         Ok(s) if s == "199209" => {
-            if timestamp.is_none() && reference.is_none() && date.is_none() {
-                if files.len() >= 2 {
-                    let s = files[0];
-                    if s.len() == 8 && all_digits(s) {
-                        true
-                    } else if s.len() == 10 && all_digits(s) {
-                        let year = get_year(s);
-                        (69..=99).contains(&year)
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
+            if timestamp.is_none() && reference.is_none() && date.is_none() && files.len() >= 2 {
+                let s = files[0];
+                all_digits(s)
+                    && (s.len() == 8 || (s.len() == 10 && (69..=99).contains(&get_year(s))))
             } else {
                 false
             }

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -935,9 +935,9 @@ fn test_obsolete_posix_format_with_year() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.env("_POSIX2_VERSION", "199209")
         .env("POSIXLY_CORRECT", "1")
-        .args(&["9001010000", "11111111"])
+        .args(&["0101000090", "11111111"])
         .succeeds()
         .no_output();
     assert!(at.file_exists("11111111"));
-    assert!(!at.file_exists("01010000"));
+    assert!(!at.file_exists("0101000090"));
 }

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -917,3 +917,27 @@ fn test_touch_reference_symlink_with_no_deref() {
     // Times should be taken from the symlink, not the destination
     assert_eq!((time, time), get_symlink_times(&at, arg));
 }
+
+#[test]
+fn test_obsolete_posix_format() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.env("_POSIX2_VERSION", "199209")
+        .env("POSIXLY_CORRECT", "1")
+        .args(&["01010000", "11111111"])
+        .succeeds()
+        .no_output();
+    assert!(at.file_exists("11111111"));
+    assert!(!at.file_exists("01010000"));
+}
+
+#[test]
+fn test_obsolete_posix_format_with_year() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.env("_POSIX2_VERSION", "199209")
+        .env("POSIXLY_CORRECT", "1")
+        .args(&["9001010000", "11111111"])
+        .succeeds()
+        .no_output();
+    assert!(at.file_exists("11111111"));
+    assert!(!at.file_exists("01010000"));
+}


### PR DESCRIPTION
Support obsolete form of timestamp argument for old POSIX versions. In summary, when older versions of POSIX are used and the first positional argument looks like a date and time, then treat it as a timestamp instead of as a filename. For example, before this commit

    _POSIX2_VERSION=199209
    POSIXLY_CORRECT=1
    touch 01010000 11111111

would create two files, `01010000` and `11111111`. After this commit, the first argument is interpreted as a date and time (in this case, midnight on January 1 of the current year) and that date and time are set on the file named `11111111`.

Fixes #7180.