### PR TITLE
who, users: check login PID liveness to match GNU behavior

### DIFF
--- a/src/uu/users/src/users.rs
+++ b/src/uu/users/src/users.rs
@@ -67,7 +67,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let filename = maybe_file.unwrap_or(utmpx::DEFAULT_FILE.as_ref());
 
         users = Utmpx::iter_all_records_from(filename)
-            .filter(utmpx::UtmpxRecord::is_user_process)
+            .filter(|ut| ut.is_user_process() && ut.pid_is_alive())
             .map(|ut| ut.user())
             .collect::<Vec<_>>();
     };

--- a/src/uu/who/src/platform/unix.rs
+++ b/src/uu/who/src/platform/unix.rs
@@ -207,7 +207,7 @@ impl Who {
         };
         if self.short_list {
             let users = utmpx::Utmpx::iter_all_records_from(f)
-                .filter(UtmpxRecord::is_user_process)
+                .filter(|ut| ut.is_user_process() && ut.pid_is_alive())
                 .map(|ut| ut.user())
                 .collect::<Vec<_>>();
             println!("{}", users.join(" "));
@@ -226,7 +226,7 @@ impl Who {
 
             for ut in records {
                 if !self.my_line_only || cur_tty == ut.tty_device() {
-                    if self.need_users && ut.is_user_process() {
+                    if self.need_users && ut.is_user_process() && ut.pid_is_alive() {
                         self.print_user(&ut)?;
                     } else {
                         match ut.record_type() {

--- a/tests/by-util/test_users.rs
+++ b/tests/by-util/test_users.rs
@@ -4,6 +4,10 @@
 // file that was distributed with this source code.
 use uutests::new_ucmd;
 #[cfg(any(target_vendor = "apple", target_os = "linux"))]
+use uutests::unwrap_or_return;
+#[cfg(any(target_vendor = "apple", target_os = "linux"))]
+use uutests::util::expected_result;
+#[cfg(any(target_vendor = "apple", target_os = "linux"))]
 use uutests::{util::TestScenario, util_name};
 
 #[ignore = "does not work as same as users > /dev/full"]
@@ -33,19 +37,9 @@ fn test_users_no_arg() {
 
 #[test]
 #[cfg(any(target_vendor = "apple", target_os = "linux"))]
-#[ignore = "issue #3219"]
 fn test_users_check_name() {
-    #[cfg(target_os = "linux")]
-    let util_name = util_name!();
-    #[cfg(target_vendor = "apple")]
-    let util_name = &format!("g{}", util_name!());
-
-    let expected = TestScenario::new(util_name)
-        .cmd(util_name)
-        .env("LC_ALL", "C")
-        .succeeds()
-        .stdout_move_str();
-
+    let ts = TestScenario::new(util_name!());
+    let expected = unwrap_or_return!(expected_result(&ts, &[])).stdout_move_str();
     new_ucmd!().succeeds().stdout_is(&expected);
 }
 


### PR DESCRIPTION
## Summary
- Add `pid_is_alive()` to `Utmpx`/`UtmpxRecord` in uucore using `kill(pid, 0)` to verify a utmp entry's process is still running, matching GNU coreutils behavior
- Wire the PID liveness check into `who` and `users` user-process filtering
- Re-enable all 10 tests that were ignored due to #3219 (9 in `who`, 1 in `users`)

Fixes #3219

## Details

GNU `who` and `users` call `kill(PID, 0)` on each utmp entry's login shell PID before displaying it. If the process is dead, GNU skips the entry. Our implementation was taking utmp at face value, showing stale entries whose processes had died — causing output mismatches with GNU in CI and the 10 tests to be ignored.

### Re-enabled tests
- **who**: `test_count`, `test_heading`, `test_short`, `test_mesg`, `test_users`, `test_lookup`, `test_all_separately`, `test_all`, `test_locale`
- **users**: `test_users_check_name`

## Test plan
- [x] `cargo test --test tests --features who -- test_who` — 19/19 pass
- [x] `cargo test --test tests --features users -- test_users` — 3/3 pass
- [x] `cargo clippy -p uu_who -p uu_users -p uucore` — no warnings