### PR TITLE
Bump `bigdecimal` & fix failing test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
+checksum = "1a22f228ab7a1b23027ccc6c350b72868017af7ea8356fbdf19f8d991c690013"
 dependencies = [
  "autocfg",
  "libm",

--- a/src/uucore/src/lib/features/format/extendedbigdecimal.rs
+++ b/src/uucore/src/lib/features/format/extendedbigdecimal.rs
@@ -21,7 +21,6 @@
 //! assert_eq!(summand1 + summand2, ExtendedBigDecimal::Infinity);
 //! ```
 use std::cmp::Ordering;
-use std::fmt::Display;
 use std::ops::Add;
 use std::ops::Neg;
 
@@ -107,25 +106,6 @@ impl ExtendedBigDecimal {
 
     pub fn one() -> Self {
         Self::BigDecimal(1.into())
-    }
-}
-
-impl Display for ExtendedBigDecimal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::BigDecimal(x) => {
-                let (n, p) = x.as_bigint_and_exponent();
-                match p {
-                    0 => Self::BigDecimal(BigDecimal::new(n * 10, 1)).fmt(f),
-                    _ => x.fmt(f),
-                }
-            }
-            Self::Infinity => f32::INFINITY.fmt(f),
-            Self::MinusInfinity => f32::NEG_INFINITY.fmt(f),
-            Self::MinusZero => (-0.0f32).fmt(f),
-            Self::Nan => "nan".fmt(f),
-            Self::MinusNan => "-nan".fmt(f),
-        }
     }
 }
 
@@ -280,17 +260,5 @@ mod tests {
             ExtendedBigDecimal::Nan => (),
             _ => unreachable!(),
         }
-    }
-
-    #[test]
-    fn test_display() {
-        assert_eq!(
-            format!("{}", ExtendedBigDecimal::BigDecimal(BigDecimal::zero())),
-            "0.0"
-        );
-        assert_eq!(format!("{}", ExtendedBigDecimal::Infinity), "inf");
-        assert_eq!(format!("{}", ExtendedBigDecimal::MinusInfinity), "-inf");
-        assert_eq!(format!("{}", ExtendedBigDecimal::Nan), "nan");
-        assert_eq!(format!("{}", ExtendedBigDecimal::MinusZero), "-0");
     }
 }

--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -246,13 +246,7 @@ impl Formatter<&ExtendedBigDecimal> for Float {
          */
         let (abs, negative) = match e {
             ExtendedBigDecimal::BigDecimal(bd) => {
-                // Workaround printing bug in BigDecimal, force 0 to scale 0.
-                // TODO: Remove after https://github.com/akubera/bigdecimal-rs/issues/144 is fixed.
-                if bd.is_zero() {
-                    (ExtendedBigDecimal::zero(), false)
-                } else {
-                    (ExtendedBigDecimal::BigDecimal(bd.abs()), bd.is_negative())
-                }
+                (ExtendedBigDecimal::BigDecimal(bd.abs()), bd.is_negative())
             }
             ExtendedBigDecimal::MinusZero => (ExtendedBigDecimal::zero(), true),
             ExtendedBigDecimal::Infinity => (ExtendedBigDecimal::Infinity, false),
@@ -730,12 +724,8 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Need https://github.com/akubera/bigdecimal-rs/issues/144 to be fixed"]
     fn decimal_float_zero() {
         use super::format_float_decimal;
-        // We've had issues with "0e10"/"0e-10" formatting.
-        // TODO: Enable after https://github.com/akubera/bigdecimal-rs/issues/144 is fixed,
-        // as our workaround is in .fmt.
         let f = |digits, scale| {
             format_float_decimal(&BigDecimal::from_bigint(digits, scale), 6, ForceDecimal::No)
         };


### PR DESCRIPTION
This PR bumps `bigdecimal` from `0.4.7` to `0.4.8` and fixes a failing test.