### PR TITLE
tests/tail: reduce delays in multiple tests to speed up execution

### DIFF
--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -647,8 +647,10 @@ fn test_follow_name_multiple() {
             .arg(FOOBAR_2_TXT)
             .run_no_wait();
 
+        let delay = 100;
+
         child
-            .make_assertion_with_delay(500)
+            .make_assertion_with_delay(delay)
             .is_alive()
             .with_current_output()
             .stdout_only_fixture("foobar_follow_multiple.expected");
@@ -657,7 +659,7 @@ fn test_follow_name_multiple() {
         at.append(FOOBAR_2_TXT, first_append);
 
         child
-            .make_assertion_with_delay(DEFAULT_SLEEP_INTERVAL_MILLIS)
+            .make_assertion_with_delay(delay)
             .with_current_output()
             .stdout_only(first_append);
 
@@ -665,7 +667,7 @@ fn test_follow_name_multiple() {
         at.append(FOOBAR_TXT, second_append);
 
         child
-            .make_assertion_with_delay(DEFAULT_SLEEP_INTERVAL_MILLIS)
+            .make_assertion_with_delay(delay)
             .with_current_output()
             .stdout_only_fixture("foobar_follow_multiple_appended.expected");
 
@@ -1421,7 +1423,7 @@ fn test_retry4() {
         missing,
         "---disable-inotify",
     ];
-    let mut delay = 1500;
+    let mut delay = 150;
     for _ in 0..2 {
         let mut p = ts.ucmd().args(&args).run_no_wait();
 
@@ -1571,7 +1573,7 @@ fn test_retry7() {
         "--use-polling",
     ];
 
-    let mut delay = 1500;
+    let mut delay = 100;
     for _ in 0..2 {
         at.mkdir(untailable);
 
@@ -1719,7 +1721,7 @@ fn test_retry9() {
     );
     let expected_stdout = "foo\nbar\nfoo\nbar\n";
 
-    let delay = 1000;
+    let delay = 100;
 
     at.mkdir(parent_dir);
     at.truncate(user_path, "foo\n");
@@ -1795,7 +1797,7 @@ fn test_follow_descriptor_vs_rename1() {
         "---disable-inotify",
     ];
 
-    let mut delay = 1500;
+    let mut delay = 100;
     for _ in 0..2 {
         at.touch(file_a);
 
@@ -1857,7 +1859,7 @@ fn test_follow_descriptor_vs_rename2() {
         "---disable-inotify",
     ];
 
-    let mut delay = 1500;
+    let mut delay = 150;
     for _ in 0..2 {
         at.touch(file_a);
         at.touch(file_b);
@@ -1922,7 +1924,7 @@ fn test_follow_name_retry_headers() {
         "---disable-inotify",
     ];
 
-    let mut delay = 1500;
+    let mut delay = 150;
     for _ in 0..2 {
         let mut p = ts.ucmd().args(&args).run_no_wait();
 
@@ -2312,7 +2314,7 @@ fn test_follow_name_move_create2() {
         "9",
     ];
 
-    let mut delay = 500;
+    let mut delay = 100;
     for i in 0..2 {
         let mut p = ts.ucmd().args(&args).run_no_wait();
 
@@ -2625,7 +2627,7 @@ fn test_follow_name_move_retry2() {
 
     let mut args = vec!["-s.1", "--max-unchanged-stats=1", "-F", file1, file2];
 
-    let mut delay = 500;
+    let mut delay = 60;
     for i in 0..2 {
         at.touch(file1);
         at.touch(file2);


### PR DESCRIPTION
each changed test now completes in under 1 second each (down from 6–12 seconds)

each test was run 50 times sequentially on my machine to verify stability, no failures were observed.

Related to #10097 