### PR TITLE
feat(rm): add localized prompt messages for interactive mode

### DIFF
--- a/src/uu/rm/locales/en-US.ftl
+++ b/src/uu/rm/locales/en-US.ftl
@@ -33,6 +33,25 @@ rm-help-progress = display a progress bar. Note: this feature is not supported b
 # Progress messages
 rm-progress-removing = Removing
 
+# Prompt messages
+rm-prompt-remove-arguments = remove { $count ->
+    [one] { $count } argument?
+   *[other] { $count } arguments?
+}
+rm-prompt-remove-arguments-recursive = remove { $count ->
+    [one] { $count } argument recursively?
+   *[other] { $count } arguments recursively?
+}
+rm-prompt-remove-symbolic-link = remove symbolic link { $file }?
+rm-prompt-remove-regular-empty-file = remove regular empty file { $file }?
+rm-prompt-remove-file = remove file { $file }?
+rm-prompt-remove-write-protected-regular-empty-file = remove write-protected regular empty file { $file }?
+rm-prompt-remove-write-protected-regular-file = remove write-protected regular file { $file }?
+rm-prompt-attempt-remove-inaccessible-directory = attempt removal of inaccessible directory { $path }?
+rm-prompt-remove-write-protected-directory = remove write-protected directory { $path }?
+rm-prompt-remove-directory = remove directory { $path }?
+rm-prompt-descend-into-directory = descend into directory { $path }?
+
 # Error messages
 rm-error-missing-operand = missing operand
   Try '{$util_name} --help' for more information.

--- a/src/uu/rm/locales/fr-FR.ftl
+++ b/src/uu/rm/locales/fr-FR.ftl
@@ -33,6 +33,25 @@ rm-help-progress = afficher une barre de progression. Note : cette fonctionnalit
 # Messages de progression
 rm-progress-removing = Suppression
 
+# Messages de confirmation
+rm-prompt-remove-arguments = supprimer { $count ->
+    [one] { $count } argument ?
+   *[other] { $count } arguments ?
+}
+rm-prompt-remove-arguments-recursive = supprimer { $count ->
+    [one] { $count } argument récursivement ?
+   *[other] { $count } arguments récursivement ?
+}
+rm-prompt-remove-symbolic-link = supprimer le lien symbolique { $file } ?
+rm-prompt-remove-regular-empty-file = supprimer le fichier ordinaire vide { $file } ?
+rm-prompt-remove-file = supprimer le fichier { $file } ?
+rm-prompt-remove-write-protected-regular-empty-file = supprimer le fichier ordinaire vide protégé en écriture { $file } ?
+rm-prompt-remove-write-protected-regular-file = supprimer le fichier ordinaire protégé en écriture { $file } ?
+rm-prompt-attempt-remove-inaccessible-directory = tenter de supprimer le répertoire inaccessible { $path } ?
+rm-prompt-remove-write-protected-directory = supprimer le répertoire protégé en écriture { $path } ?
+rm-prompt-remove-directory = supprimer le répertoire { $path } ?
+rm-prompt-descend-into-directory = descendre dans le répertoire { $path } ?
+
 # Messages d'erreur
 rm-error-missing-operand = opérande manquant
   Essayez '{$util_name} --help' pour plus d'informations.

--- a/src/uu/rm/src/platform/unix.rs
+++ b/src/uu/rm/src/platform/unix.rs
@@ -52,13 +52,22 @@ fn prompt_file_with_stat(path: &Path, stat: &libc::stat, options: &Options) -> b
     //   otherwise fall through to protected wording.
     if options.interactive == InteractiveMode::Always {
         if is_symlink {
-            return prompt_yes!("remove symbolic link {}?", path.quote());
+            return prompt_yes!(
+                "{}",
+                translate!("rm-prompt-remove-symbolic-link", "file" => path.quote())
+            );
         }
         if writable {
             return if len == 0 {
-                prompt_yes!("remove regular empty file {}?", path.quote())
+                prompt_yes!(
+                    "{}",
+                    translate!("rm-prompt-remove-regular-empty-file", "file" => path.quote())
+                )
             } else {
-                prompt_yes!("remove file {}?", path.quote())
+                prompt_yes!(
+                    "{}",
+                    translate!("rm-prompt-remove-file", "file" => path.quote())
+                )
             };
         }
         // Not writable: use protected wording below
@@ -69,10 +78,19 @@ fn prompt_file_with_stat(path: &Path, stat: &libc::stat, options: &Options) -> b
         (false, _, _) if options.interactive == InteractiveMode::PromptProtected => true,
         (_, true, _) => true,
         (_, false, true) => prompt_yes!(
-            "remove write-protected regular empty file {}?",
-            path.quote()
+            "{}",
+            translate!(
+                "rm-prompt-remove-write-protected-regular-empty-file",
+                "file" => path.quote()
+            )
         ),
-        _ => prompt_yes!("remove write-protected regular file {}?", path.quote()),
+        _ => prompt_yes!(
+            "{}",
+            translate!(
+                "rm-prompt-remove-write-protected-regular-file",
+                "file" => path.quote()
+            )
+        ),
     }
 }
 
@@ -90,17 +108,32 @@ fn prompt_dir_with_mode(path: &Path, mode: libc::mode_t, options: &Options) -> b
         (false, _, _, InteractiveMode::PromptProtected) => true,
         (false, false, false, InteractiveMode::Never) => true,
         (_, false, false, _) => prompt_yes!(
-            "attempt removal of inaccessible directory {}?",
-            path.quote()
+            "{}",
+            translate!(
+                "rm-prompt-attempt-remove-inaccessible-directory",
+                "path" => path.quote()
+            )
         ),
         (_, false, true, InteractiveMode::Always) => {
             prompt_yes!(
-                "attempt removal of inaccessible directory {}?",
-                path.quote()
+                "{}",
+                translate!(
+                    "rm-prompt-attempt-remove-inaccessible-directory",
+                    "path" => path.quote()
+                )
             )
         }
-        (_, true, false, _) => prompt_yes!("remove write-protected directory {}?", path.quote()),
-        (_, _, _, InteractiveMode::Always) => prompt_yes!("remove directory {}?", path.quote()),
+        (_, true, false, _) => prompt_yes!(
+            "{}",
+            translate!(
+                "rm-prompt-remove-write-protected-directory",
+                "path" => path.quote()
+            )
+        ),
+        (_, _, _, InteractiveMode::Always) => prompt_yes!(
+            "{}",
+            translate!("rm-prompt-remove-directory", "path" => path.quote())
+        ),
         (_, _, _, _) => true,
     }
 }

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -276,21 +276,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     if options.interactive == InteractiveMode::Once && (options.recursive || files.len() > 3) {
-        let msg: String = format!(
-            "remove {} {}{}",
-            files.len(),
-            if files.len() > 1 {
-                "arguments"
-            } else {
-                "argument"
-            },
-            if options.recursive {
-                " recursively?"
-            } else {
-                "?"
-            }
-        );
-        if !prompt_yes!("{msg}") {
+        let prompt_key = if options.recursive {
+            "rm-prompt-remove-arguments-recursive"
+        } else {
+            "rm-prompt-remove-arguments"
+        };
+        let msg = translate!(prompt_key, "count" => files.len());
+        if !prompt_yes!("{}", msg) {
             return Ok(());
         }
     }
@@ -887,21 +879,29 @@ fn prompt_file(path: &Path, options: &Options) -> bool {
     if options.interactive == InteractiveMode::Never {
         return true;
     }
-
     let Ok(metadata) = fs::symlink_metadata(path) else {
         return true;
     };
 
     if metadata.is_symlink() {
         return options.interactive != InteractiveMode::Always
-            || prompt_yes!("remove symbolic link {}?", path.quote());
+            || prompt_yes!(
+                "{}",
+                translate!("rm-prompt-remove-symbolic-link", "file" => path.quote())
+            );
     }
 
     if options.interactive == InteractiveMode::Always && is_writable_metadata(&metadata) {
         return if metadata.len() == 0 {
-            prompt_yes!("remove regular empty file {}?", path.quote())
+            prompt_yes!(
+                "{}",
+                translate!("rm-prompt-remove-regular-empty-file", "file" => path.quote())
+            )
         } else {
-            prompt_yes!("remove file {}?", path.quote())
+            prompt_yes!(
+                "{}",
+                translate!("rm-prompt-remove-file", "file" => path.quote())
+            )
         };
     }
 
@@ -914,10 +914,19 @@ fn prompt_file_permission_readonly(path: &Path, options: &Options, metadata: &Me
         (false, InteractiveMode::PromptProtected) => true,
         _ if is_writable_metadata(metadata) => true,
         _ if metadata.len() == 0 => prompt_yes!(
-            "remove write-protected regular empty file {}?",
-            path.quote()
+            "{}",
+            translate!(
+                "rm-prompt-remove-write-protected-regular-empty-file",
+                "file" => path.quote()
+            )
         ),
-        _ => prompt_yes!("remove write-protected regular file {}?", path.quote()),
+        _ => prompt_yes!(
+            "{}",
+            translate!(
+                "rm-prompt-remove-write-protected-regular-file",
+                "file" => path.quote()
+            )
+        ),
     }
 }
 
@@ -1002,15 +1011,30 @@ fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata
         (false, _, _, InteractiveMode::PromptProtected) => true,
         (false, false, false, InteractiveMode::Never) => true, // Don't prompt when interactive is never
         (_, false, false, _) => prompt_yes!(
-            "attempt removal of inaccessible directory {}?",
-            path.quote()
+            "{}",
+            translate!(
+                "rm-prompt-attempt-remove-inaccessible-directory",
+                "path" => path.quote()
+            )
         ),
         (_, false, true, InteractiveMode::Always) => prompt_yes!(
-            "attempt removal of inaccessible directory {}?",
-            path.quote()
+            "{}",
+            translate!(
+                "rm-prompt-attempt-remove-inaccessible-directory",
+                "path" => path.quote()
+            )
         ),
-        (_, true, false, _) => prompt_yes!("remove write-protected directory {}?", path.quote()),
-        (_, _, _, InteractiveMode::Always) => prompt_yes!("remove directory {}?", path.quote()),
+        (_, true, false, _) => prompt_yes!(
+            "{}",
+            translate!(
+                "rm-prompt-remove-write-protected-directory",
+                "path" => path.quote()
+            )
+        ),
+        (_, _, _, InteractiveMode::Always) => prompt_yes!(
+            "{}",
+            translate!("rm-prompt-remove-directory", "path" => path.quote())
+        ),
         (_, _, _, _) => true,
     }
 }
@@ -1024,8 +1048,19 @@ fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata
     let stdin_ok = options.__presume_input_tty.unwrap_or(false) || stdin().is_terminal();
     match (stdin_ok, not_user_writable, options.interactive) {
         (false, _, InteractiveMode::PromptProtected) => true,
-        (_, true, _) => prompt_yes!("remove write-protected directory {}?", path.quote()),
-        (_, _, InteractiveMode::Always) => prompt_yes!("remove directory {}?", path.quote()),
+        (_, true, _) => prompt_yes!(
+            "{}",
+            translate!(
+                "rm-prompt-remove-write-protected-directory",
+                "path" => path.quote()
+            )
+        ),
+        (_, _, InteractiveMode::Always) => {
+            prompt_yes!(
+                "{}",
+                translate!("rm-prompt-remove-directory", "path" => path.quote())
+            )
+        }
         (_, _, _) => true,
     }
 }
@@ -1035,7 +1070,10 @@ fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata
 #[cfg(not(unix))]
 fn handle_writable_directory(path: &Path, options: &Options, _metadata: &Metadata) -> bool {
     if options.interactive == InteractiveMode::Always {
-        prompt_yes!("remove directory {}?", path.quote())
+        prompt_yes!(
+            "{}",
+            translate!("rm-prompt-remove-directory", "path" => path.quote())
+        )
     } else {
         true
     }
@@ -1076,7 +1114,10 @@ fn clean_trailing_slashes(path: &Path) -> &Path {
 }
 
 fn prompt_descend(path: &Path) -> bool {
-    prompt_yes!("descend into directory {}?", path.quote())
+    prompt_yes!(
+        "{}",
+        translate!("rm-prompt-descend-into-directory", "path" => path.quote())
+    )
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Add translations for rm command prompts in English and French, and update Linux-specific code to use localized strings instead of hardcoded messages, improving internationalization support.

related
https://github.com/uutils/coreutils/issues/9824