### PR TITLE
uucore/safe_traversal: remove unnecessary vars

### DIFF
--- a/src/uucore/src/lib/features/safe_traversal.rs
+++ b/src/uucore/src/lib/features/safe_traversal.rs
@@ -430,7 +430,6 @@ impl Metadata {
 }
 
 // Add MetadataExt trait implementation for compatibility
-#[cfg(not(windows))]
 impl std::os::unix::fs::MetadataExt for Metadata {
     fn dev(&self) -> u64 {
         self.stat.st_dev


### PR DESCRIPTION
This PR does three trivial things:
* it removes a few variables that are used in error cases only
* it removes an unnecessary Windows-related `cfg` as the feature is Linux-only
* it adds the usual file header