### PR TITLE
rust: use const_locks feature

### DIFF
--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -492,7 +492,7 @@ mod tests {
     use super::*;
     // Required to instantiate mutex in shared context
     use clap::Command;
-    use std::sync::{LazyLock, Mutex};
+    use std::sync::Mutex;
 
     // The mutex is required here as by default all tests are run as separate
     // threads under the same parent process. As environment variables are
@@ -500,7 +500,7 @@ mod tests {
     // occur if no precautions are taken. Thus we have all tests that rely on
     // environment variables lock this empty mutex to ensure they don't access
     // it concurrently.
-    static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     // Environment variable for "VERSION_CONTROL"
     static ENV_VERSION_CONTROL: &str = "VERSION_CONTROL";

--- a/src/uucore/src/lib/features/entries.rs
+++ b/src/uucore/src/lib/features/entries.rs
@@ -43,7 +43,7 @@ use std::io::Error as IOError;
 use std::io::ErrorKind;
 use std::io::Result as IOResult;
 use std::ptr;
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 unsafe extern "C" {
     /// From: `<https://man7.org/linux/man-pages/man3/getgrouplist.3.html>`
@@ -279,7 +279,7 @@ pub trait Locate<K> {
 // to, so we must copy all the data we want before releasing the lock.
 // (Technically we must also ensure that the raw functions aren't being called
 // anywhere else in the program.)
-static PW_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static PW_LOCK: Mutex<()> = Mutex::new(());
 
 macro_rules! f {
     ($fnam:ident, $fid:ident, $t:ident, $st:ident) => {

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn utmpxname(_file: *const libc::c_char) -> libc::c_int {
     0
 }
 
-use crate::{LazyLock, libc}; // import macros from `../../macros.rs`
+use crate::libc; // import macros from `../../macros.rs`
 
 // In case the c_char array doesn't end with NULL
 macro_rules! chars2string {
@@ -380,7 +380,7 @@ impl Utmpx {
 // I believe the only technical memory unsafety that could happen is a data
 // race while copying the data out of the pointer returned by getutxent(), but
 // ordinary race conditions are also very much possible.
-static LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static LOCK: Mutex<()> = Mutex::new(());
 
 /// Iterator of login records
 pub struct UtmpxIter {


### PR DESCRIPTION
`Mutex::new` is now const so `LazyLock`is no longer needed