### PR TITLE
expr: Refactor AST evaluation to avoid stack overflow

### DIFF
--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -374,6 +374,30 @@ fn test_eager_evaluation() {
         .stderr_contains("division by zero");
 }
 
+#[test]
+fn test_long_input() {
+    // Giving expr an arbitrary long expression should succeed rather than end with a segfault due to a stack overflow.
+    #[cfg(not(windows))]
+    const MAX_NUMBER: usize = 40000;
+    #[cfg(not(windows))]
+    const RESULT: &str = "800020000\n";
+
+    // On windows there is 8192 characters input limit
+    #[cfg(windows)]
+    const MAX_NUMBER: usize = 1300; // 7993 characters (with spaces)
+    #[cfg(windows)]
+    const RESULT: &str = "845650\n";
+
+    let mut args: Vec<String> = vec!["1".to_string()];
+
+    for i in 2..=MAX_NUMBER {
+        args.push('+'.to_string());
+        args.push(i.to_string());
+    }
+
+    new_ucmd!().args(&args).succeeds().stdout_is(RESULT);
+}
+
 /// Regroup the testcases of the GNU test expr.pl
 mod gnu_expr {
     use crate::common::util::TestScenario;


### PR DESCRIPTION
## Overview

This pull request addresses a stack overflow issue in the `expr` utility when handling deeply nested expressions.

Fixes #7338

## Changes

- Replaced recursive tree traversal with stack-based approach
- Add identifiers for AST nodes
- Use a BTreeMap with node IDs for the result stack

## Testing

The implementation includes a new test case that verifies the ability to handle large expressions that would previously cause stack overflow.

## Notes

A simpler solution would be to use the [decurse](https://crates.io/crates/decurse) crate.