### PR TITLE
`du`/`ls`: Improve time-style handling based on GNU coreutils manual

### DIFF
--- a/src/uu/du/locales/en-US.ftl
+++ b/src/uu/du/locales/en-US.ftl
@@ -52,6 +52,7 @@ du-error-invalid-time-style = invalid argument { $style } for 'time style'
     - 'full-iso'
     - 'long-iso'
     - 'iso'
+    - +FORMAT (e.g., +%H:%M) for a 'date'-style format
   Try '{ $help }' for more information.
 du-error-invalid-time-arg = 'birth' and 'creation' arguments for --time are not supported on this platform.
 du-error-invalid-glob = Invalid exclude syntax: { $error }

--- a/src/uu/du/locales/fr-FR.ftl
+++ b/src/uu/du/locales/fr-FR.ftl
@@ -52,6 +52,7 @@ du-error-invalid-time-style = argument invalide { $style } pour 'style de temps'
     - 'full-iso'
     - 'long-iso'
     - 'iso'
+    - +FORMAT (e.g., +%H:%M) pour un format de type 'date'
   Essayez '{ $help }' pour plus d'informations.
 du-error-invalid-time-arg = les arguments 'birth' et 'creation' pour --time ne sont pas supportés sur cette plateforme.
 du-error-invalid-glob = Syntaxe d'exclusion invalide : { $error }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -28,7 +28,7 @@ use uucore::translate;
 use uucore::parser::parse_glob;
 use uucore::parser::parse_size::{ParseSizeError, parse_size_u64};
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
-use uucore::time::{FormatSystemTimeFallback, format_system_time};
+use uucore::time::{FormatSystemTimeFallback, format, format_system_time};
 use uucore::{format_usage, show, show_error, show_warning};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
@@ -668,7 +668,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let time_format = if time.is_some() {
         parse_time_style(matches.get_one::<String>("time-style").map(|s| s.as_str()))?.to_string()
     } else {
-        "%Y-%m-%d %H:%M".to_string()
+        format::LONG_ISO.to_string()
     };
 
     let stat_printer = StatPrinter {
@@ -758,15 +758,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 fn parse_time_style(s: Option<&str>) -> UResult<&str> {
     match s {
         Some(s) => match s {
-            "full-iso" => Ok("%Y-%m-%d %H:%M:%S.%f %z"),
-            "long-iso" => Ok("%Y-%m-%d %H:%M"),
-            "iso" => Ok("%Y-%m-%d"),
+            "full-iso" => Ok(format::FULL_ISO),
+            "long-iso" => Ok(format::LONG_ISO),
+            "iso" => Ok(format::ISO),
             _ => match s.chars().next().unwrap() {
                 '+' => Ok(&s[1..]),
                 _ => Err(DuError::InvalidTimeStyleArg(s.into()).into()),
             },
         },
-        None => Ok("%Y-%m-%d %H:%M"),
+        None => Ok(format::LONG_ISO),
     }
 }
 

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -761,7 +761,10 @@ fn parse_time_style(s: Option<&str>) -> UResult<&str> {
             "full-iso" => Ok("%Y-%m-%d %H:%M:%S.%f %z"),
             "long-iso" => Ok("%Y-%m-%d %H:%M"),
             "iso" => Ok("%Y-%m-%d"),
-            _ => Err(DuError::InvalidTimeStyleArg(s.into()).into()),
+            _ => match s.chars().next().unwrap() {
+                '+' => Ok(&s[1..]),
+                _ => Err(DuError::InvalidTimeStyleArg(s.into()).into()),
+            },
         },
         None => Ok("%Y-%m-%d %H:%M"),
     }

--- a/src/uu/ls/locales/en-US.ftl
+++ b/src/uu/ls/locales/en-US.ftl
@@ -16,7 +16,12 @@ ls-error-invalid-block-size = invalid --block-size argument {$size}
 ls-error-dired-and-zero-incompatible = --dired and --zero are incompatible
 ls-error-not-listing-already-listed = {$path}: not listing already-listed directory
 ls-error-invalid-time-style = invalid --time-style argument {$style}
-  Possible values are: {$values}
+  Possible values are:
+    - [posix-]full-iso
+    - [posix-]long-iso
+    - [posix-]iso
+    - [posix-]locale
+    - +FORMAT (e.g., +%H:%M) for a 'date'-style format
 
   For more information try --help
 

--- a/src/uu/ls/locales/fr-FR.ftl
+++ b/src/uu/ls/locales/fr-FR.ftl
@@ -16,7 +16,12 @@ ls-error-invalid-block-size = argument --block-size invalide {$size}
 ls-error-dired-and-zero-incompatible = --dired et --zero sont incompatibles
 ls-error-not-listing-already-listed = {$path} : ne liste pas un répertoire déjà listé
 ls-error-invalid-time-style = argument --time-style invalide {$style}
-  Les valeurs possibles sont : {$values}
+  Les valeurs possibles sont :
+    - [posix-]full-iso
+    - [posix-]long-iso
+    - [posix-]iso
+    - [posix-]locale
+    - +FORMAT (e.g., +%H:%M) pour un format de type 'date'
 
   Pour plus d'informations, essayez --help
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -266,7 +266,11 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
         Ok((recent.to_string(), older.map(String::from)))
     }
 
-    if let Some(field) = options.get_one::<String>(options::TIME_STYLE) {
+    if let Some(field) = options
+        .get_one::<String>(options::TIME_STYLE)
+        .map(|s| s.to_owned())
+        .or_else(|| std::env::var("TIME_STYLE").ok())
+    {
         //If both FULL_TIME and TIME_STYLE are present
         //The one added last is dominant
         if options.get_flag(options::FULL_TIME)
@@ -287,7 +291,7 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
                 }
                 field
             } else {
-                field
+                &field
             };
 
             match time_styles.get(field) {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -297,7 +297,16 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
             match time_styles.get(field) {
                 Some(formats) => ok(*formats),
                 None => match field.chars().next().unwrap() {
-                    '+' => Ok((field[1..].to_string(), None)),
+                    '+' => {
+                        // recent/older formats are (optionally) separated by a newline
+                        let mut it = field[1..].split('\n');
+                        let recent = it.next().unwrap_or_default();
+                        let older = it.next();
+                        match it.next() {
+                            None => ok((recent, older)),
+                            Some(_) => Err(LsError::TimeStyleParseError(String::from(field))),
+                        }
+                    }
                     _ => Err(LsError::TimeStyleParseError(String::from(field))),
                 },
             }

--- a/src/uucore/src/lib/features/time.rs
+++ b/src/uucore/src/lib/features/time.rs
@@ -36,6 +36,12 @@ pub fn system_time_to_sec(time: SystemTime) -> (i64, u32) {
     }
 }
 
+pub mod format {
+    pub static FULL_ISO: &str = "%Y-%m-%d %H:%M:%S.%N %z";
+    pub static LONG_ISO: &str = "%Y-%m-%d %H:%M";
+    pub static ISO: &str = "%Y-%m-%d";
+}
+
 /// Sets how `format_system_time` behaves if the time cannot be converted.
 pub enum FormatSystemTimeFallback {
     Integer,      // Just print seconds since epoch (`ls`)

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -626,6 +626,56 @@ fn test_du_time() {
         .succeeds();
     result.stdout_only("0\t2016-06-16 00:00\tdate_test\n");
 
+    // long-iso (same as default)
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("--time-style=long-iso")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16 00:00\tdate_test\n");
+
+    // full-iso
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("--time-style=full-iso")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16 00:00:00.000000000 +0000\tdate_test\n");
+
+    // iso
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("--time-style=iso")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16\tdate_test\n");
+
+    // custom +FORMAT
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("--time-style=+%Y__%H")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016__00\tdate_test\n");
+
+    // ls has special handling for new line in format, du doesn't.
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("--time-style=+%Y_\n_%H")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016_\n_00\tdate_test\n");
+
     for argument in ["--time=atime", "--time=atim", "--time=a"] {
         let result = ts
             .ucmd()

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -591,6 +591,7 @@ fn test_du_h_precision() {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 #[cfg(feature = "touch")]
 #[test]
 fn test_du_time() {
@@ -675,6 +676,57 @@ fn test_du_time() {
         .arg("date_test")
         .succeeds();
     result.stdout_only("0\t2016_\n_00\tdate_test\n");
+
+    // Time style can also be setup from environment
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .env("TIME_STYLE", "full-iso")
+        .arg("--time")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16 00:00:00.000000000 +0000\tdate_test\n");
+
+    // For compatibility reason, we also allow posix- prefix.
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .env("TIME_STYLE", "posix-full-iso")
+        .arg("--time")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16 00:00:00.000000000 +0000\tdate_test\n");
+
+    // ... and we strip content after a new line
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .env("TIME_STYLE", "+XXX\nYYY")
+        .arg("--time")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\tXXX\tdate_test\n");
+
+    // ... and we ignore "locale", fall back to full-iso.
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .env("TIME_STYLE", "locale")
+        .arg("--time")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16 00:00\tdate_test\n");
+
+    // Command line option takes precedence
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .env("TIME_STYLE", "full-iso")
+        .arg("--time")
+        .arg("--time-style=iso")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16\tdate_test\n");
 
     for argument in ["--time=atime", "--time=atim", "--time=a"] {
         let result = ts

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2068,6 +2068,23 @@ fn test_ls_styles() {
         .arg("-x")
         .succeeds()
         .stdout_is("test  test2\n");
+
+    // Time style can also be setup from environment
+    scene
+        .ucmd()
+        .env("TIME_STYLE", "full-iso")
+        .arg("-l")
+        .succeeds()
+        .stdout_matches(&re_full);
+
+    // ... but option takes precedence
+    scene
+        .ucmd()
+        .env("TIME_STYLE", "full-iso")
+        .arg("-l")
+        .arg("--time-style=long-iso")
+        .succeeds()
+        .stdout_matches(&re_long);
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1971,6 +1971,44 @@ fn test_ls_styles() {
         .succeeds()
         .stdout_matches(&re_locale);
 
+    //posix-full-iso
+    scene
+        .ucmd()
+        .arg("-l")
+        .arg("--time-style=posix-full-iso")
+        .succeeds()
+        .stdout_matches(&re_full);
+    //posix-long-iso
+    scene
+        .ucmd()
+        .arg("-l")
+        .arg("--time-style=posix-long-iso")
+        .succeeds()
+        .stdout_matches(&re_long);
+    //posix-iso
+    scene
+        .ucmd()
+        .arg("-l")
+        .arg("--time-style=posix-iso")
+        .succeeds()
+        .stdout_matches(&re_iso);
+
+    //posix-* with LC_TIME/LC_ALL=POSIX is equivalent to locale
+    scene
+        .ucmd()
+        .env("LC_TIME", "POSIX")
+        .arg("-l")
+        .arg("--time-style=posix-full-iso")
+        .succeeds()
+        .stdout_matches(&re_locale);
+    scene
+        .ucmd()
+        .env("LC_ALL", "POSIX")
+        .arg("-l")
+        .arg("--time-style=posix-iso")
+        .succeeds()
+        .stdout_matches(&re_locale);
+
     //+FORMAT
     scene
         .ucmd()


### PR DESCRIPTION
This fixes #7665, and generally bring `du`/`ls` `time-style` to feature parity with GNU (at least AFAICT...) -- apart from localization.

I was hoping the share more of the code between `du` and `ls`, but that seems difficult as the options and parsing is actually different. But at least we can share constants.

Some `pr` fixes will follow in another MR (that one only support specific FORMAT).

---

### du: Add support for reading time-style from environment

Similar as what ls does, but du has an extra compatibility layer
described in the GNU manual (and that upstream dev helped me
understand: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79113 ).

### du/ls: Move common time formats to constants in uucore/time

Along the way:
 - Fix the full-iso format, that was supposed to use %N, not %f
   (%f padded with chrono, but not with jiff, and %N is more correct
   and what GNU says in their manual)
 - The Hashmap thing in parse_time_style was too smart, to a point
   that it became too unflexible (it would have been even worse
   when we added locale support).

I was hoping the share more of the code, but that seems difficult.

### du: Add support for +FORMAT time-style

Also add to error text, which... GNU coreutils doesn't do for
some reason.

### ls: Print dates in the future as "old" ones

ls has different time format for recent (< 6 months) and older files.
Files in the future (even by just a second), are considered old,
which makes sense as we probably want the date to be printed in
that case.

### ls: Add support for newline separated format for recent/older

Documented in GNU manual.

Also improve test_ls to test for both recent and older files.

### ls: Allow reading time-style from TIME_STYLE environment variable

According to GNU manual.

### ls: Add support for --time-style=posix-*

From GNU manual, if LC_TIME=POSIX, then the "locale" timestamp is
used. Else, `posix-` is stripped and the format is parsed as usual.

Also, just move the whole text to the locale file, instead
of trying to generate it manually.