### PR TITLE
build-gnu.sh: Let SELinux optional to use it locally without libselinux

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -244,7 +244,7 @@ jobs:
     ### Build
     - name: Build binaries
       run: |
-        lima bash -c "cd ~/work/uutils/ && bash util/build-gnu.sh --release-build"
+        lima bash -c "cd ~/work/uutils/ && SELINUX_ENABLED=1 bash util/build-gnu.sh --release-build"
 
     ### Run tests as user
     - name: Generate SELinux tests list

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -105,12 +105,8 @@ echo "UU_BUILD_DIR='${UU_BUILD_DIR}'"
 
 cd "${path_UUTILS}" && echo "[ pwd:'${PWD}' ]"
 
-# Check for SELinux support
-if [ "$(uname)" == "Linux" ]; then
-    # Only attempt to enable SELinux features on Linux
-    export SELINUX_ENABLED=1
-    CARGO_FEATURE_FLAGS="${CARGO_FEATURE_FLAGS} selinux"
-fi
+export SELINUX_ENABLED # Run this script with=1 for testing SELinux
+[ "${SELINUX_ENABLED}" = 1 ] && CARGO_FEATURE_FLAGS="${CARGO_FEATURE_FLAGS} selinux"
 
 # Trim leading whitespace from feature flags
 CARGO_FEATURE_FLAGS="$(echo "${CARGO_FEATURE_FLAGS}" | sed -e 's/^[[:space:]]*//')"


### PR DESCRIPTION
`build-gnu.sh` could be used locally on the system missing selinux (not only on CI).

Separated from #8955 to reduce size of the PR.