### PR TITLE
numfmt: optimize output handling by using stdout directly

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -5,7 +5,6 @@
 
 // spell-checker:ignore powf
 
-use std::io::Write as _;
 use uucore::display::Quotable;
 use uucore::translate;
 
@@ -470,16 +469,19 @@ fn split_bytes<'a>(input: &'a [u8], delim: &'a [u8]) -> impl Iterator<Item = &'a
     })
 }
 
-pub fn format_and_print_delimited(input: &[u8], options: &NumfmtOptions) -> Result<()> {
+pub fn write_formatted_with_delimiter<W: std::io::Write>(
+    writer: &mut W,
+    input: &[u8],
+    options: &NumfmtOptions,
+) -> Result<()> {
     let delimiter = options.delimiter.as_deref().unwrap();
-    let mut stdout = std::io::stdout().lock();
 
     for (n, field) in (1..).zip(split_bytes(input, delimiter)) {
         let field_selected = uucore::ranges::contain(&options.fields, n);
 
         // add delimiter before second and subsequent fields
         if n > 1 {
-            stdout.write_all(delimiter).unwrap();
+            writer.write_all(delimiter).unwrap();
         }
 
         if field_selected {
@@ -488,10 +490,10 @@ pub fn format_and_print_delimited(input: &[u8], options: &NumfmtOptions) -> Resu
                 .map_err(|_| translate!("numfmt-error-invalid-number", "input" => String::from_utf8_lossy(field).into_owned().quote()))?
                 .trim_start();
             let formatted = format_string(field_str, options, None)?;
-            stdout.write_all(formatted.as_bytes()).unwrap();
+            writer.write_all(formatted.as_bytes()).unwrap();
         } else {
             // add unselected field without conversion
-            stdout.write_all(field).unwrap();
+            writer.write_all(field).unwrap();
         }
     }
 
@@ -500,13 +502,16 @@ pub fn format_and_print_delimited(input: &[u8], options: &NumfmtOptions) -> Resu
     } else {
         b"\n"
     };
-    stdout.write_all(eol).unwrap();
+    writer.write_all(eol).unwrap();
 
     Ok(())
 }
-pub fn format_and_print_whitespace(s: &str, options: &NumfmtOptions) -> Result<()> {
-    let mut stdout = std::io::stdout().lock();
 
+pub fn write_formatted_with_whitespace<W: std::io::Write>(
+    writer: &mut W,
+    s: &str,
+    options: &NumfmtOptions,
+) -> Result<()> {
     for (n, (prefix, field)) in (1..).zip(WhitespaceSplitter { s: Some(s) }) {
         let field_selected = uucore::ranges::contain(&options.fields, n);
 
@@ -515,7 +520,7 @@ pub fn format_and_print_whitespace(s: &str, options: &NumfmtOptions) -> Result<(
 
             // add delimiter before second and subsequent fields
             let prefix = if n > 1 {
-                stdout.write_all(b" ").unwrap();
+                writer.write_all(b" ").unwrap();
                 &prefix[1..]
             } else {
                 prefix
@@ -528,18 +533,18 @@ pub fn format_and_print_whitespace(s: &str, options: &NumfmtOptions) -> Result<(
             };
 
             let formatted = format_string(field, options, implicit_padding)?;
-            stdout.write_all(formatted.as_bytes()).unwrap();
+            writer.write_all(formatted.as_bytes()).unwrap();
         } else {
             // the -z option converts an initial \n into a space
             let prefix = if options.zero_terminated && prefix.starts_with('\n') {
-                stdout.write_all(b" ").unwrap();
+                writer.write_all(b" ").unwrap();
                 &prefix[1..]
             } else {
                 prefix
             };
             // add unselected field without conversion
-            stdout.write_all(prefix.as_bytes()).unwrap();
-            stdout.write_all(field.as_bytes()).unwrap();
+            writer.write_all(prefix.as_bytes()).unwrap();
+            writer.write_all(field.as_bytes()).unwrap();
         }
     }
 
@@ -548,7 +553,7 @@ pub fn format_and_print_whitespace(s: &str, options: &NumfmtOptions) -> Result<(
     } else {
         b"\n"
     };
-    stdout.write_all(eol).unwrap();
+    writer.write_all(eol).unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
Instead of accumulating output in a `Vec<u8>` and then writing it out, write directly to a `std::io::StdoutLock`. Since `StdoutLock` is already line-buffered, this simplifies the code and improves performance.

cc: @ChrisDryden