### PR TITLE
yes: fix use of deprecated function in test

### DIFF
--- a/tests/by-util/test_yes.rs
+++ b/tests/by-util/test_yes.rs
@@ -29,8 +29,7 @@ fn run(args: &[impl AsRef<OsStr>], expected: &[u8]) {
     let buf = child.stdout_exact_bytes(expected.len());
     child.close_stdout();
 
-    #[allow(deprecated)]
-    check_termination(child.wait_with_output().unwrap().status);
+    check_termination(child.wait().unwrap().exit_status());
     assert_eq!(buf.as_slice(), expected);
 }
 


### PR DESCRIPTION
This PR uses `wait()`  instead of the deprecated `wait_with_output()` in a test.