### PR TITLE
shred: fix random passes*

### DIFF
--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -10,6 +10,12 @@ use uutests::new_ucmd;
 use uutests::util::TestScenario;
 use uutests::util_name;
 
+const PATTERNS: [&str; 22] = [
+    "000000", "ffffff", "555555", "aaaaaa", "249249", "492492", "6db6db", "924924", "b6db6d",
+    "111111", "222222", "333333", "444444", "555555", "666666", "777777", "888888", "999999",
+    "bbbbbb", "cccccc", "dddddd", "eeeeee",
+];
+
 #[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(1);
@@ -240,4 +246,20 @@ fn test_shred_verbose_no_padding_10() {
         .arg(file)
         .succeeds()
         .stderr_contains("shred: foo: pass 1/10 (random)...\n");
+}
+
+#[test]
+fn test_all_patterns_present() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let file = "foo.txt";
+    at.touch(file);
+    at.append_bytes(file, &[0]);
+
+    let result = scene.ucmd().arg("-vn25").arg(file).succeeds();
+
+    for pat in PATTERNS {
+        result.stderr_contains(pat);
+    }
 }

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -12,7 +12,7 @@ use uutests::util_name;
 
 const PATTERNS: [&str; 22] = [
     "000000", "ffffff", "555555", "aaaaaa", "249249", "492492", "6db6db", "924924", "b6db6d",
-    "111111", "222222", "333333", "444444", "555555", "666666", "777777", "888888", "999999",
+    "db6db6", "111111", "222222", "333333", "444444", "666666", "777777", "888888", "999999",
     "bbbbbb", "cccccc", "dddddd", "eeeeee",
 ];
 
@@ -254,8 +254,7 @@ fn test_all_patterns_present() {
     let at = &scene.fixtures;
 
     let file = "foo.txt";
-    at.touch(file);
-    at.append_bytes(file, &[0]);
+    at.write(file, "bar");
 
     let result = scene.ucmd().arg("-vn25").arg(file).succeeds();
 


### PR DESCRIPTION
- **shred: fix random passes, update documentation, add test**
- **shred: update tests**

closes #7809

On my system, the number of random passes (as determined by `shred -vn$x foo.txt |& grep random | wc -l`) is not determined by `x/10`. While it's true that 25 is the tipping point at which all patterns are used, the pattern is unclear. I'll open a separate issue so I don't dump too much shell output here. For the purpose of this PR, I changed 3 + x/10 to (x/10).max(3) to get closer to GNU behavior.
