### PR TITLE
 sort: on 32 bits, decrease the buf max size

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -126,6 +126,14 @@ const POSITIVE: &u8 = &b'+';
 // reasonably large chunks for typical workloads.
 const MIN_AUTOMATIC_BUF_SIZE: usize = 512 * 1024; // 512 KiB
 const FALLBACK_AUTOMATIC_BUF_SIZE: usize = 32 * 1024 * 1024; // 32 MiB
+// TODO: On 32-bit systems, use a smaller max buffer (256 MiB) to avoid allocation
+// failures due to limited virtual address space. This is a temporary fix.
+// GNU sort has more sophisticated memory allocation fallback mechanisms that
+// detect available memory and gracefully fallback to smaller buffers when
+// allocation fails. We should implement similar logic for better compatibility.
+#[cfg(target_pointer_width = "32")]
+const MAX_AUTOMATIC_BUF_SIZE: usize = 256 * 1024 * 1024; // 256 MiB
+#[cfg(not(target_pointer_width = "32"))]
 const MAX_AUTOMATIC_BUF_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
See
https://bugs.launchpad.net/ubuntu/+source/rust-coreutils/+bug/2137562