### PR TITLE
cp: Fix panic when recursively copying a directory with a non-UTF8 name

### DIFF
--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -122,17 +122,18 @@ impl<'a> Context<'a> {
         let current_dir = env::current_dir()?;
         let root_path = current_dir.join(root);
         let target_is_file = target.is_file();
-        let root_parent = if target.exists() && !root.as_os_str().as_encoded_bytes().ends_with(b"/.") {
-            root_path.parent().map(ToOwned::to_owned)
-        } else if root == Path::new(".") && target.is_dir() {
-            // Special case: when copying current directory (.) to an existing directory,
-            // we don't want to use the parent path as root_parent because we want to
-            // copy the contents of the current directory directly into the target directory,
-            // not create a subdirectory with the current directory's name.
-            None
-        } else {
-            Some(root_path)
-        };
+        let root_parent =
+            if target.exists() && !root.as_os_str().as_encoded_bytes().ends_with(b"/.") {
+                root_path.parent().map(ToOwned::to_owned)
+            } else if root == Path::new(".") && target.is_dir() {
+                // Special case: when copying current directory (.) to an existing directory,
+                // we don't want to use the parent path as root_parent because we want to
+                // copy the contents of the current directory directly into the target directory,
+                // not create a subdirectory with the current directory's name.
+                None
+            } else {
+                Some(root_path)
+            };
         Ok(Self {
             current_dir,
             root_parent,

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -7708,3 +7708,22 @@ fn test_cp_preserve_context_with_z_fails() {
         .fails()
         .stderr_contains("cannot combine");
 }
+
+#[test]
+#[cfg(all(unix, not(target_os = "macos")))]
+fn test_cp_recursive_non_utf8_source() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir(OsStr::from_bytes(b"dir\x80"));
+    at.mkdir("dir2");
+    at.touch(OsStr::from_bytes(b"dir\x80/a"));
+
+    ucmd.arg("-r")
+        .arg(OsStr::from_bytes(b"dir\x80/."))
+        .arg("dir2")
+        .succeeds()
+        .no_output();
+
+    assert!(at.plus("dir2").join("a").exists());
+}


### PR DESCRIPTION
Comparative output from GNU cp and uu cp prior to the fix:
```
root@b082d601e194:/tmp# cp --version
cp (GNU coreutils) 9.7
Packaged by Debian (9.7-3)
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Torbjorn Granlund, David MacKenzie, and Jim Meyering.
root@b082d601e194:/tmp# mkdir dir$'\x80' dir2
root@b082d601e194:/tmp# touch dir$'\x80'/a
root@b082d601e194:/tmp# cp -r dir$'\x80'/. dir2
root@b082d601e194:/tmp# ls -l dir2/
total 0
-rw-r--r-- 1 root root 0 Feb 25 23:46 a
```

```
root@03081849be59:/tmp# cp --version
cp (uutils coreutils) 0.6.0
root@03081849be59:/tmp# mkdir dir$'\x80' dir2
root@03081849be59:/tmp# touch dir$'\x80'/a
root@03081849be59:/tmp# cp -r dir$'\x80'/. dir2

thread 'main' (1659) panicked at src/uu/cp/src/copydir.rs:113:64:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted
```


            