### PR TITLE
cp: preserve destination context for recursive permission-denied errors

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -326,7 +326,14 @@ fn copy_direntry(
                 // TODO What other kinds of errors, if any, should
                 // cause us to continue walking the directory?
                 match err {
-                    CpError::IoErrContext(e, _) if e.kind() == io::ErrorKind::PermissionDenied => {
+                    CpError::IoErrContext(e, _)
+                        if e.kind() == io::ErrorKind::PermissionDenied
+                            && !source_is_symlink
+                            && matches!(
+                                fs::File::open(&entry.source_relative),
+                                Err(read_err) if read_err.kind() == io::ErrorKind::PermissionDenied
+                            ) =>
+                    {
                         show!(uio_error!(
                             e,
                             "{}",
@@ -335,6 +342,11 @@ fn copy_direntry(
                                 "source" => entry.source_relative.quote()
                             ),
                         ));
+                    }
+                    CpError::IoErrContext(e, context)
+                        if e.kind() == io::ErrorKind::PermissionDenied =>
+                    {
+                        show!(CpError::IoErrContext(e, context));
                     }
                     e => return Err(e),
                 }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3700,6 +3700,31 @@ fn test_copy_dir_preserve_permissions_inaccessible_file() {
     assert_metadata_eq!(metadata1, metadata2);
 }
 
+/// Test for preserving destination-side context when recursive copy fails due to unwritable
+/// destination file.
+#[cfg(all(
+    not(windows),
+    not(target_os = "android"),
+    not(target_os = "freebsd"),
+    not(target_os = "openbsd")
+))]
+#[test]
+fn test_copy_dir_permission_denied_on_destination_reports_destination() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("src");
+    at.touch("src/foo");
+    at.set_mode("src/foo", 0o440);
+
+    at.mkdir_all("dst/src");
+    at.touch("dst/src/foo");
+    at.set_mode("dst/src/foo", 0o440);
+
+    ucmd.args(&["-R", "src", "dst"])
+        .fails_with_code(1)
+        .stderr_contains("cp: 'src/foo' -> 'dst/src/foo':")
+        .stderr_contains("Permission denied");
+}
+
 /// Test that copying file to itself with backup fails.
 #[test]
 fn test_same_file_backup() {


### PR DESCRIPTION
  Fixes #9235.

  ## Summary

  Recursive `cp` currently rewrites any `PermissionDenied` during directory traversal
  as:

  `cannot open '<source>' for reading: permission denied`

  That is incorrect when the failure is destination-side (for example, overwriting an
  existing unwritable destination file).

  This change preserves destination context for destination-side permission failures,
  while keeping the source-read message for true source-read permission denial cases.

  ## What changed

  - Updated recursive copy error handling in `copydir`: