### PR TITLE
Base64: Memory usage improvements

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore hexupper lsbf msbf unpadded nopad aGVsbG8sIHdvcmxkIQ
+// spell-checker:ignore hexupper lsbf msbf unpadded nopad aGVsbG8sIHdvcmxkIQ hellohello
 
 use clap::{Arg, ArgAction, Command};
 use std::ffi::OsString;


### PR DESCRIPTION
### Summary

Reworked base_common streaming so base64/basenc no longer slurp stdin into RAM; both encoder/decoder now read from any Read stream with bounded buffers, keep line-wrapping support, and reuse the SIMD wrapper.
Tightened the Base64SimdWrapper integration and added regression tests that cover streaming encode/decode behaviors plus chunked readers.
Fixed Clippy’s elidable lifetime warning and ensured Base58 handling no longer triggers gigantic buffer allocations.

### Testing

cargo test -p uu_base32
cargo test -p uu_base64
cargo test -p uu_basenc
/usr/bin/time -l sh -c "cat benchmarks/bench_500mb.bin | /usr/bin/base64 > /dev/null" → max RSS 1.85 MB
/usr/bin/time -l sh -c "cat benchmarks/bench_500mb.bin | ./target/release/base64 > /dev/null" → max RSS 2.38 MB
/usr/bin/time -l sh -c "cat benchmarks/bench_500mb.b64 | /usr/bin/base64 -D > /dev/null" → max RSS 1.85 MB
/usr/bin/time -l sh -c "cat benchmarks/bench_500mb.b64 | ./target/release/base64 -d > /dev/null" → max RSS 2.33 MB