### PR TITLE
.pre-commit-config.yaml: Do not fail cspell if all files are ignored

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
     -   id: cspell
         name: Code spell checker (cspell)
         description: Run cspell to check for spelling errors.
-        entry: cspell --
+        entry: cspell --no-must-find-files --
         pass_filenames: true
         language: system


### PR DESCRIPTION
cspell pre-commit hook would fail if the only change was a Cargo.lock change.

This fixes it.