### PR TITLE
tac: fix stdin piping on Windows by skipping empty mmap results

### DIFF
--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -411,7 +411,11 @@ fn tac(filenames: &[OsString], before: bool, regex: bool, separator: &str) -> UR
 fn try_mmap_stdin() -> Option<Mmap> {
     // SAFETY: If the file is truncated while we map it, SIGBUS will be raised
     // and our process will be terminated, thus preventing access of invalid memory.
-    unsafe { Mmap::map(&stdin()).ok() }
+    let mmap = unsafe { Mmap::map(&stdin()).ok()? };
+    // On Windows, mmap on a pipe handle can "succeed" but return 0 bytes
+    // (the file size of a pipe is reported as 0). When that happens, return
+    // None so we fall through to buffer_stdin() which reads the pipe properly.
+    if mmap.is_empty() { None } else { Some(mmap) }
 }
 
 enum StdinData {

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -29,8 +29,6 @@ fn test_invalid_arg() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_stdin_default() {
     new_ucmd!()
         .pipe_in("100\n200\n300\n400\n500")
@@ -39,8 +37,6 @@ fn test_stdin_default() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_stdin_non_newline_separator() {
     new_ucmd!()
         .args(&["-s", ":"])
@@ -50,8 +46,6 @@ fn test_stdin_non_newline_separator() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_stdin_non_newline_separator_before() {
     new_ucmd!()
         .args(&["-b", "-s", ":"])
@@ -104,14 +98,11 @@ fn test_invalid_input() {
 }
 
 #[test]
-#[cfg(not(windows))] // FIXME: https://github.com/uutils/coreutils/issues/4204
 fn test_no_line_separators() {
     new_ucmd!().pipe_in("a").succeeds().stdout_is("a");
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_before_trailing_separator_no_leading_separator() {
     new_ucmd!()
         .arg("-b")
@@ -121,8 +112,6 @@ fn test_before_trailing_separator_no_leading_separator() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_before_trailing_separator_and_leading_separator() {
     new_ucmd!()
         .arg("-b")
@@ -132,8 +121,6 @@ fn test_before_trailing_separator_and_leading_separator() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_before_leading_separator_no_trailing_separator() {
     new_ucmd!()
         .arg("-b")
@@ -143,8 +130,6 @@ fn test_before_leading_separator_no_trailing_separator() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_before_no_separator() {
     new_ucmd!()
         .arg("-b")
@@ -154,15 +139,11 @@ fn test_before_no_separator() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_before_empty_file() {
     new_ucmd!().arg("-b").pipe_in("").succeeds().stdout_is("");
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_multi_char_separator() {
     new_ucmd!()
         .args(&["-s", "xx"])
@@ -204,8 +185,6 @@ fn test_multi_char_separator_overlap() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_multi_char_separator_overlap_before() {
     // With the "-b" option, the line separator is assumed to be at the
     // beginning of the line. In this case, That is, "axxx" is
@@ -248,8 +227,6 @@ fn test_multi_char_separator_overlap_before() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_null_separator() {
     new_ucmd!()
         .args(&["-s", ""])
@@ -259,8 +236,6 @@ fn test_null_separator() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_regex() {
     new_ucmd!()
         .args(&["-r", "-s", "[xyz]+"])
@@ -289,8 +264,6 @@ fn test_regex() {
 }
 
 #[test]
-// FIXME: See https://github.com/uutils/coreutils/issues/4204
-#[cfg(not(windows))]
 fn test_regex_before() {
     new_ucmd!()
         .args(&["-b", "-r", "-s", "[xyz]+"])


### PR DESCRIPTION
This is a fix for the flaky tac tests and allows us to enable all of the disabled tac tests that were previously disabled due to the flakiness issue. The cause is that when calling mmap on stdin on windows, if the data is not ready yet it will return a 0 size which mmap will succeed on reading and then return an empty output. 

This adds a check that if it's an empty stdin when trying to mmap it will default to the tmpfile behavior. This is what already happens when stdin is not a file hander on windows since if the stdin is not empty and its not a file handler then mmap will fail regardless and it will go to the default tmpfile behavior

Fixes: https://github.com/uutils/coreutils/issues/10782