### PR TITLE
split: accept overflowing N in K/N extraction modes

### DIFF
--- a/src/uu/split/src/strategy.rs
+++ b/src/uu/split/src/strategy.rs
@@ -132,7 +132,7 @@ impl NumberType {
             (Some(k_str), Some(n_str), None, None)
                 if !k_str.starts_with('l') && !k_str.starts_with('r') =>
             {
-                let num_chunks = parse_size_u64(n_str)
+                let num_chunks = parse_size_u64_max(n_str)
                     .map_err(|_| NumberTypeError::NumberOfChunks(n_str.to_string()))?;
                 let chunk_number = parse_size_u64(k_str)
                     .map_err(|_| NumberTypeError::ChunkNumber(k_str.to_string()))?;
@@ -150,7 +150,7 @@ impl NumberType {
                 Ok(Self::Lines(num_chunks))
             }
             (Some("l"), Some(k_str), Some(n_str), None) => {
-                let num_chunks = parse_size_u64(n_str)
+                let num_chunks = parse_size_u64_max(n_str)
                     .map_err(|_| NumberTypeError::NumberOfChunks(n_str.to_string()))?;
                 let chunk_number = parse_size_u64(k_str)
                     .map_err(|_| NumberTypeError::ChunkNumber(k_str.to_string()))?;
@@ -168,7 +168,7 @@ impl NumberType {
                 Ok(Self::RoundRobin(num_chunks))
             }
             (Some("r"), Some(k_str), Some(n_str), None) => {
-                let num_chunks = parse_size_u64(n_str)
+                let num_chunks = parse_size_u64_max(n_str)
                     .map_err(|_| NumberTypeError::NumberOfChunks(n_str.to_string()))?;
                 let chunk_number = parse_size_u64(k_str)
                     .map_err(|_| NumberTypeError::ChunkNumber(k_str.to_string()))?;

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -1023,8 +1023,19 @@ fn test_number_kth_of_n() {
             "--number=9223372036854775807/18446744073709551616",
             "asciilowercase.txt",
         ])
-        .fails()
-        .stderr_contains("split: invalid number of chunks: '18446744073709551616'");
+        .succeeds()
+        .stdout_only("");
+    #[cfg(target_pointer_width = "64")]
+    {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("empty");
+        ucmd.args(&[
+            "--number=l/9223372036854775807/18446744073709551616",
+            "empty",
+        ])
+        .succeeds()
+        .stdout_only("");
+    }
 }
 
 #[test]
@@ -1057,8 +1068,7 @@ fn test_number_kth_of_n_round_robin() {
             "r/9223372036854775807/18446744073709551616",
             "fivelines.txt",
         ])
-        .fails()
-        .stderr_contains("split: invalid number of chunks: '18446744073709551616'");
+        .succeeds();
     new_ucmd!()
         .args(&["--number", "r/0/3", "fivelines.txt"])
         .fails()
@@ -2114,4 +2124,19 @@ fn test_io_error() {
         .fails_with_code(1)
         //todo: add file path with proper distinction of input/output
         .stderr_contains("Input/output error\n");
+}
+
+// Test that split rejects overflow values for plain --number=N.
+#[test]
+fn test_split_number_overflow_rejected() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("file");
+    ucmd.args(&["-n", "18446744073709551616", "file"]) // 2^64 = u64::MAX + 1
+        .fails();
+
+    let (at2, mut ucmd2) = at_and_ucmd!();
+    at2.touch("file2");
+    ucmd2
+        .args(&["-n", "999999999999999999999999999999", "file2"])
+        .fails();
 }


### PR DESCRIPTION
Fixes #10389 

where split rejected overflow values like 2^64. Now it matches GNU behavior by clamping to `u64::MAX` instead of erroring. Switched from parse_size_u64() to parse_size_u64_max() based on GNU's OVERFLOW_OK pattern. Added regression test to prevent future breakage.