### PR TITLE
cut: reject literal '' delimiter special-casing

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -511,8 +511,7 @@ fn get_delimiters(matches: &ArgMatches) -> UResult<(Delimiter<'_>, Option<&[u8]>
             ));
         }
         Some(os_string) => {
-            if os_string == "''" || os_string.is_empty() {
-                // treat `''` as empty delimiter
+            if os_string.is_empty() {
                 Delimiter::Slice(b"\0")
             } else {
                 // For delimiter `-d` option value - allow both UTF-8 (possibly multi-byte) characters
@@ -540,7 +539,7 @@ fn get_delimiters(matches: &ArgMatches) -> UResult<(Delimiter<'_>, Option<&[u8]>
     let out_delim = matches
         .get_one::<OsString>(options::OUTPUT_DELIMITER)
         .map(|os_string| {
-            if os_string.is_empty() || os_string == "''" {
+            if os_string.is_empty() {
                 b"\0"
             } else {
                 os_str_as_bytes(os_string).unwrap()

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -263,22 +263,41 @@ fn test_equal_as_delimiter() {
 
 #[test]
 fn test_empty_string_as_delimiter() {
-    for arg in ["-d''", "--delimiter=", "--delimiter=''"] {
+    new_ucmd!()
+        .args(&["-f2", "--delimiter="])
+        .pipe_in("a\0b\n")
+        .succeeds()
+        .stdout_only("b\n");
+}
+
+#[test]
+fn test_single_quote_pair_as_delimiter_is_invalid() {
+    for args in [&["-d", "''", "-f2"][..], &["--delimiter=''", "-f2"][..]] {
         new_ucmd!()
-            .args(&["-f2", arg])
-            .pipe_in("a\0b\n")
-            .succeeds()
-            .stdout_only("b\n");
+            .args(args)
+            .pipe_in("a''b\n")
+            .fails()
+            .stderr_contains("cut: the delimiter must be a single character")
+            .no_stdout();
     }
 }
 
 #[test]
 fn test_empty_string_as_delimiter_with_output_delimiter() {
     new_ucmd!()
-        .args(&["-f", "1,2", "-d", "''", "--output-delimiter=Z"])
+        .args(&["-f", "1,2", "--delimiter=", "--output-delimiter=Z"])
         .pipe_in("ab\0cd\n")
         .succeeds()
         .stdout_only_bytes("abZcd\n");
+}
+
+#[test]
+fn test_single_quote_pair_as_output_delimiter_is_literal() {
+    new_ucmd!()
+        .args(&["-f", "1,2", "-d:", "--output-delimiter=''"])
+        .pipe_in("ab:cd\n")
+        .succeeds()
+        .stdout_only_bytes("ab''cd\n");
 }
 
 #[test]


### PR DESCRIPTION
uutils cut treats the literal two-byte string `''` as an empty delimiter and maps it to NUL for both `-d` and `--output-delimiter`. GNU only maps truly empty values to NUL, rejects `-d "''"` as multi-character, and preserves `--output-delimiter="''"` literally.

## Reproduction Steps

```bash
printf 'a\x27\x27b\n' | cut -d "''" -f1
# Expected (GNU): exits 1 with "the delimiter must be a single character"
# Actual (uutils): exits 0 and prints a''b
```

## Impact

GNU incompatibility and silent data corruption in pipelines.