### PR TITLE
ls: add -T support and fix --classify output

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1087,12 +1087,13 @@ impl Config {
             Dereference::DirArgs
         };
 
-        let tab_size = match needs_color {
-            false => options
+        let tab_size = if !needs_color {
+            options
                 .get_one::<String>(options::format::TAB_SIZE)
                 .and_then(|size| size.parse::<usize>().ok())
-                .or_else(|| std::env::var("TABSIZE").ok().and_then(|s| s.parse().ok())),
-            _ => Some(0),
+                .or_else(|| std::env::var("TABSIZE").ok().and_then(|s| s.parse().ok()))
+        } else {
+            Some(0)
         }
         .unwrap_or(SPACES_IN_TAB);
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2564,10 +2564,24 @@ fn display_items(
 
         match config.format {
             Format::Columns => {
-                display_grid(names, config.width, Direction::TopToBottom, out, quoted)?;
+                display_grid(
+                    names,
+                    config.width,
+                    Direction::TopToBottom,
+                    out,
+                    quoted,
+                    config.tab_size,
+                )?;
             }
             Format::Across => {
-                display_grid(names, config.width, Direction::LeftToRight, out, quoted)?;
+                display_grid(
+                    names,
+                    config.width,
+                    Direction::LeftToRight,
+                    out,
+                    quoted,
+                    config.tab_size,
+                )?;
             }
             Format::Commas => {
                 let mut current_col = 0;
@@ -2635,6 +2649,7 @@ fn display_grid(
     direction: Direction,
     out: &mut BufWriter<Stdout>,
     quoted: bool,
+    tab_size: usize,
 ) -> UResult<()> {
     if width == 0 {
         // If the width is 0 we print one single line
@@ -2684,14 +2699,9 @@ fn display_grid(
             .map(|s| s.to_string_lossy().into_owned())
             .collect();
 
-        // Determine whether to use tabs for separation based on whether any entry ends with '/'.
-        // If any entry ends with '/', it indicates that the -F flag is likely used to classify directories.
-        let use_tabs = names.iter().any(|name| name.ends_with('/'));
-
-        let filling = if use_tabs {
-            Filling::Text("\t".to_string())
-        } else {
-            Filling::Spaces(2)
+        let filling = match tab_size {
+            0 => Filling::Spaces(2),
+            _ => Filling::Tabs(tab_size),
         };
 
         let grid = Grid::new(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) somegroup nlink tabsize dired subdired dtype colorterm stringly
+// spell-checker:ignore (ToDO) somegroup nlink dired subdired dtype colorterm stringly
 
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
@@ -2701,7 +2701,10 @@ fn display_grid(
 
         let filling = match tab_size {
             0 => Filling::Spaces(DEFAULT_SEPARATOR_SIZE),
-            _ => Filling::Tabs(tab_size),
+            _ => Filling::Tabs {
+                spaces: DEFAULT_SEPARATOR_SIZE,
+                tab_size,
+            },
         };
 
         let grid = Grid::new(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2700,6 +2700,7 @@ fn display_grid(
             .map(|s| s.to_string_lossy().into_owned())
             .collect();
 
+        // Since tab_size=0 means no \t, use Spaces separator for optimization.
         let filling = match tab_size {
             0 => Filling::Spaces(DEFAULT_SEPARATOR_SIZE),
             _ => Filling::Tabs {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -33,7 +33,7 @@ use clap::{
 };
 use glob::{MatchOptions, Pattern};
 use lscolors::LsColors;
-use term_grid::{Direction, Filling, Grid, GridOptions, SPACES_IN_TAB};
+use term_grid::{DEFAULT_SEPARATOR_SIZE, Direction, Filling, Grid, GridOptions, SPACES_IN_TAB};
 use thiserror::Error;
 use uucore::error::USimpleError;
 use uucore::format::human::{SizeFormat, human_readable};
@@ -2700,7 +2700,7 @@ fn display_grid(
             .collect();
 
         let filling = match tab_size {
-            0 => Filling::Spaces(2),
+            0 => Filling::Spaces(DEFAULT_SEPARATOR_SIZE),
             _ => Filling::Tabs(tab_size),
         };
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) somegroup nlink dired subdired dtype colorterm stringly
+// spell-checker:ignore (ToDO) somegroup nlink tabsize dired subdired dtype colorterm stringly
 
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -837,7 +837,7 @@ fn test_ls_columns() {
 
     for option in COLUMN_ARGS {
         let result = scene.ucmd().arg(option).succeeds();
-        result.stdout_only("test-columns-1  test-columns-2  test-columns-3  test-columns-4\n");
+        result.stdout_only("test-columns-1\ttest-columns-2\ttest-columns-3\ttest-columns-4\n");
     }
 
     for option in COLUMN_ARGS {
@@ -846,7 +846,7 @@ fn test_ls_columns() {
             .arg("-w=40")
             .arg(option)
             .succeeds()
-            .stdout_only("test-columns-1  test-columns-3\ntest-columns-2  test-columns-4\n");
+            .stdout_only("test-columns-1\ttest-columns-3\ntest-columns-2\ttest-columns-4\n");
     }
 
     // On windows we are always able to get the terminal size, so we can't simulate falling back to the
@@ -859,7 +859,7 @@ fn test_ls_columns() {
                 .env("COLUMNS", "40")
                 .arg(option)
                 .succeeds()
-                .stdout_only("test-columns-1  test-columns-3\ntest-columns-2  test-columns-4\n");
+                .stdout_only("test-columns-1\ttest-columns-3\ntest-columns-2\ttest-columns-4\n");
         }
 
         scene
@@ -867,7 +867,7 @@ fn test_ls_columns() {
             .env("COLUMNS", "garbage")
             .arg("-C")
             .succeeds()
-            .stdout_is("test-columns-1  test-columns-2  test-columns-3  test-columns-4\n")
+            .stdout_is("test-columns-1\ttest-columns-2\ttest-columns-3\ttest-columns-4\n")
             .stderr_is("ls: ignoring invalid width in environment variable COLUMNS: 'garbage'\n");
     }
     scene

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4366,28 +4366,36 @@ fn test_tabsize_option() {
     scene.ucmd().arg("-T").fails();
 }
 
-#[ignore = "issue #3624"]
 #[test]
 fn test_tabsize_formatting() {
-    let (at, mut ucmd) = at_and_ucmd!();
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
 
     at.touch("aaaaaaaa");
     at.touch("bbbb");
     at.touch("cccc");
     at.touch("dddddddd");
 
-    ucmd.args(&["-T", "4"])
-        .succeeds()
-        .stdout_is("aaaaaaaa bbbb\ncccc\t dddddddd");
+    // Need additional options to simulate columns output.
 
-    ucmd.args(&["-T", "2"])
+    scene
+        .ucmd()
+        .args(&["-x", "-w20", "-T4"])
         .succeeds()
-        .stdout_is("aaaaaaaa bbbb\ncccc\t\t dddddddd");
+        .stdout_is("aaaaaaaa  bbbb\ncccc\t  dddddddd\n");
+
+    scene
+        .ucmd()
+        .args(&["-x", "-w20", "-T2"])
+        .succeeds()
+        .stdout_is("aaaaaaaa\tbbbb\ncccc\t\t\tdddddddd\n");
 
     // use spaces
-    ucmd.args(&["-T", "0"])
+    scene
+        .ucmd()
+        .args(&["-x", "-w20", "-T0"])
         .succeeds()
-        .stdout_is("aaaaaaaa bbbb\ncccc     dddddddd");
+        .stdout_is("aaaaaaaa  bbbb\ncccc      dddddddd\n");
 }
 
 #[cfg(any(

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe bcdef mfoo
+// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe bcdef mfoo
 // spell-checker:ignore (words) fakeroot setcap
 #![allow(
     clippy::similar_names,

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe bcdef mfoo
+// spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe bcdef mfoo
 // spell-checker:ignore (words) fakeroot setcap
 #![allow(
     clippy::similar_names,
@@ -4380,20 +4380,20 @@ fn test_tabsize_formatting() {
 
     scene
         .ucmd()
-        .args(&["-x", "-w20", "-T4"])
+        .args(&["-x", "-w18", "-T4"])
         .succeeds()
         .stdout_is("aaaaaaaa  bbbb\ncccc\t  dddddddd\n");
 
     scene
         .ucmd()
-        .args(&["-x", "-w20", "-T2"])
+        .args(&["-x", "-w18", "-T2"])
         .succeeds()
         .stdout_is("aaaaaaaa\tbbbb\ncccc\t\t\tdddddddd\n");
 
     // use spaces
     scene
         .ucmd()
-        .args(&["-x", "-w20", "-T0"])
+        .args(&["-x", "-w18", "-T0"])
         .succeeds()
         .stdout_is("aaaaaaaa  bbbb\ncccc      dddddddd\n");
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4376,8 +4376,6 @@ fn test_tabsize_formatting() {
     at.touch("cccc");
     at.touch("dddddddd");
 
-    // Need additional options to simulate columns output.
-
     scene
         .ucmd()
         .args(&["-x", "-w18", "-T4"])
@@ -4386,9 +4384,27 @@ fn test_tabsize_formatting() {
 
     scene
         .ucmd()
+        .args(&["-C", "-w18", "-T4"])
+        .succeeds()
+        .stdout_is("aaaaaaaa  cccc\nbbbb\t  dddddddd\n");
+
+    scene
+        .ucmd()
+        .args(&["-x", "-w18", "-T2"])
+        .succeeds()
+        .stdout_is("aaaaaaaa\tbbbb\ncccc\t\t\tdddddddd\n");
+
+    scene
+        .ucmd()
         .args(&["-C", "-w18", "-T2"])
         .succeeds()
         .stdout_is("aaaaaaaa\tcccc\nbbbb\t\t\tdddddddd\n");
+
+    scene
+        .ucmd()
+        .args(&["-x", "-w18", "-T0"])
+        .succeeds()
+        .stdout_is("aaaaaaaa  bbbb\ncccc      dddddddd\n");
 
     // use spaces
     scene

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4380,9 +4380,9 @@ fn test_tabsize_formatting() {
 
     scene
         .ucmd()
-        .args(&["-C", "-w18", "-T4"])
+        .args(&["-x", "-w18", "-T4"])
         .succeeds()
-        .stdout_is("aaaaaaaa  cccc\nbbbb\t  dddddddd\n");
+        .stdout_is("aaaaaaaa  bbbb\ncccc\t  dddddddd\n");
 
     scene
         .ucmd()

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4380,22 +4380,22 @@ fn test_tabsize_formatting() {
 
     scene
         .ucmd()
-        .args(&["-x", "-w18", "-T4"])
+        .args(&["-C", "-w18", "-T4"])
         .succeeds()
-        .stdout_is("aaaaaaaa  bbbb\ncccc\t  dddddddd\n");
+        .stdout_is("aaaaaaaa  cccc\nbbbb\t  dddddddd\n");
 
     scene
         .ucmd()
-        .args(&["-x", "-w18", "-T2"])
+        .args(&["-C", "-w18", "-T2"])
         .succeeds()
-        .stdout_is("aaaaaaaa\tbbbb\ncccc\t\t\tdddddddd\n");
+        .stdout_is("aaaaaaaa\tcccc\nbbbb\t\t\tdddddddd\n");
 
     // use spaces
     scene
         .ucmd()
-        .args(&["-x", "-w18", "-T0"])
+        .args(&["-C", "-w18", "-T0"])
         .succeeds()
-        .stdout_is("aaaaaaaa  bbbb\ncccc      dddddddd\n");
+        .stdout_is("aaaaaaaa  cccc\nbbbb      dddddddd\n");
 }
 
 #[cfg(any(


### PR DESCRIPTION
This update relies on [MR46](https://github.com/uutils/uutils-term-grid/pull/46) in `uutils-term-grid` crate.

This update uses new `Filling::Tabs` option instead of explicitly setting text separator with \t.

Closes #6897 
Closes #7526 
Closes #3624 