### PR TITLE
fix(date): support timezone abbreviations in date --set`

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -454,13 +454,13 @@ fn make_format_string(settings: &Settings) -> &str {
 ///
 /// Disambiguation rationale (GNU compatible):
 /// - CST: Central Standard Time (US) preferred over China/Cuba Standard Time
-/// - EST: Eastern Standard Time (US) preferred over Australian Eastern Standard Time  
+/// - EST: Eastern Standard Time (US) preferred over Australian Eastern Standard Time
 /// - IST: India Standard Time preferred over Israel/Irish Standard Time
 /// - MST: Mountain Standard Time (US) preferred over Malaysia Standard Time
 /// - PST: Pacific Standard Time (US) - widely used abbreviation
 /// - GMT: Alias for UTC (universal)
 ///
-/// All other timezones (AWST, JST, CET, etc.) are dynamically resolved from IANA database.
+/// All other timezones (AWST, JST, CET, etc.) are dynamically resolved from IANA database. // spell-checker:disable-line
 static PREFERRED_TZ_MAPPINGS: &[(&str, &str)] = &[
     // Universal (no ambiguity, but commonly used)
     ("UTC", "UTC"),
@@ -475,7 +475,7 @@ static PREFERRED_TZ_MAPPINGS: &[(&str, &str)] = &[
     ("EST", "America/New_York"), // Ambiguous: US vs Australia
     ("EDT", "America/New_York"),
     // Other highly ambiguous cases
-    ("IST", "Asia/Kolkata"), // Ambiguous: India vs Israel vs Ireland
+    ("IST", "Asia/Kolkata"), // Ambiguous: India vs Israel vs Ireland // spell-checker:disable-line
 ];
 
 /// Lazy-loaded timezone abbreviation lookup map built from IANA database.
@@ -493,7 +493,8 @@ fn build_tz_abbrev_map() -> HashMap<String, String> {
 
     // Then, try to find additional abbreviations from IANA database
     // This gives us broader coverage while respecting disambiguation preferences
-    let tzdb = TimeZoneDatabase::from_env();
+    let tzdb = TimeZoneDatabase::from_env(); // spell-checker:disable-line
+    // spell-checker:disable-next-line
     for tz_name in tzdb.available() {
         let tz_str = tz_name.as_str();
         // Skip if we already have a preferred mapping for this zone

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -660,7 +660,7 @@ fn test_date_tz_various_formats() {
         "-0800 -08:00 -08:00:00 -08 PST\n",
     );
     // Half-hour timezone
-    test_tz("Asia/Kolkata", JAN2, "+0530 +05:30 +05:30:00 +05:30 IST\n");
+    test_tz("Asia/Kolkata", JAN2, "+0530 +05:30 +05:30:00 +05:30 IST\n"); // spell-checker:disable-line
     test_tz("Europe/Berlin", JAN2, "+0100 +01:00 +01:00:00 +01 CET\n");
     test_tz(
         "Australia/Sydney",
@@ -878,9 +878,9 @@ fn test_date_tz_abbreviation_australian_timezones() {
     // Test Australian timezone abbreviations (uutils supports, GNU does NOT)
     // This demonstrates uutils date going beyond GNU capabilities
     let au_zones = vec![
-        ("AWST", "2021-03-20 14:53:01 AWST"), // Western Australia
-        ("ACST", "2021-03-20 14:53:01 ACST"), // Central Australia (Standard)
-        ("ACDT", "2021-03-20 14:53:01 ACDT"), // Central Australia (Daylight)
+        ("AWST", "2021-03-20 14:53:01 AWST"), // Western Australia // spell-checker:disable-line
+        ("ACST", "2021-03-20 14:53:01 ACST"), // Central Australia (Standard) // spell-checker:disable-line
+        ("ACDT", "2021-03-20 14:53:01 ACDT"), // Central Australia (Daylight) // spell-checker:disable-line
         ("AEST", "2021-03-20 14:53:01 AEST"), // Eastern Australia (Standard)
         ("AEDT", "2021-03-20 14:53:01 AEDT"), // Eastern Australia (Daylight)
     ];
@@ -921,7 +921,7 @@ fn test_date_tz_abbreviation_with_day_of_week() {
     // Test timezone abbreviations with full date format including day of week
     new_ucmd!()
         .arg("-d")
-        .arg("Sat 20 Mar 2021 14:53:01 AWST")
+        .arg("Sat 20 Mar 2021 14:53:01 AWST") // spell-checker:disable-line
         .arg("+%Y-%m-%d %H:%M:%S")
         .succeeds()
         .no_stderr();


### PR DESCRIPTION
Fixes #1882 - a 4-year-old issue where `date --set` failed with timezone abbreviations like AWST, EST, PST.

The Problem:
Three tests were marked "expected to fail" since 2021 because the underlying parser couldn't handle timezone abbreviations that GNU date supports.

The Solution:
Instead of hardcoding hundreds of timezones, I built a smart resolution system:
- Only 11 truly ambiguous cases hardcoded (CST, EST, IST) following GNU's preferences
- Dynamically discovers 588+ IANA timezones from the system
- Lazy-loaded cache using `OnceLock` for zero startup cost
- Converts abbreviations to numeric offsets before parsing

This means `date --set "Sat 20 Mar 2021 14:53:01 AWST"` finally works! The implementation actually goes beyond GNU by supporting additional abbreviations like Australian timezones.