### PR TITLE
du: fix "function never used" warning in test

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -275,7 +275,9 @@ fn du_hard_link(s: &str) {
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "windows"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd"),
+    not(target_os = "android")
 ))]
 fn du_hard_link(s: &str) {
     // MS-WSL linux has altered expected output


### PR DESCRIPTION
This PR fixes a "function `du_hard_link` is never used" warning that appears in the Android jobs of the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/15069663302/job/42362538785?pr=7942#step:16:1600). It also fixes the same warning on OpenBSD.