### PR TITLE
cp: use `authors.workspace` in `Cargo.toml`

### DIFF
--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -2,13 +2,9 @@
 name = "uu_cp"
 description = "cp ~ (uutils) copy SOURCE to DESTINATION"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cp"
-authors = [
-  "Jordy Dickinson <jordy.dickinson@gmail.com>",
-  "Joshua S. Miller <jsmiller@uchicago.edu>",
-  "uutils developers",
-]
-license.workspace = true
 version.workspace = true
+authors.workspace = true
+license.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true


### PR DESCRIPTION
This PR uses `authors.workspace = true` instead of the `authors` field in `Cargo.toml`, as we do in the other utils.