### PR TITLE
uucore: replace unsafe mkfifo wrapper with nix crate implementation

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -11,15 +11,13 @@
 use libc::{
     S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK, S_IRGRP, S_IROTH,
     S_IRUSR, S_ISGID, S_ISUID, S_ISVTX, S_IWGRP, S_IWOTH, S_IWUSR, S_IXGRP, S_IXOTH, S_IXUSR,
-    mkfifo, mode_t,
+    mode_t,
 };
 #[cfg(all(unix, not(target_os = "redox")))]
 pub use libc::{major, makedev, minor};
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::env;
-#[cfg(unix)]
-use std::ffi::CString;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::fs::read_dir;
@@ -820,9 +818,8 @@ pub fn get_filename(file: &Path) -> Option<&str> {
 
 /// Make a FIFO, also known as a named pipe.
 ///
-/// This is a safe wrapper for the unsafe [`libc::mkfifo`] function,
-/// which makes a [named
-/// pipe](https://en.wikipedia.org/wiki/Named_pipe) on Unix systems.
+/// This creates a [named pipe](https://en.wikipedia.org/wiki/Named_pipe) on
+/// Unix systems.
 ///
 /// # Errors
 ///
@@ -840,13 +837,8 @@ pub fn get_filename(file: &Path) -> Option<&str> {
 /// ```
 #[cfg(unix)]
 pub fn make_fifo(path: &Path) -> std::io::Result<()> {
-    let name = CString::new(path.to_str().unwrap()).unwrap();
-    let err = unsafe { mkfifo(name.as_ptr(), 0o666) };
-    if err == -1 {
-        Err(Error::from_raw_os_error(err))
-    } else {
-        Ok(())
-    }
+    nix::unistd::mkfifo(path, nix::sys::stat::Mode::from_bits_truncate(0o666))?;
+    Ok(())
 }
 
 // Redox's libc appears not to include the following utilities


### PR DESCRIPTION
Replace the unsafe `libc::mkfifo` wrapper with a safe implementation using the `nix` crate. This change improves code safety by eliminating unsafe code blocks and leveraging the well-tested nix crate for system calls. The functionality remains identical - creating named pipes with 0o666 permissions - but now uses a safer, more idiomatic Rust approach.