### PR TITLE
shred: use 4K block

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -42,8 +42,8 @@ pub mod options {
     }
 }
 
-// This block size seems to match GNU (2^16 = 65536)
-const BLOCK_SIZE: usize = 1 << 16;
+// This block size seems to match GNU (2^12 = 4096)
+const BLOCK_SIZE: usize = 1 << 12;
 const NAME_CHARSET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_.";
 
 const PATTERN_LENGTH: usize = 3;


### PR DESCRIPTION
## About
Issue #7870

This commit changes the default block size for the shred utility to make it more consistent with the GNU coreutils version.

### Before
```
echo a > foo && cargo run -q --features shred shred -v -n1 foo && du -b foo
shred: foo: pass 1/1 (random)...
65536	foo
```

### After

```
echo a > foo && cargo run -q --features shred shred -v -n1 foo && du -b foo
shred: foo: pass 1/1 (random)...
4096	foo
```


### Expected
```
echo a > foo && shred -v -n1 foo && du -b foo
shred: foo: pass 1/1 (random)...
4096	foo
```

**Please note:**  The original shred utility uses ```fstat``` along with the macroses to determine the block size. Therefore, the block size is not constant and may vary across platforms. The most common sizes are 512 bytes and 4 KB. Here, I started by changing the constant and collecting test results and observations. However, to replicate the behavior of shred, deeper modifications are required. Please feel free to share your thoughts and opinions on which approach is preferable: simply changing the constant or moving block size detection to runtime.

Thank you