### PR TITLE
GNUmakefile: Allow changing OS for cygwin

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -66,7 +66,7 @@ TOYBOX_SRC  := $(TOYBOX_ROOT)/toybox-$(TOYBOX_VER)
 # Otherwise let it default to the kernel name returned by uname -s
 # (Linux, Darwin, FreeBSD, …).
 #------------------------------------------------------------------------
-OS := $(shell uname -s)
+OS ?= $(shell uname -s)
 
 # Windows does not allow symlink by default.
 # Allow to override LN for AppArmor.


### PR DESCRIPTION
`OS` is unstable at cygwin or MSYS2.