### PR TITLE
build-gnu.sh: Use any profile & cleanup vars

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -109,7 +109,7 @@ jobs:
       run: |
         ## Build binaries
         cd 'uutils'
-        bash util/build-gnu.sh --release-build
+        env PROFILE=release-small bash util/build-gnu.sh
 
     ### Run tests as user
     - name: Run GNU tests
@@ -244,7 +244,7 @@ jobs:
     ### Build
     - name: Build binaries
       run: |
-        lima bash -c "cd ~/work/uutils/ && SELINUX_ENABLED=1 bash util/build-gnu.sh --release-build"
+        lima bash -c "cd ~/work/uutils/ && SELINUX_ENABLED=1 PROFILE=release-small bash util/build-gnu.sh"
 
     ### Run tests as user
     - name: Generate SELinux tests list

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -230,7 +230,9 @@ To run uutils against the GNU test suite locally, run the following commands:
 ```shell
 bash util/build-gnu.sh
 # Build uutils with release optimizations
-bash util/build-gnu.sh --release-build
+env PROFILE=release bash util/build-gnu.sh
+# Build uutils with SELinux
+env SELINUX_ENABLED=1 bash util/build-gnu.sh
 bash util/run-gnu-test.sh
 # To run a single test:
 bash util/run-gnu-test.sh tests/touch/not-owner.sh # for example

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -14,33 +14,22 @@ NPROC=$(command -v gnproc||command -v nproc)
 READLINK=$(command -v greadlink||command -v readlink)
 SED=$(command -v gsed||command -v sed)
 
+SYSTEM_TIMEOUT=$(command -v timeout)
+SYSTEM_YES=$(command -v yes)
+
 ME="${0}"
 ME_dir="$(dirname -- "$("${READLINK}" -fm -- "${ME}")")"
 REPO_main_dir="$(dirname -- "${ME_dir}")"
 
-# Default profile is 'debug'
-UU_MAKE_PROFILE='debug'
+
+: ${PROFILE:=debug} # default profile
+export PROFILE
 CARGO_FEATURE_FLAGS=""
-
-for arg in "$@"
-do
-    if [ "$arg" == "--release-build" ]; then
-        UU_MAKE_PROFILE='release'
-        break
-    fi
-done
-
-echo "UU_MAKE_PROFILE='${UU_MAKE_PROFILE}'"
 
 ### * config (from environment with fallback defaults); note: GNU is expected to be a sibling repo directory
 
 path_UUTILS=${path_UUTILS:-${REPO_main_dir}}
 path_GNU="$("${READLINK}" -fm -- "${path_GNU:-${path_UUTILS}/../gnu}")"
-
-###
-
-SYSTEM_TIMEOUT=$(command -v timeout)
-SYSTEM_YES=$(command -v yes)
 
 ###
 
@@ -71,9 +60,9 @@ echo "path_GNU='${path_GNU}'"
 ###
 
 if [[ ! -z  "$CARGO_TARGET_DIR" ]]; then
-UU_BUILD_DIR="${CARGO_TARGET_DIR}/${UU_MAKE_PROFILE}"
+UU_BUILD_DIR="${CARGO_TARGET_DIR}/${PROFILE}"
 else
-UU_BUILD_DIR="${path_UUTILS}/target/${UU_MAKE_PROFILE}"
+UU_BUILD_DIR="${path_UUTILS}/target/${PROFILE}"
 fi
 echo "UU_BUILD_DIR='${UU_BUILD_DIR}'"
 
@@ -105,9 +94,9 @@ fi
 cd -
 
 # Pass the feature flags to make, which will pass them to cargo
-"${MAKE}" PROFILE="${UU_MAKE_PROFILE}" CARGOFLAGS="${CARGO_FEATURE_FLAGS}"
+"${MAKE}" PROFILE="${PROFILE}" CARGOFLAGS="${CARGO_FEATURE_FLAGS}"
 # min test for SELinux
-[ "${SELINUX_ENABLED}" = 1 ] && touch g && "${UU_MAKE_PROFILE}"/stat -c%C g && rm g
+[ "${SELINUX_ENABLED}" = 1 ] && touch g && "${PROFILE}"/stat -c%C g && rm g
 
 cp "${UU_BUILD_DIR}/install" "${UU_BUILD_DIR}/ginstall" # The GNU tests rename this script before running, to avoid confusion with the make target
 # Create *sum binaries


### PR DESCRIPTION
1. Use any profile at `build-gnu.sh` and test it by release-small.
2. Cleanup vars.