### PR TITLE
Bump `markdownlint` action & fix warnings

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -531,7 +531,7 @@ jobs:
           # TODO: Re-enable after rust-onig release: https://github.com/rust-onig/rust-onig/issues/193
           # - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
-          - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }      
+          - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -149,7 +149,7 @@ jobs:
       shell: bash
       run: |
         RUSTDOCFLAGS="-Dwarnings" cargo doc  ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-deps --workspace --document-private-items
-    - uses: DavidAnson/markdownlint-cli2-action@v19
+    - uses: DavidAnson/markdownlint-cli2-action@v20
       with:
         fix: "true"
         globs: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,7 @@ CI. However, you can use `#[cfg(...)]` attributes to create platform dependent
 features.
 
 **Tip:** For Windows, Microsoft provides some images (VMWare, Hyper-V,
-VirtualBox and Parallels) for development [here](https://developer.microsoft.com/windows/downloads/virtual-machines/).
+VirtualBox and Parallels) for development [on their official download page](https://developer.microsoft.com/windows/downloads/virtual-machines/).
 
 ## Improving the GNU compatibility
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -331,12 +331,12 @@ If you have used [Git for Windows](https://gitforwindows.org) to install `git` o
 
 Alternatively you can install [Cygwin](https://www.cygwin.com) and/or use [WSL2](https://learn.microsoft.com/en-us/windows/wsl/compare-versions#whats-new-in-wsl-2) to get access to all GNU core utilities on Windows.
 
-# Preparing a new release
+## Preparing a new release
 
 1. Modify `util/update-version.sh` (FROM & TO) and run it
 1. Submit a new PR with these changes and wait for it to be merged
 1. Tag the new release `git tag -a X.Y.Z` and `git push --tags`
-1. Once the CI is green, a new release will be automatically created in draft mode. 
+1. Once the CI is green, a new release will be automatically created in draft mode.
    Reuse this release and make sure that assets have been added.
 1. Write the release notes (it takes time) following previous examples
 1. Run `util/publish.sh --do-it` to publish the new release to crates.io

--- a/src/uu/tail/README.md
+++ b/src/uu/tail/README.md
@@ -36,7 +36,7 @@ flag name: `--use-polling`.
 * Improve resource management by adding more system calls to `inotify_rm_watch`
   when appropriate.
 
-# GNU test-suite results (9.1.8-e08752)
+## GNU test-suite results (9.1.8-e08752)
 
 The functionality for the test "gnu/tests/tail-2/follow-stdin.sh" is implemented.
 It fails because it is provoking closing a file descriptor with `tail -f <&-`


### PR DESCRIPTION
This PR bumps the `markdownlint` action in the CI from `v19` to `v20` and fixes its warnings.