### PR TITLE
ci: add space to separate comment and job name

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1225,7 +1225,7 @@ jobs:
         fail_ci_if_error: false
 
   test_separately:
-    name: Separate Builds (individual and coreutils)# duplicated with other CI, but has better appearance 
+    name: Separate Builds (individual and coreutils) # duplicated with other CI, but has better appearance
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/10488