### PR TITLE
uptime: fix typo (Gnu -> GNU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ There are currently two methods to build the uutils binaries: either Cargo or
 GNU Make.
 
 > Building the full package, including all documentation, requires both Cargo
-> and Gnu Make on a Unix platform.
+> and GNU Make on a Unix platform.
 
 For either method, we first need to fetch the repository:
 


### PR DESCRIPTION
This PR fixes a small typo reported on issue #7895 