### PR TITLE
GnuTests: Split online process to a script

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -2,7 +2,7 @@ name: GnuTests
 
 # spell-checker:ignore (abbrev/names) CodeCov gnulib GnuTests Swatinem
 # spell-checker:ignore (jargon) submodules devel
-# spell-checker:ignore (libs/utils) autopoint chksum getenforce gperf lcov libexpect limactl pyinotify setenforce shopt texinfo valgrind libattr libcap taiki-e
+# spell-checker:ignore (libs/utils) autopoint chksum dpkg getenforce gperf lcov libexpect limactl pyinotify setenforce shopt texinfo valgrind libattr libcap taiki-e
 # spell-checker:ignore (options) Ccodegen Coverflow Cpanic Zpanic
 # spell-checker:ignore (people) Dawid Dziurla * dawidd dtolnay
 # spell-checker:ignore (vars) FILESET SUBDIRS XPASS
@@ -42,16 +42,6 @@ jobs:
       with:
         path: 'uutils'
         persist-credentials: false
-    - name: Extract GNU version from build-gnu.sh
-      id: gnu-version
-      run: |
-        GNU_VERSION=$(grep '^release_tag_GNU=' uutils/util/build-gnu.sh | cut -d'"' -f2)
-        if [ -z "$GNU_VERSION" ]; then
-          echo "Error: Failed to extract GNU version from build-gnu.sh"
-          exit 1
-        fi
-        echo "REPO_GNU_REF=${GNU_VERSION}" >> $GITHUB_ENV
-        echo "Extracted GNU version: ${GNU_VERSION}"
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
@@ -60,20 +50,7 @@ jobs:
       with:
         workspaces: "./uutils -> target"
     - name: Checkout code (GNU coreutils)
-      uses: actions/checkout@v6
-      with:
-        repository: 'coreutils/coreutils'
-        path: 'gnu'
-        ref: ${{ env.REPO_GNU_REF }}
-        submodules: false
-        persist-credentials: false
-    - name: Override submodule URL and initialize submodules
-      # Use github instead of upstream git server
-      run: |
-        git submodule sync --recursive
-        git config submodule.gnulib.url https://github.com/coreutils/gnulib.git
-        git submodule update --init --recursive --depth 1
-      working-directory: gnu
+      run: (mkdir -p gnu && cd gnu && bash ../uutils/util/fetch-gnu.sh)
 
     #### Build environment setup
     - name: Install dependencies
@@ -83,6 +60,8 @@ jobs:
         sudo apt-get update
         ## Check that build-gnu.sh works on the non SELinux system by installing libselinux only on lima
         sudo apt-get install -y autopoint gperf gdb python3-pyinotify valgrind libexpect-perl libacl1-dev libattr1-dev libcap-dev attr quilt
+        curl http://launchpadlibrarian.net/831710181/automake_1.18.1-3_all.deb > automake-1.18.deb
+        sudo dpkg -i --force-depends automake-1.18.deb
     - name: Add various locales
       shell: bash
       run: |
@@ -206,16 +185,6 @@ jobs:
       with:
         path: 'uutils'
         persist-credentials: false
-    - name: Extract GNU version from build-gnu.sh
-      id: gnu-version-selinux
-      run: |
-        GNU_VERSION=$(grep '^release_tag_GNU=' uutils/util/build-gnu.sh | cut -d'"' -f2)
-        if [ -z "$GNU_VERSION" ]; then
-          echo "Error: Failed to extract GNU version from build-gnu.sh"
-          exit 1
-        fi
-        echo "REPO_GNU_REF=${GNU_VERSION}" >> $GITHUB_ENV
-        echo "Extracted GNU version: ${GNU_VERSION}"
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
@@ -224,20 +193,7 @@ jobs:
       with:
         workspaces: "./uutils -> target"
     - name: Checkout code (GNU coreutils)
-      uses: actions/checkout@v6
-      with:
-        repository: 'coreutils/coreutils'
-        path: 'gnu'
-        ref: ${{ env.REPO_GNU_REF }}
-        submodules: false
-        persist-credentials: false
-    - name: Override submodule URL and initialize submodules
-      # Use github instead of upstream git server
-      run: |
-        git submodule sync --recursive
-        git config submodule.gnulib.url https://github.com/coreutils/gnulib.git
-        git submodule update --init --recursive --depth 1
-      working-directory: gnu
+      run: (mkdir -p gnu && cd gnu && bash ../uutils/util/fetch-gnu.sh)
 
     #### Lima build environment setup
     - name: Setup Lima

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -34,18 +34,13 @@ path_GNU="$("${READLINK}" -fm -- "${path_GNU:-${path_UUTILS}/../gnu}")"
 
 ###
 
-release_tag_GNU="v9.9"
-
 # check if the GNU coreutils has been cloned, if not print instructions
-# note: the ${path_GNU} might already exist, so we check for the .git directory
-if test ! -d "${path_GNU}/.git"; then
+# note: the ${path_GNU} might already exist, so we check for the configure
+if test ! -f "${path_GNU}/configure"; then
     echo "Could not find the GNU coreutils (expected at '${path_GNU}')"
     echo "Download them to the expected path:"
-    echo "  git clone --recurse-submodules https://github.com/coreutils/coreutils.git \"${path_GNU}\""
-    echo "Afterwards, checkout the latest release tag:"
-    echo "  cd \"${path_GNU}\""
-    echo "  git fetch --all --tags"
-    echo "  git checkout tags/${release_tag_GNU}"
+    echo "  (cd '${path_GNU}' && fetch-gnu.sh ) "
+    echo "You can edit fetch-gnu.sh to change the tag"
     exit 1
 fi
 
@@ -131,8 +126,6 @@ if test -f gnu-built; then
 else
     # Disable useless checks
     "${SED}" -i 's|check-texinfo: $(syntax_checks)|check-texinfo:|' doc/local.mk
-    "${SED}" -i '/^wget.*/d' bootstrap.conf # wget is used to DL po. Remove the dep.
-    ./bootstrap --skip-po
     # Use CFLAGS for best build time since we discard GNU coreutils
     CFLAGS="${CFLAGS} -pipe -O0 -s" ./configure --quiet --disable-gcc-warnings --disable-nls --disable-dependency-tracking --disable-bold-man-page-references \
       --enable-single-binary=symlinks \
@@ -174,9 +167,6 @@ grep -rl '\$abs_path_dir_' tests/*/*.sh | xargs -r "${SED}" -i "s|\$abs_path_dir
 "${SED}" -i "s|--coreutils-prog=||g" tests/misc/coreutils.sh
 # Different message
 "${SED}" -i "s|coreutils: unknown program 'blah'|blah: function/utility not found|" tests/misc/coreutils.sh
-
-# Remove hfs dependency (should be merged to upstream)
-"${SED}" -i -e "s|hfsplus|ext4 -O casefold|" -e "s|cd mnt|rm -d mnt/lost+found;chattr +F mnt;cd mnt|" tests/mv/hardlink-case.sh
 
 # Use the system coreutils where the test fails due to error in a util that is not the one being tested
 "${SED}" -i "s|grep '^#define HAVE_CAP 1' \$CONFIG_HEADER > /dev/null|true|"  tests/ls/capability.sh

--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+ver="9.9"
+repo=https://github.com/coreutils/coreutils
+curl -L "${repo}/releases/download/v${ver}/coreutils-${ver}.tar.xz" | tar --strip-components=1 -xJf -
+
+# backport from coreutils > 9.9
+curl ${repo}/raw/refs/heads/master/tests/mv/hardlink-case.sh > tests/mv/hardlink-case.sh
+curl ${repo}/raw/refs/heads/master/tests/mkdir/writable-under-readonly.sh > tests/mkdir/writable-under-readonly.sh
+curl ${repo}/raw/refs/heads/master/tests/cp/cp-mv-enotsup-xattr.sh > tests/cp/cp-mv-enotsup-xattr.sh #spell-checker:disable-line

--- a/util/why-skip.md
+++ b/util/why-skip.md
@@ -31,5 +31,3 @@
 
 = Disabled. Enabled at GNU coreutils > 9.9 =
 * tests/misc/tac-continue.sh
-* tests/mkdir/writable-under-readonly.sh
-* tests/cp/cp-mv-enotsup-xattr.sh


### PR DESCRIPTION
Current CI:
1. Version is extracted by `grep` from script, but script is actually not a version specific. It is a confusion.
2. `build-gnu.sh` is existing for offline test, but actually has online `./bootstrap`
3. Difficult to backport tests at offline.
4. Depending on `git`.

So detatched online part.