### PR TITLE
chore: cleanup `inefficient_to_string` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -645,7 +645,6 @@ redundant_else = "allow"                     # 58
 map_unwrap_or = "allow"                      # 54
 cast_precision_loss = "allow"                # 52
 unnested_or_patterns = "allow"               # 40
-inefficient_to_string = "allow"              # 38
 unnecessary_wraps = "allow"                  # 37
 cast_lossless = "allow"                      # 33
 ignored_unit_patterns = "allow"              # 29

--- a/src/uu/head/src/parse.rs
+++ b/src/uu/head/src/parse.rs
@@ -152,7 +152,7 @@ mod tests {
     }
 
     fn obsolete_result(src: &[&str]) -> Option<Result<Vec<String>, ParseError>> {
-        Some(Ok(src.iter().map(|s| s.to_string()).collect()))
+        Some(Ok(src.iter().map(|s| (*s).to_string()).collect()))
     }
 
     #[test]

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -38,7 +38,7 @@ enum NohupError {
     #[error("{}", get_message("nohup-error-cannot-detach"))]
     CannotDetach,
 
-    #[error("{}", get_message_with_args("nohup-error-cannot-replace", HashMap::from([("name".to_string(), _0.to_string()), ("err".to_string(), _1.to_string())])))]
+    #[error("{}", get_message_with_args("nohup-error-cannot-replace", HashMap::from([("name".to_string(), (*_0).to_string()), ("err".to_string(), _1.to_string())])))]
     CannotReplace(&'static str, #[source] Error),
 
     #[error("{}", get_message_with_args("nohup-error-open-failed", HashMap::from([("path".to_string(), NOHUP_OUT.quote().to_string()), ("err".to_string(), _1.to_string())])))]

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -330,7 +330,7 @@ fn parse_type_string(params: &str) -> Result<Vec<ParsedFormatterItemInfo>, Strin
 
 #[cfg(test)]
 pub fn parse_format_flags_str(args_str: &[&'static str]) -> Result<Vec<FormatterItemInfo>, String> {
-    let args: Vec<String> = args_str.iter().map(|s| s.to_string()).collect();
+    let args: Vec<String> = args_str.iter().map(|s| (*s).to_string()).collect();
     parse_format_flags(&args).map(|v| {
         // tests using this function assume add_ascii_dump is not set
         v.into_iter()

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -198,7 +198,7 @@ enum PtxError {
     #[error("{}", get_message("ptx-error-dumb-format"))]
     DumbFormat,
 
-    #[error("{}", get_message_with_args("ptx-error-not-implemented", HashMap::from([("feature".to_string(), .0.to_string())])))]
+    #[error("{}", get_message_with_args("ptx-error-not-implemented", HashMap::from([("feature".to_string(), (*.0).to_string())])))]
     NotImplemented(&'static str),
 
     #[error("{0}")]

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -266,7 +266,7 @@ fn stty(opts: &Options) -> UResult<()> {
                         1,
                         get_message_with_args(
                             "stty-error-missing-argument",
-                            HashMap::from([("arg".to_string(), arg.to_string())]),
+                            HashMap::from([("arg".to_string(), (*arg).to_string())]),
                         ),
                     ));
                 }
@@ -282,8 +282,8 @@ fn stty(opts: &Options) -> UResult<()> {
                                 get_message_with_args(
                                     "stty-error-invalid-speed",
                                     HashMap::from([
-                                        ("arg".to_string(), arg.to_string()),
-                                        ("speed".to_string(), speed.to_string()),
+                                        ("arg".to_string(), (*arg).to_string()),
+                                        ("speed".to_string(), (*speed).to_string()),
                                     ]),
                                 ),
                             ));
@@ -294,7 +294,7 @@ fn stty(opts: &Options) -> UResult<()> {
                             1,
                             get_message_with_args(
                                 "stty-error-missing-argument",
-                                HashMap::from([("arg".to_string(), arg.to_string())]),
+                                HashMap::from([("arg".to_string(), (*arg).to_string())]),
                             ),
                         ));
                     }
@@ -316,7 +316,7 @@ fn stty(opts: &Options) -> UResult<()> {
                         1,
                         get_message_with_args(
                             "stty-error-invalid-argument",
-                            HashMap::from([("arg".to_string(), arg.to_string())]),
+                            HashMap::from([("arg".to_string(), (*arg).to_string())]),
                         ),
                     ));
                 }
@@ -339,7 +339,7 @@ fn stty(opts: &Options) -> UResult<()> {
                         1,
                         get_message_with_args(
                             "stty-error-missing-argument",
-                            HashMap::from([("arg".to_string(), arg.to_string())]),
+                            HashMap::from([("arg".to_string(), (*arg).to_string())]),
                         ),
                     ));
                 }
@@ -361,7 +361,7 @@ fn stty(opts: &Options) -> UResult<()> {
                         1,
                         get_message_with_args(
                             "stty-error-missing-argument",
-                            HashMap::from([("arg".to_string(), arg.to_string())]),
+                            HashMap::from([("arg".to_string(), (*arg).to_string())]),
                         ),
                     ));
                 }
@@ -373,7 +373,7 @@ fn stty(opts: &Options) -> UResult<()> {
                     1,
                     get_message_with_args(
                         "stty-error-invalid-argument",
-                        HashMap::from([("arg".to_string(), arg.to_string())]),
+                        HashMap::from([("arg".to_string(), (*arg).to_string())]),
                     ),
                 ));
             }
@@ -469,7 +469,7 @@ fn print_terminal_size(termios: &Termios, opts: &Options) -> nix::Result<()> {
                 "{} ",
                 get_message_with_args(
                     "stty-output-speed",
-                    HashMap::from([("speed".to_string(), text.to_string())])
+                    HashMap::from([("speed".to_string(), (*text).to_string())])
                 )
             );
             break;


### PR DESCRIPTION
Apparently this causes a slowdown per [docs](https://rust-lang.github.io/rust-clippy/master/index.html#inefficient_to_string).

I used this command and fixed a few remaining manual ones.

```sh
__CARGO_FIX_YOLO=1 cargo clippy --fix --all-targets --workspace --allow-dirty
```