### PR TITLE
ls,dir,vdir: protect names against argv[0]

### DIFF
--- a/src/uu/dir/src/dir.rs
+++ b/src/uu/dir/src/dir.rs
@@ -62,6 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 // an uu_app function, so we return the `ls` app.
 pub fn uu_app() -> Command {
     uu_ls::uu_app()
+        .name("dir")
         .override_usage(format_usage(&translate!("dir-usage")))
         .about(translate!("dir-about"))
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1265,7 +1265,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 pub fn uu_app() -> Command {
     uucore::clap_localization::configure_localized_command(
-        Command::new(uucore::util_name())
+        Command::new("ls")
             .version(uucore::crate_version!())
             .override_usage(format_usage(&translate!("ls-usage")))
             .about(translate!("ls-about")),

--- a/src/uu/vdir/src/vdir.rs
+++ b/src/uu/vdir/src/vdir.rs
@@ -62,6 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 // an uu_app function, so we need this dummy one.
 pub fn uu_app() -> Command {
     uu_ls::uu_app()
+        .name("vdir")
         .override_usage(format_usage(&translate!("vdir-usage")))
         .about(translate!("vdir-about"))
 }

--- a/tests/by-util/test_dir.rs
+++ b/tests/by-util/test_dir.rs
@@ -74,3 +74,12 @@ fn test_help_shows_dir_not_ls() {
         "Help should not show 'ls [OPTION]'"
     );
 }
+
+#[test]
+fn test_version() {
+    new_ucmd!()
+        .arg("--version")
+        .succeeds()
+        .no_stderr()
+        .stdout_is(format!("dir {}\n", uucore::crate_version!()));
+}

--- a/tests/by-util/test_vdir.rs
+++ b/tests/by-util/test_vdir.rs
@@ -74,3 +74,12 @@ fn test_help_shows_vdir_not_ls() {
         "Help should not show 'ls [OPTION]'"
     );
 }
+
+#[test]
+fn test_version() {
+    new_ucmd!()
+        .arg("--version")
+        .succeeds()
+        .no_stderr()
+        .stdout_is(format!("vdir {}\n", uucore::crate_version!()));
+}


### PR DESCRIPTION
Related: https://github.com/uutils/coreutils/issues/11343