### PR TITLE
util/build-gnu.sh: Bypass timeout/yes SIGPIPE handling bug

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -60,6 +60,13 @@ elif [ -x /usr/local/bin/timeout ]; then
     SYSTEM_TIMEOUT="/usr/local/bin/timeout"
 fi
 
+SYSTEM_YES="yes"
+if [ -x /usr/bin/yes ]; then
+    SYSTEM_YES="/usr/bin/yes"
+elif [ -x /usr/local/bin/yes ]; then
+    SYSTEM_YES="/usr/local/bin/yes"
+fi
+
 ###
 
 release_tag_GNU="v9.7"
@@ -211,6 +218,11 @@ sed -i "s|cannot create regular file 'no-such/': Not a directory|'no-such/' is n
 sed -i "s|warning: unrecognized escape|warning: incomplete hex escape|" tests/stat/stat-printf.pl
 
 sed -i 's|timeout |'"${SYSTEM_TIMEOUT}"' |' tests/tail/follow-stdin.sh
+
+# trap_sigpipe_or_skip_ fails with uutils tools because of a bug in
+# timeout/yes (https://github.com/uutils/coreutils/issues/7252), so we use
+# system's yes/timeout to make sure the tests run (instead of being skipped).
+sed -i 's|\(trap .* \)timeout\( .* \)yes|'"\1${SYSTEM_TIMEOUT}\2${SYSTEM_YES}"'|' init.cfg
 
 # Remove dup of /usr/bin/ and /usr/local/bin/ when executed several times
 grep -rlE '/usr/bin/\s?/usr/bin' init.cfg tests/* | xargs -r sed -Ei 's|/usr/bin/\s?/usr/bin/|/usr/bin/|g'

--- a/util/why-skip.md
+++ b/util/why-skip.md
@@ -1,11 +1,5 @@
 # spell-checker:ignore epipe readdir restorecon SIGALRM capget bigtime rootfs enotsup
 
-= trapping SIGPIPE is not supported =
-* tests/tail-2/pipe-f.sh
-* tests/misc/seq-epipe.sh
-* tests/misc/printf-surprise.sh
-* tests/misc/env-signal-handler.sh
-
 = skipped test: breakpoint not hit =
 * tests/tail-2/inotify-race2.sh
 * tail-2/inotify-race.sh


### PR DESCRIPTION
See #7252, both `timeout` and `yes` reset the SIGPIPE handler (actually, the Rust core does that), leading to trap_sigpipe_or_skip_ test:
```
(trap '' PIPE && timeout 10 yes |:) 2>&1 | grep 'Broken pipe'
```
to fail, causing 4 tests to be skipped.

I believe the intent here is to check if the OS supports SIGPIPE, so it probably makes sense to use System's timeout/yes here, and run the tests anyway (which, happen to pass).