### PR TITLE
ci: remove GNU build caching from GnuTests workflow

### DIFF
--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -38,7 +38,7 @@ jobs:
     name: Run GNU tests (native)
     runs-on: ubuntu-24.04
     steps:
-    #### Get the code, setup cache
+    #### Get the code
     - name: Checkout code (uutils)
       uses: actions/checkout@v6
       with:
@@ -49,15 +49,6 @@ jobs:
         workspaces: "./uutils -> target"
     - name: Checkout code (GNU coreutils)
       run: (mkdir -p gnu && cd gnu && bash ../uutils/util/fetch-gnu.sh)
-    - name: Restore files for faster configure and skipping make
-      uses: actions/cache@v5
-      id: cache-config-gnu
-      with:
-        path: |
-          gnu/config.cache
-          gnu/src/getlimits
-        key: ${{ runner.os }}-gnu-config-${{ hashFiles('gnu/NEWS') }}-${{ hashFiles('uutils/util/build-gnu.sh') }} # use build-gnu.sh for extremely safe caching
-
     #### Build environment setup
     - name: Install dependencies
       shell: bash
@@ -101,15 +92,6 @@ jobs:
         ## Build binaries
         cd 'uutils'
         env PROFILE=release-small bash util/build-gnu.sh
-
-    - name: Save files for faster configure and skipping make
-      uses: actions/cache/save@v5
-      if: always() && steps.cache-config-gnu.outputs.cache-hit != 'true'
-      with:
-        path: |
-          gnu/config.cache
-          gnu/src/getlimits
-        key: ${{ runner.os }}-gnu-config-${{ hashFiles('gnu/NEWS') }}-${{ hashFiles('uutils/util/build-gnu.sh') }}
 
     ### Run tests as user
     - name: Run GNU tests
@@ -198,7 +180,7 @@ jobs:
     name: Run GNU tests (SELinux)
     runs-on: ubuntu-24.04
     steps:
-    #### Get the code, setup cache
+    #### Get the code
     - name: Checkout code (uutils)
       uses: actions/checkout@v6
       with:


### PR DESCRIPTION
I unfortunately created a mess by trying to fix the issue of the Makefile being regenerated when the tests were being run where now when CI pulls the GNU build from the cache it will rebuild the entire project before running the GNU tests which swaps the binary thats being compared to the GNU binaries.

I think this is still the right way to fix forward because if you look at the timing: : https://github.com/uutils/coreutils/actions/runs/22039759086/job/63678632753 this one with no cache and https://github.com/uutils/coreutils/actions/runs/22039759086/job/63678632753 this one with the cache its still faster to not use the cache because the rebuilding of the Makefile takes more time than the cache saves.



