### PR TITLE
benchmarks.yml: Stop unnecessary apt-get

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -50,12 +50,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install system dependencies
-        shell: bash
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install libselinux1-dev
-
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Benchmarked utils are mostly mathmatical things. SELinux is unrelated here.