### PR TITLE
Removing the per process file flag to reduce the llvm filemerge time

### DIFF
--- a/util/build-run-test-coverage-linux.sh
+++ b/util/build-run-test-coverage-linux.sh
@@ -57,7 +57,7 @@ export CARGO_INCREMENTAL=0
 export RUSTFLAGS="-Cinstrument-coverage -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
 export RUSTDOCFLAGS="-Cpanic=abort"
 export RUSTUP_TOOLCHAIN="nightly-gnu"
-export LLVM_PROFILE_FILE="${PROFRAW_DIR}/coverage-%m-%p.profraw"
+export LLVM_PROFILE_FILE="${PROFRAW_DIR}/coverage-%4m.profraw"
 
 # Disable expanded command printing for the rest of the program
 set +x


### PR DESCRIPTION
I've been working on trying to increase the code coverage and I was finding that it takes around 30 minutes for the build suite to collect this data and that the majority of the time is spent on merging the llvm profile data files. When doing some investigation on this there was a post that mentioned that having %p has the potential to increase the file count by a factor of 1000x and since we were merging the files anyways there was no need to use this flag. 

Running this on the build fleet to see if the outputs are the same and if the time is radically different