### PR TITLE
Revert "chore(deps): update rust crate libc to v0.2.181"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,9 +1772,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libfuzzer-sys"


### PR DESCRIPTION
Unblock CI for RedoxOS

This reverts commit c5ca269d87d86f8b3a995fb5597fcde04f82752a.

Fix https://github.com/uutils/coreutils/issues/10871