### PR TITLE
fix: use jiff time for touch tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "fluent-syntax",
  "glob",
  "hex-literal",
+ "jiff",
  "libc",
  "nix",
  "num-prime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,6 +539,7 @@ chrono.workspace = true
 ctor.workspace = true
 filetime.workspace = true
 glob.workspace = true
+jiff.workspace = true
 libc.workspace = true
 num-prime.workspace = true
 pretty_assertions = "1.4.0"

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -2,11 +2,12 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (formats) cymdhm cymdhms mdhm mdhms ymdhm ymdhms datetime mktime
+// spell-checker:ignore (formats) cymdhm cymdhms datetime mdhm mdhms mktime strtime ymdhm ymdhms
 
 use filetime::FileTime;
 #[cfg(not(target_os = "freebsd"))]
 use filetime::set_symlink_file_times;
+use jiff::{fmt::strtime, tz::TimeZone};
 use std::fs::remove_file;
 use std::path::PathBuf;
 use uutests::at_and_ucmd;
@@ -36,11 +37,10 @@ fn set_file_times(at: &AtPath, path: &str, atime: FileTime, mtime: FileTime) {
 }
 
 fn str_to_filetime(format: &str, s: &str) -> FileTime {
-    let tm = chrono::NaiveDateTime::parse_from_str(s, format).unwrap();
-    FileTime::from_unix_time(
-        tm.and_utc().timestamp(),
-        tm.and_utc().timestamp_subsec_nanos(),
-    )
+    let tm = strtime::parse(format, s).unwrap();
+    let dt = tm.to_datetime().unwrap();
+    let ts = dt.to_zoned(TimeZone::UTC).unwrap().timestamp();
+    FileTime::from_unix_time(ts.as_second(), ts.subsec_nanosecond() as u32)
 }
 
 #[test]


### PR DESCRIPTION
Close #4253.

Use `jiff` to parse the timestamp in touch tests. `jiff` doesn't use the OS or `libc` to get UTC offset. This should fix the intermittent failures caused by multithreaded tests.