### PR TITLE
fix(sleep): use uucore's from_str to support parsing hex

### DIFF
--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/sleep.rs"
 [dependencies]
 clap = { workspace = true }
 fundu = { workspace = true }
-uucore = { workspace = true }
+uucore = { workspace = true, features = ["parser"] }
 
 [[bin]]
 name = "sleep"

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -77,7 +77,7 @@ fn test_command_empty_args() {
     new_ucmd!()
         .args(&["", ""])
         .fails()
-        .stderr_contains("timeout: empty string");
+        .stderr_contains("timeout: invalid time interval ''");
 }
 
 #[test]


### PR DESCRIPTION
closes #7669

`sleep` now uses uucore's `from_str` instead of `fundu` to support hex parsing. This changes some error output (although it looks to be more in line with GNU, not less), so I changed the relevant tests as well. However, at first glance, it looks like it might be returning "empty string" in unexpected cases (e.g. '\n').
