### PR TITLE
shred: correctly print zero-byte pass in verbose mode

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -376,8 +376,8 @@ fn get_size(size_str_opt: Option<String>) -> Option<u64> {
 fn pass_name(pass_type: &PassType) -> String {
     match pass_type {
         PassType::Random => String::from("random"),
-        PassType::Pattern(Pattern::Single(byte)) => format!("{byte:x}{byte:x}{byte:x}"),
-        PassType::Pattern(Pattern::Multi([a, b, c])) => format!("{a:x}{b:x}{c:x}"),
+        PassType::Pattern(Pattern::Single(byte)) => format!("{byte:02x}{byte:02x}{byte:02x}"),
+        PassType::Pattern(Pattern::Multi([a, b, c])) => format!("{a:02x}{b:02x}{c:02x}"),
     }
 }
 

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -208,3 +208,14 @@ fn test_shred_fail_no_perm() {
         .fails()
         .stderr_contains("Couldn't rename to");
 }
+
+#[test]
+fn test_shred_verbose_pass_single_0_byte_name() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "foo";
+    at.write(file, "non-empty");
+    ucmd.arg("-vn200")
+        .arg(file)
+        .succeeds()
+        .stderr_contains("/200 (000000)...\n");
+}


### PR DESCRIPTION
Fixes #7798.

Before:

```console
$ cargo run -q shred -v -n100 foo
<SNIP>
shred: foo: pass 11/100 (b6db6d)...
shred: foo: pass 12/100 (ffffff)...
shred: foo: pass 13/100 (222222)...
shred: foo: pass 14/100 (222222)...
shred: foo: pass 15/100 (000)...
shred: foo: pass 16/100 (999999)...
<SNIP>
```

After:

```console
$ cargo run -q shred -v -n100 foo
<SNIP>
shred: foo: pass 34/100 (random)...
shred: foo: pass 35/100 (6db6db)...
shred: foo: pass 36/100 (000000)...
shred: foo: pass 37/100 (db6db6)...
shred: foo: pass 38/100 (888888)...
<SNIP>
```