### PR TITLE
mktemp: Use fastrand for perf

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -8,6 +8,7 @@ advapi32-sys
 aho-corasick
 backtrace
 blake2b_simd
+fastrand
 
 # * uutils project
 uutils

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,8 +3703,8 @@ name = "uu_mktemp"
 version = "0.7.0"
 dependencies = [
  "clap",
+ "fastrand",
  "fluent",
- "rand 0.9.2",
  "tempfile",
  "thiserror 2.0.18",
  "uucore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,6 +328,7 @@ ctrlc = { version = "3.4.7", features = ["termination"] }
 divan = { package = "codspeed-divan-compat", version = "4.0.5" }
 dns-lookup = { version = "3.0.0" }
 exacl = "0.12.0"
+fastrand = "2.3.0"
 file_diff = "1.0.0"
 filetime = "0.2.23"
 fs_extra = "1.3.0"

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/mktemp.rs"
 
 [dependencies]
 clap = { workspace = true }
-rand = { workspace = true }
+fastrand = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true }

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -23,7 +23,6 @@ use std::fs;
 #[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
 
-use rand::Rng;
 use tempfile::Builder;
 use thiserror::Error;
 
@@ -510,7 +509,7 @@ fn dry_exec(tmpdir: &Path, prefix: &str, rand: usize, suffix: &str) -> PathBuf {
 
     // Randomize.
     let bytes = &mut buf[prefix.len()..prefix.len() + rand];
-    rand::rng().fill(bytes);
+    fastrand::Rng::new().fill(bytes);
     for byte in bytes {
         *byte = match *byte % 62 {
             v @ 0..=9 => v + b'0',


### PR DESCRIPTION
1225848 -> 1215816 byte.
```
$ taskset -c 1 hyperfine -N --warmup 20 'mktemp -u' 'mktemp-fast -u'
... 
Summary
  mktemp-fast -u ran
    1.06 ± 0.13 times faster than mktemp -u
```

