### PR TITLE
chore: huge clippy pass ahead of 1.92.0 release

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -133,7 +133,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let cmode = if let Some(parsed_cmode) = parsed_cmode {
         parsed_cmode
     } else {
-        modes.unwrap().to_string() // modes is required
+        modes.unwrap().to_owned() // modes is required
     };
     let mut files: Vec<OsString> = matches
         .get_many::<OsString>(options::FILE)

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -411,22 +411,22 @@ fn set_context(options: &Options) -> UResult<()> {
             let gid = uid as libc::gid_t;
             let strategy = Strategy::FromUID(uid, false);
             set_supplemental_gids_with_strategy(strategy, options.groups.as_ref())?;
-            set_gid(gid).map_err(|e| ChrootError::SetGidFailed(user.to_string(), e))?;
-            set_uid(uid).map_err(|e| ChrootError::SetUserFailed(user.to_string(), e))?;
+            set_gid(gid).map_err(|e| ChrootError::SetGidFailed(user.to_owned(), e))?;
+            set_uid(uid).map_err(|e| ChrootError::SetUserFailed(user.to_owned(), e))?;
         }
         Some(UserSpec::GroupOnly(group)) => {
             let gid = name_to_gid(group)?;
             let strategy = Strategy::Nothing;
             set_supplemental_gids_with_strategy(strategy, options.groups.as_ref())?;
-            set_gid(gid).map_err(|e| ChrootError::SetGidFailed(group.to_string(), e))?;
+            set_gid(gid).map_err(|e| ChrootError::SetGidFailed(group.to_owned(), e))?;
         }
         Some(UserSpec::UserAndGroup(user, group)) => {
             let uid = name_to_uid(user)?;
             let gid = name_to_gid(group)?;
             let strategy = Strategy::FromUID(uid, true);
             set_supplemental_gids_with_strategy(strategy, options.groups.as_ref())?;
-            set_gid(gid).map_err(|e| ChrootError::SetGidFailed(group.to_string(), e))?;
-            set_uid(uid).map_err(|e| ChrootError::SetUserFailed(user.to_string(), e))?;
+            set_gid(gid).map_err(|e| ChrootError::SetGidFailed(group.to_owned(), e))?;
+            set_uid(uid).map_err(|e| ChrootError::SetUserFailed(user.to_owned(), e))?;
         }
     }
     Ok(())

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -613,12 +613,10 @@ fn build_dir(
             0
         } as u32;
 
-        let umask = if copy_attributes_from.is_some()
-            && matches!(options.attributes.mode, Preserve::Yes { .. })
+        let umask = if let (Some(from), Preserve::Yes { .. }) =
+            (copy_attributes_from, options.attributes.mode)
         {
-            !fs::symlink_metadata(copy_attributes_from.unwrap())?
-                .permissions()
-                .mode()
+            !fs::symlink_metadata(from)?.permissions().mode()
         } else {
             uucore::mode::get_umask()
         };

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1519,6 +1519,7 @@ fn copy_source(
 // This fix adds yet another metadata read.
 // Should this metadata be read once and then reused throughout the execution?
 // https://github.com/uutils/coreutils/issues/6658
+#[allow(clippy::if_not_else)]
 fn file_mode_for_interactive_overwrite(
     #[cfg_attr(not(unix), allow(unused_variables))] path: &Path,
 ) -> Option<(String, String)> {

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -172,7 +172,7 @@ where
                         // the error happened when applying the pattern more than once
                         Err(CsplitError::LineOutOfRange(_)) if ith != 1 => {
                             return Err(CsplitError::LineOutOfRangeOnRepetition(
-                                pattern_as_str.to_string(),
+                                pattern_as_str,
                                 ith - 1,
                             ));
                         }
@@ -204,7 +204,7 @@ where
                         // the error happened when applying the pattern more than once
                         (Err(CsplitError::MatchNotFound(_)), Some(m)) if m != 1 && ith != 1 => {
                             return Err(CsplitError::MatchNotFoundOnRepetition(
-                                pattern_as_str.to_string(),
+                                pattern_as_str,
                                 ith - 1,
                             ));
                         }
@@ -623,7 +623,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let patterns: Vec<String> = matches
         .get_many::<String>(options::PATTERN)
         .unwrap()
-        .map(|s| s.to_string())
+        .map(ToOwned::to_owned)
         .collect();
     let options = CsplitOptions::new(&matches)?;
     if file_name == "-" {

--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -140,17 +140,17 @@ fn extract_patterns(args: &[String]) -> Result<Vec<Pattern>, CsplitError> {
             };
             if let Some(up_to_match) = captures.name("UPTO") {
                 let pattern = Regex::new(up_to_match.as_str())
-                    .map_err(|_| CsplitError::InvalidPattern(arg.to_string()))?;
+                    .map_err(|_| CsplitError::InvalidPattern(arg.to_owned()))?;
                 patterns.push(Pattern::UpToMatch(pattern, offset, execute_ntimes));
             } else if let Some(skip_to_match) = captures.name("SKIPTO") {
                 let pattern = Regex::new(skip_to_match.as_str())
-                    .map_err(|_| CsplitError::InvalidPattern(arg.to_string()))?;
+                    .map_err(|_| CsplitError::InvalidPattern(arg.to_owned()))?;
                 patterns.push(Pattern::SkipToMatch(pattern, offset, execute_ntimes));
             }
         } else if let Ok(line_number) = arg.parse::<usize>() {
             patterns.push(Pattern::UpToLine(line_number, execute_ntimes));
         } else {
-            return Err(CsplitError::InvalidPattern(arg.to_string()));
+            return Err(CsplitError::InvalidPattern(arg.to_owned()));
         }
     }
     Ok(patterns)

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -163,10 +163,7 @@ impl Options {
             block_size: read_block_size(matches).map_err(|e| match e {
                 ParseSizeError::InvalidSuffix(s) => OptionsError::InvalidSuffix(s),
                 ParseSizeError::SizeTooBig(_) => OptionsError::BlockSizeTooLarge(
-                    matches
-                        .get_one::<String>(OPT_BLOCKSIZE)
-                        .unwrap()
-                        .to_string(),
+                    matches.get_one::<String>(OPT_BLOCKSIZE).unwrap().to_owned(),
                 ),
                 ParseSizeError::ParseFailure(s) => OptionsError::InvalidBlockSize(s),
                 ParseSizeError::PhysicalMem(s) => OptionsError::InvalidBlockSize(s),

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -51,10 +51,7 @@ pub(crate) enum FsError {
 /// `mounts` after mount that has the same `mount_dir`.
 #[cfg(not(windows))]
 fn is_over_mounted(mounts: &[MountInfo], mount: &MountInfo) -> bool {
-    let last_mount_for_dir = mounts
-        .iter()
-        .filter(|m| m.mount_dir == mount.mount_dir)
-        .next_back();
+    let last_mount_for_dir = mounts.iter().rfind(|m| m.mount_dir == mount.mount_dir);
 
     if let Some(lmi) = last_mount_for_dir {
         lmi.dev_name != mount.dev_name

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -343,7 +343,9 @@ impl<'a> RowFormatter<'a> {
 }
 
 /// A `HeaderMode` defines what header labels should be shown.
+#[derive(Default)]
 pub(crate) enum HeaderMode {
+    #[default]
     Default,
     // the user used -h or -H
     HumanReadable,
@@ -351,12 +353,6 @@ pub(crate) enum HeaderMode {
     PosixPortability,
     // the user used --output
     Output,
-}
-
-impl Default for HeaderMode {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 /// The data of the header row.

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -530,17 +530,13 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
             head_file(&mut file_handle, options)?;
             Ok(())
         };
-        if let Err(e) = res {
+        if let Err(err) = res {
             let name = if file == "-" {
                 "standard input".to_string()
             } else {
                 file.to_string_lossy().into_owned()
             };
-            return Err(HeadError::Io {
-                name: name.to_string(),
-                err: e,
-            }
-            .into());
+            return Err(HeadError::Io { name, err }.into());
         }
         first = false;
     }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -214,7 +214,7 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
 
     let delimiter = args.get_one::<String>(DELIMITER).map_or(Ok(None), |arg| {
         if arg.len() == 1 {
-            Ok(Some(arg.to_string()))
+            Ok(Some(arg.to_owned()))
         } else {
             Err(translate!(
                 "numfmt-error-delimiter-must-be-single-character"

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -406,7 +406,7 @@ fn parse_usize(matches: &ArgMatches, opt: &str) -> Option<Result<usize, PrError>
     };
     matches
         .get_one::<String>(opt)
-        .map(|i| (i.to_string(), format!("-{opt}")))
+        .map(|i| (i.to_owned(), format!("-{opt}")))
         .map(from_parse_error_to_pr_error)
 }
 

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -152,7 +152,7 @@ impl WordFilter {
                     if v.is_empty() {
                         None
                     } else {
-                        Some(v.to_string())
+                        Some(v.to_owned())
                     }
                 }
                 None => None,
@@ -227,16 +227,16 @@ fn get_config(matches: &clap::ArgMatches) -> UResult<Config> {
     config.right_ref = matches.get_flag(options::RIGHT_SIDE_REFS);
     config.ignore_case = matches.get_flag(options::IGNORE_CASE);
     if matches.contains_id(options::MACRO_NAME) {
-        config.macro_name = matches
+        matches
             .get_one::<String>(options::MACRO_NAME)
             .expect(err_msg)
-            .to_string();
+            .clone_into(&mut config.macro_name);
     }
     if matches.contains_id(options::FLAG_TRUNCATION) {
-        config.trunc_str = matches
+        matches
             .get_one::<String>(options::FLAG_TRUNCATION)
             .expect(err_msg)
-            .to_string();
+            .clone_into(&mut config.trunc_str);
     }
     if matches.contains_id(options::WIDTH) {
         config.line_width = matches

--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -123,7 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let first = if numbers.len() > 1 {
         match numbers[0].parse() {
             Ok(num) => num,
-            Err(e) => return Err(SeqError::ParseError(numbers[0].to_string(), e).into()),
+            Err(e) => return Err(SeqError::ParseError(numbers[0].to_owned(), e).into()),
         }
     } else {
         PreciseNumber::one()
@@ -131,13 +131,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let increment = if numbers.len() > 2 {
         match numbers[1].parse() {
             Ok(num) => num,
-            Err(e) => return Err(SeqError::ParseError(numbers[1].to_string(), e).into()),
+            Err(e) => return Err(SeqError::ParseError(numbers[1].to_owned(), e).into()),
         }
     } else {
         PreciseNumber::one()
     };
     if increment.is_zero() {
-        return Err(SeqError::ZeroIncrement(numbers[1].to_string()).into());
+        return Err(SeqError::ZeroIncrement(numbers[1].to_owned()).into());
     }
     let last: PreciseNumber = {
         // We are guaranteed that `numbers.len()` is greater than zero
@@ -146,7 +146,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let n: usize = numbers.len();
         match numbers[n - 1].parse() {
             Ok(num) => num,
-            Err(e) => return Err(SeqError::ParseError(numbers[n - 1].to_string(), e).into()),
+            Err(e) => return Err(SeqError::ParseError(numbers[n - 1].to_owned(), e).into()),
         }
     };
 

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -291,7 +291,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let force = matches.get_flag(options::FORCE);
     let size_arg = matches
         .get_one::<String>(options::SIZE)
-        .map(|s| s.to_string());
+        .map(ToOwned::to_owned);
     let size = get_size(size_arg);
     let exact = matches.get_flag(options::EXACT) || size.is_some();
     let zero = matches.get_flag(options::ZERO);

--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -153,7 +153,7 @@ impl Suffix {
                 if let Some(opt) = matches.get_one::<String>(OPT_NUMERIC_SUFFIXES) {
                     start = opt
                         .parse::<usize>()
-                        .map_err(|_| SuffixError::NotParsable(opt.to_string()))?;
+                        .map_err(|_| SuffixError::NotParsable(opt.to_owned()))?;
                     auto_widening = false;
                 }
             }
@@ -162,7 +162,7 @@ impl Suffix {
                 // if option was specified, but without value - this will return None as there is no default value
                 if let Some(opt) = matches.get_one::<String>(OPT_HEX_SUFFIXES) {
                     start = usize::from_str_radix(opt, 16)
-                        .map_err(|_| SuffixError::NotParsable(opt.to_string()))?;
+                        .map_err(|_| SuffixError::NotParsable(opt.to_owned()))?;
                     auto_widening = false;
                 }
             }
@@ -177,7 +177,7 @@ impl Suffix {
                 // suffix length was specified in command line
                 (
                     v.parse::<usize>()
-                        .map_err(|_| SuffixError::NotParsable(v.to_string()))?,
+                        .map_err(|_| SuffixError::NotParsable(v.to_owned()))?,
                     true,
                 )
             } else {

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -485,9 +485,9 @@ impl Settings {
 
         let io_blksize: Option<u64> = if let Some(s) = matches.get_one::<String>(OPT_IO_BLKSIZE) {
             match parse_size_u64(s) {
-                Ok(0) => return Err(SettingsError::InvalidIOBlockSize(s.to_string())),
+                Ok(0) => return Err(SettingsError::InvalidIOBlockSize(s.to_owned())),
                 Ok(n) if n <= uucore::fs::sane_blksize::MAX => Some(n),
-                _ => return Err(SettingsError::InvalidIOBlockSize(s.to_string())),
+                _ => return Err(SettingsError::InvalidIOBlockSize(s.to_owned())),
             }
         } else {
             None

--- a/src/uu/split/src/strategy.rs
+++ b/src/uu/split/src/strategy.rs
@@ -229,7 +229,7 @@ impl Strategy {
             if n > 0 {
                 Ok(strategy(n))
             } else {
-                Err(error(ParseSizeError::ParseFailure(s.to_string())))
+                Err(error(ParseSizeError::ParseFailure(s.to_owned())))
             }
         }
         // Check that the user is not specifying more than one strategy.

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1170,12 +1170,12 @@ impl Stater {
                         process_token_filesystem(t, &meta, &display_name);
                     }
                 }
-                Err(e) => {
+                Err(error) => {
                     show_error!(
                         "{}",
                         StatError::CannotReadFilesystemInfo {
                             file: display_name.quote().to_string(),
-                            error: e.to_string()
+                            error
                         }
                     );
                     return 1;

--- a/src/uucore/src/lib/features/checksum.rs
+++ b/src/uucore/src/lib/features/checksum.rs
@@ -150,10 +150,11 @@ impl From<ChecksumError> for FileCheckError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy, Default)]
 pub enum ChecksumVerbose {
     Status,
     Quiet,
+    #[default]
     Normal,
     Warning,
 }
@@ -185,12 +186,6 @@ impl ChecksumVerbose {
     #[inline]
     pub fn at_least_warning(self) -> bool {
         self >= Self::Warning
-    }
-}
-
-impl Default for ChecksumVerbose {
-    fn default() -> Self {
-        Self::Normal
     }
 }
 

--- a/src/uucore/src/lib/features/selinux.rs
+++ b/src/uucore/src/lib/features/selinux.rs
@@ -120,7 +120,7 @@ pub fn set_selinux_security_context(
         // Create a CString from the provided context string
         let c_context = std::ffi::CString::new(ctx_str.as_str()).map_err(|e| {
             SeLinuxError::ContextConversionFailure(
-                ctx_str.to_string(),
+                ctx_str.to_owned(),
                 selinux_error_description(&e),
             )
         })?;
@@ -129,7 +129,7 @@ pub fn set_selinux_security_context(
         let security_context =
             selinux::OpaqueSecurityContext::from_c_str(&c_context).map_err(|e| {
                 SeLinuxError::ContextConversionFailure(
-                    ctx_str.to_string(),
+                    ctx_str.to_owned(),
                     selinux_error_description(&e),
                 )
             })?;
@@ -138,7 +138,7 @@ pub fn set_selinux_security_context(
         SecurityContext::from_c_str(
             &security_context.to_c_string().map_err(|e| {
                 SeLinuxError::ContextConversionFailure(
-                    ctx_str.to_string(),
+                    ctx_str.to_owned(),
                     selinux_error_description(&e),
                 )
             })?,
@@ -146,7 +146,7 @@ pub fn set_selinux_security_context(
         )
         .set_for_path(path, false, false)
         .map_err(|e| {
-            SeLinuxError::ContextSetFailure(ctx_str.to_string(), selinux_error_description(&e))
+            SeLinuxError::ContextSetFailure(ctx_str.to_owned(), selinux_error_description(&e))
         })
     } else {
         // If no context provided, set the default SELinux context for the path
@@ -569,12 +569,12 @@ mod tests {
             .expect("Failed to get security context.");
         let symlink_context = get_selinux_security_context(&symlink_path, false)
             .expect("Failed to get security context.");
-        assert_ne!(file_context.to_string(), symlink_context.to_string());
+        assert_ne!(file_context, symlink_context);
 
         // Context must be the same if we follow the link
         let symlink_follow_context = get_selinux_security_context(&symlink_path, true)
             .expect("Failed to get security context.");
-        assert_eq!(file_context.to_string(), symlink_follow_context.to_string());
+        assert_eq!(file_context, symlink_follow_context);
     }
 
     #[test]

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -275,7 +275,7 @@ impl Utmpx {
             }
         }
 
-        Ok(host.to_string())
+        Ok(host)
     }
 
     /// Iterate through all the utmp records.

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -1068,7 +1068,6 @@ invalid-syntax = This is { $missing
     #[test]
     fn test_arabic_localization_with_macro() {
         std::thread::spawn(|| {
-            use self::translate;
             let temp_dir = create_test_locales_dir();
             let locale = LanguageIdentifier::from_str("ar-SA").unwrap();
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2374,7 +2374,11 @@ fn test_cp_no_preserve_timestamps() {
     println!("creation {creation:?} / {creation2:?}");
 
     assert_ne!(creation, creation2);
-    let res = creation.elapsed().unwrap() - creation2.elapsed().unwrap();
+    let res = creation
+        .elapsed()
+        .unwrap()
+        .checked_sub(creation2.elapsed().unwrap())
+        .unwrap();
     // Some margins with time check
     assert!(res.as_secs() > 3595);
     assert!(res.as_secs() < 3605);

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1353,15 +1353,15 @@ fn test_ls_long_symlink_color() {
         expected_target: &str,
     ) {
         // Names are always compared.
-        assert_eq!(&name, &expected_name);
-        assert_eq!(&target, &expected_target);
+        assert_eq!(name, expected_name);
+        assert_eq!(target, expected_target);
 
         // Colors are only compared when we have inferred what color we are looking for.
-        if expected_name_color.is_some() {
-            assert_eq!(&name_color, &expected_name_color.unwrap());
+        if let Some(name) = expected_name_color {
+            assert_eq!(name_color, name);
         }
-        if expected_target_color.is_some() {
-            assert_eq!(&target_color, &expected_target_color.unwrap());
+        if let Some(name) = expected_target_color {
+            assert_eq!(target_color, name);
         }
     }
 


### PR DESCRIPTION
It appears clippy is getting some new lints that hit us quite hard, so I fixed what's available right now to get ahead of it; mostly so that next month we don't have to deal with CI fails and potential conflicts in every PR imaginable. It's mostly changing calls of `to_string()` in `&String` types to `to_owned()` or `clone()`, using `if let` when in the condition's body there is a refutable `unwrap()` and some unnecessary `clone()`s have been removed.