### PR TITLE
.cargo/config.toml: set `CFLAGS='-std=gnu17'`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,9 @@
+# spell-checker:ignore CFLAGS
+
 [target.x86_64-unknown-redox]
 linker = "x86_64-unknown-redox-gcc"
 
 [env]
 PROJECT_NAME_FOR_VERSION_STRING = "uutils coreutils"
+# TODO remove when there is an onig version > 6.4.0, https://github.com/rust-onig/rust-onig/issues/196
+CFLAGS='-std=gnu17'


### PR DESCRIPTION
This PR sets `CFLAGS='-std=gnu17'` in order to make `onig` compile with GCC 15, which by default uses a newer C standard (C23).

It temporarily fixes https://github.com/uutils/coreutils/issues/7904 until there is a new `onig` release. An alternative approach would be to change the dependency line for `onig` in `Cargo.toml` as suggested in https://github.com/uutils/coreutils/issues/7904#issuecomment-2873337715