### PR TITLE
ls: update chrono crate version and switch to `new_lenient` use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -933,7 +933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1329,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2064,7 +2064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2077,7 +2077,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2321,7 +2321,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3783,7 +3783,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ binary-heap-plus = "0.5.0"
 bstr = "1.9.1"
 bytecount = "0.6.8"
 byteorder = "1.5.0"
-chrono = { version = "0.4.38", default-features = false, features = [
+chrono = { version = "0.4.41", default-features = false, features = [
   "std",
   "alloc",
   "clock",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -215,9 +215,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -59,6 +59,7 @@ use uucore::libc::{dev_t, major, minor};
 use uucore::line_ending::LineEnding;
 use uucore::quoting_style::{self, QuotingStyle, escape_name};
 use uucore::{
+    custom_tz_fmt,
     display::Quotable,
     error::{UError, UResult, set_exit_code},
     format_usage,
@@ -297,7 +298,10 @@ impl TimeStyler {
             TimeStyle::Locale => StrftimeItems::new("%b %e  %Y").parse(),
             TimeStyle::Format(fmt) => {
                 // Box the fmt value to make it static.
-                StrftimeItems::new_lenient(Box::leak(fmt.clone().into_boxed_str())).parse()
+                StrftimeItems::new_lenient(Box::leak(
+                    custom_tz_fmt::custom_time_format(fmt).into_boxed_str(),
+                ))
+                .parse()
             }
         }
         .unwrap();

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -59,7 +59,6 @@ use uucore::libc::{dev_t, major, minor};
 use uucore::line_ending::LineEnding;
 use uucore::quoting_style::{self, QuotingStyle, escape_name};
 use uucore::{
-    custom_tz_fmt,
     display::Quotable,
     error::{UError, UResult, set_exit_code},
     format_usage,
@@ -297,8 +296,8 @@ impl TimeStyler {
             // So it's not yet implemented
             TimeStyle::Locale => StrftimeItems::new("%b %e  %Y").parse(),
             TimeStyle::Format(fmt) => {
-                // TODO (#7802): Replace with new_lenient
-                StrftimeItems::new(custom_tz_fmt::custom_time_format(fmt).as_str()).parse_to_owned()
+                // Box the fmt value to make it static.
+                StrftimeItems::new_lenient(Box::leak(fmt.clone().into_boxed_str())).parse()
             }
         }
         .unwrap();

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -297,11 +297,8 @@ impl TimeStyler {
             // So it's not yet implemented
             TimeStyle::Locale => StrftimeItems::new("%b %e  %Y").parse(),
             TimeStyle::Format(fmt) => {
-                // Box the fmt value to make it static.
-                StrftimeItems::new_lenient(Box::leak(
-                    custom_tz_fmt::custom_time_format(fmt).into_boxed_str(),
-                ))
-                .parse()
+                StrftimeItems::new_lenient(custom_tz_fmt::custom_time_format(fmt).as_str())
+                    .parse_to_owned()
             }
         }
         .unwrap();

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5708,10 +5708,10 @@ fn test_time_style_timezone_name() {
 
 #[test]
 fn test_unknown_format_specifier() {
-    let re_custom_format = Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d+ \d{4} %0 f\n").unwrap();
+    let re_custom_format = Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d+ \d{4} %0 \d{9} f\n").unwrap();
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("f");
-    ucmd.args(&["-l", "--time-style=+%Y %0"])
+    ucmd.args(&["-l", "--time-style=+%Y %0 %N"])
         .succeeds()
         .stdout_matches(&re_custom_format);
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5705,3 +5705,13 @@ fn test_time_style_timezone_name() {
         .succeeds()
         .stdout_matches(&re_custom_format);
 }
+
+#[test]
+fn test_unknown_format_specifier() {
+    let re_custom_format = Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d+ \d{4} %0 f\n").unwrap();
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("f");
+    ucmd.args(&["-l", "--time-style=+%Y %0"])
+        .succeeds()
+        .stdout_matches(&re_custom_format);
+}


### PR DESCRIPTION
Chrono just released a new version of their crate, introducing more flexible way to parse unknown format specifiers.

Closes #7802 