### PR TITLE
doc: bump version of ubuntu badge

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -114,7 +114,7 @@ export PATH=/usr/libexec/uutils-coreutils:$PATH
 
 ### Ubuntu
 
-[![Ubuntu package](https://repology.org/badge/version-for-repo/ubuntu_23_04/uutils-coreutils.svg)](https://packages.ubuntu.com/source/lunar/rust-coreutils)
+[![Ubuntu package](https://repology.org/badge/version-for-repo/ubuntu_25_04/uutils-coreutils.svg)](https://packages.ubuntu.com/source/plucky/rust-coreutils)
 
 ```shell
 apt install rust-coreutils


### PR DESCRIPTION
Links for ubuntu on `installation.md` are broken because they are old. This PR fixes both to the latest version.