### PR TITLE
true, false: Fix broken pipe

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -7,7 +7,6 @@ use std::{ffi::OsString, io::Write};
 use uucore::translate;
 
 // uucore::main does not support no-result
-// also remove SIGPIPE overhead
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let args: Vec<OsString> = args.collect();
     if args.len() != 2 {
@@ -23,7 +22,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         return 1;
     };
 
-    if let Err(print_fail) = error {
+    if let Err(print_fail) = error
+        && print_fail.kind() != std::io::ErrorKind::BrokenPipe
+    {
         let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
     }
     1

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -7,7 +7,6 @@ use std::{ffi::OsString, io::Write};
 use uucore::translate;
 
 // uucore::main does not support no-result
-// also remove SIGPIPE overhead
 pub fn uumain(args: impl uucore::Args) -> i32 {
     let args: Vec<OsString> = args.collect();
     if args.len() != 2 {
@@ -23,7 +22,9 @@ pub fn uumain(args: impl uucore::Args) -> i32 {
         return 0;
     };
 
-    if let Err(print_fail) = error {
+    if let Err(print_fail) = error
+        && print_fail.kind() != std::io::ErrorKind::BrokenPipe
+    {
         // Try to display this error.
         let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
         // Mirror GNU options. When failing to print warnings or version flags, then we exit


### PR DESCRIPTION
`|head -n 1` is fine. But I missed the case
```
$ coreutils true --help |:
true: Broken pipe (os error 32)
```
SIGPIPE handling is still confined in cold code path to keep performance.