### PR TITLE
Improve tr performances (Closes: #8439) 

### DIFF
--- a/src/uu/tr/BENCHMARKING.md
+++ b/src/uu/tr/BENCHMARKING.md
@@ -1,0 +1,66 @@
+# Benchmarking `tr`
+
+<!-- spell-checker:ignore aeiou -->
+
+`tr` performance is critical for large data processing pipelines. The implementation uses lookup tables for O(1) character operations.
+
+## Building
+
+```shell
+cargo build --release --package uu_tr
+```
+
+## Basic Benchmarks
+
+### Character Translation
+
+```shell
+# Create test data
+dd if=/dev/zero bs=1M count=10 | tr '\0' 'x' > 10mb_input
+
+# Benchmark translation
+hyperfine --warmup 3 \
+    'tr a b < 10mb_input > /dev/null' \
+    './target/release/tr a b < 10mb_input > /dev/null'
+```
+
+### Character Deletion
+
+```shell
+# Create mixed input
+yes "abcdefghijklmnopqrstuvwxyz" | head -n 1000000 > mixed_input
+
+# Benchmark deletion
+hyperfine --warmup 3 \
+    'tr -d aeiou < mixed_input > /dev/null' \
+    './target/release/tr -d aeiou < mixed_input > /dev/null'
+```
+
+### Character Classes
+
+```shell
+# Benchmark character classes
+hyperfine --warmup 3 \
+    'tr "[:lower:]" "[:upper:]" < mixed_input > /dev/null' \
+    './target/release/tr "[:lower:]" "[:upper:]" < mixed_input > /dev/null'
+```
+
+## Quick Regression Test
+
+```shell
+#!/bin/bash
+cargo build --release --package uu_tr
+
+echo "=== Translation ==="
+hyperfine 'tr a b < 10mb_input > /dev/null' './target/release/tr a b < 10mb_input > /dev/null'
+
+echo "=== Deletion ==="
+hyperfine 'tr -d aeiou < mixed_input > /dev/null' './target/release/tr -d aeiou < mixed_input > /dev/null'
+```
+
+## Performance Notes
+
+- Uses lookup tables instead of hash maps for O(1) operations
+- 32KB I/O buffers for improved throughput
+- Should be competitive with GNU `tr` for most operations
+


### PR DESCRIPTION
Results:
```
$ dd if=/dev/zero bs=1M count=10 | tr '\0' 'x' > 10mb_input
$ hyperfine --export-markdown tr.md --warmup 3 \
    '/usr/bin/tr a b < 10mb_input > /dev/null' \
    './target/release/tr a b < 10mb_input > /dev/null' \
    './target/release/tr.previous a b < 10mb_input > /dev/null'
Benchmark 1: /usr/bin/tr a b < 10mb_input > /dev/null
  Time (mean ± σ):       6.5 ms ±   0.7 ms    [User: 4.1 ms, System: 2.4 ms]
  Range (min … max):     5.1 ms …  10.3 ms    520 runs

Benchmark 2: ./target/release/tr a b < 10mb_input > /dev/null
  Time (mean ± σ):      10.7 ms ±   0.8 ms    [User: 7.9 ms, System: 2.7 ms]
  Range (min … max):     9.7 ms …  15.3 ms    271 runs

Benchmark 3: ./target/release/tr.previous a b < 10mb_input > /dev/null
  Time (mean ± σ):      61.2 ms ±   2.2 ms    [User: 58.5 ms, System: 2.5 ms]
  Range (min … max):    58.4 ms …  66.9 ms    47 runs

Summary
  /usr/bin/tr a b < 10mb_input > /dev/null ran
    1.64 ± 0.23 times faster than ./target/release/tr a b < 10mb_input > /dev/null
    9.39 ± 1.12 times faster than ./target/release/tr.previous a b < 10mb_input > /dev/null
```

Not as fast as GNU but much better than the previous implementation

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `/usr/bin/tr a b < 10mb_input > /dev/null` | 6.5 ± 0.7 | 5.1 | 10.3 | 1.00 |
| `./target/release/tr a b < 10mb_input > /dev/null` | 10.7 ± 0.8 | 9.7 | 15.3 | 1.64 ± 0.23 |
| `./target/release/tr.previous a b < 10mb_input > /dev/null` | 61.2 ± 2.2 | 58.4 | 66.9 | 9.39 ± 1.12 |