### PR TITLE
uucore: move SIGPIPE setup to real main and drop RUST_SIGPIPE workaround

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -16,6 +16,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 
+#[cfg(unix)]
+uucore::init_startup_state_capture!();
+
 fn usage<T>(utils: &UtilityMap<T>, name: &str) {
     let display_list = utils.keys().copied().join(", ");
     let width = cmp::min(textwrap::termwidth(), 100) - 8; // (opinion/heuristic) max 100 chars wide with 4 character side indentions
@@ -51,6 +54,13 @@ Currently defined functions:
 
 #[allow(clippy::cognitive_complexity)]
 fn main() {
+    #[cfg(unix)]
+    if !uucore::signals::sigpipe_was_ignored() {
+        let _ = uucore::signals::enable_pipe_errors();
+    }
+
+    uucore::panic::mute_sigpipe_panic();
+
     let utils = util_map();
     let mut args = uucore::args_os();
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -1139,14 +1139,6 @@ where
         signal_fn(sig)?;
         log.record(sig_value, action_kind, explicit);
 
-        // Set environment variable to communicate to Rust child processes
-        // that SIGPIPE should be default (not ignored)
-        if matches!(action_kind, SignalActionKind::Default) && sig_value == libc::SIGPIPE as usize {
-            unsafe {
-                env::set_var("RUST_SIGPIPE", "default");
-            }
-        }
-
         Ok(())
     })
 }

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -189,12 +189,17 @@ pub fn get_canonical_util_name(util_name: &str) -> &str {
 #[macro_export]
 macro_rules! bin_inner {
     ($util:ident, $post:expr) => {
+        #[cfg(unix)]
+        uucore::init_startup_state_capture!();
+
         pub fn main() {
             use std::io::Write;
             use uucore::locale;
 
-            // Preserve inherited SIGPIPE settings (e.g., from env --default-signal=PIPE)
-            uucore::panic::preserve_inherited_sigpipe();
+            #[cfg(unix)]
+            if !uucore::signals::sigpipe_was_ignored() {
+                let _ = uucore::signals::enable_pipe_errors();
+            }
 
             // suppress extraneous error output for SIGPIPE failures/panics
             uucore::panic::mute_sigpipe_panic();

--- a/src/uucore/src/lib/mods/panic.rs
+++ b/src/uucore/src/lib/mods/panic.rs
@@ -40,26 +40,3 @@ pub fn mute_sigpipe_panic() {
         }
     }));
 }
-
-/// Preserve inherited SIGPIPE settings from parent process.
-///
-/// Rust unconditionally sets SIGPIPE to SIG_IGN on startup. This function
-/// checks if the parent process (e.g., `env --default-signal=PIPE`) intended
-/// for SIGPIPE to be set to default by checking the RUST_SIGPIPE environment
-/// variable. If set to "default", it restores SIGPIPE to SIG_DFL.
-#[cfg(unix)]
-pub fn preserve_inherited_sigpipe() {
-    use nix::libc;
-
-    // Check if parent specified that SIGPIPE should be default
-    if std::env::var_os("RUST_SIGPIPE").is_some_and(|v| v == "default") {
-        unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL) };
-        // Remove the environment variable so child processes don't inherit it incorrectly
-        unsafe { std::env::remove_var("RUST_SIGPIPE") };
-    }
-}
-
-#[cfg(not(unix))]
-pub fn preserve_inherited_sigpipe() {
-    // No-op on non-Unix platforms
-}

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -18,8 +18,6 @@ use quote::quote;
 /// A procedural macro to define the main function of a uutils binary.
 ///
 /// This macro handles:
-/// - SIGPIPE state capture at process startup (before Rust runtime overrides it)
-/// - SIGPIPE restoration to default if parent didn't explicitly ignore it
 /// - Disabling Rust signal handlers for proper core dumps
 /// - Error handling and exit code management
 #[proc_macro_attribute]
@@ -29,23 +27,8 @@ pub fn main(args: TokenStream, stream: TokenStream) -> TokenStream {
     let signals = !args.to_string().contains("no_signals");
 
     let new = quote!(
-        // Initialize SIGPIPE state capture at process startup (Unix only).
-        // This must be at module level to set up the .init_array static that runs
-        // before main() to capture whether SIGPIPE was ignored by the parent process.
-        #[cfg(all(#signals, unix))]
-        uucore::init_startup_state_capture!();
-
         pub fn uumain(args: impl uucore::Args) -> i32 {
             #stream
-
-            // Restore SIGPIPE to default if it wasn't explicitly ignored by parent.
-            // The Rust runtime ignores SIGPIPE, but we need to respect the parent's
-            // signal disposition for proper pipeline behavior (GNU compatibility).
-            // needed even for true --version
-            #[cfg(unix)]
-            if !uucore::signals::sigpipe_was_ignored() {
-                let _ = uucore::signals::enable_pipe_errors();
-            }
 
             // disable rust signal handlers (otherwise processes don't dump core after e.g. one SIGSEGV)
             #[cfg(all(#signals, unix))]


### PR DESCRIPTION
### Summary

Move SIGPIPE startup handling out of the `uucore::main` proc macro and into the real binary entrypoints.

This keeps the startup-state capture at process entry, simplifies the proc macro, and removes the `RUST_SIGPIPE` workaround that was used to communicate default SIGPIPE behavior to Rust child processes.

Related: #11208

### What Changed

- moved Unix startup-state capture to the real `main` entrypoints
  - `uucore::bin!`
  - the multicall `coreutils` binary
- restored default SIGPIPE handling from the real `main` path instead of the proc-macro-generated `uumain`
- simplified `uucore::main` so it only handles:
  - disabling Rust signal handlers when needed
  - converting `UResult` into exit codes
- removed `preserve_inherited_sigpipe()`
- removed the `RUST_SIGPIPE=default` propagation in `env`
- gated the startup capture invocation with `#[cfg(unix)]` so Windows builds do not try to resolve Unix-only signal machinery

### Why

Handling SIGPIPE from the actual process entrypoint is a better fit than doing it inside the proc macro wrapper around utility logic.

This reduces SIGPIPE-specific coupling in `uucore::main`, keeps the behavior centralized at the binary boundary, and removes the extra environment-variable-based workaround for Rust child processes.

### Verification

- `cargo fmt --all`
- `cargo test --test tests test_env::test_env_default_signal_pipe -- --exact`
- `cargo test --test tests test_env::test_ignore_signal_pipe_broken_pipe_regression -- --exact`
- `cargo test --test tests test_seq::test_sigpipe_ignored_reports_write_error -- --exact`
- `cargo test --test tests test_yes::test_simple -- --exact`
- `cargo test --test tests test_sort::test_sigpipe_panic -- --exact`

### Notes

I also checked the Windows-specific failure mode reported in CI and fixed the immediate issue by ensuring the startup capture macro is only invoked on Unix.
