### PR TITLE
seq: Trim whitespaces, then try to remove +

### DIFF
--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -27,9 +27,10 @@ pub enum ParseNumberError {
 // need to be too careful.
 fn compute_num_digits(input: &str, ebd: ExtendedBigDecimal) -> PreciseNumber {
     let input = input.to_lowercase();
+    let input = input.trim_start();
 
     // Leading + is ignored for this.
-    let input = input.trim_start().strip_prefix('+').unwrap_or(&input);
+    let input = input.strip_prefix('+').unwrap_or(input);
 
     // Integral digits for any hex number is ill-defined (0 is fine as an output)
     // Fractional digits for an floating hex number is ill-defined, return None

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -869,6 +869,8 @@ fn test_parse_valid_hexadecimal_float_two_args() {
         (["0xA.A9p-1", "6"], "5.33008\n"),
         (["0xa.a9p-1", "6"], "5.33008\n"),
         (["0xffffffffffp-30", "1024"], "1024\n"), // spell-checker:disable-line
+        (["  0XA.A9P-1", "6"], "5.33008\n"),
+        (["  0xee.", "  0xef."], "238\n239\n"),
     ];
 
     for (input_arguments, expected_output) in &test_cases {


### PR DESCRIPTION
Otherwise, `seq` crashes with ` 0xee.` as input.

Also update one of the tests to catch that.