### PR TITLE
sleep: remove unused `fundu` from `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,6 @@ name = "uu_sleep"
 version = "0.0.30"
 dependencies = [
  "clap",
- "fundu",
  "uucore",
 ]
 

--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/sleep.rs"
 
 [dependencies]
 clap = { workspace = true }
-fundu = { workspace = true }
 uucore = { workspace = true, features = ["parser"] }
 
 [[bin]]


### PR DESCRIPTION
This PR removes `fundu` from `Cargo.toml` as it is no longer used due to https://github.com/uutils/coreutils/pull/7675