### PR TITLE
nl: output number separator as bytes

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -420,7 +420,7 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
                         .as_bytes(),
                 );
                 buf.extend(settings.number_separator.as_encoded_bytes());
-                buf.extend(String::from_utf8_lossy(&line).as_bytes());
+                buf.extend(&line);
                 buf.push(b'\n');
 
                 writer

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -796,10 +796,14 @@ fn test_file_with_non_utf8_content() {
 
     at.write_bytes(filename, content);
 
-    ucmd.arg(filename).succeeds().stdout_is(format!(
-        "     1\ta\n     2\t{}\n     3\tb\n",
-        String::from_utf8_lossy(invalid_utf8)
-    ));
+    let mut expected = Vec::with_capacity(30);
+    expected.extend(b"     1\ta\n");
+    expected.extend(b"     2\t");
+    expected.extend(invalid_utf8);
+    expected.extend(b"\n");
+    expected.extend(b"     3\tb\n");
+
+    ucmd.arg(filename).succeeds().stdout_is_bytes(expected);
 }
 
 // Regression tests for issue #9132: repeated flags should use last value


### PR DESCRIPTION
Currently, we output the number separator as a lossy string:
```
$ printf "a\nb" | cargo run -q nl --number-separator=$'\xFF' | hexdump -C
00000000  20 20 20 20 20 31 ef bf  bd 61 0a 20 20 20 20 20  |     1...a.     |
00000010  32 ef bf bd 62 0a                                 |2...b.|
00000016
```
Whereas GNU `nl` doesn't:
```
$ printf "a\nb" | nl --number-separator=$'\xFF' | hexdump -C
00000000  20 20 20 20 20 31 ff 61  0a 20 20 20 20 20 32 ff  |     1.a.     2.|
00000010  62 0a                                             |b.|
00000012
```
This PR fixes the issue.

Update: The PR also fixes the same issue for the content. Our current output:
```
$ printf $'\xFF' | cargo run -q nl | hexdump -C
00000000  20 20 20 20 20 31 09 ef  bf bd 0a                 |     1.....|
0000000b 
```
The output of GNU `nl`:
```
$ printf $'\xFF' | nl | hexdump -C
00000000  20 20 20 20 20 31 09 ff  0a                       |     1...|
00000009
```