### PR TITLE
uptime: fix "unused import" warnings with `musl`

### DIFF
--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -12,16 +12,16 @@ use uutests::new_ucmd;
 use uutests::util::TestScenario;
 use uutests::util_name;
 
-#[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "macos", target_os = "openbsd", target_env = "musl")))]
 use bincode::{config, serde::encode_to_vec};
 use regex::Regex;
-#[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "macos", target_os = "openbsd", target_env = "musl")))]
 use serde::Serialize;
-#[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "macos", target_os = "openbsd", target_env = "musl")))]
 use serde_big_array::BigArray;
-#[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "macos", target_os = "openbsd", target_env = "musl")))]
 use std::fs::File;
-#[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "macos", target_os = "openbsd", target_env = "musl")))]
 use std::{io::Write, path::PathBuf};
 
 #[test]


### PR DESCRIPTION
This PR fixes some "unused import" warnings in the tests. See, for example, https://github.com/uutils/coreutils/actions/runs/14763292223/job/41469042921?pr=7863#step:14:243