### PR TITLE
env: preserve non-UTF-8 environment variables and remove unwrap

### DIFF
--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -1862,3 +1862,16 @@ fn test_braced_variable_error_unexpected_character() {
         .fails_with_code(125)
         .stderr_contains("Unexpected character: '?'");
 }
+
+#[test]
+#[cfg(unix)]
+fn test_non_utf8_env_vars() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let non_utf8_value = OsString::from_vec(b"hello\x80world".to_vec());
+    new_ucmd!()
+        .env("NON_UTF8_VAR", &non_utf8_value)
+        .succeeds()
+        .stdout_contains_bytes(b"NON_UTF8_VAR=hello\x80world");
+}


### PR DESCRIPTION
This was based off of the discussion in the comments of https://github.com/uutils/coreutils/pull/9702 where I found that there was a helper method that already existed called write_all_os that could be used. 