### PR TITLE
factor: improve large integer factorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "num-prime",
+ "num-traits",
  "uucore",
 ]
 

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -20,6 +20,7 @@ uucore = { workspace = true }
 memchr = { workspace = true }
 num-bigint = { workspace = true }
 num-prime = { workspace = true }
+num-traits = { workspace = true }
 fluent = { workspace = true }
 
 [[bin]]

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -3,7 +3,14 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore funcs newtype
+// spell-checker:ignore funcs biguint modpow unfactored
+// NOTE:
+//   For BigUint > u128, this implementation attempts factorization using Miller-Rabin,
+//   an improved Pollard-rho, and p-1.
+//   However, compared to GNU factor, there may still be differences in performance
+//   and success rate.
+//   To further approach GNU factor behavior, additional algorithms (e.g. ECM)
+//   and parameter tuning may be required.
 
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -15,7 +22,8 @@ use std::num::IntErrorKind;
 use clap::{Arg, ArgAction, Command};
 use memchr::memchr3_iter;
 use num_bigint::BigUint;
-use num_prime::nt_funcs::{factorize64, factorize128, factors};
+use num_prime::nt_funcs::{factorize64, factorize128};
+use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, set_exit_code};
 use uucore::translate;
@@ -32,6 +40,14 @@ const CR: u8 = b'\r';
 const DELIM_SPACE: u8 = b' ';
 const DELIM_TAB: u8 = b'\t';
 const DELIM_NULL: u8 = b'\0';
+const POLLARD_P_MINUS_ONE_BASES: [u64; 3] = [2, 3, 5];
+const LCG_MULTIPLIER: u128 = 6_364_136_223_846_793_005;
+const LCG_INCREMENT: u128 = 1_442_695_040_888_963_407;
+const LCG_DEFAULT_SEED: u128 = 0x9e37_79b9_7f4a_7c15;
+
+fn lcg_next(x: &mut u128) {
+    *x = x.wrapping_mul(LCG_MULTIPLIER).wrapping_add(LCG_INCREMENT);
+}
 
 #[derive(Debug, PartialEq, Eq)]
 enum Number {
@@ -53,21 +69,19 @@ fn write_factors_str(
     };
 
     match x {
-        // use num_prime's factorize64 algorithm for u64 integers
         Number::U64(x) if x > 1 => write_result(w, &x, factorize64(x), print_exponents),
         Number::U64(x) => write_result(w, &x, BTreeMap::<u64, usize>::new(), print_exponents),
-        // use num_prime's factorize128 algorithm for u128 integers
         Number::U128(x) => write_result(w, &x, factorize128(x), print_exponents),
-        // use num_prime's fallible factorization for anything greater than u128::MAX
         Number::BigUint(x) => {
-            let (prime_factors, remaining) = factors(x.clone(), None);
-            if remaining.is_some() {
-                return Err(USimpleError::new(
-                    1,
-                    translate!("factor-error-factorization-incomplete"),
-                ));
+            if x <= BigUint::from_u32(1).unwrap() {
+                write_result(w, &x, BTreeMap::<BigUint, usize>::new(), print_exponents)
+            } else {
+                let mut factors = Vec::new();
+                if !factor_biguint_recursive(&x, &mut factors) {
+                    set_exit_code(1);
+                }
+                write_result(w, &x, collect_biguint_factors(&factors), print_exponents)
             }
-            write_result(w, &x, prime_factors, print_exponents)
         }
     }
     .map_err_context(|| translate!("factor-error-write-error"))
@@ -84,14 +98,12 @@ fn parse_num(slice: &[u8]) -> UResult<Number> {
 
     match num.parse::<u64>() {
         Ok(x) => return Ok(Number::U64(x)),
-        // If overflown, attempt a greater width
         Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {}
         Err(_) => return Err(err_invalid(num)),
     }
 
     match num.parse::<u128>() {
         Ok(x) => return Ok(Number::U128(x)),
-        // If overflown, attempt a greater width
         Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {}
         Err(_) => return Err(err_invalid(num)),
     }
@@ -101,17 +113,10 @@ fn parse_num(slice: &[u8]) -> UResult<Number> {
         .map_err(|_| err_invalid(num))
 }
 
-/// This is a newtype wrapper over a potentially malformed UTF-8
-/// string of a number, which has an optimized [`Display`] impl
-/// matching GNU's formatting. This can be removed in favor of
-/// the C quoting in uucore once support for byte slices is added.
 #[repr(transparent)]
 struct NumError<'a>(&'a [u8]);
 
 impl Display for NumError<'_> {
-    /// This function formats the valid string segments and displays
-    /// the invalid ones as escaped octal, like GNU. For example, the
-    /// (escaped) string "\xFFabc\x1C" is formatted as "\377abc\034".
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for chunk in self.0.utf8_chunks() {
             f.write_str(chunk.valid())?;
@@ -123,11 +128,367 @@ impl Display for NumError<'_> {
     }
 }
 
+fn collect_biguint_factors(factors: &[BigUint]) -> BTreeMap<BigUint, usize> {
+    let mut map = BTreeMap::<BigUint, usize>::new();
+    for f in factors {
+        *map.entry(f.clone()).or_insert(0) += 1;
+    }
+    map
+}
+
+fn is_even(value: &BigUint) -> bool {
+    (value & BigUint::one()).is_zero()
+}
+
+fn is_probable_prime(candidate: &BigUint) -> bool {
+    if *candidate < BigUint::from_u32(2).unwrap() {
+        return false;
+    }
+    if *candidate == BigUint::from_u32(2).unwrap() || *candidate == BigUint::from_u32(3).unwrap() {
+        return true;
+    }
+    // even check: candidate % 2 == 0
+    if is_even(candidate) {
+        return false;
+    }
+
+    let one = BigUint::one();
+    let two = BigUint::from_u32(2).unwrap();
+
+    // candidate - 1 = odd_component * 2^power_of_two
+    let mut odd_component = candidate - &one;
+    let mut power_of_two = 0u32;
+    // while odd_component is even
+    while is_even(&odd_component) {
+        odd_component >>= 1;
+        power_of_two += 1;
+    }
+
+    let bases_32: [u64; 3] = [2, 7, 61];
+    let bases_64: [u64; 12] = [
+        2,
+        325,
+        9375,
+        28178,
+        450_775,
+        9_780_504,
+        1_795_265_022,
+        3,
+        5,
+        7,
+        11,
+        13,
+    ];
+
+    let bases: Vec<u64> = if candidate.bits() <= 32 {
+        bases_32.to_vec()
+    } else if candidate.bits() <= 64 {
+        bases_64.to_vec()
+    } else {
+        vec![2, 3, 5, 7, 11, 13, 17, 19, 23]
+    };
+
+    'outer: for &base_value in &bases {
+        if BigUint::from(base_value) >= *candidate {
+            continue;
+        }
+        let base = BigUint::from(base_value);
+        let mut witness = base.modpow(&odd_component, candidate);
+        if witness == one || witness == candidate - &one {
+            continue 'outer;
+        }
+
+        for _ in 1..power_of_two {
+            witness = witness.modpow(&two, candidate);
+            if witness == candidate - &one {
+                continue 'outer;
+            }
+            if witness == one {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    true
+}
+
+fn small_trial_division(n: &BigUint) -> Option<BigUint> {
+    // Quickly strip very small prime factors before applying expensive algorithms.
+    // This is intentionally lightweight while still covering a reasonably wide range.
+    // GNU factor maintains a large trial table; here we mimic only a small portion of it.
+    //
+    // NOTE: By removing many small prime factors here, we significantly reduce the
+    //       search space and failure count of subsequent Pollard-rho / p-1 steps.
+    const SMALL_PRIMES: [u16; 54] = [
+        2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89,
+        97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181,
+        191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251,
+    ];
+
+    for &p in &SMALL_PRIMES {
+        let p_big = BigUint::from_u32(p as u32).unwrap();
+        if n == &p_big {
+            return None;
+        }
+        if (n % &p_big).is_zero() {
+            return Some(p_big);
+        }
+    }
+    None
+}
+
+/// Simplified Pollard p-1 method (Stage 1 only).
+/// Effective when p-1 (for a prime divisor p of n) is smooth with small prime factors.
+fn pollard_p_minus_1(n: &BigUint) -> Option<BigUint> {
+    // Stage 1 only (simplified).
+    // Best-effort: we do not spend too long here; give up quickly if it does not help.
+    let one = BigUint::one();
+    let two = BigUint::from_u32(2).unwrap();
+
+    if n.is_zero() || n.is_one() {
+        return None;
+    }
+
+    if is_even(n) {
+        return Some(two);
+    }
+
+    let bits = n.bits();
+
+    // Keep B1 relatively small to avoid excessive cost.
+    // (GNU factor adjusts based on input and retries; we use a fixed approximation.)
+    let b1: u64 = if bits <= 256 {
+        10_000
+    } else if bits <= 512 {
+        20_000
+    } else {
+        50_000
+    };
+
+    // Only try a few small prime bases.
+    for &base in &POLLARD_P_MINUS_ONE_BASES {
+        let mut a = BigUint::from(base);
+        if &a >= n {
+            continue;
+        }
+
+        let mut g = gcd_biguint(&a, n);
+        if g > one && &g < n {
+            return Some(g);
+        }
+
+        // Construct a^(M) step by step (approximating by extending the exponent with 2^k)
+        let mut e = 2u64;
+        while e <= b1 {
+            a = a.modpow(&BigUint::from_u64(e).unwrap(), n);
+            if a.is_one() {
+                break;
+            }
+            let am1 = if a > one { &a - &one } else { continue };
+            g = gcd_biguint(&am1, n);
+            if g > one && &g < n {
+                return Some(g);
+            }
+            e <<= 1;
+        }
+    }
+
+    None
+}
+
+/// Improved Pollard-rho (Brent variant with batched gcd).
+/// Not equivalent to GNU factor, but aims for better convergence and performance
+/// than a naive implementation.
+fn pollard_rho(composite: &BigUint) -> Option<BigUint> {
+    // NOTE:
+    //  - This implementation is inspired by the approach in GNU factor but simplified.
+    //  - For large inputs we avoid running too long; we cap the iterations so that
+    //    we do not spend many seconds on hopeless cases.
+    //  - If factorization fails, we return "Factorization incomplete"-style results.
+    let one = BigUint::one();
+    let two = BigUint::from_u32(2).unwrap();
+
+    // For small n we expect earlier code paths to have handled the input.
+    if *composite <= BigUint::from_u32(3).unwrap() {
+        return None;
+    }
+
+    // If composite is even, return 2 immediately.
+    if is_even(composite) {
+        return Some(two);
+    }
+
+    let bits = composite.bits();
+
+    // Search parameters: choose bounds based on bit length.
+    // Avoid overly large limits; when exhausted, treat as failure to find a factor.
+    let max_tries: u64 = 16;
+    let max_iter: u64 = (bits * bits).clamp(10_000, 200_000);
+
+    let mut seed: u128 = LCG_DEFAULT_SEED;
+
+    for _try in 0..max_tries {
+        lcg_next(&mut seed);
+        let mut x_state = BigUint::from(seed % (u128::MAX / 2 + 1));
+        lcg_next(&mut seed);
+        let mut constant = BigUint::from(seed % (u128::MAX / 2 + 1));
+        if constant.is_zero() {
+            constant = BigUint::from(1u32);
+        }
+        x_state %= composite;
+        constant %= composite;
+
+        let mut y_state = x_state.clone();
+        let mut current_gcd = one.clone();
+        let mut product = one.clone();
+
+        let mut iter: u64 = 0;
+        let batch_size: u64 = 128;
+
+        while current_gcd == one && iter < max_iter {
+            // Brent variant: use batched gcd.
+            let mut batch_iter = 0;
+            let x_saved = x_state.clone();
+            while batch_iter < batch_size && iter < max_iter {
+                // f(z) = z^2 + c mod composite.
+                y_state = (&y_state * &y_state + &constant) % composite;
+                let diff = if x_state > y_state {
+                    &x_state - &y_state
+                } else {
+                    &y_state - &x_state
+                };
+                if !diff.is_zero() {
+                    product = (product * diff) % composite;
+                }
+                batch_iter += 1;
+                iter += 1;
+            }
+            current_gcd = gcd_biguint(&product, composite);
+            x_state = x_saved;
+
+            if current_gcd == one {
+                // Update x_state to advance the sequence.
+                x_state.clone_from(&y_state);
+            }
+        }
+
+        if current_gcd == one {
+            continue;
+        }
+        if &current_gcd == composite {
+            // Fallback: step-by-step gcd.
+            let mut z_state = x_state.clone();
+            loop {
+                z_state = (&z_state * &z_state + &constant) % composite;
+                let diff = if z_state > y_state {
+                    &z_state - &y_state
+                } else {
+                    &y_state - &z_state
+                };
+                current_gcd = gcd_biguint(&diff, composite);
+                if current_gcd > one || z_state == y_state {
+                    break;
+                }
+            }
+        }
+
+        if current_gcd > one && &current_gcd < composite {
+            return Some(current_gcd);
+        }
+    }
+
+    None
+}
+
+/// Recursively factor n and append factors (primes or unfactored composites) to `factors`.
+/// Returns true if full factorization succeeded, false otherwise.
+fn gcd_biguint(lhs: &BigUint, rhs: &BigUint) -> BigUint {
+    // Standard Euclidean algorithm using owned BigUint values to avoid lifetime issues.
+    let mut dividend = lhs.clone();
+    let mut divisor = rhs.clone();
+    while !divisor.is_zero() {
+        let remainder = &dividend % &divisor;
+        dividend = divisor;
+        divisor = remainder;
+    }
+    dividend
+}
+
+fn factor_biguint_recursive(n: &BigUint, factors: &mut Vec<BigUint>) -> bool {
+    let one = BigUint::one();
+    if *n <= one {
+        return true;
+    }
+
+    // First remove small prime factors, then apply more expensive methods.
+    if let Some(p) = small_trial_division(n) {
+        let mut q = n.clone();
+        let mut ok = true;
+        while (&q % &p).is_zero() {
+            q /= &p;
+            factors.push(p.clone());
+        }
+        if !q.is_one() {
+            ok &= factor_biguint_recursive(&q, factors);
+        }
+        return ok;
+    }
+
+    // If n is small enough, use num_prime's factorize128 for speed.
+    if n.bits() <= 128 {
+        if let Some(x128) = n.to_u128() {
+            let pf = factorize128(x128);
+            if !pf.is_empty() {
+                for (p, e) in pf {
+                    for _ in 0..e {
+                        factors.push(BigUint::from(p));
+                    }
+                }
+                return true;
+            }
+        }
+    }
+
+    if is_probable_prime(n) {
+        factors.push(n.clone());
+        return true;
+    }
+
+    // Try Pollard p-1 first (simplified Stage 1).
+    if let Some(f) = pollard_p_minus_1(n) {
+        if f.is_one() || &f == n {
+            // Treat as failure.
+        } else {
+            let q = n / &f;
+            let left_ok = factor_biguint_recursive(&f, factors);
+            let right_ok = factor_biguint_recursive(&q, factors);
+            return left_ok && right_ok;
+        }
+    }
+
+    // Then try improved Pollard-rho (Brent variant).
+    if let Some(f) = pollard_rho(n) {
+        if f.is_one() || &f == n {
+            factors.push(n.clone());
+            return false;
+        }
+        let q = n / &f;
+        let left_ok = factor_biguint_recursive(&f, factors);
+        let right_ok = factor_biguint_recursive(&q, factors);
+        return left_ok && right_ok;
+    }
+
+    // If no factor was found, include n itself as part of the (incomplete) factorization.
+    factors.push(n.clone());
+    false
+}
+
 /// Writing out the prime factors for integers
-fn write_result(
+fn write_result<T: Display>(
     w: &mut io::BufWriter<impl Write>,
     x: &impl Display,
-    factorization: BTreeMap<impl Display, usize>,
+    factorization: BTreeMap<T, usize>,
     print_exponents: bool,
 ) -> io::Result<()> {
     write!(w, "{x}:")?;
@@ -167,16 +528,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         for line in lines {
             match line {
                 Ok(line) => {
-                    // Ignore CR on Windows if present; disabled everywhere else for GNU compatibility.
                     let le = if cfg!(windows) && line.last() == Some(&CR) {
                         line.len() - 1
                     } else {
                         line.len()
                     };
 
-                    // GNU factor treats numbers optionally as null-terminated due to its
-                    // implementation details. Here we also split the line with nulls and
-                    // ignore those chunks until another delimiter is found.
                     let (mut display, mut prev) = (true, 0);
                     for i in memchr3_iter(DELIM_SPACE, DELIM_TAB, DELIM_NULL, &line).chain(once(le))
                     {

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -183,6 +183,18 @@ fn test_cli_args() {
 }
 
 #[test]
+fn test_large_regression_number() {
+    let n = "15111234931751377131713914373267893176342349831";
+    new_ucmd!()
+        .arg(n)
+        .timeout(Duration::from_secs(240))
+        .succeeds()
+        .stdout_is(format!(
+            "{n}: 29 127 115319 1971799 82465494029827 218807630881735711\n"
+        ));
+}
+
+#[test]
 fn test_random() {
     let log_num_primes = f64::from(u32::try_from(NUM_PRIMES).unwrap()).log2().ceil();
     let primes = num_prime::nt_funcs::nprimes(NUM_PRIMES);


### PR DESCRIPTION
## Summary

- improve factorization of integers larger than `u128`
- use small-prime trial division, Miller-Rabin primality testing, Pollard p-1, and a Brent-style Pollard rho implementation
- keep the existing `num-prime` fast paths for `u64` and `u128` inputs
- preserve the existing input parsing and error-reporting behavior
- add a regression test for a large composite number

## Motivation

The previous `BigUint` path delegated factorization to `num-prime` and could fail to completely factor large inputs. This change adds bounded fallback algorithms for large integers while retaining the existing optimized paths for smaller values.

This addresses the performance problem reported in [Ubuntu bug 2131212](https://bugs.launchpad.net/ubuntu/+source/rust-coreutils/+bug/2131212) and is related to #10262.

## Implementation notes

Factorization first removes small prime factors, then checks probable primality with Miller-Rabin. Composite values are processed with Pollard p-1 followed by a Brent-style Pollard rho search. The search uses bounded retries and iteration counts so difficult inputs do not run indefinitely. If complete factorization is not achieved, `factor` keeps the partial result and returns a non-zero exit status.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p uu_factor --all-targets --tests --benches -- -D warnings`
- `cargo test -p uu_factor`
- `cargo test --test tests --features factor test_factor::test_large_regression_number -- --exact`
