### PR TITLE
CI: Default build artifact for riscv64+musl on CICD.yml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,8 @@
 linker = "x86_64-unknown-redox-gcc"
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+[target.riscv64gc-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
 
 [env]
 # See feat_external_libstdbuf in src/uu/stdbuf/Cargo.toml

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -309,7 +309,7 @@ jobs:
         ./target/release-fast/true
         # Check that the progs have prefix
         test -f /tmp/usr/local/bin/uu-tty
-        test -f /tmp/usr/local/libexec/uu-coreutils/libstdbuf.*   
+        test -f /tmp/usr/local/libexec/uu-coreutils/libstdbuf.*
         # Check that the manpage is not present
         ! test -f /tmp/usr/local/share/man/man1/uu-whoami.1
         # Check that the completion is not present
@@ -576,6 +576,7 @@ jobs:
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-24.04-arm  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
+          - { os: ubuntu-latest  , target: riscv64gc-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
           # - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl , use-cross: use-cross }
@@ -636,6 +637,7 @@ jobs:
         unset TARGET_ARCH
         case '${{ matrix.job.target }}' in
           aarch64-*) TARGET_ARCH=arm64 ;;
+          riscv64gc-*) TARGET_ARCH=riscv64 ;;
           arm-*-*hf) TARGET_ARCH=armhf ;;
           i686-*) TARGET_ARCH=i686 ;;
           x86_64-*) TARGET_ARCH=x86_64 ;;
@@ -700,6 +702,7 @@ jobs:
         STRIP="strip"
         case ${{ matrix.job.target }} in
           aarch64-*-linux-*) STRIP="aarch64-linux-gnu-strip" ;;
+          riscv64gc-*-linux-*) STRIP="riscv64-linux-gnu-strip" ;;
           arm-*-linux-gnueabihf) STRIP="arm-linux-gnueabihf-strip" ;;
           *-pc-windows-msvc) STRIP="" ;;
         esac;
@@ -725,6 +728,10 @@ jobs:
           aarch64-unknown-linux-*)
             sudo apt-get -y update
             sudo apt-get -y install gcc-aarch64-linux-gnu
+          ;;
+          riscv64gc-unknown-linux-*)
+            sudo apt-get -y update
+            sudo apt-get -y install gcc-riscv64-linux-gnu
           ;;
           *-redox*)
             sudo apt-get -y update

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,3 +5,6 @@ pre-build = [
 ]
 [build.env]
 passthrough = ["CI", "RUST_BACKTRACE", "CARGO_TERM_COLOR"]
+
+[target.riscv64gc-unknown-linux-musl]
+image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-musl:main"


### PR DESCRIPTION
Recently, I've been trying to add riscv64 support to coreutils.

I've already opened a related [issue](https://github.com/uutils/coreutils/issues/9691) to describe in detail the provision of riscv64 support. You can check the issue for more information.

This PR is slightly different from what's described in the issue. The issue describes local compilation regarding riscv64+glibc, whereas this PR uses cross-compilation for riscv64+musl. For this PR, only a few minor modifications are needed to build coreutils for riscv64, and it runs well on my riscv64 system. Everything ran smoothly in the CI on my fork - you can see the details [here](https://github.com/ffgan/coreutils/actions/runs/20678693151/job/59370151368). Since I noticed that cross-compilation for arm64 on x86 also skips tests, I haven't added tests for riscv64+musl here either.

For testing on riscv64, please refer to the content in my issue.
If you think testing for riscv64+musl is necessary, feel free to @ me directly - I'd be happy to help complete this part.

---
**Other Info**
Co-authored by: nijincheng@iscas.ac.cn;