### PR TITLE
build-gnu.sh: Enable help-version-getopt.sh (PASS)

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -159,9 +159,7 @@ else
 
     # Remove tests checking for --version & --help
     # Not really interesting for us and logs are too big
-    sed -i -e '/tests\/help\/help-version.sh/ D' \
-        -e '/tests\/help\/help-version-getopt.sh/ D' \
-        Makefile
+    sed -i '/tests\/help\/help-version.sh/ D' Makefile
     touch gnu-built
 fi
 


### PR DESCRIPTION
I noticed that we can just pass it: https://github.com/uutils/coreutils/actions/runs/21109816589/job/60706686774?pr=10305#step:11:810