### PR TITLE
uptime: fix clippy warning manual-let-else on OpenBSD

### DIFF
--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -213,9 +213,8 @@ pub fn get_nusers() -> usize {
 pub fn get_nusers(file: &str) -> usize {
     use utmp_classic::{UtmpEntry, parse_from_path};
 
-    let entries = match parse_from_path(file) {
-        Ok(e) => e,
-        Err(_) => return 0,
+    let Ok(entries) = parse_from_path(file) else {
+        return 0;
     };
 
     if entries.is_empty() {


### PR DESCRIPTION
After merge of PR #9158, there is a warning on OpenBSD with `clippy`:
```sh
(...)
  error: this could be rewritten as `let...else`
     --> src/uucore/src/lib/features/uptime.rs:216:5
      |
  216 | /     let entries = match parse_from_path(file) {
  217 | |         Ok(e) => e,
  218 | |         Err(_) => return 0,
  219 | |     };
      | |______^ help: consider writing: `let Ok(entries) = parse_from_path(file) else { return 0 };`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else
      = note: `-D clippy::manual-let-else` implied by `-D warnings`
      = help: to override `-D warnings` add `#[allow(clippy::manual_let_else)]`
```

In `src/uucore/src/lib/features/uptime.rs`, replace `match parse_from_path(file)` with a `let..else` expression to fix this warning.

**Tests OK** on OpenBSD/amd64 with Rust 1.90.0 for `uptime`:
```sh
$ cargo test -v --no-default-features --features uptime
(...)
running 7 tests
test test_uptime::test_uptime ... ok
test test_uptime::test_uptime_check_users_openbsd ... ok
test test_uptime::test_invalid_arg ... ok
test test_uptime::test_uptime_with_dir ... ok
test test_uptime::test_uptime_with_extra_argument ... ok
test test_uptime::test_uptime_with_non_existent_file ... ok
test test_uptime::test_uptime_since ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```