### PR TITLE
Do not fail if libstdbuf was not built (not only for Windows)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -472,10 +472,10 @@ endif
 
 install: build install-manpages install-completions install-locales
 	mkdir -p $(INSTALLDIR_BIN)
-ifneq ($(OS),Windows_NT)
 	mkdir -p $(DESTDIR)$(LIBSTDBUF_DIR)
-	$(INSTALL) -m 755 $(BUILDDIR)/deps/libstdbuf* $(DESTDIR)$(LIBSTDBUF_DIR)/
-endif
+	# Do not fail if libstdbuf was not built (e.g. on Windows)
+	$(INSTALL) -vm 644 $(BUILDDIR)/deps/libstdbuf* $(DESTDIR)$(LIBSTDBUF_DIR)/ || :
+
 ifeq (${MULTICALL}, y)
 	$(INSTALL) -m 755 $(BUILDDIR)/coreutils $(INSTALLDIR_BIN)/$(PROG_PREFIX)coreutils
 	$(foreach prog, $(filter-out coreutils, $(INSTALLEES)), \


### PR DESCRIPTION
Do not install `libstdbuf*`and fail for all OS (not only for Windows).
Needed for #8767