### PR TITLE
seq: support non-utf8 for `--separator` & `--terminator`

### DIFF
--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -252,6 +252,29 @@ fn test_separator_non_utf8() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_terminator_non_utf8() {
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+    fn create_arg(prefix: &[u8]) -> OsString {
+        let terminator = [0xFF, 0xFE];
+        OsString::from_vec([prefix, &terminator].concat())
+    }
+
+    let short = create_arg(b"-t");
+    let long = create_arg(b"--terminator=");
+    let expected = [b'1', b'\n', b'2', 0xFF, 0xFE];
+
+    for arg in [short, long] {
+        new_ucmd!()
+            .arg(&arg)
+            .arg("2")
+            .succeeds()
+            .stdout_is_bytes(expected);
+    }
+}
+
+#[test]
 fn test_equalize_widths() {
     let args = ["-w", "--equal-width"];
     for arg in args {


### PR DESCRIPTION
This PR adds support for non-utf8 values for `-s`/`--separator` and `-t`/`--terminator`.