### PR TITLE
i18n: conditionally load SELinux/Smack locale strings based on feature flag

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -28,7 +28,7 @@
     "vendor/**",
     "**/*.svg",
     "src/uu/*/locales/*.ftl",
-    "src/uucore/locales/*.ftl",
+    "src/uucore/locales/**/*.ftl",
     ".devcontainer/**",
     "util/gnu-patches/**",
     "docs/src/release-notes/**",

--- a/src/uucore/build.rs
+++ b/src/uucore/build.rs
@@ -149,6 +149,21 @@ fn embed_single_utility_locale(
         project_root.join(format!("src/uucore/locales/{locale}.ftl"))
     })?;
 
+    // Conditionally embed SELinux locales when the selinux feature is enabled
+    #[cfg(feature = "selinux")]
+    embed_component_locales(
+        embedded_file,
+        locales_to_embed,
+        "uucore/selinux",
+        |locale| project_root.join(format!("src/uucore/locales/selinux/{locale}.ftl")),
+    )?;
+
+    // Conditionally embed SMACK locales when the smack feature is enabled
+    #[cfg(feature = "smack")]
+    embed_component_locales(embedded_file, locales_to_embed, "uucore/smack", |locale| {
+        project_root.join(format!("src/uucore/locales/smack/{locale}.ftl"))
+    })?;
+
     Ok(())
 }
 
@@ -199,6 +214,21 @@ fn embed_all_utility_locales(
         project_root.join(format!("src/uucore/locales/{locale}.ftl"))
     })?;
 
+    // Conditionally embed SELinux locales when the selinux feature is enabled
+    #[cfg(feature = "selinux")]
+    embed_component_locales(
+        embedded_file,
+        locales_to_embed,
+        "uucore/selinux",
+        |locale| project_root.join(format!("src/uucore/locales/selinux/{locale}.ftl")),
+    )?;
+
+    // Conditionally embed SMACK locales when the smack feature is enabled
+    #[cfg(feature = "smack")]
+    embed_component_locales(embedded_file, locales_to_embed, "uucore/smack", |locale| {
+        project_root.join(format!("src/uucore/locales/smack/{locale}.ftl"))
+    })?;
+
     embedded_file.flush()?;
     Ok(())
 }
@@ -228,6 +258,21 @@ fn embed_static_utility_locales(
     // First, try to embed uucore locales - critical for common translations like "Usage:"
     embed_component_locales(embedded_file, locales_to_embed, "uucore", |locale| {
         Path::new(&manifest_dir).join(format!("locales/{locale}.ftl"))
+    })?;
+
+    // Conditionally embed SELinux locales when the selinux feature is enabled
+    #[cfg(feature = "selinux")]
+    embed_component_locales(
+        embedded_file,
+        locales_to_embed,
+        "uucore/selinux",
+        |locale| Path::new(&manifest_dir).join(format!("locales/selinux/{locale}.ftl")),
+    )?;
+
+    // Conditionally embed SMACK locales when the smack feature is enabled
+    #[cfg(feature = "smack")]
+    embed_component_locales(embedded_file, locales_to_embed, "uucore/smack", |locale| {
+        Path::new(&manifest_dir).join(format!("locales/smack/{locale}.ftl"))
     })?;
 
     // Collect and sort for deterministic builds

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -39,19 +39,6 @@ action-creating = creating
 action-reading = reading
 action-writing = writing
 
-# SELinux error messages
-selinux-error-not-enabled = SELinux is not enabled on this system
-selinux-error-file-open-failure = failed to open the file: { $error }
-selinux-error-context-retrieval-failure = failed to retrieve the security context: { $error }
-selinux-error-context-set-failure = failed to set default file creation context to '{ $context }': { $error }
-selinux-error-context-conversion-failure = failed to set default file creation context to '{ $context }': { $error }
-
-# SMACK error messages
-smack-error-not-enabled = SMACK is not enabled on this system
-smack-error-label-retrieval-failure = failed to get security context: { $error }
-smack-error-label-set-failure = failed to set default file creation context to '{ $context }': { $error }
-smack-error-no-label-set = no security context set
-
 # Safe traversal error messages
 safe-traversal-error-path-contains-null = path contains null byte
 safe-traversal-error-open-failed = failed to open { $path }: { $source }

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -39,13 +39,6 @@ action-creating = création
 action-reading = lecture
 action-writing = écriture
 
-# Messages d'erreur SELinux
-selinux-error-not-enabled = SELinux n'est pas activé sur ce système
-selinux-error-file-open-failure = échec de l'ouverture du fichier : { $error }
-selinux-error-context-retrieval-failure = échec de la récupération du contexte de sécurité : { $error }
-selinux-error-context-set-failure = échec de la définition du contexte de création de fichier par défaut à '{ $context }' : { $error }
-selinux-error-context-conversion-failure = échec de la définition du contexte de création de fichier par défaut à '{ $context }' : { $error }
-
 # Messages d'erreur de traversée sécurisée
 safe-traversal-error-path-contains-null = le chemin contient un octet null
 safe-traversal-error-open-failed = échec de l'ouverture de { $path } : { $source }

--- a/src/uucore/locales/selinux/en-US.ftl
+++ b/src/uucore/locales/selinux/en-US.ftl
@@ -1,0 +1,8 @@
+# SELinux error messages
+# These strings are only loaded when the selinux feature is enabled
+
+selinux-error-not-enabled = SELinux is not enabled on this system
+selinux-error-file-open-failure = failed to open the file: { $error }
+selinux-error-context-retrieval-failure = failed to retrieve the security context: { $error }
+selinux-error-context-set-failure = failed to set default file creation context to '{ $context }': { $error }
+selinux-error-context-conversion-failure = failed to set default file creation context to '{ $context }': { $error }

--- a/src/uucore/locales/selinux/fr-FR.ftl
+++ b/src/uucore/locales/selinux/fr-FR.ftl
@@ -1,0 +1,8 @@
+# Messages d'erreur SELinux
+# Ces chaînes ne sont chargées que lorsque la fonctionnalité selinux est activée
+
+selinux-error-not-enabled = SELinux n'est pas activé sur ce système
+selinux-error-file-open-failure = échec de l'ouverture du fichier : { $error }
+selinux-error-context-retrieval-failure = échec de la récupération du contexte de sécurité : { $error }
+selinux-error-context-set-failure = échec de la définition du contexte de création de fichier par défaut à '{ $context }' : { $error }
+selinux-error-context-conversion-failure = échec de la définition du contexte de création de fichier par défaut à '{ $context }' : { $error }

--- a/src/uucore/locales/smack/en-US.ftl
+++ b/src/uucore/locales/smack/en-US.ftl
@@ -1,0 +1,7 @@
+# SMACK error messages
+# These strings are only loaded when the smack feature is enabled
+
+smack-error-not-enabled = SMACK is not enabled on this system
+smack-error-label-retrieval-failure = failed to get security context: { $error }
+smack-error-label-set-failure = failed to set default file creation context to '{ $context }': { $error }
+smack-error-no-label-set = no security context set

--- a/src/uucore/locales/smack/fr-FR.ftl
+++ b/src/uucore/locales/smack/fr-FR.ftl
@@ -1,0 +1,7 @@
+# Messages d'erreur SMACK
+# Ces chaines ne sont chargees que lorsque la fonctionnalite smack est activee
+
+smack-error-not-enabled = SMACK n'est pas active sur ce systeme
+smack-error-label-retrieval-failure = echec de la recuperation du contexte de securite : { $error }
+smack-error-label-set-failure = echec de la definition du contexte de creation de fichier par defaut a '{ $context }' : { $error }
+smack-error-no-label-set = aucun contexte de securite defini

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -153,6 +153,15 @@ fn create_bundle(
 
     // Load common strings from uucore locales directory
     try_add_resource_from(find_uucore_locales_dir(locales_dir));
+
+    // Conditionally load SELinux locales when the selinux feature is enabled
+    #[cfg(feature = "selinux")]
+    try_add_resource_from(find_uucore_locales_dir(locales_dir).map(|p| p.join("selinux")));
+
+    // Conditionally load SMACK locales when the smack feature is enabled
+    #[cfg(feature = "smack")]
+    try_add_resource_from(find_uucore_locales_dir(locales_dir).map(|p| p.join("smack")));
+
     // Then, try to load utility-specific strings from the utility's locale directory
     try_add_resource_from(get_locales_dir(util_name).ok());
 
@@ -243,6 +252,20 @@ fn create_english_bundle_from_embedded(
     if let Some(uucore_content) = get_embedded_locale("uucore/en-US.ftl") {
         let uucore_resource = parse_fluent_resource(uucore_content)?;
         bundle.add_resource_overriding(uucore_resource);
+    }
+
+    // Conditionally load SELinux embedded locales when the selinux feature is enabled
+    #[cfg(feature = "selinux")]
+    if let Some(selinux_content) = get_embedded_locale("uucore/selinux/en-US.ftl") {
+        let selinux_resource = parse_fluent_resource(selinux_content)?;
+        bundle.add_resource_overriding(selinux_resource);
+    }
+
+    // Conditionally load SMACK embedded locales when the smack feature is enabled
+    #[cfg(feature = "smack")]
+    if let Some(smack_content) = get_embedded_locale("uucore/smack/en-US.ftl") {
+        let smack_resource = parse_fluent_resource(smack_content)?;
+        bundle.add_resource_overriding(smack_resource);
     }
 
     // Then, try to load utility-specific strings


### PR DESCRIPTION
One of the issues with enabling the Smack support is that adding the locale for the SMACK errors adds a bunch of overhead even to the non-SELINUX or SMACK enabled utilities. The goal here is to reduce the overhead of adding new shared locale files by gating them behind the feature flag.