### PR TITLE
Revert "Don't fail when sscache caused network error"

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -118,7 +118,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -180,7 +179,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -287,7 +285,6 @@ jobs:
     # Test build on the system missing libselinux (don't install libselinux1-dev at here)
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: "`make build`"
         # Also check that target/CACHEDIR.TAG is created on a fresh checkout
       shell: bash
@@ -424,7 +421,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Test
       run: cargo nextest run --hide-progress-bar --profile ci --features ${{ matrix.job.features }}
       env:
@@ -465,7 +461,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Test
       run: cargo nextest run --hide-progress-bar --profile ci --features ${{ matrix.job.features }}
       env:
@@ -504,7 +499,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: "`make install PROFILE=release`"
       shell: bash
       run: |
@@ -659,7 +653,6 @@ jobs:
         key: "${{ matrix.job.os }}_${{ matrix.job.target }}"
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Initialize workflow variables
       id: vars
       shell: bash
@@ -964,7 +957,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -1052,7 +1044,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -1141,7 +1132,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
 
     # - name: Reattach HEAD ## may be needed for accurate code coverage info
     #   run: git checkout ${{ github.head_ref }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -68,7 +68,6 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
 
       - name: Install locales
         shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -88,7 +88,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Initialize workflow variables
       id: vars
       shell: bash

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -45,7 +45,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -141,7 +140,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -313,7 +311,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -430,7 +427,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -583,7 +579,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -918,7 +913,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -1151,7 +1145,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install/setup prerequisites
       shell: bash
       run: |
@@ -1276,7 +1269,6 @@ jobs:
         key: cargo-install-locale-embedding
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-      continue-on-error: true
     - name: Install prerequisites
       run: |
         sudo apt-get -y update


### PR DESCRIPTION
This reverts commit 848f12cbaecf7063b9b502aace294fc7aaf76779. While the commit itself works, it leads to an error in a different step (see https://github.com/uutils/coreutils/pull/11138).