### PR TITLE
Prevent make check from rebuilding GNU binaries over uutils ones

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -164,6 +164,11 @@ fi
 # automake or config.status and undo our edits.
 touch Makefile.in Makefile
 
+# Patch the Makefile PATH to point to uutils build dir instead of GNU src/
+sed -i "s/^[[:blank:]]*PATH=.*/  PATH='${UU_BUILD_DIR//\//\\/}\$(PATH_SEPARATOR)'\"\$\$PATH\" \\\/" Makefile
+# Prevent make check from rebuilding the GNU binaries over the uutils ones
+sed -i 's/^check-am: all-am/check-am:/' Makefile
+
 grep -rl 'path_prepend_' tests/* | xargs -r "${SED}" -i 's| path_prepend_ ./src||'
 # path_prepend_ sets $abs_path_dir_: set it manually instead.
 grep -rl '\$abs_path_dir_' tests/*/*.sh | xargs -r "${SED}" -i "s|\$abs_path_dir_|${UU_BUILD_DIR//\//\\/}|g"


### PR DESCRIPTION
Fixes: https://github.com/uutils/coreutils/pull/10907

My changes to not rebuild the Makefile appears to have caused the SELINUX Gnu tests to rebuild the gnu binaries and make the SELINUX gnu tests to use the gnu binaries instead of the uutils binaries.