### PR TITLE
test: make the man-page readable + sync

### DIFF
--- a/src/uu/test/locales/en-US.ftl
+++ b/src/uu/test/locales/en-US.ftl
@@ -39,6 +39,12 @@ test-after-help = Exit with the status determined by EXPRESSION.
   STRING1 != STRING2
         the strings are not equal
 
+  STRING1 > STRING2
+        STRING1 is greater than STRING2 in the current locale
+
+  STRING1 < STRING2
+        STRING1 is less than STRING2 in the current locale
+
   Integer comparisons:
 
   INTEGER1 -eq INTEGER2

--- a/src/uu/test/locales/fr-FR.ftl
+++ b/src/uu/test/locales/fr-FR.ftl
@@ -39,6 +39,12 @@ test-after-help = Quitter avec le statut déterminé par EXPRESSION.
   STRING1 != STRING2
         les chaînes ne sont pas égales
 
+  STRING1 > STRING2
+        STRING1 est plus grande que STRING2 dans les paramètres régionaux actuels
+
+  STRING1 < STRING2
+        STRING1 est plus petite que STRING2 dans les paramètres régionaux actuels
+
   Comparaisons d'entiers :
 
   INTEGER1 -eq INTEGER2


### PR DESCRIPTION
The previous version was all compacted, and clearly not readable.

<img width="792" height="506" alt="image" src="https://github.com/user-attachments/assets/ce25f50c-07e6-4bed-a970-0bb35bcd632d" />

Add a bunch of new lines and indentations to fix that.

The new version looks more like the one from GNU coreutils now.

While at it, also add `STRING1 > STRING2` and `STRING1 < STRING2` that were missing but supported.

Note: this PR fixes #8362. It is similar to #9005 (with more visual changes), but here, I only focused on fixing the man page. I'm not sure adding a generic test is easy to do and that useful. More changes and tests can be added once https://github.com/clap-rs/clap/issues/5900 is implemented, but I think these modifications only in the man-pages are enough for the moment.