### PR TITLE
dd,df: fix out-of-bounds panic in suffix selection loop

### DIFF
--- a/src/uu/dd/src/numbers.rs
+++ b/src/uu/dd/src/numbers.rs
@@ -51,7 +51,7 @@ impl SuffixType {
             Self::Si => (SI_BASES, SI_SUFFIXES),
         };
         let mut i = 0;
-        while bases[i + 1] - bases[i] < n && i < suffixes.len() {
+        while i < suffixes.len() - 1 && bases[i + 1] - bases[i] < n {
             i += 1;
         }
         (bases[i], suffixes[i])

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -88,7 +88,7 @@ pub(crate) fn to_magnitude_and_suffix(
     let suffixes = suffix_type.suffixes();
     let mut i = 0;
 
-    while bases[i + 1] - bases[i] < n && i < suffixes.len() {
+    while i < suffixes.len() - 1 && bases[i + 1] - bases[i] < n {
         i += 1;
     }
 

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1298,6 +1298,25 @@ fn test_final_stats_three_char_limit() {
 }
 
 #[test]
+fn test_final_stats_mb_suffix() {
+    // Exercise the suffix selection loop in to_magnitude_and_suffix through
+    // actual dd output, ensuring MB/MiB suffixes render without panic.
+    let result = new_ucmd!()
+        .args(&["bs=1000", "count=1000"])
+        .pipe_in("0".repeat(1_000_000))
+        .succeeds();
+    let s = result.stderr_str();
+    assert!(
+        s.contains("kB") || s.contains("MB"),
+        "expected SI suffix in output: {s}"
+    );
+    assert!(
+        s.contains("KiB") || s.contains("MiB"),
+        "expected IEC suffix in output: {s}"
+    );
+}
+
+#[test]
 fn test_invalid_number_arg_gnu_compatibility() {
     let commands = vec!["bs", "cbs", "count", "ibs", "obs", "seek", "skip"];
 

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -166,6 +166,34 @@ fn test_df_rounding() {
 }
 
 #[test]
+fn test_df_human_readable_suffix() {
+    use regex::Regex;
+
+    // Exercise the suffix selection loop in to_magnitude_and_suffix through
+    // actual df output with -h (binary) and -H (SI), ensuring suffixes render
+    // without panic.
+    let re = Regex::new(r"\d[KMGTPEZY]").unwrap(); // spell-checker:disable-line
+
+    let output = new_ucmd!()
+        .args(&["-h", "--total"])
+        .succeeds()
+        .stdout_str_lossy();
+    assert!(
+        re.is_match(&output),
+        "expected human-readable suffix in -h output: {output}"
+    );
+
+    let output = new_ucmd!()
+        .args(&["-H", "--total"])
+        .succeeds()
+        .stdout_str_lossy();
+    assert!(
+        re.is_match(&output),
+        "expected human-readable suffix in -H output: {output}"
+    );
+}
+
+#[test]
 fn test_df_output_overridden() {
     let expected = if cfg!(target_os = "macos") {
         vec![


### PR DESCRIPTION
The bounds check was evaluated after the array access due to short-circuit evaluation order, and used the wrong upper bound, allowing the index to exceed the suffixes array length.