### PR TITLE
build-gnu.sh: Freeze SELinux build mode

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -140,7 +140,8 @@ else
     # Change the PATH to test the uutils coreutils instead of the GNU coreutils
     sed -i "s/^[[:blank:]]*PATH=.*/  PATH='${UU_BUILD_DIR//\//\\/}\$(PATH_SEPARATOR)'\"\$\$PATH\" \\\/" tests/local.mk
     ./bootstrap --skip-po
-    ./configure --quiet --disable-gcc-warnings --disable-nls --disable-dependency-tracking --disable-bold-man-page-references
+    ./configure --quiet --disable-gcc-warnings --disable-nls --disable-dependency-tracking --disable-bold-man-page-references \
+      "$([ ${SELINUX_ENABLED} = 1 ] && echo --with-selinux || echo --without-selinux)"
     #Add timeout to to protect against hangs
     sed -i 's|^"\$@|'"${SYSTEM_TIMEOUT}"' 600 "\$@|' build-aux/test-driver
     sed -i 's| tr | /usr/bin/tr |' tests/init.sh


### PR DESCRIPTION
Freeze deps by `--with(out)-selinux` to use `build-gnu.sh` at out side of CI. Also reduce size of the PR #8955 