### PR TITLE
clippy: set MSRV and fix warnings

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,4 @@
+msrv = "1.85.0"
 avoid-breaking-exported-api = false
 check-private-items = true
 cognitive-complexity-threshold = 24

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1259,13 +1259,17 @@ fn parse_path_args(
         return Err("missing file operand".into());
     } else if paths.len() == 1 && options.target_dir.is_none() {
         // Only one file specified
-        return Err(format!("missing destination file operand after {:?}", paths[0]).into());
+        return Err(format!(
+            "missing destination file operand after {}",
+            paths[0].display().to_string().quote()
+        )
+        .into());
     }
 
     // Return an error if the user requested to copy more than one
     // file source to a file target
     if options.no_target_dir && options.target_dir.is_none() && paths.len() > 2 {
-        return Err(format!("extra operand {:?}", paths[2]).into());
+        return Err(format!("extra operand {:}", paths[2].display().to_string().quote()).into());
     }
 
     let target = match options.target_dir {

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -84,7 +84,12 @@ pub(crate) fn copy_on_write(
         // support COW).
         match reflink_mode {
             ReflinkMode::Always => {
-                return Err(format!("failed to clone {source:?} from {dest:?}: {error}").into());
+                return Err(format!(
+                    "failed to clone {} from {}: {error}",
+                    source.display(),
+                    dest.display()
+                )
+                .into());
             }
             _ => {
                 copy_debug.reflink = OffloadReflinkDebug::Yes;

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -900,7 +900,7 @@ mod tests {
             if let Some(rows) = self.options.lines {
                 self.rows = rows;
             }
-            let pager = Pager::new(
+            Pager::new(
                 InputType::File(BufReader::new(tmpfile)),
                 self.rows,
                 None,
@@ -908,8 +908,7 @@ mod tests {
                 &self.options,
                 out,
             )
-            .unwrap();
-            pager
+            .unwrap()
         }
 
         fn silent(mut self) -> Self {

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -826,7 +826,7 @@ fn rename_dir_fallback(
                 io::ErrorKind::PermissionDenied,
                 "Permission denied",
             )),
-            _ => Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
+            _ => Err(io::Error::other(format!("{err:?}"))),
         },
         _ => Ok(()),
     }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2,13 +2,12 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
 // spell-checker:ignore (flags) reflink (fs) tmpfs (linux) rlimit Rlim NOFILE clob btrfs neve ROOTDIR USERDIR procfs outfile uufs xattrs
 // spell-checker:ignore bdfl hlsl IRWXO IRWXG nconfined matchpathcon libselinux-devel
-use uutests::at_and_ucmd;
-use uutests::new_ucmd;
-use uutests::path_concat;
+use uucore::display::Quotable;
 use uutests::util::TestScenario;
-use uutests::util_name;
+use uutests::{at_and_ucmd, new_ucmd, path_concat, util_name};
 
 #[cfg(not(windows))]
 use std::fs::set_permissions;
@@ -3946,10 +3945,10 @@ fn test_cp_only_source_no_target() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
     at.touch("a");
-    ts.ucmd()
-        .arg("a")
-        .fails()
-        .stderr_contains("missing destination file operand after \"a\"");
+    ts.ucmd().arg("a").fails().stderr_contains(format!(
+        "missing destination file operand after {}",
+        "a".quote()
+    ));
 }
 
 #[test]


### PR DESCRIPTION
This PR sets a MSRV of `1.85.0` for clippy and fixes warnings from the [io_other_error](https://rust-lang.github.io/rust-clippy/stable/index.html#io_other_error), [unnecessary_debug_formatting](https://rust-lang.github.io/rust-clippy/stable/index.html#unnecessary_debug_formatting), and [let_and_return](https://rust-lang.github.io/rust-clippy/stable/index.html#let_and_return) lints in order to get the CI back to green.

I attributed @Qelxiros as a co-author of the `mv` and `cp` fixes due to his work in #7941.

Fixes #7945 