### PR TITLE
ls: Add NotADirectory message

### DIFF
--- a/src/uu/ls/locales/en-US.ftl
+++ b/src/uu/ls/locales/en-US.ftl
@@ -23,6 +23,7 @@ ls-error-unknown-io-error = unknown io error: {$path}, '{$error}'
 ls-error-invalid-block-size = invalid --block-size argument {$size}
 ls-error-dired-and-zero-incompatible = --dired and --zero are incompatible
 ls-error-not-listing-already-listed = {$path}: not listing already-listed directory
+ls-error-not-directory = {$path}: A path component was not a directory
 ls-error-invalid-time-style = invalid --time-style argument {$style}
   Possible values are:
     - [posix-]full-iso

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -186,6 +186,7 @@ enum LsError {
 
     #[error("{}", match .1.kind() {
         ErrorKind::NotFound => translate!("ls-error-cannot-access-no-such-file", "path" => .0.quote()),
+        ErrorKind::NotADirectory => translate!("ls-error-not-directory", "path" => .0.quote()),
         ErrorKind::PermissionDenied => match .1.raw_os_error().unwrap_or(1) {
             1 => translate!("ls-error-cannot-access-operation-not-permitted", "path" => .0.quote()),
             _ => if .0.is_dir() {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2549,6 +2549,18 @@ fn test_ls_non_existing() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_ls_not_a_directory_errors() {
+    let scene = TestScenario::new(util_name!());
+    scene
+        .ucmd()
+        .arg("/etc/hosts/test")
+        .fails()
+        .code_is(2)
+        .stderr_contains("not a directory");
+}
+
+#[test]
 fn test_ls_files_dirs() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
This makes the error message for `ls ~/.bashrc/test` less scary. [Two](https://askubuntu.com/questions/1564801/why-did-ubuntu-switch-from-gnu-coreutils-to-uutils/1564802?noredirect=1#comment2754992_1564802) people [had](https://askubuntu.com/questions/1564801/why-did-ubuntu-switch-from-gnu-coreutils-to-uutils/1564802?noredirect=1#comment2755121_1564802) already complained about the phrasing "unknown io error".

# Before

Some say the error message is scarier than the GNU coreutils one.

```console
home@daniel-desktop3:~$ /bin/ls .bashrc/test
/bin/ls: unknown io error: '.bashrc/test', 'Os { code: 20, kind: NotADirectory, message: "Not a directory" }'
home@daniel-desktop3:~$ /bin/gnuls .bashrc/test
/bin/gnuls: cannot access '.bashrc/test': Not a directory
```

# After

I got rid of the word "unknown". I changed the phrasing, because Peter Cordes said "it hasn't checked which path component isn't a directory; it's not the final one".

```console
$ /usr/bin/cargo run --color=always --bin ls --profile dev --manifest-path /home/home/CLionProjects/uutils/src/uu/ls/Cargo.toml -- /home/home/.bashrc/test
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/ls /home/home/.bashrc/test`
ls: '/home/home/.bashrc/test': A path component was not a directory

Process finished with exit code 2
```