### PR TITLE
ci: Enable cspell on test on dotfiles too

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
 # EditorConfig (is awesome!; ref: http://EditorConfig.org; v2022.02.11 [rivy])
+# spell-checker:ignore akefile shellcheck vcproj
 
 # * top-most EditorConfig file
 root = true
@@ -52,7 +53,7 @@ indent_style = space
 switch_case_indent = true
 
 [*.{sln,vc{,x}proj{,.*},[Ss][Ln][Nn],[Vv][Cc]{,[Xx]}[Pp][Rr][Oo][Jj]{,.*}}]
-# MSVC sln/vcproj/vcxproj files, when used, will persistantly revert to CRLF EOLNs and eat final EOLs
+# MSVC sln/vcproj/vcxproj files, when used, will persistently revert to CRLF EOLNs and eat final EOLs
 end_of_line = crlf
 insert_final_newline = false
 

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
+# spell-checker:ignore direnv
+
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
 fi

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,10 +2,10 @@ name: CICD
 
 # spell-checker:ignore (abbrev/names) CICD CodeCOV MacOS MinGW MSVC musl taiki
 # spell-checker:ignore (env/flags) Awarnings Ccodegen Coverflow Cpanic Dwarnings RUSTDOCFLAGS RUSTFLAGS Zpanic CARGOFLAGS
-# spell-checker:ignore (jargon) SHAs deps dequote softprops subshell toolchain fuzzers
-# spell-checker:ignore (people) Peltoche rivy dtolnay
-# spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot fdesc fdescfs gmake grcov halium lcov libssl mkdir popd printf pushd rsync rustc rustfmt rustup shopt utmpdump xargs
-# spell-checker:ignore (misc) aarch alnum armhf bindir busytest coreutils defconfig DESTDIR gecos gnueabihf issuecomment maint multisize nullglob onexitbegin onexitend pell runtest Swatinem tempfile testsuite toybox uutils
+# spell-checker:ignore (jargon) SHAs deps dequote softprops subshell toolchain fuzzers dedupe devel
+# spell-checker:ignore (people) Peltoche rivy dtolnay Anson dawidd
+# spell-checker:ignore (shell/tools) binutils choco clippy dmake dpkg esac fakeroot fdesc fdescfs gmake grcov halium lcov libclang libfuse libssl limactl mkdir nextest nocross pacman popd printf pushd redoxer rsync rustc rustfmt rustup shopt sccache utmpdump xargs
+# spell-checker:ignore (misc) aarch alnum armhf bindir busytest coreutils defconfig DESTDIR gecos getenforce gnueabihf issuecomment maint manpages msys multisize noconfirm nullglob onexitbegin onexitend pell runtest Swatinem tempfile testsuite toybox uutils
 
 env:
   PROJECT_NAME: coreutils

--- a/.github/workflows/CheckScripts.yml
+++ b/.github/workflows/CheckScripts.yml
@@ -1,6 +1,6 @@
 name: CheckScripts
 
-# spell-checker:ignore ludeeus mfinelli
+# spell-checker:ignore ludeeus mfinelli shellcheck scandir shfmt
 
 env:
   SCRIPT_DIR: 'util'

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -1,6 +1,6 @@
 name: FixPR
 
-# spell-checker:ignore Swatinem dtolnay
+# spell-checker:ignore Swatinem dtolnay dedupe
 
 # Trigger automated fixes for PRs being merged (with associated commits)
 

--- a/.github/workflows/GnuComment.yml
+++ b/.github/workflows/GnuComment.yml
@@ -1,5 +1,7 @@
 name: GnuComment
 
+# spell-checker:ignore zizmor backquote
+
 on:
   workflow_run:
     workflows: ["GnuTests"]

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -1,8 +1,8 @@
 name: GnuTests
 
 # spell-checker:ignore (abbrev/names) CodeCov gnulib GnuTests Swatinem
-# spell-checker:ignore (jargon) submodules
-# spell-checker:ignore (libs/utils) autopoint chksum gperf lcov libexpect pyinotify shopt texinfo valgrind libattr libcap taiki-e
+# spell-checker:ignore (jargon) submodules devel
+# spell-checker:ignore (libs/utils) autopoint chksum getenforce gperf lcov libexpect limactl pyinotify setenforce shopt texinfo valgrind libattr libcap taiki-e
 # spell-checker:ignore (options) Ccodegen Coverflow Cpanic Zpanic
 # spell-checker:ignore (people) Dawid Dziurla * dawidd dtolnay
 # spell-checker:ignore (vars) FILESET SUBDIRS XPASS

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,8 @@
 name: Android
 
-# spell-checker:ignore TERMUX reactivecircus Swatinem  noaudio pkill swiftshader dtolnay juliangruber
+# spell-checker:ignore (people) reactivecircus Swatinem dtolnay juliangruber
+# spell-checker:ignore (shell/tools) TERMUX nextest udevadm pkill
+# spell-checker:ignore (misc) swiftshader playstore DATALOSS noaudio
 
 on:
   pull_request:
@@ -152,7 +154,7 @@ jobs:
         # The version vX at the end of the key is just a development version to avoid conflicts in
         # the github cache during the development of this workflow
         key: ${{ matrix.arch }}_${{ matrix.target}}_${{ steps.read_rustc_hash.outputs.content }}_${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}_v3
-    - name: Collect information about runner ressources
+    - name: Collect information about runner resources
       if: always()
       continue-on-error: true
       run: |
@@ -179,7 +181,7 @@ jobs:
           util/android-commands.sh build
           util/android-commands.sh tests
           if [ "${{ steps.rust-cache.outputs.cache-hit }}" != 'true' ]; then util/android-commands.sh sync_image; fi; exit 0
-    - name: Collect information about runner ressources
+    - name: Collect information about runner resources
       if: always()
       continue-on-error: true
       run: |
@@ -197,7 +199,7 @@ jobs:
       with:
         name: test_output_${{ env.AVD_CACHE_KEY }}
         path: output
-    - name: Collect information about runner ressources
+    - name: Collect information about runner resources
       if: always()
       continue-on-error: true
       run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -154,7 +154,7 @@ jobs:
         cfg_files=($(shopt -s nullglob ; echo {.vscode,.}/{,.}c[sS]pell{.json,.config{.js,.cjs,.json,.yaml,.yml},.yaml,.yml} ;))
         cfg_file=${cfg_files[0]}
         unset CSPELL_CFG_OPTION ; if [ -n "$cfg_file" ]; then CSPELL_CFG_OPTION="--config $cfg_file" ; fi
-        S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress "**/*") && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
+        S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress .) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
         if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
   toml_format:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,7 @@
 name: Code Quality
 
-# spell-checker:ignore TERMUX reactivecircus Swatinem  noaudio pkill swiftshader dtolnay juliangruber
+# spell-checker:ignore (people) reactivecircus Swatinem dtolnay juliangruber pell taplo
+# spell-checker:ignore (misc) TERMUX noaudio pkill swiftshader esac sccache pcoreutils shopt subshell dequote
 
 on:
   pull_request:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,6 +1,6 @@
 name: FreeBSD
 
-# spell-checker:ignore sshfs usesh vmactions taiki Swatinem esac fdescfs fdesc
+# spell-checker:ignore sshfs usesh vmactions taiki Swatinem esac fdescfs fdesc sccache nextest copyback
 
 env:
   # * style job configuration

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,6 +1,6 @@
 name: Fuzzing
 
-# spell-checker:ignore fuzzer
+# spell-checker:ignore fuzzer dtolnay Swatinem
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# spell-checker:ignore (misc) direnv
+
 target/
 /src/*/gen_table
 /build/

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -1,4 +1,5 @@
 // `cspell` settings
+// spell-checker:ignore oranda
 {
   // version of the setting file
   "version": "0.2",

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -19,6 +19,7 @@
 
   // files to ignore (globs supported)
   "ignorePaths": [
+    ".git/**",
     "Cargo.lock",
     "oranda.json",
     "target/**",
@@ -27,6 +28,8 @@
     "vendor/**",
     "**/*.svg"
   ],
+
+  "enableGlobDot": true,
 
   // words to ignore (even if they are in the flagWords)
   "ignoreWords": [],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
-// spell-checker:ignore (misc) matklad
+// spell-checker:ignore (misc) matklad foxundermoon
 // see <http://go.microsoft.com/fwlink/?LinkId=827846> for the documentation about the extensions.json format
 // *
 // "foxundermoon.shell-format" ~ shell script formatting ; note: ENABLE "Use EditorConfig"


### PR DESCRIPTION
### ci: Enable cspell on test on dotfiles too

Noticed this because pre-commit would try to run on dotfiles as
well (will CI ignored it)

### dotfiles: Add works to cspell dictionary

Also fix a couple of real spelling mistakes.

