### PR TITLE
cksum: two small refactorings

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -68,7 +68,7 @@ where
         let filename = Path::new(filename);
         let stdin_buf;
         let file_buf;
-        let not_file = filename == OsStr::new("-");
+        let is_stdin = filename == OsStr::new("-");
 
         if filename.is_dir() {
             show!(USimpleError::new(
@@ -79,7 +79,7 @@ where
         }
 
         // Handle the file input
-        let mut file = BufReader::new(if not_file {
+        let mut file = BufReader::new(if is_stdin {
             stdin_buf = stdin();
             Box::new(stdin_buf) as Box<dyn Read>
         } else {
@@ -128,9 +128,9 @@ where
                     "{} {}{}",
                     sum.parse::<u16>().unwrap(),
                     sz.div_ceil(options.output_bits),
-                    if not_file { "" } else { " " }
+                    if is_stdin { "" } else { " " }
                 ),
-                !not_file,
+                !is_stdin,
                 String::new(),
             ),
             ALGORITHM_OPTIONS_BSD => (
@@ -138,14 +138,14 @@ where
                     "{:0bsd_width$} {:bsd_width$}{}",
                     sum.parse::<u16>().unwrap(),
                     sz.div_ceil(options.output_bits),
-                    if not_file { "" } else { " " }
+                    if is_stdin { "" } else { " " }
                 ),
-                !not_file,
+                !is_stdin,
                 String::new(),
             ),
             ALGORITHM_OPTIONS_CRC | ALGORITHM_OPTIONS_CRC32B => (
-                format!("{sum} {sz}{}", if not_file { "" } else { " " }),
-                !not_file,
+                format!("{sum} {sz}{}", if is_stdin { "" } else { " " }),
+                !is_stdin,
                 String::new(),
             ),
             ALGORITHM_OPTIONS_BLAKE2B if options.tag => {


### PR DESCRIPTION
This PR applies two trivial refactorings:
* it does an earlier continue if a provided path is a directory to avoid creating an unused `BufReader`
* it renames a var `not_file` to `is_stdin` to avoid double negation when using `!`