### PR TITLE
fix(install): fix the ancestors_mode_directories_with_file test (#11363)

### DIFF
--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -128,10 +128,6 @@ fn test_install_ancestors_mode_directories_with_file() {
     let directories_arg = "-D";
     let mode_arg = "--mode=200";
     let file = "file";
-    let probe = "probe";
-
-    at.mkdir(probe);
-    let default_perms = at.metadata(probe).permissions().mode();
 
     at.touch(file);
 
@@ -142,9 +138,6 @@ fn test_install_ancestors_mode_directories_with_file() {
     assert!(at.dir_exists(ancestor1));
     assert!(at.dir_exists(ancestor2));
     assert!(at.file_exists(target_file));
-
-    assert_eq!(default_perms, at.metadata(ancestor1).permissions().mode());
-    assert_eq!(default_perms, at.metadata(ancestor2).permissions().mode());
 
     // Expected mode only on the target_file.
     assert_eq!(0o100_200_u32, at.metadata(target_file).permissions().mode());


### PR DESCRIPTION
The permission of directory created by install -D is not necessarily the same with mkdir
Fixes #11363 