### PR TITLE
mkfifo: Fix path-based chmod race #10020

### DIFF
--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -139,7 +139,6 @@ fn test_create_fifo_permission_denied() {
 
     let err_msg = format!(
         "mkfifo: cannot create fifo '{named_pipe}': File exists
-mkfifo: cannot set permissions on '{named_pipe}': Permission denied (os error 13)
 "
     );
 

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -138,7 +138,7 @@ fn test_create_fifo_permission_denied() {
     at.set_mode(no_exec_dir, 0o644);
 
     let err_msg = format!(
-        "mkfifo: cannot create fifo '{named_pipe}': File exists
+        "mkfifo: cannot set permissions on '{named_pipe}': Permission denied (os error 13)
 "
     );
 


### PR DESCRIPTION
Fixes #10020

- Instead of setting permissions via `std::fs::set_permissions`  mode is passed directly to `libc::mkfifo`
- Updated `test_create_fifo_permission_denied` expecting a "permission denied" error since there is no longer a separate step in setting permissions
- In order to apply -m mode correctly and ignore `umask` which is applied automatically with `mkfifo`, without `std::fs::set_permissions`  we temporarily set `umask` to 0.