### PR TITLE
rm: do "early return" earlier in `uumain`

### DIFF
--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -119,6 +119,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let force_flag = matches.get_flag(OPT_FORCE);
 
+    if files.is_empty() && !force_flag {
+        // Still check by hand and not use clap
+        // Because "rm -f" is a thing
+        return Err(UUsageError::new(1, "missing operand"));
+    }
+
     // If -f(--force) is before any -i (or variants) we want prompts else no prompts
     let force_prompt_never: bool = force_flag && {
         let force_index = matches.index_of(OPT_FORCE).unwrap_or(0);
@@ -130,71 +136,66 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             })
     };
 
-    if files.is_empty() && !force_flag {
-        // Still check by hand and not use clap
-        // Because "rm -f" is a thing
-        return Err(UUsageError::new(1, "missing operand"));
-    } else {
-        let options = Options {
-            force: force_flag,
-            interactive: {
-                if force_prompt_never {
-                    InteractiveMode::Never
-                } else if matches.get_flag(OPT_PROMPT) {
-                    InteractiveMode::Always
-                } else if matches.get_flag(OPT_PROMPT_MORE) {
-                    InteractiveMode::Once
-                } else if matches.contains_id(OPT_INTERACTIVE) {
-                    match matches.get_one::<String>(OPT_INTERACTIVE).unwrap().as_str() {
-                        "never" => InteractiveMode::Never,
-                        "once" => InteractiveMode::Once,
-                        "always" => InteractiveMode::Always,
-                        val => {
-                            return Err(USimpleError::new(
-                                1,
-                                format!("Invalid argument to interactive ({val})"),
-                            ));
-                        }
+    let options = Options {
+        force: force_flag,
+        interactive: {
+            if force_prompt_never {
+                InteractiveMode::Never
+            } else if matches.get_flag(OPT_PROMPT) {
+                InteractiveMode::Always
+            } else if matches.get_flag(OPT_PROMPT_MORE) {
+                InteractiveMode::Once
+            } else if matches.contains_id(OPT_INTERACTIVE) {
+                match matches.get_one::<String>(OPT_INTERACTIVE).unwrap().as_str() {
+                    "never" => InteractiveMode::Never,
+                    "once" => InteractiveMode::Once,
+                    "always" => InteractiveMode::Always,
+                    val => {
+                        return Err(USimpleError::new(
+                            1,
+                            format!("Invalid argument to interactive ({val})"),
+                        ));
                     }
-                } else {
-                    InteractiveMode::PromptProtected
                 }
-            },
-            one_fs: matches.get_flag(OPT_ONE_FILE_SYSTEM),
-            preserve_root: !matches.get_flag(OPT_NO_PRESERVE_ROOT),
-            recursive: matches.get_flag(OPT_RECURSIVE),
-            dir: matches.get_flag(OPT_DIR),
-            verbose: matches.get_flag(OPT_VERBOSE),
-            __presume_input_tty: if matches.get_flag(PRESUME_INPUT_TTY) {
-                Some(true)
             } else {
-                None
-            },
-        };
-        if options.interactive == InteractiveMode::Once && (options.recursive || files.len() > 3) {
-            let msg: String = format!(
-                "remove {} {}{}",
-                files.len(),
-                if files.len() > 1 {
-                    "arguments"
-                } else {
-                    "argument"
-                },
-                if options.recursive {
-                    " recursively?"
-                } else {
-                    "?"
-                }
-            );
-            if !prompt_yes!("{msg}") {
-                return Ok(());
+                InteractiveMode::PromptProtected
             }
-        }
-
-        if remove(&files, &options) {
-            return Err(1.into());
+        },
+        one_fs: matches.get_flag(OPT_ONE_FILE_SYSTEM),
+        preserve_root: !matches.get_flag(OPT_NO_PRESERVE_ROOT),
+        recursive: matches.get_flag(OPT_RECURSIVE),
+        dir: matches.get_flag(OPT_DIR),
+        verbose: matches.get_flag(OPT_VERBOSE),
+        __presume_input_tty: if matches.get_flag(PRESUME_INPUT_TTY) {
+            Some(true)
+        } else {
+            None
+        },
+    };
+    if options.interactive == InteractiveMode::Once && (options.recursive || files.len() > 3) {
+        let msg: String = format!(
+            "remove {} {}{}",
+            files.len(),
+            if files.len() > 1 {
+                "arguments"
+            } else {
+                "argument"
+            },
+            if options.recursive {
+                " recursively?"
+            } else {
+                "?"
+            }
+        );
+        if !prompt_yes!("{msg}") {
+            return Ok(());
         }
     }
+
+    if remove(&files, &options) {
+        return Err(1.into());
+    }
+
     Ok(())
 }
 

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -110,7 +110,7 @@ static ARG_FILES: &str = "files";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uu_app().after_help(AFTER_HELP).try_get_matches_from(args)?;
+    let matches = uu_app().try_get_matches_from(args)?;
 
     let files: Vec<&OsStr> = matches
         .get_many::<OsString>(ARG_FILES)
@@ -204,6 +204,7 @@ pub fn uu_app() -> Command {
         .version(uucore::crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
+        .after_help(AFTER_HELP)
         .infer_long_args(true)
         .args_override_self(true)
         .arg(

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -112,7 +112,7 @@ static ARG_FILES: &str = "files";
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uu_app().try_get_matches_from(args)?;
 
-    let files: Vec<&OsStr> = matches
+    let files: Vec<_> = matches
         .get_many::<OsString>(ARG_FILES)
         .map(|v| v.map(OsString::as_os_str).collect())
         .unwrap_or_default();
@@ -126,7 +126,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     // If -f(--force) is before any -i (or variants) we want prompts else no prompts
-    let force_prompt_never: bool = force_flag && {
+    let force_prompt_never = force_flag && {
         let force_index = matches.index_of(OPT_FORCE).unwrap_or(0);
         ![OPT_PROMPT, OPT_PROMPT_MORE, OPT_INTERACTIVE]
             .iter()


### PR DESCRIPTION
This PR does an "early return" in `uumain` a bit earlier and removes the `else` to get rid of an indentation level. It also sets the "after help" in `uu_app`, instead of `uumain`, like in most other utils. And it removes some unnecessary type information.