### PR TITLE
nl: allow zero for `--join-blank-lines`

### DIFF
--- a/src/uu/nl/locales/en-US.ftl
+++ b/src/uu/nl/locales/en-US.ftl
@@ -33,7 +33,6 @@ nl-error-invalid-arguments = Invalid arguments supplied.
 nl-error-could-not-read-line = could not read line
 nl-error-line-number-overflow = line number overflow
 nl-error-invalid-line-width = Invalid line number field width: ‘{ $value }’: Numerical result out of range
-nl-error-invalid-blank-lines = Invalid line number of blank lines: ‘{ $value }’: Numerical result out of range
 nl-error-invalid-regex = invalid regular expression
 nl-error-invalid-numbering-style = invalid numbering style: '{ $style }'
 nl-error-is-directory = { $path }: Is a directory

--- a/src/uu/nl/locales/fr-FR.ftl
+++ b/src/uu/nl/locales/fr-FR.ftl
@@ -33,7 +33,6 @@ nl-error-invalid-arguments = Arguments fournis invalides.
 nl-error-could-not-read-line = impossible de lire la ligne
 nl-error-line-number-overflow = débordement du numéro de ligne
 nl-error-invalid-line-width = Largeur de champ de numéro de ligne invalide : ‘{ $value }’ : Résultat numérique hors limites
-nl-error-invalid-blank-lines = Nombre de lignes vides invalide : ‘{ $value }’ : Résultat numérique hors limites
 nl-error-invalid-regex = expression régulière invalide
 nl-error-invalid-numbering-style = style de numérotation invalide : '{ $style }'
 nl-error-is-directory = { $path } : Est un répertoire

--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -64,10 +64,8 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
         Some(num) if *num > 0 => settings.number_width = *num,
         Some(_) => errs.push(translate!("nl-error-invalid-line-width", "value" => "0")),
     }
-    match opts.get_one::<u64>(options::JOIN_BLANK_LINES) {
-        None => {}
-        Some(num) if *num > 0 => settings.join_blank_lines = *num,
-        Some(_) => errs.push(translate!("nl-error-invalid-blank-lines", "value" => "0")),
+    if let Some(num) = opts.get_one::<u64>(options::JOIN_BLANK_LINES) {
+        settings.join_blank_lines = *num;
     }
     if let Some(num) = opts.get_one::<i64>(options::LINE_INCREMENT) {
         settings.line_increment = *num;

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -368,6 +368,7 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
                 // for numbering, and only number the last one
                 NumberingStyle::All
                     if line.is_empty()
+                        && settings.join_blank_lines > 0
                         && stats.consecutive_empty_lines % settings.join_blank_lines != 0 =>
                 {
                     false

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -327,6 +327,25 @@ fn test_join_blank_lines() {
 }
 
 #[test]
+fn test_join_blank_lines_zero() {
+    for arg in ["-l0", "--join-blank-lines=0"] {
+        new_ucmd!()
+            .arg(arg)
+            .arg("--body-numbering=a")
+            .pipe_in("\n\n\n\n\n\n")
+            .succeeds()
+            .stdout_is(concat!(
+                "     1\t\n",
+                "     2\t\n",
+                "     3\t\n",
+                "     4\t\n",
+                "     5\t\n",
+                "     6\t\n",
+            ));
+    }
+}
+
+#[test]
 fn test_join_blank_lines_multiple_files() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -348,15 +367,6 @@ fn test_join_blank_lines_multiple_files() {
                 "       \n",
                 "     2\t\n",
             ));
-    }
-}
-
-#[test]
-fn test_join_blank_lines_zero() {
-    for arg in ["-l0", "--join-blank-lines=0"] {
-        new_ucmd!().arg(arg).fails().stderr_contains(
-            "Invalid line number of blank lines: ‘0’: Numerical result out of range",
-        );
     }
 }
 


### PR DESCRIPTION
This PR allows `0` as value for `--join-blank-lines` to match the behavior of GNU `nl`:
```
$ printf "\n\n\n\n\n\n" | nl --join-blank-lines=0 --body-numbering=a
     1
     2
     3
     4
     5
     6
```
So far we failed with an "invalid number" error.