### PR TITLE
clippy: remove assigning_clones lint suppression

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1307,7 +1307,6 @@ fn parse_path_args(
     };
 
     if options.strip_trailing_slashes {
-        #[allow(clippy::assigning_clones)]
         for source in &mut paths {
             *source = source.components().as_path().to_owned();
         }

--- a/src/uu/df/src/filesystem.rs
+++ b/src/uu/df/src/filesystem.rs
@@ -291,7 +291,6 @@ mod tests {
         }
 
         #[test]
-        #[allow(clippy::assigning_clones)]
         fn test_dev_name_match() {
             let tmp = tempfile::TempDir::new().expect("Failed to create temp dir");
             let dev_name = std::fs::canonicalize(tmp.path())

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -49,7 +49,6 @@ impl WatcherRx {
             Tested for notify::InotifyWatcher and for notify::PollWatcher.
             */
             if let Some(parent) = path.parent() {
-                #[allow(clippy::assigning_clones)]
                 if parent.is_dir() {
                     path = parent.to_owned();
                 } else {


### PR DESCRIPTION
The lint was improved so suppression is unnecessary:

- https://github.com/rust-lang/rust-clippy/commit/233b5f208300c5e819185cd91208399b2a57e74b
- https://github.com/rust-lang/rust-clippy/commit/0dc265ff82fe861f673f20003e4370df52f50ff3