### PR TITLE
printf: fix %q shell quoting with control chars and quotes

### DIFF
--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1492,3 +1492,16 @@ fn test_extreme_field_width_overflow() {
         .fails_with_code(1)
         .stderr_contains("printf: write error"); //could contains additional message like "formatting width too large" not in GNU, thats fine.
 }
+
+#[test]
+fn test_q_string_control_chars_with_quotes() {
+    // Test %q with control characters and single quotes combined.
+    // This tests the fix for the GNU compatibility issue where control
+    // characters combined with single quotes should use the segmented
+    // quoting approach rather than double quotes.
+    let input = "\x01'\x01";
+    new_ucmd!()
+        .args(&["%q", input])
+        .succeeds()
+        .stdout_only("''$'\\001'\\'''$'\\001'");
+}


### PR DESCRIPTION
should fix tests/printf/printf-quote.sh
upstream change: ba3442f4fa0eec1adff9ff02b95f6b5250999aa3