### PR TITLE
install: fix error messages to align with GNU for cannot-stat and failed-to-remove.

### DIFF
--- a/src/uu/install/locales/en-US.ftl
+++ b/src/uu/install/locales/en-US.ftl
@@ -48,7 +48,8 @@ install-error-mutually-exclusive-compare-preserve = Options --compare and --pres
 install-error-mutually-exclusive-compare-strip = Options --compare and --strip are mutually exclusive
 install-error-missing-file-operand = missing file operand
 install-error-missing-destination-operand = missing destination file operand after { $path }
-install-error-failed-to-remove = Failed to remove existing file { $path }. Error: { $error }
+install-error-failed-to-remove = failed to remove existing file { $path }: { $error }
+install-error-cannot-stat = cannot stat { $path }: { $error }
 
 # Warning messages
 install-warning-compare-ignored = the --compare (-C) option is ignored when you specify a mode with non-permission bits

--- a/src/uu/install/locales/en-US.ftl
+++ b/src/uu/install/locales/en-US.ftl
@@ -48,8 +48,9 @@ install-error-mutually-exclusive-compare-preserve = Options --compare and --pres
 install-error-mutually-exclusive-compare-strip = Options --compare and --strip are mutually exclusive
 install-error-missing-file-operand = missing file operand
 install-error-missing-destination-operand = missing destination file operand after { $path }
-install-error-failed-to-remove = failed to remove existing file { $path }: { $error }
-install-error-cannot-stat = cannot stat { $path }: { $error }
+install-error-failed-to-access = failed to access { $path }
+install-error-failed-to-remove = cannot remove { $path }
+install-error-cannot-create-file = cannot create regular file { $path }
 
 # Warning messages
 install-warning-compare-ignored = the --compare (-C) option is ignored when you specify a mode with non-permission bits

--- a/src/uu/install/locales/fr-FR.ftl
+++ b/src/uu/install/locales/fr-FR.ftl
@@ -48,8 +48,9 @@ install-error-mutually-exclusive-compare-preserve = Les options --compare et --p
 install-error-mutually-exclusive-compare-strip = Les options --compare et --strip sont mutuellement exclusives
 install-error-missing-file-operand = opérande de fichier manquant
 install-error-missing-destination-operand = opérande de fichier de destination manquant après { $path }
-install-error-failed-to-remove = Échec de la suppression du fichier existant { $path }: { $error }
-install-error-cannot-stat = impossible d'obtenir des informations sur le fichier. { $path }: { $error }
+install-error-failed-to-access = impossible d'accéder à { $path }
+install-error-failed-to-remove = impossible de supprimer { $path }
+install-error-cannot-create-file = impossible de créer le fichier { $path }
 
 # Messages d'avertissement
 install-warning-compare-ignored = l'option --compare (-C) est ignorée quand un mode est indiqué avec des bits non liés à des droits

--- a/src/uu/install/locales/fr-FR.ftl
+++ b/src/uu/install/locales/fr-FR.ftl
@@ -48,7 +48,8 @@ install-error-mutually-exclusive-compare-preserve = Les options --compare et --p
 install-error-mutually-exclusive-compare-strip = Les options --compare et --strip sont mutuellement exclusives
 install-error-missing-file-operand = opérande de fichier manquant
 install-error-missing-destination-operand = opérande de fichier de destination manquant après { $path }
-install-error-failed-to-remove = Échec de la suppression du fichier existant { $path }. Erreur : { $error }
+install-error-failed-to-remove = Échec de la suppression du fichier existant { $path }: { $error }
+install-error-cannot-stat = impossible d'obtenir des informations sur le fichier. { $path }: { $error }
 
 # Messages d'avertissement
 install-warning-compare-ignored = l'option --compare (-C) est ignorée quand un mode est indiqué avec des bits non liés à des droits

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -24,6 +24,7 @@ use uucore::backup_control::{self, BackupMode};
 use uucore::buf_copy::copy_stream;
 use uucore::display::Quotable;
 use uucore::entries::{grp2gid, usr2uid};
+use uucore::error::UIoError;
 use uucore::error::{FromIo, UError, UResult, UUsageError};
 use uucore::fs::dir_strip_dot_for_creation;
 use uucore::perms::{Verbosity, VerbosityLevel, wrap_chown};
@@ -35,7 +36,6 @@ use uucore::selinux::{
 };
 use uucore::translate;
 use uucore::{format_usage, show, show_error, show_if_err};
-use uucore::error::UIoError;
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -35,6 +35,7 @@ use uucore::selinux::{
 };
 use uucore::translate;
 use uucore::{format_usage, show, show_error, show_if_err};
+use uucore::error::UIoError;
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -843,7 +844,8 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
     // see if the file exists, and it can't even be checked, this means we
     // don't have permission to access the file, so we should return an error.
     if let Err(to_stat) = to.try_exists() {
-        return Err(InstallError::CannotStat(to.to_path_buf(), to_stat.to_string()).into());
+        let err = UIoError::from(to_stat);
+        return Err(InstallError::CannotStat(to.to_path_buf(), err.to_string()).into());
     }
 
     if to.is_dir() && !from.is_dir() {
@@ -862,7 +864,8 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
             // If we get here, then remove_file failed for some
             // reason other than the file not existing. This means
             // this should be a fatal error, not a warning.
-            return Err(InstallError::FailedToRemove(to.to_path_buf(), e.to_string()).into());
+            let err = UIoError::from(e);
+            return Err(InstallError::FailedToRemove(to.to_path_buf(), err.to_string()).into());
         }
     }
 

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -123,18 +123,24 @@ fn test_install_ancestors_mode_directories() {
 fn test_install_remove_impermissible_dst_file() {
     let src_file = "/dev/null";
     let dst_file = "/dev/full";
-    new_ucmd!().args(&[src_file, dst_file]).fails().stderr_only(format!(
-        "install: failed to remove existing file '{dst_file}': Permission denied\n"
-    ));
+    new_ucmd!()
+        .args(&[src_file, dst_file])
+        .fails()
+        .stderr_only(format!(
+            "install: failed to remove existing file '{dst_file}': Permission denied\n"
+        ));
 }
 
 #[test]
 fn test_install_remove_inaccessible_dst_file() {
     let src_file = "/dev/null";
     let dst_file = "/root/file";
-    new_ucmd!().args(&[src_file, dst_file]).fails().stderr_only(format!(
-        "install: cannot stat '{dst_file}': Permission denied\n"
-    ));
+    new_ucmd!()
+        .args(&[src_file, dst_file])
+        .fails()
+        .stderr_only(format!(
+            "install: cannot stat '{dst_file}': Permission denied\n"
+        ));
 }
 
 #[test]

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -120,6 +120,24 @@ fn test_install_ancestors_mode_directories() {
 }
 
 #[test]
+fn test_install_remove_impermissible_dst_file() {
+    let src_file = "/dev/null";
+    let dst_file = "/dev/full";
+    new_ucmd!().args(&[src_file, dst_file]).fails().stderr_only(format!(
+        "install: failed to remove existing file '{dst_file}': Permission denied\n"
+    ));
+}
+
+#[test]
+fn test_install_remove_inaccessible_dst_file() {
+    let src_file = "/dev/null";
+    let dst_file = "/root/file";
+    new_ucmd!().args(&[src_file, dst_file]).fails().stderr_only(format!(
+        "install: cannot stat '{dst_file}': Permission denied\n"
+    ));
+}
+
+#[test]
 fn test_install_ancestors_mode_directories_with_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     let ancestor1 = "ancestor1";

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -120,27 +120,27 @@ fn test_install_ancestors_mode_directories() {
 }
 
 #[test]
-fn test_install_remove_impermissible_dst_file() {
-    let src_file = "/dev/null";
-    let dst_file = "/dev/full";
+#[cfg(target_os = "linux")]
+fn test_install_cannot_remove_destination() {
+    if geteuid() == 0 {
+        return;
+    }
     new_ucmd!()
-        .args(&[src_file, dst_file])
+        .args(&["/dev/null", "/dev/full"])
         .fails()
-        .stderr_only(format!(
-            "install: failed to remove existing file '{dst_file}': Permission denied\n"
-        ));
+        .stderr_only("install: cannot remove '/dev/full': Permission denied\n");
 }
 
 #[test]
-fn test_install_remove_inaccessible_dst_file() {
-    let src_file = "/dev/null";
-    let dst_file = "/root/file";
+#[cfg(target_os = "linux")]
+fn test_install_cannot_create_destination() {
+    if geteuid() == 0 {
+        return;
+    }
     new_ucmd!()
-        .args(&[src_file, dst_file])
+        .args(&["/dev/null", "/root/file"])
         .fails()
-        .stderr_only(format!(
-            "install: cannot stat '{dst_file}': Permission denied\n"
-        ));
+        .stderr_only("install: cannot create regular file '/root/file': Permission denied\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #9934 

This PR will update the failed-to-remove error message to better align with GNU coreutils. Furthermore, it adds "cannot stat" for when looking for a file to see if it exists fails. This can fail for myriad of reasons, including permission denied.

Test: original issue request
```
$ uu-install /dev/null /dev/full
install: failed to remove existing file '/dev/full': Permission denied (os error 13)
$ gnu-install /dev/null /dev/full
install: cannot remove '/dev/full': Permission denied
```

The original issue was due to the way Rust's standard library calculates `is_file`. It only checks for *regular files* to be file, but on a UNIX configuration, the files could include block and character devices as well as a FIFO device. This patch now checks the metadata to check specifically for block, character, and FIFO devices on UNIX configurations. If the configuration is not UNIX, it reverts to the original behavior.


Test: cannot stat due to permission error
```
$ uu-install /dev/null /root/file
install: cannot stat '/root/file': Permission denied (os error 13)
$ gnu-install /dev/null /root/file
install: cannot stat '/root/file': Permission denied
```

The issue here was due to the way the `main` branch does `remove_file`. Since no checks are done before this function call, we get too granular of an error: was it due to not found or not? In this patch, there is an additional check using Rust's standard `try_exists`. This will tell us if the actual calculation of a file existing failed.


