### PR TITLE
Bump `bincode` & adapt test code to API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,11 +148,22 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -922,7 +933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2069,7 +2080,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2082,7 +2093,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2326,7 +2337,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2503,6 +2514,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "utf8parse"
@@ -3655,6 +3672,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,7 +3801,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,7 +537,7 @@ xattr = { workspace = true }
 # to deserialize a utmpx struct into a binary file
 [target.'cfg(all(target_family= "unix",not(target_os = "macos")))'.dev-dependencies]
 serde = { version = "1.0.202", features = ["derive"] }
-bincode = { version = "1.3.3" }
+bincode = { version = "2.0.1" }
 serde-big-array = "0.5.1"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,7 +537,7 @@ xattr = { workspace = true }
 # to deserialize a utmpx struct into a binary file
 [target.'cfg(all(target_family= "unix",not(target_os = "macos")))'.dev-dependencies]
 serde = { version = "1.0.202", features = ["derive"] }
-bincode = { version = "2.0.1" }
+bincode = { version = "2.0.1", features = ["serde"] }
 serde-big-array = "0.5.1"
 
 

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -13,7 +13,7 @@ use uutests::util::TestScenario;
 use uutests::util_name;
 
 #[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
-use bincode::serialize;
+use bincode::{config, serde::encode_to_vec};
 use regex::Regex;
 #[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
 use serde::Serialize;
@@ -134,12 +134,14 @@ fn test_uptime_with_file_containing_valid_boot_time_utmpx_record() {
         }
         arr
     }
+
     // Creates a file utmp records of three different types including a valid BOOT_TIME entry
     fn utmp(path: &PathBuf) {
         // Definitions of our utmpx structs
         const BOOT_TIME: i32 = 2;
         const RUN_LVL: i32 = 1;
         const USER_PROCESS: i32 = 7;
+
         #[derive(Serialize)]
         #[repr(C)]
         pub struct TimeVal {
@@ -153,6 +155,7 @@ fn test_uptime_with_file_containing_valid_boot_time_utmpx_record() {
             e_termination: i16,
             e_exit: i16,
         }
+
         #[derive(Serialize)]
         #[repr(C, align(4))]
         pub struct Utmp {
@@ -230,9 +233,10 @@ fn test_uptime_with_file_containing_valid_boot_time_utmpx_record() {
             glibc_reserved: [0; 20],
         };
 
-        let mut buf = serialize(&utmp).unwrap();
-        buf.append(&mut serialize(&utmp1).unwrap());
-        buf.append(&mut serialize(&utmp2).unwrap());
+        let config = config::legacy();
+        let mut buf = encode_to_vec(utmp, config).unwrap();
+        buf.append(&mut encode_to_vec(utmp1, config).unwrap());
+        buf.append(&mut encode_to_vec(utmp2, config).unwrap());
         let mut f = File::create(path).unwrap();
         f.write_all(&buf).unwrap();
     }


### PR DESCRIPTION
This PR bumps `bincode` from `1.3.3` to `2.0.1` and adapts an `uptime` test to API changes.