### PR TITLE
uucore: remove redundant setup_localization call in help template

### DIFF
--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -287,9 +287,6 @@ pub fn localized_help_template_with_colors(
 ) -> clap::builder::StyledStr {
     use std::fmt::Write;
 
-    // Ensure localization is initialized for this utility
-    let _ = locale::setup_localization(util_name);
-
     // Get the localized "Usage" label
     let usage_label = crate::locale::translate!("common-usage");
 


### PR DESCRIPTION
Surprisingly I think that this line here is one of the biggest contributors to the flakiness in the valgrind GNU tests. When I look at the memory allocations when shuf is run, this line here is a duplicated call to setup_localization that doubles the amount of allocations for the loading of the fluent files and by removing it the time it takes to load valgrind reduces by 50%.

The best long term fix here would be to implement lazy loading for the translations to only load the translations when they're needed, but hopefully this will increase the stability of the GNU tests for now and should bring some major memory and performance benefits to every utility call.