### PR TITLE
Change fuzz_seq_parse_number to should_pass: false

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -94,7 +94,7 @@ jobs:
           - { name: fuzz_parse_glob, should_pass: true }
           - { name: fuzz_parse_size, should_pass: true }
           - { name: fuzz_parse_time, should_pass: true }
-          - { name: fuzz_seq_parse_number, should_pass: true }
+          - { name: fuzz_seq_parse_number, should_pass: false }
           - { name: fuzz_non_utf8_paths, should_pass: true }
 
     steps:


### PR DESCRIPTION
Fails with:

Failing input:

	fuzz/artifacts/fuzz_seq_parse_number/crash-880e3fa1db64b55230dca321d3c6a3aa7c1ad977

Output of `std::fmt::Debug`:

	[48, 120, 55, 46, 48, 48, 49, 49, 48, 48, 48, 48, 48, 48, 48, 112, 45, 54, 56, 48, 48, 48, 49, 49, 49, 48, 48, 49, 53, 55, 57, 49, 55, 55, 55, 91, 55, 105, 110, 102, 105, 110, 105, 116, 121]

Reproduce with:

	cargo fuzz run fuzz_seq_parse_number fuzz/artifacts/fuzz_seq_parse_number/crash-880e3fa1db64b55230dca321d3c6a3aa7c1ad977

Minimize test case with:

	cargo fuzz tmin fuzz_seq_parse_number fuzz/artifacts/fuzz_seq_parse_number/crash-880e3fa1db64b55230dca321d3c6a3aa7c1ad977