### PR TITLE
fix(wc): respect C/POSIX locale for character counting

### DIFF
--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -21,8 +21,8 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["parser"] }
 fluent = { workspace = true }
+uucore = { workspace = true, features = ["i18n-charmap", "parser"] }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -14,6 +14,7 @@ use std::num::IntErrorKind;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::format_usage;
+use uucore::i18n::charmap::is_effective_ctype_c_or_posix;
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 use uucore::posix::{OBSOLETE, posix_version};
 use uucore::translate;
@@ -186,14 +187,6 @@ impl Uniq {
         }
     }
 
-    fn is_c_locale() -> bool {
-        ["LC_ALL", "LC_CTYPE", "LANG"]
-            .iter()
-            .find_map(|&key| std::env::var_os(key))
-            .filter(|v| !v.is_empty())
-            .is_none_or(|v| v == "C" || v == "POSIX")
-    }
-
     fn key_end_index(&self, line: &[u8], key_start: usize) -> usize {
         let remainder = &line[key_start..];
         match self.slice_stop {
@@ -202,7 +195,7 @@ impl Uniq {
                 if remainder.is_empty() {
                     return key_start;
                 }
-                if Self::is_c_locale() {
+                if is_effective_ctype_c_or_posix() {
                     // for C or POSIX we count bytes
                     key_start + remainder.len().min(limit)
                 } else if let Ok(valid) = std::str::from_utf8(remainder) {

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -26,6 +26,7 @@ fluent = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = [
   "hardware",
+  "i18n-charmap",
   "parser",
   "pipes",
   "quoting-style",

--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -6,26 +6,9 @@
 // spell-checker:ignore sysconf CTYPE
 use crate::{wc_simd_allowed, word_count::WordCount};
 use uucore::hardware::SimdPolicy;
+use uucore::i18n::charmap::is_effective_ctype_c_or_posix;
 
 use super::WordCountable;
-
-/// Check if the current locale is C or POSIX (where characters == bytes).
-/// This follows GNU coreutils behavior where MB_CUR_MAX == 1 in these locales.
-pub(crate) fn is_c_or_posix_locale() -> bool {
-    // Check LC_ALL, LC_CTYPE, and LANG in order of precedence
-    let locale_val = ["LC_ALL", "LC_CTYPE", "LANG"]
-        .iter()
-        .find_map(|&var| std::env::var(var).ok().filter(|v| !v.is_empty()));
-
-    if let Some(locale) = locale_val {
-        // Extract the base locale name (before any '.' or '@')
-        let base_locale = locale.split(&['.', '@']).next().unwrap_or(&locale);
-        base_locale == "C" || base_locale == "POSIX"
-    } else {
-        // No locale set, default to POSIX behavior (chars == bytes)
-        true
-    }
-}
 
 use std::io::{self, ErrorKind, Read};
 
@@ -242,7 +225,7 @@ pub(crate) fn count_bytes_chars_and_lines_fast<
 
     // In C/POSIX locale, characters are equivalent to bytes (MB_CUR_MAX == 1).
     // This follows GNU coreutils behavior.
-    let chars_are_bytes = is_c_or_posix_locale();
+    let chars_are_bytes = is_effective_ctype_c_or_posix();
 
     loop {
         match handle.read(buf) {

--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -3,11 +3,29 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// cSpell:ignore sysconf
+// spell-checker:ignore sysconf CTYPE
 use crate::{wc_simd_allowed, word_count::WordCount};
 use uucore::hardware::SimdPolicy;
 
 use super::WordCountable;
+
+/// Check if the current locale is C or POSIX (where characters == bytes).
+/// This follows GNU coreutils behavior where MB_CUR_MAX == 1 in these locales.
+pub(crate) fn is_c_or_posix_locale() -> bool {
+    // Check LC_ALL, LC_CTYPE, and LANG in order of precedence
+    let locale_val = ["LC_ALL", "LC_CTYPE", "LANG"]
+        .iter()
+        .find_map(|&var| std::env::var(var).ok().filter(|v| !v.is_empty()));
+
+    if let Some(locale) = locale_val {
+        // Extract the base locale name (before any '.' or '@')
+        let base_locale = locale.split(&['.', '@']).next().unwrap_or(&locale);
+        base_locale == "C" || base_locale == "POSIX"
+    } else {
+        // No locale set, default to POSIX behavior (chars == bytes)
+        true
+    }
+}
 
 use std::io::{self, ErrorKind, Read};
 
@@ -221,6 +239,11 @@ pub(crate) fn count_bytes_chars_and_lines_fast<
     let buf: &mut [u8] = &mut AlignedBuffer::default().data;
     let policy = SimdPolicy::detect();
     let simd_allowed = wc_simd_allowed(policy);
+
+    // In C/POSIX locale, characters are equivalent to bytes (MB_CUR_MAX == 1).
+    // This follows GNU coreutils behavior.
+    let chars_are_bytes = is_c_or_posix_locale();
+
     loop {
         match handle.read(buf) {
             Ok(0) => return (total, None),
@@ -229,11 +252,16 @@ pub(crate) fn count_bytes_chars_and_lines_fast<
                     total.bytes += n;
                 }
                 if COUNT_CHARS {
-                    total.chars += if simd_allowed {
-                        bytecount::num_chars(&buf[..n])
+                    if chars_are_bytes {
+                        // In C/POSIX locale, count bytes instead of UTF-8 chars
+                        total.chars += n;
                     } else {
-                        bytecount::naive_num_chars(&buf[..n])
-                    };
+                        total.chars += if simd_allowed {
+                            bytecount::num_chars(&buf[..n])
+                        } else {
+                            bytecount::naive_num_chars(&buf[..n])
+                        };
+                    }
                 }
                 if COUNT_LINES {
                     total.lines += if simd_allowed {

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// cSpell:ignore ilog wc wc's
+// spell-checker:ignore ilog wc wc's
 
 mod count_fast;
 mod countable;
@@ -38,7 +38,7 @@ use uucore::{
 };
 
 use crate::{
-    count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast},
+    count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast, is_c_or_posix_locale},
     countable::WordCountable,
     word_count::WordCount,
 };
@@ -581,6 +581,7 @@ fn process_chunk<
     current_len: &mut usize,
     in_word: &mut bool,
     is_posixly_correct: bool,
+    chars_are_bytes: bool,
 ) {
     for ch in text.chars() {
         if SHOW_WORDS {
@@ -616,11 +617,16 @@ fn process_chunk<
         if SHOW_LINES && ch == '\n' {
             total.lines += 1;
         }
-        if SHOW_CHARS {
+        if SHOW_CHARS && !chars_are_bytes {
             total.chars += 1;
         }
     }
     total.bytes += text.len();
+
+    // In C/POSIX locale, chars count equals bytes count
+    if SHOW_CHARS && chars_are_bytes {
+        total.chars += text.len();
+    }
 
     total.max_line_length = max(*current_len, total.max_line_length);
 }
@@ -657,6 +663,7 @@ fn word_count_from_reader_specialized<
     let mut in_word = false;
     let mut current_len = 0;
     let is_posixly_correct = *IS_POSIXLY_CORRECT;
+    let chars_are_bytes = SHOW_CHARS && is_c_or_posix_locale();
     while let Some(chunk) = reader.next_strict() {
         match chunk {
             Ok(text) => {
@@ -666,6 +673,7 @@ fn word_count_from_reader_specialized<
                     &mut current_len,
                     &mut in_word,
                     is_posixly_correct,
+                    chars_are_bytes,
                 );
             }
             Err(e) => {

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore ilog wc wc's
+// spell-checker:ignore ctype ilog wc wc's
 
 mod count_fast;
 mod countable;
@@ -26,7 +26,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser};
 use thiserror::Error;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
-use uucore::{display::Quotable, translate};
+use uucore::{display::Quotable, i18n::charmap::is_effective_ctype_c_or_posix, translate};
 
 use uucore::{
     error::{FromIo, UError, UResult},
@@ -38,7 +38,7 @@ use uucore::{
 };
 
 use crate::{
-    count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast, is_c_or_posix_locale},
+    count_fast::{count_bytes_chars_and_lines_fast, count_bytes_fast},
     countable::WordCountable,
     word_count::WordCount,
 };
@@ -663,7 +663,7 @@ fn word_count_from_reader_specialized<
     let mut in_word = false;
     let mut current_len = 0;
     let is_posixly_correct = *IS_POSIXLY_CORRECT;
-    let chars_are_bytes = SHOW_CHARS && is_c_or_posix_locale();
+    let chars_are_bytes = SHOW_CHARS && is_effective_ctype_c_or_posix();
     while let Some(chunk) = reader.next_strict() {
         match chunk {
             Ok(text) => {

--- a/src/uucore/src/lib/features/i18n/charmap.rs
+++ b/src/uucore/src/lib/features/i18n/charmap.rs
@@ -9,6 +9,8 @@
 
 use std::sync::OnceLock;
 
+const CTYPE_LOCALE_VARS: [&str; 3] = ["LC_ALL", "LC_CTYPE", "LANG"];
+
 enum MbEncoding {
     Utf8,
     Gb18030,
@@ -27,12 +29,29 @@ fn encoding_from_name(enc: &str) -> MbEncoding {
     }
 }
 
+/// Return the effective `LC_CTYPE` locale value from the environment.
+///
+/// Empty values are ignored, matching the locale precedence used for character
+/// map detection.
+fn get_effective_ctype_locale() -> Option<String> {
+    CTYPE_LOCALE_VARS
+        .iter()
+        .find_map(|&key| std::env::var(key).ok().filter(|v| !v.is_empty()))
+}
+
+/// Return whether the effective `LC_CTYPE` locale is the byte-oriented C/POSIX locale.
+///
+/// A missing effective locale defaults to POSIX behavior. Only exact `C` and
+/// `POSIX` locale values are treated as explicit C/POSIX locales; locales such
+/// as `C.UTF-8` are not.
+pub fn is_effective_ctype_c_or_posix() -> bool {
+    get_effective_ctype_locale().is_none_or(|locale| locale == "C" || locale == "POSIX")
+}
+
 fn get_encoding() -> &'static MbEncoding {
     static ENCODING: OnceLock<MbEncoding> = OnceLock::new();
     ENCODING.get_or_init(|| {
-        let val = ["LC_ALL", "LC_CTYPE", "LANG"]
-            .iter()
-            .find_map(|&k| std::env::var(k).ok().filter(|v| !v.is_empty()));
+        let val = get_effective_ctype_locale();
         let s = match val.as_deref() {
             Some(s) if s != "C" && s != "POSIX" => s,
             _ => return MbEncoding::Utf8,

--- a/src/uucore/src/lib/features/i18n/charmap.rs
+++ b/src/uucore/src/lib/features/i18n/charmap.rs
@@ -41,11 +41,24 @@ fn get_effective_ctype_locale() -> Option<String> {
 
 /// Return whether the effective `LC_CTYPE` locale is the byte-oriented C/POSIX locale.
 ///
-/// A missing effective locale defaults to POSIX behavior. Only exact `C` and
-/// `POSIX` locale values are treated as explicit C/POSIX locales; locales such
-/// as `C.UTF-8` are not.
+/// WASI has no native locale environment, so it keeps the existing
+/// UTF-8-compatible behavior regardless of forwarded locale variables.
+#[cfg(target_os = "wasi")]
 pub fn is_effective_ctype_c_or_posix() -> bool {
-    get_effective_ctype_locale().is_none_or(|locale| locale == "C" || locale == "POSIX")
+    false
+}
+
+/// Return whether the effective `LC_CTYPE` locale is the byte-oriented C/POSIX locale.
+///
+/// A missing effective locale defaults to POSIX behavior on platforms with a
+/// native locale environment.
+#[cfg(not(target_os = "wasi"))]
+pub fn is_effective_ctype_c_or_posix() -> bool {
+    match get_effective_ctype_locale().as_deref() {
+        Some("C" | "POSIX") => true,
+        Some(_) => false,
+        None => true,
+    }
 }
 
 fn get_encoding() -> &'static MbEncoding {

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -983,6 +983,7 @@ fn test_posixly_correct_whitespace() {
 }
 
 #[test]
+#[cfg_attr(wasi_runner, ignore = "WASI has no native C/POSIX locale")]
 fn test_wc_chars_c_locale() {
     // In C/POSIX locale, wc -m should count bytes, not UTF-8 characters
     // Vietnamese "Tiếng Việt" uses diacritics (2 bytes per char in UTF-8)
@@ -1057,6 +1058,7 @@ fn test_wc_chars_utf8_locale() {
 }
 
 #[test]
+#[cfg_attr(wasi_runner, ignore = "WASI has no native C/POSIX locale")]
 fn test_wc_chars_default_locale() {
     // When no locale is set (empty LC_ALL), it defaults to POSIX (chars == bytes)
     // This ensures backward compatibility
@@ -1084,6 +1086,7 @@ fn test_wc_chars_default_locale() {
 }
 
 #[test]
+#[cfg_attr(wasi_runner, ignore = "WASI has no native C/POSIX locale")]
 fn test_wc_multibyte_c_locale() {
     // Issue #9712 and #5831: Test various multibyte characters in C locale
     // All should be counted as bytes

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -8,7 +8,8 @@ use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 use uutests::util::vec_of_size;
 
-// spell-checker:ignore (flags) lwmcL clmwL ; (path) bogusfile emptyfile manyemptylines moby notrailingnewline onelongemptyline onelongword weirdchars ioerrdir
+// spell-checker:ignore (flags) lwmcL clmwL ; (path) bogusfile emptyfile manyemptylines moby notrailingnewline onelongemptyline onelongword weirdchars ioerrdir CTYPE
+// spell-checker:ignore (Vietnamese) Tiếng Việt chào
 #[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(1);
@@ -61,8 +62,10 @@ fn test_stdin_explicit() {
 
 #[test]
 fn test_utf8() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .args(&["-lwmcL"])
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_test.txt")
         .succeeds()
         .stdout_is("    303    2178   22457   23025      79\n");
@@ -88,8 +91,10 @@ fn test_utf8_line_length_words() {
 
 #[test]
 fn test_utf8_line_length_chars() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-Lm")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("    442      48\n");
@@ -97,8 +102,10 @@ fn test_utf8_line_length_chars() {
 
 #[test]
 fn test_utf8_line_length_chars_words() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-Lmw")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("     89     442      48\n");
@@ -106,8 +113,10 @@ fn test_utf8_line_length_chars_words() {
 
 #[test]
 fn test_utf8_chars() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-m")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("442\n");
@@ -115,8 +124,10 @@ fn test_utf8_chars() {
 
 #[test]
 fn test_utf8_bytes_chars() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-cm")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("    442     513\n");
@@ -133,8 +144,10 @@ fn test_utf8_bytes_lines() {
 
 #[test]
 fn test_utf8_bytes_chars_lines() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-cml")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("     25     442     513\n");
@@ -142,8 +155,10 @@ fn test_utf8_bytes_chars_lines() {
 
 #[test]
 fn test_utf8_chars_words() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-mw")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("     89     442\n");
@@ -169,8 +184,10 @@ fn test_utf8_line_length_lines_words() {
 
 #[test]
 fn test_utf8_lines_chars() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-ml")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("     25     442\n");
@@ -178,8 +195,10 @@ fn test_utf8_lines_chars() {
 
 #[test]
 fn test_utf8_lines_words_chars() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-mlw")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("     25      89     442\n");
@@ -187,8 +206,10 @@ fn test_utf8_lines_words_chars() {
 
 #[test]
 fn test_utf8_line_length_lines_chars() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-Llm")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("     25     442      48\n");
@@ -196,8 +217,10 @@ fn test_utf8_line_length_lines_chars() {
 
 #[test]
 fn test_utf8_all() {
+    // Requires UTF-8 locale for character counting
     new_ucmd!()
         .arg("-lwmcL")
+        .env("LC_ALL", "en_US.UTF-8")
         .pipe_in_fixture("UTF_8_weirdchars.txt")
         .succeeds()
         .stdout_is("     25      89     442     513      48\n");
@@ -957,4 +980,137 @@ fn test_posixly_correct_whitespace() {
         .pipe_in(input)
         .succeeds()
         .stdout_is("1\n");
+}
+
+#[test]
+fn test_wc_chars_c_locale() {
+    // In C/POSIX locale, wc -m should count bytes, not UTF-8 characters
+    // Vietnamese "Tiếng Việt" uses diacritics (2 bytes per char in UTF-8)
+    // "Tiếng" = 5 chars, 7 bytes ("ế" is 2 bytes)
+    let vietnamese_text = "Tiếng";
+
+    // With LC_ALL=C, chars should equal bytes (7)
+    new_ucmd!()
+        .arg("-m")
+        .env("LC_ALL", "C")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("7\n");
+
+    // Same with LC_ALL=POSIX
+    new_ucmd!()
+        .arg("-m")
+        .env("LC_ALL", "POSIX")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("7\n");
+
+    // Test combined with bytes flag - should show same count
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "C")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("      7       7\n");
+}
+
+#[test]
+fn test_wc_chars_utf8_locale() {
+    // In UTF-8 locale, wc -m should count UTF-8 characters
+    // Vietnamese "Tiếng" is 7 bytes in UTF-8 but 5 characters ("ế" is 2 bytes)
+    let vietnamese_text = "Tiếng";
+
+    // With vi_VN.UTF-8 locale, chars should be 5 (not 7)
+    new_ucmd!()
+        .arg("-m")
+        .env("LC_ALL", "vi_VN.UTF-8")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("5\n");
+
+    // Test combined with bytes flag - should show different counts
+    // Order is: chars, bytes (since show_chars comes before show_bytes in print_stats)
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "vi_VN.UTF-8")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("      5       7\n");
+}
+
+#[test]
+fn test_wc_chars_default_locale() {
+    // When no locale is set (empty LC_ALL), it defaults to POSIX (chars == bytes)
+    // This ensures backward compatibility
+    let vietnamese_text = "Tiếng";
+
+    new_ucmd!()
+        .arg("-m")
+        .env("LC_ALL", "")
+        .env("LC_CTYPE", "")
+        .env("LANG", "")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("7\n");
+}
+
+#[test]
+fn test_wc_multibyte_c_locale() {
+    // Issue #9712 and #5831: Test various multibyte characters in C locale
+    // All should be counted as bytes
+
+    // Vietnamese text with multiple diacritics: "Tiếng Việt"
+    // 10 chars, 14 bytes ("ế" and "ệ" are 2 bytes each)
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "C")
+        .pipe_in("Tiếng Việt")
+        .succeeds()
+        .stdout_is("     14      14\n");
+
+    // Single Vietnamese character "ệ" = 1 char, 3 bytes in UTF-8 (e1 bb 87)
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "C")
+        .pipe_in("ệ")
+        .succeeds()
+        .stdout_is("      3       3\n");
+
+    // Mixed ASCII and Vietnamese: "Xin chào" = 8 chars, 9 bytes ("à" is 2 bytes)
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "C")
+        .pipe_in("Xin chào")
+        .succeeds()
+        .stdout_is("      9       9\n");
+}
+
+#[test]
+fn test_wc_multibyte_utf8_locale() {
+    // In UTF-8 locale, multibyte characters should be counted correctly
+    // Order is: chars, bytes (since show_chars comes before show_bytes in print_stats)
+
+    // Vietnamese "Tiếng Việt": 10 chars, 14 bytes ("ế" and "ệ" are 2 bytes each)
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "vi_VN.UTF-8")
+        .pipe_in("Tiếng Việt")
+        .succeeds()
+        .stdout_is("     10      14\n");
+
+    // Single Vietnamese character "ệ" = 1 char, 3 bytes in UTF-8 (e1 bb 87)
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "vi_VN.UTF-8")
+        .pipe_in("ệ")
+        .succeeds()
+        .stdout_is("      1       3\n");
+
+    // Mixed ASCII and Vietnamese "Xin chào": 8 chars, 9 bytes ("à" is 2 bytes)
+    new_ucmd!()
+        .args(&["-cm"])
+        .env("LC_ALL", "vi_VN.UTF-8")
+        .pipe_in("Xin chào")
+        .succeeds()
+        .stdout_is("      8       9\n");
 }

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -1012,6 +1012,15 @@ fn test_wc_chars_c_locale() {
         .pipe_in(vietnamese_text)
         .succeeds()
         .stdout_is("      7       7\n");
+
+    // Test with -w to trigger wc.rs path (word_count_from_reader_specialized)
+    // Order: words, chars, bytes
+    new_ucmd!()
+        .args(&["-cmw"])
+        .env("LC_ALL", "C")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("      1       7       7\n");
 }
 
 #[test]
@@ -1036,6 +1045,15 @@ fn test_wc_chars_utf8_locale() {
         .pipe_in(vietnamese_text)
         .succeeds()
         .stdout_is("      5       7\n");
+
+    // Test with -w to trigger wc.rs path (word_count_from_reader_specialized)
+    // Order: words, chars, bytes
+    new_ucmd!()
+        .args(&["-cmw"])
+        .env("LC_ALL", "vi_VN.UTF-8")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("      1       5       7\n");
 }
 
 #[test]
@@ -1052,6 +1070,17 @@ fn test_wc_chars_default_locale() {
         .pipe_in(vietnamese_text)
         .succeeds()
         .stdout_is("7\n");
+
+    // Test with -w to trigger wc.rs path (word_count_from_reader_specialized)
+    // Order: words, chars
+    new_ucmd!()
+        .args(&["-mw"])
+        .env("LC_ALL", "")
+        .env("LC_CTYPE", "")
+        .env("LANG", "")
+        .pipe_in(vietnamese_text)
+        .succeeds()
+        .stdout_is("      1       7\n");
 }
 
 #[test]


### PR DESCRIPTION
In C/POSIX locale, `wc -m` now counts bytes (not UTF-8 chars), matching GNU coreutils behavior using MB_CUR_MAX logic

Fixes #9712 
Fixes #5831