### PR TITLE
fix(shred): stop immediately on write errors 

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -542,12 +542,9 @@ fn wipe_file(
             );
         }
         // size is an optional argument for exactly how many bytes we want to shred
-        // Ignore failed writes; just keep trying
-        show_if_err!(
-            do_pass(&mut file, &pass_type, exact, random_source, size).map_err_context(|| {
-                translate!("shred-file-write-pass-failed", "file" => path.maybe_quote())
-            })
-        );
+        do_pass(&mut file, &pass_type, exact, random_source, size).map_err_context(
+            || translate!("shred-file-write-pass-failed", "file" => path.maybe_quote()),
+        )?;
     }
 
     if remove_method != RemoveMethod::None {


### PR DESCRIPTION
Fixes #7947 

Replace `show_if_err!()` with `?` operator in wipe_file() to properly propagate errors and stop immediately on write failures, matching GNU shred. Previously continued all passes despite errors. Enables previously ignored test `test_random_source_dir`.