### PR TITLE
feat(truncate): allow negative size values for truncation

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -145,6 +145,7 @@ pub fn uu_app() -> Command {
                 .long(options::SIZE)
                 .required_unless_present(options::REFERENCE)
                 .help(translate!("truncate-help-size"))
+                .allow_hyphen_values(true)
                 .value_name("SIZE"),
         )
         .arg(

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -386,6 +386,17 @@ fn test_underflow_relative_size() {
     assert!(at.read_bytes(FILE1).is_empty());
 }
 
+#[test]
+fn test_negative_size_with_space() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-s", "-1", FILE1])
+        .succeeds()
+        .no_stdout()
+        .no_stderr();
+    assert!(at.file_exists(FILE1));
+    assert!(at.read_bytes(FILE1).is_empty());
+}
+
 #[cfg(not(windows))]
 #[test]
 fn test_fifo_error_size_only() {


### PR DESCRIPTION
- Enable hyphen values in size argument to support negative sizes (e.g., "-1")
- Add test case verifying truncation to empty file with negative size "-1"
fixes https://github.com/uutils/coreutils/issues/9128