### PR TITLE
Cat splice perf

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -26,7 +26,7 @@ use uucore::{fast_inc::fast_inc_one, format_usage};
 /// Linux splice support
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod splice;
-const FILE_SPLICE_SIZE_THRESHOLD: u64 = 1024 * 10; // 10KB
+const FILE_SPLICE_SIZE_THRESHOLD: u64 = 1024 * 16; // 16KB
 
 // Allocate 32 digits for the line number.
 // An estimate is that we can print about 1e8 lines/seconds, so 32 digits

--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -485,6 +485,7 @@ fn get_input_type(path: &OsString) -> CatResult<InputType> {
 
 /// Writes handle to stdout with no configuration. This allows a
 /// simple memory copy.
+#[allow(unused_variables)]
 fn write_fast<R: FdReadable>(handle: &mut InputHandle<R>, skip_splice: bool) -> CatResult<()> {
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();


### PR DESCRIPTION
Based on #10832

Avoids using splice on small files.
May result in a small perf improvement


Threshold set to 16KB, determined by trial and error:

```bash
 hyperfine -w 10 -i -L coreutils "target/release/coreutils_16kb","target/release/coreutils_32kb","target/release/coreutils_128kb","target/release/coreutils_base"  "{coreutils} cat /tmp/threshold_test/file_16K*" -N
Benchmark 1: target/release/coreutils_16kb cat /tmp/threshold_test/file_16K*
  Time (mean ± σ):       1.4 ms ±   0.5 ms    [User: 0.3 ms, System: 1.0 ms]
  Range (min … max):     0.8 ms …  11.2 ms    2089 runs
 
  Warning: Ignoring non-zero exit code.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: target/release/coreutils_32kb cat /tmp/threshold_test/file_16K*
  Time (mean ± σ):       1.5 ms ±   0.4 ms    [User: 0.3 ms, System: 1.1 ms]
  Range (min … max):     0.8 ms …   3.3 ms    3211 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 3: target/release/coreutils_128kb cat /tmp/threshold_test/file_16K*
  Time (mean ± σ):       1.4 ms ±   0.4 ms    [User: 0.3 ms, System: 1.0 ms]
  Range (min … max):     0.7 ms …   4.1 ms    2657 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 4: target/release/coreutils_base cat /tmp/threshold_test/file_16K*
  Time (mean ± σ):       1.6 ms ±   0.5 ms    [User: 0.3 ms, System: 1.2 ms]
  Range (min … max):     0.7 ms …   5.1 ms    2113 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  target/release/coreutils_16kb cat /tmp/threshold_test/file_16K* ran
    1.02 ± 0.48 times faster than target/release/coreutils_128kb cat /tmp/threshold_test/file_16K*
    1.14 ± 0.50 times faster than target/release/coreutils_32kb cat /tmp/threshold_test/file_16K*
    1.17 ± 0.53 times faster than target/release/coreutils_base cat /tmp/threshold_test/file_16K*
```