### PR TITLE
GNUmakefile: support skipping manpages and completions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -278,10 +278,26 @@ jobs:
       run: make nextest CARGOFLAGS="--profile ci --hide-progress-bar"
       env:
         RUST_BACKTRACE: "1"
+    - name: "`make install COMPLETIONS=n MANPAGES=n`"
+      shell: bash
+      run: |
+        DESTDIR=/tmp/ make PROFILE=release COMPLETIONS=n MANPAGES=n install
+        # Check that the utils are present
+        test -f /tmp/usr/local/bin/tty
+        # Check that the manpage is not present
+        ! test -f /tmp/usr/local/share/man/man1/whoami.1
+        # Check that the completion is not present
+        ! test -f /tmp/usr/local/share/zsh/site-functions/_install
+        ! test -f /tmp/usr/local/share/bash-completion/completions/head
+        ! test -f /tmp/usr/local/share/fish/vendor_completions.d/cat.fish
+      env:
+        RUST_BACKTRACE: "1"
     - name: "`make install`"
       shell: bash
       run: |
         DESTDIR=/tmp/ make PROFILE=release install
+        # Check that the utils are present
+        test -f /tmp/usr/local/bin/tty
         # Check that the manpage is present
         test -f /tmp/usr/local/share/man/man1/whoami.1
         # Check that the completion is present
@@ -294,6 +310,8 @@ jobs:
       shell: bash
       run: |
         DESTDIR=/tmp/ make uninstall
+        # Check that the utils are not present
+        ! test -f /tmp/usr/local/bin/tty
         # Check that the manpage is not present
         ! test -f /tmp/usr/local/share/man/man1/whoami.1
         # Check that the completion is not present

--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ Installing with `make` installs shell completions for all installed utilities
 for `bash`, `fish` and `zsh`. Completions for `elvish` and `powershell` can also
 be generated; See `Manually install shell completions`.
 
+To skip installation of completions and manpages:
+
+```shell
+make COMPLETIONS=n MANPAGES=n install
+```
+
 ### Manually install shell completions
 
 The `coreutils` binary can generate completions for the `bash`, `elvish`,


### PR DESCRIPTION
When packaging uutils for Conda-Forge and a cross-compiled architecture, the install of completion scripts and manpages fails with the following error.

> .../coreutils manpage arch > .../man/arch.1
> /bin/sh: .../coreutils: Bad CPU type in executable
> make: *** [GNUmakefile:349: manpages] Error 126

When cross-compiling, the `coreutils` tool will be for a different architecture then the build platform. So we won't be able to extract the manpages and completions.

Provide build arguments that let us skip the build and install of manpages and completions.