### PR TITLE
tr: graph and print classes revert logic handling.

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -177,8 +177,7 @@ impl Sequence {
                         .chain(33..=47)
                         .chain(58..=64)
                         .chain(91..=96)
-                        .chain(123..=126)
-                        .chain(std::iter::once(32)), // space
+                        .chain(123..=126),
                 ),
                 Class::Print => Box::new(
                     (48..=57) // digit
@@ -188,7 +187,8 @@ impl Sequence {
                         .chain(33..=47)
                         .chain(58..=64)
                         .chain(91..=96)
-                        .chain(123..=126),
+                        .chain(123..=126)
+                        .chain(std::iter::once(32)), // space
                 ),
                 Class::Punct => Box::new((33..=47).chain(58..=64).chain(91..=96).chain(123..=126)),
                 Class::Space => Box::new(unicode_table::SPACES.iter().copied()),

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1584,3 +1584,25 @@ fn test_stdin_is_socket() {
         .succeeds()
         .stdout_is(";;");
 }
+
+#[test]
+fn test_delete_graph_does_not_delete_space() {
+    // [:graph:] is all printable characters EXCEPT space.
+    // Deleting [:graph:] from "hello world" should leave the space.
+    new_ucmd!()
+        .args(&["-d", "[:graph:]"])
+        .pipe_in("hello world")
+        .succeeds()
+        .stdout_is(" ");
+}
+
+#[test]
+fn test_delete_print_deletes_space() {
+    // [:print:] is all printable characters INCLUDING space.
+    // Deleting [:print:] from "hello world" should leave nothing.
+    new_ucmd!()
+        .args(&["-d", "[:print:]"])
+        .pipe_in("hello world")
+        .succeeds()
+        .stdout_is("");
+}


### PR DESCRIPTION
[:graph] class handle printable characters excluding spaces, [:print] on the other hand include spaces.