### PR TITLE
timeout: use nix kill/setpgid to reduce unsafe

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -27,8 +27,8 @@ use uucore::{
     signals::{signal_by_name_or_value, signal_name_by_value},
 };
 
-use nix::sys::signal::{kill, Signal};
-use nix::unistd::{getpid, setpgid, Pid};
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::{Pid, getpid, setpgid};
 
 pub mod options {
     pub static FOREGROUND: &str = "foreground";


### PR DESCRIPTION
- Replace libc::kill(getpid(), signal) and libc::setpgid(0, 0) in timeout with the nix equivalents, removing those unsafe blocks.
- Improves safety/readability by using higher‑level, checked APIs.