### PR TITLE
stdbuf: avoid double "lib" prefix

### DIFF
--- a/src/uu/stdbuf/build.rs
+++ b/src/uu/stdbuf/build.rs
@@ -69,7 +69,7 @@ fn main() {
     assert!(status.success(), "Failed to build libstdbuf");
 
     // Copy the built library to OUT_DIR for include_bytes! to find
-    let lib_name = format!("liblibstdbuf{}", platform::DYLIB_EXT);
+    let lib_name = format!("libstdbuf{}", platform::DYLIB_EXT);
     let dest_path = Path::new(&out_dir).join(format!("libstdbuf{}", platform::DYLIB_EXT));
 
     // Check multiple possible locations for the built library

--- a/src/uu/stdbuf/src/libstdbuf/Cargo.toml
+++ b/src/uu/stdbuf/src/libstdbuf/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 edition.workspace = true
 
 [lib]
-name = "libstdbuf"
+name = "stdbuf"
 path = "src/libstdbuf.rs"
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
libstdbuf is currently compiled as e.g. liblibstdbuf.so, which is confusing. Compile the library as libstdbuf.so instead.