### PR TITLE
fix(install): preserve setuid/setgid bits after chown operations

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -494,12 +494,12 @@ fn directory(paths: &[OsString], b: &Behavior) -> UResult<()> {
             }
 
             if let Err(e) = mode::chmod(path, b.mode()) {
-                    show_error!(
-                "{}",
-            translate!("install-error-chmod-failed", "error" => e.to_string())
-            );
-            uucore::error::set_exit_code(1);
-                    continue;
+                show_error!(
+                    "{}",
+                    translate!("install-error-chmod-failed", "error" => e.to_string())
+                );
+                uucore::error::set_exit_code(1);
+                continue;
             }
 
             show_if_err!(chown_optional_user_group(path, b));
@@ -921,11 +921,11 @@ fn strip_file(to: &Path, b: &Behavior) -> UResult<()> {
 ///
 fn set_ownership_and_permissions(to: &Path, b: &Behavior) -> UResult<()> {
     if let Err(e) = mode::chmod(to, b.mode()) {
-show_error!(
-    "{}",
-translate!("install-error-chmod-failed", "error" => e.to_string())
-);
-return Err(InstallError::ChmodFailed(to.to_path_buf()).into());
+        show_error!(
+            "{}",
+            translate!("install-error-chmod-failed", "error" => e.to_string())
+        );
+        return Err(InstallError::ChmodFailed(to.to_path_buf()).into());
     }
 
     chown_optional_user_group(to, b)?;
@@ -934,11 +934,11 @@ return Err(InstallError::ChmodFailed(to.to_path_buf()).into());
     // Re-apply chmod after chown to restore these bits.
     #[cfg(unix)]
     if let Err(e) = mode::chmod(to, b.mode()) {
-show_error!(
-    "{}",
-translate!("install-error-chmod-failed", "error" => e.to_string())
-);
-return Err(InstallError::ChmodFailed(to.to_path_buf()).into());
+        show_error!(
+            "{}",
+            translate!("install-error-chmod-failed", "error" => e.to_string())
+        );
+        return Err(InstallError::ChmodFailed(to.to_path_buf()).into());
     }
 
     Ok(())

--- a/src/uu/install/src/mode.rs
+++ b/src/uu/install/src/mode.rs
@@ -26,18 +26,18 @@ pub fn parse(mode_string: &str, considering_dir: bool, umask: u32) -> Result<u32
 ///
 #[cfg(any(unix, target_os = "redox"))]
 pub fn chmod(path: &Path, mode: u32) -> Result<(), std::io::Error> {
-use std::ffi::CString;
-use uucore::libc;
+    use std::ffi::CString;
+    use uucore::libc;
 
     let c_path = CString::new(path.as_os_str().as_bytes())
-    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
 
     // Use libc::chmod directly to properly handle all mode bits including special bits
-if unsafe { libc::chmod(c_path.as_ptr(), mode as libc::mode_t) } != 0 {
-    Err(std::io::Error::last_os_error())
-} else {
-    Ok(())
-}
+    if unsafe { libc::chmod(c_path.as_ptr(), mode as libc::mode_t) } != 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 /// chmod a file or directory on Windows.
@@ -46,6 +46,6 @@ if unsafe { libc::chmod(c_path.as_ptr(), mode as libc::mode_t) } != 0 {
 ///
 #[cfg(windows)]
 pub fn chmod(path: &Path, mode: u32) -> Result<(), std::io::Error> {
-// chmod on Windows only sets the readonly flag, which isn't even honored on directories
-Ok(())
+    // chmod on Windows only sets the readonly flag, which isn't even honored on directories
+    Ok(())
 }

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2445,7 +2445,11 @@ fn test_install_special_mode_bits_setuid() {
     let permissions = at.metadata(dest).permissions();
     let mode = PermissionsExt::mode(&permissions);
     // Check that setuid bit is set
-    assert_eq!(mode & (S_ISUID as u32), S_ISUID as u32, "setuid bit should be set");
+    assert_eq!(
+        mode & (S_ISUID as u32),
+        S_ISUID as u32,
+        "setuid bit should be set"
+    );
     // Check that regular permissions are correct
     assert_eq!(mode & 0o0777, 0o0755, "regular permissions should be 755");
 }
@@ -2471,7 +2475,11 @@ fn test_install_special_mode_bits_setgid() {
     let permissions = at.metadata(dest).permissions();
     let mode = PermissionsExt::mode(&permissions);
     // Check that setgid bit is set
-    assert_eq!(mode & (S_ISGID as u32), S_ISGID as u32, "setgid bit should be set");
+    assert_eq!(
+        mode & (S_ISGID as u32),
+        S_ISGID as u32,
+        "setgid bit should be set"
+    );
     // Check that regular permissions are correct
     assert_eq!(mode & 0o0777, 0o0755, "regular permissions should be 755");
 }
@@ -2560,13 +2568,17 @@ fn test_install_special_mode_bits_with_chown() {
 fn test_install_special_mode_bits_combinations() {
     // Test various combinations of special bits
     let test_cases = [
-    (0o4755u32, S_ISUID as u32, "setuid only"),
-    (0o2755u32, S_ISGID as u32, "setgid only"),
-    (0o1755u32, S_ISVTX as u32, "sticky only"),
-    (0o6755u32, (S_ISUID | S_ISGID) as u32, "setuid + setgid"),
-    (0o5755u32, (S_ISUID | S_ISVTX) as u32, "setuid + sticky"),
-    (0o3755u32, (S_ISGID | S_ISVTX) as u32, "setgid + sticky"),
-    (0o7755u32, (S_ISUID | S_ISGID | S_ISVTX) as u32, "all special bits"),
+        (0o4755u32, S_ISUID as u32, "setuid only"),
+        (0o2755u32, S_ISGID as u32, "setgid only"),
+        (0o1755u32, S_ISVTX as u32, "sticky only"),
+        (0o6755u32, (S_ISUID | S_ISGID) as u32, "setuid + setgid"),
+        (0o5755u32, (S_ISUID | S_ISVTX) as u32, "setuid + sticky"),
+        (0o3755u32, (S_ISGID | S_ISVTX) as u32, "setgid + sticky"),
+        (
+            0o7755u32,
+            (S_ISUID | S_ISGID | S_ISVTX) as u32,
+            "all special bits",
+        ),
     ];
 
     for (mode, expected_bits, description) in test_cases {


### PR DESCRIPTION
Fixes #9134 

`install -m4755` failed to set special permission bits because chown strips them for security. Added second chmod call after chown and improved error handling with libc::chmod for proper special bit support. Updated callers to handle io::Error and added localized error messages. and  tests included.