### PR TITLE
GnuTests.yml: use minimal Rust profile in VM

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -246,7 +246,7 @@ jobs:
       run: |
         lima sudo dnf -y update
         lima sudo dnf -y install autoconf bison gperf gcc gdb jq libacl-devel libattr-devel libcap-devel libselinux-devel attr rustup clang-devel automake patch quilt
-        lima rustup-init -y --default-toolchain stable
+        lima rustup-init -y --profile=minimal --default-toolchain stable
     - name: Copy the sources to VM
       run: |
         rsync -a -e ssh . lima-default:~/work/


### PR DESCRIPTION
This PR uses the minimal profile when installing Rust in the VM for the `selinux` job. 