### PR TITLE
ls: follow symlinks for xattrs, fix #8216

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -68,6 +68,7 @@ kibi
 kibibytes
 libacl
 lcase
+listxattr
 llistxattr
 lossily
 lstat

--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -79,7 +79,7 @@ pub fn apply_xattrs<P: AsRef<Path>>(
 /// `true` if the file has extended attributes (indicating an ACL), `false` otherwise.
 pub fn has_acl<P: AsRef<Path>>(file: P) -> bool {
     // don't use exacl here, it is doing more getxattr call then needed
-    xattr::list(file).is_ok_and(|acl| {
+    xattr::list_deref(file).is_ok_and(|acl| {
         // if we have extra attributes, we have an acl
         acl.count() > 0
     })

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe bcdef mfoo
-// spell-checker:ignore (words) fakeroot setcap drwxr
+// spell-checker:ignore (words) fakeroot setcap drwxr drwxrwxr
 #![allow(
     clippy::similar_names,
     clippy::too_many_lines,

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore (words) READMECAREFULLY birthtime doesntexist oneline somebackup lrwx somefile somegroup somehiddenbackup somehiddenfile tabsize aaaaaaaa bbbb cccc dddddddd ncccc neee naaaaa nbcdef nfffff dired subdired tmpfs mdir COLORTERM mexe bcdef mfoo
-// spell-checker:ignore (words) fakeroot setcap drwxr drwxrwxr
+// spell-checker:ignore (words) fakeroot setcap drwxr
 #![allow(
     clippy::similar_names,
     clippy::too_many_lines,

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5744,9 +5744,12 @@ fn test_acl_display_symlink() {
             return;
         }
     }
+
     at.symlink_dir(dir_name, link_name);
+
+    let re_with_acl = Regex::new(r"[a-z-]*\+ .*link").unwrap();
     ucmd.arg("-lLd")
         .arg(link_name)
         .succeeds()
-        .stdout_contains("drwxrwxr-x+");
+        .stdout_matches(&re_with_acl);
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5730,7 +5730,7 @@ fn test_acl_display_symlink() {
     // calling the command directly. xattr requires some dev packages to be installed
     // and it adds a complex dependency just for a test
     match Command::new("setfacl")
-        .args(["-d", "-m", "u:bin:rwx", dir_name])
+        .args(["-d", "-m", "u:bin:rwx", &at.plus_as_string(dir_name)])
         .status()
         .map(|status| status.code())
     {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5716,3 +5716,37 @@ fn test_unknown_format_specifier() {
         .succeeds()
         .stdout_matches(&re_custom_format);
 }
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn test_acl_display_symlink() {
+    use std::process::Command;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir_name = "dir";
+    let link_name = "link";
+    at.mkdir(dir_name);
+
+    // calling the command directly. xattr requires some dev packages to be installed
+    // and it adds a complex dependency just for a test
+    match Command::new("setfacl")
+        .args(["-d", "-m", "u:bin:rwx", &dir_name])
+        .status()
+        .map(|status| status.code())
+    {
+        Ok(Some(0)) => {}
+        Ok(_) => {
+            println!("test skipped: setfacl failed");
+            return;
+        }
+        Err(e) => {
+            println!("test skipped: setfacl failed with {e}");
+            return;
+        }
+    }
+    at.symlink_dir(dir_name, link_name);
+    ucmd.arg("-lLd")
+        .arg(link_name)
+        .succeeds()
+        .stdout_contains("drwxrwxr-x+");
+}

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5730,7 +5730,7 @@ fn test_acl_display_symlink() {
     // calling the command directly. xattr requires some dev packages to be installed
     // and it adds a complex dependency just for a test
     match Command::new("setfacl")
-        .args(["-d", "-m", "u:bin:rwx", &dir_name])
+        .args(["-d", "-m", "u:bin:rwx", dir_name])
         .status()
         .map(|status| status.code())
     {

--- a/util/gnu-patches/tests_ls_no_cap.patch
+++ b/util/gnu-patches/tests_ls_no_cap.patch
@@ -8,13 +8,13 @@ index 99f0563bc..f7b9e7885 100755
  LS_COLORS=ca=1; export LS_COLORS
 -strace -e capget ls --color=always > /dev/null 2> out || fail=1
 -$EGREP 'capget\(' out || skip_ "your ls doesn't call capget"
-+strace -e llistxattr ls --color=always > /dev/null 2> out || fail=1
-+$EGREP 'llistxattr\(' out || skip_ "your ls doesn't call llistxattr"
++strace -e listxattr ls --color=always > /dev/null 2> out || fail=1
++$EGREP 'listxattr\(' out || skip_ "your ls doesn't call listxattr"
  
  LS_COLORS=ca=:; export LS_COLORS
 -strace -e capget ls --color=always > /dev/null 2> out || fail=1
 -$EGREP 'capget\(' out && fail=1
-+strace -e llistxattr ls --color=always > /dev/null 2> out || fail=1
-+$EGREP 'llistxattr\(' out && fail=1
++strace -e listxattr ls --color=always > /dev/null 2> out || fail=1
++$EGREP 'listxattr\(' out && fail=1
  
  Exit $fail


### PR DESCRIPTION
```
$ strace -e llistxattr,listxattr,getxattr ./target/debug/coreutils ls -lLd l
listxattr("l", 0x1, 0)                  = 24
listxattr("l", "system.posix_acl_access\0", 24) = 24
drwxrwxr-x+ 2 sudhackar sudhackar 4096 Jun 18 16:47 l
+++ exited with 0 +++
```
as compared to no `+`