### PR TITLE
deny.toml: remove obsolete skips related to rustix

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -98,10 +98,6 @@ skip = [
   { name = "rand_chacha", version = "0.3.1" },
   # rand
   { name = "rand_core", version = "0.6.4" },
-  # crossterm, procfs, terminal_size
-  { name = "rustix", version = "0.38.43" },
-  # rustix
-  { name = "linux-raw-sys", version = "0.4.15" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
The holdup on crossterm was bumped in d5258d280, bringing rustix to 0.38.44. Meanwhile while
linux-raw-sys is still at 0.4.15 in the lock file, it is unclear to my why it got added in 2c0f97fc3
in the first place as it does not seem to trigger any complaints from `cargo deny`.
