### PR TITLE
tests: extend CmdResult metadata for GNU comparison helpers

### DIFF
--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -761,9 +761,10 @@ impl CmdResult {
 
     #[cfg(unix)]
     fn gnu_result(&self) -> std::result::Result<CmdResult, String> {
-        let util_name = self.util_name.as_ref().ok_or_else(|| {
-            format!("{UUTILS_WARNING}: matches_gnu requires a utility name")
-        })?;
+        let util_name = self
+            .util_name
+            .as_ref()
+            .ok_or_else(|| format!("{UUTILS_WARNING}: matches_gnu requires a utility name"))?;
         println!("{}", check_coreutil_version(util_name, VERSION_MIN)?);
         let gnu_name = host_name_for(util_name);
 


### PR DESCRIPTION
## Summary
- Extend `CmdResult` to carry execution metadata (args/env/cwd/stdin).
- Add GNU comparison helper (`matches_gnu`) on Unix and propagate metadata through UChild/gnu_cmd_result.


## Notes
- Split out from #9862 