### PR TITLE
cksum: improve performance (Closes: #8573)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61dd931a9d071dc6e36b8735c501601428c5aa5dfd6d2506b935498ef57e0098"
+dependencies = [
+ "crc",
+ "digest",
+ "libc",
+ "rand 0.9.2",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4116,7 @@ dependencies = [
  "bstr",
  "chrono",
  "clap",
+ "crc-fast",
  "crc32fast",
  "data-encoding",
  "data-encoding-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,6 +383,7 @@ blake2b_simd = "1.0.2"
 blake3 = "1.5.1"
 sm3 = "0.4.2"
 crc32fast = "1.4.2"
+crc-fast = "1.5.0"
 digest = "0.10.7"
 
 # Fluent dependencies

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -324,6 +324,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61dd931a9d071dc6e36b8735c501601428c5aa5dfd6d2506b935498ef57e0098"
+dependencies = [
+ "crc",
+ "digest",
+ "libc",
+ "rand",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1647,7 @@ dependencies = [
  "blake3",
  "bstr",
  "clap",
+ "crc-fast",
  "crc32fast",
  "data-encoding",
  "data-encoding-macro",

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -58,6 +58,7 @@ blake2b_simd = { workspace = true, optional = true }
 blake3 = { workspace = true, optional = true }
 sm3 = { workspace = true, optional = true }
 crc32fast = { workspace = true, optional = true }
+crc-fast = { workspace = true, optional = true }
 bigdecimal = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 selinux = { workspace = true, optional = true }
@@ -151,6 +152,7 @@ sum = [
   "blake3",
   "sm3",
   "crc32fast",
+  "crc-fast",
 ]
 update-control = ["parser"]
 utf8 = []


### PR DESCRIPTION
nice early results:
Still lower but less

```
Benchmark 1: /usr/bin/cksum /tmp/oneline_4G.txt
  Time (mean ± σ):     602.7 ms ±  25.7 ms    [User: 88.0 ms, System: 514.3 ms]
  Range (min … max):   584.5 ms … 620.8 ms    2 runs

Benchmark 2: ./target/release/coreutils cksum /tmp/oneline_4G.txt
  Time (mean ± σ):      1.918 s ±  0.121 s    [User: 0.426 s, System: 1.491 s]
  Range (min … max):    1.832 s …  2.004 s    2 runs

Benchmark 3: ./target/release/coreutils.prev cksum /tmp/oneline_4G.txt
  Time (mean ± σ):      9.502 s ±  0.186 s    [User: 8.893 s, System: 0.608 s]
  Range (min … max):    9.370 s …  9.634 s    2 runs

Summary
  /usr/bin/cksum /tmp/oneline_4G.txt ran
    3.18 ± 0.24 times faster than ./target/release/coreutils cksum /tmp/oneline_4G.txt
   15.77 ± 0.74 times faster than ./target/release/coreutils.prev cksum /tmp/oneline_4G.txt
```