### PR TITLE
true/false: Mark --help/--version cold for boot performance

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -17,7 +17,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // paths to avoid the allocation of an error object, an operation that could, in theory, fail
     // and unwind through the standard library allocation handling machinery.
     set_exit_code(1);
-
+    // We don't call clap for binary size
     let args: Vec<OsString> = args.collect();
     if args.len() != 2 {
         return Ok(());
@@ -39,6 +39,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     Ok(())
 }
 
+// We optimize the most simple usage
+#[cold]
+#[inline(never)]
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(uucore::crate_version!())

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -12,6 +12,7 @@ use uucore::translate;
 // TODO: modify proc macro to allow no-result uumain
 #[expect(clippy::unnecessary_wraps, reason = "proc macro requires UResult")]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    // We don't call clap for binary size
     let args: Vec<OsString> = args.collect();
     if args.len() != 2 {
         return Ok(());
@@ -38,6 +39,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     Ok(())
 }
 
+// We optimize the most simple usage
+#[cold]
+#[inline(never)]
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(uucore::crate_version!())


### PR DESCRIPTION
```
$ hyperfine --ignore-failure -N --warmup 5 ...
Summary
  /tmp/coreutils/target/release/true ran
    1.03 ± 0.22 times faster than /tmp/coreutils/target/release/true-prev

Summary
  /tmp/coreutils/target/release/false-prev ran
    1.05 ± 0.21 times faster than /tmp/coreutils/target/release/false
```

