### PR TITLE
deny.toml: remove three crates from skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -54,10 +54,6 @@ highlight = "all"
 # introduces it.
 # spell-checker: disable
 skip = [
-  # rustix
-  { name = "linux-raw-sys", version = "0.3.8" },
-  # terminal_size
-  { name = "rustix", version = "0.37.26" },
   # various crates
   { name = "windows-sys", version = "0.48.0" },
   # mio, nu-ansi-term, socket2
@@ -80,8 +76,6 @@ skip = [
   { name = "windows_x86_64_msvc", version = "0.48.0" },
   # kqueue-sys, onig, rustix
   { name = "bitflags", version = "1.3.2" },
-  # textwrap
-  { name = "terminal_size", version = "0.2.6" },
   # ansi-width, console, os_display
   { name = "unicode-width", version = "0.1.13" },
   # filedescriptor, utmp-classic


### PR DESCRIPTION
This PR removes the crates `linux-raw-sys`, `rustix`, and `terminal_size` from the skip list in `deny.toml`.