### PR TITLE
cksum: Backport --text --tag and --binary --tag --untagged fix from GNU's main

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -214,9 +214,7 @@ pub fn uu_app() -> Command {
                 .long(options::TAG)
                 .help(translate!("cksum-help-tag"))
                 .action(ArgAction::SetTrue)
-                .overrides_with(options::UNTAGGED)
-                .overrides_with(options::BINARY)
-                .overrides_with(options::TEXT),
+                .conflicts_with(options::TEXT),
         )
         .arg(
             Arg::new(options::LENGTH)

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1010,13 +1010,13 @@ fn test_reset_binary() {
 
     scene
         .ucmd()
-        .arg("--binary") // should disappear because of the following option
+        .arg("--binary")
         .arg("--tag")
         .arg("--untagged")
         .arg("--algorithm=md5")
         .arg(at.subdir.join("f"))
         .succeeds()
-        .stdout_contains("d41d8cd98f00b204e9800998ecf8427e  ");
+        .stdout_contains("d41d8cd98f00b204e9800998ecf8427e *");
 }
 
 #[test]
@@ -1047,13 +1047,11 @@ mod output_format {
         let (at, mut ucmd) = at_and_ucmd!();
         at.touch("f");
 
-        ucmd.arg("--text") // should disappear because of the following option
+        ucmd.arg("--text")
             .arg("--tag")
             .args(&["-a", "md5"])
             .arg(at.subdir.join("f"))
-            .succeeds()
-            // Tagged output is used
-            .stdout_contains("f) = d41d8cd98f00b204e9800998ecf8427e");
+            .fails_with_code(1); // with clap generated message
     }
 
     #[test]
@@ -1179,7 +1177,7 @@ fn test_binary_file() {
         .arg("--untagged")
         .arg("lorem_ipsum.txt")
         .succeeds()
-        .stdout_is("cd724690f7dc61775dfac400a71f2caa  lorem_ipsum.txt\n");
+        .stdout_is("cd724690f7dc61775dfac400a71f2caa *lorem_ipsum.txt\n");
 }
 
 #[test]

--- a/tests/by-util/test_hashsum.rs
+++ b/tests/by-util/test_hashsum.rs
@@ -604,6 +604,11 @@ fn test_conflicting_arg() {
         .arg("--text")
         .arg("--md5")
         .fails_with_code(1);
+    new_ucmd!()
+        .arg("--text")
+        .arg("--tag")
+        .arg("--b2sum")
+        .fails_with_code(1);
 }
 
 #[test]

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -323,6 +323,7 @@ test \$n_stat1 -ge \$n_stat2 \\' tests/ls/stat-free-color.sh
 # clap changes the error message. Check exit code only.
 "${SED}" -i -e  "s|Try 'md5sum --help' for more information.\\\n||" tests/cksum/md5sum.pl
 "${SED}" -i '/check-ignore-missing-4/,/EXIT/c \     ['\''check-ignore-missing-4'\'', '\''--ignore-missing'\'', {IN=> {f=> '\'''\''}}, {ERR_SUBST=>"s/.*//s"}, {EXIT=> 1}],' tests/cksum/md5sum.pl
+"${SED}" -i  "/^.*the --tag option is meaningless/d" tests/cksum/cksum-c.sh
 # Our ls command always outputs ANSI color codes prepended with a zero. However,
 # in the case of GNU, it seems inconsistent. Nevertheless, it looks like it
 # doesn't matter whether we prepend a zero or not.

--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -3,6 +3,9 @@ ver="9.9"
 repo=https://github.com/coreutils/coreutils
 curl -L "${repo}/releases/download/v${ver}/coreutils-${ver}.tar.xz" | tar --strip-components=1 -xJf -
 
+# Accurate error on *sum
+curl -L ${repo}/raw/refs/heads/master/tests/cksum/cksum-a.sh > tests/cksum/cksum-a.sh
+curl -L ${repo}/raw/refs/heads/master/tests/cksum/cksum-c.sh > tests/cksum/cksum-c.sh
 # TODO stop backporting tests from master at GNU coreutils > 9.9
 curl -L ${repo}/raw/refs/heads/master/tests/mv/hardlink-case.sh > tests/mv/hardlink-case.sh
 curl -L ${repo}/raw/refs/heads/master/tests/mkdir/writable-under-readonly.sh > tests/mkdir/writable-under-readonly.sh


### PR DESCRIPTION
GNU coreutils has 2 bugs:
- `--tag --untagged` bypasses `--binary`
- `--text --tag` bypasses the error
fixed at master branch. We should fix those legacy bugs too now.
Closes #10130