### PR TITLE
chmod: fix incorrect error handling when processing multiple files

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -415,7 +415,7 @@ impl Chmoder {
                 return Err(ChmodError::PreserveRoot("/".to_string()).into());
             }
             if self.recursive {
-                r = self.walk_dir_with_context(file, true);
+                r = self.walk_dir_with_context(file, true).and(r);
             } else {
                 r = self.chmod_file(file).and(r);
             }


### PR DESCRIPTION
Previously, the exit code was determined only by the last file processed,
causing scripts to miss errors from earlier files. Now, chmod returns a
non-zero exit code if any file operation fails, matching GNU behavior.

Fixes #9790."

NOTE: I'm aware a pr for this issue has already been made, I'm new to open source and wanted to try contributing to a simple issue. Thanks.