### PR TITLE
head: fix meaning of ---presume-input-pipe

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -425,7 +425,7 @@ fn head_backwards_file(input: &mut File, options: &HeadOptions) -> io::Result<u6
     let st = input.metadata()?;
     let seekable = is_seekable(input);
     let blksize_limit = uucore::fs::sane_blksize::sane_blksize_from_metadata(&st);
-    if !seekable || st.len() <= blksize_limit {
+    if !seekable || st.len() <= blksize_limit || options.presume_input_pipe {
         head_backwards_without_seek_file(input, options)
     } else {
         head_backwards_on_seekable_file(input, options)
@@ -474,8 +474,8 @@ fn head_file(input: &mut File, options: &HeadOptions) -> io::Result<u64> {
 fn uu_head(options: &HeadOptions) -> UResult<()> {
     let mut first = true;
     for file in &options.files {
-        let res = match (file.as_str(), options.presume_input_pipe) {
-            (_, true) | ("-", false) => {
+        let res = match file.as_str() {
+            "-" => {
                 if (options.files.len() > 1 && !options.quiet) || options.verbose {
                     if !first {
                         println!();
@@ -519,7 +519,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
 
                 Ok(())
             }
-            (name, false) => {
+            name => {
                 let mut file = match File::open(name) {
                     Ok(f) => f,
                     Err(err) => {

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -93,6 +93,14 @@ fn test_single_1_line() {
 }
 
 #[test]
+fn test_single_1_line_presume_input_pipe() {
+    new_ucmd!()
+        .args(&["---presume-input-pipe", "-n", "1", INPUT])
+        .succeeds()
+        .stdout_is_fixture("lorem_ipsum_1_line.expected");
+}
+
+#[test]
 fn test_single_5_chars() {
     new_ucmd!()
         .args(&["-c", "5", INPUT])


### PR DESCRIPTION
The option ---presume-input-pipe is debug option that should disable the seeking optimization, not force it to read stdin. This fixes the GNU test head-elide-tail.