### PR TITLE
mktemp,tr: replace `repeat().take()` with `repeat_n()` 

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -424,9 +424,7 @@ fn dry_exec(tmpdir: &Path, prefix: &str, rand: usize, suffix: &str) -> UResult<P
     let len = prefix.len() + suffix.len() + rand;
     let mut buf = Vec::with_capacity(len);
     buf.extend(prefix.as_bytes());
-    // In Rust v1.82.0, use `repeat_n`:
-    // <https://doc.rust-lang.org/std/iter/fn.repeat_n.html>
-    buf.extend(iter::repeat(b'X').take(rand));
+    buf.extend(iter::repeat_n(b'X', rand));
     buf.extend(suffix.as_bytes());
 
     // Randomize.

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -132,9 +132,7 @@ impl Sequence {
             Self::Char(c) => Box::new(std::iter::once(*c)),
             Self::CharRange(l, r) => Box::new(*l..=*r),
             Self::CharStar(c) => Box::new(std::iter::repeat(*c)),
-            // In Rust v1.82.0, use `repeat_n`:
-            // <https://doc.rust-lang.org/std/iter/fn.repeat_n.html>
-            Self::CharRepeat(c, n) => Box::new(std::iter::repeat(*c).take(*n)),
+            Self::CharRepeat(c, n) => Box::new(std::iter::repeat_n(*c, *n)),
             Self::Class(class) => match class {
                 Class::Alnum => Box::new((b'0'..=b'9').chain(b'A'..=b'Z').chain(b'a'..=b'z')),
                 Class::Alpha => Box::new((b'A'..=b'Z').chain(b'a'..=b'z')),


### PR DESCRIPTION
This PR fixes two todos and replaces `repeat().take()` with `repeat_n()`. It will prevent warnings from the  [manual_repeat_n](https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n) lint coming with Rust `1.86`.