### PR TITLE
cp: fix verbose output order after prompt

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2271,10 +2271,6 @@ fn copy_file(
         .into());
     }
 
-    if options.verbose {
-        print_verbose_output(options.parents, progress_bar, source, dest);
-    }
-
     if options.preserve_hard_links() {
         // if we encounter a matching device/inode pair in the source tree
         // we can arrange to create a hard link between the corresponding names
@@ -2284,6 +2280,11 @@ fn copy_file(
                 .context(format!("cannot stat {}", source.quote()))?,
         ) {
             std::fs::hard_link(new_source, dest)?;
+
+            if options.verbose {
+                print_verbose_output(options.parents, progress_bar, source, dest);
+            }
+
             return Ok(());
         };
     }
@@ -2333,6 +2334,10 @@ fn copy_file(
         #[cfg(unix)]
         source_is_stream,
     )?;
+
+    if options.verbose {
+        print_verbose_output(options.parents, progress_bar, source, dest);
+    }
 
     // TODO: implement something similar to gnu's lchown
     if !dest_is_symlink {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -6045,17 +6045,13 @@ fn test_cp_from_stdin() {
 #[test]
 fn test_cp_verbose_message_after_interactive_prompt() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let ts = time::OffsetDateTime::now_utc();
-    let previous = FileTime::from_unix_time(ts.unix_timestamp() - 3600, ts.nanosecond());
     let src_file = "a";
     let dst_file = "b";
 
     at.touch(src_file);
     at.touch(dst_file);
 
-    filetime::set_file_times(at.plus_as_string(dst_file), previous, previous).unwrap();
-
-    ucmd.args(&["-i", "--verbose", "--update=older", src_file, dst_file])
+    ucmd.args(&["-i", "--verbose", src_file, dst_file])
         .pipe_in("Y\n")
         .succeeds()
         .stderr_is("cp: overwrite 'b'? ")

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -6053,7 +6053,7 @@ fn test_cp_verbose_message_after_interactive_prompt() {
 
     ucmd.args(&["-i", "--verbose", src_file, dst_file])
         .pipe_in("Y\n")
+        .stderr_to_stdout()
         .succeeds()
-        .stderr_is("cp: overwrite 'b'? ")
-        .stdout_is("'a' -> 'b'\n");
+        .stdout_is("cp: overwrite 'b'? 'a' -> 'b'\n");
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -6043,17 +6043,35 @@ fn test_cp_from_stdin() {
 }
 
 #[test]
-fn test_cp_verbose_message_after_interactive_prompt() {
+fn test_cp_update_older_interactive_prompt_yes() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let src_file = "a";
-    let dst_file = "b";
+    let old_file = "old";
+    let new_file = "new";
 
-    at.touch(src_file);
-    at.touch(dst_file);
+    let f = at.make_file(old_file);
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
+    at.touch(new_file);
 
-    ucmd.args(&["-i", "--verbose", src_file, dst_file])
+    ucmd.args(&["-i", "-v", "--update=older", new_file, old_file])
         .pipe_in("Y\n")
         .stderr_to_stdout()
         .succeeds()
-        .stdout_is("cp: overwrite 'b'? 'a' -> 'b'\n");
+        .stdout_is("cp: overwrite 'old'? 'new' -> 'old'\n");
+}
+
+#[test]
+fn test_cp_update_older_interactive_prompt_no() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let old_file = "old";
+    let new_file = "new";
+
+    let f = at.make_file(old_file);
+    f.set_modified(std::time::UNIX_EPOCH).unwrap();
+    at.touch(new_file);
+
+    ucmd.args(&["-i", "-v", "--update=older", new_file, old_file])
+        .pipe_in("N\n")
+        .stderr_to_stdout()
+        .fails()
+        .stdout_is("cp: overwrite 'old'? ");
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -6041,3 +6041,23 @@ fn test_cp_from_stdin() {
     assert!(at.file_exists(target));
     assert_eq!(at.read(target), test_string);
 }
+
+#[test]
+fn test_cp_verbose_message_after_interactive_prompt() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let ts = time::OffsetDateTime::now_utc();
+    let previous = FileTime::from_unix_time(ts.unix_timestamp() - 3600, ts.nanosecond());
+    let src_file = "a";
+    let dst_file = "b";
+
+    at.touch(src_file);
+    at.touch(dst_file);
+
+    filetime::set_file_times(at.plus_as_string(dst_file), previous, previous).unwrap();
+
+    ucmd.args(&["-i", "--verbose", "--update=older", src_file, dst_file])
+        .pipe_in("Y\n")
+        .succeeds()
+        .stderr_is("cp: overwrite 'b'? ")
+        .stdout_is("'a' -> 'b'\n");
+}


### PR DESCRIPTION
Fixes: #7285

This pull request addresses an ordering issue in the cp command where the verbose message is printed before the interactive prompt for overwrite confirmation.

In GNU cp, the verbose output appears only after the user has responded to the prompt, and this PR adjusts our behavior to match that order.