### PR TITLE
printf: Consistently handle negative widths/precision

### DIFF
--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -119,7 +119,7 @@ fn extract_value<T: Default>(p: Result<T, ExtendedParserError<'_, T>>, input: &s
                 }
                 ExtendedParserError::PartialMatch(v, rest) => {
                     let bytes = input.as_encoded_bytes();
-                    if !bytes.is_empty() && bytes[0] == b'\'' {
+                    if !bytes.is_empty() && (bytes[0] == b'\'' || bytes[0] == b'"') {
                         show_warning!(
                             "{}: character(s) following character constant have been ignored",
                             &rest,

--- a/src/uucore/src/lib/features/parser/num_parser.rs
+++ b/src/uucore/src/lib/features/parser/num_parser.rs
@@ -360,8 +360,8 @@ fn parse(
     input: &str,
     integral_only: bool,
 ) -> Result<ExtendedBigDecimal, ExtendedParserError<'_, ExtendedBigDecimal>> {
-    // Parse the "'" prefix separately
-    if let Some(rest) = input.strip_prefix('\'') {
+    // Parse the " and ' prefixes separately
+    if let Some(rest) = input.strip_prefix(['\'', '"']) {
         let mut chars = rest.char_indices().fuse();
         let v = chars
             .next()
@@ -465,11 +465,11 @@ fn parse(
 
     // If nothing has been parsed, check if this is a special value, or declare the parsing unsuccessful
     if let Some((0, _)) = chars.peek() {
-        if integral_only {
-            return Err(ExtendedParserError::NotNumeric);
+        return if integral_only {
+            Err(ExtendedParserError::NotNumeric)
         } else {
-            return parse_special_value(unsigned, negative);
-        }
+            parse_special_value(unsigned, negative)
+        };
     }
 
     let ebd_result = construct_extended_big_decimal(digits, negative, base, scale, exponent);

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -70,6 +70,21 @@ fn escaped_octal_and_newline() {
 }
 
 #[test]
+fn variable_sized_octal() {
+    for x in ["|\\5|", "|\\05|", "|\\005|"] {
+        new_ucmd!()
+            .arg(x)
+            .succeeds()
+            .stdout_only_bytes([b'|', 5u8, b'|']);
+    }
+
+    new_ucmd!()
+        .arg("|\\0005|")
+        .succeeds()
+        .stdout_only_bytes([b'|', 0, b'5', b'|']);
+}
+
+#[test]
 fn escaped_unicode_four_digit() {
     new_ucmd!().args(&["\\u0125"]).succeeds().stdout_only("ĥ");
 }
@@ -146,6 +161,21 @@ fn sub_b_string_handle_escapes() {
         .args(&["hello %b", "\\tworld"])
         .succeeds()
         .stdout_only("hello \tworld");
+}
+
+#[test]
+fn sub_b_string_variable_size_unicode() {
+    for x in ["\\5|", "\\05|", "\\005|", "\\0005|"] {
+        new_ucmd!()
+            .args(&["|%b", x])
+            .succeeds()
+            .stdout_only_bytes([b'|', 5u8, b'|']);
+    }
+
+    new_ucmd!()
+        .args(&["|%b", "\\00005|"])
+        .succeeds()
+        .stdout_only_bytes([b'|', 0, b'5', b'|']);
 }
 
 #[test]


### PR DESCRIPTION
This pull request fixes the tests/printf/printf.sh tests. The main discrepancies between the uutil's implementation and GNU's appear to be the handling of negative widths or precisions when provided for `%*.*` - this was implemented for strings, but this PR brings other format specifications to also handle negative widths/precisions.

This PR also allows character constants with " instead of '. I had trouble finding any documentation about this; as far as I can tell GNU printf treats " and ' the same in the situations tested.
There is also a bug fix for interpolated values with %b to use \0XXX notation for octal bytes - this comes in for something like `printf '\0001'`, which should be the null byte and an ASCII '1', vs `printf '%b' '\0001'`, which is the single 0x01 byte because interpolated values use \0XXX formatted octal bytes.
