### PR TITLE
ci: add Non UTF8 locale for GNU tests

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -91,6 +91,7 @@ jobs:
         sudo locale-gen --keep-existing fa_IR.UTF-8 # Iran
         sudo locale-gen --keep-existing am_ET.UTF-8 # Ethiopia
         sudo locale-gen --keep-existing th_TH.UTF-8 # Thailand
+        sudo locale-gen --keep-existing zh_CN.GB18030 # China
 
         sudo update-locale
         echo "After:"


### PR DESCRIPTION
This test is skipping because this locale is missing. The test is still failing but at least now its running on the CI and giving a breakdown of why its failing instead of skipping. 