### PR TITLE
id: disable two tests on macOS

### DIFF
--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -292,7 +292,7 @@ fn test_id_multiple_users_non_existing() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(all(unix, not(target_vendor = "apple")))] // TODO make test work on macOS
 fn test_id_default_format() {
     let ts = TestScenario::new(util_name!());
     for opt1 in ["--name", "--real"] {
@@ -329,7 +329,7 @@ fn test_id_default_format() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(all(unix, not(target_vendor = "apple")))] // TODO make test work on macOS
 fn test_id_zero() {
     let ts = TestScenario::new(util_name!());
     for z_flag in ["-z", "--zero"] {


### PR DESCRIPTION
This PR disables two tests on macOS in order to get the CI back to green. It's a quick fix, the longer term solution is a rewrite of those tests that doesn't rely on GNU `id`.