### PR TITLE
test: handle case where euid is 0

### DIFF
--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -278,7 +278,10 @@ fn path(path: &OsStr, condition: &PathCondition) -> bool {
     }
 
     let perm = |metadata: Metadata, p: Permission| {
-        if geteuid() == metadata.uid() {
+        let euid = geteuid();
+        if euid == 0 {
+            !matches!(p, Permission::Execute) || metadata.is_dir() || (metadata.mode() & 0o111 != 0)
+        } else if euid == metadata.uid() {
             metadata.mode() & ((p as u32) << 6) != 0
         } else if getegid() == metadata.gid() {
             metadata.mode() & ((p as u32) << 3) != 0

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -515,6 +515,32 @@ fn test_file_is_not_executable() {
 }
 
 #[test]
+#[cfg(not(windows))] // FIXME: implement on Windows
+fn test_root_permissions() {
+    use uutests::{unwrap_or_return, util::run_ucmd_as_root};
+
+    let scenario = TestScenario::new(util_name!());
+    let mut chmod = scenario.cmd("chmod");
+
+    scenario.fixtures.touch("no_permissions_file");
+    chmod.args(&["0", "no_permissions_file"]).succeeds();
+
+    // root can always read
+    unwrap_or_return!(run_ucmd_as_root(&scenario, &["-r", "no_permissions_file"])).success();
+    // root can always write
+    unwrap_or_return!(run_ucmd_as_root(&scenario, &["-w", "no_permissions_file"])).success();
+    // root can not execute if nobody can execute
+    unwrap_or_return!(run_ucmd_as_root(&scenario, &["-x", "no_permissions_file"]))
+        .failure()
+        .code_is(1);
+
+    let mut chmod = scenario.cmd("chmod");
+    chmod.args(&["o+x", "no_permissions_file"]).succeeds();
+    // root can execute now because others can execute
+    unwrap_or_return!(run_ucmd_as_root(&scenario, &["-x", "no_permissions_file"])).success();
+}
+
+#[test]
 #[cfg(not(windows))]
 fn test_file_is_executable() {
     let scenario = TestScenario::new(util_name!());


### PR DESCRIPTION
Right now, the `test` binary does not handle the case where the user has root permissions. Consider the following scenario:

```bash
touch no_permissions_file
chmod 0 no_permissions_file
sudo test -r no_permissions_file; echo $?
sudo test -w no_permissions_file; echo $?
sudo test -x no_permissions_file; echo $?
chmod o+x no_permissions_file
sudo test -x no_permissions_file; echo $?
```

GNU `test` outputs

```
0
0
1
0
```

uucore `test` outputs

```
1
1
1
0
```

I have added a test case to capture this scenario and modified the permission check to follow [OpenBSD's logic](https://github.com/openbsd/src/blob/abf9f467da41af7bcc04e0f12d581e5c1f433577/sys/kern/vfs_subr.c#L1634-L1641) and to be consistent with GNU `test`. The test runs only if `sudo` works without password.