### PR TITLE
build-gnu.sh: Remove || true

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -132,7 +132,8 @@ cd -
 
 # Pass the feature flags to make, which will pass them to cargo
 "${MAKE}" PROFILE="${UU_MAKE_PROFILE}" CARGOFLAGS="${CARGO_FEATURE_FLAGS}"
-[ ${SELINUX_ENABLED} = 1 ] && touch g && echo "stat with selinux support" && "${UU_MAKE_PROFILE}"/stat -c%C g && rm g
+# min test for SELinux
+[ ${SELINUX_ENABLED} = 1 ] && touch g && "${UU_MAKE_PROFILE}"/stat -c%C g && rm g
 
 cp "${UU_BUILD_DIR}/install" "${UU_BUILD_DIR}/ginstall" # The GNU tests rename this script before running, to avoid confusion with the make target
 # Create *sum binaries


### PR DESCRIPTION
We should catch error instead of ignoring.