### PR TITLE
GnuTests.yml: Discard caches at each build-gnu.sh update

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -58,7 +58,7 @@ jobs:
         path: |
           gnu/config.cache
           gnu/src/getlimits
-        key: ${{ runner.os }}-gnu-config-${{ hashFiles('gnu/NEWS') }}-${{ hashFiles('uutils/build-gnu.sh') }} # use build-gnu.sh for extremely safe caching
+        key: ${{ runner.os }}-gnu-config-${{ hashFiles('gnu/NEWS') }}-${{ hashFiles('uutils/util/build-gnu.sh') }} # use build-gnu.sh for extremely safe caching
 
     #### Build environment setup
     - name: Install dependencies
@@ -110,7 +110,7 @@ jobs:
         path: |
           gnu/config.cache
           gnu/src/getlimits
-        key: ${{ runner.os }}-gnu-config-${{ hashFiles('gnu/NEWS') }}-${{ hashFiles('uutils/build-gnu.sh') }}
+        key: ${{ runner.os }}-gnu-config-${{ hashFiles('gnu/NEWS') }}-${{ hashFiles('uutils/util/build-gnu.sh') }}
 
     ### Run tests as user
     - name: Run GNU tests


### PR DESCRIPTION
For the case we changed flags for `./configure`.

If I previously generated invalid cache with same name, I can fix ~#9739~ #9737 to ...?