### PR TITLE
hashsum: support --text --tag for GNU compat

### DIFF
--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -216,7 +216,7 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
 mod options {
     //pub const ALGORITHM: &str = "algorithm";
     pub const FILE: &str = "file";
-    //pub const UNTAGGED: &str = "untagged";
+    pub const UNTAGGED: &str = "untagged"; //We have this only for supporting --text --tag
     pub const TAG: &str = "tag";
     pub const LENGTH: &str = "length";
     //pub const RAW: &str = "raw";
@@ -238,6 +238,12 @@ pub fn uu_app_common() -> Command {
         .override_usage(format_usage(&translate!("hashsum-usage")))
         .infer_long_args(true)
         .args_override_self(true)
+        .arg(
+            Arg::new(options::UNTAGGED)
+                .long(options::UNTAGGED)
+                .hide(true)
+                .action(ArgAction::SetTrue),
+        )
         .arg(
             Arg::new(options::BINARY)
                 .short('b')
@@ -267,7 +273,7 @@ pub fn uu_app_common() -> Command {
                 .long("tag")
                 .help(translate!("hashsum-help-tag"))
                 .action(ArgAction::SetTrue)
-                .conflicts_with("text"),
+                .overrides_with(options::TEXT),
         )
         .arg(
             Arg::new(options::TEXT)
@@ -284,6 +290,7 @@ pub fn uu_app_common() -> Command {
                     }
                 })
                 .conflicts_with("binary")
+                .requires(options::UNTAGGED)
                 .action(ArgAction::SetTrue),
         )
         .arg(


### PR DESCRIPTION
GNU accepts `md5sum --text --tag` while rejecting `--tag --text`.
It is able to support on `cksum` with clap-based arg management. But difficult to support it on `hashsum` without adding `--untagged` due to `clap`'s bug: https://github.com/clap-rs/clap/issues/4520

This PR supports `md5sum --tag --text` by adding masked `--untagged` and make `--text` depends on it. We can add error something lile

```
`md5sum: --untagged is supported only on cksum
```
if needed.