### PR TITLE
Fix touch -t with 2 digit years when YY > 68

### DIFF
--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -119,6 +119,45 @@ fn test_touch_set_mdhms_time() {
 }
 
 #[test]
+fn test_touch_2_digit_years_68() {
+    // 68 and before are 20xx
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_two_digit_68_time";
+
+    ucmd.args(&["-t", "6801010000", file])
+        .succeeds()
+        .no_output();
+
+    assert!(at.file_exists(file));
+
+    //  January 1, 2068, 00:00:00
+    let expected = FileTime::from_unix_time(3_092_601_600, 0);
+    let (atime, mtime) = get_file_times(&at, file);
+    assert_eq!(atime, mtime);
+    assert_eq!(atime, expected);
+    assert_eq!(mtime, expected);
+}
+
+#[test]
+fn test_touch_2_digit_years_69() {
+    // 69 and after are 19xx
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_two_digit_69_time";
+
+    ucmd.args(&["-t", "6901010000", file])
+        .succeeds()
+        .no_output();
+
+    assert!(at.file_exists(file));
+    // January 1, 1969, 00:00:00
+    let expected = FileTime::from_unix_time(-31_536_000, 0);
+    let (atime, mtime) = get_file_times(&at, file);
+    assert_eq!(atime, mtime);
+    assert_eq!(atime, expected);
+    assert_eq!(mtime, expected);
+}
+
+#[test]
 fn test_touch_set_ymdhm_time() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_set_ymdhm_time";

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -119,8 +119,11 @@ fn test_touch_set_mdhms_time() {
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn test_touch_2_digit_years_68() {
     // 68 and before are 20xx
+    // it will fail on 32 bits, because of wraparound for anything after
+    // 2038-01-19
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_set_two_digit_68_time";
 
@@ -132,6 +135,27 @@ fn test_touch_2_digit_years_68() {
 
     //  January 1, 2068, 00:00:00
     let expected = FileTime::from_unix_time(3_092_601_600, 0);
+    let (atime, mtime) = get_file_times(&at, file);
+    assert_eq!(atime, mtime);
+    assert_eq!(atime, expected);
+    assert_eq!(mtime, expected);
+}
+
+#[test]
+fn test_touch_2_digit_years_2038() {
+    // Same as test_touch_2_digit_years_68 but for 32 bits systems
+    // we test a date before the y2038 bug
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_two_digit_68_time";
+
+    ucmd.args(&["-t", "3801010000", file])
+        .succeeds()
+        .no_output();
+
+    assert!(at.file_exists(file));
+
+    // January 1, 2038, 00:00:00
+    let expected = FileTime::from_unix_time(2_145_916_800, 0);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, expected);


### PR DESCRIPTION
When using `touch -t` with a 2 digit year, the year is interpreted as a relative year to 2000.

When the year is 68 or less, it should be interpreted as 20xx. When the year is 69 or more, it should be interpreted as 19xx.

This is the behavior of GNU `touch`.

fixes gh-7280

Arguably 2 digits years should be deprecated as we are already closer to 2069, than 1969.