### PR TITLE
timeout: display signal 0 as '0' instead of 'EXIT' in verbose mode

### DIFF
--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -210,7 +210,11 @@ fn catch_sigterm() {
 /// Report that a signal is being sent if the verbose flag is set.
 fn report_if_verbose(signal: usize, cmd: &str, verbose: bool) {
     if verbose {
-        let s = signal_name_by_value(signal).unwrap();
+        let s = if signal == 0 {
+            "0".to_string()
+        } else {
+            signal_name_by_value(signal).unwrap().to_string()
+        };
         show_error!(
             "{}",
             translate!("timeout-verbose-sending-signal", "signal" => s, "command" => cmd.quote())

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -58,7 +58,7 @@ fn test_verbose() {
         new_ucmd!()
             .args(&[verbose_flag, "-s0", "-k.1", ".1", "sleep", "1"])
             .fails()
-            .stderr_only("timeout: sending signal EXIT to command 'sleep'\ntimeout: sending signal KILL to command 'sleep'\n");
+            .stderr_only("timeout: sending signal 0 to command 'sleep'\ntimeout: sending signal KILL to command 'sleep'\n");
     }
 }
 


### PR DESCRIPTION
I've been spending the last two days working on the timeout utility now that we have SIGPIPE handling and theres a bunch of changes required to match the newest implementation of GNU timeout. This is one of the more simple changes where there was a change to treat exit as a special case and return 0 instead of EXIT. I'm just trying to split up whatever I can since the signal handling change is going to be a bigger change.