### PR TITLE
date: fix -d with relative dates and timezone abbreviations

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -828,7 +828,7 @@ fn tz_abbrev_to_iana(abbrev: &str) -> Option<&str> {
 /// If an abbreviation is found and the date is parsable, returns `Some(Zoned)`.
 /// Returns `None` if no abbreviation is detected or if parsing fails, indicating
 /// that standard parsing should be attempted.
-fn try_parse_with_abbreviation<S: AsRef<str>>(date_str: S) -> Option<Zoned> {
+fn try_parse_with_abbreviation<S: AsRef<str>>(date_str: S, now: &Zoned) -> Option<Zoned> {
     let s = date_str.as_ref();
 
     // Look for timezone abbreviation at the end of the string
@@ -845,7 +845,9 @@ fn try_parse_with_abbreviation<S: AsRef<str>>(date_str: S) -> Option<Zoned> {
                     // Parse the date part (everything before the TZ abbreviation)
                     let date_part = s.trim_end_matches(last_word).trim();
                     // Parse in the target timezone so "10:30 EDT" means 10:30 in EDT
-                    if let Ok(parsed) = parse_datetime::parse_datetime(date_part) {
+                    if let Ok(parsed) =
+                        parse_datetime::parse_datetime_at_date(now.clone(), date_part)
+                    {
                         let dt = parsed.datetime();
                         if let Ok(zoned) = dt.to_zoned(tz) {
                             return Some(zoned);
@@ -898,7 +900,7 @@ fn parse_date<S: AsRef<str> + Clone>(
     }
 
     // First, try to parse any timezone abbreviations
-    if let Some(zoned) = try_parse_with_abbreviation(input_str) {
+    if let Some(zoned) = try_parse_with_abbreviation(input_str, now) {
         if dbg_opts.debug {
             eprintln!(
                 "date: parsed date part: (Y-M-D) {}",
@@ -1097,6 +1099,14 @@ mod tests {
         assert_eq!(parse_military_timezone_with_offset(""), None); // Empty
         assert_eq!(parse_military_timezone_with_offset("m999"), None); // Too long
         assert_eq!(parse_military_timezone_with_offset("9m"), None); // Starts with digit
+    }
+
+    #[test]
+    fn test_abbreviation_resolves_relative_date_against_now() {
+        let now = "2025-03-15T20:00:00+00:00[UTC]".parse::<Zoned>().unwrap();
+        let result =
+            parse_date("yesterday 10:00 GMT", &now, DebugOptions::new(false, false)).unwrap();
+        assert_eq!(result.date(), jiff::civil::date(2025, 3, 14));
     }
 
     #[test]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1125,6 +1125,29 @@ fn test_date_tz_abbreviation_with_day_of_week() {
 }
 
 #[test]
+fn test_date_tz_abbreviation_with_relative_date() {
+    // Verify that "yesterday" in "-u -d yesterday 10:00 GMT" is resolved
+    // relative to UTC, not the local TZ.
+    let expected = new_ucmd!()
+        .env("TZ", "UTC")
+        .arg("-u")
+        .arg("-d")
+        .arg("yesterday 10:00 GMT")
+        .arg("+%F %T %Z")
+        .succeeds()
+        .stdout_str()
+        .to_string();
+    new_ucmd!()
+        .env("TZ", "Australia/Sydney")
+        .arg("-u")
+        .arg("-d")
+        .arg("yesterday 10:00 GMT")
+        .arg("+%F %T %Z")
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
 fn test_date_tz_abbreviation_unknown() {
     // Test that unknown timezone abbreviations fall back gracefully
     // XYZ is not a valid timezone abbreviation


### PR DESCRIPTION
Fixes #10788

`try_parse_with_abbreviation` resolved relative dates like "yesterday" against the system clock instead of the caller-provided reference time. Pass `now` through so both code paths use the same reference.