### PR TITLE
csplit: fix two issues with non ASCII digits

### DIFF
--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -107,7 +107,7 @@ fn extract_patterns(args: &[String]) -> Result<Vec<Pattern>, CsplitError> {
     let mut patterns = Vec::with_capacity(args.len());
     let to_match_reg =
         Regex::new(r"^(/(?P<UPTO>.+)/|%(?P<SKIPTO>.+)%)(?P<OFFSET>[\+-]?\d+)?$").unwrap();
-    let execute_ntimes_reg = Regex::new(r"^\{(?P<TIMES>\d+)|\*\}$").unwrap();
+    let execute_ntimes_reg = Regex::new(r"^\{(?P<TIMES>[0-9]+)|\*\}$").unwrap();
     let mut iter = args.iter().peekable();
 
     while let Some(arg) = iter.next() {

--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -106,7 +106,7 @@ pub fn get_patterns(args: &[String]) -> Result<Vec<Pattern>, CsplitError> {
 fn extract_patterns(args: &[String]) -> Result<Vec<Pattern>, CsplitError> {
     let mut patterns = Vec::with_capacity(args.len());
     let to_match_reg =
-        Regex::new(r"^(/(?P<UPTO>.+)/|%(?P<SKIPTO>.+)%)(?P<OFFSET>[\+-]?\d+)?$").unwrap();
+        Regex::new(r"^(/(?P<UPTO>.+)/|%(?P<SKIPTO>.+)%)(?P<OFFSET>[\+-]?[0-9]+)?$").unwrap();
     let execute_ntimes_reg = Regex::new(r"^\{(?P<TIMES>[0-9]+)|\*\}$").unwrap();
     let mut iter = args.iter().peekable();
 

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -84,6 +84,15 @@ fn test_up_to_line_sequence() {
 }
 
 #[test]
+fn test_up_to_line_with_non_ascii_repeat() {
+    // we use a different error message than GNU
+    new_ucmd!()
+        .args(&["numbers50.txt", "10", "{𝟚}"])
+        .fails()
+        .stderr_contains("invalid pattern");
+}
+
+#[test]
 fn test_up_to_match() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "/9$/"])

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -177,6 +177,15 @@ fn test_up_to_match_offset_repeat_twice() {
 }
 
 #[test]
+fn test_up_to_match_non_ascii_offset() {
+    // we use a different error message than GNU
+    new_ucmd!()
+        .args(&["numbers50.txt", "/9$/𝟚"])
+        .fails()
+        .stderr_contains("invalid pattern");
+}
+
+#[test]
 fn test_up_to_match_negative_offset() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "/9$/-3"])


### PR DESCRIPTION
This PR fixes two issues related to the use of `\d` in regexes because it matches Unicode digits whereas we only expect ASCII digits.