### PR TITLE
remove PROJECT_NAME_FOR_VERSION_STRING

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,11 @@
+# Note: keep in mind that this file is completely ignored in several use-cases
+# like e.g. out-of-tree builds ( https://github.com/rust-lang/cargo/issues/2930 ).
+# For this reason this file should be avoided as much as possible when there are alternatives.
+
 [target.x86_64-unknown-redox]
 linker = "x86_64-unknown-redox-gcc"
 
 [env]
-PROJECT_NAME_FOR_VERSION_STRING = "uutils coreutils"
 # See feat_external_libstdbuf in src/uu/stdbuf/Cargo.toml
 LIBSTDBUF_DIR = "/usr/local/libexec/coreutils"
 

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -205,18 +205,10 @@ macro_rules! bin {
 ///
 /// The generated string has the format `(<project name>) <version>`, for
 /// example: "(uutils coreutils) 0.30.0". clap will then prefix it with the util name.
-///
-/// To use this macro, you have to add `PROJECT_NAME_FOR_VERSION_STRING = "<project name>"` to the
-/// `[env]` section in `.cargo/config.toml`.
 #[macro_export]
 macro_rules! crate_version {
     () => {
-        concat!(
-            "(",
-            env!("PROJECT_NAME_FOR_VERSION_STRING"),
-            ") ",
-            env!("CARGO_PKG_VERSION")
-        )
+        concat!("(uutils coreutils) ", env!("CARGO_PKG_VERSION"))
     };
 }
 


### PR DESCRIPTION
This fixes out-of-tree builds which are using --manifest-path and ignoring .cargo/config.toml because of https://github.com/rust-lang/cargo/issues/2930 :

```
git clone https://github.com/uutils/coreutils.git
mkdir test && cd test
cargo build --manifest-path=../coreutils/Cargo.toml
```

This also fixes installation of coreutils from crates.io, which also ignores .cargo/config.toml:
```
cargo install coreutils --locked
```

Using `option_env` is not possible because `concat!` needs a string literal. I don't see a need to change the project name using an environment variable, so let's keep things simple and simply remove it to fix this bug.

Fixes https://github.com/uutils/coreutils/issues/7992