### PR TITLE
Drop redundant || exit 1

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1210,7 +1210,7 @@ jobs:
         for f in $(util/show-utils.sh ${CARGO_FEATURES_OPTION})
         do
           echo "Building and testing $f"
-          cargo test -p "uu_$f" || exit 1
+          cargo test -p "uu_$f"
         done
 
   test_all_features:
@@ -1300,11 +1300,11 @@ jobs:
       shell: bash
       run: |
         if [ "${{ runner.os }}" = "Windows" ]; then
-          test -f target/debug/chcon.exe || exit 1
-          test -f target/debug/runcon.exe || exit 1
+          test -f target/debug/chcon.exe
+          test -f target/debug/runcon.exe
         else
-          test -f target/debug/chcon || exit 1
-          test -f target/debug/runcon || exit 1
+          test -f target/debug/chcon
+          test -f target/debug/runcon
         fi
     - name: Verify workspace builds with stubs
       run: cargo build --features ${{ matrix.job.features }}


### PR DESCRIPTION
If commands failed, it returns non 0 exit code and Ci stops by it.