### PR TITLE
codegen-units = 1 at release-{fast,small} profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -600,12 +600,14 @@ lto = true
 [profile.release-fast]
 inherits = "release"
 panic = "abort"
+codegen-units = 1
 
 # A release-like profile that is as small as possible.
 [profile.release-small]
 inherits = "release"
 opt-level = "z"
 panic = "abort"
+codegen-units = 1
 strip = true
 
 # A release-like profile with debug info, useful for profiling.


### PR DESCRIPTION
Use `codegen-units = 1` at release-fast and release-small profile (used at ripgrep).