### PR TITLE
cp: fix update prompting

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1833,13 +1833,11 @@ fn handle_existing_dest(
         return Err(format!("{} and {} are the same file", source.quote(), dest.quote()).into());
     }
 
-    if options.update == UpdateMode::ReplaceNone {
-        if dest.exists() {
-            if options.debug {
-                println!("skipped {}", dest.quote());
-            }
-            return Err(Error::Skipped(false));
+    if options.update == UpdateMode::ReplaceNone && dest.exists() {
+        if options.debug {
+            println!("skipped {}", dest.quote());
         }
+        return Err(Error::Skipped(false));
     }
 
     if options.update != UpdateMode::ReplaceIfOlder {

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1833,7 +1833,7 @@ fn handle_existing_dest(
         return Err(format!("{} and {} are the same file", source.quote(), dest.quote()).into());
     }
 
-    if options.update == UpdateMode::ReplaceNone && dest.exists() {
+    if options.update == UpdateMode::ReplaceNone {
         if options.debug {
             println!("skipped {}", dest.quote());
         }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -6172,3 +6172,21 @@ fn test_cp_update_older_interactive_prompt_no() {
         .fails()
         .stdout_is("cp: overwrite 'old'? ");
 }
+
+#[test]
+fn test_cp_update_none_interactive_promp_no() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let old_file = "old";
+    let new_file = "new";
+
+    at.write(old_file, "old content");
+    at.write(new_file, "new content");
+
+    ucmd.args(&["-i", "--update=none", new_file, old_file])
+        .succeeds()
+        .no_stderr()
+        .no_stdout();
+
+    assert_eq!(at.read(old_file), "old content");
+    assert_eq!(at.read(new_file), "new content");
+}

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -6174,7 +6174,7 @@ fn test_cp_update_older_interactive_prompt_no() {
 }
 
 #[test]
-fn test_cp_update_none_interactive_promp_no() {
+fn test_cp_update_none_interactive_prompt_no() {
     let (at, mut ucmd) = at_and_ucmd!();
     let old_file = "old";
     let new_file = "new";

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -6184,8 +6184,7 @@ fn test_cp_update_none_interactive_prompt_no() {
 
     ucmd.args(&["-i", "--update=none", new_file, old_file])
         .succeeds()
-        .no_stderr()
-        .no_stdout();
+        .no_output();
 
     assert_eq!(at.read(old_file), "old content");
     assert_eq!(at.read(new_file), "new content");


### PR DESCRIPTION
- added logic to check in `copy_source` after resolving src and dst to compare
  timestamps
   - if dst is newer, we skip the operation and prevent prompting the user
   - else, proceed to copy
 
Fixes #7660