### PR TITLE
CICD: Disable windows-latest/x86_64-pc-windows-gnu for now

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -527,7 +527,8 @@ jobs:
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
           - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
-          - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
+          # TODO: Re-enable after rust-onig release: https://github.com/rust-onig/rust-onig/issues/193
+          # - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
           - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }
     steps:


### PR DESCRIPTION
rust-orig current release is broken with GCC 15.1, and I don't think it's possible to pin to an older github image, or an older msys2 gcc...

Fixed upstream: https://github.com/rust-onig/rust-onig/issues/191
But waiting for new release: https://github.com/rust-onig/rust-onig/issues/193