### PR TITLE
uucore: format: Collection of small parser fixes

### DIFF
--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -105,9 +105,9 @@ fn extract_value<T: Default>(p: Result<T, ExtendedParserError<'_, T>>, input: &s
                 },
             );
             match e {
-                ExtendedParserError::Overflow => {
+                ExtendedParserError::Overflow(v) => {
                     show_error!("{}: Numerical result out of range", input.quote());
-                    Default::default()
+                    v
                 }
                 ExtendedParserError::NotNumeric => {
                     show_error!("{}: expected a numeric value", input.quote());

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -109,6 +109,10 @@ fn extract_value<T: Default>(p: Result<T, ExtendedParserError<'_, T>>, input: &s
                     show_error!("{}: Numerical result out of range", input.quote());
                     v
                 }
+                ExtendedParserError::Underflow(v) => {
+                    show_error!("{}: Numerical result out of range", input.quote());
+                    v
+                }
                 ExtendedParserError::NotNumeric => {
                     show_error!("{}: expected a numeric value", input.quote());
                     Default::default()

--- a/src/uucore/src/lib/features/format/extendedbigdecimal.rs
+++ b/src/uucore/src/lib/features/format/extendedbigdecimal.rs
@@ -23,6 +23,7 @@
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::ops::Add;
+use std::ops::Neg;
 
 use bigdecimal::BigDecimal;
 use num_traits::FromPrimitive;
@@ -223,6 +224,27 @@ impl PartialOrd for ExtendedBigDecimal {
             (Self::MinusNan, _) => None,
             (_, Self::Nan) => None,
             (_, Self::MinusNan) => None,
+        }
+    }
+}
+
+impl Neg for ExtendedBigDecimal {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        match self {
+            Self::BigDecimal(bd) => {
+                if bd.is_zero() {
+                    Self::MinusZero
+                } else {
+                    Self::BigDecimal(bd.neg())
+                }
+            }
+            Self::MinusZero => Self::BigDecimal(BigDecimal::zero()),
+            Self::Infinity => Self::MinusInfinity,
+            Self::MinusInfinity => Self::Infinity,
+            Self::Nan => Self::MinusNan,
+            Self::MinusNan => Self::Nan,
         }
     }
 }

--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -80,10 +80,12 @@ pub struct SignedInt {
 
 impl Formatter<i64> for SignedInt {
     fn fmt(&self, writer: impl Write, x: i64) -> std::io::Result<()> {
+        // -i64::MIN is actually 1 larger than i64::MAX, so we need to cast to i128 first.
+        let abs = (x as i128).abs();
         let s = if self.precision > 0 {
-            format!("{:0>width$}", x.abs(), width = self.precision)
+            format!("{:0>width$}", abs, width = self.precision)
         } else {
-            x.abs().to_string()
+            abs.to_string()
         };
 
         let sign_indicator = get_sign_indicator(self.positive_sign, x.is_negative());
@@ -1046,6 +1048,8 @@ mod test {
         let format = Format::<SignedInt, i64>::parse("%d").unwrap();
         assert_eq!(fmt(&format, 123i64), "123");
         assert_eq!(fmt(&format, -123i64), "-123");
+        assert_eq!(fmt(&format, i64::MAX), "9223372036854775807");
+        assert_eq!(fmt(&format, i64::MIN), "-9223372036854775808");
 
         let format = Format::<SignedInt, i64>::parse("%i").unwrap();
         assert_eq!(fmt(&format, 123i64), "123");

--- a/src/uucore/src/lib/features/format/num_parser.rs
+++ b/src/uucore/src/lib/features/format/num_parser.rs
@@ -287,7 +287,6 @@ fn make_error<'a>(overflow: bool, negative: bool) -> ExtendedParserError<'a, Ext
 }
 
 // Construct an ExtendedBigDecimal based on parsed data
-// TODO: Might be nice to implement a ExtendedBigDecimal copysign or negation function to move away some of this logic.
 fn construct_extended_big_decimal<'a>(
     digits: BigUint,
     negative: bool,

--- a/src/uucore/src/lib/features/format/num_parser.rs
+++ b/src/uucore/src/lib/features/format/num_parser.rs
@@ -432,7 +432,10 @@ fn parse(
         };
 
         // Parse the exponent part, only decimal numbers are allowed.
-        if chars.peek().is_some_and(|&(_, c)| c == exp_char) {
+        if chars
+            .peek()
+            .is_some_and(|&(_, c)| c.to_ascii_lowercase() == exp_char)
+        {
             chars.next();
             let exp_negative = match chars.peek() {
                 Some((_, '-')) => {
@@ -570,8 +573,8 @@ mod tests {
         assert_eq!(Ok(-123.15), f64::extended_parse("-0123.15"));
         assert_eq!(Ok(12315000.0), f64::extended_parse("123.15e5"));
         assert_eq!(Ok(-12315000.0), f64::extended_parse("-123.15e5"));
-        assert_eq!(Ok(12315000.0), f64::extended_parse("123.15e+5"));
-        assert_eq!(Ok(0.0012315), f64::extended_parse("123.15e-5"));
+        assert_eq!(Ok(12315000.0), f64::extended_parse("123.15E+5"));
+        assert_eq!(Ok(0.0012315), f64::extended_parse("123.15E-5"));
         assert_eq!(
             Ok(0.15),
             f64::extended_parse(".150000000000000000000000000231313")
@@ -655,7 +658,7 @@ mod tests {
                 12315.into(),
                 102
             ))),
-            ExtendedBigDecimal::extended_parse("123.15e-100")
+            ExtendedBigDecimal::extended_parse("123.15E-100")
         );
         // Very high precision that would not fit in a f64.
         assert_eq!(
@@ -724,7 +727,7 @@ mod tests {
         assert_eq!(Ok(0.0625), f64::extended_parse("0x.1"));
         assert_eq!(Ok(15.007_812_5), f64::extended_parse("0xf.02"));
         assert_eq!(Ok(16.0), f64::extended_parse("0x0.8p5"));
-        assert_eq!(Ok(0.0625), f64::extended_parse("0x1p-4"));
+        assert_eq!(Ok(0.0625), f64::extended_parse("0x1P-4"));
 
         // We cannot really check that 'e' is not a valid exponent indicator for hex floats...
         // but we can check that the number still gets parsed properly: 0x0.8e5 is 0x8e5 / 16**3
@@ -751,7 +754,7 @@ mod tests {
             Err(ExtendedParserError::Overflow(ExtendedBigDecimal::Infinity))
         ));
         assert!(matches!(
-            ExtendedBigDecimal::extended_parse(&format!("-0x100p{}", u32::MAX as u64 + 1)),
+            ExtendedBigDecimal::extended_parse(&format!("-0x100P{}", u32::MAX as u64 + 1)),
             Err(ExtendedParserError::Overflow(
                 ExtendedBigDecimal::MinusInfinity
             ))

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -675,6 +675,19 @@ fn test_overflow() {
     new_ucmd!()
         .args(&["%d", "36893488147419103232"])
         .fails_with_code(1)
+        .stdout_is("9223372036854775807")
+        .stderr_is("printf: '36893488147419103232': Numerical result out of range\n");
+
+    new_ucmd!()
+        .args(&["%d", "-36893488147419103232"])
+        .fails_with_code(1)
+        .stdout_is("-9223372036854775808")
+        .stderr_is("printf: '-36893488147419103232': Numerical result out of range\n");
+
+    new_ucmd!()
+        .args(&["%u", "36893488147419103232"])
+        .fails_with_code(1)
+        .stdout_is("18446744073709551615")
         .stderr_is("printf: '36893488147419103232': Numerical result out of range\n");
 }
 


### PR DESCRIPTION
Stacks on top of #7556. A bunch of fixes and additions to parsing code that brings common core parsing to parity with `seq` implementation, and will allow the custom `seq` parser to be removed in the next PR.

---

### uucore: format: Remove TODO

Not much more that can be easily simplified now.

### uucore: format: num_parser: Allow uppercase exponent

1E3 and 0x1P3 are acceptable numbers.

Sprinkle uppercase values in the tests.

### uucore: format: num_parser: underflow/overflow check

When parsing floating point numbers, return errors if we end up
overflowing/underflowing BigDecimal (e.g. with large/small exponents).

### uucore: format: num_parser: Add value to Overflow error

When parsing integers, we should still return the min/max value
of the type (depending on the type), and wrap that in the error.

We need to refactor the map function to handle this case better,
and add an extract function to get the value out of an error
(if any).

This fixes the integer part of #7508.

### uucore: format: Fix i64::MIN printing

-i64::MIN overflows i64, so cast to i128 first.

### uucore: format: num_parser: Carve out part of parse function

We'll need more logic in there.

### uucore: format: num_parser: "infinity" string parsing

Not just "inf" is allowed, also "infinity".

### uucore: format: extendedbigdecimal: Implement Neg trait

This is useful and will simplify some of the parsing logic later.