### PR TITLE
selinux: rename `check_selinux_enabled()`

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -294,7 +294,7 @@ fn create_dir(path: &Path, is_parent: bool, config: &Config) -> UResult<()> {
 
             // Apply SELinux context if requested
             #[cfg(feature = "selinux")]
-            if config.set_selinux_context && uucore::selinux::check_selinux_enabled().is_ok() {
+            if config.set_selinux_context && uucore::selinux::is_selinux_enabled() {
                 if let Err(e) = uucore::selinux::set_selinux_security_context(path, config.context)
                 {
                     let _ = std::fs::remove_dir(path);

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -906,7 +906,7 @@ impl Stater {
                     'C' => {
                         #[cfg(feature = "selinux")]
                         {
-                            if uucore::selinux::check_selinux_enabled().is_ok() {
+                            if uucore::selinux::is_selinux_enabled() {
                                 match uucore::selinux::get_selinux_security_context(Path::new(file))
                                 {
                                     Ok(ctx) => OutputType::Str(ctx),


### PR DESCRIPTION
This PR renames `check_selinux_enabled()` to `is_selinux_enabled()` and changes its return type from `Result<(), Error>` to `bool` to improve the API.

The PR conflicts with https://github.com/uutils/coreutils/pull/7768 and https://github.com/uutils/coreutils/pull/7769