### PR TITLE
df: add binfmt_misc to is_dummy_filesystem

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -392,7 +392,9 @@ fn is_dummy_filesystem(fs_type: &str, mount_option: &str) -> bool {
         // for NetBSD 3.0
         | "kernfs"
         // for Irix 6.5
-        | "ignore" => true,
+        | "ignore"
+        // Binary format support pseudo-filesystem
+        | "binfmt_misc" => true,
         _ => fs_type == "none"
             && !mount_option.contains(MOUNT_OPT_BIND)
     }
@@ -1219,5 +1221,12 @@ mod tests {
             info.mount_dir,
             crate::os_str_from_bytes(b"/mnt/some- -dir-\xf3").unwrap()
         );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(any(target_os = "aix", target_os = "redox"))))]
+    fn test_binfmt_misc_is_dummy() {
+        use super::is_dummy_filesystem;
+        assert!(is_dummy_filesystem("binfmt_misc", ""));
     }
 }

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -1046,3 +1046,35 @@ fn test_nonexistent_file() {
         .stderr_is("df: does-not-exist: No such file or directory\n")
         .stdout_is("File\n.\n");
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_df_all_shows_binfmt_misc() {
+    if std::path::Path::new("/proc/sys/fs/binfmt_misc").exists() {
+        let output = new_ucmd!()
+            .args(&["--all", "--output=fstype,target"])
+            .succeeds()
+            .stdout_str_lossy();
+
+        assert!(
+            output.contains("binfmt_misc"),
+            "Expected binfmt_misc filesystem to appear in df --all output"
+        );
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_df_hides_binfmt_misc_by_default() {
+    if std::path::Path::new("/proc/sys/fs/binfmt_misc").exists() {
+        let output = new_ucmd!()
+            .args(&["--output=fstype,target"])
+            .succeeds()
+            .stdout_str_lossy();
+
+        assert!(
+            !output.contains("binfmt_misc"),
+            "Expected binfmt_misc filesystem to be hidden in df output without --all"
+        );
+    }
+}


### PR DESCRIPTION
Possible fix for https://github.com/uutils/coreutils/issues/9952 

Was trying to reproduce the issue and saw that `binfmt_misc` was not marked as a dummy system. Seems like this should be the case.

See https://docs.kernel.org/admin-guide/binfmt-misc.html