### PR TITLE
wc: Speed optimization

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -32,7 +32,7 @@ use libc::S_IFIFO;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use uucore::pipes::{pipe, splice, splice_exact};
 
-const BUF_SIZE: usize = 16 * 1024;
+const BUF_SIZE: usize = 256 * 1024;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const SPLICE_SIZE: usize = 128 * 1024;
 


### PR DESCRIPTION
Fixes  #7929.

### wc: Align buffer to 32-byte boundary

bytecount uses vector operations to speed up line counting.
At least on x86 with AVX2 support, the vectors are 256-byte wide,
and operations are much faster if the data is aligned.

Saves about 4% of total performance, matching wc's performance.

### wc: Increase buffer size to 256kb

Improves performance by about 4% on large files.

---

This gets us close or better than GNU's version:
```
seq 10000000000000 1 inf | head -n 100000000 > seq100M
cargo build -r -p uu_wc && taskset -c 0 hyperfine --warmup 10 -L wc ./wc.main,target/release/wc,wc "{wc} -l tmp/seq100M"
   Compiling uu_wc v0.0.30 (/home/drinkcat/dev/coreutils/coreutils/src/uu/wc)
    Finished `release` profile [optimized] target(s) in 11.51s
Benchmark 1: ./wc.main -l tmp/seq100M
  Time (mean ± σ):     265.1 ms ±   5.4 ms    [User: 49.7 ms, System: 212.3 ms]
  Range (min … max):   259.8 ms … 279.8 ms    11 runs
 
Benchmark 2: target/release/wc -l tmp/seq100M
  Time (mean ± σ):     239.0 ms ±   4.1 ms    [User: 38.2 ms, System: 198.1 ms]
  Range (min … max):   233.2 ms … 249.2 ms    12 runs
 
Benchmark 3: wc -l tmp/seq100M
  Time (mean ± σ):     243.4 ms ±   6.2 ms    [User: 43.9 ms, System: 196.5 ms]
  Range (min … max):   237.5 ms … 258.1 ms    11 runs
 
Summary
  target/release/wc -l tmp/seq100M ran
    1.02 ± 0.03 times faster than wc -l tmp/seq100M
    1.11 ± 0.03 times faster than ./wc.main -l tmp/seq100M
```

And on 1brc dataset from original report:
```
cargo build -r -p uu_wc && taskset -c 0 hyperfine --warmup 3 -L wc ./wc.main,target/release/wc,wc "{wc} -l ../../1brc/data/measurements.txt"
    Finished `release` profile [optimized] target(s) in 0.10s
Benchmark 1: ./wc.main -l ../../1brc/data/measurements.txt
  Time (mean ± σ):      2.633 s ±  0.016 s    [User: 0.533 s, System: 2.075 s]
  Range (min … max):    2.615 s …  2.668 s    10 runs
 
Benchmark 2: target/release/wc -l ../../1brc/data/measurements.txt
  Time (mean ± σ):      2.375 s ±  0.017 s    [User: 0.404 s, System: 1.948 s]
  Range (min … max):    2.355 s …  2.406 s    10 runs
 
Benchmark 3: wc -l ../../1brc/data/measurements.txt
  Time (mean ± σ):      2.408 s ±  0.017 s    [User: 0.457 s, System: 1.928 s]
  Range (min … max):    2.383 s …  2.440 s    10 runs
 
Summary
  target/release/wc -l ../../1brc/data/measurements.txt ran
    1.01 ± 0.01 times faster than wc -l ../../1brc/data/measurements.txt
    1.11 ± 0.01 times faster than ./wc.main -l ../../1brc/data/measurements.txt
```