### PR TITLE
be prescriptive on the codspeed-divan-compat version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ compare = "0.1.0"
 crossterm = "0.29.0"
 ctor = "0.6.0"
 ctrlc = { version = "3.4.7", features = ["termination"] }
-divan = { package = "codspeed-divan-compat", version = "*" }
+divan = { package = "codspeed-divan-compat", version = "4.0.5" }
 dns-lookup = { version = "3.0.0" }
 exacl = "0.12.0"
 file_diff = "1.0.0"


### PR DESCRIPTION
cargo publish isn't publishing it otherwise