### PR TITLE
ls: Print optimizations

### DIFF
--- a/src/uu/ls/BENCHMARKING.md
+++ b/src/uu/ls/BENCHMARKING.md
@@ -1,6 +1,13 @@
 # Benchmarking ls
 
 ls majorly involves fetching a lot of details (depending upon what details are requested, eg. time/date, inode details, etc) for each path using system calls. Ideally, any system call should be done only once for each of the paths - not adhering to this principle leads to a lot of system call overhead multiplying and bubbling up, especially for recursive ls, therefore it is important to always benchmark multiple scenarios.
+
+ls _also_ prints a lot of information, so optimizing formatting operations is also critical:
+ - Try to avoid using `format` unless required.
+ - Try to avoid repeated string copies unless necessary.
+ - If a temporary buffer is required, try to allocate a reasonable capacity to start with to avoid repeated reallocations.
+ - Some values might be expensive to compute (e.g. current line width), but are only required in some cases. Consider delaying computations, e.g. by wrapping the evaluation in a LazyCell.
+
 This is an overview over what was benchmarked, and if you make changes to `ls`, you are encouraged to check
 how performance was affected for the workloads listed below. Feel free to add other workloads to the
 list that we should improve / make sure not to regress.


### PR DESCRIPTION
See #7563, I'll have more fixes, but these are low-hanging fruits in printing.

We get closer to GNU coreutils (~10%),  this improves performance by about ~15% for the use case below.
```
cargo build -r -p uu_ls && taskset -c 0 hyperfine --warmup 100 -L ls ls,target/release/ls,./ls-main "{ls} -lR /var/lib .git || true"
Benchmark 1: ls -lR /var/lib .git || true
  Time (mean ± σ):      26.7 ms ±   1.2 ms    [User: 11.3 ms, System: 14.7 ms]
  Range (min … max):    25.8 ms …  38.5 ms    109 runs
 
Benchmark 2: target/release/ls -lR /var/lib .git || true
  Time (mean ± σ):      29.5 ms ±   1.3 ms    [User: 13.2 ms, System: 15.5 ms]
  Range (min … max):    28.6 ms …  41.3 ms    100 runs
 
Benchmark 3: ./ls-main -lR /var/lib .git || true
  Time (mean ± σ):      33.8 ms ±   1.5 ms    [User: 18.3 ms, System: 14.7 ms]
  Range (min … max):    32.6 ms …  45.6 ms    86 runs
 
Summary
  ls -lR /var/lib .git || true ran
    1.10 ± 0.07 times faster than target/release/ls -lR /var/lib .git || true
    1.26 ± 0.08 times faster than ./ls-main -lR /var/lib .git || true
```

---

### ls/BENCHMARKING.md: Add some tricks

### ls: display_item_name: Make current_column a closure

In many cases, current_column value is not actually needed, but
computing its value is quite expensive (`ansi_width` isn't very
fast).

Move the computation to a LazyCell, so that we only execute it
when required.

Saves 5% on a basic `ls -lR .git`.

### ls: Add extend_pad_left/right functions that operate on Vec<u8>

Saves another ~7% performance.

### ls: Optimize display_item_long

Preallocate output_display to a larger size, and use `extend`
instead of format.

Saves about ~5% performance vs baseline implementation.