### PR TITLE
ci: fix `unexpected input 'file'` warning in coverage job

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1119,7 +1119,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ${{ steps.run_test_cov.outputs.report }}
+        files: ${{ steps.run_test_cov.outputs.report }}
         ## flags: IntegrationTests, UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
         flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
         name: codecov-umbrella


### PR DESCRIPTION
This PR fixes an `Unexpected input(s) 'file'` warning (see, for example, https://github.com/uutils/coreutils/actions/runs/15113187214/job/42477260722#step:10:1) from the `codecov-action` by changing the deprecated key `file` to `files`.