### PR TITLE
sort: making ClosedCompressedTmpFile::reopen() not panic.

### DIFF
--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -548,7 +548,9 @@ impl ClosedTmpFile for ClosedCompressedTmpFile {
 
     fn reopen(self) -> UResult<Self::Reopened> {
         let mut command = Command::new(&self.compress_prog);
-        let file = File::open(&self.path).unwrap();
+        // mirroring what is done for ClosedPlainTmpFile
+        let file =
+            File::open(&self.path).map_err(|error| SortError::OpenTmpFileFailed { error })?;
         command.stdin(file).stdout(Stdio::piped()).arg("-d");
         let mut child = command
             .spawn()


### PR DESCRIPTION
Even tough for the panic to happen, we would need specific contexts, we mirror what is done for ClosedPlainTmpFile to make it smoother.