### PR TITLE
Fix mkdir with non-unicode parameters

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -85,9 +85,25 @@ fn strip_minus_from_mode(_args: &mut [String]) -> bool {
     false
 }
 
+// Iterate 'args' and delete the first occurrence
+// of a prefix '-' if it's associated with MODE
+// e.g. "chmod -v -xw -R FILE" -> "chmod -v xw -R FILE"
 #[cfg(not(windows))]
 fn strip_minus_from_mode(args: &mut Vec<String>) -> bool {
-    mode::strip_minus_from_mode(args)
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if let Some(arg_stripped) = arg.strip_prefix('-') {
+            if let Some('r' | 'w' | 'x' | 'X' | 's' | 't' | 'u' | 'g' | 'o' | '0'..='7') =
+                arg.chars().nth(1)
+            {
+                *arg = arg_stripped.to_string();
+                return true;
+            }
+        }
+    }
+    false
 }
 
 #[uucore::main]

--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -182,26 +182,6 @@ pub fn get_umask() -> u32 {
     return mask as u32;
 }
 
-// Iterate 'args' and delete the first occurrence
-// of a prefix '-' if it's associated with MODE
-// e.g. "chmod -v -xw -R FILE" -> "chmod -v xw -R FILE"
-pub fn strip_minus_from_mode(args: &mut Vec<String>) -> bool {
-    for arg in args {
-        if arg == "--" {
-            break;
-        }
-        if let Some(arg_stripped) = arg.strip_prefix('-') {
-            if let Some('r' | 'w' | 'x' | 'X' | 's' | 't' | 'u' | 'g' | 'o' | '0'..='7') =
-                arg.chars().nth(1)
-            {
-                *arg = arg_stripped.to_string();
-                return true;
-            }
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod test {
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -5837,7 +5837,7 @@ fn test_dir_perm_race_with_preserve_mode_and_ownership() {
                 start_time.elapsed() < timeout,
                 "timed out: cp took too long to create destination directory"
             );
-            if at.dir_exists(&format!("{DEST_DIR}/{SRC_DIR}")) {
+            if at.dir_exists(format!("{DEST_DIR}/{SRC_DIR}")) {
                 break;
             }
             sleep(Duration::from_millis(100));

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -34,6 +34,18 @@ fn test_mkdir_mkdir() {
     new_ucmd!().arg("test_dir").succeeds();
 }
 
+#[cfg(feature = "test_risky_names")]
+#[test]
+fn test_mkdir_non_unicode() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let target = uucore::os_str_from_bytes(b"some-\xc0-dir-\xf3")
+        .expect("Only unix platforms can test non-unicode names");
+    ucmd.arg(&target).succeeds();
+
+    assert!(at.dir_exists(target));
+}
+
 #[test]
 fn test_mkdir_verbose() {
     let expected = "mkdir: created directory 'test_dir'\n";

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -228,8 +228,8 @@ fn test_mv_multiple_folders() {
         .succeeds()
         .no_stderr();
 
-    assert!(at.dir_exists(&format!("{target_dir}/{dir_a}")));
-    assert!(at.dir_exists(&format!("{target_dir}/{dir_b}")));
+    assert!(at.dir_exists(format!("{target_dir}/{dir_a}")));
+    assert!(at.dir_exists(format!("{target_dir}/{dir_b}")));
 }
 
 #[test]
@@ -555,7 +555,7 @@ fn test_mv_hardlink_to_symlink() {
         .arg(hardlink_to_symlink_file)
         .succeeds();
     assert!(!at2.symlink_exists(symlink_file));
-    assert!(at2.symlink_exists(&format!("{hardlink_to_symlink_file}~")));
+    assert!(at2.symlink_exists(format!("{hardlink_to_symlink_file}~")));
 }
 
 #[test]
@@ -649,7 +649,7 @@ fn test_mv_simple_backup_for_directory() {
 
     assert!(!at.dir_exists(dir_a));
     assert!(at.dir_exists(dir_b));
-    assert!(at.dir_exists(&format!("{dir_b}~")));
+    assert!(at.dir_exists(format!("{dir_b}~")));
     assert!(at.file_exists(format!("{dir_b}/file_a")));
     assert!(at.file_exists(format!("{dir_b}~/file_b")));
 }
@@ -1353,7 +1353,7 @@ fn test_mv_backup_dir() {
 
     assert!(!at.dir_exists(dir_a));
     assert!(at.dir_exists(dir_b));
-    assert!(at.dir_exists(&format!("{dir_b}~")));
+    assert!(at.dir_exists(format!("{dir_b}~")));
 }
 
 #[test]
@@ -1572,7 +1572,7 @@ fn test_mv_dir_into_dir_with_source_name_a_prefix_of_target_name() {
 
     ucmd.arg(source).arg(target).succeeds().no_output();
 
-    assert!(at.dir_exists(&format!("{target}/{source}")));
+    assert!(at.dir_exists(format!("{target}/{source}")));
 }
 
 #[test]

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -1243,14 +1243,14 @@ impl AtPath {
     }
 
     /// Decide whether the named symbolic link exists in the test directory.
-    pub fn symlink_exists(&self, path: &str) -> bool {
+    pub fn symlink_exists<P: AsRef<Path>>(&self, path: P) -> bool {
         match fs::symlink_metadata(self.plus(path)) {
             Ok(m) => m.file_type().is_symlink(),
             Err(_) => false,
         }
     }
 
-    pub fn dir_exists(&self, path: &str) -> bool {
+    pub fn dir_exists<P: AsRef<Path>>(&self, path: P) -> bool {
         match fs::metadata(self.plus(path)) {
             Ok(m) => m.is_dir(),
             Err(_) => false,


### PR DESCRIPTION
First part of #8357. Overall, I think we should review all uses of `collect_lossy()`, they might all be wrong.

---

### test_mkdir: Add a test for non-Unicode directory name

Similar to the first part of GNU test df/problematic-chars.

### uutests: Change dir_exists to take a templated AsRef<Path>

Similar to what file_exists does, allows us to pass an OsStr to the
function.

Also change symlink_exists, for consistency.

### mkdir: strip_minus_from_mode: Use uucore functions

Let's not reinvent stuff.

### mkdir: Collect OsString, instead of String.

collect_lossy incorrectly converts invalid UTF-8 strings, let's
keep the OsString everywhere.

This also means we need to modify strip_minus_from_mode to make
it work with OsString.

### uucore: Move strip_minus_from_mode to mkdir

It's only used there anyway.