### PR TITLE
deny.toml: remove `signal-hook` from skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -104,8 +104,6 @@ skip = [
   { name = "zerocopy", version = "0.7.35" },
   # zerocopy
   { name = "zerocopy-derive", version = "0.7.35" },
-  # crossterm
-  { name = "signal-hook", version = "0.3.18" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
Mentioned in https://github.com/uutils/coreutils/pull/10768#discussion_r2776346722