### PR TITLE
true/false: remove large clap call

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -10,8 +10,6 @@ use uucore::translate;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut command = uu_app();
-
     // Mirror GNU options, always return `1`. In particular even the 'successful' cases of no-op,
     // and the interrupted display of help and version should return `1`. Also, we return Ok in all
     // paths to avoid the allocation of an error object, an operation that could, in theory, fail
@@ -19,26 +17,24 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     set_exit_code(1);
 
     let args: Vec<OsString> = args.collect();
-    if args.len() > 2 {
+    if args.len() != 2 {
         return Ok(());
     }
 
-    if let Err(e) = command.try_get_matches_from_mut(args) {
-        // For the false command, we don't want to show any error messages for UnknownArgument
-        // since false should produce no output and just exit with code 1
-        let error = match e.kind() {
-            clap::error::ErrorKind::DisplayHelp => command.print_help(),
-            clap::error::ErrorKind::DisplayVersion => {
-                write!(std::io::stdout(), "{}", command.render_version())
-            }
-            _ => Ok(()),
-        };
+    // args[0] is the name of the binary.
+    let error = if args[1] == "--help" {
+        uu_app().print_help()
+    } else if args[1] == "--version" {
+        write!(std::io::stdout(), "{}", uu_app().render_version())
+    } else {
+        Ok(())
+    };
 
+    if let Err(print_fail) = error {
         // Try to display this error.
-        if let Err(print_fail) = error {
-            // Completely ignore any error here, no more failover and we will fail in any case.
-            let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
-        }
+        let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
+        // Completely ignore any error here, no more failover and we will fail in any case.
+        set_exit_code(1);
     }
 
     Ok(())

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -10,30 +10,27 @@ use uucore::translate;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let mut command = uu_app();
-
     let args: Vec<OsString> = args.collect();
-    if args.len() > 2 {
+    if args.len() != 2 {
         return Ok(());
     }
 
-    if let Err(e) = command.try_get_matches_from_mut(args) {
-        let error = match e.kind() {
-            clap::error::ErrorKind::DisplayHelp => command.print_help(),
-            clap::error::ErrorKind::DisplayVersion => {
-                write!(std::io::stdout(), "{}", command.render_version())
-            }
-            _ => Ok(()),
-        };
+    // args[0] is the name of the binary.
+    let error = if args[1] == "--help" {
+        uu_app().print_help()
+    } else if args[1] == "--version" {
+        write!(std::io::stdout(), "{}", uu_app().render_version())
+    } else {
+        Ok(())
+    };
 
-        if let Err(print_fail) = error {
-            // Try to display this error.
-            let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
-            // Mirror GNU options. When failing to print warnings or version flags, then we exit
-            // with FAIL. This avoids allocation some error information which may result in yet
-            // other types of failure.
-            set_exit_code(1);
-        }
+    if let Err(print_fail) = error {
+        // Try to display this error.
+        let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
+        // Mirror GNU options. When failing to print warnings or version flags, then we exit
+        // with FAIL. This avoids allocation some error information which may result in yet
+        // other types of failure.
+        set_exit_code(1);
     }
 
     Ok(())

--- a/tests/by-util/test_false.rs
+++ b/tests/by-util/test_false.rs
@@ -35,6 +35,13 @@ fn test_short_options() {
 }
 
 #[test]
+fn test_extra_args() {
+    for option in ["--help", "--version"] {
+        new_ucmd!().args(&[option, "test"]).fails().no_output();
+    }
+}
+
+#[test]
 fn test_conflict() {
     new_ucmd!()
         .args(&["--help", "--version"])

--- a/tests/by-util/test_true.rs
+++ b/tests/by-util/test_true.rs
@@ -38,6 +38,13 @@ fn test_short_options() {
 }
 
 #[test]
+fn test_extra_args() {
+    for option in ["--help", "--version"] {
+        new_ucmd!().args(&[option, "test"]).succeeds().no_output();
+    }
+}
+
+#[test]
 fn test_conflict() {
     new_ucmd!()
         .args(&["--help", "--version"])


### PR DESCRIPTION
This addresses #10471 by removing the large clap `Command::try_get_matches_from_mut` call from `true` and `false`.

In my local release build, the binary size has reduced from 1.26MiB to 1.13MiB (-10%).

One extra test for each command.