### PR TITLE
feat(uucore): Add locale detection from `LC_ALL` and `LC_MESSAGES`

### DIFF
--- a/src/uu/chown/src/chown.rs
+++ b/src/uu/chown/src/chown.rs
@@ -239,7 +239,7 @@ mod test {
     #[test]
     fn test_parse_spec() {
         unsafe {
-            env::set_var("LANG", "C");
+            env::set_var("LC_ALL", "C");
         }
         let _ = locale::setup_localization("chown");
         assert!(matches!(parse_spec(":", ':'), Ok((None, None))));

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -520,7 +520,7 @@ mod tests {
     use super::{ProgUpdate, ReadStat, WriteStat};
     fn init() {
         unsafe {
-            env::set_var("LANG", "C");
+            env::set_var("LC_ALL", "C");
         }
         let _ = setup_localization("dd");
     }

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -582,7 +582,7 @@ mod tests {
 
     fn init() {
         unsafe {
-            std::env::set_var("LANG", "C");
+            std::env::set_var("LC_ALL", "C");
         }
         let _ = setup_localization("df");
     }

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -846,7 +846,7 @@ mod tests {
     #[test]
     fn test_get_pathbuf_from_stdout_fails_if_stdout_is_not_a_file() {
         unsafe {
-            env::set_var("LANG", "C");
+            env::set_var("LC_ALL", "C");
         }
         let _ = locale::setup_localization("touch");
         // We can trigger an error by not setting stdout to anything (will

--- a/src/uucore/build.rs
+++ b/src/uucore/build.rs
@@ -381,6 +381,8 @@ mod tests {
     #[test]
     fn get_locales_to_embed_no_lang() {
         unsafe {
+            env::remove_var("LC_ALL");
+            env::remove_var("LC_MESSAGES");
             env::remove_var("LANG");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
@@ -388,56 +390,60 @@ mod tests {
         assert_eq!(system_locale, None);
 
         unsafe {
+            env::set_var("LC_ALL", "");
+            env::set_var("LC_MESSAGES", "");
             env::set_var("LANG", "");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, None);
         unsafe {
+            env::remove_var("LC_ALL");
+            env::remove_var("LC_MESSAGES");
             env::remove_var("LANG");
         }
 
         unsafe {
-            env::set_var("LANG", "en_US.UTF-8");
+            env::set_var("LC_ALL", "en_US.UTF-8");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, None);
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
     }
 
     #[test]
     fn get_locales_to_embed_with_lang() {
         unsafe {
-            env::set_var("LANG", "fr_FR.UTF-8");
+            env::set_var("LC_ALL", "fr_FR.UTF-8");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("fr-FR".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
 
         unsafe {
-            env::set_var("LANG", "zh_CN.UTF-8");
+            env::set_var("LC_ALL", "zh_CN.UTF-8");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("zh-CN".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
 
         unsafe {
-            env::set_var("LANG", "de");
+            env::set_var("LC_ALL", "de");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("de".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
     }
 
@@ -445,57 +451,57 @@ mod tests {
     fn get_locales_to_embed_invalid_lang() {
         // invalid locale format
         unsafe {
-            env::set_var("LANG", "invalid");
+            env::set_var("LC_ALL", "invalid");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("invalid".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
 
         // numeric values
         unsafe {
-            env::set_var("LANG", "123");
+            env::set_var("LC_ALL", "123");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("123".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
 
         // special characters
         unsafe {
-            env::set_var("LANG", "@@@@");
+            env::set_var("LC_ALL", "@@@@");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("@@@@".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
 
         // malformed locale (no country code but with encoding)
         unsafe {
-            env::set_var("LANG", "en.UTF-8");
+            env::set_var("LC_ALL", "en.UTF-8");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("en".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
 
         // valid format but unusual locale
         unsafe {
-            env::set_var("LANG", "XX_YY.UTF-8");
+            env::set_var("LC_ALL", "XX_YY.UTF-8");
         }
         let (en_locale, system_locale) = get_locales_to_embed();
         assert_eq!(en_locale, "en-US");
         assert_eq!(system_locale, Some("XX-YY".to_string()));
         unsafe {
-            env::remove_var("LANG");
+            env::remove_var("LC_ALL");
         }
     }
 

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn test_format_nusers() {
         unsafe {
-            std::env::set_var("LANG", "en_US.UTF-8");
+            std::env::set_var("LC_ALL", "en_US.UTF-8");
         }
         let _ = locale::setup_localization("uptime");
         assert_eq!("0 users", format_nusers(0));

--- a/src/uucore/src/lib/mods/clap_localization.rs
+++ b/src/uucore/src/lib/mods/clap_localization.rs
@@ -676,10 +676,10 @@ mod tests {
         use crate::locale::{get_message, setup_localization};
         use std::env;
 
-        let original_lang = env::var("LANG").unwrap_or_default();
+        let original_lang = env::var("LC_ALL").unwrap_or_default();
 
         unsafe {
-            env::set_var("LANG", "fr_FR.UTF-8");
+            env::set_var("LC_ALL", "fr_FR.UTF-8");
         }
 
         if setup_localization("test").is_ok() {
@@ -690,9 +690,9 @@ mod tests {
 
         unsafe {
             if original_lang.is_empty() {
-                env::remove_var("LANG");
+                env::remove_var("LC_ALL");
             } else {
-                env::set_var("LANG", original_lang);
+                env::set_var("LC_ALL", original_lang);
             }
         }
     }

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -1414,7 +1414,7 @@ fn test_chmod_colored_output() {
     new_ucmd!()
         .arg("--help")
         .env("CLICOLOR_FORCE", "1")
-        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
         .succeeds()
         .stdout_contains("\x1b[1m\x1b[4mUsage:\x1b[0m") // Bold+underline "Usage:"
         .stdout_contains("\x1b[1m\x1b[4mArguments:\x1b[0m"); // Bold+underline "Arguments:"
@@ -1423,7 +1423,7 @@ fn test_chmod_colored_output() {
     new_ucmd!()
         .arg("--invalid-option")
         .env("CLICOLOR_FORCE", "1")
-        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
         .fails()
         .code_is(1)
         .stderr_contains("\x1b[31merror\x1b[0m") // Red "error"
@@ -1433,7 +1433,7 @@ fn test_chmod_colored_output() {
     new_ucmd!()
         .arg("--invalid-option")
         .env("CLICOLOR_FORCE", "1")
-        .env("LANG", "fr_FR.UTF-8")
+        .env("LC_ALL", "fr_FR.UTF-8")
         .fails()
         .code_is(1)
         .stderr_contains("\x1b[31merreur\x1b[0m") // Red "erreur" in French

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1741,7 +1741,7 @@ fn test_date_format_a_french_locale() {
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 fn test_date_french_full_sentence() {
     let result = new_ucmd!()
-        .env("LANG", "fr_FR.UTF-8")
+        .env("LC_ALL", "fr_FR.UTF-8")
         .env("TZ", "UTC")
         .arg("-d")
         .arg("2026-01-21")

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -1845,7 +1845,7 @@ fn test_simulation_of_terminal_pty_write_in_data_and_sends_eot_automatically() {
 fn test_env_french() {
     new_ucmd!()
         .arg("--verbo")
-        .env("LANG", "fr_FR")
+        .env("LC_ALL", "fr_FR")
         .fails()
         .stderr_contains("erreur : argument inattendu");
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -107,7 +107,6 @@ fn test_localized_possible_values() {
 
     for (locale, expected_strings) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .arg("--color=invalid_test_value")
             .fails();

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1835,9 +1835,8 @@ fn test_g_float_hex() {
 #[test]
 fn test_french_translations() {
     // Test that French translations work for clap error messages
-    // Set LANG to French and test with an invalid argument
+    // Set LC_ALL to French and test with an invalid argument
     let result = new_ucmd!()
-        .env("LANG", "fr_FR.UTF-8")
         .env("LC_ALL", "fr_FR.UTF-8")
         .arg("--invalid-arg")
         .fails();
@@ -1857,7 +1856,6 @@ fn test_argument_suggestion() {
 
     for (locale, expected_strings) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .arg("--revrse") // Typo
             .fails();
@@ -1892,7 +1890,6 @@ fn test_clap_localization_unknown_argument() {
 
     for (locale, expected_strings) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .arg("--unknown-option")
             .fails();
@@ -1909,7 +1906,6 @@ fn test_clap_localization_unknown_argument() {
 fn test_clap_localization_help_message() {
     // Test help message in English
     let result_en = new_ucmd!()
-        .env("LANG", "en_US.UTF-8")
         .env("LC_ALL", "en_US.UTF-8")
         .arg("--help")
         .succeeds();
@@ -1920,7 +1916,6 @@ fn test_clap_localization_help_message() {
 
     // Test help message in French
     let result_fr = new_ucmd!()
-        .env("LANG", "fr_FR.UTF-8")
         .env("LC_ALL", "fr_FR.UTF-8")
         .arg("--help")
         .succeeds();
@@ -1955,7 +1950,6 @@ fn test_clap_localization_invalid_value() {
 
     for (locale, expected_message) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .arg("-k")
             .arg("invalid")
@@ -1973,7 +1967,6 @@ fn test_help_colors_enabled() {
 
     for (locale, usage_word) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .env("CLICOLOR_FORCE", "1")
             .arg("--help")
@@ -1998,7 +1991,6 @@ fn test_help_colors_disabled() {
 
     for (locale, usage_word) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .env("NO_COLOR", "1")
             .arg("--help")
@@ -2025,7 +2017,6 @@ fn test_error_colors_enabled() {
 
     for (locale, error_word, tip_word) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .env("CLICOLOR_FORCE", "1")
             .arg("--numerc") // Typo to trigger suggestion for --numeric-sort
@@ -2061,7 +2052,6 @@ fn test_error_colors_disabled() {
 
     for (locale, error_word, tip_word) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .env("NO_COLOR", "1")
             .arg("--numerc") // Typo to trigger suggestion for --numeric-sort
@@ -2089,7 +2079,6 @@ fn test_argument_suggestion_colors_enabled() {
 
     for (locale, _tip_word, suggestion) in test_cases {
         let result = new_ucmd!()
-            .env("LANG", locale)
             .env("LC_ALL", locale)
             .env("CLICOLOR_FORCE", "1")
             .arg("--revrse") // Typo to trigger suggestion
@@ -2535,7 +2524,7 @@ fn test_color_environment_variables() {
 
     for (env_vars, should_have_colors, description) in test_env_vars {
         let mut cmd = new_ucmd!();
-        cmd.env("LANG", "en_US.UTF-8");
+        cmd.env("LC_ALL", "en_US.UTF-8");
 
         for (key, value) in env_vars {
             cmd.env(key, value);
@@ -2743,7 +2732,7 @@ c d 5435 down data path1 path2 path3 path4 path5
 e f 5436 down data path1 path2 path3 path4 path5\n";
 
     new_ucmd!()
-        .env("LANG", "en_US.utf8")
+        .env("LC_ALL", "en_US.utf8")
         .arg("-k3")
         .pipe_in(input)
         .succeeds()

--- a/tests/test_localization_and_colors.rs
+++ b/tests/test_localization_and_colors.rs
@@ -92,7 +92,7 @@ fn test_help_messages_have_colors() {
         let output = create_utility_command(utility)
             .arg("--help")
             .env("CLICOLOR_FORCE", "1")
-            .env("LANG", "en_US.UTF-8")
+            .env("LC_ALL", "en_US.UTF-8")
             .output();
 
         match output {
@@ -136,7 +136,7 @@ fn test_error_messages_have_colors() {
         let output = cmd
             .arg("--invalid-option-that-should-not-exist")
             .env("CLICOLOR_FORCE", "1")
-            .env("LANG", "en_US.UTF-8")
+            .env("LC_ALL", "en_US.UTF-8")
             .output();
 
         match output {
@@ -183,7 +183,6 @@ fn test_help_messages_french_translation() {
         let output = create_utility_command(utility)
             .arg("--help")
             .env("CLICOLOR_FORCE", "1")
-            .env("LANG", "fr_FR.UTF-8")
             .env("LC_ALL", "fr_FR.UTF-8")
             .output();
 
@@ -227,7 +226,6 @@ fn test_error_messages_french_translation() {
         let output = cmd
             .arg("--invalid-option-that-should-not-exist")
             .env("CLICOLOR_FORCE", "1")
-            .env("LANG", "fr_FR.UTF-8")
             .env("LC_ALL", "fr_FR.UTF-8")
             .output();
 
@@ -271,7 +269,6 @@ fn test_french_colored_error_messages() {
         let output = cmd
             .arg("--invalid-option-that-should-not-exist")
             .env("CLICOLOR_FORCE", "1")
-            .env("LANG", "fr_FR.UTF-8")
             .env("LC_ALL", "fr_FR.UTF-8")
             .output();
 

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -39,7 +39,7 @@ fn execution_phrase_double() {
     let output = Command::new(&scenario.bin_path)
         .arg("ls")
         .arg("--some-invalid-arg")
-        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
         .output()
         .unwrap();
     assert!(


### PR DESCRIPTION
### TL;DR

Fix #8922.

---
### Implementation :

When creating the locale string, check in this order :
    `LC_ALL` -> `LC_MESSAGES` -> `LANG`
According to the documentation on the precedence of each variable.

**Important note :** I did not include the `LANGUAGE` variable as it seems more specific to gettext and does not follow the the same pattern as the other variables (specify multiple languages).

---
### Testing :

I'm using the devcontainer.
For completeness, here is the result of the `locale` command inside the container:
```
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
```

Built successfully with
```
cargo build
```

Ran tests with no error
```
cargo nextest run -p uucore -p coreutils --no-fail-fast
```

Tried all these combinations which output the correct language
```
[FRENCH OUTPUT]
$ LANG=fr_FR.UTF-8 ./target/debug/coreutils split --help
$ LC_MESSAGES=fr_FR.UTF-8 ./target/debug/coreutils split --help
$ LC_ALL=fr_FR.UTF-8 ./target/debug/coreutils split --help

$ LC_MESSAGES=fr_FR.UTF-8 LANG=en_US.UTF-8 ./target/debug/coreutils split --help
$ LC_ALL=fr_FR.UTF-8 LC_MESSAGES=en_US.UTF-8 ./target/debug/coreutils split --help
$ LC_ALL=fr_FR.UTF-8 LANG=en_US.UTF-8 ./target/debug/coreutils split --help


[ENGLISH OUTPUT]
$ LC_MESSAGES=en_US.UTF-8 LANG=fr_FR.UTF-8 ./target/debug/coreutils split --help
$ LC_ALL=en_US.UTF-8 LC_MESSAGES=fr_FR.UTF-8 ./target/debug/coreutils split --help
$ LC_ALL=en_US.UTF-8 LANG=fr_FR.UTF-8 ./target/debug/coreutils split --help
```

---
### Edit :

* I updated the code to follow more strictly the gnu system, env vars set with empty string will be invalid
* I had to update a lot of test function because `LANG` was overidden  by `LC_ALL` or `LC_MESSAGES`