### PR TITLE
fix: patch inotify-dir-recreate test for notify crate's threaded inotify

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -223,6 +223,12 @@ sed -i -e "s|---dis ||g" tests/tail/overlay-headers.sh
 # Do not FAIL, just do a regular ERROR
 "${SED}" -i -e "s|framework_failure_ 'no inotify_add_watch';|fail=1;|" tests/tail/inotify-rotate-resources.sh
 
+# The notify crate makes inotify_add_watch calls in a background thread, so strace needs -f to follow threads.
+# Also remove the HAVE_INOTIFY header check since that's for C builds.
+"${SED}" -i -e "s|grep '^#define HAVE_INOTIFY 1' \"\$CONFIG_HEADER\" >/dev/null && is_local_dir_ \. |is_local_dir_ . |" \
+    -e "s|strace -e inotify_add_watch|strace -f -e inotify_add_watch|" \
+    tests/tail/inotify-dir-recreate.sh
+
 test -f "${UU_BUILD_DIR}/getlimits" || cp src/getlimits "${UU_BUILD_DIR}"
 
 # pr produces very long log and this command isn't super interesting


### PR DESCRIPTION
This PR adds a sed patch to the GNU test inotify-dir-recreate

I've been going through every single test left and seeing many of them have characteristics that are "C" specific that make it basically impossible to pass the tests. I was looking into ways to minimally change the tests to still stay in the spirit of the tests. 

The two switches here are removing the check that looks to see if the C header is in the file, and the second one is changing the strace command to strace -f since we use multiple threads. Once those two changes are made the test passes. 

I know a bunch of contributors to the original coreutils check out the PR's and if any of you are reading I'd love to get your thoughts on whether this genuinely covers the spirit of the test?