### PR TITLE
uutests: rename check_coreutils => check_program_version for something more generic

### DIFF
--- a/tests/by-util/test_groups.rs
+++ b/tests/by-util/test_groups.rs
@@ -7,7 +7,7 @@
 
 use uutests::new_ucmd;
 use uutests::unwrap_or_return;
-use uutests::util::{TestScenario, check_coreutil_version, expected_result, whoami};
+use uutests::util::{TestScenario, check_program_version, expected_result, whoami};
 use uutests::util_name;
 
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31
@@ -49,7 +49,7 @@ fn test_groups_username() {
 #[test]
 #[cfg(unix)]
 fn test_groups_username_multiple() {
-    unwrap_or_return!(check_coreutil_version(
+    unwrap_or_return!(check_program_version(
         util_name!(),
         VERSION_MIN_MULTIPLE_USERS
     ));

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -7,7 +7,7 @@
 
 use uutests::new_ucmd;
 use uutests::unwrap_or_return;
-use uutests::util::{TestScenario, check_coreutil_version, expected_result, is_ci, whoami};
+use uutests::util::{TestScenario, check_program_version, expected_result, is_ci, whoami};
 use uutests::util_name;
 
 const VERSION_MIN_MULTIPLE_USERS: &str = "8.31"; // this feature was introduced in GNU's coreutils 8.31
@@ -179,7 +179,7 @@ fn test_id_password_style() {
 #[test]
 #[cfg(unix)]
 fn test_id_multiple_users() {
-    unwrap_or_return!(check_coreutil_version(
+    unwrap_or_return!(check_program_version(
         util_name!(),
         VERSION_MIN_MULTIPLE_USERS
     ));
@@ -237,7 +237,7 @@ fn test_id_multiple_users() {
 #[test]
 #[cfg(unix)]
 fn test_id_multiple_users_non_existing() {
-    unwrap_or_return!(check_coreutil_version(
+    unwrap_or_return!(check_program_version(
         util_name!(),
         VERSION_MIN_MULTIPLE_USERS
     ));

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -2857,7 +2857,7 @@ const UUTILS_INFO: &str = "uutils-tests-info";
 ///
 /// #[test]
 /// fn test_xyz() {
-///     unwrap_or_return!(check_coreutil_version(
+///     unwrap_or_return!(check_program_version(
 ///         util_name!(),
 ///         VERSION_MIN_MULTIPLE_USERS
 ///     ));
@@ -2865,7 +2865,7 @@ const UUTILS_INFO: &str = "uutils-tests-info";
 /// }
 /// ```
 #[cfg(unix)]
-pub fn check_coreutil_version(
+pub fn check_program_version(
     util_name: &str,
     version_expected: &str,
 ) -> std::result::Result<String, String> {
@@ -2943,7 +2943,7 @@ fn parse_coreutil_version(version_string: &str) -> f32 {
 #[cfg(unix)]
 pub fn expected_result(ts: &TestScenario, args: &[&str]) -> std::result::Result<CmdResult, String> {
     let util_name = ts.util_name.as_str();
-    println!("{}", check_coreutil_version(util_name, VERSION_MIN)?);
+    println!("{}", check_program_version(util_name, VERSION_MIN)?);
     let util_name = host_name_for(util_name);
 
     let result = ts
@@ -3312,14 +3312,14 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn test_check_coreutil_version() {
-        match check_coreutil_version("id", VERSION_MIN) {
+    fn test_check_program_version() {
+        match check_program_version("id", VERSION_MIN) {
             Ok(s) => assert!(s.starts_with("uutils-tests-")),
             Err(s) => assert!(s.starts_with("uutils-tests-warning")),
         };
         #[cfg(target_os = "linux")]
         std::assert_eq!(
-            check_coreutil_version("no test name", VERSION_MIN),
+            check_program_version("no test name", VERSION_MIN),
             Err("uutils-tests-warning: 'no test name' \
             No such file or directory (os error 2)"
                 .to_string())


### PR DESCRIPTION
as it is used by other programs now