### PR TITLE
printf: accept non-UTF-8 input in FORMAT and ARGUMENT arguments

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -8,10 +8,9 @@ use clap::{Arg, ArgAction, Command};
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::io::{self, StdoutLock, Write};
-use uucore::error::{UResult, USimpleError};
+use uucore::error::UResult;
 use uucore::format::{FormatChar, OctalParsing, parse_escape_only};
-use uucore::format_usage;
-use uucore::os_str_as_bytes;
+use uucore::{format_usage, os_str_as_bytes};
 
 use uucore::locale::get_message;
 
@@ -223,9 +222,9 @@ pub fn uu_app() -> Command {
 
 fn execute(stdout: &mut StdoutLock, args: Vec<OsString>, options: Options) -> UResult<()> {
     for (i, arg) in args.into_iter().enumerate() {
-        let bytes = os_str_as_bytes(arg.as_os_str())
-            .map_err(|_| USimpleError::new(1, get_message("echo-error-non-utf8")))?;
+        let bytes = os_str_as_bytes(&arg)?;
 
+        // Don't print a space before the first argument
         if i > 0 {
             stdout.write_all(b" ")?;
         }

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -968,7 +968,7 @@ fn process_checksum_line(
     cached_line_format: &mut Option<LineFormat>,
     last_algo: &mut Option<String>,
 ) -> Result<(), LineCheckError> {
-    let line_bytes = os_str_as_bytes(line)?;
+    let line_bytes = os_str_as_bytes(line).map_err(|e| LineCheckError::UError(Box::new(e)))?;
 
     // Early return on empty or commented lines.
     if line.is_empty() || line_bytes.starts_with(b"#") {

--- a/src/uucore/src/lib/features/extendedbigdecimal.rs
+++ b/src/uucore/src/lib/features/extendedbigdecimal.rs
@@ -101,6 +101,18 @@ impl From<f64> for ExtendedBigDecimal {
     }
 }
 
+impl From<u8> for ExtendedBigDecimal {
+    fn from(val: u8) -> Self {
+        Self::BigDecimal(val.into())
+    }
+}
+
+impl From<u32> for ExtendedBigDecimal {
+    fn from(val: u32) -> Self {
+        Self::BigDecimal(val.into())
+    }
+}
+
 impl ExtendedBigDecimal {
     pub fn zero() -> Self {
         Self::BigDecimal(0.into())

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -159,7 +159,7 @@ impl<'a> FormatArguments<'a> {
         if bytes.len() > len {
             return Err(ExtendedParserError::PartialMatch(
                 val,
-                String::from_utf8_lossy(&bytes[len..]).to_string(),
+                String::from_utf8_lossy(&bytes[len..]).into_owned(),
             ));
         }
 

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -172,7 +172,7 @@ impl<'a> FormatArguments<'a> {
     }
 }
 
-fn extract_value<T: Default>(p: Result<T, ExtendedParserError<'_, T>>, input: &str) -> T {
+fn extract_value<T: Default>(p: Result<T, ExtendedParserError<T>>, input: &str) -> T {
     match p {
         Ok(v) => v,
         Err(e) => {

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -5,8 +5,6 @@
 
 // spell-checker:ignore (vars) intmax ptrdiff padlen
 
-use crate::quoting_style::{QuotingStyle, locale_aware_escape_name};
-
 use super::{
     ExtendedBigDecimal, FormatChar, FormatError, OctalParsing,
     num_format::{
@@ -15,7 +13,11 @@ use super::{
     },
     parse_escape_only,
 };
-use crate::format::FormatArguments;
+use crate::{
+    format::FormatArguments,
+    os_str_as_bytes,
+    quoting_style::{QuotingStyle, locale_aware_escape_name},
+};
 use std::{io::Write, num::NonZero, ops::ControlFlow};
 
 /// A parsed specification for formatting a value
@@ -355,7 +357,7 @@ impl Spec {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or_default();
                 write_padded(
                     writer,
-                    &[args.next_char(position)],
+                    &[args.next_char(position)?],
                     width,
                     *align_left || neg_width,
                 )
@@ -375,22 +377,21 @@ impl Spec {
                 // TODO: We need to not use Rust's formatting for aligning the output,
                 // so that we can just write bytes to stdout without panicking.
                 let precision = resolve_asterisk_precision(*precision, args);
-                let s = args.next_string(position);
+                let os_str = args.next_string(position);
+                let bytes = os_str_as_bytes(os_str)?;
+
                 let truncated = match precision {
-                    Some(p) if p < s.len() => &s[..p],
-                    _ => s,
+                    Some(p) if p < os_str.len() => &bytes[..p],
+                    _ => bytes,
                 };
-                write_padded(
-                    writer,
-                    truncated.as_bytes(),
-                    width,
-                    *align_left || neg_width,
-                )
+                write_padded(writer, truncated, width, *align_left || neg_width)
             }
             Self::EscapedString { position } => {
-                let s = args.next_string(position);
-                let mut parsed = Vec::new();
-                for c in parse_escape_only(s.as_bytes(), OctalParsing::ThreeDigits) {
+                let os_str = args.next_string(position);
+                let bytes = os_str_as_bytes(os_str)?;
+                let mut parsed = Vec::<u8>::new();
+
+                for c in parse_escape_only(bytes, OctalParsing::ThreeDigits) {
                     match c.write(&mut parsed)? {
                         ControlFlow::Continue(()) => {}
                         ControlFlow::Break(()) => {
@@ -403,15 +404,11 @@ impl Spec {
             }
             Self::QuotedString { position } => {
                 let s = locale_aware_escape_name(
-                    args.next_string(position).as_ref(),
+                    args.next_string(position),
                     QuotingStyle::SHELL_ESCAPE,
                 );
-                #[cfg(unix)]
-                let bytes = std::os::unix::ffi::OsStringExt::into_vec(s);
-                #[cfg(not(unix))]
-                let bytes = s.to_string_lossy().as_bytes().to_owned();
-
-                writer.write_all(&bytes).map_err(FormatError::IoError)
+                let bytes = os_str_as_bytes(&s)?;
+                writer.write_all(bytes).map_err(FormatError::IoError)
             }
             Self::SignedInt {
                 width,
@@ -422,7 +419,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
-                let i = args.next_i64(position);
+                let i = args.next_i64(position)?;
 
                 if precision as u64 > i32::MAX as u64 {
                     return Err(FormatError::InvalidPrecision(precision.to_string()));
@@ -450,7 +447,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
-                let i = args.next_u64(position);
+                let i = args.next_u64(position)?;
 
                 if precision as u64 > i32::MAX as u64 {
                     return Err(FormatError::InvalidPrecision(precision.to_string()));
@@ -481,7 +478,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args);
-                let f: ExtendedBigDecimal = args.next_extended_big_decimal(position);
+                let f: ExtendedBigDecimal = args.next_extended_big_decimal(position)?;
 
                 if precision.is_some_and(|p| p as u64 > i32::MAX as u64) {
                     return Err(FormatError::InvalidPrecision(
@@ -518,7 +515,7 @@ fn resolve_asterisk_width(
     match option {
         None => None,
         Some(CanAsterisk::Asterisk(loc)) => {
-            let nb = args.next_i64(&loc);
+            let nb = args.next_i64(&loc).unwrap_or(0);
             if nb < 0 {
                 Some((usize::try_from(-(nb as isize)).ok().unwrap_or(0), true))
             } else {
@@ -537,7 +534,7 @@ fn resolve_asterisk_precision(
 ) -> Option<usize> {
     match option {
         None => None,
-        Some(CanAsterisk::Asterisk(loc)) => match args.next_i64(&loc) {
+        Some(CanAsterisk::Asterisk(loc)) => match args.next_i64(&loc).unwrap_or(0) {
             v if v >= 0 => usize::try_from(v).ok(),
             v if v < 0 => Some(0usize),
             _ => None,
@@ -646,7 +643,7 @@ mod tests {
                 Some((42, false)),
                 resolve_asterisk_width(
                     Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
-                    &mut FormatArguments::new(&[FormatArgument::Unparsed("42".to_string())]),
+                    &mut FormatArguments::new(&[FormatArgument::Unparsed("42".into())]),
                 )
             );
 
@@ -661,7 +658,7 @@ mod tests {
                 Some((42, true)),
                 resolve_asterisk_width(
                     Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
-                    &mut FormatArguments::new(&[FormatArgument::Unparsed("-42".to_string())]),
+                    &mut FormatArguments::new(&[FormatArgument::Unparsed("-42".into())]),
                 )
             );
 
@@ -672,9 +669,9 @@ mod tests {
                         NonZero::new(2).unwrap()
                     ))),
                     &mut FormatArguments::new(&[
-                        FormatArgument::Unparsed("1".to_string()),
-                        FormatArgument::Unparsed("2".to_string()),
-                        FormatArgument::Unparsed("3".to_string())
+                        FormatArgument::Unparsed("1".into()),
+                        FormatArgument::Unparsed("2".into()),
+                        FormatArgument::Unparsed("3".into())
                     ]),
                 )
             );
@@ -717,7 +714,7 @@ mod tests {
                 Some(42),
                 resolve_asterisk_precision(
                     Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
-                    &mut FormatArguments::new(&[FormatArgument::Unparsed("42".to_string())]),
+                    &mut FormatArguments::new(&[FormatArgument::Unparsed("42".into())]),
                 )
             );
 
@@ -732,7 +729,7 @@ mod tests {
                 Some(0),
                 resolve_asterisk_precision(
                     Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
-                    &mut FormatArguments::new(&[FormatArgument::Unparsed("-42".to_string())]),
+                    &mut FormatArguments::new(&[FormatArgument::Unparsed("-42".into())]),
                 )
             );
             assert_eq!(
@@ -742,9 +739,9 @@ mod tests {
                         NonZero::new(2).unwrap()
                     ))),
                     &mut FormatArguments::new(&[
-                        FormatArgument::Unparsed("1".to_string()),
-                        FormatArgument::Unparsed("2".to_string()),
-                        FormatArgument::Unparsed("3".to_string())
+                        FormatArgument::Unparsed("1".into()),
+                        FormatArgument::Unparsed("2".into()),
+                        FormatArgument::Unparsed("3".into())
                     ]),
                 )
             );

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -357,7 +357,7 @@ impl Spec {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or_default();
                 write_padded(
                     writer,
-                    &[args.next_char(position)?],
+                    &[args.next_char(position)],
                     width,
                     *align_left || neg_width,
                 )
@@ -419,7 +419,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
-                let i = args.next_i64(position)?;
+                let i = args.next_i64(position);
 
                 if precision as u64 > i32::MAX as u64 {
                     return Err(FormatError::InvalidPrecision(precision.to_string()));
@@ -447,7 +447,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
-                let i = args.next_u64(position)?;
+                let i = args.next_u64(position);
 
                 if precision as u64 > i32::MAX as u64 {
                     return Err(FormatError::InvalidPrecision(precision.to_string()));
@@ -478,7 +478,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args);
-                let f: ExtendedBigDecimal = args.next_extended_big_decimal(position)?;
+                let f: ExtendedBigDecimal = args.next_extended_big_decimal(position);
 
                 if precision.is_some_and(|p| p as u64 > i32::MAX as u64) {
                     return Err(FormatError::InvalidPrecision(
@@ -515,7 +515,7 @@ fn resolve_asterisk_width(
     match option {
         None => None,
         Some(CanAsterisk::Asterisk(loc)) => {
-            let nb = args.next_i64(&loc).unwrap_or(0);
+            let nb = args.next_i64(&loc);
             if nb < 0 {
                 Some((usize::try_from(-(nb as isize)).ok().unwrap_or(0), true))
             } else {
@@ -534,7 +534,7 @@ fn resolve_asterisk_precision(
 ) -> Option<usize> {
     match option {
         None => None,
-        Some(CanAsterisk::Asterisk(loc)) => match args.next_i64(&loc).unwrap_or(0) {
+        Some(CanAsterisk::Asterisk(loc)) => match args.next_i64(&loc) {
             v if v >= 0 => usize::try_from(v).ok(),
             v if v < 0 => Some(0usize),
             _ => None,

--- a/src/uucore/src/lib/features/parser/num_parser.rs
+++ b/src/uucore/src/lib/features/parser/num_parser.rs
@@ -546,21 +546,6 @@ pub(crate) fn parse<'a>(
     target: ParseTarget,
     allowed_suffixes: &[(char, u32)],
 ) -> Result<ExtendedBigDecimal, ExtendedParserError<'a, ExtendedBigDecimal>> {
-    // Parse the " and ' prefixes separately
-    if target != ParseTarget::Duration {
-        if let Some(rest) = input.strip_prefix(['\'', '"']) {
-            let mut chars = rest.char_indices().fuse();
-            let v = chars
-                .next()
-                .map(|(_, c)| ExtendedBigDecimal::BigDecimal(u32::from(c).into()));
-            return match (v, chars.next()) {
-                (Some(v), None) => Ok(v),
-                (Some(v), Some((i, _))) => Err(ExtendedParserError::PartialMatch(v, &rest[i..])),
-                (None, _) => Err(ExtendedParserError::NotNumeric),
-            };
-        }
-    }
-
     let trimmed_input = input.trim_ascii_start();
 
     // Initial minus/plus sign

--- a/src/uucore/src/lib/features/parser/num_parser.rs
+++ b/src/uucore/src/lib/features/parser/num_parser.rs
@@ -546,6 +546,9 @@ pub(crate) fn parse<'a>(
     target: ParseTarget,
     allowed_suffixes: &[(char, u32)],
 ) -> Result<ExtendedBigDecimal, ExtendedParserError<'a, ExtendedBigDecimal>> {
+    // Note: literals with ' and " prefixes are parsed earlier on in argument parsing,
+    // before UTF-8 conversion.
+
     let trimmed_input = input.trim_ascii_start();
 
     // Initial minus/plus sign

--- a/util/why-error.md
+++ b/util/why-error.md
@@ -38,11 +38,7 @@ This file documents why some tests are failing:
 * gnu/tests/mv/part-hardlink.sh
 * gnu/tests/od/od-N.sh
 * gnu/tests/od/od-float.sh
-* gnu/tests/printf/printf-cov.pl
-* gnu/tests/printf/printf-indexed.sh
-* gnu/tests/printf/printf-mb.sh
 * gnu/tests/printf/printf-quote.sh
-* gnu/tests/printf/printf.sh
 * gnu/tests/ptx/ptx-overrun.sh
 * gnu/tests/ptx/ptx.pl
 * gnu/tests/rm/empty-inacc.sh - https://github.com/uutils/coreutils/issues/7033


### PR DESCRIPTION
Rebased #7209 yet again (I "had" to squash 2 commits together to make the rebase slightly easier..), I'll also attempt to apply the changes I suggested.

--

Rebases https://github.com/uutils/coreutils/pull/6812 on https://github.com/uutils/coreutils/pull/7208.

EDIT: Now also includes a commit from me to pass the printf-mb GNU test, as well as a few other odds and ends. Fixes https://github.com/uutils/coreutils/issues/6804.