### PR TITLE
deps: replace ahash with foldhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy 0.8.39",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,7 +4031,6 @@ dependencies = [
 name = "uu_sort"
 version = "0.7.0"
 dependencies = [
- "ahash",
  "bigdecimal",
  "binary-heap-plus",
  "clap",
@@ -4052,6 +4038,7 @@ dependencies = [
  "compare",
  "ctrlc",
  "fluent",
+ "foldhash 0.2.0",
  "itertools 0.14.0",
  "memchr",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) ahash bigdecimal datetime serde gethostid kqueue libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner
+# spell-checker:ignore (libs) bigdecimal datetime foldhash serde gethostid kqueue libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner
 
 [package]
 name = "coreutils"
@@ -311,7 +311,6 @@ readme = "README.package.md"
 version = "0.7.0"
 
 [workspace.dependencies]
-ahash = "0.8.12"
 ansi-width = "0.1.0"
 bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"
@@ -330,6 +329,7 @@ dns-lookup = { version = "3.0.0" }
 exacl = "0.12.0"
 file_diff = "1.0.0"
 filetime = "0.2.23"
+foldhash = "0.2.0"
 fs_extra = "1.3.0"
 fts-sys = "0.2.16"
 gcd = "2.3"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -9,19 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -86,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -529,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -609,6 +596,12 @@ dependencies = [
  "memchr",
  "thiserror",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -1000,7 +993,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1462,7 +1455,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1622,7 +1615,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1860,13 +1853,13 @@ dependencies = [
 name = "uu_sort"
 version = "0.7.0"
 dependencies = [
- "ahash",
  "bigdecimal",
  "binary-heap-plus",
  "clap",
  "compare",
  "ctrlc",
  "fluent",
+ "foldhash",
  "itertools",
  "memchr",
  "nix",
@@ -2106,7 +2099,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -1,4 +1,4 @@
-# spell-checker:ignore ahash bigdecimal
+# spell-checker:ignore bigdecimal foldhash
 
 [package]
 name = "uu_sort"
@@ -44,7 +44,7 @@ uucore = { workspace = true, features = [
   "i18n-collator",
 ] }
 fluent = { workspace = true }
-ahash = { workspace = true }
+foldhash = { workspace = true }
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]
 ctrlc = { workspace = true }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -7,7 +7,7 @@
 // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sort.html
 // https://www.gnu.org/software/coreutils/manual/html_node/sort-invocation.html
 
-// spell-checker:ignore (misc) HFKJFK Mbdfhn getrlimit RLIMIT_NOFILE rlim bigdecimal extendedbigdecimal hexdigit behaviour keydef GETFD localeconv
+// spell-checker:ignore (misc) HFKJFK Mbdfhn getrlimit RLIMIT_NOFILE rlim bigdecimal extendedbigdecimal hexdigit behaviour keydef GETFD localeconv foldhash
 
 mod buffer_hint;
 mod check;
@@ -18,13 +18,14 @@ mod merge;
 mod numeric_str_cmp;
 mod tmp_dir;
 
-use ahash::AHashMap;
 use bigdecimal::BigDecimal;
 use chunks::LineData;
 use clap::builder::ValueParser;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use custom_str_cmp::custom_str_cmp;
 use ext_sort::ext_sort;
+use foldhash::fast::FoldHasher;
+use foldhash::{HashMap, SharedSeed};
 use numeric_str_cmp::{NumInfo, NumInfoParseSettings, human_numeric_str_cmp, numeric_str_cmp};
 use rand::{Rng, rng};
 use rayon::prelude::*;
@@ -32,7 +33,7 @@ use std::cmp::Ordering;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{File, OpenOptions};
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 use std::io::{BufRead, BufReader, BufWriter, Read, Write, stdin, stdout};
 use std::num::{IntErrorKind, NonZero};
 use std::ops::Range;
@@ -1680,7 +1681,7 @@ fn index_legacy_warnings(processed_args: &[OsString], legacy_warnings: &mut [Leg
         return;
     }
 
-    let mut index_by_arg = AHashMap::default();
+    let mut index_by_arg = HashMap::default();
     for (warning_idx, warning) in legacy_warnings.iter().enumerate() {
         index_by_arg.insert(warning.arg_index, warning_idx);
     }
@@ -2925,7 +2926,7 @@ fn salt_from_random_source(path: &Path) -> UResult<[u8; SALT_LEN]> {
     let mut buf = [0u8; BUF_LEN];
     let mut total = 0usize;
     // freeze seed for --random-source
-    let mut hasher = ahash::RandomState::with_seeds(1, 1, 1, 1).build_hasher();
+    let mut hasher = FoldHasher::with_seed(1, SharedSeed::global_fixed());
 
     loop {
         let n = reader
@@ -2951,7 +2952,7 @@ fn salt_from_random_source(path: &Path) -> UResult<[u8; SALT_LEN]> {
 
     let first = hasher.finish();
     // freeze seed for --random-source
-    let mut second_hasher = ahash::RandomState::with_seeds(2, 2, 2, 2).build_hasher();
+    let mut second_hasher = FoldHasher::with_seed(2, SharedSeed::global_fixed());
     second_hasher.write(RANDOM_SOURCE_TAG);
     second_hasher.write_u64(first);
     let second = second_hasher.finish();
@@ -2964,7 +2965,9 @@ fn salt_from_random_source(path: &Path) -> UResult<[u8; SALT_LEN]> {
 
 fn get_hash<T: Hash>(t: &T) -> u64 {
     // Is reproducibility of get_hash itself needed for --random-source ?
-    ahash::RandomState::with_seeds(0, 0, 0, 0).hash_one(t)
+    let mut s = FoldHasher::with_seed(0, SharedSeed::global_fixed());
+    t.hash(&mut s);
+    s.finish()
 }
 
 fn random_shuffle(a: &[u8], b: &[u8], salt: &[u8]) -> Ordering {


### PR DESCRIPTION
Drop `ahash` dependency in favor of `hashbrown`'s default hasher.

- <strike>`ahash` can be slow as it is reliant on hardware support for AES-based instructions.</strike>
- `ahash` uses different algorithms depending on whether there is hardware support for AES-based instructions, fallback algorithm is slower
- `ahash` is not well maintained: https://github.com/pascalkuthe/imara-diff/pull/17#issue-2727684318
- we already use `foldhash` (as a transitive dependency) so this is one less dependency

https://codspeed.io/uutils/coreutils/branches/xtqqczze%3Adeps%2Ffoldhash

cc: @oech3