### PR TITLE
ci: Mark runcon-no-reorder as SELinux required

### DIFF
--- a/util/gnu-patches/runcon-no-reorder.patch
+++ b/util/gnu-patches/runcon-no-reorder.patch
@@ -1,0 +1,14 @@
+--git a/tests/runcon/runcon-no-reorder.sh b/tests/runcon/runcon-no-reorder.sh
+index 2027555..956c51e 100644
+--- a/tests/runcon/runcon-no-reorder.sh
++++ b/tests/runcon/runcon-no-reorder.sh
+@@ -16,6 +16,9 @@
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ 
++# We don't have runcon buildable without libselinux.
++_require_selinux_
++
+ . "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
+ print_ver_ runcon
+ 

--- a/util/gnu-patches/series
+++ b/util/gnu-patches/series
@@ -11,3 +11,4 @@ tests_tsort.patch
 tests_du_move_dir_while_traversing.patch
 test_mkdir_restorecon.patch
 error_msg_uniq.diff
+runcon-no-reorder.patch


### PR DESCRIPTION
This test is runned at `Run GNU tests (native)` and `Run GNU tests (SELinux)`. But, we should not consider 1st test passed since we don't have `runcon` stub without `libselinux`.

Separated from #8955