### PR TITLE
seq: Directly write separator string, instead of using format

### DIFF
--- a/src/uu/seq/BENCHMARKING.md
+++ b/src/uu/seq/BENCHMARKING.md
@@ -63,4 +63,18 @@ of system time). Simply wrapping `stdout` in a `BufWriter` increased performance
 by about 2 times for a floating point increment test case, leading to similar
 performance compared with GNU `seq`.
 
+### Directly print strings
+
+As expected, directly printing a string:
+```rust
+stdout.write_all(separator.as_bytes())?
+```
+is quite a bit faster than using format to do the same operation:
+```rust
+write!(stdout, "{separator}")?
+```
+
+The change above resulted in a ~10% speedup.
+
+
 [0]: https://github.com/sharkdp/hyperfine

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -260,7 +260,7 @@ fn print_seq(
     let mut is_first_iteration = true;
     while !done_printing(&value, &increment, &last) {
         if !is_first_iteration {
-            write!(stdout, "{separator}")?;
+            stdout.write_all(separator.as_bytes())?;
         }
         format.fmt(&mut stdout, &value)?;
         // TODO Implement augmenting addition.
@@ -268,7 +268,7 @@ fn print_seq(
         is_first_iteration = false;
     }
     if !is_first_iteration {
-        write!(stdout, "{terminator}")?;
+        stdout.write_all(terminator.as_bytes())?;
     }
     stdout.flush()?;
     Ok(())


### PR DESCRIPTION
Doing `stdout.write_all(separator.as_bytes())?` is quite a bit faster than using format to do the same operation: `write!(stdout, "{separator}")?`.

This speeds up by about 10% on simple cases.

We do the same for the terminator even though this has no measurable performance impact.

---

Integer increments (no point comparing with coreutils on that one, it's much faster):
```
$ cargo build -r -p uu_seq && taskset -c 0 hyperfine --warmup 3 -L seq target/release/seq,./seq-main "{seq} 1 1000000"
    Finished `release` profile [optimized] target(s) in 0.12s
Benchmark 1: target/release/seq 1 1000000
  Time (mean ± σ):     162.9 ms ±   2.4 ms    [User: 161.5 ms, System: 0.9 ms]
  Range (min … max):   160.4 ms … 167.7 ms    17 runs
 
Benchmark 2: ./seq-main 1 1000000
  Time (mean ± σ):     182.2 ms ±   4.6 ms    [User: 179.9 ms, System: 0.8 ms]
  Range (min … max):   178.6 ms … 198.5 ms    16 runs
  
Summary
  target/release/seq 1 1000000 ran
    1.12 ± 0.03 times faster than ./seq-main 1 1000000
```

Float increments, we were already faster than coreutils, we gain another 10%:
```
$ cargo build -r -p uu_seq && taskset -c 0 hyperfine --warmup 3 -L seq target/release/seq,./seq-main,seq "{seq} 1 1.1 1000000"
    Finished `release` profile [optimized] target(s) in 0.12s
Benchmark 1: target/release/seq 1 1.1 1000000
  Time (mean ± σ):     222.0 ms ±   1.8 ms    [User: 220.9 ms, System: 0.6 ms]
  Range (min … max):   219.9 ms … 225.0 ms    13 runs
 
Benchmark 2: ./seq-main 1 1.1 1000000
  Time (mean ± σ):     246.4 ms ±   5.9 ms    [User: 243.5 ms, System: 0.8 ms]
  Range (min … max):   241.3 ms … 262.7 ms    11 runs
 
Benchmark 3: seq 1 1.1 1000000
  Time (mean ± σ):     274.2 ms ±   6.3 ms    [User: 271.1 ms, System: 0.9 ms]
  Range (min … max):   267.7 ms … 290.0 ms    10 runs
 
Summary
  target/release/seq 1 1.1 1000000 ran
    1.11 ± 0.03 times faster than ./seq-main 1 1.1 1000000
    1.23 ± 0.03 times faster than seq 1 1.1 1000000
```