### PR TITLE
fix(nl): allow repeated flags to match GNU nl behavior (fixes #9132)

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -245,6 +245,7 @@ pub fn uu_app() -> Command {
         .after_help(translate!("nl-after-help"))
         .infer_long_args(true)
         .disable_help_flag(true)
+        .args_override_self(true)
         .arg(
             Arg::new(options::HELP)
                 .long(options::HELP)

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -800,3 +800,104 @@ fn test_file_with_non_utf8_content() {
         String::from_utf8_lossy(invalid_utf8)
     ));
 }
+
+// Regression tests for issue #9132: repeated flags should use last value
+#[test]
+fn test_repeated_body_numbering_flag() {
+    // -ba -bt should use -bt (t=nonempty)
+    new_ucmd!()
+        .args(&["-ba", "-bt"])
+        .pipe_in("a\n\nb\n\nc")
+        .succeeds()
+        .stdout_is("     1\ta\n       \n     2\tb\n       \n     3\tc\n");
+}
+
+#[test]
+fn test_repeated_header_numbering_flag() {
+    // -ha -ht should use -ht (number only nonempty lines in header)
+    new_ucmd!()
+        .args(&["-ha", "-ht"])
+        .pipe_in("\\:\\:\\:\na\nb\n\nc")
+        .succeeds()
+        .stdout_is("\n     1\ta\n     2\tb\n       \n     3\tc\n");
+}
+
+#[test]
+fn test_repeated_footer_numbering_flag() {
+    // -fa -ft should use -ft (t=nonempty in footer)
+    new_ucmd!()
+        .args(&["-fa", "-ft"])
+        .pipe_in("\\:\na\nb\n\nc")
+        .succeeds()
+        .stdout_is("\n     1\ta\n     2\tb\n       \n     3\tc\n");
+}
+
+#[test]
+fn test_repeated_number_format_flag() {
+    // -n ln -n rn should use -n rn (rn=right aligned)
+    new_ucmd!()
+        .args(&["-n", "ln", "-n", "rn"])
+        .pipe_in("a\nb\nc")
+        .succeeds()
+        .stdout_is("     1\ta\n     2\tb\n     3\tc\n");
+}
+
+#[test]
+fn test_repeated_number_separator_flag() {
+    // -s ':' -s '|' should use -s '|'
+    new_ucmd!()
+        .args(&["-s", ":", "-s", "|"])
+        .pipe_in("a\nb\nc")
+        .succeeds()
+        .stdout_is("     1|a\n     2|b\n     3|c\n");
+}
+
+#[test]
+fn test_repeated_number_width_flag() {
+    // -w 3 -w 8 should use -w 8
+    new_ucmd!()
+        .args(&["-w", "3", "-w", "8"])
+        .pipe_in("a\nb\nc")
+        .succeeds()
+        .stdout_is("       1\ta\n       2\tb\n       3\tc\n");
+}
+
+#[test]
+fn test_repeated_line_increment_flag() {
+    // -i 1 -i 5 should use -i 5
+    new_ucmd!()
+        .args(&["-i", "1", "-i", "5"])
+        .pipe_in("a\nb\nc")
+        .succeeds()
+        .stdout_is("     1\ta\n     6\tb\n    11\tc\n");
+}
+
+#[test]
+fn test_repeated_starting_line_number_flag() {
+    // -v 1 -v 10 should use -v 10
+    new_ucmd!()
+        .args(&["-v", "1", "-v", "10"])
+        .pipe_in("a\nb\nc")
+        .succeeds()
+        .stdout_is("    10\ta\n    11\tb\n    12\tc\n");
+}
+
+#[test]
+fn test_repeated_join_blank_lines_flag() {
+    // -l 1 -l 2 should use -l 2
+    new_ucmd!()
+        .args(&["-l", "1", "-l", "2", "-ba"])
+        .pipe_in("a\n\n\nb")
+        .succeeds()
+        .stdout_is("     1\ta\n       \n     2\t\n     3\tb\n");
+}
+
+#[test]
+fn test_repeated_section_delimiter_flag() {
+    // -d ':' -d '|' should use -d '|'
+    new_ucmd!()
+        .args(&["-d", ":", "-d", "|"])
+        .pipe_in("|:|:|:\na\nb\nc")
+        .succeeds()
+        .stdout_is("\n       a\n       b\n       c\n");
+}


### PR DESCRIPTION
Fixes #9132. uu-nl now accepts repeated flags like GNU nl. Added args_override_self(true)to all 10 value-accepting arguments.