### PR TITLE
wc: adapt error message to pass `wc-files0-from`

### DIFF
--- a/src/uu/wc/locales/en-US.ftl
+++ b/src/uu/wc/locales/en-US.ftl
@@ -16,7 +16,7 @@ wc-help-words = print the word counts
 # Error messages
 wc-error-files-disabled = extra operand '{ $extra }'
   file operands cannot be combined with --files0-from
-wc-error-stdin-repr-not-allowed = when reading file names from stdin, no file name of '-' allowed
+wc-error-stdin-repr-not-allowed = when reading file names from standard input, no file name of '-' allowed
 wc-error-zero-length-filename = invalid zero-length file name
 wc-error-zero-length-filename-ctx = { $path }:{ $idx }: invalid zero-length file name
 wc-error-cannot-open-for-reading = cannot open { $path } for reading

--- a/src/uu/wc/locales/fr-FR.ftl
+++ b/src/uu/wc/locales/fr-FR.ftl
@@ -16,7 +16,7 @@ wc-help-words = afficher le nombre de mots
 # Messages d'erreur
 wc-error-files-disabled = opérande supplémentaire '{ $extra }'
   les opérandes de fichier ne peuvent pas être combinées avec --files0-from
-wc-error-stdin-repr-not-allowed = lors de la lecture des noms de fichiers depuis stdin, aucun nom de fichier '-' autorisé
+wc-error-stdin-repr-not-allowed = lors de la lecture des noms de fichiers depuis l'entrée standard, aucun nom de fichier '-' autorisé
 wc-error-zero-length-filename = nom de fichier de longueur nulle invalide
 wc-error-zero-length-filename-ctx = { $path }:{ $idx } : nom de fichier de longueur nulle invalide
 wc-error-cannot-open-for-reading = impossible d'ouvrir { $path } en lecture

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -544,7 +544,7 @@ fn test_files0_from_with_stdin_in_file() {
 
 #[test]
 fn test_files0_from_with_stdin_try_read_from_stdin() {
-    const MSG: &str = "when reading file names from stdin, no file name of '-' allowed";
+    const MSG: &str = "when reading file names from standard input, no file name of '-' allowed";
     new_ucmd!()
         .args(&["--files0-from=-"])
         .pipe_in("-")


### PR DESCRIPTION
This PR is similar to https://github.com/uutils/coreutils/pull/8748 and should make the GNU test `wc-files0-from` pass again.