### PR TITLE
Fix `tail -f` handling when stdin is redirected from a file

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -13,6 +13,7 @@ use same_file::Handle;
 use std::ffi::OsString;
 use std::io::IsTerminal;
 use std::time::Duration;
+use std::fs;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::parse_size::{ParseSizeError, parse_size_u64};
 use uucore::shortcut_value_parser::ShortcutValueParser;
@@ -286,9 +287,9 @@ impl Settings {
         }
 
         settings.inputs = matches
-            .get_many::<OsString>(options::ARG_FILES)
-            .map(|v| v.map(Input::from).collect())
-            .unwrap_or_else(|| vec![Input::default()]);
+        .get_many::<OsString>(options::ARG_FILES)
+        .map(|v| v.map(Input::from).collect())
+        .unwrap_or_else(|| vec![Input::default()]);
 
         settings.verbose =
             settings.inputs.len() > 1 && !matches.get_flag(options::verbosity::QUIET);
@@ -300,6 +301,11 @@ impl Settings {
         self.inputs.iter().all(|input| input.is_stdin())
     }
 
+    pub fn stdin_is_regular_file(&self) -> bool {
+        let metadata = fs::metadata("/dev/stdin");
+        metadata.map(|m| m.is_file()).unwrap_or(false)
+    }
+    
     pub fn has_stdin(&self) -> bool {
         self.inputs.iter().any(|input| input.is_stdin())
     }

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -37,7 +37,6 @@ use uucore::{show, show_error};
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let settings = parse_args(args)?;
-
     settings.check_warnings();
 
     match settings.verify() {
@@ -61,6 +60,7 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
     let mut observer = Observer::from(settings);
 
     observer.start(settings)?;
+
     // Do an initial tail print of each path's content.
     // Add `path` and `reader` to `files` map if `--follow` is selected.
     for input in &settings.inputs.clone() {
@@ -87,7 +87,7 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
         the input file is not a FIFO, pipe, or regular file, it is unspecified whether or
         not the -f option shall be ignored.
         */
-        if !settings.has_only_stdin() || settings.pid != 0 {
+        if !settings.has_only_stdin() || settings.pid != 0 || settings.stdin_is_regular_file() {
             follow::follow(observer, settings)?;
         }
     }
@@ -314,6 +314,9 @@ where
     }
     Ok(total)
 }
+
+
+
 
 /// Iterate over bytes in the file, in reverse, until we find the
 /// `num_delimiters` instance of `delimiter`. The `file` is left seek'd to the


### PR DESCRIPTION
Previously, `has_only_stdin()` returned `true` even when stdin was redirected from a file using `<file.txt>`, causing `tail -f` to not properly follow updates. This commit adds a check to detect if stdin is actually a regular file or FIFO and ensures `tail -f` behaves correctly in such cases.
issues : #7614