### PR TITLE
CICD.yml: Drop unused apt-get

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -493,12 +493,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-    - name: Install dependencies
-      shell: bash
-      run: |
-        ## Install dependencies
-        sudo apt-get update
-        sudo apt-get install libselinux1-dev libsystemd-dev
     - name: "`make install`"
       shell: bash
       run: |


### PR DESCRIPTION
`feat_systemd` and `feat_selinux` is not used at here (and should not do that for size release).