### PR TITLE
ln: Using unit test macros for ln and creating test cases for exception handling

### DIFF
--- a/src/uu/ln/locales/en-US.ftl
+++ b/src/uu/ln/locales/en-US.ftl
@@ -29,7 +29,6 @@ ln-error-missing-destination = missing destination file operand after {$operand}
 ln-error-extra-operand = extra operand {$operand}
   Try '{$program} --help' for more information.
 ln-error-could-not-update = Could not update {$target}: {$error}
-ln-error-cannot-stat = cannot stat {$path}: No such file or directory
 ln-error-will-not-overwrite = will not overwrite just-created {$target} with {$source}
 ln-prompt-replace = replace {$file}?
 ln-cannot-backup = cannot backup {$file}

--- a/src/uu/ln/locales/fr-FR.ftl
+++ b/src/uu/ln/locales/fr-FR.ftl
@@ -30,7 +30,6 @@ ln-error-missing-destination = opérande de fichier de destination manquant apr�
 ln-error-extra-operand = opérande supplémentaire {$operand}
   Essayez « {$program} --help » pour plus d'informations.
 ln-error-could-not-update = Impossible de mettre à jour {$target} : {$error}
-ln-error-cannot-stat = impossible d'analyser {$path} : Aucun fichier ou répertoire de ce nom
 ln-error-will-not-overwrite = ne remplacera pas le fichier {$target} qui vient d'être créé par {$source}
 ln-prompt-replace = remplacer {$file} ?
 ln-cannot-backup = impossible de sauvegarder {$file}

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -317,25 +317,15 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
             }
             target_dir.to_path_buf()
         } else {
-            match srcpath.as_os_str().to_str() {
-                Some(name) => {
-                    match Path::new(name).file_name() {
-                        Some(basename) => target_dir.join(basename),
-                        // This can be None only for "." or "..". Trying
-                        // to create a link with such name will fail with
-                        // EEXIST, which agrees with the behavior of GNU
-                        // coreutils.
-                        None => target_dir.join(name),
-                    }
-                }
-                None => {
-                    show_error!(
-                        "{}",
-                        translate!("ln-error-cannot-stat", "path" => srcpath.quote())
-                    );
-                    all_successful = false;
-                    continue;
-                }
+            // Use OsStr directly to handle non-UTF8 paths correctly
+            let name = srcpath.as_os_str();
+            match srcpath.file_name() {
+                Some(basename) => target_dir.join(basename),
+                // This can be None only for "." or "..". Trying
+                // to create a link with such name will fail with
+                // EEXIST, which agrees with the behavior of GNU
+                // coreutils.
+                None => target_dir.join(name),
             }
         };
 

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -5,8 +5,7 @@
 #![allow(clippy::similar_names)]
 
 use std::path::PathBuf;
-use uutests::util::TestScenario;
-use uutests::{at_and_ts, at_and_ucmd, new_ucmd, util_name};
+use uutests::{at_and_ts, at_and_ucmd, new_ucmd};
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -8,10 +8,6 @@ use std::path::PathBuf;
 use uutests::{at_and_ts, at_and_ucmd, new_ucmd};
 
 #[cfg(unix)]
-use std::ffi::OsStr;
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
-#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
 #[test]
@@ -931,9 +927,11 @@ fn test_ln_extra_operand() {
         .stderr_contains("--help");
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn test_ln_cannot_stat_non_utf8() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
     let (at, ts) = at_and_ts!();
     at.mkdir("target_dir");
     at.touch(OsStr::from_bytes(b"file_\xFF"));


### PR DESCRIPTION
Going through the coverlay of ln to see where we are missing coverage and found a few edge cases that I was looking to cover with tests. It was interesting to see that one of the error messages was actually impossible to reach on unix, so I ended up adding a cfg to only run it for windows. 

I also updated the using of the macros in the tests since half of the tests were using them and half of them weren't