### PR TITLE
expr: Fix regex anchor matching behavior with `REGEX_OPTION_SINGLELINE`

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -154,7 +154,7 @@ impl StringOp {
                 let re_string = format!("{prefix}{right}");
                 let re = Regex::with_options(
                     &re_string,
-                    RegexOptions::REGEX_OPTION_NONE,
+                    RegexOptions::REGEX_OPTION_SINGLELINE,
                     Syntax::grep(),
                 )
                 .map_err(|_| ExprError::InvalidRegexExpression)?;

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -618,7 +618,6 @@ mod gnu_expr {
             .stdout_only("1\n");
     }
 
-    #[ignore]
     #[test]
     fn test_anchor() {
         new_ucmd!()


### PR DESCRIPTION
The previously used `REGEX_OPTION_NONE` allowed anchors (^) and ($) to match across newlines.

New anchor behaviors:
- `^` matches the start of the entire string (`\A`)
- `$` matches the end of the entire string (`\Z`)

The following is copied from the documentation comments of `RegexOptions::REGEX_OPTION_SINGLELINE`:

```
onig::flags::RegexOptions

pub const REGEX_OPTION_SINGLELINE: Self = REGEX_OPTION_SINGLELINE

─────────────────────────────────────────────────────────────────
`'^'` -> `'\A'`, `'$'` -> `'\Z'`
```