### PR TITLE
expr: Fix handling of regex range quantifiers

### DIFF
--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -50,6 +50,8 @@ pub enum ExprError {
     InvalidBracketContent,
     #[error("Trailing backslash")]
     TrailingBackslash,
+    #[error("Regular expression too big")]
+    TooBigRangeQuantifierIndex,
 }
 
 impl UError for ExprError {

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -46,8 +46,6 @@ pub enum ExprError {
     UnmatchedClosingParenthesis,
     #[error("Unmatched \\{{")]
     UnmatchedOpeningBrace,
-    #[error("Unmatched ) or \\}}")]
-    UnmatchedClosingBrace,
     #[error("Invalid content of \\{{\\}}")]
     InvalidBracketContent,
     #[error("Trailing backslash")]

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -992,7 +992,7 @@ mod test {
         );
 
         assert_eq!(
-            check_posix_regex_errors(r"\{1,2"),
+            check_posix_regex_errors(r"a\{1,2"),
             Err(ExprError::UnmatchedOpeningBrace)
         );
     }

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -302,7 +302,7 @@ where
     }
 
     // Check if parsed quantifier is valid
-    let re = Regex::new(r"(\d*,\d*|\d+)").expect("valid regular expression");
+    let re = Regex::new(r"^(\d*,\d*|\d+)").expect("valid regular expression");
     match re.captures(&quantifier) {
         None => false,
         Some(captures) => {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -307,24 +307,15 @@ where
         let matched = captures.at(0).unwrap_or_default();
         match matched.split_once(',') {
             Some(("", "")) => Ok(()),
-            Some((x, "")) | Some(("", x)) => match x.parse::<i32>() {
-                Ok(x) if x <= i16::MAX.into() => Ok(()),
-                Ok(_) => Err(ExprError::TooBigRangeQuantifierIndex),
-                Err(_) => Err(ExprError::InvalidBracketContent),
-            },
-            Some((f, l)) => match (f.parse::<i32>(), l.parse::<i32>()) {
+            Some((x, "") | ("", x)) if x.parse::<i16>().is_ok() => Ok(()),
+            Some((_, "") | ("", _)) => Err(ExprError::TooBigRangeQuantifierIndex),
+            Some((f, l)) => match (f.parse::<i16>(), l.parse::<i16>()) {
                 (Ok(f), Ok(l)) if f > l => Err(ExprError::InvalidBracketContent),
-                (Ok(f), Ok(l)) if f > i16::MAX.into() || l > i16::MAX.into() => {
-                    Err(ExprError::TooBigRangeQuantifierIndex)
-                }
                 (Ok(_), Ok(_)) => Ok(()),
-                _ => Err(ExprError::InvalidBracketContent),
+                _ => Err(ExprError::TooBigRangeQuantifierIndex),
             },
-            None => match matched.parse::<i32>() {
-                Ok(x) if x <= i16::MAX.into() => Ok(()),
-                Ok(_) => Err(ExprError::TooBigRangeQuantifierIndex),
-                Err(_) => Err(ExprError::InvalidBracketContent),
-            },
+            None if matched.parse::<i16>().is_ok() => Ok(()),
+            None => Err(ExprError::TooBigRangeQuantifierIndex),
         }
     } else {
         Err(ExprError::InvalidBracketContent)

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -797,7 +797,6 @@ pub fn is_truthy(s: &NumOrStr) -> bool {
 #[cfg(test)]
 mod test {
     use crate::ExprError;
-    use crate::ExprError::InvalidBracketContent;
     use crate::syntax_tree::is_valid_range_quantifier;
 
     use super::{
@@ -1003,42 +1002,6 @@ mod test {
         assert_eq!(
             check_posix_regex_errors(r"abc\)"),
             Err(ExprError::UnmatchedClosingParenthesis)
-        );
-
-    #[test]
-    fn check_regex_empty_repeating_pattern() {
-        assert_eq!(
-            check_posix_regex_errors("ab\\{\\}"),
-            Err(InvalidBracketContent)
-        );
-    }
-
-    #[test]
-    fn check_regex_intervals_two_numbers() {
-        assert_eq!(
-            // out of order
-            check_posix_regex_errors("ab\\{1,0\\}"),
-            Err(InvalidBracketContent)
-        );
-        assert_eq!(
-            check_posix_regex_errors("ab\\{1,a\\}"),
-            Err(InvalidBracketContent)
-        );
-        assert_eq!(
-            check_posix_regex_errors("ab\\{a,3\\}"),
-            Err(InvalidBracketContent)
-        );
-        assert_eq!(
-            check_posix_regex_errors("ab\\{a,b\\}"),
-            Err(InvalidBracketContent)
-        );
-        assert_eq!(
-            check_posix_regex_errors("ab\\{a,\\}"),
-            Err(InvalidBracketContent)
-        );
-        assert_eq!(
-            check_posix_regex_errors("ab\\{,b\\}"),
-            Err(InvalidBracketContent)
         );
     }
 

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -365,9 +365,7 @@ fn check_posix_regex_errors(pattern: &str) -> ExprResult<()> {
             }
             (true, '}') => {
                 if !is_brace_ignored {
-                    escaped_braces = escaped_braces
-                        .saturating_sub(1)
-                        .ok_or(ExprError::UnmatchedClosingBrace)?;
+                    escaped_braces = escaped_braces.saturating_sub(1);
                 }
             }
             _ => {}
@@ -1006,12 +1004,6 @@ mod test {
             check_posix_regex_errors(r"abc\)"),
             Err(ExprError::UnmatchedClosingParenthesis)
         );
-
-        assert_eq!(
-            check_posix_regex_errors(r"abc\}"),
-            Err(ExprError::UnmatchedClosingBrace)
-        );
-    }
 
     #[test]
     fn check_regex_empty_repeating_pattern() {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -302,7 +302,7 @@ where
     }
 
     // Check if parsed quantifier is valid
-    let re = Regex::new(r"^(\d*,\d*|\d+)$").expect("valid regular expression");
+    let re = Regex::new(r"^([0-9]*,[0-9]*|[0-9]+)$").expect("valid regular expression");
     if let Some(captures) = re.captures(&quantifier) {
         let matched = captures.at(0).unwrap_or_default();
         match matched.split_once(',') {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -295,8 +295,9 @@ where
         if pattern_chars_clone.peek().is_none() {
             return Err(ExprError::UnmatchedOpeningBrace);
         }
-
-        quantifier.push(curr);
+        if prev != '\0' {
+            quantifier.push(prev);
+        }
         prev = curr;
     }
 

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -302,7 +302,7 @@ where
     }
 
     // Check if parsed quantifier is valid
-    let re = Regex::new(r"^(\d*,\d*|\d+)").expect("valid regular expression");
+    let re = Regex::new(r"^(\d*,\d*|\d+)$").expect("valid regular expression");
     if let Some(captures) = re.captures(&quantifier) {
         let matched = captures.at(0).unwrap_or_default();
         match matched.split_once(',') {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -282,27 +282,25 @@ fn verify_range_quantifier<I>(pattern_chars: &I) -> Result<(), ExprError>
 where
     I: Iterator<Item = char> + Clone,
 {
-    // Parse the string between braces
-    let mut quantifier = String::new();
     let mut pattern_chars_clone = pattern_chars.clone().peekable();
-    let Some(mut prev) = pattern_chars_clone.next() else {
-        return Err(ExprError::UnmatchedOpeningBrace);
-    };
     if pattern_chars_clone.peek().is_none() {
         return Err(ExprError::UnmatchedOpeningBrace);
     }
 
-    let mut prev_is_escaped = false;
+    // Parse the string between braces
+    let mut quantifier = String::new();
+    let mut prev = '\0';
+    let mut curr_is_escaped = false;
     while let Some(curr) = pattern_chars_clone.next() {
-        if prev == '\\' && curr == '}' && !prev_is_escaped {
+        curr_is_escaped = prev == '\\' && !curr_is_escaped;
+        if curr_is_escaped && curr == '}' {
             break;
         }
         if pattern_chars_clone.peek().is_none() {
             return Err(ExprError::UnmatchedOpeningBrace);
         }
 
-        quantifier.push(prev);
-        prev_is_escaped = prev == '\\' && !prev_is_escaped;
+        quantifier.push(curr);
         prev = curr;
     }
 

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -1210,7 +1210,7 @@ mod gnu_expr {
             .args(&["_", ":", "a\\{32768\\}"])
             .fails_with_code(2)
             .no_stdout()
-            .stderr_contains("Invalid content of \\{\\}");
+            .stderr_contains("Regular expression too big\n");
     }
 
     #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -472,6 +472,26 @@ fn test_regex_range_quantifier() {
         .args(&["ab", ":", "ab\\{\\}"])
         .fails()
         .stderr_only("expr: Invalid content of \\{\\}\n");
+    new_ucmd!()
+        .args(&["_", ":", "a\\{12345678901234567890\\}"])
+        .fails()
+        .stderr_only("expr: Regular expression too big\n");
+    new_ucmd!()
+        .args(&["_", ":", "a\\{12345678901234567890,\\}"])
+        .fails()
+        .stderr_only("expr: Regular expression too big\n");
+    new_ucmd!()
+        .args(&["_", ":", "a\\{,12345678901234567890\\}"])
+        .fails()
+        .stderr_only("expr: Regular expression too big\n");
+    new_ucmd!()
+        .args(&["_", ":", "a\\{1,12345678901234567890\\}"])
+        .fails()
+        .stderr_only("expr: Regular expression too big\n");
+    new_ucmd!()
+        .args(&["_", ":", "a\\{1,1234567890abcdef\\}"])
+        .fails()
+        .stderr_only("expr: Invalid content of \\{\\}\n");
 }
 
 #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -3,8 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore αbcdef ; (people) kkos
-// spell-checker:ignore aabcccd aabcd aabd abbbd abbcabc abbcac abbcbbbd abbcbd
-// spell-checker:ignore abbccd abcac acabc andand bigcmp bignum emptysub
+// spell-checker:ignore aabcccd aabcd aabd abbb abbbd abbcabc abbcac abbcbbbd abbcbd
+// spell-checker:ignore abbccd abcabc abcac acabc andand bigcmp bignum emptysub
 // spell-checker:ignore orempty oror
 
 use uutests::new_ucmd;

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -407,6 +407,74 @@ fn test_regex_dollar() {
 }
 
 #[test]
+fn test_regex_range_quantifier() {
+    new_ucmd!()
+        .args(&["a", ":", "a\\{1\\}"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["aaaaaaaaaa", ":", "a\\{1,\\}"])
+        .succeeds()
+        .stdout_only("10\n");
+    new_ucmd!()
+        .args(&["aaa", ":", "a\\{,3\\}"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["aa", ":", "a\\{1,3\\}"])
+        .succeeds()
+        .stdout_only("2\n");
+    new_ucmd!()
+        .args(&["aaaa", ":", "a\\{,\\}"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["a", ":", "ab\\{,3\\}"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["abbb", ":", "ab\\{,3\\}"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["abcabc", ":", "\\(abc\\)\\{,\\}"])
+        .succeeds()
+        .stdout_only("abc\n");
+    new_ucmd!()
+        .args(&["a", ":", "a\\{,6\\}"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["{abc}", ":", "\\{abc\\}"])
+        .succeeds()
+        .stdout_only("5\n");
+    new_ucmd!()
+        .args(&["a{bc}", ":", "a\\(\\{bc\\}\\)"])
+        .succeeds()
+        .stdout_only("{bc}\n");
+    new_ucmd!()
+        .args(&["{b}", ":", "a\\|\\{b\\}"])
+        .succeeds()
+        .stdout_only("3\n");
+    new_ucmd!()
+        .args(&["{", ":", "a\\|\\{"])
+        .succeeds()
+        .stdout_only("1\n");
+    new_ucmd!()
+        .args(&["{}}}", ":", "\\{\\}\\}\\}"])
+        .succeeds()
+        .stdout_only("4\n");
+    new_ucmd!()
+        .args(&["a{}}}", ":", "a\\{\\}\\}\\}"])
+        .fails()
+        .stderr_only("expr: Invalid content of \\{\\}\n");
+    new_ucmd!()
+        .args(&["ab", ":", "ab\\{\\}"])
+        .fails()
+        .stderr_only("expr: Invalid content of \\{\\}\n");
+}
+
+#[test]
 fn test_substr() {
     new_ucmd!()
         .args(&["substr", "abc", "1", "1"])


### PR DESCRIPTION
This PR fixes parsing and error reporting for the regex range quantifiers for `expr`. The `\{` token is handled literally when used at the start of the regex or its subexpressions. The following closing braces `\}` are also handled literally until the next `\{` that is not at the start of an expression.

Quote from #8009:

> Normally, `\{` begins a range quantifier like `{n,m}`. However, at the start of the regex or its subexpression (after `\(` or `\|`), there is no preceding item to which the quantifier can be applied. The expr command should handle `\{` literally at the start of the regex or its subexpression.

**Other changes**:

- Remove nonexistent error `UnmatchedClosingBrace`
  - The closing brace without a related opening brace is handled literally
- Fix error message for too big range quantifier index
  - "Invalid content of \{\}" --> "Regular expression too big"
- Simplify transpiling input regex pattern from BRE syntax to `onig` crate's `Syntax::grep`

fixes: #8009