### PR TITLE
feat(sort): implement automatic buffer size calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,6 +3943,7 @@ dependencies = [
  "fluent",
  "fnv",
  "itertools 0.14.0",
+ "libc",
  "memchr",
  "nix 0.30.1",
  "rand 0.9.2",

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = { workspace = true }
 unicode-width = { workspace = true }
 uucore = { workspace = true, features = ["fs", "parser", "version-cmp"] }
 fluent = { workspace = true }
+libc = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true }


### PR DESCRIPTION
Replaced fixed 1GB buffer size with dynamic calculation based on input file sizes and available memory. Added heuristics to clamp buffer size within 512 KiB to 128 MiB range, preventing overcommitment on constrained systems while optimizing for typical workloads. Updated dependencies and imports to use libc directly for better portability.