### PR TITLE
yes: Silently handle broken pipe on windows

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -27,6 +27,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     match exec(&buffer) {
         Ok(()) => Ok(()),
+        // On Windows, silently handle broken pipe since there's no SIGPIPE
+        #[cfg(windows)]
         Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(USimpleError::new(
             1,


### PR DESCRIPTION
From the feedback here, https://github.com/uutils/coreutils/pull/10254 separating this into a separate PR. This is required to pass the GNU timeout tests.