### PR TITLE
uname: output OS last

### DIFF
--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -45,9 +45,9 @@ impl UNameOutput {
             self.kernel_release.as_ref(),
             self.kernel_version.as_ref(),
             self.machine.as_ref(),
-            self.os.as_ref(),
             self.processor.as_ref(),
             self.hardware_platform.as_ref(),
+            self.os.as_ref(),
         ]
         .into_iter()
         .flatten()

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -38,8 +38,7 @@ pub struct UNameOutput {
 
 impl UNameOutput {
     fn display(&self) -> String {
-        let mut output = String::new();
-        for name in [
+        [
             self.kernel_name.as_ref(),
             self.nodename.as_ref(),
             self.kernel_release.as_ref(),
@@ -51,11 +50,9 @@ impl UNameOutput {
         ]
         .into_iter()
         .flatten()
-        {
-            output.push_str(name);
-            output.push(' ');
-        }
-        output
+        .map(|name| name.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
     }
 
     pub fn new(opts: &Options) -> UResult<Self> {
@@ -138,7 +135,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         os: matches.get_flag(options::OS),
     };
     let output = UNameOutput::new(&options)?;
-    println!("{}", output.display().trim_end());
+    println!("{}", output.display());
     Ok(())
 }
 


### PR DESCRIPTION
`uname` from `coreutils` prints the OS information last, for example:
```
$ uname -pio
unknown unknown GNU/Linux
```
whereas our `uname` doesn't:
```
$ cargo run -q --features=unix uname -pio
GNU/Linux unknown unknown
```
This PR fixes the issue. It also gets rid of the trailing space in the return of the `display` function and thus makes the `trim_end()` call unnecessary.