### PR TITLE
timeout: remove FIXME in test

### DIFF
--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -15,9 +15,6 @@ fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(125);
 }
 
-// FIXME: this depends on the system having true and false in PATH
-//        the best solution is probably to generate some test binaries that we can call for any
-//        utility that requires executing another program (kill, for instance)
 #[test]
 fn test_subcommand_return_code() {
     new_ucmd!().arg("1").arg("true").succeeds();


### PR DESCRIPTION
This FIXME comment was added in 2021 ( 5431e947bc54242d6d6fb3b1b1c55f73dd1eade0 ).

`timeout` is already in feat_require_unix_core, so having `true` and `false` on the machine running the test is quite reasonable and does not warrant a FIXME.