### PR TITLE
tee: allow multiple -a flags

### DIFF
--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -115,7 +115,8 @@ pub fn uu_app() -> Command {
                 .long(options::APPEND)
                 .short('a')
                 .help(translate!("tee-help-append"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::APPEND),
         )
         .arg(
             Arg::new(options::IGNORE_INTERRUPTS)

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -92,6 +92,30 @@ fn test_tee_append() {
 }
 
 #[test]
+fn test_tee_multiple_append_flags() {
+    // Test for bug: https://bugs.launchpad.net/ubuntu/+source/rust-coreutils/+bug/2134578
+    // The command should accept multiple -a flags for different files
+    let (at, mut ucmd) = at_and_ucmd!();
+    let content = "don't fail me now rust";
+    let file1 = "log1";
+    let file2 = "log2";
+
+    // Pre-populate files with some content to verify append behavior
+    at.write(file1, "existing1\n");
+    at.write(file2, "existing2\n");
+
+    ucmd.args(&["-a", file1, "-a", file2])
+        .pipe_in(content)
+        .succeeds()
+        .stdout_is(content);
+
+    assert!(at.file_exists(file1));
+    assert!(at.file_exists(file2));
+    assert_eq!(at.read(file1), format!("existing1\n{content}"));
+    assert_eq!(at.read(file2), format!("existing2\n{content}"));
+}
+
+#[test]
 fn test_readonly() {
     let (at, mut ucmd) = at_and_ucmd!();
     let content_tee = "hello";


### PR DESCRIPTION
fixes
https://bugs.launchpad.net/ubuntu/+source/rust-coreutils/+bug/2134578