### PR TITLE
runcon, chcon: Don't fetch crates at unsupported target

### DIFF
--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [lib]
 path = "src/chcon.rs"
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies] # todo: block fetching crates without feat_selinux
 clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs", "perms"] }
 selinux = { workspace = true }

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [lib]
 path = "src/runcon.rs"
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies] # todo: block fetching crates without feat_selinux
 clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs", "perms", "selinux"] }
 selinux = { workspace = true }


### PR DESCRIPTION
We have `*con` stubs for workspace build on Windows. But it still fetches useless crates e.g. `selinux-sys`. We should block them.

Related?: #9968