### PR TITLE
date: fix RFC-822 format to always use English names

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -487,7 +487,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 } else {
                     date
                 };
-                match format_date_with_locale_aware_months(&date, format_string, &config) {
+                let skip_localization =
+                    matches!(settings.format, Format::Rfc5322 | Format::Rfc3339(_));
+                match format_date_with_locale_aware_months(
+                    &date,
+                    format_string,
+                    &config,
+                    skip_localization,
+                ) {
                     Ok(s) => writeln!(stdout, "{s}").map_err(|e| {
                         USimpleError::new(1, translate!("date-error-write", "error" => e))
                     })?,
@@ -631,10 +638,11 @@ fn format_date_with_locale_aware_months(
     date: &Zoned,
     format_string: &str,
     config: &Config<PosixCustom>,
+    skip_localization: bool,
 ) -> Result<String, jiff::Error> {
     let broken_down = BrokenDownTime::from(date);
 
-    if !should_use_icu_locale() {
+    if !should_use_icu_locale() || skip_localization {
         return broken_down.to_string_with_config(config, format_string);
     }
 

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -87,6 +87,32 @@ fn test_date_email_multiple_aliases() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_date_rfc_822_uses_english() {
+    // RFC-822/RFC-2822/RFC-5322 formats should always use English day/month names
+    // regardless of locale (per RFC specification)
+    let scene = TestScenario::new(util_name!());
+
+    // Test with German locale - should still output "Sun" not "So"
+    scene
+        .ucmd()
+        .env("LC_ALL", "de_DE.UTF-8")
+        .env("TZ", "UTC")
+        .args(&["-R", "-d", "1997-01-19 08:17:48 +0"])
+        .succeeds()
+        .stdout_contains("Sun, 19 Jan 1997");
+
+    // Test with French locale - should still output "Sun" not "dim."
+    scene
+        .ucmd()
+        .env("LC_ALL", "fr_FR.UTF-8")
+        .env("TZ", "UTC")
+        .args(&["-R", "-d", "1997-01-19 08:17:48 +0"])
+        .succeeds()
+        .stdout_contains("Sun, 19 Jan 1997");
+}
+
+#[test]
 fn test_date_rfc_3339() {
     let scene = TestScenario::new(util_name!());
 


### PR DESCRIPTION
fixed gnu rfc822-1

RFC-822/RFC-2822/RFC-5322 formats must use English day and month names regardless of locale per RFC specification. Previously, these formats were being localized (e.g., "So" instead of "Sun" with de_DE locale).