### PR TITLE
Bump `libc` & remove unnecessary `unsafe` blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,9 +1278,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1188,7 +1188,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uu_cksum"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "hex",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "uu_cut"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bstr",
  "clap",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "uu_date"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "clap",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "uu_echo"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "uucore",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "uu_env"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "nix",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "uu_expr"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "num-bigint",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "uu_printf"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "uucore",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "uu_seq"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bigdecimal",
  "clap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "uu_sort"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "binary-heap-plus",
  "clap",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "uu_split"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "memchr",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "uu_test"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "libc",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "uu_tr"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "clap",
  "nom",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "uu_wc"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bytecount",
  "clap",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "uucore"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "uucore_procs"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "uuhelp_parser"
-version = "0.0.29"
+version = "0.0.30"
 
 [[package]]
 name = "version_check"

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3179,8 +3179,8 @@ fn display_len_or_rdev(metadata: &Metadata, config: &Config) -> SizeOrDeviceId {
         if ft.is_char_device() || ft.is_block_device() {
             // A type cast is needed here as the `dev_t` type varies across OSes.
             let dev = metadata.rdev() as dev_t;
-            let major = unsafe { major(dev) };
-            let minor = unsafe { minor(dev) };
+            let major = major(dev);
+            let minor = minor(dev);
             return SizeOrDeviceId::Device(major.to_string(), minor.to_string());
         }
     }

--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -51,7 +51,7 @@ fn count_bytes_using_splice(fd: &impl AsFd) -> Result<usize, usize> {
     let null_rdev = stat::fstat(null_file.as_raw_fd())
         .map_err(|_| 0_usize)?
         .st_rdev as libc::dev_t;
-    if unsafe { (libc::major(null_rdev), libc::minor(null_rdev)) } != (1, 3) {
+    if (libc::major(null_rdev), libc::minor(null_rdev)) != (1, 3) {
         // This is not a proper /dev/null, writing to it is probably bad
         // Bit of an edge case, but it has been known to happen
         return Err(0);

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4407,7 +4407,7 @@ fn test_device_number() {
     let blk_dev_path = blk_dev.path();
     let blk_dev_meta = metadata(blk_dev_path.as_path()).unwrap();
     let blk_dev_number = blk_dev_meta.rdev() as dev_t;
-    let (major, minor) = unsafe { (major(blk_dev_number), minor(blk_dev_number)) };
+    let (major, minor) = (major(blk_dev_number), minor(blk_dev_number));
     let major_minor_str = format!("{major}, {minor}");
 
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
This PR bumps `libc` from `0.2.170` to `0.2.171` and removes `unsafe` blocks in `ls` and `wc` that are no longer necessary with this new version.