### PR TITLE
sync: reduce use of unsafe and improve comments

### DIFF
--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 libc = { workspace = true }
 uucore = { workspace = true, features = ["wide"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(unix)'.dependencies]
 nix = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -38,13 +38,9 @@ mod platform {
     use uucore::error::UResult;
 
     /// # Safety
-    /// This function is unsafe because it calls `libc::sync` or `libc::syscall` which are unsafe.
+    /// This function is unsafe because it calls `libc::sync` which is unsafe.
     pub unsafe fn do_sync() -> UResult<()> {
         unsafe {
-            // see https://github.com/rust-lang/libc/pull/2161
-            #[cfg(target_os = "android")]
-            libc::syscall(libc::SYS_sync);
-            #[cfg(not(target_os = "android"))]
             libc::sync();
         }
         Ok(())


### PR DESCRIPTION
1. Safe wrappers exist for the unix side of things, so let's use those.
1. A function isn't `unsafe` just because it uses `unsafe` code, it's only `unsafe` if it can be invoked in a way that violates safety guarantees.
1. Safety comments shouldn't document why something is `unsafe`, they're for documenting either how to invoke something `unsafe` safely, or why the `unsafe` invocation is actually safe.