### PR TITLE
ci: fix incorrect selection of version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Get current version from Cargo.toml
         id: version
         run: |
-          VERSION=$(awk '/\[workspace\.package\]/{flag=1; next} flag && /version = /{gsub(/.*= "/, ""); gsub(/".*/, ""); print; exit}' Cargo.toml)
+          VERSION=$(awk '/\[workspace\.package\]/{flag=1; next} flag && /^version = /{gsub(/.*= "/, ""); gsub(/".*/, ""); print; exit}' Cargo.toml)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION"
 


### PR DESCRIPTION
After merging https://github.com/uutils/coreutils/pull/10778 the `documentation.yml` workflow selects the Rust version instead of the coreutils version from `Cargo.toml` and thus the `Check for correct version in ls.md` step fails (see https://github.com/uutils/coreutils/actions/runs/21781455936/job/62846075754?pr=10786#step:9:38). This PR should fix the issue.