### PR TITLE
fix: allow selinux on android

### DIFF
--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -17,7 +17,8 @@ workspace = true
 [lib]
 path = "src/chcon.rs"
 
-[target.'cfg(target_os = "linux")'.dependencies] # todo: block fetching crates without feat_selinux
+# TODO: block fetching crates without feat_selinux
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs", "perms"] }
 selinux = { workspace = true }

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -2,8 +2,10 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
 // spell-checker:ignore (vars) RFILE
-#![cfg(target_os = "linux")]
+
+#![cfg(any(target_os = "linux", target_os = "android"))]
 #![allow(clippy::upper_case_acronyms)]
 
 use clap::builder::ValueParser;

--- a/src/uu/chcon/src/errors.rs
+++ b/src/uu/chcon/src/errors.rs
@@ -2,7 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-#![cfg(target_os = "linux")]
+
+#![cfg(any(target_os = "linux", target_os = "android"))]
 
 use std::ffi::OsString;
 use std::fmt::Write;

--- a/src/uu/chcon/src/fts.rs
+++ b/src/uu/chcon/src/fts.rs
@@ -2,7 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-#![cfg(target_os = "linux")]
+
+#![cfg(any(target_os = "linux", target_os = "android"))]
 
 use std::ffi::{CStr, CString, OsStr};
 use std::marker::PhantomData;

--- a/src/uu/chcon/src/main.rs
+++ b/src/uu/chcon/src/main.rs
@@ -1,11 +1,18 @@
-// On non-Linux targets, provide a stub main to keep the binary target present
-// and the workspace buildable. Using item-level cfg avoids excluding the crate
-// entirely (via #![cfg(...)]), which can break tooling and cross builds that
-// expect this binary to exist even when it's a no-op off Linux.
-#[cfg(target_os = "linux")]
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! This package is specific to Android and some Linux distributions. On other
+//! targets, provide a stub main to keep the binary target present and the
+//! workspace buildable. Using item-level cfg avoids excluding the crate
+//! entirely (via #![cfg(...)]), which can break tooling and cross builds that
+//! expect this binary to exist even when it's a no-op off Linux.
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
 uucore::bin!(uu_chcon);
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn main() {
     eprintln!("chcon: SELinux is not supported on this platform");
     std::process::exit(1);

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1790,7 +1790,7 @@ pub(crate) fn copy_attributes(
         Ok(())
     })?;
 
-    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     handle_preserve(&attributes.context, || -> CopyResult<()> {
         // Get the source context and apply it to the destination
         if let Ok(context) = selinux::SecurityContext::of_path(source, false, false) {
@@ -2586,7 +2586,7 @@ fn copy_file(
         copy_attributes(source, dest, &options.attributes)?;
     }
 
-    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     if options.set_selinux_context && uucore::selinux::is_selinux_enabled() {
         // Set the given selinux permissions on the copied file.
         if let Err(e) =

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -10,7 +10,7 @@ mod mode;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use file_diff::diff;
 use filetime::{FileTime, set_file_times};
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 use selinux::SecurityContext;
 use std::ffi::OsString;
 use std::fmt::Debug;
@@ -27,7 +27,7 @@ use uucore::error::{FromIo, UError, UResult, UUsageError};
 use uucore::fs::dir_strip_dot_for_creation;
 use uucore::perms::{Verbosity, VerbosityLevel, wrap_chown};
 use uucore::process::{getegid, geteuid};
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 use uucore::selinux::{
     SeLinuxError, contexts_differ, get_selinux_security_context, is_selinux_enabled,
     selinux_error_description, set_selinux_security_context,
@@ -118,7 +118,7 @@ enum InstallError {
     #[error("{}", translate!("install-error-extra-operand", "operand" => .0.quote(), "usage" => .1.clone()))]
     ExtraOperand(OsString, String),
 
-    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     #[error("{}", .0)]
     SelinuxContextFailed(String),
 }
@@ -1004,7 +1004,7 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> UResult<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 fn get_context_for_selinux(b: &Behavior) -> Option<&String> {
     if b.default_context {
         None
@@ -1139,7 +1139,7 @@ fn need_copy(from: &Path, to: &Path, b: &Behavior) -> bool {
     false
 }
 
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 /// Sets the `SELinux` security context for install's -Z flag behavior.
 ///
 /// This function implements the specific behavior needed for install's -Z flag,
@@ -1173,7 +1173,7 @@ pub fn set_selinux_default_context(path: &Path) -> Result<(), SeLinuxError> {
     }
 }
 
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 /// Gets the default `SELinux` context for a path based on the system's security policy.
 ///
 /// This function attempts to determine what the "correct" `SELinux` context should be
@@ -1229,7 +1229,7 @@ fn get_default_context_for_path(path: &Path) -> Result<Option<String>, SeLinuxEr
     Ok(None)
 }
 
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 /// Derives an appropriate `SELinux` context based on a parent directory context.
 ///
 /// This is a heuristic function that attempts to generate an appropriate
@@ -1267,7 +1267,7 @@ fn derive_context_from_parent(parent_context: &str) -> String {
     }
 }
 
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 /// Helper function to collect paths that need `SELinux` context setting.
 ///
 /// Traverses from the given starting path up to existing parent directories.
@@ -1281,7 +1281,7 @@ fn collect_paths_for_context_setting(starting_path: &Path) -> Vec<&Path> {
     paths
 }
 
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 /// Sets the `SELinux` security context for a directory hierarchy.
 ///
 /// This function traverses from the given starting path up to existing parent directories
@@ -1321,7 +1321,7 @@ fn set_selinux_context_for_directories(target_path: &Path, context: Option<&Stri
     }
 }
 
-#[cfg(all(feature = "selinux", target_os = "linux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 /// Sets `SELinux` context for created directories using install's -Z default behavior.
 ///
 /// Similar to `set_selinux_context_for_directories` but uses install's
@@ -1345,10 +1345,10 @@ pub fn set_selinux_context_for_directories_install(target_path: &Path, context: 
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     use super::derive_context_from_parent;
 
-    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     #[test]
     fn test_derive_context_from_parent() {
         // Test cases: (input_context, file_type, expected_output, description)

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -373,7 +373,7 @@ pub struct Config {
     time_format_recent: String,        // Time format for recent dates
     time_format_older: Option<String>, // Time format for older dates (optional, if not present, time_format_recent is used)
     context: bool,
-    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     selinux_supported: bool,
     #[cfg(all(feature = "smack", target_os = "linux"))]
     smack_supported: bool,
@@ -1233,7 +1233,7 @@ impl Config {
             time_format_recent,
             time_format_older,
             context,
-            #[cfg(all(feature = "selinux", target_os = "linux"))]
+            #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
             selinux_supported: uucore::selinux::is_selinux_enabled(),
             #[cfg(all(feature = "smack", target_os = "linux"))]
             smack_supported: uucore::smack::is_smack_enabled(),
@@ -3531,7 +3531,7 @@ fn get_security_context<'a>(
         }
     }
 
-    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     if config.selinux_supported {
         match selinux::SecurityContext::of_path(path, must_dereference, false) {
             Err(_r) => {

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -65,7 +65,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
 
         // Apply SELinux context if requested
-        #[cfg(all(feature = "selinux", target_os = "linux"))]
+        #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
         {
             // Extract the SELinux related flags and options
             let set_security_context = matches.get_flag(options::SECURITY_CONTEXT);

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -17,7 +17,8 @@ workspace = true
 [lib]
 path = "src/runcon.rs"
 
-[target.'cfg(target_os = "linux")'.dependencies] # todo: block fetching crates without feat_selinux
+# TODO: block fetching crates without feat_selinux
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs", "perms", "selinux"] }
 selinux = { workspace = true }

--- a/src/uu/runcon/src/errors.rs
+++ b/src/uu/runcon/src/errors.rs
@@ -2,7 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-#![cfg(target_os = "linux")]
+
+#![cfg(any(target_os = "linux", target_os = "android"))]
 
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter, Write};

--- a/src/uu/runcon/src/main.rs
+++ b/src/uu/runcon/src/main.rs
@@ -1,11 +1,18 @@
-// On non-Linux targets, provide a stub main to keep the binary target present
-// and the workspace buildable. Using item-level cfg avoids excluding the crate
-// entirely (via #![cfg(...)]), which can break tooling and cross builds that
-// expect this binary to exist even when it's a no-op off Linux.
-#[cfg(target_os = "linux")]
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! This package is specific to Android and some Linux distributions. On other
+//! targets, provide a stub main to keep the binary target present and the
+//! workspace buildable. Using item-level cfg avoids excluding the crate
+//! entirely (via #![cfg(...)]), which can break tooling and cross builds that
+//! expect this binary to exist even when it's a no-op off Linux.
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
 uucore::bin!(uu_runcon);
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn main() {
     eprintln!("runcon: SELinux is not supported on this platform");
     std::process::exit(1);

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -2,8 +2,10 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
 // spell-checker:ignore (vars) RFILE execv execvp
-#![cfg(target_os = "linux")]
+
+#![cfg(any(target_os = "linux", target_os = "android"))]
 
 use clap::builder::ValueParser;
 use uucore::error::{UError, UResult};

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1044,7 +1044,10 @@ impl Stater {
                     'B' => OutputType::Unsigned(512),
                     // SELinux security context string
                     'C' => {
-                        #[cfg(all(feature = "selinux", target_os = "linux"))]
+                        #[cfg(all(
+                            feature = "selinux",
+                            any(target_os = "linux", target_os = "android")
+                        ))]
                         {
                             if uucore::selinux::is_selinux_enabled() {
                                 match uucore::selinux::get_selinux_security_context(
@@ -1060,7 +1063,10 @@ impl Stater {
                                 OutputType::Str(translate!("stat-selinux-unsupported-system"))
                             }
                         }
-                        #[cfg(not(all(feature = "selinux", target_os = "linux")))]
+                        #[cfg(not(all(
+                            feature = "selinux",
+                            any(target_os = "linux", target_os = "android")
+                        )))]
                         {
                             OutputType::Str(translate!("stat-selinux-unsupported-os"))
                         }

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -81,7 +81,7 @@ pub mod tty;
 pub mod fsxattr;
 #[cfg(feature = "hardware")]
 pub mod hardware;
-#[cfg(all(target_os = "linux", feature = "selinux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 pub mod selinux;
 #[cfg(all(unix, not(target_os = "fuchsia"), feature = "signals"))]
 pub mod signals;

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -122,7 +122,7 @@ pub use crate::features::fsext;
 #[cfg(all(unix, feature = "fsxattr"))]
 pub use crate::features::fsxattr;
 
-#[cfg(all(target_os = "linux", feature = "selinux"))]
+#[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 pub use crate::features::selinux;
 
 #[cfg(all(target_os = "linux", feature = "smack"))]


### PR DESCRIPTION
Since 0.5.2 [`selinux`](https://codeberg.org/koutheir/selinux/src/branch/main/CHANGELOG.md#0-5-2-2025-06-18) crate supports android