### PR TITLE
fsext.rs: use type inference fsid_t / __fsid_t

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -812,8 +812,9 @@ impl FsMeta for StatFs {
         target_os = "openbsd"
     ))]
     fn fsid(&self) -> u64 {
-        let f_fsid: &[u32; 2] =
-            unsafe { &*(&self.f_fsid as *const nix::sys::statfs::fsid_t as *const [u32; 2]) };
+        // Use type inference to determine the type of f_fsid
+        // (libc::__fsid_t on Android, libc::fsid_t on other platforms)
+        let f_fsid: &[u32; 2] = unsafe { &*(&self.f_fsid as *const _ as *const [u32; 2]) };
         ((u64::from(f_fsid[0])) << 32) | u64::from(f_fsid[1])
     }
     #[cfg(not(any(


### PR DESCRIPTION
Commit https://github.com/uutils/coreutils/pull/3396/commits/2a0d58d060eb51ee482e7e8a764f36bda21105e5 (part of https://github.com/uutils/coreutils/pull/3396 which contains a description of the changes) changed this line from libc::fsid_t to nix::sys::statfs::fsid_t. The pull-request description at https://github.com/uutils/coreutils/pull/3396 indicates that this was done in order to fix the android build, and indeed using a cast to nix::sys::statfs::fsid_t takes advantage of the definition of nix::sys::statfs::fsid_t which abstracts away the different name on Android:

```
/// Identifies a mounted file system
#[cfg(target_os = "android")]
pub type fsid_t = libc::__fsid_t;
/// Identifies a mounted file system
#[cfg(not(target_os = "android"))]
pub type fsid_t = libc::fsid_t;
```

This cast works as long as the libc version used by nix is the same than the libc version used by coreutils.

This cast becomes invalid when using a local libc version for local debugging, and changing Cargo.toml to point to it:
```
-libc = "0.2.153"
+libc = { path = "../path/to/libc" }
```

The cast becomes invalid because self.f_fsid is of type libc::fsid_t (local version of libc), whereas nix::sys::statfs::fsid_t still uses the libc version downloaded by cargo from crates.io in this case.

I was getting this error:

```
coreutils$ cargo build
   Compiling libc v0.2.171 (/home/ecordonnier/dev/libc)
   Compiling uucore v0.0.30 (/home/ecordonnier/dev/coreutils/src/uucore)
error[E0606]: casting `&libc::fsid_t` as `*const nix::libc::fsid_t` is invalid
   --> src/uucore/src/lib/features/fsext.rs:816:25
    |
816 |             unsafe { &*(&self.f_fsid as *const nix::sys::statfs::fsid_t as *const [u32; 2]) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0606`.
error: could not compile `uucore` (lib) due to 1 previous error
```

Let's rather use type inference to deal with libc::fsid_t vs libc::__fsid_t.