### PR TITLE
cp: better permissions mode handling with umask awareness

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -114,7 +114,7 @@ impl<'a> Context<'a> {
 ///
 /// For convenience while traversing a directory, the [`Entry::new`]
 /// function allows creating an entry from a [`Context`] and a
-/// [`DirEntry`].
+/// [`Path`].
 ///
 /// # Examples
 ///

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -267,6 +267,7 @@ fn copy_direntry(
     copied_destinations: &HashSet<PathBuf>,
     copied_files: &mut HashMap<FileInformation, PathBuf>,
     created_parent_dirs: &mut HashSet<PathBuf>,
+    #[cfg(unix)] orig_umask: u32,
 ) -> CopyResult<bool> {
     let source_is_symlink = entry_is_symlink;
     let source_is_dir = if source_is_symlink && !options.dereference {
@@ -283,12 +284,7 @@ fn copy_direntry(
         return if entry.target_is_file {
             Err(translate!("cp-error-cannot-overwrite-non-directory-with-directory").into())
         } else {
-            build_dir(
-                &entry.local_to_target,
-                false,
-                options,
-                Some(&entry.source_absolute),
-            )?;
+            build_dir(&entry.local_to_target, false)?;
             if options.verbose {
                 println!(
                     "{}",
@@ -311,6 +307,8 @@ fn copy_direntry(
             copied_files,
             created_parent_dirs,
             false,
+            #[cfg(unix)]
+            orig_umask,
         )
     {
         if preserve_hard_links {
@@ -364,6 +362,7 @@ pub(crate) fn copy_directory(
     copied_files: &mut HashMap<FileInformation, PathBuf>,
     created_parent_dirs: &mut HashSet<PathBuf>,
     source_in_command_line: bool,
+    #[cfg(unix)] orig_umask: u32,
 ) -> CopyResult<()> {
     // if no-dereference is enabled and this is a symlink, copy it as a file
     if !options.dereference(source_in_command_line) && root.is_symlink() {
@@ -377,6 +376,8 @@ pub(crate) fn copy_directory(
             copied_files,
             created_parent_dirs,
             source_in_command_line,
+            #[cfg(unix)]
+            orig_umask,
         );
     }
 
@@ -402,7 +403,7 @@ pub(crate) fn copy_directory(
     let tmp = if options.parents {
         if let Some(parent) = root.parent() {
             let new_target = target.join(parent);
-            build_dir(&new_target, true, options, None)?;
+            build_dir(&new_target, true)?;
             if options.verbose {
                 // For example, if copying file `a/b/c` and its parents
                 // to directory `d/`, then print
@@ -472,6 +473,8 @@ pub(crate) fn copy_directory(
                     copied_destinations,
                     copied_files,
                     created_parent_dirs,
+                    #[cfg(unix)]
+                    orig_umask,
                 )?;
 
                 // We omit certain permissions when creating directories
@@ -496,6 +499,8 @@ pub(crate) fn copy_directory(
                             &options.attributes,
                             false,
                             options.set_selinux_context,
+                            #[cfg(unix)]
+                            orig_umask,
                         )?;
                         continue;
                     }
@@ -539,6 +544,8 @@ pub(crate) fn copy_directory(
                                 &options.attributes,
                                 false,
                                 options.set_selinux_context,
+                                #[cfg(unix)]
+                                orig_umask,
                             )?;
                         }
                     }
@@ -561,6 +568,8 @@ pub(crate) fn copy_directory(
             &options.attributes,
             dir.was_created,
             options.set_selinux_context,
+            #[cfg(unix)]
+            orig_umask,
         )?;
 
         #[cfg(all(feature = "selinux", target_os = "linux"))]
@@ -581,6 +590,8 @@ pub(crate) fn copy_directory(
                     &options.attributes,
                     false,
                     options.set_selinux_context,
+                    #[cfg(unix)]
+                    orig_umask,
                 )?;
 
                 #[cfg(all(feature = "selinux", target_os = "linux"))]
@@ -620,59 +631,12 @@ pub fn path_has_prefix(p1: &Path, p2: &Path) -> io::Result<bool> {
 
 /// Builds a directory at the specified path with the given options.
 ///
-/// # Notes
-/// - If `copy_attributes_from` is `Some`, the new directory's attributes will be
-///   copied from the provided file. Otherwise, the new directory will have the default
-///   attributes for the current user.
-/// - This method excludes certain permissions if ownership or special mode bits could
-///   potentially change. (See `test_dir_perm_race_with_preserve_mode_and_ownership`)
-/// - The `recursive` flag determines whether parent directories should be created
-///   if they do not already exist.
-// we need to allow unused_variable since `options` might be unused in non unix systems
-#[allow(unused_variables)]
-fn build_dir(
-    path: &PathBuf,
-    recursive: bool,
-    options: &Options,
-    copy_attributes_from: Option<&Path>,
-) -> CopyResult<()> {
+/// The `recursive` flag determines whether parent directories should be created if they do not
+/// already exist.
+#[inline]
+fn build_dir(path: &PathBuf, recursive: bool) -> CopyResult<()> {
     let mut builder = fs::DirBuilder::new();
     builder.recursive(recursive);
-
-    // To prevent unauthorized access before the folder is ready,
-    // exclude certain permissions if ownership or special mode bits
-    // could potentially change.
-    #[cfg(unix)]
-    {
-        use crate::Preserve;
-        use std::os::unix::fs::PermissionsExt;
-
-        // we need to allow trivial casts here because some systems like linux have u32 constants in
-        // in libc while others don't.
-        #[allow(clippy::unnecessary_cast)]
-        let mut excluded_perms = if matches!(options.attributes.ownership, Preserve::Yes { .. }) {
-            libc::S_IRWXG | libc::S_IRWXO // exclude rwx for group and other
-        } else if matches!(options.attributes.mode, Preserve::Yes { .. }) {
-            libc::S_IWGRP | libc::S_IWOTH //exclude w for group and other
-        } else {
-            0
-        } as u32;
-
-        let umask = if let (Some(from), Preserve::Yes { .. }) =
-            (copy_attributes_from, options.attributes.mode)
-        {
-            !fs::symlink_metadata(from)?.permissions().mode()
-        } else {
-            uucore::mode::get_umask()
-        };
-
-        excluded_perms |= umask;
-        // Always keep the owner write bit so we can copy files into the directory.
-        // The correct final permissions are applied afterward by dirs_needing_permissions.
-        let mode = (!excluded_perms & 0o777) | 0o200; // mask to permission bits, always keep owner write
-        std::os::unix::fs::DirBuilderExt::mode(&mut builder, mode);
-    }
-
     builder.create(path)?;
     Ok(())
 }

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -6,7 +6,6 @@
 //! Recursively copy the contents of a directory.
 //!
 //! See the [`copy_directory`] function for more information.
-#[cfg(windows)]
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::convert::identity;
@@ -24,7 +23,7 @@ use uucore::fs::{
 use uucore::show;
 use uucore::translate;
 use uucore::uio_error;
-use walkdir::{DirEntry, WalkDir};
+use walkdir::WalkDir;
 
 #[cfg(all(feature = "selinux", target_os = "linux"))]
 use crate::set_selinux_context;
@@ -44,7 +43,7 @@ struct DirNeedingPermissions {
 }
 
 /// Ensure a Windows path starts with a `\\?`.
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn adjust_canonicalization(p: &Path) -> Cow<'_, Path> {
     // In some cases, \\? can be missing on some Windows paths.  Add it at the
     // beginning unless the path is prefixed with a device namespace.
@@ -64,39 +63,6 @@ fn adjust_canonicalization(p: &Path) -> Cow<'_, Path> {
     } else {
         Path::new(VERBATIM_PREFIX).join(p).into()
     }
-}
-
-/// Get a descendant path relative to the given parent directory.
-///
-/// If `root_parent` is `None`, then this just returns the `path`
-/// itself. Otherwise, this function strips the parent prefix from the
-/// given `path`, leaving only the portion of the path relative to the
-/// parent.
-fn get_local_to_root_parent(
-    path: &Path,
-    root_parent: Option<&Path>,
-) -> Result<PathBuf, StripPrefixError> {
-    match root_parent {
-        Some(parent) => {
-            // On Windows, some paths are starting with \\?
-            // but not always, so, make sure that we are consistent for strip_prefix
-            // See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file for more info
-            #[cfg(windows)]
-            let (path, parent) = (
-                adjust_canonicalization(path),
-                adjust_canonicalization(parent),
-            );
-            let path = path.strip_prefix(parent)?;
-            Ok(path.to_path_buf())
-        }
-        None => Ok(path.to_path_buf()),
-    }
-}
-
-/// Given an iterator, return all its items except the last.
-fn skip_last<T>(mut iter: impl Iterator<Item = T>) -> impl Iterator<Item = T> {
-    let last = iter.next();
-    iter.scan(last, Option::replace)
 }
 
 /// Paths that are invariant throughout the traversal when copying a directory.
@@ -120,11 +86,11 @@ struct Context<'a> {
 impl<'a> Context<'a> {
     fn new(root: &'a Path, target: &'a Path) -> io::Result<Self> {
         let current_dir = env::current_dir()?;
-        let root_path = current_dir.join(root);
+        let mut root_path = current_dir.join(root);
         let target_is_file = target.is_file();
         let root_parent =
             if target.exists() && !root.as_os_str().as_encoded_bytes().ends_with(b"/.") {
-                root_path.parent().map(ToOwned::to_owned)
+                root_path.pop().then_some(root_path)
             } else if root == Path::new(".") && target.is_dir() {
                 // Special case: when copying current directory (.) to an existing directory,
                 // we don't want to use the parent path as root_parent because we want to
@@ -179,12 +145,12 @@ impl<'a> Context<'a> {
 ///     }
 /// ];
 /// ```
-struct Entry {
+struct Entry<'a> {
     /// The absolute path to file or directory to copy.
     source_absolute: PathBuf,
 
     /// The relative path to file or directory to copy.
-    source_relative: PathBuf,
+    source_relative: &'a Path,
 
     /// The path to the destination, relative to the target.
     local_to_target: PathBuf,
@@ -193,24 +159,44 @@ struct Entry {
     target_is_file: bool,
 }
 
-impl Entry {
-    fn new<A: AsRef<Path>>(
+impl<'a> Entry<'a> {
+    fn new(
         context: &Context,
-        source: A,
+        source: &'a Path,
         no_target_dir: bool,
     ) -> Result<Self, StripPrefixError> {
-        let source = source.as_ref();
-        let source_relative = source.to_path_buf();
-        let source_absolute = context.current_dir.join(&source_relative);
-        let mut descendant =
-            get_local_to_root_parent(&source_absolute, context.root_parent.as_deref())?;
+        let source_relative = source;
+        let source_absolute = context.current_dir.join(source_relative);
+
+        // Get a descendant path relative to the given parent directory.
+        // On Windows, some paths are starting with \\?
+        // but not always, so, make sure that we are consistent for strip_prefix
+        // See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file for more info
+        #[cfg(windows)]
+        let (path, parent) = (
+            adjust_canonicalization(&source_absolute),
+            context
+                .root_parent
+                .as_deref()
+                .map(|p| adjust_canonicalization(p)),
+        );
+        #[cfg(not(windows))]
+        let (path, parent) = (
+            Cow::from(&source_absolute),
+            context.root_parent.as_deref().map(Cow::from),
+        );
+        let mut descendant = match parent {
+            Some(parent) => path.strip_prefix(parent)?,
+            None => &path,
+        };
+
         if no_target_dir {
             let source_is_dir = source.is_dir();
             if path_ends_with_terminator(context.target)
                 && source_is_dir
                 && !exists(context.target).is_ok_and(identity)
             {
-                if let Err(e) = fs::create_dir_all(context.target) {
+                if let Err(e) = fs::create_dir(context.target) {
                     eprintln!(
                         "{}",
                         translate!("cp-error-failed-to-create-directory", "error" => e)
@@ -222,7 +208,7 @@ impl Entry {
                 .next_back()
                 .and_then(|stripped| descendant.strip_prefix(stripped).ok())
             {
-                descendant = stripped.to_path_buf();
+                descendant = stripped;
             }
         } else if context.root == Path::new(".") && context.target.is_dir() {
             // Special case: when copying current directory (.) to an existing directory,
@@ -233,7 +219,7 @@ impl Entry {
             if let Some(current_dir_name) = context.current_dir.file_name()
                 && let Ok(stripped) = descendant.strip_prefix(current_dir_name)
             {
-                descendant = stripped.to_path_buf();
+                descendant = stripped;
             }
         }
 
@@ -288,7 +274,7 @@ fn copy_direntry(
             if options.verbose {
                 println!(
                     "{}",
-                    context_for(&entry.source_relative, &entry.local_to_target)
+                    context_for(entry.source_relative, &entry.local_to_target)
                 );
             }
             Ok(true)
@@ -299,7 +285,7 @@ fn copy_direntry(
     if !source_is_dir
         && let Err(err) = copy_file(
             progress_bar,
-            &entry.source_relative,
+            entry.source_relative,
             entry.local_to_target.as_path(),
             options,
             symlinked_files,
@@ -400,7 +386,7 @@ pub(crate) fn copy_directory(
     // a -> d/a
     // a/b -> d/a/b
     //
-    let tmp = if options.parents {
+    let target = if options.parents {
         if let Some(parent) = root.parent() {
             let new_target = target.join(parent);
             build_dir(&new_target, true)?;
@@ -415,30 +401,25 @@ pub(crate) fn copy_directory(
                     println!("{} -> {}", x.display(), y.display());
                 }
             }
-
-            new_target
+            Cow::from(new_target)
         } else {
-            target.to_path_buf()
+            Cow::from(target)
         }
     } else {
-        target.to_path_buf()
+        Cow::from(target)
     };
-    let target = tmp.as_path();
 
     let preserve_hard_links = options.preserve_hard_links();
 
     // Collect some paths here that are invariant during the traversal
     // of the given directory, like the current working directory and
     // the target directory.
-    let context = match Context::new(root, target) {
+    let context = match Context::new(root, &target) {
         Ok(c) => c,
         Err(e) => {
             return Err(translate!("cp-error-failed-get-current-dir", "error" => e).into());
         }
     };
-
-    // The directory we were in during the previous iteration
-    let mut last_iter: Option<DirEntry> = None;
 
     // Keep track of all directories we've created that need permission fixes
     let mut dirs_needing_permissions: Vec<DirNeedingPermissions> = Vec::new();
@@ -481,13 +462,6 @@ pub(crate) fn copy_directory(
                 // to prevent other users from accessing them before they're done.
                 // We thus need to fix the permissions of each directory we copy
                 // once it's contents are ready.
-                // This "fixup" is implemented here in a memory-efficient manner.
-                //
-                // We detect iterations where we "walk up" the directory tree,
-                // and fix permissions on all the directories we exited.
-                // (Note that there can be more than one! We might step out of
-                // `./a/b/c` into `./a/`, in which case we'll need to fix the
-                // permissions of both `./a/b/c` and `./a/b`, in that order.)
                 let is_dir_for_permissions =
                     entry_is_dir_no_follow || (options.dereference && direntry_path.is_dir());
                 if is_dir_for_permissions {
@@ -506,51 +480,10 @@ pub(crate) fn copy_directory(
                     }
                     // Add this directory to our list for permission fixing later
                     dirs_needing_permissions.push(DirNeedingPermissions {
-                        source: entry.source_absolute.clone(),
-                        dest: entry.local_to_target.clone(),
+                        source: entry.source_absolute,
+                        dest: entry.local_to_target,
                         was_created: created,
                     });
-
-                    // If true, last_iter is not a parent of this iter.
-                    // The means we just exited a directory.
-                    let went_up = if let Some(last_iter) = &last_iter {
-                        last_iter.path().strip_prefix(direntry_path).is_ok()
-                    } else {
-                        false
-                    };
-
-                    if went_up {
-                        // Compute the "difference" between `last_iter` and `direntry`.
-                        // For example, if...
-                        // - last_iter = `a/b/c/d`
-                        // - direntry = `a/b`
-                        // then diff = `c/d`
-                        //
-                        // All the unwraps() here are unreachable.
-                        let last_iter = last_iter.as_ref().unwrap();
-                        let diff = last_iter.path().strip_prefix(direntry_path).unwrap();
-
-                        // Fix permissions for every entry in `diff`, inside-out.
-                        // We skip the last directory (which will be `.`) because
-                        // its permissions will be fixed when we walk _out_ of it.
-                        // (at this point, we might not be done copying `.`!)
-                        for p in skip_last(diff.ancestors()) {
-                            let src = direntry_path.join(p);
-                            let entry = Entry::new(&context, &src, options.no_target_dir)?;
-
-                            copy_attributes(
-                                &entry.source_absolute,
-                                &entry.local_to_target,
-                                &options.attributes,
-                                false,
-                                options.set_selinux_context,
-                                #[cfg(unix)]
-                                orig_umask,
-                            )?;
-                        }
-                    }
-
-                    last_iter = Some(direntry);
                 }
             }
 
@@ -588,7 +521,7 @@ pub(crate) fn copy_directory(
                     &src,
                     y,
                     &options.attributes,
-                    false,
+                    true,
                     options.set_selinux_context,
                     #[cfg(unix)]
                     orig_umask,

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1789,6 +1789,7 @@ pub(crate) fn copy_attributes(
     let source_metadata = fs::symlink_metadata(source)
         .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
 
+    #[cfg(unix)]
     let mut failed_to_set_ownership = false;
 
     // Ownership must be changed first to avoid interfering with mode change.

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1587,7 +1587,7 @@ fn copy_source(
                         &src,
                         y,
                         &options.attributes,
-                        false,
+                        true,
                         options.set_selinux_context,
                         #[cfg(unix)]
                         orig_umask,

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1786,9 +1786,8 @@ pub(crate) fn copy_attributes(
     skip_selinux_xattr: bool,
     #[cfg(unix)] orig_umask: u32,
 ) -> CopyResult<()> {
-    let context = &*format!("{} -> {}", source.quote(), dest.quote());
-    let source_metadata =
-        fs::symlink_metadata(source).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let source_metadata = fs::symlink_metadata(source)
+        .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
 
     // Ownership must be changed first to avoid interfering with mode change.
     #[cfg(unix)]
@@ -1802,7 +1801,7 @@ pub(crate) fn copy_attributes(
         let dest_gid = source_metadata.gid();
         let meta = &dest
             .symlink_metadata()
-            .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+            .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
 
         let try_chown = {
             |uid| {
@@ -1824,6 +1823,30 @@ pub(crate) fn copy_attributes(
         if try_chown(Some(dest_uid)).is_err() {
             let _ = try_chown(None);
         }
+        Ok(())
+    })?;
+
+    // before mode change since newly created dir/file are not read-only.
+    handle_preserve(attributes.xattr, || -> CopyResult<()> {
+        #[cfg(all(unix, not(target_os = "android")))]
+        {
+            copy_extended_attrs(source, dest, skip_selinux_xattr)?;
+        }
+        #[cfg(not(all(unix, not(target_os = "android"))))]
+        #[allow(unused_variables)]
+        {
+            // The documentation for GNU cp states:
+            //
+            // > Try to preserve SELinux security context and
+            // > extended attributes (xattr), but ignore any failure
+            // > to do that and print no corresponding diagnostic.
+            //
+            // so we simply do nothing here.
+            //
+            // TODO Silently ignore failures in the `#[cfg(unix)]`
+            // block instead of terminating immediately on errors.
+        }
+
         Ok(())
     })?;
 
@@ -1857,7 +1880,7 @@ pub(crate) fn copy_attributes(
             let permissions = Some(source_metadata.permissions());
             if let Some(permissions) = permissions {
                 fs::set_permissions(dest, permissions)
-                    .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+                    .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
             }
             // FIXME: Implement this for windows as well
             #[cfg(feature = "feat_acl")]
@@ -1897,29 +1920,6 @@ pub(crate) fn copy_attributes(
                 translate!("cp-error-selinux-get-context", "path" => source.quote()),
             ));
         }
-        Ok(())
-    })?;
-
-    handle_preserve(attributes.xattr, || -> CopyResult<()> {
-        #[cfg(all(unix, not(target_os = "android")))]
-        {
-            copy_extended_attrs(source, dest, skip_selinux_xattr)?;
-        }
-        #[cfg(not(all(unix, not(target_os = "android"))))]
-        #[allow(unused_variables)]
-        {
-            // The documentation for GNU cp states:
-            //
-            // > Try to preserve SELinux security context and
-            // > extended attributes (xattr), but ignore any failure
-            // > to do that and print no corresponding diagnostic.
-            //
-            // so we simply do nothing here.
-            //
-            // TODO Silently ignore failures in the `#[cfg(unix)]`
-            // block instead of terminating immediately on errors.
-        }
-
         Ok(())
     })?;
 
@@ -2268,7 +2268,6 @@ fn handle_copy_mode(
     source: &Path,
     dest: &Path,
     options: &Options,
-    context: &str,
     source_metadata: &Metadata,
     symlinked_files: &mut HashSet<FileInformation>,
     source_in_command_line: bool,
@@ -2306,7 +2305,6 @@ fn handle_copy_mode(
                 source,
                 dest,
                 options,
-                context,
                 source_metadata,
                 symlinked_files,
                 created_parent_dirs,
@@ -2326,7 +2324,6 @@ fn handle_copy_mode(
                             source,
                             dest,
                             options,
-                            context,
                             source_metadata,
                             symlinked_files,
                             created_parent_dirs,
@@ -2359,7 +2356,6 @@ fn handle_copy_mode(
                             source,
                             dest,
                             options,
-                            context,
                             source_metadata,
                             symlinked_files,
                             created_parent_dirs,
@@ -2371,7 +2367,6 @@ fn handle_copy_mode(
                     source,
                     dest,
                     options,
-                    context,
                     source_metadata,
                     symlinked_files,
                     created_parent_dirs,
@@ -2398,7 +2393,6 @@ fn calculate_dest_permissions(
     dest: &Path,
     source_metadata: &Metadata,
     options: &Options,
-    context: &str,
     #[cfg(unix)] orig_umask: u32,
 ) -> Permissions {
     #[cfg(unix)]
@@ -2573,10 +2567,6 @@ fn copy_file(
         }
     }
 
-    // Calculate the context upfront before canonicalizing the path
-    let context = context_for(source, dest);
-    let context = context.as_str();
-
     let source_metadata = {
         let result = if options.dereference(source_in_command_line) {
             fs::metadata(source)
@@ -2599,7 +2589,6 @@ fn copy_file(
         dest,
         &source_metadata,
         options,
-        context,
         #[cfg(unix)]
         orig_umask,
     );
@@ -2610,7 +2599,6 @@ fn copy_file(
         source,
         dest,
         options,
-        context,
         &source_metadata,
         symlinked_files,
         source_in_command_line,
@@ -2760,7 +2748,6 @@ fn copy_helper(
     source: &Path,
     dest: &Path,
     options: &Options,
-    context: &str,
     source_metadata: &Metadata,
     symlinked_files: &mut HashSet<FileInformation>,
     created_parent_dirs: &mut HashSet<PathBuf>,
@@ -2798,7 +2785,6 @@ fn copy_helper(
             dest,
             options.reflink_mode,
             options.sparse_mode,
-            context,
             #[cfg(unix)]
             is_stream(source_metadata),
         )?;

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1693,7 +1693,7 @@ impl OverwriteMode {
 /// Note: ENOTSUP/EOPNOTSUPP errors are silently ignored when not required, as per GNU cp
 /// documentation: "Try to preserve SELinux security context and extended attributes (xattr),
 /// but ignore any failure to do that and print no corresponding diagnostic."
-fn handle_preserve<F: Fn() -> CopyResult<()>>(p: Preserve, f: F) -> CopyResult<()> {
+fn handle_preserve<F: FnMut() -> CopyResult<()>>(p: Preserve, mut f: F) -> CopyResult<()> {
     match p {
         Preserve::No { .. } => {}
         Preserve::Yes { required } => {
@@ -1789,6 +1789,8 @@ pub(crate) fn copy_attributes(
     let source_metadata = fs::symlink_metadata(source)
         .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
 
+    let mut failed_to_set_ownership = false;
+
     // Ownership must be changed first to avoid interfering with mode change.
     #[cfg(unix)]
     handle_preserve(attributes.ownership, || -> CopyResult<()> {
@@ -1821,6 +1823,7 @@ pub(crate) fn copy_attributes(
         // gnu compatibility: cp doesn't report an error if it fails to set the ownership,
         // and will fall back to changing only the gid if possible.
         if try_chown(Some(dest_uid)).is_err() {
+            failed_to_set_ownership = true;
             let _ = try_chown(None);
         }
         Ok(())
@@ -1872,6 +1875,7 @@ pub(crate) fn copy_attributes(
                 attributes.mode,
                 dest.is_dir(),
                 was_created,
+                failed_to_set_ownership,
                 source_metadata.permissions().mode(),
                 orig_umask,
             )
@@ -2401,6 +2405,7 @@ fn calculate_dest_permissions(
             options.attributes.mode,
             false,
             dest_metadata.is_none(),
+            false,
             source_metadata.permissions().mode(),
             orig_umask,
         )
@@ -2694,51 +2699,52 @@ fn is_stream(metadata: &Metadata) -> bool {
 }
 
 #[cfg(unix)]
+#[allow(clippy::unnecessary_cast)]
 /// Calculate the final permissions mode.
-///
-/// If the dir/file was not created, then returns `None` except when preserving mode in which case
-/// the source mode is returned.
-///
-/// Otherwise, see [`handle_created_mode`].
 fn handle_mode(
     mode: Preserve,
     is_dir: bool,
     was_created: bool,
+    failed_to_set_ownership: bool,
     source_mode: u32,
     umask: u32,
 ) -> Option<u32> {
-    if was_created {
-        Some(handle_created_mode(mode, is_dir, source_mode, umask))
-    } else {
-        match mode {
-            Preserve::Yes { required: true } => Some(source_mode),
-            _ => None,
+    match (was_created, mode) {
+        // If preserving mode, return Some source_mode.
+        (_, Preserve::Yes { .. }) => {
+            use libc::{S_ISGID, S_ISUID};
+            const UID_GID_MASK: u32 = !(S_ISGID | S_ISUID) as u32;
+
+            Some(if failed_to_set_ownership {
+                // "Additionally, the -p option explicitly requires that all set-user-ID and
+                // set-group-ID permissions be discarded if any of the owner or group IDs cannot be
+                // set. This is to keep users from unintentionally giving away special privilege
+                // when copying programs."
+                source_mode & UID_GID_MASK
+            } else {
+                source_mode
+            })
         }
-    }
-}
+        // If was not created (destination existed), return None
+        (false, _) => None,
+        // If was created (destination did not exist), return Some
+        // If no preserving mode, return 0o777(dir)/0o666(file) & !umask.
+        // If default, return source_mode & 0o777 & !umask.
+        (true, Preserve::No { explicit }) => {
+            use libc::{
+                S_IRGRP, S_IROTH, S_IRUSR, S_IRWXG, S_IRWXO, S_IRWXU, S_IWGRP, S_IWOTH, S_IWUSR,
+            };
+            const MODE_RW_UGO: u32 =
+                (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) as u32;
+            const S_IRWXUGO: u32 = (S_IRWXU | S_IRWXG | S_IRWXO) as u32;
 
-#[cfg(unix)]
-#[inline]
-/// Calculate the final permissions mode when the dir/file is newly created.
-///
-/// If no preserving mode, return 0o777(dir)/0o666(file) & !umask.
-/// If default, return source_mode & 0o777 & !umask.
-/// If preserving mode, return source_mode & 0o777.
-fn handle_created_mode(mode: Preserve, is_dir: bool, source_mode: u32, umask: u32) -> u32 {
-    use libc::{S_IRGRP, S_IROTH, S_IRUSR, S_IRWXG, S_IRWXO, S_IRWXU, S_IWGRP, S_IWOTH, S_IWUSR};
-    #[allow(clippy::unnecessary_cast)]
-    const MODE_RW_UGO: u32 = (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) as u32;
-    #[allow(clippy::unnecessary_cast)]
-    const S_IRWXUGO: u32 = (S_IRWXU | S_IRWXG | S_IRWXO) as u32;
-
-    if let Preserve::No { explicit } = mode {
-        (if explicit {
-            if is_dir { S_IRWXUGO } else { MODE_RW_UGO }
-        } else {
-            source_mode & S_IRWXUGO
-        }) & !umask
-    } else {
-        source_mode & S_IRWXUGO
+            let mode = if explicit {
+                if is_dir { S_IRWXUGO } else { MODE_RW_UGO }
+            } else {
+                source_mode & S_IRWXUGO
+            };
+            Some(mode & !umask)
+        }
     }
 }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -829,7 +829,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let (sources, target) = parse_path_args(paths, &options)?;
 
-    if let Err(error) = copy(&sources, &target, &options) {
+    // GNU's implementation is able to create directories and files even when umask is set to 0o777.
+    // We follow it here by setting it to permit all user modes, and passing the original down
+    // functions such that it is used when creating new dir/file and not preserving mode.
+    #[cfg(unix)]
+    let orig_umask = unsafe { libc::umask(!0o700) as u32 };
+
+    if let Err(error) = copy(
+        &sources,
+        &target,
+        &options,
+        #[cfg(unix)]
+        orig_umask,
+    ) {
         if let CpError::NotAllFilesCopied = error {
             // Error::NotAllFilesCopied is non-fatal, but the error
             // code should still be EXIT_ERR as does GNU cp
@@ -838,6 +850,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             show_error!("{error}");
         }
         set_exit_code(EXIT_ERR);
+    }
+
+    #[cfg(unix)]
+    #[allow(clippy::unnecessary_cast)]
+    unsafe {
+        libc::umask(orig_umask as mode_t);
     }
 
     Ok(())
@@ -1253,20 +1271,6 @@ impl Options {
         }
     }
 
-    #[cfg(unix)]
-    fn preserve_mode(&self) -> (bool, bool) {
-        match self.attributes.mode {
-            Preserve::No { explicit } => {
-                if explicit {
-                    (false, true)
-                } else {
-                    (false, false)
-                }
-            }
-            Preserve::Yes { .. } => (true, false),
-        }
-    }
-
     /// Whether to force overwriting the destination file.
     fn force(&self) -> bool {
         matches!(self.overwrite, OverwriteMode::Clobber(ClobberMode::Force))
@@ -1375,7 +1379,12 @@ fn show_error_if_needed(error: &CpError) {
 /// was encountered.
 ///
 /// Behavior is determined by the `options` parameter, see [`Options`] for details.
-pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult<()> {
+pub fn copy(
+    sources: &[PathBuf],
+    target: &Path,
+    options: &Options,
+    #[cfg(unix)] orig_umask: u32,
+) -> CopyResult<()> {
     let target_type = TargetType::determine(sources, target);
     verify_target_type(target, target_type)?;
 
@@ -1460,6 +1469,8 @@ pub fn copy(sources: &[PathBuf], target: &Path, options: &Options) -> CopyResult
                 &copied_destinations,
                 &mut copied_files,
                 &mut created_parent_dirs,
+                #[cfg(unix)]
+                orig_umask,
             ) {
                 show_error_if_needed(&error);
                 if !matches!(error, CpError::Skipped(false)) {
@@ -1535,6 +1546,7 @@ fn copy_source(
     copied_destinations: &HashSet<PathBuf>,
     copied_files: &mut HashMap<FileInformation, PathBuf>,
     created_parent_dirs: &mut HashSet<PathBuf>,
+    #[cfg(unix)] orig_umask: u32,
 ) -> CopyResult<()> {
     let source_path = Path::new(&source);
     if source_path.is_dir() && (options.dereference || !source_path.is_symlink()) {
@@ -1549,6 +1561,8 @@ fn copy_source(
             copied_files,
             created_parent_dirs,
             true,
+            #[cfg(unix)]
+            orig_umask,
         )
     } else {
         // Copy as file
@@ -1563,6 +1577,8 @@ fn copy_source(
             copied_files,
             created_parent_dirs,
             true,
+            #[cfg(unix)]
+            orig_umask,
         );
         if options.parents {
             for (x, y) in aligned_ancestors(source, dest.as_path()) {
@@ -1573,6 +1589,8 @@ fn copy_source(
                         &options.attributes,
                         false,
                         options.set_selinux_context,
+                        #[cfg(unix)]
+                        orig_umask,
                     )?;
                 }
             }
@@ -1764,21 +1782,13 @@ pub(crate) fn copy_attributes(
     source: &Path,
     dest: &Path,
     attributes: &Attributes,
-    dest_is_freshly_created_dir: bool,
+    was_created: bool,
     skip_selinux_xattr: bool,
+    #[cfg(unix)] orig_umask: u32,
 ) -> CopyResult<()> {
     let context = &*format!("{} -> {}", source.quote(), dest.quote());
     let source_metadata =
         fs::symlink_metadata(source).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-
-    let mode_explicitly_disabled = matches!(attributes.mode, Preserve::No { explicit: true });
-
-    // preserve is true by default if the destination is created by us and it's a directory
-    let mode = if !mode_explicitly_disabled && dest_is_freshly_created_dir {
-        Preserve::Yes { required: false }
-    } else {
-        attributes.mode
-    };
 
     // Ownership must be changed first to avoid interfering with mode change.
     #[cfg(unix)]
@@ -1817,6 +1827,16 @@ pub(crate) fn copy_attributes(
         Ok(())
     })?;
 
+    // always try to set permission to the correct one if newly created
+    #[cfg(unix)]
+    let mode = if was_created {
+        Preserve::Yes { required: true }
+    } else {
+        attributes.mode
+    };
+    #[cfg(not(unix))]
+    let mode = attributes.mode;
+
     handle_preserve(mode, || -> CopyResult<()> {
         // The `chmod()` system call that underlies the
         // `fs::set_permissions()` call is unable to change the
@@ -1824,8 +1844,21 @@ pub(crate) fn copy_attributes(
         // do nothing, since every symbolic link has the same
         // permissions.
         if !dest.is_symlink() {
-            fs::set_permissions(dest, source_metadata.permissions())
-                .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+            #[cfg(unix)]
+            let permissions = handle_mode(
+                attributes.mode,
+                dest.is_dir(),
+                was_created,
+                source_metadata.permissions().mode(),
+                orig_umask,
+            )
+            .map(Permissions::from_mode);
+            #[cfg(not(unix))]
+            let permissions = Some(source_metadata.permissions());
+            if let Some(permissions) = permissions {
+                fs::set_permissions(dest, permissions)
+                    .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+            }
             // FIXME: Implement this for windows as well
             #[cfg(feature = "feat_acl")]
             exacl::getfacl(source, None)
@@ -2359,16 +2392,6 @@ fn handle_copy_mode(
 }
 
 /// Calculates the permissions for the destination file in a copy operation.
-///
-/// If the destination file already exists, its current permissions are returned.
-/// If the destination file does not exist, the source file's permissions are used,
-/// with the `no-preserve` option and the umask taken into account on Unix platforms.
-/// # Returns
-///
-/// * `Ok(Permissions)` - The calculated permissions for the destination file.
-/// * `Err(CopyError)` - An error occurred while getting the metadata of the destination file.
-///
-// Allow unused variables for Windows (on options)
 #[allow(unused_variables)]
 fn calculate_dest_permissions(
     dest_metadata: Option<&Metadata>,
@@ -2376,23 +2399,28 @@ fn calculate_dest_permissions(
     source_metadata: &Metadata,
     options: &Options,
     context: &str,
+    #[cfg(unix)] orig_umask: u32,
 ) -> Permissions {
-    if let Some(metadata) = dest_metadata {
-        metadata.permissions()
-    } else {
-        #[cfg(unix)]
-        {
-            let mut permissions = source_metadata.permissions();
-            let mode = handle_no_preserve_mode(options, permissions.mode());
+    #[cfg(unix)]
+    {
+        handle_mode(
+            options.attributes.mode,
+            false,
+            dest_metadata.is_none(),
+            source_metadata.permissions().mode(),
+            orig_umask,
+        )
+        .map_or_else(
+            || dest_metadata.unwrap().permissions(), // existing destination and not preserving mode
+            Permissions::from_mode,
+        )
+    }
 
-            // Apply umask
-            use uucore::mode::get_umask;
-            let mode = mode & !get_umask();
-            permissions.set_mode(mode);
-            permissions
-        }
-        #[cfg(not(unix))]
-        {
+    #[cfg(not(unix))]
+    {
+        if let Some(metadata) = dest_metadata {
+            metadata.permissions()
+        } else {
             source_metadata.permissions()
         }
     }
@@ -2419,6 +2447,7 @@ fn copy_file(
     copied_files: &mut HashMap<FileInformation, PathBuf>,
     created_parent_dirs: &mut HashSet<PathBuf>,
     source_in_command_line: bool,
+    #[cfg(unix)] orig_umask: u32,
 ) -> CopyResult<()> {
     let source_is_symlink = source.is_symlink();
     let initial_dest_metadata = dest.symlink_metadata().ok();
@@ -2571,6 +2600,8 @@ fn copy_file(
         &source_metadata,
         options,
         context,
+        #[cfg(unix)]
+        orig_umask,
     );
 
     let source_is_stream = is_stream(&source_metadata);
@@ -2614,6 +2645,8 @@ fn copy_file(
             &options.attributes,
             false,
             options.set_selinux_context,
+            #[cfg(unix)]
+            orig_umask,
         )
     } else if source_is_stream && !source.exists() {
         // Some stream files may not exist after we have copied it,
@@ -2628,6 +2661,8 @@ fn copy_file(
             &options.attributes,
             false,
             options.set_selinux_context,
+            #[cfg(unix)]
+            orig_umask,
         )
     };
 
@@ -2671,13 +2706,44 @@ fn is_stream(metadata: &Metadata) -> bool {
 }
 
 #[cfg(unix)]
-fn handle_no_preserve_mode(options: &Options, org_mode: u32) -> u32 {
-    let (is_preserve_mode, is_explicit_no_preserve_mode) = options.preserve_mode();
-    if !is_preserve_mode {
-        use libc::{
-            S_IRGRP, S_IROTH, S_IRUSR, S_IRWXG, S_IRWXO, S_IRWXU, S_IWGRP, S_IWOTH, S_IWUSR,
-        };
+/// Calculate the final permissions mode.
+///
+/// If the dir/file was not created, then returns `None` except when preserving mode in which case
+/// the source mode is returned.
+///
+/// Otherwise, see [`handle_created_mode`].
+fn handle_mode(
+    mode: Preserve,
+    is_dir: bool,
+    was_created: bool,
+    source_mode: u32,
+    umask: u32,
+) -> Option<u32> {
+    if was_created {
+        Some(handle_created_mode(mode, is_dir, source_mode, umask))
+    } else {
+        match mode {
+            Preserve::Yes { required: true } => Some(source_mode),
+            _ => None,
+        }
+    }
+}
 
+#[cfg(unix)]
+#[inline]
+/// Calculate the final permissions mode when the dir/file is newly created.
+///
+/// If no preserving mode, return 0o777(dir)/0o666(file) & !umask.
+/// If default, return source_mode & 0o777 & !umask.
+/// If preserving mode, return source_mode & 0o777.
+fn handle_created_mode(mode: Preserve, is_dir: bool, source_mode: u32, umask: u32) -> u32 {
+    use libc::{S_IRGRP, S_IROTH, S_IRUSR, S_IRWXG, S_IRWXO, S_IRWXU, S_IWGRP, S_IWOTH, S_IWUSR};
+    #[allow(clippy::unnecessary_cast)]
+    const MODE_RW_UGO: u32 = (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) as u32;
+    #[allow(clippy::unnecessary_cast)]
+    const S_IRWXUGO: u32 = (S_IRWXU | S_IRWXG | S_IRWXO) as u32;
+
+    if let Preserve::No { explicit } = mode {
         #[cfg(not(any(
             target_os = "android",
             target_os = "macos",
@@ -2685,13 +2751,11 @@ fn handle_no_preserve_mode(options: &Options, org_mode: u32) -> u32 {
             target_os = "redox",
         )))]
         {
-            const MODE_RW_UGO: u32 = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
-            const S_IRWXUGO: u32 = S_IRWXU | S_IRWXG | S_IRWXO;
-            return if is_explicit_no_preserve_mode {
-                MODE_RW_UGO
+            (if explicit {
+                if is_dir { S_IRWXUGO } else { MODE_RW_UGO }
             } else {
-                org_mode & S_IRWXUGO
-            };
+                source_mode & S_IRWXUGO
+            }) & !umask
         }
 
         #[cfg(any(
@@ -2701,20 +2765,15 @@ fn handle_no_preserve_mode(options: &Options, org_mode: u32) -> u32 {
             target_os = "redox",
         ))]
         {
-            #[allow(clippy::unnecessary_cast)]
-            const MODE_RW_UGO: u32 =
-                (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) as u32;
-            #[allow(clippy::unnecessary_cast)]
-            const S_IRWXUGO: u32 = (S_IRWXU | S_IRWXG | S_IRWXO) as u32;
-            return if is_explicit_no_preserve_mode {
-                MODE_RW_UGO
+            (if explicit {
+                if is_dir { S_IRWXUGO } else { MODE_RW_UGO }
             } else {
-                org_mode & S_IRWXUGO
-            };
+                source_mode & S_IRWXUGO
+            }) & !umask
         }
+    } else {
+        source_mode & S_IRWXUGO
     }
-
-    org_mode
 }
 
 /// Copy the file from `source` to `dest` either using the normal `fs::copy` or a
@@ -2839,6 +2898,8 @@ fn copy_link(
         &options.attributes,
         false,
         options.set_selinux_context,
+        #[cfg(unix)]
+        0,
     )
 }
 

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -833,7 +833,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // We follow it here by setting it to permit all user modes, and passing the original down
     // functions such that it is used when creating new dir/file and not preserving mode.
     #[cfg(unix)]
-    let orig_umask = unsafe { libc::umask(!0o700) as u32 };
+    let orig_umask = unsafe { libc::umask(!libc::S_IRWXU) as u32 };
 
     if let Err(error) = copy(
         &sources,
@@ -2744,33 +2744,11 @@ fn handle_created_mode(mode: Preserve, is_dir: bool, source_mode: u32, umask: u3
     const S_IRWXUGO: u32 = (S_IRWXU | S_IRWXG | S_IRWXO) as u32;
 
     if let Preserve::No { explicit } = mode {
-        #[cfg(not(any(
-            target_os = "android",
-            target_os = "macos",
-            target_os = "freebsd",
-            target_os = "redox",
-        )))]
-        {
-            (if explicit {
-                if is_dir { S_IRWXUGO } else { MODE_RW_UGO }
-            } else {
-                source_mode & S_IRWXUGO
-            }) & !umask
-        }
-
-        #[cfg(any(
-            target_os = "android",
-            target_os = "macos",
-            target_os = "freebsd",
-            target_os = "redox",
-        ))]
-        {
-            (if explicit {
-                if is_dir { S_IRWXUGO } else { MODE_RW_UGO }
-            } else {
-                source_mode & S_IRWXUGO
-            }) & !umask
-        }
+        (if explicit {
+            if is_dir { S_IRWXUGO } else { MODE_RW_UGO }
+        } else {
+            source_mode & S_IRWXUGO
+        }) & !umask
     } else {
         source_mode & S_IRWXUGO
     }

--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -18,7 +18,7 @@ use uucore::translate;
 
 use crate::{
     CopyDebug, CopyResult, CpError, OffloadReflinkDebug, ReflinkMode, SparseDebug, SparseMode,
-    is_stream,
+    context_for, is_stream,
 };
 
 /// The fallback behavior for [`clone`] on failed system call.
@@ -262,7 +262,6 @@ pub(crate) fn copy_on_write(
     dest: &Path,
     reflink_mode: ReflinkMode,
     sparse_mode: SparseMode,
-    context: &str,
     source_is_stream: bool,
 ) -> CopyResult<CopyDebug> {
     let mut copy_debug = CopyDebug {
@@ -392,7 +391,7 @@ pub(crate) fn copy_on_write(
             return Err(translate!("cp-error-reflink-always-sparse-auto").into());
         }
     };
-    result.map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    result.map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
     Ok(copy_debug)
 }
 

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -17,7 +17,7 @@ use uucore::mode::get_umask;
 
 use crate::{
     CopyDebug, CopyResult, CpError, OffloadReflinkDebug, ReflinkMode, SparseDebug, SparseMode,
-    is_stream,
+    context_for, is_stream,
 };
 
 /// Copies `source` to `dest` using copy-on-write if possible.
@@ -26,7 +26,6 @@ pub(crate) fn copy_on_write(
     dest: &Path,
     reflink_mode: ReflinkMode,
     sparse_mode: SparseMode,
-    context: &str,
     source_is_stream: bool,
 ) -> CopyResult<CopyDebug> {
     if sparse_mode != SparseMode::Auto {
@@ -107,9 +106,10 @@ pub(crate) fn copy_on_write(
 
             buf_copy::copy_stream(&mut src_file, &mut dst_file)
                 .map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))
-                .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+                .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
         } else {
-            fs::copy(source, dest).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+            fs::copy(source, dest)
+                .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
         }
     }
 

--- a/src/uu/cp/src/platform/other.rs
+++ b/src/uu/cp/src/platform/other.rs
@@ -9,6 +9,7 @@ use uucore::translate;
 
 use crate::{
     CopyDebug, CopyResult, CpError, OffloadReflinkDebug, ReflinkMode, SparseDebug, SparseMode,
+    context_for,
 };
 
 /// Copies `source` to `dest` for systems without copy-on-write
@@ -17,7 +18,6 @@ pub(crate) fn copy_on_write(
     dest: &Path,
     reflink_mode: ReflinkMode,
     sparse_mode: SparseMode,
-    context: &str,
 ) -> CopyResult<CopyDebug> {
     if reflink_mode != ReflinkMode::Never {
         return Err(translate!("cp-error-reflink-not-supported")
@@ -34,7 +34,7 @@ pub(crate) fn copy_on_write(
         reflink: OffloadReflinkDebug::Unsupported,
         sparse_detection: SparseDebug::Unsupported,
     };
-    fs::copy(source, dest).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    fs::copy(source, dest).map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
 
     Ok(copy_debug)
 }

--- a/src/uu/cp/src/platform/other_unix.rs
+++ b/src/uu/cp/src/platform/other_unix.rs
@@ -13,7 +13,7 @@ use uucore::translate;
 
 use crate::{
     CopyDebug, CopyResult, CpError, OffloadReflinkDebug, ReflinkMode, SparseDebug, SparseMode,
-    is_stream,
+    context_for, is_stream,
 };
 
 /// Copies `source` to `dest` for systems without copy-on-write
@@ -22,7 +22,6 @@ pub(crate) fn copy_on_write(
     dest: &Path,
     reflink_mode: ReflinkMode,
     sparse_mode: SparseMode,
-    context: &str,
     source_is_stream: bool,
 ) -> CopyResult<CopyDebug> {
     if reflink_mode != ReflinkMode::Never {
@@ -58,12 +57,12 @@ pub(crate) fn copy_on_write(
 
         buf_copy::copy_stream(&mut src_file, &mut dst_file)
             .map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))
-            .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+            .map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
 
         return Ok(copy_debug);
     }
 
-    fs::copy(source, dest).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    fs::copy(source, dest).map_err(|e| CpError::IoErrContext(e, context_for(source, dest)))?;
 
     Ok(copy_debug)
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -8103,7 +8103,7 @@ fn test_cp_not_existing_no_preserve_dir() {
 
     let d2_mode = at.metadata("d2").mode();
 
-    assert_eq!(0o777 & !0o700, d2_mode & 0o777);
+    assert_eq!(!0o700 & 0o777, d2_mode & 0o777);
 }
 
 #[test]
@@ -8127,7 +8127,7 @@ fn test_cp_not_existing_default_file() {
 
     let f2_mode = at.metadata("f2").mode();
 
-    assert_eq!(0o770 & !0o700, f2_mode & 0o777);
+    assert_eq!(!0o700 & 0o770, f2_mode & 0o777);
 }
 
 #[test]
@@ -8152,7 +8152,7 @@ fn test_cp_not_existing_default_dir() {
 
     let d2_mode = at.metadata("d2").mode();
 
-    assert_eq!(0o770 & !0o700, d2_mode & 0o777);
+    assert_eq!(!0o700 & 0o770, d2_mode & 0o777);
 }
 
 #[test]
@@ -8208,4 +8208,40 @@ fn test_cp_not_existing_preserve_dir() {
     let d2_mode = at.metadata("d2").mode();
 
     assert_eq!(d1_mode, d2_mode);
+}
+
+#[test]
+#[cfg(unix)]
+// adapted from GNU tests/cp/cp-parents
+fn test_cp_not_existing_no_preserve_file_parents() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("mkdir").arg("d1").succeeds();
+    scene.cmd("mkdir").arg("d1/d2").succeeds();
+    scene.cmd("touch").arg("d1/d2/f").succeeds();
+    scene.cmd("chmod").arg("770").arg("d1").succeeds();
+    scene.cmd("chmod").arg("700").arg("d1/d2").succeeds();
+    scene.cmd("chmod").arg("775").arg("d1/d2/f").succeeds();
+    scene.cmd("mkdir").arg("d3").succeeds();
+
+    scene
+        .ucmd()
+        .umask(0o022)
+        .arg("--no-preserve=mode")
+        .arg("--parents")
+        .arg("d1/d2/f")
+        .arg("d3")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let d1_mode = at.metadata("d3/d1").mode();
+    let d2_mode = at.metadata("d3/d1/d2").mode();
+    let f_mode = at.metadata("d3/d1/d2/f").mode();
+
+    assert_eq!(!0o022 & 0o777, d1_mode & 0o777);
+    assert_eq!(!0o022 & 0o777, d2_mode & 0o777);
+    assert_eq!(!0o022 & 0o666, f_mode & 0o777);
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3073,7 +3073,9 @@ fn test_cp_dangling_symlink_inside_directory() {
 }
 
 /// Test for copying a dangling symbolic link and its permissions.
-#[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))] // FIXME: fix this test for FreeBSD/OpenBSD
+// FIXME: fix this test for FreeBSD/OpenBSD
+// FIXME: macos use umask permission mode
+#[cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos")))]
 #[test]
 fn test_copy_through_dangling_symlink_no_dereference_permissions() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -3093,9 +3095,9 @@ fn test_copy_through_dangling_symlink_no_dereference_permissions() {
         .no_stdout();
     assert!(at.symlink_exists("d2"), "symlink wasn't created");
 
-    // `-p` means `--preserve=mode,ownership,timestamps`
-    #[cfg(all(unix, not(target_os = "freebsd"), not(target_os = "openbsd")))]
+    #[cfg(unix)]
     {
+        // `-p` means `--preserve=mode,ownership,timestamps`
         let metadata1 = at.symlink_metadata("dangle");
         let metadata2 = at.symlink_metadata("d2");
         assert_metadata_eq!(metadata1, metadata2);
@@ -7876,4 +7878,334 @@ fn test_cp_recursive_non_utf8_source() {
         .no_output();
 
     assert!(at.plus("dir2").join("a").exists());
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_existing_no_preserve_file() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("touch").arg("f1").succeeds();
+    scene.cmd("touch").arg("f2").succeeds();
+    scene.cmd("chmod").arg("770").arg("f1").succeeds();
+    scene.cmd("chmod").arg("666").arg("f2").succeeds();
+    let f2_mode = at.metadata("f2").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("--no-preserve=mode")
+        .arg("f1")
+        .arg("f2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let f2_new_mode = at.metadata("f2").mode();
+
+    assert_eq!(f2_mode, f2_new_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_existing_no_preserve_dir() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("mkdir").arg("d1").succeeds();
+    scene.cmd("mkdir").arg("d2").succeeds();
+    scene.cmd("chmod").arg("770").arg("d1").succeeds();
+    scene.cmd("chmod").arg("700").arg("d2").succeeds();
+    let d2_mode = at.metadata("d2").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("--no-preserve=mode")
+        .arg("-r")
+        .arg("d1/.")
+        .arg("d2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let d2_new_mode = at.metadata("d2").mode();
+
+    assert_eq!(d2_mode, d2_new_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_existing_default_file() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("touch").arg("f1").succeeds();
+    scene.cmd("touch").arg("f2").succeeds();
+    scene.cmd("chmod").arg("770").arg("f1").succeeds();
+    scene.cmd("chmod").arg("666").arg("f2").succeeds();
+    let f2_mode = at.metadata("f2").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("f1")
+        .arg("f2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let f2_new_mode = at.metadata("f2").mode();
+
+    assert_eq!(f2_mode, f2_new_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_existing_default_dir() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("mkdir").arg("d1").succeeds();
+    scene.cmd("mkdir").arg("d2").succeeds();
+    scene.cmd("chmod").arg("770").arg("d1").succeeds();
+    scene.cmd("chmod").arg("700").arg("d2").succeeds();
+    let d2_mode = at.metadata("d2").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("-r")
+        .arg("d1/.")
+        .arg("d2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let d2_new_mode = at.metadata("d2").mode();
+
+    assert_eq!(d2_mode, d2_new_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_existing_preserve_file() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("touch").arg("f1").succeeds();
+    scene.cmd("touch").arg("f2").succeeds();
+    scene.cmd("chmod").arg("770").arg("f1").succeeds();
+    scene.cmd("chmod").arg("666").arg("f2").succeeds();
+    let f1_mode = at.metadata("f1").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("--preserve=mode")
+        .arg("f1")
+        .arg("f2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let f2_mode = at.metadata("f2").mode();
+
+    assert_eq!(f1_mode, f2_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_existing_preserve_dir() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("mkdir").arg("d1").succeeds();
+    scene.cmd("mkdir").arg("d2").succeeds();
+    scene.cmd("chmod").arg("770").arg("d1").succeeds();
+    scene.cmd("chmod").arg("700").arg("d2").succeeds();
+    let d1_mode = at.metadata("d1").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("--preserve=mode")
+        .arg("-r")
+        .arg("d1/.")
+        .arg("d2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let d2_mode = at.metadata("d2").mode();
+
+    assert_eq!(d1_mode, d2_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_not_existing_no_preserve_file() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("touch").arg("f1").succeeds();
+    scene.cmd("chmod").arg("770").arg("f1").succeeds();
+
+    scene
+        .ucmd()
+        .umask(0o700)
+        .arg("--no-preserve=mode")
+        .arg("f1")
+        .arg("f2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let f2_mode = at.metadata("f2").mode();
+
+    assert_eq!(0o666 & !0o700, f2_mode & 0o777);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_not_existing_no_preserve_dir() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("mkdir").arg("d1").succeeds();
+    scene.cmd("chmod").arg("770").arg("d1").succeeds();
+
+    scene
+        .ucmd()
+        .umask(0o700)
+        .arg("--no-preserve=mode")
+        .arg("-r")
+        .arg("d1")
+        .arg("d2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let d2_mode = at.metadata("d2").mode();
+
+    assert_eq!(0o777 & !0o700, d2_mode & 0o777);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_not_existing_default_file() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("touch").arg("f1").succeeds();
+    scene.cmd("chmod").arg("770").arg("f1").succeeds();
+
+    scene
+        .ucmd()
+        .umask(0o700)
+        .arg("f1")
+        .arg("f2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let f2_mode = at.metadata("f2").mode();
+
+    assert_eq!(0o770 & !0o700, f2_mode & 0o777);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_not_existing_default_dir() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("mkdir").arg("d1").succeeds();
+    scene.cmd("chmod").arg("770").arg("d1").succeeds();
+
+    scene
+        .ucmd()
+        .umask(0o700)
+        .arg("-r")
+        .arg("d1")
+        .arg("d2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let d2_mode = at.metadata("d2").mode();
+
+    assert_eq!(0o770 & !0o700, d2_mode & 0o777);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_not_existing_preserve_file() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("touch").arg("f1").succeeds();
+    scene.cmd("chmod").arg("770").arg("f1").succeeds();
+    let f1_mode = at.metadata("f1").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("--preserve=mode")
+        .arg("f1")
+        .arg("f2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let f2_mode = at.metadata("f2").mode();
+
+    assert_eq!(f1_mode, f2_mode);
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_not_existing_preserve_dir() {
+    use std::io;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    scene.cmd("mkdir").arg("d1").succeeds();
+    scene.cmd("chmod").arg("770").arg("d1").succeeds();
+    let d1_mode = at.metadata("d1").mode();
+
+    scene
+        .ucmd()
+        // umask should have no effect
+        .umask(0o700)
+        .arg("--preserve=mode")
+        .arg("-r")
+        .arg("d1")
+        .arg("d2")
+        .set_stdout(io::stdout())
+        .succeeds();
+
+    let d2_mode = at.metadata("d2").mode();
+
+    assert_eq!(d1_mode, d2_mode);
 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -7880,334 +7880,99 @@ fn test_cp_recursive_non_utf8_source() {
     assert!(at.plus("dir2").join("a").exists());
 }
 
-#[test]
+#[rstest]
 #[cfg(unix)]
-fn test_cp_existing_no_preserve_file() {
+fn test_cp_file_mode(
+    #[values(true, false)] is_existing: bool,
+    #[values(Some(true), None, Some(false))] preserve: Option<bool>,
+) {
     use std::io;
 
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     scene.cmd("touch").arg("f1").succeeds();
-    scene.cmd("touch").arg("f2").succeeds();
     scene.cmd("chmod").arg("770").arg("f1").succeeds();
-    scene.cmd("chmod").arg("666").arg("f2").succeeds();
-    let f2_mode = at.metadata("f2").mode();
 
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("--no-preserve=mode")
-        .arg("f1")
-        .arg("f2")
-        .set_stdout(io::stdout())
-        .succeeds();
+    let f1_mode = at.metadata("f1").mode();
+    let f2_mode = if is_existing {
+        scene.cmd("touch").arg("f2").succeeds();
+        scene.cmd("chmod").arg("666").arg("f2").succeeds();
+        Some(at.metadata("f2").mode())
+    } else {
+        None
+    };
+
+    let mut command = scene.ucmd();
+    match preserve {
+        Some(true) => command.arg("--preserve=mode"),
+        Some(false) => command.arg("--no-preserve=mode"),
+        _ => &mut command,
+    }
+    .umask(0o700)
+    .arg("f1")
+    .arg("f2")
+    .set_stdout(io::stdout())
+    .succeeds();
 
     let f2_new_mode = at.metadata("f2").mode();
 
-    assert_eq!(f2_mode, f2_new_mode);
+    match (is_existing, preserve) {
+        (true, Some(false) | None) => {
+            assert_eq!(f2_mode.unwrap(), f2_new_mode);
+        }
+        (false, Some(false)) => assert_eq!(0o666 & !0o700, f2_new_mode & 0o777),
+        (false, None) => assert_eq!(!0o700 & 0o770, f2_new_mode & 0o777),
+        (_, Some(true)) => assert_eq!(f1_mode, f2_new_mode),
+    }
 }
 
-#[test]
+#[rstest]
 #[cfg(unix)]
-fn test_cp_existing_no_preserve_dir() {
+fn test_cp_dir_mode(
+    #[values(true, false)] is_existing: bool,
+    #[values(Some(true), None, Some(false))] preserve: Option<bool>,
+) {
     use std::io;
 
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
 
     scene.cmd("mkdir").arg("d1").succeeds();
-    scene.cmd("mkdir").arg("d2").succeeds();
     scene.cmd("chmod").arg("770").arg("d1").succeeds();
-    scene.cmd("chmod").arg("707").arg("d2").succeeds();
-    let d2_mode = at.metadata("d2").mode();
 
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("--no-preserve=mode")
-        .arg("-r")
-        .arg("d1/.")
-        .arg("d2")
-        .set_stdout(io::stdout())
-        .succeeds();
+    let d1_mode = at.metadata("d1").mode();
+    let d2_mode = if is_existing {
+        scene.cmd("mkdir").arg("d2").succeeds();
+        scene.cmd("chmod").arg("707").arg("d2").succeeds();
+        Some(at.metadata("d2").mode())
+    } else {
+        None
+    };
+
+    let mut command = scene.ucmd();
+    match preserve {
+        Some(true) => command.arg("--preserve=mode"),
+        Some(false) => command.arg("--no-preserve=mode"),
+        _ => &mut command,
+    }
+    .umask(0o700)
+    .arg("-r")
+    .arg("d1/.")
+    .arg("d2")
+    .set_stdout(io::stdout())
+    .succeeds();
 
     let d2_new_mode = at.metadata("d2").mode();
 
-    assert_eq!(d2_mode, d2_new_mode);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_existing_default_file() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("touch").arg("f1").succeeds();
-    scene.cmd("touch").arg("f2").succeeds();
-    scene.cmd("chmod").arg("770").arg("f1").succeeds();
-    scene.cmd("chmod").arg("666").arg("f2").succeeds();
-    let f2_mode = at.metadata("f2").mode();
-
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("f1")
-        .arg("f2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let f2_new_mode = at.metadata("f2").mode();
-
-    assert_eq!(f2_mode, f2_new_mode);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_existing_default_dir() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("mkdir").arg("d1").succeeds();
-    scene.cmd("mkdir").arg("d2").succeeds();
-    scene.cmd("chmod").arg("770").arg("d1").succeeds();
-    scene.cmd("chmod").arg("707").arg("d2").succeeds();
-    let d2_mode = at.metadata("d2").mode();
-
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("-r")
-        .arg("d1/.")
-        .arg("d2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let d2_new_mode = at.metadata("d2").mode();
-
-    assert_eq!(d2_mode, d2_new_mode);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_existing_preserve_file() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("touch").arg("f1").succeeds();
-    scene.cmd("touch").arg("f2").succeeds();
-    scene.cmd("chmod").arg("770").arg("f1").succeeds();
-    scene.cmd("chmod").arg("666").arg("f2").succeeds();
-    let f1_mode = at.metadata("f1").mode();
-
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("--preserve=mode")
-        .arg("f1")
-        .arg("f2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let f2_mode = at.metadata("f2").mode();
-
-    assert_eq!(f1_mode, f2_mode);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_existing_preserve_dir() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("mkdir").arg("d1").succeeds();
-    scene.cmd("mkdir").arg("d2").succeeds();
-    scene.cmd("chmod").arg("770").arg("d1").succeeds();
-    scene.cmd("chmod").arg("707").arg("d2").succeeds();
-    let d1_mode = at.metadata("d1").mode();
-
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("--preserve=mode")
-        .arg("-r")
-        .arg("d1/.")
-        .arg("d2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let d2_mode = at.metadata("d2").mode();
-
-    assert_eq!(d1_mode, d2_mode);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_not_existing_no_preserve_file() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("touch").arg("f1").succeeds();
-    scene.cmd("chmod").arg("770").arg("f1").succeeds();
-
-    scene
-        .ucmd()
-        .umask(0o700)
-        .arg("--no-preserve=mode")
-        .arg("f1")
-        .arg("f2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let f2_mode = at.metadata("f2").mode();
-
-    assert_eq!(0o666 & !0o700, f2_mode & 0o777);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_not_existing_no_preserve_dir() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("mkdir").arg("d1").succeeds();
-    scene.cmd("chmod").arg("770").arg("d1").succeeds();
-
-    scene
-        .ucmd()
-        .umask(0o700)
-        .arg("--no-preserve=mode")
-        .arg("-r")
-        .arg("d1")
-        .arg("d2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let d2_mode = at.metadata("d2").mode();
-
-    assert_eq!(!0o700 & 0o777, d2_mode & 0o777);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_not_existing_default_file() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("touch").arg("f1").succeeds();
-    scene.cmd("chmod").arg("770").arg("f1").succeeds();
-
-    scene
-        .ucmd()
-        .umask(0o700)
-        .arg("f1")
-        .arg("f2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let f2_mode = at.metadata("f2").mode();
-
-    assert_eq!(!0o700 & 0o770, f2_mode & 0o777);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_not_existing_default_dir() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("mkdir").arg("d1").succeeds();
-    scene.cmd("chmod").arg("770").arg("d1").succeeds();
-
-    scene
-        .ucmd()
-        .umask(0o700)
-        .arg("-r")
-        .arg("d1")
-        .arg("d2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let d2_mode = at.metadata("d2").mode();
-
-    assert_eq!(!0o700 & 0o770, d2_mode & 0o777);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_not_existing_preserve_file() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("touch").arg("f1").succeeds();
-    scene.cmd("chmod").arg("770").arg("f1").succeeds();
-    let f1_mode = at.metadata("f1").mode();
-
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("--preserve=mode")
-        .arg("f1")
-        .arg("f2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let f2_mode = at.metadata("f2").mode();
-
-    assert_eq!(f1_mode, f2_mode);
-}
-
-#[test]
-#[cfg(unix)]
-fn test_cp_not_existing_preserve_dir() {
-    use std::io;
-
-    let scene = TestScenario::new(util_name!());
-    let at = &scene.fixtures;
-
-    scene.cmd("mkdir").arg("d1").succeeds();
-    scene.cmd("chmod").arg("770").arg("d1").succeeds();
-    let d1_mode = at.metadata("d1").mode();
-
-    scene
-        .ucmd()
-        // umask should have no effect
-        .umask(0o700)
-        .arg("--preserve=mode")
-        .arg("-r")
-        .arg("d1")
-        .arg("d2")
-        .set_stdout(io::stdout())
-        .succeeds();
-
-    let d2_mode = at.metadata("d2").mode();
-
-    assert_eq!(d1_mode, d2_mode);
+    match (is_existing, preserve) {
+        (true, Some(false) | None) => {
+            assert_eq!(d2_mode.unwrap(), d2_new_mode);
+        }
+        (false, Some(false)) => assert_eq!(!0o700 & 0o777, d2_new_mode & 0o777),
+        (false, None) => assert_eq!(!0o700 & 0o770, d2_new_mode & 0o777),
+        (_, Some(true)) => assert_eq!(d1_mode, d2_new_mode),
+    }
 }
 
 #[test]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -7920,7 +7920,7 @@ fn test_cp_existing_no_preserve_dir() {
     scene.cmd("mkdir").arg("d1").succeeds();
     scene.cmd("mkdir").arg("d2").succeeds();
     scene.cmd("chmod").arg("770").arg("d1").succeeds();
-    scene.cmd("chmod").arg("700").arg("d2").succeeds();
+    scene.cmd("chmod").arg("707").arg("d2").succeeds();
     let d2_mode = at.metadata("d2").mode();
 
     scene
@@ -7978,7 +7978,7 @@ fn test_cp_existing_default_dir() {
     scene.cmd("mkdir").arg("d1").succeeds();
     scene.cmd("mkdir").arg("d2").succeeds();
     scene.cmd("chmod").arg("770").arg("d1").succeeds();
-    scene.cmd("chmod").arg("700").arg("d2").succeeds();
+    scene.cmd("chmod").arg("707").arg("d2").succeeds();
     let d2_mode = at.metadata("d2").mode();
 
     scene
@@ -8036,7 +8036,7 @@ fn test_cp_existing_preserve_dir() {
     scene.cmd("mkdir").arg("d1").succeeds();
     scene.cmd("mkdir").arg("d2").succeeds();
     scene.cmd("chmod").arg("770").arg("d1").succeeds();
-    scene.cmd("chmod").arg("700").arg("d2").succeeds();
+    scene.cmd("chmod").arg("707").arg("d2").succeeds();
     let d1_mode = at.metadata("d1").mode();
 
     scene


### PR DESCRIPTION
Fix #9750, #10011, #10787, #10862, Supersede #10859.

This PR reworks the permissions mode handling such that its behaviour is in line with GNU's implementation. Specifically:

- set umask to !0o077, which means (1) cp can actually create and work with new directories/files which will have 700 permissions mode before their final calculated mode is set. the original umask is kept and passed around for calculation in the case of newly created and non-mode-preserving dir/files. umask is restored to original on exit.

- for explicit non-mode-preserving, newly created dir/files, use 777 and 666 modes for calculation respectively.

- for existing dir/files, leave existing mode unchanged except when preserving mode.

- for newly created dir/files, always set their permission mode to the correct one.

- ~~added 12 new tests for the combination of existing/not-existing, no-preserve/default/preserve, dir/file~~ one each for directory and file with rstest.

- improve performance by eliminating redundant heap allocations (e.g. PathBuf, String), ~25% from benchmark.