### PR TITLE
tests/mkfifo: added a test to check mkfifo permission denied error for code coverage

### DIFF
--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -137,9 +137,11 @@ fn test_create_fifo_permission_denied() {
     at.mkdir(no_exec_dir);
     at.set_mode(no_exec_dir, 0o644);
 
-    let err_msg = format!("mkfifo: cannot create fifo '{named_pipe}': File exists
+    let err_msg = format!(
+        "mkfifo: cannot create fifo '{named_pipe}': File exists
 mkfifo: cannot set permissions on '{named_pipe}': Permission denied (os error 13)
-");
+"
+    );
 
     scene
         .ucmd()


### PR DESCRIPTION
This PR introduces a test case that provides code coverage for the following lines in `uu/mkfifo/src/mkfifo.rs`:
```rust
        // Explicitly set the permissions to ignore umask
        if let Err(e) = fs::set_permissions(&f, fs::Permissions::from_mode(mode)) {
            return Err(USimpleError::new(
                1,
                translate!("mkfifo-error-cannot-set-permissions", "path" => f.quote(), "error" => e),
            ));
        }
```
With this, it should complete #9059 and we should have 100% code coverage for `mkfifo.rs`.