### PR TITLE
`stty`: remove quotes around strings in locale files

### DIFF
--- a/src/uu/stty/locales/en-US.ftl
+++ b/src/uu/stty/locales/en-US.ftl
@@ -1,21 +1,21 @@
-stty-usage = "stty [-F DEVICE | --file=DEVICE] [SETTING]...
+stty-usage = stty [-F DEVICE | --file=DEVICE] [SETTING]...
   or:  stty [-F DEVICE | --file=DEVICE] [-a|--all]
-  or:  stty [-F DEVICE | --file=DEVICE] [-g|--save]"
+  or:  stty [-F DEVICE | --file=DEVICE] [-g|--save]
 
-stty-about = "Print or change terminal characteristics."
+stty-about = Print or change terminal characteristics.
 
-stty-option-all = "print all current settings in human-readable form"
-stty-option-save = "print all current settings in a stty-readable form"
-stty-option-file = "open and use the specified DEVICE instead of stdin"
-stty-option-settings = "settings to change"
+stty-option-all = print all current settings in human-readable form
+stty-option-save = print all current settings in a stty-readable form
+stty-option-file = open and use the specified DEVICE instead of stdin
+stty-option-settings = settings to change
 
-stty-error-options-mutually-exclusive = "the options for verbose and stty-readable output styles are mutually exclusive"
-stty-error-output-style-no-modes = "when specifying an output style, modes may not be set"
-stty-error-missing-argument = "missing argument to '{$arg}'"
-stty-error-invalid-speed = "invalid {$arg} '{$speed}'"
-stty-error-invalid-argument = "invalid argument '{$arg}'"
-stty-error-invalid-integer-argument = "invalid integer argument: {$value}"
-stty-error-invalid-integer-argument-value-too-large = "invalid integer argument: {$value}: Value too large for defined data type"
+stty-error-options-mutually-exclusive = the options for verbose and stty-readable output styles are mutually exclusive
+stty-error-output-style-no-modes = when specifying an output style, modes may not be set
+stty-error-missing-argument = missing argument to '{$arg}'
+stty-error-invalid-speed = invalid {$arg} '{$speed}'
+stty-error-invalid-argument = invalid argument '{$arg}'
+stty-error-invalid-integer-argument = invalid integer argument: {$value}
+stty-error-invalid-integer-argument-value-too-large = invalid integer argument: {$value}: Value too large for defined data type
 
 # Output format strings
 stty-output-speed = speed {$speed} baud;

--- a/src/uu/stty/locales/fr-FR.ftl
+++ b/src/uu/stty/locales/fr-FR.ftl
@@ -1,21 +1,21 @@
-stty-usage = "stty [-F PÉRIPHÉRIQUE | --file=PÉRIPHÉRIQUE] [PARAMÈTRE]...
+stty-usage = stty [-F PÉRIPHÉRIQUE | --file=PÉRIPHÉRIQUE] [PARAMÈTRE]...
   ou:  stty [-F PÉRIPHÉRIQUE | --file=PÉRIPHÉRIQUE] [-a|--all]
-  ou:  stty [-F PÉRIPHÉRIQUE | --file=PÉRIPHÉRIQUE] [-g|--save]"
+  ou:  stty [-F PÉRIPHÉRIQUE | --file=PÉRIPHÉRIQUE] [-g|--save]
 
-stty-about = "Afficher ou modifier les caractéristiques du terminal."
+stty-about = Afficher ou modifier les caractéristiques du terminal.
 
-stty-option-all = "afficher tous les paramètres actuels sous forme lisible"
-stty-option-save = "afficher tous les paramètres actuels sous forme lisible par stty"
-stty-option-file = "ouvrir et utiliser le PÉRIPHÉRIQUE spécifié au lieu de stdin"
-stty-option-settings = "paramètres à modifier"
+stty-option-all = afficher tous les paramètres actuels sous forme lisible
+stty-option-save = afficher tous les paramètres actuels sous forme lisible par stty
+stty-option-file = ouvrir et utiliser le PÉRIPHÉRIQUE spécifié au lieu de stdin
+stty-option-settings = paramètres à modifier
 
-stty-error-options-mutually-exclusive = "les options pour les styles de sortie verbeux et lisible par stty s'excluent mutuellement"
-stty-error-output-style-no-modes = "lors de la spécification d'un style de sortie, les modes ne peuvent pas être définis"
-stty-error-missing-argument = "argument manquant pour '{$arg}'"
-stty-error-invalid-speed = "{$arg} invalide '{$speed}'"
-stty-error-invalid-argument = "argument invalide '{$arg}'"
-stty-error-invalid-integer-argument = "argument entier invalide : {$value}"
-stty-error-invalid-integer-argument-value-too-large = "argument entier invalide : {$value} : Valeur trop grande pour le type de données défini"
+stty-error-options-mutually-exclusive = les options pour les styles de sortie verbeux et lisible par stty s'excluent mutuellement
+stty-error-output-style-no-modes = lors de la spécification d'un style de sortie, les modes ne peuvent pas être définis
+stty-error-missing-argument = argument manquant pour '{$arg}'
+stty-error-invalid-speed = {$arg} invalide '{$speed}'
+stty-error-invalid-argument = argument invalide '{$arg}'
+stty-error-invalid-integer-argument = argument entier invalide : {$value}
+stty-error-invalid-integer-argument-value-too-large = argument entier invalide : {$value} : Valeur trop grande pour le type de données défini
 
 # Chaînes de format de sortie
 stty-output-speed = vitesse {$speed} bauds ;


### PR DESCRIPTION
remove extra quote symbols in locale files, these symbols were printed in stty's error messages