### PR TITLE
Fix hardware capabilities detection; cksum --debug

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -198,6 +198,8 @@ PCLMUL
 pclmul
 PCLMULQDQ
 pclmulqdq
+PMULL
+pmull
 TUNABLES
 tunables
 VMULL

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -20,14 +20,14 @@ use uucore::checksum::{
     sanitize_sha2_sha3_length_str,
 };
 use uucore::error::UResult;
-use uucore::hardware::CpuFeatures;
+use uucore::hardware::{HasHardwareFeatures as _, SimdPolicy};
 use uucore::line_ending::LineEnding;
 use uucore::{format_usage, translate};
 
 /// Print CPU hardware capability detection information to stderr
 /// This matches GNU cksum's --debug behavior
 fn print_cpu_debug_info() {
-    let features = CpuFeatures::detect();
+    let features = SimdPolicy::detect();
 
     fn print_feature(name: &str, available: bool) {
         if available {


### PR DESCRIPTION
This MR fixes the GNU `cksum.sh` by correctly taking in account the `GLIBC_TUNABLES` env var

Fixes #9518