### PR TITLE
pr: don't convert to String when storing lines to print

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1279,7 +1279,6 @@ fn get_line_for_printing(
     let blank_line = String::new();
     let formatted_line_number = get_formatted_line_number(options, file_line.line_number, index);
 
-
     // TODO: support non-UTF-8 bytes (currently replaced with U+FFFD)
     let content = String::from_utf8_lossy(&file_line.line_content);
     let mut complete_line = format!("{formatted_line_number}{content}");


### PR DESCRIPTION
Changed `FileLine.line_content` from `String` to `Vec<u8>` to avoid
unnecessary byte → String → byte conversions.

Changes:
- `FileLine.line_content` is now `Vec<u8>`
- `apply_expand_tab` now takes `&mut Vec<u8>` instead of `&mut String`
- `from_buf` no longer needs to return `Result` since UTF-8 validation
  is no longer needed
- `get_pages` also no longer needs to return `Result` as a cascade effect
- `get_line_for_printing` uses `String::from_utf8_lossy` only at the
  formatting stage

Note: `test_dd::test_iso8859_1_case_conversion` fails but is pre-existing
and unrelated to this change.

Fixes #10333