### PR TITLE
Allow compiling `uucore` with `wasm32-unknown-unknown`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -513,7 +513,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          # - { os , target , cargo-options , default-features,  features , use-cross , toolchain, skip-tests, workspace-tests }
+          # - { os , target , cargo-options , default-features,  features , use-cross , toolchain, skip-tests, workspace-tests, skip-package, skip-publish }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-24.04-arm  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix      , use-cross: use-cross , skip-tests: true }
@@ -524,7 +524,7 @@ jobs:
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
-          - { os: ubuntu-latest  , target: wasm32-unknown-unknown      , default-features: false, features: uucore/format, skip-tests: true }
+          - { os: ubuntu-latest  , target: wasm32-unknown-unknown      , default-features: false, features: uucore/format, skip-tests: true, skip-package: true, skip-publish: true }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
           - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
@@ -789,6 +789,7 @@ jobs:
         name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}${{ steps.vars.outputs.ARTIFACTS_SUFFIX }}
         path: target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}
     - name: Package
+      if: matrix.job.skip-package != true
       shell: bash
       run: |
         ## Package artifact(s)
@@ -824,7 +825,7 @@ jobs:
         fi
     - name: Publish
       uses: softprops/action-gh-release@v2
-      if: steps.vars.outputs.DEPLOY
+      if: steps.vars.outputs.DEPLOY && matrix.job.skip-publish != true
       with:
         draft: true
         files: |

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -524,6 +524,7 @@ jobs:
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
+          - { os: ubuntu-latest  , target: wasm32-unknown-unknown }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
           - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -513,7 +513,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          # - { os , target , cargo-options , features , use-cross , toolchain, skip-tests, workspace-tests }
+          # - { os , target , cargo-options , default-features,  features , use-cross , toolchain, skip-tests, workspace-tests }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-24.04-arm  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix      , use-cross: use-cross , skip-tests: true }
@@ -524,13 +524,14 @@ jobs:
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
+          - { os: ubuntu-latest  , target: wasm32-unknown-unknown      , default-features: false, features: uucore/format, skip-tests: true }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
           - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
           # TODO: Re-enable after rust-onig release: https://github.com/rust-onig/rust-onig/issues/193
           # - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
-          - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }
+          - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }      
     steps:
     - uses: actions/checkout@v4
       with:
@@ -620,6 +621,10 @@ jobs:
         CARGO_FEATURES_OPTION='' ;
         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features=${{ matrix.job.features }}' ; fi
         outputs CARGO_FEATURES_OPTION
+        # * CARGO_DEFAULT_FEATURES_OPTION
+        CARGO_DEFAULT_FEATURES_OPTION='' ;
+        if [ "${{ matrix.job.default-features }}" == "false" ]; then CARGO_DEFAULT_FEATURES_OPTION='--no-default-features' ; fi
+        outputs CARGO_DEFAULT_FEATURES_OPTION
         # * CARGO_CMD
         CARGO_CMD='cross'
         CARGO_CMD_OPTIONS='+${{ env.RUST_MIN_SRV }}'
@@ -753,20 +758,20 @@ jobs:
         # dependencies
         echo "## dependency list"
         cargo fetch --locked --quiet
-        cargo tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-dedupe -e=no-dev --prefix=none | grep -vE "$PWD" | sort --unique
+        cargo tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_DEFAULT_FEATURES_OPTION }} --no-dedupe -e=no-dev --prefix=none | grep -vE "$PWD" | sort --unique
     - name: Build
       shell: bash
       run: |
         ## Build
         ${{ steps.vars.outputs.CARGO_CMD }} ${{ steps.vars.outputs.CARGO_CMD_OPTIONS }} build --release \
-        --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+        --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_DEFAULT_FEATURES_OPTION }}
     - name: Test
       if: matrix.job.skip-tests != true
       shell: bash
       run: |
         ## Test
         ${{ steps.vars.outputs.CARGO_CMD }} ${{ steps.vars.outputs.CARGO_CMD_OPTIONS }} test --target=${{ matrix.job.target }} \
-        ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+        ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_DEFAULT_FEATURES_OPTION }}
       env:
         RUST_BACKTRACE: "1"
     - name: Test individual utilities
@@ -827,111 +832,6 @@ jobs:
           ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build_wasm:
-    name: Build/WASM
-    needs: [ min_version, deps ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
-    strategy:
-      matrix:
-        job:
-          - { crate: uu_arch }
-          - { crate: uu_base32 }
-          - { crate: uu_base64 }
-          - { crate: uu_basename }
-          - { crate: uu_basenc }
-          - { crate: uu_cksum }
-          - { crate: uu_cut }
-          - { crate: uu_date }
-          - { crate: uu_dircolors }
-          - { crate: uu_dirname }
-          - { crate: uu_echo }
-          - { crate: uu_expand }
-          - { crate: uu_false }
-          - { crate: uu_fmt }
-          - { crate: uu_fold }
-          - { crate: uu_hashsum }
-          - { crate: uu_join }
-          - { crate: uu_link }
-          - { crate: uu_nl }
-          - { crate: uu_numfmt }
-          - { crate: uu_od }
-          - { crate: uu_paste }
-          - { crate: uu_pr }
-          - { crate: uu_printenv }
-          - { crate: uu_printf }
-          - { crate: uu_ptx }
-          - { crate: uu_pwd }
-          - { crate: uu_seq }
-          - { crate: uu_sleep }
-          - { crate: uu_sum }
-          - { crate: uu_tee }
-          - { crate: uu_true }
-          - { crate: uu_truncate }
-          - { crate: uu_tsort }
-          - { crate: uu_uname }
-          - { crate: uu_unexpand }
-          - { crate: uu_uniq }
-          - { crate: uu_unlink }
-          - { crate: uu_wc }
-          - { crate: uu_yes }
-          - { crate: uucore }
-          - { crate: uucore, features: [ default ] }
-          - { crate: uucore, features: [ backup-control ] }
-          - { crate: uucore, features: [ buf-copy ] }
-          - { crate: uucore, features: [ checksum ] }
-          - { crate: uucore, features: [ colors ] }
-          - { crate: uucore, features: [ custom-tz-fmt ] }
-          - { crate: uucore, features: [ encoding ] }
-          - { crate: uucore, features: [ entries ] }
-          - { crate: uucore, features: [ extendedbigdecimal ] }
-          - { crate: uucore, features: [ fast-inc ] }
-          - { crate: uucore, features: [ format ] }
-          - { crate: uucore, features: [ fsxattr ] }
-          - { crate: uucore, features: [ lines ] }
-          - { crate: uucore, features: [ parser ] }
-          - { crate: uucore, features: [ perms ] }
-          - { crate: uucore, features: [ pipes ] }
-          - { crate: uucore, features: [ proc-info ] }
-          - { crate: uucore, features: [ process ] }
-          - { crate: uucore, features: [ quoting-style ] }
-          - { crate: uucore, features: [ ranges ] }
-          - { crate: uucore, features: [ ringbuffer ] }
-          - { crate: uucore, features: [ selinux ] }
-          - { crate: uucore, features: [ signals ] }
-          - { crate: uucore, features: [ sum ] }
-          - { crate: uucore, features: [ tty ] }
-          - { crate: uucore, features: [ update-control ] }
-          - { crate: uucore, features: [ utf8 ] }
-          - { crate: uucore, features: [ version-cmp ] }
-          - { crate: uucore, features: [ wide ] }
-          - { crate: uucore_procs }
-          - { crate: uuhelp_parser }
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ env.RUST_MIN_SRV }}
-        targets: wasm32-unknown-unknown
-    - uses: Swatinem/rust-cache@v2
-      with:
-        key: "${{ matrix.job.crate }} ${{ join(matrix.job.features || '', ' ') }}"
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
-    - name: Build
-      run: | 
-        cargo build \
-        --target wasm32-unknown-unknown \
-        --no-default-features \
-        --lib \
-        --package ${{ matrix.job.crate }} \
-        --features "${{ join(matrix.job.features || '', ',') }}"
 
   test_busybox:
     name: Tests/BusyBox test suite

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -861,7 +861,7 @@ jobs:
         --no-default-features \
         --lib \
         --package ${{ matrix.job.crate }} \
-        --features ${{ join(matrix.job.features || '', ',') }}
+        --features "${{ join(matrix.job.features || '', ',') }}"
 
   test_busybox:
     name: Tests/BusyBox test suite

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -839,8 +839,78 @@ jobs:
     strategy:
       matrix:
         job:
+          - { crate: uu_arch }
+          - { crate: uu_base32 }
+          - { crate: uu_base64 }
+          - { crate: uu_basename }
+          - { crate: uu_basenc }
+          - { crate: uu_cksum }
+          - { crate: uu_cut }
+          - { crate: uu_date }
+          - { crate: uu_dircolors }
+          - { crate: uu_dirname }
+          - { crate: uu_echo }
+          - { crate: uu_expand }
+          - { crate: uu_false }
+          - { crate: uu_fmt }
+          - { crate: uu_fold }
+          - { crate: uu_hashsum }
+          - { crate: uu_join }
+          - { crate: uu_link }
+          - { crate: uu_nl }
+          - { crate: uu_numfmt }
+          - { crate: uu_od }
+          - { crate: uu_paste }
+          - { crate: uu_pr }
+          - { crate: uu_printenv }
+          - { crate: uu_printf }
+          - { crate: uu_ptx }
+          - { crate: uu_pwd }
+          - { crate: uu_seq }
+          - { crate: uu_sleep }
+          - { crate: uu_sum }
+          - { crate: uu_tee }
+          - { crate: uu_true }
+          - { crate: uu_truncate }
+          - { crate: uu_tsort }
+          - { crate: uu_uname }
+          - { crate: uu_unexpand }
+          - { crate: uu_uniq }
+          - { crate: uu_unlink }
+          - { crate: uu_wc }
+          - { crate: uu_yes }
           - { crate: uucore }
+          - { crate: uucore, features: [ default ] }
+          - { crate: uucore, features: [ backup-control ] }
+          - { crate: uucore, features: [ buf-copy ] }
+          - { crate: uucore, features: [ checksum ] }
+          - { crate: uucore, features: [ colors ] }
+          - { crate: uucore, features: [ custom-tz-fmt ] }
+          - { crate: uucore, features: [ encoding ] }
+          - { crate: uucore, features: [ entries ] }
+          - { crate: uucore, features: [ extendedbigdecimal ] }
+          - { crate: uucore, features: [ fast-inc ] }
           - { crate: uucore, features: [ format ] }
+          - { crate: uucore, features: [ fsxattr ] }
+          - { crate: uucore, features: [ lines ] }
+          - { crate: uucore, features: [ parser ] }
+          - { crate: uucore, features: [ perms ] }
+          - { crate: uucore, features: [ pipes ] }
+          - { crate: uucore, features: [ proc-info ] }
+          - { crate: uucore, features: [ process ] }
+          - { crate: uucore, features: [ quoting-style ] }
+          - { crate: uucore, features: [ ranges ] }
+          - { crate: uucore, features: [ ringbuffer ] }
+          - { crate: uucore, features: [ selinux ] }
+          - { crate: uucore, features: [ signals ] }
+          - { crate: uucore, features: [ sum ] }
+          - { crate: uucore, features: [ tty ] }
+          - { crate: uucore, features: [ update-control ] }
+          - { crate: uucore, features: [ utf8 ] }
+          - { crate: uucore, features: [ version-cmp ] }
+          - { crate: uucore, features: [ wide ] }
+          - { crate: uucore_procs }
+          - { crate: uuhelp_parser }
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -524,7 +524,6 @@ jobs:
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix      , use-cross: use-cross }
           - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
-          - { os: ubuntu-latest  , target: wasm32-unknown-unknown }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
           - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -828,6 +828,41 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build_wasm:
+    name: Build/WASM
+    needs: [ min_version, deps ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    strategy:
+      matrix:
+        job:
+          - { crate: uucore }
+          - { crate: uucore, features: [ format ] }
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_MIN_SRV }}
+        targets: wasm32-unknown-unknown
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: "${{ matrix.job.crate }} ${{ join(matrix.job.features || '', ' ') }}"
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Build
+      run: | 
+        cargo build \
+        --target wasm32-unknown-unknown \
+        --no-default-features \
+        --lib \
+        --package ${{ matrix.job.crate }} \
+        --features ${{ join(matrix.job.features || '', ',') }}
+
   test_busybox:
     name: Tests/BusyBox test suite
     needs: [ min_version, deps ]

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -21,7 +21,12 @@ path = "src/dd.rs"
 clap = { workspace = true }
 gcd = { workspace = true }
 libc = { workspace = true }
-uucore = { workspace = true, features = ["format", "parser", "quoting-style", "fs"] }
+uucore = { workspace = true, features = [
+  "format",
+  "parser",
+  "quoting-style",
+  "fs",
+] }
 thiserror = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/dd.rs"
 clap = { workspace = true }
 gcd = { workspace = true }
 libc = { workspace = true }
-uucore = { workspace = true, features = ["format", "parser", "quoting-style"] }
+uucore = { workspace = true, features = ["format", "parser", "quoting-style", "fs"] }
 thiserror = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -24,6 +24,7 @@ pub use uucore_procs::*;
 // * cross-platform modules
 pub use crate::mods::display;
 pub use crate::mods::error;
+#[cfg(feature = "fs")]
 pub use crate::mods::io;
 pub use crate::mods::line_ending;
 pub use crate::mods::os;

--- a/src/uucore/src/lib/mods.rs
+++ b/src/uucore/src/lib/mods.rs
@@ -6,6 +6,7 @@
 
 pub mod display;
 pub mod error;
+#[cfg(feature = "fs")]
 pub mod io;
 pub mod line_ending;
 pub mod os;


### PR DESCRIPTION
Older versions of `uucore` could be compiled with `wasm32-unknown-unknown`. But inside `uucore::mods::io` are file handles used which only exist when you have a filesystem which wasm doesn't have. So I feature gated them behind `fs`. I cannot really run the tests on my machine as my german operating system doesn't report english error messages. 