### PR TITLE
refactor(mkdir): Simplify mode argument parsing

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -50,12 +50,12 @@ pub struct Config<'a> {
 }
 
 #[cfg(windows)]
-fn get_mode(_matches: &ArgMatches, _mode_had_minus_prefix: bool) -> Result<u32, String> {
+fn get_mode(_matches: &ArgMatches) -> Result<u32, String> {
     Ok(DEFAULT_PERM)
 }
 
 #[cfg(not(windows))]
-fn get_mode(matches: &ArgMatches, mode_had_minus_prefix: bool) -> Result<u32, String> {
+fn get_mode(matches: &ArgMatches) -> Result<u32, String> {
     // Not tested on Windows
     let mut new_mode = DEFAULT_PERM;
 
@@ -64,13 +64,7 @@ fn get_mode(matches: &ArgMatches, mode_had_minus_prefix: bool) -> Result<u32, St
             if mode.chars().any(|c| c.is_ascii_digit()) {
                 new_mode = mode::parse_numeric(new_mode, m, true)?;
             } else {
-                let cmode = if mode_had_minus_prefix {
-                    // clap parsing is finished, now put prefix back
-                    format!("-{mode}")
-                } else {
-                    mode.to_string()
-                };
-                new_mode = mode::parse_symbolic(new_mode, &cmode, mode::get_umask(), true)?;
+                new_mode = mode::parse_symbolic(new_mode, mode, mode::get_umask(), true)?;
             }
         }
         Ok(new_mode)
@@ -80,42 +74,8 @@ fn get_mode(matches: &ArgMatches, mode_had_minus_prefix: bool) -> Result<u32, St
     }
 }
 
-#[cfg(windows)]
-fn strip_minus_from_mode(_args: &mut [OsString]) -> UResult<bool> {
-    Ok(false)
-}
-
-// Iterate 'args' and delete the first occurrence
-// of a prefix '-' if it's associated with MODE
-// e.g. "chmod -v -xw -R FILE" -> "chmod -v xw -R FILE"
-#[cfg(not(windows))]
-fn strip_minus_from_mode(args: &mut Vec<OsString>) -> UResult<bool> {
-    for arg in args {
-        if arg == "--" {
-            break;
-        }
-        let bytes = uucore::os_str_as_bytes(arg)?;
-        if let Some(b'-') = bytes.first() {
-            if let Some(
-                b'r' | b'w' | b'x' | b'X' | b's' | b't' | b'u' | b'g' | b'o' | b'0'..=b'7',
-            ) = bytes.get(1)
-            {
-                *arg = uucore::os_str_from_bytes(&bytes[1..])?.into_owned();
-                return Ok(true);
-            }
-        }
-    }
-    Ok(false)
-}
-
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut args: Vec<OsString> = args.collect();
-
-    // Before we can parse 'args' with clap (and previously getopts),
-    // a possible MODE prefix '-' needs to be removed (e.g. "chmod -x FILE").
-    let mode_had_minus_prefix = strip_minus_from_mode(&mut args)?;
-
     // Linux-specific options, not implemented
     // opts.optflag("Z", "context", "set SELinux security context" +
     // " of each created directory to CTX"),
@@ -133,7 +93,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let set_selinux_context = matches.get_flag(options::SELINUX);
     let context = matches.get_one::<String>(options::CONTEXT);
 
-    match get_mode(&matches, mode_had_minus_prefix) {
+    match get_mode(&matches) {
         Ok(mode) => {
             let config = Config {
                 recursive,
@@ -158,7 +118,9 @@ pub fn uu_app() -> Command {
             Arg::new(options::MODE)
                 .short('m')
                 .long(options::MODE)
-                .help(get_message("mkdir-help-mode")),
+                .help(get_message("mkdir-help-mode"))
+                .allow_hyphen_values(true)
+                .num_args(1),
         )
         .arg(
             Arg::new(options::PARENTS)


### PR DESCRIPTION
This pull request refactors the argument parsing for the `mkdir` utility on the `--mode` (`-m`) option.

#### What does this PR do?

Previously, the utility relied on a manual function (`strip_minus_from_mode`) to process mode values that begin with a hyphen (e.g., `-rwx`). This required manipulating the raw argument list before it was parsed by `clap`.

This change removes the manual parsing logic and uses `clap`'s built-in `.allow_hyphen_values(true)` setting instead. This approach is cleaner, more robust, and relies directly on the features of the argument parsing library.

#### Changes made:

* Removed the `strip_minus_from_mode` function and its related logic.
* Updated the `clap` argument for `--mode` to use `.allow_hyphen_values(true)`.
* Refined the `uumain` and `get_mode` functions by removing the now-unnecessary variables and parameters.

#### How to test

I have manually tested the changes to ensure that creating directories with and without a mode flag works as expected. The following commands were used for verification:

```bash
# Test basic creation
cargo run -- test_dir

# Test symbolic mode
cargo run -- -m a=rwx test_symbolic

# Test symbolic mode with a leading hyphen
cargo run -- -m -rwx test_hyphen

# Test combined with verbose flag
cargo run -- -v -m a=rwx test_verbose
```

All commands behaved as expected.
