### PR TITLE
fix uptime on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,7 +3439,6 @@ dependencies = [
  "thiserror 2.0.12",
  "utmp-classic",
  "uucore",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -25,12 +25,6 @@ uucore = { workspace = true, features = ["libc", "utmpx", "uptime"] }
 [target.'cfg(target_os = "openbsd")'.dependencies]
 utmp-classic = { workspace = true }
 
-[target.'cfg(target_os="windows")'.dependencies]
-windows-sys = { workspace = true, features = [
-  "Win32_System_RemoteDesktop",
-  "Wdk_System_SystemInformation",
-] }
-
 [[bin]]
 name = "uptime"
 path = "src/main.rs"

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -30,11 +30,6 @@ pub mod options {
     pub static PATH: &str = "path";
 }
 
-#[cfg(windows)]
-extern "C" {
-    fn GetTickCount() -> u32;
-}
-
 #[derive(Debug, Error)]
 pub enum UptimeError {
     // io::Error wrapper

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -75,6 +75,7 @@ windows-sys = { workspace = true, optional = true, default-features = false, fea
   "Win32_Storage_FileSystem",
   "Win32_Foundation",
   "Win32_System_RemoteDesktop",
+  "Win32_System_SystemInformation",
   "Win32_System_WindowsProgramming",
 ] }
 

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -150,7 +150,7 @@ pub fn get_uptime(_boot_time: Option<time_t>) -> UResult<i64> {
     if uptime < 0 {
         Err(UptimeError::SystemUptime)?;
     }
-    Ok(uptime as i64)
+    Ok(uptime as i64 / 1000)
 }
 
 /// Get the system uptime in a human-readable format

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -140,16 +140,18 @@ pub fn get_uptime(boot_time: Option<time_t>) -> UResult<i64> {
 
 /// Get the system uptime
 ///
+/// # Arguments
+///
+/// boot_time will be ignored, pass None.
+///
 /// # Returns
 ///
 /// Returns a UResult with the uptime in seconds if successful, otherwise an UptimeError.
 #[cfg(windows)]
 pub fn get_uptime(_boot_time: Option<time_t>) -> UResult<i64> {
     use windows_sys::Win32::System::SystemInformation::GetTickCount;
+    // SAFETY: always return u32
     let uptime = unsafe { GetTickCount() };
-    if uptime < 0 {
-        Err(UptimeError::SystemUptime)?;
-    }
     Ok(uptime as i64 / 1000)
 }
 
@@ -244,6 +246,7 @@ pub fn get_nusers() -> usize {
 
     let mut num_user = 0;
 
+    // SAFETY: WTS_CURRENT_SERVER_HANDLE is a valid handle
     unsafe {
         let mut session_info_ptr = ptr::null_mut();
         let mut session_count = 0;
@@ -335,6 +338,7 @@ pub fn get_loadavg() -> UResult<(f64, f64, f64)> {
     use libc::getloadavg;
 
     let mut avg: [c_double; 3] = [0.0; 3];
+    // SAFETY: checked whether it returns -1
     let loads: i32 = unsafe { getloadavg(avg.as_mut_ptr(), 3) };
 
     if loads == -1 {


### PR DESCRIPTION
`windows_sys::Win32::System::SystemInformation::GetTickCount` returns uptime **in milisecond**. A simple mistake.

i also optimise rustdoc and SAFETY comment. If ONE PR shouldn't do so many things, I can also split it into two PRs