### PR TITLE
uptime: fix "unused import" warning in test

### DIFF
--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -6,6 +6,7 @@
 // spell-checker:ignore bincode serde utmp runlevel testusr testx
 #![allow(clippy::cast_possible_wrap, clippy::unreadable_literal)]
 
+#[cfg(not(any(target_os = "openbsd", target_os = "freebsd")))]
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 use uutests::util::TestScenario;


### PR DESCRIPTION
This PR fixes an "unused import" warning in test on FreeBSD (and on OpenBSD), see https://github.com/uutils/coreutils/actions/runs/14187800672/job/39746177169?pr=7627#step:5:4257