### PR TITLE
stat: fix mount point handling for non-UTF8 paths

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -115,6 +115,7 @@ fn pad_and_print(result: &str, left: bool, width: usize, padding: Padding) {
 #[derive(Debug)]
 pub enum OutputType {
     Str(String),
+    OsStr(OsString),
     Integer(i64),
     Unsigned(u64),
     UnsignedHex(u64),
@@ -307,6 +308,7 @@ fn print_it(output: &OutputType, flags: Flags, width: usize, precision: Precisio
 
     match output {
         OutputType::Str(s) => print_str(s, &flags, width, precision),
+        OutputType::OsStr(_s) => todo!(),
         OutputType::Integer(num) => print_integer(*num, &flags, width, precision, padding_char),
         OutputType::Unsigned(num) => print_unsigned(*num, &flags, width, precision, padding_char),
         OutputType::UnsignedOct(num) => {
@@ -891,13 +893,13 @@ impl Stater {
         })
     }
 
-    fn find_mount_point<P: AsRef<Path>>(&self, p: P) -> Option<String> {
+    fn find_mount_point<P: AsRef<Path>>(&self, p: P) -> Option<OsString> {
         let path = p.as_ref().canonicalize().ok()?;
 
         for root in self.mount_list.as_ref()? {
             if path.starts_with(root) {
                 // TODO: This is probably wrong, we should pass the OsString
-                return Some(root.to_string_lossy().into_owned());
+                return Some(root.clone());
             }
         }
         None
@@ -995,7 +997,7 @@ impl Stater {
                     // inode number
                     'i' => OutputType::Unsigned(meta.ino()),
                     // mount point: TODO: This should be an OsStr
-                    'm' => OutputType::Str(self.find_mount_point(file).unwrap()),
+                    'm' => OutputType::OsStr(self.find_mount_point(file).unwrap()),
                     // file name
                     'n' => OutputType::Str(display_name.to_string()),
                     // quoted file name with dereference if symbolic link

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -112,6 +112,47 @@ fn pad_and_print(result: &str, left: bool, width: usize, padding: Padding) {
     }
 }
 
+/// Pads and prints raw bytes (Unix-specific) or falls back to string printing
+///
+/// On Unix systems, this preserves non-UTF8 data by printing raw bytes
+/// On other platforms, falls back to lossy string conversion
+fn pad_and_print_bytes(
+    bytes: &[u8],
+    left: bool,
+    width: usize,
+    precision: Precision,
+) -> Result<(), std::io::Error> {
+    use std::io::{self, Write};
+
+    let display_bytes = match precision {
+        Precision::Number(p) if p < bytes.len() => &bytes[..p],
+        _ => bytes,
+    };
+
+    let display_string = String::from_utf8_lossy(display_bytes);
+    let display_len = display_string.chars().count();
+
+    if width > display_len {
+        let padding_needed = width - display_len;
+
+        if left {
+            io::stdout().write_all(display_bytes)?;
+            for _ in 0..padding_needed {
+                print!(" ");
+            }
+        } else {
+            for _ in 0..padding_needed {
+                print!(" ");
+            }
+            io::stdout().write_all(display_bytes)?;
+        }
+    } else {
+        io::stdout().write_all(display_bytes)?;
+    }
+
+    Ok(())
+}
+
 #[derive(Debug)]
 pub enum OutputType {
     Str(String),
@@ -308,7 +349,7 @@ fn print_it(output: &OutputType, flags: Flags, width: usize, precision: Precisio
 
     match output {
         OutputType::Str(s) => print_str(s, &flags, width, precision),
-        OutputType::OsStr(_s) => todo!(),
+        OutputType::OsStr(s) => print_os_str(s, &flags, width, precision),
         OutputType::Integer(num) => print_integer(*num, &flags, width, precision, padding_char),
         OutputType::Unsigned(num) => print_unsigned(*num, &flags, width, precision, padding_char),
         OutputType::UnsignedOct(num) => {
@@ -355,6 +396,48 @@ fn print_str(s: &str, flags: &Flags, width: usize, precision: Precision) {
         _ => s,
     };
     pad_and_print(s, flags.left, width, Padding::Space);
+}
+
+/// Prints a `OsString` value based on the provided flags, width, and precision.
+/// for unix it converts it to bytes then tries to print it if failed print the lossy string version
+/// for windows, `OsString` uses UTF-16 internally which doesn't map directly to bytes like Unix,
+/// so we fall back to lossy string conversion to handle invalid UTF-8 sequences gracefully
+///
+/// # Arguments
+///
+/// * `s` - The `OsString` to be printed.
+/// * `flags` - A reference to the Flags struct containing formatting flags.
+/// * `width` - The width of the field for the printed string.
+/// * `precision` - How many digits of precision, if any.
+fn print_os_str(s: &OsString, flags: &Flags, width: usize, precision: Precision) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        let bytes = s.as_bytes();
+
+        if let Err(e) = pad_and_print_bytes(bytes, flags.left, width, precision) {
+            show_warning!(
+                "Failed to print raw bytes: {}, falling back to lossy conversion",
+                e
+            );
+            let lossy_string = s.to_string_lossy();
+            let truncated = match precision {
+                Precision::Number(p) if p < lossy_string.len() => &lossy_string[..p],
+                _ => &lossy_string,
+            };
+            pad_and_print(truncated, flags.left, width, Padding::Space);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let lossy_string = s.to_string_lossy();
+        let truncated = match precision {
+            Precision::Number(p) if p < lossy_string.len() => &lossy_string[..p],
+            _ => &lossy_string,
+        };
+        pad_and_print(truncated, flags.left, width, Padding::Space);
+    }
 }
 
 fn quote_file_name(file_name: &str, quoting_style: &QuotingStyle) -> String {
@@ -898,7 +981,6 @@ impl Stater {
 
         for root in self.mount_list.as_ref()? {
             if path.starts_with(root) {
-                // TODO: This is probably wrong, we should pass the OsString
                 return Some(root.clone());
             }
         }
@@ -996,8 +1078,8 @@ impl Stater {
                     'h' => OutputType::Unsigned(meta.nlink()),
                     // inode number
                     'i' => OutputType::Unsigned(meta.ino()),
-                    // mount point: TODO: This should be an OsStr
-                    'm' => OutputType::OsStr(self.find_mount_point(file).unwrap()),
+                    // mount point
+                    'm' => OutputType::OsStr(self.find_mount_point(file).unwrap_or_default()),
                     // file name
                     'n' => OutputType::Str(display_name.to_string()),
                     // quoted file name with dereference if symbolic link


### PR DESCRIPTION
# Summary

This PR addresses a TODO in `find_mount_point()` by properly handling mount point paths that contain non-UTF8 bytes. Previously, `to_string_lossy()` was used, which could corrupt mount point names with invalid UTF-8 sequences. The fix ensures raw bytes are preserved on Unix-like systems and safely handled on Windows.

## Changes Made

1. **`find_mount_point()` return type updated**
   Changed from `Option<String>` → `Option<OsString>` to preserve original bytes.
2. **Added `OsStr` variant to `OutputType` enum**
   Allows proper handling of non-UTF8 data through the output pipeline.
3. **Implemented `print_os_str()`**

   * **Unix/macOS:** prints raw bytes directly, preserving non-UTF8 sequences.
   * **Windows:** falls back to `.to_string_lossy()`, safely handling UTF-16 strings.
4. **Added `pad_and_print_bytes()` helper**
   Handles alignment, width, and padding for raw byte output.
5. **Updated `'m'` format specifier**
   Returns `OutputType::OsStr` instead of a lossy string, preserving original data.

## Platform Behavior

* **Unix/macOS:** preserves non-UTF8 bytes when printing.
* **Windows:** uses `.to_string_lossy()` safely, since Windows internally uses UTF-16.

## Related Issues

Fixes the TODO in `stat.rs`:

it is mentioned in this [issue](https://github.com/uutils/coreutils/issues/8534)
