### PR TITLE
expr: Handle more special cases for regex pattern

### DIFF
--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -50,6 +50,8 @@ pub enum ExprError {
     UnmatchedClosingBrace,
     #[error("Invalid content of \\{{\\}}")]
     InvalidBracketContent,
+    #[error("Trailing backslash")]
+    TrailingBackslash,
 }
 
 impl UError for ExprError {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -185,14 +185,8 @@ impl StringOp {
                             | ('\\', false) => re_string.push(curr),
                             _ => re_string.push_str(r"\^"),
                         },
-                        '$' => {
-                            if is_end_of_expression(&pattern_chars) {
-                                re_string.push(curr);
-                            } else if !curr_is_escaped {
-                                re_string.push_str(r"\$");
-                            } else {
-                                re_string.push(curr);
-                            }
+                        '$' if !curr_is_escaped && !is_end_of_expression(&pattern_chars) => {
+                            re_string.push_str(r"\$");
                         }
                         '\\' if !curr_is_escaped && pattern_chars.peek().is_none() => {
                             return Err(ExprError::TrailingBackslash);

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -244,13 +244,7 @@ where
 {
     let mut pattern_chars_clone = pattern_chars.clone();
     match pattern_chars_clone.next() {
-        Some('\\') => {
-            match pattern_chars_clone.next() {
-                Some(')')            // End of a capturing group
-                | Some('|') => true, // End of an alternative pattern
-                _ => false,
-            }
-        }
+        Some('\\') => matches!(pattern_chars_clone.next(), Some(')' | '|')),
         None => true, // No characters left
         _ => false,
     }

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -366,6 +366,26 @@ fn test_regex() {
 }
 
 #[test]
+fn test_regex_trailing_backslash() {
+    new_ucmd!()
+        .args(&["\\", ":", "\\\\"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["\\", ":", "\\"])
+        .fails()
+        .stderr_only("expr: Trailing backslash\n");
+    new_ucmd!()
+        .args(&["abc\\", ":", "abc\\\\"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["abc\\", ":", "abc\\"])
+        .fails()
+        .stderr_only("expr: Trailing backslash\n");
+}
+
+#[test]
 fn test_substr() {
     new_ucmd!()
         .args(&["substr", "abc", "1", "1"])

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -273,110 +273,10 @@ fn test_length_mb() {
 }
 
 #[test]
-fn test_regex() {
-    new_ucmd!()
-        .args(&["a^b", ":", "a^b"])
-        .succeeds()
-        .stdout_only("3\n");
-    new_ucmd!()
-        .args(&["a^b", ":", "a\\^b"])
-        .succeeds()
-        .stdout_only("3\n");
-    new_ucmd!()
-        .args(&["b", ":", "a\\|^b"])
-        .succeeds()
-        .stdout_only("1\n");
-    new_ucmd!()
-        .args(&["ab", ":", "\\(^a\\)b"])
-        .succeeds()
-        .stdout_only("a\n");
-    new_ucmd!()
-        .args(&["a$b", ":", "a\\$b"])
-        .succeeds()
-        .stdout_only("3\n");
-    new_ucmd!()
-        .args(&["a", ":", "a$\\|b"])
-        .succeeds()
-        .stdout_only("1\n");
-    new_ucmd!()
-        .args(&["ab", ":", "a\\(b$\\)"])
-        .succeeds()
-        .stdout_only("b\n");
-    new_ucmd!()
-        .args(&["abc", ":", "^abc"])
-        .succeeds()
-        .stdout_only("3\n");
-    new_ucmd!()
-        .args(&["^abc", ":", "^^abc"])
-        .succeeds()
-        .stdout_only("4\n");
-    new_ucmd!()
-        .args(&["b^$ic", ":", "b^\\$ic"])
-        .succeeds()
-        .stdout_only("5\n");
-    new_ucmd!()
-        .args(&["a$c", ":", "a$\\c"])
-        .succeeds()
-        .stdout_only("3\n");
-    new_ucmd!()
-        .args(&["$a", ":", "$a"])
-        .succeeds()
-        .stdout_only("2\n");
-    new_ucmd!()
-        .args(&["a", ":", "a$\\|b"])
-        .succeeds()
-        .stdout_only("1\n");
-    new_ucmd!()
-        .args(&["^^^^^^^^^", ":", "^^^"])
-        .succeeds()
-        .stdout_only("2\n");
-    new_ucmd!()
-        .args(&["ab[^c]", ":", "ab[^c]"])
-        .succeeds()
-        .stdout_only("3\n"); // Matches "ab["
-    new_ucmd!()
-        .args(&["ab[^c]", ":", "ab\\[^c]"])
-        .succeeds()
-        .stdout_only("6\n");
-    new_ucmd!()
-        .args(&["[^a]", ":", "\\[^a]"])
-        .succeeds()
-        .stdout_only("4\n");
-    new_ucmd!()
-        .args(&["\\a", ":", "\\\\[^^]"])
-        .succeeds()
-        .stdout_only("2\n");
-    new_ucmd!()
-        .args(&["^a", ":", "^^[^^]"])
-        .succeeds()
-        .stdout_only("2\n");
-    new_ucmd!()
-        .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
-        .succeeds()
-        .stdout_only("2\n");
+fn test_regex_empty() {
     new_ucmd!().args(&["", ":", ""]).fails().stdout_only("0\n");
     new_ucmd!()
         .args(&["abc", ":", ""])
-        .fails()
-        .stdout_only("0\n");
-    new_ucmd!()
-        .args(&["abc", ":", "bc"])
-        .fails()
-        .stdout_only("0\n");
-    new_ucmd!()
-        .args(&["^abc", ":", "^abc"])
-        .fails()
-        .stdout_only("0\n");
-    new_ucmd!()
-        .args(&["abc", ":", "ab[^c]"])
-        .fails()
-        .stdout_only("0\n");
-    new_ucmd!()
-        .args(&["$", ":", "$"])
-        .fails()
-        .stdout_only("0\n");
-    new_ucmd!()
-        .args(&["a$", ":", "a$\\|b"])
         .fails()
         .stdout_only("0\n");
 }
@@ -399,6 +299,111 @@ fn test_regex_trailing_backslash() {
         .args(&["abc\\", ":", "abc\\"])
         .fails()
         .stderr_only("expr: Trailing backslash\n");
+}
+
+#[test]
+fn test_regex_caret() {
+    new_ucmd!()
+        .args(&["a^b", ":", "a^b"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["a^b", ":", "a\\^b"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["abc", ":", "^abc"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["^abc", ":", "^^abc"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["b", ":", "a\\|^b"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["ab", ":", "\\(^a\\)b"])
+        .succeeds()
+        .stdout_only("a\n");
+    new_ucmd!()
+        .args(&["^abc", ":", "^abc"])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["^^^^^^^^^", ":", "^^^"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["ab[^c]", ":", "ab[^c]"])
+        .succeeds()
+        .stdout_only("3\n"); // Matches "ab["
+    new_ucmd!()
+        .args(&["ab[^c]", ":", "ab\\[^c]"])
+        .succeeds()
+        .stdout_only("6\n");
+    new_ucmd!()
+        .args(&["[^a]", ":", "\\[^a]"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["\\a", ":", "\\\\[^^]"])
+        .succeeds()
+        .stdout_only("2\n");
+    // Patterns are anchored to the beginning of the pattern "^bc"
+    new_ucmd!()
+        .args(&["abc", ":", "bc"])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["^a", ":", "^^[^^]"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["abc", ":", "ab[^c]"])
+        .fails()
+        .stdout_only("0\n");
+}
+
+#[test]
+fn test_regex_dollar() {
+    new_ucmd!()
+        .args(&["a$b", ":", "a\\$b"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["a", ":", "a$\\|b"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["ab", ":", "a\\(b$\\)"])
+        .succeeds()
+        .stdout_only("b\n");
+    new_ucmd!()
+        .args(&["a$c", ":", "a$\\c"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["$a", ":", "$a"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["a", ":", "a$\\|b"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["-5", ":", "-\\{0,1\\}[0-9]*$"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["$", ":", "$"])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["a$", ":", "a$\\|b"])
+        .fails()
+        .stdout_only("0\n");
 }
 
 #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -319,6 +319,14 @@ fn test_regex() {
         .succeeds()
         .stdout_only("3\n");
     new_ucmd!()
+        .args(&["$a", ":", "$a"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["a", ":", "a$\\|b"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
         .args(&["^^^^^^^^^", ":", "^^^"])
         .succeeds()
         .stdout_only("2\n");
@@ -361,6 +369,14 @@ fn test_regex() {
         .stdout_only("0\n");
     new_ucmd!()
         .args(&["abc", ":", "ab[^c]"])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["$", ":", "$"])
+        .fails()
+        .stdout_only("0\n");
+    new_ucmd!()
+        .args(&["a$", ":", "a$\\|b"])
         .fails()
         .stdout_only("0\n");
 }


### PR DESCRIPTION
Handle the following special cases for regex patterns for `expr` and add tests for them:

- Trailing backslashes
- `$` at the beginning of the regex pattern