### PR TITLE
expr: fix substr parsing

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -685,9 +685,9 @@ impl<'a, S: AsRef<str>> Parser<'a, S> {
                 }
             }
             "substr" => {
-                let string = self.parse_expression()?;
-                let pos = self.parse_expression()?;
-                let length = self.parse_expression()?;
+                let string = self.parse_simple_expression()?;
+                let pos = self.parse_simple_expression()?;
+                let length = self.parse_simple_expression()?;
                 AstNodeInner::Substr {
                     string: Box::new(string),
                     pos: Box::new(pos),

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -508,6 +508,19 @@ fn test_substr() {
 }
 
 #[test]
+fn test_substr_precedence() {
+    new_ucmd!()
+        .args(&["substr", "ab cd", "3", "1", "!=", " "])
+        .fails_with_code(1)
+        .stdout_only("0\n");
+
+    new_ucmd!()
+        .args(&["substr", "ab cd", "2", "1", "!=", " "])
+        .succeeds()
+        .stdout_only("1\n");
+}
+
+#[test]
 fn test_invalid_substr() {
     new_ucmd!()
         .args(&["substr", "abc", "0", "1"])


### PR DESCRIPTION
Fixes #8063

Changed parsing of `expr substr` arguments, so they have a higher precedence than whatever follows. Before those changes the parser was too eager and gave incorrect results when `expr substr` arguments were followed by bash conditional ("!="). The script used to reproduce the issue now gives the correct result.

Looking forward to feedback for this short PR :)

Fixes for `index`, `length`, `match` will come, if actually needed, in future PR(s).