### PR TITLE
hashsum: --text --binary is not error

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -262,7 +262,6 @@ pub fn uu_app() -> Command {
                 .long(options::TEXT)
                 .short('t')
                 .hide(true)
-                .overrides_with(options::BINARY)
                 .action(ArgAction::SetTrue)
                 .requires(options::UNTAGGED),
         )

--- a/src/uu/hashsum/src/hashsum.rs
+++ b/src/uu/hashsum/src/hashsum.rs
@@ -245,6 +245,7 @@ pub fn uu_app_common() -> Command {
                         translate!("hashsum-help-binary-other")
                     }
                 })
+                .overrides_with(options::TEXT)
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -278,7 +279,6 @@ pub fn uu_app_common() -> Command {
                         translate!("hashsum-help-text-other")
                     }
                 })
-                .conflicts_with("binary")
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -237,6 +237,19 @@ fn test_check_sha1() {
         .stderr_is("");
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn test_text_binary_device() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ccmd("md5sum")
+        .arg("--text")
+        .arg("--binary")
+        .arg("/dev/null")
+        .succeeds();
+}
+
 #[test]
 fn test_check_md5_ignore_missing() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
1. Let `md5sum --text --binary` success.
2. Deduplicate `conflicts_with` of `cksum` as it does each other automatically.