### PR TITLE
expand: cgu=3 for binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -606,7 +606,7 @@ panic = "abort"
 codegen-units = 1
 # FIXME: https://github.com/uutils/coreutils/issues/10654
 [profile.release.package.uu_expand]
-codegen-units = 16
+codegen-units = 3
 
 # A release-like profile that is as small as possible.
 [profile.release-small]


### PR DESCRIPTION
~1349360 -> 1210472 byte. cgu=2 caused performance regression.~
https://github.com/uutils/coreutils/pull/10863#issuecomment-3898167929