### PR TITLE
df/table: Sum scaled values to compute the totals

### DIFF
--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -493,7 +493,9 @@ impl Table {
                 let row = Row::from_filesystem(filesystem, &options.block_size);
                 let fmt = RowFormatter::new(&row, options, false);
                 let values = fmt.get_cells();
-                total += row;
+                if options.show_total {
+                    total += row;
+                }
 
                 rows.push(values);
             }


### PR DESCRIPTION
In order to show the total row we are summing intermediate values as they
are and eventually scaling them.

Now, while this provides a valid output, it also implies that the total value
that we show is not matching the sum of the previously listed values, since
the sum of scaled values may different from the sum of the original values that
gets eventually scaled.

To be consistent with the output:
 - Use a new BytesCell struct to track the bytes values
 - Keep a scaled value tracked
 - Show the sum of the scaled values as total

Closes: https://github.com/uutils/coreutils/issues/10436