### PR TITLE
tr: reject unknown character classes during sequence parsing

### DIFF
--- a/src/uu/tr/locales/en-US.ftl
+++ b/src/uu/tr/locales/en-US.ftl
@@ -27,6 +27,7 @@ tr-warning-invalid-utf8 = invalid utf8 sequence
 
 # Sequence parsing error messages
 tr-error-missing-char-class-name = missing character class name '[::]'
+tr-error-invalid-char-class = invalid character class { $class }
 tr-error-missing-equivalence-class-char = missing equivalence class character '[==]'
 tr-error-multiple-char-repeat-in-set2 = only one [c*] repeat construct may appear in string2
 tr-error-char-repeat-in-set1 = the [c*] repeat construct may not appear in string1

--- a/src/uu/tr/locales/fr-FR.ftl
+++ b/src/uu/tr/locales/fr-FR.ftl
@@ -28,6 +28,7 @@ tr-warning-invalid-utf8 = séquence UTF-8 non valide
 
 # Messages d'erreur d'analyse de séquence
 tr-error-missing-char-class-name = nom de classe de caractères manquant '[::]'
+tr-error-invalid-char-class = classe de caractères non valide { $class }
 tr-error-missing-equivalence-class-char = caractère de classe d'équivalence manquant '[==]'
 tr-error-multiple-char-repeat-in-set2 = seule une construction de répétition [c*] peut apparaître dans string2
 tr-error-char-repeat-in-set1 = la construction de répétition [c*] ne peut pas apparaître dans string1

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -34,6 +34,7 @@ pub trait ChunkProcessor {
 #[derive(Debug, Clone)]
 pub enum BadSequence {
     MissingCharClassName,
+    InvalidCharClass(String),
     MissingEquivalentClassChar,
     MultipleCharRepeatInSet2,
     CharRepeatInSet1,
@@ -52,6 +53,13 @@ impl Display for BadSequence {
         match self {
             Self::MissingCharClassName => {
                 write!(f, "{}", translate!("tr-error-missing-char-class-name"))
+            }
+            Self::InvalidCharClass(class) => {
+                write!(
+                    f,
+                    "{}",
+                    translate!("tr-error-invalid-char-class", "class" => format!("'{}'", class))
+                )
             }
             Self::MissingEquivalentClassChar => {
                 write!(
@@ -499,31 +507,32 @@ impl Sequence {
     }
 
     fn parse_class(input: &[u8]) -> IResult<&[u8], Result<Self, BadSequence>> {
-        delimited(
-            tag("[:"),
-            alt((
-                map(
-                    alt((
-                        value(Self::Class(Class::Alnum), tag("alnum")),
-                        value(Self::Class(Class::Alpha), tag("alpha")),
-                        value(Self::Class(Class::Blank), tag("blank")),
-                        value(Self::Class(Class::Control), tag("cntrl")),
-                        value(Self::Class(Class::Digit), tag("digit")),
-                        value(Self::Class(Class::Graph), tag("graph")),
-                        value(Self::Class(Class::Lower), tag("lower")),
-                        value(Self::Class(Class::Print), tag("print")),
-                        value(Self::Class(Class::Punct), tag("punct")),
-                        value(Self::Class(Class::Space), tag("space")),
-                        value(Self::Class(Class::Upper), tag("upper")),
-                        value(Self::Class(Class::Xdigit), tag("xdigit")),
-                    )),
-                    Ok,
-                ),
-                value(Err(BadSequence::MissingCharClassName), tag("")),
-            )),
-            tag(":]"),
-        )
-        .parse(input)
+        preceded(tag("[:"), terminated(take_until(":]"), tag(":]")))
+            .parse(input)
+            .map(|(l, class_name)| {
+                (
+                    l,
+                    match class_name {
+                        b"" => Err(BadSequence::MissingCharClassName),
+                        b"alnum" => Ok(Self::Class(Class::Alnum)),
+                        b"alpha" => Ok(Self::Class(Class::Alpha)),
+                        b"blank" => Ok(Self::Class(Class::Blank)),
+                        b"cntrl" => Ok(Self::Class(Class::Control)),
+                        b"digit" => Ok(Self::Class(Class::Digit)),
+                        b"graph" => Ok(Self::Class(Class::Graph)),
+                        b"lower" => Ok(Self::Class(Class::Lower)),
+                        b"print" => Ok(Self::Class(Class::Print)),
+                        b"punct" => Ok(Self::Class(Class::Punct)),
+                        b"space" => Ok(Self::Class(Class::Space)),
+                        b"upper" => Ok(Self::Class(Class::Upper)),
+                        b"xdigit" => Ok(Self::Class(Class::Xdigit)),
+                        _ => Err(BadSequence::InvalidCharClass(format!(
+                            "[:{}:]",
+                            String::from_utf8_lossy(class_name)
+                        ))),
+                    },
+                )
+            })
     }
 
     fn parse_char_equal(input: &[u8]) -> IResult<&[u8], Result<Self, BadSequence>> {

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore aabbaa aabbcc aabc abbb abbbcddd abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase Gzabcdefg PQRST upcase wxyzz xdigit XXXYYY xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn asdfqqwweerr qwerr asdfqwer qwer aassddffqwer asdfqwer
+// spell-checker:ignore aabbaa aabbcc aabc abbb abbbcddd abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase fooclass Gzabcdefg PQRST upcase wxyzz xdigit XXXYYY xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn asdfqqwweerr qwerr asdfqwer qwer aassddffqwer asdfqwer
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 
@@ -1183,6 +1183,15 @@ fn check_against_gnu_tr_tests_empty_cc() {
         .pipe_in("")
         .fails()
         .stderr_is("tr: missing character class name '[::]'\n");
+}
+
+#[test]
+fn check_against_gnu_tr_tests_invalid_cc() {
+    new_ucmd!()
+        .args(&["[:fooclass:]", "x"])
+        .pipe_in("")
+        .fails()
+        .stderr_is("tr: invalid character class '[:fooclass:]'\n");
 }
 
 #[test]


### PR DESCRIPTION
uutils `tr` accepts malformed character classes like `[:fooclass:]` as literal bytes, so invalid input continues processing instead of failing. GNU `tr` treats unknown class names as a parse error and exits non-zero.

## Reproduction Steps
```bash
printf 'abc\n' | tr '[:fooclass:]' 'x'
# Expected (GNU): stderr contains "tr: invalid character class 'fooclass'" and exits 1
# Actual (uutils): outputs "xbx" with exit code 0
```

## Impact
This is a fail-open validation bug that breaks GNU-compatible error handling.

-------------------------