### PR TITLE
chmod: -R with dangling symlink does not error

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -259,7 +259,7 @@ impl Chmoder {
                         // Don't try to change the mode of the symlink itself
                         continue;
                     }
-                    if !self.quiet {
+                    if !self.recursive && !self.quiet {
                         show!(USimpleError::new(
                             1,
                             format!("cannot operate on dangling symlink {}", filename.quote()),

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -890,7 +890,7 @@ fn test_chmod_symlink_to_dangling_recursive() {
         .arg("-R")
         .arg(symlink)
         .fails()
-        .stderr_is("chmod: cannot operate on dangling symlink 'symlink'\n");
+        .stdout_is("");
     assert_eq!(
         at.symlink_metadata(symlink).permissions().mode(),
         get_expected_symlink_permissions(),


### PR DESCRIPTION
Does not show error when running `chmod -R` with an empty symlink.

Fixes #7214