### PR TITLE
cp: strip setuid/setgid when ownership preservation fails

### DIFF
--- a/.vscode/cspell.dictionaries/shell.wordlist.txt
+++ b/.vscode/cspell.dictionaries/shell.wordlist.txt
@@ -12,6 +12,7 @@ mksh
 mountinfo
 mountpoint
 mtab
+newgrp
 nullglob
 
 # * Signals

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1652,7 +1652,7 @@ impl OverwriteMode {
 /// Note: ENOTSUP/EOPNOTSUPP errors are silently ignored when not required, as per GNU cp
 /// documentation: "Try to preserve SELinux security context and extended attributes (xattr),
 /// but ignore any failure to do that and print no corresponding diagnostic."
-fn handle_preserve<F: Fn() -> CopyResult<()>>(p: Preserve, f: F) -> CopyResult<()> {
+fn handle_preserve<F: FnMut() -> CopyResult<()>>(p: Preserve, mut f: F) -> CopyResult<()> {
     match p {
         Preserve::No { .. } => {}
         Preserve::Yes { required } => {
@@ -1722,6 +1722,7 @@ pub(crate) fn copy_attributes(
     let context = &*format!("{} -> {}", source.quote(), dest.quote());
     let source_metadata =
         fs::symlink_metadata(source).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let mut ownership_failed = false;
 
     let mode_explicitly_disabled = matches!(attributes.mode, Preserve::No { explicit: true });
 
@@ -1765,6 +1766,7 @@ pub(crate) fn copy_attributes(
         // and will fall back to changing only the gid if possible.
         if try_chown(Some(dest_uid)).is_err() {
             let _ = try_chown(None);
+            ownership_failed = true;
         }
         Ok(())
     })?;
@@ -1776,7 +1778,11 @@ pub(crate) fn copy_attributes(
         // do nothing, since every symbolic link has the same
         // permissions.
         if !dest.is_symlink() {
-            fs::set_permissions(dest, source_metadata.permissions())
+            let mut permissions = source_metadata.permissions();
+            if ownership_failed {
+                permissions.set_mode(permissions.mode() & !(libc::S_ISUID | libc::S_ISGID));
+            }
+            fs::set_permissions(dest, permissions)
                 .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
             // FIXME: Implement this for windows as well
             #[cfg(feature = "feat_acl")]

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1785,22 +1785,8 @@ pub(crate) fn copy_attributes(
             let permissions = {
                 let mut perms = permissions;
                 if ownership_failed {
-                    #[cfg(not(any(
-                        target_os = "android",
-                        target_os = "macos",
-                        target_os = "freebsd",
-                        target_os = "redox",
-                    )))]
-                    let mask = libc::S_ISUID | libc::S_ISGID;
-
-                    #[cfg(any(
-                        target_os = "android",
-                        target_os = "macos",
-                        target_os = "freebsd",
-                        target_os = "redox",
-                    ))]
-                    let mask = (libc::S_ISUID | libc::S_ISGID) as u32;
-
+                    #[allow(clippy::unnecessary_cast)]
+                    let mask = (libc::S_ISUID | libc::S_ISGID | libc::S_ISVTX) as u32;
                     perms.set_mode(perms.mode() & !mask);
                 }
                 perms

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -7415,6 +7415,7 @@ fn test_cp_recurse_verbose_output_with_symlink_already_exists() {
 
 #[test]
 #[cfg(unix)]
+<<<<<<< HEAD
 fn test_cp_hlp_flag_ordering() {
     // GNU cp: "If more than one of -H, -L, and -P is specified, only the final one takes effect"
     let (at, mut ucmd) = at_and_ucmd!();
@@ -7670,4 +7671,25 @@ fn test_cp_gnu_preserve_mode() {
     let d3_mode = at.metadata("d3").mode();
 
     assert_eq!(d1_mode, d3_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_preserve_strip_setuid() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = "/bin/sh";
+    let destination = "sh_copy";
+
+    ucmd.arg("-p").arg(source).arg(destination).succeeds();
+
+    use std::os::unix::fs::PermissionsExt;
+    let mode = at.metadata(destination).permissions().mode();
+
+    let mask = libc::S_ISUID as u32 | libc::S_ISGID as u32;
+
+    assert_eq!(
+        mode & mask,
+        0,
+        "SetUID/SetGID need to be stripped if ownership preservation fails."
+    );
 }


### PR DESCRIPTION
Fixes [#9750](https://github.com/uutils/coreutils/issues/9750).

Changed handle_preserve to FnMut, such that a flag is set if ownership cannot be preserved, in which case the UID and GID bits are cleared.