### PR TITLE
Enable and fix `unused_qualifications` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -589,7 +589,7 @@ pedantic = { level = "deny", priority = -1 }
 # Eventually the clippy settings from the `[lints]` section should be moved here.
 # In order to use these, all crates have `[lints] workspace = true` section.
 [workspace.lints.rust]
-# unused_qualifications = "warn"
+unused_qualifications = "warn"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -139,7 +139,7 @@ pub fn base_app(about: &'static str, usage: &str) -> Command {
         .arg(
             Arg::new(options::FILE)
                 .index(1)
-                .action(clap::ArgAction::Append)
+                .action(ArgAction::Append)
                 .value_hint(clap::ValueHint::FilePath),
         )
 }

--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -90,7 +90,7 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::NAME)
-                .action(clap::ArgAction::Append)
+                .action(ArgAction::Append)
                 .value_hint(clap::ValueHint::AnyPath)
                 .hide(true)
                 .trailing_var_arg(true),

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -86,7 +86,7 @@ impl LineNumber {
         }
     }
 
-    fn write(&self, writer: &mut impl Write) -> std::io::Result<()> {
+    fn write(&self, writer: &mut impl Write) -> io::Result<()> {
         writer.write_all(&self.buf)
     }
 }
@@ -288,7 +288,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::FILE)
                 .hide(true)
-                .action(clap::ArgAction::Append)
+                .action(ArgAction::Append)
                 .value_hint(clap::ValueHint::FilePath),
         )
         .arg(
@@ -377,7 +377,7 @@ fn cat_handle<R: FdReadable>(
 /// Whether this process is appending to stdout.
 #[cfg(unix)]
 fn is_appending() -> bool {
-    let stdout = std::io::stdout();
+    let stdout = io::stdout();
     let flags = match fcntl(stdout.as_raw_fd(), FcntlArg::F_GETFL) {
         Ok(flags) => flags,
         Err(_) => return false,
@@ -404,7 +404,7 @@ fn cat_path(
             let in_info = FileInformation::from_file(&stdin)?;
             let mut handle = InputHandle {
                 reader: stdin,
-                is_interactive: std::io::stdin().is_terminal(),
+                is_interactive: io::stdin().is_terminal(),
             };
             if let Some(out_info) = out_info {
                 if in_info == *out_info && is_appending() {
@@ -445,7 +445,7 @@ fn cat_path(
 }
 
 fn cat_files(files: &[String], options: &OutputOptions) -> UResult<()> {
-    let out_info = FileInformation::from_file(&std::io::stdout()).ok();
+    let out_info = FileInformation::from_file(&io::stdout()).ok();
 
     let mut state = OutputState {
         line_number: LineNumber::new(),

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -312,7 +312,7 @@ struct Options {
     files: Vec<PathBuf>,
 }
 
-fn parse_command_line(config: clap::Command, args: impl uucore::Args) -> Result<Options> {
+fn parse_command_line(config: Command, args: impl uucore::Args) -> Result<Options> {
     let matches = config.try_get_matches_from(args)?;
 
     let verbose = matches.get_flag(options::VERBOSE);

--- a/src/uu/chcon/src/fts.rs
+++ b/src/uu/chcon/src/fts.rs
@@ -16,9 +16,9 @@ use crate::os_str_to_c_string;
 
 #[derive(Debug)]
 pub(crate) struct FTS {
-    fts: ptr::NonNull<fts_sys::FTS>,
+    fts: NonNull<fts_sys::FTS>,
 
-    entry: Option<ptr::NonNull<fts_sys::FTSENT>>,
+    entry: Option<NonNull<fts_sys::FTSENT>>,
     _phantom_data: PhantomData<fts_sys::FTSENT>,
 }
 
@@ -52,7 +52,7 @@ impl FTS {
         // - `compar` is None.
         let fts = unsafe { fts_sys::fts_open(path_argv.as_ptr().cast(), options, None) };
 
-        let fts = ptr::NonNull::new(fts)
+        let fts = NonNull::new(fts)
             .ok_or_else(|| Error::from_io("fts_open()", io::Error::last_os_error()))?;
 
         Ok(Self {
@@ -110,14 +110,14 @@ impl Drop for FTS {
 
 #[derive(Debug)]
 pub(crate) struct EntryRef<'fts> {
-    pub(crate) pointer: ptr::NonNull<fts_sys::FTSENT>,
+    pub(crate) pointer: NonNull<fts_sys::FTSENT>,
 
     _fts: PhantomData<&'fts FTS>,
     _phantom_data: PhantomData<fts_sys::FTSENT>,
 }
 
 impl<'fts> EntryRef<'fts> {
-    fn new(_fts: &'fts FTS, entry: ptr::NonNull<fts_sys::FTSENT>) -> Self {
+    fn new(_fts: &'fts FTS, entry: NonNull<fts_sys::FTSENT>) -> Self {
         Self {
             pointer: entry,
             _fts: PhantomData,
@@ -174,7 +174,7 @@ impl<'fts> EntryRef<'fts> {
     }
 
     pub(crate) fn access_path(&self) -> Option<&Path> {
-        ptr::NonNull::new(self.as_ref().fts_accpath)
+        NonNull::new(self.as_ref().fts_accpath)
             .map(|path_ptr| {
                 // SAFETY: `entry.fts_accpath` is a non-null pointer that is assumed to be valid.
                 unsafe { CStr::from_ptr(path_ptr.as_ptr()) }
@@ -184,7 +184,7 @@ impl<'fts> EntryRef<'fts> {
     }
 
     pub(crate) fn stat(&self) -> Option<&libc::stat> {
-        ptr::NonNull::new(self.as_ref().fts_statp).map(|stat_ptr| {
+        NonNull::new(self.as_ref().fts_statp).map(|stat_ptr| {
             // SAFETY: `entry.fts_statp` is a non-null pointer that is assumed to be valid.
             unsafe { stat_ptr.as_ref() }
         })

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -350,7 +350,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::FILE)
                 .hide(true)
-                .action(clap::ArgAction::Append)
+                .action(ArgAction::Append)
                 .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::FilePath),
         )

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -118,8 +118,8 @@ impl OrderChecker {
 // Check if two files are identical by comparing their contents
 pub fn are_files_identical(path1: &str, path2: &str) -> io::Result<bool> {
     // First compare file sizes
-    let metadata1 = std::fs::metadata(path1)?;
-    let metadata2 = std::fs::metadata(path2)?;
+    let metadata1 = metadata(path1)?;
+    let metadata2 = metadata(path2)?;
 
     if metadata1.len() != metadata2.len() {
         return Ok(false);

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -737,7 +737,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::PROGRESS_BAR)
                 .long(options::PROGRESS_BAR)
                 .short('g')
-                .action(clap::ArgAction::SetTrue)
+                .action(ArgAction::SetTrue)
                 .help(
                     "Display a progress bar. \n\
                 Note: this feature is not supported by GNU coreutils.",
@@ -2081,7 +2081,7 @@ fn handle_copy_mode(
         CopyMode::Update => {
             if dest.exists() {
                 match options.update {
-                    update_control::UpdateMode::ReplaceAll => {
+                    UpdateMode::ReplaceAll => {
                         copy_helper(
                             source,
                             dest,
@@ -2094,17 +2094,17 @@ fn handle_copy_mode(
                             source_is_stream,
                         )?;
                     }
-                    update_control::UpdateMode::ReplaceNone => {
+                    UpdateMode::ReplaceNone => {
                         if options.debug {
                             println!("skipped {}", dest.quote());
                         }
 
                         return Ok(PerformedAction::Skipped);
                     }
-                    update_control::UpdateMode::ReplaceNoneFail => {
+                    UpdateMode::ReplaceNoneFail => {
                         return Err(Error::Error(format!("not replacing '{}'", dest.display())));
                     }
-                    update_control::UpdateMode::ReplaceIfOlder => {
+                    UpdateMode::ReplaceIfOlder => {
                         let dest_metadata = fs::symlink_metadata(dest)?;
 
                         let src_time = source_metadata.modified()?;
@@ -2335,7 +2335,7 @@ fn copy_file(
             &FileInformation::from_path(source, options.dereference(source_in_command_line))
                 .context(format!("cannot stat {}", source.quote()))?,
         ) {
-            std::fs::hard_link(new_source, dest)?;
+            fs::hard_link(new_source, dest)?;
 
             if options.verbose {
                 print_verbose_output(options.parents, progress_bar, source, dest);

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -43,7 +43,7 @@ mod options {
 
 /// Command line options for csplit.
 pub struct CsplitOptions {
-    split_name: crate::SplitName,
+    split_name: SplitName,
     keep_files: bool,
     quiet: bool,
     elide_empty_files: bool,
@@ -661,7 +661,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::PATTERN)
                 .hide(true)
-                .action(clap::ArgAction::Append)
+                .action(ArgAction::Append)
                 .required(true),
         )
         .after_help(AFTER_HELP)

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -352,7 +352,7 @@ fn cut_files(mut filenames: Vec<String>, mode: &Mode) {
         filenames.push("-".to_owned());
     }
 
-    let mut out: Box<dyn Write> = if std::io::stdout().is_terminal() {
+    let mut out: Box<dyn Write> = if stdout().is_terminal() {
         Box::new(stdout())
     } else {
         Box::new(BufWriter::new(stdout())) as Box<dyn Write>

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -227,7 +227,7 @@ fn get_size_on_disk(path: &Path) -> u64 {
 
     // bind file so it stays in scope until end of function
     // if it goes out of scope the handle below becomes invalid
-    let file = match fs::File::open(path) {
+    let file = match File::open(path) {
         Ok(file) => file,
         Err(_) => return size_on_disk, // opening directories will fail
     };
@@ -240,7 +240,7 @@ fn get_size_on_disk(path: &Path) -> u64 {
             file.as_raw_handle() as HANDLE,
             FileStandardInfo,
             file_info_ptr as _,
-            std::mem::size_of::<FILE_STANDARD_INFO>() as u32,
+            size_of::<FILE_STANDARD_INFO>() as u32,
         );
 
         if success != 0 {
@@ -255,7 +255,7 @@ fn get_size_on_disk(path: &Path) -> u64 {
 fn get_file_info(path: &Path) -> Option<FileInfo> {
     let mut result = None;
 
-    let file = match fs::File::open(path) {
+    let file = match File::open(path) {
         Ok(file) => file,
         Err(_) => return result,
     };
@@ -268,7 +268,7 @@ fn get_file_info(path: &Path) -> Option<FileInfo> {
             file.as_raw_handle() as HANDLE,
             FileIdInfo,
             file_info_ptr as _,
-            std::mem::size_of::<FILE_ID_INFO>() as u32,
+            size_of::<FILE_ID_INFO>() as u32,
         );
 
         if success != 0 {

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -654,7 +654,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             files.collect()
         } else {
             // Deduplicate while preserving order
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::new();
             files
                 .filter(|path| seen.insert(path.clone()))
                 .collect::<Vec<_>>()

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -345,7 +345,7 @@ fn debug_print_args(args: &[OsString]) {
 fn check_and_handle_string_args(
     arg: &OsString,
     prefix_to_test: &str,
-    all_args: &mut Vec<std::ffi::OsString>,
+    all_args: &mut Vec<OsString>,
     do_debug_print_args: Option<&Vec<OsString>>,
 ) -> UResult<bool> {
     let native_arg = NCvt::convert(arg);
@@ -386,8 +386,8 @@ impl EnvAppData {
     fn process_all_string_arguments(
         &mut self,
         original_args: &Vec<OsString>,
-    ) -> UResult<Vec<std::ffi::OsString>> {
-        let mut all_args: Vec<std::ffi::OsString> = Vec::new();
+    ) -> UResult<Vec<OsString>> {
+        let mut all_args: Vec<OsString> = Vec::new();
         for arg in original_args {
             match arg {
                 b if check_and_handle_string_args(b, "--split-string", &mut all_args, None)? => {
@@ -454,7 +454,7 @@ impl EnvAppData {
                             uucore::show_error!("{s}");
                         }
                         uucore::show_error!("{ERROR_MSG_S_SHEBANG}");
-                        uucore::error::ExitCode::new(125)
+                        ExitCode::new(125)
                     }
                 }
             })?;
@@ -751,7 +751,7 @@ fn apply_ignore_signal(opts: &Options<'_>) -> UResult<()> {
     for &sig_value in &opts.ignore_signal {
         let sig: Signal = (sig_value as i32)
             .try_into()
-            .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+            .map_err(|e| io::Error::from_raw_os_error(e as i32))?;
 
         ignore_signal(sig)?;
     }
@@ -786,7 +786,7 @@ mod tests {
 
     #[test]
     fn test_split_string_environment_vars_test() {
-        unsafe { std::env::set_var("FOO", "BAR") };
+        unsafe { env::set_var("FOO", "BAR") };
         assert_eq!(
             NCvt::convert(vec!["FOO=bar", "sh", "-c", "echo xBARx =$FOO="]),
             parse_args_from_str(&NCvt::convert(r#"FOO=bar sh -c "echo x${FOO}x =\$FOO=""#))

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -27,10 +27,10 @@ mod options {
 
 fn print_factors_str(
     num_str: &str,
-    w: &mut io::BufWriter<impl io::Write>,
+    w: &mut io::BufWriter<impl Write>,
     print_exponents: bool,
 ) -> UResult<()> {
-    let rx = num_str.trim().parse::<num_bigint::BigUint>();
+    let rx = num_str.trim().parse::<BigUint>();
     let Ok(x) = rx else {
         // return Ok(). it's non-fatal and we should try the next number.
         show_warning!("{}: {}", num_str.maybe_quote(), rx.unwrap_err());

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -675,7 +675,7 @@ fn chown_optional_user_group(path: &Path, b: &Behavior) -> UResult<()> {
         return Ok(());
     };
 
-    let meta = match fs::metadata(path) {
+    let meta = match metadata(path) {
         Ok(meta) => meta,
         Err(e) => return Err(InstallError::MetadataFailed(e).into()),
     };
@@ -859,7 +859,7 @@ fn set_ownership_and_permissions(to: &Path, b: &Behavior) -> UResult<()> {
 /// Returns an empty Result or an error in case of failure.
 ///
 fn preserve_timestamps(from: &Path, to: &Path) -> UResult<()> {
-    let meta = match fs::metadata(from) {
+    let meta = match metadata(from) {
         Ok(meta) => meta,
         Err(e) => return Err(InstallError::MetadataFailed(e).into()),
     };
@@ -940,14 +940,14 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> UResult<()> {
 fn need_copy(from: &Path, to: &Path, b: &Behavior) -> UResult<bool> {
     // Attempt to retrieve metadata for the source file.
     // If this fails, assume the file needs to be copied.
-    let from_meta = match fs::metadata(from) {
+    let from_meta = match metadata(from) {
         Ok(meta) => meta,
         Err(_) => return Ok(true),
     };
 
     // Attempt to retrieve metadata for the destination file.
     // If this fails, assume the file needs to be copied.
-    let to_meta = match fs::metadata(to) {
+    let to_meta = match metadata(to) {
         Ok(meta) => meta,
         Err(_) => return Ok(true),
     };

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -74,7 +74,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             } else {
                 let sig = (sig as i32)
                     .try_into()
-                    .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                    .map_err(|e| Error::from_raw_os_error(e as i32))?;
                 Some(sig)
             };
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -439,7 +439,7 @@ fn extract_format(options: &clap::ArgMatches) -> (Format, Option<&'static str>) 
         (Format::Commas, Some(options::format::COMMAS))
     } else if options.get_flag(options::format::COLUMNS) {
         (Format::Columns, Some(options::format::COLUMNS))
-    } else if std::io::stdout().is_terminal() {
+    } else if stdout().is_terminal() {
         (Format::Columns, None)
     } else {
         (Format::OneLine, None)
@@ -559,7 +559,7 @@ fn extract_color(options: &clap::ArgMatches) -> bool {
         None => options.contains_id(options::COLOR),
         Some(val) => match val.as_str() {
             "" | "always" | "yes" | "force" => true,
-            "auto" | "tty" | "if-tty" => std::io::stdout().is_terminal(),
+            "auto" | "tty" | "if-tty" => stdout().is_terminal(),
             /* "never" | "no" | "none" | */ _ => false,
         },
     }
@@ -578,7 +578,7 @@ fn extract_hyperlink(options: &clap::ArgMatches) -> bool {
 
     match hyperlink {
         "always" | "yes" | "force" => true,
-        "auto" | "tty" | "if-tty" => std::io::stdout().is_terminal(),
+        "auto" | "tty" | "if-tty" => stdout().is_terminal(),
         "never" | "no" | "none" => false,
         _ => unreachable!("should be handled by clap"),
     }
@@ -673,7 +673,7 @@ fn extract_quoting_style(options: &clap::ArgMatches, show_control: bool) -> Quot
 
         // By default, `ls` uses Shell escape quoting style when writing to a terminal file
         // descriptor and Literal otherwise.
-        if std::io::stdout().is_terminal() {
+        if stdout().is_terminal() {
             QuotingStyle::Shell {
                 escape: true,
                 always_quote: false,
@@ -704,7 +704,7 @@ fn extract_indicator_style(options: &clap::ArgMatches) -> IndicatorStyle {
             "never" | "no" | "none" => IndicatorStyle::None,
             "always" | "yes" | "force" => IndicatorStyle::Classify,
             "auto" | "tty" | "if-tty" => {
-                if std::io::stdout().is_terminal() {
+                if stdout().is_terminal() {
                     IndicatorStyle::Classify
                 } else {
                     IndicatorStyle::None
@@ -933,7 +933,7 @@ impl Config {
         } else if options.get_flag(options::SHOW_CONTROL_CHARS) {
             true
         } else {
-            !std::io::stdout().is_terminal()
+            !stdout().is_terminal()
         };
 
         let mut quoting_style = extract_quoting_style(options, show_control);
@@ -2386,7 +2386,7 @@ fn get_metadata_with_deref_opt(p_buf: &Path, dereference: bool) -> std::io::Resu
 fn display_dir_entry_size(
     entry: &PathData,
     config: &Config,
-    out: &mut BufWriter<std::io::Stdout>,
+    out: &mut BufWriter<Stdout>,
 ) -> (usize, usize, usize, usize, usize, usize) {
     // TODO: Cache/memorize the display_* results so we don't have to recalculate them.
     if let Some(md) = entry.get_metadata(out) {
@@ -3070,7 +3070,7 @@ fn get_system_time(md: &Metadata, config: &Config) -> Option<SystemTime> {
     }
 }
 
-fn get_time(md: &Metadata, config: &Config) -> Option<chrono::DateTime<chrono::Local>> {
+fn get_time(md: &Metadata, config: &Config) -> Option<DateTime<Local>> {
     let time = get_system_time(md, config)?;
     Some(time.into())
 }

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -266,7 +266,7 @@ pub fn uu_app() -> Command {
 }
 
 #[cfg(not(target_os = "fuchsia"))]
-fn setup_term() -> std::io::Stdout {
+fn setup_term() -> Stdout {
     let stdout = stdout();
     terminal::enable_raw_mode().unwrap();
     stdout
@@ -279,10 +279,10 @@ fn setup_term() -> usize {
 }
 
 #[cfg(not(target_os = "fuchsia"))]
-fn reset_term(stdout: &mut std::io::Stdout) {
+fn reset_term(stdout: &mut Stdout) {
     terminal::disable_raw_mode().unwrap();
     // Clear the prompt
-    queue!(stdout, terminal::Clear(ClearType::CurrentLine)).unwrap();
+    queue!(stdout, Clear(ClearType::CurrentLine)).unwrap();
     // Move cursor to the beginning without printing new line
     print!("\r");
     stdout.flush().unwrap();
@@ -313,7 +313,7 @@ fn more(
         match search_pattern_in_file(&pager.lines, pat) {
             Some(number) => pager.upper_mark = number,
             None => {
-                execute!(stdout, terminal::Clear(terminal::ClearType::CurrentLine))?;
+                execute!(stdout, Clear(ClearType::CurrentLine))?;
                 stdout.write_all("\rPattern not found\n".as_bytes())?;
                 pager.content_rows -= 1;
             }
@@ -321,7 +321,7 @@ fn more(
     }
 
     if multiple_file {
-        execute!(stdout, terminal::Clear(terminal::ClearType::CurrentLine)).unwrap();
+        execute!(stdout, Clear(ClearType::CurrentLine)).unwrap();
         stdout.write_all(
             MULTI_FILE_TOP_PROMPT
                 .replace("{}", file.unwrap_or_default())
@@ -516,7 +516,7 @@ impl<'a> Pager<'a> {
         };
     }
 
-    fn draw(&mut self, stdout: &mut std::io::Stdout, wrong_key: Option<char>) {
+    fn draw(&mut self, stdout: &mut Stdout, wrong_key: Option<char>) {
         self.draw_lines(stdout);
         let lower_mark = self
             .line_count
@@ -525,8 +525,8 @@ impl<'a> Pager<'a> {
         stdout.flush().unwrap();
     }
 
-    fn draw_lines(&mut self, stdout: &mut std::io::Stdout) {
-        execute!(stdout, terminal::Clear(terminal::ClearType::CurrentLine)).unwrap();
+    fn draw_lines(&mut self, stdout: &mut Stdout) {
+        execute!(stdout, Clear(ClearType::CurrentLine)).unwrap();
 
         self.line_squeezed = 0;
         let mut previous_line_blank = false;
@@ -611,7 +611,7 @@ fn search_pattern_in_file(lines: &[&str], pattern: &str) -> Option<usize> {
     None
 }
 
-fn paging_add_back_message(options: &Options, stdout: &mut std::io::Stdout) -> UResult<()> {
+fn paging_add_back_message(options: &Options, stdout: &mut Stdout) -> UResult<()> {
     if options.lines.is_some() {
         execute!(stdout, MoveUp(1))?;
         stdout.write_all("\n\r...back 1 page\n".as_bytes())?;

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -131,7 +131,7 @@ fn replace_fds() -> UResult<()> {
 }
 
 fn find_stdout() -> UResult<File> {
-    let internal_failure_code = match std::env::var("POSIXLY_CORRECT") {
+    let internal_failure_code = match env::var("POSIXLY_CORRECT") {
         Ok(_) => POSIX_NOHUP_FAILURE,
         Err(_) => EXIT_CANCELED,
     };

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -234,7 +234,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
 
     let invalid = InvalidModes::from_str(args.get_one::<String>(INVALID).unwrap()).unwrap();
 
-    let zero_terminated = args.get_flag(options::ZERO_TERMINATED);
+    let zero_terminated = args.get_flag(ZERO_TERMINATED);
 
     Ok(NumfmtOptions {
         transform,
@@ -387,8 +387,8 @@ pub fn uu_app() -> Command {
                 .value_name("INVALID"),
         )
         .arg(
-            Arg::new(options::ZERO_TERMINATED)
-                .long(options::ZERO_TERMINATED)
+            Arg::new(ZERO_TERMINATED)
+                .long(ZERO_TERMINATED)
                 .short('z')
                 .help("line delimiter is NUL, not newline")
                 .action(ArgAction::SetTrue),

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -153,10 +153,10 @@ fn parse_unit_size_suffix(s: &str) -> Option<usize> {
 }
 
 fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
-    let from = parse_unit(args.get_one::<String>(options::FROM).unwrap())?;
-    let to = parse_unit(args.get_one::<String>(options::TO).unwrap())?;
-    let from_unit = parse_unit_size(args.get_one::<String>(options::FROM_UNIT).unwrap())?;
-    let to_unit = parse_unit_size(args.get_one::<String>(options::TO_UNIT).unwrap())?;
+    let from = parse_unit(args.get_one::<String>(FROM).unwrap())?;
+    let to = parse_unit(args.get_one::<String>(TO).unwrap())?;
+    let from_unit = parse_unit_size(args.get_one::<String>(FROM_UNIT).unwrap())?;
+    let to_unit = parse_unit_size(args.get_one::<String>(TO_UNIT).unwrap())?;
 
     let transform = TransformOptions {
         from,
@@ -165,7 +165,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         to_unit,
     };
 
-    let padding = match args.get_one::<String>(options::PADDING) {
+    let padding = match args.get_one::<String>(PADDING) {
         Some(s) => s
             .parse::<isize>()
             .map_err(|_| s)
@@ -177,8 +177,8 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         None => Ok(0),
     }?;
 
-    let header = if args.value_source(options::HEADER) == Some(ValueSource::CommandLine) {
-        let value = args.get_one::<String>(options::HEADER).unwrap();
+    let header = if args.value_source(HEADER) == Some(ValueSource::CommandLine) {
+        let value = args.get_one::<String>(HEADER).unwrap();
 
         value
             .parse::<usize>()
@@ -192,7 +192,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         Ok(0)
     }?;
 
-    let fields = args.get_one::<String>(options::FIELD).unwrap().as_str();
+    let fields = args.get_one::<String>(FIELD).unwrap().as_str();
     // a lone "-" means "all fields", even as part of a list of fields
     let fields = if fields.split(&[',', ' ']).any(|x| x == "-") {
         vec![Range {
@@ -203,7 +203,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         Range::from_list(fields)?
     };
 
-    let format = match args.get_one::<String>(options::FORMAT) {
+    let format = match args.get_one::<String>(FORMAT) {
         Some(s) => s.parse()?,
         None => FormatOptions::default(),
     };
@@ -212,18 +212,16 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         return Err("grouping cannot be combined with --to".to_string());
     }
 
-    let delimiter = args
-        .get_one::<String>(options::DELIMITER)
-        .map_or(Ok(None), |arg| {
-            if arg.len() == 1 {
-                Ok(Some(arg.to_string()))
-            } else {
-                Err("the delimiter must be a single character".to_string())
-            }
-        })?;
+    let delimiter = args.get_one::<String>(DELIMITER).map_or(Ok(None), |arg| {
+        if arg.len() == 1 {
+            Ok(Some(arg.to_string()))
+        } else {
+            Err("the delimiter must be a single character".to_string())
+        }
+    })?;
 
     // unwrap is fine because the argument has a default value
-    let round = match args.get_one::<String>(options::ROUND).unwrap().as_str() {
+    let round = match args.get_one::<String>(ROUND).unwrap().as_str() {
         "up" => RoundMethod::Up,
         "down" => RoundMethod::Down,
         "from-zero" => RoundMethod::FromZero,
@@ -232,10 +230,9 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
         _ => unreachable!("Should be restricted by clap"),
     };
 
-    let suffix = args.get_one::<String>(options::SUFFIX).cloned();
+    let suffix = args.get_one::<String>(SUFFIX).cloned();
 
-    let invalid =
-        InvalidModes::from_str(args.get_one::<String>(options::INVALID).unwrap()).unwrap();
+    let invalid = InvalidModes::from_str(args.get_one::<String>(INVALID).unwrap()).unwrap();
 
     let zero_terminated = args.get_flag(options::ZERO_TERMINATED);
 
@@ -259,7 +256,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let options = parse_options(&matches).map_err(NumfmtError::IllegalArgument)?;
 
-    let result = match matches.get_many::<String>(options::NUMBER) {
+    let result = match matches.get_many::<String>(NUMBER) {
         Some(values) => handle_args(values.map(|s| s.as_str()), &options),
         None => {
             let stdin = std::io::stdin();
@@ -286,58 +283,58 @@ pub fn uu_app() -> Command {
         .allow_negative_numbers(true)
         .infer_long_args(true)
         .arg(
-            Arg::new(options::DELIMITER)
+            Arg::new(DELIMITER)
                 .short('d')
-                .long(options::DELIMITER)
+                .long(DELIMITER)
                 .value_name("X")
                 .help("use X instead of whitespace for field delimiter"),
         )
         .arg(
-            Arg::new(options::FIELD)
-                .long(options::FIELD)
+            Arg::new(FIELD)
+                .long(FIELD)
                 .help("replace the numbers in these input fields; see FIELDS below")
                 .value_name("FIELDS")
                 .allow_hyphen_values(true)
-                .default_value(options::FIELD_DEFAULT),
+                .default_value(FIELD_DEFAULT),
         )
         .arg(
-            Arg::new(options::FORMAT)
-                .long(options::FORMAT)
+            Arg::new(FORMAT)
+                .long(FORMAT)
                 .help("use printf style floating-point FORMAT; see FORMAT below for details")
                 .value_name("FORMAT")
                 .allow_hyphen_values(true),
         )
         .arg(
-            Arg::new(options::FROM)
-                .long(options::FROM)
+            Arg::new(FROM)
+                .long(FROM)
                 .help("auto-scale input numbers to UNITs; see UNIT below")
                 .value_name("UNIT")
-                .default_value(options::FROM_DEFAULT),
+                .default_value(FROM_DEFAULT),
         )
         .arg(
-            Arg::new(options::FROM_UNIT)
-                .long(options::FROM_UNIT)
+            Arg::new(FROM_UNIT)
+                .long(FROM_UNIT)
                 .help("specify the input unit size")
                 .value_name("N")
-                .default_value(options::FROM_UNIT_DEFAULT),
+                .default_value(FROM_UNIT_DEFAULT),
         )
         .arg(
-            Arg::new(options::TO)
-                .long(options::TO)
+            Arg::new(TO)
+                .long(TO)
                 .help("auto-scale output numbers to UNITs; see UNIT below")
                 .value_name("UNIT")
-                .default_value(options::TO_DEFAULT),
+                .default_value(TO_DEFAULT),
         )
         .arg(
-            Arg::new(options::TO_UNIT)
-                .long(options::TO_UNIT)
+            Arg::new(TO_UNIT)
+                .long(TO_UNIT)
                 .help("the output unit size")
                 .value_name("N")
-                .default_value(options::TO_UNIT_DEFAULT),
+                .default_value(TO_UNIT_DEFAULT),
         )
         .arg(
-            Arg::new(options::PADDING)
-                .long(options::PADDING)
+            Arg::new(PADDING)
+                .long(PADDING)
                 .help(
                     "pad the output to N characters; positive N will \
                      right-align; negative N will left-align; padding is \
@@ -347,20 +344,20 @@ pub fn uu_app() -> Command {
                 .value_name("N"),
         )
         .arg(
-            Arg::new(options::HEADER)
-                .long(options::HEADER)
+            Arg::new(HEADER)
+                .long(HEADER)
                 .help(
                     "print (without converting) the first N header lines; \
                      N defaults to 1 if not specified",
                 )
                 .num_args(..=1)
                 .value_name("N")
-                .default_missing_value(options::HEADER_DEFAULT)
+                .default_missing_value(HEADER_DEFAULT)
                 .hide_default_value(true),
         )
         .arg(
-            Arg::new(options::ROUND)
-                .long(options::ROUND)
+            Arg::new(ROUND)
+                .long(ROUND)
                 .help("use METHOD for rounding when scaling")
                 .value_name("METHOD")
                 .default_value("from-zero")
@@ -373,8 +370,8 @@ pub fn uu_app() -> Command {
                 ])),
         )
         .arg(
-            Arg::new(options::SUFFIX)
-                .long(options::SUFFIX)
+            Arg::new(SUFFIX)
+                .long(SUFFIX)
                 .help(
                     "print SUFFIX after each formatted number, and accept \
                     inputs optionally ending with SUFFIX",
@@ -382,8 +379,8 @@ pub fn uu_app() -> Command {
                 .value_name("SUFFIX"),
         )
         .arg(
-            Arg::new(options::INVALID)
-                .long(options::INVALID)
+            Arg::new(INVALID)
+                .long(INVALID)
                 .help("set the failure mode for invalid input")
                 .default_value("abort")
                 .value_parser(["abort", "fail", "warn", "ignore"])
@@ -396,11 +393,7 @@ pub fn uu_app() -> Command {
                 .help("line delimiter is NUL, not newline")
                 .action(ArgAction::SetTrue),
         )
-        .arg(
-            Arg::new(options::NUMBER)
-                .hide(true)
-                .action(ArgAction::Append),
-        )
+        .arg(Arg::new(NUMBER).hide(true).action(ArgAction::Append))
 }
 
 #[cfg(test)]

--- a/src/uu/od/src/multifilereader.rs
+++ b/src/uu/od/src/multifilereader.rs
@@ -48,7 +48,7 @@ impl MultifileReader<'_> {
             }
             match self.ni.remove(0) {
                 InputSource::Stdin => {
-                    self.curr_file = Some(Box::new(BufReader::new(std::io::stdin())));
+                    self.curr_file = Some(Box::new(BufReader::new(io::stdin())));
                     break;
                 }
                 InputSource::FileName(fname) => {

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -333,7 +333,7 @@ pub fn remove(files: &[&OsStr], options: &Options) -> bool {
 /// `path` must be a directory. If there is an error reading the
 /// contents of the directory, this returns `false`.
 fn is_dir_empty(path: &Path) -> bool {
-    match std::fs::read_dir(path) {
+    match fs::read_dir(path) {
         Err(_) => false,
         Ok(iter) => iter.count() == 0,
     }
@@ -348,7 +348,7 @@ fn is_readable_metadata(metadata: &Metadata) -> bool {
 /// Whether the given file or directory is readable.
 #[cfg(unix)]
 fn is_readable(path: &Path) -> bool {
-    match std::fs::metadata(path) {
+    match fs::metadata(path) {
         Err(_) => false,
         Ok(metadata) => is_readable_metadata(&metadata),
     }
@@ -369,7 +369,7 @@ fn is_writable_metadata(metadata: &Metadata) -> bool {
 /// Whether the given file or directory is writable.
 #[cfg(unix)]
 fn is_writable(path: &Path) -> bool {
-    match std::fs::metadata(path) {
+    match fs::metadata(path) {
         Err(_) => false,
         Ok(metadata) => is_writable_metadata(&metadata),
     }
@@ -391,7 +391,7 @@ fn is_writable(_path: &Path) -> bool {
 fn remove_dir_recursive(path: &Path, options: &Options) -> bool {
     // Special case: if we cannot access the metadata because the
     // filename is too long, fall back to try
-    // `std::fs::remove_dir_all()`.
+    // `fs::remove_dir_all()`.
     //
     // TODO This is a temporary bandage; we shouldn't need to do this
     // at all. Instead of using the full path like "x/y/z", which
@@ -400,7 +400,7 @@ fn remove_dir_recursive(path: &Path, options: &Options) -> bool {
     // path, "z", and know that it is relative to the parent, "x/y".
     if let Some(s) = path.to_str() {
         if s.len() > 1000 {
-            match std::fs::remove_dir_all(path) {
+            match fs::remove_dir_all(path) {
                 Ok(_) => return false,
                 Err(e) => {
                     let e = e.map_err_context(|| format!("cannot remove {}", path.quote()));
@@ -432,7 +432,7 @@ fn remove_dir_recursive(path: &Path, options: &Options) -> bool {
 
     // Recursive case: this is a directory.
     let mut error = false;
-    match std::fs::read_dir(path) {
+    match fs::read_dir(path) {
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
             // This is not considered an error.
         }
@@ -456,7 +456,7 @@ fn remove_dir_recursive(path: &Path, options: &Options) -> bool {
     }
 
     // Try removing the directory itself.
-    match std::fs::remove_dir(path) {
+    match fs::remove_dir(path) {
         Err(_) if !error && !is_readable(path) => {
             // For compatibility with GNU test case
             // `tests/rm/unread2.sh`, show "Permission denied" in this

--- a/src/uu/rmdir/src/rmdir.rs
+++ b/src/uu/rmdir/src/rmdir.rs
@@ -163,7 +163,7 @@ struct Opts {
 }
 
 pub fn uu_app() -> Command {
-    Command::new(uucore::util_name())
+    Command::new(util_name())
         .version(uucore::crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -152,7 +152,7 @@ pub fn uu_app() -> Command {
                 .short('e')
                 .long(options::ECHO)
                 .help("treat each ARG as an input line")
-                .action(clap::ArgAction::SetTrue)
+                .action(ArgAction::SetTrue)
                 .overrides_with(options::ECHO)
                 .conflicts_with(options::INPUT_RANGE),
         )
@@ -170,7 +170,7 @@ pub fn uu_app() -> Command {
                 .short('n')
                 .long(options::HEAD_COUNT)
                 .value_name("COUNT")
-                .action(clap::ArgAction::Append)
+                .action(ArgAction::Append)
                 .help("output at most COUNT lines")
                 .value_parser(usize::from_str),
         )
@@ -209,7 +209,7 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::FILE_OR_ARGS)
-                .action(clap::ArgAction::Append)
+                .action(ArgAction::Append)
                 .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::FilePath),
         )

--- a/src/uu/sleep/src/sleep.rs
+++ b/src/uu/sleep/src/sleep.rs
@@ -90,7 +90,7 @@ fn sleep(args: &[&str]) -> UResult<()> {
             }
         })
         .fold(Duration::ZERO, |acc, n| {
-            acc.saturating_add(SaturatingInto::<std::time::Duration>::saturating_into(n))
+            acc.saturating_add(SaturatingInto::<Duration>::saturating_into(n))
         });
 
     if arg_error {

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -50,7 +50,7 @@ fn replace_output_file_in_input_files(
                         *file = copy.clone().into_os_string();
                     } else {
                         let (_file, copy_path) = tmp_dir.next_file()?;
-                        std::fs::copy(file_path, &copy_path)
+                        fs::copy(file_path, &copy_path)
                             .map_err(|error| SortError::OpenTmpFileFailed { error })?;
                         *file = copy_path.clone().into_os_string();
                         copy = Some(copy_path);

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1152,7 +1152,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 settings.merge_batch_size = parsed_value;
             }
             Err(e) => {
-                let error_message = if *e.kind() == std::num::IntErrorKind::PosOverflow {
+                let error_message = if *e.kind() == IntErrorKind::PosOverflow {
                     #[cfg(target_os = "linux")]
                     {
                         show_error!("--batch-size argument {} too large", n_merge.quote());
@@ -1987,7 +1987,7 @@ mod tests {
     fn test_line_size() {
         // We should make sure to not regress the size of the Line struct because
         // it is unconditional overhead for every line we sort.
-        assert_eq!(std::mem::size_of::<Line>(), 24);
+        assert_eq!(size_of::<Line>(), 24);
     }
 
     #[test]

--- a/src/uu/split/src/number.rs
+++ b/src/uu/split/src/number.rs
@@ -21,8 +21,8 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Debug)]
 pub struct Overflow;
 
-impl fmt::Display for Overflow {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for Overflow {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "Overflow")
     }
 }

--- a/src/uu/split/src/platform/unix.rs
+++ b/src/uu/split/src/platform/unix.rs
@@ -133,7 +133,7 @@ pub fn instantiate_current_writer(
                     .write(true)
                     .create(true)
                     .truncate(true)
-                    .open(std::path::Path::new(&filename))
+                    .open(Path::new(&filename))
                     .map_err(|_| {
                         Error::new(
                             ErrorKind::Other,
@@ -144,7 +144,7 @@ pub fn instantiate_current_writer(
                 // re-open file that we previously created to append to it
                 std::fs::OpenOptions::new()
                     .append(true)
-                    .open(std::path::Path::new(&filename))
+                    .open(Path::new(&filename))
                     .map_err(|_| {
                         Error::new(
                             ErrorKind::Other,

--- a/src/uu/split/src/platform/windows.rs
+++ b/src/uu/split/src/platform/windows.rs
@@ -22,7 +22,7 @@ pub fn instantiate_current_writer(
             .write(true)
             .create(true)
             .truncate(true)
-            .open(std::path::Path::new(&filename))
+            .open(Path::new(&filename))
             .map_err(|_| {
                 Error::new(
                     ErrorKind::Other,
@@ -33,7 +33,7 @@ pub fn instantiate_current_writer(
         // re-open file that we previously created to append to it
         std::fs::OpenOptions::new()
             .append(true)
-            .open(std::path::Path::new(&filename))
+            .open(Path::new(&filename))
             .map_err(|_| {
                 Error::new(
                     ErrorKind::Other,

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -972,8 +972,7 @@ impl Stater {
                     'Y' => {
                         let sec = meta.mtime();
                         let nsec = meta.mtime_nsec();
-                        let tm =
-                            chrono::DateTime::from_timestamp(sec, nsec as u32).unwrap_or_default();
+                        let tm = DateTime::from_timestamp(sec, nsec as u32).unwrap_or_default();
                         let tm: DateTime<Local> = tm.into();
                         match tm.timestamp_nanos_opt() {
                             None => {
@@ -1186,7 +1185,7 @@ const PRETTY_DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S.%f %z";
 
 fn pretty_time(sec: i64, nsec: i64) -> String {
     // Return the date in UTC
-    let tm = chrono::DateTime::from_timestamp(sec, nsec as u32).unwrap_or_default();
+    let tm = DateTime::from_timestamp(sec, nsec as u32).unwrap_or_default();
     let tm: DateTime<Local> = tm.into();
 
     tm.format(PRETTY_DATETIME_FORMAT).to_string()

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -181,7 +181,7 @@ impl Settings {
         settings
     }
 
-    pub fn from(matches: &clap::ArgMatches) -> UResult<Self> {
+    pub fn from(matches: &ArgMatches) -> UResult<Self> {
         // We're parsing --follow, -F and --retry under the following conditions:
         // * -F sets --retry and --follow=name
         // * plain --follow or short -f is the same like specifying --follow=descriptor
@@ -236,7 +236,7 @@ impl Settings {
             // * not applied here but it supports customizable time units and provides better error
             //   messages
             settings.sleep_sec = match DurationParser::without_time_units().parse(source) {
-                Ok(duration) => SaturatingInto::<std::time::Duration>::saturating_into(duration),
+                Ok(duration) => SaturatingInto::<Duration>::saturating_into(duration),
                 Err(_) => {
                     return Err(UUsageError::new(
                         1,

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -229,7 +229,7 @@ impl Observer {
             watcher = Box::new(notify::PollWatcher::new(tx, watcher_config).unwrap());
         } else {
             let tx_clone = tx.clone();
-            match notify::RecommendedWatcher::new(tx, notify::Config::default()) {
+            match RecommendedWatcher::new(tx, notify::Config::default()) {
                 Ok(w) => watcher = Box::new(w),
                 Err(e) if e.to_string().starts_with("Too many open files") => {
                     /*

--- a/src/uu/tail/src/platform/unix.rs
+++ b/src/uu/tail/src/platform/unix.rs
@@ -11,11 +11,11 @@ use std::io::Error;
 pub type Pid = libc::pid_t;
 
 pub struct ProcessChecker {
-    pid: self::Pid,
+    pid: Pid,
 }
 
 impl ProcessChecker {
-    pub fn new(process_id: self::Pid) -> Self {
+    pub fn new(process_id: Pid) -> Self {
         Self { pid: process_id }
     }
 
@@ -30,7 +30,7 @@ impl Drop for ProcessChecker {
     fn drop(&mut self) {}
 }
 
-pub fn supports_pid_checks(pid: self::Pid) -> bool {
+pub fn supports_pid_checks(pid: Pid) -> bool {
     unsafe { !(libc::kill(pid, 0) != 0 && get_errno() == libc::ENOSYS) }
 }
 

--- a/src/uu/tail/src/platform/windows.rs
+++ b/src/uu/tail/src/platform/windows.rs
@@ -16,7 +16,7 @@ pub struct ProcessChecker {
 }
 
 impl ProcessChecker {
-    pub fn new(process_id: self::Pid) -> Self {
+    pub fn new(process_id: Pid) -> Self {
         #[allow(non_snake_case)]
         let FALSE: BOOL = 0;
         let h = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, FALSE, process_id) };
@@ -47,6 +47,6 @@ impl Drop for ProcessChecker {
     }
 }
 
-pub fn supports_pid_checks(_pid: self::Pid) -> bool {
+pub fn supports_pid_checks(_pid: Pid) -> bool {
     true
 }

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -163,7 +163,7 @@ fn tail_file(
                     true,
                 )?;
             }
-            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            Err(e) if e.kind() == ErrorKind::PermissionDenied => {
                 observer.add_bad_path(path, input.display_name.as_str(), false)?;
                 show!(e.map_err_context(|| {
                     format!("cannot open '{}' for reading", input.display_name)
@@ -290,7 +290,7 @@ fn forwards_thru_file(
     reader: &mut impl Read,
     num_delimiters: u64,
     delimiter: u8,
-) -> std::io::Result<usize> {
+) -> io::Result<usize> {
     // If num_delimiters == 0, always return 0.
     if num_delimiters == 0 {
         return Ok(0);
@@ -405,7 +405,7 @@ fn bounded_tail(file: &mut File, settings: &Settings) {
     // Print the target section of the file.
     let stdout = stdout();
     let mut stdout = stdout.lock();
-    std::io::copy(file, &mut stdout).unwrap();
+    io::copy(file, &mut stdout).unwrap();
 }
 
 fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UResult<()> {

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -66,7 +66,7 @@ impl Config {
                     Some(signal_value) => signal_value,
                 }
             }
-            _ => uucore::signals::signal_by_name_or_value("TERM").unwrap(),
+            _ => signal_by_name_or_value("TERM").unwrap(),
         };
 
         let kill_after = match options.get_one::<String>(options::KILL_AFTER) {

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -443,7 +443,7 @@ fn touch_file(
     };
 
     if let Err(e) = metadata_result {
-        if e.kind() != std::io::ErrorKind::NotFound {
+        if e.kind() != ErrorKind::NotFound {
             return Err(e.map_err_context(|| format!("setting times of {}", filename.quote())));
         }
 
@@ -687,7 +687,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
 
     let local = NaiveDateTime::parse_from_str(&ts, format)
         .map_err(|_| USimpleError::new(1, format!("invalid date ts format {}", ts.quote())))?;
-    let LocalResult::Single(mut local) = chrono::Local.from_local_datetime(&local) else {
+    let LocalResult::Single(mut local) = Local.from_local_datetime(&local) else {
         return Err(USimpleError::new(
             1,
             format!("invalid date ts format {}", ts.quote()),

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -180,7 +180,7 @@ pub fn uu_app() -> Command {
 /// size of the file.
 fn file_truncate(filename: &str, create: bool, size: u64) -> UResult<()> {
     #[cfg(unix)]
-    if let Ok(metadata) = std::fs::metadata(filename) {
+    if let Ok(metadata) = metadata(filename) {
         if metadata.file_type().is_fifo() {
             return Err(USimpleError::new(
                 1,

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -311,7 +311,7 @@ fn next_char_info(uflag: bool, buf: &[u8], byte: usize) -> (CharType, usize, usi
 #[allow(clippy::cognitive_complexity)]
 fn unexpand_line(
     buf: &mut Vec<u8>,
-    output: &mut BufWriter<std::io::Stdout>,
+    output: &mut BufWriter<Stdout>,
     options: &Options,
     lastcol: usize,
     ts: &[usize],

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -805,7 +805,7 @@ fn files0_iter<'a>(
             }),
     );
     // Loop until there is an error; yield that error and then nothing else.
-    std::iter::from_fn(move || {
+    iter::from_fn(move || {
         let next = i.as_mut().and_then(Iterator::next);
         if matches!(next, Some(Err(_)) | None) {
             i = None;


### PR DESCRIPTION
Improve code readability.  What's even more important is that the same identifier is used identically everywhere in one file - i.e. `chrono::DateTime` would not be used with a fully-qualified name in one place, but with just `DateTime` in another.