### PR TITLE
tail: fix issue with -v flag and stdin

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -290,8 +290,9 @@ impl Settings {
             .map(|v| v.map(Input::from).collect())
             .unwrap_or_else(|| vec![Input::default()]);
 
-        settings.verbose =
-            settings.inputs.len() > 1 && !matches.get_flag(options::verbosity::QUIET);
+        settings.verbose = (matches.get_flag(options::verbosity::VERBOSE)
+            || settings.inputs.len() > 1)
+            && !matches.get_flag(options::verbosity::QUIET);
 
         Ok(settings)
     }


### PR DESCRIPTION
Fixes issue #7613
Tail now correctly handles the -v flag when only 1 input file is given. Added appropriate test.