### PR TITLE
GnuTests.yml: reduce deps

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -235,7 +235,7 @@ jobs:
     - name: Install dependencies in VM
       run: |
         lima sudo dnf -y update
-        lima sudo dnf -y install git autoconf autopoint bison texinfo gperf gcc g++ gdb jq libacl-devel libattr-devel libcap-devel libselinux-devel attr rustup clang-devel texinfo-tex wget automake patch quilt
+        lima sudo dnf -y install git autoconf autopoint bison texinfo gperf gcc gdb jq libacl-devel libattr-devel libcap-devel libselinux-devel attr rustup clang-devel texinfo-tex wget automake patch quilt
         lima rustup-init -y --default-toolchain stable
     - name: Copy the sources to VM
       run: |


### PR DESCRIPTION
`apt-get` process is very slow. Start cleaning up deps.
[Edit] Maybe, I should cleanup `dnf` 601 packages instead?