### PR TITLE
doc: escape RE with backticks (`)

### DIFF
--- a/src/uu/chmod/chmod.md
+++ b/src/uu/chmod/chmod.md
@@ -13,4 +13,4 @@ With --reference, change the mode of each FILE to that of RFILE.
 
 ## After Help
 
-Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.
+Each MODE is of the form `[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+`.

--- a/src/uu/mkdir/mkdir.md
+++ b/src/uu/mkdir/mkdir.md
@@ -10,4 +10,4 @@ Create the given DIRECTORY(ies) if they do not exist
 
 ## After Help
 
-Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'.
+Each MODE is of the form `[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+`.


### PR DESCRIPTION
On [chmod](https://uutils.github.io/coreutils/docs/utils/chmod.html) and on [mkdir](https://uutils.github.io/coreutils/docs/utils/mkdir.html) there is a RE that is valid markdown link:

This line:
Each MODE is of the form '[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+'. 
Into this:
Each MODE is of the form `[ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=]?[0-7]+`. 


I try to escape that RE using monospace/backticks.