### PR TITLE
cat: add error handling in write_fast function

### DIFF
--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -714,6 +714,26 @@ fn test_u_ignored() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_write_fast_read_error() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    // Create a file with content
+    at.write("foo", "content");
+
+    // Remove read permissions to cause a read error
+    let file_path = at.plus_as_string("foo");
+    let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
+    perms.set_mode(0o000); // No permissions
+    std::fs::set_permissions(&file_path, perms).unwrap();
+
+    // Test that cat fails with permission denied
+    ucmd.arg("foo").fails().stderr_contains("Permission denied");
+}
+
+#[test]
 #[cfg(target_os = "linux")]
 fn test_appending_same_input_output() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Closes #8068.

The `write_fast` function was silently ignoring read errors due to using `while let Ok(n) = handle.reader.read(&mut buf)` pattern. When `read()` returned an `Err`, the loop would simply exit without propagating the error, potentially leading to incomplete output without any indication of failure.

This PR replaces the while-let pattern with proper match-based error handling that immediately returns read errors using `Err(e) => return Err(e.into())`.
