### PR TITLE
benches: fix typo in sort_long_line

### DIFF
--- a/src/uu/sort/benches/sort_bench.rs
+++ b/src/uu/sort/benches/sort_bench.rs
@@ -215,7 +215,7 @@ fn sort_unique_locale(bencher: Bencher, num_lines: usize) {
 }
 
 /// Benchmark sorting with very long lines exceeding START_BUFFER_SIZE (8000 bytes)
-#[divan::bench(args = [16_0000])]
+#[divan::bench(args = [16_000])]
 fn sort_long_line(bencher: Bencher, line_size: usize) {
     // Create files with very long lines (16KB) to test buffer handling
     let mut data_a = vec![b'b'; line_size];


### PR DESCRIPTION
cc: @sylvestre