### PR TITLE
Update Dockerfile: Don't apt-get jq (preinstalled)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
        gcc \
        gdb \
        gperf \
-       jq \
        libacl1-dev \
        libattr1-dev \
        libcap-dev \


### PR DESCRIPTION
I think this is last one.