### PR TITLE
build-gnu.sh: remove workaround for timeout/yes

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -15,7 +15,6 @@ command -v gsed && sed(){ gsed "$@";}
 SED=$(command -v gsed||command -v sed) # for find...exec...
 
 SYSTEM_TIMEOUT=$(command -v timeout)
-SYSTEM_YES=$(command -v yes)
 
 ME="${0}"
 ME_dir="$(dirname -- "$(readlink -fm -- "${ME}")")"
@@ -186,13 +185,6 @@ sed -i "s|cannot create regular file 'no-such/': Not a directory|'no-such/' is n
 
 # Our message is better
 sed -i "s|warning: unrecognized escape|warning: incomplete hex escape|" tests/stat/stat-printf.pl
-
-sed -i 's|timeout |'"${SYSTEM_TIMEOUT}"' |' tests/tail/follow-stdin.sh
-
-# trap_sigpipe_or_skip_ fails with uutils tools because of a bug in
-# timeout/yes (https://github.com/uutils/coreutils/issues/7252), so we use
-# system's yes/timeout to make sure the tests run (instead of being skipped).
-sed -i 's|\(trap .* \)timeout\( .* \)yes|'"\1${SYSTEM_TIMEOUT}\2${SYSTEM_YES}"'|' init.cfg
 
 # Remove dup of /usr/bin/ and /usr/local/bin/ when executed several times
 grep -rlE '/usr/bin/\s?/usr/bin' init.cfg tests/* | xargs -r "${SED}" -Ei 's|/usr/bin/\s?/usr/bin/|/usr/bin/|g'


### PR DESCRIPTION
Now that https://github.com/uutils/coreutils/issues/7252 is fixed this workaround is not needed any more.

This is a partial revert of https://github.com/uutils/coreutils/commit/fac6c2951d5ae22eed1517bff28169ebdb37ef3d ("util/build-gnu.sh: Bypass timeout/yes SIGPIPE handling bug")
This is a revert of https://github.com/uutils/coreutils/commit/5004d4b45870a5b2e7cc90c87b04e85f7f725f30 ("build-gnu: replace `timeout` for `tests/tail/follow-stdin.sh`")