### PR TITLE
nl: improve the performances

### DIFF
--- a/src/uu/nl/locales/en-US.ftl
+++ b/src/uu/nl/locales/en-US.ftl
@@ -31,6 +31,7 @@ nl-help-number-width = use NUMBER columns for line numbers
 # Error messages
 nl-error-invalid-arguments = Invalid arguments supplied.
 nl-error-could-not-read-line = could not read line
+nl-error-could-not-write = could not write output
 nl-error-line-number-overflow = line number overflow
 nl-error-invalid-line-width = Invalid line number field width: ‘{ $value }’: Numerical result out of range
 nl-error-invalid-regex = invalid regular expression

--- a/src/uu/nl/locales/fr-FR.ftl
+++ b/src/uu/nl/locales/fr-FR.ftl
@@ -31,6 +31,7 @@ nl-help-number-width = utiliser NUMBER colonnes pour les numéros de ligne
 # Messages d'erreur
 nl-error-invalid-arguments = Arguments fournis invalides.
 nl-error-could-not-read-line = impossible de lire la ligne
+nl-error-could-not-write = impossible d'écrire la sortie
 nl-error-line-number-overflow = débordement du numéro de ligne
 nl-error-invalid-line-width = Largeur de champ de numéro de ligne invalide : ‘{ $value }’ : Résultat numérique hors limites
 nl-error-invalid-regex = expression régulière invalide


### PR DESCRIPTION
```
hyperfine --warmup 3 "/usr/bin/nl moby64.txt"                     "./target/release/coreutils.prev nl  moby64.txt" "./target/release/coreutils nl moby64.txt"
Benchmark 1: /usr/bin/nl moby64.txt
  Time (mean ± σ):     179.8 ms ±   3.1 ms    [User: 165.6 ms, System: 14.1 ms]
  Range (min … max):   173.6 ms … 184.0 ms    16 runs

Benchmark 2: ./target/release/coreutils.prev nl  moby64.txt
  Time (mean ± σ):     380.6 ms ±   4.9 ms    [User: 278.2 ms, System: 102.2 ms]
  Range (min … max):   375.4 ms … 391.4 ms    10 runs

Benchmark 3: ./target/release/coreutils nl moby64.txt
  Time (mean ± σ):     167.3 ms ±   1.7 ms    [User: 154.5 ms, System: 12.7 ms]
  Range (min … max):   163.8 ms … 170.0 ms    17 runs

Summary
  ./target/release/coreutils nl moby64.txt ran
    1.07 ± 0.02 times faster than /usr/bin/nl moby64.txt
    2.27 ± 0.04 times faster than ./target/release/coreutils.prev nl  moby64.txt
```