### PR TITLE
du: Alias -A --apparent-size

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -1257,6 +1257,7 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::APPARENT_SIZE)
+                .short('A')
                 .long(options::APPARENT_SIZE)
                 .help(translate!("du-help-apparent-size"))
                 .action(ArgAction::SetTrue),


### PR DESCRIPTION
Closes #9552 . Note that this is backported from GNU >9.9, not an extention.