### PR TITLE
*sum: Fix locales fetching from `checksum_common` after installation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -266,9 +266,13 @@ locales:
 		fi; \
 	done
 
-
+# Some utils require extra locale files outside of their package:
+# - *sum binaries need the files from checksum_common
+INSTALLEES_WITH_EXTRA_LOCALE = \
+	$(INSTALLEES) \
+	$(if $(findstring sum, $(INSTALLEES)),checksum_common, )
 install-locales:
-	@for prog in $(INSTALLEES); do \
+	@for prog in $(INSTALLEES_WITH_EXTRA_LOCALE); do \
 		if [ -d "$(BASEDIR)/src/uu/$$prog/locales" ]; then \
 			mkdir -p "$(DESTDIR)$(DATAROOTDIR)/locales/$$prog"; \
 			for locale_file in "$(BASEDIR)"/src/uu/$$prog/locales/*.ftl; do \

--- a/src/uucore/build.rs
+++ b/src/uucore/build.rs
@@ -144,6 +144,15 @@ fn embed_single_utility_locale(
             .join(format!("locales/{locale}.ftl"))
     })?;
 
+    if util_name.ends_with("sum") {
+        embed_component_locales(
+            embedded_file,
+            locales_to_embed,
+            "checksum_common",
+            |locale| project_root.join(format!("src/uu/checksum_common/locales/{locale}.ftl")),
+        )?;
+    }
+
     // Always embed uucore locale file if it exists
     embed_component_locales(embedded_file, locales_to_embed, "uucore", |locale| {
         project_root.join(format!("src/uucore/locales/{locale}.ftl"))

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -261,6 +261,14 @@ fn create_english_bundle_from_embedded(
         bundle.add_resource_overriding(uucore_resource);
     }
 
+    // Checksum algorithms need locale messages from checksum_common
+    if util_name.ends_with("sum") {
+        if let Some(uucore_content) = get_embedded_locale("checksum_common/en-US.ftl") {
+            let uucore_resource = parse_fluent_resource(uucore_content)?;
+            bundle.add_resource_overriding(uucore_resource);
+        }
+    }
+
     // Then, try to load utility-specific strings
     let locale_key = format!("{util_name}/en-US.ftl");
     if let Some(ftl_content) = get_embedded_locale(&locale_key) {


### PR DESCRIPTION
Fixes the issue raised in https://github.com/uutils/coreutils/pull/10142#issuecomment-3810581291 and #10549

Basically, this change does 3 things:
- Embeds `checksum_common` en_US locales in uucore at build time if necessary.
- Make `init_localization` look for `checksum_common` locales.
- Install extra locales for `checksum_common` when running `make install`.

cc @oech3 