### PR TITLE
Reducing sleep times and timeout times in test_timeout

### DIFF
--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -55,11 +55,11 @@ fn test_command_with_args() {
 fn test_verbose() {
     for verbose_flag in ["-v", "--verbose"] {
         new_ucmd!()
-            .args(&[verbose_flag, ".1", "sleep", "10"])
+            .args(&[verbose_flag, ".1", "sleep", "1"])
             .fails()
             .stderr_only("timeout: sending signal TERM to command 'sleep'\n");
         new_ucmd!()
-            .args(&[verbose_flag, "-s0", "-k.1", ".1", "sleep", "10"])
+            .args(&[verbose_flag, "-s0", "-k.1", ".1", "sleep", "1"])
             .fails()
             .stderr_only("timeout: sending signal EXIT to command 'sleep'\ntimeout: sending signal KILL to command 'sleep'\n");
     }
@@ -112,7 +112,7 @@ fn test_preserve_status_even_when_send_signal() {
     // So, expected result is success and code 0.
     for cont_spelling in ["CONT", "cOnT", "SIGcont"] {
         new_ucmd!()
-            .args(&["-s", cont_spelling, "--preserve-status", ".1", "sleep", "2"])
+            .args(&["-s", cont_spelling, "--preserve-status", ".1", "sleep", "1"])
             .succeeds()
             .no_output();
     }
@@ -186,10 +186,10 @@ fn test_kill_subprocess() {
     new_ucmd!()
         .args(&[
             // Make sure the CI can spawn the subprocess.
-            "10",
+            "1",
             "sh",
             "-c",
-            "trap 'echo inside_trap' TERM; sleep 30",
+            "trap 'echo inside_trap' TERM; sleep 5",
         ])
         .fails_with_code(124)
         .stdout_contains("inside_trap");


### PR DESCRIPTION
Was looking through the other open PR's related to speeding up the CI process across all of the platforms and I was finding that the vast majority of the time on most platforms is spent in the rust integ test phase and within that phase the vast majority of tests were running in milliseconds and only a few were running in times greater than 10s. 

The biggest contributor to these times is the timeout integ tests because most of them rely on a sleep command to run to perform a timeout.

From my first investigation into these times it appears that the reason that cause behind these times being so large was to mitigate race conditions and because the timeout command initially was much slower than the GNU implementation. It appears that now this command is much faster and that when looking at these types of race conditions the difference between the sleep time and the timeout time being a factor of 20x should be more than enough to mitigate these factors. My personal take is that if these tests do begin to show flakiness it could likely be that the tests are doing their job and indicating that theres unexpected timing behavior that should be investigated.