### PR TITLE
fix: #8034 chown parse trailing colon as implicit group-is-user

### DIFF
--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -277,7 +277,9 @@ mod test {
         assert!(format!("{}", parse_spec("0:", ':').err().unwrap()).starts_with("invalid spec: "));
     }
 
+    /// root user uid/gid unresolvable in some environments
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_parse_spec_named() {
         assert!(matches!(parse_spec("root:", ':'), Ok((Some(0), Some(0)))));
     }

--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -222,7 +222,7 @@ fn parse_spec(spec: &str, sep: char) -> UResult<(Option<u32>, Option<u32>)> {
     let group = args
         .next()
         .map(|g| {
-            if g.is_empty() {
+            if g.is_empty() && sep == ':' {
                 // argument ended with a colon, implicit group == user
                 implicit_group_is_user = true;
                 user

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -156,13 +156,17 @@ fn test_chown_only_owner_colon() {
             .succeeds()
             .stderr_contains("retained as");
     } else {
-        scene
+        let failure = scene
             .ucmd()
             .arg(format!("{user_name}:"))
             .arg("--verbose")
             .arg(file1)
-            .fails()
-            .stderr_contains("failed to change");
+            .fails();
+        // Depending on the environment, it may be a forbidden group (failed to change) or group not existing (invalid group)
+        assert!(
+            failure.stderr_str().contains("failed to change")
+                || failure.stderr_str().contains("invalid group")
+        );
     }
 
     scene

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -177,13 +177,17 @@ fn test_chown_only_owner_colon() {
         .succeeds()
         .stderr_contains("retained as");
 
-    scene
+    let failure = scene
         .ucmd()
         .arg("root:")
         .arg("--verbose")
         .arg(file1)
-        .fails()
-        .stderr_contains("failed to change");
+        .fails();
+    // Depending on the environment, it may be a forbidden group (failed to change) or group not existing (invalid group)
+    assert!(
+        failure.stderr_str().contains("failed to change")
+            || failure.stderr_str().contains("invalid group")
+    );
 }
 
 #[test]


### PR DESCRIPTION
fixes #8034

https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html#chown-invocation

> owner‘:’
>
>    If a colon but no group name follows owner, that user is made the owner of the files and the group of the files is changed to owner’s login group.

That case wasn't covered by `parse_spec`.

It doesn't explicitly say in the above doc, but doing it with ids like `chown 0: <dir>` produces:

`chown: invalid spec: '0:'`

So that was also implemented here.