### PR TITLE
Fix "cksum: --length 0 shouldn't fail for algorithms that don't support --length"

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -383,14 +383,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let input_length = matches.get_one::<usize>(options::LENGTH);
 
     let length = match input_length {
-        Some(length) => {
-            if algo_name == ALGORITHM_OPTIONS_BLAKE2B {
-                calculate_blake2b_length(*length)?
-            } else {
-                return Err(ChecksumError::LengthOnlyForBlake2b.into());
-            }
+        None | Some(0) => None,
+        Some(length) if algo_name == ALGORITHM_OPTIONS_BLAKE2B => {
+            calculate_blake2b_length(*length)?
         }
-        None => None,
+        _ => {
+            return Err(ChecksumError::LengthOnlyForBlake2b.into());
+        }
     };
 
     if LEGACY_ALGORITHMS.contains(&algo_name) && check {

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -348,6 +348,20 @@ fn test_length_with_wrong_algorithm() {
         .stderr_contains("cksum: --length is only supported with --algorithm=blake2b");
 }
 
+/// Giving --length to a wrong algorithm doesn't fail if the length is zero
+#[test]
+fn test_length_is_zero_with_wrong_algorithm() {
+    for algo in ["md5", "crc", "sha1", "sha224", "sha256", "sha384", "sha512"] {
+        new_ucmd!()
+            .arg("--length=0")
+            .args(&["-a", algo])
+            .arg("lorem_ipsum.txt")
+            .succeeds()
+            .no_stderr()
+            .stdout_is_fixture(format!("{algo}_single_file.expected"));
+    }
+}
+
 #[test]
 fn test_length_not_supported() {
     new_ucmd!()


### PR DESCRIPTION
Fix #9031 