### PR TITLE
chroot: remove unwrap calls

### DIFF
--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -439,7 +439,9 @@ fn enter_chroot(root: &Path, skip_chdir: bool) -> UResult<()> {
     let err = unsafe {
         chroot(
             CString::new(root.as_os_str().as_bytes().to_vec())
-                .unwrap()
+                .map_err(|e| {
+                    ChrootError::CannotEnter("Unable to enter root directory".to_string(), e.into())
+                })?
                 .as_bytes_with_nul()
                 .as_ptr()
                 .cast::<libc::c_char>(),
@@ -448,7 +450,7 @@ fn enter_chroot(root: &Path, skip_chdir: bool) -> UResult<()> {
 
     if err == 0 {
         if !skip_chdir {
-            std::env::set_current_dir("/").unwrap();
+            std::env::set_current_dir("/")?;
         }
         Ok(())
     } else {


### PR DESCRIPTION
This PR aims to solve #7876. I have not found the underlying problem to that issue, but I have removed the unwrap() calls on lines 442 and 451 as mentioned in #7876 so that the code aligns with the "never use panic!" guideline.