### PR TITLE
df: Add a mount_dev_id to use id's instead of paths

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -5,7 +5,7 @@
 
 //! Set of functions to manage file systems
 
-// spell-checker:ignore DATETIME getmntinfo subsecond (fs) cifs smbfs
+// spell-checker:ignore DATETIME getmntinfo subsecond (fs) cifs smbfs autofs binfmt
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "cygwin"))]
 const LINUX_MTAB: &str = "/etc/mtab";


### PR DESCRIPTION
I thought this would be an easier fix, but there's a lot that I did not understand from system file mounts. For example, what "over mounting" is and when a file system is over mounted.

```
ramones@fedora:~/git/coreutils$ diff <(df --all 2>/dev/null | sort) <(./target/release/df --all 2>/dev/null | sort) | head -20
20,21d19
< nsfs                   -         -         -    - /run/docker/netns/f28327792c0d
< overlay                -         -         -    - /var/lib/docker/overlay2/852ac0d36c2d3d13e4bcf9aad8d58cbb182c2b3ba289671e36138b7ce86ed7c2/merged
27c25
< systemd-1              -         -         -    - /proc/sys/fs/binfmt_misc
---
> systemd-1              0         0         0    - /proc/sys/fs/binfmt_misc
ramones@fedora:~/git/coreutils$ ./target/release/df --all 2>/dev/null | grep binfmt_misc
systemd-1              0         0         0    - /proc/sys/fs/binfmt_misc
binfmt_misc            0         0         0    - /proc/sys/fs/binfmt_misc
```