### PR TITLE
Avoid wrong PASS of cp-mv-enotsup-xattr runcon-compute and enable 1 test

### DIFF
--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -3,7 +3,10 @@ ver="9.9"
 repo=https://github.com/coreutils/coreutils
 curl -L "${repo}/releases/download/v${ver}/coreutils-${ver}.tar.xz" | tar --strip-components=1 -xJf -
 
-# backport from coreutils > 9.9
-curl ${repo}/raw/refs/heads/master/tests/mv/hardlink-case.sh > tests/mv/hardlink-case.sh
-curl ${repo}/raw/refs/heads/master/tests/mkdir/writable-under-readonly.sh > tests/mkdir/writable-under-readonly.sh
-curl ${repo}/raw/refs/heads/master/tests/cp/cp-mv-enotsup-xattr.sh > tests/cp/cp-mv-enotsup-xattr.sh #spell-checker:disable-line
+# TODO stop backporting tests from master at GNU coreutils > 9.9
+curl -L ${repo}/raw/refs/heads/master/tests/mv/hardlink-case.sh > tests/mv/hardlink-case.sh
+curl -L ${repo}/raw/refs/heads/master/tests/mkdir/writable-under-readonly.sh > tests/mkdir/writable-under-readonly.sh
+curl -L ${repo}/raw/refs/heads/master/tests/cp/cp-mv-enotsup-xattr.sh > tests/cp/cp-mv-enotsup-xattr.sh #spell-checker:disable-line
+curl -L ${repo}/raw/refs/heads/master/tests/csplit/csplit-io-err.sh > tests/csplit/csplit-io-err.sh
+# Avoid incorrect PASS
+curl -L ${repo}/raw/refs/heads/master/tests/runcon/runcon-compute.sh > tests/runcon/runcon-compute.sh


### PR DESCRIPTION
See https://github.com/uutils/coreutils/pull/9314#issuecomment-3677738418 and https://github.com/uutils/coreutils/pull/9314#issuecomment-3677820795