### PR TITLE
timeout: Fix performance regression using sigtimedwait

### DIFF
--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/timeout.rs"
 [dependencies]
 clap = { workspace = true }
 libc = { workspace = true }
-nix = { workspace = true, features = ["signal"] }
+nix = { workspace = true, features = ["signal", "event"] }
 uucore = { workspace = true, features = ["parser", "process", "signals"] }
 fluent = { workspace = true }
 

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -94,6 +94,7 @@ nix = { workspace = true, features = [
   "dir",
   "user",
   "poll",
+  "event",
 ] }
 xattr = { workspace = true, optional = true }
 


### PR DESCRIPTION
Resolves #9099

The timeout implementation was using a 100ms polling loop, causing significant performance overhead (~100ms vs GNU's 1.1ms).

This commit replaces the polling approach with POSIX sigtimedwait(), which suspends the process until SIGCHLD or timeout occurs, eliminating the busy-wait overhead.

Key changes:
- Block SIGCHLD/SIGTERM before spawning child
- Use sigtimedwait() for efficient signal-based waiting
- Properly save and restore signal mask on all exit paths
- Handle EINTR correctly with timeout recalculation

Performance improvement:
- Before: 106.9ms ± 2.0ms
- After:  1.2ms ± 0.1ms
- GNU:    1.1ms ± 0.1ms

Tested with 100+ iterations, maintains 100% reliability.

## Approach

This implementation follows the same general approach as GNU timeout:
- Use signal blocking + signal waiting (vs polling)
- GNU uses `timer_create()` + `sigsuspend()`
- We use `sigtimedwait()` with timeout parameter
- Both approaches are equally efficient (~2 syscalls for hot path)

## Related

Similar to approach in PR #9123 by @andreacorbellini, but with careful signal mask restoration to avoid state leakage.