### PR TITLE
du: already passes GNU test in spirit, adjust test

### DIFF
--- a/util/gnu-patches/series
+++ b/util/gnu-patches/series
@@ -8,3 +8,4 @@ tests_invalid_opt.patch
 tests_ls_no_cap.patch
 tests_sort_merge.pl.patch
 tests_tsort.patch
+tests_du_move_dir_while_traversing.patch

--- a/util/gnu-patches/tests_du_move_dir_while_traversing.patch
+++ b/util/gnu-patches/tests_du_move_dir_while_traversing.patch
@@ -1,0 +1,16 @@
+Index: gnu/tests/du/move-dir-while-traversing.sh
+===================================================================
+--- gnu.orig/tests/du/move-dir-while-traversing.sh
++++ gnu/tests/du/move-dir-while-traversing.sh
+@@ -91,9 +91,7 @@ retry_delay_ nonempty .1 5 || fail=1
+ # Before coreutils-8.10, du would abort.
+ returns_ 1 du -a $t d2 2> err || fail=1
+ 
+-# check for the new diagnostic
+-printf "du: fts_read failed: $t/3/a/b: No such file or directory\n" > exp \
+-  || fail=1
+-compare exp err || fail=1
++# check that it doesn't crash
++grep -Pq "^du: cannot read directory '$t/3/a/b.*': No such file or directory" err || fail=1
+ 
+ Exit $fail

--- a/util/gnu-patches/tests_env_env-S.pl.patch
+++ b/util/gnu-patches/tests_env_env-S.pl.patch
@@ -2,7 +2,7 @@ Index: gnu/tests/env/env-S.pl
 ===================================================================
 --- gnu.orig/tests/env/env-S.pl
 +++ gnu/tests/env/env-S.pl
-@@ -209,27 +209,28 @@ my @Tests =
+@@ -212,27 +212,28 @@ my @Tests =
        {ERR=>"$prog: no terminating quote in -S string\n"}],
       ['err5', q[-S'A=B\\q'], {EXIT=>125},
        {ERR=>"$prog: invalid sequence '\\q' in -S\n"}],


### PR DESCRIPTION
This PR adapts a GNU test to accept our phrasing of the error message.

I was looking at low-hanging fruit on [the table](https://uutils.github.io/coreutils/docs/test_coverage.html), and dived straight into `du/move-dir-while-traversing`.

This GNU test exists to ward against a regression: an old GNU coreutils version used to contain a bug that triggered an assertion failure. The test's intention is to make sure that `du` fails not due to an assertion error (thus not producing any information, or corrupt output), but rather due to the correct reason (files vanishing). In particular, we simply emit a slightly different error message than GNU, and that's why we technically didn't pass that test.

However, since we pass the *spirit* of the test, I think it is appropriate to adapt the test to check for our phrasing of the error message.

While I was at it, I refreshed one of the other quilt patches, since the line numbers changed. I made sure to use GNU coreutils at git tag v9.7. I ignored two other diffs introduced by `quilt refresh`, since I'm not convinced they are correct.