### PR TITLE
Fix for #7455

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -101,14 +101,29 @@ struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    fn new(root: &'a Path, target: &'a Path) -> std::io::Result<Self> {
+    /// Creates a new `Context` for copying a directory.
+    ///
+    /// # Parameters
+    ///
+    /// - `root`: The source path from which the directory will be copied.
+    /// - `target`: The target path to which the directory will be copied.
+    /// - `no_target_dir`: A boolean indicating whether the root parent
+    ///    should consider wether or not the target directory exists.
+    ///
+    /// `$ cp -r source target/` Typically behave differently wether `target`
+    /// exists or not, end in `/` or `.`. the `--no-target-dir` flag can be
+    /// used to force the behavior of the command in case where `target` exists,
+    /// and is reflected in the `no_target_dir` parameter.
+    ///
+    fn new(root: &'a Path, target: &'a Path, no_target_dir: bool) -> std::io::Result<Self> {
         let current_dir = env::current_dir()?;
         let root_path = current_dir.join(root);
-        let root_parent = if target.exists() && !root.to_str().unwrap().ends_with("/.") {
-            root_path.parent().map(|p| p.to_path_buf())
-        } else {
-            Some(root_path)
-        };
+        let root_parent =
+            if (target.exists() || no_target_dir) && !root.to_str().unwrap().ends_with("/.") {
+                root_path.parent().map(|p| p.to_path_buf())
+            } else {
+                Some(root_path)
+            };
         Ok(Self {
             current_dir,
             root_parent,
@@ -184,9 +199,8 @@ impl Entry {
                 if let Err(e) = std::fs::create_dir_all(context.target) {
                     eprintln!("Failed to create directory: {e}");
                 }
-            } else {
-                descendant = descendant.strip_prefix(context.root)?.to_path_buf();
             }
+            descendant = descendant.strip_prefix(context.root)?.to_path_buf();
         }
 
         let local_to_target = context.target.join(descendant);
@@ -406,7 +420,7 @@ pub(crate) fn copy_directory(
     // Collect some paths here that are invariant during the traversal
     // of the given directory, like the current working directory and
     // the target directory.
-    let context = match Context::new(root, target) {
+    let context = match Context::new(root, target, options.no_target_dir) {
         Ok(c) => c,
         Err(e) => return Err(format!("failed to get current directory {e}").into()),
     };

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -361,7 +361,6 @@ fn test_cp_arg_no_target_directory_with_recursive() {
 }
 
 #[test]
-#[ignore = "disabled until https://github.com/uutils/coreutils/issues/7455 is fixed"]
 fn test_cp_arg_no_target_directory_with_recursive_target_does_not_exists() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -375,6 +374,28 @@ fn test_cp_arg_no_target_directory_with_recursive_target_does_not_exists() {
     ucmd.arg("-rT")
         .arg("dir")
         .arg(target)
+        .succeeds()
+        .no_output();
+
+    assert!(at.plus(target).join("a").exists());
+    assert!(at.plus(target).join("b").exists());
+    assert!(!at.plus(target).join("dir").exists());
+}
+
+#[test]
+fn test_cp_arg_no_target_directory_with_recursive_target_does_not_exists_but_trailing_slash() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("dir");
+    at.touch("dir/a");
+    at.touch("dir/b");
+
+    let target = "create_me";
+    assert!(!at.plus(target).exists());
+
+    ucmd.arg("-rT")
+        .arg("dir")
+        .arg(format!("{}{}", target, "/"))
         .succeeds()
         .no_output();
 


### PR DESCRIPTION
This fixes the usage of the `--no-target-dir` then the target dir does not exists.

This also adds a test when the target dir ends with a trailing slash, which is for me the expected behavior fo gnu cp, but i'd like someone else to confirm this.

```
$ mkdir temp
$ touch temp/x
```

```
$ rm -rf new_temp; ...gnubin/cp -r temp -T new_temp; tree new_temp;
rm -rf new_temp; ...gnubin/cp -r temp -T new_temp/; tree new_temp;
rm -rf new_temp; mkdir new_temp; ...gnubin/cp -r temp -T new_temp; tree new_temp;
rm -rf new_temp; mkdir new_temp; ...gnubin/cp -r temp -T new_temp/; tree new_temp;

new_temp
└── x

1 directory, 1 file
new_temp
└── x

1 directory, 1 file
new_temp
└── x

1 directory, 1 file
new_temp
└── x

```

```
$ rm -rf new_temp; target/debug/coreutils cp -r temp -T new_temp; tree new_temp;
rm -rf new_temp; target/debug/coreutils cp -r temp -T new_temp/; tree new_temp;
rm -rf new_temp; mkdir new_temp; target/debug/coreutils cp -r temp -T new_temp; tree new_temp;
rm -rf new_temp; mkdir new_temp; target/debug/coreutils cp -r temp -T new_temp/; tree new_temp;

$ rm -rf new_temp; target/debug/coreutils cp -r temp -T new_temp; tree new_temp;
rm -rf new_temp; target/debug/coreutils cp -r temp -T new_temp/; tree new_temp;
rm -rf new_temp; mkdir new_temp; target/debug/coreutils cp -r temp -T new_temp; tree new_temp;
rm -rf new_temp; mkdir new_temp; target/debug/coreutils cp -r temp -T new_temp/; tree new_temp;
new_temp
└── x

1 directory, 1 file
new_temp
└── x

1 directory, 1 file
new_temp
└── x

1 directory, 1 file
```