### PR TITLE
hashsum: don't exit early on io errors

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -522,7 +522,7 @@ where
     I: Iterator<Item = &'a OsStr>,
 {
     let binary_marker = if options.binary { "*" } else { " " };
-    let mut err = None;
+    let mut err_found = None;
     for filename in files {
         let filename = Path::new(filename);
 
@@ -537,7 +537,7 @@ where
                         options.binary_name,
                         filename.to_string_lossy()
                     );
-                    err = Some(ChecksumError::Io(e));
+                    err_found = Some(ChecksumError::Io(e));
                     continue;
                 }
             };
@@ -578,7 +578,7 @@ where
             println!("{prefix}{sum} {binary_marker}{escaped_filename}");
         }
     }
-    match err {
+    match err_found {
         None => Ok(()),
         Some(e) => Err(Box::new(e)),
     }

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -33,10 +33,11 @@ const NAME: &str = "hashsum";
 const ABOUT: &str = help_about!("hashsum.md");
 const USAGE: &str = help_usage!("hashsum.md");
 
-struct Options {
+struct Options<'a> {
     algoname: &'static str,
     digest: Box<dyn Digest + 'static>,
     binary: bool,
+    binary_name: &'a str,
     //check: bool,
     tag: bool,
     nonames: bool,
@@ -274,6 +275,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
         digest: (algo.create_fn)(),
         output_bits: algo.bits,
         binary,
+        binary_name: &binary_name,
         tag: matches.get_flag("tag"),
         nonames,
         //status,
@@ -520,17 +522,25 @@ where
     I: Iterator<Item = &'a OsStr>,
 {
     let binary_marker = if options.binary { "*" } else { " " };
+    let mut err = None;
     for filename in files {
         let filename = Path::new(filename);
 
-        let stdin_buf;
-        let file_buf;
         let mut file = BufReader::new(if filename == OsStr::new("-") {
-            stdin_buf = stdin();
-            Box::new(stdin_buf) as Box<dyn Read>
+            Box::new(stdin()) as Box<dyn Read>
         } else {
-            file_buf =
-                File::open(filename).map_err_context(|| "failed to open file".to_string())?;
+            let file_buf = match File::open(filename) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!(
+                        "{}: {}: {e}",
+                        options.binary_name,
+                        filename.to_string_lossy()
+                    );
+                    err = Some(ChecksumError::Io(e));
+                    continue;
+                }
+            };
             Box::new(file_buf) as Box<dyn Read>
         });
 
@@ -568,5 +578,8 @@ where
             println!("{prefix}{sum} {binary_marker}{escaped_filename}");
         }
     }
-    Ok(())
+    match err {
+        None => Ok(()),
+        Some(e) => Err(Box::new(e)),
+    }
 }

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -233,6 +233,8 @@ pub enum ChecksumError {
     CombineMultipleAlgorithms,
     #[error("Needs an algorithm to hash with.\nUse --help for more information.")]
     NeedAlgorithmToHash,
+    #[error("")]
+    Io(#[from] io::Error),
 }
 
 impl UError for ChecksumError {

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -107,12 +107,17 @@ macro_rules! test_digest {
             at.write("a", "file1\n");
             at.write("c", "file3\n");
 
+            #[cfg(unix)]
+            let file_not_found_str = "No such file or directory";
+            #[cfg(not(unix))]
+            let file_not_found_str = "The system cannot find the file specified";
+
             ts.ucmd()
                 .args(&[DIGEST_ARG, BITS_ARG, "a", "b", "c"])
                 .fails()
                 .stdout_contains("a\n")
                 .stdout_contains("c\n")
-                .stderr_contains("b: No such file or directory");
+                .stderr_contains(format!("b: {file_not_found_str}"));
         }
     }
     )*)

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -98,6 +98,22 @@ macro_rules! test_digest {
                 .no_stderr()
                 .stdout_is(std::str::from_utf8(&expected).unwrap());
         }
+
+        #[test]
+        fn test_missing_file() {
+            let ts = TestScenario::new("hashsum");
+            let at = &ts.fixtures;
+
+            at.write("a", "file1\n");
+            at.write("c", "file3\n");
+
+            ts.ucmd()
+                .args(&[DIGEST_ARG, BITS_ARG, "a", "b", "c"])
+                .fails()
+                .stdout_contains("a\n")
+                .stdout_contains("c\n")
+                .stderr_contains("b: No such file or directory");
+        }
     }
     )*)
 }


### PR DESCRIPTION
closes #7906

exact GNU behavior is as follows (the issue wasn't very clear):
if an IO error is encountered (I tested with file not found and permission denied), the binary name, file name, and error are printed to stderr and the program continues. If any errors are found, the program exits with status code 1.
