### PR TITLE
Move clippy lints from CI to `Cargo.toml`

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -109,11 +109,10 @@ jobs:
         command: |
           ## `cargo clippy` lint testing
           unset fault
-          CLIPPY_FLAGS="-W clippy::default_trait_access -W clippy::manual_string_new -W clippy::cognitive_complexity -W clippy::implicit_clone -W clippy::range-plus-one -W clippy::redundant-clone -W clippy::match_bool"
           fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
           fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
           # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-          S=$(cargo clippy --all-targets --features ${{ matrix.job.features }} --tests -pcoreutils -- ${CLIPPY_FLAGS} -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
+          S=$(cargo clippy --all-targets --features ${{ matrix.job.features }} --tests -pcoreutils -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
           if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
   style_spellcheck:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -107,7 +107,7 @@ jobs:
           if [ -z "\${FAULT}" ]; then
             echo "## cargo clippy lint testing"
             # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
-            S=\$(cargo clippy --all-targets \${CARGO_UTILITY_LIST_OPTIONS} -- -W clippy::manual_string_new -D warnings 2>&1) && printf "%s\n" "\$S" || { printf "%s\n" "\$S" ; printf "%s" "\$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*\$/::\${FAULT_TYPE} file=\2,line=\3,col=\4::\${FAULT_PREFIX}: \\\`cargo clippy\\\`: \1 (file:'\2', line:\3)/p;" -e '}' ; FAULT=true ; }
+            S=\$(cargo clippy --all-targets \${CARGO_UTILITY_LIST_OPTIONS} -- -D warnings 2>&1) && printf "%s\n" "\$S" || { printf "%s\n" "\$S" ; printf "%s" "\$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*\$/::\${FAULT_TYPE} file=\2,line=\3,col=\4::\${FAULT_PREFIX}: \\\`cargo clippy\\\`: \1 (file:'\2', line:\3)/p;" -e '}' ; FAULT=true ; }
           fi
           # Clean to avoid to rsync back the files
           cargo clean

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -600,4 +600,11 @@ unused_qualifications = "warn"
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
 #cargo = { level = "warn", priority = -1 }
+cognitive_complexity = "warn"
+default_trait_access = "warn"
+implicit_clone = "warn"
+manual_string_new = "warn"
+match_bool = "warn"
+range-plus-one = "warn"
+redundant-clone = "warn"
 ref_option = "warn"

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -317,12 +317,12 @@ mod tests {
 
         fn mount_info_with_dev_name(mount_dir: &str, dev_name: Option<&str>) -> MountInfo {
             MountInfo {
-                dev_id: Default::default(),
+                dev_id: String::default(),
                 dev_name: dev_name.map(String::from).unwrap_or_default(),
-                fs_type: Default::default(),
+                fs_type: String::default(),
                 mount_dir: String::from(mount_dir),
-                mount_option: Default::default(),
-                mount_root: Default::default(),
+                mount_option: String::default(),
+                mount_root: String::default(),
                 remote: Default::default(),
                 dummy: Default::default(),
             }

--- a/src/uu/head/src/take.rs
+++ b/src/uu/head/src/take.rs
@@ -473,6 +473,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cognitive_complexity)]
     fn test_take_all_lines_buffer() {
         // 3 lines with new-lines and one partial line.
         let input_buffer = "a\nb\nc\ndef";


### PR DESCRIPTION
This PR moves the lints defined in the CI to the `workspace.lints.clippy` section in `Cargo.toml`. The reason for this move is to have a single place for lints we enforce.

The PR also fixes a few clippy warnings that showed up in the CI.