### PR TITLE
du: fix dead code warnings in test on Android

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -22,9 +22,9 @@ const SUB_DIR: &str = "subdir/deeper";
 const SUB_DEEPER_DIR: &str = "subdir/deeper/deeper_dir";
 const SUB_DIR_LINKS: &str = "subdir/links";
 const SUB_DIR_LINKS_DEEPER_SYM_DIR: &str = "subdir/links/deeper_dir";
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(all(not(target_os = "android"), not(target_os = "openbsd")))]
 const SUB_FILE: &str = "subdir/links/subwords.txt";
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(all(not(target_os = "android"), not(target_os = "openbsd")))]
 const SUB_LINK: &str = "subdir/links/sublink.txt";
 
 #[test]


### PR DESCRIPTION
This PR fixes two "constant is never used" warnings that show up on Android (see, for example, https://github.com/uutils/coreutils/actions/runs/19028332358/job/54336353070?pr=9126#step:16:2026):
```
warning: constant `SUB_FILE` is never used
   --> tests/by-util/test_du.rs:26:7
    |
 26 | const SUB_FILE: &str = "subdir/links/subwords.txt";
    |       ^^^^^^^^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: constant `SUB_LINK` is never used
   --> tests/by-util/test_du.rs:28:7
    |
 28 | const SUB_LINK: &str = "subdir/links/sublink.txt";
    |       ^^^^^^^^
```
There are also two "unused import" warnings shown in the link above. I left them, as they are related to https://github.com/uutils/coreutils/issues/7542