### PR TITLE
numfmt: support empty delimiter to treat line as single field

### DIFF
--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1147,3 +1147,12 @@ fn test_unit_separator() {
         new_ucmd!().args(args).succeeds().stdout_only(expected);
     }
 }
+
+#[test]
+fn test_empty_delimiter() {
+    // Empty delimiter treats entire line as single field
+    new_ucmd!()
+        .args(&["-d", "", "--from=auto", "40M"])
+        .succeeds()
+        .stdout_only("40000000\n");
+}


### PR DESCRIPTION
Around 20 of the failing GNU test cases are partially failing because they use an empty delimiter in the test case. GNU supports empty delimiters and this change adds logic to be able to parse the empty delimiter as an empty field. After this change it will be a smaller change to add the delimiter parsing