### PR TITLE
 mv:  moving dangling symlinks into directories 

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -526,7 +526,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, options: &Options) 
     };
 
     for sourcepath in files {
-        if !sourcepath.exists() {
+        if sourcepath.symlink_metadata().is_err() {
             show!(MvError::NoSuchFile(sourcepath.quote().to_string()));
             continue;
         }

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -445,6 +445,19 @@ fn test_mv_same_hardlink() {
 
 #[test]
 #[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_dangling_symlink_to_folder() {
+    let (at, mut ucmd) = at_and_ucmd!();   
+
+    at.symlink_file("404", "abc");
+    at.mkdir("x");
+    
+    ucmd.arg("abc").arg("x").succeeds();
+
+    assert!(at.symlink_exists("x/abc"));
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
 fn test_mv_same_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_same_file_a";

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -446,11 +446,11 @@ fn test_mv_same_hardlink() {
 #[test]
 #[cfg(all(unix, not(target_os = "android")))]
 fn test_mv_dangling_symlink_to_folder() {
-    let (at, mut ucmd) = at_and_ucmd!();   
+    let (at, mut ucmd) = at_and_ucmd!();
 
     at.symlink_file("404", "abc");
     at.mkdir("x");
-    
+
     ucmd.arg("abc").arg("x").succeeds();
 
     assert!(at.symlink_exists("x/abc"));


### PR DESCRIPTION
Closes #8044
dangling symlinks can now be relocated into a directory without failure, matching GNU coreutils’ behavior.
```log
cargo test mv
   Compiling uu_mv v0.1.0 (/home/albin/projects/coreutils/src/uu/mv)
   Compiling coreutils v0.1.0 (/home/albin/projects/coreutils)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.09s
     Running unittests src/bin/coreutils.rs (target/debug/deps/coreutils-d0ad6b34a65b65cb)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_util_name.rs (target/debug/deps/test_util_name-7b96ec09c97220a7)
Setting UUTESTS_BINARY_PATH=/home/albin/projects/coreutils/target/debug/coreutils

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s

     Running tests/tests.rs (target/debug/deps/tests-22678ceaad60c2c0)

running 97 tests
setfacl: a: No such file or directory
test test_mv::test_acl ... ok
test test_mv::test_mv_arg_interactive_skipped_vin ... ok
test test_mv::test_mv_arg_backup_arg_first ... ok
test test_mv::inter_partition_copying::test_mv_unlinks_dest_symlink_error_message ... ok
test test_mv::test_mv_arg_update_none ... ok
test test_mv::inter_partition_copying::test_mv_unlinks_dest_symlink ... ok
test test_mv::test_mv_arg_update_none_then_all ... ok
test test_mv::test_mv_arg_interactive_skipped ... ok
test test_mv::test_mv_arg_update_all_then_none ... ok
test test_mv::test_mv_arg_update_all ... ok
test test_mv::test_mv_arg_update_interactive ... ok
test test_mv::test_move_should_not_fallback_to_copy ... ok
test test_mv::test_mv_backup_existing ... ok
test test_mv::test_mv_arg_update_short_no_overwrite ... ok
test test_mv::test_mv_arg_update_short_overwrite ... ok
test test_mv::test_mv_arg_update_older_dest_older ... ok
test test_mv::test_mv_arg_update_older_dest_not_older ... ok
test test_mv::test_mv_backup_dir ... ok
test test_mv::test_mv_arg_update_older_dest_older_interactive ... ok
test test_mv::test_mv_backup_never ... ok
test test_mv::test_mv_backup_nil ... ok
test test_mv::test_mv_backup_none ... ok
test test_mv::test_mv_custom_backup_suffix ... ok
test test_mv::test_mv_custom_backup_suffix_hyphen_value ... ok
test test_mv::test_mv_backup_simple ... ok
test test_mv::test_mv_backup_numbered_with_t ... ok
test test_mv::test_mv_backup_off ... ok
test test_mv::test_mv_custom_backup_suffix_via_env ... ok
test test_mv::test_mv_dir_into_file_where_both_are_files ... ok
test test_mv::test_mv_dir_into_dir_with_source_name_a_prefix_of_target_name ... ok
test test_mv::test_mv_directory_self::case_01 ... ok
test test_mv::test_mv_directory_self::case_02 ... ok
test test_mv::test_mv_directory_self::case_05 ... ok
test test_mv::test_mv_directory_self::case_04 ... ok
test test_mv::test_mv_backup_conflicting_options ... ok
test test_mv::test_mv_directory_self::case_03 ... ok
test test_mv::test_mv_directory_self::case_06 ... ok
test test_mv::test_mv_directory_self::case_08 ... ok
test test_mv::test_mv_dangling_symlink_to_folder ... ok
test test_mv::test_mv_dir_into_path_slash ... ok
test test_mv::test_mv_backup_numbered ... ok
test test_mv::test_mv_directory_self::case_07 ... ok
test test_mv::test_mv_error_msg_with_multiple_sources_that_does_not_exist ... ok
test test_mv::test_mv_directory_self::case_09 ... ok
test test_mv::test_mv_directory_self::case_10 ... ok
test test_mv::test_mv_file_into_dir_where_both_are_files ... ok
test test_mv::test_mv_force_replace_file ... ok
test test_mv::test_mv_interactive_dir_to_file_not_affirmative ... ok
test test_mv::test_mv_interactive_error ... ok
test test_mv::test_mv_into_self_data ... ok
test test_mv::test_mv_interactive_with_dir_as_target ... ok
test test_mv::test_mv_missing_dest ... ok
test test_mv::test_mv_invalid_arg ... ok
test test_mv::test_mv_move_file_into_dir ... ok
test test_mv::test_mv_move_file_between_dirs ... ok
test test_mv::test_mv_interactive ... ok
test test_mv::test_mv_hardlink_to_symlink ... ok
test test_mv::test_mv_move_file_into_dir_with_target_arg ... ok
test test_mv::test_mv_move_file_into_file_with_target_arg ... ok
test test_mv::test_mv_errors ... ok
test test_mv::test_mv_move_multiple_files_into_file ... ok
test test_mv::test_mv_multiple_files ... ok
test test_mv::test_mv_multiple_folders ... ok
test test_mv::test_mv_no_clobber ... ok
test test_mv::test_mv_no_target_dir_with_dest_not_existing ... ok
test test_mv::test_mv_no_target_dir_with_dest_not_existing_and_ending_with_slash ... ok
test test_mv::test_mv_numbered_if_existing_backup_existing ... ok
test test_mv::test_mv_interactive_no_clobber_force_last_arg_wins ... ok
test test_mv::test_mv_numbered_if_existing_backup_nil ... ok
test test_mv::test_mv_overwrite_nonempty_dir ... ok
test test_mv::test_mv_overwrite_dir ... ok
test test_mv::test_mv_rename_file ... ok
test test_mv::test_mv_rename_dir ... ok
test test_mv::test_mv_same_broken_symlink ... ok
test test_mv::test_mv_replace_file ... ok
test test_mv::test_mv_same_file ... ok
test test_mv::test_mv_same_file_dot_dir ... ok
test test_mv::test_mv_same_hardlink_backup_simple ... ok
test test_mv::test_mv_same_hardlink ... ok
test test_mv::test_mv_same_hardlink_backup_simple_destroy ... ok
test test_mv::test_mv_same_file_not_dot_dir ... ok
test test_mv::test_mv_simple_backup ... ok
test test_mv::test_mv_simple_backup_for_directory ... ok
test test_mv::test_mv_seen_file ... ok
test test_mv::test_mv_seen_multiple_files_to_directory ... ok
test test_mv::test_special_file_different_filesystem ... ignored, requires access to a different filesystem
test test_mv::test_mv_permission_error ... ok
test test_mv::test_mv_simple_backup_with_file_extension ... ok
test test_mv::test_mv_symlink_into_target ... ok
test test_mv::test_mv_target_dir_single_source ... ok
test test_mv::test_mv_target_dir ... ok
test test_mv::test_mv_with_source_file_opened_and_target_file_exists ... ok
test test_mv::test_mv_update_with_dest_ending_with_slash ... ok
test test_mv::test_mv_strip_slashes ... ok
test test_mv::test_mv_update_option ... ok
test test_mv::test_mv_verbose ... ok
test test_mv::test_mv_same_symlink ... ok

test result: ok. 96 passed; 0 failed; 1 ignored; 0 measured; 3418 filtered out; finished in 0.07s
```