### PR TITLE
Adding integration tests for the braced variable parsing in env

### DIFF
--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (words) bamf chdir rlimit prlimit COMSPEC cout cerr FFFD winsize xpixel ypixel
+// spell-checker:ignore (words) bamf chdir rlimit prlimit COMSPEC cout cerr FFFD winsize xpixel ypixel Secho
 #![allow(clippy::missing_errors_doc)]
 
 #[cfg(unix)]


### PR DESCRIPTION
I have been going through the code coverage site to see which areas are still missing tests and saw that the majority of the variable parsing in the env bin did not have integration tests. This should be expanded on even further especially for the default value parsing because this feature does not exist in the GNU implementation and the current implementation does not match the BSD spec either.