### PR TITLE
Align base64 with GNU base64.pl tests

### DIFF
--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -2,6 +2,9 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
+// spell-checker:ignore unpadded, QUJD
+
 #[cfg(target_os = "linux")]
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
@@ -106,6 +109,33 @@ fn test_decode_repeat_flags() {
         .pipe_in(input)
         .succeeds()
         .stdout_only("hello, world!");
+}
+
+#[test]
+fn test_decode_padded_block_followed_by_unpadded_tail() {
+    new_ucmd!()
+        .arg("--decode")
+        .pipe_in("MTIzNA==MTIzNA")
+        .succeeds()
+        .stdout_only("12341234");
+}
+
+#[test]
+fn test_decode_padded_block_followed_by_aligned_tail() {
+    new_ucmd!()
+        .arg("--decode")
+        .pipe_in("MTIzNA==QUJD")
+        .succeeds()
+        .stdout_only("1234ABC");
+}
+
+#[test]
+fn test_decode_unpadded_stream_without_equals() {
+    new_ucmd!()
+        .arg("--decode")
+        .pipe_in("MTIzNA")
+        .succeeds()
+        .stdout_only("1234");
 }
 
 #[test]


### PR DESCRIPTION
GNU’s tests/basenc/base64.pl revealed that our base64 decoder rejected streams where = appeared before EOF. This change updates the shared base logic to detect padding anywhere in the input, teaches the SIMD decoder to process padded and unpadded segments sequentially, and adds unit coverage for the concatenated cases.

#9127 