### PR TITLE
env: ignore flags after the command or -- argument

### DIFF
--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -67,6 +67,61 @@ fn test_invalid_arg() {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))]
+fn test_flags_after_command() {
+    new_ucmd!()
+        // This would cause an error if -u=v were processed because it's malformed
+        .args(&["echo", "-u=v"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is("-u=v\n");
+
+    new_ucmd!()
+        // Ensure the string isn't split
+        // cSpell:disable
+        .args(&["printf", "%s-%s", "-Sfoo bar"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is("-Sfoo bar-");
+    // cSpell:enable
+
+    new_ucmd!()
+        // Ensure -- is recognized
+        .args(&["-i", "--", "-u=v"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is("-u=v\n");
+
+    new_ucmd!()
+        // Recognize echo as the command after a flag that takes a value
+        .args(&["-C", "..", "echo", "-u=v"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is("-u=v\n");
+
+    new_ucmd!()
+        // Recognize echo as the command after a flag that takes an inline value
+        .args(&["-C..", "echo", "-u=v"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is("-u=v\n");
+
+    new_ucmd!()
+        // Recognize echo as the command after a flag that takes a value after another flag
+        .args(&["-iC", "..", "echo", "-u=v"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is("-u=v\n");
+
+    new_ucmd!()
+        // Similar to the last two combined
+        .args(&["-iC..", "echo", "-u=v"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is("-u=v\n");
+}
+
+#[test]
 fn test_env_help() {
     new_ucmd!()
         .arg("--help")


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/7750

Problem: `env` applies special case logic to some args, such as `-u` and `-S`. However, it applies this logic to args that are supposed to be only for the program it invokes.

Solution: In the code that special cases certain args, figure out when we've gotten to the command name and stop processing.

This also puts long option names into constants since they're used in a few places now.