### PR TITLE
clippy: move `use_self` lint to workspace lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,7 +623,6 @@ missing_panics_doc = "allow"
 # TODO remove when https://github.com/rust-lang/rust-clippy/issues/13774 is fixed
 large_stack_arrays = "allow"
 
-use_self = "warn"
 needless_pass_by_value = "warn"
 semicolon_if_nothing_returned = "warn"
 single_char_pattern = "warn"
@@ -653,6 +652,7 @@ pedantic = { level = "deny", priority = -1 }
 all = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
+use_self = "warn"                            # nursery lint
 cargo_common_metadata = "allow"              # 3240
 multiple_crate_versions = "allow"            # 2882
 missing_errors_doc = "allow"                 # 1572

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -63,7 +63,7 @@ impl LineNumber {
 
         buf[print_start..].copy_from_slice(init_str.as_bytes());
 
-        LineNumber {
+        Self {
             buf,
             print_start,
             num_start,

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -41,8 +41,8 @@ enum FileNumber {
 impl FileNumber {
     fn as_str(&self) -> &'static str {
         match self {
-            FileNumber::One => "1",
-            FileNumber::Two => "2",
+            Self::One => "1",
+            Self::Two => "2",
         }
     }
 }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -175,11 +175,11 @@ impl Default for ReflinkMode {
     fn default() -> Self {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
         {
-            ReflinkMode::Auto
+            Self::Auto
         }
         #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         {
-            ReflinkMode::Never
+            Self::Never
         }
     }
 }

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -202,9 +202,9 @@ struct Cell {
 
 impl Cell {
     /// Create a cell, knowing that s contains only 1-length chars
-    fn from_ascii_string<T: AsRef<str>>(s: T) -> Cell {
+    fn from_ascii_string<T: AsRef<str>>(s: T) -> Self {
         let s = s.as_ref();
-        Cell {
+        Self {
             bytes: s.as_bytes().into(),
             width: s.len(),
         }
@@ -212,17 +212,17 @@ impl Cell {
 
     /// Create a cell from an unknown origin string that may contain
     /// wide characters.
-    fn from_string<T: AsRef<str>>(s: T) -> Cell {
+    fn from_string<T: AsRef<str>>(s: T) -> Self {
         let s = s.as_ref();
-        Cell {
+        Self {
             bytes: s.as_bytes().into(),
             width: UnicodeWidthStr::width(s),
         }
     }
 
     /// Create a cell from an `OsString`
-    fn from_os_string(os: &OsString) -> Cell {
-        Cell {
+    fn from_os_string(os: &OsString) -> Self {
+        Self {
             bytes: uucore::os_str_as_bytes(os).unwrap().to_vec(),
             width: UnicodeWidthStr::width(os.to_string_lossy().as_ref()),
         }

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -72,7 +72,7 @@ pub enum EnvError {
 
 impl From<string_parser::Error> for EnvError {
     fn from(value: string_parser::Error) -> Self {
-        EnvError::EnvInternalError(value.peek_position, value)
+        Self::EnvInternalError(value.peek_position, value)
     }
 }
 

--- a/src/uu/head/src/take.rs
+++ b/src/uu/head/src/take.rs
@@ -16,7 +16,7 @@ struct TakeAllBuffer {
 
 impl TakeAllBuffer {
     fn new() -> Self {
-        TakeAllBuffer {
+        Self {
             buffer: vec![],
             start_index: 0,
         }
@@ -151,7 +151,7 @@ struct BytesAndLines {
 
 impl TakeAllLinesBuffer {
     fn new() -> Self {
-        TakeAllLinesBuffer {
+        Self {
             inner: TakeAllBuffer::new(),
             terminated_lines: 0,
             partial_line: false,

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -40,7 +40,7 @@ enum MoreError {
 impl std::fmt::Display for MoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            MoreError::IsDirectory(path) => {
+            Self::IsDirectory(path) => {
                 write!(
                     f,
                     "{}",
@@ -50,7 +50,7 @@ impl std::fmt::Display for MoreError {
                     )
                 )
             }
-            MoreError::CannotOpenNoSuchFile(path) => {
+            Self::CannotOpenNoSuchFile(path) => {
                 write!(
                     f,
                     "{}",
@@ -60,7 +60,7 @@ impl std::fmt::Display for MoreError {
                     )
                 )
             }
-            MoreError::CannotOpenIOError(path, error) => {
+            Self::CannotOpenIOError(path, error) => {
                 write!(
                     f,
                     "{}",
@@ -71,7 +71,7 @@ impl std::fmt::Display for MoreError {
                     )
                 )
             }
-            MoreError::BadUsage => {
+            Self::BadUsage => {
                 write!(f, "{}", translate!("more-error-bad-usage"))
             }
         }
@@ -325,15 +325,15 @@ enum InputType {
 impl InputType {
     fn read_line(&mut self, buf: &mut String) -> std::io::Result<usize> {
         match self {
-            InputType::File(reader) => reader.read_line(buf),
-            InputType::Stdin(stdin) => stdin.read_line(buf),
+            Self::File(reader) => reader.read_line(buf),
+            Self::Stdin(stdin) => stdin.read_line(buf),
         }
     }
 
     fn len(&self) -> std::io::Result<Option<u64>> {
         let len = match self {
-            InputType::File(reader) => Some(reader.get_ref().metadata()?.len()),
-            InputType::Stdin(_) => None,
+            Self::File(reader) => Some(reader.get_ref().metadata()?.len()),
+            Self::Stdin(_) => None,
         };
         Ok(len)
     }
@@ -907,7 +907,7 @@ mod tests {
         type Target = Vec<u8>;
         fn deref(&self) -> &Vec<u8> {
             match self {
-                OutputType::Test(buf) => buf,
+                Self::Test(buf) => buf,
                 _ => unreachable!(),
             }
         }
@@ -916,7 +916,7 @@ mod tests {
     impl DerefMut for OutputType {
         fn deref_mut(&mut self) -> &mut Vec<u8> {
             match self {
-                OutputType::Test(buf) => buf,
+                Self::Test(buf) => buf,
                 _ => unreachable!(),
             }
         }

--- a/src/uu/mv/src/hardlink.rs
+++ b/src/uu/mv/src/hardlink.rs
@@ -53,11 +53,11 @@ pub enum HardlinkError {
 impl std::fmt::Display for HardlinkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            HardlinkError::Io(e) => write!(f, "I/O error during hardlink operation: {e}"),
-            HardlinkError::Scan(msg) => {
+            Self::Io(e) => write!(f, "I/O error during hardlink operation: {e}"),
+            Self::Scan(msg) => {
                 write!(f, "Failed to scan files for hardlinks: {msg}")
             }
-            HardlinkError::Preservation { source, target } => {
+            Self::Preservation { source, target } => {
                 write!(
                     f,
                     "Failed to preserve hardlink: {} -> {}",
@@ -65,7 +65,7 @@ impl std::fmt::Display for HardlinkError {
                     target.display()
                 )
             }
-            HardlinkError::Metadata { path, error } => {
+            Self::Metadata { path, error } => {
                 write!(f, "Metadata access error for {}: {}", path.display(), error)
             }
         }
@@ -75,8 +75,8 @@ impl std::fmt::Display for HardlinkError {
 impl std::error::Error for HardlinkError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            HardlinkError::Io(e) => Some(e),
-            HardlinkError::Metadata { error, .. } => Some(error),
+            Self::Io(e) => Some(e),
+            Self::Metadata { error, .. } => Some(error),
             _ => None,
         }
     }
@@ -84,7 +84,7 @@ impl std::error::Error for HardlinkError {
 
 impl From<io::Error> for HardlinkError {
     fn from(error: io::Error) -> Self {
-        HardlinkError::Io(error)
+        Self::Io(error)
     }
 }
 
@@ -92,14 +92,14 @@ impl From<HardlinkError> for io::Error {
     fn from(error: HardlinkError) -> Self {
         match error {
             HardlinkError::Io(e) => e,
-            HardlinkError::Scan(msg) => io::Error::other(msg),
-            HardlinkError::Preservation { source, target } => io::Error::other(format!(
+            HardlinkError::Scan(msg) => Self::other(msg),
+            HardlinkError::Preservation { source, target } => Self::other(format!(
                 "Failed to preserve hardlink: {} -> {}",
                 source.display(),
                 target.display()
             )),
 
-            HardlinkError::Metadata { path, error } => io::Error::other(format!(
+            HardlinkError::Metadata { path, error } => Self::other(format!(
                 "Metadata access error for {}: {}",
                 path.display(),
                 error

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -271,7 +271,7 @@ enum DelimiterState<'a> {
 }
 
 impl<'a> DelimiterState<'a> {
-    fn new(unescaped_and_encoded_delimiters: &'a [Box<[u8]>]) -> DelimiterState<'a> {
+    fn new(unescaped_and_encoded_delimiters: &'a [Box<[u8]>]) -> Self {
         match unescaped_and_encoded_delimiters {
             [] => DelimiterState::NoDelimiters,
             [only_delimiter] => {
@@ -364,8 +364,8 @@ enum InputSource {
 impl InputSource {
     fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> UResult<usize> {
         let us = match self {
-            InputSource::File(bu) => bu.read_until(byte, buf)?,
-            InputSource::StandardInput(rc) => rc
+            Self::File(bu) => bu.read_until(byte, buf)?,
+            Self::StandardInput(rc) => rc
                 .try_borrow()
                 .map_err(|bo| {
                     USimpleError::new(1, translate!("paste-error-stdin-borrow", "error" => bo))

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -183,9 +183,9 @@ impl std::str::FromStr for QuotingStyle {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "locale" => Ok(QuotingStyle::Locale),
-            "shell" => Ok(QuotingStyle::Shell),
-            "shell-escape-always" => Ok(QuotingStyle::ShellEscapeAlways),
+            "locale" => Ok(Self::Locale),
+            "shell" => Ok(Self::Shell),
+            "shell-escape-always" => Ok(Self::ShellEscapeAlways),
             // The others aren't exposed to the user
             _ => Err(StatError::InvalidQuotingStyle {
                 style: s.to_string(),

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -132,7 +132,7 @@ struct Graph<'input> {
 }
 
 impl<'input> Graph<'input> {
-    fn new(name: String) -> Graph<'input> {
+    fn new(name: String) -> Self {
         Self {
             name,
             nodes: HashMap::default(),

--- a/src/uucore/src/lib/features/buf_copy/common.rs
+++ b/src/uucore/src/lib/features/buf_copy/common.rs
@@ -15,8 +15,8 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::WriteError(msg) => write!(f, "splice() write error: {msg}"),
-            Error::Io(err) => write!(f, "I/O error: {err}"),
+            Self::WriteError(msg) => write!(f, "splice() write error: {msg}"),
+            Self::Io(err) => write!(f, "I/O error: {err}"),
         }
     }
 }

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -319,9 +319,9 @@ impl FileChecksumResult {
     /// either succeeded or failed.
     fn from_bool(checksum_correct: bool) -> Self {
         if checksum_correct {
-            FileChecksumResult::Ok
+            Self::Ok
         } else {
-            FileChecksumResult::Failed
+            Self::Failed
         }
     }
 
@@ -329,9 +329,9 @@ impl FileChecksumResult {
     /// comparison on STDOUT.
     fn can_display(&self, verbose: ChecksumVerbose) -> bool {
         match self {
-            FileChecksumResult::Ok => verbose.over_quiet(),
-            FileChecksumResult::Failed => verbose.over_status(),
-            FileChecksumResult::CantOpen => true,
+            Self::Ok => verbose.over_quiet(),
+            Self::Failed => verbose.over_status(),
+            Self::CantOpen => true,
         }
     }
 }
@@ -339,9 +339,9 @@ impl FileChecksumResult {
 impl Display for FileChecksumResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FileChecksumResult::Ok => write!(f, "OK"),
-            FileChecksumResult::Failed => write!(f, "FAILED"),
-            FileChecksumResult::CantOpen => write!(f, "FAILED open or read"),
+            Self::Ok => write!(f, "OK"),
+            Self::Failed => write!(f, "FAILED"),
+            Self::CantOpen => write!(f, "FAILED open or read"),
         }
     }
 }
@@ -557,7 +557,7 @@ impl LineFormat {
             algo_bit_len: algo_bits,
             checksum: checksum_utf8,
             filename: filename.to_vec(),
-            format: LineFormat::AlgoBased,
+            format: Self::AlgoBased,
         })
     }
 
@@ -587,7 +587,7 @@ impl LineFormat {
             algo_bit_len: None,
             checksum: checksum_utf8,
             filename: filename.to_vec(),
-            format: LineFormat::Untagged,
+            format: Self::Untagged,
         })
     }
 
@@ -619,7 +619,7 @@ impl LineFormat {
             algo_bit_len: None,
             checksum: checksum_utf8,
             filename: filename.to_vec(),
-            format: LineFormat::SingleSpace,
+            format: Self::SingleSpace,
         })
     }
 }

--- a/src/uucore/src/lib/features/extendedbigdecimal.rs
+++ b/src/uucore/src/lib/features/extendedbigdecimal.rs
@@ -83,20 +83,20 @@ impl From<f64> for ExtendedBigDecimal {
     fn from(val: f64) -> Self {
         if val.is_nan() {
             if val.is_sign_negative() {
-                ExtendedBigDecimal::MinusNan
+                Self::MinusNan
             } else {
-                ExtendedBigDecimal::Nan
+                Self::Nan
             }
         } else if val.is_infinite() {
             if val.is_sign_negative() {
-                ExtendedBigDecimal::MinusInfinity
+                Self::MinusInfinity
             } else {
-                ExtendedBigDecimal::Infinity
+                Self::Infinity
             }
         } else if val.is_zero() && val.is_sign_negative() {
-            ExtendedBigDecimal::MinusZero
+            Self::MinusZero
         } else {
-            ExtendedBigDecimal::BigDecimal(BigDecimal::from_f64(val).unwrap())
+            Self::BigDecimal(BigDecimal::from_f64(val).unwrap())
         }
     }
 }
@@ -124,7 +124,7 @@ impl ExtendedBigDecimal {
 
     pub fn to_biguint(&self) -> Option<BigUint> {
         match self {
-            ExtendedBigDecimal::BigDecimal(big_decimal) => {
+            Self::BigDecimal(big_decimal) => {
                 let (bi, scale) = big_decimal.as_bigint_and_scale();
                 if bi.is_negative() || scale > 0 || scale < -(u32::MAX as i64) {
                     return None;

--- a/src/uucore/src/lib/features/format/escape.rs
+++ b/src/uucore/src/lib/features/format/escape.rs
@@ -35,8 +35,8 @@ enum Base {
 impl Base {
     fn as_base(&self) -> u8 {
         match self {
-            Base::Oct(_) => 8,
-            Base::Hex => 16,
+            Self::Oct(_) => 8,
+            Self::Hex => 16,
         }
     }
 

--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -84,8 +84,8 @@ impl From<std::io::Error> for FormatError {
 }
 
 impl From<NonUtf8OsStrError> for FormatError {
-    fn from(value: NonUtf8OsStrError) -> FormatError {
-        FormatError::InvalidEncoding(value)
+    fn from(value: NonUtf8OsStrError) -> Self {
+        Self::InvalidEncoding(value)
     }
 }
 

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -130,10 +130,10 @@ impl From<&str> for MetadataTimeField {
     /// not supported), and the default branch should not be reached.
     fn from(value: &str) -> Self {
         match value {
-            "ctime" | "status" => MetadataTimeField::Change,
-            "access" | "atime" | "use" => MetadataTimeField::Access,
-            "mtime" | "modification" => MetadataTimeField::Modification,
-            "birth" | "creation" => MetadataTimeField::Birth,
+            "ctime" | "status" => Self::Change,
+            "access" | "atime" | "use" => Self::Access,
+            "mtime" | "modification" => Self::Modification,
+            "birth" | "creation" => Self::Birth,
             // below should never happen as clap already restricts the values.
             _ => unreachable!("Invalid metadata time field."),
         }

--- a/src/uucore/src/lib/features/parser/num_parser.rs
+++ b/src/uucore/src/lib/features/parser/num_parser.rs
@@ -156,12 +156,10 @@ where
         }
 
         match self {
-            ExtendedParserError::NotNumeric => ExtendedParserError::NotNumeric,
-            ExtendedParserError::PartialMatch(v, rest) => {
-                ExtendedParserError::PartialMatch(extract(f(v)), rest)
-            }
-            ExtendedParserError::Overflow(v) => ExtendedParserError::Overflow(extract(f(v))),
-            ExtendedParserError::Underflow(v) => ExtendedParserError::Underflow(extract(f(v))),
+            Self::NotNumeric => ExtendedParserError::NotNumeric,
+            Self::PartialMatch(v, rest) => ExtendedParserError::PartialMatch(extract(f(v)), rest),
+            Self::Overflow(v) => ExtendedParserError::Overflow(extract(f(v))),
+            Self::Underflow(v) => ExtendedParserError::Underflow(extract(f(v))),
         }
     }
 }
@@ -179,7 +177,7 @@ pub trait ExtendedParser {
 
 impl ExtendedParser for i64 {
     /// Parse a number as i64. No fractional part is allowed.
-    fn extended_parse(input: &str) -> Result<i64, ExtendedParserError<i64>> {
+    fn extended_parse(input: &str) -> Result<Self, ExtendedParserError<Self>> {
         fn into_i64(ebd: ExtendedBigDecimal) -> Result<i64, ExtendedParserError<i64>> {
             match ebd {
                 ExtendedBigDecimal::BigDecimal(bd) => {
@@ -214,7 +212,7 @@ impl ExtendedParser for i64 {
 
 impl ExtendedParser for u64 {
     /// Parse a number as u64. No fractional part is allowed.
-    fn extended_parse(input: &str) -> Result<u64, ExtendedParserError<u64>> {
+    fn extended_parse(input: &str) -> Result<Self, ExtendedParserError<Self>> {
         fn into_u64(ebd: ExtendedBigDecimal) -> Result<u64, ExtendedParserError<u64>> {
             match ebd {
                 ExtendedBigDecimal::BigDecimal(bd) => {
@@ -251,7 +249,7 @@ impl ExtendedParser for u64 {
 
 impl ExtendedParser for f64 {
     /// Parse a number as f64
-    fn extended_parse(input: &str) -> Result<f64, ExtendedParserError<f64>> {
+    fn extended_parse(input: &str) -> Result<Self, ExtendedParserError<Self>> {
         fn into_f64(ebd: ExtendedBigDecimal) -> Result<f64, ExtendedParserError<f64>> {
             // TODO: _Some_ of this is generic, so this should probably be implemented as an ExtendedBigDecimal trait (ToPrimitive).
             let v = match ebd {
@@ -283,9 +281,7 @@ impl ExtendedParser for f64 {
 
 impl ExtendedParser for ExtendedBigDecimal {
     /// Parse a number as an ExtendedBigDecimal
-    fn extended_parse(
-        input: &str,
-    ) -> Result<ExtendedBigDecimal, ExtendedParserError<ExtendedBigDecimal>> {
+    fn extended_parse(input: &str) -> Result<Self, ExtendedParserError<Self>> {
         parse(input, ParseTarget::Decimal, &[])
     }
 }

--- a/src/uucore/src/lib/features/safe_traversal.rs
+++ b/src/uucore/src/lib/features/safe_traversal.rs
@@ -66,7 +66,7 @@ pub enum SafeTraversalError {
 impl From<SafeTraversalError> for io::Error {
     fn from(err: SafeTraversalError) -> Self {
         match err {
-            SafeTraversalError::PathContainsNull => io::Error::new(
+            SafeTraversalError::PathContainsNull => Self::new(
                 io::ErrorKind::InvalidInput,
                 translate!("safe-traversal-error-path-contains-null"),
             ),
@@ -117,7 +117,7 @@ impl DirFd {
             }
         })?;
 
-        Ok(DirFd { fd })
+        Ok(Self { fd })
     }
 
     /// Open a subdirectory relative to this directory
@@ -133,7 +133,7 @@ impl DirFd {
             }
         })?;
 
-        Ok(DirFd { fd })
+        Ok(Self { fd })
     }
 
     /// Get raw stat data for a file relative to this directory
@@ -284,7 +284,7 @@ impl DirFd {
         }
         // SAFETY: We've verified fd >= 0, and the caller is transferring ownership
         let owned_fd = unsafe { OwnedFd::from_raw_fd(fd) };
-        Ok(DirFd { fd: owned_fd })
+        Ok(Self { fd: owned_fd })
     }
 }
 
@@ -345,23 +345,23 @@ pub enum FileType {
 impl FileType {
     pub fn from_mode(mode: libc::mode_t) -> Self {
         match mode & libc::S_IFMT {
-            libc::S_IFDIR => FileType::Directory,
-            libc::S_IFREG => FileType::RegularFile,
-            libc::S_IFLNK => FileType::Symlink,
-            _ => FileType::Other,
+            libc::S_IFDIR => Self::Directory,
+            libc::S_IFREG => Self::RegularFile,
+            libc::S_IFLNK => Self::Symlink,
+            _ => Self::Other,
         }
     }
 
     pub fn is_directory(&self) -> bool {
-        matches!(self, FileType::Directory)
+        matches!(self, Self::Directory)
     }
 
     pub fn is_regular_file(&self) -> bool {
-        matches!(self, FileType::RegularFile)
+        matches!(self, Self::RegularFile)
     }
 
     pub fn is_symlink(&self) -> bool {
-        matches!(self, FileType::Symlink)
+        matches!(self, Self::Symlink)
     }
 }
 

--- a/src/uucore/src/lib/features/selinux.rs
+++ b/src/uucore/src/lib/features/selinux.rs
@@ -31,7 +31,7 @@ pub enum SeLinuxError {
 }
 
 impl From<SeLinuxError> for i32 {
-    fn from(error: SeLinuxError) -> i32 {
+    fn from(error: SeLinuxError) -> Self {
         match error {
             SeLinuxError::SELinuxNotEnabled => 1,
             SeLinuxError::FileOpenFailure(_) => 2,

--- a/src/uucore/src/lib/features/systemd_logind.rs
+++ b/src/uucore/src/lib/features/systemd_logind.rs
@@ -524,7 +524,7 @@ pub struct SystemdUtmpxCompat {
 impl SystemdUtmpxCompat {
     /// Create new instance from a SystemdLoginRecord
     pub fn new(record: SystemdLoginRecord) -> Self {
-        SystemdUtmpxCompat { record }
+        Self { record }
     }
 
     /// A.K.A. ut.ut_type
@@ -596,7 +596,7 @@ impl SystemdUtmpxIter {
     /// Create new instance and read records from systemd-logind
     pub fn new() -> UResult<Self> {
         let records = read_login_records()?;
-        Ok(SystemdUtmpxIter {
+        Ok(Self {
             records,
             current_index: 0,
         })
@@ -604,7 +604,7 @@ impl SystemdUtmpxIter {
 
     /// Create empty iterator (for when systemd initialization fails)
     pub fn empty() -> Self {
-        SystemdUtmpxIter {
+        Self {
             records: Vec::new(),
             current_index: 0,
         }

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -412,63 +412,63 @@ impl UtmpxRecord {
     /// A.K.A. ut.ut_type
     pub fn record_type(&self) -> i16 {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.record_type(),
+            Self::Traditional(utmpx) => utmpx.record_type(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.record_type(),
+            Self::Systemd(systemd) => systemd.record_type(),
         }
     }
 
     /// A.K.A. ut.ut_pid
     pub fn pid(&self) -> i32 {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.pid(),
+            Self::Traditional(utmpx) => utmpx.pid(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.pid(),
+            Self::Systemd(systemd) => systemd.pid(),
         }
     }
 
     /// A.K.A. ut.ut_id
     pub fn terminal_suffix(&self) -> String {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.terminal_suffix(),
+            Self::Traditional(utmpx) => utmpx.terminal_suffix(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.terminal_suffix(),
+            Self::Systemd(systemd) => systemd.terminal_suffix(),
         }
     }
 
     /// A.K.A. ut.ut_user
     pub fn user(&self) -> String {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.user(),
+            Self::Traditional(utmpx) => utmpx.user(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.user(),
+            Self::Systemd(systemd) => systemd.user(),
         }
     }
 
     /// A.K.A. ut.ut_host
     pub fn host(&self) -> String {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.host(),
+            Self::Traditional(utmpx) => utmpx.host(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.host(),
+            Self::Systemd(systemd) => systemd.host(),
         }
     }
 
     /// A.K.A. ut.ut_line
     pub fn tty_device(&self) -> String {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.tty_device(),
+            Self::Traditional(utmpx) => utmpx.tty_device(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.tty_device(),
+            Self::Systemd(systemd) => systemd.tty_device(),
         }
     }
 
     /// A.K.A. ut.ut_tv
     pub fn login_time(&self) -> time::OffsetDateTime {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.login_time(),
+            Self::Traditional(utmpx) => utmpx.login_time(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.login_time(),
+            Self::Systemd(systemd) => systemd.login_time(),
         }
     }
 
@@ -477,27 +477,27 @@ impl UtmpxRecord {
     /// Return (e_termination, e_exit)
     pub fn exit_status(&self) -> (i16, i16) {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.exit_status(),
+            Self::Traditional(utmpx) => utmpx.exit_status(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.exit_status(),
+            Self::Systemd(systemd) => systemd.exit_status(),
         }
     }
 
     /// check if the record is a user process
     pub fn is_user_process(&self) -> bool {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.is_user_process(),
+            Self::Traditional(utmpx) => utmpx.is_user_process(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.is_user_process(),
+            Self::Systemd(systemd) => systemd.is_user_process(),
         }
     }
 
     /// Canonicalize host name using DNS
     pub fn canon_host(&self) -> IOResult<String> {
         match self {
-            UtmpxRecord::Traditional(utmpx) => utmpx.canon_host(),
+            Self::Traditional(utmpx) => utmpx.canon_host(),
             #[cfg(feature = "feat_systemd_logind")]
-            UtmpxRecord::Systemd(systemd) => systemd.canon_host(),
+            Self::Systemd(systemd) => systemd.canon_host(),
         }
     }
 }

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -559,19 +559,19 @@ pub enum CharByte {
 
 impl From<char> for CharByte {
     fn from(value: char) -> Self {
-        CharByte::Char(value)
+        Self::Char(value)
     }
 }
 
 impl From<u8> for CharByte {
     fn from(value: u8) -> Self {
-        CharByte::Byte(value)
+        Self::Byte(value)
     }
 }
 
 impl From<&u8> for CharByte {
     fn from(value: &u8) -> Self {
-        CharByte::Byte(*value)
+        Self::Byte(*value)
     }
 }
 
@@ -588,7 +588,7 @@ impl Iterator for Utf8ChunkIterator<'_> {
 }
 
 impl<'a> From<Utf8Chunk<'a>> for Utf8ChunkIterator<'a> {
-    fn from(chk: Utf8Chunk<'a>) -> Utf8ChunkIterator<'a> {
+    fn from(chk: Utf8Chunk<'a>) -> Self {
         Self {
             iter: Box::new(
                 chk.valid()
@@ -609,7 +609,7 @@ pub struct CharByteIterator<'a> {
 impl<'a> CharByteIterator<'a> {
     /// Make a `CharByteIterator` from a byte slice.
     /// [`CharByteIterator`]
-    pub fn new(input: &'a [u8]) -> CharByteIterator<'a> {
+    pub fn new(input: &'a [u8]) -> Self {
         Self {
             iter: Box::new(input.utf8_chunks().flat_map(Utf8ChunkIterator::from)),
         }

--- a/src/uucore/src/lib/mods/clap_localization.rs
+++ b/src/uucore/src/lib/mods/clap_localization.rs
@@ -31,9 +31,9 @@ pub enum Color {
 impl Color {
     fn code(self) -> &'static str {
         match self {
-            Color::Red => "31",
-            Color::Yellow => "33",
-            Color::Green => "32",
+            Self::Red => "31",
+            Self::Yellow => "33",
+            Self::Green => "32",
         }
     }
 }

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -42,7 +42,7 @@ pub enum LocalizationError {
 
 impl From<std::io::Error> for LocalizationError {
     fn from(error: std::io::Error) -> Self {
-        LocalizationError::Io {
+        Self::Io {
             source: error,
             path: PathBuf::from("<unknown>"),
         }


### PR DESCRIPTION
This PR moves the [use_self](https://rust-lang.github.io/rust-clippy/stable/index.html#use_self) lint from `lints.clippy` to `workspace.lints.clippy` in `Cargo.toml` and fixes its warnings.