### PR TITLE
cp -P hardlink-to-symlink hardlink-to-same-symlink should no-op

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2304,7 +2304,7 @@ fn copy_file(
         }
         handle_existing_dest(source, dest, options, source_in_command_line, copied_files)?;
         if are_hardlinks_to_same_file(source, dest) {
-            if options.copy_mode == CopyMode::Copy && options.backup != BackupMode::NoBackup {
+            if options.copy_mode == CopyMode::Copy {
                 return Ok(());
             }
             if options.copy_mode == CopyMode::Link && (!source_is_symlink || !dest_is_symlink) {


### PR DESCRIPTION
Follow up to https://github.com/uutils/coreutils/pull/7729#discussion_r2041156999

Recap:
```
# Test setup
$ ln -s nonexistent bad
$ cp -P --link bad bad2
$ ls -1i bad bad2
20145169 bad
20145169 bad2

# GNU
$ cp -P bad bad2
$ ls -1i bad bad2
20145169 bad
20145169 bad2

# This PR (7677be2075a0401f05fdf9e138d821a5673f4404)
$ cargo run -q cp -P bad bad2
$ ls -1i bad bad2
20145169 bad
20178774 bad2
```
It looks like GNU detects that the hardlinks are the same and simply no-ops (I did an `strace` and all it's doing is `stat`-ing each file and exiting). There's similar logic in `uutils`, but it's currently conditioned on the backup option. I think this is unnecessary since if source and dest are hardlinks to the same file, then no actual copy should be necessary. Let me know if I may be missing something though; there are an awful lot of obscure edge cases though (luckily there are many unit tests for them).