### PR TITLE
refactor(uptime): use FluentArgs for loadavg formatting in get_format

### DIFF
--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -421,11 +421,13 @@ pub fn get_loadavg() -> UResult<(f64, f64, f64)> {
 #[inline]
 pub fn get_formatted_loadavg() -> UResult<String> {
     let loadavg = get_loadavg()?;
-    Ok(translate!(
+    let mut args = fluent::FluentArgs::new();
+    args.set("avg1", format!("{:.2}", loadavg.0));
+    args.set("avg5", format!("{:.2}", loadavg.1));
+    args.set("avg15", format!("{:.2}", loadavg.2));
+    Ok(crate::locale::get_message_with_args(
         "uptime-lib-format-loadavg",
-        "avg1" => format!("{:.2}", loadavg.0),
-        "avg5" => format!("{:.2}", loadavg.1),
-        "avg15" => format!("{:.2}", loadavg.2),
+        args,
     ))
 }
 


### PR DESCRIPTION
### Summary

Refactored the `get_formatted_loadavg` function to explicitly build a `FluentArgs` struct with load average values formatted to two decimal places, then pass it to `crate::locale::get_message_with_args` instead of using the `translate!` macro inline. This improves argument handling for fluent localization, enhancing code structure and maintainability without altering functionality.

related
https://github.com/uutils/coreutils/issues/10056