### PR TITLE
date: add MEZ and MESZ timezone abbreviations

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -783,7 +783,10 @@ static PREFERRED_TZ_MAPPINGS: &[(&str, &str)] = &[
     ("ACDT", "Australia/Adelaide"), // Australian Central Daylight Time
     ("AEST", "Australia/Sydney"),   // Australian Eastern Standard Time
     ("AEDT", "Australia/Sydney"),   // Australian Eastern Daylight Time
-                                    /* spell-checker: enable */
+    // German timezones (cannot be discovered from IANA)
+    ("MEZ", "Europe/Berlin"), // MET in German
+    ("MESZ", "Europe/Berlin"), // MEST in German
+                              /* spell-checker: enable */
 ];
 
 /// Lazy-loaded timezone abbreviation lookup map built from IANA database.

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2636,3 +2636,20 @@ fn test_date_debug_current_time() {
     // No parsing happens for "now", so no debug output
     assert_eq!(stderr, "");
 }
+
+#[test]
+fn test_date_tz_abbreviation_german_timezones() {
+    let de_zones = vec![
+        ("MEZ", "2026-02-20 14:12:01 MEZ"), // German MET abbreviation // spell-checker:disable-line
+        ("MESZ", "2026-02-20 11:59:01 MESZ"), // German MEST abbreviation // spell-checker:disable-line
+    ];
+
+    for (_, d) in de_zones {
+        new_ucmd!()
+            .arg("-d")
+            .arg(d)
+            .arg("+%Y-%m-%d %H:%M:%S")
+            .succeeds()
+            .no_stderr();
+    }
+}


### PR DESCRIPTION
## Summary

German timezone abbreviations MEZ (Mitteleuropäische Zeit) and MESZ (Mitteleuropäische Sommerzeit) are not recognized by `date -d`, while GNU coreutils accepts them.

This adds both abbreviations to the `PREFERRED_TZ_MAPPINGS` table, mapping them to `Europe/Berlin`.

Fixes #11015

## Test plan

- Added `test_date_tz_abbreviation_german_timezones` covering both MEZ and MESZ
- `cargo test --features date --no-default-features -- test_date_tz_abbreviation` passes