### PR TITLE
Reenable windows-latest/x86_64-pc-windows-gnu (and do not update gcc)

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -528,8 +528,7 @@ jobs:
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
           - { os: macos-13       , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
-          # TODO: Re-enable after rust-onig release: https://github.com/rust-onig/rust-onig/issues/193
-          # - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
+          - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
           - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }
     steps:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -693,11 +693,6 @@ jobs:
             sudo apt-get -y update
             sudo apt-get -y install fuse3 libfuse-dev
           ;;
-          # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
-          x86_64-pc-windows-gnu)
-            C:/msys64/usr/bin/pacman.exe -Sy --needed mingw-w64-x86_64-gcc --noconfirm
-            echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
-          ;;
         esac
         case '${{ matrix.job.os }}' in
           macos-latest) brew install coreutils ;; # needed for testing


### PR DESCRIPTION
Fixes #7977.

See commit message below, I don't fully get what's going on, but... I'm not sure how much that matters really (maybe something wrong with msys...).

We could have done that in the first place to avoid the onig issue... so this doesn't even need to be stacked on top of #7976.

---

### .github/workflows/CICD.yml: Do not update gcc

The issue referenced has been long fixed, and for reasons not
totally clear to me, blake3 fails after the GCC update (I tried
to dig into this, but couldn't really figure out if this is really
a problem with GCC 15, or with the version provided by MSYS, or
some other side effect of the exact sequence in CI).

Since blake3 CI doesn't do that gcc update (it uses the default gcc ~12
in the github windows image), let's _also_ not do that, and if there's a
real problem with gcc 15+, that'll presumably fail their CI as well.

Fixes #7977.

### Revert "CICD: Disable windows-latest/x86_64-pc-windows-gnu for now"

This reverts commit deef8cbfd69856f9a631a085bc0cd032ea852767.

A new onig release has happened, this should fix the issue.