### PR TITLE
ci: lint with selinux

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1198,3 +1198,5 @@ jobs:
       run: |
         lima ls
         lima bash -c "cd work && cargo test --features 'feat_selinux'"
+    - name: Lint with SELinux
+      run: lima bash -c "cd work && cargo clippy --all-targets --features 'feat_selinux' -- -D warnings"

--- a/src/uucore/src/lib/features/selinux.rs
+++ b/src/uucore/src/lib/features/selinux.rs
@@ -144,7 +144,6 @@ pub fn set_selinux_security_context(path: &Path, context: Option<&String>) -> Re
 ///     Err(Error::ContextConversionFailure) => println!("Failed to convert the security context to a string"),
 /// }
 /// ```
-
 pub fn get_selinux_security_context(path: &Path) -> Result<String, Error> {
     if !is_selinux_enabled() {
         return Err(Error::SELinuxNotEnabled);

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4193,10 +4193,10 @@ fn test_ls_context_long() {
     for c_flag in ["-Zl", "-Zal"] {
         let result = scene.ucmd().args(&[c_flag, "foo"]).succeeds();
 
-        let line: Vec<_> = result.stdout_str().split(" ").collect();
-        assert!(line[0].ends_with("."));
+        let line: Vec<_> = result.stdout_str().split(' ').collect();
+        assert!(line[0].ends_with('.'));
         assert!(line[4].starts_with("unconfined_u"));
-        let s: Vec<_> = line[4].split(":").collect();
+        let s: Vec<_> = line[4].split(':').collect();
         assert!(s.len() == 4);
     }
 }

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -511,6 +511,6 @@ fn test_stat_selinux() {
         .stdout_contains("system_u");
     // Count that we have 4 fields
     let result = ts.ucmd().arg("--printf='%C'").arg("/bin/").succeeds();
-    let s: Vec<_> = result.stdout_str().split(":").collect();
+    let s: Vec<_> = result.stdout_str().split(':').collect();
     assert!(s.len() == 4);
 }


### PR DESCRIPTION
I noticed that clippy warnings related to SELinux don't show up in the CI. This PR adds a linting step to the `test_selinux` job in the CI.