### PR TITLE
enable utmpx feature for musl

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -516,13 +516,13 @@ jobs:
           # - { os , target , cargo-options , features , use-cross , toolchain, skip-tests, workspace-tests }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-24.04-arm  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf }
-          - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl      , use-cross: use-cross , skip-tests: true }
+          - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix      , use-cross: use-cross , skip-tests: true }
           # - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
-          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl      , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl      , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
           - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ feat_os_unix_musl = [
   "feat_require_crate_cpp",
   "feat_require_unix",
   "feat_require_unix_hostid",
+  "feat_require_unix_utmpx",
 ]
 feat_os_unix_android = [
   "feat_Tier1",
@@ -308,7 +309,7 @@ hostname = "0.4"
 iana-time-zone = "0.1.57"
 indicatif = "0.17.8"
 itertools = "0.14.0"
-libc = "0.2.153"
+libc = "0.2.172"
 linux-raw-sys = "0.9"
 lscolors = { version = "0.20.0", default-features = false, features = [
   "gnu_legacy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,8 @@ feat_os_macos = [
   #
   "feat_require_unix_hostid",
 ]
-# "feat_os_unix" == set of utilities which can be built/run on modern/usual *nix platforms
+# "feat_os_unix" == set of utilities which can be built/run on modern/usual *nix platforms.
+# Also used for targets binding to the "musl" library (ref: <https://musl.libc.org/about.html>)
 feat_os_unix = [
   "feat_Tier1",
   #
@@ -167,15 +168,6 @@ feat_os_windows = [
 feat_os_unix_gnueabihf = [
   "feat_Tier1",
   #
-  "feat_require_unix",
-  "feat_require_unix_hostid",
-  "feat_require_unix_utmpx",
-]
-# "feat_os_unix_musl" == set of utilities which can be built/run on targets binding to the "musl" library (ref: <https://musl.libc.org/about.html>)
-feat_os_unix_musl = [
-  "feat_Tier1",
-  #
-  "feat_require_crate_cpp",
   "feat_require_unix",
   "feat_require_unix_hostid",
   "feat_require_unix_utmpx",

--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -10,7 +10,18 @@ use uucore::{format_usage, help_about, help_usage};
 
 mod platform;
 
+#[cfg(target_env = "musl")]
+const ABOUT: &str = concat!(
+    help_about!("pinky.md"),
+    "\n\nWarning: When built with musl libc, the `pinky` utility may show incomplete \n",
+    "or missing user information due to musl's stub implementation of `utmpx` \n",
+    "functions. This limitation affects the ability to retrieve accurate details \n",
+    "about logged-in users."
+);
+
+#[cfg(not(target_env = "musl"))]
 const ABOUT: &str = help_about!("pinky.md");
+
 const USAGE: &str = help_usage!("pinky.md");
 
 mod options {

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -23,7 +23,17 @@ use uucore::{format_usage, help_about, help_usage};
 #[cfg(not(target_os = "openbsd"))]
 use uucore::utmpx::*;
 
+#[cfg(target_env = "musl")]
+const ABOUT: &str = concat!(
+    help_about!("uptime.md"),
+    "\n\nWarning: When built with musl libc, the `uptime` utility may show '0 users' \n",
+    "due to musl's stub implementation of utmpx functions. Boot time and load averages \n",
+    "are still calculated using alternative mechanisms."
+);
+
+#[cfg(not(target_env = "musl"))]
 const ABOUT: &str = help_about!("uptime.md");
+
 const USAGE: &str = help_usage!("uptime.md");
 pub mod options {
     pub static SINCE: &str = "since";

--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -18,7 +18,16 @@ use utmp_classic::{UtmpEntry, parse_from_path};
 #[cfg(not(target_os = "openbsd"))]
 use uucore::utmpx::{self, Utmpx};
 
+#[cfg(target_env = "musl")]
+const ABOUT: &str = concat!(
+    help_about!("users.md"),
+    "\n\nWarning: When built with musl libc, the `users` utility may show '0 users' \n",
+    "due to musl's stub implementation of utmpx functions."
+);
+
+#[cfg(not(target_env = "musl"))]
 const ABOUT: &str = help_about!("users.md");
+
 const USAGE: &str = help_usage!("users.md");
 
 #[cfg(target_os = "openbsd")]

--- a/src/uu/who/src/who.rs
+++ b/src/uu/who/src/who.rs
@@ -28,7 +28,17 @@ mod options {
     pub const FILE: &str = "FILE"; // if length=1: FILE, if length=2: ARG1 ARG2
 }
 
+#[cfg(target_env = "musl")]
+const ABOUT: &str = concat!(
+    help_about!("who.md"),
+    "\n\nNote: When built with musl libc, the `who` utility will not display any \n",
+    "information about logged-in users. This is due to musl's stub implementation \n",
+    "of `utmpx` functions, which prevents access to the necessary data."
+);
+
+#[cfg(not(target_env = "musl"))]
 const ABOUT: &str = help_about!("who.md");
+
 const USAGE: &str = help_usage!("who.md");
 
 #[cfg(target_os = "linux")]

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -76,7 +76,6 @@ pub mod signals;
     not(target_os = "fuchsia"),
     not(target_os = "openbsd"),
     not(target_os = "redox"),
-    not(target_env = "musl"),
     feature = "utmpx"
 ))]
 pub mod utmpx;

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -89,7 +89,6 @@ pub use crate::features::signals;
     not(target_os = "fuchsia"),
     not(target_os = "openbsd"),
     not(target_os = "redox"),
-    not(target_env = "musl"),
     feature = "utmpx"
 ))]
 pub use crate::features::utmpx;

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -103,6 +103,7 @@ fn test_uptime_with_non_existent_file() {
 // This will pass
 #[test]
 #[cfg(not(any(target_os = "openbsd", target_os = "macos")))]
+#[cfg(not(target_env = "musl"))]
 #[cfg_attr(
     all(target_arch = "aarch64", target_os = "linux"),
     ignore = "Issue #7159 - Test not supported on ARM64 Linux"


### PR DESCRIPTION
musl provides stubs of the utmpx functions, and those stubs are provided in the libc crate version 0.2.172. Thus let's enable the feature so that it can compile with musl. Note that those stubs always return a success exit value, and commands such as "users" will report an empty list of users, when calling those stubs.

This is consistent with the behavior of GNU coreutils which does the same thing.

The coreutils utillities using utmpx are "pinky", "uptime", "users", "who". This is the expected behavior when using those utilities compiled with those musl utmpx stubs:
```
root@qemuarm64:~# users
root@qemuarm64:~# echo $?
0
root@qemuarm64:~# pinky
Login    Name                 TTY      Idle   When         Where
root@qemuarm64:~# echo $?
0
root@qemuarm64:~# uptime
 12:58:47 up 0 min,  0 users,  load average: 0.07, 0.02, 0.00
root@qemuarm64:~# echo $?
0
root@qemuarm64:~# who
root@qemuarm64:~# echo $?
0
```

Closes #1361