### PR TITLE
Improve the `stty --all` output to match GNU version

### DIFF
--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -70,8 +70,8 @@ pub const INPUT_FLAGS: &[Flag<I>] = &[
     Flag::new("inlcr", I::INLCR),
     Flag::new("igncr", I::IGNCR),
     Flag::new("icrnl", I::ICRNL).sane(),
-    Flag::new("ixoff", I::IXOFF),
     Flag::new("ixon", I::IXON),
+    Flag::new("ixoff", I::IXOFF),
     Flag::new("tandem", I::IXOFF).hidden(),
     // not supported by nix
     // Flag::new("iuclc", I::IUCLC),

--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -71,8 +71,8 @@ pub const INPUT_FLAGS: &[Flag<I>] = &[
     Flag::new("igncr", I::IGNCR),
     Flag::new("icrnl", I::ICRNL).sane(),
     Flag::new("ixoff", I::IXOFF),
-    Flag::new("tandem", I::IXOFF),
     Flag::new("ixon", I::IXON),
+    Flag::new("tandem", I::IXOFF).hidden(),
     // not supported by nix
     // Flag::new("iuclc", I::IUCLC),
     Flag::new("ixany", I::IXANY),

--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -10,6 +10,7 @@
 // spell-checker:ignore lnext rprnt susp dsusp swtch vdiscard veof veol verase vintr vkill vlnext vquit vreprint vstart vstop vsusp vswtc vwerase werase VDSUSP
 // spell-checker:ignore sigquit sigtstp
 // spell-checker:ignore cbreak decctlq evenp litout oddp
+// spell-checker:ignore cdtrdsr CDTRDSR ofill OFILL dsusp VDSUSP VFLUSHO VSTATUS noncanonical VMIN deciseconds noncanonical VTIME
 
 use crate::Flag;
 
@@ -54,10 +55,14 @@ pub const CONTROL_FLAGS: &[Flag<C>] = &[
     Flag::new_grouped("cs7", C::CS7, C::CSIZE),
     Flag::new_grouped("cs8", C::CS8, C::CSIZE).sane(),
     Flag::new("hupcl", C::HUPCL),
+    // Not supported by nix and libc.
+    // Flag::new("hup", C::HUP).hidden(),
     Flag::new("cstopb", C::CSTOPB),
     Flag::new("cread", C::CREAD).sane(),
     Flag::new("clocal", C::CLOCAL),
     Flag::new("crtscts", C::CRTSCTS),
+    // Not supported by nix and libc.
+    // Flag::new("cdtrdsr", C::CDTRDSR),
 ];
 
 pub const INPUT_FLAGS: &[Flag<I>] = &[
@@ -73,8 +78,16 @@ pub const INPUT_FLAGS: &[Flag<I>] = &[
     Flag::new("ixon", I::IXON),
     Flag::new("ixoff", I::IXOFF),
     Flag::new("tandem", I::IXOFF).hidden(),
-    // not supported by nix
-    // Flag::new("iuclc", I::IUCLC),
+    #[cfg(any(
+        target_os = "aix",
+        target_os = "android",
+        target_os = "cygwin",
+        target_os = "haiku",
+        target_os = "hurd",
+        target_os = "nto",
+        target_os = "linux"
+    ))]
+    Flag::new("iuclc", I::IUCLC),
     Flag::new("ixany", I::IXANY),
     Flag::new("imaxbel", I::IMAXBEL).sane(),
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -94,6 +107,14 @@ pub const OUTPUT_FLAGS: &[Flag<O>] = &[
     Flag::new("onlcr", O::ONLCR).sane(),
     Flag::new("onocr", O::ONOCR),
     Flag::new("onlret", O::ONLRET),
+    #[cfg(any(
+        target_os = "android",
+        target_os = "haiku",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    ))]
+    Flag::new("ofill", O::OFILL),
     #[cfg(any(
         target_os = "android",
         target_os = "haiku",
@@ -242,8 +263,13 @@ pub const LOCAL_FLAGS: &[Flag<L>] = &[
     Flag::new("echok", L::ECHOK).sane(),
     Flag::new("echonl", L::ECHONL),
     Flag::new("noflsh", L::NOFLSH),
-    // Not supported by nix
-    // Flag::new("xcase", L::XCASE),
+    #[cfg(any(
+        target_os = "aix",
+        target_os = "android",
+        target_os = "haiku",
+        target_os = "linux",
+    ))]
+    Flag::new("xcase", L::XCASE),
     Flag::new("tostop", L::TOSTOP),
     #[cfg(not(target_os = "cygwin"))]
     Flag::new("echoprt", L::ECHOPRT),
@@ -362,6 +388,25 @@ pub const CONTROL_CHARS: &[(&str, S)] = &[
     ("lnext", S::VLNEXT),
     // Discards the current line.
     ("discard", S::VDISCARD),
+    // deprecated compat option.
+    // Not supported by nix and libc.
+    // ("flush", S::VFLUSHO),
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    ))]
+    // Status character
+    ("status", S::VSTATUS),
+    // Minimum number of characters for noncanonical read.
+    // We handle this manually.
+    // ("min", S::VMIN),
+    // Timeout in deciseconds for noncanonical read.
+    // We handle this manually.
+    // ("time", S::VTIME),
 ];
 
 /// This constant lists all possible combination settings, using a bool to represent if the setting is negatable

--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -370,4 +370,5 @@ pub const COMBINATION_SETTINGS: &[(&str, bool)] = &[
     ("pass8", true),
     ("raw", true),
     ("sane", false),
+    ("tabs", true),
 ];

--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -7,7 +7,7 @@
 // spell-checker:ignore ignbrk brkint ignpar parmrk inpck istrip inlcr igncr icrnl ixoff ixon iuclc ixany imaxbel iutf
 // spell-checker:ignore opost olcuc ocrnl onlcr onocr onlret ofdel nldly crdly tabdly bsdly vtdly ffdly
 // spell-checker:ignore isig icanon iexten echoe crterase echok echonl noflsh xcase tostop echoprt prterase echoctl ctlecho echoke crtkill flusho extproc
-// spell-checker:ignore lnext rprnt susp swtch vdiscard veof veol verase vintr vkill vlnext vquit vreprint vstart vstop vsusp vswtc vwerase werase
+// spell-checker:ignore lnext rprnt susp dsusp swtch vdiscard veof veol verase vintr vkill vlnext vquit vreprint vstart vstop vsusp vswtc vwerase werase VDSUSP
 // spell-checker:ignore sigquit sigtstp
 // spell-checker:ignore cbreak decctlq evenp litout oddp
 
@@ -342,6 +342,18 @@ pub const CONTROL_CHARS: &[(&str, S)] = &[
     ("stop", S::VSTOP),
     // Sends a suspend signal (SIGTSTP).
     ("susp", S::VSUSP),
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "aix",
+        target_os = "solaris"
+    ))]
+    // Sends a delayed suspend signal (SIGTSTP).
+    ("dsusp", S::VDSUSP),
     // Reprints the current line.
     ("rprnt", S::VREPRINT),
     // Deletes the last word typed.

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -688,12 +688,9 @@ fn print_terminal_size(
         );
     }
 
-    #[cfg(any(target_os = "linux", target_os = "redox"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "haiku"))]
     {
-        // For some reason the normal nix Termios struct does not expose the line,
-        // so we get the underlying libc::termios struct to get that information.
-        let libc_termios: nix::libc::termios = termios.clone().into();
-        let line = libc_termios.c_line;
+        let line = termios.line_discipline;
         printer.print(&translate!("stty-output-line", "line" => line));
     }
     printer.flush();
@@ -1056,7 +1053,7 @@ fn apply_special_setting(
         )]
         SpecialSetting::Line(n) => {
             // nix only defines Termios's `line_discipline` field on these platforms
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(any(target_os = "linux", target_os = "android", target_os = "haiku"))]
             {
                 _termios.line_discipline = *n;
             }


### PR DESCRIPTION
The output of `stty --all` was not really matching GNU one, adjust it to follow the same logic

Before:

```diff
--- /tmp/gnu-stty	2025-11-21 01:41:14.909020716 +0100
+++ /tmp/rust-stty	2025-11-21 00:38:42.324215733 +0100
@@ -1,10 +1,6 @@
-speed 38400 baud; rows 57; columns 112; line = 0;
-intr = ^C; quit = ^\; erase = ^?; kill = ^U; eof = ^D; eol = <undef>;
-eol2 = <undef>; swtch = <undef>; start = ^Q; stop = ^S; susp = ^Z; rprnt = ^R;
-werase = ^W; lnext = ^V; discard = ^O; min = 1; time = 0;
--parenb -parodd -cmspar cs8 -hupcl -cstopb cread -clocal -crtscts
--ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr icrnl ixon -ixoff
--iuclc -ixany -imaxbel iutf8
-opost -olcuc -ocrnl onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0
-isig icanon iexten echo echoe echok -echonl -noflsh -xcase -tostop -echoprt
-echoctl echoke -flusho -extproc
+speed 38400 baud; rows 57; columns 115; line = 0;
+intr = ^C; quit = ^\; erase = ^?; kill = ^U; eof = ^D; eol = <undef>; eol2 = <undef>; swtch = <undef>; start = ^Q; stop = ^S; susp = ^Z; rprnt = ^R; werase = ^W; lnext = ^V; discard = ^O; min = 1; time = 0;
+-parenb -parodd -cmspar cs8 -hupcl -cstopb cread -clocal -crtscts 
+-ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr icrnl -ixoff -tandem ixon -ixany -imaxbel iutf8 
+opost -olcuc -ocrnl onlcr -onocr -onlret -ofdel nl0 cr0 tab0 bs0 vt0 ff0 
+isig icanon iexten echo echoe echok -echonl -noflsh -tostop -echoprt echoctl echoke -flusho -extpro```
```

After:

```diff
--- /tmp/gnu-stty	2025-11-21 01:41:14.909020716 +0100
+++ /tmp/rust-stty	2025-11-21 04:31:16.511313289 +0100
@@ -4,7 +4,7 @@
 werase = ^W; lnext = ^V; discard = ^O; min = 1; time = 0;
 -parenb -parodd -cmspar cs8 -hupcl -cstopb cread -clocal -crtscts
 -ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr icrnl ixon -ixoff
--iuclc -ixany -imaxbel iutf8
-opost -olcuc -ocrnl onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0
-isig icanon iexten echo echoe echok -echonl -noflsh -xcase -tostop -echoprt
-echoctl echoke -flusho -extproc
+-ixany -imaxbel iutf8
+opost -olcuc -ocrnl onlcr -onocr -onlret -ofdel nl0 cr0 tab0 bs0 vt0 ff0
+isig icanon iexten echo echoe echok -echonl -noflsh -tostop -echoprt echoctl
+echoke -flusho -extproc
```

Highlight is not great for word diffing, but well:

```
❯ wdiff /tmp/stty-out /tmp/rstty-out 
speed 38400 baud; rows 57; columns 112; line = 0;
intr = ^C; quit = ^\; erase = ^?; kill = ^U; eof = ^D; eol = <undef>;
eol2 = <undef>; swtch = <undef>; start = ^Q; stop = ^S; susp = ^Z; rprnt = ^R;
werase = ^W; lnext = ^V; discard = ^O; min = 1; time = 0;
-parenb -parodd -cmspar cs8 -hupcl -cstopb cread -clocal -crtscts
-ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr icrnl ixon -ixoff
[--iuclc-]
-ixany -imaxbel iutf8
opost -olcuc -ocrnl onlcr -onocr -onlret [--ofill-] -ofdel nl0 cr0 tab0 bs0 vt0 ff0
isig icanon iexten echo echoe echok -echonl -noflsh [--xcase-] -tostop -echoprt echoctl
echoke -flusho -extpro
``` 

---

After the flags we're missing will be included upstream, the diff will be actually none.