### PR TITLE
chore: address a few clippy lints that break API

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,4 @@
+avoid-breaking-exported-api = false
+check-private-items = true
 cognitive-complexity-threshold = 24
 missing-docs-in-crate-items = true
-check-private-items = true

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -376,12 +376,12 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
 
     if dst.is_symlink() || dst.exists() {
         backup_path = match settings.backup {
-            BackupMode::NoBackup => None,
-            BackupMode::SimpleBackup => Some(simple_backup_path(dst, &settings.suffix)),
-            BackupMode::NumberedBackup => Some(numbered_backup_path(dst)),
-            BackupMode::ExistingBackup => Some(existing_backup_path(dst, &settings.suffix)),
+            BackupMode::None => None,
+            BackupMode::Simple => Some(simple_backup_path(dst, &settings.suffix)),
+            BackupMode::Numbered => Some(numbered_backup_path(dst)),
+            BackupMode::Existing => Some(existing_backup_path(dst, &settings.suffix)),
         };
-        if settings.backup == BackupMode::ExistingBackup && !settings.symbolic {
+        if settings.backup == BackupMode::Existing && !settings.symbolic {
             // when ln --backup f f, it should detect that it is the same file
             if paths_refer_to_same_file(src, dst, true) {
                 return Err(LnError::SameFile(src.to_owned(), dst.to_owned()).into());

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -40,6 +40,7 @@ const SUMMARY: &str = help_about!("stty.md");
 #[derive(Clone, Copy, Debug)]
 pub struct Flag<T> {
     name: &'static str,
+    #[expect(clippy::struct_field_names)]
     flag: T,
     show: bool,
     sane: bool,

--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -123,13 +123,13 @@ pub const DEFAULT_BACKUP_SUFFIX: &str = "~";
 pub enum BackupMode {
     /// Argument 'none', 'off'
     #[default]
-    NoBackup,
+    None,
     /// Argument 'simple', 'never'
-    SimpleBackup,
+    Simple,
     /// Argument 'numbered', 't'
-    NumberedBackup,
+    Numbered,
     /// Argument 'existing', 'nil'
-    ExistingBackup,
+    Existing,
 }
 
 /// Backup error types.
@@ -303,7 +303,7 @@ pub fn determine_backup_suffix(matches: &ArgMatches) -> String {
 ///         ]);
 ///
 ///     let backup_mode = backup_control::determine_backup_mode(&matches).unwrap();
-///     assert_eq!(backup_mode, BackupMode::NumberedBackup)
+///     assert_eq!(backup_mode, BackupMode::Numbered)
 /// }
 /// ```
 ///
@@ -348,7 +348,7 @@ pub fn determine_backup_mode(matches: &ArgMatches) -> UResult<BackupMode> {
             match_method(&method, "$VERSION_CONTROL")
         } else {
             // Default if no argument is provided to '--backup'
-            Ok(BackupMode::ExistingBackup)
+            Ok(BackupMode::Existing)
         }
     } else if matches.get_flag(arguments::OPT_BACKUP_NO_ARG) {
         // the short form of this option, -b does not accept any argument.
@@ -357,11 +357,11 @@ pub fn determine_backup_mode(matches: &ArgMatches) -> UResult<BackupMode> {
         if let Ok(method) = env::var("VERSION_CONTROL") {
             match_method(&method, "$VERSION_CONTROL")
         } else {
-            Ok(BackupMode::ExistingBackup)
+            Ok(BackupMode::Existing)
         }
     } else {
         // No option was present at all
-        Ok(BackupMode::NoBackup)
+        Ok(BackupMode::None)
     }
 }
 
@@ -391,10 +391,10 @@ fn match_method(method: &str, origin: &str) -> UResult<BackupMode> {
         .collect();
     if matches.len() == 1 {
         match *matches[0] {
-            "simple" | "never" => Ok(BackupMode::SimpleBackup),
-            "numbered" | "t" => Ok(BackupMode::NumberedBackup),
-            "existing" | "nil" => Ok(BackupMode::ExistingBackup),
-            "none" | "off" => Ok(BackupMode::NoBackup),
+            "simple" | "never" => Ok(BackupMode::Simple),
+            "numbered" | "t" => Ok(BackupMode::Numbered),
+            "existing" | "nil" => Ok(BackupMode::Existing),
+            "none" | "off" => Ok(BackupMode::None),
             _ => unreachable!(), // cannot happen as we must have exactly one match
                                  // from the list above.
         }
@@ -411,10 +411,10 @@ pub fn get_backup_path(
     suffix: &str,
 ) -> Option<PathBuf> {
     match backup_mode {
-        BackupMode::NoBackup => None,
-        BackupMode::SimpleBackup => Some(simple_backup_path(backup_path, suffix)),
-        BackupMode::NumberedBackup => Some(numbered_backup_path(backup_path)),
-        BackupMode::ExistingBackup => Some(existing_backup_path(backup_path, suffix)),
+        BackupMode::None => None,
+        BackupMode::Simple => Some(simple_backup_path(backup_path, suffix)),
+        BackupMode::Numbered => Some(numbered_backup_path(backup_path)),
+        BackupMode::Existing => Some(existing_backup_path(backup_path, suffix)),
     }
 }
 
@@ -511,7 +511,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::ExistingBackup);
+        assert_eq!(result, BackupMode::Existing);
     }
 
     // --backup takes precedence over -b
@@ -522,7 +522,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::NoBackup);
+        assert_eq!(result, BackupMode::None);
     }
 
     // --backup can be passed without an argument
@@ -533,7 +533,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::ExistingBackup);
+        assert_eq!(result, BackupMode::Existing);
     }
 
     // --backup can be passed with an argument only
@@ -544,7 +544,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::SimpleBackup);
+        assert_eq!(result, BackupMode::Simple);
     }
 
     // --backup errors on invalid argument
@@ -581,7 +581,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::SimpleBackup);
+        assert_eq!(result, BackupMode::Simple);
     }
 
     // -b doesn't ignores the "VERSION_CONTROL" environment variable
@@ -593,7 +593,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::NumberedBackup);
+        assert_eq!(result, BackupMode::Numbered);
         unsafe { env::remove_var(ENV_VERSION_CONTROL) };
     }
 
@@ -606,7 +606,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::NoBackup);
+        assert_eq!(result, BackupMode::None);
         unsafe { env::remove_var(ENV_VERSION_CONTROL) };
     }
 
@@ -649,7 +649,7 @@ mod tests {
 
         let result = determine_backup_mode(&matches).unwrap();
 
-        assert_eq!(result, BackupMode::SimpleBackup);
+        assert_eq!(result, BackupMode::Simple);
         unsafe { env::remove_var(ENV_VERSION_CONTROL) };
     }
 

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -20,8 +20,8 @@ use crate::{
     error::{FromIo, UError, UResult, USimpleError},
     os_str_as_bytes, os_str_from_bytes, read_os_string_lines, show, show_error, show_warning_caps,
     sum::{
-        BSD, Blake2b, Blake3, CRC, CRC32B, Digest, DigestWriter, Md5, SYSV, Sha1, Sha3_224,
-        Sha3_256, Sha3_384, Sha3_512, Sha224, Sha256, Sha384, Sha512, Shake128, Shake256, Sm3,
+        Blake2b, Blake3, Bsd, CRC32B, Crc, Digest, DigestWriter, Md5, Sha1, Sha3_224, Sha3_256,
+        Sha3_384, Sha3_512, Sha224, Sha256, Sha384, Sha512, Shake128, Shake256, Sm3, SysV,
     },
     util_name,
 };
@@ -364,17 +364,17 @@ pub fn detect_algo(algo: &str, length: Option<usize>) -> UResult<HashAlgorithm> 
     match algo {
         ALGORITHM_OPTIONS_SYSV => Ok(HashAlgorithm {
             name: ALGORITHM_OPTIONS_SYSV,
-            create_fn: Box::new(|| Box::new(SYSV::new())),
+            create_fn: Box::new(|| Box::new(SysV::new())),
             bits: 512,
         }),
         ALGORITHM_OPTIONS_BSD => Ok(HashAlgorithm {
             name: ALGORITHM_OPTIONS_BSD,
-            create_fn: Box::new(|| Box::new(BSD::new())),
+            create_fn: Box::new(|| Box::new(Bsd::new())),
             bits: 1024,
         }),
         ALGORITHM_OPTIONS_CRC => Ok(HashAlgorithm {
             name: ALGORITHM_OPTIONS_CRC,
-            create_fn: Box::new(|| Box::new(CRC::new())),
+            create_fn: Box::new(|| Box::new(Crc::new())),
             bits: 256,
         }),
         ALGORITHM_OPTIONS_CRC32B => Ok(HashAlgorithm {

--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -125,12 +125,12 @@ impl Digest for Sm3 {
 // NOTE: CRC_TABLE_LEN *must* be <= 256 as we cast 0..CRC_TABLE_LEN to u8
 const CRC_TABLE_LEN: usize = 256;
 
-pub struct CRC {
+pub struct Crc {
     state: u32,
     size: usize,
     crc_table: [u32; CRC_TABLE_LEN],
 }
-impl CRC {
+impl Crc {
     fn generate_crc_table() -> [u32; CRC_TABLE_LEN] {
         let mut table = [0; CRC_TABLE_LEN];
 
@@ -166,7 +166,7 @@ impl CRC {
     }
 }
 
-impl Digest for CRC {
+impl Digest for Crc {
     fn new() -> Self {
         Self {
             state: 0,
@@ -238,10 +238,10 @@ impl Digest for CRC32B {
     }
 }
 
-pub struct BSD {
+pub struct Bsd {
     state: u16,
 }
-impl Digest for BSD {
+impl Digest for Bsd {
     fn new() -> Self {
         Self { state: 0 }
     }
@@ -272,10 +272,10 @@ impl Digest for BSD {
     }
 }
 
-pub struct SYSV {
+pub struct SysV {
     state: u32,
 }
-impl Digest for SYSV {
+impl Digest for SysV {
     fn new() -> Self {
         Self { state: 0 }
     }

--- a/src/uucore/src/lib/features/update_control.rs
+++ b/src/uucore/src/lib/features/update_control.rs
@@ -39,7 +39,7 @@
 //!     let update_mode = update_control::determine_update_mode(&matches);
 //!
 //!     // handle cases
-//!     if update_mode == UpdateMode::ReplaceIfOlder {
+//!     if update_mode == UpdateMode::IfOlder {
 //!         // do
 //!     } else {
 //!         unreachable!()
@@ -53,14 +53,14 @@ use clap::ArgMatches;
 pub enum UpdateMode {
     /// --update=`all`, ``
     #[default]
-    ReplaceAll,
+    All,
     /// --update=`none`
-    ReplaceNone,
+    None,
 
     /// --update=`older`
     /// -u
-    ReplaceIfOlder,
-    ReplaceNoneFail,
+    IfOlder,
+    NoneFail,
 }
 
 pub mod arguments {
@@ -124,22 +124,22 @@ pub mod arguments {
 ///         ]);
 ///
 ///     let update_mode = update_control::determine_update_mode(&matches);
-///     assert_eq!(update_mode, UpdateMode::ReplaceAll)
+///     assert_eq!(update_mode, UpdateMode::All)
 /// }
 pub fn determine_update_mode(matches: &ArgMatches) -> UpdateMode {
     if let Some(mode) = matches.get_one::<String>(arguments::OPT_UPDATE) {
         match mode.as_str() {
-            "all" => UpdateMode::ReplaceAll,
-            "none" => UpdateMode::ReplaceNone,
-            "older" => UpdateMode::ReplaceIfOlder,
-            "none-fail" => UpdateMode::ReplaceNoneFail,
+            "all" => UpdateMode::All,
+            "none" => UpdateMode::None,
+            "older" => UpdateMode::IfOlder,
+            "none-fail" => UpdateMode::NoneFail,
             _ => unreachable!("other args restricted by clap"),
         }
     } else if matches.get_flag(arguments::OPT_UPDATE_NO_ARG) {
         // short form of this option is equivalent to using --update=older
-        UpdateMode::ReplaceIfOlder
+        UpdateMode::IfOlder
     } else {
         // no option was present
-        UpdateMode::ReplaceAll
+        UpdateMode::All
     }
 }


### PR DESCRIPTION
* Disabled `avoid-breaking-exported-api` and sorted items in Clippy.toml
* Renamed `BSD` -> `Bsd`, `SYSV` -> `SysV`, and `CRC` -> `Crc` to match Rust naming rules
* Renamed items in `BackupMode` and `UpdateMode` because they repeated the same word in every item - making it redundant and harder to read