### PR TITLE
seq: Buffer writes to stdout

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (ToDO) bigdecimal extendedbigdecimal numberparse hexadecimalfloat
 use std::ffi::OsString;
-use std::io::{stdout, ErrorKind, Write};
+use std::io::{stdout, BufWriter, ErrorKind, Write};
 
 use clap::{Arg, ArgAction, Command};
 use num_traits::{ToPrimitive, Zero};
@@ -262,8 +262,8 @@ fn print_seq(
     padding: usize,
     format: Option<&Format<num_format::Float>>,
 ) -> std::io::Result<()> {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
+    let stdout = stdout().lock();
+    let mut stdout = BufWriter::new(stdout);
     let (first, increment, last) = range;
     let mut value = first;
     let padding = if pad {


### PR DESCRIPTION
Use a BufWriter to wrap stdout: reduces the numbers of system calls, improves performance drastically (2x in some cases).

Fixes _part_ of #7482, see this comment: https://github.com/uutils/coreutils/issues/7482#issuecomment-2734399193

Thanks @mjguzik!

For floating point prints, we are now faster than GNU:
```
taskset -c 0 hyperfine -L seq seq,./seq-main,target/release/seq "{seq} 0 0.1 100000"
Benchmark 1: seq 0 0.1 100000
  Time (mean ± σ):     161.6 ms ±   0.3 ms    [User: 160.8 ms, System: 0.6 ms]
  Range (min … max):   161.2 ms … 162.4 ms    18 runs
 
Benchmark 2: ./seq-main 0 0.1 100000
  Time (mean ± σ):     282.7 ms ±   5.0 ms    [User: 221.0 ms, System: 60.0 ms]
  Range (min … max):   279.7 ms … 296.2 ms    10 runs

Benchmark 3: target/release/seq 0 0.1 100000
  Time (mean ± σ):     143.8 ms ±   0.3 ms    [User: 143.0 ms, System: 0.6 ms]
  Range (min … max):   143.2 ms … 144.4 ms    20 runs
 
Summary
  target/release/seq 0 0.1 100000 ran
    1.12 ± 0.00 times faster than seq 0 0.1 100000
    1.97 ± 0.03 times faster than ./seq-main 0 0.1 100000
```