### PR TITLE
2 makefile fixes

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -379,6 +379,11 @@ jobs:
         set -x
         # Regression-test for https://github.com/uutils/coreutils/issues/8701
         make UTILS="rm chmod chown chgrp mv du"
+        # Verifies that
+        # 1. there is no "error: none of the selected packages contains this
+        # feature: feat_external_libstdbuf"
+        # 2. the makefile doesn't try to install libstdbuf even though stdbuf is skipped
+        DESTDIR=/tmp/ make SKIP_UTILS="stdbuf" install
 
   build_rust_stable:
     name: Build/stable

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -482,7 +482,7 @@ endif
 
 install: build install-manpages install-completions install-locales
 	mkdir -p $(INSTALLDIR_BIN)
-ifneq ($(OS),Windows_NT)
+ifneq (,$(and $(findstring stdbuf,$(UTILS)),$(findstring feat_external_libstdbuf,$(CARGOFLAGS))))
 	mkdir -p $(DESTDIR)$(LIBSTDBUF_DIR)
 	$(INSTALL) -m 755 $(BUILDDIR)/deps/libstdbuf* $(DESTDIR)$(LIBSTDBUF_DIR)/
 endif


### PR DESCRIPTION
Commit 1:

    GNUmakefile: fix installation logic for libstdbuf
    
    It is better to check whether we're actually compiling libstdbuf, rather than to check whether
    we're on windows, in order to decide whether libstdbuf should get installed.
    
    Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>

Commit 2:

    GNUmakefile: filter out SKIP_UTILS from UTILS
    
    This fixes this corner-case where SKIP_UTILS was not taken into account in the logic enabling feat_external_libstdbuf:
    
    ```
    sudo make install SKIP_UTILS=stdbuf
    ...
    error: none of the selected packages contains this feature: feat_external_libstdbuf
    ```
    
    Signed-off-by: Etienne Cordonnier <ecordonnier@snap.com>