### PR TITLE
tests/misc/coreutils.sh: Fail with invalid binary name

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -60,9 +60,12 @@ fn main() {
 
     let util_name = if let Some(&util) = matched_util {
         Some(OsString::from(util))
-    } else {
+    } else if binary_as_util.ends_with("utils") || binary_as_util.ends_with("box") {
+        // todo: Remove support of "*box" from binary
         uucore::set_utility_is_second_arg();
         args.next()
+    } else {
+        validation::not_found(&OsString::from(binary_as_util));
     };
 
     // 0th argument equals util name?

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -109,7 +109,7 @@ fn util_name_single() {
 #[test]
 #[cfg(unix)]
 fn util_invalid_name_help() {
-    use std::process::{Command, Stdio};
+    use std::process::Command;
 
     let scenario = TestScenario::new("invalid_name");
     if !scenario.bin_path.exists() {
@@ -117,22 +117,12 @@ fn util_invalid_name_help() {
         return;
     }
     symlink_file(&scenario.bin_path, scenario.fixtures.plus("invalid_name")).unwrap();
-    let child = Command::new(scenario.fixtures.plus("invalid_name"))
+    let code = Command::new(scenario.fixtures.plus("invalid_name"))
         .arg("--help")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
-    assert_eq!(output.status.code(), Some(0));
-    assert_eq!(output.stderr, b"");
-    let output_str = String::from_utf8(output.stdout).unwrap();
-    assert!(output_str.contains("(multi-call binary)"), "{output_str:?}");
-    assert!(
-        output_str.contains("Usage: invalid_name [function "),
-        "{output_str:?}"
-    );
+        .status()
+        .unwrap()
+        .code();
+    assert_eq!(code, Some(1));
 }
 
 #[test]
@@ -177,7 +167,7 @@ fn util_non_utf8_name_help() {
 #[test]
 #[cfg(unix)]
 fn util_invalid_name_invalid_command() {
-    use std::process::{Command, Stdio};
+    use std::process::Command;
 
     let scenario = TestScenario::new("invalid_name");
     symlink_file(&scenario.bin_path, scenario.fixtures.plus("invalid_name")).unwrap();
@@ -186,20 +176,11 @@ fn util_invalid_name_invalid_command() {
         return;
     }
 
-    let child = Command::new(scenario.fixtures.plus("invalid_name"))
-        .arg("definitely_invalid")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
-    assert_eq!(output.status.code(), Some(1));
-    assert_eq!(output.stdout, b"");
-    assert_eq!(
-        output.stderr,
-        b"definitely_invalid: function/utility not found\n"
-    );
+    let code = Command::new(scenario.fixtures.plus("invalid_name"))
+        .status()
+        .unwrap()
+        .code();
+    assert_eq!(code, Some(1));
 }
 
 #[test]

--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -16,6 +16,8 @@ sed -i -e 's/no-mtab-status.sh/no-mtab-status-masked-proc.sh/' -e 's/nproc-quota
 curl -L ${repo}/raw/refs/heads/master/tests/df/no-mtab-status-masked-proc.sh > tests/df/no-mtab-status-masked-proc.sh
 curl -L ${repo}/raw/refs/heads/master/tests/nproc/nproc-quota-systemd.sh > tests/nproc/nproc-quota-systemd.sh
 curl -L ${repo}/raw/refs/heads/master/tests/stty/bad-speed.sh > tests/stty/bad-speed.sh
+# symlink to /bin/false should fail with --help. Freeze commit to avoid regression.
+curl -L https://raw.githubusercontent.com/coreutils/coreutils/d5164f3d216917005003877faeb1abe7cae5d765/tests/misc/coreutils.sh > tests/misc/coreutils.sh
 # Better support for single binary
 curl -L ${repo}/raw/refs/heads/master/tests/env/env.sh > tests/env/env.sh
 # Avoid incorrect PASS


### PR DESCRIPTION
Fixes #10244
Also covers some (but no all of) use case for symlinking binary to `/bin/false`.