### PR TITLE
uucore: locale: Use if let instead of match

### DIFF
--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -739,13 +739,14 @@ invalid-syntax = This is { $missing
         assert_eq!(result.unwrap(), "es-ES");
 
         // Restore original LANG value
-        match original_lang {
-            Some(val) => unsafe {
+        if let Some(val) = original_lang {
+            unsafe {
                 env::set_var("LANG", val);
-            },
-            None => unsafe {
+            }
+        } else {
+            unsafe {
                 env::remove_var("LANG");
-            },
+            }
         }
     }
 
@@ -764,11 +765,12 @@ invalid-syntax = This is { $missing
         assert_eq!(result.unwrap().to_string(), "en-US");
 
         // Restore original LANG value
-        match original_lang {
-            Some(val) => unsafe {
+        if let Some(val) = original_lang {
+            unsafe {
                 env::set_var("LANG", val);
-            },
-            None => {} // Was already unset
+            }
+        } else {
+            {} // Was already unset
         }
     }
 
@@ -791,13 +793,14 @@ invalid-syntax = This is { $missing
             assert_eq!(message, "Bonjour, le monde!");
 
             // Restore original LANG value
-            match original_lang {
-                Some(val) => unsafe {
+            if let Some(val) = original_lang {
+                unsafe {
                     env::set_var("LANG", val);
-                },
-                None => unsafe {
+                }
+            } else {
+                unsafe {
                     env::remove_var("LANG");
-                },
+                }
             }
         })
         .join()
@@ -823,13 +826,14 @@ invalid-syntax = This is { $missing
             assert_eq!(message, "Hello, world!");
 
             // Restore original LANG value
-            match original_lang {
-                Some(val) => unsafe {
+            if let Some(val) = original_lang {
+                unsafe {
                     env::set_var("LANG", val);
-                },
-                None => unsafe {
+                }
+            } else {
+                unsafe {
                     env::remove_var("LANG");
-                },
+                }
             }
         })
         .join()


### PR DESCRIPTION
Recent cargo clippy prefers to use if let for single pattern.

For some reason it only triggers on one of the LANG restore case though, but we can just fix them all.

Not completely sure why cargo clippy only complains about this one:
```
error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> src/uucore/src/lib/mods/locale.rs:767:9
    |
767 | /         match original_lang {
768 | |             Some(val) => unsafe {
769 | |                 env::set_var("LANG", val);
770 | |             },
771 | |             None => {} // Was already unset
772 | |         }
    | |_________^
    |
    = note: you might want to preserve the comments from inside the `match`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
    = note: `-D clippy::single-match` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::single_match)]`
help: try
    |
767 ~         if let Some(val) = original_lang { unsafe {
768 +             env::set_var("LANG", val);
769 +         } }
    |
```

@sylvestre FYI