### PR TITLE
utmpx.rs: use correct constant names for musl libc

### DIFF
--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -70,9 +70,21 @@ macro_rules! chars2string {
 mod ut {
     pub static DEFAULT_FILE: &str = "/var/run/utmp";
 
+    #[cfg(not(target_env = "musl"))]
     pub use libc::__UT_HOSTSIZE as UT_HOSTSIZE;
+    #[cfg(target_env = "musl")]
+    pub use libc::UT_HOSTSIZE;
+
+    #[cfg(not(target_env = "musl"))]
     pub use libc::__UT_LINESIZE as UT_LINESIZE;
+    #[cfg(target_env = "musl")]
+    pub use libc::UT_LINESIZE;
+
+    #[cfg(not(target_env = "musl"))]
     pub use libc::__UT_NAMESIZE as UT_NAMESIZE;
+    #[cfg(target_env = "musl")]
+    pub use libc::UT_NAMESIZE;
+
     pub const UT_IDSIZE: usize = 4;
 
     pub use libc::ACCOUNTING;

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -70,20 +70,20 @@ macro_rules! chars2string {
 mod ut {
     pub static DEFAULT_FILE: &str = "/var/run/utmp";
 
-    #[cfg(not(target_env = "musl"))]
-    pub use libc::__UT_HOSTSIZE as UT_HOSTSIZE;
     #[cfg(target_env = "musl")]
     pub use libc::UT_HOSTSIZE;
-
     #[cfg(not(target_env = "musl"))]
-    pub use libc::__UT_LINESIZE as UT_LINESIZE;
+    pub use libc::__UT_HOSTSIZE as UT_HOSTSIZE;
+
     #[cfg(target_env = "musl")]
     pub use libc::UT_LINESIZE;
-
     #[cfg(not(target_env = "musl"))]
-    pub use libc::__UT_NAMESIZE as UT_NAMESIZE;
+    pub use libc::__UT_LINESIZE as UT_LINESIZE;
+
     #[cfg(target_env = "musl")]
     pub use libc::UT_NAMESIZE;
+    #[cfg(not(target_env = "musl"))]
+    pub use libc::__UT_NAMESIZE as UT_NAMESIZE;
 
     pub const UT_IDSIZE: usize = 4;
 


### PR DESCRIPTION
Unfortunately, the names of those constants are not standardized:
- glibc uses __UT_HOSTSIZE, __UT_LINESIZE, __UT_NAMESIZE
- musl uses UT_HOSTSIZE, UT_LINESIZE, UT_NAMESIZE

See:
1. https://git.musl-libc.org/cgit/musl/tree/include/utmpx.h
2. https://github.com/bminor/glibc/blob/master/sysdeps/gnu/bits/utmpx.h#L35

This is a partial fix for https://github.com/uutils/coreutils/issues/1361