### PR TITLE
ci: adapt template name for Lima v2.0

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1269,7 +1269,7 @@ jobs:
         path: ~/.cache/lima
         key: lima-${{ steps.lima-actions-setup.outputs.version }}
     - name: Start Fedora VM with SELinux
-      run: limactl start --plain --name=default --cpus=4 --disk=30 --memory=4 --network=lima:user-v2 template://fedora
+      run: limactl start --plain --name=default --cpus=4 --disk=30 --memory=4 --network=lima:user-v2 template:fedora
     - run: rsync -v -a -e ssh . lima-default:~/work/
     - name: Setup Rust and other build deps in VM
       run: |

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -197,7 +197,7 @@ jobs:
         path: ~/.cache/lima
         key: lima-${{ steps.lima-actions-setup.outputs.version }}
     - name: Start Fedora VM with SELinux
-      run: limactl start --plain --name=default --cpus=4 --disk=40 --memory=8 --network=lima:user-v2 template://fedora
+      run: limactl start --plain --name=default --cpus=4 --disk=40 --memory=8 --network=lima:user-v2 template:fedora
     - name: Verify SELinux Status and Configuration
       run: |
         lima getenforce


### PR DESCRIPTION
The SELinux-related CI jobs started to fail with the following error after the Lima v2.0 release:
```
Run limactl start --plain --name=default --cpus=4 --disk=40 --memory=8 --network=lima:user-v2 template://fedora
time="2025-11-06T12:35:38Z" level=warning msg="Template locator \"template://fedora\" should be written \"template:fedora\" since Lima v2.0"
time="2025-11-06T12:35:38Z" level=fatal msg="template \"_images/fedora-43.yaml\" not found"
```
While I originally thought that the warning and the error are connected, they are two different issues. This PR fixes the warning, whereas the error is from upstream: https://github.com/lima-vm/lima/issues/4313.