### PR TITLE
printenv skips environment variables with invalid UTF-8

### DIFF
--- a/tests/by-util/test_printenv.rs
+++ b/tests/by-util/test_printenv.rs
@@ -2,6 +2,10 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 use uutests::new_ucmd;
 
 #[test]
@@ -89,4 +93,29 @@ fn test_null_separator() {
             .succeeds()
             .stdout_is("FOO\x00VALUE\x00");
     }
+}
+
+#[test]
+#[cfg(unix)]
+#[cfg(not(any(target_os = "freebsd", target_os = "android", target_os = "openbsd")))]
+fn test_non_utf8_value() {
+    // Environment variable values can contain non-UTF-8 bytes on Unix.
+    // printenv should output them correctly, matching GNU behavior.
+    // Reproduces: LD_PRELOAD=$'/tmp/lib.so\xff' printenv LD_PRELOAD
+    let value_with_invalid_utf8 = OsString::from_vec(b"/tmp/lib.so\xff".to_vec());
+
+    let result = new_ucmd!()
+        .env("LD_PRELOAD", &value_with_invalid_utf8)
+        .arg("LD_PRELOAD")
+        .run();
+
+    // Use byte-based assertions to avoid UTF-8 conversion issues
+    // when the test framework tries to format error messages
+    assert!(
+        result.succeeded(),
+        "Command failed with exit code: {:?}, stderr: {:?}",
+        result.code(),
+        String::from_utf8_lossy(result.stderr())
+    );
+    result.stdout_is_bytes(b"/tmp/lib.so\xff\n");
 }


### PR DESCRIPTION
closes: #9701