### PR TITLE
`stat`: Convert to use `uucore` functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,7 +3699,6 @@ dependencies = [
 name = "uu_stat"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "clap",
  "thiserror 2.0.12",
  "uucore",

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -27,6 +27,7 @@ use uucore::locale::{get_message, get_message_with_args};
 use uucore::parser::parse_glob;
 use uucore::parser::parse_size::{ParseSizeError, parse_size_u64};
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
+use uucore::time::{FormatSystemTimeFallback, format_system_time};
 use uucore::{format_usage, show, show_error, show_warning};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
@@ -528,7 +529,12 @@ impl StatPrinter {
 
         if let Some(md_time) = &self.time {
             if let Some(time) = metadata_get_time(&stat.metadata, *md_time) {
-                uucore::time::format_system_time(&mut stdout(), time, &self.time_format, true)?;
+                format_system_time(
+                    &mut stdout(),
+                    time,
+                    &self.time_format,
+                    FormatSystemTimeFallback::IntegerError,
+                )?;
                 print!("\t");
             } else {
                 print!("???\t");

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -60,6 +60,7 @@ use uucore::libc::{dev_t, major, minor};
 use uucore::line_ending::LineEnding;
 use uucore::locale::{get_message, get_message_with_args};
 use uucore::quoting_style::{QuotingStyle, locale_aware_escape_dir_name, locale_aware_escape_name};
+use uucore::time::{FormatSystemTimeFallback, format_system_time};
 use uucore::{
     display::Quotable,
     error::{UError, UResult, set_exit_code},
@@ -2968,7 +2969,7 @@ fn display_date(
         _ => &config.time_format_recent,
     };
 
-    uucore::time::format_system_time(out, time, fmt, false)
+    format_system_time(out, time, fmt, FormatSystemTimeFallback::Integer)
 }
 
 #[allow(dead_code)]

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -26,7 +26,6 @@ uucore = { workspace = true, features = [
   "fsext",
   "time",
 ] }
-chrono = { workspace = true }
 thiserror = { workspace = true }
 
 [features]

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -19,7 +19,13 @@ path = "src/stat.rs"
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["entries", "libc", "fs", "fsext"] }
+uucore = { workspace = true, features = [
+  "entries",
+  "libc",
+  "fs",
+  "fsext",
+  "time",
+] }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -29,7 +29,6 @@ use std::{env, fs};
 use thiserror::Error;
 use uucore::time::{FormatSystemTimeFallback, format_system_time, system_time_to_sec};
 
-
 #[derive(Debug, Error)]
 enum StatError {
     #[error("{}", translate!("stat-error-invalid-quoting-style", "style" => style.clone()))]

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -28,7 +28,7 @@ use std::{env, fs};
 use std::collections::HashMap;
 use thiserror::Error;
 use uucore::locale::{get_message, get_message_with_args};
-use uucore::time::{format_system_time, system_time_to_sec};
+use uucore::time::{FormatSystemTimeFallback, format_system_time, system_time_to_sec};
 
 #[derive(Debug, Error)]
 enum StatError {
@@ -1288,7 +1288,14 @@ const PRETTY_DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S.%N %z";
 fn pretty_time(meta: &Metadata, md_time_field: MetadataTimeField) -> String {
     if let Some(time) = metadata_get_time(meta, md_time_field) {
         let mut tmp = Vec::new();
-        if format_system_time(&mut tmp, time, PRETTY_DATETIME_FORMAT, false).is_ok() {
+        if format_system_time(
+            &mut tmp,
+            time,
+            PRETTY_DATETIME_FORMAT,
+            FormatSystemTimeFallback::Float,
+        )
+        .is_ok()
+        {
             return String::from_utf8(tmp).unwrap();
         }
     }

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -69,7 +69,9 @@ use std::io::Error as IOError;
 use std::mem;
 #[cfg(windows)]
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
+#[cfg(not(windows))]
+use std::time::UNIX_EPOCH;
 use std::{borrow::Cow, ffi::OsString};
 
 use std::fs::Metadata;
@@ -113,19 +115,6 @@ pub use libc::statfs as statfs_fn;
     target_os = "redox"
 ))]
 pub use libc::statvfs as statfs_fn;
-
-pub trait BirthTime {
-    fn birth(&self) -> Option<(u64, u32)>;
-}
-
-impl BirthTime for Metadata {
-    fn birth(&self) -> Option<(u64, u32)> {
-        self.created()
-            .ok()
-            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-            .map(|e| (e.as_secs(), e.subsec_nanos()))
-    }
-}
 
 #[derive(Debug, Copy, Clone)]
 pub enum MetadataTimeField {

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -142,8 +142,20 @@ impl From<&str> for MetadataTimeField {
 
 #[cfg(unix)]
 fn metadata_get_change_time(md: &Metadata) -> Option<SystemTime> {
-    // TODO: This is incorrect for negative timestamps.
-    Some(UNIX_EPOCH + Duration::new(md.ctime() as u64, md.ctime_nsec() as u32))
+    let mut st = UNIX_EPOCH;
+    let (secs, nsecs) = (md.ctime(), md.ctime_nsec());
+    if secs >= 0 {
+        st += Duration::from_secs(secs as u64);
+    } else {
+        st -= Duration::from_secs(-secs as u64);
+    }
+    if nsecs >= 0 {
+        st += Duration::from_nanos(nsecs as u64);
+    } else {
+        // Probably never the case, but cover just in case.
+        st -= Duration::from_nanos(-nsecs as u64);
+    }
+    Some(st)
 }
 
 #[cfg(not(unix))]

--- a/src/uucore/src/lib/features/time.rs
+++ b/src/uucore/src/lib/features/time.rs
@@ -36,12 +36,19 @@ pub fn system_time_to_sec(time: SystemTime) -> (i64, u32) {
     }
 }
 
+/// Sets how `format_system_time` behaves if the time cannot be converted.
+pub enum FormatSystemTimeFallback {
+    Integer,      // Just print seconds since epoch (`ls`)
+    IntegerError, // The above, and print an error (`du``)
+    Float,        // Just print seconds+nanoseconds since epoch (`stat`)
+}
+
 /// Format a `SystemTime` according to given fmt, and append to vector out.
 pub fn format_system_time<W: Write>(
     out: &mut W,
     time: SystemTime,
     fmt: &str,
-    show_error: bool,
+    mode: FormatSystemTimeFallback,
 ) -> UResult<()> {
     let zoned: Result<Zoned, _> = time.try_into();
     match zoned {
@@ -53,12 +60,22 @@ pub fn format_system_time<W: Write>(
             // but it still far enough in the future/past to be unlikely to matter:
             //  jiff: Year between -9999 to 9999 (UTC) [-377705023201..=253402207200]
             //  GNU: Year fits in signed 32 bits (timezone dependent)
-            let ts: i64 = system_time_to_sec(time).0;
-            let str = ts.to_string();
-            if show_error {
-                show_error!("time '{str}' is out of range");
-            }
-            out.write_all(str.as_bytes())?;
+            let (mut secs, mut nsecs) = system_time_to_sec(time);
+            match mode {
+                FormatSystemTimeFallback::Integer => out.write_all(secs.to_string().as_bytes())?,
+                FormatSystemTimeFallback::IntegerError => {
+                    let str = secs.to_string();
+                    show_error!("time '{str}' is out of range");
+                    out.write_all(str.as_bytes())?;
+                }
+                FormatSystemTimeFallback::Float => {
+                    if secs < 0 && nsecs != 0 {
+                        secs -= 1;
+                        nsecs = 1_000_000_000 - nsecs;
+                    }
+                    out.write_fmt(format_args!("{secs}.{nsecs:09}"))?;
+                }
+            };
             Ok(())
         }
     }
@@ -66,7 +83,7 @@ pub fn format_system_time<W: Write>(
 
 #[cfg(test)]
 mod tests {
-    use crate::time::format_system_time;
+    use crate::time::{FormatSystemTimeFallback, format_system_time};
     use std::time::{Duration, UNIX_EPOCH};
 
     // Test epoch SystemTime get printed correctly at UTC0, with 2 simple formats.
@@ -76,12 +93,23 @@ mod tests {
 
         let time = UNIX_EPOCH;
         let mut out = Vec::new();
-        format_system_time(&mut out, time, "%Y-%m-%d %H:%M", false).expect("Formatting error.");
+        format_system_time(
+            &mut out,
+            time,
+            "%Y-%m-%d %H:%M",
+            FormatSystemTimeFallback::Integer,
+        )
+        .expect("Formatting error.");
         assert_eq!(String::from_utf8(out).unwrap(), "1970-01-01 00:00");
 
         let mut out = Vec::new();
-        format_system_time(&mut out, time, "%Y-%m-%d %H:%M:%S.%N %z", false)
-            .expect("Formatting error.");
+        format_system_time(
+            &mut out,
+            time,
+            "%Y-%m-%d %H:%M:%S.%N %z",
+            FormatSystemTimeFallback::Integer,
+        )
+        .expect("Formatting error.");
         assert_eq!(
             String::from_utf8(out).unwrap(),
             "1970-01-01 00:00:00.000000000 +0000"
@@ -93,12 +121,58 @@ mod tests {
     fn test_large_system_time() {
         let time = UNIX_EPOCH + Duration::from_secs(67_768_036_191_763_200);
         let mut out = Vec::new();
-        format_system_time(&mut out, time, "%Y-%m-%d %H:%M", false).expect("Formatting error.");
+        format_system_time(
+            &mut out,
+            time,
+            "%Y-%m-%d %H:%M",
+            FormatSystemTimeFallback::Integer,
+        )
+        .expect("Formatting error.");
         assert_eq!(String::from_utf8(out).unwrap(), "67768036191763200");
 
         let time = UNIX_EPOCH - Duration::from_secs(67_768_040_922_076_800);
         let mut out = Vec::new();
-        format_system_time(&mut out, time, "%Y-%m-%d %H:%M", false).expect("Formatting error.");
+        format_system_time(
+            &mut out,
+            time,
+            "%Y-%m-%d %H:%M",
+            FormatSystemTimeFallback::Integer,
+        )
+        .expect("Formatting error.");
         assert_eq!(String::from_utf8(out).unwrap(), "-67768040922076800");
+    }
+
+    // Test that very large (positive or negative) lead to just the timestamp being printed.
+    #[test]
+    fn test_large_system_time_float() {
+        let time =
+            UNIX_EPOCH + Duration::from_secs(67_768_036_191_763_000) + Duration::from_nanos(123);
+        let mut out = Vec::new();
+        format_system_time(
+            &mut out,
+            time,
+            "%Y-%m-%d %H:%M",
+            FormatSystemTimeFallback::Float,
+        )
+        .expect("Formatting error.");
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "67768036191763000.000000123"
+        );
+
+        let time =
+            UNIX_EPOCH - Duration::from_secs(67_768_040_922_076_000) + Duration::from_nanos(123);
+        let mut out = Vec::new();
+        format_system_time(
+            &mut out,
+            time,
+            "%Y-%m-%d %H:%M",
+            FormatSystemTimeFallback::Float,
+        )
+        .expect("Formatting error.");
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "-67768040922076000.000000123"
+        );
     }
 }


### PR DESCRIPTION
Mostly common code elimination, and fix a crash if a file change time (ctime) is <1970 (not a terribly common thing ,-P)

---

### fsext: Fix metadata_get_time for change time (ctime) before 1970

Useful for archaeologists and time travellers, do not crash if
ctime is before 1970.

Creating a file with such a change time is a bit challenging
(touch can't change that), so we can't easily add end-to-end
tests.

Steps to create a filesystem with a file `x` with birth/change
time in 1960.
```
dd if=/dev/zero bs=100M count=0 seek=1 of=ext4
mkfs.ext4 ext4
sudo mount ext4 mnt
touch mnt/x
umount mnt
echo "set_inode_field x ctime 196001010101" | debugfs -w ext4
echo "set_inode_field x ctime_extra 1234" | debugfs -w ext4
echo "set_inode_field x crtime 196001010101" | debugfs -w ext4
echo "set_inode_field x crtime_extra 0x123400" | debugfs -w ext4
sudo mount ext4 mnt
```

```
$ cargo run -p uu_stat mnt/x
  File: mnt/x
  size: 0         	Blocks: 0          IO Block: 1024   regular empty file
Device: 700h/1792d	Inode: 13          Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2025-07-26 19:52:00.849821694 +0800
Modify: 2025-07-26 19:52:00.849821694 +0800
Change: 1960-01-02 09:01:00.000298240 +0800
 Birth: 1960-01-02 09:01:00.000298240 +0800
```

### uucore: time: Add options for format_system_time

Depending on the caller, we want the number of seconds, that
and an error printed out, or seconds+nanoseconds.

### stat: Stop relying on fsext::Birth

We can rely on other fsext/time functions, and stay a bit more
consistent.

### stat: Use uucore::time:format_system_time function