### PR TITLE
`du`/`ls`: Unify file metadata time handling

### DIFF
--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/du.rs"
 # For the --exclude & --exclude-from options
 glob = { workspace = true }
 clap = { workspace = true }
-uucore = { workspace = true, features = ["format", "parser", "time"] }
+uucore = { workspace = true, features = ["format", "fsext", "parser", "time"] }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -648,12 +648,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let time = matches.contains_id(options::TIME).then(|| {
-        match matches.get_one::<String>(options::TIME).map(AsRef::as_ref) {
-            None | Some("ctime" | "status") => MetadataTimeField::Modification,
-            Some("access" | "atime" | "use") => MetadataTimeField::Access,
-            Some("birth" | "creation") => MetadataTimeField::Birth,
-            _ => unreachable!("should be caught by clap"),
-        }
+        matches
+            .get_one::<String>(options::TIME)
+            .map_or(MetadataTimeField::Modification, |s| s.as_str().into())
     });
 
     let size_format = if matches.get_flag(options::HUMAN_READABLE) {

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -531,7 +531,7 @@ impl StatPrinter {
                 uucore::time::format_system_time(&mut stdout(), time, &self.time_format, true)?;
                 print!("\t");
             } else {
-                println!("???\t");
+                print!("???\t");
             }
         }
 

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -33,6 +33,7 @@ uucore = { workspace = true, features = [
   "entries",
   "format",
   "fs",
+  "fsext",
   "fsxattr",
   "parser",
   "quoting-style",

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -464,14 +464,7 @@ fn extract_sort(options: &clap::ArgMatches) -> Sort {
 /// A `MetadataTimeField` variant representing the time to use.
 fn extract_time(options: &clap::ArgMatches) -> MetadataTimeField {
     if let Some(field) = options.get_one::<String>(options::TIME) {
-        match field.as_str() {
-            "ctime" | "status" => MetadataTimeField::Change,
-            "access" | "atime" | "use" => MetadataTimeField::Access,
-            "mtime" | "modification" => MetadataTimeField::Modification,
-            "birth" | "creation" => MetadataTimeField::Birth,
-            // below should never happen as clap already restricts the values.
-            _ => unreachable!("Invalid field for --time"),
-        }
+        field.as_str().into()
     } else if options.get_flag(options::time::ACCESS) {
         MetadataTimeField::Access
     } else if options.get_flag(options::time::CHANGE) {

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -151,28 +151,24 @@ impl From<&str> for MetadataTimeField {
     }
 }
 
-// The implementations for get_system_time are separated because some options, such
-// as ctime will not be available
 #[cfg(unix)]
-pub fn metadata_get_time(md: &Metadata, md_time: MetadataTimeField) -> Option<SystemTime> {
-    match md_time {
-        MetadataTimeField::Change => {
-            // TODO: This is incorrect for negative timestamps.
-            Some(UNIX_EPOCH + Duration::new(md.ctime() as u64, md.ctime_nsec() as u32))
-        }
-        MetadataTimeField::Modification => md.modified().ok(),
-        MetadataTimeField::Access => md.accessed().ok(),
-        MetadataTimeField::Birth => md.created().ok(),
-    }
+fn metadata_get_change_time(md: &Metadata) -> Option<SystemTime> {
+    // TODO: This is incorrect for negative timestamps.
+    Some(UNIX_EPOCH + Duration::new(md.ctime() as u64, md.ctime_nsec() as u32))
 }
 
 #[cfg(not(unix))]
+fn metadata_get_change_time(_md: &Metadata) -> Option<SystemTime> {
+    // Not available.
+    None
+}
+
 pub fn metadata_get_time(md: &Metadata, md_time: MetadataTimeField) -> Option<SystemTime> {
     match md_time {
+        MetadataTimeField::Change => metadata_get_change_time(md),
         MetadataTimeField::Modification => md.modified().ok(),
         MetadataTimeField::Access => md.accessed().ok(),
         MetadataTimeField::Birth => md.created().ok(),
-        MetadataTimeField::Change => None,
     }
 }
 

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -135,6 +135,22 @@ pub enum MetadataTimeField {
     Birth,
 }
 
+impl From<&str> for MetadataTimeField {
+    /// Get a `MetadataTimeField` from a string, we expect the value
+    /// to come from clap, and be constrained there (e.g. if Modification is
+    /// not supported), and the default branch should not be reached.
+    fn from(value: &str) -> Self {
+        match value {
+            "ctime" | "status" => MetadataTimeField::Change,
+            "access" | "atime" | "use" => MetadataTimeField::Access,
+            "mtime" | "modification" => MetadataTimeField::Modification,
+            "birth" | "creation" => MetadataTimeField::Birth,
+            // below should never happen as clap already restricts the values.
+            _ => unreachable!("Invalid metadata time field."),
+        }
+    }
+}
+
 // The implementations for get_system_time are separated because some options, such
 // as ctime will not be available
 #[cfg(unix)]

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -594,6 +594,8 @@ fn test_du_h_precision() {
 #[cfg(feature = "touch")]
 #[test]
 fn test_du_time() {
+    use regex::Regex;
+
     let ts = TestScenario::new(util_name!());
 
     // du --time formats the timestamp according to the local timezone. We set the TZ
@@ -634,21 +636,15 @@ fn test_du_time() {
         result.stdout_only("0\t2015-05-15 00:00\tdate_test\n");
     }
 
-    let result = ts
-        .ucmd()
-        .env("TZ", "UTC")
-        .arg("--time=ctime")
-        .arg("date_test")
-        .succeeds();
-    result.stdout_only("0\t2016-06-16 00:00\tdate_test\n");
+    // Change (and birth) times can't be easily modified, so we just do a regex
+    let re_change_birth =
+        Regex::new(r"0\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}\tdate_test").unwrap();
+    let result = ts.ucmd().arg("--time=ctime").arg("date_test").succeeds();
+    result.stdout_matches(&re_change_birth);
 
     if birth_supported() {
-        use regex::Regex;
-
-        let re_birth =
-            Regex::new(r"0\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}\tdate_test").unwrap();
         let result = ts.ucmd().arg("--time=birth").arg("date_test").succeeds();
-        result.stdout_matches(&re_birth);
+        result.stdout_matches(&re_change_birth);
     }
 }
 

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -640,6 +640,9 @@ fn test_du_time() {
     let re_change_birth =
         Regex::new(r"0\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}\tdate_test").unwrap();
     let result = ts.ucmd().arg("--time=ctime").arg("date_test").succeeds();
+    #[cfg(windows)]
+    result.stdout_only("0\t???\tdate_test\n"); // ctime not supported on Windows
+    #[cfg(not(windows))]
     result.stdout_matches(&re_change_birth);
 
     if birth_supported() {


### PR DESCRIPTION
Was meant to be a maybe-not-that-useful refactoring, uncovered a bug in `du`...

`ctime` is _change_ time, not modification time.

```
$ stat date_test
  File: date_test
...
Access: 2015-05-15 00:00:00.000000000 +0800
Modify: 2016-06-16 00:00:00.000000000 +0800
Change: 2025-07-27 10:34:50.223190416 +0800
 Birth: 2025-07-27 10:34:33.814131325 +0800
$ du --time=ctime date_test 
0	2025-07-27 10:34	date_test
$ cargo build -p uu_du && ./target/debug/du --time=ctime date_test 
0	2016-06-16 00:00	date_test
```

---

### du/test_du: Fix ctime fallback on Windows, and test

### test_du: Fix --time=ctime test

It turns out `du` used to test for the wrong thing, `ctime` is
the change timestamp, not creation time.

We have to rely on a regex again, as the change timestamp is the
current time.

### uucore: fsext: Deduplicate metadata_get_time

Easier to just move the change time logic to another function.

### uucore: fsext: Provide From<&str> helper for MetadataTimeField

We assume that the string has been validated by clap ahead of
time (just like the current code does).

### du: Simplify Stat creation further

No need to have separate struct creation code for Windows and Unix.

Also remove is_dir, we can get it from metadata.

### du: Keep metadata in Stat, and make use of uucore::fsext::metadata_get_time

Removes some duplicated code, with slight, but incorrect, differences.

### uucore: fsext: Move metadata_get_time from ls

This function is useful for more than `ls` (`du` can use it too).