### PR TITLE
df(windows): fix Avail/Use% by using number_of_free_clusters for bavail

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -657,7 +657,9 @@ impl FsUsage {
             //  Total number of free blocks.
             bfree: number_of_free_clusters as u64,
             //  Total number of free blocks available to non-privileged processes.
-            bavail: 0,
+            // Windows: 'bavail' should reflect free clusters available to non-privileged processes.
+            // See: https://github.com/uutils/coreutils/issues/7461
+            bavail: number_of_free_clusters as u64,
             bavail_top_bit_set: ((bytes_per_sector as u64) & (1u64.rotate_right(1))) != 0,
             // Total number of file nodes (inodes) on the file system.
             files: 0, // Not available on windows


### PR DESCRIPTION
Fix Windows `df` incorrectly reporting 0 bytes available and 100% usage for all filesystems. The issue was caused by hardcoding `bavail` (blocks available to non-privileged processes) to 0 instead of using the actual free clusters from Windows API.

On Windows, all mounted filesystems displayed:
- **Avail**: 0 bytes (always)
- **Use%**: 100% (always)
- **--total flag**: Completely broken aggregation

This made `df` output useless for Windows users.

### Before (Broken)
```
Filesystem               Size  Used Avail Use%
\Device\HarddiskVolume2  256G  180G     0 100%
\Device\HarddiskVolume3  677G  494G     0 100%
\Device\HarddiskVolume4  1.9T  1.8T     0 100%
\Device\HarddiskVolume1   50M   35M     0 100%
\Device\HarddiskVolume8   11T  5.9T     0 100%
```

### After (Fixed)
```
Filesystem               Size  Used Avail Use%
\Device\HarddiskVolume2  256G  180G  76G  70%
\Device\HarddiskVolume3  677G  494G 183G  73%
\Device\HarddiskVolume4  1.9T  1.8T 100G  95%
\Device\HarddiskVolume1   50M   35M  15M  70%
\Device\HarddiskVolume8   11T  5.9T 5.1T  54%
```

### Windows API Context
The fix correctly implements POSIX semantics on Windows:

| POSIX | Windows | Meaning |
|-------|---------|---------|
| `f_bfree` | `lpNumberOfFreeClusters` (no quota consideration) | Total free clusters |
| `f_bavail` | `lpNumberOfFreeClusters` (quota-aware) | Free clusters available to user |

Windows `GetDiskFreeSpaceW()` already respects disk quotas, making this fix semantically correct.

## Fixes
Closes #7461

## Related Issues
- #5015: df tests failing on Windows (tests were disabled) - can now be re-enabled
- #5381: df overflow error on WSL (fixed) - works better with correct bavail

