### PR TITLE
tsort: remove duplicate sorting step

### DIFF
--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -161,9 +161,7 @@ impl<'input> Graph<'input> {
                 }
             })
             .collect();
-        independent_nodes_queue.make_contiguous().sort_unstable(); // to make sure the resulting ordering is deterministic we need to order independent nodes
-        // FIXME: this doesn't comply entirely with the GNU coreutils implementation.
-
+        
         // To make sure the resulting ordering is deterministic we
         // need to order independent nodes.
         //

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -161,7 +161,7 @@ impl<'input> Graph<'input> {
                 }
             })
             .collect();
-        
+
         // To make sure the resulting ordering is deterministic we
         // need to order independent nodes.
         //


### PR DESCRIPTION
During my previous refactor PR, a duplcate sorting step was added. 

THis PR fixes the issue. 