### PR TITLE
timeout: catch TERM signal

### DIFF
--- a/src/uu/timeout/src/status.rs
+++ b/src/uu/timeout/src/status.rs
@@ -30,6 +30,9 @@ pub(crate) enum ExitStatus {
 
     /// When there is a failure while waiting for the child process to terminate.
     WaitingFailed,
+
+    /// When `SIGTERM` signal received.
+    Terminated,
 }
 
 impl From<ExitStatus> for i32 {
@@ -39,6 +42,7 @@ impl From<ExitStatus> for i32 {
             ExitStatus::TimeoutFailed => 125,
             ExitStatus::SignalSent(s) => 128 + s as Self,
             ExitStatus::WaitingFailed => 124,
+            ExitStatus::Terminated => 143,
         }
     }
 }

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -206,3 +206,23 @@ fn test_hex_timeout_ending_with_d() {
         .fails_with_code(124)
         .no_output();
 }
+
+#[test]
+fn test_terminate_child_on_receiving_terminate() {
+    let mut timeout_cmd = new_ucmd!()
+        .args(&[
+            "10",
+            "sh",
+            "-c",
+            "trap 'echo child received TERM' TERM; sleep 5",
+        ])
+        .run_no_wait();
+    timeout_cmd.delay(100);
+    timeout_cmd.kill_with_custom_signal(nix::sys::signal::Signal::SIGTERM);
+    timeout_cmd
+        .make_assertion()
+        .is_not_alive()
+        .with_current_output()
+        .code_is(143)
+        .stdout_contains("child received TERM");
+}


### PR DESCRIPTION
fixes #8040 
set a signal handler and terminate child process on receiving SIGTERM.
I'm a bit confused about how to write tests for it, is it appropriate to use `ps` and `kill` in ci?