### PR TITLE
stdbuf: fix warning from `uninlined_format_args`

### DIFF
--- a/tests/by-util/test_stdbuf.rs
+++ b/tests/by-util/test_stdbuf.rs
@@ -105,9 +105,8 @@ fn test_stdbuf_search_order_exe_dir_first() {
 
     assert!(
         loaded_from_exe_dir,
-        "libstdbuf should be loaded from exe directory ({}), not from LIBSTDBUF_DIR. LD_DEBUG output:\n{}",
-        temp_path.display(),
-        stderr
+        "libstdbuf should be loaded from exe directory ({}), not from LIBSTDBUF_DIR. LD_DEBUG output:\n{stderr}",
+        temp_path.display()
     );
 
     // The command should succeed and produce the expected output


### PR DESCRIPTION
This PR fixes a warning from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#uninlined_format_args) lint.

Update: the issue is mentioned in https://github.com/uutils/coreutils/pull/10730#issuecomment-3864348150