### PR TITLE
cksum: Don't panic when checked file returned EIO

### DIFF
--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -3046,3 +3046,17 @@ mod debug_flag {
             .stderr_contains("pclmul");
     }
 }
+
+#[test]
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+fn test_check_file_with_io_error() {
+    // /proc/self/mem causes EIO when read without proper seeking
+    new_ucmd!()
+        .arg("-a")
+        .arg("md5")
+        .arg("--check")
+        .pipe_in("d8e8fca2dc0f896fd7cb4cb0031ba249  /proc/self/mem\n")
+        .fails()
+        .stderr_contains("Input/output error")
+        .stdout_contains("FAILED open or read");
+}


### PR DESCRIPTION
Closes #10175 .
We cannot add tests for device returning EIO and cannot backport corresponding GNU tests until we backport proper args managenent too.