### PR TITLE
yes: handled stdout being closed (EBADF)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,6 +4451,7 @@ dependencies = [
  "clap",
  "fluent",
  "itertools 0.14.0",
+ "libc",
  "rustix",
  "uucore",
 ]

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -25,6 +25,9 @@ fluent = { workspace = true }
 rustix = { workspace = true, features = ["stdio", "pipe"] }
 uucore = { workspace = true, features = ["fs", "pipes"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [[bin]]
 name = "yes"
 path = "src/main.rs"

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -97,6 +97,11 @@ fn repeat_content_to_capacity(buf: &mut Vec<u8>) {
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
+    #[cfg(unix)]
+    if uucore::signals::stdout_was_closed() {
+        return Err(io::Error::from_raw_os_error(libc::EBADF));
+    }
+
     repeat_content_to_capacity(&mut bytes);
     let bytes = bytes.as_slice();
     let mut stdout = io::stdout().lock();
@@ -109,6 +114,10 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
 pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
     use uucore::io::RawWriter;
     use uucore::pipes::{pipe, splice, tee};
+
+    if uucore::signals::stdout_was_closed() {
+        return Err(io::Error::from_raw_os_error(libc::EBADF));
+    }
 
     let safe_partial_send = rustix::pipe::PIPE_BUF.is_multiple_of(bytes.len());
     repeat_content_to_capacity(&mut bytes);


### PR DESCRIPTION
Now, both exit 1:
```
$ yes >&-
yes: standard output: Bad file descriptor

$ ./target/debug/yes >&-
yes: standard output: Bad file descriptor (os error 9)
```

closes #11090 (infinitely writing its buffer to `/dev/null` on FD 1)
