### PR TITLE
uucore(quoting_style): Improve quoting style handling

### DIFF
--- a/src/uu/dir/src/dir.rs
+++ b/src/uu/dir/src/dir.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 use std::path::Path;
 use uu_ls::{Config, Format, options};
 use uucore::error::UResult;
-use uucore::quoting_style::{Quotes, QuotingStyle};
+use uucore::quoting_style::QuotingStyle;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -45,9 +45,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut config = Config::from(&matches)?;
 
     if default_quoting_style {
-        config.quoting_style = QuotingStyle::C {
-            quotes: Quotes::None,
-        };
+        config.quoting_style = QuotingStyle::C_NO_QUOTES;
     }
     if default_format_style {
         config.format = Format::Columns;

--- a/src/uu/vdir/src/vdir.rs
+++ b/src/uu/vdir/src/vdir.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 use std::path::Path;
 use uu_ls::{Config, Format, options};
 use uucore::error::UResult;
-use uucore::quoting_style::{Quotes, QuotingStyle};
+use uucore::quoting_style::QuotingStyle;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -44,9 +44,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut config = Config::from(&matches)?;
 
     if default_quoting_style {
-        config.quoting_style = QuotingStyle::C {
-            quotes: Quotes::None,
-        };
+        config.quoting_style = QuotingStyle::C_NO_QUOTES;
     }
     if default_format_style {
         config.format = Format::Long;

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -127,17 +127,6 @@ mod options {
 static ARG_FILES: &str = "files";
 static STDIN_REPR: &str = "-";
 
-static QS_ESCAPE: &QuotingStyle = &QuotingStyle::Shell {
-    escape: true,
-    always_quote: false,
-    show_control: false,
-};
-static QS_QUOTE_ESCAPE: &QuotingStyle = &QuotingStyle::Shell {
-    escape: true,
-    always_quote: true,
-    show_control: false,
-};
-
 /// Supported inputs.
 #[derive(Debug)]
 enum Inputs<'a> {
@@ -260,7 +249,8 @@ impl<'a> Input<'a> {
                 let path = path.as_os_str();
                 if path.to_string_lossy().contains('\n') {
                     Some(Cow::Owned(quoting_style::locale_aware_escape_name(
-                        path, QS_ESCAPE,
+                        path,
+                        QuotingStyle::SHELL_ESCAPE,
                     )))
                 } else {
                     Some(Cow::Borrowed(path))
@@ -761,9 +751,12 @@ fn files0_iter_file<'a>(path: &Path) -> UResult<impl Iterator<Item = InputIterIt
                 "wc-error-cannot-open-for-reading",
                 HashMap::from([(
                     "path".to_string(),
-                    quoting_style::locale_aware_escape_name(path.as_os_str(), QS_QUOTE_ESCAPE)
-                        .into_string()
-                        .expect("All escaped names with the escaping option return valid strings."),
+                    quoting_style::locale_aware_escape_name(
+                        path.as_os_str(),
+                        QuotingStyle::SHELL_ESCAPE_QUOTE,
+                    )
+                    .into_string()
+                    .expect("All escaped names with the escaping option return valid strings."),
                 )]),
             )
         })),
@@ -814,7 +807,7 @@ fn files0_iter<'a>(
 }
 
 fn escape_name_wrapper(name: &OsStr) -> String {
-    quoting_style::locale_aware_escape_name(name, QS_ESCAPE)
+    quoting_style::locale_aware_escape_name(name, QuotingStyle::SHELL_ESCAPE)
         .into_string()
         .expect("All escaped names with the escaping option return valid strings.")
 }

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -8,7 +8,7 @@ use crate::format::spec::ArgumentLocation;
 use crate::{
     error::set_exit_code,
     parser::num_parser::{ExtendedParser, ExtendedParserError},
-    quoting_style::{Quotes, QuotingStyle, locale_aware_escape_name},
+    quoting_style::{QuotingStyle, locale_aware_escape_name},
     show_error, show_warning,
 };
 use os_display::Quotable;
@@ -153,12 +153,7 @@ fn extract_value<T: Default>(p: Result<T, ExtendedParserError<'_, T>>, input: &s
         Ok(v) => v,
         Err(e) => {
             set_exit_code(1);
-            let input = locale_aware_escape_name(
-                OsStr::new(input),
-                &QuotingStyle::C {
-                    quotes: Quotes::None,
-                },
-            );
+            let input = locale_aware_escape_name(OsStr::new(input), QuotingStyle::C_NO_QUOTES);
             match e {
                 ExtendedParserError::Overflow(v) => {
                     show_error!("{}: Numerical result out of range", input.quote());

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -404,11 +404,7 @@ impl Spec {
             Self::QuotedString { position } => {
                 let s = locale_aware_escape_name(
                     args.next_string(position).as_ref(),
-                    &QuotingStyle::Shell {
-                        escape: true,
-                        always_quote: false,
-                        show_control: false,
-                    },
+                    QuotingStyle::SHELL_ESCAPE,
                 );
                 #[cfg(unix)]
                 let bytes = std::os::unix::ffi::OsStringExt::into_vec(s);


### PR DESCRIPTION
This MR introduces constants for quoting styles to simplify the declaration of quoting style variables throughout the codebase.

It also changes the interface of `escape_name` family of function to take `QuotingStyle` instead of `&QuotingStyle` as a parameter, because the struct implements `Copy` anyway