### PR TITLE
Fuzzing: minor fixes

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -84,7 +84,7 @@ jobs:
       shell: bash
       continue-on-error: ${{ !matrix.test-target.name.should_pass }}
       run: |
-        cargo +nightly fuzz run ${{ matrix.test-target.name }} -- -max_total_time=${{ env.RUN_FOR }} -detect_leaks=0
+        cargo +nightly fuzz run ${{ matrix.test-target.name }} -- -max_total_time=${{ env.RUN_FOR }} -timeout=${{ env.RUN_FOR }} -detect_leaks=0
     - name: Save Corpus Cache
       uses: actions/cache/save@v4
       with:

--- a/fuzz/fuzz_targets/fuzz_cksum.rs
+++ b/fuzz/fuzz_targets/fuzz_cksum.rs
@@ -10,9 +10,10 @@ use std::ffi::OsString;
 use uu_cksum::uumain;
 mod fuzz_common;
 use crate::fuzz_common::{
-    compare_result, generate_and_run_uumain, generate_random_file, generate_random_string,
+    CommandResult, compare_result, generate_and_run_uumain, generate_random_file,
+    generate_random_string,
     pretty_print::{print_or_empty, print_test_begin},
-    replace_fuzz_binary_name, run_gnu_cmd, CommandResult,
+    replace_fuzz_binary_name, run_gnu_cmd,
 };
 use rand::Rng;
 use std::env::temp_dir;

--- a/fuzz/fuzz_targets/fuzz_common/mod.rs
+++ b/fuzz/fuzz_targets/fuzz_common/mod.rs
@@ -5,12 +5,12 @@
 
 use console::Style;
 use libc::STDIN_FILENO;
-use libc::{close, dup, dup2, pipe, STDERR_FILENO, STDOUT_FILENO};
+use libc::{STDERR_FILENO, STDOUT_FILENO, close, dup, dup2, pipe};
 use pretty_print::{
     print_diff, print_end_with_status, print_or_empty, print_section, print_with_style,
 };
-use rand::prelude::IndexedRandom;
 use rand::Rng;
+use rand::prelude::IndexedRandom;
 use std::env::temp_dir;
 use std::ffi::OsString;
 use std::fs::File;
@@ -18,7 +18,7 @@ use std::io::{Seek, SeekFrom, Write};
 use std::os::fd::{AsRawFd, RawFd};
 use std::process::{Command, Stdio};
 use std::sync::atomic::Ordering;
-use std::sync::{atomic::AtomicBool, Once};
+use std::sync::{Once, atomic::AtomicBool};
 use std::{io, thread};
 
 pub mod pretty_print;

--- a/fuzz/fuzz_targets/fuzz_common/mod.rs
+++ b/fuzz/fuzz_targets/fuzz_common/mod.rs
@@ -132,6 +132,8 @@ where
     let (uumain_exit_status, captured_stdout, captured_stderr) = thread::scope(|s| {
         let out = s.spawn(|| read_from_fd(pipe_stdout_fds[0]));
         let err = s.spawn(|| read_from_fd(pipe_stderr_fds[0]));
+        #[allow(clippy::unnecessary_to_owned)]
+        // TODO: clippy wants us to use args.iter().cloned() ?
         let status = uumain_function(args.to_owned().into_iter());
         // Reset the exit code global variable in case we run another test after this one
         // See https://github.com/uutils/coreutils/issues/5777
@@ -409,6 +411,7 @@ pub fn generate_random_string(max_length: usize) -> String {
     result
 }
 
+#[allow(dead_code)]
 pub fn generate_random_file() -> Result<String, std::io::Error> {
     let mut rng = rand::rng();
     let file_name: String = (0..10)
@@ -429,6 +432,7 @@ pub fn generate_random_file() -> Result<String, std::io::Error> {
     Ok(file_path.to_str().unwrap().to_string())
 }
 
+#[allow(dead_code)]
 pub fn replace_fuzz_binary_name(cmd: &str, result: &mut CommandResult) {
     let fuzz_bin_name = format!("fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_{cmd}");
 

--- a/fuzz/fuzz_targets/fuzz_common/pretty_print.rs
+++ b/fuzz/fuzz_targets/fuzz_common/pretty_print.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use console::{style, Style};
+use console::{Style, style};
 use similar::TextDiff;
 
 pub fn print_section<S: fmt::Display>(s: S) {

--- a/fuzz/fuzz_targets/fuzz_common/pretty_print.rs
+++ b/fuzz/fuzz_targets/fuzz_common/pretty_print.rs
@@ -16,6 +16,7 @@ pub fn print_subsection<S: fmt::Display>(s: S) {
     println!("{}", style(format!("--- {}", s)).bright());
 }
 
+#[allow(dead_code)]
 pub fn print_test_begin<S: fmt::Display>(msg: S) {
     println!(
         "{} {} {}",
@@ -50,7 +51,7 @@ pub fn print_with_style<S: fmt::Display>(msg: S, style: Style) {
     println!("{}", style.apply_to(msg));
 }
 
-pub fn print_diff<'a, 'b>(got: &'a str, expected: &'b str) {
+pub fn print_diff(got: &str, expected: &str) {
     let diff = TextDiff::from_lines(got, expected);
 
     print_subsection("START diff");

--- a/fuzz/fuzz_targets/fuzz_cut.rs
+++ b/fuzz/fuzz_targets/fuzz_cut.rs
@@ -13,7 +13,7 @@ use std::ffi::OsString;
 
 mod fuzz_common;
 use crate::fuzz_common::{
-    compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd, CommandResult,
+    CommandResult, compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd,
 };
 static CMD_PATH: &str = "cut";
 

--- a/fuzz/fuzz_targets/fuzz_echo.rs
+++ b/fuzz/fuzz_targets/fuzz_echo.rs
@@ -2,8 +2,8 @@
 use libfuzzer_sys::fuzz_target;
 use uu_echo::uumain;
 
-use rand::prelude::IndexedRandom;
 use rand::Rng;
+use rand::prelude::IndexedRandom;
 use std::ffi::OsString;
 
 mod fuzz_common;

--- a/fuzz/fuzz_targets/fuzz_env.rs
+++ b/fuzz/fuzz_targets/fuzz_env.rs
@@ -12,7 +12,7 @@ use std::ffi::OsString;
 
 mod fuzz_common;
 use crate::fuzz_common::{
-    compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd, CommandResult,
+    CommandResult, compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd,
 };
 use rand::Rng;
 

--- a/fuzz/fuzz_targets/fuzz_expr.rs
+++ b/fuzz/fuzz_targets/fuzz_expr.rs
@@ -8,8 +8,8 @@
 use libfuzzer_sys::fuzz_target;
 use uu_expr::uumain;
 
-use rand::prelude::IndexedRandom;
 use rand::Rng;
+use rand::prelude::IndexedRandom;
 use std::{env, ffi::OsString};
 
 mod fuzz_common;

--- a/fuzz/fuzz_targets/fuzz_printf.rs
+++ b/fuzz/fuzz_targets/fuzz_printf.rs
@@ -8,8 +8,8 @@
 use libfuzzer_sys::fuzz_target;
 use uu_printf::uumain;
 
-use rand::seq::IndexedRandom;
 use rand::Rng;
+use rand::seq::IndexedRandom;
 use std::env;
 use std::ffi::OsString;
 

--- a/fuzz/fuzz_targets/fuzz_split.rs
+++ b/fuzz/fuzz_targets/fuzz_split.rs
@@ -13,7 +13,7 @@ use std::ffi::OsString;
 
 mod fuzz_common;
 use crate::fuzz_common::{
-    compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd, CommandResult,
+    CommandResult, compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd,
 };
 static CMD_PATH: &str = "split";
 

--- a/fuzz/fuzz_targets/fuzz_test.rs
+++ b/fuzz/fuzz_targets/fuzz_test.rs
@@ -8,8 +8,8 @@
 use libfuzzer_sys::fuzz_target;
 use uu_test::uumain;
 
-use rand::prelude::IndexedRandom;
 use rand::Rng;
+use rand::prelude::IndexedRandom;
 use std::ffi::OsString;
 
 mod fuzz_common;

--- a/fuzz/fuzz_targets/fuzz_tr.rs
+++ b/fuzz/fuzz_targets/fuzz_tr.rs
@@ -12,7 +12,7 @@ use rand::Rng;
 
 mod fuzz_common;
 use crate::fuzz_common::{
-    compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd, CommandResult,
+    CommandResult, compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd,
 };
 static CMD_PATH: &str = "tr";
 

--- a/fuzz/fuzz_targets/fuzz_wc.rs
+++ b/fuzz/fuzz_targets/fuzz_wc.rs
@@ -13,7 +13,7 @@ use std::ffi::OsString;
 
 mod fuzz_common;
 use crate::fuzz_common::{
-    compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd, CommandResult,
+    CommandResult, compare_result, generate_and_run_uumain, generate_random_string, run_gnu_cmd,
 };
 static CMD_PATH: &str = "wc";
 


### PR DESCRIPTION
Not quite sure what's the proper way to run `cargo clippy` in fuzz, as it fails if I do `cd fuzz && cargo clippy`.

Let's fix what we can for now, we can think about how to add `fmt`/`clippy` tests to CI later (#7718).

---

### workflows/fuzzing.yml: Add timeout equal to total run time

Just in case some of the values cause an infinite loop (or at
least take a _very_ long time, see #7708), timeout, with the same
duration as the maximum total fuzzing time.

That'll allow us to _see_ what input causes the infinite loop.

### fuzz: Run cargo clippy

Unfortunately, cargo clippy fails when testing fuzz_seq_parse_number:

```
error[E0603]: module `number` is private
  --> fuzz_targets/fuzz_seq_parse_number.rs:9:13
   |
9  | use uu_seq::number::PreciseNumber;
   |             ^^^^^^ private module
   |
note: the module `number` is defined here
  --> /home/drinkcat/dev/coreutils/coreutils/src/uu/seq/src/seq.rs:24:1
   |
24 | mod number;
   | ^^^^^^^^^^
```

But we can still fix the rest...

### fuzz: Run cargo fmt