### PR TITLE
fuzz: enable debug symbols in release builds

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,6 +18,11 @@ license = "MIT"
 [package.metadata]
 cargo-fuzz = true
 
+# Enable debug symbols in release builds for readable backtraces
+# when fuzzing discovers crashes. This addresses issue #5343.
+[profile.release]
+debug = true
+
 [dependencies]
 libfuzzer-sys = "0.4.7"
 rand = { version = "0.9.0", features = ["small_rng"] }


### PR DESCRIPTION
When fuzzing discovers crashes, backtraces only show memory addresses like `0xc03481` instead of function names and line numbers. Makes debugging really hard.

This adds `debug = true` to the release profile in `fuzz/Cargo.toml`. Now backtraces will include symbols while keeping the release optimizations.

Fixes #5343