### PR TITLE
tac: avoid mmap on regular files to prevent SIGBUS on truncation

### DIFF
--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -383,20 +383,19 @@ fn tac(filenames: &[OsString], before: bool, regex: bool, separator: &OsStr) -> 
                 }
             };
 
-            if let Some(mmap1) = try_mmap_file(&file) {
-                mmap = mmap1;
-                &mmap
-            } else {
-                let mut contents = Vec::new();
-                match file.read_to_end(&mut contents) {
-                    Ok(_) => {
-                        buf = contents;
-                        &buf
-                    }
-                    Err(e) => {
-                        show!(TacError::ReadError(filename.clone(), e));
-                        continue;
-                    }
+            // Read the file into memory instead of memory-mapping it.
+            // Using mmap on regular files is unsafe because if the file is
+            // truncated while mapped, accessing the now-invalid region
+            // triggers SIGBUS and crashes the process (see #9748).
+            let mut contents = Vec::new();
+            match file.read_to_end(&mut contents) {
+                Ok(_) => {
+                    buf = contents;
+                    &buf
+                }
+                Err(e) => {
+                    show!(TacError::ReadError(filename.clone(), e));
+                    continue;
                 }
             }
         };
@@ -450,11 +449,6 @@ fn buffer_stdin() -> std::io::Result<StdinData> {
     }
 }
 
-fn try_mmap_file(file: &File) -> Option<Mmap> {
-    // SAFETY: If the file is truncated while we map it, SIGBUS will be raised
-    // and our process will be terminated, thus preventing access of invalid memory.
-    unsafe { Mmap::map(file).ok() }
-}
 
 #[cfg(test)]
 mod tests_hybrid_flavor {


### PR DESCRIPTION
## Summary
- Replace mmap-based file reading in `tac` with `read_to_end()` to prevent SIGBUS crashes when input files are truncated during read
- Remove the now-unused `try_mmap_file()` function
- Retain mmap for stdin (via temp files owned by the process) where external truncation is not a concern

## Context
When `tac` memory-maps a regular file and another process truncates that file concurrently, accessing the now-invalid mapped memory region triggers SIGBUS and crashes the process. This is a real concern in log rotation scenarios where `tac` might be reading logs that get rotated/truncated at the same time.

GNU `tac` avoids this by not directly memory-mapping untrusted input files. This PR brings the same safety to the uutils implementation by reading files into a heap buffer instead.

## Test plan
- [x] All existing `tac` tests should continue to pass (file reads, stdin, separators, regex modes)
- [x] The reproduction scenario from the issue should no longer crash:
  ```bash
  dd if=/dev/zero of=/tmp/tactest bs=1M count=10 2>/dev/null
  (sleep 0.001; truncate -s 0 /tmp/tactest) &
  tac /tmp/tactest
  ```

Fixes #9748

Generated with [Claude Code](https://claude.com/claude-code)