### PR TITLE
ci: set `-no-metrics` for Android emulator

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -166,7 +166,7 @@ jobs:
         disk-size: ${{ env.EMULATOR_DISK_SIZE }}
         cores: ${{ env.EMULATOR_CORES }}
         force-avd-creation: false
-        emulator-options: ${{ env.COMMON_EMULATOR_OPTIONS }} -no-snapshot-save -snapshot ${{ env.AVD_CACHE_KEY }}
+        emulator-options: ${{ env.COMMON_EMULATOR_OPTIONS }} -no-metrics -no-snapshot-save -snapshot ${{ env.AVD_CACHE_KEY }}
         emulator-boot-timeout: ${{ env.EMULATOR_BOOT_TIMEOUT }}
         # This is not a usual script. Every line is executed in a separate shell with `sh -c`. If
         # one of the lines returns with error the whole script is failed (like running a script with


### PR DESCRIPTION
In the `Build and Test` step of the Android jobs (see, for example, https://github.com/uutils/coreutils/actions/runs/20693195299/job/59407023258?pr=9804#step:16:84) the following warning is shown:
```
##############################################################################
  ##                        WARNING - ACTION REQUIRED                         ##
  ##  Consider using the '-metrics-collection' flag to help improve the       ##
  ##  emulator by sending anonymized usage data. Or use the '-no-metrics'     ##
  ##  flag to bypass this warning and turn off the metrics collection.        ##
  ##  In a future release this warning will turn into a one-time blocking     ##
  ##  prompt to ask for explicit user input regarding metrics collection.     ##
  ##                                                                          ##
  ##  Please see '-help-metrics-collection' for more details. You can use     ##
  ##  '-metrics-to-file' or '-metrics-to-console' flags to see what type of   ##
  ##  data is being collected by emulator as part of usage statistics.        ##
  ##############################################################################
```
This PR sets `-no-metrics` to remove the warning.