### PR TITLE
ptx: use char count instead of byte index to handle utf-8 characters

### DIFF
--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -174,3 +174,17 @@ fn test_failed_write_is_reported() {
         .fails()
         .stderr_is("ptx: write failed: No space left on device\n");
 }
+
+#[test]
+fn test_utf8() {
+    new_ucmd!()
+        .args(&["-G"])
+        .pipe_in("it’s disabled\n")
+        .succeeds()
+        .stdout_only(".xx \"\" \"it’s\" \"disabled\" \"\"\n.xx \"\" \"\" \"it’s disabled\" \"\"\n");
+    new_ucmd!()
+        .args(&["-G", "-T"])
+        .pipe_in("it’s disabled\n")
+        .succeeds()
+        .stdout_only("\\xx {}{it’s}{disabled}{}{}\n\\xx {}{}{it’s}{ disabled}{}\n");
+}


### PR DESCRIPTION
close #2049

As discussed in the issue, `ptx` breaks when handling utf-8 characters (which may span multiple bytes). We need to use character positions instead of byte positions to index into `chars_line`. We can do so using `.chars().count()`. I created a helper function to consolidate this change since `format_roff_line` and `format_tex_line` use the same logic. I've also added some comments and renamed variables for readability.