### PR TITLE
coreutils: Print usage to stderr.

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -20,18 +20,18 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 
 fn usage<T>(utils: &UtilityMap<T>, name: &str) {
-    println!("{name} {VERSION} (multi-call binary)\n");
-    println!("Usage: {name} [function [arguments...]]");
-    println!("       {name} --list\n");
-    println!("Options:");
-    println!("      --list    lists all defined functions, one per row\n");
-    println!("Currently defined functions:\n");
+    eprintln!("{name} {VERSION} (multi-call binary)\n");
+    eprintln!("Usage: {name} [function [arguments...]]");
+    eprintln!("       {name} --list\n");
+    eprintln!("Options:");
+    eprintln!("      --list    lists all defined functions, one per row\n");
+    eprintln!("Currently defined functions:\n");
     #[allow(clippy::map_clone)]
     let mut utils: Vec<&str> = utils.keys().map(|&s| s).collect();
     utils.sort_unstable();
     let display_list = utils.join(", ");
     let width = cmp::min(textwrap::termwidth(), 100) - 4 * 2; // (opinion/heuristic) max 100 chars wide with 4 character side indentions
-    println!(
+    eprintln!(
         "{}",
         textwrap::indent(&textwrap::fill(&display_list, width), "    ")
     );

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -120,8 +120,8 @@ fn util_invalid_name_help() {
         .unwrap();
     let output = child.wait_with_output().unwrap();
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(output.stderr, b"");
-    let output_str = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(output.stdout, b"");
+    let output_str = String::from_utf8(output.stderr).unwrap();
     assert!(output_str.contains("(multi-call binary)"), "{output_str:?}");
     assert!(
         output_str.contains("Usage: invalid_name [function "),
@@ -159,8 +159,8 @@ fn util_non_utf8_name_help() {
         .unwrap();
     let output = child.wait_with_output().unwrap();
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(output.stderr, b"");
-    let output_str = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(output.stdout, b"");
+    let output_str = String::from_utf8(output.stderr).unwrap();
     assert!(output_str.contains("(multi-call binary)"), "{output_str:?}");
     assert!(
         output_str.contains("Usage: <unknown binary name> [function "),


### PR DESCRIPTION
Scripts exist that may call one of the multi-binary entry points with argument 0 set to some other value than the name of the entry point.

One example is the Open vSwitch testsuite which makes use of /bin/true as an argument to the bash builtin `exec` to check whether it supports the '-a' argument [0].

In this situation coreutils will print usage on standard output, which makes unnecessary noise.

Printing usage on standard error, which is customary for other tools, allows the script to succeed.

0: https://github.com/openvswitch/ovs/blob/28064e9fa50d/tests/ovs-macros.at#L199