### PR TITLE
Reduce duplicated management of supported utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,6 @@ feat_common_core = [
 # "feat_Tier1" == expanded set of utilities which can be built/run on the usual rust "Tier 1" target platforms (ref: <https://forge.rust-lang.org/release/platform-support.html>)
 feat_Tier1 = [
   "feat_common_core",
-  #
   "arch",
   "hostname",
   "nproc",

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -78,106 +78,15 @@ endif
 LN ?= ln -sf
 
 # Possible programs
-PROGS       := \
-	arch \
-	base32 \
-	base64 \
-	basenc \
-	basename \
-	cat \
-	cksum \
-	comm \
-	cp \
-	csplit \
-	cut \
-	date \
-	dd \
-	df \
-	dir \
-	dircolors \
-	dirname \
-	du \
-	echo \
-	env \
-	expand \
-	expr \
-	factor \
-	false \
-	fmt \
-	fold \
-	hashsum \
-	head \
-	hostname \
-	join \
-	link \
-	ln \
-	ls \
-	mkdir \
-	mktemp \
-	more \
-	mv \
-	nl \
-	numfmt \
-	nproc \
-	od \
-	paste \
-	pr \
-	printenv \
-	printf \
-	ptx \
-	pwd \
-	readlink \
-	realpath \
-	rm \
-	rmdir \
-	seq \
-	shred \
-	shuf \
-	sleep \
-	sort \
-	split \
-	sum \
-	sync \
-	tac \
-	tail \
-	tee \
-	test \
-	touch \
-	tr \
-	true \
-	truncate \
-	tsort \
-	uname \
-	unexpand \
-	uniq \
-	unlink \
-	vdir \
-	wc \
-	whoami \
-	yes
+PROGS := \
+	$(shell sed -n '/feat_Tier1 = \[/,/\]/p' Cargo.toml | sed '1d;2d' |tr -d '],"\n')\
+	$(shell sed -n '/feat_common_core = \[/,/\]/p' Cargo.toml | sed '1d' |tr -d '],"\n')
 
 UNIX_PROGS := \
-	chgrp \
-	chmod \
-	chown \
-	chroot \
-	groups \
+	$(shell sed -n '/feat_require_unix_core = \[/,/\]/p' Cargo.toml | sed '1d' |tr -d '],"\n') \
 	hostid \
-	id \
-	install \
-	kill \
-	logname \
-	mkfifo \
-	mknod \
-	nice \
-	nohup \
-	pathchk \
 	pinky \
-	stat \
 	stdbuf \
-	stty \
-	timeout \
-	tty \
 	uptime \
 	users \
 	who

--- a/util/show-utils.sh
+++ b/util/show-utils.sh
@@ -14,8 +14,8 @@ ME_parent_dir_abs="$("${REALPATH}" -mP -- "${ME_parent_dir}" || "${REALPATH}" --
 
 # refs: <https://forge.rust-lang.org/release/platform-support.html> , <https://docs.rs/platforms/0.2.1/platforms/platform/tier1/index.html>
 
-# default ("Tier 1" cross-platform) utility list
-default_utils="base32 base64 basename cat cksum comm cp cut date dircolors dirname echo env expand expr factor false fmt fold hashsum head join link ln ls mkdir mktemp more mv nl od paste printenv printf ptx pwd readlink realpath rm rmdir seq shred shuf sleep sort split sum tac tail tee test tr true truncate tsort unexpand uniq wc yes"
+# default utility list
+default_utils=$(sed -n '/feat_common_core = \[/,/\]/p' Cargo.toml | sed '1d' |tr -d '],"\n') # $(sed -n '/feat_Tier1 = \[/,/\]/p' Cargo.toml | sed '1d;2d' |tr -d '],"\n') too?
 
 project_main_dir="${ME_parent_dir_abs}"
 # printf 'project_main_dir="%s"\n' "${project_main_dir}"


### PR DESCRIPTION
Duplicated management pulls bugs related with build failure. Closes #9819
The environment having `make` should have `sed` too at least for...