### PR TITLE
uucore/echo:handle ControlFlow result

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -9,7 +9,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::io::{self, StdoutLock, Write};
 use uucore::error::{UResult, USimpleError};
-use uucore::format::{EscapedChar, FormatChar, OctalParsing, parse_escape_only};
+use uucore::format::{FormatChar, OctalParsing, parse_escape_only};
 use uucore::{format_usage, help_about, help_section, help_usage};
 
 const ABOUT: &str = help_about!("echo.md");
@@ -150,10 +150,9 @@ fn execute(
 
         if escaped {
             for item in parse_escape_only(bytes, OctalParsing::ThreeDigits) {
-                match item {
-                    EscapedChar::End => return Ok(()),
-                    c => c.write(&mut *stdout_lock)?,
-                };
+                if item.write(&mut *stdout_lock)?.is_break() {
+                    return Ok(());
+                }
             }
         } else {
             stdout_lock.write_all(bytes)?;

--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -283,7 +283,9 @@ fn printf_writer<'a>(
     let args = args.into_iter().cloned().collect::<Vec<_>>();
     let mut args = FormatArguments::new(&args);
     for item in parse_spec_only(format_string.as_ref()) {
-        item?.write(&mut writer, &mut args)?;
+        if item?.write(&mut writer, &mut args)?.is_break() {
+            break;
+        }
     }
     Ok(())
 }

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -657,3 +657,12 @@ fn test_uchild_when_run_no_wait_with_a_non_blocking_util() {
     // we should be able to call wait without panics and apply some assertions
     child.wait().unwrap().code_is(0).no_stdout().no_stderr();
 }
+
+#[test]
+fn test_escape_sequence_ctrl_c() {
+    new_ucmd!()
+        .args(&["-e", "show\\c123"])
+        .run()
+        .success()
+        .stdout_only("show");
+}


### PR DESCRIPTION
## About
[Issue 7736](https://github.com/uutils/coreutils/issues/7736)

Hello Everyone,

This PR introduces analysis of returned `ControlFlow` values, helping to eliminate compiler warnings about unused return values on nightly toolchains. It also adds the ability to exit early when encountering `EscapedCharacter::End`, which seems like the correct behavior in that case. [1]

While working on this, I noticed that the `printf` utility already relies on `ControlFlow` results. So this change also helps unify the approaches and code between `printf` and `echo`.

Please note: these are initial changes, intended for review, discussion, and testing on real examples. Any feedback or observations are highly appreciated.

Thank you


[1] Output of GNU Coreutils (9.7) and uutils/coreutils

GNU coreutils
```
/usr/bin/echo -e "abc\c123"
abc
```

uutils/coreutils
```
./target/debug/echo -e "abc\c123"
abc
```


