### PR TITLE
chore: fix expl_impl_clone_on_copy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -663,4 +663,3 @@ inline_always = "allow"                      # 6
 fn_params_excessive_bools = "allow"          # 6
 used_underscore_items = "allow"              # 2
 should_panic_without_expect = "allow"        # 2
-expl_impl_clone_on_copy = "allow"            # 2

--- a/src/uu/od/src/formatteriteminfo.rs
+++ b/src/uu/od/src/formatteriteminfo.rs
@@ -7,18 +7,11 @@
 use std::fmt;
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FormatWriter {
     IntWriter(fn(u64) -> String),
     FloatWriter(fn(f64) -> String),
     MultibyteWriter(fn(&[u8]) -> String),
-}
-
-impl Clone for FormatWriter {
-    #[inline]
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl fmt::Debug for FormatWriter {


### PR DESCRIPTION
auto-derived clone generates identical assembly: https://rust.godbolt.org/z/GvenxKcKo