### PR TITLE
stty: Add bad-speed.sh test script to fetch-gnu.sh

### DIFF
--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -8,5 +8,6 @@ curl -L ${repo}/raw/refs/heads/master/tests/mv/hardlink-case.sh > tests/mv/hardl
 curl -L ${repo}/raw/refs/heads/master/tests/mkdir/writable-under-readonly.sh > tests/mkdir/writable-under-readonly.sh
 curl -L ${repo}/raw/refs/heads/master/tests/cp/cp-mv-enotsup-xattr.sh > tests/cp/cp-mv-enotsup-xattr.sh #spell-checker:disable-line
 curl -L ${repo}/raw/refs/heads/master/tests/csplit/csplit-io-err.sh > tests/csplit/csplit-io-err.sh
+curl -L ${repo}/raw/refs/heads/master/tests/stty/bad-speed.sh > tests/stty/bad-speed.sh
 # Avoid incorrect PASS
 curl -L ${repo}/raw/refs/heads/master/tests/runcon/runcon-compute.sh > tests/runcon/runcon-compute.sh


### PR DESCRIPTION
I made an update to the GNU test-suite since the test was missing a skip flag. This pulls the latest version and allows us to remove a patch in the bad-speed fix PR.

https://github.com/coreutils/coreutils/pull/160

This is the PR that implements the fixes for bad-speed. We currently do not have the capability to separately set ispeed and ospeed: https://github.com/uutils/coreutils/pull/9517 