### PR TITLE
Fix chroot trying to change into non-existent directory

### DIFF
--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -448,7 +448,7 @@ fn enter_chroot(root: &Path, skip_chdir: bool) -> UResult<()> {
 
     if err == 0 {
         if !skip_chdir {
-            std::env::set_current_dir(root).unwrap();
+            std::env::set_current_dir("/").unwrap();
         }
         Ok(())
     } else {


### PR DESCRIPTION
I tried to use the uutils `chroot` binary, it failed saying it can't switch to the new root. I found that the line I'm changing in this PR was the culprit, and commented it out. This made it work, however the new shell opened in the directory I had previously opened (I believe it was mapped inside the new root somewhere). Changing the `set_current_dir` call to target `/` (which is always the new root AFAIK, since this call runs after `chroot`) seems to do the right thing (it worked for me).

I did not look into how other implementations of `chroot` work, I only observed that this implementation was broken (initially the version AerynOS ships, then a self-built binary from the latest state of this repo, a little over two weeks ago), and played around with it until I had a fix that worked, and seemed reasonable, to me.