### PR TITLE
Backporting coreutils.sh gnu test

### DIFF
--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -4,7 +4,7 @@ repo=https://github.com/coreutils/coreutils
 curl -L "${repo}/releases/download/v${ver}/coreutils-${ver}.tar.xz" | tar --strip-components=1 -xJf -
 
 # TODO stop backporting tests from master at GNU coreutils > $ver
-# backport = ()
-# for f in ${backport[@]}
-#  do curl -L ${repo}/raw/refs/heads/master/tests/$f > tests/$f
-# done
+backport=(misc/coreutils.sh)
+for f in ${backport[@]}
+ do curl -L ${repo}/raw/refs/heads/master/tests/$f > tests/$f
+done


### PR DESCRIPTION
Exclude coreutils.sh from the search and replace for abs_top_builddir in Perl tests because it causes the coreutils header file to be skipped. This was the cause of the regression of the coreutils gnu test in the following PR: https://github.com/uutils/coreutils/pull/10840