### PR TITLE
cat: Formatting performance improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,6 +2535,7 @@ name = "uu_cat"
 version = "0.0.30"
 dependencies = [
  "clap",
+ "memchr",
  "nix",
  "thiserror 2.0.12",
  "uucore",

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/cat.rs"
 
 [dependencies]
 clap = { workspace = true }
+memchr = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = ["fs", "pipes"] }
 

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -17,6 +17,7 @@ use std::os::unix::fs::FileTypeExt;
 use std::os::unix::net::UnixStream;
 
 use clap::{Arg, ArgAction, Command};
+use memchr::memchr2;
 #[cfg(unix)]
 use nix::fcntl::{FcntlArg, fcntl};
 use thiserror::Error;
@@ -118,12 +119,12 @@ struct OutputState {
 }
 
 #[cfg(unix)]
-trait FdReadable: Read + AsFd + AsRawFd {}
+trait FdReadable: Read + AsFd {}
 #[cfg(not(unix))]
 trait FdReadable: Read {}
 
 #[cfg(unix)]
-impl<T> FdReadable for T where T: Read + AsFd + AsRawFd {}
+impl<T> FdReadable for T where T: Read + AsFd {}
 #[cfg(not(unix))]
 impl<T> FdReadable for T where T: Read {}
 
@@ -612,7 +613,7 @@ fn write_end<W: Write>(writer: &mut W, in_buf: &[u8], options: &OutputOptions) -
 // however, write_nonprint_to_end doesn't need to stop at \r because it will always write \r as ^M.
 // Return the number of written symbols
 fn write_to_end<W: Write>(in_buf: &[u8], writer: &mut W) -> usize {
-    match in_buf.iter().position(|c| *c == b'\n' || *c == b'\r') {
+    match memchr2(b'\n', b'\r', in_buf) {
         Some(p) => {
             writer.write_all(&in_buf[..p]).unwrap();
             p

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -613,6 +613,7 @@ fn write_end<W: Write>(writer: &mut W, in_buf: &[u8], options: &OutputOptions) -
 // however, write_nonprint_to_end doesn't need to stop at \r because it will always write \r as ^M.
 // Return the number of written symbols
 fn write_to_end<W: Write>(in_buf: &[u8], writer: &mut W) -> usize {
+    // using memchr2 significantly improves performances
     match memchr2(b'\n', b'\r', in_buf) {
         Some(p) => {
             writer.write_all(&in_buf[..p]).unwrap();


### PR DESCRIPTION
Use memchr library in `cat` to improve performance when detecting newlines.
Significantly improves performance when running with -n, -s, -E, -b flags.