### PR TITLE
Implement `Default` for `Options` of `mv` and `cp`

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -131,7 +131,7 @@ pub enum OverwriteMode {
 
 impl Default for OverwriteMode {
     fn default() -> Self {
-        Self::Clobber(Default::default())
+        Self::Clobber(ClobberMode::default())
     }
 }
 
@@ -144,6 +144,7 @@ pub enum ReflinkMode {
 }
 
 impl Default for ReflinkMode {
+    #[allow(clippy::derivable_impls)]
     fn default() -> Self {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
         {
@@ -320,23 +321,23 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             attributes_only: false,
-            backup: Default::default(),
+            backup: BackupMode::default(),
             copy_contents: false,
             cli_dereference: false,
-            copy_mode: Default::default(),
+            copy_mode: CopyMode::default(),
             dereference: false,
             no_target_dir: false,
             one_file_system: false,
-            overwrite: Default::default(),
+            overwrite: OverwriteMode::default(),
             parents: false,
-            sparse_mode: Default::default(),
+            sparse_mode: SparseMode::default(),
             strip_trailing_slashes: false,
-            reflink_mode: Default::default(),
-            attributes: Default::default(),
+            reflink_mode: ReflinkMode::default(),
+            attributes: Attributes::default(),
             recursive: false,
             backup_suffix: backup_control::DEFAULT_BACKUP_SUFFIX.to_owned(),
             target_dir: None,
-            update: Default::default(),
+            update: UpdateMode::default(),
             debug: false,
             verbose: false,
             progress_bar: false,
@@ -1148,7 +1149,7 @@ impl Options {
                         }
                     }
                 } else {
-                    Default::default()
+                    ReflinkMode::default()
                 }
             },
             sparse_mode: {

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -110,15 +110,16 @@ impl UError for Error {
 pub type CopyResult<T> = Result<T, Error>;
 
 /// Specifies how to overwrite files.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum ClobberMode {
     Force,
     RemoveDestination,
+    #[default]
     Standard,
 }
 
 /// Specifies whether files should be overwritten.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum OverwriteMode {
     /// [Default] Always overwrite existing files
     Clobber(ClobberMode),
@@ -128,18 +129,38 @@ pub enum OverwriteMode {
     NoClobber,
 }
 
+impl Default for OverwriteMode {
+    fn default() -> Self {
+        Self::Clobber(Default::default())
+    }
+}
+
 /// Possible arguments for `--reflink`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ReflinkMode {
     Always,
     Auto,
     Never,
 }
 
+impl Default for ReflinkMode {
+    fn default() -> Self {
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+        {
+            ReflinkMode::Auto
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+        {
+            ReflinkMode::Never
+        }
+    }
+}
+
 /// Possible arguments for `--sparse`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum SparseMode {
     Always,
+    #[default]
     Auto,
     Never,
 }
@@ -152,10 +173,11 @@ pub enum TargetType {
 }
 
 /// Copy action to perform
-#[derive(PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub enum CopyMode {
     Link,
     SymLink,
+    #[default]
     Copy,
     Update,
     AttrOnly,
@@ -174,7 +196,7 @@ pub enum CopyMode {
 /// For full compatibility with GNU, these options should also combine. We
 /// currently only do a best effort imitation of that behavior, because it is
 /// difficult to achieve in clap, especially with `--no-preserve`.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Attributes {
     #[cfg(unix)]
     pub ownership: Preserve,
@@ -183,6 +205,12 @@ pub struct Attributes {
     pub context: Preserve,
     pub links: Preserve,
     pub xattr: Preserve,
+}
+
+impl Default for Attributes {
+    fn default() -> Self {
+        Self::NONE
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -224,6 +252,7 @@ impl Ord for Preserve {
 ///
 /// The fields are documented with the arguments that determine their value.
 #[allow(dead_code)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Options {
     /// `--attributes-only`
     pub attributes_only: bool,
@@ -285,6 +314,34 @@ pub struct Options {
     pub verbose: bool,
     /// `-g`, `--progress`
     pub progress_bar: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            attributes_only: false,
+            backup: Default::default(),
+            copy_contents: false,
+            cli_dereference: false,
+            copy_mode: Default::default(),
+            dereference: false,
+            no_target_dir: false,
+            one_file_system: false,
+            overwrite: Default::default(),
+            parents: false,
+            sparse_mode: Default::default(),
+            strip_trailing_slashes: false,
+            reflink_mode: Default::default(),
+            attributes: Default::default(),
+            recursive: false,
+            backup_suffix: backup_control::DEFAULT_BACKUP_SUFFIX.to_owned(),
+            target_dir: None,
+            update: Default::default(),
+            debug: false,
+            verbose: false,
+            progress_bar: false,
+        }
+    }
 }
 
 /// Enum representing if a file has been skipped.
@@ -1091,18 +1148,7 @@ impl Options {
                         }
                     }
                 } else {
-                    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
-                    {
-                        ReflinkMode::Auto
-                    }
-                    #[cfg(not(any(
-                        target_os = "linux",
-                        target_os = "android",
-                        target_os = "macos"
-                    )))]
-                    {
-                        ReflinkMode::Never
-                    }
+                    Default::default()
                 }
             },
             sparse_mode: {

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -88,14 +88,32 @@ pub struct Options {
     pub debug: bool,
 }
 
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            overwrite: Default::default(),
+            backup: Default::default(),
+            suffix: backup_control::DEFAULT_BACKUP_SUFFIX.to_owned(),
+            update: Default::default(),
+            target_dir: None,
+            no_target_dir: false,
+            verbose: false,
+            strip_slashes: false,
+            progress_bar: false,
+            debug: false,
+        }
+    }
+}
+
 /// specifies behavior of the overwrite flag
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub enum OverwriteMode {
     /// '-n' '--no-clobber'   do not overwrite
     NoClobber,
     /// '-i' '--interactive'  prompt before overwrite
     Interactive,
     ///'-f' '--force'         overwrite without prompt
+    #[default]
     Force,
 }
 

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -91,10 +91,10 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            overwrite: Default::default(),
-            backup: Default::default(),
+            overwrite: OverwriteMode::default(),
+            backup: BackupMode::default(),
             suffix: backup_control::DEFAULT_BACKUP_SUFFIX.to_owned(),
-            update: Default::default(),
+            update: UpdateMode::default(),
             target_dir: None,
             no_target_dir: false,
             verbose: false,

--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -114,13 +114,16 @@ static VALID_ARGS_HELP: &str = "Valid arguments are:
   - 'existing', 'nil'
   - 'numbered', 't'";
 
+pub const DEFAULT_BACKUP_SUFFIX: &str = "~";
+
 /// Available backup modes.
 ///
 /// The mapping of the backup modes to the CLI arguments is annotated on the
 /// enum variants.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum BackupMode {
     /// Argument 'none', 'off'
+    #[default]
     NoBackup,
     /// Argument 'simple', 'never'
     SimpleBackup,
@@ -254,7 +257,7 @@ pub fn determine_backup_suffix(matches: &ArgMatches) -> String {
     if let Some(suffix) = supplied_suffix {
         String::from(suffix)
     } else {
-        env::var("SIMPLE_BACKUP_SUFFIX").unwrap_or_else(|_| "~".to_owned())
+        env::var("SIMPLE_BACKUP_SUFFIX").unwrap_or_else(|_| DEFAULT_BACKUP_SUFFIX.to_owned())
     }
 }
 

--- a/src/uucore/src/lib/features/update_control.rs
+++ b/src/uucore/src/lib/features/update_control.rs
@@ -49,9 +49,10 @@
 use clap::ArgMatches;
 
 /// Available update mode
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub enum UpdateMode {
     /// --update=`all`, ``
+    #[default]
     ReplaceAll,
     /// --update=`none`
     ReplaceNone,


### PR DESCRIPTION
Resolve https://github.com/uutils/coreutils/discussions/7502

This pull request includes several changes to the `cp`, `mv`, and `uucore` utilities, focusing on adding `Default` implementations to various enums and structs.

The selection of default values is based on the values that would be set when no flag are passed in the command line.

Key changes include:

### Enhancements to `cp` utility:

* Added `Default` implementations for enums `ClobberMode`, `OverwriteMode`, `ReflinkMode`, `SparseMode`, `CopyMode`, and struct `Attributes`. This simplifies the initialization of these types. [[1]](diffhunk://#diff-fed63f74214c092a801901cdce011f1941f6378a84d9c7947b5bd02adce2de43L113-R122) [[2]](diffhunk://#diff-fed63f74214c092a801901cdce011f1941f6378a84d9c7947b5bd02adce2de43R132-R163) [[3]](diffhunk://#diff-fed63f74214c092a801901cdce011f1941f6378a84d9c7947b5bd02adce2de43L155-R180) [[4]](diffhunk://#diff-fed63f74214c092a801901cdce011f1941f6378a84d9c7947b5bd02adce2de43L177-R199) [[5]](diffhunk://#diff-fed63f74214c092a801901cdce011f1941f6378a84d9c7947b5bd02adce2de43R210-R215)
* Added a `Default` implementation for the `Options` struct, setting default values for all fields.
* Replaced custom initialization logic with the `Default` trait for `ReflinkMode` in the `Options` struct.

### Enhancements to `mv` utility:

* Added a `Default` implementation for the `Options` struct, setting default values for all fields.
* Added a `Default` implementation for the `OverwriteMode` enum.

### Enhancements to `uucore` library:

* Added a `Default` implementation for the `BackupMode` enum and replaced the hardcoded backup suffix with a constant `DEFAULT_BACKUP_SUFFIX`. [[1]](diffhunk://#diff-d1cf21943054cc87abbecfa41b22f0ebc1291a180906161ba10208fae4cc6a75R117-R126) [[2]](diffhunk://#diff-d1cf21943054cc87abbecfa41b22f0ebc1291a180906161ba10208fae4cc6a75L257-R260)
* Added a `Default` implementation for the `UpdateMode` enum.