### PR TITLE
tests: replace `run()` with `succeeds()` or `fails()`

### DIFF
--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -662,8 +662,7 @@ fn test_appending_same_input_output() {
     ucmd.set_stdin(file_read);
     ucmd.set_stdout(file_write);
 
-    ucmd.run()
-        .failure()
+    ucmd.fails()
         .no_stdout()
         .stderr_contains("input file is output file");
 }

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -487,8 +487,7 @@ fn test_chmod_symlink_non_existing_file() {
         .arg("-v")
         .arg("-f")
         .arg(test_symlink)
-        .run()
-        .code_is(1)
+        .fails_with_code(1)
         .no_stderr()
         .stdout_contains(expected_stdout);
 
@@ -498,8 +497,7 @@ fn test_chmod_symlink_non_existing_file() {
         .ucmd()
         .arg("755")
         .arg(test_symlink)
-        .run()
-        .code_is(1)
+        .fails_with_code(1)
         .no_stdout()
         .stderr_contains(expected_stderr);
 }

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -102,13 +102,13 @@ fn test_chown_only_owner() {
     at.touch(file1);
 
     // since only superuser can change owner, we have to change from ourself to ourself
-    let result = scene
+    scene
         .ucmd()
         .arg(user_name)
         .arg("--verbose")
         .arg(file1)
-        .run();
-    result.stderr_contains("retained as");
+        .succeeds()
+        .stderr_contains("retained as");
 
     // try to change to another existing user, e.g. 'root'
     scene
@@ -672,16 +672,16 @@ fn test_chown_recursive() {
     at.touch(at.plus_as_string("a/b/c/c"));
     at.touch(at.plus_as_string("z/y"));
 
-    let result = scene
+    scene
         .ucmd()
         .arg("-R")
         .arg("--verbose")
         .arg(user_name)
         .arg("a")
         .arg("z")
-        .run();
-    result.stderr_contains("ownership of 'a/a' retained as");
-    result.stderr_contains("ownership of 'z/y' retained as");
+        .succeeds()
+        .stderr_contains("ownership of 'a/a' retained as")
+        .stderr_contains("ownership of 'z/y' retained as");
 }
 
 #[test]

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -2053,7 +2053,7 @@ mod gnu_cksum_c {
             .arg("--warn")
             .arg("--check")
             .arg("CHECKSUMS")
-            .run()
+            .fails()
             .stderr_contains("CHECKSUMS: 6: improperly formatted SM3 checksum line")
             .stderr_contains("CHECKSUMS: 9: improperly formatted BLAKE2b checksum line");
     }

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -120,8 +120,7 @@ fn test_stdin_stdout() {
     new_ucmd!()
         .args(&["status=none"])
         .pipe_in(input)
-        .run()
-        .no_stderr()
+        .succeeds()
         .stdout_only(output);
 }
 
@@ -135,8 +134,7 @@ fn test_stdin_stdout_count() {
     new_ucmd!()
         .args(&["status=none", "count=2", "ibs=128"])
         .pipe_in(input)
-        .run()
-        .no_stderr()
+        .succeeds()
         .stdout_only(output);
 }
 
@@ -148,8 +146,7 @@ fn test_stdin_stdout_count_bytes() {
     new_ucmd!()
         .args(&["status=none", "count=256", "iflag=count_bytes"])
         .pipe_in(input)
-        .run()
-        .no_stderr()
+        .succeeds()
         .stdout_only(output);
 }
 
@@ -161,8 +158,7 @@ fn test_stdin_stdout_skip() {
     new_ucmd!()
         .args(&["status=none", "skip=2", "ibs=128"])
         .pipe_in(input)
-        .run()
-        .no_stderr()
+        .succeeds()
         .stdout_only(output);
 }
 
@@ -174,8 +170,7 @@ fn test_stdin_stdout_skip_bytes() {
     new_ucmd!()
         .args(&["status=none", "skip=256", "ibs=128", "iflag=skip_bytes"])
         .pipe_in(input)
-        .run()
-        .no_stderr()
+        .succeeds()
         .stdout_only(output);
 }
 
@@ -186,10 +181,8 @@ fn test_stdin_stdout_skip_w_multiplier() {
     new_ucmd!()
         .args(&["status=none", "skip=5K", "iflag=skip_bytes"])
         .pipe_in(input)
-        .run()
-        .no_stderr()
-        .stdout_is(output)
-        .success();
+        .succeeds()
+        .stdout_is(output);
 }
 
 #[test]
@@ -199,10 +192,8 @@ fn test_stdin_stdout_count_w_multiplier() {
     new_ucmd!()
         .args(&["status=none", "count=2KiB", "iflag=count_bytes"])
         .pipe_in(input)
-        .run()
-        .no_stderr()
-        .stdout_is(output)
-        .success();
+        .succeeds()
+        .stdout_only(output);
 }
 
 #[test]
@@ -276,11 +267,10 @@ fn test_final_stats_noxfer() {
 #[test]
 fn test_final_stats_unspec() {
     new_ucmd!()
-        .run()
+        .succeeds()
         .stderr_contains("0+0 records in\n0+0 records out\n0 bytes copied, ")
         .stderr_matches(&Regex::new(r"\d(\.\d+)?(e-\d\d)? s, ").unwrap())
-        .stderr_contains("0.0 B/s")
-        .success();
+        .stderr_contains("0.0 B/s");
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -308,7 +298,7 @@ fn test_noatime_does_not_update_infile_atime() {
 
     let pre_atime = fix.metadata(fname).accessed().unwrap();
 
-    ucmd.run().no_stderr().success();
+    ucmd.succeeds().no_output();
 
     let post_atime = fix.metadata(fname).accessed().unwrap();
     assert_eq!(pre_atime, post_atime);
@@ -328,7 +318,7 @@ fn test_noatime_does_not_update_ofile_atime() {
 
     let pre_atime = fix.metadata(fname).accessed().unwrap();
 
-    ucmd.pipe_in("").run().no_stderr().success();
+    ucmd.pipe_in("").succeeds().no_output();
 
     let post_atime = fix.metadata(fname).accessed().unwrap();
     assert_eq!(pre_atime, post_atime);
@@ -362,10 +352,8 @@ fn test_notrunc_does_not_truncate() {
 
     let (fix, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["status=none", "conv=notrunc", of!(&fname), "if=null.txt"])
-        .run()
-        .no_stdout()
-        .no_stderr()
-        .success();
+        .succeeds()
+        .no_output();
 
     assert_eq!(256, fix.metadata(fname).len());
 }
@@ -382,10 +370,8 @@ fn test_existing_file_truncated() {
 
     let (fix, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["status=none", "if=null.txt", of!(fname)])
-        .run()
-        .no_stdout()
-        .no_stderr()
-        .success();
+        .succeeds()
+        .no_output();
 
     assert_eq!(0, fix.metadata(fname).len());
 }
@@ -394,21 +380,18 @@ fn test_existing_file_truncated() {
 fn test_null_stats() {
     new_ucmd!()
         .arg("if=null.txt")
-        .run()
+        .succeeds()
         .stderr_contains("0+0 records in\n0+0 records out\n0 bytes copied, ")
         .stderr_matches(&Regex::new(r"\d(\.\d+)?(e-\d\d)? s, ").unwrap())
-        .stderr_contains("0.0 B/s")
-        .success();
+        .stderr_contains("0.0 B/s");
 }
 
 #[test]
 fn test_null_fullblock() {
     new_ucmd!()
         .args(&["if=null.txt", "status=none", "iflag=fullblock"])
-        .run()
-        .no_stdout()
-        .no_stderr()
-        .success();
+        .succeeds()
+        .no_output();
 }
 
 #[cfg(unix)]
@@ -441,8 +424,7 @@ fn test_fullblock() {
             "count=1",
             "iflag=fullblock",
         ])
-        .run();
-    ucmd.success();
+        .succeeds();
 
     let run_stats = &ucmd.stderr()[..exp_stats.len()];
     assert_eq!(exp_stats, run_stats);
@@ -456,10 +438,8 @@ fn test_ys_to_stdout() {
 
     new_ucmd!()
         .args(&["status=none", "if=y-nl-1k.txt"])
-        .run()
-        .no_stderr()
-        .stdout_is(output)
-        .success();
+        .succeeds()
+        .stdout_only(output);
 }
 
 #[test]
@@ -468,10 +448,8 @@ fn test_zeros_to_stdout() {
     let output = String::from_utf8(output).unwrap();
     new_ucmd!()
         .args(&["status=none", "if=zero-256k.txt"])
-        .run()
-        .no_stderr()
-        .stdout_is(output)
-        .success();
+        .succeeds()
+        .stdout_only(output);
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -480,9 +458,8 @@ fn test_oversized_bs_32_bit() {
     for bs_param in ["bs", "ibs", "obs", "cbs"] {
         new_ucmd!()
             .args(&[format!("{}=5GB", bs_param)])
-            .run()
+            .fails()
             .no_stdout()
-            .failure()
             .code_is(1)
             .stderr_is(format!("dd: {}=N cannot fit into memory\n", bs_param));
     }
@@ -495,10 +472,8 @@ fn test_to_stdout_with_ibs_obs() {
 
     new_ucmd!()
         .args(&["status=none", "if=y-nl-1k.txt", "ibs=521", "obs=1031"])
-        .run()
-        .no_stderr()
-        .stdout_is(output)
-        .success();
+        .succeeds()
+        .stdout_only(output);
 }
 
 #[test]
@@ -509,10 +484,8 @@ fn test_ascii_10k_to_stdout() {
 
     new_ucmd!()
         .args(&["status=none", "if=ascii-10k.txt"])
-        .run()
-        .no_stderr()
-        .stdout_is(output)
-        .success();
+        .succeeds()
+        .stdout_only(output);
 }
 
 #[test]
@@ -524,10 +497,8 @@ fn test_zeros_to_file() {
 
     let (fix, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["status=none", inf!(test_fn), of!(tmp_fn)])
-        .run()
-        .no_stderr()
-        .no_stdout()
-        .success();
+        .succeeds()
+        .no_output();
 
     cmp_file!(
         File::open(fixture_path!(&test_fn)).unwrap(),
@@ -550,10 +521,8 @@ fn test_to_file_with_ibs_obs() {
         "ibs=222",
         "obs=111",
     ])
-    .run()
-    .no_stderr()
-    .no_stdout()
-    .success();
+    .succeeds()
+    .no_output();
 
     cmp_file!(
         File::open(fixture_path!(&test_fn)).unwrap(),
@@ -570,10 +539,8 @@ fn test_ascii_521k_to_file() {
     let (fix, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["status=none", of!(tmp_fn)])
         .pipe_in(input.clone())
-        .run()
-        .no_stderr()
-        .no_stdout()
-        .success();
+        .succeeds()
+        .no_output();
 
     assert_eq!(512 * 1024, fix.metadata(&tmp_fn).len());
 
@@ -602,10 +569,8 @@ fn test_ascii_5_gibi_to_file() {
         "if=/dev/zero",
         of!(tmp_fn),
     ])
-    .run()
-    .no_stderr()
-    .no_stdout()
-    .success();
+    .succeeds()
+    .no_output();
 
     assert_eq!(5 * 1024 * 1024 * 1024, fix.metadata(&tmp_fn).len());
 }
@@ -621,7 +586,7 @@ fn test_self_transfer() {
     assert!(fix.file_exists(fname));
     assert_eq!(256 * 1024, fix.metadata(fname).len());
 
-    ucmd.run().no_stdout().no_stderr().success();
+    ucmd.succeeds().no_output();
 
     assert!(fix.file_exists(fname));
     assert_eq!(256 * 1024, fix.metadata(fname).len());
@@ -636,10 +601,8 @@ fn test_unicode_filenames() {
 
     let (fix, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["status=none", inf!(test_fn), of!(tmp_fn)])
-        .run()
-        .no_stderr()
-        .no_stdout()
-        .success();
+        .succeeds()
+        .no_output();
 
     cmp_file!(
         File::open(fixture_path!(&test_fn)).unwrap(),

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -66,7 +66,7 @@ fn test_keywords() {
 fn test_internal_db() {
     new_ucmd!()
         .arg("-p")
-        .run()
+        .succeeds()
         .stdout_is_fixture("internal.expected");
 }
 
@@ -74,7 +74,7 @@ fn test_internal_db() {
 fn test_ls_colors() {
     new_ucmd!()
         .arg("--print-ls-colors")
-        .run()
+        .succeeds()
         .stdout_is_fixture("ls_colors.expected");
 }
 
@@ -83,7 +83,7 @@ fn test_bash_default() {
     new_ucmd!()
         .env("TERM", "screen")
         .arg("-b")
-        .run()
+        .succeeds()
         .stdout_is_fixture("bash_def.expected");
 }
 
@@ -92,7 +92,7 @@ fn test_csh_default() {
     new_ucmd!()
         .env("TERM", "screen")
         .arg("-c")
-        .run()
+        .succeeds()
         .stdout_is_fixture("csh_def.expected");
 }
 #[test]
@@ -100,12 +100,12 @@ fn test_overridable_args() {
     new_ucmd!()
         .env("TERM", "screen")
         .arg("-bc")
-        .run()
+        .succeeds()
         .stdout_is_fixture("csh_def.expected");
     new_ucmd!()
         .env("TERM", "screen")
         .arg("-cb")
-        .run()
+        .succeeds()
         .stdout_is_fixture("bash_def.expected");
 }
 
@@ -226,14 +226,14 @@ fn test_helper(file_name: &str, term: &str) {
         .env("TERM", term)
         .arg("-c")
         .arg(format!("{file_name}.txt"))
-        .run()
+        .succeeds()
         .stdout_is_fixture(format!("{file_name}.csh.expected"));
 
     new_ucmd!()
         .env("TERM", term)
         .arg("-b")
         .arg(format!("{file_name}.txt"))
-        .run()
+        .succeeds()
         .stdout_is_fixture(format!("{file_name}.sh.expected"));
 }
 

--- a/tests/by-util/test_dirname.rs
+++ b/tests/by-util/test_dirname.rs
@@ -13,7 +13,7 @@ fn test_invalid_arg() {
 fn test_path_with_trailing_slashes() {
     new_ucmd!()
         .arg("/root/alpha/beta/gamma/delta/epsilon/omega//")
-        .run()
+        .succeeds()
         .stdout_is("/root/alpha/beta/gamma/delta/epsilon\n");
 }
 
@@ -21,7 +21,7 @@ fn test_path_with_trailing_slashes() {
 fn test_path_without_trailing_slashes() {
     new_ucmd!()
         .arg("/root/alpha/beta/gamma/delta/epsilon/omega")
-        .run()
+        .succeeds()
         .stdout_is("/root/alpha/beta/gamma/delta/epsilon\n");
 }
 
@@ -52,15 +52,15 @@ fn test_repeated_zero() {
 
 #[test]
 fn test_root() {
-    new_ucmd!().arg("/").run().stdout_is("/\n");
+    new_ucmd!().arg("/").succeeds().stdout_is("/\n");
 }
 
 #[test]
 fn test_pwd() {
-    new_ucmd!().arg(".").run().stdout_is(".\n");
+    new_ucmd!().arg(".").succeeds().stdout_is(".\n");
 }
 
 #[test]
 fn test_empty() {
-    new_ucmd!().arg("").run().stdout_is(".\n");
+    new_ucmd!().arg("").succeeds().stdout_is(".\n");
 }

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -210,7 +210,7 @@ fn test_file_option() {
     let out = new_ucmd!()
         .arg("-f")
         .arg("vars.conf.txt")
-        .run()
+        .succeeds()
         .stdout_move_str();
 
     assert_eq!(
@@ -227,7 +227,7 @@ fn test_combined_file_set() {
         .arg("-f")
         .arg("vars.conf.txt")
         .arg("FOO=bar.alt")
-        .run()
+        .succeeds()
         .stdout_move_str();
 
     assert_eq!(out.lines().filter(|&line| line == "FOO=bar.alt").count(), 1);
@@ -259,7 +259,7 @@ fn test_unset_invalid_variables() {
     // Cannot test input with \0 in it, since output will also contain \0. rlimit::prlimit fails
     // with this error: Error { kind: InvalidInput, message: "nul byte found in provided data" }
     for var in ["", "a=b"] {
-        new_ucmd!().arg("-u").arg(var).run().stderr_only(format!(
+        new_ucmd!().arg("-u").arg(var).fails().stderr_only(format!(
             "env: cannot unset {}: Invalid argument\n",
             var.quote()
         ));
@@ -268,14 +268,17 @@ fn test_unset_invalid_variables() {
 
 #[test]
 fn test_single_name_value_pair() {
-    let out = new_ucmd!().arg("FOO=bar").run();
-
-    assert!(out.stdout_str().lines().any(|line| line == "FOO=bar"));
+    new_ucmd!()
+        .arg("FOO=bar")
+        .succeeds()
+        .stdout_str()
+        .lines()
+        .any(|line| line == "FOO=bar");
 }
 
 #[test]
 fn test_multiple_name_value_pairs() {
-    let out = new_ucmd!().arg("FOO=bar").arg("ABC=xyz").run();
+    let out = new_ucmd!().arg("FOO=bar").arg("ABC=xyz").succeeds();
 
     assert_eq!(
         out.stdout_str()
@@ -299,7 +302,7 @@ fn test_empty_name() {
     new_ucmd!()
         .arg("-i")
         .arg("=xyz")
-        .run()
+        .succeeds()
         .stderr_only("env: warning: no name specified for value 'xyz'\n");
 }
 

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -397,7 +397,7 @@ fn test_comma_with_plus_4() {
 fn test_args_override() {
     new_ucmd!()
         .args(&["-i", "-i", "with-trailing-tab.txt"])
-        .run()
+        .succeeds()
         .stdout_is(
             "// !note: file contains significant whitespace
 // * indentation uses <TAB> characters

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -155,13 +155,19 @@ fn test_or() {
         .succeeds()
         .stdout_only("12\n");
 
-    new_ucmd!().args(&["", "|", ""]).run().stdout_only("0\n");
+    new_ucmd!().args(&["", "|", ""]).fails().stdout_only("0\n");
 
-    new_ucmd!().args(&["", "|", "0"]).run().stdout_only("0\n");
+    new_ucmd!().args(&["", "|", "0"]).fails().stdout_only("0\n");
 
-    new_ucmd!().args(&["", "|", "00"]).run().stdout_only("0\n");
+    new_ucmd!()
+        .args(&["", "|", "00"])
+        .fails()
+        .stdout_only("0\n");
 
-    new_ucmd!().args(&["", "|", "-0"]).run().stdout_only("0\n");
+    new_ucmd!()
+        .args(&["", "|", "-0"])
+        .fails()
+        .stdout_only("0\n");
 }
 
 #[test]
@@ -188,17 +194,17 @@ fn test_and() {
 
     new_ucmd!()
         .args(&["0", "&", "a", "/", "5"])
-        .run()
+        .fails()
         .stdout_only("0\n");
 
     new_ucmd!()
         .args(&["", "&", "a", "/", "5"])
-        .run()
+        .fails()
         .stdout_only("0\n");
 
-    new_ucmd!().args(&["", "&", "1"]).run().stdout_only("0\n");
+    new_ucmd!().args(&["", "&", "1"]).fails().stdout_only("0\n");
 
-    new_ucmd!().args(&["", "&", ""]).run().stdout_only("0\n");
+    new_ucmd!().args(&["", "&", ""]).fails().stdout_only("0\n");
 }
 
 #[test]

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -313,7 +313,7 @@ fn run(input_string: &[u8], output_string: &[u8]) {
     new_ucmd!()
         .timeout(Duration::from_secs(240))
         .pipe_in(input_string)
-        .run()
+        .succeeds()
         .stdout_is(String::from_utf8(output_string.to_owned()).unwrap());
 }
 
@@ -342,7 +342,7 @@ fn test_primes_with_exponents() {
         .timeout(Duration::from_secs(240))
         .arg("--exponents")
         .pipe_in(input_string)
-        .run()
+        .succeeds()
         .stdout_is(String::from_utf8(output_string.as_bytes().to_owned()).unwrap());
 }
 

--- a/tests/by-util/test_fold.rs
+++ b/tests/by-util/test_fold.rs
@@ -13,7 +13,7 @@ fn test_invalid_arg() {
 fn test_default_80_column_wrap() {
     new_ucmd!()
         .arg("lorem_ipsum.txt")
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_80_column.expected");
 }
 
@@ -21,7 +21,7 @@ fn test_default_80_column_wrap() {
 fn test_40_column_hard_cutoff() {
     new_ucmd!()
         .args(&["-w", "40", "lorem_ipsum.txt"])
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_40_column_hard.expected");
 }
 
@@ -29,7 +29,7 @@ fn test_40_column_hard_cutoff() {
 fn test_40_column_word_boundary() {
     new_ucmd!()
         .args(&["-s", "-w", "40", "lorem_ipsum.txt"])
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_40_column_word.expected");
 }
 
@@ -37,7 +37,7 @@ fn test_40_column_word_boundary() {
 fn test_default_wrap_with_newlines() {
     new_ucmd!()
         .arg("lorem_ipsum_new_line.txt")
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_new_line_80_column.expected");
 }
 

--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -19,7 +19,7 @@ fn test_invalid_arg() {
 #[cfg(unix)]
 fn test_groups() {
     let ts = TestScenario::new(util_name!());
-    let result = ts.ucmd().run();
+    let result = ts.ucmd().succeeds();
     let exp_result = unwrap_or_return!(expected_result(&ts, &[]));
 
     result
@@ -34,7 +34,7 @@ fn test_groups_username() {
     let test_users = [&whoami()[..]];
 
     let ts = TestScenario::new(util_name!());
-    let result = ts.ucmd().args(&test_users).run();
+    let result = ts.ucmd().args(&test_users).succeeds();
     let exp_result = unwrap_or_return!(expected_result(&ts, &test_users));
 
     result
@@ -53,7 +53,7 @@ fn test_groups_username_multiple() {
     let test_users = ["root", "man", "postfix", "sshd", &whoami()];
 
     let ts = TestScenario::new(util_name!());
-    let result = ts.ucmd().args(&test_users).run();
+    let result = ts.ucmd().args(&test_users).fails();
     let exp_result = unwrap_or_return!(expected_result(&ts, &test_users));
 
     result

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -27,7 +27,7 @@ fn test_invalid_arg() {
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_default.expected");
 }
 
@@ -36,7 +36,7 @@ fn test_stdin_1_line_obsolete() {
     new_ucmd!()
         .args(&["-1"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
@@ -45,7 +45,7 @@ fn test_stdin_1_line() {
     new_ucmd!()
         .args(&["-n", "1"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
@@ -54,7 +54,7 @@ fn test_stdin_negative_23_line() {
     new_ucmd!()
         .args(&["-n", "-23"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
@@ -63,7 +63,7 @@ fn test_stdin_5_chars() {
     new_ucmd!()
         .args(&["-c", "5"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_5_chars.expected");
 }
 
@@ -71,7 +71,7 @@ fn test_stdin_5_chars() {
 fn test_single_default() {
     new_ucmd!()
         .arg(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_default.expected");
 }
 
@@ -79,7 +79,7 @@ fn test_single_default() {
 fn test_single_1_line_obsolete() {
     new_ucmd!()
         .args(&["-1", INPUT])
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
@@ -87,7 +87,7 @@ fn test_single_1_line_obsolete() {
 fn test_single_1_line() {
     new_ucmd!()
         .args(&["-n", "1", INPUT])
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_1_line.expected");
 }
 
@@ -95,7 +95,7 @@ fn test_single_1_line() {
 fn test_single_5_chars() {
     new_ucmd!()
         .args(&["-c", "5", INPUT])
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_5_chars.expected");
 }
 
@@ -103,7 +103,7 @@ fn test_single_5_chars() {
 fn test_verbose() {
     new_ucmd!()
         .args(&["-v", INPUT])
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_verbose.expected");
 }
 
@@ -117,7 +117,7 @@ fn test_byte_syntax() {
     new_ucmd!()
         .args(&["-1c"])
         .pipe_in("abc")
-        .run()
+        .succeeds()
         .stdout_is("a");
 }
 
@@ -126,7 +126,7 @@ fn test_line_syntax() {
     new_ucmd!()
         .args(&["-n", "2048m"])
         .pipe_in("a\n")
-        .run()
+        .succeeds()
         .stdout_is("a\n");
 }
 
@@ -135,7 +135,7 @@ fn test_zero_terminated_syntax() {
     new_ucmd!()
         .args(&["-z", "-n", "1"])
         .pipe_in("x\0y")
-        .run()
+        .succeeds()
         .stdout_is("x\0");
 }
 
@@ -144,7 +144,7 @@ fn test_zero_terminated_syntax_2() {
     new_ucmd!()
         .args(&["-z", "-n", "2"])
         .pipe_in("x\0y")
-        .run()
+        .succeeds()
         .stdout_is("x\0y");
 }
 
@@ -153,7 +153,7 @@ fn test_zero_terminated_negative_lines() {
     new_ucmd!()
         .args(&["-z", "-n", "-1"])
         .pipe_in("x\0y\0z\0")
-        .run()
+        .succeeds()
         .stdout_is("x\0y\0");
 }
 
@@ -162,7 +162,7 @@ fn test_negative_byte_syntax() {
     new_ucmd!()
         .args(&["--bytes=-2"])
         .pipe_in("a\n")
-        .run()
+        .succeeds()
         .stdout_is("");
 }
 
@@ -241,14 +241,14 @@ fn test_multiple_nonexistent_files() {
 fn test_sequence_fixture() {
     new_ucmd!()
         .args(&["-n", "-10", "sequence"])
-        .run()
+        .succeeds()
         .stdout_is_fixture("sequence.expected");
 }
 #[test]
 fn test_file_backwards() {
     new_ucmd!()
         .args(&["-c", "-10", "lorem_ipsum.txt"])
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_backwards_file.expected");
 }
 
@@ -256,7 +256,7 @@ fn test_file_backwards() {
 fn test_zero_terminated() {
     new_ucmd!()
         .args(&["-z", "zero_terminated.txt"])
-        .run()
+        .succeeds()
         .stdout_is_fixture("zero_terminated.expected");
 }
 
@@ -388,7 +388,7 @@ fn test_presume_input_pipe_default() {
     new_ucmd!()
         .args(&["---presume-input-pipe"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_default.expected");
 }
 
@@ -397,7 +397,7 @@ fn test_presume_input_pipe_5_chars() {
     new_ucmd!()
         .args(&["-c", "5", "---presume-input-pipe"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("lorem_ipsum_5_chars.expected");
 }
 
@@ -805,7 +805,7 @@ fn test_write_to_dev_full() {
             new_ucmd!()
                 .pipe_in_fixture(INPUT)
                 .set_stdout(dev_full)
-                .run()
+                .fails()
                 .stderr_contains("error writing 'standard output': No space left on device");
         }
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1707,7 +1707,7 @@ fn test_ls_group_directories_first() {
         .ucmd()
         .arg("-1a")
         .arg("--group-directories-first")
-        .run();
+        .succeeds();
     assert_eq!(
         result.stdout_str().split('\n').collect::<Vec<_>>(),
         dots.into_iter()
@@ -1721,7 +1721,7 @@ fn test_ls_group_directories_first() {
         .ucmd()
         .arg("-1ar")
         .arg("--group-directories-first")
-        .run();
+        .succeeds();
     assert_eq!(
         result.stdout_str().split('\n').collect::<Vec<_>>(),
         (dirnames.into_iter().rev())
@@ -1735,8 +1735,8 @@ fn test_ls_group_directories_first() {
         .ucmd()
         .arg("-1aU")
         .arg("--group-directories-first")
-        .run();
-    let result2 = scene.ucmd().arg("-1aU").run();
+        .succeeds();
+    let result2 = scene.ucmd().arg("-1aU").succeeds();
     assert_eq!(result.stdout_str(), result2.stdout_str());
 }
 #[test]
@@ -1901,7 +1901,7 @@ fn test_ls_order_birthtime() {
     at.make_file("test-birthtime-2").sync_all().unwrap();
     at.open("test-birthtime-1");
 
-    let result = scene.ucmd().arg("--time=birth").arg("-t").run();
+    let result = scene.ucmd().arg("--time=birth").arg("-t").succeeds();
 
     #[cfg(not(windows))]
     assert_eq!(result.stdout_str(), "test-birthtime-2\ntest-birthtime-1\n");
@@ -2962,7 +2962,7 @@ fn test_ls_human_si() {
         .arg("-s")
         .arg("+1000k")
         .arg(file1)
-        .run();
+        .succeeds();
 
     scene
         .ucmd()
@@ -4002,13 +4002,13 @@ fn test_ls_sort_extension() {
         "", // because of '\n' at the end of the output
     ];
 
-    let result = scene.ucmd().arg("-1aX").run();
+    let result = scene.ucmd().arg("-1aX").succeeds();
     assert_eq!(
         result.stdout_str().split('\n').collect::<Vec<_>>(),
         expected,
     );
 
-    let result = scene.ucmd().arg("-1a").arg("--sort=extension").run();
+    let result = scene.ucmd().arg("-1a").arg("--sort=extension").succeeds();
     assert_eq!(
         result.stdout_str().split('\n').collect::<Vec<_>>(),
         expected,
@@ -4030,26 +4030,30 @@ fn test_ls_path() {
     at.touch(path);
 
     let expected_stdout = &format!("{path}\n");
-    scene.ucmd().arg(path).run().stdout_is(expected_stdout);
+    scene.ucmd().arg(path).succeeds().stdout_is(expected_stdout);
 
     let expected_stdout = &format!("./{path}\n");
     scene
         .ucmd()
         .arg(format!("./{path}"))
-        .run()
+        .succeeds()
         .stdout_is(expected_stdout);
 
     let abs_path = format!("{}/{}", at.as_string(), path);
     let expected_stdout = format!("{abs_path}\n");
 
-    scene.ucmd().arg(&abs_path).run().stdout_is(expected_stdout);
+    scene
+        .ucmd()
+        .arg(&abs_path)
+        .succeeds()
+        .stdout_is(expected_stdout);
 
     let expected_stdout = format!("{path}\n{file1}\n");
     scene
         .ucmd()
         .arg(file1)
         .arg(path)
-        .run()
+        .succeeds()
         .stdout_is(expected_stdout);
 }
 
@@ -4299,7 +4303,7 @@ fn test_ls_dereference_looped_symlinks_recursive() {
 fn test_dereference_dangling_color() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.relative_symlink_file("wat", "nonexistent");
-    let out_exp = ucmd.args(&["--color"]).run().stdout_move_str();
+    let out_exp = ucmd.args(&["--color"]).succeeds().stdout_move_str();
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.relative_symlink_file("wat", "nonexistent");
@@ -4314,7 +4318,7 @@ fn test_dereference_symlink_dir_color() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("dir1");
     at.mkdir("dir1/link");
-    let out_exp = ucmd.args(&["--color", "dir1"]).run().stdout_move_str();
+    let out_exp = ucmd.args(&["--color", "dir1"]).succeeds().stdout_move_str();
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("dir1");
@@ -4330,7 +4334,7 @@ fn test_dereference_symlink_file_color() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("dir1");
     at.touch("dir1/link");
-    let out_exp = ucmd.args(&["--color", "dir1"]).run().stdout_move_str();
+    let out_exp = ucmd.args(&["--color", "dir1"]).succeeds().stdout_move_str();
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("dir1");
@@ -4558,7 +4562,7 @@ fn test_ls_dired_outputs_same_date_time_format() {
     let at = &scene.fixtures;
     at.mkdir("dir");
     at.mkdir("dir/a");
-    let binding = scene.ucmd().arg("-l").arg("dir").run();
+    let binding = scene.ucmd().arg("-l").arg("dir").succeeds();
     let long_output_str = binding.stdout_str();
     let split_lines: Vec<&str> = long_output_str.split('\n').collect();
     // the second line should contain the long output which includes date

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -36,7 +36,7 @@ fn test_mkdir_verbose() {
     new_ucmd!()
         .arg("test_dir")
         .arg("-v")
-        .run()
+        .succeeds()
         .stdout_is(expected);
 }
 

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -954,7 +954,12 @@ fn test_mv_update_option() {
     filetime::set_file_times(at.plus_as_string(file_a), now, now).unwrap();
     filetime::set_file_times(at.plus_as_string(file_b), now, later).unwrap();
 
-    scene.ucmd().arg("--update").arg(file_a).arg(file_b).run();
+    scene
+        .ucmd()
+        .arg("--update")
+        .arg(file_a)
+        .arg(file_b)
+        .succeeds();
 
     assert!(at.file_exists(file_a));
     assert!(at.file_exists(file_b));
@@ -1492,11 +1497,14 @@ fn test_mv_into_self_data() {
     at.touch(file1);
     at.touch(file2);
 
-    let result = scene.ucmd().arg(file1).arg(sub_dir).arg(sub_dir).run();
+    scene
+        .ucmd()
+        .arg(file1)
+        .arg(sub_dir)
+        .arg(sub_dir)
+        .fails_with_code(1);
 
     // sub_dir exists, file1 has been moved, file2 still exists.
-    result.code_is(1);
-
     assert!(at.dir_exists(sub_dir));
     assert!(at.file_exists(file1_result_location));
     assert!(at.file_exists(file2));

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -11,7 +11,7 @@ fn test_get_current_niceness() {
     // Test that the nice command with no arguments returns the default nice
     // value, which we determine by querying libc's `nice` in our own process.
     new_ucmd!()
-        .run()
+        .succeeds()
         .stdout_is(format!("{}\n", unsafe { libc::nice(0) }));
 }
 
@@ -23,7 +23,7 @@ fn test_negative_adjustment() {
     // the OS.  If it gets denied, then we know a negative value was parsed
     // correctly.
 
-    let res = new_ucmd!().args(&["-n", "-1", "true"]).run();
+    let res = new_ucmd!().args(&["-n", "-1", "true"]).succeeds();
     assert!(res
         .stderr_str()
         .starts_with("nice: warning: setpriority: Permission denied")); // spell-checker:disable-line
@@ -39,14 +39,14 @@ fn test_adjustment_with_no_command_should_error() {
 
 #[test]
 fn test_command_with_no_adjustment() {
-    new_ucmd!().args(&["echo", "a"]).run().stdout_is("a\n");
+    new_ucmd!().args(&["echo", "a"]).succeeds().stdout_is("a\n");
 }
 
 #[test]
 fn test_command_with_no_args() {
     new_ucmd!()
         .args(&["-n", "19", "echo"])
-        .run()
+        .succeeds()
         .stdout_is("\n");
 }
 
@@ -54,7 +54,7 @@ fn test_command_with_no_args() {
 fn test_command_with_args() {
     new_ucmd!()
         .args(&["-n", "19", "echo", "a", "b", "c"])
-        .run()
+        .succeeds()
         .stdout_is("a b c\n");
 }
 
@@ -62,7 +62,7 @@ fn test_command_with_args() {
 fn test_command_where_command_takes_n_flag() {
     new_ucmd!()
         .args(&["-n", "19", "echo", "-n", "a"])
-        .run()
+        .succeeds()
         .stdout_is("a");
 }
 
@@ -75,7 +75,7 @@ fn test_invalid_argument() {
 fn test_bare_adjustment() {
     new_ucmd!()
         .args(&["-1", "echo", "-n", "a"])
-        .run()
+        .succeeds()
         .stdout_is("a");
 }
 

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -15,7 +15,7 @@ fn test_invalid_arg() {
 fn test_stdin_no_newline() {
     new_ucmd!()
         .pipe_in("No Newline")
-        .run()
+        .succeeds()
         .stdout_is("     1\tNo Newline\n");
 }
 
@@ -24,7 +24,7 @@ fn test_stdin_newline() {
     new_ucmd!()
         .args(&["-s", "-", "-w", "1"])
         .pipe_in("Line One\nLine Two\n")
-        .run()
+        .succeeds()
         .stdout_is("1-Line One\n2-Line Two\n");
 }
 
@@ -32,7 +32,7 @@ fn test_stdin_newline() {
 fn test_padding_without_overflow() {
     new_ucmd!()
         .args(&["-i", "1000", "-s", "x", "-n", "rz", "simple.txt"])
-        .run()
+        .succeeds()
         .stdout_is(
             "000001xL1\n001001xL2\n002001xL3\n003001xL4\n004001xL5\n005001xL6\n006001xL7\n0070\
              01xL8\n008001xL9\n009001xL10\n010001xL11\n011001xL12\n012001xL13\n013001xL14\n014\
@@ -44,7 +44,7 @@ fn test_padding_without_overflow() {
 fn test_padding_with_overflow() {
     new_ucmd!()
         .args(&["-i", "1000", "-s", "x", "-n", "rz", "-w", "4", "simple.txt"])
-        .run()
+        .succeeds()
         .stdout_is(
             "0001xL1\n1001xL2\n2001xL3\n3001xL4\n4001xL5\n5001xL6\n6001xL7\n7001xL8\n8001xL9\n\
              9001xL10\n10001xL11\n11001xL12\n12001xL13\n13001xL14\n14001xL15\n",
@@ -73,7 +73,7 @@ fn test_sections_and_styles() {
             .args(&[
                 "-s", "|", "-n", "ln", "-w", "3", "-b", "a", "-l", "5", fixture,
             ])
-            .run()
+            .succeeds()
             .stdout_is(output);
     }
     // spell-checker:enable

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -146,7 +146,7 @@ fn test_combine_pairs_of_lines() {
         for d in ["-d", "--delimiters"] {
             new_ucmd!()
                 .args(&[s, d, "\t\n", "html_colors.txt"])
-                .run()
+                .succeeds()
                 .stdout_is_fixture("html_colors.expected");
         }
     }

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -265,7 +265,7 @@ fn test_with_stdin() {
     scenario
         .pipe_in_fixture("stdin.log")
         .args(&["--pages=1:2", "-n", "-"])
-        .run()
+        .succeeds()
         .stdout_is_templated_fixture_any(
             expected_file_path,
             &valid_last_modified_template_vars(start),
@@ -452,7 +452,7 @@ fn test_with_join_lines_option() {
     let start = Utc::now();
     scenario
         .args(&["+1:2", "-J", "-m", test_file_1, test_file_2])
-        .run()
+        .succeeds()
         .stdout_is_templated_fixture_any(
             expected_file_path,
             &valid_last_modified_template_vars(start),

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -129,7 +129,7 @@ fn sub_b_string_handle_escapes() {
 fn sub_b_string_validate_field_params() {
     new_ucmd!()
         .args(&["hello %7b", "world"])
-        .run()
+        .fails()
         .stdout_is("hello ")
         .stderr_is("printf: %7b: invalid conversion specification\n");
 }
@@ -154,7 +154,7 @@ fn sub_q_string_non_printable() {
 fn sub_q_string_validate_field_params() {
     new_ucmd!()
         .args(&["hello %7q", "world"])
-        .run()
+        .fails()
         .stdout_is("hello ")
         .stderr_is("printf: %7q: invalid conversion specification\n");
 }

--- a/tests/by-util/test_readlink.rs
+++ b/tests/by-util/test_readlink.rs
@@ -31,7 +31,7 @@ fn test_resolve() {
 #[test]
 fn test_canonicalize() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let actual = ucmd.arg("-f").arg(".").run().stdout_move_str();
+    let actual = ucmd.arg("-f").arg(".").succeeds().stdout_move_str();
     let expect = at.root_dir_resolved() + "\n";
     println!("actual: {actual:?}");
     println!("expect: {expect:?}");
@@ -41,7 +41,7 @@ fn test_canonicalize() {
 #[test]
 fn test_canonicalize_existing() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let actual = ucmd.arg("-e").arg(".").run().stdout_move_str();
+    let actual = ucmd.arg("-e").arg(".").succeeds().stdout_move_str();
     let expect = at.root_dir_resolved() + "\n";
     println!("actual: {actual:?}");
     println!("expect: {expect:?}");
@@ -51,7 +51,7 @@ fn test_canonicalize_existing() {
 #[test]
 fn test_canonicalize_missing() {
     let (at, mut ucmd) = at_and_ucmd!();
-    let actual = ucmd.arg("-m").arg(GIBBERISH).run().stdout_move_str();
+    let actual = ucmd.arg("-m").arg(GIBBERISH).succeeds().stdout_move_str();
     let expect = path_concat!(at.root_dir_resolved(), GIBBERISH) + "\n";
     println!("actual: {actual:?}");
     println!("expect: {expect:?}");
@@ -63,7 +63,12 @@ fn test_long_redirection_to_current_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     // Create a 256-character path to current directory
     let dir = path_concat!(".", ..128);
-    let actual = ucmd.arg("-n").arg("-m").arg(dir).run().stdout_move_str();
+    let actual = ucmd
+        .arg("-n")
+        .arg("-m")
+        .arg(dir)
+        .succeeds()
+        .stdout_move_str();
     let expect = at.root_dir_resolved();
     println!("actual: {actual:?}");
     println!("expect: {expect:?}");
@@ -78,7 +83,7 @@ fn test_long_redirection_to_root() {
         .arg("-n")
         .arg("-m")
         .arg(dir)
-        .run()
+        .succeeds()
         .stdout_move_str();
     let expect = get_root_path();
     println!("actual: {actual:?}");

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -232,7 +232,7 @@ fn test_realpath_when_symlink_is_absolute_and_enoent() {
     ucmd.arg("dir1/foo1")
         .arg("dir1/foo2")
         .arg("dir1/foo3")
-        .run()
+        .fails()
         .stdout_contains("/dir2/bar\n")
         .stdout_contains("/dir2/baz\n")
         .stderr_is("realpath: dir1/foo2: No such file or directory\n");
@@ -241,7 +241,7 @@ fn test_realpath_when_symlink_is_absolute_and_enoent() {
     ucmd.arg("dir1/foo1")
         .arg("dir1/foo2")
         .arg("dir1/foo3")
-        .run()
+        .fails()
         .stdout_contains("\\dir2\\bar\n")
         .stdout_contains("\\dir2\\baz\n")
         .stderr_is("realpath: dir1/foo2: No such file or directory\n");
@@ -264,7 +264,7 @@ fn test_realpath_when_symlink_part_is_missing() {
     let expect2 = format!("dir2{MAIN_SEPARATOR}baz");
 
     ucmd.args(&["dir1/foo1", "dir1/foo2", "dir1/foo3", "dir1/foo4"])
-        .run()
+        .fails()
         .stdout_contains(expect1 + "\n")
         .stdout_contains(expect2 + "\n")
         .stderr_contains("realpath: dir1/foo2: No such file or directory\n")

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -181,7 +181,7 @@ fn test_width_invalid_float() {
 fn test_count_up() {
     new_ucmd!()
         .args(&["10"])
-        .run()
+        .succeeds()
         .stdout_is("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n");
 }
 
@@ -189,11 +189,11 @@ fn test_count_up() {
 fn test_count_down() {
     new_ucmd!()
         .args(&["--", "5", "-1", "1"])
-        .run()
+        .succeeds()
         .stdout_is("5\n4\n3\n2\n1\n");
     new_ucmd!()
         .args(&["5", "-1", "1"])
-        .run()
+        .succeeds()
         .stdout_is("5\n4\n3\n2\n1\n");
 }
 
@@ -201,19 +201,19 @@ fn test_count_down() {
 fn test_separator_and_terminator() {
     new_ucmd!()
         .args(&["-s", ",", "-t", "!", "2", "6"])
-        .run()
+        .succeeds()
         .stdout_is("2,3,4,5,6!");
     new_ucmd!()
         .args(&["-s", ",", "2", "6"])
-        .run()
+        .succeeds()
         .stdout_is("2,3,4,5,6\n");
     new_ucmd!()
         .args(&["-s", "\n", "2", "6"])
-        .run()
+        .succeeds()
         .stdout_is("2\n3\n4\n5\n6\n");
     new_ucmd!()
         .args(&["-s", "\\n", "2", "6"])
-        .run()
+        .succeeds()
         .stdout_is("2\\n3\\n4\\n5\\n6\n");
 }
 
@@ -223,7 +223,7 @@ fn test_equalize_widths() {
     for arg in args {
         new_ucmd!()
             .args(&[arg, "5", "10"])
-            .run()
+            .succeeds()
             .stdout_is("05\n06\n07\n08\n09\n10\n");
     }
 }
@@ -255,7 +255,7 @@ fn test_big_numbers() {
 fn test_count_up_floats() {
     new_ucmd!()
         .args(&["10.0"])
-        .run()
+        .succeeds()
         .stdout_is("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n");
 }
 
@@ -263,11 +263,11 @@ fn test_count_up_floats() {
 fn test_count_down_floats() {
     new_ucmd!()
         .args(&["--", "5", "-1.0", "1"])
-        .run()
+        .succeeds()
         .stdout_is("5.0\n4.0\n3.0\n2.0\n1.0\n");
     new_ucmd!()
         .args(&["5", "-1", "1.0"])
-        .run()
+        .succeeds()
         .stdout_is("5\n4\n3\n2\n1\n");
 }
 
@@ -275,7 +275,7 @@ fn test_count_down_floats() {
 fn test_separator_and_terminator_floats() {
     new_ucmd!()
         .args(&["-s", ",", "-t", "!", "2.0", "6"])
-        .run()
+        .succeeds()
         .stdout_is("2.0,3.0,4.0,5.0,6.0!");
 }
 
@@ -283,7 +283,7 @@ fn test_separator_and_terminator_floats() {
 fn test_equalize_widths_floats() {
     new_ucmd!()
         .args(&["-w", "5", "10.0"])
-        .run()
+        .succeeds()
         .stdout_is("05\n06\n07\n08\n09\n10\n");
 }
 

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -126,13 +126,13 @@ fn test_shred_force() {
     at.set_readonly(file);
 
     // Try shred -u.
-    scene.ucmd().arg("-u").arg(file).run();
+    scene.ucmd().arg("-u").arg(file).fails();
 
     // file_a was not deleted because it is readonly.
     assert!(at.file_exists(file));
 
     // Try shred -u -f.
-    scene.ucmd().arg("-u").arg("-f").arg(file).run();
+    scene.ucmd().arg("-u").arg("-f").arg(file).succeeds();
 
     // file_a was deleted.
     assert!(!at.file_exists(file));

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -262,7 +262,7 @@ fn test_random_shuffle_len() {
     // check whether output is the same length as the input
     const FILE: &str = "default_unsorted_ints.expected";
     let (at, _ucmd) = at_and_ucmd!();
-    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
+    let result = new_ucmd!().arg("-R").arg(FILE).succeeds().stdout_move_str();
     let expected = at.read(FILE);
 
     assert_ne!(result, expected);
@@ -274,9 +274,12 @@ fn test_random_shuffle_contains_all_lines() {
     // check whether lines of input are all in output
     const FILE: &str = "default_unsorted_ints.expected";
     let (at, _ucmd) = at_and_ucmd!();
-    let result = new_ucmd!().arg("-R").arg(FILE).run().stdout_move_str();
+    let result = new_ucmd!().arg("-R").arg(FILE).succeeds().stdout_move_str();
     let expected = at.read(FILE);
-    let result_sorted = new_ucmd!().pipe_in(result.clone()).run().stdout_move_str();
+    let result_sorted = new_ucmd!()
+        .pipe_in(result.clone())
+        .succeeds()
+        .stdout_move_str();
 
     assert_ne!(result, expected);
     assert_eq!(result_sorted, expected);
@@ -290,9 +293,9 @@ fn test_random_shuffle_two_runs_not_the_same() {
         // as the starting order, or if both random sorts end up having the same order.
         const FILE: &str = "default_unsorted_ints.expected";
         let (at, _ucmd) = at_and_ucmd!();
-        let result = new_ucmd!().arg(arg).arg(FILE).run().stdout_move_str();
+        let result = new_ucmd!().arg(arg).arg(FILE).succeeds().stdout_move_str();
         let expected = at.read(FILE);
-        let unexpected = new_ucmd!().arg(arg).arg(FILE).run().stdout_move_str();
+        let unexpected = new_ucmd!().arg(arg).arg(FILE).succeeds().stdout_move_str();
 
         assert_ne!(result, expected);
         assert_ne!(result, unexpected);

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -30,7 +30,7 @@ fn test_terse_fs_format() {
     let args = ["-f", "-t", "/proc"];
     let ts = TestScenario::new(util_name!());
     let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
-    ts.ucmd().args(&args).run().stdout_is(expected_stdout);
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn test_fs_format() {
     let args = ["-f", "-c", FS_FORMAT_STR, "/dev/shm"];
     let ts = TestScenario::new(util_name!());
     let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
-    ts.ucmd().args(&args).run().stdout_is(expected_stdout);
+    ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }
 
 #[cfg(unix)]

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -35,7 +35,7 @@ fn test_stdbuf_unbuffered_stdout() {
     new_ucmd!()
         .args(&["-o0", "head"])
         .pipe_in("The quick brown fox jumps over the lazy dog.")
-        .run()
+        .succeeds()
         .stdout_is("The quick brown fox jumps over the lazy dog.");
 }
 
@@ -45,7 +45,7 @@ fn test_stdbuf_line_buffered_stdout() {
     new_ucmd!()
         .args(&["-oL", "head"])
         .pipe_in("The quick brown fox jumps over the lazy dog.")
-        .run()
+        .succeeds()
         .stdout_is("The quick brown fox jumps over the lazy dog.");
 }
 
@@ -66,7 +66,7 @@ fn test_stdbuf_trailing_var_arg() {
     new_ucmd!()
         .args(&["-i", "1024", "tail", "-1"])
         .pipe_in("The quick brown fox\njumps over the lazy dog.")
-        .run()
+        .succeeds()
         .stdout_is("jumps over the lazy dog.");
 }
 

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -16,7 +16,7 @@ fn test_invalid_arg() {
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in("100\n200\n300\n400\n500")
-        .run()
+        .succeeds()
         .stdout_is("500400\n300\n200\n100\n");
 }
 
@@ -27,7 +27,7 @@ fn test_stdin_non_newline_separator() {
     new_ucmd!()
         .args(&["-s", ":"])
         .pipe_in("100:200:300:400:500")
-        .run()
+        .succeeds()
         .stdout_is("500400:300:200:100:");
 }
 
@@ -38,7 +38,7 @@ fn test_stdin_non_newline_separator_before() {
     new_ucmd!()
         .args(&["-b", "-s", ":"])
         .pipe_in("100:200:300:400:500")
-        .run()
+        .succeeds()
         .stdout_is(":500:400:300:200100");
 }
 
@@ -46,7 +46,7 @@ fn test_stdin_non_newline_separator_before() {
 fn test_single_default() {
     new_ucmd!()
         .arg("prime_per_line.txt")
-        .run()
+        .succeeds()
         .stdout_is_fixture("prime_per_line.expected");
 }
 
@@ -54,7 +54,7 @@ fn test_single_default() {
 fn test_single_non_newline_separator() {
     new_ucmd!()
         .args(&["-s", ":", "delimited_primes.txt"])
-        .run()
+        .succeeds()
         .stdout_is_fixture("delimited_primes.expected");
 }
 
@@ -62,7 +62,7 @@ fn test_single_non_newline_separator() {
 fn test_single_non_newline_separator_before() {
     new_ucmd!()
         .args(&["-b", "-s", ":", "delimited_primes.txt"])
-        .run()
+        .succeeds()
         .stdout_is_fixture("delimited_primes_before.expected");
 }
 

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -74,7 +74,7 @@ fn test_invalid_arg() {
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in_fixture(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_stdin_default.expected")
         .no_stderr();
 }
@@ -84,7 +84,7 @@ fn test_stdin_explicit() {
     new_ucmd!()
         .pipe_in_fixture(FOOBAR_TXT)
         .arg("-")
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_stdin_default.expected")
         .no_stderr();
 }
@@ -109,16 +109,13 @@ fn test_stdin_redirect_file() {
 
     ts.ucmd()
         .set_stdin(File::open(at.plus("f")).unwrap())
-        .run()
-        .stdout_is("foo")
-        .succeeded();
+        .succeeds()
+        .stdout_is("foo");
     ts.ucmd()
         .set_stdin(File::open(at.plus("f")).unwrap())
         .arg("-v")
-        .run()
-        .no_stderr()
-        .stdout_is("==> standard input <==\nfoo")
-        .succeeded();
+        .succeeds()
+        .stdout_only("==> standard input <==\nfoo");
 
     let mut p = ts
         .ucmd()
@@ -145,12 +142,7 @@ fn test_stdin_redirect_offset() {
     let mut fh = File::open(at.plus("k")).unwrap();
     fh.seek(SeekFrom::Start(2)).unwrap();
 
-    ts.ucmd()
-        .set_stdin(fh)
-        .run()
-        .no_stderr()
-        .stdout_is("2\n")
-        .succeeded();
+    ts.ucmd().set_stdin(fh).succeeds().stdout_only("2\n");
 }
 
 #[test]
@@ -170,12 +162,10 @@ fn test_stdin_redirect_offset2() {
     ts.ucmd()
         .set_stdin(fh)
         .args(&["k", "-", "l", "m"])
-        .run()
-        .no_stderr()
-        .stdout_is(
+        .succeeds()
+        .stdout_only(
             "==> k <==\n1\n2\n\n==> standard input <==\n2\n\n==> l <==\n3\n4\n\n==> m <==\n5\n6\n",
-        )
-        .succeeded();
+        );
 }
 
 #[test]
@@ -183,18 +173,8 @@ fn test_nc_0_wo_follow() {
     // verify that -[nc]0 without -f, exit without reading
 
     let ts = TestScenario::new(util_name!());
-    ts.ucmd()
-        .args(&["-n0", "missing"])
-        .run()
-        .no_stderr()
-        .no_stdout()
-        .succeeded();
-    ts.ucmd()
-        .args(&["-c0", "missing"])
-        .run()
-        .no_stderr()
-        .no_stdout()
-        .succeeded();
+    ts.ucmd().args(&["-n0", "missing"]).succeeds().no_output();
+    ts.ucmd().args(&["-c0", "missing"]).succeeds().no_output();
 }
 
 #[test]
@@ -212,16 +192,12 @@ fn test_nc_0_wo_follow2() {
 
     ts.ucmd()
         .args(&["-n0", "unreadable"])
-        .run()
-        .no_stderr()
-        .no_stdout()
-        .succeeded();
+        .succeeds()
+        .no_output();
     ts.ucmd()
         .args(&["-c0", "unreadable"])
-        .run()
-        .no_stderr()
-        .no_stdout()
-        .succeeded();
+        .succeeds()
+        .no_output();
 }
 
 // TODO: Add similar test for windows
@@ -410,7 +386,7 @@ fn test_follow_bad_fd() {
 fn test_single_default() {
     new_ucmd!()
         .arg(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_single_default.expected");
 }
 
@@ -420,7 +396,7 @@ fn test_n_greater_than_number_of_lines() {
         .arg("-n")
         .arg("99999999")
         .arg(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture(FOOBAR_TXT);
 }
 
@@ -429,7 +405,7 @@ fn test_null_default() {
     new_ucmd!()
         .arg("-z")
         .arg(FOOBAR_WITH_NULL_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_with_null_default.expected");
 }
 
@@ -606,7 +582,7 @@ fn test_follow_stdin_pipe() {
     new_ucmd!()
         .arg("-f")
         .pipe_in_fixture(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("follow_stdin.expected")
         .no_stderr();
 }
@@ -727,7 +703,7 @@ fn test_single_big_args() {
     }
     big_expected.flush().expect("Could not flush EXPECTED_FILE");
 
-    ucmd.arg(FILE).arg("-n").arg(format!("{N_ARG}")).run();
+    ucmd.arg(FILE).arg("-n").arg(format!("{N_ARG}")).succeeds();
     // .stdout_is(at.read(EXPECTED_FILE));
 }
 
@@ -737,7 +713,7 @@ fn test_bytes_single() {
         .arg("-c")
         .arg("10")
         .arg(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_bytes_single.expected");
 }
 
@@ -747,7 +723,7 @@ fn test_bytes_stdin() {
         .pipe_in_fixture(FOOBAR_TXT)
         .arg("-c")
         .arg("13")
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_bytes_stdin.expected")
         .no_stderr();
 }
@@ -813,7 +789,7 @@ fn test_lines_with_size_suffix() {
     ucmd.arg(FILE)
         .arg("-n")
         .arg("2K")
-        .run()
+        .succeeds()
         .stdout_is_fixture(EXPECTED_FILE);
 }
 
@@ -822,7 +798,7 @@ fn test_multiple_input_files() {
     new_ucmd!()
         .arg(FOOBAR_TXT)
         .arg(FOOBAR_2_TXT)
-        .run()
+        .succeeds()
         .no_stderr()
         .stdout_is_fixture("foobar_follow_multiple.expected");
 }
@@ -834,7 +810,7 @@ fn test_multiple_input_files_missing() {
         .arg("missing1")
         .arg(FOOBAR_2_TXT)
         .arg("missing2")
-        .run()
+        .fails()
         .stdout_is_fixture("foobar_follow_multiple.expected")
         .stderr_is(
             "tail: cannot open 'missing1' for reading: No such file or directory\n\
@@ -886,7 +862,7 @@ fn test_multiple_input_files_with_suppressed_headers() {
         .arg(FOOBAR_TXT)
         .arg(FOOBAR_2_TXT)
         .arg("-q")
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_multiple_quiet.expected");
 }
 
@@ -897,7 +873,7 @@ fn test_multiple_input_quiet_flag_overrides_verbose_flag_for_suppressing_headers
         .arg(FOOBAR_2_TXT)
         .arg("-v")
         .arg("-q")
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_multiple_quiet.expected");
 }
 
@@ -949,13 +925,13 @@ fn test_dir_follow_retry() {
 
 #[test]
 fn test_negative_indexing() {
-    let positive_lines_index = new_ucmd!().arg("-n").arg("5").arg(FOOBAR_TXT).run();
+    let positive_lines_index = new_ucmd!().arg("-n").arg("5").arg(FOOBAR_TXT).succeeds();
 
-    let negative_lines_index = new_ucmd!().arg("-n").arg("-5").arg(FOOBAR_TXT).run();
+    let negative_lines_index = new_ucmd!().arg("-n").arg("-5").arg(FOOBAR_TXT).succeeds();
 
-    let positive_bytes_index = new_ucmd!().arg("-c").arg("20").arg(FOOBAR_TXT).run();
+    let positive_bytes_index = new_ucmd!().arg("-c").arg("20").arg(FOOBAR_TXT).succeeds();
 
-    let negative_bytes_index = new_ucmd!().arg("-c").arg("-20").arg(FOOBAR_TXT).run();
+    let negative_bytes_index = new_ucmd!().arg("-c").arg("-20").arg(FOOBAR_TXT).succeeds();
 
     assert_eq!(positive_lines_index.stdout(), negative_lines_index.stdout());
     assert_eq!(positive_bytes_index.stdout(), negative_bytes_index.stdout());
@@ -1172,8 +1148,10 @@ fn test_retry1() {
     let file_name = "FILE";
     at.touch(file_name);
 
-    let result = ts.ucmd().arg(file_name).arg("--retry").run();
-    result
+    ts.ucmd()
+        .arg(file_name)
+        .arg("--retry")
+        .succeeds()
         .stderr_is("tail: warning: --retry ignored; --retry is useful only when following\n")
         .code_is(0);
 }
@@ -1186,11 +1164,14 @@ fn test_retry2() {
     let ts = TestScenario::new(util_name!());
     let missing = "missing";
 
-    let result = ts.ucmd().arg(missing).arg("--retry").fails_with_code(1);
-    result.stderr_is(
-        "tail: warning: --retry ignored; --retry is useful only when following\n\
+    ts.ucmd()
+        .arg(missing)
+        .arg("--retry")
+        .fails_with_code(1)
+        .stderr_is(
+            "tail: warning: --retry ignored; --retry is useful only when following\n\
                 tail: cannot open 'missing' for reading: No such file or directory\n",
-    );
+        );
 }
 
 #[test]
@@ -2565,7 +2546,7 @@ fn test_presume_input_pipe_default() {
     new_ucmd!()
         .arg("---presume-input-pipe")
         .pipe_in_fixture(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("foobar_stdin_default.expected")
         .no_stderr();
 }
@@ -3349,7 +3330,7 @@ fn test_seek_bytes_backward_outside_file() {
         .arg("-c")
         .arg("100")
         .arg(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is_fixture(FOOBAR_TXT);
 }
 
@@ -3359,7 +3340,7 @@ fn test_seek_bytes_forward_outside_file() {
         .arg("-c")
         .arg("+100")
         .arg(FOOBAR_TXT)
-        .run()
+        .succeeds()
         .stdout_is("");
 }
 
@@ -3626,8 +3607,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "-", "empty"])
         .set_stdin(File::open(at.plus("fifo")).unwrap())
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 
     let expected = "==> standard input <==\n\
@@ -3637,8 +3617,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "-", "empty"])
         .pipe_in("")
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 
     let expected = "==> empty <==\n\
@@ -3648,8 +3627,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "empty", "-"])
         .pipe_in("")
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 
     let expected = "==> empty <==\n\
@@ -3660,8 +3638,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "empty", "-"])
         .set_stdin(File::open(at.plus("fifo")).unwrap())
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 
     let expected = "==> standard input <==\n\
@@ -3672,8 +3649,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "-", "data"])
         .pipe_in("pipe data")
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 
     let expected = "==> data <==\n\
@@ -3684,8 +3660,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "data", "-"])
         .pipe_in("pipe data")
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 
     let expected = "==> standard input <==\n\
@@ -3695,8 +3670,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "-", "-"])
         .pipe_in("pipe data")
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 
     let expected = "==> standard input <==\n\
@@ -3706,8 +3680,7 @@ fn test_when_argument_files_are_simple_combinations_of_stdin_and_regular_file() 
         .ucmd()
         .args(&["-c", "+0", "-", "-"])
         .set_stdin(File::open(at.plus("fifo")).unwrap())
-        .run()
-        .success()
+        .succeeds()
         .stdout_only(expected);
 }
 
@@ -3731,9 +3704,8 @@ fn test_when_argument_files_are_triple_combinations_of_fifo_pipe_and_regular_fil
         .ucmd()
         .args(&["-c", "+0", "-", "empty", "-"])
         .set_stdin(File::open(at.plus("empty")).unwrap())
-        .run()
-        .stdout_only(expected)
-        .success();
+        .succeeds()
+        .stdout_only(expected);
 
     let expected = "==> standard input <==\n\
                 \n\
@@ -3745,9 +3717,8 @@ fn test_when_argument_files_are_triple_combinations_of_fifo_pipe_and_regular_fil
         .args(&["-c", "+0", "-", "empty", "-"])
         .pipe_in("")
         .stderr_to_stdout()
-        .run()
-        .stdout_only(expected)
-        .success();
+        .succeeds()
+        .stdout_only(expected);
 
     let expected = "==> standard input <==\n\
                 pipe data\n\
@@ -3758,9 +3729,8 @@ fn test_when_argument_files_are_triple_combinations_of_fifo_pipe_and_regular_fil
         .ucmd()
         .args(&["-c", "+0", "-", "data", "-"])
         .pipe_in("pipe data")
-        .run()
-        .stdout_only(expected)
-        .success();
+        .succeeds()
+        .stdout_only(expected);
 
     // Correct behavior in a sh shell is to remember the file pointer for the fifo, so we don't
     // print the fifo twice. This matches the behavior, if only the pipe is present without fifo
@@ -3798,9 +3768,8 @@ fn test_when_argument_files_are_triple_combinations_of_fifo_pipe_and_regular_fil
             "echo pipe data | {} tail -c +0  - data - < fifo",
             scene.bin_path.display(),
         ))
-        .run()
-        .stdout_only(expected)
-        .success();
+        .succeeds()
+        .stdout_only(expected);
 
     let expected = "==> standard input <==\n\
                 fifo data\n\
@@ -3811,9 +3780,8 @@ fn test_when_argument_files_are_triple_combinations_of_fifo_pipe_and_regular_fil
         .ucmd()
         .args(&["-c", "+0", "-", "data", "-"])
         .set_stdin(File::open(at.plus("fifo")).unwrap())
-        .run()
-        .stdout_only(expected)
-        .success();
+        .succeeds()
+        .stdout_only(expected);
 }
 
 // Bug description: The content of a file is not printed to stdout if the output data does not
@@ -3861,9 +3829,8 @@ fn test_args_when_settings_check_warnings_then_shows_warnings() {
         .ucmd()
         .args(&["--retry", "data"])
         .stderr_to_stdout()
-        .run()
-        .stdout_only(expected_stdout)
-        .success();
+        .succeeds()
+        .stdout_only(expected_stdout);
 
     let expected_stdout = format!(
         "tail: warning: --retry only effective for the initial open\n\
@@ -3890,9 +3857,8 @@ fn test_args_when_settings_check_warnings_then_shows_warnings() {
         .ucmd()
         .args(&["--pid=1000", "data"])
         .stderr_to_stdout()
-        .run()
-        .stdout_only(expected_stdout)
-        .success();
+        .succeeds()
+        .stdout_only(expected_stdout);
 
     let expected_stdout = format!(
         "tail: warning: --retry ignored; --retry is useful only when following\n\
@@ -3903,16 +3869,14 @@ fn test_args_when_settings_check_warnings_then_shows_warnings() {
         .ucmd()
         .args(&["--pid=1000", "--retry", "data"])
         .stderr_to_stdout()
-        .run()
-        .stdout_only(&expected_stdout)
-        .success();
+        .succeeds()
+        .stdout_only(&expected_stdout);
     scene
         .ucmd()
         .args(&["--pid=1000", "--pid=1000", "--retry", "data"])
         .stderr_to_stdout()
-        .run()
-        .stdout_only(expected_stdout)
-        .success();
+        .succeeds()
+        .stdout_only(expected_stdout);
 }
 
 /// TODO: Write similar tests for windows

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -503,8 +503,7 @@ fn test_is_not_empty() {
 fn test_nonexistent_file_size_test_is_false() {
     new_ucmd!()
         .args(&["-s", "nonexistent_file"])
-        .run()
-        .code_is(1);
+        .fails_with_code(1);
 }
 
 #[test]
@@ -613,8 +612,7 @@ fn test_parenthesized_literal() {
             .arg("(")
             .arg(test)
             .arg(")")
-            .run()
-            .code_is(1);
+            .fails_with_code(1);
     }
 }
 
@@ -828,8 +826,7 @@ fn test_inverted_parenthetical_bool_op_precedence() {
 fn test_dangling_parenthesis() {
     new_ucmd!()
         .args(&["(", "(", "a", "!=", "b", ")", "-o", "-n", "c"])
-        .run()
-        .code_is(2);
+        .fails_with_code(2);
     new_ucmd!()
         .args(&["(", "(", "a", "!=", "b", ")", "-o", "-n", "c", ")"])
         .succeeds();

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -33,7 +33,7 @@ fn test_to_upper() {
     new_ucmd!()
         .args(&["a-z", "A-Z"])
         .pipe_in("!abcd!")
-        .run()
+        .succeeds()
         .stdout_is("!ABCD!");
 }
 
@@ -42,7 +42,7 @@ fn test_small_set2() {
     new_ucmd!()
         .args(&["0-9", "X"])
         .pipe_in("@0123456789")
-        .run()
+        .succeeds()
         .stdout_is("@XXXXXXXXXX");
 }
 
@@ -60,7 +60,7 @@ fn test_delete() {
     new_ucmd!()
         .args(&["-d", "a-z"])
         .pipe_in("aBcD")
-        .run()
+        .succeeds()
         .stdout_is("BD");
 }
 
@@ -95,7 +95,7 @@ fn test_delete_complement() {
     new_ucmd!()
         .args(&["-d", "-c", "a-z"])
         .pipe_in("aBcD")
-        .run()
+        .succeeds()
         .stdout_is("ac");
 }
 
@@ -118,7 +118,7 @@ fn test_complement1() {
     new_ucmd!()
         .args(&["-c", "a", "X"])
         .pipe_in("ab")
-        .run()
+        .succeeds()
         .stdout_is("aX");
 }
 
@@ -135,7 +135,7 @@ fn test_complement2() {
     new_ucmd!()
         .args(&["-c", "0-9", "x"])
         .pipe_in("Phone: 01234 567890")
-        .run()
+        .succeeds()
         .stdout_is("xxxxxxx01234x567890");
 }
 
@@ -144,7 +144,7 @@ fn test_complement3() {
     new_ucmd!()
         .args(&["-c", "abcdefgh", "123"])
         .pipe_in("the cat and the bat")
-        .run()
+        .succeeds()
         .stdout_is("3he3ca33a3d33he3ba3");
 }
 
@@ -155,7 +155,7 @@ fn test_complement4() {
     new_ucmd!()
         .args(&["-c", "0-@", "*-~"])
         .pipe_in("0x1y2z3")
-        .run()
+        .succeeds()
         .stdout_is("0~1~2~3");
 }
 
@@ -166,7 +166,7 @@ fn test_complement5() {
     new_ucmd!()
         .args(&["-c", r"\0-@", "*-~"])
         .pipe_in("0x1y2z3")
-        .run()
+        .succeeds()
         .stdout_is("0a1b2c3");
 }
 
@@ -236,7 +236,7 @@ fn test_squeeze_complement_two_sets() {
     new_ucmd!()
         .args(&["-sc", "a", "_"])
         .pipe_in("test a aa with 3 ___ spaaaces +++") // spell-checker:disable-line
-        .run()
+        .succeeds()
         .stdout_is("_a_aa_aaa_");
 }
 
@@ -245,7 +245,7 @@ fn test_translate_and_squeeze() {
     new_ucmd!()
         .args(&["-s", "x", "y"])
         .pipe_in("xx")
-        .run()
+        .succeeds()
         .stdout_is("y");
 }
 
@@ -254,7 +254,7 @@ fn test_translate_and_squeeze_multiple_lines() {
     new_ucmd!()
         .args(&["-s", "x", "y"])
         .pipe_in("xxaax\nxaaxx") // spell-checker:disable-line
-        .run()
+        .succeeds()
         .stdout_is("yaay\nyaay"); // spell-checker:disable-line
 }
 
@@ -272,7 +272,7 @@ fn test_delete_and_squeeze() {
     new_ucmd!()
         .args(&["-ds", "a-z", "A-Z"])
         .pipe_in("abBcB")
-        .run()
+        .succeeds()
         .stdout_is("B");
 }
 
@@ -281,7 +281,7 @@ fn test_delete_and_squeeze_complement() {
     new_ucmd!()
         .args(&["-dsc", "a-z", "A-Z"])
         .pipe_in("abBcB")
-        .run()
+        .succeeds()
         .stdout_is("abc");
 }
 
@@ -299,7 +299,7 @@ fn test_set1_longer_than_set2() {
     new_ucmd!()
         .args(&["abc", "xy"])
         .pipe_in("abcde")
-        .run()
+        .succeeds()
         .stdout_is("xyyde"); // spell-checker:disable-line
 }
 
@@ -308,7 +308,7 @@ fn test_set1_shorter_than_set2() {
     new_ucmd!()
         .args(&["ab", "xyz"])
         .pipe_in("abcde")
-        .run()
+        .succeeds()
         .stdout_is("xycde");
 }
 
@@ -336,7 +336,7 @@ fn test_truncate_with_set1_shorter_than_set2() {
     new_ucmd!()
         .args(&["-t", "ab", "xyz"])
         .pipe_in("abcde")
-        .run()
+        .succeeds()
         .stdout_is("xycde");
 }
 

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -14,7 +14,7 @@ fn test_invalid_arg() {
 fn test_sort_call_graph() {
     new_ucmd!()
         .arg("call_graph.txt")
-        .run()
+        .succeeds()
         .stdout_is_fixture("call_graph.expected");
 }
 

--- a/tests/by-util/test_unexpand.rs
+++ b/tests/by-util/test_unexpand.rs
@@ -15,7 +15,7 @@ fn unexpand_init_0() {
     new_ucmd!()
         .args(&["-t4"])
         .pipe_in(" 1\n  2\n   3\n    4\n")
-        .run()
+        .succeeds()
         .stdout_is(" 1\n  2\n   3\n\t4\n");
 }
 
@@ -24,7 +24,7 @@ fn unexpand_init_1() {
     new_ucmd!()
         .args(&["-t4"])
         .pipe_in("     5\n      6\n       7\n        8\n")
-        .run()
+        .succeeds()
         .stdout_is("\t 5\n\t  6\n\t   7\n\t\t8\n");
 }
 
@@ -33,7 +33,7 @@ fn unexpand_init_list_0() {
     new_ucmd!()
         .args(&["-t2,4"])
         .pipe_in(" 1\n  2\n   3\n    4\n")
-        .run()
+        .succeeds()
         .stdout_is(" 1\n\t2\n\t 3\n\t\t4\n");
 }
 
@@ -43,7 +43,7 @@ fn unexpand_init_list_1() {
     new_ucmd!()
         .args(&["-t2,4"])
         .pipe_in("     5\n      6\n       7\n        8\n")
-        .run()
+        .succeeds()
         .stdout_is("\t\t 5\n\t\t  6\n\t\t   7\n\t\t    8\n");
 }
 
@@ -52,7 +52,7 @@ fn unexpand_flag_a_0() {
     new_ucmd!()
         .args(&["--"])
         .pipe_in("e     E\nf      F\ng       G\nh        H\n")
-        .run()
+        .succeeds()
         .stdout_is("e     E\nf      F\ng       G\nh        H\n");
 }
 
@@ -61,7 +61,7 @@ fn unexpand_flag_a_1() {
     new_ucmd!()
         .args(&["-a"])
         .pipe_in("e     E\nf      F\ng       G\nh        H\n")
-        .run()
+        .succeeds()
         .stdout_is("e     E\nf      F\ng\tG\nh\t H\n");
 }
 
@@ -70,7 +70,7 @@ fn unexpand_flag_a_2() {
     new_ucmd!()
         .args(&["-t8"])
         .pipe_in("e     E\nf      F\ng       G\nh        H\n")
-        .run()
+        .succeeds()
         .stdout_is("e     E\nf      F\ng\tG\nh\t H\n");
 }
 
@@ -79,7 +79,7 @@ fn unexpand_first_only_0() {
     new_ucmd!()
         .args(&["-t3"])
         .pipe_in("        A     B")
-        .run()
+        .succeeds()
         .stdout_is("\t\t  A\t  B");
 }
 
@@ -88,7 +88,7 @@ fn unexpand_first_only_1() {
     new_ucmd!()
         .args(&["-t3", "--first-only"])
         .pipe_in("        A     B")
-        .run()
+        .succeeds()
         .stdout_is("\t\t  A     B");
 }
 
@@ -100,7 +100,7 @@ fn unexpand_trailing_space_0() {
     new_ucmd!()
         .args(&["-t4"])
         .pipe_in("123 \t1\n123 1\n123 \n123 ")
-        .run()
+        .succeeds()
         .stdout_is("123\t\t1\n123 1\n123 \n123 ");
 }
 
@@ -110,7 +110,7 @@ fn unexpand_trailing_space_1() {
     new_ucmd!()
         .args(&["-t1"])
         .pipe_in(" abc d e  f  g ")
-        .run()
+        .succeeds()
         .stdout_is("\tabc d e\t\tf\t\tg ");
 }
 
@@ -119,7 +119,7 @@ fn unexpand_spaces_follow_tabs_0() {
     // The two first spaces can be included into the first tab.
     new_ucmd!()
         .pipe_in("  \t\t   A")
-        .run()
+        .succeeds()
         .stdout_is("\t\t   A");
 }
 
@@ -134,7 +134,7 @@ fn unexpand_spaces_follow_tabs_1() {
     new_ucmd!()
         .args(&["-t1,4,5"])
         .pipe_in("a \t   B \t")
-        .run()
+        .succeeds()
         .stdout_is("a\t\t  B \t");
 }
 
@@ -143,17 +143,13 @@ fn unexpand_spaces_after_fields() {
     new_ucmd!()
         .args(&["-a"])
         .pipe_in("   \t        A B C D             A\t\n")
-        .run()
+        .succeeds()
         .stdout_is("\t\tA B C D\t\t    A\t\n");
 }
 
 #[test]
 fn unexpand_read_from_file() {
-    new_ucmd!()
-        .arg("with_spaces.txt")
-        .arg("-t4")
-        .run()
-        .success();
+    new_ucmd!().arg("with_spaces.txt").arg("-t4").succeeds();
 }
 
 #[test]
@@ -162,8 +158,7 @@ fn unexpand_read_from_two_file() {
         .arg("with_spaces.txt")
         .arg("with_spaces.txt")
         .arg("-t4")
-        .run()
-        .success();
+        .succeeds();
 }
 
 #[test]
@@ -171,7 +166,7 @@ fn test_tabs_shortcut() {
     new_ucmd!()
         .arg("-3")
         .pipe_in("   a   b")
-        .run()
+        .succeeds()
         .stdout_is("\ta   b");
 }
 
@@ -181,7 +176,7 @@ fn test_tabs_shortcut_combined_with_all_arg() {
         new_ucmd!()
             .args(&[all_arg, "-3"])
             .pipe_in("a  b  c")
-            .run()
+            .succeeds()
             .stdout_is("a\tb\tc");
     }
 
@@ -197,7 +192,7 @@ fn test_comma_separated_tabs_shortcut() {
     new_ucmd!()
         .args(&["-a", "-3,9"])
         .pipe_in("a  b     c")
-        .run()
+        .succeeds()
         .stdout_is("a\tb\tc");
 }
 

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -36,7 +36,7 @@ fn test_help_and_version_on_stdout() {
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-simple.expected");
 }
 
@@ -44,7 +44,7 @@ fn test_stdin_default() {
 fn test_single_default() {
     new_ucmd!()
         .arg(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-simple.expected");
 }
 
@@ -52,7 +52,7 @@ fn test_single_default() {
 fn test_single_default_output() {
     let (at, mut ucmd) = at_and_ucmd!();
     let expected = at.read("sorted-simple.expected");
-    ucmd.args(&[INPUT, OUTPUT]).run();
+    ucmd.args(&[INPUT, OUTPUT]).succeeds();
     let found = at.read(OUTPUT);
     assert_eq!(found, expected);
 }
@@ -62,7 +62,7 @@ fn test_stdin_counts() {
     new_ucmd!()
         .args(&["-c"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-counts.expected");
 }
 
@@ -71,7 +71,7 @@ fn test_stdin_skip_1_char() {
     new_ucmd!()
         .args(&["-s1"])
         .pipe_in_fixture(SKIP_CHARS)
-        .run()
+        .succeeds()
         .stdout_is_fixture("skip-1-char.expected");
 }
 
@@ -80,7 +80,7 @@ fn test_stdin_skip_5_chars() {
     new_ucmd!()
         .args(&["-s5"])
         .pipe_in_fixture(SKIP_CHARS)
-        .run()
+        .succeeds()
         .stdout_is_fixture("skip-5-chars.expected");
 }
 
@@ -89,7 +89,7 @@ fn test_stdin_skip_and_check_2_chars() {
     new_ucmd!()
         .args(&["-s3", "-w2"])
         .pipe_in_fixture(SKIP_CHARS)
-        .run()
+        .succeeds()
         .stdout_is_fixture("skip-3-check-2-chars.expected");
 }
 
@@ -98,7 +98,7 @@ fn test_stdin_skip_2_fields() {
     new_ucmd!()
         .args(&["-f2"])
         .pipe_in_fixture(SKIP_FIELDS)
-        .run()
+        .succeeds()
         .stdout_is_fixture("skip-2-fields.expected");
 }
 
@@ -107,7 +107,7 @@ fn test_stdin_skip_2_fields_obsolete() {
     new_ucmd!()
         .args(&["-2"])
         .pipe_in_fixture(SKIP_FIELDS)
-        .run()
+        .succeeds()
         .stdout_is_fixture("skip-2-fields.expected");
 }
 
@@ -116,7 +116,7 @@ fn test_stdin_skip_21_fields() {
     new_ucmd!()
         .args(&["-f21"])
         .pipe_in_fixture(SKIP_FIELDS)
-        .run()
+        .succeeds()
         .stdout_is_fixture("skip-21-fields.expected");
 }
 
@@ -125,7 +125,7 @@ fn test_stdin_skip_21_fields_obsolete() {
     new_ucmd!()
         .args(&["-21"])
         .pipe_in_fixture(SKIP_FIELDS)
-        .run()
+        .succeeds()
         .stdout_is_fixture("skip-21-fields.expected");
 }
 
@@ -133,8 +133,7 @@ fn test_stdin_skip_21_fields_obsolete() {
 fn test_stdin_skip_invalid_fields_obsolete() {
     new_ucmd!()
         .args(&["-5q"])
-        .run()
-        .failure()
+        .fails()
         .stderr_contains("error: unexpected argument '-q' found\n");
 }
 
@@ -143,22 +142,22 @@ fn test_stdin_all_repeated() {
     new_ucmd!()
         .args(&["--all-repeated"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated.expected");
     new_ucmd!()
         .args(&["--all-repeated=none"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated.expected");
     new_ucmd!()
         .args(&["--all-repeated=non"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated.expected");
     new_ucmd!()
         .args(&["--all-repeated=n"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated.expected");
 }
 
@@ -170,8 +169,7 @@ fn test_all_repeated_followed_by_filename() {
     at.write(filename, "a\na\n");
 
     ucmd.args(&["--all-repeated", filename])
-        .run()
-        .success()
+        .succeeds()
         .stdout_is("a\na\n");
 }
 
@@ -180,17 +178,17 @@ fn test_stdin_all_repeated_separate() {
     new_ucmd!()
         .args(&["--all-repeated=separate"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated-separate.expected");
     new_ucmd!()
         .args(&["--all-repeated=separat"]) // spell-checker:disable-line
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated-separate.expected");
     new_ucmd!()
         .args(&["--all-repeated=s"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated-separate.expected");
 }
 
@@ -199,17 +197,17 @@ fn test_stdin_all_repeated_prepend() {
     new_ucmd!()
         .args(&["--all-repeated=prepend"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated-prepend.expected");
     new_ucmd!()
         .args(&["--all-repeated=prepen"]) // spell-checker:disable-line
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated-prepend.expected");
     new_ucmd!()
         .args(&["--all-repeated=p"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-all-repeated-prepend.expected");
 }
 
@@ -218,7 +216,7 @@ fn test_stdin_unique_only() {
     new_ucmd!()
         .args(&["-u"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-unique-only.expected");
 }
 
@@ -227,7 +225,7 @@ fn test_stdin_repeated_only() {
     new_ucmd!()
         .args(&["-d"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-repeated-only.expected");
 }
 
@@ -236,7 +234,7 @@ fn test_stdin_ignore_case() {
     new_ucmd!()
         .args(&["-i"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-ignore-case.expected");
 }
 
@@ -245,7 +243,7 @@ fn test_stdin_zero_terminated() {
     new_ucmd!()
         .args(&["-z"])
         .pipe_in_fixture(SORTED_ZERO_TERMINATED)
-        .run()
+        .succeeds()
         .stdout_is_fixture("sorted-zero-terminated.expected");
 }
 
@@ -254,8 +252,7 @@ fn test_gnu_locale_fr_schar() {
     new_ucmd!()
         .args(&["-f1", "locale-fr-schar.txt"])
         .env("LC_ALL", "C")
-        .run()
-        .success()
+        .succeeds()
         .stdout_is_fixture_bytes("locale-fr-schar.txt");
 }
 
@@ -264,7 +261,7 @@ fn test_group() {
     new_ucmd!()
         .args(&["--group"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group.expected");
 }
 
@@ -276,8 +273,7 @@ fn test_group_followed_by_filename() {
     at.write(filename, "a\na\n");
 
     ucmd.args(&["--group", filename])
-        .run()
-        .success()
+        .succeeds()
         .stdout_is("a\na\n");
 }
 
@@ -286,12 +282,12 @@ fn test_group_prepend() {
     new_ucmd!()
         .args(&["--group=prepend"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group-prepend.expected");
     new_ucmd!()
         .args(&["--group=p"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group-prepend.expected");
 }
 
@@ -300,12 +296,12 @@ fn test_group_append() {
     new_ucmd!()
         .args(&["--group=append"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group-append.expected");
     new_ucmd!()
         .args(&["--group=a"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group-append.expected");
 }
 
@@ -314,17 +310,17 @@ fn test_group_both() {
     new_ucmd!()
         .args(&["--group=both"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group-both.expected");
     new_ucmd!()
         .args(&["--group=bot"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group-both.expected");
     new_ucmd!()
         .args(&["--group=b"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group-both.expected");
 }
 
@@ -333,18 +329,18 @@ fn test_group_separate() {
     new_ucmd!()
         .args(&["--group=separate"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group.expected");
     new_ucmd!()
         .args(&["--group=s"])
         .pipe_in_fixture(INPUT)
-        .run()
+        .succeeds()
         .stdout_is_fixture("group.expected");
 }
 
 #[test]
 fn test_case2() {
-    new_ucmd!().pipe_in("a\na\n").run().stdout_is("a\n");
+    new_ucmd!().pipe_in("a\na\n").succeeds().stdout_is("a\n");
 }
 
 struct TestCase {
@@ -1179,6 +1175,6 @@ fn test_stdin_w1_multibyte() {
     new_ucmd!()
         .args(&["-w1"])
         .pipe_in(input)
-        .run()
+        .succeeds()
         .stdout_is("à\ná\n");
 }

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -263,7 +263,7 @@ fn test_uptime_with_dir() {
 fn test_uptime_check_users_openbsd() {
     new_ucmd!()
         .args(&["openbsd_utmp"])
-        .run()
+        .succeeds()
         .stdout_contains("4 users");
 }
 

--- a/tests/by-util/test_users.rs
+++ b/tests/by-util/test_users.rs
@@ -37,6 +37,6 @@ fn test_users_check_name() {
 fn test_users_check_name_openbsd() {
     new_ucmd!()
         .args(&["openbsd_utmp"])
-        .run()
+        .succeeds()
         .stdout_contains("test");
 }

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -43,7 +43,7 @@ fn test_count_bytes_large_stdin() {
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in_fixture("lorem_ipsum.txt")
-        .run()
+        .succeeds()
         .stdout_is("     13     109     772\n");
 }
 
@@ -52,7 +52,7 @@ fn test_stdin_explicit() {
     new_ucmd!()
         .pipe_in_fixture("lorem_ipsum.txt")
         .arg("-")
-        .run()
+        .succeeds()
         .stdout_is("     13     109     772 -\n");
 }
 
@@ -61,7 +61,7 @@ fn test_utf8() {
     new_ucmd!()
         .args(&["-lwmcL"])
         .pipe_in_fixture("UTF_8_test.txt")
-        .run()
+        .succeeds()
         .stdout_is("    303    2119   22457   23025      79\n");
 }
 
@@ -70,7 +70,7 @@ fn test_utf8_words() {
     new_ucmd!()
         .arg("-w")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("89\n");
 }
 
@@ -79,7 +79,7 @@ fn test_utf8_line_length_words() {
     new_ucmd!()
         .arg("-Lw")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     89      48\n");
 }
 
@@ -88,7 +88,7 @@ fn test_utf8_line_length_chars() {
     new_ucmd!()
         .arg("-Lm")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("    442      48\n");
 }
 
@@ -97,7 +97,7 @@ fn test_utf8_line_length_chars_words() {
     new_ucmd!()
         .arg("-Lmw")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     89     442      48\n");
 }
 
@@ -106,7 +106,7 @@ fn test_utf8_chars() {
     new_ucmd!()
         .arg("-m")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("442\n");
 }
 
@@ -115,7 +115,7 @@ fn test_utf8_bytes_chars() {
     new_ucmd!()
         .arg("-cm")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("    442     513\n");
 }
 
@@ -124,7 +124,7 @@ fn test_utf8_bytes_lines() {
     new_ucmd!()
         .arg("-cl")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25     513\n");
 }
 
@@ -133,7 +133,7 @@ fn test_utf8_bytes_chars_lines() {
     new_ucmd!()
         .arg("-cml")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25     442     513\n");
 }
 
@@ -142,7 +142,7 @@ fn test_utf8_chars_words() {
     new_ucmd!()
         .arg("-mw")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     89     442\n");
 }
 
@@ -151,7 +151,7 @@ fn test_utf8_line_length_lines() {
     new_ucmd!()
         .arg("-Ll")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25      48\n");
 }
 
@@ -160,7 +160,7 @@ fn test_utf8_line_length_lines_words() {
     new_ucmd!()
         .arg("-Llw")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25      89      48\n");
 }
 
@@ -169,7 +169,7 @@ fn test_utf8_lines_chars() {
     new_ucmd!()
         .arg("-ml")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25     442\n");
 }
 
@@ -178,7 +178,7 @@ fn test_utf8_lines_words_chars() {
     new_ucmd!()
         .arg("-mlw")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25      89     442\n");
 }
 
@@ -187,7 +187,7 @@ fn test_utf8_line_length_lines_chars() {
     new_ucmd!()
         .arg("-Llm")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25     442      48\n");
 }
 
@@ -196,7 +196,7 @@ fn test_utf8_all() {
     new_ucmd!()
         .arg("-lwmcL")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
-        .run()
+        .succeeds()
         .stdout_is("     25      89     442     513      48\n");
 }
 
@@ -206,7 +206,7 @@ fn test_ascii_control() {
     new_ucmd!()
         .arg("-w")
         .pipe_in(*b"\x01\n")
-        .run()
+        .succeeds()
         .stdout_is("1\n");
 }
 
@@ -215,7 +215,7 @@ fn test_stdin_line_len_regression() {
     new_ucmd!()
         .args(&["-L"])
         .pipe_in("\n123456")
-        .run()
+        .succeeds()
         .stdout_is("6\n");
 }
 
@@ -224,7 +224,7 @@ fn test_stdin_only_bytes() {
     new_ucmd!()
         .args(&["-c"])
         .pipe_in_fixture("lorem_ipsum.txt")
-        .run()
+        .succeeds()
         .stdout_is("772\n");
 }
 
@@ -233,7 +233,7 @@ fn test_stdin_all_counts() {
     new_ucmd!()
         .args(&["-c", "-m", "-l", "-L", "-w"])
         .pipe_in_fixture("alice_in_wonderland.txt")
-        .run()
+        .succeeds()
         .stdout_is("      5      57     302     302      66\n");
 }
 
@@ -241,7 +241,7 @@ fn test_stdin_all_counts() {
 fn test_single_default() {
     new_ucmd!()
         .arg("moby_dick.txt")
-        .run()
+        .succeeds()
         .stdout_is("  18  204 1115 moby_dick.txt\n");
 }
 
@@ -249,7 +249,7 @@ fn test_single_default() {
 fn test_single_only_lines() {
     new_ucmd!()
         .args(&["-l", "moby_dick.txt"])
-        .run()
+        .succeeds()
         .stdout_is("18 moby_dick.txt\n");
 }
 
@@ -257,7 +257,7 @@ fn test_single_only_lines() {
 fn test_single_only_bytes() {
     new_ucmd!()
         .args(&["-c", "lorem_ipsum.txt"])
-        .run()
+        .succeeds()
         .stdout_is("772 lorem_ipsum.txt\n");
 }
 
@@ -265,7 +265,7 @@ fn test_single_only_bytes() {
 fn test_single_all_counts() {
     new_ucmd!()
         .args(&["-c", "-l", "-L", "-m", "-w", "alice_in_wonderland.txt"])
-        .run()
+        .succeeds()
         .stdout_is("  5  57 302 302  66 alice_in_wonderland.txt\n");
 }
 
@@ -279,7 +279,7 @@ fn test_gnu_compatible_quotation() {
     scene
         .ucmd()
         .args(&["some-dir1/12\n34.txt"])
-        .run()
+        .succeeds()
         .stdout_is("0 0 0 'some-dir1/12'$'\\n''34.txt'\n");
 }
 
@@ -298,7 +298,7 @@ fn test_non_unicode_names() {
     scene
         .ucmd()
         .args(&[target1, target2])
-        .run()
+        .succeeds()
         .stdout_is_bytes(
             [
                 b"0 0 0 'some-dir1/1'$'\\300\\n''.txt'\n".to_vec(),
@@ -318,7 +318,7 @@ fn test_multiple_default() {
             "alice_in_wonderland.txt",
             "alice in wonderland.txt",
         ])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             "  13  109  772 lorem_ipsum.txt\n",
             "  18  204 1115 moby_dick.txt\n",
@@ -333,7 +333,7 @@ fn test_multiple_default() {
 fn test_file_empty() {
     new_ucmd!()
         .args(&["-clmwL", "emptyfile.txt"])
-        .run()
+        .succeeds()
         .stdout_is("0 0 0 0 0 emptyfile.txt\n");
 }
 
@@ -343,7 +343,7 @@ fn test_file_empty() {
 fn test_file_single_line_no_trailing_newline() {
     new_ucmd!()
         .args(&["-clmwL", "notrailingnewline.txt"])
-        .run()
+        .succeeds()
         .stdout_is("1 1 2 2 1 notrailingnewline.txt\n");
 }
 
@@ -353,7 +353,7 @@ fn test_file_single_line_no_trailing_newline() {
 fn test_file_many_empty_lines() {
     new_ucmd!()
         .args(&["-clmwL", "manyemptylines.txt"])
-        .run()
+        .succeeds()
         .stdout_is("100   0 100 100   0 manyemptylines.txt\n");
 }
 
@@ -362,7 +362,7 @@ fn test_file_many_empty_lines() {
 fn test_file_one_long_line_only_spaces() {
     new_ucmd!()
         .args(&["-clmwL", "onelongemptyline.txt"])
-        .run()
+        .succeeds()
         .stdout_is("    1     0 10001 10001 10000 onelongemptyline.txt\n");
 }
 
@@ -371,7 +371,7 @@ fn test_file_one_long_line_only_spaces() {
 fn test_file_one_long_word() {
     new_ucmd!()
         .args(&["-clmwL", "onelongword.txt"])
-        .run()
+        .succeeds()
         .stdout_is("    1     1 10001 10001 10000 onelongword.txt\n");
 }
 
@@ -402,21 +402,21 @@ fn test_file_bytes_dictate_width() {
     // five characters, filled with whitespace.
     new_ucmd!()
         .args(&["-lw", "onelongemptyline.txt"])
-        .run()
+        .succeeds()
         .stdout_is("    1     0 onelongemptyline.txt\n");
 
     // This file has zero bytes. Only one digit is required to
     // represent that.
     new_ucmd!()
         .args(&["-lw", "emptyfile.txt"])
-        .run()
+        .succeeds()
         .stdout_is("0 0 emptyfile.txt\n");
 
     // lorem_ipsum.txt contains 772 bytes, and alice_in_wonderland.txt contains
     // 302 bytes. The total is 1074 bytes, which has a width of 4
     new_ucmd!()
         .args(&["-lwc", "alice_in_wonderland.txt", "lorem_ipsum.txt"])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             "   5   57  302 alice_in_wonderland.txt\n",
             "  13  109  772 lorem_ipsum.txt\n",
@@ -425,7 +425,7 @@ fn test_file_bytes_dictate_width() {
 
     new_ucmd!()
         .args(&["-lwc", "emptyfile.txt", "."])
-        .run()
+        .fails()
         .stdout_is(STDOUT);
 }
 
@@ -495,8 +495,7 @@ fn test_files0_from() {
     // file
     new_ucmd!()
         .args(&["--files0-from=files0_list.txt"])
-        .run()
-        .success()
+        .succeeds()
         .stdout_is(concat!(
             "  13  109  772 lorem_ipsum.txt\n",
             "  18  204 1115 moby_dick.txt\n",
@@ -508,8 +507,7 @@ fn test_files0_from() {
     new_ucmd!()
         .args(&["--files0-from=-"])
         .pipe_in_fixture("files0_list.txt")
-        .run()
-        .success()
+        .succeeds()
         .stdout_is(concat!(
             "13 109 772 lorem_ipsum.txt\n",
             "18 204 1115 moby_dick.txt\n",
@@ -523,7 +521,7 @@ fn test_files0_from_with_stdin() {
     new_ucmd!()
         .args(&["--files0-from=-"])
         .pipe_in("lorem_ipsum.txt")
-        .run()
+        .succeeds()
         .stdout_is("13 109 772 lorem_ipsum.txt\n");
 }
 
@@ -532,7 +530,7 @@ fn test_files0_from_with_stdin_in_file() {
     new_ucmd!()
         .args(&["--files0-from=files0_list_with_stdin.txt"])
         .pipe_in_fixture("alice_in_wonderland.txt")
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             "     13     109     772 lorem_ipsum.txt\n",
             "     18     204    1115 moby_dick.txt\n",
@@ -556,16 +554,16 @@ fn test_files0_from_with_stdin_try_read_from_stdin() {
 fn test_total_auto() {
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "--total=auto"])
-        .run()
+        .succeeds()
         .stdout_is(" 13 109 772 lorem_ipsum.txt\n");
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "--tot=au"])
-        .run()
+        .succeeds()
         .stdout_is(" 13 109 772 lorem_ipsum.txt\n");
 
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=auto"])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             "  13  109  772 lorem_ipsum.txt\n",
             "  18  204 1115 moby_dick.txt\n",
@@ -577,14 +575,14 @@ fn test_total_auto() {
 fn test_total_always() {
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "--total=always"])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             " 13 109 772 lorem_ipsum.txt\n",
             " 13 109 772 total\n",
         ));
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "--total=al"])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             " 13 109 772 lorem_ipsum.txt\n",
             " 13 109 772 total\n",
@@ -592,7 +590,7 @@ fn test_total_always() {
 
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=always"])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             "  13  109  772 lorem_ipsum.txt\n",
             "  18  204 1115 moby_dick.txt\n",
@@ -604,19 +602,19 @@ fn test_total_always() {
 fn test_total_never() {
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "--total=never"])
-        .run()
+        .succeeds()
         .stdout_is(" 13 109 772 lorem_ipsum.txt\n");
 
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=never"])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             "  13  109  772 lorem_ipsum.txt\n",
             "  18  204 1115 moby_dick.txt\n",
         ));
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=n"])
-        .run()
+        .succeeds()
         .stdout_is(concat!(
             "  13  109  772 lorem_ipsum.txt\n",
             "  18  204 1115 moby_dick.txt\n",
@@ -627,16 +625,16 @@ fn test_total_never() {
 fn test_total_only() {
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "--total=only"])
-        .run()
+        .succeeds()
         .stdout_is("13 109 772\n");
 
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--total=only"])
-        .run()
+        .succeeds()
         .stdout_is("31 313 1887\n");
     new_ucmd!()
         .args(&["lorem_ipsum.txt", "moby_dick.txt", "--t=o"])
-        .run()
+        .succeeds()
         .stdout_is("31 313 1887\n");
 }
 
@@ -650,8 +648,7 @@ fn test_zero_length_files() {
         new_ucmd!()
             .args(&["--files0-from=-"])
             .pipe_in(&LIST[..l])
-            .run()
-            .failure()
+            .fails()
             .stdout_is(concat!(
                 "18 204 1115 moby_dick.txt\n",
                 "5 57 302 alice_in_wonderland.txt\n",
@@ -675,8 +672,7 @@ fn test_zero_length_files() {
                 .copied()
                 .collect::<Vec<_>>(),
         )
-        .run()
-        .failure()
+        .fails()
         .stdout_is(concat!(
             "18 204 1115 moby_dick.txt\n",
             "5 57 302 alice_in_wonderland.txt\n",
@@ -695,8 +691,7 @@ fn test_zero_length_files() {
 fn test_files0_errors_quoting() {
     new_ucmd!()
         .args(&["--files0-from=files0 with nonexistent.txt"])
-        .run()
-        .failure()
+        .fails()
         .stderr_is(concat!(
             "wc: this_file_does_not_exist.txt: No such file or directory\n",
             "wc: 'files0 with nonexistent.txt':2: invalid zero-length file name\n",
@@ -793,11 +788,11 @@ fn files0_from_dir() {
 fn test_args_override() {
     new_ucmd!()
         .args(&["-ll", "-l", "alice_in_wonderland.txt"])
-        .run()
+        .succeeds()
         .stdout_is("5 alice_in_wonderland.txt\n");
 
     new_ucmd!()
         .args(&["--total=always", "--total=never", "alice_in_wonderland.txt"])
-        .run()
+        .succeeds()
         .stdout_is("  5  57 302 alice_in_wonderland.txt\n");
 }


### PR DESCRIPTION
This PR replaces a lot of `run()` calls in the tests with either `succeeds()` or `fails()` for better readability. It also fixes some small things I noticed while doing those replacements, for example, replacing `.no_stdout().no_stderr()` with `.no_output()`.