### PR TITLE
id: adapt error message to match the one from GNU `id`

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -157,7 +157,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if (state.nflag || state.rflag) && default_format && !state.cflag {
         return Err(USimpleError::new(
             1,
-            "cannot print only names or real IDs in default format",
+            "printing only names or real IDs requires -u, -g, or -G",
         ));
     }
     if state.zflag && default_format && !state.cflag {

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -292,16 +292,20 @@ fn test_id_multiple_users_non_existing() {
 }
 
 #[test]
+fn test_id_name_or_real_with_default_format() {
+    for flag in ["-n", "--name", "-r", "--real"] {
+        new_ucmd!()
+            .arg(flag)
+            .fails()
+            .stderr_only("id: printing only names or real IDs requires -u, -g, or -G\n");
+    }
+}
+
+#[test]
 #[cfg(unix)]
 fn test_id_default_format() {
     let ts = TestScenario::new(util_name!());
     for opt1 in ["--name", "--real"] {
-        // id: cannot print only names or real IDs in default format
-        let args = [opt1];
-        ts.ucmd()
-            .args(&args)
-            .fails()
-            .stderr_only(unwrap_or_return!(expected_result(&ts, &args)).stderr_str());
         for opt2 in ["--user", "--group", "--groups"] {
             // u/g/G n/r
             let args = [opt2, opt1];
@@ -329,22 +333,33 @@ fn test_id_default_format() {
 }
 
 #[test]
+fn test_id_zero_with_default_format() {
+    for z_flag in ["-z", "--zero"] {
+        new_ucmd!()
+            .arg(z_flag)
+            .fails()
+            .stderr_only("id: option --zero not permitted in default format\n");
+    }
+}
+
+#[test]
+fn test_id_zero_with_name_or_real() {
+    for z_flag in ["-z", "--zero"] {
+        for flag in ["-n", "--name", "-r", "--real"] {
+            new_ucmd!()
+                .args(&[z_flag, flag])
+                .fails()
+                .stderr_only("id: printing only names or real IDs requires -u, -g, or -G\n");
+        }
+    }
+}
+
+#[test]
 #[cfg(unix)]
 fn test_id_zero() {
     let ts = TestScenario::new(util_name!());
     for z_flag in ["-z", "--zero"] {
-        // id: option --zero not permitted in default format
-        ts.ucmd()
-            .args(&[z_flag])
-            .fails()
-            .stderr_only(unwrap_or_return!(expected_result(&ts, &[z_flag])).stderr_str());
         for opt1 in ["--name", "--real"] {
-            // id: cannot print only names or real IDs in default format
-            let args = [opt1, z_flag];
-            ts.ucmd()
-                .args(&args)
-                .fails()
-                .stderr_only(unwrap_or_return!(expected_result(&ts, &args)).stderr_str());
             for opt2 in ["--user", "--group", "--groups"] {
                 // u/g/G n/r z
                 let args = [opt2, z_flag, opt1];

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -18,7 +18,6 @@ fn test_invalid_arg() {
 }
 
 #[test]
-#[cfg(unix)]
 #[allow(unused_mut)]
 fn test_id_no_specified_user() {
     let ts = TestScenario::new(util_name!());
@@ -44,7 +43,6 @@ fn test_id_no_specified_user() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_single_user() {
     let test_users = [&whoami()[..]];
 
@@ -96,7 +94,6 @@ fn test_id_single_user() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_single_user_non_existing() {
     let args = &["hopefully_non_existing_username"];
     let ts = TestScenario::new(util_name!());
@@ -114,7 +111,6 @@ fn test_id_single_user_non_existing() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_name() {
     let ts = TestScenario::new(util_name!());
     for opt in ["--user", "--group", "--groups"] {
@@ -133,7 +129,6 @@ fn test_id_name() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_real() {
     let ts = TestScenario::new(util_name!());
     for opt in ["--user", "--group", "--groups"] {
@@ -148,7 +143,7 @@ fn test_id_real() {
 }
 
 #[test]
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn test_id_pretty_print() {
     // `-p` is BSD only and not supported on GNU's `id`
     let username = whoami();
@@ -157,7 +152,7 @@ fn test_id_pretty_print() {
 }
 
 #[test]
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn test_id_password_style() {
     // `-P` is BSD only and not supported on GNU's `id`
     let username = whoami();
@@ -166,7 +161,6 @@ fn test_id_password_style() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_multiple_users() {
     unwrap_or_return!(check_coreutil_version(
         util_name!(),
@@ -224,7 +218,6 @@ fn test_id_multiple_users() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_multiple_users_non_existing() {
     unwrap_or_return!(check_coreutil_version(
         util_name!(),
@@ -302,7 +295,6 @@ fn test_id_name_or_real_with_default_format() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_default_format() {
     let ts = TestScenario::new(util_name!());
     for opt1 in ["--name", "--real"] {
@@ -355,7 +347,6 @@ fn test_id_zero_with_name_or_real() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_zero() {
     let ts = TestScenario::new(util_name!());
     for z_flag in ["-z", "--zero"] {
@@ -444,7 +435,6 @@ fn test_id_context() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_id_no_specified_user_posixly() {
     // gnu/tests/id/no-context.sh
 
@@ -471,7 +461,7 @@ fn test_id_no_specified_user_posixly() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_id_pretty_print_password_record() {
     // `-p` is BSD only and not supported on GNU's `id`.
     // `-P` is our own extension, and not supported by either GNU nor BSD.


### PR DESCRIPTION
Fixes #7835

The PR should get the CI back to green and does the following things:

- adapts an error message to match the one from GNU `id` 9.7
- simplifies the `test_id_default_format` and `test_id_zero` tests by extracting three new test functions that ensure a specific error message is shown
- removes all `[#[cfg(unix)]` in the tests because `id` is unix-only