### PR TITLE
rm: report permission denied for unreadable subdirectories

### DIFF
--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -1008,6 +1008,22 @@ fn test_unreadable_and_nonempty_dir() {
 
 #[cfg(not(windows))]
 #[test]
+fn test_recursive_remove_unreadable_subdir() {
+    // Regression test for https://github.com/uutils/coreutils/issues/10966
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir_all("foo/bar");
+    at.touch("foo/bar/baz");
+    at.set_mode("foo/bar", 0o0000);
+
+    let result = ucmd.args(&["-r", "-f", "foo"]).fails();
+    result.stderr_contains("Permission denied");
+    result.stderr_contains("foo/bar");
+
+    at.set_mode("foo/bar", 0o0755);
+}
+
+#[cfg(not(windows))]
+#[test]
 fn test_inaccessible_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.mkdir("dir");


### PR DESCRIPTION
When `rm -rf foo` encounters `foo/bar` without read permission (and `bar` is non-empty), it currently reports:

```
rm: cannot remove 'foo': Directory not empty
```

GNU rm instead reports:

```
rm: cannot remove 'foo/bar': Permission denied
```

The problem is in `handle_permission_denied` in `platform/unix.rs`. When `open_subdir` fails with EACCES, it tries `unlink_at` on the directory. If that fails with ENOTEMPTY (directory has children we can't see), force mode was silently swallowing the error (`return !options.force` → `false`). The caller then thought nothing went wrong and tried to remove the parent, which failed with the misleading "Directory not empty".

The fix: when we can't open a subdirectory (permission denied) and can't remove it directly (any reason), always report the original permission denied. We already know the root cause — we lack read permission to traverse the directory contents.

Fixes #10966