### PR TITLE
Revert "nohup: use Command::exec() instead of libc::execvp()"

### DIFF
--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -76,6 +76,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut args: Vec<*const c_char> = cstrs.iter().map(|s| s.as_ptr()).collect();
     args.push(std::ptr::null());
 
+    // FIXME: libc::execvp can be replaced with Command::exec() once https://github.com/rust-lang/rust/issues/97889#issuecomment-2010074982
+    // is fixed in a stable rust version.
     let ret = unsafe { execvp(args[0], args.as_mut_ptr()) };
     match ret {
         libc::ENOENT => set_exit_code(EXIT_ENOENT),


### PR DESCRIPTION
Reverts uutils/coreutils#9613

We can't use `Command::exec()` because it resets the SIGPIPE signal handler to its default handler. See https://github.com/uutils/coreutils/issues/9617 for details.