### PR TITLE
clippy: fix warnings from `uninlined_format_args` lint

### DIFF
--- a/src/uucore/src/lib/features/selinux.rs
+++ b/src/uucore/src/lib/features/selinux.rs
@@ -345,7 +345,7 @@ mod tests {
                 SeLinuxError::SELinuxNotEnabled => {
                     // This is the expected error when SELinux is not enabled
                 }
-                err => panic!("Expected SELinuxNotEnabled error but got: {}", err),
+                err => panic!("Expected SELinuxNotEnabled error but got: {err}"),
             }
             return;
         }
@@ -372,8 +372,7 @@ mod tests {
 
             assert!(
                 new_context.contains("tmp_t"),
-                "Expected context to contain 'tmp_t', but got: {}",
-                new_context
+                "Expected context to contain 'tmp_t', but got: {new_context}"
             );
         } else {
             println!(
@@ -425,7 +424,7 @@ mod tests {
 
         if result.is_ok() {
             let context = result.unwrap();
-            println!("Retrieved SELinux context: {}", context);
+            println!("Retrieved SELinux context: {context}");
 
             assert!(
                 is_selinux_enabled(),
@@ -435,8 +434,7 @@ mod tests {
             if !context.is_empty() {
                 assert!(
                     context.contains(':'),
-                    "SELinux context '{}' doesn't match expected format",
-                    context
+                    "SELinux context '{context}' doesn't match expected format"
                 );
             }
         } else {
@@ -455,7 +453,7 @@ mod tests {
                         "Got ContextRetrievalFailure when SELinux is not enabled"
                     );
                     assert!(!e.is_empty(), "Error message should not be empty");
-                    println!("Context retrieval failure: {}", e);
+                    println!("Context retrieval failure: {e}");
                 }
                 SeLinuxError::ContextConversionFailure(ctx, e) => {
                     assert!(
@@ -463,17 +461,16 @@ mod tests {
                         "Got ContextConversionFailure when SELinux is not enabled"
                     );
                     assert!(!e.is_empty(), "Error message should not be empty");
-                    println!("Context conversion failure for '{}': {}", ctx, e);
+                    println!("Context conversion failure for '{ctx}': {e}");
                 }
                 SeLinuxError::ContextSetFailure(ctx, e) => {
                     assert!(!e.is_empty(), "Error message should not be empty");
-                    println!("Context conversion failure for '{}': {}", ctx, e);
+                    println!("Context conversion failure for '{ctx}': {e}");
                 }
                 SeLinuxError::FileOpenFailure(e) => {
                     assert!(
                         Path::new(path).exists(),
-                        "File open failure occurred despite file being created: {}",
-                        e
+                        "File open failure occurred despite file being created: {e}"
                     );
                 }
             }
@@ -618,10 +615,10 @@ mod tests {
         if let Err(err) = result {
             match err {
                 SeLinuxError::ContextSetFailure(_, _) => {
-                    println!("Note: Could not set context due to permissions: {}", err);
+                    println!("Note: Could not set context due to permissions: {err}");
                 }
                 unexpected => {
-                    panic!("Unexpected error: {}", unexpected);
+                    panic!("Unexpected error: {unexpected}");
                 }
             }
         }

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -1071,12 +1071,12 @@ invalid-syntax = This is { $missing
             source: std::io::Error::new(std::io::ErrorKind::NotFound, "File not found"),
             path: PathBuf::from("/test/path.ftl"),
         };
-        let error_string = format!("{}", io_error);
+        let error_string = format!("{io_error}");
         assert!(error_string.contains("I/O error loading"));
         assert!(error_string.contains("/test/path.ftl"));
 
         let bundle_error = LocalizationError::Bundle("Bundle creation failed".to_string());
-        let bundle_string = format!("{}", bundle_error);
+        let bundle_string = format!("{bundle_error}");
         assert!(bundle_string.contains("Bundle error: Bundle creation failed"));
     }
 
@@ -1096,8 +1096,7 @@ invalid-syntax = This is { $missing
             // The snippet should contain exactly the invalid text from es-ES.ftl
             assert!(
                 snippet.contains("This is { $missing"),
-                "snippet was `{}` but did not include the invalid text",
-                snippet
+                "snippet was `{snippet}` but did not include the invalid text"
             );
         } else {
             panic!("Expected LocalizationError::ParseResource with snippet");


### PR DESCRIPTION
This PR fixes warnings from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lint in some `uucore` unit tests.