### PR TITLE
Reduce variance in sort benchmarks by reusing temp file

### DIFF
--- a/src/uu/sort/benches/sort_locale_bench.rs
+++ b/src/uu/sort/benches/sort_locale_bench.rs
@@ -14,16 +14,17 @@ use uucore::benchmark::{run_util_function, setup_test_file, text_data};
 fn sort_ascii_c_locale(bencher: Bencher) {
     let data = text_data::generate_ascii_data_simple(100_000);
     let file_path = setup_test_file(&data);
+    // Reuse the same output file across iterations to reduce filesystem variance
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
 
     bencher.bench(|| {
         unsafe {
             env::set_var("LC_ALL", "C");
         }
-        let output_file = NamedTempFile::new().unwrap();
-        let output_path = output_file.path().to_str().unwrap();
         black_box(run_util_function(
             uumain,
-            &["-o", output_path, file_path.to_str().unwrap()],
+            &["-o", &output_path, file_path.to_str().unwrap()],
         ));
     });
 }
@@ -33,16 +34,17 @@ fn sort_ascii_c_locale(bencher: Bencher) {
 fn sort_ascii_utf8_locale(bencher: Bencher) {
     let data = text_data::generate_ascii_data_simple(200_000);
     let file_path = setup_test_file(&data);
+    // Reuse the same output file across iterations to reduce filesystem variance
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
 
     bencher.bench(|| {
         unsafe {
             env::set_var("LC_ALL", "en_US.UTF-8");
         }
-        let output_file = NamedTempFile::new().unwrap();
-        let output_path = output_file.path().to_str().unwrap();
         black_box(run_util_function(
             uumain,
-            &["-o", output_path, file_path.to_str().unwrap()],
+            &["-o", &output_path, file_path.to_str().unwrap()],
         ));
     });
 }
@@ -52,16 +54,17 @@ fn sort_ascii_utf8_locale(bencher: Bencher) {
 fn sort_mixed_c_locale(bencher: Bencher) {
     let data = text_data::generate_mixed_locale_data(50_000);
     let file_path = setup_test_file(&data);
+    // Reuse the same output file across iterations to reduce filesystem variance
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
 
     bencher.bench(|| {
         unsafe {
             env::set_var("LC_ALL", "C");
         }
-        let output_file = NamedTempFile::new().unwrap();
-        let output_path = output_file.path().to_str().unwrap();
         black_box(run_util_function(
             uumain,
-            &["-o", output_path, file_path.to_str().unwrap()],
+            &["-o", &output_path, file_path.to_str().unwrap()],
         ));
     });
 }
@@ -71,16 +74,17 @@ fn sort_mixed_c_locale(bencher: Bencher) {
 fn sort_mixed_utf8_locale(bencher: Bencher) {
     let data = text_data::generate_mixed_locale_data(50_000);
     let file_path = setup_test_file(&data);
+    // Reuse the same output file across iterations to reduce filesystem variance
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
 
     bencher.bench(|| {
         unsafe {
             env::set_var("LC_ALL", "en_US.UTF-8");
         }
-        let output_file = NamedTempFile::new().unwrap();
-        let output_path = output_file.path().to_str().unwrap();
         black_box(run_util_function(
             uumain,
-            &["-o", output_path, file_path.to_str().unwrap()],
+            &["-o", &output_path, file_path.to_str().unwrap()],
         ));
     });
 }
@@ -90,16 +94,17 @@ fn sort_mixed_utf8_locale(bencher: Bencher) {
 fn sort_german_c_locale(bencher: Bencher) {
     let data = text_data::generate_german_locale_data(50_000);
     let file_path = setup_test_file(&data);
+    // Reuse the same output file across iterations to reduce filesystem variance
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
 
     bencher.bench(|| {
         unsafe {
             env::set_var("LC_ALL", "C");
         }
-        let output_file = NamedTempFile::new().unwrap();
-        let output_path = output_file.path().to_str().unwrap();
         black_box(run_util_function(
             uumain,
-            &["-o", output_path, file_path.to_str().unwrap()],
+            &["-o", &output_path, file_path.to_str().unwrap()],
         ));
     });
 }
@@ -109,16 +114,17 @@ fn sort_german_c_locale(bencher: Bencher) {
 fn sort_german_locale(bencher: Bencher) {
     let data = text_data::generate_german_locale_data(50_000);
     let file_path = setup_test_file(&data);
+    // Reuse the same output file across iterations to reduce filesystem variance
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
 
     bencher.bench(|| {
         unsafe {
             env::set_var("LC_ALL", "de_DE.UTF-8");
         }
-        let output_file = NamedTempFile::new().unwrap();
-        let output_path = output_file.path().to_str().unwrap();
         black_box(run_util_function(
             uumain,
-            &["-o", output_path, file_path.to_str().unwrap()],
+            &["-o", &output_path, file_path.to_str().unwrap()],
         ));
     });
 }
@@ -128,16 +134,17 @@ fn sort_german_locale(bencher: Bencher) {
 fn sort_random_strings(bencher: Bencher) {
     let data = text_data::generate_random_strings(50_000, 50);
     let file_path = setup_test_file(&data);
+    // Reuse the same output file across iterations to reduce filesystem variance
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
 
     bencher.bench(|| {
         unsafe {
             env::set_var("LC_ALL", "en_US.UTF-8");
         }
-        let output_file = NamedTempFile::new().unwrap();
-        let output_path = output_file.path().to_str().unwrap();
         black_box(run_util_function(
             uumain,
-            &["-o", output_path, file_path.to_str().unwrap()],
+            &["-o", &output_path, file_path.to_str().unwrap()],
         ));
     });
 }


### PR DESCRIPTION
Bug existed since Sept 2024 but variance was below CodSpeed's threshold (~1-3%). On Oct 11, CI changed to run 19 benchmarks in parallel (f19d7ec40, 6df73f033) instead of sequentially. This amplified `/tmp` contention, pushing variance to 2.64%—above detection threshold. The parallel execution exposed what was always there.

## Solution

Move `NamedTempFile::new()` outside loop, matching `sort_bench.rs` pattern:

Eliminates filesystem noise while preserving correct semantics (sort overwrites file each iteration, no caching)

Notes 
Affected PRs: #8935, #8936, #8927, #8926, #8930, #8932.