### PR TITLE
expand: single-pass fast path check with early exit

### DIFF
--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -400,8 +400,12 @@ fn expand_buf(
     use self::CharType::{Backspace, Other, Tab};
 
     // Fast path: if there are no tabs, backspaces, and (in UTF-8 mode or no carriage returns),
-    // we can write the buffer directly without character-by-character processing
-    if !buf.contains(&b'\t') && !buf.contains(&b'\x08') && (options.utf8 || !buf.contains(&b'\r')) {
+    // we can write the buffer directly without character-by-character processing.
+    // Single pass with early exit instead of up to 3 separate .contains() scans.
+    let needs_processing = buf
+        .iter()
+        .any(|&b| b == b'\t' || b == b'\x08' || (!options.utf8 && b == b'\r'));
+    if !needs_processing {
         output.write_all(buf)?;
         if let Some(n) = buf.iter().rposition(|&b| b == b'\n') {
             *col = buf.len() - n - 1;


### PR DESCRIPTION
Replace up to 3 separate .contains() scans with a single .any() pass that short-circuits on the first special byte found. Avoids redundant buffer traversals with zero allocation overhead.