### PR TITLE
truncate: eliminate duplicate stat() syscall

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -75,7 +75,7 @@ impl TruncateMode {
             Self::AtMost(size) => Some(fsize.min(*size)),
             Self::AtLeast(size) => Some(fsize.max(*size)),
             Self::RoundDown(size) => fsize.checked_rem(*size).map(|remainder| fsize - remainder),
-            Self::RoundUp(size) => fsize.checked_rem(*size).map(|remainder| fsize + remainder),
+            Self::RoundUp(size) => fsize.checked_next_multiple_of(*size),
         }
     }
 
@@ -359,6 +359,8 @@ mod tests {
         assert_eq!(TruncateMode::Reduce(5).to_size(10), Some(5));
         assert_eq!(TruncateMode::Reduce(5).to_size(3), Some(0));
         assert_eq!(TruncateMode::RoundDown(4).to_size(13), Some(12));
+        assert_eq!(TruncateMode::RoundDown(4).to_size(16), Some(16));
+        assert_eq!(TruncateMode::RoundUp(8).to_size(10), Some(16));
         assert_eq!(TruncateMode::RoundUp(8).to_size(16), Some(16));
         assert_eq!(TruncateMode::RoundDown(0).to_size(123), None);
     }


### PR DESCRIPTION
When no reference file is given, `truncate` performs two `stat()` syscalls:

1. The first one to retrieve the size of the file.
2. The second one to check if the file if a pipe.

This commit fixes this issue by restructuring the code. The main change resides in the elimination of the initial match performed at the top level to select between different scenarios. Instead, the new implementation:

1. Check if a reference file has been given. If so, retrieve its size.
2. Determine the given mode. If no mode has been given, `TruncateMode::Extend(0)` is implied.
3. Retrieve the size of the file, while checking if it is a pipe. This is the key point of this PR.
4. Determine the truncate size based on the reference size and the mode. If no reference file has been provided, use the size of the file to be resized as a reference size.
5. Finally, perform `ftruncate()` to resize the file.