### PR TITLE
uudoc: respect SKIP_UTILS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ expensive_tests = []
 # "test_risky_names" == enable tests that create problematic file names (would make a network share inaccessible to Windows, breaks SVN on Mac OS, etc.)
 test_risky_names = []
 # * only build `uudoc` when `--feature uudoc` is activated
-uudoc = ["clap_complete", "clap_mangen", "fluent-syntax", "zip", "feat_Tier1"]
+uudoc = ["clap_complete", "clap_mangen", "fluent-syntax", "zip"]
 ## features
 ## Optional feature for stdbuf
 # "feat_external_libstdbuf" == use an external libstdbuf.so for stdbuf instead of embedding it


### PR DESCRIPTION
Including `feat_Tier1` cause building manual for `SKIP_UTILS` and builds unused crates.