### PR TITLE
ci: add df/skip-rootfs test to SMACK/ROOTFS CI

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -31,7 +31,7 @@ env:
   TEST_STTY_FULL_SUMMARY_FILE: 'gnu-stty-full-result.json'
   TEST_SELINUX_FULL_SUMMARY_FILE: 'selinux-gnu-full-result.json'
   TEST_SELINUX_ROOT_FULL_SUMMARY_FILE: 'selinux-root-gnu-full-result.json'
-  TEST_SMACK_FULL_SUMMARY_FILE: 'smack-gnu-full-result.json'
+  TEST_QEMU_FULL_SUMMARY_FILE: 'qemu-gnu-full-result.json'
 
 jobs:
   native:
@@ -317,8 +317,8 @@ jobs:
           gnu/tests-selinux/*.log
           gnu/tests-selinux/*/*.log.gz
 
-  smack:
-    name: Run GNU tests (SMACK)
+  qemu:
+    name: Run GNU tests (SMACK/ROOTFS)
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout code (uutils)
@@ -338,30 +338,30 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y qemu-system-x86 zstd cpio
-    - name: Run GNU SMACK tests
+    - name: Run GNU SMACK/ROOTFS tests
       run: |
         cd uutils
-        bash util/run-gnu-tests-smack-ci.sh "$GITHUB_WORKSPACE/gnu" "$GITHUB_WORKSPACE/gnu/tests-smack"
+        bash util/run-gnu-tests-smack-ci.sh "$GITHUB_WORKSPACE/gnu" "$GITHUB_WORKSPACE/gnu/tests-qemu"
     - name: Extract testing info into JSON
       run: |
-        python3 uutils/util/gnu-json-result.py gnu/tests-smack > ${{ env.TEST_SMACK_FULL_SUMMARY_FILE }}
-    - name: Upload SMACK json results
+        python3 uutils/util/gnu-json-result.py gnu/tests-qemu > ${{ env.TEST_QEMU_FULL_SUMMARY_FILE }}
+    - name: Upload SMACK/ROOTFS json results
       uses: actions/upload-artifact@v6
       with:
-        name: smack-gnu-full-result
-        path: ${{ env.TEST_SMACK_FULL_SUMMARY_FILE }}
-    - name: Compress SMACK test logs
-      run: gzip gnu/tests-smack/*/*.log 2>/dev/null || true
-    - name: Upload SMACK test logs
+        name: qemu-gnu-full-result
+        path: ${{ env.TEST_QEMU_FULL_SUMMARY_FILE }}
+    - name: Compress SMACK/ROOTFS test logs
+      run: gzip gnu/tests-qemu/*/*.log 2>/dev/null || true
+    - name: Upload SMACK/ROOTFS test logs
       uses: actions/upload-artifact@v6
       with:
-        name: smack-test-logs
+        name: qemu-test-logs
         path: |
-          gnu/tests-smack/*.log
-          gnu/tests-smack/*/*.log.gz
+          gnu/tests-qemu/*.log
+          gnu/tests-qemu/*/*.log.gz
 
   aggregate:
-    needs: [native, selinux, smack]
+    needs: [native, selinux, qemu]
     permissions:
       actions: read  # for dawidd6/action-download-artifact to query and download artifacts
       contents: read  # for actions/checkout to fetch code
@@ -426,10 +426,10 @@ jobs:
         name: selinux-root-gnu-full-result
         path: results
         merge-multiple: true
-    - name: Download smack json results
+    - name: Download SMACK/ROOTFS json results
       uses: actions/download-artifact@v7
       with:
-        name: smack-gnu-full-result
+        name: qemu-gnu-full-result
         path: results
         merge-multiple: true
     - name: Extract/summarize testing info

--- a/.vscode/cspell.dictionaries/jargon.wordlist.txt
+++ b/.vscode/cspell.dictionaries/jargon.wordlist.txt
@@ -126,6 +126,7 @@ pseudoprime
 pseudoprimes
 quantiles
 readonly
+ROOTFS
 reparse
 rposition
 seedable

--- a/util/run-gnu-tests-smack-ci.sh
+++ b/util/run-gnu-tests-smack-ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run GNU SMACK tests in QEMU with SMACK-enabled kernel
+# Run GNU SMACK/ROOTFS tests in QEMU with SMACK-enabled kernel
 # Usage: run-gnu-tests-smack-ci.sh [GNU_DIR] [OUTPUT_DIR]
 # spell-checker:ignore rootfs zstd unzstd cpio newc nographic smackfs devtmpfs tmpfs poweroff libm libgcc libpthread libdl librt sysfs rwxat setuidgid
 set -e
@@ -7,12 +7,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 GNU_DIR="${1:-$REPO_DIR/../gnu}"
-OUTPUT_DIR="${2:-$REPO_DIR/target/smack-test-results}"
-SMACK_DIR="$REPO_DIR/target/smack-test"
+OUTPUT_DIR="${2:-$REPO_DIR/target/qemu-test-results}"
+QEMU_DIR="$REPO_DIR/target/qemu-test"
 
-echo "Setting up SMACK test environment..."
-rm -rf "$SMACK_DIR"
-mkdir -p "$SMACK_DIR"/{rootfs/{bin,lib64,proc,sys,dev,tmp,etc,gnu},kernel}
+echo "Setting up SMACK/ROOTFS test environment..."
+rm -rf "$QEMU_DIR"
+mkdir -p "$QEMU_DIR"/{rootfs/{bin,lib64,proc,sys,dev,tmp,etc,gnu},kernel}
 
 # Download Arch Linux kernel (has SMACK built-in)
 if [ ! -f /tmp/arch-vmlinuz ]; then
@@ -24,31 +24,31 @@ if [ ! -f /tmp/arch-vmlinuz ]; then
     mv "/tmp/$VMLINUZ_PATH" /tmp/arch-vmlinuz
     rm -rf /tmp/usr /tmp/arch-kernel.pkg.tar /tmp/arch-kernel.pkg.tar.zst
 fi
-cp /tmp/arch-vmlinuz "$SMACK_DIR/kernel/vmlinuz"
+cp /tmp/arch-vmlinuz "$QEMU_DIR/kernel/vmlinuz"
 
 # Setup busybox
 BUSYBOX=/tmp/busybox
 [ -f "$BUSYBOX" ] || curl -sL -o "$BUSYBOX" https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox
 chmod +x "$BUSYBOX"
-cp "$BUSYBOX" "$SMACK_DIR/rootfs/bin/"
-(cd "$SMACK_DIR/rootfs/bin" && "$BUSYBOX" --list | xargs -I{} ln -sf busybox {} 2>/dev/null)
+cp "$BUSYBOX" "$QEMU_DIR/rootfs/bin/"
+(cd "$QEMU_DIR/rootfs/bin" && "$BUSYBOX" --list | xargs -I{} ln -sf busybox {} 2>/dev/null)
 
 # Copy required libraries
 for lib in ld-linux-x86-64.so.2 libc.so.6 libm.so.6 libgcc_s.so.1 libpthread.so.0 libdl.so.2 librt.so.1; do
     path=$(ldconfig -p | grep "$lib" | head -1 | awk '{print $NF}')
-    [ -n "$path" ] && [ -f "$path" ] && cp -L "$path" "$SMACK_DIR/rootfs/lib64/" 2>/dev/null || true
+    [ -n "$path" ] && [ -f "$path" ] && cp -L "$path" "$QEMU_DIR/rootfs/lib64/" 2>/dev/null || true
 done
 
 # Create minimal config files
-echo -e "root:x:0:0:root:/root:/bin/sh\nnobody:x:65534:65534:nobody:/nonexistent:/bin/sh" > "$SMACK_DIR/rootfs/etc/passwd"
-echo -e "root:x:0:\nnobody:x:65534:" > "$SMACK_DIR/rootfs/etc/group"
-touch "$SMACK_DIR/rootfs/etc/mtab"
+echo -e "root:x:0:0:root:/root:/bin/sh\nnobody:x:65534:65534:nobody:/nonexistent:/bin/sh" > "$QEMU_DIR/rootfs/etc/passwd"
+echo -e "root:x:0:\nnobody:x:65534:" > "$QEMU_DIR/rootfs/etc/group"
+touch "$QEMU_DIR/rootfs/etc/mtab"
 
 # Copy GNU tests
-cp -r "$GNU_DIR/tests" "$SMACK_DIR/rootfs/gnu/"
+cp -r "$GNU_DIR/tests" "$QEMU_DIR/rootfs/gnu/"
 
 # Create init script
-cat > "$SMACK_DIR/rootfs/init" << 'INIT'
+cat > "$QEMU_DIR/rootfs/init" << 'INIT'
 #!/bin/sh
 mount -t proc proc /proc
 mount -t sysfs sys /sys
@@ -73,24 +73,24 @@ fi
 echo "EXIT:$?"
 poweroff -f
 INIT
-chmod +x "$SMACK_DIR/rootfs/init"
+chmod +x "$QEMU_DIR/rootfs/init"
 
-# Build utilities with SMACK support
-echo "Building utilities with SMACK support..."
-cargo build --release --manifest-path="$REPO_DIR/Cargo.toml" --package uu_id --features uu_id/smack --package uu_ls --features uu_ls/smack --package uu_mkdir --features uu_mkdir/smack --package uu_mkfifo --features uu_mkfifo/smack --package uu_mknod --features uu_mknod/smack
+# Build utilities for SMACK/ROOTFS tests
+echo "Building utilities for SMACK/ROOTFS tests..."
+cargo build --release --manifest-path="$REPO_DIR/Cargo.toml" --package uu_id --features uu_id/smack --package uu_ls --features uu_ls/smack --package uu_mkdir --features uu_mkdir/smack --package uu_mkfifo --features uu_mkfifo/smack --package uu_mknod --features uu_mknod/smack --package uu_df
 
-# Find SMACK tests
-SMACK_TESTS=$(grep -l 'require_smack_' -r "$GNU_DIR/tests/" 2>/dev/null || true)
-[ -z "$SMACK_TESTS" ] && { echo "No SMACK tests found"; exit 0; }
+# Find SMACK tests and tests requiring rootfs in mtab (only available in QEMU environment)
+QEMU_TESTS=$(grep -l -E 'require_smack_|rootfs in mtab' -r "$GNU_DIR/tests/" 2>/dev/null | sort -u || true)
+[ -z "$QEMU_TESTS" ] && { echo "No SMACK/ROOTFS tests found"; exit 0; }
 
-echo "Found $(echo "$SMACK_TESTS" | wc -l) SMACK tests"
+echo "Found $(echo "$QEMU_TESTS" | wc -l) SMACK/ROOTFS tests"
 
 # Create output directory
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
 # Run each test
-for TEST_PATH in $SMACK_TESTS; do
+for TEST_PATH in $QEMU_TESTS; do
     TEST_REL="${TEST_PATH#"$GNU_DIR"/tests/}"
     TEST_DIR=$(dirname "$TEST_REL")
     TEST_NAME=$(basename "$TEST_REL" .sh)
@@ -104,12 +104,12 @@ for TEST_PATH in $SMACK_TESTS; do
     fi
 
     # Create working copy
-    WORK="/tmp/smack-test-$$"
+    WORK="/tmp/qemu-test-$$"
     rm -rf "$WORK" "$WORK.gz"
-    cp -a "$SMACK_DIR/rootfs" "$WORK"
+    cp -a "$QEMU_DIR/rootfs" "$WORK"
 
-    # Copy built utilities with SMACK support
-    for U in id ls mkdir mkfifo mknod; do
+    # Copy built utilities for SMACK/ROOTFS tests
+    for U in id ls mkdir mkfifo mknod df; do
         rm -f "$WORK/bin/$U"
         cp "$REPO_DIR/target/release/$U" "$WORK/bin/$U"
     done
@@ -126,7 +126,7 @@ for TEST_PATH in $SMACK_TESTS; do
     (cd "$WORK" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK.gz")
 
     OUTPUT=$(timeout 120 qemu-system-x86_64 \
-        -kernel "$SMACK_DIR/kernel/vmlinuz" \
+        -kernel "$QEMU_DIR/kernel/vmlinuz" \
         -initrd "$WORK.gz" \
         -append "console=ttyS0 quiet panic=-1 security=smack lsm=smack" \
         -nographic -m 256M -no-reboot 2>&1) || true


### PR DESCRIPTION
So from first glance this PR seems more complicated than it actually is, the only functional change in the whole PR is adding 

```
--package uu_df
```

and

Adding rootfs in mtab to the grep to search for tests. The rest of the changes are renaming all of the places I named the CI runner the "SMACK" runner to reflect that the tests being run here are the QEMU tests that will use QEMU to emulate environments for the more unique environments.

This doesn't actually make any fixes for the rootfs test, it just lets us run it on the SMACK host that happens to have rootfs visible. 