### PR TITLE
chore: manual inline formatting - tests

### DIFF
--- a/fuzz/fuzz_targets/fuzz_cksum.rs
+++ b/fuzz/fuzz_targets/fuzz_cksum.rs
@@ -130,10 +130,10 @@ fuzz_target!(|_data: &[u8]| {
         if let Ok(checksum_file_path) =
             generate_checksum_file(algo, &file_path, &selected_digest_opts)
         {
-            print_test_begin(format!("cksum {:?}", args));
+            print_test_begin(format!("cksum {args:?}"));
 
             if let Ok(content) = fs::read_to_string(&checksum_file_path) {
-                println!("File content ({})", checksum_file_path);
+                println!("File content ({checksum_file_path})");
                 print_or_empty(&content);
             } else {
                 eprintln!("Error reading the checksum file.");

--- a/fuzz/fuzz_targets/fuzz_common/mod.rs
+++ b/fuzz/fuzz_targets/fuzz_common/mod.rs
@@ -43,7 +43,7 @@ pub fn is_gnu_cmd(cmd_path: &str) -> Result<(), std::io::Error> {
     CHECK_GNU.call_once(|| {
         let version_output = Command::new(cmd_path).arg("--version").output().unwrap();
 
-        println!("version_output {:#?}", version_output);
+        println!("version_output {version_output:#?}");
 
         let version_str = String::from_utf8_lossy(&version_output.stdout).to_string();
         if version_str.contains("GNU coreutils") {
@@ -112,7 +112,7 @@ where
     let original_stdin_fd = if let Some(input_str) = pipe_input {
         // we have pipe input
         let mut input_file = tempfile::tempfile().unwrap();
-        write!(input_file, "{}", input_str).unwrap();
+        write!(input_file, "{input_str}").unwrap();
         input_file.seek(SeekFrom::Start(0)).unwrap();
 
         // Redirect stdin to read from the in-memory file
@@ -320,10 +320,10 @@ pub fn compare_result(
     gnu_result: &CommandResult,
     fail_on_stderr_diff: bool,
 ) {
-    print_section(format!("Compare result for: {} {}", test_type, input));
+    print_section(format!("Compare result for: {test_type} {input}"));
 
     if let Some(pipe) = pipe_input {
-        println!("Pipe: {}", pipe);
+        println!("Pipe: {pipe}");
     }
 
     let mut discrepancies = Vec::new();
@@ -369,16 +369,13 @@ pub fn compare_result(
         );
         if should_panic {
             print_end_with_status(
-                format!("Test failed and will panic for: {} {}", test_type, input),
+                format!("Test failed and will panic for: {test_type} {input}"),
                 false,
             );
-            panic!("Test failed for: {} {}", test_type, input);
+            panic!("Test failed for: {test_type} {input}");
         } else {
             print_end_with_status(
-                format!(
-                    "Test completed with discrepancies for: {} {}",
-                    test_type, input
-                ),
+                format!("Test completed with discrepancies for: {test_type} {input}"),
                 false,
             );
         }

--- a/fuzz/fuzz_targets/fuzz_common/pretty_print.rs
+++ b/fuzz/fuzz_targets/fuzz_common/pretty_print.rs
@@ -9,11 +9,11 @@ use console::{style, Style};
 use similar::TextDiff;
 
 pub fn print_section<S: fmt::Display>(s: S) {
-    println!("{}", style(format!("=== {}", s)).bold());
+    println!("{}", style(format!("=== {s}")).bold());
 }
 
 pub fn print_subsection<S: fmt::Display>(s: S) {
-    println!("{}", style(format!("--- {}", s)).bright());
+    println!("{}", style(format!("--- {s}")).bright());
 }
 
 pub fn print_test_begin<S: fmt::Display>(msg: S) {
@@ -33,9 +33,8 @@ pub fn print_end_with_status<S: fmt::Display>(msg: S, ok: bool) {
     };
 
     println!(
-        "{} {} {}",
+        "{} {ok} {}",
         style("===").bold(), // Kind of gray
-        ok,
         style(msg).bold()
     );
 }

--- a/fuzz/fuzz_targets/fuzz_expr.rs
+++ b/fuzz/fuzz_targets/fuzz_expr.rs
@@ -39,7 +39,7 @@ fn generate_expr(max_depth: u32) -> String {
             // 90% chance to add an operator followed by a number
             if rng.random_bool(0.9) {
                 let op = *ops.choose(&mut rng).unwrap();
-                expr.push_str(&format!(" {} ", op));
+                expr.push_str(&format!(" {op} "));
                 last_was_operator = true;
             }
             // 10% chance to add a random string (potentially invalid syntax)

--- a/fuzz/fuzz_targets/fuzz_test.rs
+++ b/fuzz/fuzz_targets/fuzz_test.rs
@@ -138,28 +138,28 @@ fn generate_test_arg() -> String {
             if test_arg.arg_type == ArgType::INTEGER {
                 arg.push_str(&format!(
                     "{} {} {}",
-                    &rng.random_range(-100..=100).to_string(),
+                    rng.random_range(-100..=100).to_string(),
                     test_arg.arg,
-                    &rng.random_range(-100..=100).to_string()
+                    rng.random_range(-100..=100).to_string()
                 ));
             } else if test_arg.arg_type == ArgType::STRINGSTRING {
                 let random_str = generate_random_string(rng.random_range(1..=10));
                 let random_str2 = generate_random_string(rng.random_range(1..=10));
 
                 arg.push_str(&format!(
-                    "{} {} {}",
-                    &random_str, test_arg.arg, &random_str2
+                    "{random_str} {} {random_str2}",
+                    test_arg.arg,
                 ));
             } else if test_arg.arg_type == ArgType::STRING {
                 let random_str = generate_random_string(rng.random_range(1..=10));
-                arg.push_str(&format!("{} {}", test_arg.arg, &random_str));
+                arg.push_str(&format!("{} {random_str}", test_arg.arg));
             } else if test_arg.arg_type == ArgType::FILEFILE {
                 let path = generate_random_path(&mut rng);
                 let path2 = generate_random_path(&mut rng);
-                arg.push_str(&format!("{} {} {}", path, test_arg.arg, path2));
+                arg.push_str(&format!("{path} {} {path2}", test_arg.arg));
             } else if test_arg.arg_type == ArgType::FILE {
                 let path = generate_random_path(&mut rng);
-                arg.push_str(&format!("{} {}", test_arg.arg, path));
+                arg.push_str(&format!("{} {path}", test_arg.arg));
             }
         }
         4 => {
@@ -176,7 +176,7 @@ fn generate_test_arg() -> String {
                 .collect();
 
             if let Some(test_arg) = file_test_args.choose(&mut rng) {
-                arg.push_str(&format!("{}{}", test_arg.arg, path));
+                arg.push_str(&format!("{}{path}", test_arg.arg));
             }
         }
     }

--- a/tests/benches/factor/benches/table.rs
+++ b/tests/benches/factor/benches/table.rs
@@ -27,7 +27,7 @@ fn table(c: &mut Criterion) {
     let mut group = c.benchmark_group("table");
     group.throughput(Throughput::Elements(INPUT_SIZE as _));
     for a in inputs.take(10) {
-        let a_str = format!("{:?}", a);
+        let a_str = format!("{a:?}");
         group.bench_with_input(BenchmarkId::new("factor", &a_str), &a, |b, &a| {
             b.iter(|| {
                 for n in a {
@@ -46,18 +46,15 @@ fn check_personality() {
     const PERSONALITY_PATH: &str = "/proc/self/personality";
 
     let p_string = fs::read_to_string(PERSONALITY_PATH)
-        .unwrap_or_else(|_| panic!("Couldn't read '{}'", PERSONALITY_PATH))
+        .unwrap_or_else(|_| panic!("Couldn't read '{PERSONALITY_PATH}'"))
         .strip_suffix('\n')
         .unwrap()
         .to_owned();
 
     let personality = u64::from_str_radix(&p_string, 16)
-        .unwrap_or_else(|_| panic!("Expected a hex value for personality, got '{:?}'", p_string));
+        .unwrap_or_else(|_| panic!("Expected a hex value for personality, got '{p_string:?}'"));
     if personality & ADDR_NO_RANDOMIZE == 0 {
-        eprintln!(
-            "WARNING: Benchmarking with ASLR enabled (personality is {:x}), results might not be reproducible.",
-            personality
-        );
+        eprintln!("WARNING: Benchmarking with ASLR enabled (personality is {personality:x}), results might not be reproducible.");
     }
 }
 

--- a/tests/by-util/test_chcon.rs
+++ b/tests/by-util/test_chcon.rs
@@ -596,7 +596,7 @@ fn get_file_context(path: impl AsRef<Path>) -> Result<Option<String>, selinux::e
     let path = path.as_ref();
     match selinux::SecurityContext::of_path(path, false, false) {
         Err(r) => {
-            println!("get_file_context failed: '{}': {}.", path.display(), &r);
+            println!("get_file_context failed: '{}': {r}.", path.display());
             Err(r)
         }
 
@@ -615,7 +615,7 @@ fn get_file_context(path: impl AsRef<Path>) -> Result<Option<String>, selinux::e
                 .next()
                 .unwrap_or_default();
             let context = String::from_utf8(bytes.into()).unwrap_or_default();
-            println!("get_file_context: '{}' => '{}'.", context, path.display());
+            println!("get_file_context: '{context}' => '{}'.", path.display());
             Ok(Some(context))
         }
     }
@@ -632,13 +632,11 @@ fn set_file_context(path: impl AsRef<Path>, context: &str) -> Result<(), selinux
         selinux::SecurityContext::from_c_str(&c_context, false).set_for_path(path, false, false);
     if let Err(r) = &r {
         println!(
-            "set_file_context failed: '{}' => '{}': {}.",
-            context,
+            "set_file_context failed: '{context}' => '{}': {r}.",
             path.display(),
-            r
         );
     } else {
-        println!("set_file_context: '{}' => '{}'.", context, path.display());
+        println!("set_file_context: '{context}' => '{}'.", path.display());
     }
     r
 }

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -101,8 +101,7 @@ fn test_preserve_root() {
         "./../../../../../../../../../../../../../../",
     ] {
         let expected_error = format!(
-            "chgrp: it is dangerous to operate recursively on '{}' (same as '/')\nchgrp: use --no-preserve-root to override this failsafe\n",
-            d,
+            "chgrp: it is dangerous to operate recursively on '{d}' (same as '/')\nchgrp: use --no-preserve-root to override this failsafe\n",
         );
         new_ucmd!()
             .arg("--preserve-root")

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -40,10 +40,9 @@ fn run_single_test(test: &TestCase, at: &AtPath, mut ucmd: UCommand) {
 
     assert!(
         perms == test.before,
-        "{}: expected: {:o} got: {:o}",
+        "{}: expected: {:o} got: {perms:o}",
         "setting permissions on test files before actual test run failed",
         test.after,
-        perms
     );
 
     for arg in &test.args {
@@ -61,10 +60,8 @@ fn run_single_test(test: &TestCase, at: &AtPath, mut ucmd: UCommand) {
     let perms = at.metadata(TEST_FILE).permissions().mode();
     assert!(
         perms == test.after,
-        "{}: expected: {:o} got: {:o}",
-        ucmd,
+        "{ucmd}: expected: {:o} got: {perms:o}",
         test.after,
-        perms
     );
 }
 
@@ -243,8 +240,7 @@ fn test_chmod_umask_expected() {
     let current_umask = uucore::mode::get_umask();
     assert_eq!(
         current_umask, 0o022,
-        "Unexpected umask value: expected 022 (octal), but got {:03o}. Please adjust the test environment.",
-        current_umask
+        "Unexpected umask value: expected 022 (octal), but got {current_umask:03o}. Please adjust the test environment.",
     );
 }
 
@@ -847,7 +843,7 @@ fn test_chmod_symlink_to_dangling_target_dereference() {
         .arg("u+x")
         .arg(symlink)
         .fails()
-        .stderr_contains(format!("cannot operate on dangling symlink '{}'", symlink));
+        .stderr_contains(format!("cannot operate on dangling symlink '{symlink}'"));
 }
 
 #[test]
@@ -1019,8 +1015,7 @@ fn test_chmod_traverse_symlink_combo() {
         let actual_target = at.metadata(target).permissions().mode();
         assert_eq!(
             actual_target, expected_target_perms,
-            "For flags {:?}, expected target perms = {:o}, got = {:o}",
-            flags, expected_target_perms, actual_target
+            "For flags {flags:?}, expected target perms = {expected_target_perms:o}, got = {actual_target:o}",
         );
 
         let actual_symlink = at
@@ -1029,8 +1024,7 @@ fn test_chmod_traverse_symlink_combo() {
             .mode();
         assert_eq!(
             actual_symlink, expected_symlink_perms,
-            "For flags {:?}, expected symlink perms = {:o}, got = {:o}",
-            flags, expected_symlink_perms, actual_symlink
+            "For flags {flags:?}, expected symlink perms = {expected_symlink_perms:o}, got = {actual_symlink:o}",
         );
     }
 }

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1722,7 +1722,7 @@ mod gnu_cksum_base64 {
         if ["sysv", "bsd", "crc", "crc32b"].contains(&algo) {
             digest.to_string()
         } else {
-            format!("{} (f) = {}", algo.to_uppercase(), digest).replace("BLAKE2B", "BLAKE2b")
+            format!("{} (f) = {digest}", algo.to_uppercase()).replace("BLAKE2B", "BLAKE2b")
         }
     }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2040,31 +2040,31 @@ fn test_cp_deref_folder_to_folder() {
         // No action as this test is disabled but kept in case we want to
         // try to make it work in the future.
         let a = Command::new("cmd").args(&["/C", "dir"]).output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", &at.as_string()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", path_to_new_symlink.to_str().unwrap()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let path_to_new_symlink = at.subdir.join(TEST_COPY_FROM_FOLDER);
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", path_to_new_symlink.to_str().unwrap()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let path_to_new_symlink = at.subdir.join(TEST_COPY_TO_FOLDER_NEW);
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", path_to_new_symlink.to_str().unwrap()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
     }
 
     let path_to_new_symlink = at
@@ -2138,31 +2138,31 @@ fn test_cp_no_deref_folder_to_folder() {
         // No action as this test is disabled but kept in case we want to
         // try to make it work in the future.
         let a = Command::new("cmd").args(&["/C", "dir"]).output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", &at.as_string()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", path_to_new_symlink.to_str().unwrap()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let path_to_new_symlink = at.subdir.join(TEST_COPY_FROM_FOLDER);
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", path_to_new_symlink.to_str().unwrap()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
 
         let path_to_new_symlink = at.subdir.join(TEST_COPY_TO_FOLDER_NEW);
 
         let a = Command::new("cmd")
             .args(&["/C", "dir", path_to_new_symlink.to_str().unwrap()])
             .output();
-        println!("output {:#?}", a);
+        println!("output {a:#?}");
     }
 
     let path_to_new_symlink = at
@@ -2552,7 +2552,7 @@ fn test_closes_file_descriptors() {
     // For debugging purposes:
     for f in me.fd().unwrap() {
         let fd = f.unwrap();
-        println!("{:?} {:?}", fd, fd.mode());
+        println!("{fd:?} {:?}", fd.mode());
     }
 
     new_ucmd!()
@@ -6093,9 +6093,7 @@ fn test_cp_preserve_xattr_readonly_source() {
     let stdout = String::from_utf8_lossy(&getfattr_output.stdout);
     assert!(
         stdout.contains(xattr_key),
-        "Expected '{}' not found in getfattr output:\n{}",
-        xattr_key,
-        stdout
+        "Expected '{xattr_key}' not found in getfattr output:\n{stdout}"
     );
 
     at.set_readonly(source_file);

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -1457,7 +1457,7 @@ fn create_named_pipe_with_writer(path: &str, data: &str) -> std::process::Child 
     nix::unistd::mkfifo(path, nix::sys::stat::Mode::S_IRWXU).unwrap();
     std::process::Command::new("sh")
         .arg("-c")
-        .arg(format!("printf '{}' > {path}", data))
+        .arg(format!("printf '{data}' > {path}"))
         .spawn()
         .unwrap()
 }

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -51,7 +51,7 @@ macro_rules! fixture_path {
 macro_rules! assert_fixture_exists {
     ($fname:expr) => {{
         let fpath = fixture_path!($fname);
-        assert!(fpath.exists(), "Fixture missing: {:?}", fpath);
+        assert!(fpath.exists(), "Fixture missing: {fpath:?}");
     }};
 }
 
@@ -59,7 +59,7 @@ macro_rules! assert_fixture_exists {
 macro_rules! assert_fixture_not_exists {
     ($fname:expr) => {{
         let fpath = PathBuf::from(format!("./fixtures/dd/{}", $fname));
-        assert!(!fpath.exists(), "Fixture present: {:?}", fpath);
+        assert!(!fpath.exists(), "Fixture present: {fpath:?}");
     }};
 }
 
@@ -400,7 +400,7 @@ fn test_null_fullblock() {
 #[test]
 fn test_fullblock() {
     let tname = "fullblock-from-urand";
-    let tmp_fn = format!("TESTFILE-{}.tmp", &tname);
+    let tmp_fn = format!("TESTFILE-{tname}.tmp");
     let exp_stats = vec![
         "1+0 records in\n",
         "1+0 records out\n",
@@ -458,11 +458,11 @@ fn test_zeros_to_stdout() {
 fn test_oversized_bs_32_bit() {
     for bs_param in ["bs", "ibs", "obs", "cbs"] {
         new_ucmd!()
-            .args(&[format!("{}=5GB", bs_param)])
+            .args(&[format!("{bs_param}=5GB")])
             .fails()
             .no_stdout()
             .code_is(1)
-            .stderr_is(format!("dd: {}=N cannot fit into memory\n", bs_param));
+            .stderr_is(format!("dd: {bs_param}=N cannot fit into memory\n"));
     }
 }
 
@@ -493,7 +493,7 @@ fn test_ascii_10k_to_stdout() {
 fn test_zeros_to_file() {
     let tname = "zero-256k";
     let test_fn = format!("{tname}.txt");
-    let tmp_fn = format!("TESTFILE-{}.tmp", &tname);
+    let tmp_fn = format!("TESTFILE-{tname}.tmp");
     assert_fixture_exists!(test_fn);
 
     let (fix, mut ucmd) = at_and_ucmd!();
@@ -511,7 +511,7 @@ fn test_zeros_to_file() {
 fn test_to_file_with_ibs_obs() {
     let tname = "zero-256k";
     let test_fn = format!("{tname}.txt");
-    let tmp_fn = format!("TESTFILE-{}.tmp", &tname);
+    let tmp_fn = format!("TESTFILE-{tname}.tmp");
     assert_fixture_exists!(test_fn);
 
     let (fix, mut ucmd) = at_and_ucmd!();
@@ -535,7 +535,7 @@ fn test_to_file_with_ibs_obs() {
 fn test_ascii_521k_to_file() {
     let tname = "ascii-521k";
     let input = build_ascii_block(512 * 1024);
-    let tmp_fn = format!("TESTFILE-{}.tmp", &tname);
+    let tmp_fn = format!("TESTFILE-{tname}.tmp");
 
     let (fix, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["status=none", &of!(tmp_fn)])
@@ -560,7 +560,7 @@ fn test_ascii_521k_to_file() {
 #[test]
 fn test_ascii_5_gibi_to_file() {
     let tname = "ascii-5G";
-    let tmp_fn = format!("TESTFILE-{}.tmp", &tname);
+    let tmp_fn = format!("TESTFILE-{tname}.tmp");
 
     let (fix, mut ucmd) = at_and_ucmd!();
     ucmd.args(&[
@@ -597,7 +597,7 @@ fn test_self_transfer() {
 fn test_unicode_filenames() {
     let tname = "😎💚🦊";
     let test_fn = format!("{tname}.txt");
-    let tmp_fn = format!("TESTFILE-{}.tmp", &tname);
+    let tmp_fn = format!("TESTFILE-{tname}.tmp");
     assert_fixture_exists!(test_fn);
 
     let (fix, mut ucmd) = at_and_ucmd!();

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -585,11 +585,7 @@ fn test_du_h_precision() {
             .arg("--apparent-size")
             .arg(&fpath)
             .succeeds()
-            .stdout_only(format!(
-                "{}\t{}\n",
-                expected_output,
-                &fpath.to_string_lossy()
-            ));
+            .stdout_only(format!("{expected_output}\t{}\n", fpath.to_string_lossy()));
     }
 }
 
@@ -659,7 +655,7 @@ fn birth_supported() -> bool {
     let ts = TestScenario::new(util_name!());
     let m = match std::fs::metadata(&ts.fixtures.subdir) {
         Ok(m) => m,
-        Err(e) => panic!("{}", e),
+        Err(e) => panic!("{e}"),
     };
     m.created().is_ok()
 }

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -435,7 +435,7 @@ fn test_all_but_last_bytes_large_file_piped() {
         .len();
     scene
         .ucmd()
-        .args(&["-c", &format!("-{}", seq_19001_20000_file_length)])
+        .args(&["-c", &format!("-{seq_19001_20000_file_length}")])
         .pipe_in_fixture(seq_20000_file_name)
         .succeeds()
         .stdout_only_fixture(seq_19000_file_name);
@@ -695,7 +695,7 @@ fn test_validate_stdin_offset_bytes() {
         .len();
     scene
         .ucmd()
-        .args(&["-c", &format!("-{}", seq_19001_20000_file_length)])
+        .args(&["-c", &format!("-{seq_19001_20000_file_length}")])
         .set_stdin(file)
         .succeeds()
         .stdout_only_fixture(seq_19000_file_name);

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -1670,7 +1670,7 @@ fn test_target_file_ends_with_slash() {
     let source = "source_file";
     let target_dir = "dir";
     let target_file = "dir/target_file";
-    let target_file_slash = format!("{}/", target_file);
+    let target_file_slash = format!("{target_file}/");
 
     at.touch(source);
     at.mkdir(target_dir);

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -429,7 +429,7 @@ fn test_symlink_implicit_target_dir() {
 fn test_symlink_to_dir_2args() {
     let (at, mut ucmd) = at_and_ucmd!();
     let filename = "test_symlink_to_dir_2args_file";
-    let from_file = &format!("{}/{}", at.as_string(), filename);
+    let from_file = &format!("{}/{filename}", at.as_string());
     let to_dir = "test_symlink_to_dir_2args_to_dir";
     let to_file = &format!("{to_dir}/{filename}");
 
@@ -493,7 +493,7 @@ fn test_symlink_relative_path() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["-s", "-v", &p.to_string_lossy(), link])
         .succeeds()
-        .stdout_only(format!("'{}' -> '{}'\n", link, &p.to_string_lossy()));
+        .stdout_only(format!("'{link}' -> '{}'\n", p.to_string_lossy()));
     assert!(at.is_symlink(link));
     assert_eq!(at.resolve_link(link), p.to_string_lossy());
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2247,14 +2247,12 @@ mod quoting {
             at.mkdir(dirname);
 
             let expected = format!(
-                "{}:\n{}\n\n{}:\n",
+                "{}:\n{regular_mode}\n\n{dir_mode}:\n",
                 match *qt_style {
                     "shell-always" | "shell-escape-always" => "'.'",
                     "c" => "\".\"",
                     _ => ".",
                 },
-                regular_mode,
-                dir_mode
             );
 
             scene
@@ -4051,7 +4049,7 @@ fn test_ls_path() {
         .succeeds()
         .stdout_is(expected_stdout);
 
-    let abs_path = format!("{}/{}", at.as_string(), path);
+    let abs_path = format!("{}/{path}", at.as_string());
     let expected_stdout = format!("{abs_path}\n");
 
     scene
@@ -4160,7 +4158,7 @@ fn test_ls_context1() {
     }
 
     let file = "test_ls_context_file";
-    let expected = format!("unconfined_u:object_r:user_tmp_t:s0 {}\n", file);
+    let expected = format!("unconfined_u:object_r:user_tmp_t:s0 {file}\n");
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch(file);
     ucmd.args(&["-Z", file]).succeeds().stdout_is(expected);
@@ -4204,7 +4202,7 @@ fn test_ls_context_format() {
         // "verbose",
         "vertical",
     ] {
-        let format = format!("--format={}", word);
+        let format = format!("--format={word}");
         ts.ucmd()
             .args(&["-Z", format.as_str(), "/"])
             .succeeds()

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -57,9 +57,8 @@ macro_rules! assert_suffix_matches_template {
         let suffix = &$s[n - m..n];
         assert!(
             matches_template($template, suffix),
-            "\"{}\" does not end with \"{}\"",
+            "\"{}\" does not end with \"{suffix}\"",
             $template,
-            suffix
         );
     }};
 }
@@ -780,13 +779,11 @@ fn test_nonexistent_tmpdir_env_var() {
         let stderr = result.stderr_str();
         assert!(
             stderr.starts_with("mktemp: failed to create file via template"),
-            "{}",
-            stderr
+            "{stderr}",
         );
         assert!(
             stderr.ends_with("no\\such\\dir\\tmp.XXXXXXXXXX': No such file or directory\n"),
-            "{}",
-            stderr
+            "{stderr}",
         );
     }
 
@@ -799,13 +796,11 @@ fn test_nonexistent_tmpdir_env_var() {
         let stderr = result.stderr_str();
         assert!(
             stderr.starts_with("mktemp: failed to create directory via template"),
-            "{}",
-            stderr
+            "{stderr}",
         );
         assert!(
             stderr.ends_with("no\\such\\dir\\tmp.XXXXXXXXXX': No such file or directory\n"),
-            "{}",
-            stderr
+            "{stderr}",
         );
     }
 }
@@ -823,13 +818,11 @@ fn test_nonexistent_dir_prefix() {
         let stderr = result.stderr_str();
         assert!(
             stderr.starts_with("mktemp: failed to create file via template"),
-            "{}",
-            stderr
+            "{stderr}",
         );
         assert!(
             stderr.ends_with("d\\XXX': No such file or directory\n"),
-            "{}",
-            stderr
+            "{stderr}",
         );
     }
 
@@ -844,13 +837,11 @@ fn test_nonexistent_dir_prefix() {
         let stderr = result.stderr_str();
         assert!(
             stderr.starts_with("mktemp: failed to create directory via template"),
-            "{}",
-            stderr
+            "{stderr}",
         );
         assert!(
             stderr.ends_with("d\\XXX': No such file or directory\n"),
-            "{}",
-            stderr
+            "{stderr}",
         );
     }
 }

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -385,44 +385,44 @@ fn test_realpath_trailing_slash() {
         .ucmd()
         .arg("link_file")
         .succeeds()
-        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}file\n"));
     scene.ucmd().arg("link_file/").fails_with_code(1);
     scene
         .ucmd()
         .arg("link_dir")
         .succeeds()
-        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}dir\n"));
     scene
         .ucmd()
         .arg("link_dir/")
         .succeeds()
-        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}dir\n"));
     scene
         .ucmd()
         .arg("link_no_dir")
         .succeeds()
-        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}no_dir\n"));
     scene
         .ucmd()
         .arg("link_no_dir/")
         .succeeds()
-        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}no_dir\n"));
     scene
         .ucmd()
         .args(&["-e", "link_file"])
         .succeeds()
-        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}file\n"));
     scene.ucmd().args(&["-e", "link_file/"]).fails_with_code(1);
     scene
         .ucmd()
         .args(&["-e", "link_dir"])
         .succeeds()
-        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}dir\n"));
     scene
         .ucmd()
         .args(&["-e", "link_dir/"])
         .succeeds()
-        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}dir\n"));
     scene.ucmd().args(&["-e", "link_no_dir"]).fails_with_code(1);
     scene
         .ucmd()
@@ -432,32 +432,32 @@ fn test_realpath_trailing_slash() {
         .ucmd()
         .args(&["-m", "link_file"])
         .succeeds()
-        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}file\n"));
     scene
         .ucmd()
         .args(&["-m", "link_file/"])
         .succeeds()
-        .stdout_contains(format!("{}file\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}file\n"));
     scene
         .ucmd()
         .args(&["-m", "link_dir"])
         .succeeds()
-        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}dir\n"));
     scene
         .ucmd()
         .args(&["-m", "link_dir/"])
         .succeeds()
-        .stdout_contains(format!("{}dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}dir\n"));
     scene
         .ucmd()
         .args(&["-m", "link_no_dir"])
         .succeeds()
-        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}no_dir\n"));
     scene
         .ucmd()
         .args(&["-m", "link_no_dir/"])
         .succeeds()
-        .stdout_contains(format!("{}no_dir\n", std::path::MAIN_SEPARATOR));
+        .stdout_contains(format!("{MAIN_SEPARATOR}no_dir\n"));
 }
 
 #[test]

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -333,8 +333,7 @@ fn test_rm_verbose_slash() {
     at.touch(file_a);
 
     let file_a_normalized = &format!(
-        "{}{}test_rm_verbose_slash_file_a",
-        dir,
+        "{dir}{}test_rm_verbose_slash_file_a",
         std::path::MAIN_SEPARATOR
     );
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -105,8 +105,7 @@ fn test_invalid_buffer_size() {
                 .arg("ext_sort.txt")
                 .fails_with_code(2)
                 .stderr_only(format!(
-                    "sort: --buffer-size argument '{}' too large\n",
-                    buffer_size
+                    "sort: --buffer-size argument '{buffer_size}' too large\n"
                 ));
         }
     }

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -248,10 +248,7 @@ fn test_timestamp_format() {
         assert_eq!(
             result,
             format!("{expected}\n"),
-            "Format '{}' failed.\nExpected: '{}'\nGot: '{}'",
-            format_str,
-            expected,
-            result,
+            "Format '{format_str}' failed.\nExpected: '{expected}'\nGot: '{result}'",
         );
     }
 }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1801,12 +1801,12 @@ fn test_follow_name_remove() {
     let expected_stdout = at.read(FOLLOW_NAME_SHORT_EXP);
     let expected_stderr = [
         format!(
-            "{}: {}: No such file or directory\n{0}: no files remaining\n",
-            ts.util_name, source_copy
+            "{}: {source_copy}: No such file or directory\n{0}: no files remaining\n",
+            ts.util_name,
         ),
         format!(
-            "{}: {}: No such file or directory\n",
-            ts.util_name, source_copy
+            "{}: {source_copy}: No such file or directory\n",
+            ts.util_name,
         ),
     ];
 
@@ -1862,7 +1862,7 @@ fn test_follow_name_truncate1() {
     let backup = "backup";
 
     let expected_stdout = at.read(FOLLOW_NAME_EXP);
-    let expected_stderr = format!("{}: {}: file truncated\n", ts.util_name, source);
+    let expected_stderr = format!("{}: {source}: file truncated\n", ts.util_name);
 
     let args = ["--follow=name", source];
     let mut p = ts.ucmd().args(&args).run_no_wait();
@@ -1904,7 +1904,7 @@ fn test_follow_name_truncate2() {
     at.touch(source);
 
     let expected_stdout = "x\nx\nx\nx\n";
-    let expected_stderr = format!("{}: {}: file truncated\n", ts.util_name, source);
+    let expected_stderr = format!("{}: {source}: file truncated\n", ts.util_name);
 
     let args = ["--follow=name", source];
     let mut p = ts.ucmd().args(&args).run_no_wait();
@@ -2071,8 +2071,8 @@ fn test_follow_name_move_create1() {
 
     #[cfg(target_os = "linux")]
     let expected_stderr = format!(
-        "{}: {}: No such file or directory\n{0}: '{1}' has appeared;  following new file\n",
-        ts.util_name, source
+        "{}: {source}: No such file or directory\n{0}: '{source}' has appeared;  following new file\n",
+        ts.util_name,
     );
 
     // NOTE: We are less strict if not on Linux (inotify backend).
@@ -2081,7 +2081,7 @@ fn test_follow_name_move_create1() {
     let expected_stdout = at.read(FOLLOW_NAME_SHORT_EXP);
 
     #[cfg(not(target_os = "linux"))]
-    let expected_stderr = format!("{}: {}: No such file or directory\n", ts.util_name, source);
+    let expected_stderr = format!("{}: {source}: No such file or directory\n", ts.util_name);
 
     let delay = 500;
     let args = ["--follow=name", source];
@@ -2205,10 +2205,10 @@ fn test_follow_name_move1() {
 
     let expected_stdout = at.read(FOLLOW_NAME_SHORT_EXP);
     let expected_stderr = [
-        format!("{}: {}: No such file or directory\n", ts.util_name, source),
+        format!("{}: {source}: No such file or directory\n", ts.util_name),
         format!(
-            "{}: {}: No such file or directory\n{0}: no files remaining\n",
-            ts.util_name, source
+            "{}: {source}: No such file or directory\n{0}: no files remaining\n",
+            ts.util_name,
         ),
     ];
 
@@ -3558,15 +3558,11 @@ fn test_when_argument_file_is_non_existent_unix_socket_address_then_error() {
     let expected_stderr =
         format!("tail: cannot open '{socket}' for reading: No such device or address\n");
     #[cfg(target_os = "freebsd")]
-    let expected_stderr = format!(
-        "tail: cannot open '{}' for reading: Operation not supported\n",
-        socket
-    );
+    let expected_stderr =
+        format!("tail: cannot open '{socket}' for reading: Operation not supported\n",);
     #[cfg(target_os = "macos")]
-    let expected_stderr = format!(
-        "tail: cannot open '{}' for reading: Operation not supported on socket\n",
-        socket
-    );
+    let expected_stderr =
+        format!("tail: cannot open '{socket}' for reading: Operation not supported on socket\n",);
 
     ts.ucmd()
         .arg(socket)

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -243,8 +243,7 @@ mod linux_only {
         );
         assert!(
             result.stderr_str().contains(message),
-            "Expected to see error message fragment {} in stderr, but did not.\n stderr = {}",
-            message,
+            "Expected to see error message fragment {message} in stderr, but did not.\n stderr = {}",
             std::str::from_utf8(result.stderr()).unwrap(),
         );
     }
@@ -274,9 +273,8 @@ mod linux_only {
         let compare = at.read(name);
         assert!(
             compare.len() < contents.len(),
-            "Too many bytes ({}) written to {} (should be a short count from {})",
+            "Too many bytes ({}) written to {name} (should be a short count from {})",
             compare.len(),
-            name,
             contents.len()
         );
         assert!(

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -824,8 +824,7 @@ fn test_touch_permission_denied_error_msg() {
 
     let full_path = at.plus_as_string(path_str);
     ucmd.arg(&full_path).fails().stderr_only(format!(
-        "touch: cannot touch '{}': Permission denied\n",
-        &full_path
+        "touch: cannot touch '{full_path}': Permission denied\n",
     ));
 }
 

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -20,7 +20,7 @@ fn init() {
         std::env::set_var("UUTESTS_BINARY_PATH", TESTS_BINARY);
     }
     // Print for debugging
-    eprintln!("Setting UUTESTS_BINARY_PATH={}", TESTS_BINARY);
+    eprintln!("Setting UUTESTS_BINARY_PATH={TESTS_BINARY}");
 }
 
 #[test]

--- a/tests/uutests/src/lib/macros.rs
+++ b/tests/uutests/src/lib/macros.rs
@@ -85,7 +85,7 @@ macro_rules! unwrap_or_return {
         match $e {
             Ok(x) => x,
             Err(e) => {
-                println!("test skipped: {}", e);
+                println!("test skipped: {e}");
                 return;
             }
         }

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -216,8 +216,8 @@ impl CmdResult {
         assert!(
             predicate(&self.stdout),
             "Predicate for stdout as `bytes` evaluated to false.\nstdout='{:?}'\nstderr='{:?}'\n",
-            &self.stdout,
-            &self.stderr
+            self.stdout,
+            self.stderr
         );
         self
     }
@@ -246,8 +246,8 @@ impl CmdResult {
         assert!(
             predicate(&self.stderr),
             "Predicate for stderr as `bytes` evaluated to false.\nstdout='{:?}'\nstderr='{:?}'\n",
-            &self.stdout,
-            &self.stderr
+            self.stdout,
+            self.stderr
         );
         self
     }
@@ -306,8 +306,7 @@ impl CmdResult {
     pub fn signal_is(&self, value: i32) -> &Self {
         let actual = self.signal().unwrap_or_else(|| {
             panic!(
-                "Expected process to be terminated by the '{}' signal, but exit status is: '{}'",
-                value,
+                "Expected process to be terminated by the '{value}' signal, but exit status is: '{}'",
                 self.try_exit_status()
                     .map_or("Not available".to_string(), |e| e.to_string())
             )
@@ -337,8 +336,7 @@ impl CmdResult {
 
         let actual = self.signal().unwrap_or_else(|| {
             panic!(
-                "Expected process to be terminated by the '{}' signal, but exit status is: '{}'",
-                name,
+                "Expected process to be terminated by the '{name}' signal, but exit status is: '{}'",
                 self.try_exit_status()
                     .map_or("Not available".to_string(), |e| e.to_string())
             )
@@ -527,9 +525,8 @@ impl CmdResult {
     pub fn stdout_is_any<T: AsRef<str> + std::fmt::Debug>(&self, expected: &[T]) -> &Self {
         assert!(
             expected.iter().any(|msg| self.stdout_str() == msg.as_ref()),
-            "stdout was {}\nExpected any of {:#?}",
+            "stdout was {}\nExpected any of {expected:#?}",
             self.stdout_str(),
-            expected
         );
         self
     }
@@ -1059,7 +1056,7 @@ impl AtPath {
     pub fn make_file(&self, name: &str) -> File {
         match File::create(self.plus(name)) {
             Ok(f) => f,
-            Err(e) => panic!("{}", e),
+            Err(e) => panic!("{e}"),
         }
     }
 
@@ -1121,7 +1118,7 @@ impl AtPath {
         let original = original.replace('/', MAIN_SEPARATOR_STR);
         log_info(
             "symlink",
-            format!("{},{}", &original, &self.plus_as_string(link)),
+            format!("{original},{}", self.plus_as_string(link)),
         );
         symlink_file(original, self.plus(link)).unwrap();
     }
@@ -1143,7 +1140,7 @@ impl AtPath {
         let original = original.replace('/', MAIN_SEPARATOR_STR);
         log_info(
             "symlink",
-            format!("{},{}", &original, &self.plus_as_string(link)),
+            format!("{original},{}", self.plus_as_string(link)),
         );
         symlink_dir(original, self.plus(link)).unwrap();
     }
@@ -1176,14 +1173,14 @@ impl AtPath {
     pub fn symlink_metadata(&self, path: &str) -> fs::Metadata {
         match fs::symlink_metadata(self.plus(path)) {
             Ok(m) => m,
-            Err(e) => panic!("{}", e),
+            Err(e) => panic!("{e}"),
         }
     }
 
     pub fn metadata(&self, path: &str) -> fs::Metadata {
         match fs::metadata(self.plus(path)) {
             Ok(m) => m,
-            Err(e) => panic!("{}", e),
+            Err(e) => panic!("{e}"),
         }
     }
 
@@ -1522,8 +1519,7 @@ impl UCommand {
     pub fn pipe_in<T: Into<Vec<u8>>>(&mut self, input: T) -> &mut Self {
         assert!(
             self.bytes_into_stdin.is_none(),
-            "{}",
-            MULTIPLE_STDIN_MEANINGLESS
+            "{MULTIPLE_STDIN_MEANINGLESS}",
         );
         self.set_stdin(Stdio::piped());
         self.bytes_into_stdin = Some(input.into());
@@ -1894,7 +1890,7 @@ impl UCommand {
     /// Spawns the command, feeds the stdin if any, and returns the
     /// child process immediately.
     pub fn run_no_wait(&mut self) -> UChild {
-        assert!(!self.has_run, "{}", ALREADY_RUN);
+        assert!(!self.has_run, "{ALREADY_RUN}");
         self.has_run = true;
 
         let (mut command, captured_stdout, captured_stderr, stdin_pty) = self.build();
@@ -2162,9 +2158,8 @@ impl<'a> UChildAssertion<'a> {
     pub fn is_alive(&mut self) -> &mut Self {
         match self.uchild.raw.try_wait() {
             Ok(Some(status)) => panic!(
-                "Assertion failed. Expected '{}' to be running but exited with status={}.\nstdout: {}\nstderr: {}",
+                "Assertion failed. Expected '{}' to be running but exited with status={status}.\nstdout: {}\nstderr: {}",
                 uucore::util_name(),
-                status,
                 self.uchild.stdout_all(),
                 self.uchild.stderr_all()
             ),


### PR DESCRIPTION
Follow up to the other few lint PRs - keeping test PRs separate to ensure stability

Minor manual cleanup - inlined many format args.  This makes the code a bit more readable, and helps spot a few inefficiencies and possible bugs.  Note that `&foo` in a `format!` parameter results in a 6% extra performance cost, and does not get inlined by the compiler (yet).