### PR TITLE
uucore: replace `PanicInfo` with `PanicHookInfo`

### DIFF
--- a/src/uucore/src/lib/mods/panic.rs
+++ b/src/uucore/src/lib/mods/panic.rs
@@ -13,15 +13,10 @@
 //! $ seq inf | head -n 1
 //! ```
 //!
-use std::panic;
-// TODO: use PanicHookInfo when we have a MSRV of 1.81
-#[allow(deprecated)]
-use std::panic::PanicInfo;
+use std::panic::{self, PanicHookInfo};
 
 /// Decide whether a panic was caused by a broken pipe (SIGPIPE) error.
-// TODO: use PanicHookInfo when we have a MSRV of 1.81
-#[allow(deprecated)]
-fn is_broken_pipe(info: &PanicInfo) -> bool {
+fn is_broken_pipe(info: &PanicHookInfo) -> bool {
     if let Some(res) = info.payload().downcast_ref::<String>() {
         if res.contains("BrokenPipe") || res.contains("Broken pipe") {
             return true;


### PR DESCRIPTION
This PR uses `PanicHookInfo` instead of the deprecated `PanicInfo`.