### PR TITLE
tail: fix tailing /dev/zero

### DIFF
--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -158,7 +158,6 @@ impl FileExtTail for File {
 pub trait MetadataExtTail {
     fn is_tailable(&self) -> bool;
     fn got_truncated(&self, other: &Metadata) -> UResult<bool>;
-    fn get_block_size(&self) -> u64;
     fn file_id_eq(&self, other: &Metadata) -> bool;
 }
 
@@ -178,17 +177,6 @@ impl MetadataExtTail for Metadata {
     /// Return true if the file was modified and is now shorter
     fn got_truncated(&self, other: &Metadata) -> UResult<bool> {
         Ok(other.len() < self.len() && other.modified()? != self.modified()?)
-    }
-
-    fn get_block_size(&self) -> u64 {
-        #[cfg(unix)]
-        {
-            self.blocks()
-        }
-        #[cfg(not(unix))]
-        {
-            self.len()
-        }
     }
 
     fn file_id_eq(&self, _other: &Metadata) -> bool {

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -26,12 +26,13 @@ use args::{FilterMode, Settings, Signum, parse_args};
 use chunks::ReverseChunks;
 use follow::Observer;
 use memchr::{memchr_iter, memrchr_iter};
-use paths::{FileExtTail, HeaderPrinter, Input, InputKind, MetadataExtTail};
+use paths::{FileExtTail, HeaderPrinter, Input, InputKind};
 use same_file::Handle;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write, stdin, stdout};
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, get_exit_code, set_exit_code};
@@ -169,14 +170,15 @@ fn tail_file(
         }
         observer.add_bad_path(path, input.display_name.as_str(), false)?;
     } else if input.is_tailable() {
-        let metadata = path.metadata().ok();
         match File::open(path) {
             Ok(mut file) => {
+                let st = file.metadata()?;
+                let usable_size = st.is_file();
                 header_printer.print_input(input);
                 let mut reader;
                 if !settings.presume_input_pipe
                     && file.is_seekable(if input.is_stdin() { offset } else { 0 })
-                    && metadata.as_ref().unwrap().get_block_size() > 0
+                    && (!usable_size || st.size() > st.blksize())
                 {
                     bounded_tail(&mut file, settings);
                     reader = BufReader::new(file);
@@ -448,6 +450,7 @@ fn backwards_thru_file(file: &mut File, num_delimiters: u64, delimiter: u8) {
 /// being a nice performance win for very large files.
 fn bounded_tail(file: &mut File, settings: &Settings) {
     debug_assert!(!settings.presume_input_pipe);
+    let mut limit = None;
 
     // Find the position in the file to start printing from.
     match &settings.mode {
@@ -462,9 +465,8 @@ fn bounded_tail(file: &mut File, settings: &Settings) {
             return;
         }
         FilterMode::Bytes(Signum::Negative(count)) => {
-            let len = file.seek(SeekFrom::End(0)).unwrap();
-            file.seek(SeekFrom::End(-((*count).min(len) as i64)))
-                .unwrap();
+            file.seek(SeekFrom::End(-(*count as i64))).unwrap();
+            limit = Some(*count);
         }
         FilterMode::Bytes(Signum::Positive(count)) if count > &1 => {
             // GNU `tail` seems to index bytes and lines starting at 1, not
@@ -477,10 +479,7 @@ fn bounded_tail(file: &mut File, settings: &Settings) {
         _ => {}
     }
 
-    // Print the target section of the file.
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    io::copy(file, &mut stdout).unwrap();
+    print_target_section(file, limit);
 }
 
 fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UResult<()> {
@@ -545,6 +544,21 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
     }
     writer.flush()?;
     Ok(())
+}
+
+fn print_target_section<R>(file: &mut R, limit: Option<u64>)
+where
+    R: Read + ?Sized,
+{
+    // Print the target section of the file.
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    if let Some(limit) = limit {
+        let mut reader = file.take(limit);
+        io::copy(&mut reader, &mut stdout).unwrap();
+    } else {
+        io::copy(file, &mut stdout).unwrap();
+    }
 }
 
 #[cfg(test)]

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -4923,3 +4923,13 @@ fn test_failed_write_is_reported() {
         .fails()
         .stderr_is("tail: No space left on device\n");
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_dev_zero() {
+    let ts = TestScenario::new("tail");
+    ts.ucmd()
+        .args(&["-c", "1", "/dev/zero"])
+        .succeeds()
+        .stdout_only("\0");
+}


### PR DESCRIPTION
This fixes a bug where tail would run forever when tailing /dev/zero.  This behavior matches GNU tail.