### PR TITLE
Checksum ignore binary

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -216,7 +216,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         algo_kind: algo,
         output_format,
         line_ending,
-        binary: false,
         no_names: false,
     };
 

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -229,7 +229,6 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
             /* base64: */ false,
         ),
         line_ending,
-        binary,
         no_names,
     };
 

--- a/src/uucore/src/lib/features/checksum/compute.rs
+++ b/src/uucore/src/lib/features/checksum/compute.rs
@@ -20,6 +20,11 @@ use crate::{show, translate};
 /// from it: 32 KiB.
 const READ_BUFFER_SIZE: usize = 32 * 1024;
 
+/// Necessary options when computing a checksum. Historically, these options
+/// included a `binary` field to differentiate `--binary` and `--text` modes on
+/// windows. Since the support for this feature is approximate in GNU, and it's
+/// deprecated anyway, it was decided in #9168 to ignore the difference when
+/// computing the checksum.
 pub struct ChecksumComputeOptions {
     /// Which algorithm to use to compute the digest.
     pub algo_kind: SizedAlgoKind,
@@ -30,9 +35,6 @@ pub struct ChecksumComputeOptions {
     /// Whether to finish lines with '\n' or '\0'.
     pub line_ending: LineEnding,
 
-    /// On windows, open files as binary instead of text
-    pub binary: bool,
-
     /// (non-GNU option) Do not print file names
     pub no_names: bool,
 }
@@ -42,6 +44,12 @@ pub struct ChecksumComputeOptions {
 /// On most linux systems, this is irrelevant, as there is no distinction
 /// between text and binary files. Refer to GNU's cksum documentation for more
 /// information.
+///
+/// As discussed in #9168, we decide to ignore the reading mode to compute the
+/// digest, both on Windows and UNIX. The reason for that is that this is a
+/// legacy feature that is poorly documented and used. This enum is kept
+/// nonetheless to still take into account the flags passed to cksum when
+/// generating untagged lines.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReadingMode {
     Binary,
@@ -280,7 +288,9 @@ where
 
         let mut digest = options.algo_kind.create_digest();
 
-        let (digest_output, sz) = digest_reader(&mut digest, &mut file, options.binary)
+        // Always compute the "binary" version of the digest, i.e. on Windows,
+        // never handle CRLFs specifically.
+        let (digest_output, sz) = digest_reader(&mut digest, &mut file, /* binary: */ true)
             .map_err_context(|| translate!("checksum-error-failed-to-read-input"))?;
 
         // Encodes the sum if df is Base64, leaves as-is otherwise.

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -74,33 +74,6 @@ macro_rules! test_digest {
                        get_hash!(ts.ucmd().arg(DIGEST_ARG).arg(BITS_ARG).arg("--zero").arg(INPUT_FILE).succeeds().no_stderr().stdout_str()));
         }
 
-
-        #[cfg(windows)]
-        #[test]
-        fn test_text_mode() {
-            use uutests::new_ucmd;
-
-            // TODO Replace this with hard-coded files that store the
-            // expected output of text mode on an input file that has
-            // "\r\n" line endings.
-            let result = new_ucmd!()
-                .args(&[DIGEST_ARG, BITS_ARG, "-b"])
-                .pipe_in("a\nb\nc\n")
-                .succeeds();
-            let expected = result.no_stderr().stdout();
-            // Replace the "*-\n" at the end of the output with " -\n".
-            // The asterisk indicates that the digest was computed in
-            // binary mode.
-            let n = expected.len();
-            let expected = [&expected[..n - 3], b" -\n"].concat();
-            new_ucmd!()
-                .args(&[DIGEST_ARG, BITS_ARG, "-t"])
-                .pipe_in("a\r\nb\r\nc\r\n")
-                .succeeds()
-                .no_stderr()
-                .stdout_is(std::str::from_utf8(&expected).unwrap());
-        }
-
         #[test]
         fn test_missing_file() {
             let ts = TestScenario::new(util_name!());


### PR DESCRIPTION
As discussed in #9168 , drop the support for special "text" digest handling on Windows, since it is a legacy feature