### PR TITLE
feat(more): parse extra args

### DIFF
--- a/src/uu/more/locales/en-US.ftl
+++ b/src/uu/more/locales/en-US.ftl
@@ -20,7 +20,6 @@ more-help-clean-print = Do not scroll, display text and clean line ends
 more-help-squeeze = Squeeze multiple blank lines into one
 more-help-plain = Suppress underlining
 more-help-lines = The number of lines per screen full
-more-help-number = Same as --lines option argument
 more-help-from-line = Start displaying each file at line number
 more-help-pattern = The string to be searched in each file before starting to display it
 more-help-files = Path to the files to be read

--- a/src/uu/more/locales/fr-FR.ftl
+++ b/src/uu/more/locales/fr-FR.ftl
@@ -20,7 +20,6 @@ more-help-clean-print = Ne pas défiler, afficher le texte et nettoyer les fins 
 more-help-squeeze = Compresser plusieurs lignes vides en une seule
 more-help-plain = Supprimer le soulignement
 more-help-lines = Le nombre de lignes par écran complet
-more-help-number = Identique à l'argument de l'option --lines
 more-help-from-line = Commencer l'affichage de chaque fichier au numéro de ligne
 more-help-pattern = La chaîne à rechercher dans chaque fichier avant de commencer à l'afficher
 more-help-files = Chemin vers les fichiers à lire

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -29,6 +29,8 @@ use uucore::{display::Quotable, show};
 
 use uucore::translate;
 
+mod parse;
+
 #[derive(Debug)]
 enum MoreError {
     IsDirectory(PathBuf),
@@ -96,7 +98,8 @@ pub mod options {
     pub const SQUEEZE: &str = "squeeze";
     pub const PLAIN: &str = "plain";
     pub const LINES: &str = "lines";
-    pub const NUMBER: &str = "number";
+    // PATTERN and FROM_LINE are uutils-only long flags hidden from --help;
+    // they exist as expansion targets for the GNU `+/pattern` and `+number` extra args.
     pub const PATTERN: &str = "pattern";
     pub const FROM_LINE: &str = "from-line";
     pub const FILES: &str = "files";
@@ -117,15 +120,13 @@ struct Options {
 
 impl Options {
     fn from(matches: &ArgMatches) -> Self {
-        let lines = match (
-            matches.get_one::<u16>(options::LINES).copied(),
-            matches.get_one::<u16>(options::NUMBER).copied(),
-        ) {
-            // We add 1 to the number of lines to display because the last line
-            // is used for the banner
-            (Some(n), _) | (None, Some(n)) if n > 0 => Some(n + 1),
-            _ => None, // Use terminal height
-        };
+        // We add 1 to the number of lines to display because the last line
+        // is used for the banner
+        let lines = matches
+            .get_one::<u16>(options::LINES)
+            .copied()
+            .filter(|&n| n > 0)
+            .map(|n| n + 1);
         let from_line = match matches.get_one::<usize>(options::FROM_LINE).copied() {
             Some(number) => number.saturating_sub(1),
             _ => 0,
@@ -152,6 +153,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         print!("\r");
         println!("{panic_info}");
     }));
+    let args = parse::preprocess_args(args);
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
     let mut options = Options::from(&matches);
     if let Some(files) = matches.get_many::<OsString>(options::FILES) {
@@ -278,29 +280,23 @@ pub fn uu_app() -> Command {
                 .value_parser(value_parser!(u16).range(0..))
                 .help(translate!("more-help-lines")),
         )
-        .arg(
-            Arg::new(options::NUMBER)
-                .long(options::NUMBER)
-                .num_args(1)
-                .value_parser(value_parser!(u16).range(0..))
-                .help(translate!("more-help-number")),
-        )
+        // Hidden long flags: targets for `+number` and `+/pattern` extra-arg expansion.
         .arg(
             Arg::new(options::FROM_LINE)
-                .short('F')
                 .long(options::FROM_LINE)
                 .num_args(1)
                 .value_name("number")
                 .value_parser(value_parser!(usize))
+                .hide(true)
                 .help(translate!("more-help-from-line")),
         )
         .arg(
             Arg::new(options::PATTERN)
-                .short('P')
                 .long(options::PATTERN)
                 .allow_hyphen_values(true)
                 .required(false)
                 .value_name("pattern")
+                .hide(true)
                 .help(translate!("more-help-pattern")),
         )
         .arg(

--- a/src/uu/more/src/parse.rs
+++ b/src/uu/more/src/parse.rs
@@ -1,0 +1,139 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use std::ffi::OsString;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ExtraArg {
+    /// `-number` (also available as `--lines`)
+    Lines(u16),
+    /// `+number` (also available as `--from-line`)
+    FromLine(usize),
+    /// `+/string` (also available as `--pattern`)
+    Pattern(String),
+}
+
+pub fn parse_extra_arg(src: &str) -> Option<ExtraArg> {
+    if let Some(rest) = src.strip_prefix("+/") {
+        if !rest.is_empty() {
+            return Some(ExtraArg::Pattern(rest.to_string()));
+        }
+    } else if let Some(rest) = src.strip_prefix('+') {
+        if let Ok(n) = rest.parse::<usize>() {
+            return Some(ExtraArg::FromLine(n));
+        }
+    } else if let Some(rest) = src.strip_prefix('-') {
+        if let Ok(n) = rest.parse::<u16>() {
+            return Some(ExtraArg::Lines(n));
+        }
+    }
+    None
+}
+
+fn expand_extra_arg(result: &mut Vec<OsString>, arg: ExtraArg) {
+    match arg {
+        ExtraArg::Lines(n) => {
+            result.push("--lines".into());
+            result.push(n.to_string().into());
+        }
+        ExtraArg::FromLine(n) => {
+            result.push("--from-line".into());
+            result.push(n.to_string().into());
+        }
+        ExtraArg::Pattern(p) => {
+            result.push("--pattern".into());
+            result.push(p.into());
+        }
+    }
+}
+
+pub fn preprocess_args(args: impl Iterator<Item = OsString>) -> Vec<OsString> {
+    let mut result = Vec::new();
+    for arg in args {
+        if let Some(extra) = arg.to_str().and_then(parse_extra_arg) {
+            expand_extra_arg(&mut result, extra);
+        } else {
+            result.push(arg);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_minus_number() {
+        assert_eq!(parse_extra_arg("-10"), Some(ExtraArg::Lines(10)));
+        assert_eq!(parse_extra_arg("-1"), Some(ExtraArg::Lines(1)));
+        assert_eq!(parse_extra_arg("-abc"), None);
+        assert_eq!(parse_extra_arg("-"), None);
+    }
+
+    #[test]
+    fn test_parse_plus_number() {
+        assert_eq!(parse_extra_arg("+5"), Some(ExtraArg::FromLine(5)));
+        assert_eq!(parse_extra_arg("+100"), Some(ExtraArg::FromLine(100)));
+        assert_eq!(parse_extra_arg("+abc"), None);
+    }
+
+    #[test]
+    fn test_parse_plus_pattern() {
+        assert_eq!(
+            parse_extra_arg("+/foo"),
+            Some(ExtraArg::Pattern("foo".into()))
+        );
+        assert_eq!(
+            parse_extra_arg("+/hello world"),
+            Some(ExtraArg::Pattern("hello world".into()))
+        );
+        assert_eq!(parse_extra_arg("+/"), None);
+    }
+
+    #[test]
+    fn test_preprocess_args() {
+        // Test -number
+        let args = ["more", "-5"];
+        let result = preprocess_args(args.iter().map(OsString::from));
+        assert_eq!(
+            result,
+            vec![
+                OsString::from("more"),
+                OsString::from("--lines"),
+                OsString::from("5")
+            ]
+        );
+
+        // Test +number
+        let args = ["more", "+10"];
+        let result = preprocess_args(args.iter().map(OsString::from));
+        assert_eq!(
+            result,
+            vec![
+                OsString::from("more"),
+                OsString::from("--from-line"),
+                OsString::from("10")
+            ]
+        );
+
+        // Test +/pattern
+        let args = ["more", "+/hello"];
+        let result = preprocess_args(args.iter().map(OsString::from));
+        assert_eq!(
+            result,
+            vec![
+                OsString::from("more"),
+                OsString::from("--pattern"),
+                OsString::from("hello")
+            ]
+        );
+
+        // Test regular args unchanged
+        let args = ["more", "file.txt"];
+        let result = preprocess_args(args.iter().map(OsString::from));
+        assert_eq!(result, args.iter().map(OsString::from).collect::<Vec<_>>());
+    }
+}

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -64,21 +64,29 @@ fn test_no_arg() {
 #[cfg(unix)]
 fn test_valid_arg() {
     let args_list: Vec<&[&str]> = vec![
-        &["-c"],
-        &["--clean-print"],
+        &["-d"],
+        &["--silent"],
+        &["-l"],
+        &["--logical"],
+        &["-e"],
+        &["--exit-on-eof"],
+        &["-f"],
+        &["--no-pause"],
         &["-p"],
         &["--print-over"],
+        &["-c"],
+        &["--clean-print"],
         &["-s"],
         &["--squeeze"],
         &["-u"],
         &["--plain"],
         &["-n", "10"],
         &["--lines", "0"],
-        &["--number", "0"],
-        &["-F", "10"],
-        &["--from-line", "0"],
-        &["-P", "something"],
-        &["--pattern", "-1"],
+        &["-0"],
+        &["+10"],
+        &["+0"],
+        &["+/something"],
+        &["+/-1"],
     ];
     for args in args_list {
         test_alive(args);
@@ -234,11 +242,8 @@ fn test_squeeze_blank_lines() {
 #[test]
 #[cfg(unix)]
 fn test_pattern_search() {
-    let (child, controller, output) = run_more_with_pty(
-        &["-P", "target"],
-        "test.txt",
-        "foo\nbar\nbaz\ntarget\nend\n",
-    );
+    let (child, controller, output) =
+        run_more_with_pty(&["+/target"], "test.txt", "foo\nbar\nbaz\ntarget\nend\n");
     assert!(output.contains("target"));
     assert!(!output.contains("foo"));
     quit_more(&controller, child);
@@ -248,7 +253,7 @@ fn test_pattern_search() {
 #[cfg(unix)]
 fn test_from_line_option() {
     let (child, controller, output) =
-        run_more_with_pty(&["-F", "2"], "test.txt", "line1\nline2\nline3\nline4\n");
+        run_more_with_pty(&["+2"], "test.txt", "line1\nline2\nline3\nline4\n");
     assert!(output.contains("line2"));
     assert!(!output.contains("line1"));
     quit_more(&controller, child);


### PR DESCRIPTION
Parse `+/`, `+`, and `-`  prefix for lines, from_line, and pattern args, based on [manpage](https://man7.org/linux/man-pages/man1/more.1.html).