### PR TITLE
build-gnu.sh: correct path suggestion for fetch-gnu.sh

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -37,7 +37,7 @@ path_GNU="$("${READLINK}" -fm -- "${path_GNU:-${path_UUTILS}/../gnu}")"
 if test ! -f "${path_GNU}/configure"; then
     echo "Could not find the GNU coreutils (expected at '${path_GNU}')"
     echo "Download them to the expected path:"
-    echo "  (cd '${path_GNU}' && fetch-gnu.sh ) "
+    echo " (mkdir -p '${path_GNU}' && cd '${path_GNU}' && bash '${path_UUTILS}/util/fetch-gnu.sh')"
     echo "You can edit fetch-gnu.sh to change the tag"
     exit 1
 fi


### PR DESCRIPTION
This PR fixes an incorrect path suggestion in the `util/build-gnu.sh` script.

I have updated the suggestion to:
- Adding `mkdir -p` to ensure the target directory is created.
- Change the `fetch-gnu.sh` path to `util/fetch-gnu.sh`.

Fixes #9780