### PR TITLE
expr: Remove `expr.pl` from `why-error.md`

### DIFF
--- a/util/why-error.md
+++ b/util/why-error.md
@@ -14,7 +14,6 @@ This file documents why some tests are failing:
 * gnu/tests/du/long-from-unreadable.sh - https://github.com/uutils/coreutils/issues/7217
 * gnu/tests/du/move-dir-while-traversing.sh
 * gnu/tests/expr/expr-multibyte.pl
-* gnu/tests/expr/expr.pl
 * gnu/tests/fmt/goal-option.sh
 * gnu/tests/fmt/non-space.sh
 * gnu/tests/head/head-elide-tail.pl


### PR DESCRIPTION
The `expr` command passes the tests in the GNU test file `expr.pl`. Remove the `expr.pl` from `why-error.md`.