### PR TITLE
Chgrp verbose prints unmapped gid

### DIFF
--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -163,7 +163,7 @@ pub fn wrap_chown<P: AsRef<Path>>(
             format!(
                 "group of {} retained as {}",
                 path.quote(),
-                entries::gid2grp(dest_gid).unwrap_or_default()
+                entries::gid2grp(dest_gid).unwrap_or_else(|_| dest_gid.to_string())
             )
         } else {
             format!(

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -224,6 +224,14 @@ fn test_reference() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
 fn test_reference_multi_no_equal() {
+    use nix::unistd::{Gid, Group};
+    let gid = getegid();
+    let expected_print = Group::from_gid(Gid::from_raw(gid))
+        .ok()
+        .flatten()
+        .map(|g| g.name)
+        .unwrap_or_else(|| gid.to_string());
+
     new_ucmd!()
         .arg("-v")
         .arg("--reference")
@@ -231,16 +239,27 @@ fn test_reference_multi_no_equal() {
         .arg("file1")
         .arg("file2")
         .succeeds()
-        .stderr_contains(format!("chgrp: group of 'file1' retained as {}", getegid()))
+        .stderr_contains(format!(
+            "chgrp: group of 'file1' retained as {}",
+            expected_print
+        ))
         .stderr_contains(format!(
             "\nchgrp: group of 'file2' retained as {}",
-            getegid()
+            expected_print
         ));
 }
 
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
 fn test_reference_last() {
+    use nix::unistd::{Gid, Group};
+    let gid = getegid();
+    let expected_print = Group::from_gid(Gid::from_raw(gid))
+        .ok()
+        .flatten()
+        .map(|g| g.name)
+        .unwrap_or_else(|| gid.to_string());
+
     new_ucmd!()
         .arg("-v")
         .arg("file1")
@@ -249,14 +268,17 @@ fn test_reference_last() {
         .arg("--reference")
         .arg("ref_file")
         .succeeds()
-        .stderr_contains(format!("chgrp: group of 'file1' retained as {}", getegid()))
+        .stderr_contains(format!(
+            "chgrp: group of 'file1' retained as {}",
+            expected_print
+        ))
         .stderr_contains(format!(
             "\nchgrp: group of 'file2' retained as {}",
-            getegid()
+            expected_print
         ))
         .stderr_contains(format!(
             "\nchgrp: group of 'file3' retained as {}",
-            getegid()
+            expected_print
         ));
 }
 

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -231,8 +231,8 @@ fn test_reference_multi_no_equal() {
         .arg("file1")
         .arg("file2")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as")
-        .stderr_contains("\nchgrp: group of 'file2' retained as");
+        .stderr_contains("chgrp: group of 'file1' retained as ")
+        .stderr_contains("\nchgrp: group of 'file2' retained as ");
 }
 
 #[test]
@@ -246,9 +246,9 @@ fn test_reference_last() {
         .arg("--reference")
         .arg("ref_file")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as")
-        .stderr_contains("\nchgrp: group of 'file2' retained as")
-        .stderr_contains("\nchgrp: group of 'file3' retained as");
+        .stderr_contains("chgrp: group of 'file1' retained as ")
+        .stderr_contains("\nchgrp: group of 'file2' retained as ")
+        .stderr_contains("\nchgrp: group of 'file3' retained as ");
 }
 
 #[test]
@@ -511,7 +511,7 @@ fn test_verbosity_messages() {
         .arg("--reference=ref_file")
         .arg("target_file")
         .succeeds()
-        .stderr_contains("group of 'target_file' retained as");
+        .stderr_contains("group of 'target_file' retained as ");
 }
 
 #[test]
@@ -639,4 +639,22 @@ fn test_chgrp_recursive_on_file() {
         at.plus("regular_file").metadata().unwrap().gid(),
         current_gid
     );
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_chgrp_verbose_for_unmapped_gid() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("tmp");
+
+    ucmd.arg("1337")
+        .arg("tmp")
+        .succeeds()
+        .no_stderr();
+
+    ucmd.arg("-v")
+        .arg("1337")
+        .arg("tmp")
+        .succeeds()
+        .stderr_contains("chgrp: group of 'tmp' retained as 1337");
 }

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -224,14 +224,6 @@ fn test_reference() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
 fn test_reference_multi_no_equal() {
-    use nix::unistd::{Gid, Group};
-    let gid = getegid();
-    let expected_print = Group::from_gid(Gid::from_raw(gid))
-        .ok()
-        .flatten()
-        .map(|g| g.name)
-        .unwrap_or_else(|| gid.to_string());
-
     new_ucmd!()
         .arg("-v")
         .arg("--reference")
@@ -239,27 +231,13 @@ fn test_reference_multi_no_equal() {
         .arg("file1")
         .arg("file2")
         .succeeds()
-        .stderr_contains(format!(
-            "chgrp: group of 'file1' retained as {}",
-            expected_print
-        ))
-        .stderr_contains(format!(
-            "\nchgrp: group of 'file2' retained as {}",
-            expected_print
-        ));
+        .stderr_contains("chgrp: group of 'file1' retained as")
+        .stderr_contains("\nchgrp: group of 'file2' retained as");
 }
 
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
 fn test_reference_last() {
-    use nix::unistd::{Gid, Group};
-    let gid = getegid();
-    let expected_print = Group::from_gid(Gid::from_raw(gid))
-        .ok()
-        .flatten()
-        .map(|g| g.name)
-        .unwrap_or_else(|| gid.to_string());
-
     new_ucmd!()
         .arg("-v")
         .arg("file1")
@@ -268,18 +246,9 @@ fn test_reference_last() {
         .arg("--reference")
         .arg("ref_file")
         .succeeds()
-        .stderr_contains(format!(
-            "chgrp: group of 'file1' retained as {}",
-            expected_print
-        ))
-        .stderr_contains(format!(
-            "\nchgrp: group of 'file2' retained as {}",
-            expected_print
-        ))
-        .stderr_contains(format!(
-            "\nchgrp: group of 'file3' retained as {}",
-            expected_print
-        ));
+        .stderr_contains("chgrp: group of 'file1' retained as")
+        .stderr_contains("\nchgrp: group of 'file2' retained as")
+        .stderr_contains("\nchgrp: group of 'file3' retained as");
 }
 
 #[test]
@@ -542,7 +511,7 @@ fn test_verbosity_messages() {
         .arg("--reference=ref_file")
         .arg("target_file")
         .succeeds()
-        .stderr_contains(format!("group of 'target_file' retained as {}", getegid()));
+        .stderr_contains("group of 'target_file' retained as");
 }
 
 #[test]

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -231,8 +231,8 @@ fn test_reference_multi_no_equal() {
         .arg("file1")
         .arg("file2")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as ")
-        .stderr_contains("\nchgrp: group of 'file2' retained as ");
+        .stderr_contains("chgrp: group of 'file1' retained as {}", getegid())
+        .stderr_contains("\nchgrp: group of 'file2' retained as {}", getegid());
 }
 
 #[test]
@@ -246,9 +246,9 @@ fn test_reference_last() {
         .arg("--reference")
         .arg("ref_file")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as ")
-        .stderr_contains("\nchgrp: group of 'file2' retained as ")
-        .stderr_contains("\nchgrp: group of 'file3' retained as ");
+        .stderr_contains("chgrp: group of 'file1' retained as {}", getegid())
+        .stderr_contains("\nchgrp: group of 'file2' retained as {}", getegid())
+        .stderr_contains("\nchgrp: group of 'file3' retained as {}", getegid());
 }
 
 #[test]
@@ -511,7 +511,7 @@ fn test_verbosity_messages() {
         .arg("--reference=ref_file")
         .arg("target_file")
         .succeeds()
-        .stderr_contains("group of 'target_file' retained as ");
+        .stderr_contains("group of 'target_file' retained as {}", getegid());
 }
 
 #[test]

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -231,8 +231,11 @@ fn test_reference_multi_no_equal() {
         .arg("file1")
         .arg("file2")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as {}", getegid())
-        .stderr_contains("\nchgrp: group of 'file2' retained as {}", getegid());
+        .stderr_contains(format!("chgrp: group of 'file1' retained as {}", getegid()))
+        .stderr_contains(format!(
+            "\nchgrp: group of 'file2' retained as {}",
+            getegid()
+        ));
 }
 
 #[test]
@@ -246,9 +249,15 @@ fn test_reference_last() {
         .arg("--reference")
         .arg("ref_file")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as {}", getegid())
-        .stderr_contains("\nchgrp: group of 'file2' retained as {}", getegid())
-        .stderr_contains("\nchgrp: group of 'file3' retained as {}", getegid());
+        .stderr_contains(format!("chgrp: group of 'file1' retained as {}", getegid()))
+        .stderr_contains(format!(
+            "\nchgrp: group of 'file2' retained as {}",
+            getegid()
+        ))
+        .stderr_contains(format!(
+            "\nchgrp: group of 'file3' retained as {}",
+            getegid()
+        ));
 }
 
 #[test]
@@ -511,7 +520,7 @@ fn test_verbosity_messages() {
         .arg("--reference=ref_file")
         .arg("target_file")
         .succeeds()
-        .stderr_contains("group of 'target_file' retained as {}", getegid());
+        .stderr_contains(format!("group of 'target_file' retained as {}", getegid()));
 }
 
 #[test]


### PR DESCRIPTION
chgrp with verbosity flag prints an empty string instead of the gid.

fix #9915