### PR TITLE
Run cargo fmt on missed files

### DIFF
--- a/fuzz/fuzz_targets/fuzz_test.rs
+++ b/fuzz/fuzz_targets/fuzz_test.rs
@@ -146,10 +146,7 @@ fn generate_test_arg() -> String {
                 let random_str = generate_random_string(rng.random_range(1..=10));
                 let random_str2 = generate_random_string(rng.random_range(1..=10));
 
-                arg.push_str(&format!(
-                    "{random_str} {} {random_str2}",
-                    test_arg.arg,
-                ));
+                arg.push_str(&format!("{random_str} {} {random_str2}", test_arg.arg,));
             } else if test_arg.arg_type == ArgType::STRING {
                 let random_str = generate_random_string(rng.random_range(1..=10));
                 arg.push_str(&format!("{} {random_str}", test_arg.arg));

--- a/tests/benches/factor/benches/table.rs
+++ b/tests/benches/factor/benches/table.rs
@@ -6,7 +6,7 @@
 // spell-checker:ignore funcs
 
 use array_init::array_init;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 fn table(c: &mut Criterion) {
     #[cfg(target_os = "linux")]
@@ -54,7 +54,9 @@ fn check_personality() {
     let personality = u64::from_str_radix(&p_string, 16)
         .unwrap_or_else(|_| panic!("Expected a hex value for personality, got '{p_string:?}'"));
     if personality & ADDR_NO_RANDOMIZE == 0 {
-        eprintln!("WARNING: Benchmarking with ASLR enabled (personality is {personality:x}), results might not be reproducible.");
+        eprintln!(
+            "WARNING: Benchmarking with ASLR enabled (personality is {personality:x}), results might not be reproducible."
+        );
     }
 }
 


### PR DESCRIPTION
It seems these files were missed by CI. Command to run cargo fmt on absolutely *everything* (and possibly too much)

```console
$ find tests -name "*.rs" -print0 | xargs -0 cargo fmt --
```