### PR TITLE
.pre-commit-config.yaml: Also run cspell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,9 @@ repos:
         pass_filenames: false
         types: [file, rust]
         language: system
+    -   id: cspell
+        name: Code spell checker (cspell)
+        description: Run cspell to check for spelling errors.
+        entry: cspell --
+        pass_filenames: true
+        language: system


### PR DESCRIPTION
That cuaght me a few times... I think it's reasonable to ask devs to install cspell locally if they want to use the pre-commit hook.