### PR TITLE
whoami: remove unused libc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3557,7 +3557,6 @@ name = "uu_whoami"
 version = "0.0.30"
 dependencies = [
  "clap",
- "libc",
  "uucore",
  "windows-sys 0.59.0",
 ]

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -28,9 +28,6 @@ windows-sys = { workspace = true, features = [
   "Win32_Foundation",
 ] }
 
-[target.'cfg(unix)'.dependencies]
-libc = { workspace = true }
-
 [[bin]]
 name = "whoami"
 path = "src/main.rs"


### PR DESCRIPTION
This dependency was specified under cfg(unix) but is no longer used in the whoami crate.