### PR TITLE
tr: Fix GNU behavior deviation

### DIFF
--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1167,6 +1167,15 @@ fn check_against_gnu_tr_tests_empty_eq() {
 }
 
 #[test]
+fn check_too_many_chars_in_eq() {
+    new_ucmd!()
+        .args(&["-d", "[=aa=]"])
+        .pipe_in("")
+        .fails()
+        .stderr_contains("aa: equivalence class operand must be a single character\n");
+}
+
+#[test]
 fn check_against_gnu_tr_tests_empty_cc() {
     // ['empty-cc', qw('[::]' x), {IN=>''}, {OUT=>''}, {EXIT=>1},
     //  {ERR=>"$prog: missing character class name '[::]'\n"}],


### PR DESCRIPTION
Fix the remaining edge case of #6777:
```sh
$ ./target/debug/tr -d '[=aa=]'
./target/debug/tr: aa: equivalence class operand must be a single character
```