### PR TITLE
Avoid hostid > /dev/full panic

### DIFF
--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -7,6 +7,7 @@
 
 use clap::Command;
 use libc::{c_long, gethostid};
+use std::io::{Write, stdout};
 use uucore::{error::UResult, format_usage};
 
 use uucore::translate;
@@ -14,20 +15,6 @@ use uucore::translate;
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     uucore::clap_localization::handle_clap_result(uu_app(), args)?;
-    hostid();
-    Ok(())
-}
-
-pub fn uu_app() -> Command {
-    Command::new(uucore::util_name())
-        .version(uucore::crate_version!())
-        .help_template(uucore::localized_help_template(uucore::util_name()))
-        .about(translate!("hostid-about"))
-        .override_usage(format_usage(&translate!("hostid-usage")))
-        .infer_long_args(true)
-}
-
-fn hostid() {
     /*
      * POSIX says gethostid returns a "32-bit identifier" but is silent
      * whether it's sign-extended.  Turn off any sign-extension.  This
@@ -43,5 +30,15 @@ fn hostid() {
     let mask = 0xffff_ffff;
 
     result &= mask;
-    println!("{result:0>8x}");
+    writeln!(stdout().lock(), "{result:0>8x}")?;
+    Ok(())
+}
+
+pub fn uu_app() -> Command {
+    Command::new(uucore::util_name())
+        .version(uucore::crate_version!())
+        .help_template(uucore::localized_help_template(uucore::util_name()))
+        .about(translate!("hostid-about"))
+        .override_usage(format_usage(&translate!("hostid-usage")))
+        .infer_long_args(true)
 }


### PR DESCRIPTION
By unknown reason, the Rust test writing to /dev/full does not work as I expects.