### PR TITLE
ci: fix broken CICD workflow

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -473,7 +473,9 @@ jobs:
         # strip the results
         strip target/size*/usr/local/bin/*
     - name: Test for hardlinks
-      run: [ $(stat -c %i target/size-multi-release/usr/local/bin/cp) = $(stat -c %i target/size-multi-release/usr/local/bin/coreutils) ]
+      shell: bash
+      run: |
+        [ $(stat -c %i target/size-multi-release/usr/local/bin/cp) = $(stat -c %i target/size-multi-release/usr/local/bin/coreutils) ]
     - name: Compute uutil release sizes
       shell: bash
       run: |
@@ -1284,10 +1286,10 @@ jobs:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    
+
     - name: Build SELinux utilities as stubs
       run: cargo build -p uu_chcon -p uu_runcon
-        
+
     - name: Verify stub binaries exist
       shell: bash
       run: |
@@ -1298,7 +1300,7 @@ jobs:
           test -f target/debug/chcon || exit 1
           test -f target/debug/runcon || exit 1
         fi
-        
+
     - name: Verify workspace builds with stubs
       run: cargo build --features ${{ matrix.job.features }}
 


### PR DESCRIPTION
This PR is an attempt to make the `CICD.yml` workflow work again. It currently fails with the following error and none of its checks are executed.
```
[Invalid workflow file: .github/workflows/CICD.yml#L1](https://github.com/uutils/coreutils/actions/runs/18274741656/workflow)
(Line: 476, Col: 12): A sequence was not expected
```