### PR TITLE
ci: increase timeout for tests on OpenBSD

### DIFF
--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -114,7 +114,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Recently, the tests job on OpenBSD started to run into timeouts. This PR increases the timeout from 60 minutes to 75 minutes.