### PR TITLE
chore: clean up a few code paths

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -264,55 +264,40 @@ fn copy_direntry(
 
     // If the source is not a directory, then we need to copy the file.
     if !source_absolute.is_dir() {
-        if preserve_hard_links {
-            match copy_file(
-                progress_bar,
-                &source_absolute,
-                local_to_target.as_path(),
-                options,
-                symlinked_files,
-                copied_destinations,
-                copied_files,
-                false,
-            ) {
-                Ok(_) => Ok(()),
-                Err(err) => {
-                    if source_absolute.is_symlink() {
-                        // silent the error with a symlink
-                        // In case we do --archive, we might copy the symlink
-                        // before the file itself
-                        Ok(())
-                    } else {
-                        Err(err)
+        if let Err(err) = copy_file(
+            progress_bar,
+            &source_absolute,
+            local_to_target.as_path(),
+            options,
+            symlinked_files,
+            copied_destinations,
+            copied_files,
+            false,
+        ) {
+            if preserve_hard_links {
+                if !source_absolute.is_symlink() {
+                    return Err(err);
+                }
+                // silent the error with a symlink
+                // In case we do --archive, we might copy the symlink
+                // before the file itself
+            } else {
+                // At this point, `path` is just a plain old file.
+                // Terminate this function immediately if there is any
+                // kind of error *except* a "permission denied" error.
+                //
+                // TODO What other kinds of errors, if any, should
+                // cause us to continue walking the directory?
+                match err {
+                    Error::IoErrContext(e, _) if e.kind() == io::ErrorKind::PermissionDenied => {
+                        show!(uio_error!(
+                            e,
+                            "cannot open {} for reading",
+                            source_relative.quote(),
+                        ));
                     }
+                    e => return Err(e),
                 }
-            }?;
-        } else {
-            // At this point, `path` is just a plain old file.
-            // Terminate this function immediately if there is any
-            // kind of error *except* a "permission denied" error.
-            //
-            // TODO What other kinds of errors, if any, should
-            // cause us to continue walking the directory?
-            match copy_file(
-                progress_bar,
-                &source_absolute,
-                local_to_target.as_path(),
-                options,
-                symlinked_files,
-                copied_destinations,
-                copied_files,
-                false,
-            ) {
-                Ok(_) => {}
-                Err(Error::IoErrContext(e, _)) if e.kind() == io::ErrorKind::PermissionDenied => {
-                    show!(uio_error!(
-                        e,
-                        "cannot open {} for reading",
-                        source_relative.quote(),
-                    ));
-                }
-                Err(e) => return Err(e),
             }
         }
     }

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -867,13 +867,11 @@ fn preserve_timestamps(from: &Path, to: &Path) -> UResult<()> {
     let modified_time = FileTime::from_last_modification_time(&meta);
     let accessed_time = FileTime::from_last_access_time(&meta);
 
-    match set_file_times(to, accessed_time, modified_time) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            show_error!("{e}");
-            Ok(())
-        }
+    if let Err(e) = set_file_times(to, accessed_time, modified_time) {
+        show_error!("{e}");
+        // ignore error
     }
+    Ok(())
 }
 
 /// Copy one file to a new location, changing metadata.

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -91,10 +91,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         output_error,
     };
 
-    match tee(&options) {
-        Ok(_) => Ok(()),
-        Err(_) => Err(1.into()),
-    }
+    tee(&options).map_err(|_| 1.into())
 }
 
 pub fn uu_app() -> Command {


### PR DESCRIPTION
* `cp`: in `copy_dir.rs`, remove duplicate copy_file() calls and streamline error handling
* `install`: simplify `preserve_timestamp`
* `tee` - simplify error handling