### PR TITLE
whoami: add Spanish translation

### DIFF
--- a/src/uu/whoami/locales/es-ES.ftl
+++ b/src/uu/whoami/locales/es-ES.ftl
@@ -1,0 +1,5 @@
+whoami-about = Imprime el nombre de usuario actual.
+
+# Mensajes de error
+whoami-error-failed-to-print = no se pudo imprimir el nombre de usuario
+whoami-error-failed-to-get = no se pudo obtener el nombre de usuario


### PR DESCRIPTION
Hi! I'm adding the Spanish translation for the whoami command using the Fluent system. This includes the 'about' description and error messages. This is my first contribution!