### PR TITLE
cp: Fix "No such file or directory" error in test_acl_preserve

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -4055,11 +4055,11 @@ fn test_acl_preserve() {
     at.mkdir(path2);
     at.touch(file);
 
-    let path = at.plus_as_string(file);
+    let path1 = at.plus_as_string(path1);
     // calling the command directly. xattr requires some dev packages to be installed
     // and it adds a complex dependency just for a test
     match Command::new("setfacl")
-        .args(["-m", "group::rwx", path1])
+        .args(["-m", "group::rwx", &path1])
         .status()
         .map(|status| status.code())
     {
@@ -4074,6 +4074,7 @@ fn test_acl_preserve() {
         }
     }
 
+    let path = at.plus_as_string(file);
     scene.ucmd().args(&["-p", &path, path2]).succeeds();
 
     assert!(compare_xattrs(&file, &file_target));


### PR DESCRIPTION
Issue: https://github.com/uutils/coreutils/issues/7030

Fix a bug in test_acl_preserve that was causing "setfacl: a: No such file or directory" error messages when running with `cargo test --features=cp test_acl_preserve`.

Changes:
- Use plus_as_string on path1 to generate the correct absolute path
- Move the file path generation closer to where it's used for better code organization