### PR TITLE
chore(deps): update rust crate nix to 0.31.1 and libc to 0.2.180

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
  "getrandom 0.2.17",
  "glob",
  "libc",
- "nix",
+ "nix 0.30.1",
  "serde",
  "serde_json",
  "statrs",
@@ -553,7 +553,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "libc",
- "nix",
+ "nix 0.31.1",
  "num-prime",
  "phf",
  "phf_codegen",
@@ -814,12 +814,12 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.31.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1922,6 +1922,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -3204,7 +3216,7 @@ dependencies = [
  "clap",
  "fluent",
  "memchr",
- "nix",
+ "nix 0.31.1",
  "tempfile",
  "thiserror 2.0.18",
  "uucore",
@@ -3346,7 +3358,7 @@ dependencies = [
  "icu_locale",
  "jiff",
  "jiff-icu",
- "nix",
+ "nix 0.31.1",
  "parse_datetime",
  "regex",
  "tempfile",
@@ -3363,7 +3375,7 @@ dependencies = [
  "fluent",
  "gcd",
  "libc",
- "nix",
+ "nix 0.31.1",
  "tempfile",
  "thiserror 2.0.18",
  "uucore",
@@ -3439,7 +3451,7 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "fluent",
- "nix",
+ "nix 0.31.1",
  "rust-ini",
  "thiserror 2.0.18",
  "uucore",
@@ -3601,7 +3613,7 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "fluent",
- "nix",
+ "nix 0.31.1",
  "uucore",
 ]
 
@@ -3679,7 +3691,7 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "fluent",
- "nix",
+ "nix 0.31.1",
  "uucore",
 ]
 
@@ -3739,7 +3751,7 @@ dependencies = [
  "clap",
  "fluent",
  "libc",
- "nix",
+ "nix 0.31.1",
  "uucore",
 ]
 
@@ -4047,7 +4059,7 @@ dependencies = [
  "fluent",
  "itertools 0.14.0",
  "memchr",
- "nix",
+ "nix 0.31.1",
  "rand 0.9.2",
  "rayon",
  "self_cell",
@@ -4106,7 +4118,7 @@ dependencies = [
  "cfg_aliases",
  "clap",
  "fluent",
- "nix",
+ "nix 0.31.1",
  "uucore",
 ]
 
@@ -4125,7 +4137,7 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "fluent",
- "nix",
+ "nix 0.31.1",
  "uucore",
  "windows-sys 0.61.2",
 ]
@@ -4153,7 +4165,7 @@ dependencies = [
  "fluent",
  "libc",
  "memchr",
- "nix",
+ "nix 0.31.1",
  "notify",
  "rstest",
  "same-file",
@@ -4189,7 +4201,7 @@ dependencies = [
  "clap",
  "fluent",
  "libc",
- "nix",
+ "nix 0.31.1",
  "uucore",
 ]
 
@@ -4243,7 +4255,7 @@ dependencies = [
  "clap",
  "codspeed-divan-compat",
  "fluent",
- "nix",
+ "nix 0.31.1",
  "rustc-hash",
  "string-interner",
  "thiserror 2.0.18",
@@ -4256,7 +4268,7 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "fluent",
- "nix",
+ "nix 0.31.1",
  "uucore",
 ]
 
@@ -4340,7 +4352,7 @@ dependencies = [
  "codspeed-divan-compat",
  "fluent",
  "libc",
- "nix",
+ "nix 0.31.1",
  "tempfile",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",
@@ -4410,7 +4422,7 @@ dependencies = [
  "libc",
  "md-5",
  "memchr",
- "nix",
+ "nix 0.31.1",
  "num-traits",
  "os_display",
  "procfs",
@@ -4458,7 +4470,7 @@ version = "0.6.0"
 dependencies = [
  "ctor",
  "libc",
- "nix",
+ "nix 0.31.1",
  "pretty_assertions",
  "rand 0.9.2",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -347,13 +347,13 @@ itertools = "0.14.0"
 itoa = "1.0.15"
 jiff = "0.2.18"
 jiff-icu = "0.2.2"
-libc = "0.2.172"
+libc = "0.2.180"
 lscolors = { version = "0.21.0", default-features = false, features = [
   "gnu_legacy",
 ] }
 memchr = "2.7.2"
 memmap2 = "0.9.4"
-nix = { version = "0.30", default-features = false }
+nix = { version = "0.31.1", default-features = false }
 nom = "8.0.0"
 notify = { version = "=8.2.0", features = ["macos_kqueue"] }
 num-bigint = "0.4.4"


### PR DESCRIPTION
We need those to complete https://github.com/uutils/coreutils/pull/9432

Replaces #10433