### PR TITLE
date: bump parse_datetime & add test for leap-1 GNU test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "parse_datetime"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acea383beda9652270f3c9678d83aa58cbfc16880343cae0c0c8c7d6c0974132"
+checksum = "413775a7eac2261d2211a79d10ef275e5b6f7b527eec42ad09adce2ffa92b6e5"
 dependencies = [
  "jiff",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,7 +360,7 @@ num-bigint = "0.4.4"
 num-prime = "0.4.4"
 num-traits = "0.2.19"
 onig = { version = "~6.5.1", default-features = false }
-parse_datetime = "0.13.0"
+parse_datetime = "0.14.0"
 phf = "0.13.1"
 phf_codegen = "0.13.1"
 platform-info = "2.0.3"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -66,7 +66,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -77,7 +77,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -520,7 +520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -991,7 +991,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1251,9 +1251,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parse_datetime"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acea383beda9652270f3c9678d83aa58cbfc16880343cae0c0c8c7d6c0974132"
+checksum = "413775a7eac2261d2211a79d10ef275e5b6f7b527eec42ad09adce2ffa92b6e5"
 dependencies = [
  "jiff",
  "num-traits",
@@ -1430,7 +1430,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1590,7 +1590,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2072,7 +2072,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2087,3 +2087,26 @@ fn test_date_write_error_dev_full() {
         .fails()
         .stderr_contains("write error");
 }
+
+// Tests for GNU test leap-1: leap year overflow in date arithmetic
+#[test]
+fn test_date_leap1_leap_year_overflow() {
+    // GNU test leap-1: Adding years to Feb 29 should overflow to March 1
+    // if target year is not a leap year
+    new_ucmd!()
+        .args(&["--date", "02/29/1996 1 year", "+%Y-%m-%d"])
+        .succeeds()
+        .stdout_is("1997-03-01\n");
+
+    // Additional cases: 2 years
+    new_ucmd!()
+        .args(&["--date", "1996-02-29 + 2 years", "+%Y-%m-%d"])
+        .succeeds()
+        .stdout_is("1998-03-01\n");
+
+    // Leap year to leap year should not overflow
+    new_ucmd!()
+        .args(&["--date", "1996-02-29 + 4 years", "+%Y-%m-%d"])
+        .succeeds()
+        .stdout_is("2000-02-29\n");
+}


### PR DESCRIPTION
Rely on parse_datetime update

Test that adding years to Feb 29 overflows to March 1 when target year is not a leap year (matching GNU behavior).