### PR TITLE
Removing flaky inotify-dir patch

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -223,12 +223,6 @@ sed -i -e "s|---dis ||g" tests/tail/overlay-headers.sh
 # Do not FAIL, just do a regular ERROR
 "${SED}" -i -e "s|framework_failure_ 'no inotify_add_watch';|fail=1;|" tests/tail/inotify-rotate-resources.sh
 
-# The notify crate makes inotify_add_watch calls in a background thread, so strace needs -f to follow threads.
-# Also remove the HAVE_INOTIFY header check since that's for C builds.
-"${SED}" -i -e "s|grep '^#define HAVE_INOTIFY 1' \"\$CONFIG_HEADER\" >/dev/null && is_local_dir_ \. |is_local_dir_ . |" \
-    -e "s|strace -e inotify_add_watch|strace -f -e inotify_add_watch|" \
-    tests/tail/inotify-dir-recreate.sh
-
 # pr produces very long log and this command isn't super interesting
 # SKIP for now
 "${SED}" -i -e "s|my \$prog = 'pr';$|my \$prog = 'pr';CuSkip::skip \"\$prog: SKIP for producing too long logs\";|" tests/pr/pr-tests.pl


### PR DESCRIPTION
I made the original PR to add this to remove to change the strace to strace -f as well as removing the search for the header file in the tests. This test is flaky and adding a bunch of noise to everyones PR's.

I know personally its affecting my own PR's by adding the noise of the comments, and I don't think theres much value in keeping the patch in while we don't have a plan on how to address the flakyness. When anyone is starting to work on a plan to address the test failures we can re-add the patch. 