### PR TITLE
id: remove unnecessary `to_string` calls

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -174,13 +174,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    let delimiter = {
-        if state.zflag {
-            "\0".to_string()
-        } else {
-            " ".to_string()
-        }
-    };
+    let delimiter = if state.zflag { "\0" } else { " " };
     let line_ending = LineEnding::from_zero_flag(state.zflag);
 
     if state.cflag {
@@ -307,7 +301,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         }
                     })
                     .collect::<Vec<_>>()
-                    .join(&delimiter),
+                    .join(delimiter),
                 // NOTE: this is necessary to pass GNU's "tests/id/zero.sh":
                 if state.zflag && state.user_specified && users.len() > 1 {
                     "\0"


### PR DESCRIPTION
This PR removes two unnecessary `to_string` calls (plus a block).