### PR TITLE
split: flush BufWriter before replacing to detect write errors

### DIFF
--- a/src/uu/split/src/platform/mod.rs
+++ b/src/uu/split/src/platform/mod.rs
@@ -5,10 +5,14 @@
 #[cfg(unix)]
 pub use self::unix::instantiate_current_writer;
 #[cfg(unix)]
+pub use self::unix::open_output_writer;
+#[cfg(unix)]
 pub use self::unix::paths_refer_to_same_file;
 
 #[cfg(windows)]
 pub use self::windows::instantiate_current_writer;
+#[cfg(windows)]
+pub use self::windows::open_output_writer;
 #[cfg(windows)]
 pub use self::windows::paths_refer_to_same_file;
 

--- a/src/uu/split/src/platform/windows.rs
+++ b/src/uu/split/src/platform/windows.rs
@@ -9,15 +9,15 @@ use std::path::Path;
 use uucore::fs;
 use uucore::translate;
 
-/// Get a file writer
+/// Open an output writer without BufWriter wrapping.
 ///
 /// Unlike the unix version of this function, this _always_ returns
 /// a file writer
-pub fn instantiate_current_writer(
+pub fn open_output_writer(
     _filter: Option<&str>,
     filename: &str,
     is_new: bool,
-) -> Result<BufWriter<Box<dyn Write>>> {
+) -> Result<Box<dyn Write>> {
     let file = if is_new {
         // create new file
         std::fs::OpenOptions::new()
@@ -42,7 +42,18 @@ pub fn instantiate_current_writer(
                 Error::other(translate!("split-error-unable-to-reopen-file", "file" => filename))
             })?
     };
-    Ok(BufWriter::new(Box::new(file) as Box<dyn Write>))
+    Ok(Box::new(file) as Box<dyn Write>)
+}
+
+/// Get a file writer wrapped in a BufWriter.
+pub fn instantiate_current_writer(
+    filter: Option<&str>,
+    filename: &str,
+    is_new: bool,
+) -> Result<BufWriter<Box<dyn Write>>> {
+    Ok(BufWriter::new(open_output_writer(
+        filter, filename, is_new,
+    )?))
 }
 
 pub fn paths_refer_to_same_file(p1: &OsStr, p2: &OsStr) -> bool {


### PR DESCRIPTION
This fixes an issue we have with our buffer writers where we do not flush the buffers before they are dropped which means that if there is an error when writing the buffers it will be suppressed. This change also adds the filename to the struct so that the error message is able to provide the file name to match the gnu implementation.

This should address the test `tests/split/split-io-err`