### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// cspell:disable-next-line
+				"foxundermoon.shell-format",
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	},
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "./.devcontainer/postCreateCommand.sh"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sudo apt update && sudo apt install -y --no-install-recommends \
+    clang

--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -28,6 +28,8 @@ denoland
 deque
 dequeue
 dev
+devcontainer
+devcontainers
 devs
 discoverability
 duplicative


### PR DESCRIPTION
Adds basic devcontainer configuration using Microsoft's rust:1-1-bookworm container.

The existing recommended extensions are included.

Suggested here https://github.com/uutils/coreutils/pull/6947#issuecomment-2657933974, this devcontainer was very useful to me to test a small change.

I wasn't sure how to best format the commit message for this change. Please let me know if you'd like me to amend it.