### PR TITLE
Add stty to GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -127,6 +127,7 @@ PROGS       := \
 	sleep \
 	sort \
 	split \
+	stty \
 	sum \
 	sync \
 	tac \


### PR DESCRIPTION
This adds `stty` to `GNUmakefile` and build it by default.

This is [no longer WIP](https://github.com/uutils/coreutils/pull/310). 