### PR TITLE
mv: use `RENAME_NOREPLACE` when we can

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,7 @@ dependencies = [
  "fs_extra",
  "indicatif",
  "libc",
+ "nix",
  "thiserror 2.0.12",
  "uucore",
  "windows-sys 0.59.0",

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -22,6 +22,7 @@ clap = { workspace = true }
 fs_extra = { workspace = true }
 indicatif = { workspace = true }
 libc = { workspace = true }
+nix = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = [
   "backup-control",


### PR DESCRIPTION
Fixes #7791. This currently fails to build with cross, because the release version of cross uses ancient Ubuntu 16.04 images, which ship glibc 2.23, while [`renameat2`](https://www.man7.org/linux/man-pages/man2/rename.2.html#HISTORY) support was added in glibc 2.28. We could fix this now by using a git release of cross, but there should hopefully be a [new release](https://github.com/cross-rs/cross/milestone/2) soon, so it probably makes more sense to wait for that. (Though there's no real timeline for what "soon" means here; it was supposed to release a year ago, but there is still activity at least.) It also only enables the new syscall on GNU/Linux targets, because that's all nix exposes, even though it exists on other OSs and libc implementations. Someone might want to file a PR upstream if they'd like wider support, or we could write our own wrapper around libc.

As for the PR itself, it does the classic "ask forgiveness, not permission" TOCTOU solution: if there's any behavior depending on whether there's an existing file at the target, just try to move anyway with the `RENAME_NOREPLACE` flag, and handle the `EEXIST` case if it occurs. This restructuring should also remove some extraneous system calls, especially on Windows, where there was a bunch of duplicate work being done.