### PR TITLE
Use system timezone database when available

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -648,10 +648,6 @@ jobs:
             ;;
         esac
         outputs CARGO_TEST_OPTIONS
-        # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
-        if [ "${CARGO_CMD}" = 'cross' ] && [ ! -e "Cross.toml" ] ; then
-          printf "[build.env]\npassthrough = [\"CI\", \"RUST_BACKTRACE\", \"CARGO_TERM_COLOR\"]\n" > Cross.toml
-        fi
         # * executable for `strip`?
         STRIP="strip"
         case ${{ matrix.job.target }} in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "tzfile"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59c22c42a2537e4c7ad21a4007273bbc5bebed7f36bc93730a5780e22a4592e"
+dependencies = [
+ "byteorder",
+ "chrono",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3601,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "time",
+ "tzfile",
  "utmp-classic",
  "uucore_procs",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime serde bincode gethostid kqueue libselinux mangen memmap procfs uuhelp startswith constness expl
+# spell-checker:ignore (libs) bigdecimal datetime serde bincode gethostid kqueue libselinux mangen memmap procfs tzfile uuhelp startswith constness expl
 
 [package]
 name = "coreutils"
@@ -341,6 +341,7 @@ terminal_size = "0.4.0"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }
 thiserror = "2.0.3"
 time = { version = "0.3.36" }
+tzfile = "0.1.3"
 unicode-segmentation = "1.11.0"
 unicode-width = "0.2.0"
 utf-8 = "0.7.6"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,7 @@
+# spell-checker:ignore (misc) dpkg noninteractive tzdata
+[build]
+pre-build = [
+  "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install tzdata",
+]
+[build.env]
+passthrough = ["CI", "RUST_BACKTRACE", "CARGO_TERM_COLOR"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -191,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1143,6 +1143,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "tzfile"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59c22c42a2537e4c7ad21a4007273bbc5bebed7f36bc93730a5780e22a4592e"
+dependencies = [
+ "byteorder",
+ "chrono",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1346,7 @@ dependencies = [
  "sha3",
  "sm3",
  "thiserror",
+ "tzfile",
  "uucore_procs",
  "wild",
  "winapi-util",

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -1,4 +1,4 @@
-# spell-checker:ignore (features) bigdecimal zerocopy extendedbigdecimal
+# spell-checker:ignore (features) bigdecimal zerocopy extendedbigdecimal tzfile
 
 [package]
 name = "uucore"
@@ -59,6 +59,7 @@ regex = { workspace = true, optional = true }
 bigdecimal = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 selinux = { workspace = true, optional = true }
+tzfile = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 walkdir = { workspace = true, optional = true }
@@ -134,6 +135,6 @@ utf8 = []
 utmpx = ["time", "time/macros", "libc", "dns-lookup"]
 version-cmp = []
 wide = []
-custom-tz-fmt = ["chrono", "chrono-tz", "iana-time-zone"]
+custom-tz-fmt = ["chrono", "chrono-tz", "tzfile", "iana-time-zone"]
 tty = []
 uptime = ["chrono", "libc", "windows-sys", "utmpx", "utmp-classic", "thiserror"]

--- a/src/uucore/build.rs
+++ b/src/uucore/build.rs
@@ -1,0 +1,26 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+// spell-checker:ignore (vars) tzfile zoneinfo
+
+use std::env;
+
+pub fn main() {
+    // If custom-tz-fmt feature is enabled, set an "embed_tz" config to decide whether
+    // to embed a full timezone database, or we can just use `tzfile` (which reads
+    // from /usr/share/zoneinfo).
+    println!("cargo::rustc-check-cfg=cfg(embed_tz)");
+    let custom_tz_fmt = env::var("CARGO_FEATURE_CUSTOM_TZ_FMT");
+    if custom_tz_fmt.is_ok() {
+        // TODO: It might be worth considering making this an option:
+        //  - People concerned with executable size may be willing to forgo timezone database
+        //    completely.
+        //  - Some other people may want to use an embedded timezone database _anyway_, instead
+        //    of the one provided by the system.
+        if cfg!(windows) || cfg!(target_os = "android") {
+            println!("cargo::rustc-cfg=embed_tz");
+        }
+    }
+}

--- a/src/uucore/src/lib/features/custom_tz_fmt.rs
+++ b/src/uucore/src/lib/features/custom_tz_fmt.rs
@@ -3,6 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+// spell-checker:ignore (misc) WARST zoneinfo
+
 use chrono::{TimeZone, Utc};
 use chrono_tz::{OffsetName, Tz};
 use iana_time_zone::get_timezone;
@@ -69,5 +71,42 @@ mod tests {
             "%Y-%m-%d %H-%M-%S.%f"
         );
         assert_eq!(custom_time_format("%Z"), timezone_abbreviation());
+    }
+
+    #[test]
+    fn test_timezone_abbreviation() {
+        // Test if a timezone abbreviation is one of the values in ok_abbr.
+        // TODO(#7659): We should modify this test to 2 fixed dates, one that falls in
+        // daylight savings, and the other not. But right now the abbreviation depends
+        // on the current time.
+        fn test_zone(zone: &str, ok_abbr: &[&str]) {
+            unsafe {
+                std::env::set_var("TZ", zone);
+            }
+            let abbr = timezone_abbreviation();
+            assert!(
+                ok_abbr.contains(&abbr.as_str()),
+                "Timezone {zone} abbreviation {abbr} is not contained within [{}].",
+                ok_abbr.join(", ")
+            )
+        }
+
+        // Test a few random timezones.
+        test_zone("US/Pacific", &["PST", "PDT"]);
+        test_zone("Europe/Zurich", &["CEST", "CET"]);
+        test_zone("Africa/Cairo", &["EET", "EEST"]); // spell-checker:disable-line
+        test_zone("Asia/Taipei", &["CST"]);
+        test_zone("Australia/Sydney", &["AEDT", "AEST"]); // spell-checker:disable-line
+        // Looks like Pacific/Tahiti is provided in /usr/share/zoneinfo, but not in chrono-tz (yet).
+        //test_zone("Pacific/Tahiti", &["-10"]); // No abbreviation?
+        test_zone("Antarctica/South_Pole", &["NZDT", "NZST"]); // spell-checker:disable-line
+
+        // TODO: This is not fully exhaustive, we should understand how to handle
+        // invalid TZ values and more complex POSIX-specified values:
+        // https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
+        // Examples:
+        //test_zone("WART4WARST,J1/0,J365/25", &["WART", "WARST"])
+        //test_zone(":Europe/Zurich", &["CEST", "CET"]);
+        //test_zone("invalid", &["invalid"]);
     }
 }

--- a/src/uucore/src/lib/features/custom_tz_fmt.rs
+++ b/src/uucore/src/lib/features/custom_tz_fmt.rs
@@ -5,8 +5,8 @@
 
 // spell-checker:ignore (misc) WARST zoneinfo
 
-use chrono::{TimeZone, Utc};
-use chrono_tz::{OffsetName, Tz};
+use chrono::Local;
+use chrono_tz::Tz;
 use iana_time_zone::get_timezone;
 
 /// Get the alphabetic abbreviation of the current timezone.
@@ -37,8 +37,12 @@ fn timezone_abbreviation() -> String {
         },
     };
 
-    let offset = tz.offset_from_utc_date(&Utc::now().date_naive());
-    offset.abbreviation().unwrap_or("UTC").to_string()
+    // TODO: It looks a bit absurd to use `%Z` here and manually expand it
+    // in `custom_time_format`, instead of directly modifying the date to be
+    // formatted. We should create another function that returns
+    // `localtime.with_timezone(&tz)` (a local time with fully specified
+    // timezone abbreviation).
+    Local::now().with_timezone(&tz).format("%Z").to_string()
 }
 
 /// Adapt the given string to be accepted by the chrono library crate.

--- a/src/uucore/src/lib/features/custom_tz_fmt.rs
+++ b/src/uucore/src/lib/features/custom_tz_fmt.rs
@@ -8,19 +8,17 @@
 use chrono::Local;
 use iana_time_zone::get_timezone;
 
-// TODO: Is there any other case where we'd be interested in using
-// chrono_tz instead of system timezone database?
-#[cfg(windows)]
+#[cfg(embed_tz)]
 use chrono_tz::{ParseError, Tz};
-#[cfg(not(windows))]
+#[cfg(not(embed_tz))]
 use tzfile::Tz;
 
-#[cfg(windows)]
+#[cfg(embed_tz)]
 fn str_to_timezone(str: &str) -> Result<Tz, ParseError> {
     str.parse()
 }
 
-#[cfg(not(windows))]
+#[cfg(not(embed_tz))]
 fn str_to_timezone(str: &str) -> Result<Tz, std::io::Error> {
     Tz::named(str)
 }
@@ -54,7 +52,7 @@ fn timezone_abbreviation() -> String {
         },
     };
 
-    #[cfg(not(windows))]
+    #[cfg(not(embed_tz))]
     let tz = &tz;
 
     // TODO: It looks a bit absurd to use `%Z` here and manually expand it


### PR DESCRIPTION
There are a lot of challenges around timezone handling, and IMHO some refactoring will be needed.

Decided to focus on #7504 for now: we use a system timezone database is available through `tzfile`.

Also, added some tests, and a bunch of TODO in the code to give pointers to the next person fixing this (maybe me...).

Shrinks `date`/`ls` by about 2 megabytes on Linux:
```
cargo build -r -p uu_date && cargo build -r -p uu_ls && ls -l target/release/{date,ls}
-rwxr-xr-x 2 drinkcat drinkcat 4828144 Apr 27 13:57 target/release/date
-rwxr-xr-x 2 drinkcat drinkcat 3769336 Apr 27 13:57 target/release/ls
## after
-rwxr-xr-x 2 drinkcat drinkcat 2949080 Apr 27 13:58 target/release/date
-rwxr-xr-x 2 drinkcat drinkcat 1894176 Apr 27 13:59 target/release/ls
```

---

### uucore: custom_tz_fmt: test: Setting TZ is not reliable

Not 100% clear why, but setting TZ in CI is not fully reliable,
so let's pass a parameter instead.

### Cross.toml: Install tzdata in container

Linux tests require that now, as we now assume /usr/share/zoneinfo
is present.

### uucore: custom_tz_fmt: Set an embed_tz feature based on platform

Instead of repeating complex logic (and its inverse), set a
feature in build.rs.

### fuzz/Cargo.lock: Update

### uucore: Use tzfile instead of chrono-tz

Unless we're on Windows.

Fixes #7504, reduces ls/date executable size by about 2 MB.

### uucore: custom_tz_fmt: use format("%Z")

### uucore: custom_tz_fmt: Add abbreviation tests

This function will still need some love, but at least with this,
we have basic tests.

### uucore: custom_tz_fmt: Improve TZ environment variable handling

iana_time_zone::get_timezone doesn't cover all cases, so we need
to handle some of the timezone parsing manually.

Also add a bunch of TODO, this function is by no means complete.

(change similar to #7597 for this file)