### PR TITLE
ls: fix zero block size handling to match GNU ls

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -68,7 +68,7 @@ use uucore::{
     line_ending::LineEnding,
     os_str_as_bytes_lossy,
     parser::parse_glob,
-    parser::parse_size::parse_size_u64,
+    parser::parse_size::parse_size_non_zero_u64,
     parser::shortcut_value_parser::ShortcutValueParser,
     quoting_style::{QuotingStyle, locale_aware_escape_dir_name, locale_aware_escape_name},
     show, show_error, show_warning,
@@ -902,7 +902,7 @@ impl Config {
 
         let (file_size_block_size, block_size) = if !opt_si && !opt_hr && !raw_block_size.is_empty()
         {
-            match parse_size_u64(&raw_block_size.to_string_lossy()) {
+            match parse_size_non_zero_u64(&raw_block_size.to_string_lossy()) {
                 Ok(size) => match (is_env_var_blocksize, opt_kb) {
                     (true, true) => (DEFAULT_FILE_SIZE_BLOCK_SIZE, DEFAULT_BLOCK_SIZE),
                     (true, false) => (DEFAULT_FILE_SIZE_BLOCK_SIZE, size),

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5355,6 +5355,12 @@ fn test_ls_invalid_block_size() {
         .fails_with_code(2)
         .no_stdout()
         .stderr_is("ls: invalid --block-size argument 'invalid'\n");
+
+    new_ucmd!()
+        .arg("--block-size=0")
+        .fails_with_code(2)
+        .no_stdout()
+        .stderr_is("ls: invalid --block-size argument '0'\n");
 }
 
 #[cfg(all(unix, feature = "dd"))]
@@ -5391,6 +5397,14 @@ fn test_ls_invalid_block_size_in_env_var() {
         .ucmd()
         .arg("-og")
         .env("BLOCKSIZE", "invalid")
+        .succeeds()
+        .stdout_contains_line("total 4")
+        .stdout_contains(" 1024 ");
+
+    scene
+        .ucmd()
+        .arg("-og")
+        .env("BLOCKSIZE", "0")
         .succeeds()
         .stdout_contains_line("total 4")
         .stdout_contains(" 1024 ");


### PR DESCRIPTION
Fixes #8917 