### PR TITLE
uudoc: Fix for edition 2024

### DIFF
--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -114,7 +114,7 @@ fn main() -> io::Result<()> {
             "| util             | Linux | macOS | Windows | FreeBSD | Android |\n\
              | ---------------- | ----- | ----- | ------- | ------- | ------- |"
         )?;
-        for (&name, _) in &utils {
+        for &(&name, _) in &utils {
             if name == "[" {
                 continue;
             }


### PR DESCRIPTION
This change is documented here: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html

I'm... not sure to understand everything, but this change is what `cargo fix --edition --features="uudoc" --allow-dirty` suggests.

Fixes #7572.