### PR TITLE
uudoc: print tldr.zip warning only once per process

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (vars) krate mangen
+// spell-checker:ignore (vars) krate mangen tldr
 
 use std::env;
 use std::fs::File;
@@ -18,6 +18,18 @@ pub fn main() {
     // Do not rebuild build script unless the script itself or the enabled features are modified
     // See <https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection>
     println!("cargo:rerun-if-changed=build.rs");
+
+    // Check for tldr.zip when building uudoc to warn users once at build time
+    // instead of repeatedly at runtime for each utility
+    if env::var("CARGO_FEATURE_UUDOC").is_ok() && !Path::new("docs/tldr.zip").exists() {
+        println!(
+            "cargo:warning=No tldr archive found, so the documentation will not include examples."
+        );
+        println!("cargo:warning=To include examples, download the tldr archive:");
+        println!(
+            "cargo:warning=  curl -L https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip -o docs/tldr.zip"
+        );
+    }
 
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=build={profile:?}");

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -133,19 +133,6 @@ fn gen_completions<T: Args>(args: impl Iterator<Item = OsString>, util_map: &Uti
     process::exit(0);
 }
 
-/// print tldr error
-fn print_tldr_error() {
-    eprintln!("Warning: No tldr archive found, so the documentation will not include examples.");
-    eprintln!(
-        "To include examples in the documentation, download the tldr archive and put it in the docs/ folder."
-    );
-    eprintln!();
-    eprintln!(
-        "  curl -L https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip -o docs/tldr.zip"
-    );
-    eprintln!();
-}
-
 /// # Errors
 /// Returns an error if the writer fails.
 #[allow(clippy::too_many_lines)]
@@ -162,9 +149,6 @@ fn main() -> io::Result<()> {
         match command {
             "manpage" => {
                 let args_iter = args.into_iter().skip(2);
-                if tldr_zip.is_none() {
-                    print_tldr_error();
-                }
                 gen_manpage(
                     &mut tldr_zip,
                     args_iter,
@@ -185,9 +169,6 @@ fn main() -> io::Result<()> {
                 process::exit(1);
             }
         }
-    }
-    if tldr_zip.is_none() {
-        print_tldr_error();
     }
     let utils = util_map::<Box<dyn Iterator<Item = OsString>>>();
     match std::fs::create_dir("docs/src/utils/") {

--- a/tests/uudoc/mod.rs
+++ b/tests/uudoc/mod.rs
@@ -28,9 +28,11 @@ fn test_manpage_generation() {
         "Command failed with status: {}",
         output.status
     );
+    // Note: tldr warning is now printed at build time (in build.rs), not at runtime
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("Warning: No tldr archive found"),
-        "stderr should contains tldr alert",
+        output.stderr.is_empty(),
+        "stderr should be empty but got: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 
     let output_str = String::from_utf8_lossy(&output.stdout);
@@ -52,9 +54,11 @@ fn test_manpage_coreutils() {
         "Command failed with status: {}",
         output.status
     );
+    // Note: tldr warning is now printed at build time (in build.rs), not at runtime
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("Warning: No tldr archive found"),
-        "stderr should contains tldr alert",
+        output.stderr.is_empty(),
+        "stderr should be empty but got: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 
     let output_str = String::from_utf8_lossy(&output.stdout);
@@ -123,9 +127,11 @@ fn test_manpage_base64() {
         "Command failed with status: {}",
         output.status
     );
+    // Note: tldr warning is now printed at build time (in build.rs), not at runtime
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("Warning: No tldr archive found"),
-        "stderr should contains tldr alert",
+        output.stderr.is_empty(),
+        "stderr should be empty but got: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 
     let output_str = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
Move the tldr.zip missing warning from runtime (`uudoc.rs`) to compile time (`build.rs`). This ensures the warning is printed only once during the build, instead of 100+ times when `make` calls `uudoc` separately for each utility.

## The Problem

From issue #9940:
> Calling this for all utils pollutes the build log. No need to show it 100+ times.

The previous `OnceLock` approach did not work because `make install-manpages` invokes `uudoc manpage <utility>` as a **separate process** for each utility. Since each process has its own memory, `OnceLock` resets every time.

## The Fix

Check for `docs/tldr.zip` in `build.rs` and emit a `cargo:warning=` message at compile time:

```rust
// build.rs
if env::var("CARGO_FEATURE_UUDOC").is_ok() && !Path::new("docs/tldr.zip").exists() {
    println!("cargo:warning=No tldr archive found, so the documentation will not include examples.");
    println!("cargo:warning=To include examples, download the tldr archive:");
    println!("cargo:warning=  curl -L https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip -o docs/tldr.zip");
}
```

This prints the warning exactly once when `cargo build --features uudoc` runs, not during the 100+ runtime invocations.

## Testing

Build prints the warning once:
```
$ cargo build --bin uudoc --features "uudoc feat_os_unix"
   Compiling coreutils v0.5.0 (/workspace)
warning: coreutils@0.5.0: No tldr archive found, so the documentation will not include examples.
warning: coreutils@0.5.0: To include examples, download the tldr archive:
warning: coreutils@0.5.0:   curl -L https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip -o docs/tldr.zip
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.39s
```

Running `uudoc manpage` for multiple utilities (simulating `make install-manpages`) prints no warnings:
```
$ for util in ls cat cp mv rm mkdir rmdir echo head tail; do ./target/debug/uudoc manpage $util 2>&1 >/dev/null; done
(no output - no warnings printed!)
```

Fixes #9940