### PR TITLE
stty: fix mappings with empty string literal args

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -598,7 +598,7 @@ fn apply_char_mapping(termios: &mut Termios, mapping: &(SpecialCharacterIndices,
 //
 // This function returns the ascii value of valid control chars, or ControlCharMappingError if invalid
 fn string_to_control_char(s: &str) -> Result<u8, ControlCharMappingError> {
-    if s == "undef" || s == "^-" {
+    if s == "undef" || s == "^-" || s.is_empty() {
         return Ok(0);
     }
 

--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -14,19 +14,17 @@ fn test_invalid_arg() {
 }
 
 #[test]
-#[ignore = "Fails because cargo test does not run in a tty"]
 fn runs() {
     new_ucmd!().succeeds();
 }
 
 #[test]
-#[ignore = "Fails because cargo test does not run in a tty"]
 fn print_all() {
-    let res = new_ucmd!().succeeds();
+    let res = new_ucmd!().args(&["--all"]).succeeds();
 
     // Random selection of flags to check for
     for flag in [
-        "parenb", "parmrk", "ixany", "iuclc", "onlcr", "ofdel", "icanon", "noflsh",
+        "parenb", "parmrk", "ixany", "onlcr", "ofdel", "icanon", "noflsh",
     ] {
         res.stdout_contains(flag);
     }
@@ -96,6 +94,16 @@ fn invalid_mapping() {
         .args(&["intr", "0400"])
         .fails()
         .stderr_contains("invalid integer argument: '0400': Value too large for defined data type");
+
+    new_ucmd!()
+        .args(&["-econl"])
+        .fails()
+        .stderr_contains("invalid argument '-econl'");
+
+    new_ucmd!()
+        .args(&["igpar"])
+        .fails()
+        .stderr_contains("invalid argument 'igpar'");
 }
 
 #[test]
@@ -166,4 +174,36 @@ fn invalid_baud_setting() {
         .args(&["ospeed", "995"])
         .fails()
         .stderr_contains("invalid ospeed '995'");
+}
+
+#[test]
+fn set_mapping() {
+    new_ucmd!().args(&["intr", "'"]).succeeds();
+    new_ucmd!()
+        .args(&["--all"])
+        .succeeds()
+        .stdout_contains("intr = '");
+
+    new_ucmd!().args(&["intr", "undef"]).succeeds();
+    new_ucmd!()
+        .args(&["--all"])
+        .succeeds()
+        .stdout_contains("intr = <undef>");
+
+    new_ucmd!().args(&["intr", "^-"]).succeeds();
+    new_ucmd!()
+        .args(&["--all"])
+        .succeeds()
+        .stdout_contains("intr = <undef>");
+
+    new_ucmd!().args(&["intr", "^C"]).succeeds();
+    new_ucmd!()
+        .args(&["--all"])
+        .succeeds()
+        .stdout_contains("intr = ^C");
+
+    new_ucmd!()
+        .args(&["intr", "''"])
+        .fails()
+        .stderr_contains("invalid integer argument: ''''");
 }

--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -14,11 +14,13 @@ fn test_invalid_arg() {
 }
 
 #[test]
+#[ignore = "Fails because cargo test does not run in a tty"]
 fn runs() {
     new_ucmd!().succeeds();
 }
 
 #[test]
+#[ignore = "Fails because cargo test does not run in a tty"]
 fn print_all() {
     let res = new_ucmd!().args(&["--all"]).succeeds();
 
@@ -94,16 +96,6 @@ fn invalid_mapping() {
         .args(&["intr", "0400"])
         .fails()
         .stderr_contains("invalid integer argument: '0400': Value too large for defined data type");
-
-    new_ucmd!()
-        .args(&["-econl"])
-        .fails()
-        .stderr_contains("invalid argument '-econl'");
-
-    new_ucmd!()
-        .args(&["igpar"])
-        .fails()
-        .stderr_contains("invalid argument 'igpar'");
 }
 
 #[test]
@@ -177,6 +169,7 @@ fn invalid_baud_setting() {
 }
 
 #[test]
+#[ignore = "Fails because cargo test does not run in a tty"]
 fn set_mapping() {
     new_ucmd!().args(&["intr", "'"]).succeeds();
     new_ucmd!()
@@ -196,14 +189,15 @@ fn set_mapping() {
         .succeeds()
         .stdout_contains("intr = <undef>");
 
+    new_ucmd!().args(&["intr", ""]).succeeds();
+    new_ucmd!()
+        .args(&["--all"])
+        .succeeds()
+        .stdout_contains("intr = <undef>");
+
     new_ucmd!().args(&["intr", "^C"]).succeeds();
     new_ucmd!()
         .args(&["--all"])
         .succeeds()
         .stdout_contains("intr = ^C");
-
-    new_ucmd!()
-        .args(&["intr", "''"])
-        .fails()
-        .stderr_contains("invalid integer argument: ''''");
 }


### PR DESCRIPTION
fixes #8134. adds a new way to set a control character to undefined, eg `stty intr ''`, which disables the interrupt signal control character.