### PR TITLE
cp: Fixed posixly correct dangling symlink test

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2991,11 +2991,15 @@ fn test_copy_through_dangling_symlink() {
 fn test_copy_through_dangling_symlink_posixly_correct() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("file");
+    at.write("file", "content");
     at.symlink_file("nonexistent", "target");
     ucmd.arg("file")
         .arg("target")
         .env("POSIXLY_CORRECT", "1")
         .succeeds();
+    assert!(at.file_exists("nonexistent"));
+    let contents = at.read("nonexistent");
+    assert_eq!(contents, "content");
 }
 
 #[test]


### PR DESCRIPTION
Currently the check for copying through a dangling symlink doesn't check if the file was actually created and if the contents of the file is correct. This doesn't match GNU behaviour in `thru_dangling.sh`.

Issue met while implementing #10011.