### PR TITLE
stty: add ispeed/ospeed settings

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore clocal erange tcgetattr tcsetattr tcsanow tiocgwinsz tiocswinsz cfgetospeed cfsetospeed ushort vmin vtime cflag lflag
+// spell-checker:ignore clocal erange tcgetattr tcsetattr tcsanow tiocgwinsz tiocswinsz cfgetospeed cfsetospeed ushort vmin vtime cflag lflag ispeed ospeed
 
 mod flags;
 

--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore parenb parmrk ixany iuclc onlcr ofdel icanon noflsh econl igpar
+// spell-checker:ignore parenb parmrk ixany iuclc onlcr ofdel icanon noflsh econl igpar ispeed ospeed
 
 use uutests::new_ucmd;
 use uutests::util::TestScenario;

--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -110,3 +110,60 @@ fn invalid_setting() {
         .fails()
         .stderr_contains("invalid argument 'igpar'");
 }
+
+#[test]
+fn invalid_baud_setting() {
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    new_ucmd!()
+        .args(&["100"])
+        .fails()
+        .stderr_contains("invalid argument '100'");
+
+    new_ucmd!()
+        .args(&["-1"])
+        .fails()
+        .stderr_contains("invalid argument '-1'");
+
+    new_ucmd!()
+        .args(&["ispeed"])
+        .fails()
+        .stderr_contains("missing argument to 'ispeed'");
+
+    new_ucmd!()
+        .args(&["ospeed"])
+        .fails()
+        .stderr_contains("missing argument to 'ospeed'");
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    new_ucmd!()
+        .args(&["ispeed", "995"])
+        .fails()
+        .stderr_contains("invalid ispeed '995'");
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    new_ucmd!()
+        .args(&["ospeed", "995"])
+        .fails()
+        .stderr_contains("invalid ospeed '995'");
+}


### PR DESCRIPTION
this addition is part of #3859. on almost all platforms, setting asymmetric ispeed/ospeed is not supported, so `stty ispeed 110`, `stty ospeed 110` and `stty 110` all have the exact same effect. still, its useful to add these options which are found in the GNU version. 