### PR TITLE
chore: remove unneeded parens

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -65,7 +65,7 @@ fn main() {
 
     // binary name equals util name?
     if let Some(&(uumain, _)) = utils.get(binary_as_util) {
-        process::exit(uumain((vec![binary.into()].into_iter()).chain(args)));
+        process::exit(uumain(vec![binary.into()].into_iter().chain(args)));
     }
 
     // binary name equals prefixed util name?
@@ -111,7 +111,7 @@ fn main() {
 
         match utils.get(util) {
             Some(&(uumain, _)) => {
-                process::exit(uumain((vec![util_os].into_iter()).chain(args)));
+                process::exit(uumain(vec![util_os].into_iter().chain(args)));
             }
             None => {
                 if util == "--help" || util == "-h" {
@@ -124,7 +124,8 @@ fn main() {
                         match utils.get(util) {
                             Some(&(uumain, _)) => {
                                 let code = uumain(
-                                    (vec![util_os, OsString::from("--help")].into_iter())
+                                    vec![util_os, OsString::from("--help")]
+                                        .into_iter()
                                         .chain(args),
                                 );
                                 io::stdout().flush().expect("could not flush stdout");

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -160,7 +160,7 @@ fn parse_signal_opt<'a>(opts: &mut Options<'a>, opt: &'a OsStr) -> UResult<()> {
 
     let mut sig_vec = Vec::with_capacity(signals.len());
     signals.into_iter().for_each(|sig| {
-        if !(sig.is_empty()) {
+        if !sig.is_empty() {
             sig_vec.push(sig);
         }
     });

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2392,11 +2392,9 @@ fn display_dir_entry_size(
     // TODO: Cache/memorize the display_* results so we don't have to recalculate them.
     if let Some(md) = entry.get_metadata(out) {
         let (size_len, major_len, minor_len) = match display_len_or_rdev(md, config) {
-            SizeOrDeviceId::Device(major, minor) => (
-                (major.len() + minor.len() + 2usize),
-                major.len(),
-                minor.len(),
-            ),
+            SizeOrDeviceId::Device(major, minor) => {
+                (major.len() + minor.len() + 2usize, major.len(), minor.len())
+            }
             SizeOrDeviceId::Size(size) => (size.len(), 0usize, 0usize),
         };
         (

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -655,8 +655,7 @@ fn build_options(
 
     let page_length_le_ht = page_length < (HEADER_LINES_PER_PAGE + TRAILER_LINES_PER_PAGE);
 
-    let display_header_and_trailer =
-        !(page_length_le_ht) && !matches.get_flag(options::OMIT_HEADER);
+    let display_header_and_trailer = !page_length_le_ht && !matches.get_flag(options::OMIT_HEADER);
 
     let content_lines_per_page = if page_length_le_ht {
         page_length

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -323,7 +323,7 @@ fn create_word_set(config: &Config, filter: &WordFilter, file_map: &FileMap) -> 
                     continue;
                 }
                 let mut word = line[beg..end].to_owned();
-                if filter.only_specified && !(filter.only_set.contains(&word)) {
+                if filter.only_specified && !filter.only_set.contains(&word) {
                     continue;
                 }
                 if filter.ignore_specified && filter.ignore_set.contains(&word) {

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -289,7 +289,7 @@ impl BytesChunkBuffer {
         let mut chunk = Box::new(BytesChunk::new());
 
         // fill chunks with all bytes from reader and reuse already instantiated chunks if possible
-        while (chunk.fill(reader)?).is_some() {
+        while chunk.fill(reader)?.is_some() {
             self.bytes += chunk.bytes as u64;
             self.chunks.push_back(chunk);
 
@@ -565,7 +565,7 @@ impl LinesChunkBuffer {
     pub fn fill(&mut self, reader: &mut impl BufRead) -> UResult<()> {
         let mut chunk = Box::new(LinesChunk::new(self.delimiter));
 
-        while (chunk.fill(reader)?).is_some() {
+        while chunk.fill(reader)?.is_some() {
             self.lines += chunk.lines as u64;
             self.chunks.push_back(chunk);
 

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -136,7 +136,7 @@ fn tail_file(
                 msg
             );
         }
-        if !(observer.follow_name_retry()) {
+        if !observer.follow_name_retry() {
             // skip directory if not retry
             return Ok(());
         }

--- a/src/uucore/src/lib/features/parser/parse_size.rs
+++ b/src/uucore/src/lib/features/parser/parse_size.rs
@@ -512,23 +512,23 @@ mod tests {
 
         for &(c, exp) in &suffixes {
             let s = format!("2{c}B"); // KB
-            assert_eq!(Ok(2 * (1000_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(2 * 1000_u128.pow(exp)), parse_size_u128(&s));
             let s = format!("2{c}"); // K
-            assert_eq!(Ok(2 * (1024_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(2 * 1024_u128.pow(exp)), parse_size_u128(&s));
             let s = format!("2{c}iB"); // KiB
-            assert_eq!(Ok(2 * (1024_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(2 * 1024_u128.pow(exp)), parse_size_u128(&s));
             let s = format!("2{}iB", c.to_lowercase()); // kiB
-            assert_eq!(Ok(2 * (1024_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(2 * 1024_u128.pow(exp)), parse_size_u128(&s));
 
             // suffix only
             let s = format!("{c}B"); // KB
-            assert_eq!(Ok((1000_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(1000_u128.pow(exp)), parse_size_u128(&s));
             let s = format!("{c}"); // K
-            assert_eq!(Ok((1024_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(1024_u128.pow(exp)), parse_size_u128(&s));
             let s = format!("{c}iB"); // KiB
-            assert_eq!(Ok((1024_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(1024_u128.pow(exp)), parse_size_u128(&s));
             let s = format!("{}iB", c.to_lowercase()); // kiB
-            assert_eq!(Ok((1024_u128).pow(exp)), parse_size_u128(&s));
+            assert_eq!(Ok(1024_u128.pow(exp)), parse_size_u128(&s));
         }
     }
 

--- a/src/uucore/src/lib/mods/error.rs
+++ b/src/uucore/src/lib/mods/error.rs
@@ -474,7 +474,7 @@ pub trait FromIo<T> {
 impl FromIo<Box<UIoError>> for std::io::Error {
     fn map_err_context(self, context: impl FnOnce() -> String) -> Box<UIoError> {
         Box::new(UIoError {
-            context: Some((context)()),
+            context: Some(context()),
             inner: self,
         })
     }
@@ -489,7 +489,7 @@ impl<T> FromIo<UResult<T>> for std::io::Result<T> {
 impl FromIo<Box<UIoError>> for std::io::ErrorKind {
     fn map_err_context(self, context: impl FnOnce() -> String) -> Box<UIoError> {
         Box::new(UIoError {
-            context: Some((context)()),
+            context: Some(context()),
             inner: std::io::Error::new(self, ""),
         })
     }
@@ -530,7 +530,7 @@ impl<T> FromIo<UResult<T>> for Result<T, nix::Error> {
     fn map_err_context(self, context: impl FnOnce() -> String) -> UResult<T> {
         self.map_err(|e| {
             Box::new(UIoError {
-                context: Some((context)()),
+                context: Some(context()),
                 inner: std::io::Error::from_raw_os_error(e as i32),
             }) as Box<dyn UError>
         })
@@ -541,7 +541,7 @@ impl<T> FromIo<UResult<T>> for Result<T, nix::Error> {
 impl<T> FromIo<UResult<T>> for nix::Error {
     fn map_err_context(self, context: impl FnOnce() -> String) -> UResult<T> {
         Err(Box::new(UIoError {
-            context: Some((context)()),
+            context: Some(context()),
             inner: std::io::Error::from_raw_os_error(self as i32),
         }) as Box<dyn UError>)
     }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -5787,11 +5787,7 @@ fn test_dir_perm_race_with_preserve_mode_and_ownership() {
         } else {
             libc::S_IRWXG | libc::S_IRWXO
         } as u32;
-        assert_eq!(
-            (mode & mask),
-            0,
-            "unwanted permissions are present - {attr}"
-        );
+        assert_eq!(mode & mask, 0, "unwanted permissions are present - {attr}");
         at.write(FIFO, "done");
         child.wait().unwrap().succeeded();
     }

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -14,6 +14,7 @@ use uutests::new_ucmd;
 use uutests::util::TestScenario;
 use uutests::util_name;
 
+use std::fmt::Write;
 use std::time::{Duration, SystemTime};
 
 use rand::distr::{Distribution, Uniform};
@@ -55,7 +56,7 @@ fn test_parallel() {
     let n_integers = 100_000;
     let mut input_string = String::new();
     for i in 0..=n_integers {
-        input_string.push_str(&format!("{i} "));
+        let _ = write!(input_string, "{i} ");
     }
 
     let tmp_dir = TempDir::new().unwrap();
@@ -100,7 +101,7 @@ fn test_first_1000_integers() {
     let n_integers = 1000;
     let mut input_string = String::new();
     for i in 0..=n_integers {
-        input_string.push_str(&format!("{i} "));
+        let _ = write!(input_string, "{i} ");
     }
 
     println!("STDIN='{input_string}'");
@@ -124,7 +125,7 @@ fn test_first_1000_integers_with_exponents() {
     let n_integers = 1000;
     let mut input_string = String::new();
     for i in 0..=n_integers {
-        input_string.push_str(&format!("{i} "));
+        let _ = write!(input_string, "{i} ");
     }
 
     println!("STDIN='{input_string}'");
@@ -197,11 +198,11 @@ fn test_random() {
     let mut output_string = String::new();
     for _ in 0..NUM_TESTS {
         let (product, factors) = rand_gt(1 << 63);
-        input_string.push_str(&format!("{product} "));
+        let _ = write!(input_string, "{product} ");
 
-        output_string.push_str(&format!("{product}:"));
+        let _ = write!(output_string, "{product}:");
         for factor in factors {
-            output_string.push_str(&format!(" {factor}"));
+            let _ = write!(output_string, " {factor}");
         }
         output_string.push('\n');
     }
@@ -281,11 +282,11 @@ fn test_random_big() {
     let mut output_string = String::new();
     for _ in 0..NUM_TESTS {
         let (product, factors) = rand_64();
-        input_string.push_str(&format!("{product} "));
+        let _ = write!(input_string, "{product} ");
 
-        output_string.push_str(&format!("{product}:"));
+        let _ = write!(output_string, "{product}:");
         for factor in factors {
-            output_string.push_str(&format!(" {factor}"));
+            let _ = write!(output_string, " {factor}");
         }
         output_string.push('\n');
     }
@@ -298,8 +299,8 @@ fn test_big_primes() {
     let mut input_string = String::new();
     let mut output_string = String::new();
     for prime in PRIMES64 {
-        input_string.push_str(&format!("{prime} "));
-        output_string.push_str(&format!("{prime}: {prime}\n"));
+        let _ = write!(input_string, "{prime} ");
+        let _ = writeln!(output_string, "{prime}: {prime}");
     }
 
     run(input_string.as_bytes(), output_string.as_bytes());
@@ -325,8 +326,8 @@ fn test_primes_with_exponents() {
     let mut output_string = String::new();
     for primes in PRIMES_BY_BITS {
         for &prime in *primes {
-            input_string.push_str(&format!("{prime} "));
-            output_string.push_str(&format!("{prime}: {prime}\n"));
+            let _ = write!(input_string, "{prime} ");
+            let _ = writeln!(output_string, "{prime}: {prime}");
         }
     }
 

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -55,7 +55,7 @@ fn test_parallel() {
     let n_integers = 100_000;
     let mut input_string = String::new();
     for i in 0..=n_integers {
-        input_string.push_str(&(format!("{i} "))[..]);
+        input_string.push_str(&format!("{i} "));
     }
 
     let tmp_dir = TempDir::new().unwrap();
@@ -100,7 +100,7 @@ fn test_first_1000_integers() {
     let n_integers = 1000;
     let mut input_string = String::new();
     for i in 0..=n_integers {
-        input_string.push_str(&(format!("{i} "))[..]);
+        input_string.push_str(&format!("{i} "));
     }
 
     println!("STDIN='{input_string}'");
@@ -124,7 +124,7 @@ fn test_first_1000_integers_with_exponents() {
     let n_integers = 1000;
     let mut input_string = String::new();
     for i in 0..=n_integers {
-        input_string.push_str(&(format!("{i} "))[..]);
+        input_string.push_str(&format!("{i} "));
     }
 
     println!("STDIN='{input_string}'");
@@ -197,11 +197,11 @@ fn test_random() {
     let mut output_string = String::new();
     for _ in 0..NUM_TESTS {
         let (product, factors) = rand_gt(1 << 63);
-        input_string.push_str(&(format!("{product} "))[..]);
+        input_string.push_str(&format!("{product} "));
 
-        output_string.push_str(&(format!("{product}:"))[..]);
+        output_string.push_str(&format!("{product}:"));
         for factor in factors {
-            output_string.push_str(&(format!(" {factor}"))[..]);
+            output_string.push_str(&format!(" {factor}"));
         }
         output_string.push('\n');
     }
@@ -281,11 +281,11 @@ fn test_random_big() {
     let mut output_string = String::new();
     for _ in 0..NUM_TESTS {
         let (product, factors) = rand_64();
-        input_string.push_str(&(format!("{product} "))[..]);
+        input_string.push_str(&format!("{product} "));
 
-        output_string.push_str(&(format!("{product}:"))[..]);
+        output_string.push_str(&format!("{product}:"));
         for factor in factors {
-            output_string.push_str(&(format!(" {factor}"))[..]);
+            output_string.push_str(&format!(" {factor}"));
         }
         output_string.push('\n');
     }
@@ -298,8 +298,8 @@ fn test_big_primes() {
     let mut input_string = String::new();
     let mut output_string = String::new();
     for prime in PRIMES64 {
-        input_string.push_str(&(format!("{prime} "))[..]);
-        output_string.push_str(&(format!("{prime}: {prime}\n"))[..]);
+        input_string.push_str(&format!("{prime} "));
+        output_string.push_str(&format!("{prime}: {prime}\n"));
     }
 
     run(input_string.as_bytes(), output_string.as_bytes());
@@ -325,8 +325,8 @@ fn test_primes_with_exponents() {
     let mut output_string = String::new();
     for primes in PRIMES_BY_BITS {
         for &prime in *primes {
-            input_string.push_str(&(format!("{prime} "))[..]);
-            output_string.push_str(&(format!("{prime}: {prime}\n"))[..]);
+            input_string.push_str(&format!("{prime} "));
+            output_string.push_str(&format!("{prime}: {prime}\n"));
         }
     }
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1733,7 +1733,9 @@ fn test_ls_group_directories_first() {
         .succeeds();
     assert_eq!(
         result.stdout_str().split('\n').collect::<Vec<_>>(),
-        (dirnames.into_iter().rev())
+        dirnames
+            .into_iter()
+            .rev()
             .chain(dots.into_iter().rev())
             .chain(filenames.into_iter().rev())
             .chain([""].into_iter())


### PR DESCRIPTION
Keeps code a bit more readable. Also uses `write!` macro to optimize writing to a `String` using `format!`