### PR TITLE
freebsd.yml: remove not working PROFILE=

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -204,7 +204,7 @@ jobs:
             cargo nextest run --hide-progress-bar --profile ci --features "\$UUCORE_FEATURES" -p uucore || FAULT=1
           fi
           # Test building with make
-          if (test -z "\$FAULT"); then make PROFILE=ci || FAULT=1 ; fi
+          if (test -z "\$FAULT"); then make || FAULT=1 ; fi
           # Clean to avoid to rsync back the files
           cargo clean
           if (test -n "\$FAULT"); then exit 1 ; fi


### PR DESCRIPTION
`ci` profile is defined at `nextest.toml`. So `make PROFILE=ci` is not used actually.
One of this or #9080 should be merged and other should be closed.