### PR TITLE
build: statically link the CRT for MSVC targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,8 @@ linker = "x86_64-unknown-redox-gcc"
 linker = "aarch64-linux-gnu-gcc"
 [target.riscv64gc-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.'cfg(target_env = "msvc")']
+rustflags = ["-C", "target-feature=+crt-static"]
 
 [env]
 # See feat_external_libstdbuf in src/uu/stdbuf/Cargo.toml


### PR DESCRIPTION
Windows MSVC builds currently depend on `vcruntime140.dll` at runtime because Rust defaults to dynamic CRT linking for MSVC targets. This makes the release binaries non-self-contained.

See discussion about binaries size difference and compatibility issues at #10929

fixes #10929