### PR TITLE
stty: fix negated options getting rejected by clap

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -578,7 +578,7 @@ fn apply_char_mapping(termios: &mut Termios, mapping: &(SpecialCharacterIndices,
 //
 // This function returns the ascii value of valid control chars, or ControlCharMappingError if invalid
 fn string_to_control_char(s: &str) -> Result<u8, ControlCharMappingError> {
-    if s == "undef" || s == "^-" {
+    if s == "undef" || s == "^-" || s.is_empty() {
         return Ok(0);
     }
 


### PR DESCRIPTION
fix for #6820. currently, there is no way to negate or disable an stty setting. for example, `stty echonl` works, but it cannot be undone with `stty -echonl` since clap tries to parse `-echonl` as an option. allowing hyphen values for settings fixes this.