### PR TITLE
ci: reduce timeout of freebsd jobs

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -24,7 +24,7 @@ jobs:
   style:
     name: Style and Lint
     runs-on: ${{ matrix.job.os }}
-    timeout-minutes: 90
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +117,7 @@ jobs:
   test:
     name: Tests
     runs-on: ${{ matrix.job.os }}
-    timeout-minutes: 90
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I noticed that one of the freebsd jobs hangs occasionally and runs into the 90 min timeout. As the freebsd jobs usually take less than ten minutes to run, I think it makes sense to reduce the timeout to avoid wasting resources. And thus this PR reduces the timeout from 90 min to <del>60</del> 45 min.