### PR TITLE
date: implement E and O locale modifiers

### DIFF
--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -511,7 +511,10 @@ mod tests {
         assert!(boot_time > 0, "Boot time should be positive");
 
         // Boot time should be after 2000-01-01 (946684800 seconds since epoch)
-        assert!(boot_time > 946684800, "Boot time should be after year 2000");
+        assert!(
+            boot_time > 946_684_800,
+            "Boot time should be after year 2000"
+        );
 
         // Boot time should be before current time
         let now = Timestamp::now().as_second();

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2334,6 +2334,78 @@ fn test_date_format_modifier_percent_escape() {
         .stdout_is("%Y=0000001999\n");
 }
 
+// Tests for E and O locale modifiers (POSIX extension)
+#[test]
+fn test_date_format_modifier_e_alternative_representation() {
+    // Test E modifier for alternative representation
+    // %EY should provide locale's alternative year representation (e.g., era names in Japanese)
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01", "+%EY"])
+        .succeeds();
+
+    // Test %EC for alternative century representation
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01", "+%EC"])
+        .succeeds();
+}
+
+#[test]
+fn test_date_format_modifier_o_alternative_numerals() {
+    // Test O modifier for alternative numeric symbols
+    // %Od should provide locale's alternative day representation
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01", "+%Od"])
+        .succeeds();
+
+    // Test %Om for alternative month representation
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01", "+%Om"])
+        .succeeds();
+
+    // Test %OH for alternative hour representation
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01 12:00:00", "+%OH"])
+        .succeeds();
+}
+
+#[test]
+fn test_date_format_modifier_eo_combined_with_other_modifiers() {
+    // Test that E/O modifiers can be combined with other modifiers
+    // %_10EY should use alternative year with space padding
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01", "+%_10EY"])
+        .succeeds();
+
+    // Test %010Od with zero padding and alternative numerals
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01", "+%010Od"])
+        .succeeds();
+}
+
+#[test]
+fn test_date_format_modifier_ob_alternative_month_name() {
+    // Test %OB for alternative month names (standalone format)
+    new_ucmd!()
+        .env("TZ", "UTC")
+        .env("LC_ALL", "C")
+        .args(&["-d", "1999-06-01", "+%OB"])
+        .succeeds();
+}
+
 // Tests for --debug flag
 #[test]
 fn test_date_debug_basic() {


### PR DESCRIPTION
This adds support for POSIX locale extension modifiers:
- E modifiers (%EY, %Ey, %EC, %EB) for alternative representations
- O modifiers (%Od, %Om, etc.)  falls back to standard numerals

Implemented via ICU integration for calendar conversions and localized month names.

Note: Full alternative numeric system support (Arabic-Indic digits, Devanagari, blabla...) is deferred to a future enhancement as it requires ICU FixedDecimalFormatter integration 

Fixes #10958
