### PR TITLE
CONTRIBUTING.md: update crate structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ crates is as follows:
 - `Cargo.toml`
 - `src/main.rs`: contains only a single macro call
 - `src/<util name>.rs`: the actual code for the utility
-- `<util name>.md`: the documentation for the utility
+- `locales/en-US.ftl`: the util's strings
+- `locales/fr-FR.ftl`: French translation of the util's strings
 
 We have separated repositories for crates that we maintain but also publish for
 use by others:


### PR DESCRIPTION
This PR removes `<util-name>.md` from the crate structure description in `CONTRIBUTING.md` because those files no longer exist. Instead, it mentions the `.ftl` files in `locales`.

The PR supersedes https://github.com/uutils/coreutils/pull/9113.