### PR TITLE
Fix test job in FreeBSD workflow

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -196,7 +196,7 @@ jobs:
           if (test -z "\$FAULT"); then cargo nextest run --hide-progress-bar --profile ci --features '${{ matrix.job.features }}' || FAULT=1 ; fi
           # There is no systemd-logind on FreeBSD, so test all features except feat_systemd_logind ( https://github.com/rust-lang/cargo/issues/3126#issuecomment-2523441905 )
           if (test -z "\$FAULT"); then
-            UUCORE_FEATURES=\$(cargo metadata --format-version=1 --no-deps -p uucore | jq -r '.packages[] | select(.name == "uucore") | .features | keys | .[]' | grep -v "feat_systemd_logind" | paste -s -d "," -)
+            UUCORE_FEATURES=\$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "uucore") | .features | keys | .[]' | grep -v "feat_systemd_logind" | paste -s -d "," -)
             cargo nextest run --hide-progress-bar --profile ci --features "\$UUCORE_FEATURES" -p uucore || FAULT=1
           fi
           # Test building with make


### PR DESCRIPTION
In PR #8483 (add `feat_systemd_logind` feature), job `test` in FreeBSD workflow was modified to disable tests for `feat_systemd_logind` feature (not supported on FreeBSD). But the `cargo metadata` command is wrong => `-p uucore` does not exist.
```yaml
UUCORE_FEATURES=\$(cargo metadata --format-version=1 --no-deps -p uucore | jq -r '.packages[] | select(.name == "uucore") | .features | keys | .[]' | grep -v "feat_systemd_logind" | paste -s -d "," -)
```

There are some errors when running `test` job in FreeBSD workflow (but not trapped by the shell script). For example in this run of FreeBSD workflow (https://github.com/uutils/coreutils/actions/runs/19094908884/job/54553168173#step:5:8891):
```sh
 error: unexpected argument '-p' found
```

---

Fix in `.github/workflows/freebsd.yml`: remove wrong flag `-p uucore` for `cargo metadata` command to get features.

**Tests OK** => see this run in my personal fork, https://github.com/lcheylus/rust-coreutils/actions/runs/19126450509