### PR TITLE
cut: honor only-delimited in newline-delimiter mode

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -260,9 +260,9 @@ fn cut_fields_newline_char_delim<R: Read, W: Write>(
     reader: R,
     out: &mut W,
     ranges: &[Range],
-    only_delimited: bool,
     newline_char: u8,
     out_delim: &[u8],
+    only_delimited: bool,
 ) -> UResult<()> {
     let mut reader = BufReader::new(reader);
     let mut line = Vec::new();
@@ -398,9 +398,9 @@ fn cut_fields<R: Read, W: Write>(
                 reader,
                 out,
                 ranges,
-                field_opts.only_delimited,
                 newline_char,
                 out_delim,
+                field_opts.only_delimited,
             )
         }
         Delimiter::Slice(delim) => {

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -230,6 +230,21 @@ fn test_zero_terminated_only_delimited() {
 }
 
 #[test]
+fn test_suppresses_unterminated_segment() {
+    new_ucmd!()
+        .args(&["-z", "-d", "", "-s", "-f", "1"])
+        .pipe_in("unterminated")
+        .succeeds()
+        .stdout_only_bytes("");
+
+    new_ucmd!()
+        .args(&["-z", "-d", "", "-s", "-f", "1"])
+        .pipe_in("terminated\0unterminated")
+        .succeeds()
+        .stdout_only_bytes("terminated\0");
+}
+
+#[test]
 fn test_is_a_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
uutils cut routes `-z -d ''` through a special newline-delimiter code path that ignores the `-s` only-delimited flag. GNU still suppresses undelimited records in this mode, but uutils emits the whole record plus NUL.

## Reproduction Steps

```bash
printf 'abc' | cut -z -d '' -s -f 1 | od -An -tx1
# Expected (GNU): no output bytes
# Actual (uutils): 61 62 63 00
```

## Impact

Pipelines that rely on `cut -s` to drop undelimited records process data that should be filtered out.