### PR TITLE
du: don't panic on block-size 0

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -683,11 +683,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     } else if matches.get_flag(options::BLOCK_SIZE_1M) {
         SizeFormat::BlockSize(1024 * 1024)
     } else {
-        SizeFormat::BlockSize(read_block_size(
-            matches
-                .get_one::<String>(options::BLOCK_SIZE)
-                .map(AsRef::as_ref),
-        )?)
+        let block_size_str = matches.get_one::<String>(options::BLOCK_SIZE);
+        let block_size = read_block_size(block_size_str.map(AsRef::as_ref))?;
+        if block_size == 0 {
+            return Err(std::io::Error::other(format!(
+                "invalid --{} argument {}",
+                options::BLOCK_SIZE,
+                block_size_str.map_or("???BUG", |v| v).quote()
+            ))
+            .into());
+        }
+        SizeFormat::BlockSize(block_size)
     };
 
     let traversal_options = TraversalOptions {

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -1248,3 +1248,19 @@ fn test_du_no_deduplicated_input_args() {
         .collect();
     assert_eq!(result_seq, ["2\td", "2\td", "2\td"]);
 }
+
+#[test]
+fn test_du_blocksize_zero_do_not_panic() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.write("foo", "some content");
+    for block_size in ["0", "00", "000", "0x0"] {
+        ts.ucmd()
+            .arg(format!("-B{block_size}"))
+            .arg("foo")
+            .fails()
+            .stderr_only(format!(
+                "du: invalid --block-size argument '{block_size}'\n"
+            ));
+    }
+}


### PR DESCRIPTION
```console
$ cargo run du -B0
     Running `target/debug/coreutils du -B0`

thread '<unnamed>' panicked at src/uu/du/src/du.rs:551:26:
attempt to divide by zero
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
du: sending on a closed channel
[$? = 1]
```

I think that's a new record for fewest characters needed to cause a panic :D

This PR fixes the panic, and adds a test to ensure we don't regress.

This addresses only part of #7738.