### PR TITLE
Fix `nan` print, simplify negative number printing.

### DIFF
--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -324,8 +324,9 @@ fn get_sign_indicator<T: PartialOrd + Default>(sign: PositiveSign, x: &T) -> Str
 fn format_float_non_finite(f: f64, case: Case) -> String {
     debug_assert!(!f.is_finite());
     let mut s = format!("{f}");
-    if case == Case::Uppercase {
-        s.make_ascii_uppercase();
+    match case {
+        Case::Lowercase => s.make_ascii_lowercase(), // Forces NaN back to nan.
+        Case::Uppercase => s.make_ascii_uppercase(),
     }
     s
 }
@@ -548,6 +549,18 @@ mod test {
         assert_eq!(f(0), "0");
         assert_eq!(f(5), "05");
         assert_eq!(f(8), "010");
+    }
+
+    #[test]
+    fn non_finite_float() {
+        use super::format_float_non_finite;
+        let f = |x| format_float_non_finite(x, Case::Lowercase);
+        assert_eq!(f(f64::NAN), "nan");
+        assert_eq!(f(f64::INFINITY), "inf");
+
+        let f = |x| format_float_non_finite(x, Case::Uppercase);
+        assert_eq!(f(f64::NAN), "NAN");
+        assert_eq!(f(f64::INFINITY), "INF");
     }
 
     #[test]

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -887,6 +887,30 @@ fn float_with_zero_precision_should_pad() {
 }
 
 #[test]
+fn float_non_finite() {
+    new_ucmd!()
+        .args(&[
+            "%f %f %F %f %f %F",
+            "nan",
+            "-nan",
+            "nan",
+            "inf",
+            "-inf",
+            "inf",
+        ])
+        .succeeds()
+        .stdout_only("nan -nan NAN inf -inf INF");
+}
+
+#[test]
+fn float_zero_neg_zero() {
+    new_ucmd!()
+        .args(&["%f %f", "0.0", "-0.0"])
+        .succeeds()
+        .stdout_only("0.000000 -0.000000");
+}
+
+#[test]
 fn precision_check() {
     new_ucmd!()
         .args(&["%.3d", "1"])

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -380,6 +380,14 @@ fn sub_num_dec_trunc() {
         .stdout_only("pi is ~ 3.14159");
 }
 
+#[test]
+fn sub_num_sci_negative() {
+    new_ucmd!()
+        .args(&["-1234 is %e", "-1234"])
+        .succeeds()
+        .stdout_only("-1234 is -1.234000e+03");
+}
+
 #[cfg_attr(not(feature = "test_unimplemented"), ignore)]
 #[test]
 fn sub_num_hex_float_lower() {


### PR DESCRIPTION
### test: printf: Add a test for scientific printing of negative number

This was broken before the last few commits.

### test: printf: Add nan, inf, negative zero

Add a few end-to-end tests for printf of unusual floats (nan,
infinity, negative zero).

### uucore: format: print absolute value of float, then add sign

Simplifies the code, but also fixes printing of negative and positive `NaN`:
`cargo run printf "%f %f\n" nan -nan`

Fixes part 2 of #7412.

### uucore: format: force NaN back to lowercase

Fixes formatting of `NaN` to `nan`.

Fixes part 1 of #7412.