### PR TITLE
ci: add `apt-get update` to `code-quality` workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -110,6 +110,7 @@ jobs:
         ## Install/setup prerequisites
         case '${{ matrix.job.os }}' in
           ubuntu-*)
+            sudo apt-get -y update
             # selinux and systemd headers needed to enable all features
             sudo apt-get -y install libselinux1-dev libsystemd-dev
           ;;


### PR DESCRIPTION
This PR runs `apt-get update` before running `apt-get install` in the `code-quality` workflow.