### PR TITLE
uucore/uptime: remove unreachable code on Windows

### DIFF
--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -338,13 +338,8 @@ pub fn get_nusers() -> usize {
                 continue;
             }
 
-            let username = if !buffer.is_null() {
-                let cstr = std::ffi::CStr::from_ptr(buffer as *const i8);
-                cstr.to_string_lossy().to_string()
-            } else {
-                String::new()
-            };
-            if !username.is_empty() {
+            let cstr = std::ffi::CStr::from_ptr(buffer.cast());
+            if !cstr.is_empty() {
                 num_user += 1;
             }
 


### PR DESCRIPTION
On lines 337 - 339 we have the following code:
```rust
if result == 0 || buffer.is_null() {
    continue;
}
```
On line 341 we check whether the `buffer` is not null. Due to the code above `buffer` can't be null at this point, thus the check is unnecessary and the `else` part is unreachable.
```rust
let username = if !buffer.is_null() {
    // do something
} else {
    // do something else
};
```