### PR TITLE
expr: Escape anchor characters within pattern

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -925,6 +925,33 @@ mod test {
     }
 
     #[test]
+    fn anchor_characters_are_escaped() {
+        let result = AstNode::parse(&["^$", ":", "^^$$"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "2");
+
+        let result = AstNode::parse(&["^cats$", ":", "^^cats$$"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "6");
+
+        let result = AstNode::parse(&["b^$ic", ":", "b^$ic"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "5");
+
+        let result = AstNode::parse(&["$^$^", ":", "$^$^"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "4");
+    }
+
+    #[test]
     fn only_match_in_beginning() {
         let result = AstNode::parse(&["budget", ":", r"get"])
             .unwrap()

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -154,7 +154,7 @@ impl StringOp {
                 // Escape start of string anchor characters when they are not the first character
                 let mut core_pattern = right.to_string();
                 if let Some(stripped) = right.strip_prefix('^') {
-                    core_pattern = stripped.to_string()
+                    core_pattern = stripped.to_string();
                 };
                 core_pattern = core_pattern.replace('^', r"\^");
 

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -904,6 +904,27 @@ mod test {
     }
 
     #[test]
+    fn ending_dollar_is_not_escaped() {
+        let result = AstNode::parse(&["cats", ":", "cats$"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "4");
+
+        let result = AstNode::parse(&["cats$", ":", "cats$$"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "5");
+
+        let result = AstNode::parse(&["cats$", ":", "cats$"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "0");
+    }
+
+    #[test]
     fn only_match_in_beginning() {
         let result = AstNode::parse(&["budget", ":", r"get"])
             .unwrap()

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -156,7 +156,8 @@ impl StringOp {
                 if let Some(stripped) = right.strip_prefix('^') {
                     core_pattern = stripped.to_string();
                 };
-                core_pattern = core_pattern.replace('^', r"\^");
+                let unescaped_anchor_re = Regex::new(r"(?<!\\)\^").unwrap();
+                core_pattern = unescaped_anchor_re.replace_all(&core_pattern, r"\^");
 
                 // Escape asterisk if it is the first character
                 if core_pattern.starts_with('*') {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -151,16 +151,12 @@ impl StringOp {
                 let right = right?.eval_as_string();
                 check_posix_regex_errors(&right)?;
 
-                // Parse core pattern from between the possible anchor characters
-                // - Start of string => ^
-                // - End of string   => $
+                // Escape start of string anchor characters when they are not the first character
                 let mut core_pattern = right.to_string();
                 if let Some(stripped) = right.strip_prefix('^') {
                     core_pattern = stripped.to_string()
                 };
-
-                // Escape anchor characters
-                core_pattern = core_pattern.replace('^', r"\^").replace('$', r"\$");
+                core_pattern = core_pattern.replace('^', r"\^");
 
                 // Escape asterisk if it is the first character
                 if core_pattern.starts_with('*') {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -932,6 +932,12 @@ mod test {
             .unwrap();
         assert_eq!(result.eval_as_string(), "2");
 
+        let result = AstNode::parse(&["a^b", ":", "a^b"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "3");
+
         let result = AstNode::parse(&["^cats$", ":", "^^cats$$"])
             .unwrap()
             .eval()

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -907,7 +907,7 @@ mod test {
             .unwrap();
         assert_eq!(result.eval_as_string(), "5");
 
-        let result = AstNode::parse(&["b^$ic", ":", "b^$ic"])
+        let result = AstNode::parse(&["b^$ic", ":", r"b^\$ic"])
             .unwrap()
             .eval()
             .unwrap();

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -874,54 +874,6 @@ mod test {
     }
 
     #[test]
-    fn starting_caret_is_not_escaped() {
-        let result = AstNode::parse(&["cats", ":", "^cats"])
-            .unwrap()
-            .eval()
-            .unwrap();
-        assert_eq!(result.eval_as_string(), "4");
-
-        let result = AstNode::parse(&["^cats", ":", "^^cats"])
-            .unwrap()
-            .eval()
-            .unwrap();
-        assert_eq!(result.eval_as_string(), "5");
-
-        let result = AstNode::parse(&["^cats", ":", "^cats"])
-            .unwrap()
-            .eval()
-            .unwrap();
-        assert_eq!(result.eval_as_string(), "0");
-    }
-
-    #[test]
-    fn non_starting_carets_become_escaped() {
-        let result = AstNode::parse(&["a^b", ":", "a^b"])
-            .unwrap()
-            .eval()
-            .unwrap();
-        assert_eq!(result.eval_as_string(), "3");
-
-        let result = AstNode::parse(&["^cats", ":", "^^cats"])
-            .unwrap()
-            .eval()
-            .unwrap();
-        assert_eq!(result.eval_as_string(), "5");
-
-        let result = AstNode::parse(&["b^$ic", ":", r"b^\$ic"])
-            .unwrap()
-            .eval()
-            .unwrap();
-        assert_eq!(result.eval_as_string(), "5");
-
-        let result = AstNode::parse(&["^^^^^^^^^", ":", "^^^"])
-            .unwrap()
-            .eval()
-            .unwrap();
-        assert_eq!(result.eval_as_string(), "2");
-    }
-
-    #[test]
     fn only_match_in_beginning() {
         let result = AstNode::parse(&["budget", ":", r"get"])
             .unwrap()

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -883,6 +883,27 @@ mod test {
     }
 
     #[test]
+    fn starting_caret_is_not_escaped() {
+        let result = AstNode::parse(&["cats", ":", "^cats"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "4");
+
+        let result = AstNode::parse(&["^cats", ":", "^^cats"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "5");
+
+        let result = AstNode::parse(&["^cats", ":", "^cats"])
+            .unwrap()
+            .eval()
+            .unwrap();
+        assert_eq!(result.eval_as_string(), "0");
+    }
+
+    #[test]
     fn only_match_in_beginning() {
         let result = AstNode::parse(&["budget", ":", r"get"])
             .unwrap()

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -306,10 +306,7 @@ fn test_regex() {
         .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
         .succeeds()
         .stdout_only("2\n");
-    new_ucmd!()
-        .args(&["", ":", ""])
-        .fails()
-        .stdout_only("0\n");
+    new_ucmd!().args(&["", ":", ""]).fails().stdout_only("0\n");
     new_ucmd!()
         .args(&["abc", ":", ""])
         .fails()

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -730,7 +730,6 @@ mod gnu_expr {
             .stdout_only("\n");
     }
 
-    #[ignore = "rust-onig bug, see https://github.com/rust-onig/rust-onig/issues/188"]
     #[test]
     fn test_bre10() {
         new_ucmd!()

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -275,6 +275,10 @@ fn test_length_mb() {
 #[test]
 fn test_regex() {
     new_ucmd!()
+        .args(&["a^b", ":", "a^b"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
         .args(&["a^b", ":", "a\\^b"])
         .succeeds()
         .stdout_only("3\n");
@@ -283,11 +287,31 @@ fn test_regex() {
         .succeeds()
         .stdout_only("3\n");
     new_ucmd!()
+        .args(&["abc", ":", "^abc"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["^abc", ":", "^^abc"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["b^$ic", ":", "b^\\$ic"])
+        .succeeds()
+        .stdout_only("5\n");
+    new_ucmd!()
+        .args(&["^^^^^^^^^", ":", "^^^"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
         .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
         .succeeds()
         .stdout_only("2\n");
     new_ucmd!()
         .args(&["abc", ":", "bc"])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["^abc", ":", "^abc"])
         .fails()
         .stdout_only("0\n");
 }

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -307,6 +307,14 @@ fn test_regex() {
         .succeeds()
         .stdout_only("2\n");
     new_ucmd!()
+        .args(&["", ":", ""])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["abc", ":", ""])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
         .args(&["abc", ":", "bc"])
         .fails()
         .stdout_only("0\n");

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -274,11 +274,6 @@ fn test_length_mb() {
 
 #[test]
 fn test_regex() {
-    // FixME: [2022-12-19; rivy] test disabled as it currently fails due to 'oniguruma' bug (see GH:kkos/oniguruma/issues/279)
-    // new_ucmd!()
-    //     .args(&["a^b", ":", "a^b"])
-    //     .succeeds()
-    //     .stdout_only("3\n");
     new_ucmd!()
         .args(&["a^b", ":", "a\\^b"])
         .succeeds()


### PR DESCRIPTION
Escape the regexp start of string anchor characters '^' within pattern definitions. Only keep the start anchor as is if it is at the beginning of the user input pattern.

### Changes

- Extracts a core pattern by removing a single leading ^
- Escapes any '^' characters inside the pattern body
- Ensures an asterisk (*) at the beginning of the pattern is escaped to avoid unintended regex behavior
- Always prepend a start anchor ^ to the core pattern

### Testing

- Test that the start anchor (^) is not escaped if it is at the start of the input pattern
- Test that start (^) anchors are escaped within the core pattern

fixes #7663