### PR TITLE
shred: remove obsolete test

### DIFF
--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -216,17 +216,6 @@ fn test_shred_fail_no_perm() {
 }
 
 #[test]
-fn test_shred_verbose_pass_single_0_byte_name() {
-    let (at, mut ucmd) = at_and_ucmd!();
-    let file = "foo";
-    at.write(file, "non-empty");
-    ucmd.arg("-vn200")
-        .arg(file)
-        .succeeds()
-        .stderr_contains("/200 (000000)...\n");
-}
-
-#[test]
 fn test_shred_verbose_no_padding_1() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "foo";


### PR DESCRIPTION
This PR removes the test `test_shred_verbose_pass_single_0_byte_name`. It ensures that the `000000` pattern is used at least once within 200 iterations. A new test, `test_all_patterns_present`, introduced with https://github.com/uutils/coreutils/pull/7830, ensures that each pattern is used at least once within 25 iterations, and thus covers the previous case, too.