### PR TITLE
cp: Use FICLONE ioctl constant from linux-raw-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,6 +2617,7 @@ dependencies = [
  "filetime",
  "indicatif",
  "libc",
+ "linux-raw-sys 0.9.2",
  "quick-error",
  "selinux",
  "uucore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,7 @@ iana-time-zone = "0.1.57"
 indicatif = "0.17.8"
 itertools = "0.14.0"
 libc = "0.2.153"
+linux-raw-sys = "0.9"
 lscolors = { version = "0.20.0", default-features = false, features = [
   "gnu_legacy",
 ] }

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/cp.rs"
 clap = { workspace = true }
 filetime = { workspace = true }
 libc = { workspace = true }
+linux-raw-sys = { workspace = true }
 quick-error = { workspace = true }
 selinux = { workspace = true, optional = true }
 uucore = { workspace = true, features = [


### PR DESCRIPTION
The current ioctl operation code for FICLONE is fully open-coded instead of using the ioctl macros, which makes it non-portable to other architectures including mips, arm & powerpc. Get the constant from the linux-raw-sys crate instead, which is already a transitive dependency.