### PR TITLE
whoami: bypass clap for performance

### DIFF
--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -13,9 +13,16 @@ mod platform;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    // bypass clap for performance
+    let args: Vec<_> = args.collect();
+    if args.len() == 1 || (args.len() == 2 && args[1] == "--") {
+        let username = whoami()?;
+        println_verbatim(username)
+            .map_err_context(|| translate!("whoami-error-failed-to-print"))?;
+        return Ok(());
+    }
+    // todo: avoid large clap call for binary size
     uucore::clap_localization::handle_clap_result(uu_app(), args)?;
-    let username = whoami()?;
-    println_verbatim(username).map_err_context(|| translate!("whoami-error-failed-to-print"))?;
     Ok(())
 }
 


### PR DESCRIPTION
```
Summary
  whoami-bypass ran
    1.05 ± 0.24 times faster than whoami
```