### PR TITLE
ls: remove unnecessary getgrgid handling for Redox OS

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2969,7 +2969,7 @@ fn display_uname<'a>(metadata: &Metadata, config: &Config, state: &'a mut ListSt
 fn display_group<'a>(metadata: &Metadata, config: &Config, state: &'a mut ListState) -> &'a String {
     let gid = metadata.gid();
     state.gid_cache.entry(gid).or_insert_with(|| {
-        if cfg!(target_os = "redox") || config.long.numeric_uid_gid {
+        if config.long.numeric_uid_gid {
             gid.to_string()
         } else {
             entries::gid2grp(gid).unwrap_or_else(|_| gid.to_string())


### PR DESCRIPTION
Redox OS now has getgrgid as seen in https://gitlab.redox-os.org/redox-os/relibc/-/blob/master/src/header/grp/mod.rs?ref_type=0636af21a468f04971bad11eb4571bcb94fdfa81#L253, so we can remove this special handling. This allows the group name to show up on Redox OS, instead of just the group id.
