### PR TITLE
chore(deps): update `os_display` to 0.1.4

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -44,7 +44,7 @@ data-encoding = { version = "2.6", optional = true }
 data-encoding-macro = { version = "0.1.15", optional = true }
 z85 = { version = "3.0.5", optional = true }
 libc = { workspace = true, optional = true }
-os_display = "0.1.3"
+os_display = "0.1.4"
 
 digest = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }


### PR DESCRIPTION
This is a part of my upgrade efforts to ensure that all Nushell downstream dependencies use `unicode-width` 0.2.0 to avoid duplicating all of the unicode tables in the binary.