### PR TITLE
timeout: Use common parser to parse time duration

### DIFF
--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -126,6 +126,24 @@ fn test_dont_overflow() {
 }
 
 #[test]
+fn test_dont_underflow() {
+    new_ucmd!()
+        .args(&[".0000000001", "sleep", "1"])
+        .fails_with_code(124)
+        .no_output();
+    new_ucmd!()
+        .args(&["1e-100", "sleep", "1"])
+        .fails_with_code(124)
+        .no_output();
+    // Unlike GNU coreutils, we underflow to 1ns for very short timeouts.
+    // https://debbugs.gnu.org/cgi/bugreport.cgi?bug=77535
+    new_ucmd!()
+        .args(&["1e-18172487393827593258", "sleep", "1"])
+        .fails_with_code(124)
+        .no_output();
+}
+
+#[test]
 fn test_negative_interval() {
     new_ucmd!()
         .args(&["--", "-1", "sleep", "0"])


### PR DESCRIPTION
### test_timeout: Add tests for very short timeouts

Note that unlike GNU coreutils, any value > 0 will not be treated
as 0, even if the exponent is very large.

### uucore: parser: parse_time: Use ExtendedBigDecimal parser

Gives a little bit more flexibility in terms of allowed input
for durations (e.g. in `timeout`), e.g. hex floating point
numbers are now allowed.

Fixes another part of #7475.

### uucore: parser: num_parser: Do not Underflow/Overflow when parsing 0

Values like 0e18172487393827593258 and 0e-18172487393827593258 should
just be parsed as 0, and do not need to return an error.

### uucore: parser: parse_time: Handle infinity and nan

There were some missing corner cases when handling infinity and
nan:
 - inf/infinity can be capitalized
 - nan must always be rejected, even if a suffix is provided

Also, return Duration::MAX with infinite values, just for consistency
(num.fract() returns 0 for infinity so technically we were just
short of that).

Add unit tests too.

Fixes some of #7475.