### PR TITLE
users: fix unused imports in tests on FreeBSD

### DIFF
--- a/tests/by-util/test_users.rs
+++ b/tests/by-util/test_users.rs
@@ -3,8 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
+#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+use uutests::{util::TestScenario, util_name};
 
 #[test]
 fn test_invalid_arg() {


### PR DESCRIPTION
This PR fixes two "unused import" warnings that show up in the FreeBSD job in the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/17008637021/job/48221643186#step:5:4574)