### PR TITLE
shred: document simplified (better?) number of random passes

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -97,3 +97,7 @@ Similar to the proc-ps implementation and unlike GNU/Coreutils, `uptime` provide
 ## `base32/base64/basenc`
 
 Just like on macOS, `base32/base64/basenc` provides `-D` to decode data.
+
+## `shred`
+
+The number of random passes is deterministic in both GNU and uutils. However, uutils `shred` computes the number of random passes in a simplified way, specifically `max(3, x / 10)`, which is very close but not identical to the number of random passes that GNU would do. This also satisfies an expectation that reasonable users might have, namely that the number of random passes increases monotonically with the number of passes overall; GNU `shred` violates this assumption.


### PR DESCRIPTION
See also #7823.

In short: Our method of computing the number of passes is simpler and presumably matches user expectations more closely. See the diff for a longer explanation.

Closes #7823.