### PR TITLE
Adding TTY helper for unix to be able to create tests for stty and more

### DIFF
--- a/tests/by-util/test_stty.rs
+++ b/tests/by-util/test_stty.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore parenb parmrk ixany iuclc onlcr ofdel icanon noflsh econl igpar ispeed ospeed
+// spell-checker:ignore parenb parmrk ixany iuclc onlcr icanon noflsh econl igpar ispeed ospeed
 
 use uutests::new_ucmd;
 use uutests::util::pty_path;
@@ -28,9 +28,7 @@ fn test_all_flag() {
     let (path, _controller, _replica) = pty_path();
     let result = new_ucmd!().args(&["--all", "--file", &path]).succeeds();
 
-    for flag in [
-        "parenb", "parmrk", "ixany", "onlcr", "ofdel", "icanon", "noflsh",
-    ] {
+    for flag in ["parenb", "parmrk", "ixany", "onlcr", "icanon", "noflsh"] {
         result.stdout_contains(flag);
     }
 }

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 //spell-checker: ignore (linux) rlimit prlimit coreutil ggroups uchild uncaptured scmd SHLVL canonicalized openpty
 //spell-checker: ignore (linux) winsize xpixel ypixel setrlimit FSIZE SIGBUS SIGSEGV sigbus tmpfs mksocket
+//spell-checker: ignore (ToDO) ttyname
 
 #![allow(dead_code)]
 #![allow(


### PR DESCRIPTION
Currently the two biggest areas of missing testing coverage in this project are stty and more. These two do not currently have tests because it requires a pty to run the program. The nix crate contains helpers that allow you to create one and then the --file parameter of the location of the pty can be passed in as a parameter. 

This is just a short PR to add the util functionality and a basic test, but will be able to build on this in the more and stty tests.