### PR TITLE
benchmarks: use `simulation` mode

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           CODSPEED_LOG: debug
         with:
-          mode: instrumentation
+          mode: simulation
           run: |
             echo "Running benchmarks for ${{ matrix.benchmark-target.package }}"
             cargo codspeed run -p ${{ matrix.benchmark-target.package }} > /dev/null


### PR DESCRIPTION
When running the benchmarks in the CI, the following warning is shown in the log (see, for example, https://github.com/uutils/coreutils/actions/runs/20661274163/job/59324172817?pr=9985#step:8:177):
```
Warning: The 'instrumentation' runner mode is deprecated and will be removed in a future version. Please use 'simulation' instead.
```
This PR fixes the warning by using `simulation` mode instead.