### PR TITLE
ptx: fix incorrect column width calculation and padding logic

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -614,11 +614,17 @@ fn format_dumb_line(
     };
 
     // Calculate the width for the left half (before the keyword)
-    let half_width = config.line_width / 2;
+    let half_width = cmp::max(config.line_width / 2, config.gap_size);
+
+    let left_part_len = if left_part.contains(&config.trunc_str) {
+        left_part.len() - config.trunc_str.len()
+    } else {
+        left_part.len()
+    };
 
     // Right-justify the left part within the left half
     let padding = if left_part.len() < half_width {
-        half_width - left_part.len()
+        half_width - left_part_len
     } else {
         0
     };

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -264,3 +264,40 @@ fn test_gnu_mode_dumb_format() {
         "                                       a b\n                                   a   b\n",
     );
 }
+
+#[test]
+fn test_gnu_compatibility_narrow_width() {
+    new_ucmd!()
+        .args(&["-w", "2"])
+        .pipe_in("qux")
+        .succeeds()
+        .stdout_only("      qux\n");
+}
+
+#[test]
+fn test_gnu_compatibility_truncation_width() {
+    new_ucmd!()
+        .args(&["-w", "10"])
+        .pipe_in("foo bar")
+        .succeeds()
+        .stdout_only("     /   bar\n        foo/\n");
+}
+
+#[test]
+fn test_unicode_padding_alignment() {
+    let input = "a\né";
+    new_ucmd!()
+        .args(&["-w", "10"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("        a\n        é\n");
+}
+
+#[test]
+fn test_unicode_truncation_alignment() {
+    new_ucmd!()
+        .args(&["-w", "10"])
+        .pipe_in("föö bar")
+        .succeeds()
+        .stdout_only("     /   bar\n        föö/\n");
+}


### PR DESCRIPTION
This PR fixes ptx output alignment to match GNU coreutils.

**Fixes:**

- Corrects half_width calculation to respect gap_size (Fixes narrow, 2files).
- Excludes truncation string from visual width calculation (Fixes 2tok).

**GNU Tests:**

- tests/ptx/ptx.pl now passes 5 previously failing tests.
- (Note: S-infloop still fails as -S is not implemented).
