### PR TITLE
cat: bugfix when running with -T option

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -644,7 +644,7 @@ fn write_tab_to_end<W: Write>(mut in_buf: &[u8], writer: &mut W) -> usize {
             }
             None => {
                 writer.write_all(in_buf).unwrap();
-                return in_buf.len();
+                return in_buf.len() + count;
             }
         };
     }
@@ -687,6 +687,20 @@ fn write_end_of_line<W: Write>(
 #[cfg(test)]
 mod tests {
     use std::io::{BufWriter, stdout};
+
+    #[test]
+    fn test_write_tab_to_end_with_newline() {
+        let mut writer = BufWriter::with_capacity(1024 * 64, stdout());
+        let in_buf = b"a\tb\tc\n";
+        assert_eq!(super::write_tab_to_end(in_buf, &mut writer), 5);
+    }
+
+    #[test]
+    fn test_write_tab_to_end_no_newline() {
+        let mut writer = BufWriter::with_capacity(1024 * 64, stdout());
+        let in_buf = b"a\tb\tc";
+        assert_eq!(super::write_tab_to_end(in_buf, &mut writer), 5);
+    }
 
     #[test]
     fn test_write_nonprint_to_end_new_line() {

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -415,6 +415,15 @@ fn test_stdin_nonprinting_and_tabs_repeated() {
 }
 
 #[test]
+fn test_stdin_tabs_no_newline() {
+    new_ucmd!()
+        .args(&["-T"])
+        .pipe_in("\ta")
+        .succeeds()
+        .stdout_only("^Ia");
+}
+
+#[test]
 fn test_stdin_squeeze_blank() {
     for same_param in ["-s", "--squeeze-blank", "--squeeze"] {
         new_ucmd!()


### PR DESCRIPTION
Fixes #7637
Fixes an crash seen when running with -T option if no newline is found in a buffer.
Added unit test to validate.