### PR TITLE
coreutils: --help args is same with --help

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -125,26 +125,8 @@ fn main() {
                 process::exit(uumain(vec![util_os].into_iter().chain(args)));
             }
             None => {
+                // GNU coreutils --help string shows help for coreutils
                 if util == "--help" || util == "-h" {
-                    // see if they want help on a specific util
-                    if let Some(util_os) = args.next() {
-                        let Some(util) = util_os.to_str() else {
-                            validation::not_found(&util_os)
-                        };
-
-                        match utils.get(util) {
-                            Some(&(uumain, _)) => {
-                                let code = uumain(
-                                    vec![util_os, OsString::from("--help")]
-                                        .into_iter()
-                                        .chain(args),
-                                );
-                                io::stdout().flush().expect("could not flush stdout");
-                                process::exit(code);
-                            }
-                            None => validation::not_found(&util_os),
-                        }
-                    }
                     usage(&utils, binary_as_util);
                     process::exit(0);
                 } else if util.starts_with('-') {

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -41,6 +41,18 @@ fn binary_name_protection() {
 }
 
 #[test]
+fn test_coreutils_help_ignore_args() {
+    let scenario = TestScenario::new("help_ignoring_args");
+    let output = std::process::Command::new(&scenario.bin_path)
+        .arg("--help")
+        .arg("---")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
 #[cfg(feature = "ls")]
 fn execution_phrase_double() {
     use std::process::Command;


### PR DESCRIPTION
GNU coreutils just ignores strings after `--help/--version`.
Closes #11365