### PR TITLE
pr: Enable pr-tests.pl with suppressed diff output

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -223,9 +223,9 @@ sed -i -e "s|---dis ||g" tests/tail/overlay-headers.sh
 # Do not FAIL, just do a regular ERROR
 "${SED}" -i -e "s|framework_failure_ 'no inotify_add_watch';|fail=1;|" tests/tail/inotify-rotate-resources.sh
 
-# pr produces very long log and this command isn't super interesting
-# SKIP for now
-"${SED}" -i -e "s|my \$prog = 'pr';$|my \$prog = 'pr';CuSkip::skip \"\$prog: SKIP for producing too long logs\";|" tests/pr/pr-tests.pl
+# pr-tests.pl: Override the comparison function to suppress diff output
+# This prevents the test from overwhelming logs while still reporting failures
+"${SED}" -i '/^my $fail = run_tests/i no warnings "redefine"; *Coreutils::_compare_files = sub { my ($p, $t, $io, $a, $e) = @_; my $d = File::Compare::compare($a, $e); warn "$p: test $t: mismatch\\n" if $d; return $d; };' tests/pr/pr-tests.pl
 
 # We don't have the same error message and no need to be that specific
 "${SED}" -i -e "s|invalid suffix in --pages argument|invalid --pages argument|" \


### PR DESCRIPTION
This changes the patch to skip the test with a patch to override the diff functionality in the test to only output which test failed so now the output looks like this:
```
  FAIL: tests/pr/pr-tests
  =======================

  pr: test 1b: mismatch
  pr: test 1b.r: mismatch
  pr: test 1b.p: mismatch
  pr: test 1c: mismatch
  ...
  pr: test 1i failed: exit status mismatch:  expected 0, got 1
  pr: test 1j failed: exit status mismatch:  expected 0, got 1
  ...
  pr: test margin-0 passed.
  ...
  ```

This should allow us to work on fixing these issues in the pr tests in the CI while still having the same patch to not overwhelm the logs
  