### PR TITLE
uucore: locale: Fix clippy warning

### DIFF
--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -747,7 +747,7 @@ invalid-syntax = This is { $missing
 
             let result = init_localization(&locale, temp_dir.path(), "nonexistent_test_util");
             if let Err(e) = &result {
-                eprintln!("Init localization failed: {}", e);
+                eprintln!("Init localization failed: {e}");
             }
             assert!(result.is_ok());
 


### PR DESCRIPTION
Looks like there is a CI coverage gap...

cargo +stable clippy --workspace --all-targets --all-features -- -D warnings
```
error: variables can be used directly in the `format!` string
   --> src/uucore/src/lib/mods/locale.rs:750:17
    |
750 |                 eprintln!("Init localization failed: {}", e);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
    |
750 -                 eprintln!("Init localization failed: {}", e);
750 +                 eprintln!("Init localization failed: {e}");
    |

error: could not compile `uucore` (lib test) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```