### PR TITLE
why-{skip,error}.md: Remove stty tests and shared strings

### DIFF
--- a/util/why-error.md
+++ b/util/why-error.md
@@ -1,40 +1,42 @@
-This file documents why some tests are failing:
-* gnu/tests/cp/cp-a-selinux.sh
-* gnu/tests/cp/preserve-gid.sh
-* gnu/tests/date/date-debug.sh
-* gnu/tests/date/date.pl
-* gnu/tests/dd/no-allocate.sh
-* gnu/tests/dd/nocache_eof.sh
-* gnu/tests/dd/skip-seek-past-file.sh - https://github.com/uutils/coreutils/issues/7216
-* gnu/tests/dd/stderr.sh
-* gnu/tests/fmt/non-space.sh
-* gnu/tests/help/help-version-getopt.sh
-* gnu/tests/help/help-version.sh
-* gnu/tests/ls/ls-misc.pl
-* gnu/tests/ls/stat-free-symlinks.sh
-* gnu/tests/misc/close-stdout.sh
-* gnu/tests/misc/nohup.sh
-* gnu/tests/numfmt/numfmt.pl - https://github.com/uutils/coreutils/issues/7219 / https://github.com/uutils/coreutils/issues/7221
-* gnu/tests/misc/stdbuf.sh - https://github.com/uutils/coreutils/issues/7072
-* gnu/tests/misc/tsort.pl - https://github.com/uutils/coreutils/issues/7074
-* gnu/tests/misc/write-errors.sh
-* gnu/tests/od/od-float.sh
-* gnu/tests/ptx/ptx-overrun.sh
-* gnu/tests/ptx/ptx.pl
-* gnu/tests/rm/one-file-system.sh - https://github.com/uutils/coreutils/issues/7011
-* gnu/tests/rm/rm1.sh - https://github.com/uutils/coreutils/issues/9479
-* gnu/tests/shred/shred-passes.sh
-* gnu/tests/sort/sort-continue.sh
-* gnu/tests/sort/sort-debug-keys.sh
-* gnu/tests/sort/sort-debug-warn.sh
-* gnu/tests/sort/sort-float.sh
-* gnu/tests/sort/sort-h-thousands-sep.sh
-* gnu/tests/sort/sort-merge-fdlimit.sh
-* gnu/tests/sort/sort-month.sh
-* gnu/tests/sort/sort.pl
-* gnu/tests/tac/tac-2-nonseekable.sh
-* gnu/tests/tail/end-of-device.sh
-* gnu/tests/tail/follow-stdin.sh
-* gnu/tests/tail/inotify-rotate-resources.sh
-* gnu/tests/tail/symlink.sh
-* gnu/tests/tty/tty-eof.pl
+This file documents why some GNU tests are failing:
+* cp/cp-a-selinux.sh
+* cp/preserve-gid.sh
+* date/date-debug.sh
+* date/date.pl
+* dd/no-allocate.sh
+* dd/nocache_eof.sh
+* dd/skip-seek-past-file.sh - https://github.com/uutils/coreutils/issues/7216
+* dd/stderr.sh
+* fmt/non-space.sh
+* help/help-version-getopt.sh
+* help/help-version.sh
+* ls/ls-misc.pl
+* ls/stat-free-symlinks.sh
+* misc/close-stdout.sh
+* misc/nohup.sh
+* numfmt/numfmt.pl - https://github.com/uutils/coreutils/issues/7219 / https://github.com/uutils/coreutils/issues/7221
+* misc/stdbuf.sh - https://github.com/uutils/coreutils/issues/7072
+* misc/tsort.pl - https://github.com/uutils/coreutils/issues/7074
+* misc/write-errors.sh
+* od/od-float.sh
+* ptx/ptx-overrun.sh
+* ptx/ptx.pl
+* rm/one-file-system.sh - https://github.com/uutils/coreutils/issues/7011
+* rm/rm1.sh - https://github.com/uutils/coreutils/issues/9479
+* shred/shred-passes.sh
+* sort/sort-continue.sh
+* sort/sort-debug-keys.sh
+* sort/sort-debug-warn.sh
+* sort/sort-float.sh
+* sort/sort-h-thousands-sep.sh
+* sort/sort-merge-fdlimit.sh
+* sort/sort-month.sh
+* sort/sort.pl
+* tac/tac-2-nonseekable.sh
+* tail/end-of-device.sh
+* tail/follow-stdin.sh
+* tail/inotify-rotate-resources.sh
+* tail/symlink.sh
+* stty/stty-row-col.sh
+* stty/stty.sh
+* tty/tty-eof.pl

--- a/util/why-skip.md
+++ b/util/why-skip.md
@@ -20,9 +20,6 @@
 = timeout returned 142. SIGALRM not handled? =
 * tests/misc/timeout-group.sh
 
-= can't get window size =
-* tests/misc/stty-row-col.sh
-
 = The Swedish locale with blank thousands separator is unavailable. =
 * tests/misc/sort-h-thousands-sep.sh
 
@@ -31,11 +28,6 @@
 
 = no rootfs in mtab =
 * tests/df/skip-rootfs.sh
-
-= requires controlling input terminal =
-* tests/misc/stty-pairs.sh
-* tests/misc/stty.sh
-* tests/misc/stty-invalid.sh
 
 = Disabled. Enabled at GNU coreutils > 9.9 =
 * tests/misc/tac-continue.sh


### PR DESCRIPTION
https://github.com/uutils/coreutils/actions/runs/20092019349/job/57641430131#step:15:219

https://github.com/uutils/coreutils/actions/runs/20092019349/job/57641430131#step:15:138

https://github.com/uutils/coreutils/actions/runs/20092019349/job/57641430131#step:15:192

https://github.com/uutils/coreutils/actions/runs/20092019349/job/57641430131#step:15:85