### PR TITLE
perf(date): wrap stdout in BufWriter to improve batch processing

### DIFF
--- a/src/uu/date/locales/en-US.ftl
+++ b/src/uu/date/locales/en-US.ftl
@@ -105,3 +105,4 @@ date-error-setting-date-not-supported-macos = setting the date is not supported 
 date-error-setting-date-not-supported-redox = setting the date is not supported by Redox
 date-error-cannot-set-date = cannot set date
 date-error-extra-operand = extra operand '{$operand}'
+date-error-write = write error: {$error}

--- a/src/uu/date/locales/fr-FR.ftl
+++ b/src/uu/date/locales/fr-FR.ftl
@@ -100,3 +100,4 @@ date-error-setting-date-not-supported-macos = la définition de la date n'est pa
 date-error-setting-date-not-supported-redox = la définition de la date n'est pas prise en charge par Redox
 date-error-cannot-set-date = impossible de définir la date
 date-error-extra-operand = opérande supplémentaire '{$operand}'
+date-error-write = erreur d'écriture: {$error}


### PR DESCRIPTION
This PR addresses a performance bottleneck when processing large numbers of dates (e.g., using `date -f large_file.txt`).

Previously, the main loop used `println!`, which locks and flushes `stdout` on every iteration. This change wraps `stdout` in a `BufWriter` and uses `writeln!`, significantly improving throughput for batch operations.
