### PR TITLE
publish.sh: be more prescriptive on the grep

### DIFF
--- a/util/publish.sh
+++ b/util/publish.sh
@@ -51,7 +51,7 @@ TOTAL_ORDER=$(echo -e $PARTIAL_ORDER | tsort | tac)
 # Remove the ROOT node from the start
 TOTAL_ORDER=${TOTAL_ORDER#ROOT}
 
-CRATE_VERSION=$(grep '^version' Cargo.toml | head -n1 | cut -d '"' -f2)
+CRATE_VERSION=$(grep '^version =' Cargo.toml | head -n1 | cut -d '"' -f2)
 
 set -e
 for dir in src/uuhelp_parser/ src/uucore_procs/ src/uucore/ src/uu/stdbuf/src/libstdbuf/; do


### PR DESCRIPTION
otherwise, we are getting version.workspace first