### PR TITLE
cksum --debug 2>/dev/full does not abort

### DIFF
--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -6,6 +6,7 @@
 // spell-checker:ignore (ToDO) fname, algo, bitlen
 
 use std::ffi::OsStr;
+use std::io::{Write, stderr};
 
 use clap::Command;
 use uu_checksum_common::{ChecksumCommand, checksum_main, default_checksum_app, options};
@@ -16,18 +17,19 @@ use uucore::checksum::{
 };
 use uucore::error::UResult;
 use uucore::hardware::{HasHardwareFeatures as _, SimdPolicy};
-use uucore::{show_error, translate};
+use uucore::translate;
 
 /// Print CPU hardware capability detection information to stderr
+/// 2>/dev/full does not abort
 /// This matches GNU cksum's --debug behavior
 fn print_cpu_debug_info() {
     let features = SimdPolicy::detect();
 
     fn print_feature(name: &str, available: bool) {
         if available {
-            show_error!("using {name} hardware support");
+            let _ = writeln!(stderr(), "using {name} hardware support");
         } else {
-            show_error!("{name} support not detected");
+            let _ = writeln!(stderr(), "{name} support not detected");
         }
     }
 


### PR DESCRIPTION
Fixes #10588 . The >/dev/full operation is difficult to add to tests. So I think I submit a test to GNU.