### PR TITLE
freebsd.yml: Use ci profile at test correctly

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -204,7 +204,8 @@ jobs:
             cargo nextest run --hide-progress-bar --profile ci --features "\$UUCORE_FEATURES" -p uucore || FAULT=1
           fi
           # Test building with make
-          if (test -z "\$FAULT"); then make PROFILE=ci || FAULT=1 ; fi
+          export LIBSTDBUF_DIR=/home/runner/work/coreutils/coreutils/target/debug/deps # see https://github.com/uutils/coreutils/pull/8684#discussion_r2383492924
+          if (test -z "\$FAULT"); then make nextest PROFILE=ci || FAULT=1 ; fi
           # Clean to avoid to rsync back the files
           cargo clean
           if (test -n "\$FAULT"); then exit 1 ; fi


### PR DESCRIPTION
ci profile is defined at `nextest.toml`. So `make nextest` is needed instead of `make`.
Fixing it happens another bug, but this PR has workaround.

Separated from #8730 since it is related with another issue.