### PR TITLE
cp: refuse to copy symlink over itself

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1808,7 +1808,13 @@ fn is_forbidden_to_copy_to_same_file(
     if options.copy_mode == CopyMode::SymLink && dest_is_symlink {
         return false;
     }
-    if dest_is_symlink && source_is_symlink && !options.dereference {
+    // If source and dest are both the same symlink but with different names, then allow the copy.
+    // This can occur, for example, if source and dest are both hardlinks to the same symlink.
+    if dest_is_symlink
+        && source_is_symlink
+        && source.file_name() != dest.file_name()
+        && !options.dereference
+    {
         return false;
     }
     true

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -5217,6 +5217,31 @@ mod same_file {
         assert_eq!(symlink1, at.resolve_link(symlink2));
     }
 
+    #[test]
+    fn test_same_symlink_to_itself_no_dereference() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.write(FILE_NAME, CONTENTS);
+        at.symlink_file(FILE_NAME, SYMLINK_NAME);
+        scene
+            .ucmd()
+            .args(&["-P", SYMLINK_NAME, SYMLINK_NAME])
+            .fails()
+            .stderr_contains("are the same file");
+    }
+
+    #[test]
+    fn test_same_dangling_symlink_to_itself_no_dereference() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.symlink_file("nonexistent_file", SYMLINK_NAME);
+        scene
+            .ucmd()
+            .args(&["-P", SYMLINK_NAME, SYMLINK_NAME])
+            .fails()
+            .stderr_contains("are the same file");
+    }
+
     // the following tests tries to copy file to a hardlink of the same file with
     // various options
     #[test]


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/6589

Here's a quick recap of the issue:
```
# Test setup
$ touch exists
$ ln -s exists good
$ ln -s nonexistent bad

# GNU test
$ cp -P good bad .
cp: 'good' and './good' are the same file
cp: 'bad' and './bad' are the same file

# uutils test
$ cargo run -q cp -P good bad .  # succeeds!
```

This doesn't affect the GNU compatibility tests.

Note that the other cases described in https://github.com/uutils/coreutils/issues/6589 have the correct behavior and exit statuses, just different error messages. So I didn't bother to change those since I don't think matching error messages is a goal of this project (correct me if I'm wrong).
