### PR TITLE
deny.toml: add `rustix` & `linux-raw-sys` to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -74,7 +74,7 @@ skip = [
   { name = "windows_x86_64_gnullvm", version = "0.48.0" },
   # windows-targets
   { name = "windows_x86_64_msvc", version = "0.48.0" },
-  # kqueue-sys, onig, rustix
+  # kqueue-sys, onig
   { name = "bitflags", version = "1.3.2" },
   # ansi-width, console, os_display
   { name = "unicode-width", version = "0.1.13" },
@@ -86,7 +86,7 @@ skip = [
   { name = "itertools", version = "0.13.0" },
   # indexmap
   { name = "hashbrown", version = "0.14.5" },
-  # parse_datetime, cexpr (via bindgen)
+  # cexpr (via bindgen)
   { name = "nom", version = "7.1.3" },
   # const-random-macro, rand_core
   { name = "getrandom", version = "0.2.15" },
@@ -104,6 +104,10 @@ skip = [
   { name = "bindgen", version = "0.70.1" },
   # bindgen
   { name = "rustc-hash", version = "1.1.0" },
+  # crossterm, procfs, terminal_size
+  { name = "rustix", version = "0.38.43" },
+  # rustix
+  { name = "linux-raw-sys", version = "0.4.15" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR adds `rustix` and `linux-raw-sys` to the skip list in `deny.toml` to allow the merging of https://github.com/uutils/coreutils/pull/7409 and https://github.com/uutils/coreutils/pull/7410.