### PR TITLE
GNUmakefile: Extract *PROGS from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,6 @@ feat_common_core = [
 # "feat_Tier1" == expanded set of utilities which can be built/run on the usual rust "Tier 1" target platforms (ref: <https://forge.rust-lang.org/release/platform-support.html>)
 feat_Tier1 = [
   "feat_common_core",
-  #
   "arch",
   "hostname",
   "nproc",

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -77,110 +77,23 @@ ifneq (,$(findstring _NT,$(OS)))
 endif
 LN ?= ln -sf
 
-# Possible programs
-PROGS       := \
+PROGS :=  \
 	arch \
-	base32 \
-	base64 \
-	basenc \
-	basename \
-	cat \
-	cksum \
-	comm \
-	cp \
-	csplit \
-	cut \
-	date \
-	dd \
-	df \
-	dir \
-	dircolors \
-	dirname \
-	du \
-	echo \
-	env \
-	expand \
-	expr \
-	factor \
-	false \
-	fmt \
-	fold \
-	hashsum \
-	head \
 	hostname \
-	join \
-	link \
-	ln \
-	ls \
-	mkdir \
-	mktemp \
-	more \
-	mv \
-	nl \
-	numfmt \
 	nproc \
-	od \
-	paste \
-	pr \
-	printenv \
-	printf \
-	ptx \
-	pwd \
-	readlink \
-	realpath \
-	rm \
-	rmdir \
-	seq \
-	shred \
-	shuf \
-	sleep \
-	sort \
-	split \
-	sum \
 	sync \
-	tac \
-	tail \
-	tee \
-	test \
-	touch \
-	tr \
-	true \
-	truncate \
-	tsort \
 	uname \
-	unexpand \
-	uniq \
-	unlink \
-	vdir \
-	wc \
 	whoami \
-	yes
+	$(shell rustc examples/feat_common_core.rs && ./feat_common_core)
 
 UNIX_PROGS := \
-	chgrp \
-	chmod \
-	chown \
-	chroot \
-	groups \
 	hostid \
-	id \
-	install \
-	kill \
-	logname \
-	mkfifo \
-	mknod \
-	nice \
-	nohup \
-	pathchk \
 	pinky \
-	stat \
 	stdbuf \
-	stty \
-	timeout \
-	tty \
 	uptime \
 	users \
-	who
+	who \
+	$(shell rustc examples/feat_require_unix_core.rs && ./feat_require_unix_core)
 
 SELINUX_PROGS := \
 	chcon \

--- a/examples/feat_common_core.rs
+++ b/examples/feat_common_core.rs
@@ -1,0 +1,10 @@
+
+fn main() {
+    let s = std::fs::read_to_string("Cargo.toml").unwrap();
+    let v: Vec<_> = s.lines()
+        .skip_while(|l| !l.contains("feat_common_core = [")).skip(1)
+        .take_while(|l| !l.contains(']'))
+        .filter_map(|l| l.split('"').nth(1))
+        .collect();
+    println!("{}", v.join(" "));
+}

--- a/examples/feat_require_unix_core.rs
+++ b/examples/feat_require_unix_core.rs
@@ -1,0 +1,10 @@
+
+fn main() {
+    let s = std::fs::read_to_string("Cargo.toml").unwrap();
+    let v: Vec<_> = s.lines()
+        .skip_while(|l| !l.contains("feat_require_unix_core = [")).skip(1)
+        .take_while(|l| !l.contains(']'))
+        .filter_map(|l| l.split('"').nth(1))
+        .collect();
+    println!("{}", v.join(" "));
+}


### PR DESCRIPTION
Duplicated management of `*PROGS` previously caused build failure on Windows by unwanted `stty`.
So we should list them at build time. But it would add a build dep...

We should extend this for all `*PROGS`.