### PR TITLE
l10n: replace `\n` with a new line in ftl files

### DIFF
--- a/src/uu/chroot/locales/en-US.ftl
+++ b/src/uu/chroot/locales/en-US.ftl
@@ -14,7 +14,8 @@ chroot-error-command-not-found = failed to run command { $cmd }: { $err }
 chroot-error-groups-parsing-failed = --groups parsing failed
 chroot-error-invalid-group = invalid group: { $group }
 chroot-error-invalid-group-list = invalid group list: { $list }
-chroot-error-missing-newroot = Missing operand: NEWROOT\nTry '{ $util_name } --help' for more information.
+chroot-error-missing-newroot = Missing operand: NEWROOT
+  Try '{ $util_name } --help' for more information.
 chroot-error-no-group-specified = no group specified for unknown uid: { $uid }
 chroot-error-no-such-user = invalid user
 chroot-error-no-such-group = invalid group

--- a/src/uu/chroot/locales/fr-FR.ftl
+++ b/src/uu/chroot/locales/fr-FR.ftl
@@ -14,7 +14,8 @@ chroot-error-command-not-found = échec de l'exécution de la commande { $cmd } 
 chroot-error-groups-parsing-failed = échec de l'analyse de --groups
 chroot-error-invalid-group = groupe invalide : { $group }
 chroot-error-invalid-group-list = liste de groupes invalide : { $list }
-chroot-error-missing-newroot = Opérande manquant : NOUVRACINE\nEssayez '{ $util_name } --help' pour plus d'informations.
+chroot-error-missing-newroot = Opérande manquant : NOUVRACINE
+  Essayez '{ $util_name } --help' pour plus d'informations.
 chroot-error-no-group-specified = aucun groupe spécifié pour l'uid inconnu : { $uid }
 chroot-error-no-such-user = utilisateur invalide
 chroot-error-no-such-group = groupe invalide

--- a/src/uu/du/locales/en-US.ftl
+++ b/src/uu/du/locales/en-US.ftl
@@ -47,7 +47,12 @@ du-help-time-style = show times using style STYLE: full-iso, long-iso, iso, +FOR
 # Error messages
 du-error-invalid-max-depth = invalid maximum depth { $depth }
 du-error-summarize-depth-conflict = summarizing conflicts with --max-depth={ $depth }
-du-error-invalid-time-style = invalid argument { $style } for 'time style'\nValid arguments are:\n- 'full-iso'\n- 'long-iso'\n- 'iso'\nTry '{ $help }' for more information.
+du-error-invalid-time-style = invalid argument { $style } for 'time style'
+  Valid arguments are:
+    - 'full-iso'
+    - 'long-iso'
+    - 'iso'
+  Try '{ $help }' for more information.
 du-error-invalid-time-arg = 'birth' and 'creation' arguments for --time are not supported on this platform.
 du-error-invalid-glob = Invalid exclude syntax: { $error }
 du-error-cannot-read-directory = cannot read directory { $path }
@@ -55,7 +60,8 @@ du-error-cannot-access = cannot access { $path }
 du-error-read-error-is-directory = { $file }: read error: Is a directory
 du-error-cannot-open-for-reading = cannot open '{ $file }' for reading: No such file or directory
 du-error-invalid-zero-length-file-name = { $file }:{ $line }: invalid zero-length file name
-du-error-extra-operand-with-files0-from = extra operand { $file }\nfile operands cannot be combined with --files0-from
+du-error-extra-operand-with-files0-from = extra operand { $file }
+  file operands cannot be combined with --files0-from
 du-error-invalid-block-size-argument = invalid --{ $option } argument { $value }
 du-error-cannot-access-no-such-file = cannot access { $path }: No such file or directory
 du-error-printing-thread-panicked = Printing thread panicked.

--- a/src/uu/du/locales/fr-FR.ftl
+++ b/src/uu/du/locales/fr-FR.ftl
@@ -47,7 +47,12 @@ du-help-time-style = montrer les heures en utilisant le style STYLE : full-iso, 
 # Messages d'erreur
 du-error-invalid-max-depth = profondeur maximale invalide { $depth }
 du-error-summarize-depth-conflict = la synthèse entre en conflit avec --max-depth={ $depth }
-du-error-invalid-time-style = argument invalide { $style } pour 'style de temps'\nLes arguments valides sont :\n- 'full-iso'\n- 'long-iso'\n- 'iso'\nEssayez '{ $help }' pour plus d'informations.
+du-error-invalid-time-style = argument invalide { $style } pour 'style de temps'
+  Les arguments valides sont :
+    - 'full-iso'
+    - 'long-iso'
+    - 'iso'
+  Essayez '{ $help }' pour plus d'informations.
 du-error-invalid-time-arg = les arguments 'birth' et 'creation' pour --time ne sont pas supportés sur cette plateforme.
 du-error-invalid-glob = Syntaxe d'exclusion invalide : { $error }
 du-error-cannot-read-directory = impossible de lire le répertoire { $path }
@@ -55,7 +60,8 @@ du-error-cannot-access = impossible d'accéder à { $path }
 du-error-read-error-is-directory = { $file } : erreur de lecture : C'est un répertoire
 du-error-cannot-open-for-reading = impossible d'ouvrir '{ $file }' en lecture : Aucun fichier ou répertoire de ce type
 du-error-invalid-zero-length-file-name = { $file }:{ $line } : nom de fichier de longueur zéro invalide
-du-error-extra-operand-with-files0-from = opérande supplémentaire { $file }\nles opérandes de fichier ne peuvent pas être combinées avec --files0-from
+du-error-extra-operand-with-files0-from = opérande supplémentaire { $file }
+  les opérandes de fichier ne peuvent pas être combinées avec --files0-from
 du-error-invalid-block-size-argument = argument --{ $option } invalide { $value }
 du-error-cannot-access-no-such-file = impossible d'accéder à { $path } : Aucun fichier ou répertoire de ce type
 du-error-printing-thread-panicked = Le thread d'affichage a paniqué.

--- a/src/uu/nohup/locales/en-US.ftl
+++ b/src/uu/nohup/locales/en-US.ftl
@@ -10,7 +10,8 @@ nohup-after-help = If standard input is terminal, it'll be replaced with /dev/nu
 nohup-error-cannot-detach = Cannot detach from console
 nohup-error-cannot-replace = Cannot replace { $name }: { $err }
 nohup-error-open-failed = failed to open { $path }: { $err }
-nohup-error-open-failed-both = failed to open { $first_path }: { $first_err }\nfailed to open { $second_path }: { $second_err }
+nohup-error-open-failed-both = failed to open { $first_path }: { $first_err }
+  failed to open { $second_path }: { $second_err }
 
 # Status messages
 nohup-ignoring-input-appending-output = ignoring input and appending output to { $path }

--- a/src/uu/nohup/locales/fr-FR.ftl
+++ b/src/uu/nohup/locales/fr-FR.ftl
@@ -10,7 +10,8 @@ nohup-after-help = Si l'entrée standard est un terminal, elle sera remplacée p
 nohup-error-cannot-detach = Impossible de se détacher de la console
 nohup-error-cannot-replace = Impossible de remplacer { $name } : { $err }
 nohup-error-open-failed = échec de l'ouverture de { $path } : { $err }
-nohup-error-open-failed-both = échec de l'ouverture de { $first_path } : { $first_err }\néchec de l'ouverture de { $second_path } : { $second_err }
+nohup-error-open-failed-both = échec de l'ouverture de { $first_path } : { $first_err }
+  échec de l'ouverture de { $second_path } : { $second_err }
 
 # Messages de statut
 nohup-ignoring-input-appending-output = entrée ignorée et sortie ajoutée à { $path }


### PR DESCRIPTION
This PR replaces some `\n` with a new line in ftl files. It should make [tests/du/files0-from.pl](https://github.com/coreutils/coreutils/blob/master/tests/du/files0-from.pl) pass.