### PR TITLE
tail: Performance improvements

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -3,7 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) seekable seek'd tail'ing ringbuffer ringbuf unwatch Uncategorized filehandle Signum
+// spell-checker:ignore (ToDO) seekable seek'd tail'ing ringbuffer ringbuf unwatch
+// spell-checker:ignore (ToDO) Uncategorized filehandle Signum memrchr
 // spell-checker:ignore (libs) kqueue
 // spell-checker:ignore (acronyms)
 // spell-checker:ignore (env/flags)
@@ -24,11 +25,12 @@ pub use args::uu_app;
 use args::{FilterMode, Settings, Signum, parse_args};
 use chunks::ReverseChunks;
 use follow::Observer;
+use memchr::{memchr_iter, memrchr_iter};
 use paths::{FileExtTail, HeaderPrinter, Input, InputKind, MetadataExtTail};
 use same_file::Handle;
 use std::cmp::Ordering;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write, stdin, stdout};
+use std::io::{self, BufReader, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write, stdin, stdout};
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, get_exit_code, set_exit_code};
@@ -293,26 +295,29 @@ fn forwards_thru_file<R>(
 where
     R: Read,
 {
-    let mut reader = BufReader::new(reader);
-
-    let mut buf = vec![];
+    if num_delimiters == 0 {
+        return Ok(0);
+    }
+    // Use a 32K buffer.
+    let mut buf = [0; 32 * 1024];
     let mut total = 0;
-    for _ in 0..num_delimiters {
-        match reader.read_until(delimiter, &mut buf) {
-            Ok(0) => {
-                return Ok(total);
-            }
+    let mut count = 0;
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => return Ok(total),
             Ok(n) => {
+                for offset in memchr_iter(delimiter, &buf[..n]) {
+                    count += 1;
+                    if count == num_delimiters {
+                        return Ok(total + offset + 1);
+                    }
+                }
                 total += n;
-                buf.clear();
-                continue;
             }
-            Err(e) => {
-                return Err(e);
-            }
+            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
         }
     }
-    Ok(total)
 }
 
 /// Iterate over bytes in the file, in reverse, until we find the
@@ -322,35 +327,36 @@ fn backwards_thru_file(file: &mut File, num_delimiters: u64, delimiter: u8) {
     // This variable counts the number of delimiters found in the file
     // so far (reading from the end of the file toward the beginning).
     let mut counter = 0;
-
-    for (block_idx, slice) in ReverseChunks::new(file).enumerate() {
+    let mut first_slice = true;
+    for slice in ReverseChunks::new(file) {
         // Iterate over each byte in the slice in reverse order.
-        let mut iter = slice.iter().enumerate().rev();
+        let mut iter = memrchr_iter(delimiter, &slice);
 
         // Ignore a trailing newline in the last block, if there is one.
-        if block_idx == 0 {
+        if first_slice {
             if let Some(c) = slice.last() {
                 if *c == delimiter {
                     iter.next();
                 }
             }
+            first_slice = false;
         }
 
         // For each byte, increment the count of the number of
         // delimiters found. If we have found more than the specified
         // number of delimiters, terminate the search and seek to the
         // appropriate location in the file.
-        for (i, ch) in iter {
-            if *ch == delimiter {
-                counter += 1;
-                if counter >= num_delimiters {
-                    // After each iteration of the outer loop, the
-                    // cursor in the file is at the *beginning* of the
-                    // block, so seeking forward by `i + 1` bytes puts
-                    // us right after the found delimiter.
-                    file.seek(SeekFrom::Current((i + 1) as i64)).unwrap();
-                    return;
-                }
+        for i in iter {
+            counter += 1;
+            if counter >= num_delimiters {
+                // We should never over-count - assert that.
+                assert_eq!(counter, num_delimiters);
+                // After each iteration of the outer loop, the
+                // cursor in the file is at the *beginning* of the
+                // block, so seeking forward by `i + 1` bytes puts
+                // us right after the found delimiter.
+                file.seek(SeekFrom::Current((i + 1) as i64)).unwrap();
+                return;
             }
         }
     }


### PR DESCRIPTION
Not ready for review yet, I need to write some unit-tests for the `backwards_thru_file` fn (since it doesn't currently have any). Just want to see what CI thinks of it and if it blows up...

These are the performance gains I see...

```
$ hyperfine "/usr/bin/tail -n +100000 ./shakespeare.txt" "./target/release/tail.original -n +100000 ./shakespeare.txt" "./target/release/tail -n +100000 ./shakespeare.txt"
Benchmark 1: /usr/bin/tail -n +100000 ./shakespeare.txt
  Time (mean ± σ):       4.1 ms ±   0.3 ms    [User: 2.1 ms, System: 2.0 ms]
  Range (min … max):     3.8 ms …   5.6 ms    597 runs
 
Benchmark 2: ./target/release/tail.original -n +100000 ./shakespeare.txt
  Time (mean ± σ):       5.4 ms ±   0.3 ms    [User: 3.8 ms, System: 1.5 ms]
  Range (min … max):     4.9 ms …   6.3 ms    461 runs
 
Benchmark 3: ./target/release/tail -n +100000 ./shakespeare.txt
  Time (mean ± σ):       3.2 ms ±   0.3 ms    [User: 1.8 ms, System: 1.4 ms]
  Range (min … max):     2.8 ms …   4.9 ms    704 runs
 
Summary
  ./target/release/tail -n +100000 ./shakespeare.txt ran
    1.31 ± 0.13 times faster than /usr/bin/tail -n +100000 ./shakespeare.txt
    1.69 ± 0.16 times faster than ./target/release/tail.original -n +100000 ./shakespeare.txt
```
and
```
$ hyperfine "/usr/bin/tail -n 100000 ./shakespeare.txt" "./target/release/tail.original -n 100000 ./shakespeare.txt" "./target/release/tail -n 100000 ./shakespeare.txt"
Benchmark 1: /usr/bin/tail -n 100000 ./shakespeare.txt
  Time (mean ± σ):       4.6 ms ±   0.4 ms    [User: 2.4 ms, System: 2.1 ms]
  Range (min … max):     4.2 ms …   7.2 ms    430 runs
 
Benchmark 2: ./target/release/tail.original -n 100000 ./shakespeare.txt
  Time (mean ± σ):       4.4 ms ±   0.3 ms    [User: 2.9 ms, System: 1.5 ms]
  Range (min … max):     3.9 ms …   6.7 ms    595 runs
 
Benchmark 3: ./target/release/tail -n 100000 ./shakespeare.txt
  Time (mean ± σ):       3.4 ms ±   0.3 ms    [User: 2.1 ms, System: 1.3 ms]
  Range (min … max):     3.0 ms …   5.1 ms    715 runs
 
Summary
  ./target/release/tail -n 100000 ./shakespeare.txt ran
    1.28 ± 0.14 times faster than ./target/release/tail.original -n 100000 ./shakespeare.txt
    1.35 ± 0.16 times faster than /usr/bin/tail -n 100000 ./shakespeare.txt
```

So not an order-of-magnitude gain, but a nice little boost none the less.
