### PR TITLE
id -p crashes with panic when the real GID doesn't exist in /etc/group

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -468,7 +468,7 @@ fn pretty(possible_pw: Option<Passwd>) {
             "{}",
             p.belongs_to()
                 .iter()
-                .map(|&gr| entries::gid2grp(gr).unwrap())
+                .map(|&gr| entries::gid2grp(gr).unwrap_or_else(|_| gr.to_string()))
                 .collect::<Vec<_>>()
                 .join(" ")
         );
@@ -508,7 +508,7 @@ fn pretty(possible_pw: Option<Passwd>) {
             entries::get_groups_gnu(None)
                 .unwrap()
                 .iter()
-                .map(|&gr| entries::gid2grp(gr).unwrap())
+                .map(|&gr| entries::gid2grp(gr).unwrap_or_else(|_| gr.to_string()))
                 .collect::<Vec<_>>()
                 .join(" ")
         );


### PR DESCRIPTION
hard to reproduce in an automated test
but here are the steps:
* edit /etc/passwd
* change one group id by another (non existing)
* run "id -p <user>"