### PR TITLE
more: tests: cleanup processes in test_valid_arg

### DIFF
--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -46,14 +46,22 @@ fn test_valid_arg() {
 
 fn test_alive(args: &[&str]) {
     let (at, mut ucmd) = at_and_ucmd!();
-    let file = "test_file";
-    at.touch(file);
 
-    ucmd.args(args)
-        .arg(file)
-        .run_no_wait()
-        .make_assertion()
-        .is_alive();
+    let content = "test content";
+    let file = "test_file";
+    at.write(file, content);
+
+    let mut cmd = ucmd.args(args).arg(file).run_no_wait();
+
+    // wait for more to start and display the file
+    while cmd.is_alive() && !cmd.stdout_all().contains(content) {
+        cmd.delay(50);
+    }
+
+    assert!(cmd.is_alive(), "Command should still be alive");
+
+    // cleanup
+    cmd.kill();
 }
 
 #[test]


### PR DESCRIPTION
Added cleanup in test_alive to ensure all spawned processes are terminated on successful test execution.

This also fixes a race condition that could occur: the check for process is_alive might be executing while more is still parsing the arguments.

Fixes #8429 