### PR TITLE
ls: Implement locale-aware time formatting for --time-style=locale

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -175,3 +175,8 @@ nofield
 # * clippy
 uninlined
 nonminimal
+
+# * locale and internationalization
+CTYPE
+CLDR
+Guillemets

--- a/src/uu/ls/src/locale_time.rs
+++ b/src/uu/ls/src/locale_time.rs
@@ -1,0 +1,321 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+// spell-checker:ignore (acronyms) CTYPE
+
+//! Locale-specific time format detection and mapping.
+//!
+//! This module provides functionality to determine appropriate time/date format strings
+//! based on the system's locale settings (LC_ALL, LC_TIME, or LANG).
+//!
+//! # Time Format Structure
+//!
+//! Different locales use different date/time conventions:
+//! - Date component ordering: DMY (European), MDY (American), YMD (Asian)
+//! - Time format: 24-hour (military) vs 12-hour (AM/PM)
+//! - Month representation: Abbreviated names vs numbers
+//!
+//! # Format String Pairs
+//!
+//! ls uses two format strings:
+//! - Recent files (modified within last 6 months): Shows month, day, and time
+//! - Older files (modified more than 6 months ago): Shows month, day, and year
+//!
+//! # References
+//!
+//! - POSIX locale specifications
+//! - GNU ls source code (ls.c, timespec format)
+//! - Common Locale Data Repository (CLDR)
+
+use std::env;
+
+/// Returns locale-specific time format strings for ls --time-style=locale.
+///
+/// This function examines the environment variables in the following order:
+/// 1. `LC_ALL` - Overrides all other locale settings
+/// 2. `LC_TIME` - Controls time and date formatting
+/// 3. `LANG` - Default locale setting
+///
+/// # Returns
+///
+/// A tuple of `(recent_format, older_format_option)`:
+/// - `recent_format`: Format for files modified within last 6 months (shows time)
+/// - `older_format`: Optional different format for older files (shows year)
+///
+/// Returns English/POSIX default format for unknown locales.
+///
+/// # Format Code Reference
+///
+/// Common strftime codes used:
+/// - `%b` - Abbreviated month name
+/// - `%d` - Day of month (01-31), zero-padded
+/// - `%e` - Day of month ( 1-31), space-padded
+/// - `%m` - Month number (01-12)
+/// - `%Y` - Year (4 digits)
+/// - `%H` - Hour (00-23), 24-hour format
+/// - `%I` - Hour (01-12), 12-hour format
+/// - `%M` - Minute (00-59)
+/// - `%p` - AM/PM designator
+///
+/// # Examples
+///
+/// ```ignore
+/// use uu_ls::locale_time::get_locale_time_formats;
+///
+/// // With default or English locale
+/// let (recent, older) = get_locale_time_formats();
+/// assert_eq!(recent, "%b %e %H:%M");
+/// assert_eq!(older, Some("%b %e  %Y"));
+/// ```
+///
+/// # Safety
+///
+/// This function only reads environment variables and performs string matching.
+/// All returned format strings are valid strftime format strings.
+pub fn get_locale_time_formats() -> (&'static str, Option<&'static str>) {
+    // Try environment variables in order of precedence
+    let locale = env::var("LC_ALL")
+        .or_else(|_| env::var("LC_TIME"))
+        .or_else(|_| env::var("LANG"))
+        .unwrap_or_default();
+
+    // Parse locale identifier: lang_COUNTRY.encoding@modifier -> lang_COUNTRY
+    // Examples: fr_FR.UTF-8, de_DE@euro, en_US, ja_JP.eucJP
+    let locale = locale
+        .split('.')
+        .next()
+        .unwrap_or(&locale)
+        .split('@')
+        .next()
+        .unwrap_or("");
+
+    map_locale_to_time_formats(locale)
+}
+
+/// Maps a locale identifier to appropriate time format strings.
+///
+/// # Arguments
+///
+/// * `locale` - A locale identifier (e.g., "fr_FR", "de_DE", "ja_JP")
+///
+/// # Returns
+///
+/// A tuple of (recent_format, older_format) strings.
+///
+/// # Locale Format Conventions
+///
+/// This function follows common date/time formatting conventions:
+/// - **European (DMY)**: Day-Month-Year ordering, 24-hour time
+/// - **American (MDY)**: Month-Day-Year ordering, preference varies
+/// - **Asian (YMD)**: Year-Month-Day ordering, 24-hour time
+/// - **Default/POSIX**: Follows traditional Unix ls format
+#[allow(clippy::match_like_matches_macro)] // Clearer as explicit match for documentation
+fn map_locale_to_time_formats(locale: &str) -> (&'static str, Option<&'static str>) {
+    // Extract language code (first 2-3 characters before underscore)
+    let lang = locale.split('_').next().unwrap_or(locale);
+
+    match lang {
+        // English locales (US, GB, AU, etc.) - MDY or DMY
+        // US: Month Day, Year - 12-hour time preference but 24-hour is standard for ls
+        "en" => {
+            if locale.starts_with("en_US") {
+                // American: MDY format
+                ("%b %e %H:%M", Some("%b %e  %Y"))
+            } else {
+                // British/Commonwealth: DMY format
+                ("%d %b %H:%M", Some("%d %b  %Y"))
+            }
+        }
+
+        // Romance languages - typically DMY with 24-hour time
+        // French: DD Mon YYYY HH:MM
+        "fr" => ("%e %b %H:%M", Some("%e %b  %Y")),
+
+        // Spanish: DD Mon YYYY HH:MM
+        "es" => ("%e %b %H:%M", Some("%e %b  %Y")),
+
+        // Italian: DD Mon YYYY HH:MM
+        "it" => ("%e %b %H:%M", Some("%e %b  %Y")),
+
+        // Portuguese: DD/MM HH:MM and DD/MM/YYYY
+        "pt" => ("%d/%m %H:%M", Some("%d/%m/%Y")),
+
+        // Catalan: DD Mon YYYY HH:MM
+        "ca" => ("%e %b %H:%M", Some("%e %b  %Y")),
+
+        // Romanian: DD.MM.YYYY HH:MM
+        "ro" => ("%d.%m %H:%M", Some("%d.%m.%Y")),
+
+        // Germanic languages - typically DMY with 24-hour time
+        // German: DD. Mon YYYY HH:MM
+        "de" => ("%e. %b %H:%M", Some("%e. %b  %Y")),
+
+        // Dutch: DD Mon YYYY HH:MM
+        "nl" => ("%e %b %H:%M", Some("%e %b  %Y")),
+
+        // Danish: DD-MM HH:MM and DD-MM-YYYY
+        "da" => ("%d-%m %H:%M", Some("%d-%m-%Y")),
+
+        // Swedish: DD Mon HH:MM and DD Mon YYYY
+        "sv" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Norwegian: DD. Mon HH:MM and DD. Mon YYYY
+        "no" | "nb" | "nn" => ("%e. %b %H:%M", Some("%e. %b %Y")),
+
+        // Finnish: DD.MM. HH:MM and DD.MM.YYYY
+        "fi" => ("%d.%m. %H:%M", Some("%d.%m.%Y")),
+
+        // Slavic languages - typically DMY with 24-hour time
+        // Russian: DD Mon HH:MM and DD Mon YYYY
+        "ru" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Polish: DD Mon HH:MM and DD Mon YYYY
+        "pl" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Czech: DD. Mon HH:MM and DD. Mon YYYY
+        "cs" => ("%e. %b %H:%M", Some("%e. %b %Y")),
+
+        // Slovak: DD. Mon HH:MM and DD. Mon YYYY
+        "sk" => ("%e. %b %H:%M", Some("%e. %b %Y")),
+
+        // Ukrainian: DD Mon HH:MM and DD Mon YYYY
+        "uk" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Bulgarian: DD.MM. HH:MM and DD.MM.YYYY
+        "bg" => ("%d.%m. %H:%M", Some("%d.%m.%Y")),
+
+        // Serbian: DD. Mon HH:MM and DD. Mon YYYY
+        "sr" => ("%e. %b %H:%M", Some("%e. %b %Y")),
+
+        // Croatian: DD. Mon HH:MM and DD. Mon YYYY
+        "hr" => ("%e. %b %H:%M", Some("%e. %b %Y")),
+
+        // Asian languages - typically YMD with 24-hour time
+        // Japanese: MM月DD日 HH:MM and YYYY年MM月DD日
+        "ja" => ("%m月%d日 %H:%M", Some("%Y年%m月%d日")),
+
+        // Chinese (Simplified and Traditional): MM月DD日 HH:MM and YYYY年MM月DD日
+        "zh" => {
+            if locale.contains("TW") || locale.contains("HK") {
+                // Traditional Chinese: might use different format
+                ("%m月%d日 %H:%M", Some("%Y年%m月%d日"))
+            } else {
+                // Simplified Chinese
+                ("%m月%d日 %H:%M", Some("%Y年%m月%d日"))
+            }
+        }
+
+        // Korean: MM. DD. HH:MM and YYYY. MM. DD.
+        "ko" => ("%m. %d. %H:%M", Some("%Y. %m. %d.")),
+
+        // Other European languages
+        // Greek: DD Mon HH:MM and DD Mon YYYY
+        "el" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Turkish: DD Mon HH:MM and DD Mon YYYY
+        "tr" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Hungarian: Mon DD. HH:MM and YYYY Mon DD.
+        "hu" => ("%b %e. %H:%M", Some("%Y %b %e.")),
+
+        // Baltic languages
+        // Estonian: DD. Mon HH:MM and DD. Mon YYYY
+        "et" => ("%e. %b %H:%M", Some("%e. %b %Y")),
+
+        // Latvian: DD. Mon HH:MM and DD. Mon YYYY
+        "lv" => ("%e. %b %H:%M", Some("%e. %b %Y")),
+
+        // Lithuanian: Mon DD HH:MM and YYYY Mon DD
+        "lt" => ("%b %e %H:%M", Some("%Y %b %e")),
+
+        // Arabic/Hebrew/Persian - RTL languages, typically DMY
+        // Note: Month names will still be English due to %b limitation
+        "ar" | "he" | "fa" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Thai: DD Mon HH:MM and DD Mon YYYY
+        "th" => ("%e %b %H:%M", Some("%e %b %Y")),
+
+        // Vietnamese: Mon DD HH:MM and Mon DD YYYY
+        // Note: Vietnamese traditionally uses DMY, but GNU ls uses MDY format
+        "vi" => ("%b %e %H:%M", Some("%b %e  %Y")),
+
+        // Indonesian/Malay: DD Mon HH:MM and DD Mon YYYY
+        "id" | "ms" => ("%d %b %H:%M", Some("%d %b %Y")),
+
+        // C, POSIX, and default - Traditional Unix ls format
+        "C" | "POSIX" | "" => ("%b %e %H:%M", Some("%b %e  %Y")),
+
+        // Default fallback - POSIX/English format
+        _ => ("%b %e %H:%M", Some("%b %e  %Y")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_english_us() {
+        let (recent, older) = map_locale_to_time_formats("en_US");
+        assert_eq!(recent, "%b %e %H:%M");
+        assert_eq!(older, Some("%b %e  %Y"));
+    }
+
+    #[test]
+    fn test_english_gb() {
+        let (recent, older) = map_locale_to_time_formats("en_GB");
+        assert_eq!(recent, "%d %b %H:%M");
+        assert_eq!(older, Some("%d %b  %Y"));
+    }
+
+    #[test]
+    fn test_french() {
+        let (recent, older) = map_locale_to_time_formats("fr_FR");
+        assert_eq!(recent, "%e %b %H:%M");
+        assert_eq!(older, Some("%e %b  %Y"));
+    }
+
+    #[test]
+    fn test_german() {
+        let (recent, older) = map_locale_to_time_formats("de_DE");
+        assert_eq!(recent, "%e. %b %H:%M");
+        assert_eq!(older, Some("%e. %b  %Y"));
+    }
+
+    #[test]
+    fn test_japanese() {
+        let (recent, older) = map_locale_to_time_formats("ja_JP");
+        assert_eq!(recent, "%m月%d日 %H:%M");
+        assert_eq!(older, Some("%Y年%m月%d日"));
+    }
+
+    #[test]
+    fn test_chinese() {
+        let (recent, older) = map_locale_to_time_formats("zh_CN");
+        assert_eq!(recent, "%m月%d日 %H:%M");
+        assert_eq!(older, Some("%Y年%m月%d日"));
+    }
+
+    #[test]
+    fn test_default_fallback() {
+        let (recent, older) = map_locale_to_time_formats("unknown_XX");
+        assert_eq!(recent, "%b %e %H:%M");
+        assert_eq!(older, Some("%b %e  %Y"));
+    }
+
+    #[test]
+    fn test_posix() {
+        let (recent, older) = map_locale_to_time_formats("POSIX");
+        assert_eq!(recent, "%b %e %H:%M");
+        assert_eq!(older, Some("%b %e  %Y"));
+    }
+
+    #[test]
+    fn test_vietnamese() {
+        let (recent, older) = map_locale_to_time_formats("vi_VN");
+        assert_eq!(recent, "%b %e %H:%M");
+        assert_eq!(older, Some("%b %e  %Y"));
+    }
+}

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -82,6 +82,8 @@ use dired::{DiredOutput, is_dired_arg_present};
 mod colors;
 use crate::options::QUOTING_STYLE;
 use colors::{StyleManager, color_name};
+mod locale_time;
+use locale_time::get_locale_time_formats;
 
 pub mod options {
     pub mod format {
@@ -255,9 +257,6 @@ enum Files {
 }
 
 fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String>), LsError> {
-    // TODO: Using correct locale string is not implemented.
-    const LOCALE_FORMAT: (&str, Option<&str>) = ("%b %e %H:%M", Some("%b %e  %Y"));
-
     // Convert time_styles references to owned String/option.
     fn ok((recent, older): (&str, Option<&str>)) -> Result<(String, Option<String>), LsError> {
         Ok((recent.to_string(), older.map(String::from)))
@@ -284,7 +283,7 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
                 if std::env::var("LC_TIME").unwrap_or_default() == "POSIX"
                     || std::env::var("LC_ALL").unwrap_or_default() == "POSIX"
                 {
-                    return ok(LOCALE_FORMAT);
+                    return ok(get_locale_time_formats());
                 }
                 field
             } else {
@@ -299,7 +298,7 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
                     "%m-%d %H:%M".to_string(),
                     Some(format::ISO.to_string() + " "),
                 )),
-                "locale" => ok(LOCALE_FORMAT),
+                "locale" => ok(get_locale_time_formats()),
                 _ => match field.chars().next().unwrap() {
                     '+' => {
                         // recent/older formats are (optionally) separated by a newline
@@ -318,7 +317,7 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
     } else if options.get_flag(options::FULL_TIME) {
         ok((format::FULL_ISO, None))
     } else {
-        ok(LOCALE_FORMAT)
+        ok(get_locale_time_formats())
     }
 }
 


### PR DESCRIPTION
# ls: Implement locale-aware time formatting for --time-style=locale

## Summary

Implements proper locale-aware date/time formatting for `ls --time-style=locale`. Previously, the format was hardcoded to English regardless of system locale settings.

## Problem

```rust
// TODO: Using correct locale string is not implemented.
const LOCALE_FORMAT: (&str, Option<&str>) = ("%b %e %H:%M", Some("%b %e  %Y"));
```

The `ls` command always showed dates in English format regardless of `LC_ALL`, `LC_TIME`, or `LANG` settings.

## Solution

Created `locale_time` module that:
- Detects locale from `LC_ALL` > `LC_TIME` > `LANG` (POSIX priority order)
- Maps ~40 major locales to appropriate format strings
- Follows regional conventions: DMY (European), MDY (American), YMD (Asian)
- Falls back to POSIX format for unknown locales

## Changes

**New:** `src/uu/ls/src/locale_time.rs` (321 lines)
- `get_locale_time_formats()`: Reads environment and returns format tuple
- `map_locale_to_time_formats()`: Maps locale codes to format strings
- 9 unit tests for major locale families

**Modified:** `src/uu/ls/src/ls.rs`
- Removed hardcoded `LOCALE_FORMAT` constant and TODO
- Replaced with `get_locale_time_formats()` calls

## Supported Locales

**Romance:** fr, es, it, pt, ca, ro  
**Germanic:** de, nl, da, sv, no/nb/nn, fi  
**Slavic:** ru, pl, cs, sk, uk, bg, sr, hr  
**Asian:** ja, zh, ko, vi  
**Other:** el, tr, hu, et, lv, lt, ar, he, fa, th, id, ms, en variants, C, POSIX  

**Total:** ~40 locale mappings with fallback

## Example Output

### English (US) - `en_US.UTF-8`
```
-rw-r--r-- 1 user wheel 0 Jan  1  2024 old_file
-rw-r--r-- 1 user wheel 0 Oct  6 08:08 recent_file
```

### German - `de_DE.UTF-8`
```
-rw-r--r-- 1 user wheel 0  1. Jan  2024 old_file
-rw-r--r-- 1 user wheel 0  6. Oct 08:08 recent_file
```

### Japanese - `ja_JP.UTF-8`
```
-rw-r--r-- 1 user wheel 0 2024年01月01日 old_file
-rw-r--r-- 1 user wheel 0 10月06日 08:08 recent_file
```

### Vietnamese - `vi_VN.UTF-8`
```
-rw-r--r-- 1 user wheel 0 Jan 15  2024 old_file
-rw-r--r-- 1 user wheel 0 Oct  6 08:13 recent_file
```

## Implementation Notes

**Why not use jiff's `%x`, `%X`, `%c`?**  
The `jiff` crate doesn't support locale-aware format codes because it doesn't access system locale databases.

**Approach:**  
Created a mapping module (similar to existing `locale_quotes`) that detects locale from environment variables and maps to appropriate strftime format strings. This is simple, maintainable, and compatible with jiff.

## Limitations

- Month names are always in English ("Jan", "Feb", etc.) due to jiff's strftime
- Full locale-aware month/day names would require system locale database integration
