### PR TITLE
docs: fix url of file with coverage results

### DIFF
--- a/docs/src/test_coverage.js
+++ b/docs/src/test_coverage.js
@@ -19,7 +19,7 @@ function progressBar(totals) {
         var(--SKIP) ${skipPercentage}%`
 		)
         + (skipPercentage === 100 ? ")" : ", var(--FAIL) 0)");
-	
+
 	const progress = document.createElement("div");
 	progress.className = "progress"
 	progress.innerHTML = `
@@ -74,7 +74,7 @@ function parse_result(parent, obj) {
 	return totals;
 }
 
-fetch("https://raw.githubusercontent.com/uutils/coreutils-tracking/main/gnu-full-result.json")
+fetch("https://raw.githubusercontent.com/uutils/coreutils-tracking/main/aggregated-result.json")
 	.then((r) => r.json())
 	.then((obj) => {
 		let parent = document.getElementById("test-cov");


### PR DESCRIPTION
Currently, the ["Coverage per category" section](https://uutils.github.io/coreutils/docs/test_coverage.html#coverage-per-category) doesn't show any categories and there's a 404 error in the browser's console. This PR fixes the url of the file with the coverage results, as we recently changed its name in https://github.com/uutils/coreutils-tracking