### PR TITLE
build: Allow to drop non-unix progs for Linux emu

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -89,8 +89,8 @@ $(info SELINUX_ENABLED=1 but /sbin/selinuxenabled failed)
 	endif
 endif
 
-# Possible programs
-PROGS       := \
+# Possible programs for all platforms. Allow to drop by make PROGS="" for WSL
+PROGS ?= \
 	base32 \
 	base64 \
 	basenc \


### PR DESCRIPTION
Allow to skip `PROGS`.
This allows to build windows native `PROGS` and build `UNIX_PROGS` for Linux emulator.