### PR TITLE
deny.toml: add `constant_time_eq` to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,8 @@ skip = [
   { name = "linux-raw-sys", version = "0.11.0" },
   # crossterm
   { name = "signal-hook", version = "0.3.18" },
+  # blake2b_simd
+  { name = "constant_time_eq", version = "0.3.1" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
This PR adds `constant_time_eq` to the skip list in `deny.toml` because https://github.com/uutils/coreutils/pull/10132 added an additional version of `constant_time_eq`.