### PR TITLE
printf 1 > /dev/full is not silent

### DIFF
--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -113,7 +113,7 @@ impl Display for FormatError {
             Self::InvalidPrecision(precision) => write!(f, "invalid precision: '{precision}'"),
             // TODO: Error message below needs some work
             Self::WrongSpecType => write!(f, "wrong % directive type was given"),
-            Self::IoError(_) => write!(f, "write error"),
+            Self::IoError(e) => write!(f, "write error: {e}"),
             Self::NoMoreArguments => write!(f, "no more arguments"),
             Self::InvalidArgument(_) => write!(f, "invalid argument"),
             Self::MissingHex => write!(f, "missing hexadecimal number in escape"),

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1490,5 +1490,5 @@ fn test_extreme_field_width_overflow() {
     new_ucmd!()
         .args(&["%999999999999999999999999d", "1"])
         .fails_with_code(1)
-        .stderr_only("printf: write error\n");
+        .stderr_contains("printf: write error"); //could contains additional message like "formatting width too large" not in GNU, thats fine.
 }


### PR DESCRIPTION
Make `printf 1 > /dev/full` error. Message is still wrong, but exit 1 at least.

By unknown reason, I can't add proper test stdout to `/dev/full`.