### PR TITLE
clippy: fix clippy::unnecessary_debug_formatting and clippy::io_other_error, adjusting cp tests to align with GNU

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1259,13 +1259,17 @@ fn parse_path_args(
         return Err("missing file operand".into());
     } else if paths.len() == 1 && options.target_dir.is_none() {
         // Only one file specified
-        return Err(format!("missing destination file operand after {:?}", paths[0]).into());
+        return Err(format!(
+            "missing destination file operand after {}",
+            paths[0].display().to_string().quote()
+        )
+        .into());
     }
 
     // Return an error if the user requested to copy more than one
     // file source to a file target
     if options.no_target_dir && options.target_dir.is_none() && paths.len() > 2 {
-        return Err(format!("extra operand {:?}", paths[2]).into());
+        return Err(format!("extra operand {}", paths[2].display().to_string().quote()).into());
     }
 
     let target = match options.target_dir {

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -84,7 +84,12 @@ pub(crate) fn copy_on_write(
         // support COW).
         match reflink_mode {
             ReflinkMode::Always => {
-                return Err(format!("failed to clone {source:?} from {dest:?}: {error}").into());
+                return Err(format!(
+                    "failed to clone {} from {}: {error}",
+                    source.display(),
+                    dest.display()
+                )
+                .into());
             }
             _ => {
                 copy_debug.reflink = OffloadReflinkDebug::Yes;

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -60,7 +60,7 @@ enum LnError {
     MissingDestination(PathBuf),
 
     #[error("extra operand {}\nTry '{} --help' for more information.",
-    format!("{_0:?}").trim_matches('"'), _1)]
+    _0.display(), _1)]
     ExtraOperand(OsString, String),
 }
 

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -826,7 +826,7 @@ fn rename_dir_fallback(
                 io::ErrorKind::PermissionDenied,
                 "Permission denied",
             )),
-            _ => Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
+            _ => Err(io::Error::other(format!("{err:?}"))),
         },
         _ => Ok(()),
     }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1,3 +1,4 @@
+use uucore::display::Quotable;
 // This file is part of the uutils coreutils package.
 //
 // For the full copyright and license information, please view the LICENSE
@@ -3946,10 +3947,10 @@ fn test_cp_only_source_no_target() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
     at.touch("a");
-    ts.ucmd()
-        .arg("a")
-        .fails()
-        .stderr_contains("missing destination file operand after \"a\"");
+    ts.ucmd().arg("a").fails().stderr_contains(format!(
+        "missing destination file operand after {}",
+        "a".quote()
+    ));
 }
 
 #[test]


### PR DESCRIPTION
On my machine `cp a` returns the error message `cp: missing destination file operand after 'a'`. Prior to this PR, uutils double quoted the `a`. This PR uses `Path::display` instead of `Debug` output and quotes the file path with `os_display`. I also fixed an `io::Error`-related clippy warning in `ln`.
