### PR TITLE
Cargo.toml: Add profiling profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -548,9 +548,9 @@ name = "uudoc"
 path = "src/bin/uudoc.rs"
 required-features = ["uudoc"]
 
-# The default release profile. It contains all optimizations, without
-# sacrificing debug info. With this profile (like in the standard
-# release profile), the debug info and the stack traces will still be available.
+# The default release profile. It contains all optimizations.
+# With this profile (like in the standard release profile),
+# the stack traces will still be available.
 [profile.release]
 lto = true
 
@@ -566,6 +566,12 @@ inherits = "release"
 opt-level = "z"
 panic = "abort"
 strip = true
+
+# A release-like profile with debug info, useful for profiling.
+# See https://github.com/mstange/samply .
+[profile.profiling]
+inherits = "release"
+debug = true
 
 [lints.clippy]
 multiple_crate_versions = "allow"

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -70,6 +70,14 @@ samply record ./target/debug/coreutils ls -R
 samply record --rate 1000 ./target/debug/coreutils seq 1 1000
 ```
 
+The output using the `debug` profile might be easier to understand, but the performance characteristics may be somewhat different from `release` profile that we _actually_ care about.
+
+Consider using the `profiling` profile, that compiles in `release` mode but with debug symbols. For example:
+```bash
+cargo build --profile profiling -p uu_ls
+samply record -r 10000 target/profiling/ls -lR /var .git .git .git > /dev/null
+```
+
 ## Workflow: Measuring Performance Improvements
 
 1. **Establish baselines**:


### PR DESCRIPTION
Also fix comment about release profile, debug info is not there.

@tertsdiepraam not sure if you meant something else by "debug info", but the `release` binaries definitely don't have debug(ger?) information (`strip` removes nothing).