### PR TITLE
test(nohup): improve coverage for fd replacement and error paths

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -94,6 +94,7 @@ nonportable
 nonprinting
 nonseekable
 notrunc
+nowrite
 noxfer
 ofile
 oflag


### PR DESCRIPTION
Working on issue #1857 about nohup test coverage.

**What's here:**
- Added 6 tests covering the main code paths that weren't tested
- Tests validate output file creation, HOME fallback, stderr redirection, and exit codes

**The uncovered lines:**
[Line 119](https://github.com/uutils/coreutils/blob/96fde9ed51f92c37d8bf75f7673dd57e5fb332f0/src/uu/nohup/src/nohup.rs#L119) (and similar at [L110](https://github.com/uutils/coreutils/blob/96fde9ed51f92c37d8bf75f7673dd57e5fb332f0/src/uu/nohup/src/nohup.rs#L110), [L124](https://github.com/uutils/coreutils/blob/96fde9ed51f92c37d8bf75f7673dd57e5fb332f0/src/uu/nohup/src/nohup.rs#L124)) are `dup2()` syscall error paths. These only trigger if the kernel fails to duplicate file descriptors - basically unreachable without fault injection tools. I documented this in the coverage analysis.

The remaining uncovered lines are defensive error handling that's realistically untestable in the current test environment. IMO they should stay as-is - better to have defensive code than risk removing safety checks.