### PR TITLE
stdbuf: add support for OpenBSD

### DIFF
--- a/src/uu/stdbuf/build.rs
+++ b/src/uu/stdbuf/build.rs
@@ -14,6 +14,7 @@ use std::process::Command;
     target_os = "android",
     target_os = "freebsd",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "dragonfly"
 ))]
 mod platform {

--- a/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
+++ b/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
@@ -27,7 +27,15 @@ pub unsafe extern "C" fn __stdbuf_get_stdin() -> *mut FILE {
         unsafe { __stdinp() }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
+    #[cfg(target_os = "openbsd")]
+    {
+        unsafe extern "C" {
+            static mut __stdin: *mut FILE;
+        }
+        unsafe { __stdin }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")))]
     {
         unsafe extern "C" {
             static mut stdin: *mut FILE;
@@ -48,7 +56,15 @@ pub unsafe extern "C" fn __stdbuf_get_stdout() -> *mut FILE {
         unsafe { __stdoutp() }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
+    #[cfg(target_os = "openbsd")]
+    {
+        unsafe extern "C" {
+            static mut __stdout: *mut FILE;
+        }
+        unsafe { __stdout }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")))]
     {
         unsafe extern "C" {
             static mut stdout: *mut FILE;
@@ -69,7 +85,15 @@ pub unsafe extern "C" fn __stdbuf_get_stderr() -> *mut FILE {
         unsafe { __stderrp() }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
+    #[cfg(target_os = "openbsd")]
+    {
+        unsafe extern "C" {
+            static mut __stderr: *mut FILE;
+        }
+        unsafe { __stderr }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")))]
     {
         unsafe extern "C" {
             static mut stderr: *mut FILE;

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -35,6 +35,7 @@ mod options {
         target_os = "android",
         target_os = "freebsd",
         target_os = "netbsd",
+        target_os = "openbsd",
         target_os = "dragonfly"
     )
 ))]
@@ -82,6 +83,7 @@ enum ProgramOptionsError {
     target_os = "android",
     target_os = "freebsd",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "dragonfly"
 ))]
 fn preload_strings() -> UResult<(&'static str, &'static str)> {
@@ -98,6 +100,7 @@ fn preload_strings() -> UResult<(&'static str, &'static str)> {
     target_os = "android",
     target_os = "freebsd",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "dragonfly",
     target_vendor = "apple"
 )))]


### PR DESCRIPTION
- `src/uu/stdbuf/build.rs`: add OS "openbsd" to define const `DYLIB_EXT = .so`
- `src/uu/stdbuf/src/stdbuf.rs`: add OS "openbsd" in cfg conditional checks
- `src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs`: define `stdin`, `stdout`, `stderr` on OpenBSD using `__stdin`, `__stdout` and `__stderr`

Fix #9178 

---
**Tests OK for stdbuf** on OpenBSD current/amd64 with Rust 1.90.0
```sh
$ rustc -vV
rustc 1.90.0 (1159e78c4 2025-09-14) (built from a source tarball)
binary: rustc
commit-hash: 1159e78c4747b02ef996e55082b704c09b970588
commit-date: 2025-09-14
host: x86_64-unknown-openbsd
release: 1.90.0
LLVM version: 19.1.7

$ cargo test -v --no-default-features --features stdbuf
(...)
running 6 tests
test test_stdbuf::invalid_input ... ok
test test_stdbuf::test_no_such ... ok
test test_stdbuf::test_permission ... ok
test test_stdbuf::test_stdbuf_line_buffering_stdin_fails ... ok
test test_stdbuf::test_stdbuf_no_buffer_option_fails ... ok
test test_stdbuf::test_stdbuf_invalid_mode_fails ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
```