### PR TITLE
whoami: fix usage line for unexpected arguments

### DIFF
--- a/src/uu/whoami/locales/en-US.ftl
+++ b/src/uu/whoami/locales/en-US.ftl
@@ -1,4 +1,5 @@
 whoami-about = Print the current username.
+whoami-usage = whoami
 
 # Error messages
 whoami-error-failed-to-print = failed to print username

--- a/src/uu/whoami/locales/fr-FR.ftl
+++ b/src/uu/whoami/locales/fr-FR.ftl
@@ -1,4 +1,5 @@
 whoami-about = Affiche le nom d'utilisateur actuel.
+whoami-usage = whoami
 
 # Messages d'erreur
 whoami-error-failed-to-print = échec de l'affichage du nom d'utilisateur

--- a/src/uu/whoami/src/whoami.rs
+++ b/src/uu/whoami/src/whoami.rs
@@ -29,6 +29,6 @@ pub fn uu_app() -> Command {
         .version(uucore::crate_version!())
         .help_template(uucore::localized_help_template(uucore::util_name()))
         .about(translate!("whoami-about"))
-        .override_usage(uucore::util_name())
+        .override_usage(translate!("whoami-usage"))
         .infer_long_args(true)
 }


### PR DESCRIPTION
## Summary
- fix `whoami` clap usage override to use a localized key instead of util name
- add `whoami-usage = whoami` in `en-US` and `fr-FR` locale files

Fixes #11155

## Testing
- Could not run local Rust checks in this environment because `cargo` is not installed.
- Change mirrors the existing accepted pattern used in similar utils (e.g. `logname`).
