### PR TITLE
uucore: ringbuffer pre-allocates memory based on size given

### DIFF
--- a/src/uucore/src/lib/features/ringbuffer.rs
+++ b/src/uucore/src/lib/features/ringbuffer.rs
@@ -43,17 +43,13 @@ use std::collections::VecDeque;
 pub struct RingBuffer<T> {
     /// The data stored in the ring buffer.
     pub data: VecDeque<T>,
-
-    /// The maximum number of elements that the ring buffer can hold.
-    size: usize,
 }
 
 impl<T> RingBuffer<T> {
     /// Create a new ring buffer with a maximum size of `size`.
     pub fn new(size: usize) -> Self {
         Self {
-            data: VecDeque::new(),
-            size,
+            data: VecDeque::with_capacity(size),
         }
     }
 
@@ -100,10 +96,10 @@ impl<T> RingBuffer<T> {
     /// assert_eq!(Some(2), buf.push_back(2));
     /// ```
     pub fn push_back(&mut self, value: T) -> Option<T> {
-        if self.size == 0 {
+        if self.data.capacity() == 0 {
             return Some(value);
         }
-        let result = if self.size <= self.data.len() {
+        let result = if self.data.len() == self.data.capacity() {
             self.data.pop_front()
         } else {
             None


### PR DESCRIPTION
This PR makes a slight change to the existing code in uucore/features/ringbuffer.rs. 

Currently, the `RingBuffer<T>` struct's `new()` function creates the ringbuffer with an empty `VecDeque<T>` that does not reserve a certain capacity for elements. Internally, `VecDeque<T>` resizes and copies the element of its buffer to a new double sized buffer when it's at capacity and `push_back()` call is invoked. For a fixed-size ringbuffer, instead of paying the cost of resizing the buffer at every power of 2, we can pay the cost of directly allocating exactly the memory we want from the requested size in the `new()` function upfront to avoid resizing. It also removes the need for a `size` field in the `RingBuffer<T>` struct because `VecDeque<T>` has a `capacity()` method that tells you how many items the buffer can contain without reallocating.