### PR TITLE
bug: fix id printing of egid

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -587,8 +587,7 @@ fn id_print(state: &State, groups: &[u32]) {
     }
     if !state.user_specified && (egid != gid) {
         print!(
-            " egid={}({})",
-            euid,
+            " egid={egid}({})",
             entries::gid2grp(egid).unwrap_or_else(|_| {
                 show_error!("cannot find name for group ID {}", egid);
                 set_exit_code(1);


### PR DESCRIPTION
Spotted while doing format arg inlining, and confirmed in https://github.com/uutils/coreutils/pull/7689#issuecomment-2786827777

cc: @cakebaker 