### PR TITLE
locale, factor, shuf: Example of deferred locale loading for clap

### DIFF
--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -148,7 +148,7 @@ fn write_result_big_uint(
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uucore::clap_localization::parse_deferred(uu_app, args)?;
+    let matches = uucore::clap_localization::parse_deferred(uu_app_base, args)?;
 
     // If matches find --exponents flag than variable print_exponents is true and p^e output format will be used.
     let print_exponents = matches.get_flag(options::EXPONENTS);
@@ -188,6 +188,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> Command {
+    uucore::clap_localization::localize_command(uu_app_base())
+}
+
+fn uu_app_base() -> Command {
     Command::new(uucore::util_name())
         .version(uucore::crate_version!())
         .infer_long_args(true)

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -15,7 +15,7 @@ use num_traits::FromPrimitive;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, set_exit_code};
 use uucore::translate;
-use uucore::{format_usage, show_error, show_warning};
+use uucore::{show_error, show_warning};
 
 mod options {
     pub static EXPONENTS: &str = "exponents";
@@ -148,7 +148,7 @@ fn write_result_big_uint(
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
+    let matches = uucore::clap_localization::parse_deferred(uu_app, args)?;
 
     // If matches find --exponents flag than variable print_exponents is true and p^e output format will be used.
     let print_exponents = matches.get_flag(options::EXPONENTS);
@@ -190,9 +190,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(uucore::crate_version!())
-        .help_template(uucore::localized_help_template(uucore::util_name()))
-        .about(translate!("factor-about"))
-        .override_usage(format_usage(&translate!("factor-usage")))
         .infer_long_args(true)
         .disable_help_flag(true)
         .args_override_self(true)
@@ -201,13 +198,11 @@ pub fn uu_app() -> Command {
             Arg::new(options::EXPONENTS)
                 .short('h')
                 .long(options::EXPONENTS)
-                .help(translate!("factor-help-exponents"))
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new(options::HELP)
                 .long(options::HELP)
-                .help(translate!("factor-help-help"))
                 .action(ArgAction::Help),
         )
 }

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -21,7 +21,6 @@ use rand::{
 
 use uucore::display::{OsWrite, Quotable};
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
-use uucore::format_usage;
 use uucore::translate;
 
 mod compat_random_source;
@@ -68,7 +67,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
+    let matches = uucore::clap_localization::parse_deferred(uu_app, args)?;
 
     let mode = if matches.get_flag(options::ECHO) {
         Mode::Echo(
@@ -173,16 +172,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
-        .about(translate!("shuf-about"))
         .version(uucore::crate_version!())
-        .help_template(uucore::localized_help_template(uucore::util_name()))
-        .override_usage(format_usage(&translate!("shuf-usage")))
         .infer_long_args(true)
         .arg(
             Arg::new(options::ECHO)
                 .short('e')
                 .long(options::ECHO)
-                .help(translate!("shuf-help-echo"))
                 .action(ArgAction::SetTrue)
                 .overrides_with(options::ECHO)
                 .conflicts_with(options::INPUT_RANGE),
@@ -192,7 +187,6 @@ pub fn uu_app() -> Command {
                 .short('i')
                 .long(options::INPUT_RANGE)
                 .value_name("LO-HI")
-                .help(translate!("shuf-help-input-range"))
                 .value_parser(parse_range)
                 .conflicts_with(options::FILE_OR_ARGS),
         )
@@ -202,7 +196,6 @@ pub fn uu_app() -> Command {
                 .long(options::HEAD_COUNT)
                 .value_name("COUNT")
                 .action(ArgAction::Append)
-                .help(translate!("shuf-help-head-count"))
                 .value_parser(u64::from_str),
         )
         .arg(
@@ -210,7 +203,6 @@ pub fn uu_app() -> Command {
                 .short('o')
                 .long(options::OUTPUT)
                 .value_name("FILE")
-                .help(translate!("shuf-help-output"))
                 .value_parser(ValueParser::path_buf())
                 .value_hint(clap::ValueHint::FilePath),
         )
@@ -218,7 +210,6 @@ pub fn uu_app() -> Command {
             Arg::new(options::RANDOM_SEED)
                 .long(options::RANDOM_SEED)
                 .value_name("STRING")
-                .help(translate!("shuf-help-random-seed"))
                 .value_parser(ValueParser::string())
                 .value_hint(clap::ValueHint::Other)
                 .conflicts_with(options::RANDOM_SOURCE),
@@ -227,7 +218,6 @@ pub fn uu_app() -> Command {
             Arg::new(options::RANDOM_SOURCE)
                 .long(options::RANDOM_SOURCE)
                 .value_name("FILE")
-                .help(translate!("shuf-help-random-source"))
                 .value_parser(ValueParser::path_buf())
                 .value_hint(clap::ValueHint::FilePath),
         )
@@ -235,7 +225,6 @@ pub fn uu_app() -> Command {
             Arg::new(options::REPEAT)
                 .short('r')
                 .long(options::REPEAT)
-                .help(translate!("shuf-help-repeat"))
                 .action(ArgAction::SetTrue)
                 .overrides_with(options::REPEAT),
         )
@@ -243,7 +232,6 @@ pub fn uu_app() -> Command {
             Arg::new(options::ZERO_TERMINATED)
                 .short('z')
                 .long(options::ZERO_TERMINATED)
-                .help(translate!("shuf-help-zero-terminated"))
                 .action(ArgAction::SetTrue)
                 .overrides_with(options::ZERO_TERMINATED),
         )

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -67,7 +67,7 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uucore::clap_localization::parse_deferred(uu_app, args)?;
+    let matches = uucore::clap_localization::parse_deferred(uu_app_base, args)?;
 
     let mode = if matches.get_flag(options::ECHO) {
         Mode::Echo(
@@ -171,6 +171,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 pub fn uu_app() -> Command {
+    uucore::clap_localization::localize_command(uu_app_base())
+}
+
+fn uu_app_base() -> Command {
     Command::new(uucore::util_name())
         .version(uucore::crate_version!())
         .infer_long_args(true)

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -287,9 +287,6 @@ pub fn localized_help_template_with_colors(
 ) -> clap::builder::StyledStr {
     use std::fmt::Write;
 
-    // Ensure localization is initialized for this utility
-    let _ = locale::setup_localization(util_name);
-
     // Get the localized "Usage" label
     let usage_label = crate::locale::translate!("common-usage");
 

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -263,7 +263,7 @@ pub fn format_usage(s: &str) -> String {
 /// let app = Command::new("myutil")
 ///     .help_template(localized_help_template("myutil"));
 /// ```
-pub fn localized_help_template(util_name: &str) -> clap::builder::StyledStr {
+pub fn localized_help_template(_util_name: &str) -> clap::builder::StyledStr {
     use std::io::IsTerminal;
 
     // Determine if colors should be enabled - same logic as configure_localized_command
@@ -276,15 +276,12 @@ pub fn localized_help_template(util_name: &str) -> clap::builder::StyledStr {
             && std::env::var("TERM").unwrap_or_default() != "dumb"
     };
 
-    localized_help_template_with_colors(util_name, colors_enabled)
+    localized_help_template_with_colors(colors_enabled)
 }
 
 /// Create a localized help template with explicit color control
 /// This ensures color detection consistency between clap and our template
-pub fn localized_help_template_with_colors(
-    util_name: &str,
-    colors_enabled: bool,
-) -> clap::builder::StyledStr {
+pub fn localized_help_template_with_colors(colors_enabled: bool) -> clap::builder::StyledStr {
     use std::fmt::Write;
 
     // Get the localized "Usage" label


### PR DESCRIPTION
A few month ago I attempted the same thing but now I've got a much better understanding of the project to attempt it again. The change here is that there is a parse_deferred handler now that attempts to parse the clap arguments and it it fails it will reattempt it with the locale files loaded. This combined with changes in the default locale initialization to take the util_name at the beginning from the arguments allows us to not have to load the locale file until the translation is actually required.

This requires migrating each utility to this new format, but I already started the process for factor and shuf to start.

This change is also required for the `ls/stat-free-symlink` gnu test and it should make the valgrind tests much more stable since it runs twice as fast in local testing and less likely to timeout.