### PR TITLE
fix: resolve missing vdir l10n strings by sharing ls ftl files (#10363)

### DIFF
--- a/src/uu/ls/locales/en-US.ftl
+++ b/src/uu/ls/locales/en-US.ftl
@@ -1,6 +1,11 @@
 ls-about = List directory contents.
   Ignore files and directories starting with a '.' by default
+vdir-about = List directory contents.
+  Ignore files and directories starting with a '.' by default.
+
+  Mandatory arguments to long options are mandatory for short options too.
 ls-usage = ls [OPTION]... [FILE]...
+vdir-usage = vdir [OPTION]... [FILE]...
 ls-after-help = The TIME_STYLE argument can be full-iso, long-iso, iso, locale or +FORMAT. FORMAT is interpreted like in date. Also the TIME_STYLE environment variable sets the default style to use.
 
 # Error messages

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1260,11 +1260,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> Command {
+    let util_name = uucore::util_name();
     uucore::clap_localization::configure_localized_command(
-        Command::new(uucore::util_name())
+        Command::new(util_name)
             .version(uucore::crate_version!())
-            .override_usage(format_usage(&translate!("ls-usage")))
-            .about(translate!("ls-about")),
+            .override_usage(format_usage(&translate!(&format!("{}-usage", util_name))))
+            .about(translate!(&format!("{}-about", util_name))),
     )
     .infer_long_args(true)
     .disable_help_flag(true)

--- a/src/uu/vdir/locales
+++ b/src/uu/vdir/locales
@@ -1,0 +1,1 @@
+../ls/locales

--- a/src/uu/vdir/locales/en-US.ftl
+++ b/src/uu/vdir/locales/en-US.ftl
@@ -1,5 +1,0 @@
-vdir-about = List directory contents.
-  Ignore files and directories starting with a '.' by default.
-
-  Mandatory arguments to long options are mandatory for short options too.
-vdir-usage = vdir [OPTION]... [FILE]...


### PR DESCRIPTION
Previously, vdir was unable to access the ftl files defined in ls, leading to missing localization strings.

This commit resolves the issue by:
1. Merging vdir's ftl content into ls/locales.
2. Replacing the vdir/locales directory with a symbolic link to ls/locales.

This ensures vdir inherits all existing and future translations from ls while eliminating resource duplication.