### PR TITLE
id: Fix incorrect human-readable output

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -468,6 +468,16 @@ fn pretty(possible_pw: Option<Passwd>) {
             }
         }
 
+        let rgid = getgid();
+        let egid = getegid();
+        if egid != rgid {
+            if let Ok(g) = Group::locate(rgid) {
+                println!("rgid\t{}", g.name);
+            } else {
+                println!("rgid\t{rgid}");
+            }
+        }
+
         println!(
             "groups\t{}",
             entries::get_groups_gnu(None)

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -459,8 +459,8 @@ fn pretty(possible_pw: Option<Passwd>) {
             println!("uid\t{rid}");
         }
 
-        let eid = getegid();
-        if eid == rid {
+        let eid = geteuid();
+        if eid != rid {
             if let Ok(p) = Passwd::locate(eid) {
                 println!("euid\t{}", p.name);
             } else {

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -468,15 +468,6 @@ fn pretty(possible_pw: Option<Passwd>) {
             }
         }
 
-        let rid = getgid();
-        if rid != eid {
-            if let Ok(g) = Group::locate(rid) {
-                println!("euid\t{}", g.name);
-            } else {
-                println!("euid\t{rid}");
-            }
-        }
-
         println!(
             "groups\t{}",
             entries::get_groups_gnu(None)


### PR DESCRIPTION
This PR fixes the human-readable output of the `-p` flag. Currently, it reports incorrect information about euid and does not include `rgid` when it differs from `egid`.

Reproduction instructions can be found in the related issue #7812.

fixes #7812