### PR TITLE
refactor: replace manual last()+pop() patterns with Vec::pop_if

### DIFF
--- a/src/uu/dd/src/blocks.rs
+++ b/src/uu/dd/src/blocks.rs
@@ -39,11 +39,8 @@ fn block(buf: &[u8], cbs: usize, sync: bool, rstat: &mut ReadStat) -> Vec<Vec<u8
     // If `sync` is true and there has been at least one partial
     // record read from the input, then leave the all-spaces block at
     // the end. Otherwise, remove it.
-    if let Some(last) = blocks.last() {
-        if (!sync || rstat.reads_partial == 0) && last.iter().all(|&e| e == SPACE) {
-            blocks.pop();
-        }
-    }
+    let _ = blocks
+        .pop_if(|last| (!sync || rstat.reads_partial == 0) && last.iter().all(|&e| e == SPACE));
 
     blocks
 }

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -395,9 +395,7 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
             break;
         }
 
-        if line.last().copied() == Some(b'\n') {
-            line.pop();
-        }
+        let _ = line.pop_if(|byte| *byte == b'\n');
 
         if line.is_empty() {
             stats.consecutive_empty_lines += 1;

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -273,11 +273,7 @@ fn parse_delimiters(delimiters: &OsString) -> UResult<Box<[Box<[u8]>]>> {
 }
 
 fn remove_trailing_line_ending_byte(line_ending_byte: u8, output: &mut Vec<u8>) {
-    if let Some(&byte) = output.last() {
-        if byte == line_ending_byte {
-            assert_eq!(output.pop(), Some(line_ending_byte));
-        }
-    }
+    let _ = output.pop_if(|byte| *byte == line_ending_byte);
 }
 
 enum DelimiterState<'a> {

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -276,9 +276,7 @@ fn split_seps(data: &[u8], sep: u8) -> Vec<&[u8]> {
     let predicted_capacity = data.len() / PREDICTED_LINE_LENGTH;
     let mut elements = Vec::with_capacity(predicted_capacity);
     elements.extend(data.split(|&b| b == sep));
-    if elements.last().is_some_and(|e| e.is_empty()) {
-        elements.pop();
-    }
+    let _ = elements.pop_if(|e| e.is_empty());
     elements
 }
 

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -247,9 +247,7 @@ impl Uniq {
         if bytes_read == 0 {
             return Ok(false);
         }
-        if buffer.last().is_some_and(|last| *last == line_terminator) {
-            buffer.pop();
-        }
+        let _ = buffer.pop_if(|last| *last == line_terminator);
         Ok(true)
     }
 


### PR DESCRIPTION
## Summary

- replace manual `last()` + `pop()` patterns with `Vec::pop_if`
- simplify trailing-element removal in `shuf`, `uniq`, `nl`, `dd`, and `paste`
- remove the redundant `assert_eq!(output.pop(), ...)` in `paste`

This is a small refactor enabled by the current MSRV and is not intended to change behavior.
