### PR TITLE
build-gnu: fix factor tests being re-added by automake during make check

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -140,7 +140,7 @@ else
 
     # Handle generated factor tests
     t_first=00
-    t_max=37
+    t_max=40
     seq=$(
         i=${t_first}
         while test "${i}" -le "${t_max}"; do
@@ -149,8 +149,8 @@ else
         done
        )
     for i in ${seq}; do
-        echo "strip t${i}.sh from Makefile"
-        sed -i -e "s/\$(tf)\/t${i}.sh//g" Makefile
+        echo "strip t${i}.sh from Makefile and tests/local.mk"
+        sed -i -e "s/\$(tf)\/t${i}.sh//g" Makefile tests/local.mk
     done
 
     # Remove tests checking for --version & --help
@@ -158,6 +158,11 @@ else
     sed -i '/tests\/help\/help-version.sh/ D' Makefile
     touch gnu-built
 fi
+
+# Keep Makefile.in newer than the local.mk files we just modified,
+# and Makefile newer than Makefile.in, so make won't re-run
+# automake or config.status and undo our edits.
+touch Makefile.in Makefile
 
 grep -rl 'path_prepend_' tests/* | xargs -r "${SED}" -i 's| path_prepend_ ./src||'
 # path_prepend_ sets $abs_path_dir_: set it manually instead.


### PR DESCRIPTION
This isn't the most elegant of fixes, but the reason that we see varying integration test numbers is that if we don't re-use the gnu build from the cache then before we run the tests we will regenerate the test files again which includes all of the files that we patched out and all of the factor tests. This removes all of the patches to the Makefile and also causes the test suite to take double the amount of time to run.

The three changes are: changing the factor total test count to 40 from 37 since this was update upstream, removing all of these tests from the tests/local.mk so that even if in the future we regress and rebuild the tests again it will not have those factor tests, then lastly touching Makefile.in Makefile after all of the modifications to the build files so that when we run make-check it wont rebuild the test files again.

I made a branch to stress test this to validate that it fixes the bug and it appears that it does, but at the same time the conditions don't match the main CI exactly so I'm not 100% confident that this fixes it completely.