### PR TITLE
stty: Updating coreutils version on x86 musl ci hosts for stty tests

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -722,6 +722,10 @@ jobs:
             sudo apt-get -y update
             sudo apt-get -y install gcc-arm-linux-gnueabihf
           ;;
+          x86_64-unknown-linux-musl)
+            sudo apt-get -y update
+            sudo apt-get -y install coreutils
+          ;;
           aarch64-unknown-linux-*)
             sudo apt-get -y update
             sudo apt-get -y install gcc-aarch64-linux-gnu


### PR DESCRIPTION
One of the GNU comparison tests in one of my PR's https://github.com/uutils/coreutils/pull/9517 is failing because of conflicting behaviour in different versions of GNU, this is the only one that's failing and adding this will make sure its using a more current version of coreutils to test against.