### PR TITLE
test(cksum): regression test for write errors to /dev/full

### DIFF
--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -3423,3 +3423,20 @@ fn test_check_blake3_untagged(
         .succeeds()
         .stdout_only("FILE: OK\n");
 }
+
+// Regression test: cksum should handle write errors to /dev/full without aborting.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_write_error_dev_full() {
+    use std::fs::OpenOptions;
+    let dev_full = OpenOptions::new()
+        .write(true)
+        .open("/dev/full")
+        .expect("Failed to open /dev/full - test must run on Linux");
+
+    new_ucmd!()
+        .arg("/dev/null")
+        .set_stdout(dev_full)
+        .fails()
+        .code_is(1);
+}


### PR DESCRIPTION
Adds a Linux-only regression test verifying that `cksum` exits with code 1 (instead of panicking) when stdout is `/dev/full`.

Refs #10947, which has been fixed by #12099. Per @xtqqczze's suggestion in [this comment](https://github.com/uutils/coreutils/pull/10978#issuecomment-4371357980), this PR has been reduced to the regression test only; the original implementation has been dropped.