### PR TITLE
Use `Duration` based uptime across uucore

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -92,7 +92,8 @@ also provides a `-v`/`--verbose` flag.
 
 ## `uptime`
 
-Similar to the proc-ps implementation and unlike GNU/Coreutils, `uptime` provides `-s`/`--since` to show since when the system is up.
+Similar to the proc-ps implementation and unlike GNU/Coreutils, `uptime` provides `-s`/`--since` to show since when the system is up
+and `-p`/`--pretty` to display uptime in a pretty-printed format.
 
 ## `base32/base64/basenc`
 

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -38,6 +38,7 @@ const USAGE: &str = help_usage!("uptime.md");
 pub mod options {
     pub static SINCE: &str = "since";
     pub static PATH: &str = "path";
+    pub static PRETTY: &str = "pretty";
 }
 
 #[derive(Debug, Error)]
@@ -68,6 +69,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if matches.get_flag(options::SINCE) {
         uptime_since()
+    } else if matches.get_flag(options::PRETTY) {
+        pretty_print_uptime(None)
     } else if let Some(path) = file_path {
         uptime_with_file(path)
     } else {
@@ -86,6 +89,13 @@ pub fn uu_app() -> Command {
                 .short('s')
                 .long(options::SINCE)
                 .help("system up since")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::PRETTY)
+                .short('p')
+                .long(options::PRETTY)
+                .help("show uptime in pretty format")
                 .action(ArgAction::SetTrue),
         );
     #[cfg(unix)]
@@ -276,6 +286,17 @@ fn print_time() {
 }
 
 fn print_uptime(boot_time: Option<time_t>) -> UResult<()> {
-    print!("up  {},  ", get_formatted_uptime(boot_time)?);
+    print!(
+        "up  {},  ",
+        get_formatted_uptime(boot_time, OutputFormat::HumanReadable)?
+    );
+    Ok(())
+}
+
+fn pretty_print_uptime(boot_time: Option<time_t>) -> UResult<()> {
+    print!(
+        "up {}",
+        get_formatted_uptime(boot_time, OutputFormat::PrettyPrint)?
+    );
     Ok(())
 }

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -184,9 +184,9 @@ fn uptime_with_file(file_path: &OsString) -> UResult<()> {
 
     #[cfg(target_os = "openbsd")]
     {
-        let upsecs = get_uptime(None);
-        if upsecs >= 0 {
-            print_uptime(Some(upsecs))?;
+        let uptime = get_uptime(None);
+        if uptime.is_ok() >= 0 {
+            print_uptime(uptime.unwrap())?;
         } else {
             show_error!("couldn't get boot time");
             set_exit_code(1);
@@ -215,8 +215,9 @@ fn uptime_since() -> UResult<()> {
     #[cfg(target_os = "windows")]
     let uptime = get_uptime(None)?;
 
+    // It is safe to cast Unix timestamps from u64->i64 at least for several trillion centuries.
     let initial_date = Local
-        .timestamp_opt(Utc::now().timestamp() - uptime, 0)
+        .timestamp_opt(Utc::now().timestamp() - uptime.as_secs() as i64, 0)
         .unwrap();
     println!("{}", initial_date.format("%Y-%m-%d %H:%M:%S"));
 

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -155,8 +155,12 @@ pub fn get_uptime(_boot_time: Option<time_t>) -> UResult<i64> {
     Ok(uptime as i64 / 1000)
 }
 
+/// The format used to display a FormattedUptime.
 pub enum OutputFormat {
+    /// Typical `uptime` output (e.g. 2 days, 3:04).
     HumanReadable,
+
+    /// Pretty printed output (e.g. 2 days, 3 hours, 04 minutes).
     PrettyPrint,
 }
 

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -282,3 +282,12 @@ fn test_uptime_since() {
 
     new_ucmd!().arg("--since").succeeds().stdout_matches(&re);
 }
+
+#[test]
+fn test_uptime_pretty_print() {
+    new_ucmd!()
+        .arg("-p")
+        .succeeds()
+        .stdout_contains("up")
+        .stdout_contains("min");
+}


### PR DESCRIPTION
Closes #7851

Changes the `i64` based uptime returned by uucore's `get_uptime` into an `std::time::Duration` and updates callsites.

- [x] `get_uptime` modified to accept fractional seconds from `/proc/uptime` and return `Duration`
- [x] Callsites in `uucore/.../features/uptime.rs` and `uu/.../uptime.rs` use Duration