### PR TITLE
uptime: refactor `uumain`

### DIFF
--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -251,7 +251,7 @@ fn test_uptime_with_extra_argument() {
         .arg("a")
         .arg("b")
         .fails()
-        .stderr_contains("extra operand 'b'");
+        .stderr_contains("unexpected value 'b'");
 }
 /// Checks whether uptime displays the correct stderr msg when its called with a directory
 #[test]


### PR DESCRIPTION
This PR refactors `uumain`. It applies the following changes:
* use clap to handle the "too many paths provided" error case
* remove `unix` block and make a single var platform-specific instead
* split `default_uptime` into two functions