### PR TITLE
factor: use num_prime crate's u64 and u128 factorization methods to speed up the performance of calculating prime numbers for u64 and u128

### DIFF
--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -36,26 +36,95 @@ fn print_factors_str(
         return Ok(());
     };
 
-    let (factorization, remaining) = if x > BigUint::from_u32(1).unwrap() {
-        num_prime::nt_funcs::factors(x.clone(), None)
+    if x > BigUint::from_u32(1).unwrap() {
+        // use num_prime's factorize64 algorithm for u64 integers
+        if x <= BigUint::from_u64(u64::MAX).unwrap() {
+            let prime_factors = num_prime::nt_funcs::factorize64(x.clone().to_u64_digits()[0]);
+            write_result_u64(w, &x, prime_factors, print_exponents)
+                .map_err_context(|| translate!("factor-error-write-error"))?;
+        }
+        // use num_prime's factorize128 algorithm for u128 integers
+        else if x <= BigUint::from_u128(u128::MAX).unwrap() {
+            let rx = num_str.trim().parse::<u128>();
+            let Ok(x) = rx else {
+                // return Ok(). it's non-fatal and we should try the next number.
+                show_warning!("{}: {}", num_str.maybe_quote(), rx.unwrap_err());
+                set_exit_code(1);
+                return Ok(());
+            };
+            let prime_factors = num_prime::nt_funcs::factorize128(x);
+            write_result_u128(w, &x, prime_factors, print_exponents)
+                .map_err_context(|| translate!("factor-error-write-error"))?;
+        }
+        // use num_prime's fallible factorization for anything greater than u128::MAX
+        else {
+            let (prime_factors, remaining) = num_prime::nt_funcs::factors(x.clone(), None);
+            if let Some(_remaining) = remaining {
+                return Err(USimpleError::new(
+                    1,
+                    translate!("factor-error-factorization-incomplete"),
+                ));
+            }
+            write_result_big_uint(w, &x, prime_factors, print_exponents)
+                .map_err_context(|| translate!("factor-error-write-error"))?;
+        }
     } else {
-        (BTreeMap::new(), None)
-    };
-
-    if let Some(_remaining) = remaining {
-        return Err(USimpleError::new(
-            1,
-            translate!("factor-error-factorization-incomplete"),
-        ));
+        let empty_primes: BTreeMap<BigUint, usize> = BTreeMap::new();
+        write_result_big_uint(w, &x, empty_primes, print_exponents)
+            .map_err_context(|| translate!("factor-error-write-error"))?;
     }
-
-    write_result(w, &x, factorization, print_exponents)
-        .map_err_context(|| translate!("factor-error-write-error"))?;
 
     Ok(())
 }
 
-fn write_result(
+/// Writing out the prime factors for u64 integers
+fn write_result_u64(
+    w: &mut io::BufWriter<impl Write>,
+    x: &BigUint,
+    factorization: BTreeMap<u64, usize>,
+    print_exponents: bool,
+) -> io::Result<()> {
+    write!(w, "{x}:")?;
+    for (factor, n) in factorization {
+        if print_exponents {
+            if n > 1 {
+                write!(w, " {factor}^{n}")?;
+            } else {
+                write!(w, " {factor}")?;
+            }
+        } else {
+            w.write_all(format!(" {factor}").repeat(n).as_bytes())?;
+        }
+    }
+    writeln!(w)?;
+    w.flush()
+}
+
+/// Writing out the prime factors for u128 integers
+fn write_result_u128(
+    w: &mut io::BufWriter<impl Write>,
+    x: &u128,
+    factorization: BTreeMap<u128, usize>,
+    print_exponents: bool,
+) -> io::Result<()> {
+    write!(w, "{x}:")?;
+    for (factor, n) in factorization {
+        if print_exponents {
+            if n > 1 {
+                write!(w, " {factor}^{n}")?;
+            } else {
+                write!(w, " {factor}")?;
+            }
+        } else {
+            w.write_all(format!(" {factor}").repeat(n).as_bytes())?;
+        }
+    }
+    writeln!(w)?;
+    w.flush()
+}
+
+/// Writing out the prime factors for BigUint integers
+fn write_result_big_uint(
     w: &mut io::BufWriter<impl Write>,
     x: &BigUint,
     factorization: BTreeMap<BigUint, usize>,


### PR DESCRIPTION
Currently, in `factor.rs`, it opts to use `num_prime` crate's `factors()` method only. `num_prime` also has specific prime factorization methods for `u64` and `u128` targets (`factorize64()` and `factorize128()`), which seems to be suited and faster for those situations (which improves partially upon the performance issue mentioned in #1456). This PR uses those specific methods in the event that we're given an integer that fits as a u64 or u128.

In terms of performance, running `seq 2 10000000 | factor` using `num_prime`'s `factors()` vs `num_prime`'s `factorizeu64()` shows the following results from hyperfine:

With `factors()`
```
$ hyperfine '~/coding-project/coreutils/target/release/seq 2 10000000 | ~/coding-project/coreutils/target/release/factor'
Benchmark 1: ~/coding-project/coreutils/target/release/seq 2 10000000 | ~/coding-project/coreutils/target/release/factor
  Time (mean ± σ):     16.946 s ±  0.147 s    [User: 14.600 s, System: 2.385 s]
  Range (min … max):   16.816 s … 17.175 s    10 runs
```

With `factorize64()`
```
$ hyperfine '~/coding-project/coreutils/target/release/seq 2 10000000 | ~/coding-project/coreutils/target/release/factor'
Benchmark 1: ~/coding-project/coreutils/target/release/seq 2 10000000 | ~/coding-project/coreutils/target/release/factor
  Time (mean ± σ):     11.778 s ±  0.087 s    [User: 9.526 s, System: 2.310 s]
  Range (min … max):   11.632 s … 11.950 s    10 runs
```

Any feedback and suggestions on making the changes in this PR compact would be nice as well. I haven't found a way to neatly convert `BigUint` to `u64` or `u128` from reading through the `num_bigint` crate docs, and due to using `u64`/`u128`/`BigUint` types for the `BTreeMap`, I have three different write_result methods to handle each case.

Pertaining to comparing this with GNU's factor, I'm skeptical about the timing results mentioned on hyperfine. Without any visible outputs, hyperfine indicates that GNU's factor runs the following command in 1.2 seconds:
```
$ hyperfine '~/coding-project/coreutils/target/release/seq 2 10000000 | factor'
Benchmark 1: ~/coding-project/coreutils/target/release/seq 2 10000000 | factor
  Time (mean ± σ):      1.224 s ±  0.004 s    [User: 1.264 s, System: 0.056 s]
  Range (min … max):    1.217 s …  1.230 s    10 runs
``` 

However, I read through this closed issue mentioned in hyperfine's repo: https://github.com/sharkdp/hyperfine/issues/377 and it seems like there are situations where GNU's commands changes its execution if it detects that stdout is `/dev/null` (which Hyperfine attaches `Stdio::null()` to stdout of the command). I'm not certain if this is the case for how GNU's factor work, but when I run GNU's factor with `--show-output flag`, it gives me the following timing result (which seems to be more accurate on how long GNU's factor takes):
```
$ hyperfine --show-output '~/coding-project/coreutils/target/release/seq 2 10000000 | factor'
Time (mean ± σ):     16.148 s ±  0.134 s    [User: 3.926 s, System: 12.290 s]
  Range (min … max):   15.967 s … 16.433 s    10 runs
```

Comparing GNU's factor to the changes made by this PR with --show-output flag on in hyperfine shows the following:
```
$ hyperfine --show-output '~/coding-project/coreutils/target/release/seq 2 10000000 | ~/coding-project/coreutils/target/release/factor'
Time (mean ± σ):     28.907 s ±  0.177 s    [User: 15.908 s, System: 13.013 s]
  Range (min … max):   28.610 s … 29.177 s    10 runs
```

GNU's factor is definitely still faster than uutils' factor. In the future, it might be better to experiment with other prime factorization crates or make our own efficient implementation of prime factorization in Rust for performance gain.