### PR TITLE
seq: Add a print_seq fast path function for integer and positive increments

### DIFF
--- a/src/uu/seq/BENCHMARKING.md
+++ b/src/uu/seq/BENCHMARKING.md
@@ -88,7 +88,8 @@ with the default implementation, at the expense of some added code complexity.
 
 Just from performance numbers, it is clear that GNU `seq` uses similar
 tricks, but we are more liberal on when we use our fast path (e.g. large
-increments are supported). Our fast path implementation gets within ~10%
-of `seq` performance.
+increments are supported, equal width is supported). Our fast path
+implementation gets within ~10% of `seq` performance when its fast
+path is activated.
 
 [0]: https://github.com/sharkdp/hyperfine

--- a/src/uu/seq/BENCHMARKING.md
+++ b/src/uu/seq/BENCHMARKING.md
@@ -76,5 +76,19 @@ write!(stdout, "{separator}")?
 
 The change above resulted in a ~10% speedup.
 
+### Fast increment path
+
+When dealing with positive integer values (first/increment/last), and
+the default format is used, we use a custom fast path that does arithmetic
+on u8 arrays (i.e. strings), instead of repeatedly calling into
+formatting format.
+
+This provides _massive_ performance gains, in the order of 10-20x compared
+with the default implementation, at the expense of some added code complexity.
+
+Just from performance numbers, it is clear that GNU `seq` uses similar
+tricks, but we are more liberal on when we use our fast path (e.g. large
+increments are supported). Our fast path implementation gets within ~10%
+of `seq` performance.
 
 [0]: https://github.com/sharkdp/hyperfine

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -259,10 +259,16 @@ pub fn uu_app() -> Command {
         )
 }
 
-// Fast code path increment function.
-// Add inc to the string val[start..end]. This operates on ASCII digits, assuming
-// val and inc are well formed.
-// Returns the new value for start.
+/// Fast code path increment function.
+///
+/// Add inc to the string val[start..end]. This operates on ASCII digits, assuming
+/// val and inc are well formed.
+///
+/// Returns the new value for start (can be less that the original value if we
+/// have a carry or if inc > start).
+///
+/// We also assume that there is enough space in val to expand if start needs
+/// to be updated.
 fn fast_inc(val: &mut [u8], start: usize, end: usize, inc: &[u8]) -> usize {
     // To avoid a lot of casts to signed integers, we make sure to decrement pos
     // as late as possible, so that it does not ever go negative.

--- a/src/uucore/src/lib/features/extendedbigdecimal.rs
+++ b/src/uucore/src/lib/features/extendedbigdecimal.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore bigdecimal extendedbigdecimal
+// spell-checker:ignore bigdecimal extendedbigdecimal biguint
 //! An arbitrary precision float that can also represent infinity, NaN, etc.
 //!
 //! The finite values are stored as [`BigDecimal`] instances. Because
@@ -25,7 +25,9 @@ use std::ops::Add;
 use std::ops::Neg;
 
 use bigdecimal::BigDecimal;
+use bigdecimal::num_bigint::BigUint;
 use num_traits::FromPrimitive;
+use num_traits::Signed;
 use num_traits::Zero;
 
 #[derive(Debug, Clone)]
@@ -106,6 +108,20 @@ impl ExtendedBigDecimal {
 
     pub fn one() -> Self {
         Self::BigDecimal(1.into())
+    }
+
+    pub fn to_biguint(&self) -> Option<BigUint> {
+        match self {
+            ExtendedBigDecimal::BigDecimal(big_decimal) => {
+                let (bi, scale) = big_decimal.as_bigint_and_scale();
+                if bi.is_negative() || scale > 0 || scale < -(u32::MAX as i64) {
+                    return None;
+                }
+                bi.to_biguint()
+                    .map(|bi| bi * BigUint::from(10u32).pow(-scale as u32))
+            }
+            _ => None,
+        }
     }
 }
 

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -217,6 +217,10 @@ fn test_separator_and_terminator() {
         .succeeds()
         .stdout_is("2,3,4,5,6\n");
     new_ucmd!()
+        .args(&["-s", "", "2", "6"])
+        .succeeds()
+        .stdout_is("23456\n");
+    new_ucmd!()
         .args(&["-s", "\n", "2", "6"])
         .succeeds()
         .stdout_is("2\n3\n4\n5\n6\n");
@@ -286,6 +290,10 @@ fn test_separator_and_terminator_floats() {
         .args(&["-s", ",", "-t", "!", "2.0", "6"])
         .succeeds()
         .stdout_is("2.0,3.0,4.0,5.0,6.0!");
+    new_ucmd!()
+        .args(&["-s", "", "-t", "!", "2.0", "6"])
+        .succeeds()
+        .stdout_is("2.03.04.05.06.0!");
 }
 
 #[test]


### PR DESCRIPTION
A lot of custom logic, we basically do arithmetic on character arrays, but this comes at with huge performance gains.

Unlike coreutils `seq`, we do this for all positive increments (because why not), and we don't fall back to slow path if the last parameter is in scientific notation.

Fixes #7482

---

I'm not too sure what I think about this ,-) This is a lot of added code, but this comes with _huge_ performance gains, around 17x in some cases (and also, it was a fun puzzle, and I learnt quite a few new Rust things ,-P), and we are now competitive with GNU `seq`:

```
$ cargo build -r -p uu_seq && taskset -c 0 hyperfine --warmup 3 -L seq target/release/seq,./seq-main,seq "{seq} 1000000"
Benchmark 1: target/release/seq 1000000
  Time (mean ± σ):      10.6 ms ±   1.1 ms    [User: 9.9 ms, System: 0.7 ms]
  Range (min … max):    10.0 ms …  22.4 ms    249 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: ./seq-main 1000000
  Time (mean ± σ):     165.7 ms ±   5.4 ms    [User: 163.5 ms, System: 0.8 ms]
  Range (min … max):   160.8 ms … 182.3 ms    18 runs
 
Benchmark 3: seq 1000000
  Time (mean ± σ):       9.3 ms ±   0.1 ms    [User: 9.0 ms, System: 0.5 ms]
  Range (min … max):     8.8 ms …   9.5 ms    275 runs
 
Summary
  seq 1000000 ran
    1.14 ± 0.12 times faster than target/release/seq 1000000
   17.83 ± 0.60 times faster than ./seq-main 1000000
```

We're less conservative than `GNU`, so this path also activates for ranges likes `1 123 100000000` (the GNU manual says they do something special below 200 increment, but I suspect that value is lower) and `1e11`, as long as the desired precision is still zero (a.k.a. integers).

Still a draft, probably want to add something to `BENCHMARKING.md`, a few more tests, and see if I can extract a bit more performance...