### PR TITLE
date: allow multiple `-d`, last wins

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -275,6 +275,7 @@ pub fn uu_app() -> Command {
                 .long(OPT_DATE)
                 .value_name("STRING")
                 .allow_hyphen_values(true)
+                .overrides_with(OPT_DATE)
                 .help(translate!("date-help-date")),
         )
         .arg(

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -505,6 +505,19 @@ fn test_invalid_date_string() {
 }
 
 #[test]
+fn test_multiple_dates() {
+    new_ucmd!()
+        .arg("-d")
+        .arg("invalid")
+        .arg("-d")
+        .arg("2000-02-02")
+        .arg("+%Y")
+        .succeeds()
+        .stdout_is("2000\n")
+        .no_stderr();
+}
+
+#[test]
 fn test_date_one_digit_date() {
     new_ucmd!()
         .env("TZ", "UTC0")


### PR DESCRIPTION
When using `-d` multiple times, our implementation fails with an "argument cannot be used multiple times" error whereas GNU `date` allows it and uses the last value.
```
$ cargo run -q date -d "invalid" -d "2000-02-02"
error: the argument '--date <STRING>' cannot be used multiple times

For more information, try '--help'.

$ date -d "invalid" -d "2000-02-02"
Wed Feb  2 00:00:00 CET 2000
```
This PR fixes the issue.