### PR TITLE
Revert #7944

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,5 @@
-# spell-checker:ignore CFLAGS
-
 [target.x86_64-unknown-redox]
 linker = "x86_64-unknown-redox-gcc"
 
 [env]
 PROJECT_NAME_FOR_VERSION_STRING = "uutils coreutils"
-# TODO remove when there is an onig version > 6.4.0, https://github.com/rust-onig/rust-onig/issues/196
-CFLAGS='-std=gnu17'


### PR DESCRIPTION
This PR reverts #7944 because some CI jobs fail with "unrecognized command line option '-std=gnu17'", see https://github.com/uutils/coreutils/pull/7944#issuecomment-2893987688