### PR TITLE
fix(uudoc): Correctly parse version string for documentation (#8600)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -74,8 +74,8 @@ jobs:
             exit 1
           fi
 
-          if ! grep -q "$VERSION" docs/src/utils/ls.md; then
-            echo "Version '$VERSION' not found in docs/src/utils/ls.md"
+          if ! grep -q "<div class=\"version\">v$VERSION</div>" docs/src/utils/ls.md; then
+            echo "Expected '<div class=\"version\">v$VERSION</div>' not found in docs/src/utils/ls.md"
             echo "Full version section:"
             grep -C 2 "version" docs/src/utils/ls.md || echo "No version section found"
             exit 1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -74,12 +74,10 @@ jobs:
             exit 1
           fi
 
-          if ! grep -q "v(uutils coreutils) $VERSION" docs/src/utils/ls.md; then
+          if ! grep -q "$VERSION" docs/src/utils/ls.md; then
             echo "Version '$VERSION' not found in docs/src/utils/ls.md"
-            echo "Found version info:"
-            grep "v(uutils coreutils)" docs/src/utils/ls.md || echo "No version info found"
             echo "Full version section:"
-            grep -A2 -B2 "version" docs/src/utils/ls.md || echo "No version section found"
+            grep -C 2 "version" docs/src/utils/ls.md || echo "No version section found"
             exit 1
           fi
 

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -514,11 +514,17 @@ impl MDWriter<'_, '_> {
     /// # Panics
     /// Panics if the version is not found.
     fn version(&mut self) -> io::Result<()> {
-        writeln!(
-            self.w,
-            "<div class=\"version\">v{}</div>",
-            self.command.render_version().split_once(' ').unwrap().1
-        )
+        let full_version_string = self.command.render_version();
+
+        // The version string format often includes command name and metadata,
+        // like "b2sum (uutils coreutils) 0.3.0". We reliably extract the
+        // version number, which is expected to be the last item.
+        let version_only = full_version_string
+            .split_whitespace()
+            .last()
+            .unwrap_or(&full_version_string); // Fallback to full string if parsing fails
+
+        writeln!(self.w, "<div class=\"version\">{version_only}</div>")
     }
 
     /// # Errors

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -511,20 +511,18 @@ impl MDWriter<'_, '_> {
 
     /// # Errors
     /// Returns an error if the writer fails.
-    /// # Panics
-    /// Panics if the version is not found.
     fn version(&mut self) -> io::Result<()> {
         let full_version_string = self.command.render_version();
 
-        // The version string format often includes command name and metadata,
-        // like "b2sum (uutils coreutils) 0.3.0". We reliably extract the
-        // version number, which is expected to be the last item.
+        // clap renders the version as "<name> (uutils coreutils) <version>",
+        // e.g. "b2sum (uutils coreutils) 0.3.0". Keep only the version number,
+        // which is the last whitespace-separated token.
         let version_only = full_version_string
             .split_whitespace()
             .last()
-            .unwrap_or(&full_version_string); // Fallback to full string if parsing fails
+            .unwrap_or(&full_version_string);
 
-        writeln!(self.w, "<div class=\"version\">{version_only}</div>")
+        writeln!(self.w, "<div class=\"version\">v{version_only}</div>")
     }
 
     /// # Errors

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -208,7 +208,7 @@ impl BytesChunk {
 
     /// Fills `self.buffer` with maximal [`BUFFER_SIZE`] number of bytes, draining the reader by
     /// that number of bytes. If EOF is reached (so 0 bytes are read), it returns
-    /// [`UResult<None>`]; otherwise, it returns [`UResult<Some(bytes)>`], where bytes is the
+    /// [`UResult<None>`]; otherwise, it returns `UResult<Some(bytes)>`, where bytes is the
     /// number of bytes read from the source.
     pub fn fill(&mut self, filehandle: &mut impl BufRead) -> UResult<Option<usize>> {
         let num_bytes = filehandle.read(&mut self.buffer)?;

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -208,7 +208,7 @@ impl BytesChunk {
 
     /// Fills `self.buffer` with maximal [`BUFFER_SIZE`] number of bytes, draining the reader by
     /// that number of bytes. If EOF is reached (so 0 bytes are read), it returns
-    /// [`UResult<None>`]; otherwise, it returns `UResult<Some(bytes)>`, where bytes is the
+    /// [`UResult<None>`]; otherwise, it returns [`UResult<Some(bytes)>`], where bytes is the
     /// number of bytes read from the source.
     pub fn fill(&mut self, filehandle: &mut impl BufRead) -> UResult<Option<usize>> {
         let num_bytes = filehandle.read(&mut self.buffer)?;


### PR DESCRIPTION
Fixes #8600

The version parsing logic in `src/bin/uudoc.rs` was not fully accounting for the version string format generated by `clap`, which includes the application metadata (e.g., `b2sum (uutils coreutils) 0.3.0`).

This change modifies the version extraction logic to strip the application metadata and reliably retain only the clean version number string, ensuring that documentation links are correctly generated as `v0.3.0`.