### PR TITLE
true, false, echo: avoid uu_app().render_version() for smaller binary

### DIFF
--- a/src/uu/echo/src/echo.rs
+++ b/src/uu/echo/src/echo.rs
@@ -10,7 +10,7 @@ use std::ffi::{OsStr, OsString};
 use std::io::{StdoutLock, Write, stdout};
 use uucore::error::UResult;
 use uucore::format::{FormatChar, OctalParsing, parse_escape_only};
-use uucore::{format_usage, os_str_as_bytes};
+use uucore::{crate_version, format_usage, os_str_as_bytes};
 
 use uucore::translate;
 
@@ -166,7 +166,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             uu_app().print_help()?;
             return Ok(());
         } else if first_arg == "--version" && args.peek().is_none() {
-            write!(stdout(), "{}", uu_app().render_version())?;
+            writeln!(stdout(), "echo {}", crate_version!())?;
             return Ok(());
         }
 
@@ -186,17 +186,17 @@ pub fn uu_app() -> Command {
     // Note: echo is different from the other utils in that it should **not**
     // have `infer_long_args(true)`, because, for example, `--ver` should be
     // printed as `--ver` and not show the version text.
-    Command::new(uucore::util_name())
+    Command::new("echo")
         // TrailingVarArg specifies the final positional argument is a VarArg
         // and it doesn't attempts the parse any further args.
         // Final argument must have multiple(true) or the usage string equivalent.
         .trailing_var_arg(true)
         .allow_hyphen_values(true)
-        .version(uucore::crate_version!())
+        .version(crate_version!())
         .about(translate!("echo-about"))
         .after_help(translate!("echo-after-help"))
         .override_usage(format_usage(&translate!("echo-usage")))
-        .help_template(uucore::localized_help_template(uucore::util_name()))
+        .help_template(uucore::localized_help_template("echo"))
         .arg(
             Arg::new(options::NO_NEWLINE)
                 .short('n')

--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 use clap::{Arg, ArgAction, Command};
 use std::io::Write;
-use uucore::translate;
+use uucore::{crate_version, translate};
 
 // uucore::main does not support no-result
 pub fn uumain(mut args: impl uucore::Args) -> i32 {
@@ -16,7 +16,8 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     let error = if flag == "--help" {
         uu_app().print_help()
     } else if flag == "--version" {
-        write!(std::io::stdout(), "{}", uu_app().render_version())
+        // avoid uu_app for smaller binary size
+        writeln!(std::io::stdout(), "false {}", crate_version!())
     } else {
         return 1;
     };
@@ -24,15 +25,15 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     if let Err(print_fail) = error
         && print_fail.kind() != std::io::ErrorKind::BrokenPipe
     {
-        let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
+        let _ = writeln!(std::io::stderr(), "false: {print_fail}");
     }
     1
 }
 
 pub fn uu_app() -> Command {
-    Command::new(uucore::util_name())
-        .version(uucore::crate_version!())
-        .help_template(uucore::localized_help_template(uucore::util_name()))
+    Command::new("false")
+        .version(crate_version!())
+        .help_template(uucore::localized_help_template("false"))
         .about(translate!("false-about"))
         // We provide our own help and version options, to ensure maximum compatibility with GNU.
         .disable_help_flag(true)

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 use clap::{Arg, ArgAction, Command};
 use std::io::Write;
-use uucore::translate;
+use uucore::{crate_version, translate};
 
 // uucore::main does not support no-result
 pub fn uumain(mut args: impl uucore::Args) -> i32 {
@@ -16,7 +16,8 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     let error = if flag == "--help" {
         uu_app().print_help()
     } else if flag == "--version" {
-        write!(std::io::stdout(), "{}", uu_app().render_version())
+        // avoid uu_app for smaller binary size
+        writeln!(std::io::stdout(), "true {}", crate_version!())
     } else {
         return 0;
     };
@@ -25,7 +26,7 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
         && print_fail.kind() != std::io::ErrorKind::BrokenPipe
     {
         // Try to display this error.
-        let _ = writeln!(std::io::stderr(), "{}: {print_fail}", uucore::util_name());
+        let _ = writeln!(std::io::stderr(), "true: {print_fail}");
         // Mirror GNU options. When failing to print warnings or version flags, then we exit
         // with FAIL. This avoids allocation some error information which may result in yet
         // other types of failure.
@@ -35,9 +36,9 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
 }
 
 pub fn uu_app() -> Command {
-    Command::new(uucore::util_name())
-        .version(uucore::crate_version!())
-        .help_template(uucore::localized_help_template(uucore::util_name()))
+    Command::new("true")
+        .version(crate_version!())
+        .help_template(uucore::localized_help_template("true"))
         .about(translate!("true-about"))
         // We provide our own help and version options, to ensure maximum compatibility with GNU.
         .disable_help_flag(true)


### PR DESCRIPTION
about 1 kb saved at each bins.
Also protects name against binary name.