### PR TITLE
feat: minor linting

### DIFF
--- a/src/uu/csplit/src/split_name.rs
+++ b/src/uu/csplit/src/split_name.rs
@@ -47,10 +47,7 @@ impl SplitName {
             .transpose()?
             .unwrap_or(2);
 
-        let format_string = match format_opt {
-            Some(f) => f,
-            None => format!("%0{n_digits}u"),
-        };
+        let format_string = format_opt.unwrap_or_else(|| format!("%0{n_digits}u"));
 
         let format = match Format::<UnsignedInt, u64>::parse(format_string) {
             Ok(format) => Ok(format),

--- a/src/uu/cut/src/searcher.rs
+++ b/src/uu/cut/src/searcher.rs
@@ -61,7 +61,7 @@ mod exact_searcher_tests {
         let matcher = ExactMatcher::new("a".as_bytes());
         let iter = Searcher::new(&matcher, "".as_bytes());
         let items: Vec<(usize, usize)> = iter.collect();
-        assert_eq!(vec![] as Vec<(usize, usize)>, items);
+        assert!(items.is_empty());
     }
 
     fn test_multibyte(line: &[u8], expected: &[(usize, usize)]) {
@@ -140,7 +140,7 @@ mod whitespace_searcher_tests {
         let matcher = WhitespaceMatcher {};
         let iter = Searcher::new(&matcher, "".as_bytes());
         let items: Vec<(usize, usize)> = iter.collect();
-        assert_eq!(vec![] as Vec<(usize, usize)>, items);
+        assert!(items.is_empty());
     }
 
     fn test_multispace(line: &[u8], expected: &[(usize, usize)]) {

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -442,7 +442,7 @@ fn parse_bytes_only(s: &str, i: usize) -> Result<u64, ParseError> {
 /// 512. You can also use standard block size suffixes like `'k'` for
 /// 1024.
 ///
-/// If the number would be too large, return [`std::u64::MAX`] instead.
+/// If the number would be too large, return [`u64::MAX`] instead.
 ///
 /// # Errors
 ///

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -124,10 +124,7 @@ pub enum MainFunction {
 impl Behavior {
     /// Determine the mode for chmod after copy.
     pub fn mode(&self) -> u32 {
-        match self.specified_mode {
-            Some(x) => x,
-            None => DEFAULT_MODE,
-        }
+        self.specified_mode.unwrap_or(DEFAULT_MODE)
     }
 }
 

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -59,7 +59,7 @@ enum LnError {
     #[error("missing destination file operand after {}", _0.quote())]
     MissingDestination(PathBuf),
 
-    #[error("extra operand {}\nTry '{} --help' for more information.", 
+    #[error("extra operand {}\nTry '{} --help' for more information.",
     format!("{_0:?}").trim_matches('"'), _1)]
     ExtraOperand(OsString, String),
 }

--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -104,11 +104,11 @@ impl<'a> StyleManager<'a> {
         ret
     }
 
-    pub(crate) fn is_current_style(&mut self, new_style: &Style) -> bool {
-        matches!(&self.current_style,Some(style) if style == new_style )
+    pub(crate) fn is_current_style(&self, new_style: &Style) -> bool {
+        matches!(&self.current_style, Some(style) if style == new_style)
     }
 
-    pub(crate) fn is_reset(&mut self) -> bool {
+    pub(crate) fn is_reset(&self) -> bool {
         self.current_style.is_none()
     }
 

--- a/src/uu/od/src/prn_float.rs
+++ b/src/uu/od/src/prn_float.rs
@@ -3,8 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use half::f16;
-use std::f32;
-use std::f64;
 use std::num::FpCategory;
 
 use crate::formatteriteminfo::{FormatWriter, FormatterItemInfo};

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -535,7 +535,7 @@ impl LineFormat {
 
             let mut parts = checksum.splitn(2, |&b| b == b'=');
             let main = parts.next().unwrap(); // Always exists since checksum isn't empty
-            let padding = parts.next().unwrap_or(&b""[..]); // Empty if no '='
+            let padding = parts.next().unwrap_or_default(); // Empty if no '='
 
             main.iter()
                 .all(|&b| b.is_ascii_alphanumeric() || b == b'+' || b == b'/')

--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -1123,7 +1123,7 @@ mod test {
         U: Formatter<T>,
     {
         let mut v = Vec::<u8>::new();
-        format.fmt(&mut v, n as T).unwrap();
+        format.fmt(&mut v, n).unwrap();
         String::from_utf8_lossy(&v).to_string()
     }
 


### PR DESCRIPTION
A few minor linting changes:

* simplify a few `match` statements
* use `.is_empty()` instead of creating a new vector just to see if there is nothing in it
* do not use `std::u64` - use `u64` keyword instead. Note that `MAX` is deprecated when used the old way.
* remove `mut` in the `&mut self` for few functions that don't need it
* remove unneeded casting