### PR TITLE
refactor: removing unnecessary references in fn signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -664,7 +664,6 @@ match_same_arms = "allow"                    # 204
 redundant_closure_for_method_calls = "allow" # 125
 cast_possible_truncation = "allow"           # 122
 too_many_lines = "allow"                     # 101
-trivially_copy_pass_by_ref = "allow"         # 84
 cast_possible_wrap = "allow"                 # 78
 cast_sign_loss = "allow"                     # 70
 struct_excessive_bools = "allow"             # 68

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -40,7 +40,7 @@ enum FileNumber {
 }
 
 impl FileNumber {
-    fn as_str(&self) -> &'static str {
+    fn as_str(self) -> &'static str {
         match self {
             Self::One => "1",
             Self::Two => "2",

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1360,7 +1360,7 @@ fn show_error_if_needed(error: &CpError) {
 /// Behavior is determined by the `options` parameter, see [`Options`] for details.
 pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult<()> {
     let target_type = TargetType::determine(sources, target);
-    verify_target_type(target, &target_type)?;
+    verify_target_type(target, target_type)?;
 
     let mut non_fatal_errors = false;
     let mut seen_sources = HashSet::with_capacity(sources.len());
@@ -1614,8 +1614,8 @@ fn file_mode_for_interactive_overwrite(
 }
 
 impl OverwriteMode {
-    fn verify(&self, path: &Path, debug: bool) -> CopyResult<()> {
-        match *self {
+    fn verify(self, path: &Path, debug: bool) -> CopyResult<()> {
+        match self {
             Self::NoClobber => {
                 if debug {
                     println!("{}", translate!("cp-debug-skipped", "path" => path.quote()));
@@ -1652,12 +1652,12 @@ impl OverwriteMode {
 /// Note: ENOTSUP/EOPNOTSUPP errors are silently ignored when not required, as per GNU cp
 /// documentation: "Try to preserve SELinux security context and extended attributes (xattr),
 /// but ignore any failure to do that and print no corresponding diagnostic."
-fn handle_preserve<F: Fn() -> CopyResult<()>>(p: &Preserve, f: F) -> CopyResult<()> {
+fn handle_preserve<F: Fn() -> CopyResult<()>>(p: Preserve, f: F) -> CopyResult<()> {
     match p {
         Preserve::No { .. } => {}
         Preserve::Yes { required } => {
             let result = f();
-            if *required {
+            if required {
                 result?;
             } else if let Err(ref error) = result {
                 // Suppress ENOTSUP errors when preservation is optional.
@@ -1724,7 +1724,7 @@ pub(crate) fn copy_attributes(
 
     // Ownership must be changed first to avoid interfering with mode change.
     #[cfg(unix)]
-    handle_preserve(&attributes.ownership, || -> CopyResult<()> {
+    handle_preserve(attributes.ownership, || -> CopyResult<()> {
         use std::os::unix::prelude::MetadataExt;
         use uucore::perms::Verbosity;
         use uucore::perms::VerbosityLevel;
@@ -1759,7 +1759,7 @@ pub(crate) fn copy_attributes(
         Ok(())
     })?;
 
-    handle_preserve(&attributes.mode, || -> CopyResult<()> {
+    handle_preserve(attributes.mode, || -> CopyResult<()> {
         // The `chmod()` system call that underlies the
         // `fs::set_permissions()` call is unable to change the
         // permissions of a symbolic link. In that case, we just
@@ -1778,7 +1778,7 @@ pub(crate) fn copy_attributes(
         Ok(())
     })?;
 
-    handle_preserve(&attributes.timestamps, || -> CopyResult<()> {
+    handle_preserve(attributes.timestamps, || -> CopyResult<()> {
         let atime = FileTime::from_last_access_time(&source_metadata);
         let mtime = FileTime::from_last_modification_time(&source_metadata);
         if dest.is_symlink() {
@@ -1791,7 +1791,7 @@ pub(crate) fn copy_attributes(
     })?;
 
     #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
-    handle_preserve(&attributes.context, || -> CopyResult<()> {
+    handle_preserve(attributes.context, || -> CopyResult<()> {
         // Get the source context and apply it to the destination
         if let Ok(context) = selinux::SecurityContext::of_path(source, false, false) {
             if let Some(context) = context {
@@ -1809,7 +1809,7 @@ pub(crate) fn copy_attributes(
         Ok(())
     })?;
 
-    handle_preserve(&attributes.xattr, || -> CopyResult<()> {
+    handle_preserve(attributes.xattr, || -> CopyResult<()> {
         #[cfg(all(unix, not(target_os = "android")))]
         {
             copy_extended_attrs(source, dest)?;
@@ -2767,11 +2767,11 @@ fn copy_link(
 }
 
 /// Generate an error message if `target` is not the correct `target_type`
-pub fn verify_target_type(target: &Path, target_type: &TargetType) -> CopyResult<()> {
+pub fn verify_target_type(target: &Path, target_type: TargetType) -> CopyResult<()> {
     match (target_type, target.is_dir()) {
-        (&TargetType::Directory, false) => Err(translate!("cp-error-target-not-directory", "target" => target.quote())
+        (TargetType::Directory, false) => Err(translate!("cp-error-target-not-directory", "target" => target.quote())
         .into()),
-        (&TargetType::File, true) => Err(translate!("cp-error-cannot-overwrite-directory-with-non-directory", "dir" => target.quote())
+        (TargetType::File, true) => Err(translate!("cp-error-cannot-overwrite-directory-with-non-directory", "dir" => target.quote())
         .into()),
         _ => Ok(()),
     }

--- a/src/uu/dd/src/numbers.rs
+++ b/src/uu/dd/src/numbers.rs
@@ -45,7 +45,7 @@ pub(crate) enum SuffixType {
 }
 
 impl SuffixType {
-    fn base_and_suffix(&self, n: u128) -> (u128, &'static str) {
+    fn base_and_suffix(self, n: u128) -> (u128, &'static str) {
         let (bases, suffixes) = match self {
             Self::Iec => (IEC_BASES, IEC_SUFFIXES),
             Self::Si => (SI_BASES, SI_SUFFIXES),

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -51,7 +51,7 @@ pub(crate) enum SuffixType {
 
 impl SuffixType {
     /// The first ten powers of 1024 and 1000, respectively.
-    fn bases(&self) -> [u128; 10] {
+    fn bases(self) -> [u128; 10] {
         match self {
             Self::Iec | Self::HumanReadable(HumanReadable::Binary) => IEC_BASES,
             Self::Si | Self::HumanReadable(HumanReadable::Decimal) => SI_BASES,
@@ -59,7 +59,7 @@ impl SuffixType {
     }
 
     /// Suffixes for the first nine multi-byte unit suffixes.
-    fn suffixes(&self) -> [&'static str; 9] {
+    fn suffixes(self) -> [&'static str; 9] {
         match self {
             // we use "kB" instead of "KB", same as GNU df
             Self::Si => ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],

--- a/src/uu/df/src/columns.rs
+++ b/src/uu/df/src/columns.rs
@@ -191,16 +191,16 @@ impl Column {
     }
 
     /// Return the alignment of the specified column.
-    pub(crate) fn alignment(column: &Self) -> Alignment {
-        match column {
+    pub(crate) fn alignment(self) -> Alignment {
+        match self {
             Self::Source | Self::Target | Self::File | Self::Fstype => Alignment::Left,
             _ => Alignment::Right,
         }
     }
 
     /// Return the minimum width of the specified column.
-    pub(crate) fn min_width(column: &Self) -> usize {
-        match column {
+    pub(crate) fn min_width(self) -> usize {
+        match self {
             // 14 = length of "Filesystem" plus 4 spaces
             Self::Source => 14,
             Self::Used => 5,

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -474,7 +474,7 @@ impl Table {
             .columns
             .iter()
             .enumerate()
-            .map(|(i, col)| Column::min_width(col).max(headers[i].len()))
+            .map(|(i, col)| col.min_width().max(headers[i].len()))
             .collect();
 
         let mut rows = vec![headers.iter().map(Cell::from_string).collect()];
@@ -527,7 +527,7 @@ impl Table {
         let mut alignments = Vec::new();
 
         for column in columns {
-            alignments.push(Column::alignment(column));
+            alignments.push(column.alignment());
         }
 
         alignments

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -118,7 +118,7 @@ struct Options<'a> {
 fn parse_name_value_opt<'a>(opts: &mut Options<'a>, opt: &'a OsStr) -> UResult<bool> {
     // is it a NAME=VALUE like opt ?
     let wrap = NativeStr::<'a>::new(opt);
-    let split_o = wrap.split_once(&'=');
+    let split_o = wrap.split_once('=');
     if let Some((name, value)) = split_o {
         // yes, so push name, value pair
         opts.sets.push((name, value));
@@ -930,8 +930,8 @@ fn apply_unset_env_vars(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
     for name in &opts.unsets {
         let native_name = NativeStr::new(name);
         if name.is_empty()
-            || native_name.contains(&'\0').unwrap()
-            || native_name.contains(&'=').unwrap()
+            || native_name.contains('\0').unwrap()
+            || native_name.contains('=').unwrap()
         {
             return Err(USimpleError::new(
                 125,

--- a/src/uu/env/src/native_int_str.rs
+++ b/src/uu/env/src/native_int_str.rs
@@ -173,7 +173,7 @@ pub fn from_native_int_representation_owned(input: NativeIntString) -> OsString 
     }
 }
 
-pub fn get_single_native_int_value(c: &char) -> Option<NativeCharInt> {
+pub fn get_single_native_int_value(c: char) -> Option<NativeCharInt> {
     #[cfg(target_os = "windows")]
     {
         let mut buf = [0u16, 0];
@@ -229,7 +229,7 @@ impl<'a> NativeStr<'a> {
         self.native
     }
 
-    pub fn contains(&self, x: &char) -> Option<bool> {
+    pub fn contains(&self, x: char) -> Option<bool> {
         let n_c = get_single_native_int_value(x)?;
         Some(self.native.contains(&n_c))
     }
@@ -239,7 +239,7 @@ impl<'a> NativeStr<'a> {
         result.unwrap()
     }
 
-    pub fn split_once(&self, pred: &char) -> Option<(Cow<'a, OsStr>, Cow<'a, OsStr>)> {
+    pub fn split_once(&self, pred: char) -> Option<(Cow<'a, OsStr>, Cow<'a, OsStr>)> {
         let n_c = get_single_native_int_value(pred)?;
         let p = self.native.iter().position(|&x| x == n_c)?;
         let before = self.slice(0, p);

--- a/src/uu/env/src/string_parser.rs
+++ b/src/uu/env/src/string_parser.rs
@@ -153,7 +153,7 @@ impl<'a> StringParser<'a> {
     }
 
     pub fn skip_until_char_or_end(&mut self, c: char) {
-        let native_rep = get_single_native_int_value(&c).unwrap();
+        let native_rep = get_single_native_int_value(c).unwrap();
         let pos = self.remaining.iter().position(|x| *x == native_rep);
 
         if let Some(pos) = pos {

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -56,11 +56,7 @@ pub enum StringOp {
 }
 
 impl BinOp {
-    fn eval(
-        &self,
-        left: ExprResult<NumOrStr>,
-        right: ExprResult<NumOrStr>,
-    ) -> ExprResult<NumOrStr> {
+    fn eval(self, left: ExprResult<NumOrStr>, right: ExprResult<NumOrStr>) -> ExprResult<NumOrStr> {
         match self {
             Self::Relation(op) => op.eval(left, right),
             Self::Numeric(op) => op.eval(left, right),
@@ -70,7 +66,7 @@ impl BinOp {
 }
 
 impl RelationOp {
-    fn eval(&self, a: ExprResult<NumOrStr>, b: ExprResult<NumOrStr>) -> ExprResult<NumOrStr> {
+    fn eval(self, a: ExprResult<NumOrStr>, b: ExprResult<NumOrStr>) -> ExprResult<NumOrStr> {
         // Make sure that the given comparison validates the relational operator.
         let check_cmp = |cmp| {
             use RelationOp::{Eq, Geq, Gt, Leq, Lt, Neq};
@@ -98,11 +94,7 @@ impl RelationOp {
 }
 
 impl NumericOp {
-    fn eval(
-        &self,
-        left: ExprResult<NumOrStr>,
-        right: ExprResult<NumOrStr>,
-    ) -> ExprResult<NumOrStr> {
+    fn eval(self, left: ExprResult<NumOrStr>, right: ExprResult<NumOrStr>) -> ExprResult<NumOrStr> {
         let a = left?.eval_as_bigint()?;
         let b = right?.eval_as_bigint()?;
         Ok(NumOrStr::Num(match self {
@@ -124,11 +116,7 @@ impl NumericOp {
 }
 
 impl StringOp {
-    fn eval(
-        &self,
-        left: ExprResult<NumOrStr>,
-        right: ExprResult<NumOrStr>,
-    ) -> ExprResult<NumOrStr> {
+    fn eval(self, left: ExprResult<NumOrStr>, right: ExprResult<NumOrStr>) -> ExprResult<NumOrStr> {
         match self {
             Self::Or => {
                 let left = left?;

--- a/src/uu/groups/src/groups.rs
+++ b/src/uu/groups/src/groups.rs
@@ -35,12 +35,12 @@ enum GroupsError {
 
 impl UError for GroupsError {}
 
-fn infallible_gid2grp(gid: &u32) -> String {
-    if let Ok(grp) = gid2grp(*gid) {
+fn infallible_gid2grp(gid: u32) -> String {
+    if let Ok(grp) = gid2grp(gid) {
         grp
     } else {
         // The `show!()` macro sets the global exit code for the program.
-        show!(GroupsError::GroupNotFound(*gid));
+        show!(GroupsError::GroupNotFound(gid));
         gid.to_string()
     }
 }
@@ -58,7 +58,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let Ok(gids) = get_groups_gnu(None) else {
             return Err(GroupsError::GetGroupsFailed.into());
         };
-        let groups: Vec<String> = gids.iter().map(infallible_gid2grp).collect();
+        let groups: Vec<String> = gids.into_iter().map(infallible_gid2grp).collect();
         writeln!(stdout(), "{}", groups.join(" "))?;
         return Ok(());
     }
@@ -66,7 +66,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     for user in users {
         match Passwd::locate(user.as_str()) {
             Ok(p) => {
-                let groups: Vec<String> = p.belongs_to().iter().map(infallible_gid2grp).collect();
+                let groups: Vec<String> =
+                    p.belongs_to().into_iter().map(infallible_gid2grp).collect();
                 writeln!(stdout(), "{user} : {}", groups.join(" "))?;
             }
             Err(_) => {

--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -376,7 +376,7 @@ impl<'a> StyleManager<'a> {
         } else if file_type.is_dir() {
             self.indicator_for_directory(path)
         } else {
-            self.indicator_for_special_file(file_type)
+            self.indicator_for_special_file(*file_type)
         }
     }
 
@@ -478,7 +478,7 @@ impl<'a> StyleManager<'a> {
     }
 
     #[cfg(unix)]
-    fn indicator_for_special_file(&self, file_type: &fs::FileType) -> Option<Indicator> {
+    fn indicator_for_special_file(&self, file_type: fs::FileType) -> Option<Indicator> {
         if file_type.is_fifo() && self.has_indicator_style(Indicator::FIFO) {
             return Some(Indicator::FIFO);
         }
@@ -495,7 +495,7 @@ impl<'a> StyleManager<'a> {
     }
 
     #[cfg(not(unix))]
-    fn indicator_for_special_file(&self, _file_type: &fs::FileType) -> Option<Indicator> {
+    fn indicator_for_special_file(&self, _file_type: fs::FileType) -> Option<Indicator> {
         None
     }
 

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -71,7 +71,7 @@ pub enum RoundMethod {
 }
 
 impl RoundMethod {
-    pub fn round(&self, f: f64) -> f64 {
+    pub fn round(self, f: f64) -> f64 {
         match self {
             Self::Up => f.ceil(),
             Self::Down => f.floor(),

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -191,6 +191,8 @@ impl UError for SortError {
     }
 }
 
+// refs are required because this fn is used by thiserror macro
+#[expect(clippy::trivially_copy_pass_by_ref)]
 fn format_disorder(file: &OsString, line_number: &usize, line: &String, silent: &bool) -> String {
     if *silent {
         String::new()
@@ -304,7 +306,7 @@ impl Default for NumericLocaleSettings {
 }
 
 impl NumericLocaleSettings {
-    fn num_info_settings(&self, accept_si_units: bool) -> NumInfoParseSettings {
+    fn num_info_settings(self, accept_si_units: bool) -> NumInfoParseSettings {
         NumInfoParseSettings {
             accept_si_units,
             thousands_separator: self.thousands_sep,
@@ -658,7 +660,7 @@ impl<'a> Line<'a> {
         for (selector, selection) in settings.selectors.iter().map(|selector| {
             (
                 selector,
-                selector.get_selection(line, token_buffer, &settings.numeric_locale),
+                selector.get_selection(line, token_buffer, settings.numeric_locale),
             )
         }) {
             match selection {
@@ -1186,7 +1188,7 @@ impl FieldSelector {
         &self,
         line: &'a [u8],
         tokens: &[Field],
-        numeric_locale: &NumericLocaleSettings,
+        numeric_locale: NumericLocaleSettings,
     ) -> Selection<'a> {
         // `get_range` expects `None` when we don't need tokens and would get confused by an empty vector.
         let tokens = if self.needs_tokens {

--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -61,7 +61,7 @@ pub enum SuffixType {
 
 impl SuffixType {
     /// The radix to use when representing the suffix string as digits.
-    pub fn radix(&self) -> u8 {
+    pub fn radix(self) -> u8 {
         match self {
             Self::Alphabetic => 26,
             Self::Decimal => 10,

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -106,8 +106,8 @@ fn filter_args(
     if let Some(slice) = os_slice.to_str() {
         if should_extract_obs_lines(
             slice,
-            preceding_long_opt_req_value,
-            preceding_short_opt_req_value,
+            *preceding_long_opt_req_value,
+            *preceding_short_opt_req_value,
         ) {
             // start of the short option string
             // that can have obsolete lines option value in it
@@ -137,8 +137,8 @@ fn filter_args(
 /// and if so, a short option that can contain obsolete lines value
 fn should_extract_obs_lines(
     slice: &str,
-    preceding_long_opt_req_value: &bool,
-    preceding_short_opt_req_value: &bool,
+    preceding_long_opt_req_value: bool,
+    preceding_short_opt_req_value: bool,
 ) -> bool {
     slice.starts_with('-')
         && !slice.starts_with("--")

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -351,21 +351,21 @@ fn print_it(output: &OutputType, flags: Flags, width: usize, precision: Precisio
     // A sign (+ or -) should always be placed before a number produced by a signed conversion.
     // By default, a sign  is  used only for negative numbers.
     // A + overrides a space if both are used.
-    let padding_char = determine_padding_char(&flags);
+    let padding_char = determine_padding_char(flags);
 
     match output {
-        OutputType::Str(s) => print_str(s, &flags, width, precision),
-        OutputType::OsStr(s) => print_os_str(s, &flags, width, precision),
-        OutputType::Integer(num) => print_integer(*num, &flags, width, precision, padding_char),
-        OutputType::Unsigned(num) => print_unsigned(*num, &flags, width, precision, padding_char),
+        OutputType::Str(s) => print_str(s, flags, width, precision),
+        OutputType::OsStr(s) => print_os_str(s, flags, width, precision),
+        OutputType::Integer(num) => print_integer(*num, flags, width, precision, padding_char),
+        OutputType::Unsigned(num) => print_unsigned(*num, flags, width, precision, padding_char),
         OutputType::UnsignedOct(num) => {
-            print_unsigned_oct(*num, &flags, width, precision, padding_char);
+            print_unsigned_oct(*num, flags, width, precision, padding_char);
         }
         OutputType::UnsignedHex(num) => {
-            print_unsigned_hex(*num, &flags, width, precision, padding_char);
+            print_unsigned_hex(*num, flags, width, precision, padding_char);
         }
         OutputType::Float(num) => {
-            print_float(*num, &flags, width, precision, padding_char);
+            print_float(*num, flags, width, precision, padding_char);
         }
         OutputType::Unknown => print!("?"),
     }
@@ -380,7 +380,7 @@ fn print_it(output: &OutputType, flags: Flags, width: usize, precision: Precisio
 /// # Returns
 ///
 /// * Padding - An instance of the Padding enum representing the padding character.
-fn determine_padding_char(flags: &Flags) -> Padding {
+fn determine_padding_char(flags: Flags) -> Padding {
     if flags.zero && !flags.left {
         Padding::Zero
     } else {
@@ -396,7 +396,7 @@ fn determine_padding_char(flags: &Flags) -> Padding {
 /// * `flags` - A reference to the Flags struct containing formatting flags.
 /// * `width` - The width of the field for the printed string.
 /// * `precision` - How many digits of precision, if any.
-fn print_str(s: &str, flags: &Flags, width: usize, precision: Precision) {
+fn print_str(s: &str, flags: Flags, width: usize, precision: Precision) {
     let s = match precision {
         Precision::Number(p) if p < s.len() => &s[..p],
         _ => s,
@@ -415,7 +415,7 @@ fn print_str(s: &str, flags: &Flags, width: usize, precision: Precision) {
 /// * `flags` - A reference to the Flags struct containing formatting flags.
 /// * `width` - The width of the field for the printed string.
 /// * `precision` - How many digits of precision, if any.
-fn print_os_str(s: &OsString, flags: &Flags, width: usize, precision: Precision) {
+fn print_os_str(s: &OsString, flags: Flags, width: usize, precision: Precision) {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
@@ -452,7 +452,7 @@ fn quote_file_name(file_name: &str, quoting_style: &QuotingStyle) -> String {
 fn get_quoted_file_name(
     display_name: &str,
     file: &OsString,
-    file_type: &FileType,
+    file_type: FileType,
     from_user: bool,
 ) -> Result<String, i32> {
     let quoting_style = env::var("QUOTING_STYLE")
@@ -536,7 +536,7 @@ fn process_token_filesystem(t: &Token, meta: &StatFs, display_name: &str) {
 /// * `padding_char` - The padding character as determined by `determine_padding_char`.
 fn print_integer(
     num: i64,
-    flags: &Flags,
+    flags: Flags,
     width: usize,
     precision: Precision,
     padding_char: Padding,
@@ -601,7 +601,7 @@ fn precision_trunc(num: f64, precision: Precision) -> String {
     }
 }
 
-fn print_float(num: f64, flags: &Flags, width: usize, precision: Precision, padding_char: Padding) {
+fn print_float(num: f64, flags: Flags, width: usize, precision: Precision, padding_char: Padding) {
     let prefix = if flags.sign {
         "+"
     } else if flags.space {
@@ -625,7 +625,7 @@ fn print_float(num: f64, flags: &Flags, width: usize, precision: Precision, padd
 /// * `padding_char` - The padding character as determined by `determine_padding_char`.
 fn print_unsigned(
     num: u64,
-    flags: &Flags,
+    flags: Flags,
     width: usize,
     precision: Precision,
     padding_char: Padding,
@@ -655,7 +655,7 @@ fn print_unsigned(
 /// * `padding_char` - The padding character as determined by `determine_padding_char`.
 fn print_unsigned_oct(
     num: u32,
-    flags: &Flags,
+    flags: Flags,
     width: usize,
     precision: Precision,
     padding_char: Padding,
@@ -680,7 +680,7 @@ fn print_unsigned_oct(
 /// * `padding_char` - The padding character as determined by `determine_padding_char`.
 fn print_unsigned_hex(
     num: u64,
-    flags: &Flags,
+    flags: Flags,
     width: usize,
     precision: Precision,
     padding_char: Padding,
@@ -1015,7 +1015,7 @@ impl Stater {
         meta: &Metadata,
         display_name: &str,
         file: &OsString,
-        file_type: &FileType,
+        file_type: FileType,
         from_user: bool,
         #[cfg(feature = "selinux")] follow_symbolic_links: bool,
         #[cfg(not(feature = "selinux"))] _: bool,
@@ -1230,7 +1230,7 @@ impl Stater {
                             &meta,
                             &display_name,
                             &file,
-                            &file_type,
+                            file_type,
                             self.from_user,
                             follow_symbolic_links,
                         ) {

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -105,8 +105,8 @@ impl Display for BadSequence {
                 )
             }
             Self::BackwardsRange { end, start } => {
-                fn end_or_start_to_string(ut: &u32) -> String {
-                    match char::from_u32(*ut) {
+                fn end_or_start_to_string(ut: u32) -> String {
+                    match char::from_u32(ut) {
                         Some(ch @ '\x20'..='\x7E') => ch.escape_default().to_string(),
                         _ => {
                             format!("\\{ut:03o}")
@@ -116,7 +116,7 @@ impl Display for BadSequence {
                 write!(
                     f,
                     "{}",
-                    translate!("tr-error-backwards-range", "start" => end_or_start_to_string(start), "end" => end_or_start_to_string(end))
+                    translate!("tr-error-backwards-range", "start" => end_or_start_to_string(*start), "end" => end_or_start_to_string(*end))
                 )
             }
             Self::MultipleCharInEquivalence(s) => write!(

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -387,16 +387,16 @@ fn filter_args(
     if let Some(slice) = os_slice.to_str() {
         if should_extract_obs_skip_fields(
             slice,
-            preceding_long_opt_req_value,
-            preceding_short_opt_req_value,
+            *preceding_long_opt_req_value,
+            *preceding_short_opt_req_value,
         ) {
             // start of the short option string
             // that can have obsolete skip fields option value in it
             filter = handle_extract_obs_skip_fields(slice, skip_fields_old);
         } else if should_extract_obs_skip_chars(
             slice,
-            preceding_long_opt_req_value,
-            preceding_short_opt_req_value,
+            *preceding_long_opt_req_value,
+            *preceding_short_opt_req_value,
         ) {
             // the obsolete skip chars option
             filter = handle_extract_obs_skip_chars(slice, skip_chars_old);
@@ -436,8 +436,8 @@ fn filter_args(
 /// and if so, a short option that can contain obsolete skip fields value
 fn should_extract_obs_skip_fields(
     slice: &str,
-    preceding_long_opt_req_value: &bool,
-    preceding_short_opt_req_value: &bool,
+    preceding_long_opt_req_value: bool,
+    preceding_short_opt_req_value: bool,
 ) -> bool {
     slice.starts_with('-')
         && !slice.starts_with("--")
@@ -452,8 +452,8 @@ fn should_extract_obs_skip_fields(
 /// Checks if the slice is a true obsolete skip chars short option
 fn should_extract_obs_skip_chars(
     slice: &str,
-    preceding_long_opt_req_value: &bool,
-    preceding_short_opt_req_value: &bool,
+    preceding_long_opt_req_value: bool,
+    preceding_short_opt_req_value: bool,
 ) -> bool {
     slice.starts_with('+')
         && posix_version().is_some_and(|v| v <= OBSOLETE)

--- a/src/uu/wc/src/utf8/mod.rs
+++ b/src/uu/wc/src/utf8/mod.rs
@@ -33,7 +33,7 @@ impl Incomplete {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(self) -> bool {
         self.buffer_len == 0
     }
 

--- a/src/uucore/src/lib/features/checksum/compute.rs
+++ b/src/uucore/src/lib/features/checksum/compute.rs
@@ -55,7 +55,7 @@ pub enum ReadingMode {
 
 impl ReadingMode {
     #[inline]
-    fn as_char(&self) -> char {
+    fn as_char(self) -> char {
         match self {
             Self::Binary => '*',
             Self::Text => ' ',
@@ -72,8 +72,8 @@ pub enum DigestFormat {
 
 impl DigestFormat {
     #[inline]
-    fn is_base64(&self) -> bool {
-        *self == Self::Base64
+    fn is_base64(self) -> bool {
+        self == Self::Base64
     }
 }
 

--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -215,7 +215,7 @@ impl FileChecksumResult {
 
     /// The cli options might prevent to display on the outcome of the
     /// comparison on STDOUT.
-    fn can_display(&self, verbose: ChecksumVerbose) -> bool {
+    fn can_display(self, verbose: ChecksumVerbose) -> bool {
         match self {
             Self::Ok => verbose.over_quiet(),
             Self::Failed => verbose.over_status(),

--- a/src/uucore/src/lib/features/format/escape.rs
+++ b/src/uucore/src/lib/features/format/escape.rs
@@ -33,21 +33,21 @@ enum Base {
 }
 
 impl Base {
-    fn as_base(&self) -> u8 {
+    fn as_base(self) -> u8 {
         match self {
             Self::Oct(_) => 8,
             Self::Hex => 16,
         }
     }
 
-    fn max_digits(&self) -> u8 {
+    fn max_digits(self) -> u8 {
         match self {
-            Self::Oct(parsing) => *parsing as u8,
+            Self::Oct(parsing) => parsing as u8,
             Self::Hex => 2,
         }
     }
 
-    fn convert_digit(&self, c: u8) -> Option<u8> {
+    fn convert_digit(self, c: u8) -> Option<u8> {
         match self {
             Self::Oct(_) => {
                 if matches!(c, b'0'..=b'7') {

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -357,7 +357,7 @@ impl Spec {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or_default();
                 write_padded(
                     writer,
-                    &[args.next_char(position)],
+                    &[args.next_char(*position)],
                     width,
                     *align_left || neg_width,
                 )
@@ -377,7 +377,7 @@ impl Spec {
                 // TODO: We need to not use Rust's formatting for aligning the output,
                 // so that we can just write bytes to stdout without panicking.
                 let precision = resolve_asterisk_precision(*precision, args);
-                let os_str = args.next_string(position);
+                let os_str = args.next_string(*position);
                 let bytes = os_str_as_bytes(os_str)?;
 
                 let truncated = match precision {
@@ -387,7 +387,7 @@ impl Spec {
                 write_padded(writer, truncated, width, *align_left || neg_width)
             }
             Self::EscapedString { position } => {
-                let os_str = args.next_string(position);
+                let os_str = args.next_string(*position);
                 let bytes = os_str_as_bytes(os_str)?;
                 let mut parsed = Vec::<u8>::new();
 
@@ -404,7 +404,7 @@ impl Spec {
             }
             Self::QuotedString { position } => {
                 let s = locale_aware_escape_name(
-                    args.next_string(position),
+                    args.next_string(*position),
                     QuotingStyle::SHELL_ESCAPE,
                 );
                 let bytes = os_str_as_bytes(&s)?;
@@ -419,7 +419,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
-                let i = args.next_i64(position);
+                let i = args.next_i64(*position);
 
                 if precision as u64 > i32::MAX as u64 {
                     return Err(FormatError::InvalidPrecision(precision.to_string()));
@@ -447,7 +447,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
-                let i = args.next_u64(position);
+                let i = args.next_u64(*position);
 
                 if precision as u64 > i32::MAX as u64 {
                     return Err(FormatError::InvalidPrecision(precision.to_string()));
@@ -478,7 +478,7 @@ impl Spec {
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
                 let precision = resolve_asterisk_precision(*precision, args);
-                let f: ExtendedBigDecimal = args.next_extended_big_decimal(position);
+                let f: ExtendedBigDecimal = args.next_extended_big_decimal(*position);
 
                 if precision.is_some_and(|p| p as u64 > i32::MAX as u64) {
                     return Err(FormatError::InvalidPrecision(
@@ -515,7 +515,7 @@ fn resolve_asterisk_width(
     match option {
         None => None,
         Some(CanAsterisk::Asterisk(loc)) => {
-            let nb = args.next_i64(&loc);
+            let nb = args.next_i64(loc);
             if nb < 0 {
                 Some((usize::try_from(-(nb as isize)).ok().unwrap_or(0), true))
             } else {
@@ -534,7 +534,7 @@ fn resolve_asterisk_precision(
 ) -> Option<usize> {
     match option {
         None => None,
-        Some(CanAsterisk::Asterisk(loc)) => match args.next_i64(&loc) {
+        Some(CanAsterisk::Asterisk(loc)) => match args.next_i64(loc) {
             v if v >= 0 => usize::try_from(v).ok(),
             v if v < 0 => Some(0usize),
             _ => None,

--- a/src/uucore/src/lib/features/parser/num_parser.rs
+++ b/src/uucore/src/lib/features/parser/num_parser.rs
@@ -35,7 +35,7 @@ enum Base {
 
 impl Base {
     /// Return the digit value of a character in the given base
-    fn digit(&self, c: char) -> Option<u64> {
+    fn digit(self, c: char) -> Option<u64> {
         fn from_decimal(c: char) -> u64 {
             u64::from(c) - u64::from('0')
         }
@@ -53,7 +53,7 @@ impl Base {
 
     /// Greedily parse as many digits as possible from the string
     /// Returns parsed digits (if any), and the rest of the string.
-    fn parse_digits<'a>(&self, str: &'a str) -> (Option<BigUint>, &'a str) {
+    fn parse_digits(self, str: &str) -> (Option<BigUint>, &str) {
         let (digits, _, rest) = self.parse_digits_count(str, None);
         (digits, rest)
     }
@@ -61,11 +61,11 @@ impl Base {
     /// Greedily parse as many digits as possible from the string, adding to already parsed digits.
     /// This is meant to be used (directly) for the part after a decimal point.
     /// Returns parsed digits (if any), the number of parsed digits, and the rest of the string.
-    fn parse_digits_count<'a>(
-        &self,
-        str: &'a str,
+    fn parse_digits_count(
+        self,
+        str: &str,
         digits: Option<BigUint>,
-    ) -> (Option<BigUint>, i64, &'a str) {
+    ) -> (Option<BigUint>, i64, &str) {
         let mut digits: Option<BigUint> = digits;
         let mut count: i64 = 0;
         let mut rest = str;
@@ -77,9 +77,9 @@ impl Base {
         let mut mul_tmp: u64 = 1;
         while let Some(d) = rest.chars().next().and_then(|c| self.digit(c)) {
             (digits_tmp, count_tmp, mul_tmp) = (
-                digits_tmp * *self as u64 + d,
+                digits_tmp * self as u64 + d,
                 count_tmp + 1,
-                mul_tmp * *self as u64,
+                mul_tmp * self as u64,
             );
             rest = &rest[1..];
             // In base 16, we parse 4 bits at a time, so we can parse 16 digits at most in a u64.

--- a/src/uucore/src/lib/features/safe_traversal.rs
+++ b/src/uucore/src/lib/features/safe_traversal.rs
@@ -345,15 +345,15 @@ impl FileType {
         }
     }
 
-    pub fn is_directory(&self) -> bool {
+    pub fn is_directory(self) -> bool {
         matches!(self, Self::Directory)
     }
 
-    pub fn is_regular_file(&self) -> bool {
+    pub fn is_regular_file(self) -> bool {
         matches!(self, Self::RegularFile)
     }
 
-    pub fn is_symlink(&self) -> bool {
+    pub fn is_symlink(self) -> bool {
         matches!(self, Self::Symlink)
     }
 }


### PR DESCRIPTION
Address all suggestions of [`clippy::trivially_copy_pass_by_ref`](https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref)

Seems cleaner, and I wonder if perf would be affected