### PR TITLE
ls: parallelize with rayon

### DIFF
--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -40,6 +40,7 @@ uucore = { workspace = true, features = [
   "version-cmp",
 ] }
 uutils_term_grid = { workspace = true }
+rayon = { workspace = true }
 
 [[bin]]
 name = "ls"


### PR DESCRIPTION
I work on the [Lustre](https://en.wikipedia.org/wiki/Lustre_(file_system)) filesystem. Lustre is a parallel filesystem (i.e. scale-out network filesystem) commonly used in HPC and AI.

I'm interested in making the Rust coreutils perform well on Lustre and other networked filesystems. I've started with `ls -l` (a historic challenge for Lustre, due to the high volume of `statx` calls). The latest versions of Lustre (using statahead or multiple metadata servers) can improve the performance of sequential `statx` calls significantly. But parallelizing the calls with `ls -l` could also net huge gains - especially on older systems.

I have a simple patch which parallelizes the `statx` calls using rayon. When iterating over the `readdir()` results in
`enter_directory()`, we can preemptively cache the entries metadata by calling `get_metadata_no_flush()` within a rayon parallel iterator.

I've done a small benchmark that shows around a 2.5x improvement when running `ls -l` on a directory with 10,000 files:
```
root@big-debian-desktop-kvm:/mnt/lustre/testdir# hyperfine --warmup 2 --prepare "echo 3 > /proc/sys/vm/drop_caches" "/workspace/coreutils/target/release/coreutils ls -l /mnt/lustre/testdir > /dev/null" "ls -l /mnt/lustre/testdir > /dev/null"
Benchmark 1: /workspace/coreutils/target/release/coreutils ls -l /mnt/lustre/testdir > /dev/null
  Time (mean ± σ):     47.553 s ±  0.108 s    [User: 0.078 s, System: 41.647 s]
  Range (min … max):   47.311 s … 47.658 s    10 runs
 
Benchmark 2: ls -l /mnt/lustre/testdir > /dev/null
  Time (mean ± σ):     127.087 s ±  0.351 s    [User: 0.046 s, System: 42.776 s]
  Range (min … max):   126.790 s … 127.961 s    10 runs
 
Summary
  /workspace/coreutils/target/release/coreutils ls -l /mnt/lustre/testdir > /dev/null ran
    2.67 ± 0.01 times faster than ls -l /mnt/lustre/testdir > /dev/null
```
This compares parallelized Rust `ls -l` with Debian's packaged GNU `ls` version `9.7-2`. Without this patch, they performed nearly identically. I used the latest Lustre development branch. The entire filesystem (client, 1 metadata server, 2 object servers) are collocated on the same node. I'm using the in-memory storage backend for Lustre. I've artificially added a 2ms network delay to each RPC. I'm not using statahead. In a real setup, I'd expect the performance to scale linearly with the core count of the client.

I don't think this PR is yet in good enough shape to be merged. I have a few open questions:

1. This patch unconditionally stats each file, which is bad for the regular `ls` case. So some refactor is needed.
2. When a utility does parallelization "under the hood", how do we handle default configuration? Rayon has an environment variable `RAYON_NUM_THREADS` that defaults to the core count. This would be overkill for local NVMe, but critical for larger scale systems.
3. Each thread ought to start at different offsets in the directory. If we had a statahead of 10 entries and a directory of 100 entries, it wouldn't make sense to assign 10 threads to stat each of those entries individually. They should start at offsets of 10. I'm not yet sure how to do this with Rayon.

I'm interested in getting some feedback before doing another revision.

