### PR TITLE
uptime: Remove wincode and wincode-derive dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,8 +667,6 @@ dependencies = [
  "uucore",
  "uutests",
  "walkdir",
- "wincode",
- "wincode-derive",
  "zip",
 ]
 
@@ -810,41 +808,6 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1606,12 +1569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e10b0e5e87a2c84bd5fa407705732052edebe69291d347d0c3033785470edbf"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,12 +2156,6 @@ dependencies = [
  "num-traits",
  "winnow",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "phf"
@@ -4647,30 +4598,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wincode"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f27315388539620cef3386d77b05305dbfb7fccbd32eead533a7a3779313532"
-dependencies = [
- "pastey",
- "proc-macro2",
- "quote",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "wincode-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89833c7743abd1a831b7eb0fdfd7210bd8bedc297435e9426aad9b63d7c7f77"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime serde wincode gethostid kqueue libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner
+# spell-checker:ignore (libs) bigdecimal datetime serde gethostid kqueue libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner
 
 [package]
 name = "coreutils"
@@ -587,11 +587,6 @@ nix = { workspace = true, features = [
 ] }
 rlimit = { workspace = true }
 
-# Used in test_uptime::test_uptime_with_file_containing_valid_boot_time_utmpx_record
-# to deserialize an utmpx struct into a binary file
-[target.'cfg(all(target_family= "unix",not(target_os = "macos")))'.dev-dependencies]
-wincode = "0.3.1"
-wincode-derive = "0.3.1"
 
 [build-dependencies]
 phf_codegen.workspace = true

--- a/tests/by-util/test_uptime.rs
+++ b/tests/by-util/test_uptime.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
-// spell-checker:ignore wincode serde utmp runlevel testusr testx boottime
+// spell-checker:ignore utmp runlevel testusr testx boottime
 #![allow(clippy::cast_possible_wrap, clippy::unreadable_literal)]
 
 use uutests::{at_and_ucmd, new_ucmd};
@@ -97,8 +97,6 @@ fn test_uptime_with_non_existent_file() {
 fn test_uptime_with_file_containing_valid_boot_time_utmpx_record() {
     use std::fs::File;
     use std::{io::Write, path::PathBuf};
-    use wincode::serialize;
-    use wincode_derive::SchemaWrite;
 
     // This test will pass for freebsd but we currently don't support changing the utmpx file for
     // freebsd.
@@ -132,21 +130,18 @@ fn test_uptime_with_file_containing_valid_boot_time_utmpx_record() {
         const RUN_LVL: i32 = 1;
         const USER_PROCESS: i32 = 7;
 
-        #[derive(SchemaWrite)]
         #[repr(C)]
         pub struct TimeVal {
             pub tv_sec: i32,
             pub tv_usec: i32,
         }
 
-        #[derive(SchemaWrite)]
         #[repr(C)]
         pub struct ExitStatus {
             e_termination: i16,
             e_exit: i16,
         }
 
-        #[derive(SchemaWrite)]
         #[repr(C, align(4))]
         pub struct Utmp {
             pub ut_type: i32,
@@ -222,9 +217,35 @@ fn test_uptime_with_file_containing_valid_boot_time_utmpx_record() {
             glibc_reserved: [0; 20],
         };
 
-        let mut buf = serialize(&utmp).unwrap();
-        buf.append(&mut serialize(&utmp1).unwrap());
-        buf.append(&mut serialize(&utmp2).unwrap());
+        fn serialize_i8_arr(buf: &mut Vec<u8>, arr: &[i8]) {
+            for b in arr {
+                buf.push(*b as u8);
+            }
+        }
+
+        fn serialize(utmp: &Utmp) -> Vec<u8> {
+            let mut buf = Vec::new();
+            buf.extend_from_slice(&utmp.ut_type.to_ne_bytes());
+            buf.extend_from_slice(&utmp.ut_pid.to_ne_bytes());
+            serialize_i8_arr(&mut buf, &utmp.ut_line);
+            serialize_i8_arr(&mut buf, &utmp.ut_id);
+            serialize_i8_arr(&mut buf, &utmp.ut_user);
+            serialize_i8_arr(&mut buf, &utmp.ut_host);
+            buf.extend_from_slice(&utmp.ut_exit.e_termination.to_ne_bytes());
+            buf.extend_from_slice(&utmp.ut_exit.e_exit.to_ne_bytes());
+            buf.extend_from_slice(&utmp.ut_session.to_ne_bytes());
+            buf.extend_from_slice(&utmp.ut_tv.tv_sec.to_ne_bytes());
+            buf.extend_from_slice(&utmp.ut_tv.tv_usec.to_ne_bytes());
+            for v in &utmp.ut_addr_v6 {
+                buf.extend_from_slice(&v.to_ne_bytes());
+            }
+            serialize_i8_arr(&mut buf, &utmp.glibc_reserved);
+            buf
+        }
+
+        let mut buf = serialize(&utmp);
+        buf.append(&mut serialize(&utmp1));
+        buf.append(&mut serialize(&utmp2));
         let mut f = File::create(path).unwrap();
         f.write_all(&buf).unwrap();
     }


### PR DESCRIPTION
I've been working on brainstorming ways to reduce the dependency tree, which I think is important for the longer term adoption of this project and currently we have three pr's in our queue related to the use of wincode and wincode-derive. There were some breaking changes in the last version upgrade and I wanted to see what it would take for us to remove this dependency. 

There are 7 other dependencies in the dependency chain that is removed by removing this dependency.

```
wincode, wincode-derive, pastey, darling, darling_macro, darling_core, ident_case
```