### PR TITLE
CICD.yml: Publish both of coreutils and individual MSVC *.exe

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -386,7 +386,8 @@ jobs:
           - { os: macos-latest   , target: aarch64-apple-darwin        , workspace-tests: true, check-only: true } # M1 CPU
           - { os: macos-latest   , target: x86_64-apple-darwin         , features: feat_os_unix, workspace-tests: true }
           - { os: windows-latest , target: i686-pc-windows-msvc        , features: feat_os_windows }
-          - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows }
+          # msvc and gnu works on the same target. So publishing msvc is enough.
+          - { os: windows-latest , target: x86_64-pc-windows-gnu       , features: feat_os_windows, skip-publish: true }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
           - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }
     steps:
@@ -632,13 +633,15 @@ jobs:
         ${{ steps.vars.outputs.CARGO_CMD }} ${{ steps.vars.outputs.CARGO_CMD_OPTIONS }} build --release --config=profile.release.strip=true \
         --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} ${{ steps.vars.outputs.CARGO_DEFAULT_FEATURES_OPTION }}
     # We don't want to have many duplicated long jobs at here
-    # So we build individual binaries for few platforms until we deduplicate many release build for Linux
-    - name: Build individual binaries
+    # So we build individual binaries (including coreutils) for few platforms until we deduplicate many release build for Linux
+    - name: Build all binaries
       if: matrix.job.skip-tests != true && matrix.job.target == 'x86_64-pc-windows-msvc'
       shell: bash
       run: |
         ${{ steps.vars.outputs.CARGO_CMD }} ${{ steps.vars.outputs.CARGO_CMD_OPTIONS }} build --release --config=profile.release.strip=true \
-        --target=${{ matrix.job.target }} ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }}
+        --target=${{ matrix.job.target }} \
+        ${{ steps.dep_vars.outputs.CARGO_UTILITY_LIST_OPTIONS }} \
+        -p coreutils --features=${{ matrix.job.features }}
     - name: Package
       if: matrix.job.skip-publish != true && matrix.job.check-only != true
       shell: bash


### PR DESCRIPTION
- Closes #11268 
- Restrict x86_64-pc-windows-gnu  to test only since publishing 2 Windows x64 binary cause confusion and both binaries are linked against UCRT.