### PR TITLE
clippy: fix warnings from `unnecessary_map_or` lint

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -508,14 +508,12 @@ impl StatPrinter {
                             grand_total += size;
                         }
 
-                        // TODO fix requires an MSRV of 1.82
-                        #[allow(clippy::unnecessary_map_or)]
                         if !self
                             .threshold
                             .is_some_and(|threshold| threshold.should_exclude(size))
                             && self
                                 .max_depth
-                                .map_or(true, |max_depth| stat_info.depth <= max_depth)
+                                .is_none_or(|max_depth| stat_info.depth <= max_depth)
                             && (!self.summarize || stat_info.depth == 0)
                         {
                             self.print_stat(&stat_info.stat, size)?;

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -869,8 +869,6 @@ fn read_stream_and_create_pages(
     let last_page = options.end_page;
     let lines_needed_per_page = lines_to_read_for_page(options);
 
-    // TODO fix requires an MSRV of 1.82
-    #[allow(clippy::unnecessary_map_or)]
     Box::new(
         lines
             .flat_map(split_lines_if_form_feed)
@@ -919,7 +917,7 @@ fn read_stream_and_create_pages(
                 let current_page = x + 1;
 
                 current_page >= start_page
-                    && last_page.map_or(true, |last_page| current_page <= last_page)
+                    && last_page.is_none_or(|last_page| current_page <= last_page)
             }),
     )
 }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -605,8 +605,7 @@ impl<'a> Line<'a> {
                 )?;
             }
         }
-        // TODO fix requires an MSRV of 1.82
-        #[allow(clippy::unnecessary_map_or)]
+
         if settings.mode != SortMode::Random
             && !settings.stable
             && !settings.unique
@@ -618,7 +617,7 @@ impl<'a> Line<'a> {
                 || settings
                     .selectors
                     .last()
-                    .map_or(true, |selector| selector != &FieldSelector::default()))
+                    .is_none_or(|selector| selector != &FieldSelector::default()))
         {
             // A last resort comparator is in use, underline the whole line.
             if self.line.is_empty() {

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -497,11 +497,9 @@ pub fn uu_app() -> Command {
 }
 
 impl TermiosFlag for ControlFlags {
-    // TODO fix requires an MSRV of 1.82
-    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.control_flags.contains(*self)
-            && group.map_or(true, |g| !termios.control_flags.intersects(g - *self))
+            && group.is_none_or(|g| !termios.control_flags.intersects(g - *self))
     }
 
     fn apply(&self, termios: &mut Termios, val: bool) {
@@ -510,11 +508,9 @@ impl TermiosFlag for ControlFlags {
 }
 
 impl TermiosFlag for InputFlags {
-    // TODO fix requires an MSRV of 1.82
-    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.input_flags.contains(*self)
-            && group.map_or(true, |g| !termios.input_flags.intersects(g - *self))
+            && group.is_none_or(|g| !termios.input_flags.intersects(g - *self))
     }
 
     fn apply(&self, termios: &mut Termios, val: bool) {
@@ -523,11 +519,9 @@ impl TermiosFlag for InputFlags {
 }
 
 impl TermiosFlag for OutputFlags {
-    // TODO fix requires an MSRV of 1.82
-    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.output_flags.contains(*self)
-            && group.map_or(true, |g| !termios.output_flags.intersects(g - *self))
+            && group.is_none_or(|g| !termios.output_flags.intersects(g - *self))
     }
 
     fn apply(&self, termios: &mut Termios, val: bool) {
@@ -536,11 +530,9 @@ impl TermiosFlag for OutputFlags {
 }
 
 impl TermiosFlag for LocalFlags {
-    // TODO fix requires an MSRV of 1.82
-    #[allow(clippy::unnecessary_map_or)]
     fn is_in(&self, termios: &Termios, group: Option<Self>) -> bool {
         termios.local_flags.contains(*self)
-            && group.map_or(true, |g| !termios.local_flags.intersects(g - *self))
+            && group.is_none_or(|g| !termios.local_flags.intersects(g - *self))
     }
 
     fn apply(&self, termios: &mut Termios, val: bool) {


### PR DESCRIPTION
This PR fixes warnings from the [unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or) and replaces `map_or` with `is_none_or`.