### PR TITLE
docs(performance): Use gnuls where ls is uutils

### DIFF
--- a/.vscode/cspell.dictionaries/shell.wordlist.txt
+++ b/.vscode/cspell.dictionaries/shell.wordlist.txt
@@ -101,6 +101,7 @@ flamegraph
 flamegraphs
 gcov
 gmake
+gnuls
 grcov
 grep
 markdownlint

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -41,6 +41,8 @@ hyperfine \
   "{ls} -R ."
 ```
 
+For Ubuntu 25.10 and other distributions that use uutils by default, replace `bin/ls` with `bin/gnuls`. Also:
+
 ```
 # to improve the reproducibility of the results:
 taskset -c 0


### PR DESCRIPTION
Some distributions have already adopted uutils as `/bin/ls`. Continuing to compare against the binary at that path would only result in comparing against a much older uutils version and fail to compare against GNU Coreutils at all. Ubuntu 25.10 has prefixed GNU's binaries with "gnu", so mention this to retain the intended behavior.