### PR TITLE
Fixes error for fold -b if line split splits a char

### DIFF
--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -162,7 +162,12 @@ fn fold_file_bytewise<T: Read>(mut file: BufReader<T>, spaces: bool, width: usiz
         while i < len {
             let width = if len - i >= width { width } else { len - i };
             let slice = {
-                let slice = &line[i..i + width];
+                // cannot directly slice the line as it might panic if boundaries
+                // split a char
+                let slice = (0..=width)
+                    .rev()
+                    .find_map(|w| line.get(i..i + w))
+                    .unwrap_or("");
                 if spaces && i + width < len {
                     match slice.rfind(|c: char| c.is_whitespace() && c != '\r') {
                         Some(m) => &slice[..=m],


### PR DESCRIPTION
fixes #7606

The problem was that the splitting of lines would split within a Char boundaries which would lead to runtime panics ... using the safe version of .get() instead of raw slicing will let us iterate backwards from a given split position until we are not splitting a Char anymore 