### PR TITLE
ci/android: use `--locked` when installing `nextest`

### DIFF
--- a/util/android-commands.sh
+++ b/util/android-commands.sh
@@ -534,7 +534,7 @@ snapshot() {
     # We need to install nextest via cargo currently, since there is no pre-built binary for android x86
     # explicitly set CARGO_TARGET_DIR as otherwise a random generated tmp directory is used,
     # which prevents incremental build for the retries.
-    command="export CARGO_TERM_COLOR=always && export CARGO_TARGET_DIR=\"cargo_install_target_dir\" && cargo install cargo-nextest"
+    command="export CARGO_TERM_COLOR=always && export CARGO_TARGET_DIR=\"cargo_install_target_dir\" && cargo install cargo-nextest --locked"
 
     run_with_retry 3 run_command_via_ssh "$command"
     return_code=$?


### PR DESCRIPTION
The Android job in the CI currently fails with a compilation error (see, for example, https://github.com/uutils/coreutils/actions/runs/21314048084/job/61358741807?pr=10464#step:11:3573) after `nextest` was updated:
```
error[E0283]: type annotations needed
[2026-01-24 13:48:47]   --> /data/data/com.termux/files/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nextest-runner-0.104.0/src/rustc_cli.rs:50:44
```
The issue has already been reported and fixed upstream (https://github.com/nextest-rs/nextest/issues/2990), though the maintainer recommends to use `--locked` (https://github.com/nextest-rs/nextest/issues/2990#issuecomment-3793377341).