### PR TITLE
ci: remove deprecated `lima-actions/ssh`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1269,8 +1269,6 @@ jobs:
         key: lima-${{ steps.lima-actions-setup.outputs.version }}
     - name: Start Fedora VM with SELinux
       run: limactl start --plain --name=default --cpus=4 --disk=30 --memory=4 --network=lima:user-v2 template://fedora
-    - name: Setup SSH
-      uses: lima-vm/lima-actions/ssh@v1
     - run: rsync -v -a -e ssh . lima-default:~/work/
     - name: Setup Rust and other build deps in VM
       run: |

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -198,8 +198,6 @@ jobs:
         key: lima-${{ steps.lima-actions-setup.outputs.version }}
     - name: Start Fedora VM with SELinux
       run: limactl start --plain --name=default --cpus=4 --disk=40 --memory=8 --network=lima:user-v2 template://fedora
-    - name: Setup SSH
-      uses: lima-vm/lima-actions/ssh@v1
     - name: Verify SELinux Status and Configuration
       run: |
         lima getenforce


### PR DESCRIPTION
This PR removes the deprecated `lima-actions/ssh` as it got merged into `lima-actions/setup` (which we already use in both affected workflows) and has no functionality anymore. See https://github.com/lima-vm/lima-actions/releases/tag/v1.1.0. 