### PR TITLE
pr: uniformly scan for form feed and newline chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,6 +3690,7 @@ dependencies = [
  "clap",
  "fluent",
  "itertools 0.14.0",
+ "memchr",
  "regex",
  "thiserror 2.0.17",
  "uucore",

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/pr.rs"
 clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "time"] }
 itertools = { workspace = true }
+memchr = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
 fluent = { workspace = true }


### PR DESCRIPTION
Fix the way form feed characters are interpreted by changing the way
lines and pages are found. Before this commit, a file comprising two
form feed characters (`/f/f`) would result in too few trailing newlines
at the end of the second page. After this change, each page is produced
with the correct number of lines.

This merge request changes the way files are read, replacing complex iterators
with a loop-based approach, iteratively scanning for newline or form
feed characters. The `memchr` library is used to efficiently scan for
these two characters. One downside of this implementation is that it
currently reads the entire input file into memory; this can be improved
in subsequent merge requests. The behavior of uutils `pr` is still quite different from GNU `pr`, so hopefully this is acceptable as a temporary debt to make many more straightforward improvements.

This merge request also removes a unit test that was enforcing incorrect behavior. These
tests were ostensibly designed to match corresponding ones in the GNU
test suite, but most of them don't match the current behavior of GNU `pr`, so it
does not seem valuable to keep them. As we improve uutils `pr`, we can add more targeted and minimal test cases to replace them.
