### PR TITLE
fuzz: use new `<`/`>` operators in `fuzz_test.rs`

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -665,12 +665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,16 +674,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -793,12 +777,12 @@ dependencies = [
 
 [[package]]
 name = "parse_datetime"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae130e79b384861c193d6016a46baa2733a6f8f17486eb36a5c098c577ce01e8"
+checksum = "4bffd1156cebf13f681d7769924d3edfb9d9d71ba206a8d8e8e7eb9df4f4b1e7"
 dependencies = [
  "chrono",
- "nom 7.1.3",
+ "nom",
  "regex",
 ]
 
@@ -1314,7 +1298,7 @@ name = "uu_tr"
 version = "0.0.29"
 dependencies = [
  "clap",
- "nom 8.0.0",
+ "nom",
  "uucore",
 ]
 

--- a/fuzz/fuzz_targets/fuzz_test.rs
+++ b/fuzz/fuzz_targets/fuzz_test.rs
@@ -66,6 +66,14 @@ fn generate_test_args() -> Vec<TestArg> {
             arg_type: ArgType::STRINGSTRING,
         },
         TestArg {
+            arg: ">".to_string(),
+            arg_type: ArgType::STRINGSTRING,
+        },
+        TestArg {
+            arg: "<".to_string(),
+            arg_type: ArgType::STRINGSTRING,
+        },
+        TestArg {
             arg: "-eq".to_string(),
             arg_type: ArgType::INTEGERINTEGER,
         },


### PR DESCRIPTION
This PR uses the new `<`/`>` operators, introduced with https://github.com/uutils/coreutils/pull/7315, in `fuzz_test.rs`. The PR also bumps `parse_datetime` from `0.7` to `0.8`.