### PR TITLE
clippy: fix warnings introduced with Rust `1.89`

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -794,7 +794,7 @@ enum SELinuxSecurityContext<'t> {
 }
 
 impl SELinuxSecurityContext<'_> {
-    fn to_c_string(&self) -> Result<Option<Cow<CStr>>> {
+    fn to_c_string(&self) -> Result<Option<Cow<'_, CStr>>> {
         match self {
             Self::File(context) => context
                 .to_c_string()

--- a/src/uu/chcon/src/fts.rs
+++ b/src/uu/chcon/src/fts.rs
@@ -61,7 +61,7 @@ impl FTS {
         })
     }
 
-    pub(crate) fn last_entry_ref(&mut self) -> Option<EntryRef> {
+    pub(crate) fn last_entry_ref(&mut self) -> Option<EntryRef<'_>> {
         self.entry.map(move |entry| EntryRef::new(self, entry))
     }
 

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -34,7 +34,7 @@ use crate::{
 
 /// Ensure a Windows path starts with a `\\?`.
 #[cfg(target_os = "windows")]
-fn adjust_canonicalization(p: &Path) -> Cow<Path> {
+fn adjust_canonicalization(p: &Path) -> Cow<'_, Path> {
     // In some cases, \\? can be missing on some Windows paths.  Add it at the
     // beginning unless the path is prefixed with a device namespace.
     const VERBATIM_PREFIX: &str = r"\\?";

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -239,7 +239,7 @@ impl Drop for SplitWriter<'_> {
 }
 
 impl SplitWriter<'_> {
-    fn new(options: &CsplitOptions) -> SplitWriter {
+    fn new(options: &CsplitOptions) -> SplitWriter<'_> {
         SplitWriter {
             options,
             counter: 0,

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -404,7 +404,7 @@ fn cut_files(mut filenames: Vec<String>, mode: &Mode) {
 
 /// Get delimiter and output delimiter from `-d`/`--delimiter` and `--output-delimiter` options respectively
 /// Allow either delimiter to have a value that is neither UTF-8 nor ASCII to align with GNU behavior
-fn get_delimiters(matches: &ArgMatches) -> UResult<(Delimiter, Option<&[u8]>)> {
+fn get_delimiters(matches: &ArgMatches) -> UResult<(Delimiter<'_>, Option<&[u8]>)> {
     let whitespace_delimited = matches.get_flag(options::WHITESPACE_DELIMITED);
     let delim_opt = matches.get_one::<OsString>(options::DELIMITER);
     let delim = match delim_opt {

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -688,7 +688,7 @@ mod tests {
         fn test_different_dev_id() {
             let m1 = mount_info("0", "/mnt/bar");
             let m2 = mount_info("1", "/mnt/bar");
-            assert!(is_best(&[m1.clone()], &m2));
+            assert!(is_best(std::slice::from_ref(&m1), &m2));
             assert!(is_best(&[m2], &m1));
         }
 
@@ -699,7 +699,7 @@ mod tests {
             // one condition in this test.
             let m1 = mount_info("0", "/mnt/bar");
             let m2 = mount_info("0", "/mnt/bar/baz");
-            assert!(!is_best(&[m1.clone()], &m2));
+            assert!(!is_best(std::slice::from_ref(&m1), &m2));
             assert!(is_best(&[m2], &m1));
         }
     }

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -362,11 +362,13 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
     }
 
     // Check if compare is used with non-permission mode bits
-    if compare && specified_mode.is_some() {
-        let mode = specified_mode.unwrap();
-        let non_permission_bits = 0o7000; // setuid, setgid, sticky bits
-        if mode & non_permission_bits != 0 {
-            show_error!("{}", translate!("install-warning-compare-ignored"));
+    // TODO use a let chain once we have a MSRV of 1.88 or greater
+    if compare {
+        if let Some(mode) = specified_mode {
+            let non_permission_bits = 0o7000; // setuid, setgid, sticky bits
+            if mode & non_permission_bits != 0 {
+                show_error!("{}", translate!("install-warning-compare-ignored"));
+            }
         }
     }
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -198,20 +198,17 @@ impl Params {
         // Get the start and end indices of the randomized part of the template.
         //
         // For example, if the template is "abcXXXXyz", then `i` is 3 and `j` is 7.
-        let (i, j) = match find_last_contiguous_block_of_xs(&options.template) {
-            None => {
-                let s = match options.suffix {
-                    // If a suffix is specified, the error message includes the template without the suffix.
-                    Some(_) => options
-                        .template
-                        .chars()
-                        .take(options.template.len())
-                        .collect::<String>(),
-                    None => options.template,
-                };
-                return Err(MkTempError::TooFewXs(s));
-            }
-            Some(indices) => indices,
+        let Some((i, j)) = find_last_contiguous_block_of_xs(&options.template) else {
+            let s = match options.suffix {
+                // If a suffix is specified, the error message includes the template without the suffix.
+                Some(_) => options
+                    .template
+                    .chars()
+                    .take(options.template.len())
+                    .collect::<String>(),
+                None => options.template,
+            };
+            return Err(MkTempError::TooFewXs(s));
         };
 
         // Combine the directory given as an option and the prefix of the template.

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -143,9 +143,8 @@ fn find_stdout() -> UResult<File> {
             Ok(t)
         }
         Err(e1) => {
-            let home = match env::var("HOME") {
-                Err(_) => return Err(NohupError::OpenFailed(internal_failure_code, e1).into()),
-                Ok(h) => h,
+            let Ok(home) = env::var("HOME") else {
+                return Err(NohupError::OpenFailed(internal_failure_code, e1).into());
             };
             let mut homeout = PathBuf::from(home);
             homeout.push(NOHUP_OUT);

--- a/src/uu/od/src/formatter_item_info.rs
+++ b/src/uu/od/src/formatter_item_info.rs
@@ -7,6 +7,7 @@
 use std::fmt;
 
 #[allow(clippy::enum_variant_names)]
+#[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FormatWriter {
     IntWriter(fn(u64) -> String),

--- a/src/uu/od/src/input_decoder.rs
+++ b/src/uu/od/src/input_decoder.rs
@@ -44,7 +44,7 @@ impl<I> InputDecoder<'_, I> {
         normal_length: usize,
         peek_length: usize,
         byte_order: ByteOrder,
-    ) -> InputDecoder<I> {
+    ) -> InputDecoder<'_, I> {
         let bytes = vec![0; normal_length + peek_length];
 
         InputDecoder {
@@ -64,7 +64,7 @@ where
 {
     /// calls `peek_read` on the internal stream to (re)fill the buffer. Returns a
     /// `MemoryDecoder` providing access to the result or returns an i/o error.
-    pub fn peek_read(&mut self) -> io::Result<MemoryDecoder> {
+    pub fn peek_read(&mut self) -> io::Result<MemoryDecoder<'_>> {
         match self
             .input
             .peek_read(self.data.as_mut_slice(), self.reserved_peek_length)

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -603,7 +603,7 @@ fn open_input_peek_reader(
     input_strings: &[String],
     skip_bytes: u64,
     read_bytes: Option<u64>,
-) -> PeekReader<BufReader<PartialReader<MultifileReader>>> {
+) -> PeekReader<BufReader<PartialReader<MultifileReader<'_>>>> {
     // should return  "impl PeekRead + Read + HasError" when supported in (stable) rust
     let inputs = input_strings
         .iter()

--- a/src/uu/od/src/output_info.rs
+++ b/src/uu/od/src/output_info.rs
@@ -47,7 +47,7 @@ pub struct OutputInfo {
 
 impl OutputInfo {
     /// Returns an iterator over the `SpacedFormatterItemInfo` vector.
-    pub fn spaced_formatters_iter(&self) -> Iter<SpacedFormatterItemInfo> {
+    pub fn spaced_formatters_iter(&self) -> Iter<'_, SpacedFormatterItemInfo> {
         self.spaced_formatters.iter()
     }
 

--- a/src/uu/od/src/prn_float.rs
+++ b/src/uu/od/src/prn_float.rs
@@ -120,7 +120,7 @@ fn format_float(f: f64, width: usize, precision: usize) -> String {
     } else if l == -1 {
         format!("{f:width$.precision$}")
     } else {
-        return format_f64_exp_precision(f, width, precision - 1); // subnormal numbers
+        format_f64_exp_precision(f, width, precision - 1) // subnormal numbers
     }
 }
 

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -282,7 +282,7 @@ fn get_plain_context(context: &OsStr) -> Result<OpaqueSecurityContext> {
         .map_err(|r| Error::from_selinux("runcon-operation-creating-context", r))
 }
 
-fn get_transition_context(command: &OsStr) -> Result<SecurityContext> {
+fn get_transition_context(command: &OsStr) -> Result<SecurityContext<'_>> {
     // Generate context based on process transition.
     let sec_class = SecurityClass::from_name("process")
         .map_err(|r| Error::from_selinux("runcon-operation-getting-process-class", r))?;

--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -88,10 +88,11 @@ impl Chunk {
         }
     }
 
-    pub fn lines(&self) -> &Vec<Line> {
+    pub fn lines(&self) -> &Vec<Line<'_>> {
         &self.borrow_dependent().lines
     }
-    pub fn line_data(&self) -> &LineData {
+
+    pub fn line_data(&self) -> &LineData<'_> {
         &self.borrow_dependent().line_data
     }
 }

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -144,7 +144,7 @@ pub fn merge_with_file_limit<
 fn merge_without_limit<M: MergeInput + 'static, F: Iterator<Item = UResult<M>>>(
     files: F,
     settings: &GlobalSettings,
-) -> UResult<FileMerger> {
+) -> UResult<FileMerger<'_>> {
     let (request_sender, request_receiver) = channel();
     let mut reader_files = Vec::with_capacity(files.size_hint().0);
     let mut loaded_receivers = Vec::with_capacity(files.size_hint().0);

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -630,9 +630,9 @@ where
     } else if input == "-" {
         // STDIN stream that did not fit all content into a buffer
         // Most likely continuous/infinite input stream
-        return Err(io::Error::other(
+        Err(io::Error::other(
             translate!("split-error-cannot-determine-input-size", "input" => input),
-        ));
+        ))
     } else {
         // Could be that file size is larger than set read limit
         // Get the file size from filesystem metadata
@@ -655,9 +655,9 @@ where
                 // Give up and return an error
                 // TODO It might be possible to do more here
                 // to address all possible file types and edge cases
-                return Err(io::Error::other(
+                Err(io::Error::other(
                     translate!("split-error-cannot-determine-file-size", "input" => input),
-                ));
+                ))
             }
         }
     }

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -228,7 +228,7 @@ impl ScanUtil for str {
     }
 }
 
-fn group_num(s: &str) -> Cow<str> {
+fn group_num(s: &str) -> Cow<'_, str> {
     let is_negative = s.starts_with('-');
     assert!(is_negative || s.chars().take(1).all(|c| c.is_ascii_digit()));
     assert!(s.chars().skip(1).all(|c| c.is_ascii_digit()));

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -564,7 +564,7 @@ fn string_to_combo(arg: &str) -> Option<&str> {
         .map(|_| arg)
 }
 
-fn string_to_baud(arg: &str) -> Option<AllFlags> {
+fn string_to_baud(arg: &str) -> Option<AllFlags<'_>> {
     // BSDs use a u32 for the baud rate, so any decimal number applies.
     #[cfg(any(
         target_os = "freebsd",
@@ -595,7 +595,7 @@ fn string_to_baud(arg: &str) -> Option<AllFlags> {
 }
 
 /// return `Some(flag)` if the input is a valid flag, `None` if not
-fn string_to_flag(option: &str) -> Option<AllFlags> {
+fn string_to_flag(option: &str) -> Option<AllFlags<'_>> {
     let remove = option.starts_with('-');
     let name = option.trim_start_matches('-');
 
@@ -868,7 +868,7 @@ fn string_to_control_char(s: &str) -> Result<u8, ControlCharMappingError> {
 }
 
 // decomposes a combination argument into a vec of corresponding flags
-fn combo_to_flags(combo: &str) -> Vec<ArgOptions> {
+fn combo_to_flags(combo: &str) -> Vec<ArgOptions<'_>> {
     let mut flags = Vec::new();
     let mut ccs = Vec::new();
     match combo {

--- a/src/uu/tail/src/follow/files.rs
+++ b/src/uu/tail/src/follow/files.rs
@@ -74,7 +74,7 @@ impl FileHandling {
         self.get_mut(path).metadata.as_ref()
     }
 
-    pub fn keys(&self) -> Keys<PathBuf, PathData> {
+    pub fn keys(&self) -> Keys<'_, PathBuf, PathData> {
         self.map.keys()
     }
 

--- a/src/uu/wc/src/utf8/read.rs
+++ b/src/uu/wc/src/utf8/read.rs
@@ -46,7 +46,7 @@ impl<B: BufRead> BufReadDecoder<B> {
     /// except that decoded chunks borrow the decoder (~iterator)
     /// so they need to be handled or copied before the next chunk can start decoding.
     #[allow(clippy::cognitive_complexity)]
-    pub fn next_strict(&mut self) -> Option<Result<&str, BufReadDecoderError>> {
+    pub fn next_strict(&mut self) -> Option<Result<&str, BufReadDecoderError<'_>>> {
         enum BytesSource {
             BufRead(usize),
             Incomplete,

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -242,7 +242,7 @@ impl<'a> Input<'a> {
     }
 
     /// Converts input to title that appears in stats.
-    fn to_title(&self) -> Option<Cow<OsStr>> {
+    fn to_title(&self) -> Option<Cow<'_, OsStr>> {
         match self {
             Self::Path(path) => {
                 let path = path.as_os_str();

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -989,7 +989,7 @@ fn process_checksum_line(
         process_non_algo_based_line(i, &line_info, cli_algo, cli_algo_length, opts)
     } else {
         // We have no clue of what algorithm to use
-        return Err(LineCheckError::ImproperlyFormatted);
+        Err(LineCheckError::ImproperlyFormatted)
     }
 }
 

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -701,7 +701,7 @@ fn get_filename_for_output(filename: &OsStr, input_is_stdin: bool) -> String {
 fn get_expected_digest_as_hex_string(
     line_info: &LineInfo,
     len_hint: Option<usize>,
-) -> Option<Cow<str>> {
+) -> Option<Cow<'_, str>> {
     let ck = &line_info.checksum;
 
     let against_hint = |len| len_hint.is_none_or(|l| l == len);

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -344,7 +344,7 @@ pub fn os_str_as_bytes(os_string: &OsStr) -> Result<&[u8], NonUtf8OsStrError> {
 ///
 /// This is always lossless on unix platforms,
 /// and wraps [`OsStr::to_string_lossy`] on non-unix platforms.
-pub fn os_str_as_bytes_lossy(os_string: &OsStr) -> Cow<[u8]> {
+pub fn os_str_as_bytes_lossy(os_string: &OsStr) -> Cow<'_, [u8]> {
     #[cfg(unix)]
     return Cow::from(os_string.as_bytes());
 

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -1009,7 +1009,7 @@ mod tests_split_iterator {
     ///
     /// It tries to avoid introducing any unnecessary quotes or escape characters,
     /// but specifics regarding quoting style are left unspecified.
-    pub fn quote(s: &str) -> std::borrow::Cow<str> {
+    pub fn quote(s: &str) -> std::borrow::Cow<'_, str> {
         // We are going somewhat out of the way to provide
         // minimal amount of quoting in typical cases.
         match escape_style(s) {

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -2318,12 +2318,12 @@ impl UChild {
     }
 
     /// Return a [`UChildAssertion`]
-    pub fn make_assertion(&mut self) -> UChildAssertion {
+    pub fn make_assertion(&mut self) -> UChildAssertion<'_> {
         UChildAssertion::new(self)
     }
 
     /// Convenience function for calling [`UChild::delay`] and then [`UChild::make_assertion`]
-    pub fn make_assertion_with_delay(&mut self, millis: u64) -> UChildAssertion {
+    pub fn make_assertion_with_delay(&mut self, millis: u64) -> UChildAssertion<'_> {
         self.delay(millis).make_assertion()
     }
 
@@ -2879,7 +2879,7 @@ pub fn whoami() -> String {
 
 /// Add prefix 'g' for `util_name` if not on linux
 #[cfg(unix)]
-pub fn host_name_for(util_name: &str) -> Cow<str> {
+pub fn host_name_for(util_name: &str) -> Cow<'_, str> {
     // In some environments, e.g. macOS/freebsd, the GNU coreutils are prefixed with "g"
     // to not interfere with the BSD counterparts already in `$PATH`.
     #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
This PR fixes a bunch of clippy warnings introduced with Rust `1.89`. Most are related to the [mismatched lifetime syntaxes lint](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint) described in the announcement. Other warnings are from the [needless_return](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return), [manual_let_else](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else), [unnecessary_unwrap](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap), and [cloned_ref_to_slice_refs](https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs) lints. 

Additionally, in `od` I suppressed warnings from the `unpredictable_function_pointer_comparisons` Rust lint (https://github.com/rust-lang/rust/pull/134536).