### PR TITLE
stty: remove redundant `cfg`

### DIFF
--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -175,13 +175,6 @@ pub const OUTPUT_FLAGS: &[Flag<O>] = &[
         target_os = "linux",
         target_os = "macos"
     ))]
-    #[cfg(any(
-        target_os = "android",
-        target_os = "haiku",
-        target_os = "ios",
-        target_os = "linux",
-        target_os = "macos"
-    ))]
     Flag::new_grouped("tab1", O::TAB1, O::TABDLY),
     #[cfg(any(
         target_os = "android",


### PR DESCRIPTION
I noticed the following snippet in our code:
```rust
#[cfg(any(
    target_os = "android",
    target_os = "haiku",
    target_os = "ios",
    target_os = "linux",
    target_os = "macos"
))]
#[cfg(any(
    target_os = "android",
    target_os = "haiku",
    target_os = "ios",
    target_os = "linux",
    target_os = "macos"
))]
Flag::new_grouped("tab1", O::TAB1, O::TABDLY),
```
This PR removes the redundant `cfg`.