### PR TITLE
Fix chown tests for FreeBSD and macOS

### DIFF
--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -363,13 +363,16 @@ fn test_chown_only_group() {
     result.stderr_contains("retained as");
     result.success();
 
-    scene
-        .ucmd()
-        .arg(format!(":{ROOT_GROUP}"))
-        .arg("--verbose")
-        .arg(file1)
-        .fails()
-        .stderr_contains("failed to change");
+    // FreeBSD user on CI is part of wheel group
+    if group_name != ROOT_GROUP {
+        scene
+            .ucmd()
+            .arg(format!(":{ROOT_GROUP}"))
+            .arg("--verbose")
+            .arg(file1)
+            .fails()
+            .stderr_contains("failed to change");
+    }
 }
 
 #[test]
@@ -494,13 +497,16 @@ fn test_chown_only_group_id() {
     // Apparently on CI "macos-latest, x86_64-apple-darwin, feat_os_macos"
     // the process has the rights to change from runner:staff to runner:wheel
     #[cfg(any(windows, all(unix, not(target_os = "macos"))))]
-    scene
-        .ucmd()
-        .arg(":0")
-        .arg("--verbose")
-        .arg(file1)
-        .fails()
-        .stderr_contains("failed to change");
+    // FreeBSD user on CI is part of wheel group
+    if group_id != "0" {
+        scene
+            .ucmd()
+            .arg(":0")
+            .arg("--verbose")
+            .arg(file1)
+            .fails()
+            .stderr_contains("failed to change");
+    }
 }
 
 /// Test for setting the group to a group ID for a group that does not exist.


### PR DESCRIPTION
I have fixed some of the `chown` tests for FreeBSD and for macOS.

- The group `root` was hardcoded in some places, but it's `wheel` on BSD systems.
- In `test_chown_only_group`, the username is taken and used to set the group of a file. I guess this is a bug and the group name was intended to use here.
- The FreeBSD CI setup uses a user which is in the `wheel` group. That's why setting the file group to `wheel` succeeds. I have added a check here to see if the user is in `wheel` already and if so, to not run `chown` again. Because the case where we run `chown` on the current group is covered already in the very same tests.