### PR TITLE
cp: Adding dd to SELinux CI to enable cp-a-selinux

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -93,7 +93,7 @@ export CARGOFLAGS # tell to make
 ln -vf "${UU_BUILD_DIR}/install" "${UU_BUILD_DIR}/ginstall" # The GNU tests use renamed install to ginstall
 if [ "${SELINUX_ENABLED}" = 1 ];then
     # Build few utils for SELinux for faster build. MULTICALL=y fails...
-    "${MAKE}" UTILS="cat chcon chmod cp cut echo env groups id ln ls mkdir mkfifo mknod mktemp mv printf rm rmdir runcon stat test touch tr true uname wc whoami"
+    "${MAKE}" UTILS="cat chcon chmod cp cut dd echo env groups id ln ls mkdir mkfifo mknod mktemp mv printf rm rmdir runcon stat test touch tr true uname wc whoami"
 else
     # Use MULTICALL=y for faster build
     "${MAKE}" MULTICALL=y SKIP_UTILS="install more seq"


### PR DESCRIPTION
The GNU test cp-a-selinux was failing previously, but after the optimization to reduce the amount of built bins in the SELinux GNU CI it began skipping this test because this test relied on dd to setup the test. By adding this back the test moves from SKIP to FAIL and I have a followup PR with the fixes to make this test PASS