### PR TITLE
id: fix selinux/smack platform guards for non-Linux platforms

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -99,9 +99,9 @@ struct State {
     rflag: bool,  // --real
     zflag: bool,  // --zero
     cflag: bool,  // --context
-    #[cfg(feature = "selinux")]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     selinux_supported: bool,
-    #[cfg(feature = "smack")]
+    #[cfg(all(target_os = "linux", feature = "smack"))]
     smack_supported: bool,
     ids: Option<Ids>,
     // The behavior for calling GNU's `id` and calling GNU's `id $USER` is similar but different.
@@ -141,9 +141,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         zflag: matches.get_flag(options::OPT_ZERO),
         cflag: matches.get_flag(options::OPT_CONTEXT),
 
-        #[cfg(feature = "selinux")]
+        #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
         selinux_supported: uucore::selinux::is_selinux_enabled(),
-        #[cfg(feature = "smack")]
+        #[cfg(all(target_os = "linux", feature = "smack"))]
         smack_supported: uucore::smack::is_smack_enabled(),
         user_specified: !users.is_empty(),
         ids: None,
@@ -179,7 +179,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if state.cflag {
         // SELinux context
-        #[cfg(feature = "selinux")]
+        #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
         if state.selinux_supported {
             if let Ok(context) = selinux::SecurityContext::current(false) {
                 let bytes = context.as_bytes();
@@ -193,7 +193,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
 
         // SMACK label
-        #[cfg(feature = "smack")]
+        #[cfg(all(target_os = "linux", feature = "smack"))]
         if state.smack_supported {
             match uucore::smack::get_smack_label_for_self() {
                 Ok(label) => {
@@ -702,7 +702,7 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
             .join(",")
     )?;
 
-    #[cfg(feature = "selinux")]
+    #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
     if state.selinux_supported
         && !state.user_specified
         && std::env::var_os("POSIXLY_CORRECT").is_none()
@@ -714,7 +714,7 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
         }
     }
 
-    #[cfg(feature = "smack")]
+    #[cfg(all(target_os = "linux", feature = "smack"))]
     if state.smack_supported
         && !state.user_specified
         && std::env::var_os("POSIXLY_CORRECT").is_none()


### PR DESCRIPTION
Fixes pre-commit hook failures on non-Linux platforms by adding proper `#[cfg(target_os = "linux")]` guards to selinux/smack feature gates. 

The `uucore` crate only exposes these modules on Linux/Android, so the caller must match those platform restrictions.