### PR TITLE
cksum: Move handle_tag_text_binary_flags to clap

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -74,42 +74,6 @@ mod options {
 /// Returns a pair of boolean. The first one indicates if we should use tagged
 /// output format, the second one indicates if we should use the binary flag in
 /// the untagged case.
-fn handle_tag_text_binary_flags<S: AsRef<OsStr>>(
-    args: impl Iterator<Item = S>,
-) -> UResult<(bool, bool)> {
-    let mut tag = true;
-    let mut binary = false;
-    let mut text = false;
-
-    // --binary, --tag and --untagged are tight together: none of them
-    // conflicts with each other but --tag will reset "binary" and "text" and
-    // set "tag".
-
-    for arg in args {
-        let arg = arg.as_ref();
-        if arg == "-b" || arg == "--binary" {
-            text = false;
-            binary = true;
-        } else if arg == "--text" {
-            text = true;
-            binary = false;
-        } else if arg == "--tag" {
-            tag = true;
-            binary = false;
-            text = false;
-        } else if arg == "--untagged" {
-            tag = false;
-        }
-    }
-
-    // Specifying --text without ever mentioning --untagged fails.
-    if text && tag {
-        return Err(ChecksumError::TextWithoutUntagged.into());
-    }
-
-    Ok((tag, binary))
-}
-
 /// Sanitize the `--length` argument depending on `--algorithm` and `--length`.
 fn maybe_sanitize_length(
     algo_cli: Option<AlgoKind>,
@@ -208,7 +172,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Set the default algorithm to CRC when not '--check'ing.
     let algo_kind = algo_cli.unwrap_or(AlgoKind::Crc);
 
-    let (tag, binary) = handle_tag_text_binary_flags(std::env::args_os())?;
+    let tag = matches.get_flag(options::TAG) || !matches.get_flag(options::UNTAGGED);
+    let binary = matches.get_flag(options::BINARY);
 
     let algo = SizedAlgoKind::from_unsized(algo_kind, length)?;
     let line_ending = LineEnding::from_zero_flag(matches.get_flag(options::ZERO));
@@ -265,7 +230,9 @@ pub fn uu_app() -> Command {
                 .long(options::TAG)
                 .help(translate!("cksum-help-tag"))
                 .action(ArgAction::SetTrue)
-                .overrides_with(options::UNTAGGED),
+                .overrides_with(options::UNTAGGED)
+                .overrides_with(options::BINARY)
+                .overrides_with(options::TEXT),
         )
         .arg(
             Arg::new(options::LENGTH)
@@ -308,7 +275,8 @@ pub fn uu_app() -> Command {
                 .short('t')
                 .hide(true)
                 .overrides_with(options::BINARY)
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .requires(options::UNTAGGED),
         )
         .arg(
             Arg::new(options::BINARY)

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1066,7 +1066,7 @@ mod output_format {
             .args(&["-a", "md5"])
             .arg(at.subdir.join("f"))
             .fails_with_code(1)
-            .stderr_contains("--text mode is only supported with --untagged");
+            .stderr_contains("the following required arguments were not provided"); //clap does not change the meaning
     }
 
     #[test]


### PR DESCRIPTION
Does not change the meaning:
```
error: the following required arguments were not provided:
  --untagged

Usage: cksum [OPTIONS] [FILE]...

For more information, try '--help'.
```
#9992