### PR TITLE
pinky: move unit test away from the integration tests

### DIFF
--- a/src/uu/pinky/src/pinky.rs
+++ b/src/uu/pinky/src/pinky.rs
@@ -135,3 +135,16 @@ impl Capitalize for str {
             })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_capitalize() {
+        assert_eq!("Zbnmasd", "zbnmasd".capitalize()); // spell-checker:disable-line
+        assert_eq!("Abnmasd", "Abnmasd".capitalize()); // spell-checker:disable-line
+        assert_eq!("1masd", "1masd".capitalize()); // spell-checker:disable-line
+        assert_eq!("", "".capitalize());
+    }
+}

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -5,13 +5,9 @@
 
 #[cfg(not(target_os = "openbsd"))]
 use uucore::entries::{Locate, Passwd};
-use uutests::new_ucmd;
-use uutests::unwrap_or_return;
-#[cfg(target_os = "openbsd")]
-use uutests::util::TestScenario;
 #[cfg(not(target_os = "openbsd"))]
 use uutests::util::{TestScenario, expected_result};
-use uutests::util_name;
+use uutests::{new_ucmd, unwrap_or_return, util_name};
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_pinky.rs
+++ b/tests/by-util/test_pinky.rs
@@ -3,7 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use pinky::Capitalize;
 #[cfg(not(target_os = "openbsd"))]
 use uucore::entries::{Locate, Passwd};
 use uutests::new_ucmd;
@@ -20,16 +19,10 @@ fn test_invalid_arg() {
 }
 
 #[test]
-fn test_capitalize() {
-    assert_eq!("Zbnmasd", "zbnmasd".capitalize()); // spell-checker:disable-line
-    assert_eq!("Abnmasd", "Abnmasd".capitalize()); // spell-checker:disable-line
-    assert_eq!("1masd", "1masd".capitalize()); // spell-checker:disable-line
-    assert_eq!("", "".capitalize());
-}
-
-#[test]
 #[cfg(not(target_os = "openbsd"))]
 fn test_long_format() {
+    use pinky::Capitalize;
+
     let login = "root";
     let pw: Passwd = Passwd::locate(login).unwrap();
     let user_info = pw.user_info.unwrap_or_default();


### PR DESCRIPTION
While reviewing https://github.com/uutils/coreutils/pull/8669 I noticed a unit test among the integration tests. This PR moves the unit test to `pinky.rs`. It also cleans up the imports in the test file and removes an unnecessary import on OpenBSD.