### PR TITLE
chore: fix `ref_option` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -599,3 +599,4 @@ unused_qualifications = "warn"
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
 #cargo = { level = "warn", priority = -1 }
+ref_option = "warn"

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -390,7 +390,7 @@ fn handle_missing_groups(strategy: Strategy) -> Result<(), ChrootError> {
 /// Set supplemental groups for this process.
 fn set_supplemental_gids_with_strategy(
     strategy: Strategy,
-    groups: &Option<Vec<String>>,
+    groups: Option<&Vec<String>>,
 ) -> Result<(), ChrootError> {
     match groups {
         None => handle_missing_groups(strategy),
@@ -410,27 +410,27 @@ fn set_context(options: &Options) -> UResult<()> {
     match &options.userspec {
         None | Some(UserSpec::NeitherGroupNorUser) => {
             let strategy = Strategy::Nothing;
-            set_supplemental_gids_with_strategy(strategy, &options.groups)?;
+            set_supplemental_gids_with_strategy(strategy, options.groups.as_ref())?;
         }
         Some(UserSpec::UserOnly(user)) => {
             let uid = name_to_uid(user)?;
             let gid = uid as libc::gid_t;
             let strategy = Strategy::FromUID(uid, false);
-            set_supplemental_gids_with_strategy(strategy, &options.groups)?;
+            set_supplemental_gids_with_strategy(strategy, options.groups.as_ref())?;
             set_gid(gid).map_err(|e| ChrootError::SetGidFailed(user.to_string(), e))?;
             set_uid(uid).map_err(|e| ChrootError::SetUserFailed(user.to_string(), e))?;
         }
         Some(UserSpec::GroupOnly(group)) => {
             let gid = name_to_gid(group)?;
             let strategy = Strategy::Nothing;
-            set_supplemental_gids_with_strategy(strategy, &options.groups)?;
+            set_supplemental_gids_with_strategy(strategy, options.groups.as_ref())?;
             set_gid(gid).map_err(|e| ChrootError::SetGidFailed(group.to_string(), e))?;
         }
         Some(UserSpec::UserAndGroup(user, group)) => {
             let uid = name_to_uid(user)?;
             let gid = name_to_gid(group)?;
             let strategy = Strategy::FromUID(uid, true);
-            set_supplemental_gids_with_strategy(strategy, &options.groups)?;
+            set_supplemental_gids_with_strategy(strategy, options.groups.as_ref())?;
             set_gid(gid).map_err(|e| ChrootError::SetGidFailed(group.to_string(), e))?;
             set_uid(uid).map_err(|e| ChrootError::SetUserFailed(user.to_string(), e))?;
         }

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -224,7 +224,7 @@ where
 #[allow(clippy::too_many_arguments)]
 /// Copy a single entry during a directory traversal.
 fn copy_direntry(
-    progress_bar: &Option<ProgressBar>,
+    progress_bar: Option<&ProgressBar>,
     entry: Entry,
     options: &Options,
     symlinked_files: &mut HashSet<FileInformation>,
@@ -314,7 +314,7 @@ fn copy_direntry(
 /// will not cause a short-circuit.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn copy_directory(
-    progress_bar: &Option<ProgressBar>,
+    progress_bar: Option<&ProgressBar>,
     root: &Path,
     target: &Path,
     options: &Options,

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1366,7 +1366,7 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
             }
 
             if let Err(error) = copy_source(
-                &progress_bar,
+                progress_bar.as_ref(),
                 source,
                 target,
                 target_type,
@@ -1433,7 +1433,7 @@ fn construct_dest_path(
 }
 #[allow(clippy::too_many_arguments)]
 fn copy_source(
-    progress_bar: &Option<ProgressBar>,
+    progress_bar: Option<&ProgressBar>,
     source: &Path,
     target: &Path,
     target_type: TargetType,
@@ -1979,7 +1979,7 @@ fn aligned_ancestors<'a>(source: &'a Path, dest: &'a Path) -> Vec<(&'a Path, &'a
 
 fn print_verbose_output(
     parents: bool,
-    progress_bar: &Option<ProgressBar>,
+    progress_bar: Option<&ProgressBar>,
     source: &Path,
     dest: &Path,
 ) {
@@ -2207,7 +2207,7 @@ fn calculate_dest_permissions(
 /// after a successful copy.
 #[allow(clippy::cognitive_complexity, clippy::too_many_arguments)]
 fn copy_file(
-    progress_bar: &Option<ProgressBar>,
+    progress_bar: Option<&ProgressBar>,
     source: &Path,
     dest: &Path,
     options: &Options,

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1106,13 +1106,13 @@ fn dd_copy(mut i: Input, o: Output) -> io::Result<()> {
     // blocks to this output. Read/write statistics are updated on
     // each iteration and cumulative statistics are reported to
     // the progress reporting thread.
-    while below_count_limit(&i.settings.count, &rstat) {
+    while below_count_limit(i.settings.count, &rstat) {
         // Read a block from the input then write the block to the output.
         //
         // As an optimization, make an educated guess about the
         // best buffer size for reading based on the number of
         // blocks already read and the number of blocks remaining.
-        let loop_bsize = calc_loop_bsize(&i.settings.count, &rstat, &wstat, i.settings.ibs, bsize);
+        let loop_bsize = calc_loop_bsize(i.settings.count, &rstat, &wstat, i.settings.ibs, bsize);
         let rstat_update = read_helper(&mut i, &mut buf, loop_bsize)?;
         if rstat_update.is_empty() {
             break;
@@ -1295,7 +1295,7 @@ fn calc_bsize(ibs: usize, obs: usize) -> usize {
 // Calculate the buffer size appropriate for this loop iteration, respecting
 // a count=N if present.
 fn calc_loop_bsize(
-    count: &Option<Num>,
+    count: Option<Num>,
     rstat: &ReadStat,
     wstat: &WriteStat,
     ibs: usize,
@@ -1308,7 +1308,7 @@ fn calc_loop_bsize(
             cmp::min(ideal_bsize as u64, rremain * ibs as u64) as usize
         }
         Some(Num::Bytes(bmax)) => {
-            let bmax: u128 = (*bmax).into();
+            let bmax: u128 = bmax.into();
             let bremain: u128 = bmax - wstat.bytes_total;
             cmp::min(ideal_bsize as u128, bremain) as usize
         }
@@ -1318,10 +1318,10 @@ fn calc_loop_bsize(
 
 // Decide if the current progress is below a count=N limit or return
 // true if no such limit is set.
-fn below_count_limit(count: &Option<Num>, rstat: &ReadStat) -> bool {
+fn below_count_limit(count: Option<Num>, rstat: &ReadStat) -> bool {
     match count {
-        Some(Num::Blocks(n)) => rstat.reads_complete + rstat.reads_partial < *n,
-        Some(Num::Bytes(n)) => rstat.bytes_total < *n,
+        Some(Num::Blocks(n)) => rstat.reads_complete + rstat.reads_partial < n,
+        Some(Num::Bytes(n)) => rstat.bytes_total < n,
         None => true,
     }
 }

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1085,7 +1085,7 @@ fn write_columns(
         for (i, cell) in row.iter().enumerate() {
             if cell.is_none() && options.merge_files_print.is_some() {
                 out.write_all(
-                    get_line_for_printing(options, &blank_line, columns, i, &line_width, indexes)
+                    get_line_for_printing(options, &blank_line, columns, i, line_width, indexes)
                         .as_bytes(),
                 )?;
             } else if cell.is_none() {
@@ -1095,7 +1095,7 @@ fn write_columns(
                 let file_line = cell.unwrap();
 
                 out.write_all(
-                    get_line_for_printing(options, file_line, columns, i, &line_width, indexes)
+                    get_line_for_printing(options, file_line, columns, i, line_width, indexes)
                         .as_bytes(),
                 )?;
                 lines_printed += 1;
@@ -1116,7 +1116,7 @@ fn get_line_for_printing(
     file_line: &FileLine,
     columns: usize,
     index: usize,
-    line_width: &Option<usize>,
+    line_width: Option<usize>,
     indexes: usize,
 ) -> String {
     let blank_line = String::new();

--- a/src/uu/split/src/platform/unix.rs
+++ b/src/uu/split/src/platform/unix.rs
@@ -121,7 +121,7 @@ impl Drop for FilterWriter {
 
 /// Instantiate either a file writer or a "write to shell process's stdin" writer
 pub fn instantiate_current_writer(
-    filter: &Option<String>,
+    filter: Option<&str>,
     filename: &str,
     is_new: bool,
 ) -> Result<BufWriter<Box<dyn Write>>> {

--- a/src/uu/split/src/platform/windows.rs
+++ b/src/uu/split/src/platform/windows.rs
@@ -12,7 +12,7 @@ use uucore::fs;
 /// Unlike the unix version of this function, this _always_ returns
 /// a file writer
 pub fn instantiate_current_writer(
-    _filter: &Option<String>,
+    _filter: Option<&str>,
     filename: &str,
     is_new: bool,
 ) -> Result<BufWriter<Box<dyn Write>>> {

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -55,7 +55,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let (args, obs_lines) = handle_obsolete(args);
     let matches = uu_app().try_get_matches_from(args)?;
 
-    match Settings::from(&matches, &obs_lines) {
+    match Settings::from(&matches, obs_lines.as_deref()) {
         Ok(settings) => split(&settings),
         Err(e) if e.requires_usage() => Err(UUsageError::new(1, format!("{e}"))),
         Err(e) => Err(USimpleError::new(1, format!("{e}"))),
@@ -460,7 +460,7 @@ impl SettingsError {
 
 impl Settings {
     /// Parse a strategy from the command-line arguments.
-    fn from(matches: &ArgMatches, obs_lines: &Option<String>) -> Result<Self, SettingsError> {
+    fn from(matches: &ArgMatches, obs_lines: Option<&str>) -> Result<Self, SettingsError> {
         let strategy = Strategy::from(matches, obs_lines).map_err(SettingsError::Strategy)?;
         let suffix = Suffix::from(matches, &strategy).map_err(SettingsError::Suffix)?;
 
@@ -539,7 +539,7 @@ impl Settings {
             ));
         }
 
-        platform::instantiate_current_writer(&self.filter, filename, is_new)
+        platform::instantiate_current_writer(self.filter.as_deref(), filename, is_new)
     }
 }
 
@@ -605,14 +605,14 @@ fn get_input_size<R>(
     input: &String,
     reader: &mut R,
     buf: &mut Vec<u8>,
-    io_blksize: &Option<u64>,
+    io_blksize: Option<u64>,
 ) -> io::Result<u64>
 where
     R: BufRead,
 {
     // Set read limit to io_blksize if specified
     let read_limit: u64 = if let Some(custom_blksize) = io_blksize {
-        *custom_blksize
+        custom_blksize
     } else {
         // otherwise try to get it from filesystem, or use default
         uucore::fs::sane_blksize::sane_blksize_from_path(Path::new(input))
@@ -1082,7 +1082,7 @@ where
 {
     // Get the size of the input in bytes
     let initial_buf = &mut Vec::new();
-    let mut num_bytes = get_input_size(&settings.input, reader, initial_buf, &settings.io_blksize)?;
+    let mut num_bytes = get_input_size(&settings.input, reader, initial_buf, settings.io_blksize)?;
     let mut reader = initial_buf.chain(reader);
 
     // If input file is empty and we would not have determined the Kth chunk
@@ -1228,7 +1228,7 @@ where
     // Get the size of the input in bytes and compute the number
     // of bytes per chunk.
     let initial_buf = &mut Vec::new();
-    let num_bytes = get_input_size(&settings.input, reader, initial_buf, &settings.io_blksize)?;
+    let num_bytes = get_input_size(&settings.input, reader, initial_buf, settings.io_blksize)?;
     let reader = initial_buf.chain(reader);
 
     // If input file is empty and we would not have determined the Kth chunk

--- a/src/uu/split/src/strategy.rs
+++ b/src/uu/split/src/strategy.rs
@@ -214,7 +214,7 @@ pub enum StrategyError {
 
 impl Strategy {
     /// Parse a strategy from the command-line arguments.
-    pub fn from(matches: &ArgMatches, obs_lines: &Option<String>) -> Result<Self, StrategyError> {
+    pub fn from(matches: &ArgMatches, obs_lines: Option<&str>) -> Result<Self, StrategyError> {
         fn get_and_parse(
             matches: &ArgMatches,
             option: &str,


### PR DESCRIPTION
Resolve [ref_option](https://rust-lang.github.io/rust-clippy/master/index.html#ref_option) lint.  Also, I optimized `is_first_filename_timestamp` a bit to make it faster and more streamlined.  In some cases, I replaced `&Option<T>` with `Option<T>` instead of a reference when `T` was copyable.

p.s. disclaimer: I'm the author of that lint