### PR TITLE
clippy: enable `needless_raw_string_hashes` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -667,7 +667,6 @@ should_panic_without_expect = "allow"        # 2
 doc_markdown = "allow"
 unused_self = "allow"
 enum_glob_use = "allow"
-needless_raw_string_hashes = "allow"
 unreadable_literal = "allow"
 unnested_or_patterns = "allow"
 implicit_hasher = "allow"

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -201,9 +201,9 @@ fn replace_special_chars(s: &[u8]) -> Vec<u8> {
     // * \011 ASCII horizontal tab with a tab character,
     // * ASCII backslash with an actual backslash character.
     //
-    s.replace(r#"\040"#, " ")
-        .replace(r#"\011"#, "	")
-        .replace(r#"\134"#, r#"\"#)
+    s.replace(r"\040", " ")
+        .replace(r"\011", "	")
+        .replace(r"\134", r"\")
 }
 
 impl MountInfo {
@@ -1171,23 +1171,23 @@ mod tests {
     fn test_mountinfo_dir_special_chars() {
         let info = MountInfo::new(
             LINUX_MOUNTINFO,
-            &br#"317 61 7:0 / /mnt/f\134\040\011oo rw,relatime shared:641 - ext4 /dev/loop0 rw"#
+            &br"317 61 7:0 / /mnt/f\134\040\011oo rw,relatime shared:641 - ext4 /dev/loop0 rw"
                 .split(|c| *c == b' ')
                 .collect::<Vec<_>>(),
         )
         .unwrap();
 
-        assert_eq!(info.mount_dir, r#"/mnt/f\ 	oo"#);
+        assert_eq!(info.mount_dir, r"/mnt/f\ 	oo");
 
         let info = MountInfo::new(
             LINUX_MTAB,
-            &br#"/dev/loop0 /mnt/f\134\040\011oo ext4 rw,relatime 0 0"#
+            &br"/dev/loop0 /mnt/f\134\040\011oo ext4 rw,relatime 0 0"
                 .split(|c| *c == b' ')
                 .collect::<Vec<_>>(),
         )
         .unwrap();
 
-        assert_eq!(info.mount_dir, r#"/mnt/f\ 	oo"#);
+        assert_eq!(info.mount_dir, r"/mnt/f\ 	oo");
     }
 
     #[test]

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -617,7 +617,7 @@ mod tests {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
 
         // Create en-US.ftl
-        let en_content = r#"
+        let en_content = r"
 greeting = Hello, world!
 welcome = Welcome, { $name }!
 count-items = You have { $count ->
@@ -625,27 +625,27 @@ count-items = You have { $count ->
    *[other] { $count } items
 }
 missing-in-other = This message only exists in English
-"#;
+";
 
         // Create fr-FR.ftl
-        let fr_content = r#"
+        let fr_content = r"
 greeting = Bonjour, le monde!
 welcome = Bienvenue, { $name }!
 count-items = Vous avez { $count ->
     [one] { $count } élément
    *[other] { $count } éléments
 }
-"#;
+";
 
         // Create ja-JP.ftl (Japanese)
-        let ja_content = r#"
+        let ja_content = r"
 greeting = こんにちは、世界！
 welcome = ようこそ、{ $name }さん！
 count-items = { $count }個のアイテムがあります
-"#;
+";
 
         // Create ar-SA.ftl (Arabic - Right-to-Left)
-        let ar_content = r#"
+        let ar_content = r"
 greeting = أهلاً بالعالم！
 welcome = أهلاً وسهلاً، { $name }！
 count-items = لديك { $count ->
@@ -655,13 +655,13 @@ count-items = لديك { $count ->
     [few] { $count } عناصر
    *[other] { $count } عنصر
 }
-"#;
+";
 
         // Create es-ES.ftl with invalid syntax
-        let es_invalid_content = r#"
+        let es_invalid_content = r"
 greeting = Hola, mundo!
 invalid-syntax = This is { $missing
-"#;
+";
 
         fs::write(temp_dir.path().join("en-US.ftl"), en_content)
             .expect("Failed to write en-US.ftl");

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -2061,7 +2061,7 @@ fn debug_key_annotation_output(ts: &TestScenario) -> String {
     output
 }
 
-const EXPECTED_DEBUG_KEY_ANNOTATION: &str = r#"1
+const EXPECTED_DEBUG_KEY_ANNOTATION: &str = r"1
  ^ no match for key
 
 ^ no match for key
@@ -2281,9 +2281,9 @@ B>chr1
  __
 1 3
  __
-"#;
+";
 
-const EXPECTED_DEBUG_KEY_ANNOTATION_LOCALE: &str = r#"   1²---++3   1,234  Mi
+const EXPECTED_DEBUG_KEY_ANNOTATION_LOCALE: &str = r"   1²---++3   1,234  Mi
                _
    _________
 ________________________
@@ -2302,7 +2302,7 @@ _____
              _____
              ______
 ___________________
-"#;
+";
 
 #[test]
 fn test_color_environment_variables() {


### PR DESCRIPTION
This PR enables the [needless_raw_string_hashes](https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_raw_string_hashes) lint. It's a follow-up to https://github.com/uutils/coreutils/pull/9837 and partially addresses https://github.com/uutils/coreutils/pull/9837#issuecomment-3691446890