### PR TITLE
sync: move call to unsafe fn to unsafe block

### DIFF
--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -40,10 +40,10 @@ mod platform {
     /// # Safety
     /// This function is unsafe because it calls `libc::sync` or `libc::syscall` which are unsafe.
     pub unsafe fn do_sync() -> UResult<()> {
-        // see https://github.com/rust-lang/libc/pull/2161
-        #[cfg(target_os = "android")]
-        libc::syscall(libc::SYS_sync);
         unsafe {
+            // see https://github.com/rust-lang/libc/pull/2161
+            #[cfg(target_os = "android")]
+            libc::syscall(libc::SYS_sync);
             #[cfg(not(target_os = "android"))]
             libc::sync();
         }


### PR DESCRIPTION
I noticed the following warning in the Android jobs of the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/15039807606/job/42268624578#step:16:836):
```
[2025-05-15 08:08:33] warning[E0133]: call to unsafe function `libc::syscall` is unsafe and requires unsafe block
[2025-05-15 08:08:33]   --> src/uu/sync/src/sync.rs:45:9
[2025-05-15 08:08:33]    |
[2025-05-15 08:08:33] 45 |         libc::syscall(libc::SYS_sync);
[2025-05-15 08:08:33]    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
```
This PR fixes this warning by moving the function call inside the already existing `unsafe` block used for the non-Android code.
