### PR TITLE
stty: add options to set and print terminal size

### DIFF
--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -49,6 +49,14 @@ fn all_and_setting() {
 }
 
 #[test]
+fn all_and_print_setting() {
+    new_ucmd!()
+        .args(&["--all", "size"])
+        .fails()
+        .stderr_contains("when specifying an output style, modes may not be set");
+}
+
+#[test]
 fn save_and_all() {
     new_ucmd!()
         .args(&["--save", "--all"])


### PR DESCRIPTION
fixes for #3859. adds options for setting the size of the terminal's rows and columns, and printing the current size. 
* `stty rows <n>`
*  `stty columns <n>` or `stty cols <n>`
* `stty size`

i did add some new `unsafe` blocks, as ioctl calls are needed to get and set terminal size. i couldn't find documentation of what row/col sizes are accepted by GNU's `stty`, but i did some testing and am matching their behavior. i also added tests to confirm this behavior.