### PR TITLE
date: add hidden aliases --rfc-2822/822 for GNU compat

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -37,6 +37,8 @@ const OPT_FILE: &str = "file";
 const OPT_DEBUG: &str = "debug";
 const OPT_ISO_8601: &str = "iso-8601";
 const OPT_RFC_EMAIL: &str = "rfc-email";
+const OPT_RFC_822: &str = "rfc-822";
+const OPT_RFC_2822: &str = "rfc-2822";
 const OPT_RFC_3339: &str = "rfc-3339";
 const OPT_SET: &str = "set";
 const OPT_REFERENCE: &str = "reference";
@@ -302,6 +304,8 @@ pub fn uu_app() -> Command {
             Arg::new(OPT_RFC_EMAIL)
                 .short('R')
                 .long(OPT_RFC_EMAIL)
+                .alias(OPT_RFC_2822)
+                .alias(OPT_RFC_822)
                 .help(translate!("date-help-rfc-email"))
                 .action(ArgAction::SetTrue),
         )

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -19,7 +19,7 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_date_email() {
-    for param in ["--rfc-email", "--rfc-e", "-R"] {
+    for param in ["--rfc-email", "--rfc-e", "-R", "--rfc-2822", "--rfc-822"] {
         new_ucmd!().arg(param).succeeds();
     }
 }


### PR DESCRIPTION
In GNU date, those two long options are undocumented aliases for the email format:

❯ date -R
Wed, 03 Sep 2025 17:55:15 +0200

❯ date --rfc-822
Wed, 03 Sep 2025 17:55:22 +0200

❯ date --rfc-2822
Wed, 03 Sep 2025 17:55:27 +0200

Initially noticed as the 2822 option is used in the glibc packaging in Debian and Ubuntu.