### PR TITLE
i18n: filter out empty env variables

### DIFF
--- a/src/uucore/src/lib/features/i18n/mod.rs
+++ b/src/uucore/src/lib/features/i18n/mod.rs
@@ -34,11 +34,13 @@ const DEFAULT_LOCALE: Locale = locale!("und");
 /// 2. `locale_name`
 /// 3. LANG
 ///
-/// Or fallback on Posix locale, with ASCII encoding.
+/// If they are all unset or empty, fallback on Posix locale, with ASCII encoding.
+/// See the [POSIX specification](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html#tag_08_02).
 pub fn get_locale_from_env(locale_name: &str) -> (Locale, UEncoding) {
+    // Read env variables, filtering out empty ones.
     let locale_var = ["LC_ALL", locale_name, "LANG"]
         .iter()
-        .find_map(|&key| std::env::var(key).ok());
+        .find_map(|&key| std::env::var(key).ok().filter(|l| !l.is_empty()));
 
     if let Some(locale_var_str) = locale_var {
         let mut split = locale_var_str.split(&['.', '@']);

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -2765,4 +2765,53 @@ e f 5436 down data path1 path2 path3 path4 path5\n";
         .stdout_is(input);
 }
 
+#[test]
+fn test_locale_empty_lc_all_hungarian_lc_collate() {
+    // Regression test for issue #11136
+    // The host machine should have the hungarian locale
+    // for this test to pass
+    let input = "gx\ngy\ngz\n";
+    let output = "gx\ngz\ngy\n";
+
+    new_ucmd!()
+        .env("LC_ALL", "")
+        .env("LC_COLLATE", "hu_HU.UTF-8")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(output);
+}
+
+#[test]
+fn test_locale_empty_lc_all_hungarian_lang() {
+    // Regression test for issue #11136
+    // The host machine should have the hungarian locale
+    // for this test to pass
+    let input = "gx\ngy\ngz\n";
+    let output = "gx\ngz\ngy\n";
+
+    new_ucmd!()
+        .env("LC_ALL", "")
+        .env("LANG", "hu_HU.UTF-8")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(output);
+}
+
+#[test]
+fn test_locale_empty_lc_vars_hungarian_lang() {
+    // Regression test for issue #11136
+    // The host machine should have the hungarian locale
+    // for this test to pass
+    let input = "gx\ngy\ngz\n";
+    let output = "gx\ngz\ngy\n";
+
+    new_ucmd!()
+        .env("LC_ALL", "")
+        .env("LC_COLLATE", "")
+        .env("LANG", "hu_HU.UTF-8")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(output);
+}
+
 /* spell-checker: enable */


### PR DESCRIPTION
Make `get_locale_from_env` POSIX compliant by ignoring empty env variables. 

Fixes #11136.
