### PR TITLE
true,false: remove unnecessary newline from version string

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -28,7 +28,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let error = match e.kind() {
             clap::error::ErrorKind::DisplayHelp => command.print_help(),
             clap::error::ErrorKind::DisplayVersion => {
-                writeln!(std::io::stdout(), "{}", command.render_version())
+                write!(std::io::stdout(), "{}", command.render_version())
             }
             _ => Ok(()),
         };

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -22,7 +22,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let error = match e.kind() {
             clap::error::ErrorKind::DisplayHelp => command.print_help(),
             clap::error::ErrorKind::DisplayVersion => {
-                writeln!(std::io::stdout(), "{}", command.render_version())
+                write!(std::io::stdout(), "{}", command.render_version())
             }
             _ => Ok(()),
         };

--- a/tests/by-util/test_false.rs
+++ b/tests/by-util/test_false.rs
@@ -2,7 +2,10 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
 use crate::common::util::TestScenario;
+use regex::Regex;
+
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
 use std::fs::OpenOptions;
 
@@ -13,10 +16,9 @@ fn test_no_args() {
 
 #[test]
 fn test_version() {
-    new_ucmd!()
-        .args(&["--version"])
-        .fails()
-        .stdout_contains("false");
+    let re = Regex::new(r"^false .*\d+\.\d+\.\d+\n$").unwrap();
+
+    new_ucmd!().args(&["--version"]).fails().stdout_matches(&re);
 }
 
 #[test]

--- a/tests/by-util/test_false.rs
+++ b/tests/by-util/test_false.rs
@@ -7,7 +7,7 @@ use crate::common::util::TestScenario;
 use std::fs::OpenOptions;
 
 #[test]
-fn test_exit_code() {
+fn test_no_args() {
     new_ucmd!().fails().no_output();
 }
 

--- a/tests/by-util/test_false.rs
+++ b/tests/by-util/test_false.rs
@@ -8,7 +8,7 @@ use std::fs::OpenOptions;
 
 #[test]
 fn test_exit_code() {
-    new_ucmd!().fails();
+    new_ucmd!().fails().no_output();
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn test_help() {
 #[test]
 fn test_short_options() {
     for option in ["-h", "-V"] {
-        new_ucmd!().arg(option).fails().stdout_is("");
+        new_ucmd!().arg(option).fails().no_output();
     }
 }
 
@@ -39,7 +39,7 @@ fn test_conflict() {
     new_ucmd!()
         .args(&["--help", "--version"])
         .fails()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]

--- a/tests/by-util/test_true.rs
+++ b/tests/by-util/test_true.rs
@@ -7,7 +7,7 @@ use crate::common::util::TestScenario;
 use std::fs::OpenOptions;
 
 #[test]
-fn test_exit_code() {
+fn test_no_args() {
     new_ucmd!().succeeds().no_output();
 }
 

--- a/tests/by-util/test_true.rs
+++ b/tests/by-util/test_true.rs
@@ -2,7 +2,10 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
 use crate::common::util::TestScenario;
+use regex::Regex;
+
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
 use std::fs::OpenOptions;
 
@@ -13,10 +16,12 @@ fn test_no_args() {
 
 #[test]
 fn test_version() {
+    let re = Regex::new(r"^true .*\d+\.\d+\.\d+\n$").unwrap();
+
     new_ucmd!()
         .args(&["--version"])
         .succeeds()
-        .stdout_contains("true");
+        .stdout_matches(&re);
 }
 
 #[test]

--- a/tests/by-util/test_true.rs
+++ b/tests/by-util/test_true.rs
@@ -8,7 +8,7 @@ use std::fs::OpenOptions;
 
 #[test]
 fn test_exit_code() {
-    new_ucmd!().succeeds();
+    new_ucmd!().succeeds().no_output();
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn test_help() {
 #[test]
 fn test_short_options() {
     for option in ["-h", "-V"] {
-        new_ucmd!().arg(option).succeeds().stdout_is("");
+        new_ucmd!().arg(option).succeeds().no_output();
     }
 }
 
@@ -39,7 +39,7 @@ fn test_conflict() {
     new_ucmd!()
         .args(&["--help", "--version"])
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]


### PR DESCRIPTION
This PR removes an unnecessary newline from the version strings of `true` and `false`.

Before change:
```bash
$ cargo run -q false --version
false 0.0.30

$
```
After change:
```bash
$ cargo run -q false --version
false 0.0.30
$
```
The PR also makes some minor improvements to the tests of `true` and `false`.