### PR TITLE
Consolidate lint management with workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -584,3 +584,13 @@ manual_let_else = "warn"
 all = { level = "deny", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 pedantic = { level = "deny", priority = -1 }
+
+# This is the linting configuration for all crates.
+# Eventually the clippy settings from the `[lints]` section should be moved here.
+# In order to use these, all crates have `[lints] workspace = true` section.
+[workspace.lints.rust]
+# unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+#cargo = { level = "warn", priority = -1 }

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/arch.rs"
 

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/base32.rs"
 

--- a/src/uu/base64/Cargo.toml
+++ b/src/uu/base64/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/base64.rs"
 

--- a/src/uu/basename/Cargo.toml
+++ b/src/uu/basename/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/basename.rs"
 

--- a/src/uu/basenc/Cargo.toml
+++ b/src/uu/basenc/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/basenc.rs"
 

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/cat.rs"
 

--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/chcon.rs"
 

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/chgrp.rs"
 

--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/chmod.rs"
 

--- a/src/uu/chown/Cargo.toml
+++ b/src/uu/chown/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/chown.rs"
 

--- a/src/uu/chroot/Cargo.toml
+++ b/src/uu/chroot/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/chroot.rs"
 

--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/cksum.rs"
 

--- a/src/uu/comm/Cargo.toml
+++ b/src/uu/comm/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/comm.rs"
 

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -17,6 +17,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/cp.rs"
 

--- a/src/uu/csplit/Cargo.toml
+++ b/src/uu/csplit/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/csplit.rs"
 

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/cut.rs"
 

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/date.rs"
 

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/dd.rs"
 

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/df.rs"
 

--- a/src/uu/dir/Cargo.toml
+++ b/src/uu/dir/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/dir.rs"
 

--- a/src/uu/dircolors/Cargo.toml
+++ b/src/uu/dircolors/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/dircolors.rs"
 

--- a/src/uu/dirname/Cargo.toml
+++ b/src/uu/dirname/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/dirname.rs"
 

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/du.rs"
 

--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/echo.rs"
 

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/env.rs"
 

--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/expand.rs"
 

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/expr.rs"
 

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [build-dependencies]
 num-traits = { workspace = true } # used in src/numerics.rs, which is included by build.rs
 

--- a/src/uu/false/Cargo.toml
+++ b/src/uu/false/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/false.rs"
 

--- a/src/uu/fmt/Cargo.toml
+++ b/src/uu/fmt/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/fmt.rs"
 

--- a/src/uu/fold/Cargo.toml
+++ b/src/uu/fold/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/fold.rs"
 

--- a/src/uu/groups/Cargo.toml
+++ b/src/uu/groups/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/groups.rs"
 

--- a/src/uu/hashsum/Cargo.toml
+++ b/src/uu/hashsum/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/hashsum.rs"
 

--- a/src/uu/head/Cargo.toml
+++ b/src/uu/head/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/head.rs"
 

--- a/src/uu/hostid/Cargo.toml
+++ b/src/uu/hostid/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/hostid.rs"
 

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/hostname.rs"
 

--- a/src/uu/id/Cargo.toml
+++ b/src/uu/id/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/id.rs"
 

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/install.rs"
 

--- a/src/uu/join/Cargo.toml
+++ b/src/uu/join/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/join.rs"
 

--- a/src/uu/kill/Cargo.toml
+++ b/src/uu/kill/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/kill.rs"
 

--- a/src/uu/link/Cargo.toml
+++ b/src/uu/link/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/link.rs"
 

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/ln.rs"
 

--- a/src/uu/logname/Cargo.toml
+++ b/src/uu/logname/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/logname.rs"
 

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/ls.rs"
 

--- a/src/uu/mkdir/Cargo.toml
+++ b/src/uu/mkdir/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/mkdir.rs"
 

--- a/src/uu/mkfifo/Cargo.toml
+++ b/src/uu/mkfifo/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/mkfifo.rs"
 

--- a/src/uu/mknod/Cargo.toml
+++ b/src/uu/mknod/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "uu_mknod"
 path = "src/mknod.rs"

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/mktemp.rs"
 

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/more.rs"
 

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/mv.rs"
 

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/nice.rs"
 

--- a/src/uu/nl/Cargo.toml
+++ b/src/uu/nl/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/nl.rs"
 

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/nohup.rs"
 

--- a/src/uu/nproc/Cargo.toml
+++ b/src/uu/nproc/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/nproc.rs"
 

--- a/src/uu/numfmt/Cargo.toml
+++ b/src/uu/numfmt/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/numfmt.rs"
 

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/od.rs"
 

--- a/src/uu/paste/Cargo.toml
+++ b/src/uu/paste/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/paste.rs"
 

--- a/src/uu/pathchk/Cargo.toml
+++ b/src/uu/pathchk/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/pathchk.rs"
 

--- a/src/uu/pinky/Cargo.toml
+++ b/src/uu/pinky/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/pinky.rs"
 

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/pr.rs"
 

--- a/src/uu/printenv/Cargo.toml
+++ b/src/uu/printenv/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/printenv.rs"
 

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/printf.rs"
 

--- a/src/uu/ptx/Cargo.toml
+++ b/src/uu/ptx/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/ptx.rs"
 

--- a/src/uu/pwd/Cargo.toml
+++ b/src/uu/pwd/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/pwd.rs"
 

--- a/src/uu/readlink/Cargo.toml
+++ b/src/uu/readlink/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/readlink.rs"
 

--- a/src/uu/realpath/Cargo.toml
+++ b/src/uu/realpath/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/realpath.rs"
 

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/rm.rs"
 

--- a/src/uu/rmdir/Cargo.toml
+++ b/src/uu/rmdir/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/rmdir.rs"
 

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/runcon.rs"
 

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -34,6 +34,11 @@ uucore = { workspace = true, features = [
 name = "seq"
 path = "src/main.rs"
 
+# FIXME: this is the only crate that has a separate lints configuration,
+#        which for now means a full copy of all clippy and rust lints here.
+[lints.clippy]
+all = { level = "deny", priority = -1 }
+
 # Allow "fuzzing" as a "cfg" condition name
 # https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
 [lints.rust]

--- a/src/uu/shred/Cargo.toml
+++ b/src/uu/shred/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/shred.rs"
 

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/shuf.rs"
 

--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/sleep.rs"
 

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/sort.rs"
 

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/split.rs"
 

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/stat.rs"
 

--- a/src/uu/stdbuf/Cargo.toml
+++ b/src/uu/stdbuf/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/stdbuf.rs"
 

--- a/src/uu/stty/Cargo.toml
+++ b/src/uu/stty/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/stty.rs"
 

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/sum.rs"
 

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/sync.rs"
 

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/tac.rs"
 

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/tail.rs"
 

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/tee.rs"
 

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/test.rs"
 

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/timeout.rs"
 

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/touch.rs"
 

--- a/src/uu/tr/Cargo.toml
+++ b/src/uu/tr/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/tr.rs"
 

--- a/src/uu/true/Cargo.toml
+++ b/src/uu/true/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/true.rs"
 

--- a/src/uu/truncate/Cargo.toml
+++ b/src/uu/truncate/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/truncate.rs"
 

--- a/src/uu/tsort/Cargo.toml
+++ b/src/uu/tsort/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/tsort.rs"
 

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/tty.rs"
 

--- a/src/uu/uname/Cargo.toml
+++ b/src/uu/uname/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/uname.rs"
 

--- a/src/uu/unexpand/Cargo.toml
+++ b/src/uu/unexpand/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/unexpand.rs"
 

--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/uniq.rs"
 

--- a/src/uu/unlink/Cargo.toml
+++ b/src/uu/unlink/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/unlink.rs"
 

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/uptime.rs"
 

--- a/src/uu/users/Cargo.toml
+++ b/src/uu/users/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/users.rs"
 

--- a/src/uu/vdir/Cargo.toml
+++ b/src/uu/vdir/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/vdir.rs"
 

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/wc.rs"
 

--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/who.rs"
 

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/whoami.rs"
 

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/yes.rs"
 


### PR DESCRIPTION
At the moment, most crates rely on build scripts and other methods to keep lint-consistency. As of recent, Rust can use workspaces to globally set all the lint configurations.

This PR only adds lint configuration to each crate, but it does not introduce any changes to the code or lint configuration. In the subsequent PRs, I plan to gradually move lints from `uucore` to workspace, making all code consistent.

Note that `seq` relies on a custom lint config - which means its configuration may need to be managed by hand until Cargo introduces per-crate overrides.