### PR TITLE
printf: use non-zero indexes

### DIFF
--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1342,6 +1342,11 @@ fn positional_format_specifiers() {
         .stdout_only("05-");
 
     new_ucmd!()
+        .args(&["%0$d%d-", "5", "10", "6", "20"])
+        .fails_with_code(1)
+        .stderr_only("printf: %0$: invalid conversion specification\n");
+
+    new_ucmd!()
         .args(&[
             "Octal: %6$o, Int: %1$d, Float: %4$f, String: %2$s, Hex: %7$x, Scientific: %5$e, Char: %9$c, Unsigned: %3$u, Integer: %8$i",
             "42",          // 1$d - Int


### PR DESCRIPTION
#7837 added support for indexing in format strings, but allowed for an index of 0, treating it as equivalent to an index of 1. GNU rejects 0 indexes, which makes sense, as all the other indexes are 1-indexed, which means a user could encounter difficult to debug off-by-one errors if printf didn't return an error (e.g., if looping indexes from `0..$n`).

This commit forbids 0 indexes, expressed at the type level with `std::num::NonZero`. Doing so also cuts the aligned size of `ArgumentLocation` in half, from two pointer widths to one, which is the sort of thing that could help some optimizations (I didn't run any benchmarks, the benefit is likely pretty tiny).