### PR TITLE
Add test to ensure arch output is not empty

### DIFF
--- a/tests/by-util/test_arch.rs
+++ b/tests/by-util/test_arch.rs
@@ -21,3 +21,10 @@ fn test_arch_help() {
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(1);
 }
+
+#[test]
+fn test_arch_output_is_not_empty() {
+    let result = new_ucmd!().run();
+    result.success();
+    assert!(!result.stdout_str().trim().is_empty(), "arch output was empty");
+}

--- a/tests/by-util/test_arch.rs
+++ b/tests/by-util/test_arch.rs
@@ -25,5 +25,8 @@ fn test_invalid_arg() {
 #[test]
 fn test_arch_output_is_not_empty() {
     let result = new_ucmd!().succeeds();
-    assert!(!result.stdout_str().trim().is_empty(), "arch output was empty");
+    assert!(
+        !result.stdout_str().trim().is_empty(),
+        "arch output was empty"
+    );
 }

--- a/tests/by-util/test_arch.rs
+++ b/tests/by-util/test_arch.rs
@@ -24,7 +24,6 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_arch_output_is_not_empty() {
-    let result = new_ucmd!().run();
-    result.success();
+    let result = new_ucmd!().succeeds();
     assert!(!result.stdout_str().trim().is_empty(), "arch output was empty");
 }


### PR DESCRIPTION
This test ensures that the output of the arch command is non-empty, which is a minimal expectation across all supported architectures.

This helps avoid regressions or edge cases where the command might unexpectedly return an empty string on unsupported or misconfigured platforms.