### PR TITLE
Adding temporary root owned file in tmp folder for eperm test

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -355,3 +355,10 @@ test \$n_stat1 -ge \$n_stat2 \\' tests/ls/stat-free-color.sh
 # * the selinux crate is handling errors
 # * the test says "maybe we should not fail when no context available"
 "${SED}" -i -e "s|returns_ 1||g" tests/cp/no-ctx.sh
+
+# Create a file not owned by current user in the /tmp folder. This is because 
+# the tests/rm/fail-eperm.xpl test will skip the test if it cannot find a file that 
+# the run as user did not create. This file needs to be created outside of the tests.
+if command -v sudo >/dev/null 2>&1; then
+    sudo touch /tmp/root-owned-file 2>/dev/null || true
+fi


### PR DESCRIPTION
This test is passing locally and failing on the build fleet because there's no files in the /tmp folder that are not owned by the runner of the test. Adding this to the build-gnu step to create this file so that there's something that the test can use and pass.
```
fail-eperm.xpl: couldn't find a file not owned by you
in any of the following directories:
/tmp /var/tmp /usr/tmp
...so, skipping this test
SKIP: tests/rm/fail-eperm.xpl
```

