### PR TITLE
df: add rootfs to is_dummy_filesystem

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -393,6 +393,8 @@ fn is_dummy_filesystem(fs_type: &str, mount_option: &str) -> bool {
         | "kernfs"
         // for Irix 6.5
         | "ignore"
+        // Linux initial root filesystem
+        | "rootfs"
         // Binary format support pseudo-filesystem
         | "binfmt_misc" => true,
         _ => fs_type == "none"


### PR DESCRIPTION
The purpose of the rootfs file system test is to validate that the df treats rootfs as a "dummy" filesystem and we already had all of the logic related to dummy filesystems implemented, just was missing the entry of the rootfs filesystem in the list. 

This should fix the "rootfs" GNU test.