### PR TITLE
perf(split): reuse buffer in chunked splitting loop

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1156,9 +1156,10 @@ where
         out_files = OutFiles::init(num_chunks, settings, false)?;
     }
 
+    let buf = &mut Vec::new();
     for i in 1_u64..=num_chunks {
         let chunk_size = chunk_size_base + (chunk_size_reminder > i - 1) as u64;
-        let buf = &mut Vec::new();
+        buf.clear();
         if num_bytes > 0 {
             // Read `chunk_size` bytes from the reader into `buf`
             // except the last.


### PR DESCRIPTION
This PR optimizes the memory allocation strategy in the `split` utility when handling chunked output.

Moved the `Vec` initialization outside of the for loop to avoid unnecessary `malloc` and `free` calls, leading to a more efficient execution path