### PR TITLE
Drop find_prefixed_util

### DIFF
--- a/src/common/validation.rs
+++ b/src/common/validation.rs
@@ -62,19 +62,6 @@ fn get_canonical_util_name(util_name: &str) -> &str {
     }
 }
 
-/// Finds a utility with a prefix (e.g., "uu_test" -> "test")
-pub fn find_prefixed_util<'a>(
-    binary_name: &str,
-    mut util_keys: impl Iterator<Item = &'a str>,
-) -> Option<&'a str> {
-    util_keys.find(|util| {
-        binary_name.ends_with(*util)
-            && binary_name.len() > util.len() // Ensure there's actually a prefix
-            && !binary_name[..binary_name.len() - (*util).len()]
-                .ends_with(char::is_alphanumeric)
-    })
-}
-
 /// Gets the binary path from command line arguments
 /// # Panics
 /// Panics if the binary path cannot be determined
@@ -122,36 +109,5 @@ mod tests {
         // Test edge cases
         assert_eq!(name(Path::new("")), None);
         assert_eq!(name(Path::new("/")), None);
-    }
-
-    #[test]
-    fn test_find_prefixed_util() {
-        let utils = ["test", "cat", "ls", "cp"];
-
-        // Test exact prefixed matches
-        assert_eq!(
-            find_prefixed_util("uu_test", utils.iter().copied()),
-            Some("test")
-        );
-        assert_eq!(
-            find_prefixed_util("my-cat", utils.iter().copied()),
-            Some("cat")
-        );
-        assert_eq!(
-            find_prefixed_util("prefix_ls", utils.iter().copied()),
-            Some("ls")
-        );
-
-        // Test non-alphanumeric separator requirement
-        assert_eq!(find_prefixed_util("prefixcat", utils.iter().copied()), None); // no separator
-        assert_eq!(find_prefixed_util("testcat", utils.iter().copied()), None); // no separator
-
-        // Test no match
-        assert_eq!(find_prefixed_util("unknown", utils.iter().copied()), None);
-        assert_eq!(find_prefixed_util("", utils.iter().copied()), None);
-
-        // Test exact util name (should not match as prefixed)
-        assert_eq!(find_prefixed_util("test", utils.iter().copied()), None);
-        assert_eq!(find_prefixed_util("cat", utils.iter().copied()), None);
     }
 }


### PR DESCRIPTION
I guess it was used only for `coreutils` before https://github.com/uutils/coreutils/pull/10261