### PR TITLE
uucore: document that libselinux caches is_selinux_enabled

### DIFF
--- a/src/uucore/src/lib/features/selinux.rs
+++ b/src/uucore/src/lib/features/selinux.rs
@@ -53,6 +53,7 @@ impl From<SeLinuxError> for i32 {
 /// Checks if SELinux is enabled on the system.
 ///
 /// This function verifies whether the kernel has SELinux support enabled.
+/// Note: libselinux internally caches this value, so no additional caching is needed.
 pub fn is_selinux_enabled() -> bool {
     selinux::kernel_support() != selinux::KernelSupport::Unsupported
 }


### PR DESCRIPTION
This was just a comment I wanted to add after I added caching to the Smack enabled check based off of a conversation in another PR: https://github.com/uutils/coreutils/pull/9868#discussion_r2648719874  I didn't realize that this check was using a library that internally caches this result so there's no need to cache this value.

Adding the comment so whoever gets the same idea doesn't go down the same rabbit hole