### PR TITLE
makefile: fix build with overriden UTILS

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -387,6 +387,13 @@ jobs:
         test -h /tmp/usr/local/bin/sha512sum
         test -h /tmp/usr/local/bin/shake128sum
         test -h /tmp/usr/local/bin/shake256sum
+    - name: "`make UTILS=XXX`"
+      shell: bash
+      run: |
+        set -x
+        # Regression-test for https://github.com/uutils/coreutils/issues/8701
+        make UTILS="rm chmod chown chgrp mv du"
+
   build_rust_stable:
     name: Build/stable
     needs: [ min_version, deps ]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -219,11 +219,14 @@ ifneq ($(OS),Windows_NT)
 	PROGS := $(PROGS) $(UNIX_PROGS)
 # Build the selinux command even if not on the system
 	PROGS := $(PROGS) $(SELINUX_PROGS)
-# Always use external libstdbuf when building with make (Unix only)
-	CARGOFLAGS += --features feat_external_libstdbuf
 endif
 
 UTILS ?= $(PROGS)
+
+ifneq ($(findstring stdbuf,$(UTILS)),)
+    # Use external libstdbuf per default. It is more robust than embedding libstdbuf.
+	CARGOFLAGS += --features feat_external_libstdbuf
+endif
 
 # Programs with usable tests
 TEST_PROGS  := \


### PR DESCRIPTION
The make build was failing when the list of UTILS didn't contain stdbuf. This fixes this issue by adding feat_externa_libstdbuf only when stdbuf is being compiled.

Fixes https://github.com/uutils/coreutils/issues/8701