### PR TITLE
Fix sort-files0-from.log

### DIFF
--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -13,7 +13,7 @@
 
 use std::{
     cmp::Ordering,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     fs::{self, File},
     io::{BufWriter, Read, Write},
     iter,
@@ -38,7 +38,7 @@ use crate::{
 /// and replace its occurrences in the inputs with that copy.
 fn replace_output_file_in_input_files(
     files: &mut [OsString],
-    output: Option<&str>,
+    output: Option<&OsStr>,
     tmp_dir: &mut TmpDirWrapper,
 ) -> UResult<()> {
     let mut copy: Option<PathBuf> = None;

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -171,6 +171,9 @@ pub enum SortError {
 
     #[error("no input from '{}'", .file.display())]
     EmptyInputFile { file: OsString },
+
+    #[error("{}:{}: invalid zero-length file name", .file.display(), .line_num)]
+    ZeroLengthFileName { file: OsString, line_num: usize },
 }
 
 impl UError for SortError {
@@ -1080,12 +1083,23 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let mut files = Vec::new();
         let reader = open(&files0_from)?;
         let buf_reader = BufReader::new(reader);
-        for line in buf_reader.split(b'\0').flatten() {
+        for (line_num, line) in buf_reader.split(b'\0').flatten().enumerate() {
             let f = std::str::from_utf8(&line)
                 .expect("Could not parse string from zero terminated input.");
-            if f == STDIN_FILE {
-                return Err(SortError::MinusInStdIn.into());
+            match f {
+                STDIN_FILE => {
+                    return Err(SortError::MinusInStdIn.into());
+                }
+                "" => {
+                    return Err(SortError::ZeroLengthFileName {
+                        file: files0_from,
+                        line_num: line_num + 1,
+                    }
+                    .into());
+                }
+                _ => {}
             }
+
             files.push(OsString::from(
                 std::str::from_utf8(&line)
                     .expect("Could not parse string from zero terminated input."),

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -168,6 +168,9 @@ pub enum SortError {
 
     #[error("when reading file names from stdin, no file name of '-' allowed")]
     MinusInStdIn,
+
+    #[error("no input from '{}'", .file.display())]
+    EmptyInputFile { file: OsString },
 }
 
 impl UError for SortError {
@@ -1075,7 +1078,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
 
         let mut files = Vec::new();
-        let reader = open(files0_from)?;
+        let reader = open(&files0_from)?;
         let buf_reader = BufReader::new(reader);
         for line in buf_reader.split(b'\0').flatten() {
             let f = std::str::from_utf8(&line)
@@ -1087,6 +1090,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 std::str::from_utf8(&line)
                     .expect("Could not parse string from zero terminated input."),
             ));
+        }
+        if files.is_empty() {
+            return Err(SortError::EmptyInputFile { file: files0_from }.into());
         }
         files
     } else {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -165,6 +165,9 @@ pub enum SortError {
 
     #[error("multiple output files specified")]
     MultipleOutputFiles,
+
+    #[error("when reading file names from stdin, no file name of '-' allowed")]
+    MinusInStdIn,
 }
 
 impl UError for SortError {
@@ -1075,6 +1078,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let reader = open(files0_from)?;
         let buf_reader = BufReader::new(reader);
         for line in buf_reader.split(b'\0').flatten() {
+            let f = std::str::from_utf8(&line)
+                .expect("Could not parse string from zero terminated input.");
+            if f == STDIN_FILE {
+                return Err(SortError::MinusInStdIn.into());
+            }
             files.push(OsString::from(
                 std::str::from_utf8(&line)
                     .expect("Could not parse string from zero terminated input."),

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1049,21 +1049,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // check whether user specified a zero terminated list of files for input, otherwise read files from args
     let mut files: Vec<OsString> = if matches.contains_id(options::FILES0_FROM) {
-        let files0_from: Vec<OsString> = matches
-            .get_many::<OsString>(options::FILES0_FROM)
-            .map(|v| v.map(ToOwned::to_owned).collect())
+        let files0_from: OsString = matches
+            .get_one::<OsString>(options::FILES0_FROM)
+            .map(|v| v.to_owned())
             .unwrap_or_default();
 
         let mut files = Vec::new();
-        for path in &files0_from {
-            let reader = open(path)?;
-            let buf_reader = BufReader::new(reader);
-            for line in buf_reader.split(b'\0').flatten() {
-                files.push(OsString::from(
-                    std::str::from_utf8(&line)
-                        .expect("Could not parse string from zero terminated input."),
-                ));
-            }
+
+        let reader = open(files0_from)?;
+        let buf_reader = BufReader::new(reader);
+        for line in buf_reader.split(b'\0').flatten() {
+            files.push(OsString::from(
+                std::str::from_utf8(&line)
+                    .expect("Could not parse string from zero terminated input."),
+            ));
         }
         files
     } else {
@@ -1522,9 +1521,8 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::FILES0_FROM)
                 .long(options::FILES0_FROM)
-                .help("read input from the files specified by NUL-terminated NUL_FILES")
-                .value_name("NUL_FILES")
-                .action(ArgAction::Append)
+                .help("read input from the files specified by NUL-terminated NUL_FILE")
+                .value_name("NUL_FILE")
                 .value_parser(ValueParser::os_string())
                 .value_hint(clap::ValueHint::FilePath),
         )

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -131,7 +131,10 @@ pub enum SortError {
     },
 
     #[error("open failed: {}: {}", .path.maybe_quote(), strip_errno(.error))]
-    OpenFailed { path: String, error: std::io::Error },
+    OpenFailed {
+        path: PathBuf,
+        error: std::io::Error,
+    },
 
     #[error("failed to parse key {}: {}", .key.quote(), .msg)]
     ParseKeyError { key: String, msg: String },
@@ -207,24 +210,25 @@ impl SortMode {
 }
 
 pub struct Output {
-    file: Option<(String, File)>,
+    file: Option<(OsString, File)>,
 }
 
 impl Output {
-    fn new(name: Option<&str>) -> UResult<Self> {
+    fn new(name: Option<&OsStr>) -> UResult<Self> {
         let file = if let Some(name) = name {
+            let path = Path::new(name);
             // This is different from `File::create()` because we don't truncate the output yet.
             // This allows using the output file as an input file.
             #[allow(clippy::suspicious_open_options)]
             let file = OpenOptions::new()
                 .write(true)
                 .create(true)
-                .open(name)
+                .open(path)
                 .map_err(|e| SortError::OpenFailed {
-                    path: name.to_owned(),
+                    path: path.to_owned(),
                     error: e,
                 })?;
-            Some((name.to_owned(), file))
+            Some((name.to_os_string(), file))
         } else {
             None
         };
@@ -242,9 +246,9 @@ impl Output {
         })
     }
 
-    fn as_output_name(&self) -> Option<&str> {
+    fn as_output_name(&self) -> Option<&OsStr> {
         match &self.file {
-            Some((name, _file)) => Some(name),
+            Some((name, _file)) => Some(name.as_os_str()),
             None => None,
         }
     }
@@ -1293,8 +1297,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let output = Output::new(
         matches
-            .get_one::<String>(options::OUTPUT)
-            .map(|s| s.as_str()),
+            .get_one::<OsString>(options::OUTPUT)
+            .map(|s| s.as_os_str()),
     )?;
 
     settings.init_precomputed();
@@ -1875,7 +1879,7 @@ fn print_sorted<'a, T: Iterator<Item = &'a Line<'a>>>(
 ) -> UResult<()> {
     let output_name = output
         .as_output_name()
-        .unwrap_or("standard output")
+        .unwrap_or(OsStr::new("standard output"))
         .to_owned();
     let ctx = || format!("write failed: {}", output_name.maybe_quote());
 
@@ -1895,10 +1899,9 @@ fn open(path: impl AsRef<OsStr>) -> UResult<Box<dyn Read + Send>> {
     }
 
     let path = Path::new(path);
-
     match File::open(path) {
         Ok(f) => Ok(Box::new(f) as Box<dyn Read + Send>),
-        Err(error) => Err(SortError::ReadFailed {
+        Err(error) => Err(SortError::OpenFailed {
             path: path.to_owned(),
             error,
         }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -154,6 +154,9 @@ pub enum SortError {
     #[error("cannot create temporary file in '{}':", .path.display())]
     TmpFileCreationFailed { path: PathBuf },
 
+    #[error("extra operand '{}'\nfile operands cannot be combined with --files0-from\nTry '{} --help' for more information.", .file.display(), uucore::execution_phrase())]
+    FileOperandsCombined { file: OsString },
+
     #[error("{error}")]
     Uft8Error { error: Utf8Error },
 
@@ -1016,6 +1019,8 @@ fn get_rlimit() -> UResult<usize> {
     }
 }
 
+const STDIN_FILE: &str = "-";
+
 #[uucore::main]
 #[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -1054,8 +1059,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .map(|v| v.to_owned())
             .unwrap_or_default();
 
-        let mut files = Vec::new();
+        // Cannot combine FILES with FILES0_FROM
+        if let Some(s) = matches.get_one::<OsString>(options::FILES) {
+            return Err(SortError::FileOperandsCombined {
+                file: s.to_os_string(),
+            }
+            .into());
+        }
 
+        let mut files = Vec::new();
         let reader = open(files0_from)?;
         let buf_reader = BufReader::new(reader);
         for line in buf_reader.split(b'\0').flatten() {
@@ -1211,7 +1223,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if files.is_empty() {
         /* if no file, default to stdin */
-        files.push("-".to_string().into());
+        files.push(OsString::from(STDIN_FILE));
     } else if settings.check && files.len() != 1 {
         return Err(UUsageError::new(
             2,
@@ -1877,7 +1889,7 @@ fn print_sorted<'a, T: Iterator<Item = &'a Line<'a>>>(
 
 fn open(path: impl AsRef<OsStr>) -> UResult<Box<dyn Read + Send>> {
     let path = path.as_ref();
-    if path == "-" {
+    if path == STDIN_FILE {
         let stdin = stdin();
         return Ok(Box::new(stdin) as Box<dyn Read + Send>);
     }


### PR DESCRIPTION
I noticed some discrepancy in how files with `'` or `"` are displayed. Is there a function that will automatically adjust the display of file names?

This is the output from GNU sort
```
$ sort --files0-from=- "ab"
sort: extra operand 'ab'
file operands cannot be combined with --files0-from
Try 'sort --help' for more information.
```


```
$ sort --files0-from=- "a'b"
sort: extra operand "a'b"
file operands cannot be combined with --files0-from
Try 'sort --help' for more information.
```

```
$ sort --files0-from=- "a'\"b"
sort: extra operand 'a'\''"b'
file operands cannot be combined with --files0-from
Try 'sort --help' for more information.
```