### PR TITLE
.github: CICD: add workspace test to build matrix

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -505,7 +505,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          # - { os , target , cargo-options , features , use-cross , toolchain, skip-tests }
+          # - { os , target , cargo-options , features , use-cross , toolchain, skip-tests, workspace-tests }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-24.04-arm  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl      , use-cross: use-cross , skip-tests: true }
@@ -513,6 +513,7 @@ jobs:
           - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix"         , use-cross: no, workspace-tests: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos } # M1 CPU
@@ -613,9 +614,12 @@ jobs:
         # * CARGO_CMD
         CARGO_CMD='cross'
         CARGO_CMD_OPTIONS='+${{ env.RUST_MIN_SRV }}'
+        # Added suffix for artifacts, needed when multiple jobs use the same target.
+        ARTIFACTS_SUFFIX=''
         case '${{ matrix.job.use-cross }}' in
           ''|0|f|false|n|no)
             CARGO_CMD='cargo'
+            ARTIFACTS_SUFFIX='-nocross'
             ;;
           redoxer)
             CARGO_CMD='redoxer'
@@ -624,6 +628,18 @@ jobs:
         esac
         outputs CARGO_CMD
         outputs CARGO_CMD_OPTIONS
+        outputs ARTIFACTS_SUFFIX
+        CARGO_TEST_OPTIONS=''
+        case '${{ matrix.job.workspace-tests }}' in
+          1|t|true|y|yes)
+            # This also runs tests in other packages in the source directory (e.g. uucore).
+            # We cannot enable this everywhere as some platforms are currently broken, and
+            # we cannot use `cross` as its Docker image is ancient (Ubuntu 16.04) and is
+            # missing required system dependencies (e.g. recent libclang-dev).
+            CARGO_TEST_OPTIONS='--workspace'
+            ;;
+        esac
+        outputs CARGO_TEST_OPTIONS
         # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
         if [ "${CARGO_CMD}" = 'cross' ] && [ ! -e "Cross.toml" ] ; then
           printf "[build.env]\npassthrough = [\"CI\", \"RUST_BACKTRACE\", \"CARGO_TERM_COLOR\"]\n" > Cross.toml
@@ -675,6 +691,9 @@ jobs:
         esac
         case '${{ matrix.job.os }}' in
           ubuntu-*)
+            # selinux headers needed to build tests
+            sudo apt-get -y update
+            sudo apt-get -y install libselinux1-dev
             # pinky is a tool to show logged-in users from utmp, and gecos fields from /etc/passwd.
             # In GitHub Action *nix VMs, no accounts log in, even the "runner" account that runs the commands. The account also has empty gecos fields.
             # To work around this for pinky tests, we create a fake login entry for the GH runner account...
@@ -753,7 +772,7 @@ jobs:
     - name: Archive executable artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}
+        name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}${{ steps.vars.outputs.ARTIFACTS_SUFFIX }}
         path: target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}
     - name: Package
       shell: bash


### PR DESCRIPTION
Add a new Linux build that runs without `cross`, and adds
`--workspace` to the cargo test command.

From cargo test documentation, this option "tests all members in
the workspace.". For example, this includes running tests within
the `uucore` package (see #7383).

Fixes #7392.