### PR TITLE
basename: Simply logic, do not trim path separators `/`

### DIFF
--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -7,7 +7,7 @@
 
 use clap::{Arg, ArgAction, Command};
 use std::collections::HashMap;
-use std::path::{PathBuf, is_separator};
+use std::path::PathBuf;
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
 use uucore::format_usage;
@@ -119,17 +119,8 @@ pub fn uu_app() -> Command {
 }
 
 fn basename(fullname: &str, suffix: &str) -> String {
-    // Remove all platform-specific path separators from the end.
-    let path = fullname.trim_end_matches(is_separator);
-
-    // If the path contained *only* suffix characters (for example, if
-    // `fullname` were "///" and `suffix` were "/"), then `path` would
-    // be left with the empty string. In that case, we set `path` to be
-    // the original `fullname` to avoid returning the empty path.
-    let path = if path.is_empty() { fullname } else { path };
-
     // Convert to path buffer and get last path component
-    let pb = PathBuf::from(path);
+    let pb = PathBuf::from(fullname);
 
     pb.components().next_back().map_or_else(String::new, |c| {
         let name = c.as_os_str().to_str().unwrap();


### PR DESCRIPTION
Looks like this is not needed, and Pathbuf already behaves as expected.

Tiny simple PR, I'll stack OsStr changes on top.