### PR TITLE
seq: Avoid allocating arbitrarily large bigints (cap set to 10^{4932}…

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -144,9 +144,12 @@ matter the parameters (integers, decimal numbers, positive or negative increment
 format specified, etc.), so its output will be more correct than GNU coreutils for
 some inputs (e.g. small fractional increments where GNU coreutils uses `long double`).
 
-The only limitation is that the position of the decimal point is stored in a `i64`,
-so values smaller than 10**(-2**63) will underflow to 0, and some values larger
-than 10**(2**63) may overflow to infinity.
+The main limitation is that the position of the decimal point is stored in a `i64`,
+so values smaller than `10**(-2**63)` will underflow to 0, and some values larger
+than `10**(2**63)` may overflow to infinity.
+
+Additionally, for positive exponents, values exceeding `10**4932` (the maximum 
+supported by GNU seq) are considered invalid.
 
 See also comments under `printf` for formatting precision and differences.
 

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -100,6 +100,11 @@ impl FromStr for PreciseNumber {
         let ebd = match ExtendedBigDecimal::extended_parse(input) {
             Ok(ebd) => match ebd {
                 // Handle special values
+                ExtendedBigDecimal::BigDecimal(ref x)
+                    if x.digits() as i128 - x.fractional_digit_count() as i128 > 4933 =>
+                {
+                    return Err(ParseNumberError::Float);
+                }
                 ExtendedBigDecimal::BigDecimal(_) | ExtendedBigDecimal::MinusZero => {
                     // TODO: GNU `seq` treats small numbers < 1e-4950 as 0, we could do the same
                     // to avoid printing senselessly small numbers.
@@ -374,7 +379,9 @@ mod tests {
     #[test]
     fn test_parse_max_exponents() {
         // Make sure exponents much bigger than i64::MAX cause errors
-        assert!("1e9223372036854775807".parse::<PreciseNumber>().is_ok());
+        assert!("1e4932".parse::<PreciseNumber>().is_ok());
+        assert!("1e4933".parse::<PreciseNumber>().is_err());
+        assert!("1e9223372036854775807".parse::<PreciseNumber>().is_err());
         assert!("1e92233720368547758070".parse::<PreciseNumber>().is_err());
     }
 }

--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -370,7 +370,11 @@ fn format_float_decimal(
             return format!("{bd:.0}.");
         }
     }
-    format!("{bd:.precision$}")
+    if u16::try_from(precision).is_ok() {
+        format!("{bd:.precision$}")
+    } else {
+        bd.to_plain_string()
+    }
 }
 
 /// Converts a `&BigDecimal` to a scientific-like `X.XX * 10^e`.

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -849,6 +849,11 @@ fn test_invalid_float_point_fail_properly() {
         .fails()
         .no_stdout()
         .usage_error("invalid floating point argument: '-.1e92233720368547758070'");
+    new_ucmd!()
+        .args(&["1e4933"])
+        .fails()
+        .no_stdout()
+        .usage_error("invalid floating point argument: '1e4933'");
 }
 
 #[test]
@@ -1128,4 +1133,9 @@ fn test_equalize_widths_corner_cases() {
         .args(&["-w", "0x1.1", "1.00002", "3"])
         .succeeds()
         .stdout_is("1.0625\n2.06252\n");
+}
+
+#[test]
+fn test_seq_one_e_negative_u16_max() {
+    new_ucmd!().args(&["1e-65536", "1e-65536"]).succeeds();
 }


### PR DESCRIPTION
… for GNU compatibility).

seq: Avoid panicing on decimals smaller than 10^{-65535}.