### PR TITLE
Allow to replace ln -fs and hardlink on Windows by default

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -364,29 +364,15 @@ jobs:
         test -h /tmp/usr/local/bin/sha512sum
         test -h /tmp/usr/local/bin/shake128sum
         test -h /tmp/usr/local/bin/shake256sum
-    - name: "`make install MULTICALL=y`"
+    - name: "`make install MULTICALL=y LN=ln -svf`"
       shell: bash
       run: |
         set -x
-        DESTDIR=/tmp/ make PROFILE=release MULTICALL=y install
-        # Check that the utils are present
-        test -f /tmp/usr/local/bin/coreutils
-        # Check that hashsum symlinks are present
-        test -h /tmp/usr/local/bin/b2sum
-        test -h /tmp/usr/local/bin/b3sum
-        test -h /tmp/usr/local/bin/md5sum
-        test -h /tmp/usr/local/bin/sha1sum
-        test -h /tmp/usr/local/bin/sha224sum
-        test -h /tmp/usr/local/bin/sha256sum
-        test -h /tmp/usr/local/bin/sha3-224sum
-        test -h /tmp/usr/local/bin/sha3-256sum
-        test -h /tmp/usr/local/bin/sha3-384sum
-        test -h /tmp/usr/local/bin/sha3-512sum
-        test -h /tmp/usr/local/bin/sha384sum
-        test -h /tmp/usr/local/bin/sha3sum
-        test -h /tmp/usr/local/bin/sha512sum
-        test -h /tmp/usr/local/bin/shake128sum
-        test -h /tmp/usr/local/bin/shake256sum
+        DESTDIR=/tmp/ make PROFILE=release MULTICALL=y LN="ln -svf" install
+        # Check that relative symlinks of hashsum are present
+        [ $(readlink /tmp/usr/local/bin/b2sum) = coreutils ]
+        [ $(readlink /tmp/usr/local/bin/md5sum) = coreutils ]
+        [ $(readlink /tmp/usr/local/bin/sha512sum) = coreutils ]
     - name: "`make UTILS=XXX`"
       shell: bash
       run: |
@@ -483,9 +469,11 @@ jobs:
       run: |
         ## `make install`
         make install DESTDIR=target/size-release/
-        make install MULTICALL=y DESTDIR=target/size-multi-release/
+        make install MULTICALL=y LN="ln -vf" DESTDIR=target/size-multi-release/
         # strip the results
         strip target/size*/usr/local/bin/*
+    - name: Test for hardlinks
+      run: [ $(stat -c %i target/size-multi-release/usr/local/bin/cp) = $(stat -c %i target/size-multi-release/usr/local/bin/coreutils) ]
     - name: Compute uutil release sizes
       shell: bash
       run: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,6 +69,13 @@ TOYBOX_SRC  := $(TOYBOX_ROOT)/toybox-$(TOYBOX_VER)
 #------------------------------------------------------------------------
 OS ?= $(shell uname -s)
 
+# Windows does not allow symlink by default.
+# Allow to override LN for AppArmor.
+ifeq ($(OS),Windows_NT)
+	LN ?= ln -f
+endif
+LN ?= ln -sf
+
 ifdef SELINUX_ENABLED
 	override SELINUX_ENABLED := 0
 # Now check if we should enable it (only on non-Windows)
@@ -482,18 +489,18 @@ endif
 ifeq (${MULTICALL}, y)
 	$(INSTALL) -m 755 $(BUILDDIR)/coreutils $(INSTALLDIR_BIN)/$(PROG_PREFIX)coreutils
 	$(foreach prog, $(filter-out coreutils, $(INSTALLEES)), \
-		cd $(INSTALLDIR_BIN) && ln -fs $(PROG_PREFIX)coreutils $(PROG_PREFIX)$(prog) $(newline) \
+		cd $(INSTALLDIR_BIN) && $(LN) $(PROG_PREFIX)coreutils $(PROG_PREFIX)$(prog) $(newline) \
 	)
 	$(foreach prog, $(HASHSUM_PROGS), \
-		cd $(INSTALLDIR_BIN) && ln -fs $(PROG_PREFIX)coreutils $(PROG_PREFIX)$(prog) $(newline) \
+		cd $(INSTALLDIR_BIN) && $(LN) $(PROG_PREFIX)coreutils $(PROG_PREFIX)$(prog) $(newline) \
 	)
-	$(if $(findstring test,$(INSTALLEES)), cd $(INSTALLDIR_BIN) && ln -fs $(PROG_PREFIX)coreutils $(PROG_PREFIX)[)
+	$(if $(findstring test,$(INSTALLEES)), cd $(INSTALLDIR_BIN) && $(LN) $(PROG_PREFIX)coreutils $(PROG_PREFIX)[)
 else
 	$(foreach prog, $(INSTALLEES), \
 		$(INSTALL) -m 755 $(BUILDDIR)/$(prog) $(INSTALLDIR_BIN)/$(PROG_PREFIX)$(prog) $(newline) \
 	)
 	$(foreach prog, $(HASHSUM_PROGS), \
-		cd $(INSTALLDIR_BIN) && ln -fs $(PROG_PREFIX)hashsum $(PROG_PREFIX)$(prog) $(newline) \
+		cd $(INSTALLDIR_BIN) && $(LN) $(PROG_PREFIX)hashsum $(PROG_PREFIX)$(prog) $(newline) \
 	)
 	$(if $(findstring test,$(INSTALLEES)), $(INSTALL) -m 755 $(BUILDDIR)/test $(INSTALLDIR_BIN)/$(PROG_PREFIX)[)
 endif


### PR DESCRIPTION
Allow to replace `ln-fs` by `make LN=ln` (Minimized replacement for #8790 and #7928 ).

Reasons:
1. Windows does not allow symlinking by default. It blocks to build this as single binary at MSYS2.
2. AppArmor needs proper argv[0] .

~I have no idea what test should we have for this feature.~