### PR TITLE
ci: specify bash shell for background jobs

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -394,6 +394,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Avoid no space left on device
+      shell: bash
       run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android &
     - uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -125,6 +125,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Avoid no space left on device (Ubuntu runner)
+      shell: bash
       run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android &
     - name: Prepare, build and test
       uses: vmactions/freebsd-vm@v1.3.9


### PR DESCRIPTION
GitHub Actions defaults to PowerShell on some runners, which swallows background job output and can behave differently with `&`.