### PR TITLE
nl: allow non-UTF8 section delimiter

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -16,11 +16,13 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
     // This vector holds error messages encountered.
     let mut errs: Vec<String> = vec![];
     settings.renumber = opts.get_flag(options::NO_RENUMBER);
-    if let Some(delimiter) = opts.get_one::<String>(options::SECTION_DELIMITER) {
-        // check whether the delimiter is a single ASCII char (1 byte)
-        // because GNU nl doesn't add a ':' to single non-ASCII chars
+    if let Some(delimiter) = opts.get_one::<OsString>(options::SECTION_DELIMITER) {
+        // GNU nl determines whether a delimiter is a "single character" based on byte length, not
+        // character length. A "single character" implies the second character is a ':'.
         settings.section_delimiter = if delimiter.len() == 1 {
-            format!("{delimiter}:")
+            let mut delimiter = delimiter.clone();
+            delimiter.push(":");
+            delimiter
         } else {
             delimiter.clone()
         };

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 use clap::{Arg, ArgAction, Command};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, stdin};
 use std::path::Path;
@@ -20,7 +20,7 @@ pub struct Settings {
     body_numbering: NumberingStyle,
     footer_numbering: NumberingStyle,
     // The variable corresponding to -d
-    section_delimiter: String,
+    section_delimiter: OsString,
     // The variables corresponding to the options -v, -i, -l, -w.
     starting_line_number: i64,
     line_increment: i64,
@@ -40,7 +40,7 @@ impl Default for Settings {
             header_numbering: NumberingStyle::None,
             body_numbering: NumberingStyle::NonEmpty,
             footer_numbering: NumberingStyle::None,
-            section_delimiter: String::from("\\:"),
+            section_delimiter: OsString::from("\\:"),
             starting_line_number: 1,
             line_increment: 1,
             join_blank_lines: 1,
@@ -140,8 +140,8 @@ enum SectionDelimiter {
 impl SectionDelimiter {
     /// A valid section delimiter contains the pattern one to three times,
     /// and nothing else.
-    fn parse(bytes: &[u8], pattern: &str) -> Option<Self> {
-        let pattern = pattern.as_bytes();
+    fn parse(bytes: &[u8], pattern: &OsStr) -> Option<Self> {
+        let pattern = pattern.as_encoded_bytes();
 
         if bytes.is_empty() || pattern.is_empty() || bytes.len() % pattern.len() != 0 {
             return None;
@@ -270,6 +270,7 @@ pub fn uu_app() -> Command {
                 .short('d')
                 .long(options::SECTION_DELIMITER)
                 .help(translate!("nl-help-section-delimiter"))
+                .value_parser(clap::value_parser!(OsString))
                 .value_name("CC"),
         )
         .arg(


### PR DESCRIPTION
This PR adds support for non-UTF8 values for `-d`/`--section-delimiter`.