### PR TITLE
doc: add `-h` & `-V` to extensions

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -22,6 +22,9 @@ We support a third way:
 $ ls -w=80
 ```
 
+With GNU coreutils, `--help` usually prints the help message and `--version` prints the version.
+We also commonly provide short options: `-h` for help and `-V` for version.
+
 ## `env`
 
 GNU `env` allows the empty string to be used as an environment variable name.
@@ -51,7 +54,7 @@ etc.).
 
 This utility does not exist in GNU coreutils. The behavior is modeled after both
 the `b2sum` utility of GNU and the
-[`b3sum`](https://github.com/BLAKE3-team/BLAKE3) utility by the BLAKE3 team. It also 
+[`b3sum`](https://github.com/BLAKE3-team/BLAKE3) utility by the BLAKE3 team. It also
 supports the `--no-names` option, that does not appear in the GNU utility.
 
 ## `more`


### PR DESCRIPTION
This PR adds the short options `-h` (for `--help`) and `-V` (for `--version`), which are provided by `clap`, to the extensions documentation.