### PR TITLE
rm: fix error reporting for `-r` on Linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
           gperf
           gettext
           texinfo
+          perl
         ];
       in {
         default = pkgsFor.${system}.pkgs.mkShell {


### PR DESCRIPTION
This was the cause of the `rm1.sh` failure for the GNU testsuite.

Effectively, the error boolean only kept track of the last file that we attempted to remove rather than the entire set of files.

I've also added `perl` to `flake.nix`, since I'm currently using `nix` on a system that doesn't have it by default.