### PR TITLE
CICD: Introduce check-only for Redox CI

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -630,11 +630,11 @@ jobs:
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,test_risky_names", use-cross: use-cross, skip-publish: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
           - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true }
+          - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true , check-only: true }
           - { os: ubuntu-latest  , target: wasm32-wasip1, default-features: false, features: "basenc,cksum", skip-tests: true }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_macos, workspace-tests: true } # M1 CPU
-          # PR #7964: Mac should still build even if the feature is not enabled. Do not publish this.
-          - { os: macos-latest   , target: aarch64-apple-darwin        , workspace-tests: true, skip-publish: true } # M1 CPU
+          # PR #7964: chcon should not break build without the feature. cargo check is enough to detect it.
+          - { os: macos-latest   , target: aarch64-apple-darwin        , workspace-tests: true, check-only: true } # M1 CPU
           - { os: macos-latest   , target: x86_64-apple-darwin         , features: feat_os_macos, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
           - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
@@ -849,8 +849,16 @@ jobs:
         echo "## dependency list"
         cargo fetch --locked --quiet --target $(rustc --print host-tuple)
         cargo tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_DEFAULT_FEATURES_OPTION }} --no-dedupe -e=no-dev --prefix=none | grep -vE "$PWD" | sort --unique
+    - name: Check
+      shell: bash
+      if: matrix.job.skip-publish != true && matrix.job.check-only == true
+      run: |
+        # expr breaks redox
+        sed -i.b '/"expr",/d' Cargo.toml
+        ${{ steps.vars.outputs.CARGO_CMD }} ${{ steps.vars.outputs.CARGO_CMD_OPTIONS }} check \
+        --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_DEFAULT_FEATURES_OPTION }}
     - name: Test
-      if: matrix.job.skip-tests != true
+      if: matrix.job.skip-tests != true && matrix.job.check-only != true
       shell: bash
       run: |
         ## Test
@@ -861,13 +869,13 @@ jobs:
         RUST_BACKTRACE: "1"
     - name: Build
       shell: bash
-      if: matrix.job.skip-publish != true
+      if: matrix.job.skip-publish != true && matrix.job.check-only != true
       run: |
         ## Build
         ${{ steps.vars.outputs.CARGO_CMD }} ${{ steps.vars.outputs.CARGO_CMD_OPTIONS }} build --release --config=profile.release.strip=true \
         --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_DEFAULT_FEATURES_OPTION }}
     - name: Package
-      if: matrix.job.skip-publish != true
+      if: matrix.job.skip-publish != true && matrix.job.check-only != true
       shell: bash
       run: |
         ## Package artifact(s)
@@ -901,7 +909,7 @@ jobs:
         tar --zstd -cf docs.tar.zst share
     - name: Publish
       uses: softprops/action-gh-release@v2
-      if: steps.vars.outputs.DEPLOY && matrix.job.skip-publish != true
+      if: steps.vars.outputs.DEPLOY && matrix.job.skip-publish != true && matrix.job.check-only != true
       with:
         draft: true
         files: |
@@ -911,7 +919,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish latest commit
       uses: softprops/action-gh-release@v2
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.job.skip-publish != true
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.job.skip-publish != true && matrix.job.check-only != true
       with:
         tag_name: latest-commit
         body: |
@@ -1317,8 +1325,9 @@ jobs:
       run: |
         test -f target/debug/chcon || test -f target/debug/chcon.exe
         test -f target/debug/runcon || test -f target/debug/runcon.exe
+    # check is enough to detect workspace breakage by chcon
     - name: Verify workspace builds with stubs
-      run: cargo build --features ${{ matrix.job.features }}
+      run: cargo check --features ${{ matrix.job.features }}
 
   test_safe_traversal:
     name: Safe Traversal Security Check


### PR DESCRIPTION
- While we don't have enough contributor to fix `cargo build` on Redox, we can still keep `cargo check` for Redox. Closes https://github.com/uutils/coreutils/issues/10918 by keeping minimal check.
- Some tests exist only for checking that `*con` does not cause build failure. But `cargo build` only for it is overkill. Do check only since `cargo check -p uu_chcon` fails on the wrong platform.

We should avoid all red anyway.