### PR TITLE
GNUmakefile: drop not used use_default:=1

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -317,8 +317,6 @@ endif
 
 all: build
 
-use_default := 1
-
 build-pkgs:
 ifneq (${MULTICALL}, y)
 ifdef BUILD_SPEC_FEATURE


### PR DESCRIPTION
`GNUmakefile` is already cpmplex. Let simpler a bit.