### PR TITLE
 dd: should terminate with error if skip argument is too large #7275

### DIFF
--- a/src/uu/dd/locales/en-US.ftl
+++ b/src/uu/dd/locales/en-US.ftl
@@ -142,6 +142,7 @@ dd-error-status-not-recognized = status=LEVEL not recognized -> { $level }
 dd-error-unimplemented = feature not implemented on this system -> { $feature }
 dd-error-bs-out-of-range = { $param }=N cannot fit into memory
 dd-error-invalid-number = invalid number: ‘{ $input }’
+dd-error-invalid-number-too-large = invalid number: { $input }: Value too large for defined data type
 
 # Progress messages
 dd-progress-records-in = { $complete }+{ $partial } records in

--- a/src/uu/dd/locales/fr-FR.ftl
+++ b/src/uu/dd/locales/fr-FR.ftl
@@ -142,6 +142,7 @@ dd-error-status-not-recognized = status=NIVEAU non reconnu -> { $level }
 dd-error-unimplemented = fonctionnalité non implémentée sur ce système -> { $feature }
 dd-error-bs-out-of-range = { $param }=N ne peut pas tenir en mémoire
 dd-error-invalid-number = nombre invalide : ‘{ $input }‘
+dd-error-invalid-number-too-large = nombre invalide : { $input }: Valeur trop grande pour le type défini de données
 
 # Progress messages
 dd-progress-records-in = { $complete }+{ $partial } enregistrements en entrée

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1830,3 +1830,13 @@ fn test_oflag_direct_partial_block() {
     at.remove(input_file);
     at.remove(output_file);
 }
+
+#[test]
+fn test_skip_overflow() {
+    new_ucmd!()
+        .args(&["bs=1", "skip=9223372036854775808", "count=0"])
+        .fails()
+        .stderr_contains(
+            "dd: invalid number: ‘9223372036854775808’: Value too large for defined data type",
+        );
+}

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1840,3 +1840,13 @@ fn test_skip_overflow() {
             "dd: invalid number: ‘9223372036854775808’: Value too large for defined data type",
         );
 }
+
+#[test]
+fn test_seek_overflow() {
+    new_ucmd!()
+        .args(&["bs=1", "seek=9223372036854775809", "count=0"])
+        .fails()
+        .stderr_contains(
+            "dd: invalid number: ‘9223372036854775809’: Value too large for defined data type",
+        );
+}

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1837,7 +1837,7 @@ fn test_skip_overflow() {
         .args(&["bs=1", "skip=9223372036854775808", "count=0"])
         .fails()
         .stderr_contains(
-            "dd: invalid number: ‘9223372036854775808’: Value too large for defined data type",
+            "dd: invalid number: ‘9223372036854775808’: Value too large for defined data type\n",
         );
 }
 
@@ -1847,6 +1847,6 @@ fn test_seek_overflow() {
         .args(&["bs=1", "seek=9223372036854775809", "count=0"])
         .fails()
         .stderr_contains(
-            "dd: invalid number: ‘9223372036854775809’: Value too large for defined data type",
+            "dd: invalid number: ‘9223372036854775809’: Value too large for defined data type\n",
         );
 }


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/7216

```shell
cargo run dd bs=1 skip=9223372036854775808 count=0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/coreutils dd bs=1 skip=9223372036854775808 count=0`
dd: invalid number: ‘'9223372036854775808': Value too large for defined data type’
```

Original PR: https://github.com/uutils/coreutils/pull/7275