### PR TITLE
date/ls: Switch from chrono to jiff

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -654,10 +654,6 @@ jobs:
             ;;
         esac
         outputs CARGO_TEST_OPTIONS
-        # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
-        if [ "${CARGO_CMD}" = 'cross' ] && [ ! -e "Cross.toml" ] ; then
-          printf "[build.env]\npassthrough = [\"CI\", \"RUST_BACKTRACE\", \"CARGO_TERM_COLOR\"]\n" > Cross.toml
-        fi
         # * executable for `strip`?
         STRIP="strip"
         case ${{ matrix.job.target }} in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,6 +3019,7 @@ dependencies = [
  "clap",
  "glob",
  "hostname",
+ "jiff",
  "lscolors",
  "number_prefix",
  "selinux",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e77966151130221b079bcec80f1f34a9e414fa489d99152a201c07fd2182bc"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97265751f8a9a4228476f2fc17874a9e7e70e96b893368e42619880fe143b48a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +1804,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2696,6 +2746,7 @@ version = "0.0.30"
 dependencies = [
  "chrono",
  "clap",
+ "jiff",
  "libc",
  "parse_datetime",
  "uucore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,11 @@ hostname = "0.4"
 iana-time-zone = "0.1.57"
 indicatif = "0.17.8"
 itertools = "0.14.0"
+jiff = { version = "0.2.10", default-features = false, features = [
+  "std",
+  "alloc",
+  "tz-system",
+] }
 libc = "0.2.172"
 linux-raw-sys = "0.9"
 lscolors = { version = "0.20.0", default-features = false, features = [

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,7 @@
+# spell-checker:ignore (misc) dpkg noninteractive tzdata
+[build]
+pre-build = [
+  "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install tzdata",
+]
+[build.env]
+passthrough = ["CI", "RUST_BACKTRACE", "CARGO_TERM_COLOR"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -576,6 +576,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e77966151130221b079bcec80f1f34a9e414fa489d99152a201c07fd2182bc"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97265751f8a9a4228476f2fc17874a9e7e70e96b893368e42619880fe143b48a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +860,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1186,6 +1242,7 @@ version = "0.0.30"
 dependencies = [
  "chrono",
  "clap",
+ "jiff",
  "libc",
  "parse_datetime",
  "uucore",

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -1,4 +1,4 @@
-# spell-checker:ignore datetime
+# spell-checker:ignore datetime tzdb zoneinfo
 [package]
 name = "uu_date"
 description = "date ~ (uutils) display or set the current time"
@@ -19,8 +19,13 @@ workspace = true
 path = "src/date.rs"
 
 [dependencies]
-chrono = { workspace = true }
 clap = { workspace = true }
+chrono = { workspace = true } # TODO: Eventually we'll want to remove this
+jiff = { workspace = true, features = [
+  "tzdb-bundle-platform",
+  "tzdb-zoneinfo",
+  "tzdb-concatenated",
+] }
 uucore = { workspace = true, features = ["custom-tz-fmt", "parser"] }
 parse_datetime = { workspace = true }
 

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -1,3 +1,5 @@
+# spell-checker:ignore tzdb zoneinfo
+
 [package]
 name = "uu_ls"
 description = "ls ~ (uutils) display directory contents"
@@ -23,6 +25,11 @@ chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 glob = { workspace = true }
 hostname = { workspace = true }
+jiff = { workspace = true, features = [
+  "tzdb-bundle-platform",
+  "tzdb-zoneinfo",
+  "tzdb-concatenated",
+] }
 lscolors = { workspace = true }
 number_prefix = { workspace = true }
 selinux = { workspace = true, optional = true }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -27,7 +27,6 @@ use std::{
 use std::{collections::HashSet, io::IsTerminal};
 
 use ansi_width::ansi_width;
-use chrono::format::{Item, StrftimeItems};
 use chrono::{DateTime, Local, TimeDelta};
 use clap::{
     Arg, ArgAction, Command,
@@ -274,64 +273,32 @@ enum TimeStyle {
     Format(String),
 }
 
-/// A struct/impl used to format a file DateTime, precomputing the format for performance reasons.
-struct TimeStyler {
-    // default format, always specified.
-    default: Vec<Item<'static>>,
-    // format for a recent time, only specified it is is different from the default
-    recent: Option<Vec<Item<'static>>>,
-    // If `recent` is set, cache the threshold time when we switch from recent to default format.
-    recent_time_threshold: Option<DateTime<Local>>,
+/// Whether the given date is considered recent (i.e., in the last 6 months).
+fn is_recent(time: DateTime<Local>) -> bool {
+    // According to GNU a Gregorian year has 365.2425 * 24 * 60 * 60 == 31556952 seconds on the average.
+    time + TimeDelta::try_seconds(31_556_952 / 2).unwrap() > Local::now()
 }
 
-impl TimeStyler {
-    /// Create a TimeStyler based on a TimeStyle specification.
-    fn new(style: &TimeStyle) -> TimeStyler {
-        let default: Vec<Item<'static>> = match style {
-            TimeStyle::FullIso => StrftimeItems::new("%Y-%m-%d %H:%M:%S.%f %z").parse(),
-            TimeStyle::LongIso => StrftimeItems::new("%Y-%m-%d %H:%M").parse(),
-            TimeStyle::Iso => StrftimeItems::new("%Y-%m-%d ").parse(),
-            // In this version of chrono translating can be done
-            // The function is chrono::datetime::DateTime::format_localized
-            // However it's currently still hard to get the current pure-rust-locale
-            // So it's not yet implemented
-            TimeStyle::Locale => StrftimeItems::new("%b %e  %Y").parse(),
-            TimeStyle::Format(fmt) => {
-                StrftimeItems::new_lenient(custom_tz_fmt::custom_time_format(fmt).as_str())
-                    .parse_to_owned()
-            }
-        }
-        .unwrap();
-        let recent = match style {
-            TimeStyle::Iso => Some(StrftimeItems::new("%m-%d %H:%M")),
-            // See comment above about locale
-            TimeStyle::Locale => Some(StrftimeItems::new("%b %e %H:%M")),
-            _ => None,
-        }
-        .map(|x| x.collect());
-        let recent_time_threshold = if recent.is_some() {
-            // According to GNU a Gregorian year has 365.2425 * 24 * 60 * 60 == 31556952 seconds on the average.
-            Some(Local::now() - TimeDelta::try_seconds(31_556_952 / 2).unwrap())
-        } else {
-            None
-        };
-
-        TimeStyler {
-            default,
-            recent,
-            recent_time_threshold,
-        }
-    }
-
-    /// Format a DateTime, using `recent` format if available, and the DateTime
-    /// is recent enough.
+impl TimeStyle {
+    /// Format the given time according to this time format style.
     fn format(&self, time: DateTime<Local>) -> String {
-        if self.recent.is_none() || time <= self.recent_time_threshold.unwrap() {
-            time.format_with_items(self.default.iter())
-        } else {
-            time.format_with_items(self.recent.as_ref().unwrap().iter())
+        let recent = is_recent(time);
+        match (self, recent) {
+            (Self::FullIso, _) => time.format("%Y-%m-%d %H:%M:%S.%f %z").to_string(),
+            (Self::LongIso, _) => time.format("%Y-%m-%d %H:%M").to_string(),
+            (Self::Iso, true) => time.format("%m-%d %H:%M").to_string(),
+            (Self::Iso, false) => time.format("%Y-%m-%d ").to_string(),
+            // spell-checker:ignore (word) datetime
+            //In this version of chrono translating can be done
+            //The function is chrono::datetime::DateTime::format_localized
+            //However it's currently still hard to get the current pure-rust-locale
+            //So it's not yet implemented
+            (Self::Locale, true) => time.format("%b %e %H:%M").to_string(),
+            (Self::Locale, false) => time.format("%b %e  %Y").to_string(),
+            (Self::Format(fmt), _) => time
+                .format(custom_tz_fmt::custom_time_format(fmt).as_str())
+                .to_string(),
         }
-        .to_string()
     }
 }
 
@@ -2093,8 +2060,6 @@ struct ListState<'a> {
     uid_cache: HashMap<u32, String>,
     #[cfg(unix)]
     gid_cache: HashMap<u32, String>,
-
-    time_styler: TimeStyler,
 }
 
 #[allow(clippy::cognitive_complexity)]
@@ -2111,7 +2076,6 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
         uid_cache: HashMap::new(),
         #[cfg(unix)]
         gid_cache: HashMap::new(),
-        time_styler: TimeStyler::new(&config.time_style),
     };
 
     for loc in locs {
@@ -2912,7 +2876,7 @@ fn display_item_long(
         };
 
         output_display.extend(b" ");
-        output_display.extend(display_date(md, config, state).as_bytes());
+        output_display.extend(display_date(md, config).as_bytes());
         output_display.extend(b" ");
 
         let item_name = display_item_name(
@@ -3116,9 +3080,9 @@ fn get_time(md: &Metadata, config: &Config) -> Option<DateTime<Local>> {
     Some(time.into())
 }
 
-fn display_date(metadata: &Metadata, config: &Config, state: &mut ListState) -> String {
+fn display_date(metadata: &Metadata, config: &Config) -> String {
     match get_time(metadata, config) {
-        Some(time) => state.time_styler.format(time),
+        Some(time) => config.time_style.format(time),
         None => "???".into(),
     }
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -289,21 +289,24 @@ impl TimeStyle {
     ) -> Result<(), jiff::Error> {
         let recent = is_recent(date.timestamp(), state);
         let tm = BrokenDownTime::from(&date);
-        let out = StdIoWrite(out);
+        let mut out = StdIoWrite(out);
+        let config = jiff::fmt::strtime::Config::new().lenient(true);
 
         match (self, recent) {
-            (Self::FullIso, _) => tm.format("%Y-%m-%d %H:%M:%S.%f %z", out),
-            (Self::LongIso, _) => tm.format("%Y-%m-%d %H:%M", out),
-            (Self::Iso, true) => tm.format("%m-%d %H:%M", out),
-            (Self::Iso, false) => tm.format("%Y-%m-%d ", out),
+            (Self::FullIso, _) => {
+                tm.format_with_config(&config, "%Y-%m-%d %H:%M:%S.%f %z", &mut out)
+            }
+            (Self::LongIso, _) => tm.format_with_config(&config, "%Y-%m-%d %H:%M", &mut out),
+            (Self::Iso, true) => tm.format_with_config(&config, "%m-%d %H:%M", &mut out),
+            (Self::Iso, false) => tm.format_with_config(&config, "%Y-%m-%d ", &mut out),
             // spell-checker:ignore (word) datetime
             //In this version of chrono translating can be done
             //The function is chrono::datetime::DateTime::format_localized
             //However it's currently still hard to get the current pure-rust-locale
             //So it's not yet implemented
-            (Self::Locale, true) => tm.format("%b %e %H:%M", out),
-            (Self::Locale, false) => tm.format("%b %e  %Y", out),
-            (Self::Format(fmt), _) => tm.format(&fmt, out),
+            (Self::Locale, true) => tm.format_with_config(&config, "%b %e %H:%M", &mut out),
+            (Self::Locale, false) => tm.format_with_config(&config, "%b %e  %Y", &mut out),
+            (Self::Format(fmt), _) => tm.format_with_config(&config, fmt, &mut out),
         }
     }
 }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -572,3 +572,113 @@ fn test_date_empty_tz() {
         .succeeds()
         .stdout_only("UTC\n");
 }
+
+#[test]
+fn test_date_tz_utc() {
+    new_ucmd!()
+        .env("TZ", "UTC0")
+        .arg("+%Z")
+        .succeeds()
+        .stdout_only("UTC\n");
+}
+
+#[test]
+fn test_date_tz_berlin() {
+    new_ucmd!()
+        .env("TZ", "Europe/Berlin")
+        .arg("+%Z")
+        .succeeds()
+        .stdout_matches(&Regex::new(r"^(CET|CEST)\n$").unwrap());
+}
+
+#[test]
+fn test_date_tz_vancouver() {
+    new_ucmd!()
+        .env("TZ", "America/Vancouver")
+        .arg("+%Z")
+        .succeeds()
+        .stdout_matches(&Regex::new(r"^(PDT|PST)\n$").unwrap());
+}
+
+#[test]
+fn test_date_tz_invalid() {
+    new_ucmd!()
+        .env("TZ", "Invalid/Timezone")
+        .arg("+%Z")
+        .succeeds()
+        .stdout_only("UTC\n");
+}
+
+#[test]
+fn test_date_tz_with_format() {
+    new_ucmd!()
+        .env("TZ", "Europe/Berlin")
+        .arg("+%Y-%m-%d %H:%M:%S %Z")
+        .succeeds()
+        .stdout_matches(
+            &Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (CET|CEST)\n$").unwrap(),
+        );
+}
+
+#[test]
+fn test_date_tz_with_utc_flag() {
+    new_ucmd!()
+        .env("TZ", "Europe/Berlin")
+        .arg("-u")
+        .arg("+%Z")
+        .succeeds()
+        .stdout_only("UTC\n");
+}
+
+#[test]
+fn test_date_tz_with_date_string() {
+    new_ucmd!()
+        .env("TZ", "Asia/Tokyo")
+        .arg("-d")
+        .arg("2024-01-01 12:00:00")
+        .arg("+%Y-%m-%d %H:%M:%S %Z")
+        .succeeds()
+        .stdout_only("2024-01-01 12:00:00 JST\n");
+}
+
+#[test]
+fn test_date_tz_with_relative_time() {
+    new_ucmd!()
+        .env("TZ", "America/Vancouver")
+        .arg("-d")
+        .arg("1 hour ago")
+        .arg("+%Y-%m-%d %H:%M:%S %Z")
+        .succeeds()
+        .stdout_matches(&Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} PDT\n$").unwrap());
+}
+
+#[test]
+fn test_date_utc_time() {
+    // Test that -u flag shows correct UTC time
+    new_ucmd!().arg("-u").arg("+%H:%M").succeeds();
+
+    // Test that -u flag shows UTC timezone
+    new_ucmd!()
+        .arg("-u")
+        .arg("+%Z")
+        .succeeds()
+        .stdout_only("UTC\n");
+
+    // Test that -u flag with specific timestamp shows correct UTC time
+    new_ucmd!()
+        .arg("-u")
+        .arg("-d")
+        .arg("@0")
+        .succeeds()
+        .stdout_only("Thu Jan  1 00:00:00 UTC 1970\n");
+}
+
+#[test]
+fn test_date_empty_tz_time() {
+    new_ucmd!()
+        .env("TZ", "")
+        .arg("-d")
+        .arg("@0")
+        .succeeds()
+        .stdout_only("Thu Jan  1 00:00:00 UTC 1970\n");
+}


### PR DESCRIPTION
`jiff` handling of timezones makes our life so much easier. Also, jiff provides
a convenient feature to only embed the timezone database when necessary (e.g. Windows).

 - Fixes #7497, #7498, #7659.
 - Helps with #7504, but still adds an extra ~300k compared to a chrono-only solution
   (that did not fix all issues, FWIW):
```
-rwxr-xr-x 2 drinkcat drinkcat 4828144 Apr 27 13:57 target/release/date ## HEAD
-rwxr-xr-x 2 drinkcat drinkcat 3279432 Apr 28 15:42 target/release/date ## jiff
-rwxr-xr-x 2 drinkcat drinkcat 2949080 Apr 27 13:58 target/release/date ## with #7849
```

Part of the tests taken from #7597 (@jadijadi FYI), then refactored on top of those to add more test cases.

@BurntSushi thanks for your support!

--

### Cross.toml: Install tzdata in container

Linux tests require that now, as we now assume /usr/share/zoneinfo
is present.

### test_date: Extend coverage to a lot more timezones

Also test %z/%Z formats.

### date: Add more TZ tests

[drinkcat: separated test changes]

### ls: switch to lenient formating configuration

### ls: Avoid additional String creation/copy in display_date

From code provided in #7852 by @BurntSushi.

Depending on the benchmarks, there is _still_ a small performance
difference (~4%) vs main, but it's seen mostly on small trees
getting printed repeatedly, which is probably not a terribly
interesting use case.

### ls: cache recent time threshold in jiff implementation

### ls: convert to jiff

### Revert "ls: Optimize time formatting"

This reverts commit fc6b896c271eed5654418acc267eb21377c55690.

This also reverts the change from new to new_lenient, we'll
recover that later as part of the jiff conversion.

### date: switch from chrono to jiff

Also adds cargo dependency.