### PR TITLE
tail: fix pipe-f test by detecting broken stdout pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3995,7 +3995,6 @@ version = "0.5.0"
 dependencies = [
  "clap",
  "fluent",
- "nix",
  "uucore",
 ]
 

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -265,7 +265,6 @@ fn tail_stdin(
             } else {
                 let mut reader = BufReader::new(stdin());
                 unbounded_tail(&mut reader, settings)?;
-                observer.add_stdin(input.display_name.as_str(), Some(Box::new(reader)), true)?;
             }
         }
     }

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/tee.rs"
 
 [dependencies]
 clap = { workspace = true }
-nix = { workspace = true, features = ["poll", "fs"] }
 uucore = { workspace = true, features = ["libc", "parser", "signals"] }
 fluent = { workspace = true }
 

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -93,6 +93,7 @@ nix = { workspace = true, features = [
   "signal",
   "dir",
   "user",
+  "poll",
 ] }
 xattr = { workspace = true, optional = true }
 

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -4961,3 +4961,29 @@ fn tail_n_lines_with_emoji() {
         .succeeds()
         .stdout_only("💐\n");
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_follow_pipe_f() {
+    new_ucmd!()
+        .args(&["-f", "-c3", "-s.1", "--max-unchanged-stats=1"])
+        .pipe_in("foo\n")
+        .succeeds()
+        .stdout_only("oo\n");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_follow_stdout_pipe_close() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("f", "line1\nline2\n");
+
+    let mut child = ucmd
+        .args(&["-f", "-s.1", "--max-unchanged-stats=1", "f"])
+        .set_stdout(Stdio::piped())
+        .run_no_wait();
+
+    child.stdout_exact_bytes(6); // read "line1\n"
+    child.close_stdout();
+    child.delay(2000).make_assertion().is_not_alive();
+}


### PR DESCRIPTION
There are two high level changes in this PR, the first is that when timing out, validating that stdout is still valid. This was implemented by moving the function that validates stdout from tee to signal and then using it in the tail utility.

The second change is harder to wrap my head around, its removing stdin from the observing group. Which was implemented like this:
```
observer.add_stdin(input.display_name.as_str(), Some(Box::new(reader)), true)?;
```

When I was doing research on why one would follow stdin, all of the information I could find said that stdin cannot be meaningfully followed and that no new information could arrive after EOF, so that removing this would solve the issue of continuously waiting on stdin instead of waiting forever.

Maybe someone could explain to me why we were doing this, but as far as I can tell it is not required and has the side effect of causing it to hang even when the stdin is closed.