### PR TITLE
Feat/add wezterm to terms

### DIFF
--- a/src/uucore/src/lib/features/colors.rs
+++ b/src/uucore/src/lib/features/colors.rs
@@ -38,6 +38,7 @@ pub static TERMS: &[&str] = &[
     "terminator",
     "tmux*",
     "vt100",
+    "wezterm*",
     "xterm*",
 ];
 

--- a/tests/fixtures/dircolors/internal.expected
+++ b/tests/fixtures/dircolors/internal.expected
@@ -32,6 +32,7 @@ TERM st
 TERM terminator
 TERM tmux*
 TERM vt100
+TERM wezterm*
 TERM xterm*
 # Below are the color init strings for the basic file types.
 # One can use codes for 256 or more colors supported by modern terminals.


### PR DESCRIPTION
Adds color support for WezTerm.

Relevant Issue: https://github.com/uutils/coreutils/issues/8046