### PR TITLE
Enable common pre-commit.ci fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,41 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: local
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
-    -   id: rust-linting
+      - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-shebang-scripts-are-executable
+        exclude: '.+\.rs' # would be triggered by #![some_attribute]
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+        args: [ --allow-multiple-documents ]
+      - id: destroyed-symlinks
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [ --fix=lf ]
+      - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: rust-linting
         name: Rust linting
         description: Run cargo fmt on files included in the commit.
         entry: cargo +stable fmt --
         pass_filenames: true
         types: [file, rust]
         language: system
-    -   id: rust-clippy
+      - id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit.
         entry: cargo +stable clippy --workspace --all-targets --all-features -- -D warnings
         pass_filenames: false
         types: [file, rust]
         language: system
-    -   id: cspell
+      - id: cspell
         name: Code spell checker (cspell)
         description: Run cspell to check for spelling errors.
         entry: cspell --no-must-find-files --


### PR DESCRIPTION
ATTENTION admins:  I don't see pre-commit in the list of actions that ran on this PR - perhaps it was never enabled?  https://pre-commit.ci/

Pre-commits are usually used to minimize busy work by the contributors, e.g., by fixing extra spacing, formatting, etc. This PR adds various basic text file checks to the repo.  I copied these settings from many other projects I maintain - they have proven to be fairly useful. I also made yaml spacing a bit cleaner.

I was a bit surprised it is used for `cargo clippy` because you wouldn't want clippy's auto-fixes to be auto-applied by CI, so usually GitHub workflow simply runs it as a regular step. This is outside of the scope for this PR, but perhaps it should be removed here?