### PR TITLE
fix(ptx): Align text wrapping behavior with GNU in traditional mode

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -224,7 +224,7 @@ fn get_config(matches: &clap::ArgMatches) -> UResult<Config> {
     }
     config.auto_ref = matches.get_flag(options::AUTO_REFERENCE);
     config.input_ref = matches.get_flag(options::REFERENCES);
-    config.right_ref &= matches.get_flag(options::RIGHT_SIDE_REFS);
+    config.right_ref = matches.get_flag(options::RIGHT_SIDE_REFS);
     config.ignore_case = matches.get_flag(options::IGNORE_CASE);
     if matches.contains_id(options::MACRO_NAME) {
         config.macro_name = matches
@@ -661,7 +661,7 @@ fn prepare_line_chunks(
 }
 
 fn write_traditional_output(
-    config: &Config,
+    config: &mut Config,
     file_map: &FileMap,
     words: &BTreeSet<WordRef>,
     output_filename: &OsStr,
@@ -676,6 +676,15 @@ fn write_traditional_output(
         });
 
     let context_reg = Regex::new(&config.context_regex).unwrap();
+
+    if !config.right_ref {
+        let max_ref_len = if config.auto_ref {
+            get_auto_max_reference_len(words)
+        } else {
+            0
+        };
+        config.line_width -= max_ref_len;
+    }
 
     for word_ref in words {
         let file_map_value: &FileContent = file_map
@@ -722,6 +731,31 @@ fn write_traditional_output(
     Ok(())
 }
 
+fn get_auto_max_reference_len(words: &BTreeSet<WordRef>) -> usize {
+    //Get the maximum length of the reference field
+    let line_num = words
+        .iter()
+        .map(|w| {
+            if w.local_line_nr == 0 {
+                1
+            } else {
+                (w.local_line_nr as f64).log10() as usize + 1
+            }
+        })
+        .max()
+        .unwrap_or(0);
+
+    let filename_len = words
+        .iter()
+        .filter(|w| w.filename != "-")
+        .map(|w| w.filename.maybe_quote().to_string().len())
+        .max()
+        .unwrap_or(0);
+
+    // +1 for the colon
+    line_num + filename_len + 1
+}
+
 mod options {
     pub mod format {
         pub static ROFF: &str = "roff";
@@ -749,7 +783,7 @@ mod options {
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
-    let config = get_config(&matches)?;
+    let mut config = get_config(&matches)?;
 
     let input_files;
     let output_file: OsString;
@@ -783,7 +817,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let word_filter = WordFilter::new(&matches, &config)?;
     let file_map = read_input(&input_files).map_err_context(String::new)?;
     let word_set = create_word_set(&config, &word_filter, &file_map);
-    write_traditional_output(&config, &file_map, &word_set, &output_file)
+    write_traditional_output(&mut config, &file_map, &word_set, &output_file)
 }
 
 pub fn uu_app() -> Command {

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -58,6 +58,30 @@ fn test_truncation_no_extra_space_in_after() {
 }
 
 #[test]
+fn gnu_ext_disabled_reference_calculation() {
+    let input = "Hello World Rust is good language";
+    let expected_output = concat!(
+        r#".xx "language" "" "Hello World Rust is good" "" ":1""#,
+        "\n",
+        r#".xx "" "Hello World" "Rust is good language" "" ":1""#,
+        "\n",
+        r#".xx "" "Hello" "World Rust is good language" "" ":1""#,
+        "\n",
+        r#".xx "" "Hello World Rust is" "good language" "" ":1""#,
+        "\n",
+        r#".xx "" "Hello World Rust" "is good language" "" ":1""#,
+        "\n",
+        r#".xx "" "Hello World Rust is good" "language" "" ":1""#,
+        "\n",
+    );
+    new_ucmd!()
+        .args(&["-G", "-A"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only(expected_output);
+}
+
+#[test]
 fn gnu_ext_disabled_rightward_no_ref() {
     new_ucmd!()
         .args(&["-G", "-R", "input"])


### PR DESCRIPTION
### Summary

This PR fixes a layout bug in `ptx`'s traditional mode (`-G`). When references are enabled, the available line width was not being correctly adjusted, causing text wrapping to be inconsistent with the GNU `ptx` reference implementation.

### The Bug

In traditional mode with references (`-G -A`), GNU `ptx` performs text wrapping on long lines. The `uutils` implementation failed to replicate this behavior because it was not correctly reducing the available line width to account for the space occupied by the reference column.

This resulted in an overly large layout budget, which prevented wrapping and produced output that was inconsistent with GNU `ptx`.

### Changes Made

- The configuration logic is updated to subtract the maximum reference length from `config.line_width` when references are enabled in traditional mode. This provides the correct layout budget to the text chunking algorithm.
- Add related regression test

**GNU (Correct edition)**
```bash
charlotte@Misakait ~ at 21:14:45
❯ echo "Hello World Rust is good language" | ptx -G -A
.xx "language" "" "Hello World Rust is good" "" ":1"
.xx "" "Hello World" "Rust is good language" "" ":1"
.xx "" "Hello" "World Rust is good language" "" ":1"
.xx "" "Hello World Rust is" "good language" "" ":1"
.xx "" "Hello World Rust" "is good language" "" ":1"
.xx "" "Hello World Rust is good" "language" "" ":1"
````
<img width="568" height="165" alt="image" src="https://github.com/user-attachments/assets/6bf8f808-9fef-4b90-a288-22ac2b43f3ac" />

**Before fix**
```bash
wanan@Misakait coreutils/src/uu/ptx on  fix/reference-calculate [$?] is 📦 v0.2.2 via 🦀 v1.90.0 at 21:41:00
❯ echo "Hello World Rust is good language" | cargo run -- -G -A
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `/home/wanan/coreutils/target/debug/ptx -G -A`
.xx "" "" "Hello World Rust is good language" "" ":1"
.xx "" "Hello World" "Rust is good language" "" ":1"
.xx "" "Hello" "World Rust is good language" "" ":1"
.xx "" "Hello World Rust is" "good language" "" ":1"
.xx "" "Hello World Rust" "is good language" "" ":1"
.xx "" "Hello World Rust is good" "language" "" ":1"
```
<img width="726" height="206" alt="image" src="https://github.com/user-attachments/assets/51e1d190-1b52-42c3-a911-c47bc5ec6c69" />


**After fix**
```bash
wanan@Misakait coreutils/src/uu/ptx on  fix/reference-calculate [$!?] is 📦 v0.2.2 via 🦀 v1.90.0 took 2s at 21:37:36
❯ echo "Hello World Rust is good language" | cargo run -- -G -A
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `/home/wanan/coreutils/target/debug/ptx -G -A`
.xx "language" "" "Hello World Rust is good" "" ":1"
.xx "" "Hello World" "Rust is good language" "" ":1"
.xx "" "Hello" "World Rust is good language" "" ":1"
.xx "" "Hello World Rust is" "good language" "" ":1"
.xx "" "Hello World Rust" "is good language" "" ":1"
.xx "" "Hello World Rust is good" "language" "" ":1"
```
<img width="716" height="215" alt="image" src="https://github.com/user-attachments/assets/b5c82212-ad04-4120-ad4d-fe8d1957af62" />
