### PR TITLE
date: implement `--resolution` flag

### DIFF
--- a/src/uu/date/locales/en-US.ftl
+++ b/src/uu/date/locales/en-US.ftl
@@ -82,6 +82,8 @@ date-help-iso-8601 = output date/time in ISO 8601 format.
   'hours', 'minutes', 'seconds', or 'ns'
   for date and time to the indicated precision.
   Example: 2006-08-14T02:34:56-06:00
+date-help-resolution = output the available resolution of timestamps
+  Example: 0.000000001
 date-help-rfc-email = output date and time in RFC 5322 format.
   Example: Mon, 14 Aug 2006 02:34:56 -0600
 date-help-rfc-3339 = output date/time in RFC 3339 format.

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -447,7 +447,8 @@ fn get_clock_resolution() -> Timestamp {
         // https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
         clock_getres(CLOCK_REALTIME, &raw mut timespec);
     }
-    Timestamp::constant(timespec.tv_sec, timespec.tv_nsec as i32)
+    #[allow(clippy::unnecessary_cast)] // Cast required on 32-bit platforms
+    Timestamp::constant(timespec.tv_sec as i64, timespec.tv_nsec as i32)
 }
 
 #[cfg(windows)]

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -298,6 +298,7 @@ pub fn uu_app() -> Command {
                 .long(OPT_FILE)
                 .value_name("DATEFILE")
                 .value_hint(clap::ValueHint::FilePath)
+                .conflicts_with(OPT_DATE)
                 .help(translate!("date-help-file")),
         )
         .arg(
@@ -315,6 +316,7 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(OPT_RESOLUTION)
                 .long(OPT_RESOLUTION)
+                .conflicts_with_all([OPT_DATE, OPT_FILE])
                 .overrides_with(OPT_RESOLUTION)
                 .help(translate!("date-help-resolution"))
                 .action(ArgAction::SetTrue),
@@ -347,6 +349,7 @@ pub fn uu_app() -> Command {
                 .long(OPT_REFERENCE)
                 .value_name("FILE")
                 .value_hint(clap::ValueHint::AnyPath)
+                .conflicts_with_all([OPT_DATE, OPT_FILE, OPT_RESOLUTION])
                 .help(translate!("date-help-reference")),
         )
         .arg(

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
-// spell-checker: ignore: AEDT AEST EEST NZDT NZST Kolkata
+// spell-checker: ignore: AEDT AEST EEST NZDT NZST Kolkata Iseconds
 
 use chrono::{DateTime, Datelike, Duration, NaiveTime, Utc}; // spell-checker:disable-line
 use regex::Regex;

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -745,3 +745,36 @@ fn test_date_empty_tz_time() {
         .succeeds()
         .stdout_only("Thu Jan  1 00:00:00 UTC 1970\n");
 }
+
+#[test]
+fn test_date_resolution() {
+    // Test that --resolution flag returns a floating point number by default
+    new_ucmd!()
+        .arg("--resolution")
+        .succeeds()
+        .stdout_str_check(|s| s.trim().parse::<f64>().is_ok());
+
+    // Test that --resolution flag can be passed twice to match gnu
+    new_ucmd!()
+        .arg("--resolution")
+        .arg("--resolution")
+        .succeeds()
+        .stdout_str_check(|s| s.trim().parse::<f64>().is_ok());
+
+    // Test that can --resolution output can be formatted as a date
+    new_ucmd!()
+        .arg("--resolution")
+        .arg("-Iseconds")
+        .succeeds()
+        .stdout_only("1970-01-01T00:00:00+00:00\n");
+}
+
+#[test]
+fn test_date_resolution_no_combine() {
+    // Test that date fails when --resolution flag is passed with date flag
+    new_ucmd!()
+        .arg("--resolution")
+        .arg("-d")
+        .arg("2025-01-01")
+        .fails();
+}


### PR DESCRIPTION
Implements the `--resolution` flag for `date`. On unix platforms this uses the posix function `clock_getres`. I could not find an equivalent syscall on windows, however every windows operating system since at least Windows 2000 has used a resolution of 100ns, so I decided to hardcode that as the returned resolution. 

I treated the `--resolution` flag as a date source like it is in GNU date, this allows other formatting flags to apply to the output of the `--resolution` flag. I also tried to make sure the implementation would interact well with a future implementation of the `--debug` flag. 

As a bit of a drive by I also add conflicts_with annotations to the four date source options, this is to make the GNU date behaviour of failing when multiple date sources are specified. However, I'm not sure if I've taken the best approach for this, since the error message is different to GNU make and I'm not sure whether or not this is an issue. 

```
date -d "2025-01-01" --resolution

gnu date:
date: the options to specify dates for printing are mutually exclusive
Try 'date --help' for more information.

this pr:
error: the argument '--date <STRING>' cannot be used with '--resolution'

For more information, try '--help'.
```

fixes #6143 