### PR TITLE
pr: ignore empty line after form feed char

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -849,9 +849,14 @@ fn get_pages(
         } else {
             // Add everything up to (but not including) the newline
             // character as one line of the page.
-            let file_line = FileLine::from_buf(file_id, page_num, line_num, &buf[prev..i])?;
-            page.push(file_line);
-            line_num += 1;
+            if i > 0 && i == prev && buf[i - 1] == FF {
+                // If the file has the pattern `\f\n`, don't treat the
+                // `\n` as its own line; instead ignore the empty line.
+            } else {
+                let file_line = FileLine::from_buf(file_id, page_num, line_num, &buf[prev..i])?;
+                page.push(file_line);
+                line_num += 1;
+            }
 
             // Remember where the last line ended.
             prev = i + 1;

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -631,3 +631,22 @@ fn test_form_feed_newlines() {
         .succeeds()
         .stdout_matches(&regex);
 }
+
+#[test]
+fn test_form_feed_followed_by_new_line() {
+    // Here we define the expected output.
+    let whitespace = " ".repeat(50);
+    let datetime_pattern = r"\d\d\d\d-\d\d-\d\d \d\d:\d\d";
+    let blank_lines_61 = "\n".repeat(61);
+    let blank_lines_60 = "\n".repeat(60);
+    let page1 = format!("\n\n{datetime_pattern}{whitespace}Page 1\n\n\n{blank_lines_61}");
+    let page2 = format!("\n\n{datetime_pattern}{whitespace}Page 2\n\n\nabc\n{blank_lines_60}");
+    let pattern = format!("{page1}{page2}");
+    let regex = Regex::new(&pattern).unwrap();
+
+    // Command line: `printf "\f\nabc" | pr`.
+    new_ucmd!()
+        .pipe_in("\x0c\nabc")
+        .succeeds()
+        .stdout_matches(&regex);
+}


### PR DESCRIPTION
*Depends on #10303.*

Fix a bug in `pr` where a newline character (`\n`) immediately following
a form feed character (`\f`) was incorrectly rendered as an extra blank
line in the output. After this commit, the newline is correctly ignored.