### PR TITLE
seq: returning exit code 1 on broken pipe, fixes seq-epipe

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -211,12 +211,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     match result {
         Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => {
-            // GNU seq prints the Broken pipe message but still exits with status 0
-            let err = err.map_err_context(|| "write error".into());
-            uucore::show_error!("{err}");
-            Ok(())
-        }
         Err(err) => Err(err.map_err_context(|| "write error".into())),
     }
 }


### PR DESCRIPTION
Work in progress for me trying to understand the whole EPIPE situation, on one hand the GNU implementation is supposed to clearly return a 1 in this case, but when the ignore sigpipe is set it should return 0 and we don't have that in any of the utilities. I think the plan could be set this for now and when the library that all of the utilities use for ignoring the sig-pipe is made we add it here.