### PR TITLE
test_stat: Disable test_stdin_pipe_fifo1/2 on Mac OS X

### DIFF
--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -331,10 +331,16 @@ fn test_pipe_fifo() {
         .stdout_contains("File: FIFO");
 }
 
+// TODO(#7583): Re-enable on Mac OS X (and possibly other Unix platforms)
 #[test]
 #[cfg(all(
     unix,
-    not(any(target_os = "android", target_os = "freebsd", target_os = "openbsd"))
+    not(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "macos"
+    ))
 ))]
 fn test_stdin_pipe_fifo1() {
     // $ echo | stat -
@@ -356,8 +362,9 @@ fn test_stdin_pipe_fifo1() {
         .stdout_contains("File: -");
 }
 
+// TODO(#7583): Re-enable on Mac OS X (and maybe Android)
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
 fn test_stdin_pipe_fifo2() {
     // $ stat -
     // File: -


### PR DESCRIPTION
These tests have been so flaky, sounds better to just disable for now. We can try to implement the fix documented in #7583 and re-enable at some point.

---

It's not totally clear why they sometimes work, sometimes fail, but it does appear that running `stat` on `/dev/stdin` is perhaps not the most reliable approach.

A likely more solid approach is described in #7583.