### PR TITLE
Get 'test' working properly with acls and supplementary groups

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -152,7 +152,9 @@ vmsplice
 
 # * vars/libc
 COMFOLLOW
+EACCESS
 EXDEV
+FDCWD
 FILENO
 FTSENT
 HOSTSIZE
@@ -197,7 +199,10 @@ blocksize
 canonname
 chroot
 dlsym
+eaccess
+euidaccess
 execvp
+faccessat
 fdatasync
 freeaddrinfo
 getaddrinfo

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -279,7 +279,6 @@ fn path(path: &OsStr, condition: &PathCondition) -> bool {
             #[cfg(any(
                 target_os = "linux",
                 target_os = "hurd",
-                target_os = "redox",
                 target_os = "cygwin",
                 target_os = "solaris",
                 target_os = "illumos"
@@ -308,7 +307,6 @@ fn path(path: &OsStr, condition: &PathCondition) -> bool {
             #[cfg(not(any(
                 target_os = "linux",
                 target_os = "hurd",
-                target_os = "redox",
                 target_os = "cygwin",
                 target_os = "solaris",
                 target_os = "illumos",

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -258,26 +258,71 @@ enum PathCondition {
 
 #[cfg(not(windows))]
 fn path(path: &OsStr, condition: &PathCondition) -> bool {
-    use std::fs::Metadata;
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::FileTypeExt;
 
     const S_ISUID: u32 = 0o4000;
     const S_ISGID: u32 = 0o2000;
     const S_ISVTX: u32 = 0o1000;
 
-    enum Permission {
-        Read = 0o4,
-        Write = 0o2,
-        Execute = 0o1,
-    }
+    // Helper function to check file access permissions.
+    // Uses platform-specific access functions that properly handle supplementary groups
+    // and ACLs.
+    let check_access = |path: &OsStr, mode: i32| -> bool {
+        let path_bytes = path.as_bytes();
+        let Ok(c_path) = CString::new(path_bytes) else {
+            return false; // Path contains null byte
+        };
 
-    let perm = |metadata: Metadata, p: Permission| {
-        if geteuid() == metadata.uid() {
-            metadata.mode() & ((p as u32) << 6) != 0
-        } else if getegid() == metadata.gid() {
-            metadata.mode() & ((p as u32) << 3) != 0
-        } else {
-            metadata.mode() & (p as u32) != 0
+        unsafe {
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "hurd",
+                target_os = "redox",
+                target_os = "cygwin",
+                target_os = "solaris",
+                target_os = "illumos"
+            ))]
+            {
+                libc::euidaccess(c_path.as_ptr(), mode) == 0
+            }
+
+            #[cfg(target_os = "freebsd")]
+            {
+                libc::eaccess(c_path.as_ptr(), mode) == 0
+            }
+
+            #[cfg(any(
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "netbsd",
+                target_os = "openbsd",
+                target_os = "dragonfly"
+            ))]
+            {
+                libc::faccessat(libc::AT_FDCWD, c_path.as_ptr(), mode, libc::AT_EACCESS) == 0
+            }
+
+            // Fallback for other OSes
+            #[cfg(not(any(
+                target_os = "linux",
+                target_os = "hurd",
+                target_os = "redox",
+                target_os = "cygwin",
+                target_os = "solaris",
+                target_os = "illumos",
+                target_os = "freebsd",
+                target_os = "macos",
+                target_os = "ios",
+                target_os = "netbsd",
+                target_os = "openbsd",
+                target_os = "dragonfly"
+            )))]
+            {
+                // fallback: use regular access()
+                libc::access(c_path.as_ptr(), mode) == 0
+            }
         }
     };
 
@@ -308,12 +353,12 @@ fn path(path: &OsStr, condition: &PathCondition) -> bool {
         PathCondition::Sticky => metadata.mode() & S_ISVTX != 0,
         PathCondition::UserOwns => metadata.uid() == geteuid(),
         PathCondition::Fifo => file_type.is_fifo(),
-        PathCondition::Readable => perm(metadata, Permission::Read),
+        PathCondition::Readable => check_access(path, libc::R_OK),
         PathCondition::Socket => file_type.is_socket(),
         PathCondition::NonEmpty => metadata.size() > 0,
         PathCondition::UserIdFlag => metadata.mode() & S_ISUID != 0,
-        PathCondition::Writable => perm(metadata, Permission::Write),
-        PathCondition::Executable => perm(metadata, Permission::Execute),
+        PathCondition::Writable => check_access(path, libc::W_OK),
+        PathCondition::Executable => check_access(path, libc::X_OK),
     }
 }
 


### PR DESCRIPTION
Fixes #8960 and #9147. Delegate to libc `euidaccess` to avoid bugs (#9147) and respect ACLs (#8960). 

Note, the tests are independent commits that can be applied first, where they should fail before the 'fix' commit is applied. Run the tests with:

```
cargo test --test tests test_permission_with_acl
cargo test --test tests test_permission_with_supplementary_group
```

Warning: code is partly Claude-generated as I'm not that familiar with Rust.