### PR TITLE
Fixed tail --follow=name continuing to tail a symlink target, unlike GNU tail. Closes #10328

### DIFF
--- a/src/uu/tail/locales/en-US.ftl
+++ b/src/uu/tail/locales/en-US.ftl
@@ -58,6 +58,7 @@ tail-status-has-been-replaced-following-new-file = { $file } has been replaced; 
 tail-status-file-truncated = { $file }: file truncated
 tail-status-replaced-with-untailable-file = { $file } has been replaced with an untailable file
 tail-status-replaced-with-untailable-file-giving-up = { $file } has been replaced with an untailable file; giving up on this name
+tail-status-replaced-with-untailable-symlink = { $file } has been replaced with an untailable symbolic link
 tail-status-file-became-inaccessible = { $file } { $become_inaccessible }: { $no_such_file }
 tail-status-directory-containing-watched-file-removed = directory containing watched file was removed
 tail-status-backend-cannot-be-used-reverting-to-polling = { $backend } cannot be used, reverting to polling

--- a/src/uu/tail/locales/fr-FR.ftl
+++ b/src/uu/tail/locales/fr-FR.ftl
@@ -57,6 +57,7 @@ tail-status-has-been-replaced-following-new-file = { $file } a été remplacé ;
 tail-status-file-truncated = { $file } : fichier tronqué
 tail-status-replaced-with-untailable-file = { $file } a été remplacé par un fichier non suivable
 tail-status-replaced-with-untailable-file-giving-up = { $file } a été remplacé par un fichier non suivable ; abandon de ce nom
+tail-status-replaced-with-untailable-symlink = { $file } a été remplacé par un lien symbolique non suivable
 tail-status-file-became-inaccessible = { $file } { $become_inaccessible } : { $no_such_file }
 tail-status-directory-containing-watched-file-removed = le répertoire contenant le fichier surveillé a été supprimé
 tail-status-backend-cannot-be-used-reverting-to-polling = { $backend } ne peut pas être utilisé, retour au sondage

--- a/src/uu/tail/src/follow/files.rs
+++ b/src/uu/tail/src/follow/files.rs
@@ -7,7 +7,7 @@
 
 use crate::args::Settings;
 use crate::chunks::BytesChunkBuffer;
-use crate::paths::{HeaderPrinter, PathExtTail};
+use crate::paths::{HeaderPrinter, PathExtTail, path_is_symlink};
 use crate::text;
 use std::collections::HashMap;
 use std::collections::hash_map::Keys;
@@ -212,9 +212,7 @@ impl PathData {
             // Probably file was renamed/moved or removed again
             None
         };
-        let is_symlink = path
-            .symlink_metadata()
-            .is_ok_and(|meta| meta.file_type().is_symlink());
+        let is_symlink = path_is_symlink(path);
 
         Self::new(
             reader,

--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -228,6 +228,11 @@ pub fn path_is_tailable(path: &Path) -> bool {
     path.is_file() || path.exists() && path.metadata().is_ok_and(|meta| meta.is_tailable())
 }
 
+pub fn path_is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .is_ok_and(|meta| meta.file_type().is_symlink())
+}
+
 #[inline]
 #[cfg(unix)]
 pub fn stdin_is_bad_fd() -> bool {


### PR DESCRIPTION
Fixed tail --follow=name continuing to tail a symlink target, unlike GNU tail. Closes #10328. Also added a regression test for it. Note that I had a translation app do the French string, as I wasn't entirely sure on the protocol for PRs introducing new strings. Let me know if I need to change anything!
