### PR TITLE
fix(deps): update rust crate keccak to v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]


### PR DESCRIPTION
Fix https://github.com/uutils/coreutils/issues/10987

cc: @sylvestre @cakebaker this is needed to unblock CI