### PR TITLE
tests/timeout: remove unnecessary stderr check for test_kill_subprocess

### DIFF
--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -192,8 +192,7 @@ fn test_kill_subprocess() {
             "trap 'echo inside_trap' TERM; sleep 30",
         ])
         .fails_with_code(124)
-        .stdout_contains("inside_trap")
-        .stderr_contains("Terminated");
+        .stdout_contains("inside_trap");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #8844 .

`test_timeout::test_kill_subprocess` now passes, as it was already producing the correct output.