### PR TITLE
date: extend the tz abbreviation db

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -783,7 +783,13 @@ static PREFERRED_TZ_MAPPINGS: &[(&str, &str)] = &[
     ("ACDT", "Australia/Adelaide"), // Australian Central Daylight Time
     ("AEST", "Australia/Sydney"),   // Australian Eastern Standard Time
     ("AEDT", "Australia/Sydney"),   // Australian Eastern Daylight Time
-                                    /* spell-checker: enable */
+    // Not ambigious but not resolvable by IANA database but resolved in GNU
+    ("MET", "CET"),   // Middle European Time (Same as CET)
+    ("MEST", "CEST"), // Middle European Summer Time (Same as CEST)
+    ("MEZ", "CET"),   // German MET abbreviation
+    ("MESZ", "CEST"), // German MEST abbreviation
+    ("KST", "Asia/Seoul"), // Korean Standard Time
+                      /* spell-checker: enable */
 ];
 
 /// Lazy-loaded timezone abbreviation lookup map built from IANA database.


### PR DESCRIPTION
Problem is that not all abbreviations are in the IANA DB. GNU manually handles some abbreviations that are not in the IANA DB. I have added all outstanding manual cases except for 2 (HAST and HADT). HAST and HADT are Hawaii-Aleutian Standard and Hawaii-Aleutian Daylight. I did not find a quick substution as just setting it to Pacific/Honululu wouldn't take the difference of daylight/standard into account. 

Fix: #11015