### PR TITLE
uucore: tr, nice -n . 2>/dev/full does not abort

### DIFF
--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -59,7 +59,8 @@ pub fn main(args: TokenStream, stream: TokenStream) -> TokenStream {
                         uucore::show_error!("{s}");
                     }
                     if e.usage() {
-                        eprintln!("Try '{} --help' for more information.", uucore::execution_phrase());
+                        use std::io::{stderr, Write as _};
+                        let _ = writeln!(stderr(),"Try '{} --help' for more information.", uucore::execution_phrase());
                     }
                     e.code()
                 }


### PR DESCRIPTION
Closes #10747 . Removes Try `--help` message which matches with gnu 9.10.
[Edit] Closes #10621