### PR TITLE
tests(df): Fix test_total to avoid whitespace parsing issues

### DIFF
--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -395,34 +395,36 @@ fn test_total() {
     //     ...
     //     /dev/loop14               63488    63488         0 100% /snap/core20/1361
     //     total                 258775268 98099712 148220200  40% -
-    let output = new_ucmd!().arg("--total").succeeds().stdout_str_lossy();
+    // Use explicit numeric-only columns to avoid whitespace issues in Filesystem or Mounted on columns
+    let output = new_ucmd!()
+        .arg("--output=size,used,avail")
+        .arg("--total")
+        .succeeds()
+        .stdout_str_lossy();
 
     // Skip the header line.
     let lines: Vec<&str> = output.lines().skip(1).collect();
 
-    // Parse the values from the last row.
+    // Parse the values from the last row (report totals)
     let last_line = lines.last().unwrap();
     let mut iter = last_line.split_whitespace();
-    assert_eq!(iter.next().unwrap(), "total");
-    let reported_total_size = iter.next().unwrap().parse().unwrap();
-    let reported_total_used = iter.next().unwrap().parse().unwrap();
-    let reported_total_avail = iter.next().unwrap().parse().unwrap();
+    let reported_total_size: u64 = iter.next().unwrap().parse().unwrap();
+    let reported_total_used: u64 = iter.next().unwrap().parse().unwrap();
+    let reported_total_avail: u64 = iter.next().unwrap().parse().unwrap();
 
     // Loop over each row except the last, computing the sum of each column.
-    let mut computed_total_size = 0;
-    let mut computed_total_used = 0;
-    let mut computed_total_avail = 0;
+    let mut computed_total_size: u64 = 0;
+    let mut computed_total_used: u64 = 0;
+    let mut computed_total_avail: u64 = 0;
     let n = lines.len();
     for line in &lines[..n - 1] {
         let mut iter = line.split_whitespace();
-        iter.next().unwrap();
         computed_total_size += iter.next().unwrap().parse::<u64>().unwrap();
         computed_total_used += iter.next().unwrap().parse::<u64>().unwrap();
         computed_total_avail += iter.next().unwrap().parse::<u64>().unwrap();
     }
 
-    // Check that the sum of each column matches the reported value in
-    // the last row.
+    // Check that the sum of each column matches the reported value in the last row.
     assert_eq!(computed_total_size, reported_total_size);
     assert_eq!(computed_total_used, reported_total_used);
     assert_eq!(computed_total_avail, reported_total_avail);


### PR DESCRIPTION
Use --output=size,used,avail when validating totals to avoid fragile parsing of Filesystem/Mounted on columns that may include spaces.

Benefit: makes the test robust across different mount point naming conventions and filesystem layouts.