### PR TITLE
build-gnu.sh: improve setup instructions

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -75,13 +75,13 @@ release_tag_GNU="v9.8"
 # check if the GNU coreutils has been cloned, if not print instructions
 # note: the ${path_GNU} might already exist, so we check for the .git directory
 if test ! -d "${path_GNU}/.git"; then
-    echo "Could not find GNU coreutils (expected at '${path_GNU}')"
-    echo "Run the following to download into the expected path:"
-    echo "git clone --recurse-submodules https://github.com/coreutils/coreutils.git \"${path_GNU}\""
-    echo "After downloading GNU coreutils to \"${path_GNU}\" run the following commands to checkout latest release tag"
-    echo "cd \"${path_GNU}\""
-    echo "git fetch --all --tags"
-    echo "git checkout tags/${release_tag_GNU}"
+    echo "Could not find the GNU coreutils (expected at '${path_GNU}')"
+    echo "Download them to the expected path:"
+    echo "  git clone --recurse-submodules https://github.com/coreutils/coreutils.git \"${path_GNU}\""
+    echo "Afterwards, checkout the latest release tag:"
+    echo "  cd \"${path_GNU}\""
+    echo "  git fetch --all --tags"
+    echo "  git checkout tags/${release_tag_GNU}"
     exit 1
 fi
 


### PR DESCRIPTION
This PR improves the instructions to setup the GNU `coreutils`.

Before the changes:
```
$ ./util/build-gnu.sh 
UU_MAKE_PROFILE='debug'
Could not find GNU coreutils (expected at '/home/dho/projects/gnu')
Run the following to download into the expected path:
git clone --recurse-submodules https://github.com/coreutils/coreutils.git "/home/dho/projects/gnu"
After downloading GNU coreutils to "/home/dho/projects/gnu" run the following commands to checkout latest release tag
cd "/home/dho/projects/gnu"
git fetch --all --tags
git checkout tags/v9.8
```
After the changes:
```
$ ./util/build-gnu.sh 
UU_MAKE_PROFILE='debug'
Could not find the GNU coreutils (expected at '/home/dho/projects/gnu')
Download them to the expected path:
  git clone --recurse-submodules https://github.com/coreutils/coreutils.git "/home/dho/projects/gnu"
Afterwards, checkout the latest release tag:
  cd "/home/dho/projects/gnu"
  git fetch --all --tags
  git checkout tags/v9.8
```