### PR TITLE
uucore: format: Fix hexadecimal default format print

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -169,7 +169,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     variant: FloatVariant::Decimal,
                     width: padding,
                     alignment: num_format::NumberAlignment::RightZero,
-                    precision,
+                    precision: Some(precision),
                     ..Default::default()
                 },
                 // format without precision: hexadecimal floats

--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -509,9 +509,9 @@ fn format_float_hexadecimal(
 ) -> String {
     debug_assert!(!bd.is_negative());
 
-    let exp_char = match case {
-        Case::Lowercase => 'p',
-        Case::Uppercase => 'P',
+    let (prefix, exp_char) = match case {
+        Case::Lowercase => ("0x", 'p'),
+        Case::Uppercase => ("0X", 'P'),
     };
 
     if BigDecimal::zero().eq(bd) {
@@ -607,7 +607,7 @@ fn format_float_hexadecimal(
             ""
         };
 
-    format!("0x{first_digit}{dot}{remaining_digits}{exp_char}{exponent:+}")
+    format!("{prefix}{first_digit}{dot}{remaining_digits}{exp_char}{exponent:+}")
 }
 
 fn strip_fractional_zeroes_and_dot(s: &mut String) {
@@ -964,8 +964,8 @@ mod test {
                 ForceDecimal::No,
             )
         };
-        assert_eq!(f("0.00001"), "0xA.7C5AC4P-20");
-        assert_eq!(f("0.125"), "0x8.000000P-6");
+        assert_eq!(f("0.00001"), "0XA.7C5AC4P-20");
+        assert_eq!(f("0.125"), "0X8.000000P-6");
 
         // Test "0e10"/"0e-10". From cppreference.com: "If the value is ​0​, the exponent is also ​0​."
         let f = |digits, scale| {
@@ -1178,7 +1178,7 @@ mod test {
         assert_eq!(f("%e", &(-123.0).into()), "-1.230000e+02");
         assert_eq!(f("%#09.e", &(-100.0).into()), "-001.e+02");
         assert_eq!(f("%# 9.E", &100.0.into()), "   1.E+02");
-        assert_eq!(f("% 12.2A", &(-100.0).into()), "  -0xC.80P+3");
+        assert_eq!(f("% 12.2A", &(-100.0).into()), "  -0XC.80P+3");
     }
 
     #[test]

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -432,11 +432,13 @@ impl Spec {
                 precision,
             } => {
                 let width = resolve_asterisk(*width, &mut args).unwrap_or(0);
-                let precision = resolve_asterisk(*precision, &mut args).unwrap_or(6);
+                let precision = resolve_asterisk(*precision, &mut args);
                 let f: ExtendedBigDecimal = args.get_extended_big_decimal();
 
-                if precision as u64 > i32::MAX as u64 {
-                    return Err(FormatError::InvalidPrecision(precision.to_string()));
+                if precision.is_some_and(|p| p as u64 > i32::MAX as u64) {
+                    return Err(FormatError::InvalidPrecision(
+                        precision.unwrap().to_string(),
+                    ));
                 }
 
                 num_format::Float {

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -390,7 +390,6 @@ fn sub_num_sci_negative() {
         .stdout_only("-1234 is -1.234000e+03");
 }
 
-#[cfg_attr(not(feature = "test_unimplemented"), ignore)]
 #[test]
 fn sub_num_hex_float_lower() {
     new_ucmd!()
@@ -399,7 +398,6 @@ fn sub_num_hex_float_lower() {
         .stdout_only("0xep-4");
 }
 
-#[cfg_attr(not(feature = "test_unimplemented"), ignore)]
 #[test]
 fn sub_num_hex_float_upper() {
     new_ucmd!()


### PR DESCRIPTION
Fix 2 more printing issues. For now, we print like GNU coreutils on x86-64 does. I plan to write up a bit more about float precision handling (and how we are different from GNU coreutils, not just in `printf`, but also in `seq`), but I think I'll do that as a separate PR.

---

### uucore: format: Fix hexadecimal default format print

The default hex format, on x86(-64) prints 15 digits after the
decimal point, _but_ also trims trailing zeros, so it's not just
a simple default precision and a little bit of extra handling is
required.

Also add a bunch of tests.

Fixes #7364.

### uucore: format: Use Option for Float precision

The default precision for float actually depends on the format.
It's _usually_ 6, but it's architecture-specific for hexadecimal
floats.

Set the precision as an Option, so that:
 - We don't need to sprinkle `6` in callers
 - We can actually handle unspecified precision correctly in
   float printing (next change).

### uucore: format: Fix hexadecimal uppercase print (again)

When '%A' format is specified, we also need to capitalize the
`0x`, i.e. `0XEP-3`, not `0xEP-3`.