### PR TITLE
numfmt: fix from iec-i without suffix are bytes

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -135,9 +135,6 @@ fn remove_suffix(i: f64, s: Option<Suffix>, u: &Unit) -> Result<f64> {
             RawSuffix::Z => Ok(i * IEC_BASES[7]),
             RawSuffix::Y => Ok(i * IEC_BASES[8]),
         },
-        (None, &Unit::Iec(true)) => {
-            Err(format!("missing 'i' suffix in input: '{i}' (e.g Ki/Mi/Gi)"))
-        }
         (Some((raw_suffix, false)), &Unit::Iec(true)) => Err(format!(
             "missing 'i' suffix in input: '{i}{raw_suffix:?}' (e.g Ki/Mi/Gi)"
         )),

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -56,17 +56,19 @@ fn test_from_iec_i() {
 
 #[test]
 fn test_from_iec_i_requires_suffix() {
-    let numbers = vec!["1024", "10M"];
+    new_ucmd!()
+        .args(&["--from=iec-i", "10M"])
+        .fails()
+        .code_is(2)
+        .stderr_is("numfmt: missing 'i' suffix in input: '10M' (e.g Ki/Mi/Gi)\n");
+}
 
-    for number in numbers {
-        new_ucmd!()
-            .args(&["--from=iec-i", number])
-            .fails()
-            .code_is(2)
-            .stderr_is(format!(
-                "numfmt: missing 'i' suffix in input: '{number}' (e.g Ki/Mi/Gi)\n"
-            ));
-    }
+#[test]
+fn test_from_iec_i_without_suffix_are_bytes() {
+    new_ucmd!()
+        .args(&["--from=iec-i", "1024"])
+        .succeeds()
+        .stdout_is("1024\n");
 }
 
 #[test]


### PR DESCRIPTION
Fix #7219 
The change to GNU coreutils has been real recent, part of 9.6