### PR TITLE
date: Fix format optional argument to capture all following parameters

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -624,7 +624,7 @@ pub fn uu_app() -> Command {
                 .help(translate!("date-help-universal"))
                 .action(ArgAction::SetTrue),
         )
-        .arg(Arg::new(OPT_FORMAT).num_args(0..).trailing_var_arg(true))
+        .arg(Arg::new(OPT_FORMAT).num_args(0..))
 }
 
 fn format_date_with_locale_aware_months(

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -52,6 +52,15 @@ fn test_invalid_short_option() {
 }
 
 #[test]
+fn test_format_option_not_to_capture_other_valid_arguments() {
+    new_ucmd!()
+        .arg("+%Y%m%d%H%M%S")
+        .arg("--date")
+        .arg("@1770996496")
+        .succeeds();
+}
+
+#[test]
 fn test_single_dash_as_date() {
     new_ucmd!()
         .arg("-")


### PR DESCRIPTION
Fixed the format argument to capture all following parameters. Also added a regression test.

Fix: #10910
