### PR TITLE
pr: add -T/--omit-pagination option

### DIFF
--- a/src/uu/pr/locales/en-US.ftl
+++ b/src/uu/pr/locales/en-US.ftl
@@ -30,6 +30,9 @@ pr-help-omit-header =
   Write neither the five-line identifying header nor the five-line
                   trailer usually supplied for each page. Quit writing after the last line
                    of each file without spacing to the end of the page.
+pr-help-omit-pagination =
+  omit page headers and trailers, eliminate any pagination
+                  by form feeds set in input files
 pr-help-page-length =
   Override the 66-line default (default number of lines of text 56,
                   and with -F 63) and reset the page length to lines.  If lines is not

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -42,6 +42,7 @@ mod options {
     pub const FIRST_LINE_NUMBER: &str = "first-line-number";
     pub const PAGES: &str = "pages";
     pub const OMIT_HEADER: &str = "omit-header";
+    pub const OMIT_PAGINATION: &str = "omit-pagination";
     pub const PAGE_LENGTH: &str = "length";
     pub const NO_FILE_WARNINGS: &str = "no-file-warnings";
     pub const FORM_FEED: &str = "form-feed";
@@ -213,6 +214,13 @@ pub fn uu_app() -> Command {
                 .short('t')
                 .long(options::OMIT_HEADER)
                 .help(translate!("pr-help-omit-header"))
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::OMIT_PAGINATION)
+                .short('T')
+                .long(options::OMIT_PAGINATION)
+                .help(translate!("pr-help-omit-pagination"))
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -633,7 +641,9 @@ fn build_options(
 
     let page_length_le_ht = page_length < (HEADER_LINES_PER_PAGE + TRAILER_LINES_PER_PAGE);
 
-    let display_header_and_trailer = !page_length_le_ht && !matches.get_flag(options::OMIT_HEADER);
+    let display_header_and_trailer = !page_length_le_ht
+        && !matches.get_flag(options::OMIT_HEADER)
+        && !matches.get_flag(options::OMIT_PAGINATION);
 
     let content_lines_per_page = if page_length_le_ht {
         page_length

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -641,3 +641,14 @@ fn test_separator_options_default_values() {
         .pipe_in("a\nb\n")
         .succeeds();
 }
+
+#[test]
+fn test_omit_pagination_option() {
+    // -T/--omit-pagination omits headers/trailers and eliminates form feeds
+    // TODO: verify output matches GNU pr behavior (form feed elimination)
+    new_ucmd!().args(&["-T"]).pipe_in("a\nb\n").succeeds();
+    new_ucmd!()
+        .args(&["--omit-pagination"])
+        .pipe_in("a\nb\n")
+        .succeeds();
+}


### PR DESCRIPTION
The strategy I'm taking with fixing all of the issues with the PR utility is to first add all of the missing options, then to focus on fixing how those options are used. Right now we are down to 665 failing tests and 87 of those failures are status code mismatches from invalid options. This makes the failures stay at 665 but the amount of status code mismatches goes down to 48 after this. The logic for omit pagination is added here, but the stripping of the form feeds is not implemented. 

There are multiple underlying issues in the PR implementation that I don't think it would be the best idea to try and implement it all at once, I'm hoping after all of the options are recognized and parsed correctly we can start tackling the output matching logic to make more of the tests pass and implement tests that validate the output.