### PR TITLE
printf: make negative values wrap around with unsigned/hex format

### DIFF
--- a/src/uucore/src/lib/features/parser/num_parser.rs
+++ b/src/uucore/src/lib/features/parser/num_parser.rs
@@ -165,23 +165,24 @@ impl ExtendedParser for u64 {
                 ExtendedBigDecimal::BigDecimal(bd) => {
                     let (digits, scale) = bd.into_bigint_and_scale();
                     if scale == 0 {
-                        let negative = digits.sign() == Sign::Minus;
+                        let (sign, digits) = digits.into_parts();
+
                         match u64::try_from(digits) {
-                            Ok(i) => Ok(i),
-                            _ => Err(ExtendedParserError::Overflow(if negative {
-                                // TODO: We should wrap around here #7488
-                                0
-                            } else {
-                                u64::MAX
-                            })),
+                            Ok(i) => {
+                                if sign == Sign::Minus {
+                                    Ok(!i + 1)
+                                } else {
+                                    Ok(i)
+                                }
+                            }
+                            _ => Err(ExtendedParserError::Overflow(u64::MAX)),
                         }
                     } else {
                         // Should not happen.
                         Err(ExtendedParserError::NotNumeric)
                     }
                 }
-                // TODO: Handle -0 too #7488
-                // No other case should not happen.
+                ExtendedBigDecimal::MinusZero => Ok(0),
                 _ => Err(ExtendedParserError::NotNumeric),
             }
         }
@@ -500,10 +501,28 @@ mod tests {
     fn test_decimal_u64() {
         assert_eq!(Ok(123), u64::extended_parse("123"));
         assert_eq!(Ok(u64::MAX), u64::extended_parse(&format!("{}", u64::MAX)));
-        // TODO: We should wrap around here #7488
+        assert_eq!(Ok(0), u64::extended_parse("-0"));
+        assert_eq!(Ok(u64::MAX), u64::extended_parse("-1"));
+        assert_eq!(
+            Ok(u64::MAX / 2 + 1),
+            u64::extended_parse("-9223372036854775808") // i64::MIN
+        );
+        assert_eq!(
+            Ok(1123372036854675616),
+            u64::extended_parse("-17323372036854876000") // 2*i64::MIN
+        );
+        assert_eq!(Ok(1), u64::extended_parse("-18446744073709551615")); // -u64::MAX
         assert!(matches!(
-            u64::extended_parse("-123"),
-            Err(ExtendedParserError::Overflow(0))
+            u64::extended_parse("-18446744073709551616"), // -u64::MAX - 1
+            Err(ExtendedParserError::Overflow(u64::MAX))
+        ));
+        assert!(matches!(
+            u64::extended_parse("-92233720368547758150"),
+            Err(ExtendedParserError::Overflow(u64::MAX))
+        ));
+        assert!(matches!(
+            u64::extended_parse("-170141183460469231731687303715884105729"),
+            Err(ExtendedParserError::Overflow(u64::MAX))
         ));
         assert!(matches!(
             u64::extended_parse(""),

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -2,6 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
+// spell-checker:ignore fffffffffffffffc
 use uutests::new_ucmd;
 use uutests::util::TestScenario;
 use uutests::util_name;
@@ -666,6 +668,41 @@ fn partial_integer() {
         .fails_with_code(1)
         .stdout_is("42 is a lot")
         .stderr_is("printf: '42x23': value not completely converted\n");
+}
+
+#[test]
+fn unsigned_hex_negative_wraparound() {
+    new_ucmd!()
+        .args(&["%x", "-0b100"])
+        .succeeds()
+        .stdout_only("fffffffffffffffc");
+
+    new_ucmd!()
+        .args(&["%x", "-0100"])
+        .succeeds()
+        .stdout_only("ffffffffffffffc0");
+
+    new_ucmd!()
+        .args(&["%x", "-100"])
+        .succeeds()
+        .stdout_only("ffffffffffffff9c");
+
+    new_ucmd!()
+        .args(&["%x", "-0x100"])
+        .succeeds()
+        .stdout_only("ffffffffffffff00");
+
+    new_ucmd!()
+        .args(&["%x", "-92233720368547758150"])
+        .fails_with_code(1)
+        .stdout_is("ffffffffffffffff")
+        .stderr_is("printf: '-92233720368547758150': Numerical result out of range\n");
+
+    new_ucmd!()
+        .args(&["%u", "-1002233720368547758150"])
+        .fails_with_code(1)
+        .stdout_is("18446744073709551615")
+        .stderr_is("printf: '-1002233720368547758150': Numerical result out of range\n");
 }
 
 #[test]


### PR DESCRIPTION
When printing unsigned numbers, GNU coreutils makes negative numbers around, so when we try to get a u64 from a BigInt and it's negative, convert it to an i64 and from that to a u64 so it wraps around.

For the test cases I used the same ones as in the original issue https://github.com/uutils/coreutils/issues/7488

Closes https://github.com/uutils/coreutils/issues/7488