### PR TITLE
uudoc: Move tldr warning to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ So, to install the manpage for `ls` to `/usr/local/share/man/man1/ls.1` run:
 uudoc manpage ls > /usr/local/share/man/man1/ls.1
 ```
 
+### tldr examples
+
+tldr examples are added to man pages if `docs/tldr.zip` is present. Download it from https://github.com/tldr-pages/tldr/releases
+
 ## Un-installation
 
 Un-installation differs depending on how you have installed uutils. If you used

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -133,19 +133,6 @@ fn gen_completions<T: Args>(args: impl Iterator<Item = OsString>, util_map: &Uti
     process::exit(0);
 }
 
-/// print tldr error
-fn print_tldr_error() {
-    eprintln!("Warning: No tldr archive found, so the documentation will not include examples.");
-    eprintln!(
-        "To include examples in the documentation, download the tldr archive and put it in the docs/ folder."
-    );
-    eprintln!();
-    eprintln!(
-        "  curl -L https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip -o docs/tldr.zip"
-    );
-    eprintln!();
-}
-
 /// # Errors
 /// Returns an error if the writer fails.
 #[allow(clippy::too_many_lines)]
@@ -162,9 +149,6 @@ fn main() -> io::Result<()> {
         match command {
             "manpage" => {
                 let args_iter = args.into_iter().skip(2);
-                if tldr_zip.is_none() {
-                    print_tldr_error();
-                }
                 gen_manpage(
                     &mut tldr_zip,
                     args_iter,
@@ -185,9 +169,6 @@ fn main() -> io::Result<()> {
                 process::exit(1);
             }
         }
-    }
-    if tldr_zip.is_none() {
-        print_tldr_error();
     }
     let utils = util_map::<Box<dyn Iterator<Item = OsString>>>();
     match std::fs::create_dir("docs/src/utils/") {


### PR DESCRIPTION
Closes #9940