### PR TITLE
clippy: fix warnings from Rust 1.86

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -157,7 +157,7 @@ mod tests {
         ];
 
         for (line, final_len) in tests {
-            let mut v = std::iter::repeat(b'a').take(line).collect::<Vec<_>>();
+            let mut v = std::iter::repeat_n(b'a', line).collect::<Vec<_>>();
             prepare_buffer(&mut v);
             assert_eq!(v.len(), final_len);
         }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -5637,7 +5637,7 @@ mod link_deref {
                 let mut args = vec!["--link", "-P", src, DST];
                 if r {
                     args.push("-R");
-                };
+                }
                 scene.ucmd().args(&args).succeeds().no_stderr();
                 at.is_symlink(DST);
                 let src_ino = at.symlink_metadata(src).ino();
@@ -5658,7 +5658,7 @@ mod link_deref {
                 let mut args = vec!["--link", DANG_LINK, DST];
                 if r {
                     args.push("-R");
-                };
+                }
                 if !option.is_empty() {
                     args.push(option);
                 }

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -7,7 +7,7 @@
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 use uutests::util::TestScenario;
-#[cfg(unix)]
+#[cfg(all(unix, not(feature = "feat_selinux")))]
 use uutests::util::run_ucmd_as_root_with_stdin_stdout;
 #[cfg(all(not(windows), feature = "printf"))]
 use uutests::util::{UCommand, get_tests_binary};

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -185,7 +185,7 @@ fn test_random() {
                     factors.push(factor);
                 }
                 None => break,
-            };
+            }
         }
 
         factors.sort_unstable();

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -1374,9 +1374,9 @@ pub struct TerminalSimulation {
 
 /// A `UCommand` is a builder wrapping an individual Command that provides several additional features:
 /// 1. it has convenience functions that are more ergonomic to use for piping in stdin, spawning the command
-///       and asserting on the results.
+///    and asserting on the results.
 /// 2. it tracks arguments provided so that in test cases which may provide variations of an arg in loops
-///     the test failure can display the exact call which preceded an assertion failure.
+///    the test failure can display the exact call which preceded an assertion failure.
 /// 3. it provides convenience construction methods to set the Command uutils utility and temporary directory.
 ///
 /// Per default `UCommand` runs a command given as an argument in a shell, platform independently.


### PR DESCRIPTION
This PR fixes warnings from the [doc_overindented_list_items](https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items), [unnecessary_semicolon](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon), and [manual_repeat_n](https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n) lints. It also fixes an "unused import" warning in a test.