### PR TITLE
refactor(chroot): replace libc with nix crate for Unix system calls

### DIFF
--- a/src/uu/chroot/Cargo.toml
+++ b/src/uu/chroot/Cargo.toml
@@ -22,6 +22,7 @@ clap = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs"] }
 fluent = { workspace = true }
+nix = { workspace = true }
 
 [[bin]]
 name = "chroot"

--- a/src/uu/chroot/src/error.rs
+++ b/src/uu/chroot/src/error.rs
@@ -4,12 +4,12 @@
 // file that was distributed with this source code.
 // spell-checker:ignore NEWROOT Userspec userspec
 //! Errors returned by chroot.
+use nix::unistd::Uid;
 use std::io::Error;
 use std::path::PathBuf;
 use thiserror::Error;
 use uucore::display::Quotable;
 use uucore::error::UError;
-use uucore::libc;
 use uucore::translate;
 
 /// Errors that can happen while executing chroot.
@@ -41,7 +41,7 @@ pub enum ChrootError {
     MissingNewRoot,
 
     #[error("{}", translate!("chroot-error-no-group-specified", "uid" => _0))]
-    NoGroupSpecified(libc::uid_t),
+    NoGroupSpecified(Uid),
 
     /// Failed to find the specified user.
     #[error("{}", translate!("chroot-error-no-such-user"))]


### PR DESCRIPTION
### Summary
Replace direct calls to libc functions (chroot, setgid, setgroups, setuid) with safer nix crate equivalents. Update types from libc::uid_t/gid_t to nix::unistd::Uid/Gid for consistency and improved error handling. This enhances portability and reduces unsafe code usage.