### PR TITLE
test: Trim whitespace in integer comparisons

### DIFF
--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -183,11 +183,13 @@ fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
     // Parse the two inputs
     let a: i128 = a
         .to_str()
+        .map(|s| s.trim())
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| ParseError::InvalidInteger(a.quote().to_string()))?;
 
     let b: i128 = b
         .to_str()
+        .map(|s| s.trim())
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| ParseError::InvalidInteger(b.quote().to_string()))?;
 
@@ -229,6 +231,7 @@ fn files(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
 
 fn isatty(fd: &OsStr) -> ParseResult<bool> {
     fd.to_str()
+        .map(|s| s.trim())
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| ParseError::InvalidInteger(fd.quote().to_string()))
         .map(|i| unsafe { libc::isatty(i) == 1 })

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -315,6 +315,26 @@ fn test_invalid_utf8_integer_compare() {
 }
 
 #[test]
+fn test_integer_whitespace_stripping() {
+    new_ucmd!().args(&["42", "-eq", " 42 "]).succeeds();
+    new_ucmd!().args(&["42", "-eq", " 42"]).succeeds();
+    new_ucmd!().args(&["42", "-eq", "42 "]).succeeds();
+    new_ucmd!().args(&[" 42 ", "-eq", "42"]).succeeds();
+
+    new_ucmd!().args(&["42", "-eq", "\t42"]).succeeds();
+    new_ucmd!().args(&["42", "-eq", "\n42"]).succeeds();
+    new_ucmd!().args(&["42", "-eq", "\x0b42"]).succeeds(); // Vertical tab
+    new_ucmd!().args(&["42", "-eq", "\x0c42"]).succeeds(); // Form feed
+    new_ucmd!().args(&["42", "-eq", "\r42"]).succeeds();
+}
+
+#[test]
+fn test_isatty_whitespace_stripping() {
+    new_ucmd!().args(&["-t", " 0 "]).fails_with_code(1);
+    new_ucmd!().args(&["-t", "\n0\t"]).fails_with_code(1);
+}
+
+#[test]
 #[cfg(unix)]
 fn test_file_is_itself() {
     new_ucmd!()


### PR DESCRIPTION
Matches upstream behaviour.

Fixes #10410.