### PR TITLE
shred: remove unwanted padding in verbose messages

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -484,7 +484,7 @@ fn wipe_file(
         if verbose {
             let pass_name = pass_name(&pass_type);
             show_error!(
-                "{}: pass {:2}/{total_passes} ({pass_name})...",
+                "{}: pass {}/{total_passes} ({pass_name})...",
                 path.maybe_quote(),
                 i + 1,
             );

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -208,3 +208,25 @@ fn test_shred_fail_no_perm() {
         .fails()
         .stderr_contains("Couldn't rename to");
 }
+
+#[test]
+fn test_shred_verbose_no_padding_1() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "foo";
+    at.write(file, "non-empty");
+    ucmd.arg("-vn1")
+        .arg(file)
+        .succeeds()
+        .stderr_only("shred: foo: pass 1/1 (random)...\n");
+}
+
+#[test]
+fn test_shred_verbose_no_padding_10() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "foo";
+    at.write(file, "non-empty");
+    ucmd.arg("-vn10")
+        .arg(file)
+        .succeeds()
+        .stderr_contains("shred: foo: pass 1/10 (random)...\n");
+}


### PR DESCRIPTION
This is tested for in the GNU shred-passes test, so we don't have a choice if we want to stay compatible.

Found while getting ready for #5711.