### PR TITLE
fix(cksum): add debug option and resolve GNU cksum.sh --debug option test

### DIFF
--- a/src/uu/cksum/locales/en-US.ftl
+++ b/src/uu/cksum/locales/en-US.ftl
@@ -22,6 +22,7 @@ cksum-help-raw = emit a raw binary digest, not hexadecimal
 cksum-help-strict = exit non-zero for improperly formatted checksum lines
 cksum-help-check = read hashsums from the FILEs and check them
 cksum-help-base64 = emit a base64 digest, not hexadecimal
+cksum-help-debug = indicate which implementation is used
 cksum-help-warn = warn about improperly formatted checksum lines
 cksum-help-status = don't output anything, status code shows success
 cksum-help-quiet = don't print OK for each successfully verified file

--- a/src/uu/cksum/locales/fr-FR.ftl
+++ b/src/uu/cksum/locales/fr-FR.ftl
@@ -22,6 +22,7 @@ cksum-help-raw = émettre un condensé binaire brut, pas hexadécimal
 cksum-help-strict = sortir avec un code non-zéro pour les lignes de somme de contrôle mal formatées
 cksum-help-check = lire les sommes de hachage des FICHIERs et les vérifier
 cksum-help-base64 = émettre un condensé base64, pas hexadécimal
+cksum-help-debug = indiquer quelle implémentation est utilisée
 cksum-help-warn = avertir des lignes de somme de contrôle mal formatées
 cksum-help-status = ne rien afficher, le code de statut indique le succès
 cksum-help-quiet = ne pas afficher OK pour chaque fichier vérifié avec succès

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -22,6 +22,11 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_debug_flag_is_accepted() {
+    new_ucmd!().arg("--debug").arg("lorem_ipsum.txt").succeeds();
+}
+
+#[test]
 fn test_single_file() {
     new_ucmd!()
         .arg("lorem_ipsum.txt")


### PR DESCRIPTION
Implement cksum --debug option by mirroring GNU’s hardware reporting (including GLIBC_TUNABLES handling), documenting the helper, adding localized help text, and extending the cksum tests to cover the new flag and hwcap parser.

#9127 