### PR TITLE
mv: test broken symlink file/dir as target

### DIFF
--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -468,6 +468,36 @@ fn test_mv_replace_symlink_with_file() {
 
 #[test]
 #[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_file_to_broken_symlink_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.touch("file");
+    at.symlink_file("missing-target", "broken");
+
+    ucmd.arg("file").arg("broken").succeeds().no_stderr();
+
+    assert!(at.file_exists("broken"));
+    assert!(!at.is_symlink("broken"));
+    assert!(!at.file_exists("file"));
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_file_to_broken_symlink_directory() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.touch("file");
+    at.symlink_dir("missing-target", "broken");
+
+    ucmd.arg("file").arg("broken").succeeds().no_stderr();
+
+    assert!(at.file_exists("broken"));
+    assert!(!at.is_symlink("broken"));
+    assert!(!at.file_exists("file"));
+}
+
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
 fn test_mv_file_to_symlink_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
### Overview

This PR adds a **test suite** for the `mv` utility covering broken symlink scenarios. 

The tests verify that moving a file onto a broken symlink behaves correctly, matching GNU `mv` behavior:

- Broken symlink pointing to a file
- Broken symlink pointing to a directory

### Test Cases
Create a file and a broken symlink to a file:
   ```bash
   touch file
   ln -s missing-target broken
   ./coreutils mv file broken
