### PR TITLE
echo: fix duplication of `--` arguments

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -29,8 +29,8 @@ fn handle_double_hyphens(args: impl uucore::Args) -> impl uucore::Args {
     let mut result = Vec::new();
     let mut is_first_double_hyphen = true;
 
-    for arg in args {
-        if arg == "--" && is_first_double_hyphen {
+    for (i, arg) in args.enumerate() {
+        if i < 2 && arg == "--" && is_first_double_hyphen {
             result.push(OsString::from("--"));
             is_first_double_hyphen = false;
         }


### PR DESCRIPTION
Fixes #7558.

Previously, a workaround for handling double hyphens had the erroneous side effect of echoing `--` twice in a row if the `--` is the first double hyphen to be passed on the argument list and it is also not the first argument to `echo`. This commit fixes the aforementioned issue.