### PR TITLE
fix(install): preserve setuid/setgid bits after chown operations

### DIFF
--- a/src/uu/install/src/mode.rs
+++ b/src/uu/install/src/mode.rs
@@ -2,24 +2,31 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-use std::fs;
+#[cfg(any(unix, target_os = "redox"))]
+use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
-use uucore::translate;
 
 /// chmod a file or directory on UNIX.
 ///
 /// Adapted from mkdir.rs.  Handles own error printing.
 ///
+/// Uses libc::chmod directly instead of fs::set_permissions to properly
+/// handle special mode bits (setuid, setgid, sticky) when running as root.
+///
 #[cfg(any(unix, target_os = "redox"))]
-pub fn chmod(path: &Path, mode: u32) -> Result<(), ()> {
-    use std::os::unix::fs::PermissionsExt;
-    use uucore::{display::Quotable, show_error};
-    fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|err| {
-        show_error!(
-            "{}",
-            translate!("install-error-chmod-failed-detailed", "path" => path.maybe_quote(), "error" => err)
-        );
-    })
+pub fn chmod(path: &Path, mode: u32) -> Result<(), std::io::Error> {
+    use std::ffi::CString;
+    use uucore::libc;
+
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+
+    // Use libc::chmod directly to properly handle all mode bits including special bits
+    if unsafe { libc::chmod(c_path.as_ptr(), mode as libc::mode_t) } != 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 /// chmod a file or directory on Windows.
@@ -27,7 +34,7 @@ pub fn chmod(path: &Path, mode: u32) -> Result<(), ()> {
 /// Adapted from mkdir.rs.
 ///
 #[cfg(windows)]
-pub fn chmod(path: &Path, mode: u32) -> Result<(), ()> {
+pub fn chmod(path: &Path, mode: u32) -> Result<(), std::io::Error> {
     // chmod on Windows only sets the readonly flag, which isn't even honored on directories
     Ok(())
 }


### PR DESCRIPTION
Fixes #9134

`install -m4755` failed to set special permission bits because chown strips them for security. Added second chmod call after chown and improved error handling with libc::chmod for proper special bit support. Updated callers to handle io::Error and added localized error messages. and  tests included.