### PR TITLE
head: remove `BadEncoding` variant of `HeadError`

### DIFF
--- a/src/uu/head/locales/en-US.ftl
+++ b/src/uu/head/locales/en-US.ftl
@@ -19,7 +19,6 @@ head-help-zero-terminated = line delimiter is NUL, not newline
 # Error messages
 head-error-reading-file = error reading {$name}: {$err}
 head-error-parse-error = parse error: {$err}
-head-error-bad-encoding = bad argument encoding
 head-error-num-too-large = number of -bytes or -lines is too large
 head-error-clap = clap error: {$err}
 head-error-invalid-bytes = invalid number of bytes: {$err}

--- a/src/uu/head/locales/fr-FR.ftl
+++ b/src/uu/head/locales/fr-FR.ftl
@@ -19,7 +19,6 @@ head-help-zero-terminated = le délimiteur de ligne est NUL, pas nouvelle ligne
 # Messages d'erreur
 head-error-reading-file = erreur lors de la lecture de {$name} : {$err}
 head-error-parse-error = erreur d'analyse : {$err}
-head-error-bad-encoding = mauvais encodage d'argument
 head-error-num-too-large = le nombre d'octets ou de lignes est trop grand
 head-error-clap = erreur clap : {$err}
 head-error-invalid-bytes = nombre d'octets invalide : {$err}

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -48,10 +48,6 @@ enum HeadError {
     #[error("{}", translate!("head-error-parse-error", "err" => 0))]
     ParseError(String),
 
-    #[error("{}", translate!("head-error-bad-encoding"))]
-    #[allow(dead_code)]
-    BadEncoding,
-
     #[error("{}", translate!("head-error-num-too-large"))]
     NumTooLarge(#[from] TryFromIntError),
 


### PR DESCRIPTION
This PR removes the `BadEncoding` variant of `HeadError`. It's currently marked as `#[allow(dead_code)]` and not used anymore.