### PR TITLE
install: Fix --no-target-directory with existing file

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -607,7 +607,7 @@ fn standard(mut paths: Vec<String>, b: &Behavior) -> UResult<()> {
             return Err(InstallError::OmittingDirectory(source.clone()).into());
         }
 
-        if b.no_target_dir && target.exists() {
+        if b.no_target_dir && target.is_dir() {
             return Err(
                 InstallError::OverrideDirectoryFailed(target.clone(), source.clone()).into(),
             );

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2083,6 +2083,20 @@ fn test_install_no_target_directory_failing_cannot_overwrite() {
 }
 
 #[test]
+fn test_install_no_target_directory_overwrite_file() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    let file = "file";
+    let dest = "dest";
+
+    at.touch(file);
+    scene.ucmd().arg("-T").arg(file).arg(dest).succeeds();
+    scene.ucmd().arg("-T").arg(file).arg(dest).succeeds();
+
+    assert!(!at.dir_exists("dir/file"));
+}
+
+#[test]
 fn test_install_no_target_directory_failing_omitting_directory() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
install should silently override existing target files, but it inadvertently checked whether the target exists rather than for the target being a directory, hence the overwrite failed, saying it cannot overwrite the directory with non-directory.

Bug-Ubuntu: https://bugs.launchpad.net/bugs/2118785