### PR TITLE
ls: Reduce xattr calls

### DIFF
--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -530,7 +530,7 @@ pub(crate) fn color_name(
         let has_capabilities = style_manager
             .colors
             .has_explicit_style_for(Indicator::Capabilities)
-            && uucore::fsxattr::has_security_cap_acl(path.p_buf.as_path());
+            && path.has_security_cap();
 
         // If the file has capabilities, use a specific style for `ca` (capabilities)
         if has_capabilities {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2057,7 +2057,7 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_acl(&self) -> bool {
-        if self.file_type().is_some_and(|ft| ft.is_symlink()) {
+        if self.file_type().is_some_and(FileType::is_symlink) {
             return false;
         }
 
@@ -2075,7 +2075,7 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_security_cap(&self) -> bool {
-        if self.file_type().is_some_and(|ft| ft.is_symlink()) {
+        if self.file_type().is_some_and(FileType::is_symlink) {
             return false;
         }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2068,7 +2068,7 @@ impl PathData {
         opt_xattrs.as_ref().is_some_and(|inner| {
             inner
                 .iter()
-                .filter_map(|key| key.to_str().map(|inner| inner.to_lowercase()))
+                .filter_map(|key| key.to_str().map(str::to_lowercase))
                 .any(|xattr| xattr.contains("acl"))
         })
     }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2068,7 +2068,7 @@ impl PathData {
         opt_xattrs.as_ref().is_some_and(|inner| {
             inner
                 .iter()
-                .map(|key| key.to_string_lossy())
+                .filter_map(|key| key.to_str().map(|inner| inner.to_lowercase()))
                 .any(|xattr| xattr.contains("acl"))
         })
     }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2062,7 +2062,7 @@ impl PathData {
             .get_or_init(|| retrieve_xattr_list(self.path()).ok());
 
         opt_xattrs.as_ref().is_some_and(|inner| {
-            self.file_type().is_some_and(FileType::is_symlink)
+            !self.file_type().is_some_and(FileType::is_symlink)
                 && inner
                     .iter()
                     .filter_map(|key| key.to_str().map(str::to_lowercase))
@@ -2079,7 +2079,7 @@ impl PathData {
             .get_or_init(|| retrieve_xattr_list(self.path()).ok());
 
         opt_xattrs.as_ref().is_some_and(|inner| {
-            self.file_type().is_some_and(FileType::is_symlink) && inner.get(cap_key).is_some()
+            !self.file_type().is_some_and(FileType::is_symlink) && inner.get(cap_key).is_some()
         })
     }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2057,15 +2057,15 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_acl(&self) -> bool {
-        if self.file_type().is_some_and(FileType::is_symlink) {
-            return false;
-        }
-
-        let opt_xattrs = self
-            .xattrs
-            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
-
         opt_xattrs.as_ref().is_some_and(|inner| {
+            if self.file_type().is_some_and(FileType::is_symlink) {
+                return false;
+            }
+
+            let opt_xattrs = self
+                .xattrs
+                .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+
             inner
                 .iter()
                 .filter_map(|key| key.to_str().map(str::to_lowercase))
@@ -2075,19 +2075,19 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_security_cap(&self) -> bool {
-        if self.file_type().is_some_and(FileType::is_symlink) {
-            return false;
-        }
+        xattrs.as_ref().is_some_and(|inner| {
+            if self.file_type().is_some_and(FileType::is_symlink) {
+                return false;
+            }
 
-        let cap_key = OsStr::new("security.capability");
+            let cap_key = OsStr::new("security.capability");
 
-        let xattrs = self
-            .xattrs
-            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+            let xattrs = self
+                .xattrs
+                .get_or_init(|| retrieve_xattr_list(self.path()).ok());
 
-        xattrs
-            .as_ref()
-            .is_some_and(|inner| inner.get(cap_key).is_some())
+            inner.get(cap_key).is_some()
+        })
     }
 
     fn file_type(&self) -> Option<&FileType> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1931,7 +1931,7 @@ struct PathData {
     // https://www.gnu.org/software/libc/manual/html_node/Directory-Entries.html
     de: RefCell<Option<Box<DirEntry>>>,
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-    xattrs: OnceCell<FxHashSet<OsString>>,
+    xattrs: OnceCell<Option<FxHashSet<OsString>>>,
     security_context: OnceCell<Box<str>>,
     // Name of the file - will be empty for . or ..
     display_name: OsString,
@@ -2061,12 +2061,16 @@ impl PathData {
             return false;
         }
 
-        let opt_xattrs = self.xattrs.get_or_init(|| retrieve_xattr_list(self.path()));
-        // don't use exacl here, it is doing more getxattr call then needed
-        opt_xattrs
-            .iter()
-            .map(|key| key.to_string_lossy())
-            .any(|xattr| xattr.contains("acl"))
+        let opt_xattrs = self
+            .xattrs
+            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+
+        opt_xattrs.is_some_and(|inner| {
+            inner
+                .iter()
+                .map(|key| key.to_string_lossy())
+                .any(|xattr| xattr.contains("acl"))
+        })
     }
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
@@ -2077,9 +2081,11 @@ impl PathData {
 
         let cap_key = OsStr::new("security.capability");
 
-        let xattrs = self.xattrs.get_or_init(|| retrieve_xattr_list(self.path()));
-        // don't use exacl here, it is doing more getxattr call then needed
-        xattrs.get(cap_key).is_some()
+        let xattrs = self
+            .xattrs
+            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+
+        xattrs.is_some_and(|inner| inner.get(cap_key).is_some())
     }
 
     fn file_type(&self) -> Option<&FileType> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2057,37 +2057,30 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_acl(&self) -> bool {
-        if self.file_type().is_some_and(FileType::is_symlink) {
-            return false;
-        }
+        let opt_xattrs = self
+            .xattrs
+            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+
+        opt_xattrs.as_ref().is_some_and(|inner| {
+            self.file_type().is_some_and(FileType::is_symlink)
+                && inner
+                    .iter()
+                    .filter_map(|key| key.to_str().map(str::to_lowercase))
+                    .any(|xattr| xattr.contains("acl"))
+        })
+    }
+
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+    pub fn has_security_cap(&self) -> bool {
+        let cap_key = OsStr::new("security.capability");
 
         let opt_xattrs = self
             .xattrs
             .get_or_init(|| retrieve_xattr_list(self.path()).ok());
 
         opt_xattrs.as_ref().is_some_and(|inner| {
-            inner
-                .iter()
-                .filter_map(|key| key.to_str().map(str::to_lowercase))
-                .any(|xattr| xattr.contains("acl"))
+            self.file_type().is_some_and(FileType::is_symlink) && inner.get(cap_key).is_some()
         })
-    }
-
-    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-    pub fn has_security_cap(&self) -> bool {
-        if self.file_type().is_some_and(FileType::is_symlink) {
-            return false;
-        }
-
-        let cap_key = OsStr::new("security.capability");
-
-        let xattrs = self
-            .xattrs
-            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
-
-        xattrs
-            .as_ref()
-            .is_some_and(|inner| inner.get(cap_key).is_some())
     }
 
     fn file_type(&self) -> Option<&FileType> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1984,7 +1984,7 @@ impl PathData {
         let ft: OnceCell<Option<FileType>> = OnceCell::new();
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
         #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-        let xattrs: OnceCell<FxHashSet<OsString>> = OnceCell::new();
+        let xattrs: OnceCell<Option<FxHashSet<OsString>>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
 
         let de: RefCell<Option<Box<DirEntry>>> = if let Some(de) = dir_entry {
@@ -2065,7 +2065,7 @@ impl PathData {
             .xattrs
             .get_or_init(|| retrieve_xattr_list(self.path()).ok());
 
-        opt_xattrs.is_some_and(|inner| {
+        opt_xattrs.as_ref().is_some_and(|inner| {
             inner
                 .iter()
                 .map(|key| key.to_string_lossy())
@@ -2085,7 +2085,9 @@ impl PathData {
             .xattrs
             .get_or_init(|| retrieve_xattr_list(self.path()).ok());
 
-        xattrs.is_some_and(|inner| inner.get(cap_key).is_some())
+        xattrs
+            .as_ref()
+            .is_some_and(|inner| inner.get(cap_key).is_some())
     }
 
     fn file_type(&self) -> Option<&FileType> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2082,8 +2082,7 @@ impl PathData {
                 self.has_security_cap.get_or_init(|| {
                     let cap_key = OsStr::new("security.capability");
 
-                    !self.file_type().is_some_and(FileType::is_symlink)
-                        && inner.get(cap_key).is_some()
+                    !self.file_type().is_some_and(FileType::is_symlink) && inner.contains(cap_key)
                 });
 
                 self.has_acl.get_or_init(|| {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -9,12 +9,11 @@
 #[cfg(unix)]
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
-use std::borrow::Cow;
-use std::cell::RefCell;
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
+use std::{borrow::Cow, cell::RefCell};
 use std::{
     cell::{LazyCell, OnceCell},
     cmp::Reverse,
@@ -42,7 +41,7 @@ use thiserror::Error;
 #[cfg(unix)]
 use uucore::entries;
 #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-use uucore::fsxattr::has_acl;
+use uucore::fsxattr::retrieve_xattr_list;
 #[cfg(unix)]
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 #[cfg(any(
@@ -63,14 +62,13 @@ use uucore::{
     error::{UError, UResult, set_exit_code},
     format::human::{SizeFormat, human_readable},
     format_usage,
-    fs::FileInformation,
-    fs::display_permissions,
+    fs::{FileInformation, display_permissions},
     fsext::{MetadataTimeField, metadata_get_time},
     line_ending::LineEnding,
     os_str_as_bytes_lossy,
-    parser::parse_glob,
-    parser::parse_size::parse_size_non_zero_u64,
-    parser::shortcut_value_parser::ShortcutValueParser,
+    parser::{
+        parse_glob, parse_size::parse_size_non_zero_u64, shortcut_value_parser::ShortcutValueParser,
+    },
     quoting_style::{QuotingStyle, locale_aware_escape_dir_name, locale_aware_escape_name},
     show, show_error, show_warning,
     time::{FormatSystemTimeFallback, format, format_system_time},
@@ -1932,6 +1930,8 @@ struct PathData {
     // can be used to avoid reading the filetype. Can be also called d_type:
     // https://www.gnu.org/software/libc/manual/html_node/Directory-Entries.html
     de: RefCell<Option<Box<DirEntry>>>,
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+    xattrs: OnceCell<FxHashSet<OsString>>,
     security_context: OnceCell<Box<str>>,
     // Name of the file - will be empty for . or ..
     display_name: OsString,
@@ -1983,6 +1983,8 @@ impl PathData {
         // nearly free compared to a metadata() call on a Path
         let ft: OnceCell<Option<FileType>> = OnceCell::new();
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
+        #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+        let xattrs: OnceCell<FxHashSet<OsString>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
 
         let de: RefCell<Option<Box<DirEntry>>> = if let Some(de) = dir_entry {
@@ -2006,6 +2008,8 @@ impl PathData {
             md,
             ft,
             de,
+            #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+            xattrs,
             security_context,
             display_name,
             p_buf,
@@ -2049,6 +2053,33 @@ impl PathData {
                 }
             })
             .as_ref()
+    }
+
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+    pub fn has_acl(&self) -> bool {
+        if self.file_type().is_some_and(|ft| ft.is_symlink()) {
+            return false;
+        }
+
+        let opt_xattrs = self.xattrs.get_or_init(|| retrieve_xattr_list(self.path()));
+        // don't use exacl here, it is doing more getxattr call then needed
+        opt_xattrs
+            .iter()
+            .map(|key| key.to_string_lossy())
+            .any(|xattr| xattr.contains("acl"))
+    }
+
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+    pub fn has_security_cap(&self) -> bool {
+        if self.file_type().is_some_and(|ft| ft.is_symlink()) {
+            return false;
+        }
+
+        let cap_key = OsStr::new("security.capability");
+
+        let xattrs = self.xattrs.get_or_init(|| retrieve_xattr_list(self.path()));
+        // don't use exacl here, it is doing more getxattr call then needed
+        xattrs.get(cap_key).is_some()
     }
 
     fn file_type(&self) -> Option<&FileType> {
@@ -3018,7 +3049,7 @@ fn display_item_long(
         // TODO: See how Mac should work here
         let is_acl_set = false;
         #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-        let is_acl_set = has_acl(item.path());
+        let is_acl_set = item.has_acl();
         output_display.extend(display_permissions(md, true).as_bytes());
         if item.security_context(config).len() > 1 {
             // GNU `ls` uses a "." character to indicate a file with a security context,
@@ -3737,7 +3768,7 @@ fn calculate_padding_collection(
                 // TODO: See how Mac should work here
                 let is_acl_set = false;
                 #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-                let is_acl_set = has_acl(item.display_name());
+                let is_acl_set = item.has_acl();
                 if context_len > 1 || is_acl_set {
                     padding_collections.link_count += 1;
                 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2057,6 +2057,10 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_acl(&self) -> bool {
+        if self.file_type().is_some_and(FileType::is_symlink) {
+            return false;
+        }
+
         let opt_xattrs = self
             .xattrs
             .get_or_init(|| retrieve_xattr_list(self.path()).ok());
@@ -2071,6 +2075,10 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_security_cap(&self) -> bool {
+        if self.file_type().is_some_and(FileType::is_symlink) {
+            return false;
+        }
+
         let cap_key = OsStr::new("security.capability");
 
         let xattrs = self

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -13,6 +13,8 @@ use rustc_hash::FxHashSet;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+use std::sync::Once;
 use std::{borrow::Cow, cell::RefCell};
 use std::{
     cell::{LazyCell, OnceCell},
@@ -1930,8 +1932,6 @@ struct PathData {
     // can be used to avoid reading the filetype. Can be also called d_type:
     // https://www.gnu.org/software/libc/manual/html_node/Directory-Entries.html
     de: RefCell<Option<Box<DirEntry>>>,
-    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-    xattrs: OnceCell<Option<FxHashSet<OsString>>>,
     security_context: OnceCell<Box<str>>,
     // Name of the file - will be empty for . or ..
     display_name: OsString,
@@ -1939,6 +1939,10 @@ struct PathData {
     p_buf: PathBuf,
     must_dereference: bool,
     command_line: bool,
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+    has_acl: OnceCell<bool>,
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+    has_security_cap: OnceCell<bool>,
 }
 
 impl PathData {
@@ -1983,8 +1987,6 @@ impl PathData {
         // nearly free compared to a metadata() call on a Path
         let ft: OnceCell<Option<FileType>> = OnceCell::new();
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
-        #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-        let xattrs: OnceCell<Option<FxHashSet<OsString>>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
 
         let de: RefCell<Option<Box<DirEntry>>> = if let Some(de) = dir_entry {
@@ -2008,13 +2010,15 @@ impl PathData {
             md,
             ft,
             de,
-            #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-            xattrs,
             security_context,
             display_name,
             p_buf,
             must_dereference,
             command_line,
+            #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+            has_acl: OnceCell::new(),
+            #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+            has_security_cap: OnceCell::new(),
         }
     }
 
@@ -2057,30 +2061,40 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_acl(&self) -> bool {
-        let opt_xattrs = self
-            .xattrs
-            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+        self.init_xattrs_once();
 
-        opt_xattrs.as_ref().is_some_and(|inner| {
-            !self.file_type().is_some_and(FileType::is_symlink)
-                && inner
-                    .iter()
-                    .filter_map(|key| key.to_str().map(str::to_lowercase))
-                    .any(|xattr| xattr.contains("acl"))
-        })
+        self.has_acl.get().is_some_and(|inner| *inner)
     }
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_security_cap(&self) -> bool {
-        let cap_key = OsStr::new("security.capability");
+        self.init_xattrs_once();
 
-        let opt_xattrs = self
-            .xattrs
-            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+        self.has_security_cap.get().is_some_and(|inner| *inner)
+    }
 
-        opt_xattrs.as_ref().is_some_and(|inner| {
-            !self.file_type().is_some_and(FileType::is_symlink) && inner.get(cap_key).is_some()
-        })
+    #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+    pub fn init_xattrs_once(&self) {
+        static START: Once = Once::new();
+
+        START.call_once(|| {
+            let _ = retrieve_xattr_list(self.path()).map(|inner| {
+                self.has_security_cap.get_or_init(|| {
+                    let cap_key = OsStr::new("security.capability");
+
+                    !self.file_type().is_some_and(FileType::is_symlink)
+                        && inner.get(cap_key).is_some()
+                });
+
+                self.has_acl.get_or_init(|| {
+                    !self.file_type().is_some_and(FileType::is_symlink)
+                        && inner
+                            .iter()
+                            .filter_map(|key| key.to_str().map(str::to_lowercase))
+                            .any(|xattr| xattr.contains("acl"))
+                });
+            });
+        });
     }
 
     fn file_type(&self) -> Option<&FileType> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2057,15 +2057,15 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_acl(&self) -> bool {
+        if self.file_type().is_some_and(FileType::is_symlink) {
+            return false;
+        }
+
+        let opt_xattrs = self
+            .xattrs
+            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+
         opt_xattrs.as_ref().is_some_and(|inner| {
-            if self.file_type().is_some_and(FileType::is_symlink) {
-                return false;
-            }
-
-            let opt_xattrs = self
-                .xattrs
-                .get_or_init(|| retrieve_xattr_list(self.path()).ok());
-
             inner
                 .iter()
                 .filter_map(|key| key.to_str().map(str::to_lowercase))
@@ -2075,19 +2075,19 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_security_cap(&self) -> bool {
-        xattrs.as_ref().is_some_and(|inner| {
-            if self.file_type().is_some_and(FileType::is_symlink) {
-                return false;
-            }
+        if self.file_type().is_some_and(FileType::is_symlink) {
+            return false;
+        }
 
-            let cap_key = OsStr::new("security.capability");
+        let cap_key = OsStr::new("security.capability");
 
-            let xattrs = self
-                .xattrs
-                .get_or_init(|| retrieve_xattr_list(self.path()).ok());
+        let xattrs = self
+            .xattrs
+            .get_or_init(|| retrieve_xattr_list(self.path()).ok());
 
-            inner.get(cap_key).is_some()
-        })
+        xattrs
+            .as_ref()
+            .is_some_and(|inner| inner.get(cap_key).is_some())
     }
 
     fn file_type(&self) -> Option<&FileType> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2057,10 +2057,6 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_acl(&self) -> bool {
-        if self.file_type().is_some_and(FileType::is_symlink) {
-            return false;
-        }
-
         let opt_xattrs = self
             .xattrs
             .get_or_init(|| retrieve_xattr_list(self.path()).ok());
@@ -2075,10 +2071,6 @@ impl PathData {
 
     #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
     pub fn has_security_cap(&self) -> bool {
-        if self.file_type().is_some_and(FileType::is_symlink) {
-            return false;
-        }
-
         let cap_key = OsStr::new("security.capability");
 
         let xattrs = self

--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -54,7 +54,7 @@ pub fn copy_xattrs_skip_selinux<P: AsRef<Path>>(source: P, dest: P) -> std::io::
 /// A result containing a HashMap of attributes names and values, or an error.
 pub fn retrieve_xattrs<P: AsRef<Path>>(source: P) -> std::io::Result<FxHashMap<OsString, Vec<u8>>> {
     let mut attrs = FxHashMap::default();
-    for attr_name in xattr::list(&source)? {
+    for attr_name in retrieve_xattr_list(&source)? {
         if let Some(value) = xattr::get(&source, &attr_name)? {
             attrs.insert(attr_name, value);
         }
@@ -71,11 +71,8 @@ pub fn retrieve_xattrs<P: AsRef<Path>>(source: P) -> std::io::Result<FxHashMap<O
 /// # Returns
 ///
 /// A result containing a HashSet of attributes names
-pub fn retrieve_xattr_list<P: AsRef<Path>>(source: P) -> FxHashSet<OsString> {
-    xattr::list(&source)
-        .unwrap_or_default()
-        .into_iter()
-        .collect()
+pub fn retrieve_xattr_list<P: AsRef<Path>>(source: P) -> std::io::Result<FxHashSet<OsString>> {
+    Ok(xattr::list(&source)?.collect())
 }
 
 /// Applies extended attributes (xattrs) to a given file or directory.

--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -6,11 +6,9 @@
 // spell-checker:ignore getxattr posix_acl_default
 
 //! Set of functions to manage xattr on files and dirs
-use itertools::Itertools;
 use rustc_hash::FxHashMap;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 #[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
 /// Copies extended attributes (xattrs) from one file or directory to another.

--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -137,38 +137,39 @@ pub fn get_acl_perm_bits_from_xattr<P: AsRef<Path>>(source: P) -> u32 {
 
     // Only default acl entries get inherited by objects under the path i.e. if child directories
     // will have their permissions modified.
-    if let Ok(entries) = retrieve_xattrs(source) {
-        let mut perm: u32 = 0;
-        if let Some(value) = entries.get(&OsString::from("system.posix_acl_default")) {
-            // value is xattr byte vector
-            // value follows a starts with a 4 byte header, and then has posix_acl_entries, each
-            // posix_acl_entry is separated by a u32 sequence i.e. 0xFFFFFFFF
-            //
-            // struct posix_acl_entries {
-            // e_tag: u16
-            //  e_perm: u16
-            //  e_id: u32
-            // }
-            //
-            // Reference: `https://github.com/torvalds/linux/blob/master/include/uapi/linux/posix_acl_xattr.h`
-            //
-            // The value of the header is 0x0002, so we skip the first four bytes of the value and
-            // process the rest
+    let mut perm: u32 = 0;
+    if let Some(value) = xattr::get(source, "system.posix_acl_default")
+        .ok()
+        .flatten()
+    {
+        // value is xattr byte vector
+        // value follows a starts with a 4 byte header, and then has posix_acl_entries, each
+        // posix_acl_entry is separated by a u32 sequence i.e. 0xFFFFFFFF
+        //
+        // struct posix_acl_entries {
+        // e_tag: u16
+        //  e_perm: u16
+        //  e_id: u32
+        // }
+        //
+        // Reference: `https://github.com/torvalds/linux/blob/master/include/uapi/linux/posix_acl_xattr.h`
+        //
+        // The value of the header is 0x0002, so we skip the first four bytes of the value and
+        // process the rest
 
-            let acl_entries = value
-                .split_at(3)
-                .1
-                .iter()
-                .filter(|&x| *x != 255)
-                .copied()
-                .collect::<Vec<u8>>();
+        let acl_entries = value
+            .split_at(3)
+            .1
+            .iter()
+            .filter(|&x| *x != 255)
+            .copied()
+            .collect::<Vec<u8>>();
 
-            for entry in acl_entries.chunks_exact(4) {
-                // Third byte and fourth byte will be the perm bits
-                perm = (perm << 3) | u32::from(entry[2]) | u32::from(entry[3]);
-            }
-            return perm;
+        for entry in acl_entries.chunks_exact(4) {
+            // Third byte and fourth byte will be the perm bits
+            perm = (perm << 3) | u32::from(entry[2]) | u32::from(entry[3]);
         }
+        return perm;
     }
     0
 }

--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -6,7 +6,7 @@
 // spell-checker:ignore getxattr posix_acl_default
 
 //! Set of functions to manage xattr on files and dirs
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::path::Path;
@@ -60,6 +60,22 @@ pub fn retrieve_xattrs<P: AsRef<Path>>(source: P) -> std::io::Result<FxHashMap<O
         }
     }
     Ok(attrs)
+}
+
+/// Retrieves the extended attributes keys only of a given file or directory.
+///
+/// # Arguments
+///
+/// * `source` - A reference to the path of the file or directory.
+///
+/// # Returns
+///
+/// A result containing a HashSet of attributes names
+pub fn retrieve_xattr_list<P: AsRef<Path>>(source: P) -> FxHashSet<OsString> {
+    xattr::list(&source)
+        .unwrap_or_default()
+        .into_iter()
+        .collect()
 }
 
 /// Applies extended attributes (xattrs) to a given file or directory.

--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -112,13 +112,10 @@ pub fn has_acl<P: AsRef<Path>>(file: P) -> bool {
 /// `true` if the file has an extended attribute named "security.capability", `false` otherwise.
 pub fn has_security_cap_acl<P: AsRef<Path>>(file: P) -> bool {
     // don't use exacl here, it is doing more getxattr call then needed
-    xattr::list_deref(file).is_ok_and(|mut acl| {
-        #[cfg(unix)]
-        return acl.contains(OsStr::from_bytes(b"security.capability"));
-
-        #[cfg(not(unix))]
-        return false;
-    })
+    xattr::get_deref(file, "security.capability")
+        .ok()
+        .flatten()
+        .is_some()
 }
 
 /// Returns the permissions bits of a file or directory which has Access Control List (ACL) entries based on its


### PR DESCRIPTION
`Master` calls listxattr more times than necessary:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 17.83    0.000783         783         1           execve
 15.87    0.000697          15        44           getdents64
 11.82    0.000519           6        84           listxattr
 10.00    0.000439           8        53         6 statx
  8.72    0.000383          12        31         1 openat
  6.67    0.000293          22        13           mmap
  5.05    0.000222           6        34           close
  4.94    0.000217          19        11           read
  4.19    0.000184           6        30           fstat
  1.73    0.000076          15         5           mprotect
  1.53    0.000067          33         2           munmap
  1.46    0.000064          16         4         4 connect
  1.30    0.000057           9         6           brk
  1.09    0.000048          12         4           socket
  1.07    0.000047          47         1           write
  0.89    0.000039           7         5           ioctl
  0.82    0.000036           9         4           newfstatat
  0.77    0.000034           3         9           rt_sigaction
  0.59    0.000026          26         1           set_robust_list
  0.48    0.000021          10         2           pread64
  0.46    0.000020           6         3           fcntl
  0.43    0.000019          19         1         1 access
  0.32    0.000014           7         2           prlimit64
  0.30    0.000013          13         1           poll
  0.30    0.000013           1         9         6 readlink
  0.27    0.000012           4         3           sigaltstack
  0.23    0.000010           3         3           lseek
  0.23    0.000010          10         1           getrandom
  0.20    0.000009           9         1           sched_getaffinity
  0.16    0.000007           7         1           arch_prctl
  0.16    0.000007           7         1           set_tid_address
  0.14    0.000006           6         1           rseq
  0.00    0.000000           0         1           gettid
------ ----------- ----------- --------- --------- ------------------
100.00    0.004392          11       372        18 total
```

This PR reduces those calls:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 19.28    0.000822         822         1           execve
 11.75    0.000501          11        42           llistxattr
  8.66    0.000369           8        44           getdents64
  8.02    0.000342           6        53         6 statx
  7.62    0.000325          10        31         1 openat
  7.55    0.000322          24        13           mmap
  5.98    0.000255          51         5           mprotect
  4.60    0.000196          17        11           read
  4.41    0.000188           5        34           close
  4.03    0.000172           5        30           fstat
  2.63    0.000112          12         9         6 readlink
  2.42    0.000103          25         4         4 connect
  2.18    0.000093          23         4           socket
  1.81    0.000077          12         6           brk
  1.55    0.000066          33         2           munmap
  1.31    0.000056           6         9           rt_sigaction
  0.89    0.000038          38         1           write
  0.84    0.000036           9         4           newfstatat
  0.61    0.000026          13         2           pread64
  0.47    0.000020           6         3           fcntl
  0.42    0.000018          18         1         1 access
  0.38    0.000016           5         3           sigaltstack
  0.35    0.000015           7         2           prlimit64
  0.30    0.000013          13         1           poll
  0.30    0.000013           4         3           lseek
  0.28    0.000012           2         5           ioctl
  0.23    0.000010          10         1           sched_getaffinity
  0.21    0.000009           9         1           arch_prctl
  0.21    0.000009           9         1           getrandom
  0.19    0.000008           8         1           set_tid_address
  0.19    0.000008           8         1           rseq
  0.16    0.000007           7         1           set_robust_list
  0.14    0.000006           6         1           gettid
------ ----------- ----------- --------- --------- ------------------
100.00    0.004263          12       330        18 total
```