### PR TITLE
test(more): Fix test_from_line_option race condition by increasing PTY delay

### DIFF
--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -35,7 +35,7 @@ fn run_more_with_pty(
         .arg(file)
         .run_no_wait();
 
-    child.delay(500);
+    child.delay(200);
     let mut output = vec![0u8; 1024];
     let n = read(&controller, &mut output).unwrap();
     let output_str = String::from_utf8_lossy(&output[..n]).to_string();


### PR DESCRIPTION
Fixes `test_from_line_option` race condition by increasing delay from 100ms to 500ms, allowing `more` to fully render output before test reads PTY.

Fixes noise #9587

https://github.com/uutils/coreutils/actions/runs/20107767279/job/57697301129?pr=9587