### PR TITLE
cp: use FileInformation without dereference for symlink destination check to match GNU behaviour for test/nfs-removal-race

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1390,7 +1390,8 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
             let dest = construct_dest_path(source, target, target_type, options)
                 .unwrap_or_else(|_| target.to_path_buf());
 
-            if FileInformation::from_path(&dest, false).is_ok_and(|info| !info.is_symlink())
+            if FileInformation::from_path(&dest, true).is_ok()
+                && !fs::symlink_metadata(&dest).is_ok_and(|m| m.file_type().is_symlink())
                 // if both `source` and `dest` are symlinks, it should be considered as an overwrite.
                 || fs::metadata(source).is_ok()
                     && fs::symlink_metadata(source)?.file_type().is_symlink()

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -166,20 +166,6 @@ impl FileInformation {
         #[cfg(any(target_os = "netbsd", not(target_pointer_width = "64")))]
         return self.0.st_ino.into();
     }
-
-    // The concept of symlinks doesn't map exactly to Windows (which has reparse
-    // points, junctions, etc.), so having our own method lets us control what
-    // we consider a symlink across platforms.
-    #[cfg(unix)]
-    pub fn is_symlink(&self) -> bool {
-        (self.0.st_mode as mode_t & S_IFMT) == S_IFLNK
-    }
-
-    #[cfg(windows)]
-    pub fn is_symlink(&self) -> bool {
-        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
-        self.0.file_attributes() & u64::from(FILE_ATTRIBUTE_REPARSE_POINT) != 0
-    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
I was testing around to see the different GLIBC calls on different versions of GLIBC and what was going on with this test. Turns out that the test doesn't even pass on the original cp on different versions of GLIBC. I was able to make a PR to the main coreutils repository that covers both GLIBC versions and when that in, this should pass the nfs-race GNU test

Update: 
The PR was merged https://github.com/coreutils/coreutils/commit/1afe4109f2e568141ea8d36e62e38ad704dc44f3 here and now it should allow us to use the FileInformation helpers so that we can replicate the types of calls that are made to better match how the file metadata is fetched.