### PR TITLE
uutests: preserve PATH in UCommand to fix NixOS test failures

### DIFF
--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -1823,6 +1823,12 @@ impl UCommand {
         }
 
         command.env_clear();
+
+        // Preserve PATH
+        if let Some(path) = env::var_os("PATH") {
+            command.env("PATH", path);
+        }
+
         if cfg!(windows) {
             // spell-checker:ignore (dll) rsaenh
             // %SYSTEMROOT% is required on Windows to initialize crypto provider


### PR DESCRIPTION
This ensures that the PATH environment variable is preserved even when cleared, allowing tests to find system utilities on NixOS where they are not in standard locations like /bin.

Fixes #10756