### PR TITLE
uptime: fix "unused import" warnings in test file

### DIFF
--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -6,9 +6,7 @@
 // spell-checker:ignore wincode serde utmp runlevel testusr testx boottime
 #![allow(clippy::cast_possible_wrap, clippy::unreadable_literal)]
 
-use uutests::at_and_ucmd;
-use uutests::util::TestScenario;
-use uutests::{new_ucmd, util_name};
+use uutests::{at_and_ucmd, new_ucmd};
 
 use regex::Regex;
 
@@ -47,6 +45,8 @@ fn test_uptime_for_file_without_utmpx_records() {
 #[test]
 #[cfg(all(unix, feature = "cp"))]
 fn test_uptime_with_fifo() {
+    use uutests::{util::TestScenario, util_name};
+
     // This test can go on forever in the CI in some cases, might need aborting
     // Sometimes writing to the pipe is broken
     let ts = TestScenario::new(util_name!());


### PR DESCRIPTION
This PR fixes two "unused import" warnings that show up when running the `uptime` tests (see, for example, https://github.com/uutils/coreutils/actions/runs/21583221848/job/62185076026?pr=10648#step:6:13085)