### PR TITLE
sort: Make use of ExtendedBigDecimal in -g sorting, then attempt to recover some performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,6 +3287,7 @@ dependencies = [
 name = "uu_sort"
 version = "0.1.0"
 dependencies = [
+ "bigdecimal",
  "binary-heap-plus",
  "clap",
  "compare",

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -153,6 +153,15 @@ See also comments under `printf` for formatting precision and differences.
 
 `seq` provides `-t`/`--terminator` to set the terminator character.
 
+## `sort`
+
+When sorting with `-g`/`--general-numeric-sort`, arbitrary precision decimal numbers
+are parsed and compared, unlike GNU coreutils that uses platform-specific long
+double floating point numbers.
+
+Extremely large or small values can still overflow or underflow to infinity or zero,
+see note in `seq`.
+
 ## `ls`
 
 GNU `ls` provides two ways to use a long listing format: `-l` and `--format=long`. We support a

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
 name = "uu_sort"
 version = "0.1.0"
 dependencies = [
+ "bigdecimal",
  "binary-heap-plus",
  "clap",
  "compare",

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -1,3 +1,5 @@
+# spell-checker:ignore bigdecimal
+
 [package]
 name = "uu_sort"
 description = "sort ~ (uutils) sort input lines"
@@ -18,6 +20,7 @@ workspace = true
 path = "src/sort.rs"
 
 [dependencies]
+bigdecimal = { workspace = true }
 binary-heap-plus = { workspace = true }
 clap = { workspace = true }
 compare = { workspace = true }

--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -17,7 +17,9 @@ use memchr::memchr_iter;
 use self_cell::self_cell;
 use uucore::error::{UResult, USimpleError};
 
-use crate::{GeneralF64ParseResult, GlobalSettings, Line, SortError, numeric_str_cmp::NumInfo};
+use crate::{
+    GeneralBigDecimalParseResult, GlobalSettings, Line, SortError, numeric_str_cmp::NumInfo,
+};
 
 self_cell!(
     /// The chunk that is passed around between threads.
@@ -41,7 +43,7 @@ pub struct ChunkContents<'a> {
 pub struct LineData<'a> {
     pub selections: Vec<&'a str>,
     pub num_infos: Vec<NumInfo>,
-    pub parsed_floats: Vec<GeneralF64ParseResult>,
+    pub parsed_floats: Vec<GeneralBigDecimalParseResult>,
     pub line_num_floats: Vec<Option<f64>>,
 }
 
@@ -100,7 +102,7 @@ pub struct RecycledChunk {
     lines: Vec<Line<'static>>,
     selections: Vec<&'static str>,
     num_infos: Vec<NumInfo>,
-    parsed_floats: Vec<GeneralF64ParseResult>,
+    parsed_floats: Vec<GeneralBigDecimalParseResult>,
     line_num_floats: Vec<Option<f64>>,
     buffer: Vec<u8>,
 }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1503,3 +1503,27 @@ fn test_files0_from_zero_length() {
         .fails_with_code(2)
         .stderr_only("sort: -:2: invalid zero-length file name\n");
 }
+
+#[test]
+// Test for GNU tests/sort/sort-float.sh
+fn test_g_float() {
+    let input = "0\n-3.3621031431120935063e-4932\n3.3621031431120935063e-4932\n";
+    let output = "-3.3621031431120935063e-4932\n0\n3.3621031431120935063e-4932\n";
+    new_ucmd!()
+        .args(&["-g"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(output);
+}
+
+#[test]
+// Test misc numbers ("'a" is not interpreted as literal, trailing text is ignored...)
+fn test_g_misc() {
+    let input = "1\n100\n90\n'a\n85hello\n";
+    let output = "'a\n1\n85hello\n90\n100\n";
+    new_ucmd!()
+        .args(&["-g"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(output);
+}


### PR DESCRIPTION
See #8031.

This fixes GNUTest sort-float, and actually improves a bit on GNU coreutils behaviour as we now use arbitrary precision to sort floats.

This comes with significant performance cost, so I tried to recover some of the performance by optimizing parsing, but couldn't get back to original runtime. We're still much faster than GNU sort.

`./sort-main` is current `upstream/main`, `./sort-baseline` is after just the first commit, and `target/release/sort` is after optimizations. `sort` is GNU coreutils:
```
cargo build -r -p uu_sort && LANG= LC_ALL= hyperfine -L sort sort,./sort-main,./sort-baseline,target/release/sort "{sort} -g tmp/floatdata"
Benchmark 1: sort -g tmp/floatdata
  Time (mean ± σ):     320.1 ms ±  11.2 ms    [User: 1007.3 ms, System: 10.5 ms]
  Range (min … max):   306.5 ms … 339.8 ms    10 runs
 
Benchmark 2: ./sort-main -g tmp/floatdata
  Time (mean ± σ):      76.4 ms ±   8.9 ms    [User: 348.1 ms, System: 22.1 ms]
  Range (min … max):    59.6 ms …  92.1 ms    45 runs
 
Benchmark 3: ./sort-baseline -g tmp/floatdata
  Time (mean ± σ):     164.4 ms ±  12.8 ms    [User: 559.4 ms, System: 27.9 ms]
  Range (min … max):   143.5 ms … 194.2 ms    18 runs
 
Benchmark 4: target/release/sort -g tmp/floatdata
  Time (mean ± σ):     142.1 ms ±  15.3 ms    [User: 575.7 ms, System: 30.7 ms]
  Range (min … max):   108.6 ms … 165.3 ms    18 runs
 
Summary
  ./sort-main -g tmp/floatdata ran
    1.86 ± 0.29 times faster than target/release/sort -g tmp/floatdata
    2.15 ± 0.30 times faster than ./sort-baseline -g tmp/floatdata
    4.19 ± 0.51 times faster than sort -g tmp/floatdata
```

---

### test_sort: Add more sort use cases

test_g_float comes from GNU test, the other one is manually crafted.

### docs/src/extensions: Sort uses arbitrary precision decimal numbers

### uucore: num_parser: Optimize bigdecimal create when exponent is 0

Makes creating float number without an exponent part quite a bit
faster. Saves about 9% speed in sort -g.

### uucore: num_parser: Optimize parse_digits_count

parse_digits_count is a significant hotspot in parsing code.
In particular, any add/mul operation on BigUint is fairly slow,
so it's better to accumulate digits in a u64, then add them
to the resulting BigUint.

Saves about 15-20% performance in `sort -g`.

### uucore: num_parser: Improve scale conversion to i64

It turns out repeatedly calling i64::MAX.into() and i64::MIN.into()
is actually very expensive. Just do the conversion first, and if
it fails, we know why.

Sadly there is still a conversion happening under the hood in
`-exponent + scale`, but that'd need to be fixed in Bigint.

Improves sort -g performance by ~5%.

### sort: Make use of ExtendedBigDecimal in -g sorting

This provides better precision than f64, which we need.

Fixed #8031.

