### PR TITLE
Cargo.toml: remove `lints.clippy` section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -616,25 +616,10 @@ strip = true
 inherits = "release"
 debug = true
 
-[lints.clippy]
-multiple_crate_versions = "allow"
-cargo_common_metadata = "allow"
-missing_panics_doc = "allow"
-# TODO remove when https://github.com/rust-lang/rust-clippy/issues/13774 is fixed
-large_stack_arrays = "allow"
-
-needless_pass_by_value = "warn"
-semicolon_if_nothing_returned = "warn"
-single_char_pattern = "warn"
-explicit_iter_loop = "warn"
-if_not_else = "warn"
-
-all = { level = "deny", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-pedantic = { level = "deny", priority = -1 }
+[lints]
+workspace = true
 
 # This is the linting configuration for all crates.
-# Eventually the clippy settings from the `[lints]` section should be moved here.
 # In order to use these, all crates have `[lints] workspace = true` section.
 [workspace.lints.rust]
 # Allow "fuzzing" as a "cfg" condition name


### PR DESCRIPTION
This PR removes the `lints.clippy` section as the settings have been moved to the `workspace.lints.clippy` section in the meantime.