### PR TITLE
Make `shuf` OsStr-compliant and bring newline handling in line with GNU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,7 +3184,6 @@ name = "uu_shuf"
 version = "0.0.30"
 dependencies = [
  "clap",
- "memchr",
  "rand 0.9.0",
  "rand_core 0.9.3",
  "uucore",

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/shuf.rs"
 
 [dependencies]
 clap = { workspace = true }
-memchr = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
 uucore = { workspace = true }

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -892,7 +892,8 @@ impl AtPath {
             .unwrap_or_else(|e| panic!("Couldn't write {name}: {e}"));
     }
 
-    pub fn append(&self, name: &str, contents: &str) {
+    pub fn append(&self, name: impl AsRef<Path>, contents: &str) {
+        let name = name.as_ref();
         log_info("write(append)", self.plus_as_string(name));
         let mut f = OpenOptions::new()
             .append(true)
@@ -900,7 +901,7 @@ impl AtPath {
             .open(self.plus(name))
             .unwrap();
         f.write_all(contents.as_bytes())
-            .unwrap_or_else(|e| panic!("Couldn't write(append) {name}: {e}"));
+            .unwrap_or_else(|e| panic!("Couldn't write(append) {}: {e}", name.display()));
     }
 
     pub fn append_bytes(&self, name: &str, contents: &[u8]) {


### PR DESCRIPTION
- shuf now uses OS strings, so it can read from filenames that are invalid Unicode and it can shuffle arguments that are invalid Unicode. `uucore` now has an `OsWrite` trait to support this without platform-specific boilerplate.

- shuf no longer tries to split individual command line arguments, only bulk input from a file/stdin. (This matches GNU and busybox.)

- More values are parsed inside clap instead of manually, leading to better error messages and less code.

- Some code has been simplified or made more idiomatic.

I plan to follow up with a PR to optimize shuf with vectored writes and mmap. (Last time I tried this I got sidetracked by a stdlib bug: https://github.com/rust-lang/rust/pull/121938)