### PR TITLE
Using the pty helper function for the more bin testing

### DIFF
--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -15,6 +15,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use uutests::util::pty_path;
+#[cfg(unix)]
 use uutests::{at_and_ucmd, new_ucmd};
 
 #[cfg(unix)]


### PR DESCRIPTION
Now that we have a pty helper function to allow us to run integration tests on utilities that require a pty, I have modified the existing tests to use this new helper function and added a few more tests. If my estimates are correct, this should bring around a 1% boost to the coverage of the package.