### PR TITLE
ci: install `libselinux1-dev` for coverage job

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1079,6 +1079,7 @@ jobs:
 
         case '${{ matrix.job.os }}' in
           ubuntu-latest)
+            sudo apt-get -y update ; sudo apt-get -y install libselinux1-dev
             # pinky is a tool to show logged-in users from utmp, and gecos fields from /etc/passwd.
             # In GitHub Action *nix VMs, no accounts log in, even the "runner" account that runs the commands. The account also has empty gecos fields.
             # To work around this for pinky tests, we create a fake login entry for the GH runner account...


### PR DESCRIPTION
I noticed the following error in the `Code Coverage` job (see, for example, https://github.com/uutils/coreutils/actions/runs/15113187214/job/42477260722#step:9:5458):
```
thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/selinux-sys-0.6.14/build.rs:258:10:
  selinux-sys: Failed to find 'selinux/selinux.h'. Please make sure the C header files of libselinux are installed and accessible: Kind(NotFound)
```
This PR (hopefully) fixes this issue by installing `libselinux1-dev`.