### PR TITLE
clippy: fix/disable warnings introduced with Rust `1.85`

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -508,6 +508,8 @@ impl StatPrinter {
                             grand_total += size;
                         }
 
+                        // TODO fix requires an MSRV of 1.82
+                        #[allow(clippy::unnecessary_map_or)]
                         if !self
                             .threshold
                             .is_some_and(|threshold| threshold.should_exclude(size))

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -869,6 +869,8 @@ fn read_stream_and_create_pages(
     let last_page = options.end_page;
     let lines_needed_per_page = lines_to_read_for_page(options);
 
+    // TODO fix requires an MSRV of 1.82
+    #[allow(clippy::unnecessary_map_or)]
     Box::new(
         lines
             .flat_map(split_lines_if_form_feed)

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -605,6 +605,8 @@ impl<'a> Line<'a> {
                 )?;
             }
         }
+        // TODO fix requires an MSRV of 1.82
+        #[allow(clippy::unnecessary_map_or)]
         if settings.mode != SortMode::Random
             && !settings.stable
             && !settings.unique

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -497,6 +497,8 @@ pub fn uu_app() -> Command {
 }
 
 impl TermiosFlag for ControlFlags {
+    // TODO fix requires an MSRV of 1.82
+    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.control_flags.contains(*self)
             && group.map_or(true, |g| !termios.control_flags.intersects(g - *self))
@@ -508,6 +510,8 @@ impl TermiosFlag for ControlFlags {
 }
 
 impl TermiosFlag for InputFlags {
+    // TODO fix requires an MSRV of 1.82
+    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.input_flags.contains(*self)
             && group.map_or(true, |g| !termios.input_flags.intersects(g - *self))
@@ -519,6 +523,8 @@ impl TermiosFlag for InputFlags {
 }
 
 impl TermiosFlag for OutputFlags {
+    // TODO fix requires an MSRV of 1.82
+    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.output_flags.contains(*self)
             && group.map_or(true, |g| !termios.output_flags.intersects(g - *self))
@@ -530,6 +536,8 @@ impl TermiosFlag for OutputFlags {
 }
 
 impl TermiosFlag for LocalFlags {
+    // TODO fix requires an MSRV of 1.82
+    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.local_flags.contains(*self)
             && group.map_or(true, |g| !termios.local_flags.intersects(g - *self))

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -814,7 +814,7 @@ impl FsMeta for StatFs {
     fn fsid(&self) -> u64 {
         let f_fsid: &[u32; 2] =
             unsafe { &*(&self.f_fsid as *const nix::sys::statfs::fsid_t as *const [u32; 2]) };
-        (u64::from(f_fsid[0])) << 32 | u64::from(f_fsid[1])
+        ((u64::from(f_fsid[0])) << 32) | u64::from(f_fsid[1])
     }
     #[cfg(not(any(
         target_vendor = "apple",


### PR DESCRIPTION
This PR fixes a clippy warning from the [precedence](https://rust-lang.github.io/rust-clippy/master/index.html#precedence) lint and disables warnings from the [unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or) lint. Those warnings are disabled instead of fixed because the fix requires a MSRV of `1.82`.