### PR TITLE
Add example to manpage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,138 +47,138 @@ feat_acl = ["cp/feat_acl"]
 # * The selinux(-sys) crate requires `libselinux` headers and shared library to be accessible in the C toolchain at compile time.
 # * Running a uutils compiled with `feat_selinux` requires an SELinux enabled Kernel at run time.
 feat_selinux = [
-    "cp/selinux",
-    "id/selinux",
-    "ls/selinux",
-    "mkdir/selinux",
-    "mkfifo/selinux",
-    "mknod/selinux",
-    "stat/selinux",
-    "selinux",
-    "feat_require_selinux",
+  "cp/selinux",
+  "id/selinux",
+  "ls/selinux",
+  "mkdir/selinux",
+  "mkfifo/selinux",
+  "mknod/selinux",
+  "stat/selinux",
+  "selinux",
+  "feat_require_selinux",
 ]
 ##
 ## feature sets
 ## (common/core and Tier1) feature sets
 # "feat_common_core" == baseline core set of utilities which can be built/run on most targets
 feat_common_core = [
-    "base32",
-    "base64",
-    "basename",
-    "basenc",
-    "cat",
-    "cksum",
-    "comm",
-    "cp",
-    "csplit",
-    "cut",
-    "date",
-    "df",
-    "dir",
-    "dircolors",
-    "dirname",
-    "dd",
-    "du",
-    "echo",
-    "env",
-    "expand",
-    "expr",
-    "factor",
-    "false",
-    "fmt",
-    "fold",
-    "hashsum",
-    "head",
-    "join",
-    "link",
-    "ln",
-    "ls",
-    "mkdir",
-    "mktemp",
-    "more",
-    "mv",
-    "nl",
-    "numfmt",
-    "od",
-    "paste",
-    "pr",
-    "printenv",
-    "printf",
-    "ptx",
-    "pwd",
-    "readlink",
-    "realpath",
-    "rm",
-    "rmdir",
-    "seq",
-    "shred",
-    "shuf",
-    "sleep",
-    "sort",
-    "split",
-    "sum",
-    "tac",
-    "tail",
-    "tee",
-    "test",
-    "tr",
-    "true",
-    "truncate",
-    "tsort",
-    "touch",
-    "unexpand",
-    "uniq",
-    "unlink",
-    "vdir",
-    "wc",
-    "yes",
+  "base32",
+  "base64",
+  "basename",
+  "basenc",
+  "cat",
+  "cksum",
+  "comm",
+  "cp",
+  "csplit",
+  "cut",
+  "date",
+  "df",
+  "dir",
+  "dircolors",
+  "dirname",
+  "dd",
+  "du",
+  "echo",
+  "env",
+  "expand",
+  "expr",
+  "factor",
+  "false",
+  "fmt",
+  "fold",
+  "hashsum",
+  "head",
+  "join",
+  "link",
+  "ln",
+  "ls",
+  "mkdir",
+  "mktemp",
+  "more",
+  "mv",
+  "nl",
+  "numfmt",
+  "od",
+  "paste",
+  "pr",
+  "printenv",
+  "printf",
+  "ptx",
+  "pwd",
+  "readlink",
+  "realpath",
+  "rm",
+  "rmdir",
+  "seq",
+  "shred",
+  "shuf",
+  "sleep",
+  "sort",
+  "split",
+  "sum",
+  "tac",
+  "tail",
+  "tee",
+  "test",
+  "tr",
+  "true",
+  "truncate",
+  "tsort",
+  "touch",
+  "unexpand",
+  "uniq",
+  "unlink",
+  "vdir",
+  "wc",
+  "yes",
 ]
 # "feat_Tier1" == expanded set of utilities which can be built/run on the usual rust "Tier 1" target platforms (ref: <https://forge.rust-lang.org/release/platform-support.html>)
 feat_Tier1 = [
-    "feat_common_core",
-    #
-    "arch",
-    "hostname",
-    "nproc",
-    "sync",
-    "touch",
-    "uname",
-    "whoami",
+  "feat_common_core",
+  #
+  "arch",
+  "hostname",
+  "nproc",
+  "sync",
+  "touch",
+  "uname",
+  "whoami",
 ]
 ## (primary platforms) feature sets
 # "feat_os_macos" == set of utilities which can be built/run on the MacOS platform
 feat_os_macos = [
-    "feat_os_unix", ## == a modern/usual *nix platform
-    #
-    "feat_require_unix_hostid",
+  "feat_os_unix", ## == a modern/usual *nix platform
+  #
+  "feat_require_unix_hostid",
 ]
 # "feat_os_unix" == set of utilities which can be built/run on modern/usual *nix platforms.
 # Also used for targets binding to the "musl" library (ref: <https://musl.libc.org/about.html>)
 feat_os_unix = [
-    "feat_Tier1",
-    #
-    "feat_require_crate_cpp",
-    "feat_require_unix",
-    "feat_require_unix_utmpx",
-    "feat_require_unix_hostid",
+  "feat_Tier1",
+  #
+  "feat_require_crate_cpp",
+  "feat_require_unix",
+  "feat_require_unix_utmpx",
+  "feat_require_unix_hostid",
 ]
 # "feat_os_windows" == set of utilities which can be built/run on modern/usual windows platforms
 feat_os_windows = [
-    "feat_Tier1", ## == "feat_os_windows_legacy" + "hostname"
+  "feat_Tier1", ## == "feat_os_windows_legacy" + "hostname"
 ]
 ## (secondary platforms) feature sets
 # "feat_os_unix_gnueabihf" == set of utilities which can be built/run on the "arm-unknown-linux-gnueabihf" target (ARMv6 Linux [hardfloat])
 feat_os_unix_gnueabihf = [
-    "feat_Tier1",
-    #
-    "feat_require_unix",
-    "feat_require_unix_hostid",
-    "feat_require_unix_utmpx",
+  "feat_Tier1",
+  #
+  "feat_require_unix",
+  "feat_require_unix_hostid",
+  "feat_require_unix_utmpx",
 ]
 feat_os_unix_android = [
-    "feat_Tier1",
-    #
-    "feat_require_unix",
+  "feat_Tier1",
+  #
+  "feat_require_unix",
 ]
 ## feature sets with requirements (restricting cross-platform availability)
 #
@@ -188,24 +188,24 @@ feat_os_unix_android = [
 feat_require_crate_cpp = ["stdbuf"]
 # "feat_require_unix" == set of utilities requiring support which is only available on unix platforms (as of 2020-04-23)
 feat_require_unix = [
-    "chgrp",
-    "chmod",
-    "chown",
-    "chroot",
-    "groups",
-    "id",
-    "install",
-    "kill",
-    "logname",
-    "mkfifo",
-    "mknod",
-    "nice",
-    "nohup",
-    "pathchk",
-    "stat",
-    "stty",
-    "timeout",
-    "tty",
+  "chgrp",
+  "chmod",
+  "chown",
+  "chroot",
+  "groups",
+  "id",
+  "install",
+  "kill",
+  "logname",
+  "mkfifo",
+  "mknod",
+  "nice",
+  "nohup",
+  "pathchk",
+  "stat",
+  "stty",
+  "timeout",
+  "tty",
 ]
 # "feat_require_unix_utmpx" == set of utilities requiring unix utmp/utmpx support
 # * ref: <https://wiki.musl-libc.org/faq.html#Q:-Why-is-the-utmp/wtmp-functionality-only-implemented-as-stubs?>
@@ -217,43 +217,43 @@ feat_require_selinux = ["chcon", "runcon"]
 ## (alternate/newer/smaller platforms) feature sets
 # "feat_os_unix_fuchsia" == set of utilities which can be built/run on the "Fuchsia" OS (refs: <https://fuchsia.dev>; <https://en.wikipedia.org/wiki/Google_Fuchsia>)
 feat_os_unix_fuchsia = [
-    "feat_common_core",
-    #
-    "feat_require_crate_cpp",
-    #
-    "chgrp",
-    "chmod",
-    "chown",
-    "du",
-    "groups",
-    "hostid",
-    "install",
-    "logname",
-    "mkfifo",
-    "mknod",
-    "nice",
-    "pathchk",
-    "tty",
-    "uname",
-    "unlink",
+  "feat_common_core",
+  #
+  "feat_require_crate_cpp",
+  #
+  "chgrp",
+  "chmod",
+  "chown",
+  "du",
+  "groups",
+  "hostid",
+  "install",
+  "logname",
+  "mkfifo",
+  "mknod",
+  "nice",
+  "pathchk",
+  "tty",
+  "uname",
+  "unlink",
 ]
 # "feat_os_unix_redox" == set of utilities which can be built/run on "Redox OS" (refs: <https://www.redox-os.org>; <https://en.wikipedia.org/wiki/Redox_(operating_system)>)
 feat_os_unix_redox = [
-    "feat_common_core",
-    #
-    "chmod",
-    "stat",
-    "uname",
+  "feat_common_core",
+  #
+  "chmod",
+  "stat",
+  "uname",
 ]
 # "feat_os_windows_legacy" == slightly restricted set of utilities which can be built/run on early windows platforms (eg, "WinXP")
 feat_os_windows_legacy = [
-    "feat_common_core",
-    #
-    "arch",
-    "nproc",
-    "sync",
-    "touch",
-    "whoami",
+  "feat_common_core",
+  #
+  "arch",
+  "nproc",
+  "sync",
+  "touch",
+  "whoami",
 ]
 ##
 # * bypass/override ~ translate 'test' feature name to avoid dependency collision with rust core 'test' crate (o/w surfaces as compiler errors during testing)
@@ -277,9 +277,9 @@ bstr = "1.9.1"
 bytecount = "0.6.8"
 byteorder = "1.5.0"
 chrono = { version = "0.4.38", default-features = false, features = [
-    "std",
-    "alloc",
-    "clock",
+  "std",
+  "alloc",
+  "clock",
 ] }
 chrono-tz = "0.10.0"
 clap = { version = "4.5", features = ["wrap_help", "cargo"] }
@@ -306,7 +306,7 @@ itertools = "0.14.0"
 libc = "0.2.172"
 linux-raw-sys = "0.9"
 lscolors = { version = "0.20.0", default-features = false, features = [
-    "gnu_legacy",
+  "gnu_legacy",
 ] }
 memchr = "2.7.2"
 memmap2 = "0.9.4"
@@ -509,11 +509,11 @@ time = { workspace = true, features = ["local-offset"] }
 unindent = "0.2.3"
 uutests = { workspace = true }
 uucore = { workspace = true, features = [
-    "mode",
-    "entries",
-    "process",
-    "signals",
-    "utmpx",
+  "mode",
+  "entries",
+  "process",
+  "signals",
+  "utmpx",
 ] }
 walkdir = { workspace = true }
 hex-literal = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition.workspace = true
 all-features = true
 
 [features]
-default = ["feat_common_core"]
+default = ["feat_common_core", "zip"]
 ## OS feature shortcodes
 macos = ["feat_os_macos"]
 unix = ["feat_os_unix"]
@@ -47,138 +47,138 @@ feat_acl = ["cp/feat_acl"]
 # * The selinux(-sys) crate requires `libselinux` headers and shared library to be accessible in the C toolchain at compile time.
 # * Running a uutils compiled with `feat_selinux` requires an SELinux enabled Kernel at run time.
 feat_selinux = [
-  "cp/selinux",
-  "id/selinux",
-  "ls/selinux",
-  "mkdir/selinux",
-  "mkfifo/selinux",
-  "mknod/selinux",
-  "stat/selinux",
-  "selinux",
-  "feat_require_selinux",
+    "cp/selinux",
+    "id/selinux",
+    "ls/selinux",
+    "mkdir/selinux",
+    "mkfifo/selinux",
+    "mknod/selinux",
+    "stat/selinux",
+    "selinux",
+    "feat_require_selinux",
 ]
 ##
 ## feature sets
 ## (common/core and Tier1) feature sets
 # "feat_common_core" == baseline core set of utilities which can be built/run on most targets
 feat_common_core = [
-  "base32",
-  "base64",
-  "basename",
-  "basenc",
-  "cat",
-  "cksum",
-  "comm",
-  "cp",
-  "csplit",
-  "cut",
-  "date",
-  "df",
-  "dir",
-  "dircolors",
-  "dirname",
-  "dd",
-  "du",
-  "echo",
-  "env",
-  "expand",
-  "expr",
-  "factor",
-  "false",
-  "fmt",
-  "fold",
-  "hashsum",
-  "head",
-  "join",
-  "link",
-  "ln",
-  "ls",
-  "mkdir",
-  "mktemp",
-  "more",
-  "mv",
-  "nl",
-  "numfmt",
-  "od",
-  "paste",
-  "pr",
-  "printenv",
-  "printf",
-  "ptx",
-  "pwd",
-  "readlink",
-  "realpath",
-  "rm",
-  "rmdir",
-  "seq",
-  "shred",
-  "shuf",
-  "sleep",
-  "sort",
-  "split",
-  "sum",
-  "tac",
-  "tail",
-  "tee",
-  "test",
-  "tr",
-  "true",
-  "truncate",
-  "tsort",
-  "touch",
-  "unexpand",
-  "uniq",
-  "unlink",
-  "vdir",
-  "wc",
-  "yes",
+    "base32",
+    "base64",
+    "basename",
+    "basenc",
+    "cat",
+    "cksum",
+    "comm",
+    "cp",
+    "csplit",
+    "cut",
+    "date",
+    "df",
+    "dir",
+    "dircolors",
+    "dirname",
+    "dd",
+    "du",
+    "echo",
+    "env",
+    "expand",
+    "expr",
+    "factor",
+    "false",
+    "fmt",
+    "fold",
+    "hashsum",
+    "head",
+    "join",
+    "link",
+    "ln",
+    "ls",
+    "mkdir",
+    "mktemp",
+    "more",
+    "mv",
+    "nl",
+    "numfmt",
+    "od",
+    "paste",
+    "pr",
+    "printenv",
+    "printf",
+    "ptx",
+    "pwd",
+    "readlink",
+    "realpath",
+    "rm",
+    "rmdir",
+    "seq",
+    "shred",
+    "shuf",
+    "sleep",
+    "sort",
+    "split",
+    "sum",
+    "tac",
+    "tail",
+    "tee",
+    "test",
+    "tr",
+    "true",
+    "truncate",
+    "tsort",
+    "touch",
+    "unexpand",
+    "uniq",
+    "unlink",
+    "vdir",
+    "wc",
+    "yes",
 ]
 # "feat_Tier1" == expanded set of utilities which can be built/run on the usual rust "Tier 1" target platforms (ref: <https://forge.rust-lang.org/release/platform-support.html>)
 feat_Tier1 = [
-  "feat_common_core",
-  #
-  "arch",
-  "hostname",
-  "nproc",
-  "sync",
-  "touch",
-  "uname",
-  "whoami",
+    "feat_common_core",
+    #
+    "arch",
+    "hostname",
+    "nproc",
+    "sync",
+    "touch",
+    "uname",
+    "whoami",
 ]
 ## (primary platforms) feature sets
 # "feat_os_macos" == set of utilities which can be built/run on the MacOS platform
 feat_os_macos = [
-  "feat_os_unix", ## == a modern/usual *nix platform
-  #
-  "feat_require_unix_hostid",
+    "feat_os_unix", ## == a modern/usual *nix platform
+    #
+    "feat_require_unix_hostid",
 ]
 # "feat_os_unix" == set of utilities which can be built/run on modern/usual *nix platforms.
 # Also used for targets binding to the "musl" library (ref: <https://musl.libc.org/about.html>)
 feat_os_unix = [
-  "feat_Tier1",
-  #
-  "feat_require_crate_cpp",
-  "feat_require_unix",
-  "feat_require_unix_utmpx",
-  "feat_require_unix_hostid",
+    "feat_Tier1",
+    #
+    "feat_require_crate_cpp",
+    "feat_require_unix",
+    "feat_require_unix_utmpx",
+    "feat_require_unix_hostid",
 ]
 # "feat_os_windows" == set of utilities which can be built/run on modern/usual windows platforms
 feat_os_windows = [
-  "feat_Tier1", ## == "feat_os_windows_legacy" + "hostname"
+    "feat_Tier1", ## == "feat_os_windows_legacy" + "hostname"
 ]
 ## (secondary platforms) feature sets
 # "feat_os_unix_gnueabihf" == set of utilities which can be built/run on the "arm-unknown-linux-gnueabihf" target (ARMv6 Linux [hardfloat])
 feat_os_unix_gnueabihf = [
-  "feat_Tier1",
-  #
-  "feat_require_unix",
-  "feat_require_unix_hostid",
-  "feat_require_unix_utmpx",
+    "feat_Tier1",
+    #
+    "feat_require_unix",
+    "feat_require_unix_hostid",
+    "feat_require_unix_utmpx",
 ]
 feat_os_unix_android = [
-  "feat_Tier1",
-  #
-  "feat_require_unix",
+    "feat_Tier1",
+    #
+    "feat_require_unix",
 ]
 ## feature sets with requirements (restricting cross-platform availability)
 #
@@ -188,24 +188,24 @@ feat_os_unix_android = [
 feat_require_crate_cpp = ["stdbuf"]
 # "feat_require_unix" == set of utilities requiring support which is only available on unix platforms (as of 2020-04-23)
 feat_require_unix = [
-  "chgrp",
-  "chmod",
-  "chown",
-  "chroot",
-  "groups",
-  "id",
-  "install",
-  "kill",
-  "logname",
-  "mkfifo",
-  "mknod",
-  "nice",
-  "nohup",
-  "pathchk",
-  "stat",
-  "stty",
-  "timeout",
-  "tty",
+    "chgrp",
+    "chmod",
+    "chown",
+    "chroot",
+    "groups",
+    "id",
+    "install",
+    "kill",
+    "logname",
+    "mkfifo",
+    "mknod",
+    "nice",
+    "nohup",
+    "pathchk",
+    "stat",
+    "stty",
+    "timeout",
+    "tty",
 ]
 # "feat_require_unix_utmpx" == set of utilities requiring unix utmp/utmpx support
 # * ref: <https://wiki.musl-libc.org/faq.html#Q:-Why-is-the-utmp/wtmp-functionality-only-implemented-as-stubs?>
@@ -217,43 +217,43 @@ feat_require_selinux = ["chcon", "runcon"]
 ## (alternate/newer/smaller platforms) feature sets
 # "feat_os_unix_fuchsia" == set of utilities which can be built/run on the "Fuchsia" OS (refs: <https://fuchsia.dev>; <https://en.wikipedia.org/wiki/Google_Fuchsia>)
 feat_os_unix_fuchsia = [
-  "feat_common_core",
-  #
-  "feat_require_crate_cpp",
-  #
-  "chgrp",
-  "chmod",
-  "chown",
-  "du",
-  "groups",
-  "hostid",
-  "install",
-  "logname",
-  "mkfifo",
-  "mknod",
-  "nice",
-  "pathchk",
-  "tty",
-  "uname",
-  "unlink",
+    "feat_common_core",
+    #
+    "feat_require_crate_cpp",
+    #
+    "chgrp",
+    "chmod",
+    "chown",
+    "du",
+    "groups",
+    "hostid",
+    "install",
+    "logname",
+    "mkfifo",
+    "mknod",
+    "nice",
+    "pathchk",
+    "tty",
+    "uname",
+    "unlink",
 ]
 # "feat_os_unix_redox" == set of utilities which can be built/run on "Redox OS" (refs: <https://www.redox-os.org>; <https://en.wikipedia.org/wiki/Redox_(operating_system)>)
 feat_os_unix_redox = [
-  "feat_common_core",
-  #
-  "chmod",
-  "stat",
-  "uname",
+    "feat_common_core",
+    #
+    "chmod",
+    "stat",
+    "uname",
 ]
 # "feat_os_windows_legacy" == slightly restricted set of utilities which can be built/run on early windows platforms (eg, "WinXP")
 feat_os_windows_legacy = [
-  "feat_common_core",
-  #
-  "arch",
-  "nproc",
-  "sync",
-  "touch",
-  "whoami",
+    "feat_common_core",
+    #
+    "arch",
+    "nproc",
+    "sync",
+    "touch",
+    "whoami",
 ]
 ##
 # * bypass/override ~ translate 'test' feature name to avoid dependency collision with rust core 'test' crate (o/w surfaces as compiler errors during testing)
@@ -277,9 +277,9 @@ bstr = "1.9.1"
 bytecount = "0.6.8"
 byteorder = "1.5.0"
 chrono = { version = "0.4.38", default-features = false, features = [
-  "std",
-  "alloc",
-  "clock",
+    "std",
+    "alloc",
+    "clock",
 ] }
 chrono-tz = "0.10.0"
 clap = { version = "4.5", features = ["wrap_help", "cargo"] }
@@ -306,7 +306,7 @@ itertools = "0.14.0"
 libc = "0.2.172"
 linux-raw-sys = "0.9"
 lscolors = { version = "0.20.0", default-features = false, features = [
-  "gnu_legacy",
+    "gnu_legacy",
 ] }
 memchr = "2.7.2"
 memmap2 = "0.9.4"
@@ -509,11 +509,11 @@ time = { workspace = true, features = ["local-offset"] }
 unindent = "0.2.3"
 uutests = { workspace = true }
 uucore = { workspace = true, features = [
-  "mode",
-  "entries",
-  "process",
-  "signals",
-  "utmpx",
+    "mode",
+    "entries",
+    "process",
+    "signals",
+    "utmpx",
 ] }
 walkdir = { workspace = true }
 hex-literal = "1.0.0"

--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -10,19 +10,34 @@ use clap_complete::Shell;
 use std::cmp;
 use std::ffi::OsStr;
 use std::ffi::OsString;
+use std::fs::File;
+use std::io::Read;
+use std::io::Seek;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 use uucore::display::Quotable;
+use zip::ZipArchive;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const COMPLETION: &str = "completion";
+const MANPAGE: &str = "manpage";
 
 include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 
 fn usage<T>(utils: &UtilityMap<T>, name: &str) {
     println!("{name} {VERSION} (multi-call binary)\n");
     println!("Usage: {name} [function [arguments...]]");
-    println!("       {name} --list\n");
+    println!("       {name} --list");
+    println!();
+    println!("Functions:");
+    println!("      {COMPLETION}",);
+    println!("           {}", get_completion_args(utils).render_usage());
+    println!("      '{MANPAGE}'",);
+    println!("           {}", get_manpage_args(utils).render_usage());
+    println!("      '<uutils>' [arguments...]");
+    println!();
     println!("Options:");
     println!("      --list    lists all defined functions, one per row\n");
     println!("Currently defined functions:\n");
@@ -95,8 +110,14 @@ fn main() {
         };
 
         match util {
-            "completion" => gen_completions(args, &utils),
-            "manpage" => gen_manpage(args, &utils),
+            COMPLETION => {
+                gen_completions(args, &utils);
+                process::exit(0);
+            }
+            MANPAGE => {
+                gen_manpage(args, &utils);
+                process::exit(0);
+            }
             "--list" => {
                 let mut utils: Vec<_> = utils.keys().collect();
                 utils.sort();
@@ -148,18 +169,11 @@ fn main() {
     }
 }
 
-/// Prints completions for the utility in the first parameter for the shell in the second parameter to stdout
-/// # Panics
-/// Panics if the utility map is empty
-fn gen_completions<T: uucore::Args>(
-    args: impl Iterator<Item = OsString>,
-    util_map: &UtilityMap<T>,
-) -> ! {
+fn get_completion_args<T>(util_map: &UtilityMap<T>) -> clap::Command {
     let all_utilities: Vec<_> = std::iter::once("coreutils")
         .chain(util_map.keys().copied())
         .collect();
-
-    let matches = Command::new("completion")
+    Command::new(COMPLETION)
         .about("Prints completions to stdout")
         .arg(
             Arg::new("utility")
@@ -171,7 +185,17 @@ fn gen_completions<T: uucore::Args>(
                 .value_parser(clap::builder::EnumValueParser::<Shell>::new())
                 .required(true),
         )
-        .get_matches_from(std::iter::once(OsString::from("completion")).chain(args));
+}
+
+/// Prints completions for the utility in the first parameter for the shell in the second parameter to stdout
+/// # Panics
+/// Panics if the utility map is empty
+fn gen_completions<T: uucore::Args>(
+    args: impl Iterator<Item = OsString>,
+    util_map: &UtilityMap<T>,
+) {
+    let matches = get_completion_args(util_map)
+        .get_matches_from(std::iter::once(OsString::from(COMPLETION)).chain(args));
 
     let utility = matches.get_one::<String>("utility").unwrap();
     let shell = *matches.get_one::<Shell>("shell").unwrap();
@@ -185,42 +209,49 @@ fn gen_completions<T: uucore::Args>(
 
     clap_complete::generate(shell, &mut command, bin_name, &mut io::stdout());
     io::stdout().flush().unwrap();
-    process::exit(0);
+}
+
+fn get_manpage_args<T>(util_map: &UtilityMap<T>) -> clap::Command {
+    let all_utilities: Vec<_> = std::iter::once("coreutils")
+        .chain(util_map.keys().copied())
+        .collect();
+    Command::new(MANPAGE).about("Prints manpage to stdout").arg(
+        Arg::new("utility")
+            .value_parser(clap::builder::PossibleValuesParser::new(all_utilities))
+            .required(true),
+    )
 }
 
 /// Generate the manpage for the utility in the first parameter
 /// # Panics
 /// Panics if the utility map is empty
-fn gen_manpage<T: uucore::Args>(
-    args: impl Iterator<Item = OsString>,
-    util_map: &UtilityMap<T>,
-) -> ! {
-    let all_utilities: Vec<_> = std::iter::once("coreutils")
-        .chain(util_map.keys().copied())
-        .collect();
+fn gen_manpage<T: uucore::Args>(args: impl Iterator<Item = OsString>, util_map: &UtilityMap<T>) {
+    let tldr_zip = File::open("docs/tldr.zip")
+        .ok()
+        .and_then(|f| ZipArchive::new(f).ok());
 
-    let matches = Command::new("manpage")
-        .about("Prints manpage to stdout")
-        .arg(
-            Arg::new("utility")
-                .value_parser(clap::builder::PossibleValuesParser::new(all_utilities))
-                .required(true),
-        )
-        .get_matches_from(std::iter::once(OsString::from("manpage")).chain(args));
+    if tldr_zip.is_none() {
+        // Could not open tldr.zip
+    }
+    let matches = get_manpage_args(util_map)
+        .get_matches_from(std::iter::once(OsString::from(MANPAGE)).chain(args));
 
     let utility = matches.get_one::<String>("utility").unwrap();
 
     let command = if utility == "coreutils" {
         gen_coreutils_app(util_map)
     } else {
-        util_map.get(utility).unwrap().1()
+        let mut cmd = util_map.get(utility).unwrap().1();
+        if let Ok(examples) = get_zip_examples(utility) {
+            cmd = cmd.after_help(examples);
+        }
+        cmd
     };
 
     let man = clap_mangen::Man::new(command);
     man.render(&mut io::stdout())
         .expect("Man page generation failed");
     io::stdout().flush().unwrap();
-    process::exit(0);
 }
 
 /// # Panics
@@ -238,4 +269,65 @@ fn gen_coreutils_app<T: uucore::Args>(util_map: &UtilityMap<T>) -> Command {
         command = command.subcommand(sub_app);
     }
     command
+}
+
+/// # Errors
+/// Returns an error if the tldr.zip file cannot be opened or read
+fn get_zip_examples(name: &str) -> io::Result<String> {
+    fn get_zip_content(archive: &mut ZipArchive<impl Read + Seek>, name: &str) -> Option<String> {
+        let mut s = String::new();
+        archive.by_name(name).ok()?.read_to_string(&mut s).unwrap();
+        Some(s)
+    }
+
+    let mut w = io::BufWriter::new(Vec::new());
+    let file = File::open("docs/tldr.zip")?;
+    let mut tldr_zip = match ZipArchive::new(file) {
+        Ok(zip) => zip,
+        Err(e) => {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Error reading tldr.zip: {}", e),
+            ));
+        }
+    };
+
+    let content = if let Some(f) =
+        get_zip_content(&mut tldr_zip, &format!("pages/common/{}.md", name))
+    {
+        f
+    } else if let Some(f) = get_zip_content(&mut tldr_zip, &format!("pages/linux/{}.md", name)) {
+        f
+    } else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Could not find tldr examples",
+        ));
+    };
+
+    writeln!(w, "Examples")?;
+    writeln!(w)?;
+    for line in content.lines().skip_while(|l| !l.starts_with('-')) {
+        if let Some(l) = line.strip_prefix("- ") {
+            writeln!(w, "{l}")?;
+        } else if line.starts_with('`') {
+            writeln!(w, "{}", line.trim_matches('`'))?;
+        } else if line.is_empty() {
+            writeln!(w)?;
+        } else {
+            // println!("Not sure what to do with this line:");
+            // println!("{line}");
+        }
+    }
+    writeln!(w)?;
+    writeln!(
+        w,
+        "> The examples are provided by the [tldr-pages project](https://tldr.sh) under the [CC BY 4.0 License](https://github.com/tldr-pages/tldr/blob/main/LICENSE.md)."
+    )?;
+    writeln!(w, "\n\n\n")?;
+    writeln!(
+        w,
+        "> Please note that, as uutils is a work in progress, some examples might fail."
+    )?;
+    Ok(String::from_utf8(w.into_inner().unwrap()).unwrap())
 }


### PR DESCRIPTION
This PR do
- fix https://github.com/uutils/coreutils/issues/5094
- cleaner help for `coreutils` bin (why not using clap ?)


![image](https://github.com/user-attachments/assets/be31f64e-f14d-42a6-92cd-5f636152f2d9)


Questions
- Why not using clap for argments in `coreutils` ?
- Why not moving creating a function to uucore to explore a the tldrzip file (both `coreutils` and `uudoc` use zip)
   - to do that, the zip crate need to be added to `uucore` - not sure about the idea