### PR TITLE
timeout: backport timeout tests from master

### DIFF
--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -4,6 +4,8 @@ repo=https://github.com/coreutils/coreutils
 curl -L "${repo}/releases/download/v${ver}/coreutils-${ver}.tar.xz" | tar --strip-components=1 -xJf -
 
 # TODO stop backporting tests from master at GNU coreutils > 9.9
+curl -L ${repo}/raw/refs/heads/master/tests/timeout/timeout.sh > tests/timeout/timeout.sh
+curl -L ${repo}/raw/refs/heads/master/tests/timeout/timeout-group.sh > tests/timeout/timeout-group.sh
 curl -L ${repo}/raw/refs/heads/master/tests/mv/hardlink-case.sh > tests/mv/hardlink-case.sh
 curl -L ${repo}/raw/refs/heads/master/tests/mkdir/writable-under-readonly.sh > tests/mkdir/writable-under-readonly.sh
 curl -L ${repo}/raw/refs/heads/master/tests/cp/cp-mv-enotsup-xattr.sh > tests/cp/cp-mv-enotsup-xattr.sh #spell-checker:disable-line


### PR DESCRIPTION
I was hoping to propose that from now on we base our tests in timeout for the latest changes to timeout post 9.9

The implementation when it comes to signal handling has changed quite a bit and I found that making changes to pass the original tests are incompatible with the newest tests and vice versa. It would be good to have only a single implementation to target to not waste time in having to update it again when we update the tests. This should also fix the flakiness we currently have with the timeout test