### PR TITLE
cat,comm,expand,unexpand: remove is_dir() pre-checks to let read() report errors

### DIFF
--- a/src/uu/cat/locales/en-US.ftl
+++ b/src/uu/cat/locales/en-US.ftl
@@ -16,7 +16,6 @@ cat-help-ignored-u = (ignored)
 
 # Error messages
 cat-error-unknown-filetype = unknown filetype: { $ft_debug }
-cat-error-is-directory = Is a directory
 cat-error-input-file-is-output-file = input file is output file
 cat-error-too-many-symbolic-links = Too many levels of symbolic links
 cat-error-no-such-device-or-address = No such device or address

--- a/src/uu/cat/locales/fr-FR.ftl
+++ b/src/uu/cat/locales/fr-FR.ftl
@@ -16,7 +16,6 @@ cat-help-ignored-u = (ignoré)
 
 # Messages d'erreur
 cat-error-unknown-filetype = type de fichier inconnu : { $ft_debug }
-cat-error-is-directory = Est un répertoire
 cat-error-input-file-is-output-file = le fichier d'entrée est le fichier de sortie
 cat-error-too-many-symbolic-links = Trop de niveaux de liens symboliques
 cat-error-no-such-device-or-address = Aucun appareil ou adresse de ce type

--- a/src/uu/comm/locales/en-US.ftl
+++ b/src/uu/comm/locales/en-US.ftl
@@ -20,7 +20,6 @@ comm-help-no-check-order = do not check that the input is correctly sorted
 # Error messages
 comm-error-file-not-sorted = comm: file { $file_num } is not in sorted order
 comm-error-input-not-sorted = comm: input is not in sorted order
-comm-error-is-directory = Is a directory
 comm-error-multiple-conflicting-delimiters = multiple conflicting output delimiters specified
 
 # Other messages

--- a/src/uu/comm/locales/fr-FR.ftl
+++ b/src/uu/comm/locales/fr-FR.ftl
@@ -20,7 +20,6 @@ comm-help-no-check-order = ne pas vérifier que l'entrée est correctement trié
 # Messages d'erreur
 comm-error-file-not-sorted = comm : le fichier { $file_num } n'est pas dans l'ordre trié
 comm-error-input-not-sorted = comm : l'entrée n'est pas dans l'ordre trié
-comm-error-is-directory = Est un répertoire
 comm-error-multiple-conflicting-delimiters = plusieurs délimiteurs de sortie en conflit spécifiés
 
 # Autres messages

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -327,9 +327,6 @@ fn open_file(name: &OsString, line_ending: LineEnding) -> io::Result<LineReader>
     if name == "-" {
         Ok(LineReader::new(Input::stdin(), line_ending))
     } else {
-        if metadata(name)?.is_dir() {
-            return Err(io::Error::other(translate!("comm-error-is-directory")));
-        }
         let f = File::open(name)?;
         Ok(LineReader::new(Input::from_file(f), line_ending))
     }

--- a/src/uu/expand/locales/en-US.ftl
+++ b/src/uu/expand/locales/en-US.ftl
@@ -14,5 +14,4 @@ expand-error-specifier-only-allowed-with-last = { $specifier } specifier only al
 expand-error-tab-size-cannot-be-zero = tab size cannot be 0
 expand-error-tab-size-too-large = tab stop is too large { $size }
 expand-error-tab-sizes-must-be-ascending = tab sizes must be ascending
-expand-error-is-directory = { $file }: Is a directory
 expand-error-failed-to-write-output = failed to write output

--- a/src/uu/expand/locales/fr-FR.ftl
+++ b/src/uu/expand/locales/fr-FR.ftl
@@ -14,5 +14,4 @@ expand-error-specifier-only-allowed-with-last = le spécificateur { $specifier }
 expand-error-tab-size-cannot-be-zero = la taille de tabulation ne peut pas être 0
 expand-error-tab-size-too-large = l'arrêt de tabulation est trop grand { $size }
 expand-error-tab-sizes-must-be-ascending = les tailles de tabulation doivent être croissantes
-expand-error-is-directory = { $file } : Est un répertoire
 expand-error-failed-to-write-output = échec de l'écriture de la sortie

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -15,7 +15,7 @@ use std::str::from_utf8;
 use thiserror::Error;
 use unicode_width::UnicodeWidthChar;
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UError, UResult, USimpleError, set_exit_code};
+use uucore::error::{FromIo, UError, UResult, set_exit_code};
 use uucore::translate;
 use uucore::{format_usage, show};
 
@@ -296,12 +296,6 @@ fn open(path: &OsString) -> UResult<BufReader<Box<dyn Read + 'static>>> {
         Ok(BufReader::new(Box::new(stdin()) as Box<dyn Read>))
     } else {
         let path_ref = Path::new(path);
-        if path_ref.is_dir() {
-            return Err(USimpleError::new(
-                1,
-                translate!("expand-error-is-directory", "file" => path.maybe_quote()),
-            ));
-        }
         file_buf = File::open(path_ref).map_err_context(|| path.maybe_quote().to_string())?;
         Ok(BufReader::new(Box::new(file_buf) as Box<dyn Read>))
     }

--- a/src/uu/unexpand/locales/en-US.ftl
+++ b/src/uu/unexpand/locales/en-US.ftl
@@ -13,4 +13,3 @@ unexpand-error-invalid-character = tab size contains invalid character(s): { $ch
 unexpand-error-tab-size-cannot-be-zero = tab size cannot be 0
 unexpand-error-tab-size-too-large = tab stop value is too large
 unexpand-error-tab-sizes-must-be-ascending = tab sizes must be ascending
-unexpand-error-is-directory = { $path }: Is a directory

--- a/src/uu/unexpand/locales/fr-FR.ftl
+++ b/src/uu/unexpand/locales/fr-FR.ftl
@@ -13,4 +13,3 @@ unexpand-error-invalid-character = la taille de tabulation contient des caractè
 unexpand-error-tab-size-cannot-be-zero = la taille de tabulation ne peut pas être 0
 unexpand-error-tab-size-too-large = la valeur d'arrêt de tabulation est trop grande
 unexpand-error-tab-sizes-must-be-ascending = les tailles de tabulation doivent être croissantes
-unexpand-error-is-directory = { $path } : Est un répertoire

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -10,11 +10,10 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Stdout, Write, stdin, stdout};
 use std::num::IntErrorKind;
-use std::path::Path;
 use std::str::from_utf8;
 use thiserror::Error;
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UError, UResult, USimpleError, set_exit_code};
+use uucore::error::{FromIo, UError, UResult, set_exit_code};
 use uucore::translate;
 use uucore::{format_usage, show};
 
@@ -281,13 +280,7 @@ pub fn uu_app() -> Command {
 
 fn open(path: &OsString) -> UResult<BufReader<Box<dyn Read + 'static>>> {
     let file_buf;
-    let filename = Path::new(path);
-    if filename.is_dir() {
-        Err(Box::new(USimpleError {
-            code: 1,
-            message: translate!("unexpand-error-is-directory", "path" => filename.maybe_quote()),
-        }))
-    } else if path == "-" {
+    if path == "-" {
         Ok(BufReader::new(Box::new(stdin()) as Box<dyn Read>))
     } else {
         file_buf = File::open(path).map_err_context(|| path.maybe_quote().to_string())?;

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -234,7 +234,7 @@ fn test_directory() {
     s.fixtures.mkdir("test_directory");
     s.ucmd()
         .args(&["test_directory"])
-        .fails()
+        .fails_with_code(1)
         .stderr_is("cat: test_directory: Is a directory\n");
 }
 

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -424,28 +424,28 @@ fn test_is_dir() {
     scene
         .ucmd()
         .args(&[".", "."])
-        .fails()
+        .fails_with_code(1)
         .stderr_only("comm: .: Is a directory\n");
 
     at.mkdir("dir");
     scene
         .ucmd()
         .args(&["dir", "."])
-        .fails()
+        .fails_with_code(1)
         .stderr_only("comm: dir: Is a directory\n");
 
     at.touch("file");
     scene
         .ucmd()
         .args(&[".", "file"])
-        .fails()
+        .fails_with_code(1)
         .stderr_only("comm: .: Is a directory\n");
 
     at.touch("file");
     scene
         .ucmd()
         .args(&["file", "."])
-        .fails()
+        .fails_with_code(1)
         .stderr_only("comm: .: Is a directory\n");
 }
 

--- a/tests/by-util/test_expand.rs
+++ b/tests/by-util/test_expand.rs
@@ -414,8 +414,8 @@ int main() {
 fn test_expand_directory() {
     new_ucmd!()
         .args(&["."])
-        .fails()
-        .stderr_contains("expand: .: Is a directory");
+        .fails_with_code(1)
+        .stderr_is("expand: .: Is a directory\n");
 }
 
 #[test]

--- a/tests/by-util/test_unexpand.rs
+++ b/tests/by-util/test_unexpand.rs
@@ -259,8 +259,8 @@ fn test_is_directory() {
     at.mkdir(dir_name);
 
     ucmd.arg(dir_name)
-        .fails()
-        .stderr_contains(format!("unexpand: {dir_name}: Is a directory"));
+        .fails_with_code(1)
+        .stderr_is(format!("unexpand: {dir_name}: Is a directory\n"));
 }
 
 #[test]


### PR DESCRIPTION
This PR is based on the investigation of the read-error gnu test failures. Even though we correctly identify that the test is trying to use a directory we are failing the test because the error coming from the read function is different. This led me down the path to discover that we actually do not need to do additional stat checks to check if we are trying to read a directory because that is handled by read() and it is the expectation that we rely on the read() checks to provide the error message.

Every utility in this PR already had integration tests for validating that the error message matches the GNU error message and I have made them more exact by also validating error code and making it stderr_is instead of stderr_contains.

There will probably be two more PR's basically the same as this one for the other utilities