### PR TITLE
Setup localization for utility symlinks

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -108,6 +108,7 @@ fn main() {
 
     // binary name equals util name?
     if let Some(&(uumain, _)) = utils.get(binary_as_util) {
+        setup_localization_or_exit(binary_as_util);
         process::exit(uumain(vec![binary.into()].into_iter().chain(args)));
     }
 


### PR DESCRIPTION
If we are invoked via utility symlinks such as "ln", we need to setup localization before calling the utility's main function.

Fixes: #8332