### PR TITLE
Fix usage strings for #5692

### DIFF
--- a/src/uu/hashsum/hashsum.md
+++ b/src/uu/hashsum/hashsum.md
@@ -1,7 +1,7 @@
 # hashsum
 
 ```
-hashsum [OPTIONS] [FILE]...
+hashsum --<digest> [OPTIONS]... [FILE]...
 ```
 
 Compute and check message digests.

--- a/src/uu/runcon/runcon.md
+++ b/src/uu/runcon/runcon.md
@@ -1,7 +1,7 @@
 # runcon
 
 ```
-runcon [CONTEXT COMMAND [ARG...]]
+runcon CONTEXT COMMAND [ARG...]
 runcon [-c] [-u USER] [-r ROLE] [-t TYPE] [-l RANGE] COMMAND [ARG...]
 ```
 

--- a/src/uu/test/test.md
+++ b/src/uu/test/test.md
@@ -2,11 +2,10 @@
 
 ```
 test EXPRESSION
-[
+test
 [ EXPRESSION ]
 [ ]
 [ OPTION
-]
 ```
 
 Check file types and compare values.

--- a/src/uu/unlink/unlink.md
+++ b/src/uu/unlink/unlink.md
@@ -1,7 +1,7 @@
 # unlink
 
 ```
-unlink [FILE]
+unlink FILE
 unlink OPTION
 ```
 


### PR DESCRIPTION
Went through the list in #5692 and found inconsistencies for unlink, runcon, test, and hashsum.

`runcon` uutils:

    runcon [CONTEXT COMMAND [ARG...]]

but `runcon` requires a context command to function:

    runcon: No command is specified

`unlink` uutils:

    unlink [FILE]

but `unlink` requires a file to unlink:

    error: the following required arguments were not provided:
      <FILE>

`hashsum`:

    hashsum [OPTIONS] [FILE]...

but `hashsum` requires a digest to operate and may take multiple options:

    hashsum: Needs an algorithm to hash with.

`test` uutils:

    test EXPRESSION
    [
    [ EXPRESSION ]
    [ ]
    [ OPTION
    ]

but:

1. `[` alone is not a valid test command:

        [: missing ']'

2. `test` alone is a valid test command.
3. `]` alone is not a valid test command.

As appropriate, this matches GNU behavior.