### PR TITLE
feat: add wasi support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1259,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1989,20 +1989,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2245,8 +2245,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix 1.0.1",
- "windows-sys 0.52.0",
+ "rustix 1.0.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2255,7 +2255,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.1",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -2582,6 +2582,7 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.3",
  "quick-error",
+ "rustix 1.0.3",
  "selinux",
  "uucore",
  "walkdir",
@@ -3495,6 +3496,7 @@ dependencies = [
  "number_prefix",
  "os_display",
  "regex",
+ "rustix 1.0.3",
  "sha1",
  "sha2",
  "sha3",
@@ -3670,7 +3672,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3886,7 +3888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.1",
+ "rustix 1.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ default = ["feat_common_core"]
 macos = ["feat_os_macos"]
 unix = ["feat_os_unix"]
 windows = ["feat_os_windows"]
+
 ## project-specific feature shortcodes
 nightly = []
 test_unimplemented = []
@@ -310,6 +311,7 @@ lscolors = { version = "0.20.0", default-features = false, features = [
 memchr = "2.7.2"
 memmap2 = "0.9.4"
 nix = { version = "0.29", default-features = false }
+rustix = { version = "1.0.3" }
 nom = "8.0.0"
 notify = { version = "=8.0.0", features = ["macos_kqueue"] }
 num-bigint = "0.4.4"
@@ -530,7 +532,6 @@ xattr = { workspace = true }
 serde = { version = "1.0.202", features = ["derive"] }
 bincode = { version = "1.3.3" }
 serde-big-array = "0.5.1"
-
 
 [build-dependencies]
 phf_codegen = { workspace = true }

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -24,7 +24,6 @@ path = "src/cp.rs"
 clap = { workspace = true }
 filetime = { workspace = true }
 libc = { workspace = true }
-linux-raw-sys = { workspace = true }
 quick-error = { workspace = true }
 selinux = { workspace = true, optional = true }
 uucore = { workspace = true, features = [
@@ -39,10 +38,14 @@ uucore = { workspace = true, features = [
 ] }
 walkdir = { workspace = true }
 indicatif = { workspace = true }
+rustix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(unix)'.dependencies]
 xattr = { workspace = true }
 exacl = { workspace = true, optional = true }
+
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+linux-raw-sys = { workspace = true }
 
 [[bin]]
 name = "cp"

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1736,11 +1736,14 @@ fn symlink_file(
 ) -> CopyResult<()> {
     #[cfg(not(windows))]
     {
-        std::os::unix::fs::symlink(source, dest).context(format!(
-            "cannot create symlink {} to {}",
-            get_filename(dest).unwrap_or("invalid file name").quote(),
-            get_filename(source).unwrap_or("invalid file name").quote()
-        ))?;
+        rustix::fs::symlink(source, dest).map_err(|e| {
+            Error::Error(format!(
+                "cannot create symlink {} to {}: {}",
+                get_filename(dest).unwrap_or("invalid file name").quote(),
+                get_filename(source).unwrap_or("invalid file name").quote(),
+                e
+            ))
+        })?;
     }
     #[cfg(windows)]
     {
@@ -1750,6 +1753,7 @@ fn symlink_file(
             get_filename(source).unwrap_or("invalid file name").quote()
         ))?;
     }
+
     if let Ok(file_info) = FileInformation::from_path(dest, false) {
         symlinked_files.insert(file_info);
     }

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -30,7 +30,6 @@ dns-lookup = { workspace = true, optional = true }
 dunce = { version = "1.0.4", optional = true }
 wild = "2.2.1"
 glob = { workspace = true }
-iana-time-zone = { workspace = true }
 # * optional
 itertools = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
@@ -63,8 +62,16 @@ num-traits = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 walkdir = { workspace = true, optional = true }
-nix = { workspace = true, features = ["fs", "uio", "zerocopy", "signal"] }
+nix = { workspace = true, features = ["uio", "zerocopy", "signal"] }
+rustix = { workspace = true, features = ["fs"] }
 xattr = { workspace = true, optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iana-time-zone = { workspace = true, features = ["fallback"] }
+rustix = { workspace = true, features = ["fs"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+iana-time-zone = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true }

--- a/src/uucore/src/lib/mods/io.rs
+++ b/src/uucore/src/lib/mods/io.rs
@@ -18,11 +18,12 @@
 use std::os::fd::{AsFd, OwnedFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsHandle, OwnedHandle};
+#[cfg(not(target_os = "wasi"))]
+use std::process::Stdio;
 use std::{
     fs::{File, OpenOptions},
     io,
     path::Path,
-    process::Stdio,
 };
 
 #[cfg(windows)]
@@ -73,6 +74,7 @@ impl OwnedFileDescriptorOrHandle {
     }
 
     /// instantiates a corresponding `Stdio`
+    #[cfg(not(target_os = "wasi"))]
     pub fn into_stdio(self) -> Stdio {
         Stdio::from(self.fx)
     }
@@ -91,6 +93,7 @@ impl OwnedFileDescriptorOrHandle {
 }
 
 /// instantiates a corresponding `Stdio`
+#[cfg(not(target_os = "wasi"))]
 impl From<OwnedFileDescriptorOrHandle> for Stdio {
     fn from(value: OwnedFileDescriptorOrHandle) -> Self {
         value.into_stdio()


### PR DESCRIPTION
The rustix dependency is currently needed for wasi support because nix::sys::* and std::os::unix::fs don't work on wasi. The nightly only std feature for wasi_ext could help once it is stabilized, but functions like fstat  might still need rustix.