### PR TITLE
split: use delegation to avoid code duplication in test

### DIFF
--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -17,9 +17,7 @@ use std::{
 };
 use uutests::util::{AtPath, TestScenario};
 
-use uutests::at_and_ucmd;
-use uutests::new_ucmd;
-use uutests::util_name;
+use uutests::{at_and_ucmd, new_ucmd, util_name};
 
 fn random_chars(n: usize) -> String {
     rng()

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -112,11 +112,7 @@ impl RandomFile {
 
     /// Add n lines each of size `RandomFile::LINESIZE`
     fn add_lines(&mut self, lines: usize) {
-        let mut n = lines;
-        while n > 0 {
-            writeln!(self.inner, "{}", random_chars(Self::LINESIZE)).unwrap();
-            n -= 1;
-        }
+        self.add_lines_with_line_size(lines, Self::LINESIZE);
     }
 
     /// Add n lines each of the given size.


### PR DESCRIPTION
Currently,  `add_lines` and `add_lines_with_line_size` in the test are almost identical. This PR uses delegation to remove the duplicate code. It also merges some imports.