### PR TITLE
numfmt: add --zero-terminated option

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -392,12 +392,20 @@ fn format_and_print_whitespace(s: &str, options: &NumfmtOptions) -> Result<()> {
 
             print!("{}", format_string(field, options, implicit_padding)?);
         } else {
+            // the -z option converts an initial \n into a space
+            let prefix = if options.zero_terminated && prefix.starts_with('\n') {
+                print!(" ");
+                &prefix[1..]
+            } else {
+                prefix
+            };
             // print unselected field without conversion
             print!("{prefix}{field}");
         }
     }
 
-    println!();
+    let eol = if options.zero_terminated { '\0' } else { '\n' };
+    print!("{}", eol);
 
     Ok(())
 }

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -26,6 +26,7 @@ pub const TO: &str = "to";
 pub const TO_DEFAULT: &str = "none";
 pub const TO_UNIT: &str = "to-unit";
 pub const TO_UNIT_DEFAULT: &str = "1";
+pub const ZERO_TERMINATED: &str = "zero-terminated";
 
 pub struct TransformOptions {
     pub from: Unit,
@@ -52,6 +53,7 @@ pub struct NumfmtOptions {
     pub suffix: Option<String>,
     pub format: FormatOptions,
     pub invalid: InvalidModes,
+    pub zero_terminated: bool,
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
This partially fixes https://github.com/uutils/coreutils/issues/1280. With this patch, the GNU compatibility tests for `numfmt --zero-terminated` pass:
```
$ bash util/run-gnu-test.sh tests/misc/numfmt.pl
...
z1...
z3...
z2...
z4...
z5...
...
```

One thing to note is that this patch does an `unwrap` on `String::from_utf8` because `BufRead.split(0)` results in `Vec<u8>` instead of `String`. This isn't a regression though because the rest of the program already assumes input can be put into `String`. Here's an example from the `main` branch:
```
$ printf "\xED\xBF\xBF" | cargo run -q --bin coreutils numfmt
numfmt: stream did not contain valid UTF-8
```
I don't see a bug report for that so I'm happy to file one. I just didn't want to do more than one thing in this PR.