### PR TITLE
logname: use `translate!("logname-usage")` for usage

### DIFF
--- a/src/uu/logname/locales/en-US.ftl
+++ b/src/uu/logname/locales/en-US.ftl
@@ -1,2 +1,3 @@
 logname-about = Print user's login name
 logname-error-no-login-name = no login name
+logname-usage = logname

--- a/src/uu/logname/locales/fr-FR.ftl
+++ b/src/uu/logname/locales/fr-FR.ftl
@@ -1,2 +1,3 @@
 logname-about = Afficher le nom de connexion de l'utilisateur
 logname-error-no-login-name = aucun nom de connexion
+logname-usage = logname

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -39,7 +39,7 @@ pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(uucore::crate_version!())
         .help_template(uucore::localized_help_template(uucore::util_name()))
-        .override_usage(uucore::util_name())
+        .override_usage(translate!("logname-usage"))
         .about(translate!("logname-about"))
         .infer_long_args(true)
 }


### PR DESCRIPTION
This PR adds missing `logname-usage` entries to the `*.ftl` files. And uses the key in the code for consistency reasons and to make it visible that the key is used.

Fixes #11142 