### PR TITLE
feat: add `--version` argument to print main binary version

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -145,7 +145,7 @@ fn main() {
                 }
                 process::exit(0);
             }
-            "--version" => {
+            "--version" | "-V" => {
                 println!("{binary_as_util} {VERSION} (multi-call binary)");
                 process::exit(0);
             }

--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -145,6 +145,10 @@ fn main() {
                 }
                 process::exit(0);
             }
+            "--version" => {
+                println!("{binary_as_util} {VERSION} (multi-call binary)");
+                process::exit(0);
+            }
             // Not a special command: fallthrough to calling a util
             _ => {}
         }


### PR DESCRIPTION
fixes #8071

Output is the same as in usage, but no trailing newline:

```bash
coreutils 0.1.0 (multi-call binary)
```
