### PR TITLE
deny.toml: remove old `windows-sys` version from skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -54,44 +54,26 @@ highlight = "all"
 # introduces it.
 # spell-checker: disable
 skip = [
-  # dns-lookup
-  { name = "windows-sys", version = "0.48.0" },
   # mio, nu-ansi-term, socket2
   { name = "windows-sys", version = "0.52.0" },
   # anstyle-query
   { name = "windows-sys", version = "0.59.0" },
-  # windows-sys
-  { name = "windows-targets", version = "0.48.5" },
   # parking_lot_core
   { name = "windows-targets", version = "0.52.6" },
   # windows-targets
-  { name = "windows_aarch64_gnullvm", version = "0.48.5" },
-  # windows-targets
   { name = "windows_aarch64_gnullvm", version = "0.52.6" },
   # windows-targets
-  { name = "windows_aarch64_msvc", version = "0.48.5" },
-  # windows-targets
   { name = "windows_aarch64_msvc", version = "0.52.6" },
-  # windows-targets
-  { name = "windows_i686_gnu", version = "0.48.5" },
   # windows-targets
   { name = "windows_i686_gnu", version = "0.52.6" },
   # windows-targets
   { name = "windows_i686_gnullvm", version = "0.52.6" },
   # windows-targets
-  { name = "windows_i686_msvc", version = "0.48.5" },
-  # windows-targets
   { name = "windows_i686_msvc", version = "0.52.6" },
-  # windows-targets
-  { name = "windows_x86_64_gnu", version = "0.48.5" },
   # windows-targets
   { name = "windows_x86_64_gnu", version = "0.52.6" },
   # windows-targets
-  { name = "windows_x86_64_gnullvm", version = "0.48.5" },
-  # windows-targets
   { name = "windows_x86_64_gnullvm", version = "0.52.6" },
-  # windows-targets
-  { name = "windows_x86_64_msvc", version = "0.48.5" },
   # windows-targets
   { name = "windows_x86_64_msvc", version = "0.52.6" },
   # kqueue-sys, onig


### PR DESCRIPTION
This PR removes version `0.48.0` of `windows-sys` and its dependencies from the skip list as those dependencies have been removed in https://github.com/uutils/coreutils/pull/8436