### PR TITLE
cksum: Move --check confliction to clap

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -134,14 +134,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             return Err(ChecksumError::AlgorithmNotSupportedWithCheck.into());
         }
 
-        let text_flag = matches.get_flag(options::TEXT);
-        let binary_flag = matches.get_flag(options::BINARY);
-        let tag = matches.get_flag(options::TAG);
-
-        if tag || binary_flag || text_flag {
-            return Err(ChecksumError::BinaryTextConflict.into());
-        }
-
         // Execute the checksum validation based on the presence of files or the use of stdin
 
         let verbose = ChecksumVerbose::new(status, quiet, warn);
@@ -251,6 +243,9 @@ pub fn uu_app() -> Command {
                 .short('c')
                 .long(options::CHECK)
                 .help(translate!("cksum-help-check"))
+                .conflicts_with(options::TAG)
+                .conflicts_with(options::BINARY)
+                .conflicts_with(options::TEXT)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1216,7 +1216,7 @@ fn test_conflicting_options() {
         .fails_with_code(1)
         .no_stdout()
         .stderr_contains(
-            "cksum: the --binary and --text options are meaningless when verifying checksums",
+            "cannot be used with", //clap generated error
         );
 
     scene
@@ -1228,7 +1228,7 @@ fn test_conflicting_options() {
         .fails_with_code(1)
         .no_stdout()
         .stderr_contains(
-            "cksum: the --binary and --text options are meaningless when verifying checksums",
+            "cannot be used with", //clap generated error
         );
 }
 


### PR DESCRIPTION
ref #9992
```
error: the argument '--check' cannot be used with '--****'

For more information, try '--help'.
```