### PR TITLE
expr: Fix parsing negated character classes "[^a]"

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -171,7 +171,8 @@ impl StringOp {
                 let mut prev_is_escaped = false;
                 for curr in pattern_chars {
                     match curr {
-                        '^' if prev_is_escaped || prev != '\\' => {
+                        // Carets are interpreted literally, unless used as character class negation "[^a]"
+                        '^' if prev_is_escaped || !matches!(prev, '\\' | '[') => {
                             re_string.push_str(r"\^")
                         }
                         char => re_string.push(char),

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -166,13 +166,21 @@ impl StringOp {
                 };
 
                 // Handle the rest of the input pattern.
-                // Escape characters that should be handled literally within the pattern.
+                // Escaped previous character should not affect the current.
                 let mut prev = first.unwrap_or_default();
+                let mut prev_is_escaped = false;
                 for curr in pattern_chars {
                     match curr {
-                        '^' if prev != '\\' => re_string.push_str(r"\^"),
+                        '^' if prev_is_escaped || prev != '\\' => {
+                            re_string.push_str(r"\^")
+                        }
                         char => re_string.push(char),
                     }
+
+                    prev_is_escaped = match prev {
+                        '\\' => !prev_is_escaped,
+                        _ => false,
+                    };
                     prev = curr;
                 }
 

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -173,7 +173,7 @@ impl StringOp {
                     match curr {
                         // Carets are interpreted literally, unless used as character class negation "[^a]"
                         '^' if prev_is_escaped || !matches!(prev, '\\' | '[') => {
-                            re_string.push_str(r"\^")
+                            re_string.push_str(r"\^");
                         }
                         char => re_string.push(char),
                     }

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -303,6 +303,26 @@ fn test_regex() {
         .succeeds()
         .stdout_only("2\n");
     new_ucmd!()
+        .args(&["ab[^c]", ":", "ab[^c]"])
+        .succeeds()
+        .stdout_only("3\n"); // Matches "ab["
+    new_ucmd!()
+        .args(&["ab[^c]", ":", "ab\\[^c]"])
+        .succeeds()
+        .stdout_only("6\n");
+    new_ucmd!()
+        .args(&["[^a]", ":", "\\[^a]"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["\\a", ":", "\\\\[^^]"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["^a", ":", "^^[^^]"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
         .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
         .succeeds()
         .stdout_only("2\n");
@@ -317,6 +337,10 @@ fn test_regex() {
         .stdout_only("0\n");
     new_ucmd!()
         .args(&["^abc", ":", "^abc"])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["abc", ":", "ab[^c]"])
         .fails()
         .stdout_only("0\n");
 }


### PR DESCRIPTION
Fix the logic for parsing carets (^) when used as a character class negation token. Also, the '\' character is now only interpreted as an escape token if it is not already escaped.

Added tests to verify the caret parsing and escaping logic.

fixes #7880