### PR TITLE
stty: fix negated options getting rejected by clap

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -646,6 +646,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::SETTINGS)
                 .action(ArgAction::Append)
+                .allow_hyphen_values(true)
                 .help("settings to change"),
         )
 }

--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore parenb parmrk ixany iuclc onlcr ofdel icanon noflsh
+// spell-checker:ignore parenb parmrk ixany iuclc onlcr ofdel icanon noflsh econl igpar
 
 use uutests::new_ucmd;
 use uutests::util::TestScenario;
@@ -96,4 +96,17 @@ fn invalid_mapping() {
         .args(&["intr", "0400"])
         .fails()
         .stderr_contains("invalid integer argument: '0400': Value too large for defined data type");
+}
+
+#[test]
+fn invalid_setting() {
+    new_ucmd!()
+        .args(&["-econl"])
+        .fails()
+        .stderr_contains("invalid argument '-econl'");
+
+    new_ucmd!()
+        .args(&["igpar"])
+        .fails()
+        .stderr_contains("invalid argument 'igpar'");
 }


### PR DESCRIPTION
fix for https://github.com/uutils/coreutils/issues/6820. currently, there is no way to negate or disable an stty setting. for example, `stty echonl` works, but it cannot be undone with `stty -echonl` since clap tries to parse `-echonl` as an option. allowing hyphen values for settings fixes this.