### PR TITLE
bench(sort): add general numeric benchmark

### DIFF
--- a/src/uu/sort/benches/sort_bench.rs
+++ b/src/uu/sort/benches/sort_bench.rs
@@ -129,7 +129,7 @@ fn sort_numeric(bencher: Bencher, num_lines: usize) {
 }
 
 /// Benchmark general numeric sorting (-g) with decimal and exponent notation
-#[divan::bench(args = [500_000])]
+#[divan::bench(args = [200_000])]
 fn sort_general_numeric(bencher: Bencher, num_lines: usize) {
     let mut data = Vec::new();
 


### PR DESCRIPTION
## Summary
- Add a benchmark for `sort -g` (general numeric sort) using decimal and exponent notation data.
- Focus on performance coverage for mixed numeric formats.

## related
https://github.com/uutils/coreutils/pull/9839