### PR TITLE
seq: adding large integers benchmarks

### DIFF
--- a/src/uu/seq/benches/seq_bench.rs
+++ b/src/uu/seq/benches/seq_bench.rs
@@ -15,6 +15,14 @@ fn seq_integers(bencher: Bencher) {
     });
 }
 
+/// Benchmark large integer
+#[divan::bench]
+fn seq_large_integers(bencher: Bencher) {
+    bencher.bench(|| {
+        black_box(run_util_function(uumain, &["4e10003", "4e10003"]));
+    });
+}
+
 /// Benchmark sequence with custom separator
 #[divan::bench]
 fn seq_custom_separator(bencher: Bencher) {


### PR DESCRIPTION
This is for the recent PR: https://github.com/uutils/coreutils/pull/9557

You can validate its testing the correct code path in the profiling data:

<img width="1228" height="712" alt="Screenshot 2025-12-04 at 1 43 13 PM" src="https://github.com/user-attachments/assets/4abbacfc-b5cf-4c16-9ddb-f0977edd17e0" />
