### PR TITLE
GNUmakefile: move `du` & `touch` to `PROGS`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -107,6 +107,7 @@ PROGS       := \
 	dir \
 	dircolors \
 	dirname \
+	du \
 	echo \
 	env \
 	expand \
@@ -151,6 +152,7 @@ PROGS       := \
 	tail \
 	tee \
 	test \
+	touch \
 	tr \
 	true \
 	truncate \
@@ -168,7 +170,6 @@ UNIX_PROGS := \
 	chmod \
 	chown \
 	chroot \
-	du \
 	groups \
 	hostid \
 	hostname \
@@ -186,7 +187,6 @@ UNIX_PROGS := \
 	stdbuf \
 	stty \
 	timeout \
-	touch \
 	tty \
 	uname \
 	unlink \


### PR DESCRIPTION
While reviewing https://github.com/uutils/coreutils/pull/8925 I noticed that `du` and `touch` are listed as `UNIX_PROGS` whereas in `Cargo.toml` they are not listed under a unix-specific feature. There they are listed under `feat_common_core`, like the majority of utils.

Assuming the settings in `Cargo.toml` are correct, this PR moves `du` and `touch` to the `PROGS` list.