### PR TITLE
WIP Draft: Validating that mattsu2020 approach to pipes works with all pipe tests

### DIFF
--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -191,6 +191,21 @@ nofield
 uninlined
 nonminimal
 
+# * poll/signal constants
+GETFD
+iopoll
+isapipe
+pollfd
+POLLERR
+POLLHUP
+POLLNVAL
+POLLRDBAND
+revents
+Sigmask
+sigprocmask
+sigset
+SIGTTIN
+
 # * CPU/hardware features
 ASIMD
 asimd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,7 +3782,6 @@ dependencies = [
  "clap",
  "codspeed-divan-compat",
  "fluent",
- "nix",
  "num-bigint",
  "num-traits",
  "tempfile",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -196,9 +196,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -753,9 +753,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -1366,9 +1366,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -1653,7 +1653,6 @@ dependencies = [
  "bigdecimal",
  "clap",
  "fluent",
- "nix",
  "num-bigint",
  "num-traits",
  "thiserror",

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-uucore = { workspace = true }
+uucore = { workspace = true, features = ["signals"] }
 fluent = { workspace = true }
 
 [[bin]]

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/printf.rs"
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["format", "quoting-style"] }
+uucore = { workspace = true, features = ["format", "quoting-style", "signals"] }
 fluent = { workspace = true }
 
 [[bin]]

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/seq.rs"
 [dependencies]
 bigdecimal = { workspace = true }
 clap = { workspace = true }
-nix = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 thiserror = { workspace = true }
@@ -31,6 +30,7 @@ uucore = { workspace = true, features = [
   "format",
   "parser",
   "quoting-style",
+  "signals",
 ] }
 fluent = { workspace = true }
 

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -23,7 +23,7 @@ clap = { workspace = true }
 libc = { workspace = true }
 memchr = { workspace = true }
 notify = { workspace = true }
-uucore = { workspace = true, features = ["fs", "parser-size"] }
+uucore = { workspace = true, features = ["fs", "parser-size", "signals"] }
 same-file = { workspace = true }
 fluent = { workspace = true }
 

--- a/src/uu/tail/locales/en-US.ftl
+++ b/src/uu/tail/locales/en-US.ftl
@@ -42,6 +42,7 @@ tail-error-backend-cannot-be-used-too-many-files = { $backend } cannot be used, 
 tail-error-backend-resources-exhausted = { $backend } resources exhausted
 tail-error-notify-error = NotifyError: { $error }
 tail-error-recv-timeout-error = RecvTimeoutError: { $error }
+tail-error-stdout = standard output: { $error }
 
 # Warning messages
 tail-warning-retry-ignored = --retry ignored; --retry is useful only when following

--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -230,13 +230,15 @@ pub fn path_is_tailable(path: &Path) -> bool {
 
 #[inline]
 pub fn stdin_is_bad_fd() -> bool {
-    // FIXME : Rust's stdlib is reopening fds as /dev/null
-    // see also: https://github.com/uutils/coreutils/issues/2873
-    // (gnu/tests/tail-2/follow-stdin.sh fails because of this)
-    //#[cfg(unix)]
+    // Use the early-capture mechanism from uucore to detect if stdin was closed
+    // before Rust's runtime reopened it as /dev/null.
+    // See: https://github.com/uutils/coreutils/issues/2873
+    #[cfg(unix)]
     {
-        //platform::stdin_is_bad_fd()
+        uucore::signals::stdin_was_closed()
     }
-    //#[cfg(not(unix))]
-    false
+    #[cfg(not(unix))]
+    {
+        false
+    }
 }

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -209,7 +209,9 @@ macro_rules! bin {
             let code = $util::uumain(uucore::args_os());
             // (defensively) flush stdout for utility prior to exit; see <https://github.com/rust-lang/rust/issues/23818>
             if let Err(e) = std::io::stdout().flush() {
-                eprintln!("Error flushing stdout: {e}");
+                if e.kind() != std::io::ErrorKind::BrokenPipe {
+                    eprintln!("Error flushing stdout: {e}");
+                }
             }
 
             std::process::exit(code);

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -15,27 +15,6 @@ fn test_invalid_arg() {
 }
 
 #[test]
-#[cfg(unix)]
-fn test_broken_pipe_still_exits_success() {
-    use std::process::Stdio;
-
-    let mut child = new_ucmd!()
-        // Use an infinite sequence so a burst of output happens immediately after spawn.
-        // With small output the process can finish before stdout is closed and the Broken pipe never occurs.
-        .args(&["inf"])
-        .set_stdout(Stdio::piped())
-        .run_no_wait();
-
-    // Trigger a Broken pipe by writing to a pipe whose reader closed first.
-    child.close_stdout();
-    let result = child.wait().unwrap();
-
-    result
-        .code_is(0)
-        .stderr_contains("write error: Broken pipe");
-}
-
-#[test]
 fn test_no_args() {
     new_ucmd!()
         .fails_with_code(1)
@@ -675,7 +654,7 @@ fn test_neg_inf() {
     new_ucmd!()
         .args(&["--", "-inf", "0"])
         .run_stdout_starts_with(b"-inf\n-inf\n-inf\n")
-        .success();
+        .signal_name_is("PIPE");
 }
 
 #[test]
@@ -683,7 +662,7 @@ fn test_neg_infinity() {
     new_ucmd!()
         .args(&["--", "-infinity", "0"])
         .run_stdout_starts_with(b"-inf\n-inf\n-inf\n")
-        .success();
+        .signal_name_is("PIPE");
 }
 
 #[test]
@@ -691,7 +670,7 @@ fn test_inf() {
     new_ucmd!()
         .args(&["inf"])
         .run_stdout_starts_with(b"1\n2\n3\n")
-        .success();
+        .signal_name_is("PIPE");
 }
 
 #[test]
@@ -699,7 +678,7 @@ fn test_infinity() {
     new_ucmd!()
         .args(&["infinity"])
         .run_stdout_starts_with(b"1\n2\n3\n")
-        .success();
+        .signal_name_is("PIPE");
 }
 
 #[test]
@@ -707,7 +686,7 @@ fn test_inf_width() {
     new_ucmd!()
         .args(&["-w", "1.000", "inf", "inf"])
         .run_stdout_starts_with(b"1.000\n  inf\n  inf\n  inf\n")
-        .success();
+        .signal_name_is("PIPE");
 }
 
 #[test]
@@ -715,7 +694,7 @@ fn test_neg_inf_width() {
     new_ucmd!()
         .args(&["-w", "1.000", "-inf", "-inf"])
         .run_stdout_starts_with(b"1.000\n -inf\n -inf\n -inf\n")
-        .success();
+        .signal_name_is("PIPE");
 }
 
 #[test]
@@ -1100,7 +1079,7 @@ fn test_precision_corner_cases() {
     new_ucmd!()
         .args(&["1", "1.2", "inf"])
         .run_stdout_starts_with(b"1.0\n2.2\n3.4\n")
-        .success();
+        .signal_name_is("PIPE");
 }
 
 // GNU `seq` manual only makes guarantees about `-w` working if the
@@ -1163,5 +1142,5 @@ fn test_equalize_widths_corner_cases() {
     new_ucmd!()
         .args(&["-w", "1", "1.2", "inf"])
         .run_stdout_starts_with(b"1.0\n2.2\n3.4\n")
-        .success();
+        .signal_name_is("PIPE");
 }


### PR DESCRIPTION
Not for review just for discussion and validation of pipeline handler approach

I took the change that mattsu2020 made to be able to track the pipe signals and just did some messing around to see if that approach could work for all of the pipe related tests. Will use this for inspiration to make PR's for each one individually. I found that some of the original changes didn't work and that the other GNU tests have different expectations for how seq fails