### PR TITLE
 Refactor uniq field skipping to avoid allocations

### DIFF
--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -113,28 +113,26 @@ impl Uniq {
         Ok(())
     }
 
-    fn skip_fields(&self, line: &[u8]) -> Vec<u8> {
+    fn skip_fields<'a>(&self, line: &'a [u8]) -> &'a [u8] {
         if let Some(skip_fields) = self.skip_fields {
-            let mut line = line.iter();
-            let mut line_after_skipped_field: Vec<u8>;
+            let mut idx = 0;
             for _ in 0..skip_fields {
-                if line.all(|u| u.is_ascii_whitespace()) {
-                    return Vec::new();
+                while idx < line.len() && line[idx].is_ascii_whitespace() {
+                    idx += 1;
                 }
-                line_after_skipped_field = line
-                    .by_ref()
-                    .skip_while(|u| !u.is_ascii_whitespace())
-                    .copied()
-                    .collect::<Vec<u8>>();
-
-                if line_after_skipped_field.is_empty() {
-                    return Vec::new();
+                if idx >= line.len() {
+                    return &line[line.len()..];
                 }
-                line = line_after_skipped_field.iter();
+                while idx < line.len() && !line[idx].is_ascii_whitespace() {
+                    idx += 1;
+                }
+                if idx >= line.len() {
+                    return &line[line.len()..];
+                }
             }
-            line.copied().collect::<Vec<u8>>()
+            &line[idx..]
         } else {
-            line.to_vec()
+            line
         }
     }
 


### PR DESCRIPTION
### Summary

Reworked skip_fields to walk the input buffer directly and return the borrowed tail slice, eliminating the repeated Vec<u8> allocations while preserving the existing whitespace/field semantics.

Updated cmp_key to operate on the borrowed slice so that byte-based --skip-chars handling and the invalid-UTF-8 fallback continue to match the original behavior without extra copies.

### Testing

✅ cargo test uniq --features=default

### Benchmark

Baseline target/debug/uniq_baseline --skip-fields=3 --skip-chars=10 uniq_bench_input.txt > /dev/null: 18.475 s, 18.113 s, 17.271 s (avg 17.95 s).

Refactored target/debug/uniq --skip-fields=3 --skip-chars=10 uniq_bench_input.txt > /dev/null: 1.348 s, 1.288 s, 1.339 s (avg 1.33 s, ≈13.5× faster)