### PR TITLE
clippy: fix nightly lints

### DIFF
--- a/fuzz/fuzz_targets/fuzz_test.rs
+++ b/fuzz/fuzz_targets/fuzz_test.rs
@@ -143,7 +143,7 @@ fn generate_test_arg() -> String {
                 let random_str = generate_random_string(rng.random_range(1..=10));
                 let random_str2 = generate_random_string(rng.random_range(1..=10));
 
-                arg.push_str(&format!("{random_str} {} {random_str2}", test_arg.arg,));
+                arg.push_str(&format!("{random_str} {} {random_str2}", test_arg.arg));
             } else if test_arg.arg_type == ArgType::STRING {
                 let random_str = generate_random_string(rng.random_range(1..=10));
                 arg.push_str(&format!("{} {random_str}", test_arg.arg));

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -112,7 +112,7 @@ fn generate_ls_colors(fmt: &OutputFmt, sep: &str) -> String {
         }
         let (prefix, suffix) = get_colors_format_strings(fmt);
         let ls_colors = parts.join(sep);
-        format!("{prefix}{}:{ls_colors}:{suffix}", generate_type_output(fmt),)
+        format!("{prefix}{}:{ls_colors}:{suffix}", generate_type_output(fmt))
     }
 }
 

--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -126,7 +126,5 @@ fn num_cpus_all() -> usize {
 /// In some cases, [`thread::available_parallelism`]() may return an Err
 /// In this case, we will return 1 (like GNU)
 fn available_parallelism() -> usize {
-    thread::available_parallelism()
-        .map(std::num::NonZeroUsize::get)
-        .unwrap_or(1)
+    thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get)
 }

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1330,7 +1330,7 @@ fn get_formatted_line_number(opts: &OutputOptions, line_number: usize, index: us
         let width = num_opt.width;
         let separator = &num_opt.separator;
         if line_str.len() >= width {
-            format!("{:>width$}{separator}", &line_str[line_str.len() - width..],)
+            format!("{:>width$}{separator}", &line_str[line_str.len() - width..])
         } else {
             format!("{line_str:>width$}{separator}")
         }

--- a/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
+++ b/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
@@ -207,7 +207,7 @@ fn set_buffer(stream: *mut FILE, value: &str) {
     if res != 0 {
         eprintln!("could not set buffering of {} to mode {mode}", unsafe {
             fileno(stream)
-        },);
+        });
     }
 }
 

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -203,7 +203,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .ok_or_else(|| {
             USimpleError::new(
                 1,
-                translate!("touch-error-missing-file-operand", "help_command" => uucore::execution_phrase().to_string(),),
+                translate!("touch-error-missing-file-operand", "help_command" => uucore::execution_phrase().to_string()),
             )
         })?
         .collect();

--- a/src/uucore/src/lib/features/systemd_logind.rs
+++ b/src/uucore/src/lib/features/systemd_logind.rs
@@ -89,7 +89,7 @@ mod login {
 
         if result < 0 {
             return Err(
-                format!("sd_session_get_uid failed for session '{session_id}': {result}",).into(),
+                format!("sd_session_get_uid failed for session '{session_id}': {result}").into(),
             );
         }
 
@@ -123,7 +123,7 @@ mod login {
 
         if result < 0 {
             return Err(
-                format!("sd_session_get_tty failed for session '{session_id}': {result}",).into(),
+                format!("sd_session_get_tty failed for session '{session_id}': {result}").into(),
             );
         }
 
@@ -209,7 +209,7 @@ mod login {
 
         if result < 0 {
             return Err(
-                format!("sd_session_get_type failed for session '{session_id}': {result}",).into(),
+                format!("sd_session_get_type failed for session '{session_id}': {result}").into(),
             );
         }
 
@@ -237,7 +237,7 @@ mod login {
 
         if result < 0 {
             return Err(
-                format!("sd_session_get_seat failed for session '{session_id}': {result}",).into(),
+                format!("sd_session_get_seat failed for session '{session_id}': {result}").into(),
             );
         }
 

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1610,7 +1610,7 @@ fn test_date_locale_en_us_vs_c_difference() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple",))]
+#[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
 fn test_date_locale_fr_french() {
     // Test French locale (fr_FR.UTF-8) behavior
     // French typically uses 24-hour format and may have localized day/month names

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -3773,10 +3773,10 @@ fn test_when_argument_file_is_non_existent_unix_socket_address_then_error() {
         format!("tail: cannot open '{socket}' for reading: No such device or address\n");
     #[cfg(target_os = "freebsd")]
     let expected_stderr =
-        format!("tail: cannot open '{socket}' for reading: Operation not supported\n",);
+        format!("tail: cannot open '{socket}' for reading: Operation not supported\n");
     #[cfg(target_os = "macos")]
     let expected_stderr =
-        format!("tail: cannot open '{socket}' for reading: Operation not supported on socket\n",);
+        format!("tail: cannot open '{socket}' for reading: Operation not supported on socket\n");
 
     ts.ucmd()
         .arg(socket)


### PR DESCRIPTION
- [`clippy::unnecessary_trailing_comma`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_trailing_comma)
- [`clippy::map_unwrap_or`](https://rust-lang.github.io/rust-clippy/master/index.html#map_unwrap_or)