### PR TITLE
install: remove todos

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -730,11 +730,9 @@ fn perform_backup(to: &Path, b: &Behavior) -> UResult<Option<PathBuf>> {
         }
         let backup_path = backup_control::get_backup_path(b.backup_mode, to, &b.suffix);
         if let Some(ref backup_path) = backup_path {
-            if let Err(err) = fs::rename(to, backup_path) {
-                return Err(
-                    InstallError::BackupFailed(to.to_path_buf(), backup_path.clone(), err).into(),
-                );
-            }
+            fs::rename(to, backup_path).map_err(|err| {
+                InstallError::BackupFailed(to.to_path_buf(), backup_path.clone(), err)
+            })?;
         }
         Ok(backup_path)
     } else {

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -217,7 +217,6 @@ pub fn uu_app() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
-            // TODO implement flag
             Arg::new(OPT_CREATE_LEADING)
                 .short('D')
                 .help(
@@ -274,7 +273,6 @@ pub fn uu_app() -> Command {
         )
         .arg(backup_control::arguments::suffix())
         .arg(
-            // TODO implement flag
             Arg::new(OPT_TARGET_DIRECTORY)
                 .short('t')
                 .long(OPT_TARGET_DIRECTORY)
@@ -732,7 +730,6 @@ fn perform_backup(to: &Path, b: &Behavior) -> UResult<Option<PathBuf>> {
         }
         let backup_path = backup_control::get_backup_path(b.backup_mode, to, &b.suffix);
         if let Some(ref backup_path) = backup_path {
-            // TODO!!
             if let Err(err) = fs::rename(to, backup_path) {
                 return Err(
                     InstallError::BackupFailed(to.to_path_buf(), backup_path.clone(), err).into(),


### PR DESCRIPTION
This PR removes three todos. Two have been fixed in the meantime. With the last one it's unclear to me what needs to be done: I did a simple refactoring (replacing `if let Err` with `map_err`) to make the code a bit cleaner.