### PR TITLE
timeout: add missing extra help

### DIFF
--- a/src/uu/timeout/locales/en-US.ftl
+++ b/src/uu/timeout/locales/en-US.ftl
@@ -7,6 +7,17 @@ timeout-help-kill-after = also send a KILL signal if COMMAND is still running th
 timeout-help-preserve-status = exit with the same status as COMMAND, even when the command times out
 timeout-help-signal = specify the signal to be sent on timeout; SIGNAL may be a name like 'HUP' or a number; see 'kill -l' for a list of signals
 timeout-help-verbose = diagnose to stderr any signal sent upon timeout
+timeout-help-duration = a floating point number with an optional suffix: 's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days ; a duration of 0 disables the associated timeout
+timeout-help-command = a command to execute with optional arguments
+timeout-after-help = Upon timeout, send the TERM signal to COMMAND, if no other SIGNAL specified. The TERM signal kills any process that does not block or catch that signal. It may be necessary to use the KILL signal, since this signal can't be caught.
+
+  Exit status:
+    124  if COMMAND times out, and --preserve-status is not specified
+    125  if the timeout command itself fails
+    126  if COMMAND is found but cannot be invoked
+    127  if COMMAND cannot be found
+    137  if COMMAND (or timeout itself) is sent the KILL (9) signal (128+9)
+    -    the exit status of COMMAND otherwise
 
 # Error messages
 timeout-error-invalid-signal = { $signal }: invalid signal

--- a/src/uu/timeout/locales/fr-FR.ftl
+++ b/src/uu/timeout/locales/fr-FR.ftl
@@ -7,6 +7,17 @@ timeout-help-kill-after = envoyer aussi un signal KILL si COMMANDE fonctionne en
 timeout-help-preserve-status = sortir avec le même statut que COMMANDE, même quand la commande dépasse le délai
 timeout-help-signal = spécifier le signal à envoyer en cas de délai dépassé ; SIGNAL peut être un nom comme 'HUP' ou un nombre ; voir 'kill -l' pour une liste des signaux
 timeout-help-verbose = diagnostiquer vers stderr tout signal envoyé lors d'un dépassement de délai
+timeout-help-duration = un nombre à virgule flottante avec un suffixe facultatif : 's' pour les secondes (par défaut), 'm' pour les minutes, 'h' pour les heures ou 'd' pour les jours ; une durée de 0 désactive le délai d'expiration associé
+timeout-help-command = une commande à exécuter avec des arguments optionels
+timeout-after-help = À l'expiration du délai, le signal TERM est envoyé à COMMANDE, si aucun autre SIGNAL n'est spécifié. Le signal TERM tue tout processus qui ne bloque pas ou n'intercepte pas ce signal. Il peut être nécessaire d'utiliser le signal KILL, puisque ce signal ne peut pas être intercepté.
+
+  Statut de sortie :
+    124  si COMMANDE expire et que --preserve-status n'est pas spécifié
+    125  si la commande timeout elle-même échoue
+    126  si COMMANDE est trouvé mais ne peut être invoqué
+    127  si COMMANDE est introuvable
+    137  si COMMANDE (ou timeout lui-même) reçoit le signal KILL (9) (128+9)
+    -    sinon, le statut de sortie de COMMANDE
 
 # Messages d'erreur
 timeout-error-invalid-signal = { $signal } : signal invalide

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -159,15 +159,21 @@ pub fn uu_app() -> Command {
                 .help(translate!("timeout-help-verbose"))
                 .action(ArgAction::SetTrue),
         )
-        .arg(Arg::new(options::DURATION).required(true))
+        .arg(
+            Arg::new(options::DURATION)
+                .required(true)
+                .help(translate!("timeout-help-duration")),
+        )
         .arg(
             Arg::new(options::COMMAND)
                 .required(true)
                 .action(ArgAction::Append)
+                .help(translate!("timeout-help-command"))
                 .value_hint(clap::ValueHint::CommandName),
         )
         .trailing_var_arg(true)
         .infer_long_args(true)
+        .after_help(translate!("timeout-after-help"))
 }
 
 /// Remove pre-existing SIGCHLD handlers that would make waiting for the child's exit code fail.


### PR DESCRIPTION
Compared to the GNU Coreutils timeout usage menu and man page, some parts were missing here:

 - What the `<duration>` and `<command>` arguments stand for.

 - Which signal is being sent by default.

 - What the different exit status are.

All the new descriptions are coming from the GNU Coreutils project, except the one for `<command>` which is a new one.

French translations are also provided. (I am a French native speaker.)