### PR TITLE
base32/base64/basenc: add -D flag

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -96,4 +96,4 @@ Similar to the proc-ps implementation and unlike GNU/Coreutils, `uptime` provide
 
 ## `base32/base64/basenc`
 
-`base32/base64/basenc` provides `-D` to decode data.
+Just like on macOS, `base32/base64/basenc` provides `-D` to decode data.

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -94,14 +94,6 @@ also provides a `-v`/`--verbose` flag.
 
 Similar to the proc-ps implementation and unlike GNU/Coreutils, `uptime` provides `-s`/`--since` to show since when the system is up.
 
-## `base32`
+## `base32/base64/basenc`
 
-`base32` provides `-D` to decode data.
-
-## `base64`
-
-`base64` provides `-D` to decode data.
-
-## `basenc`
-
-`basenc` provides `-D` to decode data.
+`base32/base64/basenc` provides `-D` to decode data.

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -93,3 +93,15 @@ also provides a `-v`/`--verbose` flag.
 ## `uptime`
 
 Similar to the proc-ps implementation and unlike GNU/Coreutils, `uptime` provides `-s`/`--since` to show since when the system is up.
+
+## `base32`
+
+`base32` provides `-D` to decode data.
+
+## `base64`
+
+`base64` provides `-D` to decode data.
+
+## `basenc`
+
+`basenc` provides `-D` to decode data.

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -112,6 +112,7 @@ pub fn base_app(about: &'static str, usage: &str) -> Command {
         .arg(
             Arg::new(options::DECODE)
                 .short('d')
+                .visible_short_alias('D')
                 .long(options::DECODE)
                 .help("decode data")
                 .action(ArgAction::SetTrue)

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -52,7 +52,7 @@ fn test_base32_encode_file() {
 
 #[test]
 fn test_decode() {
-    for decode_param in ["-d", "--decode", "--dec"] {
+    for decode_param in ["-d", "--decode", "--dec", "-D"] {
         let input = "JBSWY3DPFQQFO33SNRSCC===\n"; // spell-checker:disable-line
         new_ucmd!()
             .arg(decode_param)

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -72,7 +72,7 @@ fn test_base64_encode_file() {
 
 #[test]
 fn test_decode() {
-    for decode_param in ["-d", "--decode", "--dec"] {
+    for decode_param in ["-d", "--decode", "--dec", "-D"] {
         let input = "aGVsbG8sIHdvcmxkIQ=="; // spell-checker:disable-line
         new_ucmd!()
             .arg(decode_param)

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -52,7 +52,7 @@ fn test_base64() {
 #[test]
 fn test_base64_decode() {
     new_ucmd!()
-        .args(&["--base64", "-d"])
+        .args(&["--base64", "-d", "-D"])
         .pipe_in("dG8+YmU/")
         .succeeds()
         .stdout_only("to>be?");

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -52,7 +52,7 @@ fn test_base64() {
 #[test]
 fn test_base64_decode() {
     new_ucmd!()
-        .args(&["--base64", "-d", "-D"])
+        .args(&["--base64", "-d"])
         .pipe_in("dG8+YmU/")
         .succeeds()
         .stdout_only("to>be?");


### PR DESCRIPTION
I noticed that the base64 that comes with macOS includes a `-D` flag.
> Usage:	base64 [-Ddh] [-b num] [-i in_file] [-o out_file]
>   -b, --break       break encoded output up into lines of length num
>   -D, -d, --decode  decode input
>   -h, --help        display this message
>   -i, --input       input file (default: "-" for stdin)
>   -o, --output      output file (default: "-" for stdout)

Implementing this flag makes it easy to replace the system default implementation with coreutils on macOS, as there are programs that rely on this flag (e.g. imgcat).