### PR TITLE
CICD.yml: Use windows-11-arm runner

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -641,7 +641,7 @@ jobs:
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
-          - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }
+          - { os: windows-11-arm , target: aarch64-pc-windows-msvc     , features: feat_os_windows, skip-tests: true }
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
Currently slower than cross.