### PR TITLE
Avoid panic in stty

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -404,7 +404,7 @@ fn stty(opts: &Options) -> UResult<()> {
         }
 
         // TODO: Figure out the right error message for when tcgetattr fails
-        let mut termios = tcgetattr(opts.file.as_fd()).expect("Could not get terminal attributes");
+        let mut termios = tcgetattr(opts.file.as_fd())?;
 
         // iterate over valid_args, match on the arg type, do the matching apply function
         for arg in &valid_args {
@@ -419,12 +419,11 @@ fn stty(opts: &Options) -> UResult<()> {
                 }
             }
         }
-        tcsetattr(opts.file.as_fd(), set_arg, &termios)
-            .expect("Could not write terminal attributes");
+        tcsetattr(opts.file.as_fd(), set_arg, &termios)?;
     } else {
         // TODO: Figure out the right error message for when tcgetattr fails
-        let termios = tcgetattr(opts.file.as_fd()).expect("Could not get terminal attributes");
-        print_settings(&termios, opts).expect("TODO: make proper error here from nix error");
+        let termios = tcgetattr(opts.file.as_fd())?;
+        print_settings(&termios, opts)?;
     }
     Ok(())
 }


### PR DESCRIPTION
The expect() calls cause stty to panic if we are not attached to a tty with ENOTTY. This in turn causes shells to print messages "Aborted (core dumped)", breaking tests that assume empty stderr [with normal stderr of the process being redirected].

Refactor the code to use .and_then() and .map_err() to map the resulting nix Errno into a boxed UIoError.