### PR TITLE
rustdoc: fix broken intra doc links

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -280,7 +280,7 @@ impl SplitWriter<'_> {
     }
 
     /// Writes the line to the current split.
-    /// If [`self.dev_null`] is true, then the line is discarded.
+    /// If `self.dev_null` is true, then the line is discarded.
     ///
     /// # Errors
     ///
@@ -572,7 +572,7 @@ where
         self.size = size;
     }
 
-    /// Add a line to the buffer. If the buffer has [`self.size`] elements, then its head is removed and
+    /// Add a line to the buffer. If the buffer has `self.size` elements, then its head is removed and
     /// the new line is pushed to the buffer. The removed head is then available in the returned
     /// option.
     fn add_line_to_buffer(&mut self, ln: usize, line: String) -> Option<String> {

--- a/src/uu/split/src/number.rs
+++ b/src/uu/split/src/number.rs
@@ -112,7 +112,7 @@ impl Number {
     ///
     /// If incrementing this number would result in an overflow beyond
     /// the maximum representable number, then return
-    /// [`Err(Overflow)`]. The [`FixedWidthNumber`] overflows, but
+    /// `Err(Overflow)`. The [`FixedWidthNumber`] overflows, but
     /// [`DynamicWidthNumber`] does not.
     ///
     /// The [`DynamicWidthNumber`] follows a non-standard incrementing
@@ -122,7 +122,7 @@ impl Number {
     ///
     /// # Errors
     ///
-    /// This method returns [`Err(Overflow)`] when attempting to
+    /// This method returns `Err(Overflow)` when attempting to
     /// increment beyond the largest representable number.
     ///
     /// # Examples
@@ -212,7 +212,7 @@ impl FixedWidthNumber {
     ///
     /// This method adds one to this number. If incrementing this
     /// number would require more digits than are available with the
-    /// specified width, then this method returns [`Err(Overflow)`].
+    /// specified width, then this method returns `Err(Overflow)`.
     fn increment(&mut self) -> Result<(), Overflow> {
         for i in (0..self.digits.len()).rev() {
             // Increment the current digit.

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -207,9 +207,9 @@ impl BytesChunk {
     }
 
     /// Fills `self.buffer` with maximal [`BUFFER_SIZE`] number of bytes, draining the reader by
-    /// that number of bytes. If EOF is reached (so 0 bytes are read), then returns
-    /// [`UResult<None>`] or else the result with [`Some(bytes)`] where bytes is the number of bytes
-    /// read from the source.
+    /// that number of bytes. If EOF is reached (so 0 bytes are read), it returns
+    /// [`UResult<None>`]; otherwise, it returns [`UResult<Some(bytes)>`], where bytes is the
+    /// number of bytes read from the source.
     pub fn fill(&mut self, filehandle: &mut impl BufRead) -> UResult<Option<usize>> {
         let num_bytes = filehandle.read(&mut self.buffer)?;
         self.bytes = num_bytes;

--- a/src/uucore/src/lib/features/version_cmp.rs
+++ b/src/uucore/src/lib/features/version_cmp.rs
@@ -32,7 +32,7 @@ fn version_non_digit_cmp(a: &[u8], b: &[u8]) -> Ordering {
     }
 }
 
-/// Remove file endings matching the regex (\.[A-Za-z~][A-Za-z0-9~]*)*$
+/// Remove file endings matching the regex `(\.[A-Za-z~][A-Za-z0-9~]*)*$`
 fn remove_file_ending(a: &[u8]) -> &[u8] {
     let mut ending_start = None;
     let mut prev_was_dot = false;

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -1672,7 +1672,7 @@ impl UCommand {
 
     /// Set if process should be run in a simulated terminal
     ///
-    /// This is useful to test behavior that is only active if e.g. [`stdout.is_terminal()`] is [`true`].
+    /// This is useful to test behavior that is only active if e.g. `stdout.is_terminal()` is `true`.
     /// This function uses default terminal size and attaches stdin, stdout and stderr to that terminal.
     /// For more control over the terminal simulation, use `terminal_sim_stdio`
     /// (unix: pty, windows: `ConPTY`[not yet supported])
@@ -1693,7 +1693,7 @@ impl UCommand {
 
     /// Allows to simulate a terminal use-case with specific properties.
     ///
-    /// This is useful to test behavior that is only active if e.g. [`stdout.is_terminal()`] is [`true`].
+    /// This is useful to test behavior that is only active if e.g. `stdout.is_terminal()` is `true`.
     /// This function allows to set a specific size and to attach the terminal to only parts of the in/out.
     #[cfg(unix)]
     pub fn terminal_sim_stdio(&mut self, config: TerminalSimulation) -> &mut Self {


### PR DESCRIPTION
This PR fixes some broken intra doc links. It should fix the following error shown by the `CICD / Documentation/warnings` job in the CI (see, for example, https://github.com/uutils/coreutils/actions/runs/18963810909/job/54156487338?pr=9094):
```
error: unresolved link to `Some(bytes)`
   --> src/uu/tail/src/chunks.rs:211:53
    |
211 |     /// [`UResult<None>`] or else the result with [`Some(bytes)`] where bytes is the number of bytes
    |                                                     ^^^^^^^^^^^ no item named `Some(bytes)` in scope
   |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
    = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(rustdoc::broken_intra_doc_links)]`
```