### PR TITLE
Bump `phf` and `phf_codegen` & fix compilation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,18 +1810,19 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1829,19 +1830,19 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,8 +336,8 @@ num-traits = "0.2.19"
 number_prefix = "0.4"
 onig = { version = "~6.5.1", default-features = false }
 parse_datetime = "0.9.0"
-phf = "0.11.2"
-phf_codegen = "0.11.2"
+phf = "0.12.1"
+phf_codegen = "0.12.1"
 platform-info = "2.0.3"
 rand = { version = "0.9.0", features = ["small_rng"] }
 rand_core = "0.9.0"

--- a/build.rs
+++ b/build.rs
@@ -65,39 +65,39 @@ pub fn main() {
             // 'test' is named uu_test to avoid collision with rust core crate 'test'.
             // It can also be invoked by name '[' for the '[ expr ] syntax'.
             "uu_test" => {
-                phf_map.entry("test", &map_value);
-                phf_map.entry("[", &map_value);
+                phf_map.entry("test", map_value.clone());
+                phf_map.entry("[", map_value.clone());
             }
             k if k.starts_with(OVERRIDE_PREFIX) => {
-                phf_map.entry(&k[OVERRIDE_PREFIX.len()..], &map_value);
+                phf_map.entry(&k[OVERRIDE_PREFIX.len()..], map_value.clone());
             }
             "false" | "true" => {
-                phf_map.entry(krate, &format!("(r#{krate}::uumain, r#{krate}::uu_app)"));
+                phf_map.entry(krate, format!("(r#{krate}::uumain, r#{krate}::uu_app)"));
             }
             "hashsum" => {
-                phf_map.entry(krate, &format!("({krate}::uumain, {krate}::uu_app_custom)"));
+                phf_map.entry(krate, format!("({krate}::uumain, {krate}::uu_app_custom)"));
 
                 let map_value = format!("({krate}::uumain, {krate}::uu_app_common)");
                 let map_value_bits = format!("({krate}::uumain, {krate}::uu_app_bits)");
                 let map_value_b3sum = format!("({krate}::uumain, {krate}::uu_app_b3sum)");
-                phf_map.entry("md5sum", &map_value);
-                phf_map.entry("sha1sum", &map_value);
-                phf_map.entry("sha224sum", &map_value);
-                phf_map.entry("sha256sum", &map_value);
-                phf_map.entry("sha384sum", &map_value);
-                phf_map.entry("sha512sum", &map_value);
-                phf_map.entry("sha3sum", &map_value_bits);
-                phf_map.entry("sha3-224sum", &map_value);
-                phf_map.entry("sha3-256sum", &map_value);
-                phf_map.entry("sha3-384sum", &map_value);
-                phf_map.entry("sha3-512sum", &map_value);
-                phf_map.entry("shake128sum", &map_value_bits);
-                phf_map.entry("shake256sum", &map_value_bits);
-                phf_map.entry("b2sum", &map_value);
-                phf_map.entry("b3sum", &map_value_b3sum);
+                phf_map.entry("md5sum", map_value.clone());
+                phf_map.entry("sha1sum", map_value.clone());
+                phf_map.entry("sha224sum", map_value.clone());
+                phf_map.entry("sha256sum", map_value.clone());
+                phf_map.entry("sha384sum", map_value.clone());
+                phf_map.entry("sha512sum", map_value.clone());
+                phf_map.entry("sha3sum", map_value_bits.clone());
+                phf_map.entry("sha3-224sum", map_value.clone());
+                phf_map.entry("sha3-256sum", map_value.clone());
+                phf_map.entry("sha3-384sum", map_value.clone());
+                phf_map.entry("sha3-512sum", map_value.clone());
+                phf_map.entry("shake128sum", map_value_bits.clone());
+                phf_map.entry("shake256sum", map_value_bits.clone());
+                phf_map.entry("b2sum", map_value.clone());
+                phf_map.entry("b3sum", map_value_b3sum);
             }
             _ => {
-                phf_map.entry(krate, &map_value);
+                phf_map.entry(krate, map_value.clone());
             }
         }
     }


### PR DESCRIPTION
This PR bumps both `phf` and `phf_codegen` from `0.11.2` to `0.12.1` and fixes errors in `build.rs` due to a breaking change in `phf_codegen`.