### PR TITLE
Id: don't panic on write error

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -183,7 +183,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         if state.selinux_supported {
             if let Ok(context) = selinux::SecurityContext::current(false) {
                 let bytes = context.as_bytes();
-                return write!(lock, "{}{line_ending}", String::from_utf8_lossy(bytes));
+                write!(lock, "{}{line_ending}", String::from_utf8_lossy(bytes))?;
+                return Ok(());
             }
             return Err(USimpleError::new(
                 1,
@@ -196,7 +197,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         if state.smack_supported {
             match uucore::smack::get_smack_label_for_self() {
                 Ok(label) => {
-                    return write!(lock, "{label}{line_ending}");
+                    write!(lock, "{label}{line_ending}")?;
+                    return Ok(());
                 }
                 Err(_) => {
                     return Err(USimpleError::new(


### PR DESCRIPTION
fixes #10561 

As many functions now return Result<()> instead of (), also got rid of some unwrap()s where possible.
