### PR TITLE
chcon: link to libfts on musl targets

### DIFF
--- a/src/uu/chcon/build.rs
+++ b/src/uu/chcon/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+
+pub fn main() {
+    // Do not rebuild build script unless the script itself or the enabled features are modified
+    // See <https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection>
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+
+    // On musl, fts is not part of libc, but in its own library.
+    if target_os == "linux" && target_env == "musl" {
+        println!("cargo:rustc-link-lib=fts");
+    }
+}


### PR DESCRIPTION
This fixes a build failure on aarch64-unknown-linux-musl.

On musl‐based targets the fts API is not provided by libc but by a separate libfts library.

## `src/uu/chcon/build.rs`

Add a build script (`build.rs`) that detects when `CARGO_CFG_TARGET_OS=linux` && `CARGO_CFG_TARGET_ENV=musl` and emits `rustc-link-lib=fts`, so that `uu_chcon` can link successfully.

## `src/uu/chcon/src/fts.rs`

In the glibc version of the header, `level` is `short`, under musl it's `int`; likewise, `pathlen` is `unsigned` on musl but signed on glibc.

# Note

To test this, I build as: `RUSTFLAGS='-Ctarget-feature=-crt-static' make` in Alpine Linux.