### PR TITLE
stty: fix: reject "+hex" in `parse_saved_state`

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -530,8 +530,14 @@ fn parse_saved_state(arg: &str) -> Option<Vec<u32>> {
     // Validate all parts are non-empty valid hex
     let mut values = Vec::with_capacity(expected_parts);
     for (i, part) in parts.iter().enumerate() {
+        // `from_str_radix` doesn't document its behavior for this case,
+        // thus, we do this to guarantee stability
         if part.is_empty() {
             return None; // GNU rejects empty hex values
+        }
+        // TO-DO: avoid `from_str_radix`
+        if part.as_bytes()[0] == b'+' {
+            return None;
         }
         let val = u32::from_str_radix(part, 16).ok()?;
 

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -1428,6 +1428,18 @@ mod tests {
         assert_eq!(parse_rows_cols("65537"), Some(1)); // wraps to 1
     }
 
+    #[test]
+    fn test_sane_parse_saved_state() {
+        let result = parse_saved_state("00:01:ff:7f");
+        assert_eq!(&result, Some(&[0, 1, 255, 127]));
+    }
+
+    #[test]
+    fn test_parse_saved_state_no_plus() {
+        let result = parse_saved_state("+00:+01:+ff:+7f");
+        assert_eq!(&result, None);
+    }
+
     // Sane control character defaults
     #[test]
     fn test_get_sane_control_char_values() {

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -1436,6 +1436,24 @@ mod tests {
         assert_eq!(parse_rows_cols("65537"), Some(1)); // wraps to 1
     }
 
+    #[test]
+    fn test_sane_parse_saved_state() {
+        let expected_parts = 4 + nix::libc::NCCS;
+        let mut parts: Vec<String> = ["00", "01", "ff", "7f"].map(str::to_string).into();
+        parts.resize(expected_parts, "00".to_string());
+        let input = parts.join(":");
+        assert!(parse_saved_state(&input).is_some());
+    }
+
+    #[test]
+    fn test_parse_saved_state_no_plus() {
+        let expected_parts = 4 + nix::libc::NCCS;
+        let mut parts: Vec<String> = ["+00", "00", "00", "00"].map(str::to_string).into();
+        parts.resize(expected_parts, "00".to_string());
+        let input = parts.join(":");
+        assert_eq!(parse_saved_state(&input), None);
+    }
+
     // Sane control character defaults
     #[test]
     fn test_get_sane_control_char_values() {

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -532,8 +532,14 @@ fn parse_saved_state(arg: &str) -> Option<Vec<u32>> {
     // Validate all parts are non-empty valid hex
     let mut values = Vec::with_capacity(expected_parts);
     for (i, part) in parts.iter().enumerate() {
+        // `from_str_radix` doesn't document its behavior for this case,
+        // thus, we do this to guarantee stability
         if part.is_empty() {
             return None; // GNU rejects empty hex values
+        }
+        // TO-DO: avoid `from_str_radix`
+        if part.as_bytes()[0] == b'+' {
+            return None;
         }
         let val = u32::from_str_radix(part, 16).ok()?;
 


### PR DESCRIPTION
Fixes this pitfall: rust-lang/rust-clippy#16213

Related: #9255