### PR TITLE
hashsum: Fix --text --tag, improve message for --warn --text, and make code similar with cksum

### DIFF
--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -606,6 +606,19 @@ fn test_conflicting_arg() {
         .fails_with_code(1);
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn test_text_tag_device() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ccmd("md5sum")
+        .arg("--text")
+        .arg("--tag")
+        .arg("/dev/null")
+        .succeeds();
+}
+
 #[test]
 fn test_tag() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
I noticed that it is useful to add `--untagged` to keep code similar with `cksum`.
This PR fixes
1. `md5sum --text --tag`, fixes #10114 (Replaces #10125 with reduced lines) 
2. Use better error message for `--warn --text` and improve a workaround for clap's bug
3. Add virtual `--untagged` to keep code similar with `cksum`