### PR TITLE
use github URLs for fetching tldr.zip

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Download tldr
-        run: curl https://tldr.sh/assets/tldr.zip -o docs/tldr.zip
+        run: curl -L https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip -o docs/tldr.zip
 
       - name: Generate documentation
         run: cargo run --bin uudoc --all-features

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -139,7 +139,9 @@ fn print_tldr_error() {
         "To include examples in the documentation, download the tldr archive and put it in the docs/ folder."
     );
     eprintln!();
-    eprintln!("  curl https://tldr.sh/assets/tldr.zip -o docs/tldr.zip");
+    eprintln!(
+        "  curl -L https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip -o docs/tldr.zip"
+    );
     eprintln!();
 }
 


### PR DESCRIPTION
According to [this release](https://github.com/tldr-pages/tldr/releases/tag/v2.3) the tldr.sh domain will stop working at the end of 2025. At any rate the Python and official Rust clients use this URL for fetching their copies of tldr.zip so it seems official.