### PR TITLE
Disable strip related tests on Android

### DIFF
--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -764,6 +764,7 @@ fn strip_source_file() -> &'static str {
 
 #[test]
 #[cfg(not(windows))]
+#[cfg(not(target_os = "android"))] // missing strip binary
 // FIXME test runs in a timeout with macos-latest on x86_64 in the CI
 #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
 fn test_install_and_strip() {
@@ -789,6 +790,7 @@ fn test_install_and_strip() {
 
 #[test]
 #[cfg(not(windows))]
+#[cfg(not(target_os = "android"))] // missing strip binary
 // FIXME test runs in a timeout with macos-latest on x86_64 in the CI
 #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
 fn test_install_and_strip_with_program() {


### PR DESCRIPTION
Android does not have `strip`. Thus, those tests always fails.