### PR TITLE
yes: align buf, improve |pv>/dev/null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +987,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -4419,6 +4448,7 @@ dependencies = [
 name = "uu_yes"
 version = "0.7.0"
 dependencies = [
+ "aligned-vec",
  "clap",
  "fluent",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,6 +372,7 @@ version = "0.7.0"
 
 [workspace.dependencies]
 ansi-width = "0.1.0"
+aligned-vec = "0.6.4"
 bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"
 bstr = "1.9.1"

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 path = "src/yes.rs"
 
 [dependencies]
+aligned-vec = { workspace = true }
 clap = { workspace = true }
 itertools = { workspace = true }
 fluent = { workspace = true }

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 // cSpell:ignore strs
-
+use aligned_vec::{AVec, Alignment, ConstAlign};
 use clap::{Arg, ArgAction, Command, builder::ValueParser};
 use std::error::Error;
 use std::ffi::OsString;
@@ -14,14 +14,15 @@ use uucore::format_usage;
 use uucore::translate;
 
 // it's possible that using a smaller or larger buffer might provide better performance on some
-// systems, but honestly this is good enough
+// systems, but honestly this is good enough (without zero-copy)
+// but let it multiple of page size at least for
 const BUF_SIZE: usize = 16 * 1024;
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
-    let mut buffer = Vec::with_capacity(BUF_SIZE);
+    let mut buffer: AVec<u8, ConstAlign<BUF_SIZE>> = AVec::with_capacity(BUF_SIZE, BUF_SIZE);
     #[allow(clippy::unwrap_used, reason = "clap provides 'y' by default")]
     let _ = args_into_buffer(&mut buffer, matches.get_many::<OsString>("STRING").unwrap());
     prepare_buffer(&mut buffer);
@@ -55,8 +56,8 @@ pub fn uu_app() -> Command {
 
 /// Copies words from `i` into `buf`, separated by spaces.
 #[allow(clippy::unnecessary_wraps, reason = "needed on some platforms")]
-fn args_into_buffer<'a>(
-    buf: &mut Vec<u8>,
+fn args_into_buffer<'a, A: Alignment>(
+    buf: &mut AVec<u8, A>,
     i: impl Iterator<Item = &'a OsString>,
 ) -> Result<(), Box<dyn Error>> {
     // On Unix (and wasi), OsStrs are just &[u8]'s underneath...
@@ -91,7 +92,7 @@ fn args_into_buffer<'a>(
 
 /// Assumes buf holds a single output line forged from the command line arguments, copies it
 /// repeatedly until the buffer holds as many copies as it can under [`BUF_SIZE`].
-fn prepare_buffer(buf: &mut Vec<u8>) {
+fn prepare_buffer<A: Alignment>(buf: &mut AVec<u8, A>) {
     if buf.len() * 2 > BUF_SIZE {
         return;
     }
@@ -102,9 +103,14 @@ fn prepare_buffer(buf: &mut Vec<u8>) {
     let target_size = line_len * (BUF_SIZE / line_len);
 
     while buf.len() < target_size {
-        let to_copy = std::cmp::min(target_size - buf.len(), buf.len());
+        let current_len = buf.len();
+        let to_copy = std::cmp::min(target_size - current_len, current_len);
         debug_assert_eq!(to_copy % line_len, 0);
-        buf.extend_from_within(..to_copy);
+        #[allow(
+            clippy::unnecessary_to_owned,
+            reason = "needs useless copy without unsafe"
+        )]
+        buf.extend_from_slice(&buf[..to_copy].to_vec());
     }
 }
 
@@ -142,7 +148,8 @@ mod tests {
         ];
 
         for (line, final_len) in tests {
-            let mut v = std::iter::repeat_n(b'a', line).collect::<Vec<_>>();
+            let mut v: AVec<u8, ConstAlign<BUF_SIZE>> =
+                AVec::from_iter(BUF_SIZE, std::iter::repeat_n(b'a', line));
             prepare_buffer(&mut v);
             assert_eq!(v.len(), final_len);
         }
@@ -151,24 +158,27 @@ mod tests {
     #[test]
     fn test_args_into_buf() {
         {
-            let mut v = Vec::with_capacity(BUF_SIZE);
+            let mut v: AVec<u8, ConstAlign<BUF_SIZE>> = AVec::with_capacity(BUF_SIZE, BUF_SIZE);
             let default_args = ["y".into()];
             args_into_buffer(&mut v, default_args.iter()).unwrap();
-            assert_eq!(String::from_utf8(v).unwrap(), "y\n");
+            assert_eq!(String::from_utf8(v.to_vec()).unwrap(), "y\n");
         }
 
         {
-            let mut v = Vec::with_capacity(BUF_SIZE);
+            let mut v: AVec<u8, ConstAlign<BUF_SIZE>> = AVec::with_capacity(BUF_SIZE, BUF_SIZE);
             let args = ["foo".into()];
             args_into_buffer(&mut v, args.iter()).unwrap();
-            assert_eq!(String::from_utf8(v).unwrap(), "foo\n");
+            assert_eq!(String::from_utf8(v.to_vec()).unwrap(), "foo\n");
         }
 
         {
-            let mut v = Vec::with_capacity(BUF_SIZE);
+            let mut v: AVec<u8, ConstAlign<BUF_SIZE>> = AVec::with_capacity(BUF_SIZE, BUF_SIZE);
             let args = ["foo".into(), "bar    baz".into(), "qux".into()];
             args_into_buffer(&mut v, args.iter()).unwrap();
-            assert_eq!(String::from_utf8(v).unwrap(), "foo bar    baz qux\n");
+            assert_eq!(
+                String::from_utf8(v.to_vec()).unwrap(),
+                "foo bar    baz qux\n"
+            );
         }
     }
 }


### PR DESCRIPTION
Closes #11415 . Split https://github.com/uutils/coreutils/pull/11294
```
$ timeout 20 taskset -c 2 target/release/yes-align | pv>/dev/null
92.2GiB
$ timeout 20 taskset -c 2 target/release/yes-main | pv>/dev/null
89.6GiB