### PR TITLE
Bump `fts-sys` from `0.2.13` to `0.2.14`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn",
 ]
@@ -949,11 +969,11 @@ dependencies = [
 
 [[package]]
 name = "fts-sys"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c427b250eff90452a35afd79fdfcbcf4880e307225bc28bd36d9a2cd78bb6d90"
+checksum = "82a568c1a1bf43f3ba449e446d85537fd914fb3abb003b21bc4ec6747f80596e"
 dependencies = [
- "bindgen",
+ "bindgen 0.71.1",
  "libc",
 ]
 
@@ -1287,7 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2000,6 +2020,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,7 +2108,7 @@ version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5e6e2b8e07a8ff45c90f8e3611bf10c4da7a28d73a26f9ede04f927da234f52"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "dunce",
  "walkdir",

--- a/deny.toml
+++ b/deny.toml
@@ -60,7 +60,7 @@ skip = [
   { name = "rustix", version = "0.37.26" },
   # various crates
   { name = "windows-sys", version = "0.48.0" },
-  # various crates
+  # mio, nu-ansi-term, socket2
   { name = "windows-sys", version = "0.52.0" },
   # windows-sys
   { name = "windows-targets", version = "0.48.0" },
@@ -78,13 +78,13 @@ skip = [
   { name = "windows_x86_64_gnullvm", version = "0.48.0" },
   # windows-targets
   { name = "windows_x86_64_msvc", version = "0.48.0" },
-  # various crates
+  # kqueue-sys, onig, rustix
   { name = "bitflags", version = "1.3.2" },
   # textwrap
   { name = "terminal_size", version = "0.2.6" },
   # ansi-width, console, os_display
   { name = "unicode-width", version = "0.1.13" },
-  # various crates
+  # filedescriptor, utmp-classic
   { name = "thiserror", version = "1.0.69" },
   # thiserror
   { name = "thiserror-impl", version = "1.0.69" },
@@ -106,6 +106,10 @@ skip = [
   { name = "rand_core", version = "0.6.4" },
   # ppv-lite86, utmp-classic, utmp-classic-raw
   { name = "zerocopy", version = "0.7.35" },
+  # selinux-sys
+  { name = "bindgen", version = "0.70.1" },
+  # bindgen
+  { name = "rustc-hash", version = "1.1.0" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR bumps `fts-sys` from `0.2.13` to `0.2.14` and adds `bindgen` and `rustc-hash` to the skip list in `deny.toml`. It also updates a few comments there.