### PR TITLE
Changing integration tests to use sudo in instances where its required

### DIFF
--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -6,10 +6,9 @@
 
 #[cfg(not(target_os = "openbsd"))]
 use filetime::FileTime;
-use std::fs;
 #[cfg(target_os = "linux")]
 use std::os::unix::ffi::OsStringExt;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 #[cfg(not(windows))]
 use std::process::Command;
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -19,7 +18,7 @@ use uucore::process::{getegid, geteuid};
 use uucore::selinux::get_getfattr_output;
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
-use uutests::util::{TestScenario, is_ci, run_ucmd_as_root};
+use uutests::util::{TestScenario, is_ci};
 use uutests::util_name;
 
 #[test]
@@ -2017,7 +2016,12 @@ fn test_target_file_ends_with_slash() {
 }
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn test_install_root_combined() {
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+    use uutests::util::run_ucmd_as_root;
+
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
     at.touch("a");

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -3143,6 +3143,21 @@ pub fn run_ucmd_as_root(
     run_ucmd_as_root_with_stdin_stdout(ts, args, None, None)
 }
 
+// Using this function as a temporary measure to keep the tests that are not passing
+// either locally or on the build fleet to be able to allow all of the tests that require root
+// to pass. This will be removed one all of the tests that use this are fixed.
+#[cfg(unix)]
+pub fn run_ucmd_as_root_to_migrate(
+    ts: &TestScenario,
+    args: &[&str],
+) -> std::result::Result<CmdResult, String> {
+    if is_ci() {
+        Err(format!("{UUTILS_INFO}: {}", "cannot run inside CI"))
+    } else {
+        run_ucmd_as_root_with_stdin_stdout(ts, args, None, None)
+    }
+}
+
 #[cfg(unix)]
 pub fn run_ucmd_as_root_with_stdin_stdout(
     ts: &TestScenario,


### PR DESCRIPTION
I have been noticing that when I run the test suite locally I have a bunch of failing tests and it appears that a common cause of the failures is that the tests broke long ago but we skip a bunch of tests in the CI if the root permission is needed to test a feature. 

To be able to track regressions and determine whether we have code coverage across the library in the long term we need to have a mechanism to be able to run these commands on the build fleet. I first tried running the integration tests as sudo but found that it ended up changing the behaviour of the tests. The next thing I tried was to change the util that runs the sudo command in the tests to be able to run on the CI fleet.