### PR TITLE
use var_os in a few places

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -285,8 +285,8 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
                 // else just strip the prefix and continue (even "posix+FORMAT" is
                 // supported).
                 // TODO: This needs to be moved to uucore and handled by icu?
-                if std::env::var("LC_TIME").unwrap_or_default() == "POSIX"
-                    || std::env::var("LC_ALL").unwrap_or_default() == "POSIX"
+                if std::env::var_os("LC_TIME").as_deref() == Some(OsStr::new("POSIX"))
+                    || std::env::var_os("LC_ALL").as_deref() == Some(OsStr::new("POSIX"))
                 {
                     return ok(LOCALE_FORMAT);
                 }

--- a/src/uu/pinky/src/platform/unix.rs
+++ b/src/uu/pinky/src/platform/unix.rs
@@ -138,12 +138,12 @@ fn idle_string(when: i64) -> String {
 }
 
 fn time_string(ut: &UtmpxRecord) -> String {
-    let lc_time: String = std::env::var("LC_ALL")
-        .or_else(|_| std::env::var("LC_TIME"))
-        .or_else(|_| std::env::var("LANG"))
-        .unwrap_or_default();
-
-    let time_format: Vec<time::format_description::FormatItem> = if lc_time == "C" {
+    let time_format: Vec<time::format_description::FormatItem> = if ["LC_ALL", "LC_TIME", "LANG"]
+        .into_iter()
+        .find_map(std::env::var_os)
+        .as_deref()
+        == Some(std::ffi::OsStr::new("C"))
+    {
         // "%b %e %H:%M"
         time::format_description::parse("[month repr:short] [day padding:space] [hour]:[minute]")
             .unwrap()

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -9,6 +9,7 @@
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use itertools::Itertools;
 use regex::Regex;
+use std::ffi::OsStr;
 use std::fs::metadata;
 use std::io::{Read, Write, stderr, stdin, stdout};
 use std::str::Utf8Error;
@@ -495,8 +496,8 @@ fn get_date_format(matches: &ArgMatches) -> String {
             // Replicate behavior from GNU manual.
             if std::env::var("POSIXLY_CORRECT").is_ok()
                 // TODO: This needs to be moved to uucore and handled by icu?
-                && (std::env::var("LC_TIME").unwrap_or_default() == "POSIX"
-                    || std::env::var("LC_ALL").unwrap_or_default() == "POSIX")
+                && (std::env::var_os("LC_TIME").as_deref() == Some(OsStr::new("POSIX"))
+                    || std::env::var_os("LC_ALL").as_deref() == Some(OsStr::new("POSIX")))
             {
                 "%b %e %H:%M %Y"
             } else {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1755,7 +1755,7 @@ fn default_merge_batch_size() -> usize {
 
 #[cfg(not(unix))]
 fn locale_failed_to_set() -> bool {
-    matches!(env::var("LC_ALL").ok().as_deref(), Some("missing"))
+    env::var_os("LC_ALL").as_deref() == Some(OsStr::new("missing"))
 }
 
 #[cfg(unix)]

--- a/src/uucore/src/lib/mods/clap_localization.rs
+++ b/src/uucore/src/lib/mods/clap_localization.rs
@@ -682,7 +682,7 @@ mod tests {
         use crate::locale::{get_message, setup_localization};
         use std::env;
 
-        let original_lang = env::var("LANG").unwrap_or_default();
+        let original_lang = env::var_os("LANG").unwrap_or_default();
 
         unsafe {
             env::set_var("LANG", "fr_FR.UTF-8");


### PR DESCRIPTION
Use `var_os` for `LC_ALL`, `LC_TIME`, etc.

Contributes to https://github.com/uutils/coreutils/issues/11076