### PR TITLE
seq:fix test_broken_pipe_still_exits_success

### DIFF
--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -16,7 +16,9 @@ fn test_broken_pipe_still_exits_success() {
     use std::process::Stdio;
 
     let mut child = new_ucmd!()
-        .args(&["1", "5"])
+        // Use an infinite sequence so a burst of output happens immediately after spawn.
+        // With small output the process can finish before stdout is closed and the Broken pipe never occurs.
+        .args(&["inf"])
         .set_stdout(Stdio::piped())
         .run_no_wait();
 


### PR DESCRIPTION
Use an infinite sequence in `test_broken_pipe_still_exits_success` instead of finite range (1-5) to guarantee a burst of output immediately after spawn, preventing the process from finishing before stdout closure and avoiding missed broken pipe errors.

related
https://github.com/uutils/coreutils/pull/9471#issuecomment-3587706426