### PR TITLE
ls: prevent ReadDir from closing before entries are processed

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2305,7 +2305,7 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
 #[allow(clippy::cognitive_complexity)]
 fn enter_directory(
     path_data: &PathData,
-    read_dir: ReadDir,
+    mut read_dir: ReadDir,
     config: &Config,
     state: &mut ListState,
     listed_ancestors: &mut HashSet<FileInformation>,
@@ -2334,7 +2334,7 @@ fn enter_directory(
     };
 
     // Convert those entries to the PathData struct
-    for raw_entry in read_dir {
+    for raw_entry in read_dir.by_ref() {
         let dir_entry = match raw_entry {
             Ok(path) => path,
             Err(err) => {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -6663,3 +6663,18 @@ fn test_f_with_long_format() {
     // Long format should still work (contains permissions, etc.)
     assert!(result.contains("-rw"));
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_ls_proc_self_fd_no_errors() {
+    // Regression test: ReadDir must stay alive until metadata() is called
+    // to prevent "cannot access '/proc/self/fd/3'" errors.
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ucmd()
+        .arg("-l")
+        .arg("/proc/self/fd")
+        .succeeds()
+        .stderr_does_not_contain("cannot access");
+}


### PR DESCRIPTION
The issue occurred because ReadDir was being consumed by the for loop, causing it to be dropped immediately after iteration. This closed the directory file descriptor (FD 3) before metadata() could be called on the entries, since /proc/self/fd shows the process's own open FDs.

By using read_dir.by_ref() in the loop, we borrow the iterator instead of consuming it, keeping the ReadDir (and its underlying FD) alive until enter_directory() completes.

Fixes: #9332