### PR TITLE
dd: use actual filename in nocache error messages

### DIFF
--- a/src/uu/dd/locales/en-US.ftl
+++ b/src/uu/dd/locales/en-US.ftl
@@ -114,6 +114,10 @@ dd-after-help = ### Operands
   - noctty : do not assign a controlling tty.
   - nofollow : do not follow system links.
 
+# Common strings
+dd-standard-input = 'standard input'
+dd-standard-output = 'standard output'
+
 # Error messages
 dd-error-failed-to-open = failed to open { $path }
 dd-error-write-error = write error
@@ -123,8 +127,7 @@ dd-error-cannot-skip-offset = '{ $file }': cannot skip to specified offset
 dd-error-cannot-skip-invalid = '{ $file }': cannot skip: Invalid argument
 dd-error-cannot-seek-invalid = '{ $output }': cannot seek: Invalid argument
 dd-error-not-directory = setting flags for '{ $file }': Not a directory
-dd-error-failed-discard-cache-input = failed to discard cache for: 'standard input'
-dd-error-failed-discard-cache-output = failed to discard cache for: 'standard output'
+dd-error-failed-discard-cache = failed to discard cache for: { $file }
 
 # Parse errors
 dd-error-unrecognized-operand = Unrecognized operand '{ $operand }'

--- a/src/uu/dd/locales/fr-FR.ftl
+++ b/src/uu/dd/locales/fr-FR.ftl
@@ -114,6 +114,10 @@ dd-after-help = ### Opérandes
   - noctty : ne pas assigner un tty de contrôle.
   - nofollow : ne pas suivre les liens système.
 
+# Common strings
+dd-standard-input = 'entrée standard'
+dd-standard-output = 'sortie standard'
+
 # Error messages
 dd-error-failed-to-open = échec de l'ouverture de { $path }
 dd-error-write-error = erreur d'écriture
@@ -123,8 +127,7 @@ dd-error-cannot-skip-offset = '{ $file }' : impossible d'ignorer jusqu'au décal
 dd-error-cannot-skip-invalid = '{ $file }' : impossible d'ignorer : Argument invalide
 dd-error-cannot-seek-invalid = '{ $output }' : impossible de rechercher : Argument invalide
 dd-error-not-directory = définir les indicateurs pour '{ $file }' : N'est pas un répertoire
-dd-error-failed-discard-cache-input = échec de la suppression du cache pour : 'entrée standard'
-dd-error-failed-discard-cache-output = échec de la suppression du cache pour : 'sortie standard'
+dd-error-failed-discard-cache = échec de la suppression du cache pour : { $file }
 
 # Parse errors
 dd-error-unrecognized-operand = Opérande non reconnue '{ $operand }'

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -467,10 +467,15 @@ impl Input<'_> {
     fn discard_cache(&self, offset: libc::off_t, len: libc::off_t) {
         #[cfg(target_os = "linux")]
         {
+            let file = self
+                .settings
+                .infile
+                .clone()
+                .unwrap_or_else(|| translate!("dd-standard-input"));
             show_if_err!(
-                self.src
-                    .discard_cache(offset, len)
-                    .map_err_context(|| translate!("dd-error-failed-discard-cache-input"))
+                self.src.discard_cache(offset, len).map_err_context(
+                    || translate!("dd-error-failed-discard-cache", "file" => file)
+                )
             );
         }
         #[cfg(not(target_os = "linux"))]
@@ -909,10 +914,15 @@ impl<'a> Output<'a> {
     fn discard_cache(&self, offset: libc::off_t, len: libc::off_t) {
         #[cfg(target_os = "linux")]
         {
+            let file = self
+                .settings
+                .outfile
+                .clone()
+                .unwrap_or_else(|| translate!("dd-standard-output"));
             show_if_err!(
-                self.dst
-                    .discard_cache(offset, len)
-                    .map_err_context(|| { translate!("dd-error-failed-discard-cache-output") })
+                self.dst.discard_cache(offset, len).map_err_context(
+                    || translate!("dd-error-failed-discard-cache", "file" => file)
+                )
             );
         }
         #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
Was investigating the nocache_fail changes and it appears that the reason it is failing is actually just because the GNU implementation uses the actual name of the file instead of a hardcoded value if its not stdin or stdout. This simple change just changes the error message to take in the filename if its provided.