### PR TITLE
chore: fix uninlined_format_args lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -589,7 +589,6 @@ debug = true
 [lints.clippy]
 multiple_crate_versions = "allow"
 cargo_common_metadata = "allow"
-uninlined_format_args = "allow"
 missing_panics_doc = "allow"
 # TODO remove when https://github.com/rust-lang/rust-clippy/issues/13774 is fixed
 large_stack_arrays = "allow"
@@ -639,7 +638,6 @@ cast_possible_wrap = "allow"                 # 78
 cast_sign_loss = "allow"                     # 70
 struct_excessive_bools = "allow"             # 68
 cast_precision_loss = "allow"                # 52
-uninlined_format_args = "allow"              # 35
 cast_lossless = "allow"                      # 35
 unnecessary_wraps = "allow"                  # 33
 ignored_unit_patterns = "allow"              # 21

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -429,7 +429,7 @@ impl Display for OffloadReflinkDebug {
             Self::Unsupported => get_message("cp-debug-enum-unsupported"),
             Self::Unknown => get_message("cp-debug-enum-unknown"),
         };
-        write!(f, "{}", msg)
+        write!(f, "{msg}")
     }
 }
 
@@ -443,7 +443,7 @@ impl Display for SparseDebug {
             Self::Unsupported => get_message("cp-debug-enum-unsupported"),
             Self::Unknown => get_message("cp-debug-enum-unknown"),
         };
-        write!(f, "{}", msg)
+        write!(f, "{msg}")
     }
 }
 
@@ -1399,7 +1399,7 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
                     ("source".to_string(), source.quote().to_string()),
                 ]),
             );
-            show_warning!("{}", msg);
+            show_warning!("{msg}");
         } else {
             let dest = construct_dest_path(source, target, target_type, options)
                 .unwrap_or_else(|_| target.to_path_buf());
@@ -1614,13 +1614,13 @@ impl OverwriteMode {
                         "cp-prompt-overwrite-with-mode",
                         HashMap::from([("path".to_string(), path.quote().to_string())]),
                     );
-                    prompt_yes!("{} {octal} ({human_readable})?", prompt_msg)
+                    prompt_yes!("{prompt_msg} {octal} ({human_readable})?")
                 } else {
                     let prompt_msg = get_message_with_args(
                         "cp-prompt-overwrite",
                         HashMap::from([("path".to_string(), path.quote().to_string())]),
                     );
-                    prompt_yes!("{}", prompt_msg)
+                    prompt_yes!("{prompt_msg}")
                 };
 
                 if prompt_yes_result {

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -110,7 +110,7 @@ impl ProgUpdate {
                     "dd-progress-truncated-record",
                     HashMap::from([("count".to_string(), count.to_string())]),
                 );
-                writeln!(w, "{}", message)?;
+                writeln!(w, "{message}")?;
             }
         }
         Ok(())
@@ -347,7 +347,7 @@ impl ReadStat {
                 ("partial".to_string(), self.reads_partial.to_string()),
             ]),
         );
-        writeln!(w, "{}", message)?;
+        writeln!(w, "{message}")?;
         Ok(())
     }
 }
@@ -407,7 +407,7 @@ impl WriteStat {
                 ("partial".to_string(), self.writes_partial.to_string()),
             ]),
         );
-        writeln!(w, "{}", message)
+        writeln!(w, "{message}")
     }
 }
 

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -453,11 +453,11 @@ impl fmt::Display for Table {
                             // no trailing spaces in last column
                             write!(f, "{elem}")?;
                         } else {
-                            write!(f, "{:<width$}", elem, width = self.widths[i])?;
+                            write!(f, "{elem:<width$}", width = self.widths[i])?;
                         }
                     }
                     Some(Alignment::Right) => {
-                        write!(f, "{:>width$}", elem, width = self.widths[i])?;
+                        write!(f, "{elem:>width$}", width = self.widths[i])?;
                     }
                     None => break,
                 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -173,7 +173,7 @@ const DEFAULT_FILE_SIZE_BLOCK_SIZE: u64 = 1;
 
 #[derive(Error, Debug)]
 enum LsError {
-    #[error("{}", get_message_with_args("ls-error-invalid-line-width", HashMap::from([("width".to_string(), format!("'{}'", _0))])))]
+    #[error("{}", get_message_with_args("ls-error-invalid-line-width", HashMap::from([("width".to_string(), format!("'{_0}'"))])))]
     InvalidLineWidth(String),
 
     #[error("{}", get_message_with_args("ls-error-general-io", HashMap::from([("error".to_string(), _0.to_string())])))]
@@ -196,7 +196,7 @@ enum LsError {
     })]
     IOErrorContext(PathBuf, std::io::Error, bool),
 
-    #[error("{}", get_message_with_args("ls-error-invalid-block-size", HashMap::from([("size".to_string(), format!("'{}'", _0))])))]
+    #[error("{}", get_message_with_args("ls-error-invalid-block-size", HashMap::from([("size".to_string(), format!("'{_0}'"))])))]
     BlockSizeParseError(String),
 
     #[error("{}", get_message("ls-error-dired-and-zero-incompatible"))]

--- a/src/uu/mv/src/hardlink.rs
+++ b/src/uu/mv/src/hardlink.rs
@@ -53,9 +53,9 @@ pub enum HardlinkError {
 impl std::fmt::Display for HardlinkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            HardlinkError::Io(e) => write!(f, "I/O error during hardlink operation: {}", e),
+            HardlinkError::Io(e) => write!(f, "I/O error during hardlink operation: {e}"),
             HardlinkError::Scan(msg) => {
-                write!(f, "Failed to scan files for hardlinks: {}", msg)
+                write!(f, "Failed to scan files for hardlinks: {msg}")
             }
             HardlinkError::Preservation { source, target } => {
                 write!(

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -563,7 +563,7 @@ fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, options: &Options) 
         // Pre-scan files if needed
         if let Err(e) = scanner.scan_files(files, &hardlink_options) {
             if hardlink_options.verbose {
-                eprintln!("mv: warning: failed to scan files for hardlinks: {}", e);
+                eprintln!("mv: warning: failed to scan files for hardlinks: {e}");
                 eprintln!("mv: continuing without hardlink preservation");
             } else {
                 // Show warning in non-verbose mode for serious errors

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -162,7 +162,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             ]),
         );
 
-        if write!(std::io::stderr(), "{}", warning_msg).is_err() {
+        if write!(std::io::stderr(), "{warning_msg}").is_err() {
             set_exit_code(125);
             return Ok(());
         }

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -557,8 +557,7 @@ fn wipe_file(
                 HashMap::from([("file".to_string(), path.maybe_quote().to_string())]),
             );
             show_error!(
-                "{} {}/{total_passes} ({pass_name})...",
-                msg,
+                "{msg} {}/{total_passes} ({pass_name})...",
                 (i + 1).to_string()
             );
         }
@@ -679,7 +678,7 @@ fn wipe_name(orig_path: &Path, verbose: bool, remove_method: RemoveMethod) -> Op
                             ("error".to_string(), e.to_string()),
                         ]),
                     );
-                    show_error!("{}", msg);
+                    show_error!("{msg}");
                     // TODO: replace with our error management
                     std::process::exit(1);
                 }

--- a/src/uu/stdbuf/build.rs
+++ b/src/uu/stdbuf/build.rs
@@ -121,7 +121,6 @@ fn main() {
 
     assert!(
         found,
-        "Could not find built libstdbuf library. Searched in: {:?}.",
-        possible_paths
+        "Could not find built libstdbuf library. Searched in: {possible_paths:?}."
     );
 }

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -255,11 +255,11 @@ fn stty(opts: &Options) -> UResult<()> {
                         let message = match e {
                             ControlCharMappingError::IntOutOfRange(val) => get_message_with_args(
                                 "stty-error-invalid-integer-argument-value-too-large",
-                                HashMap::from([("value".to_string(), format!("'{}'", val))]),
+                                HashMap::from([("value".to_string(), format!("'{val}'"))]),
                             ),
                             ControlCharMappingError::MultipleChars(val) => get_message_with_args(
                                 "stty-error-invalid-integer-argument",
-                                HashMap::from([("value".to_string(), format!("'{}'", val))]),
+                                HashMap::from([("value".to_string(), format!("'{val}'"))]),
                             ),
                         };
                         USimpleError::new(1, message)
@@ -386,7 +386,7 @@ fn stty(opts: &Options) -> UResult<()> {
                             1,
                             get_message_with_args(
                                 "stty-error-invalid-integer-argument",
-                                HashMap::from([("value".to_string(), format!("'{}'", rows))]),
+                                HashMap::from([("value".to_string(), format!("'{rows}'"))]),
                             ),
                         ));
                     }
@@ -408,7 +408,7 @@ fn stty(opts: &Options) -> UResult<()> {
                             1,
                             get_message_with_args(
                                 "stty-error-invalid-integer-argument",
-                                HashMap::from([("value".to_string(), format!("'{}'", cols))]),
+                                HashMap::from([("value".to_string(), format!("'{cols}'"))]),
                             ),
                         ));
                     }
@@ -471,11 +471,11 @@ fn parse_u8_or_err(arg: &str) -> Result<u8, String> {
     arg.parse::<u8>().map_err(|e| match e.kind() {
         IntErrorKind::PosOverflow => get_message_with_args(
             "stty-error-invalid-integer-argument-value-too-large",
-            HashMap::from([("value".to_string(), format!("'{}'", arg))]),
+            HashMap::from([("value".to_string(), format!("'{arg}'"))]),
         ),
         _ => get_message_with_args(
             "stty-error-invalid-integer-argument",
-            HashMap::from([("value".to_string(), format!("'{}'", arg))]),
+            HashMap::from([("value".to_string(), format!("'{arg}'"))]),
         ),
     })
 }

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -105,8 +105,7 @@ impl<'a> FormatArguments<'a> {
                             // Emit a warning if there are additional characters
                             let remaining: String = chars.collect();
                             show_warning!(
-                                "{}: character(s) following character constant have been ignored",
-                                remaining
+                                "{remaining}: character(s) following character constant have been ignored"
                             );
                         }
                         return first_char as u64; // Use only the first character

--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -115,8 +115,7 @@ impl Display for FormatError {
             Self::MissingHex => write!(f, "missing hexadecimal number in escape"),
             Self::InvalidCharacter(escape_char, digits) => write!(
                 f,
-                "invalid universal character name \\{}{}",
-                escape_char,
+                "invalid universal character name \\{escape_char}{}",
                 String::from_utf8_lossy(digits)
             ),
         }

--- a/src/uucore/src/lib/features/selinux.rs
+++ b/src/uucore/src/lib/features/selinux.rs
@@ -91,7 +91,7 @@ fn selinux_error_description(mut error: &dyn Error) -> String {
 /// // Set the default SELinux context for a file
 /// let result = set_selinux_security_context(Path::new("/path/to/file"), None);
 /// if let Err(err) = result {
-///     eprintln!("Failed to set default context: {}", err);
+///     eprintln!("Failed to set default context: {err}");
 /// }
 /// ```
 ///
@@ -104,7 +104,7 @@ fn selinux_error_description(mut error: &dyn Error) -> String {
 /// let context = String::from("unconfined_u:object_r:user_home_t:s0");
 /// let result = set_selinux_security_context(Path::new("/path/to/file"), Some(&context));
 /// if let Err(err) = result {
-///     eprintln!("Failed to set context: {}", err);
+///     eprintln!("Failed to set context: {err}");
 /// }
 /// ```
 pub fn set_selinux_security_context(
@@ -187,14 +187,14 @@ pub fn set_selinux_security_context(
 ///         if context.is_empty() {
 ///             println!("No SELinux context found for the file");
 ///         } else {
-///             println!("SELinux context: {}", context);
+///             println!("SELinux context: {context}");
 ///         }
 ///     },
 ///     Err(SeLinuxError::SELinuxNotEnabled) => println!("SELinux is not enabled on this system"),
-///     Err(SeLinuxError::FileOpenFailure(e)) => println!("Failed to open the file: {}", e),
-///     Err(SeLinuxError::ContextRetrievalFailure(e)) => println!("Failed to retrieve the security context: {}", e),
-///     Err(SeLinuxError::ContextConversionFailure(ctx, e)) => println!("Failed to convert context '{}': {}", ctx, e),
-///     Err(SeLinuxError::ContextSetFailure(ctx, e)) => println!("Failed to set context '{}': {}", ctx, e),
+///     Err(SeLinuxError::FileOpenFailure(e)) => println!("Failed to open the file: {e}"),
+///     Err(SeLinuxError::ContextRetrievalFailure(e)) => println!("Failed to retrieve the security context: {e}"),
+///     Err(SeLinuxError::ContextConversionFailure(ctx, e)) => println!("Failed to convert context '{ctx}': {e}"),
+///     Err(SeLinuxError::ContextSetFailure(ctx, e)) => println!("Failed to set context '{ctx}': {e}"),
 /// }
 /// ```
 pub fn get_selinux_security_context(path: &Path) -> Result<String, SeLinuxError> {
@@ -307,7 +307,7 @@ pub fn contexts_differ(from_path: &Path, to_path: &Path) -> bool {
 /// // Preserve the SELinux context from source to destination
 /// match preserve_security_context(Path::new("/path/to/source"), Path::new("/path/to/destination")) {
 ///     Ok(_) => println!("Context preserved successfully (or SELinux is not enabled)"),
-///     Err(err) => eprintln!("Failed to preserve context: {}", err),
+///     Err(err) => eprintln!("Failed to preserve context: {err}"),
 /// }
 /// ```
 pub fn preserve_security_context(from_path: &Path, to_path: &Path) -> Result<(), SeLinuxError> {

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -211,7 +211,7 @@ fn get_message_internal(id: &str, args: Option<FluentArgs>) -> String {
 ///
 /// // Get a localized greeting (from .ftl files)
 /// let greeting = get_message("greeting");
-/// println!("{}", greeting);
+/// println!("{greeting}");
 /// ```
 pub fn get_message(id: &str) -> String {
     get_message_internal(id, None)
@@ -246,7 +246,7 @@ pub fn get_message(id: &str) -> String {
 /// args.insert("count".to_string(), "3".to_string());
 ///
 /// let message = get_message_with_args("notification", args);
-/// println!("{}", message);
+/// println!("{message}");
 /// ```
 pub fn get_message_with_args(id: &str, ftl_args: HashMap<String, String>) -> String {
     let mut args = FluentArgs::new();
@@ -312,7 +312,7 @@ fn detect_system_locale() -> Result<LanguageIdentifier, LocalizationError> {
 /// // Other locale files like "fr-FR.ftl" are optional
 /// match setup_localization("./locales") {
 ///     Ok(_) => println!("Localization initialized successfully"),
-///     Err(e) => eprintln!("Failed to initialize localization: {}", e),
+///     Err(e) => eprintln!("Failed to initialize localization: {e}"),
 /// }
 /// ```
 pub fn setup_localization(p: &str) -> Result<(), LocalizationError> {
@@ -383,7 +383,7 @@ fn get_locales_dir(p: &str) -> Result<PathBuf, LocalizationError> {
         use std::env;
         // In release builds, look relative to executable
         let exe_path = env::current_exe().map_err(|e| {
-            LocalizationError::PathResolution(format!("Failed to get executable path: {}", e))
+            LocalizationError::PathResolution(format!("Failed to get executable path: {e}"))
         })?;
 
         let exe_dir = exe_path.parent().ok_or_else(|| {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -927,7 +927,7 @@ fn test_cp_arg_no_clobber_twice() {
         .arg(TEST_HELLO_WORLD_DEST)
         .arg("--debug")
         .succeeds()
-        .stdout_contains(format!("skipped '{}'", TEST_HELLO_WORLD_DEST));
+        .stdout_contains(format!("skipped '{TEST_HELLO_WORLD_DEST}'"));
 
     assert_eq!(at.read(TEST_HELLO_WORLD_SOURCE), "some-content");
     // Should be empty as the "no-clobber" should keep
@@ -6306,7 +6306,7 @@ fn get_getfattr_output(f: &str) -> String {
         .arg("security.selinux")
         .output()
         .expect("Failed to run `getfattr` on the destination file");
-    println!("{:?}", getfattr_output);
+    println!("{getfattr_output:?}");
     assert!(
         getfattr_output.status.success(),
         "getfattr did not run successfully: {}",
@@ -6444,12 +6444,12 @@ fn test_cp_preserve_selinux_admin_context() {
     let cmd_result = ts
         .ucmd()
         .arg("-Z")
-        .arg(format!("--context={}", default_context))
+        .arg(format!("--context={default_context}"))
         .arg(TEST_HELLO_WORLD_SOURCE)
         .arg(TEST_HELLO_WORLD_DEST)
         .run();
 
-    println!("cp command result: {:?}", cmd_result);
+    println!("cp command result: {cmd_result:?}");
 
     if !cmd_result.succeeded() {
         println!("Skipping test: Cannot set SELinux context, system may not support this context");
@@ -6459,7 +6459,7 @@ fn test_cp_preserve_selinux_admin_context() {
     assert!(at.file_exists(TEST_HELLO_WORLD_DEST));
 
     let selinux_perm_dest = get_getfattr_output(&at.plus_as_string(TEST_HELLO_WORLD_DEST));
-    println!("Destination SELinux context: {}", selinux_perm_dest);
+    println!("Destination SELinux context: {selinux_perm_dest}");
 
     assert_eq!(default_context, selinux_perm_dest);
 
@@ -6679,7 +6679,7 @@ fn test_cp_preserve_context_root() {
         .status();
 
     if !chcon_result.is_ok_and(|status| status.success()) {
-        println!("Skipping test: Failed to set context: {}", context);
+        println!("Skipping test: Failed to set context: {context}");
         return;
     }
 
@@ -6688,8 +6688,8 @@ fn test_cp_preserve_context_root() {
     if let Ok(result) = run_ucmd_as_root(&scene, &["--preserve=context", source_file, dest_file]) {
         let src_ctx = get_getfattr_output(&at.plus_as_string(source_file));
         let dest_ctx = get_getfattr_output(&at.plus_as_string(dest_file));
-        println!("Source context: {}", src_ctx);
-        println!("Destination context: {}", dest_ctx);
+        println!("Source context: {src_ctx}");
+        println!("Destination context: {dest_ctx}");
 
         if !result.succeeded() {
             println!("Skipping test: Failed to copy with preserved context");
@@ -6700,9 +6700,7 @@ fn test_cp_preserve_context_root() {
 
         assert!(
             dest_context.contains("root:object_r:tmp_t"),
-            "Expected context '{}' not found in destination context: '{}'",
-            context,
-            dest_context
+            "Expected context '{context}' not found in destination context: '{dest_context}'",
         );
     } else {
         print!("Test skipped; requires root user");

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -467,7 +467,7 @@ fn test_relative_weekdays() {
                 .to_lowercase();
             new_ucmd!()
                 .arg("-d")
-                .arg(format!("{} {}", direction, weekday))
+                .arg(format!("{direction} {weekday}"))
                 .arg("--rfc-3339=seconds")
                 .arg("--utc")
                 .succeeds()

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2255,7 +2255,7 @@ fn test_selinux() {
             at.remove(&at.plus_as_string(dest));
             continue;
         };
-        println!("{:?}", getfattr_output);
+        println!("{getfattr_output:?}");
         assert!(
             getfattr_output.status.success(),
             "getfattr did not run successfully: {}",
@@ -2297,8 +2297,7 @@ fn test_selinux_invalid_args() {
         assert!(
             stderr.contains("failed to set default file creation")
                 || stderr.contains("SELinux is not enabled on this system"),
-            "Expected stderr to contain either 'failed to set default file creation' or 'SELinux is not enabled on this system', but got: '{}'",
-            stderr
+            "Expected stderr to contain either 'failed to set default file creation' or 'SELinux is not enabled on this system', but got: '{stderr}'"
         );
 
         at.remove(&at.plus_as_string(dest));
@@ -2319,12 +2318,12 @@ fn test_install_compare_with_mode_bits() {
     for (mode, description, should_warn) in test_cases {
         let scene = TestScenario::new(util_name!());
         let at = &scene.fixtures;
-        let source = format!("source_file_{}", mode);
-        let dest = format!("dest_file_{}", mode);
+        let source = format!("source_file_{mode}");
+        let dest = format!("dest_file_{mode}");
 
         at.write(&source, "test content");
 
-        let mode_arg = format!("--mode={}", mode);
+        let mode_arg = format!("--mode={mode}");
 
         if should_warn {
             scene.ucmd().args(&["-C", &mode_arg, &source, &dest])
@@ -2347,8 +2346,7 @@ fn test_install_compare_with_mode_bits() {
 
         assert!(
             at.file_exists(&dest),
-            "Failed to create dest file for {}",
-            description
+            "Failed to create dest file for {description}"
         );
     }
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4302,15 +4302,13 @@ fn test_ls_context_format() {
 fn validate_selinux_context(context: &str) {
     assert!(
         context.contains(':'),
-        "Expected SELinux context format (user:role:type:level), got: {}",
-        context
+        "Expected SELinux context format (user:role:type:level), got: {context}"
     );
 
     assert_eq!(
         context.split(':').count(),
         4,
-        "SELinux context should have 4 components separated by colons, got: {}",
-        context
+        "SELinux context should have 4 components separated by colons, got: {context}"
     );
 }
 

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -127,7 +127,7 @@ fn test_mkfifo_selinux() {
             .arg("security.selinux")
             .output()
             .expect("Failed to run `getfattr` on the destination file");
-        println!("{:?}", getfattr_output);
+        println!("{getfattr_output:?}");
         assert!(
             getfattr_output.status.success(),
             "getfattr did not run successfully: {}",

--- a/tests/by-util/test_mknod.rs
+++ b/tests/by-util/test_mknod.rs
@@ -149,7 +149,7 @@ fn test_mknod_selinux() {
             .arg("security.selinux")
             .output()
             .expect("Failed to run `getfattr` on the destination file");
-        println!("{:?}", getfattr_output);
+        println!("{getfattr_output:?}");
         assert!(
             getfattr_output.status.success(),
             "getfattr did not run successfully: {}",

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -84,10 +84,10 @@ fn escaped_unicode_incomplete() {
 #[test]
 fn escaped_unicode_invalid() {
     for arg in ["\\ud9d0", "\\U0000D8F9"] {
-        new_ucmd!().arg(arg).fails_with_code(1).stderr_only(format!(
-            "printf: invalid universal character name {}\n",
-            arg
-        ));
+        new_ucmd!()
+            .arg(arg)
+            .fails_with_code(1)
+            .stderr_only(format!("printf: invalid universal character name {arg}\n"));
     }
 }
 

--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -198,13 +198,13 @@ fn test_libstdbuf_preload() {
     let arch_mismatch_line = uutils_debug
         .lines()
         .find(|line| line.contains("cannot be preloaded"));
-    println!("LD_DEBUG output: {}", uutils_debug);
+    println!("LD_DEBUG output: {uutils_debug}");
     let no_arch_mismatch = arch_mismatch_line.is_none();
 
-    println!("libstdbuf in lookup path: {}", libstdbuf_in_path);
-    println!("No architecture mismatch: {}", no_arch_mismatch);
+    println!("libstdbuf in lookup path: {libstdbuf_in_path}");
+    println!("No architecture mismatch: {no_arch_mismatch}");
     if let Some(error_line) = arch_mismatch_line {
-        println!("Architecture mismatch error: {}", error_line);
+        println!("Architecture mismatch error: {error_line}");
     }
 
     assert!(


### PR DESCRIPTION
I used this command, plus some manual fixes:

```sh
__CARGO_FIX_YOLO=1 cargo clippy --fix --all-targets --workspace --all-features --allow-dirty
```