### PR TITLE
Cargo.toml: move codegen-units to release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -592,13 +592,13 @@ required-features = ["uudoc"]
 # the stack traces will still be available.
 [profile.release]
 lto = true
+codegen-units = 1
 
 # A release-like profile that is tuned to be fast, even when being fast
 # compromises on binary size. This includes aborting on panic.
 [profile.release-fast]
 inherits = "release"
 panic = "abort"
-codegen-units = 1
 
 # A release-like profile that is as small as possible.
 [profile.release-small]


### PR DESCRIPTION
Retrying this since CodSpeed was unstable previously. Release page should provide this binary.