### PR TITLE
wc: increase buffer size for Unicode counting paths

### DIFF
--- a/src/uu/wc/src/countable.rs
+++ b/src/uu/wc/src/countable.rs
@@ -13,6 +13,8 @@ use std::io::{BufRead, BufReader, Read, StdinLock};
 #[cfg(unix)]
 use std::os::fd::{AsFd, AsRawFd};
 
+const WORD_COUNT_BUF_SIZE: usize = 256 * 1024;
+
 #[cfg(unix)]
 pub trait WordCountable: AsFd + AsRawFd + Read {
     type Buffered: BufRead;
@@ -28,10 +30,10 @@ pub trait WordCountable: Read {
 }
 
 impl WordCountable for StdinLock<'_> {
-    type Buffered = Self;
+    type Buffered = BufReader<Self>;
 
     fn buffered(self) -> Self::Buffered {
-        self
+        BufReader::with_capacity(WORD_COUNT_BUF_SIZE, self)
     }
     fn inner_file(&mut self) -> Option<&mut File> {
         None
@@ -42,7 +44,7 @@ impl WordCountable for File {
     type Buffered = BufReader<Self>;
 
     fn buffered(self) -> Self::Buffered {
-        BufReader::new(self)
+        BufReader::with_capacity(WORD_COUNT_BUF_SIZE, self)
     }
 
     fn inner_file(&mut self) -> Option<&mut File> {


### PR DESCRIPTION
## Summary

The Unicode path in `wc` was still using the default `BufReader` capacity of 8 KiB. That made `-w`, `-L`, and the default `-lwc` path pay more `fill_buf` and UTF-8 decoding overhead than necessary.

This PR switches the Unicode counting path to use a 256 KiB buffer, matching the fast path buffer size and reducing per-chunk overhead.

## Changes

- add `WORD_COUNT_BUF_SIZE = 256 * 1024` in `src/uu/wc/src/countable.rs`
- change `File`'s `WordCountable::buffered()` to use `BufReader::with_capacity(...)`
- change `StdinLock`'s `WordCountable::buffered()` to use `BufReader::with_capacity(...)`

## Background

The `-c/-l/-m` fast path already uses a 256 KiB buffer, but the Unicode path used by `-w`, `-L`, and related combinations goes through `BufReadDecoder` and was still backed by the default 8 KiB `BufReader`.

As a result, large inputs on the Unicode path were processed in much smaller chunks, adding avoidable fixed overhead.

## Testing

- `cargo build -p uu_wc --release`
- `cargo test -p uu_wc`
- `cargo test --features wc test_wc`

The `wc` integration tests passed (`57 passed`).

