### PR TITLE
refactor: move generated code into sub-mod

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,11 +62,14 @@ pub fn main() {
     let mut mf = File::create(Path::new(&out_dir).join("uutils_map.rs")).unwrap();
 
     mf.write_all(
-        "type UtilityMap<T> = phf::OrderedMap<&'static str, (fn(T) -> i32, fn() -> Command)>;\n\
+        "use ::clap::Command;\n\
+         use ::uucore::Args;\n\
+         \n\
+         pub(crate) type UtilityMap<T> = phf::OrderedMap<&'static str, (fn(T) -> i32, fn() -> Command)>;\n\
          \n\
          #[allow(clippy::too_many_lines)]
          #[allow(clippy::unreadable_literal)]
-         fn util_map<T: Args>() -> UtilityMap<T> {\n"
+         pub(crate) fn util_map<T: Args>() -> UtilityMap<T> {\n"
             .as_bytes(),
     )
     .unwrap();

--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -3,18 +3,20 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use clap::Command;
+mod uutils_map {
+    include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
+}
+
+use crate::uutils_map::UtilityMap;
+use crate::uutils_map::util_map;
 use coreutils::validation;
 use itertools::Itertools as _;
 use std::cmp;
 use std::ffi::OsString;
 use std::io::{self, Write};
 use std::process;
-use uucore::Args;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 
 fn usage<T>(utils: &UtilityMap<T>, name: &str) {
     println!("{name} {VERSION} (multi-call binary)\n");

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -5,6 +5,10 @@
 
 // spell-checker:ignore mangen tldr
 
+mod uutils_map {
+    include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
+}
+
 use std::{
     collections::HashMap,
     ffi::OsString,
@@ -21,10 +25,10 @@ use fluent_syntax::parser;
 use textwrap::{fill, indent, termwidth};
 use zip::ZipArchive;
 
+use crate::uutils_map::UtilityMap;
+use crate::uutils_map::util_map;
 use coreutils::validation;
 use uucore::Args;
-
-include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 
 /// Print usage information for uudoc
 fn usage<T: Args>(utils: &UtilityMap<T>) {

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -4,7 +4,14 @@
 // file that was distributed with this source code.
 // spell-checker:disable
 
+#[expect(clippy::match_same_arms)]
+mod embedded_locales {
+    // Include embedded locale files as fallback
+    include!(concat!(env!("OUT_DIR"), "/embedded_locales.rs"));
+}
+
 use crate::error::UError;
+use crate::locale::embedded_locales::get_embedded_locale;
 
 use fluent::{FluentArgs, FluentBundle, FluentResource};
 use fluent_syntax::parser::ParserError;
@@ -58,9 +65,6 @@ impl UError for LocalizationError {
 }
 
 pub const DEFAULT_LOCALE: &str = "en-US";
-
-// Include embedded locale files as fallback
-include!(concat!(env!("OUT_DIR"), "/embedded_locales.rs"));
 
 // A struct to handle localization with optional English fallback
 struct Localizer {


### PR DESCRIPTION
generated/included code should always be inside its own `mod` to avoid accidentally adding new names to the current scope. This also allows clean way of adding new attributes to the whole file - something not possible to do to a single `include!` statement.