### PR TITLE
echo: show version when `--version` is the only argument

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -167,6 +167,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         //                     echo --help
         uu_app().print_help()?;
         return Ok(());
+    } else if args.len() == 1 && args[0] == "--version" {
+        print!("{}", uu_app().render_version());
+        return Ok(());
     } else {
         // if POSIXLY_CORRECT is not set we filter the flags normally
         filter_flags(args.into_iter())

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (words) araba merci efjkow
 
+use regex::Regex;
 use uutests::new_ucmd;
 use uutests::util::TestScenario;
 use uutests::util::UCommand;
@@ -512,6 +513,14 @@ fn partial_version_argument() {
 #[test]
 fn partial_help_argument() {
     new_ucmd!().arg("--he").succeeds().stdout_is("--he\n");
+}
+
+#[test]
+fn full_version_argument() {
+    new_ucmd!()
+        .arg("--version")
+        .succeeds()
+        .stdout_matches(&Regex::new(r"^echo \(uutils coreutils\) (\d+\.\d+\.\d+)\n$").unwrap());
 }
 
 #[test]

--- a/tests/by-util/test_echo.rs
+++ b/tests/by-util/test_echo.rs
@@ -524,7 +524,7 @@ fn full_version_argument() {
 }
 
 #[test]
-fn only_help_argument_prints_help() {
+fn full_help_argument() {
     assert_ne!(new_ucmd!().arg("--help").succeeds().stdout(), b"--help\n");
     assert_ne!(new_ucmd!().arg("--help").succeeds().stdout(), b"--help"); // This one is just in case.
 }


### PR DESCRIPTION
This PR shows the version info when `--version` is the only argument and `POSIXLY_CORRECT` is not set. It matches the behavior of GNU `echo`:
```
$ ../gnu/src/echo --version
echo (GNU coreutils) 9.7-modified
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Brian Fox and Chet Ramey.
$ POSIXLY_CORRECT=1 ../gnu/src/echo --version
--version
```
The PR also renames a test function to make the naming more consistent.