### PR TITLE
chore: `clippy::wildcard_imports`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -674,7 +674,6 @@ unnecessary_wraps = "allow"                  # 33
 ignored_unit_patterns = "allow"              # 21
 similar_names = "allow"                      # 20
 large_stack_arrays = "allow"                 # 20
-wildcard_imports = "allow"                   # 18
 needless_pass_by_value = "allow"             # 16
 float_cmp = "allow"                          # 12
 items_after_statements = "allow"             # 11

--- a/src/uu/arch/src/arch.rs
+++ b/src/uu/arch/src/arch.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 use clap::Command;
-use platform_info::*;
+use platform_info::{PlatformInfo, PlatformInfoAPI, UNameAPI};
 use std::io::{Write, stdout};
 use uucore::error::{UResult, USimpleError};
 use uucore::translate;

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -25,7 +25,7 @@ use std::{fs, io};
 mod errors;
 mod fts;
 
-use errors::*;
+use errors::{Error, Result, report_full_error};
 
 pub mod options {
     pub static HELP: &str = "help";

--- a/src/uu/dd/src/datastructures.rs
+++ b/src/uu/dd/src/datastructures.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 // spell-checker:ignore ctable, outfile, iseek, oseek
 
-use crate::conversion_tables::*;
+use crate::conversion_tables::ConversionTable;
 
 type Cbs = usize;
 

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -15,7 +15,7 @@ mod progress;
 
 use crate::bufferedoutput::BufferedOutput;
 use blocks::conv_block_unblock_helper;
-use datastructures::*;
+use datastructures::{ConversionMode, IConvFlags, IFlags, OConvFlags, OFlags, options};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::fcntl::FcntlArg;
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -541,7 +541,9 @@ fn get_ctable(
     conversion: Option<Conversion>,
     case: Option<Case>,
 ) -> Option<&'static ConversionTable> {
+    #[allow(clippy::wildcard_imports)]
     use crate::conversion_tables::*;
+
     Some(match (conversion, case) {
         (None, None) => return None,
         (Some(conv), None) => match conv {

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -460,7 +460,7 @@ impl SignalHandler {
     pub(crate) fn install_signal_handler(
         f: Box<dyn Send + Sync + Fn()>,
     ) -> Result<Self, std::io::Error> {
-        use signal_hook::consts::signal::*;
+        use signal_hook::consts::signal::SIGUSR1;
         use signal_hook::iterator::Signals;
 
         let mut signals = Signals::new([SIGUSR1])?;

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -3,9 +3,14 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use crate::errors::*;
+use crate::errors::NumfmtError;
 use crate::format::{format_and_print_delimited, format_and_print_whitespace};
-use crate::options::*;
+use crate::options::{
+    DEBUG, DELIMITER, FIELD, FIELD_DEFAULT, FORMAT, FROM, FROM_DEFAULT, FROM_UNIT,
+    FROM_UNIT_DEFAULT, FormatOptions, HEADER, HEADER_DEFAULT, INVALID, InvalidModes, NUMBER,
+    NumfmtOptions, PADDING, ROUND, RoundMethod, SUFFIX, TO, TO_DEFAULT, TO_UNIT, TO_UNIT_DEFAULT,
+    TransformOptions, UNIT_SEPARATOR, ZERO_TERMINATED,
+};
 use crate::units::{Result, Unit};
 use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser, parser::ValueSource};
 use std::ffi::OsString;

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -8,9 +8,16 @@ use uucore::display::Quotable;
 use uucore::translate;
 
 use crate::formatter_item_info::FormatterItemInfo;
-use crate::prn_char::*;
-use crate::prn_float::*;
-use crate::prn_int::*;
+use crate::prn_char::{FORMAT_ITEM_A, FORMAT_ITEM_C};
+use crate::prn_float::{
+    FORMAT_ITEM_BF16, FORMAT_ITEM_F16, FORMAT_ITEM_F32, FORMAT_ITEM_F64, FORMAT_ITEM_LONG_DOUBLE,
+};
+use crate::prn_int::{
+    FORMAT_ITEM_DEC8S, FORMAT_ITEM_DEC8U, FORMAT_ITEM_DEC16S, FORMAT_ITEM_DEC16U,
+    FORMAT_ITEM_DEC32S, FORMAT_ITEM_DEC32U, FORMAT_ITEM_DEC64S, FORMAT_ITEM_DEC64U,
+    FORMAT_ITEM_HEX8, FORMAT_ITEM_HEX16, FORMAT_ITEM_HEX32, FORMAT_ITEM_HEX64, FORMAT_ITEM_OCT8,
+    FORMAT_ITEM_OCT16, FORMAT_ITEM_OCT32, FORMAT_ITEM_OCT64,
+};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct ParsedFormatterItemInfo {

--- a/src/uu/od/src/prn_int.rs
+++ b/src/uu/od/src/prn_int.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-use crate::formatter_item_info::*;
+use crate::formatter_item_info::{FormatWriter, FormatterItemInfo};
 
 /// format string to print octal using `int_writer_unsigned`
 macro_rules! OCT {

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -298,7 +298,9 @@ impl Observer {
         event: &notify::Event,
         settings: &Settings,
     ) -> UResult<Vec<PathBuf>> {
-        use notify::event::*;
+        use notify::event::{
+            CreateKind, DataChange, EventKind, MetadataKind, ModifyKind, RemoveKind, RenameMode,
+        };
 
         let event_path = event.paths.first().unwrap();
         let mut paths: Vec<PathBuf> = vec![];

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -702,7 +702,7 @@ fn prepend_century(s: &str) -> UResult<String> {
 /// then cc is 20 for years in the range 0 … 68, and 19 for years in 69 … 99.
 /// in order to be compatible with GNU `touch`.
 fn parse_timestamp(s: &str) -> UResult<FileTime> {
-    use format::*;
+    use format::{YYYYMMDDHHMM, YYYYMMDDHHMM_DOT_SS};
 
     let current_year = || Timestamp::now().to_zoned(TimeZone::system()).year();
 

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -8,7 +8,7 @@
 use std::ffi::{OsStr, OsString};
 
 use clap::{Arg, ArgAction, Command};
-use platform_info::*;
+use platform_info::{PlatformInfo, PlatformInfoAPI, UNameAPI};
 use uucore::display::println_verbatim;
 use uucore::translate;
 use uucore::{

--- a/src/uu/uptime/src/uptime.rs
+++ b/src/uu/uptime/src/uptime.rs
@@ -14,7 +14,10 @@ use thiserror::Error;
 use uucore::error::{UError, UResult};
 use uucore::libc::time_t;
 use uucore::translate;
-use uucore::uptime::*;
+use uucore::uptime::{
+    OutputFormat, format_nusers, get_formatted_loadavg, get_formatted_nusers, get_formatted_time,
+    get_formatted_uptime, get_uptime,
+};
 
 use clap::{Arg, ArgAction, Command, ValueHint, builder::ValueParser};
 
@@ -22,7 +25,7 @@ use uucore::format_usage;
 
 #[cfg(unix)]
 #[cfg(not(target_os = "openbsd"))]
-use uucore::utmpx::*;
+use uucore::utmpx::{BOOT_TIME, USER_PROCESS, Utmpx};
 
 pub mod options {
     pub static SINCE: &str = "since";

--- a/src/uu/wc/src/utf8/read.rs
+++ b/src/uu/wc/src/utf8/read.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore bytestream
-use super::*;
+use super::{Incomplete, str};
 use std::io::{self, BufRead};
 use thiserror::Error;
 use uucore::translate;

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn utmpxname(_file: *const libc::c_char) -> libc::c_int {
     0
 }
 
-use crate::*; // import macros from `../../macros.rs`
+use crate::{LazyLock, libc}; // import macros from `../../macros.rs`
 
 // In case the c_char array doesn't end with NULL
 macro_rules! chars2string {


### PR DESCRIPTION
* [`clippy::wildcard_imports`](https://rust-lang.github.io/rust-clippy/master/index.html?search=wildcard_imports#wildcard_imports)

Usually wildcards lead to less certain code, so best to avoid it.