### PR TITLE
Example of translation after parsing clap for performance

### DIFF
--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -190,20 +190,13 @@ macro_rules! bin {
     ($util:ident) => {
         pub fn main() {
             use std::io::Write;
-            use uucore::locale;
             // suppress extraneous error output for SIGPIPE failures/panics
             uucore::panic::mute_sigpipe_panic();
-            locale::setup_localization(uucore::get_canonical_util_name(stringify!($util)))
-                .unwrap_or_else(|err| {
-                    match err {
-                        uucore::locale::LocalizationError::ParseResource {
-                            error: err_msg,
-                            snippet,
-                        } => eprintln!("Localization parse error at {snippet}: {err_msg:?}"),
-                        other => eprintln!("Could not init the localization system: {other}"),
-                    }
-                    std::process::exit(99)
-                });
+
+            // Store util name for lazy localization initialization
+            uucore::locale::set_util_name_for_lazy_init(
+                uucore::get_canonical_util_name(stringify!($util)),
+            );
 
             // execute utility code
             let code = $util::uumain(uucore::args_os());


### PR DESCRIPTION
I wanted to learn a bit about the performance characteristics of coreutils for the commands that were listed as being slower than the GNU implementations. One of the reasons listed for being slower is that the translation files are parsed even when they are not needed: https://github.com/uutils/coreutils/issues/9103

I was able to find some examples online of how you can add a wrapper to the clap parser that can modify the clap command if it recognizes that the help command is being called and then the translation keys can be obtained. When doing the original comparisons using hyperfine commands shown in that issue, my timing was similar to what was described in the issue but afterwards it moved from 2. ms to 1.0 ms. 

Metric | GNU ln | uutils glibc 
-- | -- | --
Speed | 805 µs | 1.0 ms


This tells me that after adding the fix for the translations to not be parsed, we have a clear path to replacing some of the glibc calls with more native functionality using nix and we should be able to perform faster than the GNU implementation.