### PR TITLE
cksum: take out regex pattern matching

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -89,7 +89,7 @@ default = []
 # * non-default features
 backup-control = []
 colors = []
-checksum = ["data-encoding", "thiserror", "regex", "sum"]
+checksum = ["data-encoding", "thiserror", "sum"]
 encoding = ["data-encoding", "data-encoding-macro", "z85"]
 entries = ["libc"]
 fs = ["dunce", "libc", "winapi-util", "windows-sys"]


### PR DESCRIPTION
After reading https://github.com/uutils/coreutils/issues/7504, i looked in https://github.com/uutils/coreutils-tracking/blob/main/individual-size-results/ and saw that `cksum` had a big jump in size as well. I identified the culprit: bringing in the regex crate. 

After looking a bit into regex for bytes, I tried removing the regex calls altogether and i came up with this branch.

The binary size is much smaller: `1.4MB` vs `3.1MB` .
The binary is much faster (?!) tested on a 162500 lines long file of b2sum 50% tagged and 50%untagged checksum :
```bash
taskset -c 0 hyperfine --warmup 10 -L cksum ../cksum.latest,../target/release/cksum "{cksum} -c checkbig.b2sum" --export-csv output.csv
Benchmark 1: ../cksum.latest -c checkbig.b2sum
  Time (mean ± σ):     914.7 ms ±   2.8 ms    [User: 451.6 ms, System: 447.8 ms]
  Range (min … max):   910.0 ms … 920.1 ms    10 runs

Benchmark 2: ../target/release/cksum -c checkbig.b2sum
  Time (mean ± σ):     658.5 ms ±   1.4 ms    [User: 196.4 ms, System: 446.7 ms]
  Range (min … max):   656.4 ms … 660.2 ms    10 runs

Summary
  '../target/release/cksum -c checkbig.b2sum' ran
    1.39 ± 0.01 times faster than '../cksum.latest -c checkbig.b2sum'
```

And passes the gnu tests:
```
bash util/run-gnu-test.sh ../gnu/tests/cksum/*.pl ../gnu/tests/cksum/*.sh
```
```text
PASS: ../gnu/tests/cksum/md5sum-newline.pl
PASS: ../gnu/tests/cksum/sha224sum.pl
PASS: ../gnu/tests/cksum/sha256sum.pl
PASS: ../gnu/tests/cksum/sum.pl
PASS: ../gnu/tests/cksum/sm3sum.pl
PASS: ../gnu/tests/cksum/sha1sum.pl
PASS: ../gnu/tests/cksum/sha384sum.pl
PASS: ../gnu/tests/cksum/sha512sum.pl
PASS: ../gnu/tests/cksum/md5sum.pl
PASS: ../gnu/tests/cksum/cksum-base64.pl
PASS: ../gnu/tests/cksum/cksum-raw.sh
PASS: ../gnu/tests/cksum/cksum-c.sh
PASS: ../gnu/tests/cksum/md5sum-bsd.sh
PASS: ../gnu/tests/cksum/md5sum-parallel.sh
PASS: ../gnu/tests/cksum/b2sum.sh
PASS: ../gnu/tests/cksum/cksum-a.sh
PASS: ../gnu/tests/cksum/cksum.sh
PASS: ../gnu/tests/cksum/sum-sysv.sh
PASS: ../gnu/tests/cksum/sha1sum-vec.pl
============================================================================
Testsuite summary for GNU coreutils 9.6-dirty
============================================================================
# TOTAL: 19
# PASS:  19
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

as well as:
```
make UTILS=cksum test
```
```
test result: ok. 135 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.54s
```

**If this is of value, please let me know. Then I would still have some cleanup to do.**

**Any remarks/thoughts are very welcome.**
