### PR TITLE
tail: Ignore a few tests on selinux

### DIFF
--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1967,7 +1967,7 @@ fn test_follow_name_truncate3() {
 
 #[test]
 #[cfg(all(
-    not(target_os = "apple"),
+    not(target_vendor = "apple"),
     not(target_os = "windows"),
     not(feature = "feat_selinux") // flaky
 ))] // FIXME: for currently not working platforms


### PR DESCRIPTION
test_follow_when_files_are_pointing_to_same_relative_file_and_file_stays_same_size is flaky