### PR TITLE
fix: df: filter filesystem types after mount point resolution

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -12,8 +12,8 @@ use blocks::HumanReadable;
 use clap::builder::ValueParser;
 use table::HeaderMode;
 use uucore::display::Quotable;
-use uucore::error::{get_exit_code, UError, UResult, USimpleError};
-use uucore::fsext::{read_fs_list, MountInfo};
+use uucore::error::{UError, UResult, USimpleError, get_exit_code};
+use uucore::fsext::{MountInfo, read_fs_list};
 use uucore::parse_size::ParseSizeError;
 use uucore::{format_usage, help_about, help_section, help_usage, show};
 

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -299,6 +299,12 @@ fn test_type_option_with_file() {
         .fails()
         .stderr_contains("no file systems processed");
 
+    // Assume the mount point at /dev has a different filesystem type to the mount point at /
+    new_ucmd!()
+        .args(&["-t", fs_type, "/dev"])
+        .fails()
+        .stderr_contains("no file systems processed");
+
     let fs_types = new_ucmd!()
         .arg("--output=fstype")
         .succeeds()


### PR DESCRIPTION
This PR fixes #6194 .

When `df` receives both a `-t` type filter and file paths, the mount point for each path must be determined before the filesystem type filter is applied.

The cause of this bug was that the filtering was applied at https://github.com/uutils/coreutils/blob/e147063e26c42647f9b3b6cf018ac5dfe11183da/src/uu/df/src/df.rs#L387 before the mount point was determined at https://github.com/uutils/coreutils/blob/e147063e26c42647f9b3b6cf018ac5dfe11183da/src/uu/df/src/df.rs#L403 

This led to mount points being incorrectly determined for paths in some cases. For instance, on MacOS `cargo run df -a -t apfs /dev` would print the mount point at `/`. More examples are given in #6194 

The fix was to re-order filtering and mount point resolution.