### PR TITLE
basenc: allow non-UTF8 filenames

### DIFF
--- a/src/uu/basenc/src/basenc.rs
+++ b/src/uu/basenc/src/basenc.rs
@@ -63,7 +63,7 @@ pub fn uu_app() -> Command {
 }
 
 fn parse_cmd_args(args: impl uucore::Args) -> UResult<(Config, Format)> {
-    let matches = uucore::clap_localization::handle_clap_result(uu_app(), args.collect_lossy())?;
+    let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let encodings = get_encodings();
     let format = encodings


### PR DESCRIPTION
While reviewing https://github.com/uutils/coreutils/pull/8542 I noticed that we use `collect_lossy` for the arguments. It leads to a "file not found" error when providing a non-UTF8 filename. This PR fixes the issue.