### PR TITLE
refactor: rename print functions to write for consistency

### DIFF
--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -23,7 +23,7 @@ mod options {
     pub static NUMBER: &str = "NUMBER";
 }
 
-fn print_factors_str(
+fn write_factors_str(
     num_str: &str,
     w: &mut io::BufWriter<impl Write>,
     print_exponents: bool,
@@ -159,7 +159,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if let Some(values) = matches.get_many::<String>(options::NUMBER) {
         for number in values {
-            print_factors_str(number, &mut w, print_exponents)?;
+            write_factors_str(number, &mut w, print_exponents)?;
         }
     } else {
         let stdin = stdin();
@@ -168,7 +168,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             match line {
                 Ok(line) => {
                     for number in line.split_whitespace() {
-                        print_factors_str(number, &mut w, print_exponents)?;
+                        write_factors_str(number, &mut w, print_exponents)?;
                     }
                 }
                 Err(e) => {

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -220,8 +220,8 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
         !self.format.is_empty()
     }
 
-    /// Print the field or empty filler if the field is not set.
-    fn print_field(
+    /// Write the field or empty filler if the field is not set.
+    fn write_field(
         &self,
         writer: &mut impl Write,
         field: Option<&[u8]>,
@@ -234,8 +234,8 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
         writer.write_all(value)
     }
 
-    /// Print each field except the one at the index.
-    fn print_fields(
+    /// Write each field except the one at the index.
+    fn write_fields(
         &self,
         writer: &mut impl Write,
         line: &Line,
@@ -250,8 +250,8 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
         Ok(())
     }
 
-    /// Print each field or the empty filler if the field is not set.
-    fn print_format<F>(&self, writer: &mut impl Write, f: F) -> Result<(), std::io::Error>
+    /// Write each field or the empty filler if the field is not set.
+    fn write_format<F>(&self, writer: &mut impl Write, f: F) -> Result<(), std::io::Error>
     where
         F: Fn(&Spec) -> Option<&'a [u8]>,
     {
@@ -270,7 +270,7 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
         Ok(())
     }
 
-    fn print_line_ending(&self, writer: &mut impl Write) -> Result<(), std::io::Error> {
+    fn write_line_ending(&self, writer: &mut impl Write) -> Result<(), std::io::Error> {
         writer.write_all(&[self.line_ending as u8])
     }
 }
@@ -468,7 +468,7 @@ impl<'a> State<'a> {
         repr: &Repr<'a, Sep>,
     ) -> UResult<()> {
         if self.print_unpaired {
-            self.print_first_line(writer, repr)?;
+            self.write_first_line(writer, repr)?;
         }
 
         self.reset_next_line(input)?;
@@ -491,8 +491,8 @@ impl<'a> State<'a> {
         Ok(None)
     }
 
-    /// Print lines in the buffers as headers.
-    fn print_headers<Sep: Separator>(
+    /// Write lines in the buffers as headers.
+    fn write_headers<Sep: Separator>(
         &self,
         writer: &mut impl Write,
         other: &State,
@@ -502,10 +502,10 @@ impl<'a> State<'a> {
             if other.has_line() {
                 self.combine(writer, other, repr)?;
             } else {
-                self.print_first_line(writer, repr)?;
+                self.write_first_line(writer, repr)?;
             }
         } else if other.has_line() {
-            other.print_first_line(writer, repr)?;
+            other.write_first_line(writer, repr)?;
         }
 
         Ok(())
@@ -523,7 +523,7 @@ impl<'a> State<'a> {
         for line1 in &self.seq {
             for line2 in &other.seq {
                 if repr.uses_format() {
-                    repr.print_format(writer, |spec| match *spec {
+                    repr.write_format(writer, |spec| match *spec {
                         Spec::Key => key,
                         Spec::Field(file_num, field_num) => {
                             if file_num == self.file_num {
@@ -538,12 +538,12 @@ impl<'a> State<'a> {
                         }
                     })?;
                 } else {
-                    repr.print_field(writer, key)?;
-                    repr.print_fields(writer, line1, self.key)?;
-                    repr.print_fields(writer, line2, other.key)?;
+                    repr.write_field(writer, key)?;
+                    repr.write_fields(writer, line1, self.key)?;
+                    repr.write_fields(writer, line2, other.key)?;
                 }
 
-                repr.print_line_ending(writer)?;
+                repr.write_line_ending(writer)?;
             }
         }
 
@@ -601,13 +601,13 @@ impl<'a> State<'a> {
     ) -> UResult<()> {
         if self.has_line() {
             if self.print_unpaired {
-                self.print_first_line(writer, repr)?;
+                self.write_first_line(writer, repr)?;
             }
 
             let mut next_line = self.next_line(input)?;
             while let Some(line) = &next_line {
                 if self.print_unpaired {
-                    self.print_line(writer, line, repr)?;
+                    self.write_line(writer, line, repr)?;
                 }
                 self.reset(next_line);
                 next_line = self.next_line(input)?;
@@ -665,14 +665,14 @@ impl<'a> State<'a> {
         self.seq[0].get_field(self.key)
     }
 
-    fn print_line<Sep: Separator>(
+    fn write_line<Sep: Separator>(
         &self,
         writer: &mut impl Write,
         line: &Line,
         repr: &Repr<'a, Sep>,
     ) -> Result<(), std::io::Error> {
         if repr.uses_format() {
-            repr.print_format(writer, |spec| match *spec {
+            repr.write_format(writer, |spec| match *spec {
                 Spec::Key => line.get_field(self.key),
                 Spec::Field(file_num, field_num) => {
                     if file_num == self.file_num {
@@ -683,19 +683,19 @@ impl<'a> State<'a> {
                 }
             })?;
         } else {
-            repr.print_field(writer, line.get_field(self.key))?;
-            repr.print_fields(writer, line, self.key)?;
+            repr.write_field(writer, line.get_field(self.key))?;
+            repr.write_fields(writer, line, self.key)?;
         }
 
-        repr.print_line_ending(writer)
+        repr.write_line_ending(writer)
     }
 
-    fn print_first_line<Sep: Separator>(
+    fn write_first_line<Sep: Separator>(
         &self,
         writer: &mut impl Write,
         repr: &Repr<'a, Sep>,
     ) -> Result<(), std::io::Error> {
-        self.print_line(writer, &self.seq[0], repr)
+        self.write_line(writer, &self.seq[0], repr)
     }
 }
 
@@ -1033,7 +1033,7 @@ fn exec<Sep: Separator>(
     let mut writer = BufWriter::new(stdout.lock());
 
     if settings.headers {
-        state1.print_headers(&mut writer, &state2, &repr)?;
+        state1.write_headers(&mut writer, &state2, &repr)?;
         state1.reset_read_line(&input)?;
         state2.reset_read_line(&input)?;
     }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -630,7 +630,7 @@ impl<'a> Line<'a> {
 
     fn print(&self, writer: &mut impl Write, settings: &GlobalSettings) -> std::io::Result<()> {
         if settings.debug {
-            self.print_debug(settings, writer)?;
+            self.write_debug(settings, writer)?;
         } else {
             writer.write_all(self.line)?;
             writer.write_all(&[settings.line_ending.into()])?;
@@ -640,7 +640,7 @@ impl<'a> Line<'a> {
 
     /// Writes indicators for the selections this line matched. The original line content is NOT expected
     /// to be already printed.
-    fn print_debug(
+    fn write_debug(
         &self,
         settings: &GlobalSettings,
         writer: &mut impl Write,

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -139,20 +139,20 @@ fn pad_and_print_bytes<W: Write>(
     };
 
     if left_pad > 0 {
-        print_padding(&mut writer, left_pad)?;
+        write_padding(&mut writer, left_pad)?;
     }
     writer.write_all(display_bytes)?;
     if right_pad > 0 {
-        print_padding(&mut writer, right_pad)?;
+        write_padding(&mut writer, right_pad)?;
     }
 
     Ok(())
 }
 
-/// print padding based on a writer W and n size
+/// write padding based on a writer W and n size
 /// writer is genric to be any buffer like: `std::io::stdout`
 /// n is the calculated padding size
-fn print_padding<W: Write>(writer: &mut W, n: usize) -> Result<(), std::io::Error> {
+fn write_padding<W: Write>(writer: &mut W, n: usize) -> Result<(), std::io::Error> {
     for _ in 0..n {
         writer.write_all(b" ")?;
     }
@@ -1406,7 +1406,7 @@ fn pretty_time(meta: &Metadata, md_time_field: MetadataTimeField) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::{pad_and_print_bytes, print_padding, quote_file_name};
+    use crate::{pad_and_print_bytes, quote_file_name, write_padding};
 
     use super::{Flags, Precision, ScanUtil, Stater, Token, group_num, precision_trunc};
 
@@ -1554,7 +1554,7 @@ mod tests {
     #[test]
     fn test_print_padding() {
         let mut buffer = Vec::new();
-        print_padding(&mut buffer, 5).unwrap();
+        write_padding(&mut buffer, 5).unwrap();
         assert_eq!(&buffer, b"     ");
     }
 

--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -507,24 +507,24 @@ impl LinesChunk {
         bytes_offset
     }
 
-    /// Print the bytes contained in this buffer calculated with the given offset in number of
+    /// Write the bytes contained in this buffer calculated with the given offset in number of
     /// lines.
     ///
     /// # Arguments
     ///
     /// * `writer`: must implement [`Write`]
     /// * `offset`: An offset in number of lines.
-    pub fn print_lines(&self, writer: &mut impl Write, offset: usize) -> UResult<()> {
-        self.print_bytes(writer, self.calculate_bytes_offset_from(offset))
+    pub fn write_lines(&self, writer: &mut impl Write, offset: usize) -> UResult<()> {
+        self.write_bytes(writer, self.calculate_bytes_offset_from(offset))
     }
 
-    /// Print the bytes contained in this buffer beginning from the given offset in number of bytes.
+    /// Write the bytes contained in this buffer beginning from the given offset in number of bytes.
     ///
     /// # Arguments
     ///
     /// * `writer`: must implement [`Write`]
     /// * `offset`: An offset in number of bytes.
-    pub fn print_bytes(&self, writer: &mut impl Write, offset: usize) -> UResult<()> {
+    pub fn write_bytes(&self, writer: &mut impl Write, offset: usize) -> UResult<()> {
         writer.write_all(self.get_buffer_with(offset))?;
         Ok(())
     }
@@ -617,9 +617,9 @@ impl LinesChunkBuffer {
         Ok(())
     }
 
-    pub fn print(&self, mut writer: impl Write) -> UResult<()> {
+    pub fn write(&self, mut writer: impl Write) -> UResult<()> {
         for chunk in &self.chunks {
-            chunk.print_bytes(&mut writer, 0)?;
+            chunk.write_bytes(&mut writer, 0)?;
         }
         Ok(())
     }

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -502,7 +502,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
         FilterMode::Lines(Signum::Negative(count), sep) => {
             let mut chunks = chunks::LinesChunkBuffer::new(*sep, *count);
             chunks.fill(reader)?;
-            chunks.print(&mut writer)?;
+            chunks.write(&mut writer)?;
         }
         FilterMode::Lines(Signum::PlusZero | Signum::Positive(1), _) => {
             io::copy(reader, &mut writer)?;
@@ -519,7 +519,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
                 }
             }
             if chunk.has_data() {
-                chunk.print_lines(&mut writer, num_skip as usize)?;
+                chunk.write_lines(&mut writer, num_skip as usize)?;
                 io::copy(reader, &mut writer)?;
             }
         }
@@ -531,7 +531,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
         FilterMode::Lines(Signum::MinusZero, sep) => {
             let mut chunks = chunks::LinesChunkBuffer::new(*sep, 0);
             chunks.fill(reader)?;
-            chunks.print(&mut writer)?;
+            chunks.write(&mut writer)?;
         }
         FilterMode::Bytes(Signum::PlusZero | Signum::Positive(1)) => {
             io::copy(reader, &mut writer)?;

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -72,7 +72,7 @@ macro_rules! write_line_terminator {
 }
 
 impl Uniq {
-    pub fn print_uniq(&self, mut reader: impl BufRead, mut writer: impl Write) -> UResult<()> {
+    pub fn write_uniq(&self, mut reader: impl BufRead, mut writer: impl Write) -> UResult<()> {
         let mut first_line_printed = false;
         let mut group_count = 1;
         let line_terminator = self.get_line_terminator();
@@ -97,7 +97,7 @@ impl Uniq {
 
             if self.keys_are_equal(&current_buf, &current_meta, &next_buf, &next_meta) {
                 if self.all_repeated {
-                    self.print_line(writer, &current_buf, group_count, first_line_printed)?;
+                    self.write_line(writer, &current_buf, group_count, first_line_printed)?;
                     first_line_printed = true;
                     std::mem::swap(&mut current_buf, &mut next_buf);
                     std::mem::swap(&mut current_meta, &mut next_meta);
@@ -107,7 +107,7 @@ impl Uniq {
                 if (group_count == 1 && !self.repeats_only)
                     || (group_count > 1 && !self.uniques_only)
                 {
-                    self.print_line(writer, &current_buf, group_count, first_line_printed)?;
+                    self.write_line(writer, &current_buf, group_count, first_line_printed)?;
                     first_line_printed = true;
                 }
                 std::mem::swap(&mut current_buf, &mut next_buf);
@@ -118,7 +118,7 @@ impl Uniq {
         }
 
         if (group_count == 1 && !self.repeats_only) || (group_count > 1 && !self.uniques_only) {
-            self.print_line(writer, &current_buf, group_count, first_line_printed)?;
+            self.write_line(writer, &current_buf, group_count, first_line_printed)?;
             first_line_printed = true;
         }
         if (self.delimiters == Delimiters::Append || self.delimiters == Delimiters::Both)
@@ -250,7 +250,7 @@ impl Uniq {
                 || self.delimiters == Delimiters::Both)
     }
 
-    fn print_line(
+    fn write_line(
         &self,
         writer: &mut impl Write,
         line: &[u8],
@@ -678,7 +678,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    uniq.print_uniq(
+    uniq.write_uniq(
         open_input_file(in_file_name)?,
         open_output_file(out_file_name)?,
     )

--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -229,9 +229,9 @@ impl Display for FileChecksumResult {
     }
 }
 
-/// Print to the given buffer the checksum validation status of a file which
+/// Write to the given buffer the checksum validation status of a file which
 /// name might contain non-utf-8 characters.
-fn print_file_report<W: Write>(
+fn write_file_report<W: Write>(
     mut w: W,
     filename: &[u8],
     result: FileChecksumResult,
@@ -533,7 +533,7 @@ fn get_file_to_check(
         Ok(Box::new(io::stdin())) // Use stdin if "-" is specified in the checksum file
     } else {
         let failed_open = || {
-            print_file_report(
+            write_file_report(
                 io::stdout(),
                 filename_bytes,
                 FileChecksumResult::CantOpen,
@@ -685,7 +685,7 @@ fn compute_and_check_digest_from_file(
         DigestOutput::Crc(n) => n.to_be_bytes() == expected_checksum,
         DigestOutput::U16(n) => n.to_be_bytes() == expected_checksum,
     };
-    print_file_report(
+    write_file_report(
         std::io::stdout(),
         filename,
         FileChecksumResult::from_bool(checksum_correct),
@@ -1212,7 +1212,7 @@ mod tests {
     }
 
     #[test]
-    fn test_print_file_report() {
+    fn test_write_file_report() {
         let opts = ChecksumValidateOptions::default();
 
         let cases: &[(&[u8], FileChecksumResult, &str, &[u8])] = &[
@@ -1245,7 +1245,7 @@ mod tests {
 
         for (filename, result, prefix, expected) in cases {
             let mut buffer: Vec<u8> = vec![];
-            print_file_report(&mut buffer, filename, *result, prefix, opts.verbose);
+            write_file_report(&mut buffer, filename, *result, prefix, opts.verbose);
             assert_eq!(&buffer, expected);
         }
     }


### PR DESCRIPTION
All these functions have a parameter like: `mut writer: impl Write`