### PR TITLE
seq: optimize slow path loop by implementing AddAssign for ExtendedBigDecimal

### DIFF
--- a/src/uu/seq/src/seq.rs
+++ b/src/uu/seq/src/seq.rs
@@ -384,8 +384,7 @@ fn print_seq(
             stdout.write_all(separator.as_encoded_bytes())?;
         }
         format.fmt(&mut stdout, &value)?;
-        // TODO Implement augmenting addition.
-        value = value + increment.clone();
+        value += &increment;
         is_first_iteration = false;
     }
     if !is_first_iteration {


### PR DESCRIPTION
This PR optimizes the "slow path" of `seq` by replacing the allocation-heavy addition loop with in-place mutation.

Currently, the `print_seq` loop performs the following operation:
```
value = value + increment.clone();
```

It explicitly clones the increment (a potential BigInt allocation) on every iteration.

I have implemented `std::ops::AddAssign<&ExtendedBigDecimal>` for `ExtendedBigDecimal` and updated `seq` to use:
```
value += &increment;
```

I reviewed the upstream `bigdecimal` crate and noticed that [addassign_bigdecimal_ref](https://github.com/akubera/bigdecimal-rs/blob/7f0243e737024a617162f2e61d33866559775287/src/arithmetic/addition.rs#L100) currently contains a `TODO` and performs a `to_owned()` internally. Even with that upstream limitation, this PR provides immediate benefits.