### PR TITLE
enable feature_require_crate_cpp for musl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,7 @@ feat_os_unix_gnueabihf = [
 feat_os_unix_musl = [
   "feat_Tier1",
   #
+  "feat_require_crate_cpp",
   "feat_require_unix",
   "feat_require_unix_hostid",
 ]


### PR DESCRIPTION
I am not sure what the original issue was, but it seems to work:

```
cargo build --target=x86_64-unknown-linux-musl --features feat_os_unix_musl
...
coreutils$ ./target/x86_64-unknown-linux-musl/debug/coreutils stdbuf -o L echo "foobar"
foobar
```