### PR TITLE
hashsum: Remove non-GNU binaries (fix cksum interface divergence #8984)

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -355,20 +355,12 @@ jobs:
         test -f /tmp/usr/local/bin/hashsum
         # Check that hashsum symlinks are present
         test -h /tmp/usr/local/bin/b2sum
-        test -h /tmp/usr/local/bin/b3sum
         test -h /tmp/usr/local/bin/md5sum
         test -h /tmp/usr/local/bin/sha1sum
         test -h /tmp/usr/local/bin/sha224sum
         test -h /tmp/usr/local/bin/sha256sum
-        test -h /tmp/usr/local/bin/sha3-224sum
-        test -h /tmp/usr/local/bin/sha3-256sum
-        test -h /tmp/usr/local/bin/sha3-384sum
-        test -h /tmp/usr/local/bin/sha3-512sum
         test -h /tmp/usr/local/bin/sha384sum
-        test -h /tmp/usr/local/bin/sha3sum
         test -h /tmp/usr/local/bin/sha512sum
-        test -h /tmp/usr/local/bin/shake128sum
-        test -h /tmp/usr/local/bin/shake256sum
     - name: "`make install MULTICALL=y LN=ln -svf`"
       shell: bash
       run: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -199,20 +199,12 @@ SELINUX_PROGS := \
 
 HASHSUM_PROGS := \
 	b2sum \
-	b3sum \
 	md5sum \
 	sha1sum \
 	sha224sum \
 	sha256sum \
-	sha3-224sum \
-	sha3-256sum \
-	sha3-384sum \
-	sha3-512sum \
 	sha384sum \
-	sha3sum \
-	sha512sum \
-	shake128sum \
-	shake256sum
+	sha512sum
 
 $(info Detected OS = $(OS))
 

--- a/build.rs
+++ b/build.rs
@@ -79,23 +79,13 @@ pub fn main() {
                 phf_map.entry(krate, format!("({krate}::uumain, {krate}::uu_app_custom)"));
 
                 let map_value = format!("({krate}::uumain, {krate}::uu_app_common)");
-                let map_value_bits = format!("({krate}::uumain, {krate}::uu_app_bits)");
-                let map_value_b3sum = format!("({krate}::uumain, {krate}::uu_app_b3sum)");
                 phf_map.entry("md5sum", map_value.clone());
                 phf_map.entry("sha1sum", map_value.clone());
                 phf_map.entry("sha224sum", map_value.clone());
                 phf_map.entry("sha256sum", map_value.clone());
                 phf_map.entry("sha384sum", map_value.clone());
                 phf_map.entry("sha512sum", map_value.clone());
-                phf_map.entry("sha3sum", map_value_bits.clone());
-                phf_map.entry("sha3-224sum", map_value.clone());
-                phf_map.entry("sha3-256sum", map_value.clone());
-                phf_map.entry("sha3-384sum", map_value.clone());
-                phf_map.entry("sha3-512sum", map_value.clone());
-                phf_map.entry("shake128sum", map_value_bits.clone());
-                phf_map.entry("shake256sum", map_value_bits.clone());
                 phf_map.entry("b2sum", map_value.clone());
-                phf_map.entry("b3sum", map_value_b3sum);
             }
             _ => {
                 phf_map.entry(krate, map_value.clone());

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -54,13 +54,6 @@ supports computing the checksums with several algorithms. The flags and options
 are identical to the `*sum` family of utils (`sha1sum`, `sha256sum`, `b2sum`,
 etc.). This utility will be removed in the future and it is advised to use `cksum --untagged` instead.
 
-## `b3sum`
-
-This utility does not exist in GNU coreutils. The behavior is modeled after both
-the `b2sum` utility of GNU and the
-[`b3sum`](https://github.com/BLAKE3-team/BLAKE3) utility by the BLAKE3 team. It also
-supports the `--no-names` option, that does not appear in the GNU utility.
-
 ## `more`
 
 We provide a simple implementation of `more`, which is not part of GNU

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -507,15 +507,6 @@ fn uu_app(binary_name: &str) -> (Command, bool) {
         }
         // b2sum supports the md5sum options plus -l/--length.
         "b2sum" => (uu_app_length(), false),
-        // These have never been part of GNU Coreutils, but can function with the same
-        // options as md5sum.
-        "sha3-224sum" | "sha3-256sum" | "sha3-384sum" | "sha3-512sum" => (uu_app_common(), false),
-        // These have never been part of GNU Coreutils, and require an additional --bits
-        // option to specify their output size.
-        "sha3sum" | "shake128sum" | "shake256sum" => (uu_app_bits(), false),
-        // b3sum has never been part of GNU Coreutils, and has a --no-names option in
-        // addition to the b2sum options.
-        "b3sum" => (uu_app_b3sum(), false),
         // We're probably just being called as `hashsum`, so give them everything.
         _ => (uu_app_custom(), true),
     };

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -1142,14 +1142,6 @@ fn test_help_shows_correct_utility_name() {
         .stdout_contains("Usage: b2sum")
         .stdout_does_not_contain("Usage: hashsum");
 
-    // Test b3sum
-    scene
-        .ccmd("b3sum")
-        .arg("--help")
-        .succeeds()
-        .stdout_contains("Usage: b3sum")
-        .stdout_does_not_contain("Usage: hashsum");
-
     // Test that generic hashsum still shows the correct usage
     scene
         .ccmd("hashsum")


### PR DESCRIPTION
Remove non-GNU checksum binaries since they are already broken at 0.3.0 (#9108) and causing many confusions.

Closes #9106 . Closes #8996 . Closes #8995 . Closes #8861 . Closes #8654 Fixes #8984.

Reverting this should be easy after someone made compat utils with another projects.