### PR TITLE
expr: fix builtin functions precedence

### DIFF
--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -676,8 +676,8 @@ impl<'a, S: AsRef<str>> Parser<'a, S> {
         let first = self.next()?;
         let inner = match first {
             "match" => {
-                let left = self.parse_expression()?;
-                let right = self.parse_expression()?;
+                let left = self.parse_simple_expression()?;
+                let right = self.parse_simple_expression()?;
                 AstNodeInner::BinOp {
                     op_type: BinOp::String(StringOp::Match),
                     left: Box::new(left),
@@ -695,8 +695,8 @@ impl<'a, S: AsRef<str>> Parser<'a, S> {
                 }
             }
             "index" => {
-                let left = self.parse_expression()?;
-                let right = self.parse_expression()?;
+                let left = self.parse_simple_expression()?;
+                let right = self.parse_simple_expression()?;
                 AstNodeInner::BinOp {
                     op_type: BinOp::String(StringOp::Index),
                     left: Box::new(left),
@@ -704,7 +704,7 @@ impl<'a, S: AsRef<str>> Parser<'a, S> {
                 }
             }
             "length" => {
-                let string = self.parse_expression()?;
+                let string = self.parse_simple_expression()?;
                 AstNodeInner::Length {
                     string: Box::new(string),
                 }

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -508,14 +508,44 @@ fn test_substr() {
 }
 
 #[test]
-fn test_substr_precedence() {
+fn test_builtin_functions_precedence() {
     new_ucmd!()
         .args(&["substr", "ab cd", "3", "1", "!=", " "])
         .fails_with_code(1)
         .stdout_only("0\n");
 
     new_ucmd!()
-        .args(&["substr", "ab cd", "2", "1", "!=", " "])
+        .args(&["substr", "ab cd", "3", "1", "=", " "])
+        .succeeds()
+        .stdout_only("1\n");
+
+    new_ucmd!()
+        .args(&["length", "abcd", "!=", "4"])
+        .fails_with_code(1)
+        .stdout_only("0\n");
+
+    new_ucmd!()
+        .args(&["length", "abcd", "=", "4"])
+        .succeeds()
+        .stdout_only("1\n");
+
+    new_ucmd!()
+        .args(&["index", "abcd", "c", "!=", "3"])
+        .fails_with_code(1)
+        .stdout_only("0\n");
+
+    new_ucmd!()
+        .args(&["index", "abcd", "c", "=", "3"])
+        .succeeds()
+        .stdout_only("1\n");
+
+    new_ucmd!()
+        .args(&["match", "abcd", "ab\\(.*\\)", "!=", "cd"])
+        .fails_with_code(1)
+        .stdout_only("0\n");
+
+    new_ucmd!()
+        .args(&["match", "abcd", "ab\\(.*\\)", "=", "cd"])
         .succeeds()
         .stdout_only("1\n");
 }


### PR DESCRIPTION
Follow up to #8158

The issue #8063 found in `expr substr` was also present in `index`, `length`, `match`. This PR applies the same fix for those remaining builtin expr functions.