### PR TITLE
nl: preserve raw bytes in output instead of using from_utf8_lossy

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -345,6 +345,13 @@ pub fn uu_app() -> Command {
         )
 }
 
+/// Helper to write: prefix bytes + line bytes + newline
+fn write_line(writer: &mut impl Write, prefix: &[u8], line: &[u8]) -> std::io::Result<()> {
+    writer.write_all(prefix)?;
+    writer.write_all(line)?;
+    writeln!(writer)
+}
+
 /// `nl` implements the main functionality for an individual buffer.
 fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings) -> UResult<()> {
     let mut writer = BufWriter::new(stdout());
@@ -409,24 +416,17 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
                         translate!("nl-error-line-number-overflow"),
                     ));
                 };
-                writeln!(
-                    writer,
-                    "{}{}{}",
-                    settings
-                        .number_format
-                        .format(line_number, settings.number_width),
-                    settings.number_separator.to_string_lossy(),
-                    String::from_utf8_lossy(&line),
-                )
-                .map_err_context(|| translate!("nl-error-could-not-write"))?;
-                // update line number for the potential next line
-                match line_number.checked_add(settings.line_increment) {
-                    Some(new_line_number) => stats.line_number = Some(new_line_number),
-                    None => stats.line_number = None, // overflow
-                }
+                let mut prefix = settings
+                    .number_format
+                    .format(line_number, settings.number_width)
+                    .into_bytes();
+                prefix.extend_from_slice(settings.number_separator.as_encoded_bytes());
+                write_line(&mut writer, &prefix, &line)
+                    .map_err_context(|| translate!("nl-error-could-not-write"))?;
+                stats.line_number = line_number.checked_add(settings.line_increment);
             } else {
-                let spaces = " ".repeat(settings.number_width + 1);
-                writeln!(writer, "{spaces}{}", String::from_utf8_lossy(&line))
+                let prefix = " ".repeat(settings.number_width + 1);
+                write_line(&mut writer, prefix.as_bytes(), &line)
                     .map_err_context(|| translate!("nl-error-could-not-write"))?;
             }
         }


### PR DESCRIPTION
This bug sent me caused me a bunch of difficulty while working on the locale GNU integration tests, since non utf-8 values were being piped into nl in the GNU integration tests and then coming out as UTF-8 breaking the tests. I am curious to see if this was the root cause for some more integration tests failing in the CI. 


Its a bit rough to see that there were integration tests specifically made for this scenario but the tests were implemented with the same "to_string_lossy" which made the tests actually check nothing. Ideally we should add the "matches_gnu()" to all of these integration tests: https://github.com/uutils/coreutils/pull/9660 so that we can detect these issues preemptively. 