### PR TITLE
install: do not call chown when called as root

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -711,10 +711,9 @@ fn copy_files_into_dir(files: &[PathBuf], target_dir: &Path, b: &Behavior) -> UR
     Ok(())
 }
 
-/// Handle incomplete user/group parings for chown.
+/// Handle ownership changes when -o/--owner or -g/--group flags are used.
 ///
 /// Returns a Result type with the Err variant containing the error message.
-/// If the user is root, revert the uid & gid
 ///
 /// # Parameters
 ///
@@ -735,11 +734,8 @@ fn chown_optional_user_group(path: &Path, b: &Behavior) -> UResult<()> {
     // Determine the owner and group IDs to be used for chown.
     let (owner_id, group_id) = if b.owner_id.is_some() || b.group_id.is_some() {
         (b.owner_id, b.group_id)
-    } else if geteuid() == 0 {
-        // Special case for root user.
-        (Some(0), Some(0))
     } else {
-        // No chown operation needed.
+        // No chown operation needed - file ownership comes from process naturally.
         return Ok(());
     };
 


### PR DESCRIPTION
- [pseudo](https://git.yoctoproject.org/pseudo) is a tool which simulates being root by intercepting calls to e.g. `geteuid` and `chown` (by using the `LD_PRELOAD` mechanism). This is used e.g. by yocto to build filesystems for embedded devices without running as root on the build machine.

- the `chown` call getting removed in this commit does not work when running with `pseudo` and using `PSEUDO_IGNORE_PATHS`: in this case, the call to `geteuid()` gets intercepted by `libpseudo.so` and returns 0, however the call to `chown()` isn't intercepted by `libpseudo.so` in case it is in a path from `PSEUDO_IGNORE_PATHS`, and will thus fail since the process is not really root

- the call to `chown()` was added in https://github.com/uutils/coreutils/pull/5735 with the intent of making the test `install-C-root.sh` pass, however it isn't required (GNU coreutils also does not call `chown` just because `install` was called as root)

Fixes https://github.com/uutils/coreutils/issues/9116