### PR TITLE
ls: fix symlink chain target coloring

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3398,10 +3398,15 @@ fn display_item_name(
                         }
                     }
 
-                    match fs::metadata(&absolute_target) {
-                        Ok(_) => {
-                            let target_data =
-                                PathData::new(absolute_target, None, None, config, false);
+                    match fs::canonicalize(&absolute_target) {
+                        Ok(resolved_target) => {
+                            let target_data = PathData::new(
+                                resolved_target,
+                                None,
+                                target_path.file_name().map(|s| s.to_os_string()),
+                                config,
+                                false,
+                            );
                             name.push(color_name(
                                 escaped_target,
                                 &target_data,


### PR DESCRIPTION
When I was reviewing this PR https://github.com/uutils/coreutils/pull/9006 I tried to do some fuzzing of the existing implementation to see if the PR was implementing any behaviour that was missing and came across that the ls utility was matching all of GNU's coloring except for on nested symlinks. 

When looking at what that was the case I saw that it was just a three line fix when compared to the the current implementation