### PR TITLE
Cargo.toml: Split debug symbol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime serde bincode gethostid kqueue libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs
+# spell-checker:ignore (libs) bigdecimal datetime serde bincode gethostid kqueue libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs debuginfo
 
 [package]
 name = "coreutils"
@@ -611,6 +611,7 @@ strip = true
 [profile.profiling]
 inherits = "release"
 debug = true
+split-debuginfo = "unpacked"
 
 [lints]
 workspace = true


### PR DESCRIPTION
Someone may want to get smaller binary and debug info at one build. Not sure that can we remove 1 profile and merge to release.