### PR TITLE
tr: fix complemented class truncation ordering

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -319,8 +319,7 @@ impl Sequence {
                     // GNU applies -t before complementing a character class.
                     // That means we must first truncate the expanded, non-complemented
                     // source set, then complement the truncated prefix to recover the
-                    // final translation domain. Complementing first would incorrectly
-                    // shrink the complemented domain to the prefix length.
+                    // final translation domain.
                     let truncated_set1: Vec<_> = set1
                         .iter()
                         .flat_map(Self::flatten)
@@ -329,6 +328,11 @@ impl Sequence {
                     set1_solved = (0..=u8::MAX)
                         .filter(|x| !truncated_set1.contains(x))
                         .collect();
+                    // After expansion the complemented domain may be larger than set2.
+                    // Re-check the complement validity constraint.
+                    if set2_uniques.len() > 1 || set1_solved.len() > set2_solved.len() {
+                        return Err(BadSequence::ComplementMoreThanOneUniqueInSet2);
+                    }
                 } else {
                     set1_solved.truncate(set2_solved.len());
                 }

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -346,9 +346,10 @@ fn test_truncate_applies_before_complement_with_class() {
     new_ucmd!()
         .args(&["-ct", "[:digit:]", "X"])
         .pipe_in("A")
-        .succeeds()
-        .stdout_is("X");
+        .fails()
+        .stderr_contains("when translating with complemented character classes,\nstring2 must map all characters in the domain to one");
 }
+
 #[test]
 fn missing_args_fails() {
     let (_, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
uutils `tr` applies the complemented-character-class guard before `--truncate-set1`, then truncates the translated set afterward. That allows `-ct` to translate only a subset of complemented bytes, while GNU rejects this shape instead of allowing partial mapping.

## Reproduction Steps

```bash
printf A | tr -ct '[:digit:]' X
# Expected (GNU): exit 1 with "when translating with complemented character classes, string2 must map all characters in the domain to one"
# Actual (uutils): exit 0 & outputs "A"
```

## Impact

This breaks GNU compatibility and weakens sanitization pipelines that rely on `tr -ct` to enforce translation coverage. Inputs that should be rejected can be accepted with under-filtered output.