### PR TITLE
split: avoid extremely long format width in test

### DIFF
--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -1977,9 +1977,9 @@ fn test_split_separator_same_multiple() {
 #[test]
 fn test_long_lines() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let line1 = format!("{:131070}\n", "");
-    let line2 = format!("{:1}\n", "");
-    let line3 = format!("{:131071}\n", "");
+    let line1 = [" ".repeat(131_070), String::from("\n")].concat();
+    let line2 = [" ", "\n"].concat();
+    let line3 = [" ".repeat(131_071), String::from("\n")].concat();
     let infile = [line1, line2, line3].concat();
     ucmd.args(&["-C", "131072"])
         .pipe_in(infile)


### PR DESCRIPTION
Avoid an extremely long format width specifier in test case `test_long_lines`. The Rust compiler is planning an upcoming change to restrict the maximum width that can be specified to 65535, so this change defends against future limitations in the compiler. For more information, see
<https://github.com/uutils/coreutils/pull/7128#discussion_r1955787665>.