### PR TITLE
ci: enable memory profiling again

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
     strategy:
       matrix:
-        type: [simulation] # , memory]  # memory profile disabled due to variance
+        type: [simulation, memory]
         package: [
           uu_base64,
           uu_cksum,


### PR DESCRIPTION
Hey! We've fixed an issue in memory profiling which caused benchmarks to have huge variance, and the results are very stable now.

I've run your benchmark CI 10 times on our fork, and there's now 0% variance across those runs: https://codspeed.io/AvalancheHQ/coreutils-1/benchmarks?q=mode%3Amemory
<img width="1104" height="575" alt="image" src="https://github.com/user-attachments/assets/b3b06c8c-f989-4d24-86e8-e4e8e94bad03" />

Let me know if you run into any other issues or if you have further questions!