### PR TITLE
refactor(tests): use absolute difference of dates to check if they are within a window

### DIFF
--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -435,8 +435,7 @@ fn test_negative_offset() {
 
                 // Is the resulting date roughly what is expected?
                 let expected_date = Utc::now() - offset;
-                date > expected_date - Duration::minutes(10)
-                    && date < expected_date + Duration::minutes(10)
+                (date.to_utc() - expected_date).abs() < Duration::minutes(10)
             });
     }
 }


### PR DESCRIPTION
### Changes
- Converts the resultant date to UTC.
- Takes the absolute difference of the result and the expected value.
- Checks if this value is less than (within) a window.