### PR TITLE
hashsum: improve hashsum using 32KiB bufreader

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -31,6 +31,7 @@ use uucore::sum::{Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shak
 use uucore::translate;
 
 const NAME: &str = "hashsum";
+// Using the same read buffer size as GNU
 const READ_BUFFER_SIZE: usize = 32 * 1024;
 
 struct Options<'a> {


### PR DESCRIPTION
Hello,

In my WSL environment, I found that gnu md5sum was faster than coreutils md5sum. So I investigated via strace and found that GNU used 32KiB size buffers while coreutils used 8KiB as shown below to read files. This PR aims to do the same, there by closing the performance gap to an extent.

md5sum
```bash
truncate -s 10M nullbytes
strace md5sum nullbytes 
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 32768) = 32768

strace ./coreutils_main hashsum --md5 nullbytes
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 8192) = 8192
```

Version details
```bash
md5sum --version
md5sum (GNU coreutils) 9.4
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Ulrich Drepper, Scott Miller, and David Madore.
```

With this PR I dont much improvement when compared to main branch for smaller inputs. Its only for larger inputs that we will notice anything.

<details>

<summary>Benchmarks when compared to main</summary>

```bash
truncate -s 1K nullbytes;
hyperfine --warmup 3 "./coreutils_main hashsum --md5 nullbytes" "./coreutils_patch hashsum --md5 nullbytes";
Benchmark 1: ./coreutils_main hashsum --md5 nullbytes
  Time (mean ± σ):      11.3 ms ±   0.3 ms    [User: 1.4 ms, System: 0.8 ms]
  Range (min … max):     9.7 ms …  12.9 ms    243 runs

Benchmark 2: ./coreutils_patch hashsum --md5 nullbytes
  Time (mean ± σ):      10.8 ms ±   0.9 ms    [User: 1.4 ms, System: 0.8 ms]
  Range (min … max):     9.0 ms …  12.2 ms    243 runs

Summary
  ./coreutils_patch hashsum --md5 nullbytes ran

truncate -s 10K nullbytes;
hyperfine --warmup 3 "./coreutils_main hashsum --md5 nullbytes" "./coreutils_patch hashsum --md5 nullbytes";
Benchmark 1: ./coreutils_main hashsum --md5 nullbytes
  Time (mean ± σ):      11.5 ms ±   0.4 ms    [User: 1.5 ms, System: 0.8 ms]
  Range (min … max):     9.3 ms …  12.2 ms    232 runs

Benchmark 2: ./coreutils_patch hashsum --md5 nullbytes
  Time (mean ± σ):      11.2 ms ±   0.6 ms    [User: 1.5 ms, System: 0.7 ms]
  Range (min … max):     8.9 ms …  12.4 ms    248 runs

Summary
  ./coreutils_patch hashsum --md5 nullbytes ran
    1.02 ± 0.06 times faster than ./coreutils_main hashsum --md5 nullbytes

truncate -s 100K nullbytes;
hyperfine --warmup 3 "./coreutils_main hashsum --md5 nullbytes" "./coreutils_patch hashsum --md5 nullbytes";
Benchmark 1: ./coreutils_main hashsum --md5 nullbytes
  Time (mean ± σ):      13.0 ms ±   0.3 ms    [User: 1.7 ms, System: 0.8 ms]
  Range (min … max):    12.4 ms …  14.0 ms    206 runs

Benchmark 2: ./coreutils_patch hashsum --md5 nullbytes
  Time (mean ± σ):      12.0 ms ±   0.3 ms    [User: 1.5 ms, System: 0.9 ms]
  Range (min … max):    11.4 ms …  13.4 ms    231 runs

Summary
  ./coreutils_patch hashsum --md5 nullbytes ran
    1.08 ± 0.03 times faster than ./coreutils_main hashsum --md5 nullbytes

truncate -s 1M nullbytes;
hyperfine --warmup 3 "./coreutils_main hashsum --md5 nullbytes" "./coreutils_patch hashsum --md5 nullbytes";
Benchmark 1: ./coreutils_main hashsum --md5 nullbytes
  Time (mean ± σ):      27.9 ms ±   0.4 ms    [User: 2.8 ms, System: 2.4 ms]
  Range (min … max):    27.1 ms …  29.1 ms    102 runs

Benchmark 2: ./coreutils_patch hashsum --md5 nullbytes
  Time (mean ± σ):      17.3 ms ±   0.4 ms    [User: 2.8 ms, System: 1.2 ms]
  Range (min … max):    15.0 ms …  18.4 ms    165 runs

Summary
  ./coreutils_patch hashsum --md5 nullbytes ran
    1.61 ± 0.04 times faster than ./coreutils_main hashsum --md5 nullbytes

truncate -s 10M nullbytes;
hyperfine --warmup 3 "./coreutils_main hashsum --md5 nullbytes" "./coreutils_patch hashsum --md5 nullbytes";
Benchmark 1: ./coreutils_main hashsum --md5 nullbytes
  Time (mean ± σ):     181.7 ms ±   2.2 ms    [User: 18.6 ms, System: 13.8 ms]
  Range (min … max):   174.8 ms … 183.8 ms    16 runs

Benchmark 2: ./coreutils_patch hashsum --md5 nullbytes
  Time (mean ± σ):      69.6 ms ±   3.5 ms    [User: 15.3 ms, System: 4.3 ms]
  Range (min … max):    60.3 ms …  73.2 ms    40 runs

Summary
  ./coreutils_patch hashsum --md5 nullbytes ran
    2.61 ± 0.13 times faster than ./coreutils_main hashsum --md5 nullbytes
```

</details>

Even with this PR, I still find that GNU hashsum is still 20% faster in my system for very large inputs.

```bash
truncate -s 10M nullbytes;
hyperfine --warmup 3 "./coreutils_patch hashsum --md5 nullbytes" "md5sum nullbytes"
Benchmark 1: ./coreutils_patch hashsum --md5 nullbytes
  Time (mean ± σ):      69.1 ms ±   1.1 ms    [User: 15.8 ms, System: 4.3 ms]
  Range (min … max):    66.9 ms …  71.2 ms    42 runs

Benchmark 2: md5sum nullbytes
  Time (mean ± σ):      57.7 ms ±   1.7 ms    [User: 13.1 ms, System: 2.6 ms]
  Range (min … max):    51.0 ms …  61.3 ms    50 runs

Summary
  md5sum nullbytes ran
    1.20 ± 0.04 times faster than ./coreutils_patch hashsum --md5 nullbytes
```


Since I am doing this with WSL, it would be nice if others could also check this patch once on there linux systems.

