### PR TITLE
pr: add -b flag for backwards compatibility

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -48,6 +48,7 @@ mod options {
     pub const COLUMN_WIDTH: &str = "width";
     pub const PAGE_WIDTH: &str = "page-width";
     pub const ACROSS: &str = "across";
+    pub const COLUMN_DOWN: &str = "column-down";
     pub const COLUMN: &str = "column";
     pub const COLUMN_CHAR_SEPARATOR: &str = "separator";
     pub const COLUMN_STRING_SEPARATOR: &str = "sep-string";
@@ -255,6 +256,13 @@ pub fn uu_app() -> Command {
                 .short('a')
                 .long(options::ACROSS)
                 .help(translate!("pr-help-across"))
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            // -b is a no-op for backwards compatibility (column-down is now the default)
+            Arg::new(options::COLUMN_DOWN)
+                .short('b')
+                .hide(true)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -616,3 +616,9 @@ fn test_version() {
 fn test_pr_char_device_dev_null() {
     new_ucmd!().arg("/dev/null").succeeds();
 }
+
+#[test]
+fn test_b_flag_backwards_compat() {
+    // -b is a no-op for backwards compatibility (column-down is now the default)
+    new_ucmd!().args(&["-b", "-t"]).pipe_in("a\nb\n").succeeds();
+}


### PR DESCRIPTION
The PR GNU test has around 700 test failures and I'm hoping to start chipping away at them 1 by 1. The first one that impacts around 30 tests is that even though the -b flag is not used it is expected to be parsed without throwing an error. This just adds this options as a hidden flag and will not fail if the b flag is provided. I also added a simple regression test. 