### PR TITLE
ci: move `-no-metrics` to `COMMON_EMULATOR_OPTIONS`

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,7 +22,7 @@ concurrency:
 env:
   TERMUX: v0.118.0
   KEY_POSTFIX: nextest+rustc-hash+adb+sshd+upgrade+XGB+inc18
-  COMMON_EMULATOR_OPTIONS: -no-window -noaudio -no-boot-anim -camera-back none -gpu off
+  COMMON_EMULATOR_OPTIONS: -no-metrics -no-window -noaudio -no-boot-anim -camera-back none -gpu off
   EMULATOR_DISK_SIZE: 12GB
   EMULATOR_HEAP_SIZE: 2048M
   EMULATOR_BOOT_TIMEOUT: 1200 # 20min
@@ -166,7 +166,7 @@ jobs:
         disk-size: ${{ env.EMULATOR_DISK_SIZE }}
         cores: ${{ env.EMULATOR_CORES }}
         force-avd-creation: false
-        emulator-options: ${{ env.COMMON_EMULATOR_OPTIONS }} -no-metrics -no-snapshot-save -snapshot ${{ env.AVD_CACHE_KEY }}
+        emulator-options: ${{ env.COMMON_EMULATOR_OPTIONS }} -no-snapshot-save -snapshot ${{ env.AVD_CACHE_KEY }}
         emulator-boot-timeout: ${{ env.EMULATOR_BOOT_TIMEOUT }}
         # This is not a usual script. Every line is executed in a separate shell with `sh -c`. If
         # one of the lines returns with error the whole script is failed (like running a script with


### PR DESCRIPTION
This PR is a follow-up to https://github.com/uutils/coreutils/pull/10051 where I overlooked that we set the `emulator-options` in two steps (`Build and Test` and `Create and cache emulator image`) and so I set `-no-metrics` only once. Thus the warning about the metrics collection is still shown.

The PR moves the `-no-metrics` setting to the `COMMON_EMULATOR_OPTIONS`, which should remove the warning.