### PR TITLE
refactor: use slice::get for clarity

### DIFF
--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -365,12 +365,12 @@ fn classify_char(buf: &[u8], byte: usize, utf8: bool) -> (CharType, usize, usize
     if utf8 {
         let nbytes = char::from(buf[byte]).len_utf8();
 
-        if byte + nbytes > buf.len() {
+        let Some(slice) = buf.get(byte..byte + nbytes) else {
             // don't overrun buffer because of invalid UTF-8
             return (Other, 1, 1);
-        }
+        };
 
-        if let Ok(t) = from_utf8(&buf[byte..byte + nbytes]) {
+        if let Ok(t) = from_utf8(slice) {
             match t.chars().next() {
                 Some('\t') => (Tab, 0, 1),
                 Some('\x08') => (Backspace, 0, 1),

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -387,10 +387,12 @@ fn next_char_info(uflag: bool, buf: &[u8], byte: usize) -> (CharType, usize, usi
     let (ctype, cwidth, nbytes) = if uflag {
         let nbytes = char::from(buf[byte]).len_utf8();
 
-        if byte + nbytes > buf.len() {
-            // make sure we don't overrun the buffer because of invalid UTF-8
-            (CharType::Other, 1, 1)
-        } else if let Ok(t) = from_utf8(&buf[byte..byte + nbytes]) {
+        let Some(slice) = buf.get(byte..byte + nbytes) else {
+            // don't overrun buffer because of invalid UTF-8
+            return (CharType::Other, 1, 1);
+        };
+
+        if let Ok(t) = from_utf8(slice) {
             // Now that we think it's UTF-8, figure out what kind of char it is
             match t.chars().next() {
                 Some(' ') => (CharType::Space, 0, 1),


### PR DESCRIPTION
use [`slice::get`](https://doc.rust-lang.org/std/primitive.slice.html#method.get) in a few places for clarity