### PR TITLE
Do not build SELinux progs if libselinux is not installed

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -298,13 +298,15 @@ jobs:
       run: make nextest CARGOFLAGS="--profile ci --hide-progress-bar"
       env:
         RUST_BACKTRACE: "1"
-    - name: "`make install COMPLETIONS=n MANPAGES=n`"
+    - name: "`make install COMPLETIONS=n MANPAGES=n SELINUX_ENABLED=0`"
       shell: bash
       run: |
         set -x
-        DESTDIR=/tmp/ make PROFILE=release COMPLETIONS=n MANPAGES=n install
+        DESTDIR=/tmp/ make PROFILE=release COMPLETIONS=n MANPAGES=n SELINUX_ENABLED=0 install
         # Check that the utils are present
         test -f /tmp/usr/local/bin/tty
+        # Check that SELinux utils are disabled
+        ! test -f /tmp/usr/local/bin/chcon
         # Check that the manpage is not present
         ! test -f /tmp/usr/local/share/man/man1/whoami.1
         # Check that the completion is not present

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -305,8 +305,8 @@ jobs:
         DESTDIR=/tmp/ make PROFILE=release COMPLETIONS=n MANPAGES=n SELINUX_ENABLED=0 install
         # Check that the utils are present
         test -f /tmp/usr/local/bin/tty
-        # Check that SELinux utils are disabled
-        ! test -f /tmp/usr/local/bin/chcon
+        # Check that SELinux utils are exists if libselinux is installed even SELINUX_ENABLED=0
+        pkg-config --extsts libselinux && test -f /tmp/usr/local/bin/chcon
         # Check that the manpage is not present
         ! test -f /tmp/usr/local/share/man/man1/whoami.1
         # Check that the completion is not present

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -306,7 +306,7 @@ jobs:
         # Check that the utils are present
         test -f /tmp/usr/local/bin/tty
         # Check that SELinux utils are exists if libselinux is installed even SELINUX_ENABLED=0
-        pkg-config --extsts libselinux && test -f /tmp/usr/local/bin/chcon
+        pkg-config --exists libselinux && test -f /tmp/usr/local/bin/chcon
         # Check that the manpage is not present
         ! test -f /tmp/usr/local/share/man/man1/whoami.1
         # Check that the completion is not present

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -305,7 +305,7 @@ jobs:
         DESTDIR=/tmp/ make PROFILE=release COMPLETIONS=n MANPAGES=n SELINUX_ENABLED=0 install
         # Check that the utils are present
         test -f /tmp/usr/local/bin/tty
-        # Check that SELinux utils are exists if libselinux is installed even SELINUX_ENABLED=0
+        # Check that SELinux utils get installed if libselinux is installed, even with the parameter "SELINUX_ENABLED=0"
         pkg-config --exists libselinux && test -f /tmp/usr/local/bin/chcon
         # Check that the manpage is not present
         ! test -f /tmp/usr/local/share/man/man1/whoami.1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -216,7 +216,7 @@ ifeq ($(filter $(OS),Darwin FreeBSD),$(OS))
 endif
 
 # Build and test SELinux programs if enabled
-ifeq ($(SELINUX_ENABLED),0)
+ifeq ($(SELINUX_ENABLED),1)
 	PROGS := $(PROGS) $(SELINUX_PROGS)
 else
 	SKIP_UTILS := $(SKIP_UTILS) $(SELINUX_PROGS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -215,10 +215,15 @@ ifeq ($(filter $(OS),Darwin FreeBSD),$(OS))
 	SELINUX_PROGS :=
 endif
 
+# Build and test SELinux programs if enabled
+ifeq ($(SELINUX_ENABLED),0)
+	PROGS := $(PROGS) $(SELINUX_PROGS)
+else
+	SKIP_UTILS := $(SKIP_UTILS) $(SELINUX_PROGS)
+endif
+
 ifneq ($(OS),Windows_NT)
 	PROGS := $(PROGS) $(UNIX_PROGS)
-# Build the selinux command even if not on the system
-	PROGS := $(PROGS) $(SELINUX_PROGS)
 endif
 
 UTILS ?= $(PROGS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -210,16 +210,10 @@ HASHSUM_PROGS := \
 
 $(info Detected OS = $(OS))
 
-# Don't build the SELinux programs on macOS (Darwin) and FreeBSD
-ifeq ($(filter $(OS),Darwin FreeBSD),$(OS))
-	SELINUX_PROGS :=
-endif
-
-# Build and test SELinux programs if enabled
-ifeq ($(SELINUX_ENABLED),1)
+# Since we don't have dummies of SELinux progs, we build them if libselinux installed even SELINUX_ENABLED=0
+ifeq ($(shell pkg-config --exists libselinux ; echo $$?),0)
+	$(info linselinux found)
 	PROGS := $(PROGS) $(SELINUX_PROGS)
-else
-	SKIP_UTILS := $(SKIP_UTILS) $(SELINUX_PROGS)
 endif
 
 ifneq ($(OS),Windows_NT)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -212,7 +212,6 @@ $(info Detected OS = $(OS))
 
 # Since we don't have dummies of SELinux progs, we build them if libselinux installed even SELINUX_ENABLED=0
 ifeq ($(shell pkg-config --exists libselinux ; echo $$?),0)
-	$(info linselinux found)
 	PROGS := $(PROGS) $(SELINUX_PROGS)
 endif
 


### PR DESCRIPTION
Closes #7996 .
Replaces #8729 using `SKIP_UTILS` also for skipping tests.