### PR TITLE
ls: fixed incorrect alignment when using --classify option

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2675,20 +2675,10 @@ fn display_grid(
             .map(|s| s.to_string_lossy().into_owned())
             .collect();
 
-        // Determine whether to use tabs for separation based on whether any entry ends with '/'.
-        // If any entry ends with '/', it indicates that the -F flag is likely used to classify directories.
-        let use_tabs = names.iter().any(|name| name.ends_with('/'));
-
-        let filling = if use_tabs {
-            Filling::Text("\t".to_string())
-        } else {
-            Filling::Spaces(2)
-        };
-
         let grid = Grid::new(
             names,
             GridOptions {
-                filling,
+                filling: Filling::Spaces(2),
                 direction,
                 width: width as usize,
             },

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4786,7 +4786,7 @@ fn test_ls_subdired_complex() {
 }
 
 #[test]
-fn test_ls_cf_output_should_be_delimited_by_tab() {
+fn test_ls_cf_output_should_be_delimited_by_spaces() {
     let (at, mut ucmd) = at_and_ucmd!();
 
     at.mkdir("e");
@@ -4795,7 +4795,7 @@ fn test_ls_cf_output_should_be_delimited_by_tab() {
 
     ucmd.args(&["-CF", "e"])
         .succeeds()
-        .stdout_is("a2345/\tb/\n");
+        .stdout_is("a2345/  b/\n");
 }
 
 #[cfg(all(unix, feature = "dd"))]


### PR DESCRIPTION
Removing the insertion of tabs instead of spaces when using the `--classify` or `-F` option seems to fix the mentioned issue. All of the tests pass, except for one, which obviously checks for tabs, which my fix changed.

It seems to me that the `uutils_term_grid` crate cannot properly align columns when using tabs as text.

With the fix, sometimes the alignment differs from the GNU implementation of ls, but I don't know how much of an issue that is.

fixes #7526