### PR TITLE
sort: adapt error message to pass `sort-files0-from`

### DIFF
--- a/src/uu/sort/locales/en-US.ftl
+++ b/src/uu/sort/locales/en-US.ftl
@@ -22,7 +22,7 @@ sort-file-operands-combined = extra operand '{$file}'
     file operands cannot be combined with --files0-from
     Try '{$help} --help' for more information.
 sort-multiple-output-files = multiple output files specified
-sort-minus-in-stdin = when reading file names from stdin, no file name of '-' allowed
+sort-minus-in-stdin = when reading file names from standard input, no file name of '-' allowed
 sort-no-input-from = no input from '{$file}'
 sort-invalid-zero-length-filename = {$file}:{$line_num}: invalid zero-length file name
 sort-options-incompatible = options '-{$opt1}{$opt2}' are incompatible

--- a/src/uu/sort/locales/fr-FR.ftl
+++ b/src/uu/sort/locales/fr-FR.ftl
@@ -22,7 +22,7 @@ sort-file-operands-combined = opérande supplémentaire '{$file}'
     les opérandes de fichier ne peuvent pas être combinées avec --files0-from
     Essayez '{$help} --help' pour plus d'informations.
 sort-multiple-output-files = plusieurs fichiers de sortie spécifiés
-sort-minus-in-stdin = lors de la lecture des noms de fichiers depuis stdin, aucun nom de fichier '-' n'est autorisé
+sort-minus-in-stdin = lors de la lecture des noms de fichiers depuis l'entrée standard, aucun nom de fichier '-' n'est autorisé
 sort-no-input-from = aucune entrée depuis '{$file}'
 sort-invalid-zero-length-filename = {$file}:{$line_num} : nom de fichier de longueur zéro invalide
 sort-options-incompatible = les options '-{$opt1}{$opt2}' sont incompatibles

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1405,7 +1405,9 @@ fn test_files0_from_minus_in_stdin() {
         .args(&["--files0-from", "-"])
         .pipe_in("-")
         .fails_with_code(2)
-        .stderr_only("sort: when reading file names from stdin, no file name of '-' allowed\n");
+        .stderr_only(
+            "sort: when reading file names from standard input, no file name of '-' allowed\n",
+        );
 }
 
 #[test]


### PR DESCRIPTION
An expected error message in the GNU test `sort-files0-from` changed slightly in version `9.8`. This PR adapts our error message to make the test pass again.