### PR TITLE
Allow to replace ln -fs and hardlink on Windows by default

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -498,8 +498,8 @@ else
 		cd $(INSTALLDIR_BIN) && $(LN) $(PROG_PREFIX)hashsum $(PROG_PREFIX)$(prog) $(newline) \
 	)
 endif
-# symlink test if we have
-$(shell cd $(INSTALLDIR_BIN) && $(LN) $(shell readlink $(PROG_PREFIX)test) $(PROG_PREFIX)[ || true)
+	# symlink test if we have
+	$(shell cd $(INSTALLDIR_BIN) && $(LN) $(shell readlink $(PROG_PREFIX)test) $(PROG_PREFIX)[ || true)
 
 uninstall:
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
Allow to replace `ln -fs` for multicall-binary with any command.
`make LN=ln` fixes  argv[0] .
Closes #7928