### PR TITLE
ci: add locales for GNU tests

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -89,6 +89,9 @@ jobs:
         sudo locale-gen --keep-existing en_US
         sudo locale-gen --keep-existing en_US.UTF-8
         sudo locale-gen --keep-existing ru_RU.KOI8-R
+        sudo locale-gen --keep-existing fa_IR.UTF-8 # Iran
+        sudo locale-gen --keep-existing am_ET.UTF-8 # Ethiopia
+        sudo locale-gen --keep-existing th_TH.UTF-8 # Thailand
 
         sudo update-locale
         echo "After:"


### PR DESCRIPTION
This PR adds the locales of Iran, Ethiopia, and Thailand to the `GnuTests` workflow in order to run the new `date-<country>.sh` tests introduced with GNU coreutils `9.8`.