### PR TITLE
expr: Fix parsing range quantifiers in regex

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -793,6 +793,7 @@ pub fn is_truthy(s: &NumOrStr) -> bool {
 mod test {
     use crate::ExprError;
     use crate::ExprError::InvalidBracketContent;
+    use crate::syntax_tree::is_valid_range_quantifier;
 
     use super::{
         AstNode, AstNodeInner, BinOp, NumericOp, RelationOp, StringOp, check_posix_regex_errors,
@@ -1040,5 +1041,23 @@ mod test {
             check_posix_regex_errors("ab\\{,b\\}"),
             Err(InvalidBracketContent)
         );
+    }
+
+    #[test]
+    fn test_is_valid_range_quantifier() {
+        assert!(is_valid_range_quantifier(&"3\\}".chars()));
+        assert!(is_valid_range_quantifier(&"3,\\}".chars()));
+        assert!(is_valid_range_quantifier(&",6\\}".chars()));
+        assert!(is_valid_range_quantifier(&"3,6\\}".chars()));
+        assert!(is_valid_range_quantifier(&",\\}".chars()));
+        assert!(is_valid_range_quantifier(&"3,6\\}anything".chars()));
+        assert!(!is_valid_range_quantifier(&"\\{3,6\\}".chars()));
+        assert!(!is_valid_range_quantifier(&"\\}".chars()));
+        assert!(!is_valid_range_quantifier(&"".chars()));
+        assert!(!is_valid_range_quantifier(&"3".chars()));
+        assert!(!is_valid_range_quantifier(&"3,".chars()));
+        assert!(!is_valid_range_quantifier(&",6".chars()));
+        assert!(!is_valid_range_quantifier(&"3,6".chars()));
+        assert!(!is_valid_range_quantifier(&",".chars()));
     }
 }

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -160,7 +160,6 @@ impl StringOp {
                 let first = pattern_chars.next();
                 match first {
                     Some('^') => {} // Start of string anchor is already added
-                    Some('*') => re_string.push_str(r"\*"),
                     Some('$') if !is_end_of_expression(&pattern_chars) => re_string.push_str(r"\$"),
                     Some('\\') if right.len() == 1 => return Err(ExprError::TrailingBackslash),
                     Some(char) => re_string.push(char),

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -875,7 +875,6 @@ mod gnu_expr {
             .stdout_only("\n");
     }
 
-    #[ignore]
     #[test]
     fn test_bre17() {
         new_ucmd!()
@@ -884,7 +883,6 @@ mod gnu_expr {
             .stdout_only("{1}a\n");
     }
 
-    #[ignore]
     #[test]
     fn test_bre18() {
         new_ucmd!()
@@ -893,7 +891,6 @@ mod gnu_expr {
             .stdout_only("1\n");
     }
 
-    #[ignore]
     #[test]
     fn test_bre19() {
         new_ucmd!()
@@ -1105,7 +1102,6 @@ mod gnu_expr {
             .stderr_contains("Invalid content of \\{\\}");
     }
 
-    #[ignore]
     #[test]
     fn test_bre45() {
         new_ucmd!()
@@ -1114,7 +1110,6 @@ mod gnu_expr {
             .stdout_only("1\n");
     }
 
-    #[ignore]
     #[test]
     fn test_bre46() {
         new_ucmd!()


### PR DESCRIPTION
Fix parsing the following special cases for range quantifiers in the regex of the `expr` command.

- `\{,\}` zero or more
- `\{,6\}` six or less

This PR also enables the rest of the ignored `test_bre*` tests and removes redundant escaping of the '*' character.

fixes #7664