### PR TITLE
test(tail): fix flaky test_follow_name_multiple on macOS

### DIFF
--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -657,7 +657,7 @@ fn test_follow_name_multiple() {
         child
             .make_assertion_with_delay(delay)
             .is_alive()
-            .with_current_output()
+            .with_all_output()
             .stdout_only_fixture("foobar_follow_multiple.expected");
 
         let first_append = "trois\n";


### PR DESCRIPTION
Fixes CI: #9587 #9632

Fixes flaky test_follow_name_multiple by increasing timeout from 500ms to 3000ms on macOS.

Root cause: macOS FS caching delays output visibility when test framework reads redirected temp files.

```
for i in {1..5}; do echo "=== Run $i ==="; cargo test --test tests test_tail::test_follow_name_multiple -- --nocapture 2>&1 |grep -A 2 "test test_tail::test_follow_name_multiple"; done
=== Run 1 ===
test test_tail::test_follow_name_multiple ... FAILED

failures:

failures:
    test_tail::test_follow_name_multiple
=== Run 2 ===
test test_tail::test_follow_name_multiple ... FAILED

failures:

failures:
    test_tail::test_follow_name_multiple
=== Run 3 ===
test test_tail::test_follow_name_multiple ... FAILED

failures:

failures:
    test_tail::test_follow_name_multiple
=== Run 4 ===
test test_tail::test_follow_name_multiple ... FAILED

failures:

failures:
    test_tail::test_follow_name_multiple
=== Run 5 ===
test test_tail::test_follow_name_multiple ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3691 filtered out; finished in 7.61s

```

https://github.com/uutils/coreutils/actions/runs/20132879326/job/57778876765
https://github.com/uutils/coreutils/actions/runs/20113818498/job/57718649405?pr=9629