### PR TITLE
cp: fix recursive cp fails on files with trailing backslashes

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -696,7 +696,7 @@ pub fn path_ends_with_terminator(path: &Path) -> bool {
     path.as_os_str()
         .as_bytes()
         .last()
-        .is_some_and(|&byte| byte == b'/' || byte == b'\\')
+        .is_some_and(|&byte| byte == b'/')
 }
 
 #[cfg(windows)]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -7079,3 +7079,16 @@ fn test_cp_no_dereference_symlink_with_parents() {
         .succeeds();
     assert_eq!(at.resolve_link("x/symlink-to-directory"), "directory");
 }
+
+#[test]
+#[cfg(unix)]
+fn test_cp_recursive_files_ending_in_backslash(){
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.mkdir("a");
+    at.touch("a/foo\\");
+    ts.ucmd()
+        .args(&["-r","a","b"])
+        .succeeds();  
+    assert!(at.file_exists("b/foo\\"));
+}


### PR DESCRIPTION
Fixes #8739 

Windows style seperator ('\') is not required to be included for path_ends_with_terminator function for unix