### PR TITLE
fsext.rs: use correct type for fsid_t

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -813,7 +813,7 @@ impl FsMeta for StatFs {
     ))]
     fn fsid(&self) -> u64 {
         let f_fsid: &[u32; 2] =
-            unsafe { &*(&self.f_fsid as *const nix::sys::statfs::fsid_t as *const [u32; 2]) };
+            unsafe { &*(&self.f_fsid as *const libc::fsid_t as *const [u32; 2]) };
         ((u64::from(f_fsid[0])) << 32) | u64::from(f_fsid[1])
     }
     #[cfg(not(any(


### PR DESCRIPTION
Commit https://github.com/uutils/coreutils/pull/3396/commits/2a0d58d060eb51ee482e7e8a764f36bda21105e5 changed this line from libc::fsid_t to nix::sys::statfs::fsid_t. The pull-request description at https://github.com/uutils/coreutils/pull/3396 indicates that this was done in order to fix the android build, however I think it should compile for android without this change.

Inside the nix crate, fsid_t is defined as:
```
pub type fsid_t = libc::fsid_t;
```

This all works as long as the libc version used by nix is the same than the libc version used by coreutils.

This breaks when using a local libc version (for local debugging, I was modifying libc and testing changes), because self.f_fsid which is of type libc::fsid_t (local version of libc) is then incompatible with nix::sys::statfs::fsid_t (upstream version of libc).

I was getting this error:

```
coreutils$ cargo build
   Compiling libc v0.2.171 (/home/ecordonnier/dev/libc)
   Compiling uucore v0.0.30 (/home/ecordonnier/dev/coreutils/src/uucore)
error[E0606]: casting `&libc::fsid_t` as `*const nix::libc::fsid_t` is invalid
   --> src/uucore/src/lib/features/fsext.rs:816:25
    |
816 |             unsafe { &*(&self.f_fsid as *const nix::sys::statfs::fsid_t as *const [u32; 2]) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0606`.
error: could not compile `uucore` (lib) due to 1 previous error
```