### PR TITLE
chore(deps): update rust crate console to v0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,13 +483,12 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]


### PR DESCRIPTION
Follow-up https://github.com/uutils/coreutils/pull/11319

@cakebaker For some reason @renovate only updated fuzz