### PR TITLE
Cargo.toml: dedup feat_require_unix_hostid dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,8 +226,6 @@ feat_wasm = [
 # "feat_os_macos" == set of utilities which can be built/run on the MacOS platform
 feat_os_macos = [
   "feat_os_unix", ## == a modern/usual *nix platform
-  #
-  "feat_require_unix_hostid",
 ]
 # "feat_os_unix" == set of utilities which can be built/run on modern/usual *nix platforms.
 feat_os_unix = [


### PR DESCRIPTION
`feat_os_macos` depends on `feat_os_unix` which depends on `feat_require_unix_hostid`.