### PR TITLE
clippy: re-enable `manual_let_else` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -628,7 +628,6 @@ semicolon_if_nothing_returned = "warn"
 single_char_pattern = "warn"
 explicit_iter_loop = "warn"
 if_not_else = "warn"
-manual_let_else = "warn"
 
 all = { level = "deny", priority = -1 }
 cargo = { level = "warn", priority = -1 }
@@ -695,7 +694,6 @@ enum_glob_use = "allow"
 ptr_cast_constness = "allow"
 borrow_as_ptr = "allow"
 ptr_as_ptr = "allow"
-manual_let_else = "allow"
 unnecessary_semicolon = "allow"
 needless_raw_string_hashes = "allow"
 unreadable_literal = "allow"

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -122,18 +122,14 @@ impl<'a> FormatArguments<'a> {
     {
         // If this fails (this can only happens on Windows), then just
         // return NotNumeric.
-        let s = match os_str_as_bytes(os) {
-            Ok(s) => s,
-            Err(_) => return Err(ExtendedParserError::NotNumeric),
+        let Ok(s) = os_str_as_bytes(os) else {
+            return Err(ExtendedParserError::NotNumeric);
         };
 
-        let bytes = match s.split_first() {
-            Some((b'"', bytes)) | Some((b'\'', bytes)) => bytes,
-            _ => {
-                // This really can't happen, the string we are given must start with '/".
-                debug_assert!(false);
-                return Err(ExtendedParserError::NotNumeric);
-            }
+        let (Some((b'"', bytes)) | Some((b'\'', bytes))) = s.split_first() else {
+            // This really can't happen, the string we are given must start with '/".
+            debug_assert!(false);
+            return Err(ExtendedParserError::NotNumeric);
         };
 
         if bytes.is_empty() {

--- a/src/uucore/src/lib/features/systemd_logind.rs
+++ b/src/uucore/src/lib/features/systemd_logind.rs
@@ -350,9 +350,8 @@ pub fn read_login_records() -> UResult<Vec<SystemdLoginRecord>> {
     // Iterate through all sessions
     for session_id in sessions {
         // Get session UID using safe wrapper
-        let uid = match login::get_session_uid(&session_id) {
-            Ok(uid) => uid,
-            Err(_) => continue,
+        let Ok(uid) = login::get_session_uid(&session_id) else {
+            continue;
         };
 
         // Get username from UID


### PR DESCRIPTION
This PR re-enables the [manual_let_else](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else) lint  and fixes three warnings in `uucore`.