### PR TITLE
fix(ptx): Correct reference format for stdin

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -352,11 +352,15 @@ fn create_word_set(config: &Config, filter: &WordFilter, file_map: &FileMap) -> 
 
 fn get_reference(config: &Config, word_ref: &WordRef, line: &str, context_reg: &Regex) -> String {
     if config.auto_ref {
-        format!(
-            "{}:{}",
-            word_ref.filename.maybe_quote(),
-            word_ref.local_line_nr + 1
-        )
+        if word_ref.filename == "-" {
+            format!(":{}", word_ref.local_line_nr + 1)
+        } else {
+            format!(
+                "{}:{}",
+                word_ref.filename.maybe_quote(),
+                word_ref.local_line_nr + 1
+            )
+        }
     } else if config.input_ref {
         let (beg, end) = match context_reg.find(line) {
             Some(x) => (x.start(), x.end()),

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -10,7 +10,25 @@ use uutests::new_ucmd;
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(1);
 }
-
+#[test]
+fn test_reference_format_for_stdin() {
+    let input = "Rust is good language";
+    let expected_output = concat!(
+        r#".xx "" "" "Rust is good language" "" ":1""#,
+        "\n",
+        r#".xx "" "Rust is" "good language" "" ":1""#,
+        "\n",
+        r#".xx "" "Rust" "is good language" "" ":1""#,
+        "\n",
+        r#".xx "" "Rust is good" "language" "" ":1""#,
+        "\n",
+    );
+    new_ucmd!()
+        .args(&["-G", "-A"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only(expected_output);
+}
 #[test]
 fn test_tex_format_no_truncation_markers() {
     let input = "Hello world Rust is a fun language";


### PR DESCRIPTION
### Summary

This PR fixes a compatibility bug where `ptx` incorrectly formatted references when the input source was standard input (stdin). The change ensures the output matches GNU `ptx`'s behavior for all reference modes (`-A` and `-r`).



### The Bug

When processing stdin, `uutils/ptx` was generating references with a hyphen `"-"` as a placeholder for the filename (e.g., `"-:1"` for auto-references). The correct GNU `ptx` behavior is to use an empty string for the filename part in this scenario (e.g., `":1"`).

This inconsistency affects any workflow that relies on parsing `ptx`'s output when using stdin.


### Changes Made

- The reference generation logic was updated to specifically check if the input source is stdin.
- When the input is stdin, an empty string is now used for the filename portion of the reference, ensuring compliance with GNU `ptx`.
- And I added regression test for stdin reference format.

**GNU**
```bash
charlotte@Misakait ~ at 16:59:59
❯ echo "Rust is good language" | ptx -G -A
.xx "" "" "Rust is good language" "" ":1"
.xx "" "Rust is" "good language" "" ":1"
.xx "" "Rust" "is good language" "" ":1"
.xx "" "Rust is good" "language" "" ":1"
```
<img width="461" height="139" alt="image" src="https://github.com/user-attachments/assets/595b51f2-02b1-4334-bbc8-eca76d371f80" />

**Before fix**

```bash
wanan@Misakait coreutils/src/uu/ptx on  fix/reference-stdin [$!?] is 📦 v0.2.2 via 🦀 v1.90.0 at 17:07:33
❯ echo "Rust is good language" | cargo run -- -G -A
   Compiling uu_ptx v0.2.2 (/home/wanan/coreutils/src/uu/ptx)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.77s
     Running `/home/wanan/coreutils/target/debug/ptx -G -A`
.xx "" "" "Rust is good language" "" "-:1"
.xx "" "Rust is" "good language" "" "-:1"
.xx "" "Rust" "is good language" "" "-:1"
.xx "" "Rust is good" "language" "" "-:1"
```
<img width="754" height="186" alt="image" src="https://github.com/user-attachments/assets/47c40a23-827d-4d50-abe1-9fb0ebe0303e" />

**After fix**
```bash
wanan@Misakait coreutils/src/uu/ptx on  fix/reference-stdin [$?] is 📦 v0.2.2 via 🦀 v1.90.0 at 16:59:07
❯ echo "Rust is good language" | cargo run -- -G -A
   Compiling uu_ptx v0.2.2 (/home/wanan/coreutils/src/uu/ptx)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.81s
     Running `/home/wanan/coreutils/target/debug/ptx -G -A`
.xx "" "" "Rust is good language" "" ":1"
.xx "" "Rust is" "good language" "" ":1"
.xx "" "Rust" "is good language" "" ":1"
.xx "" "Rust is good" "language" "" ":1"
```
<img width="730" height="192" alt="image" src="https://github.com/user-attachments/assets/f4f3e641-cdf0-4f2a-909f-cf70f13abd3c" />
