### PR TITLE
ls: Remove potentially redundant syscall, only use direntries for file types

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1976,6 +1976,10 @@ impl PathData {
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
 
+        if !must_dereference {
+            opt_dir_entry.map(|de| ft.get_or_init(|| de.file_type().ok()));
+        }
+
         Self {
             md,
             ft,

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2497,7 +2497,7 @@ fn depth_first_list(
     };
 
     // Convert those entries to the PathData struct
-    for raw_entry in read_dir.into_iter() {
+    for raw_entry in read_dir {
         match raw_entry {
             Ok(dir_entry) => {
                 let path_data =

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3481,7 +3481,7 @@ fn display_item_name(
                                     style_manager,
                                     None,
                                     is_wrap(name.len()),
-                                ))
+                                ));
                             } else {
                                 name.push(escaped_target);
                             }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2245,7 +2245,7 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
         let needs_blank_line = pos != 0 || !files.is_empty();
         // Do read_dir call here to match GNU semantics by printing
         // read_dir errors before directory headings, names and totals
-        let read_dir = match fs::read_dir(path_data.path()) {
+        let mut read_dir = match fs::read_dir(path_data.path()) {
             Err(err) => {
                 // flush stdout buffer before the error to preserve formatting and order
                 state.out.flush()?;
@@ -2267,7 +2267,7 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
         // List each of the arguments to ls first.
         depth_first_list(
             (path_data.path().to_path_buf(), needs_blank_line),
-            read_dir,
+            &mut read_dir,
             config,
             &mut state,
             &mut dired,
@@ -2276,7 +2276,7 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
 
         // Only runs if it must list recursively.
         while let Some(dir_data) = state.stack.pop() {
-            let read_dir = match fs::read_dir(&dir_data.0) {
+            let mut read_dir = match fs::read_dir(&dir_data.0) {
                 Err(err) => {
                     // flush stdout buffer before the error to preserve formatting and order
                     state.out.flush()?;
@@ -2290,7 +2290,14 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
                 Ok(rd) => rd,
             };
 
-            depth_first_list(dir_data, read_dir, config, &mut state, &mut dired, false)?;
+            depth_first_list(
+                dir_data,
+                &mut read_dir,
+                config,
+                &mut state,
+                &mut dired,
+                false,
+            )?;
 
             // Heuristic to ensure stack does not keep its capacity forever if there is
             // combinatorial explosion; we decrease it logarithmically here.
@@ -2417,7 +2424,7 @@ fn should_display(path_data: &PathData, config: &Config) -> bool {
 
 fn depth_first_list(
     (dir_path, needs_blank_line): DirData,
-    read_dir: ReadDir,
+    read_dir: &mut ReadDir,
     config: &Config,
     state: &mut ListState,
     dired: &mut DiredOutput,
@@ -2483,7 +2490,7 @@ fn depth_first_list(
     };
 
     // Convert those entries to the PathData struct
-    for raw_entry in read_dir {
+    for raw_entry in read_dir.into_iter() {
         match raw_entry {
             Ok(dir_entry) => {
                 let path_data = PathData::new(dir_entry.path(), None, config, false);

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -2497,7 +2497,7 @@ fn depth_first_list(
     };
 
     // Convert those entries to the PathData struct
-    for raw_entry in read_dir {
+    for raw_entry in read_dir.into_iter() {
         match raw_entry {
             Ok(dir_entry) => {
                 let path_data =
@@ -3443,7 +3443,7 @@ fn display_item_name(
                     }
 
                     match fs::canonicalize(&absolute_target) {
-                        Ok(resolved_target) => {
+                        Ok(resolved_target) if config.color.is_some() => {
                             let target_data = PathData::new(
                                 resolved_target,
                                 None,
@@ -3452,19 +3452,15 @@ fn display_item_name(
                                 false,
                             );
 
-                            if config.color.is_some() {
-                                name.push(color_name(
-                                    escaped_target,
-                                    &target_data,
-                                    style_manager,
-                                    None,
-                                    is_wrap(name.len()),
-                                ));
-                            } else {
-                                name.push(escaped_target);
-                            }
+                            name.push(color_name(
+                                escaped_target,
+                                &target_data,
+                                style_manager,
+                                None,
+                                is_wrap(name.len()),
+                            ));
                         }
-                        Err(_) => {
+                        _ => {
                             name.push(
                                 style_manager.apply_missing_target_style(
                                     escaped_target,

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -3481,29 +3481,13 @@ fn display_item_name(
                                 false,
                             );
 
-                            // Check if the target actually needs coloring
-                            let md_option: Option<Metadata> = target_data
-                                .metadata()
-                                .cloned()
-                                .or_else(|| target_data.p_buf.symlink_metadata().ok());
-                            let style = style_manager.colors.style_for_path_with_metadata(
-                                &target_data.p_buf,
-                                md_option.as_ref(),
-                            );
-
-                            if style.is_some() {
-                                // Only apply coloring if there's actually a style
-                                name.push(color_name(
-                                    escaped_target,
-                                    &target_data,
-                                    style_manager,
-                                    None,
-                                    is_wrap(name.len()),
-                                ));
-                            } else {
-                                // For regular files with no coloring, just use plain text
-                                name.push(escaped_target);
-                            }
+                            name.push(color_name(
+                                escaped_target,
+                                &target_data,
+                                style_manager,
+                                None,
+                                is_wrap(name.len()),
+                            ))
                         }
                         Err(_) => {
                             name.push(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1948,8 +1948,10 @@ impl PathData {
         // For '..', the filename is None
         let display_name = if let Some(name) = file_name {
             name
-        } else {
+        } else if command_line {
             p_buf.as_os_str().to_os_string()
+        } else {
+            p_buf.file_name().unwrap_or_default().to_os_string()
         };
 
         let must_dereference = match &config.dereference {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1985,21 +1985,14 @@ impl PathData {
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
 
-        let de: RefCell<Option<Box<DirEntry>>> = if let Some(de) = dir_entry {
-            if must_dereference {
-                if let Ok(md_pb) = p_buf.metadata() {
-                    md.get_or_init(|| Some(md_pb.clone()));
-                    ft.get_or_init(|| Some(md_pb.file_type()));
-                }
-            }
-
-            if let Ok(ft_de) = de.file_type() {
-                ft.get_or_init(|| Some(ft_de));
-            }
-
-            RefCell::new(Some(de.into()))
-        } else {
+        let de: RefCell<Option<Box<DirEntry>>> = if must_dereference {
             RefCell::new(None)
+        } else {
+            if let Some(de) = dir_entry {
+                RefCell::new(Some(de.into()))
+            } else {
+                RefCell::new(None)
+            }
         };
 
         Self {
@@ -3481,13 +3474,17 @@ fn display_item_name(
                                 false,
                             );
 
-                            name.push(color_name(
-                                escaped_target,
-                                &target_data,
-                                style_manager,
-                                None,
-                                is_wrap(name.len()),
-                            ))
+                            if config.color.is_some() {
+                                name.push(color_name(
+                                    escaped_target,
+                                    &target_data,
+                                    style_manager,
+                                    None,
+                                    is_wrap(name.len()),
+                                ))
+                            } else {
+                                name.push(escaped_target);
+                            }
                         }
                         Err(_) => {
                             name.push(

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -10,7 +10,6 @@
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use std::borrow::Cow;
-use std::cell::RefCell;
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 #[cfg(windows)]
@@ -1929,9 +1928,6 @@ struct PathData {
     // Result<MetaData> got from symlink_metadata() or metadata() based on config
     md: OnceCell<Option<Metadata>>,
     ft: OnceCell<Option<FileType>>,
-    // can be used to avoid reading the filetype. Can be also called d_type:
-    // https://www.gnu.org/software/libc/manual/html_node/Directory-Entries.html
-    de: RefCell<Option<Box<DirEntry>>>,
     security_context: OnceCell<Box<str>>,
     // Name of the file - will be empty for . or ..
     display_name: OsString,
@@ -1944,7 +1940,6 @@ struct PathData {
 impl PathData {
     fn new(
         p_buf: PathBuf,
-        dir_entry: Option<DirEntry>,
         file_name: Option<OsString>,
         config: &Config,
         command_line: bool,
@@ -1953,13 +1948,8 @@ impl PathData {
         // For '..', the filename is None
         let display_name = if let Some(name) = file_name {
             name
-        } else if command_line {
-            p_buf.as_os_str().to_os_string()
         } else {
-            dir_entry
-                .as_ref()
-                .map(DirEntry::file_name)
-                .unwrap_or_default()
+            p_buf.as_os_str().to_os_string()
         };
 
         let must_dereference = match &config.dereference {
@@ -1985,20 +1975,9 @@ impl PathData {
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
 
-        let de: RefCell<Option<Box<DirEntry>>> = if must_dereference {
-            RefCell::new(None)
-        } else {
-            if let Some(de) = dir_entry {
-                RefCell::new(Some(de.into()))
-            } else {
-                RefCell::new(None)
-            }
-        };
-
         Self {
             md,
             ft,
-            de,
             security_context,
             display_name,
             p_buf,
@@ -2010,12 +1989,6 @@ impl PathData {
     fn metadata(&self) -> Option<&Metadata> {
         self.md
             .get_or_init(|| {
-                if !self.must_dereference {
-                    if let Some(dir_entry) = RefCell::take(&self.de).as_deref() {
-                        return dir_entry.metadata().ok();
-                    }
-                }
-
                 match get_metadata_with_deref_opt(self.path(), self.must_dereference) {
                     Err(err) => {
                         // FIXME: A bit tricky to propagate the result here
@@ -2228,7 +2201,7 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
     };
 
     for loc in locs {
-        let path_data = PathData::new(PathBuf::from(loc), None, None, config, true);
+        let path_data = PathData::new(PathBuf::from(loc), None, config, true);
 
         // Getting metadata here is no big deal as it's just the CWD
         // and we really just want to know if the strings exist as files/dirs
@@ -2447,13 +2420,13 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
 
 fn depth_first_list(
     (dir_path, needs_blank_line): DirData,
-    mut read_dir: ReadDir,
+    read_dir: ReadDir,
     config: &Config,
     state: &mut ListState,
     dired: &mut DiredOutput,
     is_top_level: bool,
 ) -> UResult<()> {
-    let path_data = PathData::new(dir_path, None, None, config, false);
+    let path_data = PathData::new(dir_path, None, config, false);
 
     // Print dir heading - name... 'total' comes after error display
     if state.initial_locs_len > 1 || config.recursive {
@@ -2496,14 +2469,12 @@ fn depth_first_list(
         let v = vec![
             PathData::new(
                 path_data.path().to_path_buf(),
-                None,
                 Some(".".into()),
                 config,
                 false,
             ),
             PathData::new(
                 path_data.path().join(".."),
-                None,
                 Some("..".into()),
                 config,
                 false,
@@ -2515,17 +2486,11 @@ fn depth_first_list(
     };
 
     // Convert those entries to the PathData struct
-    for raw_entry in read_dir.by_ref() {
+    for raw_entry in read_dir {
         match raw_entry {
             Ok(dir_entry) => {
                 if should_display(&dir_entry, config) {
-                    buf.push(PathData::new(
-                        dir_entry.path(),
-                        Some(dir_entry),
-                        None,
-                        config,
-                        false,
-                    ));
+                    buf.push(PathData::new(dir_entry.path(), None, config, false));
                 }
             }
             Err(err) => {
@@ -3468,7 +3433,6 @@ fn display_item_name(
                         Ok(resolved_target) => {
                             let target_data = PathData::new(
                                 resolved_target,
-                                None,
                                 target_path.file_name().map(OsStr::to_os_string),
                                 config,
                                 false,

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -19,7 +19,7 @@ use std::{
     cmp::Reverse,
     ffi::{OsStr, OsString},
     fmt::Write as _,
-    fs::{self, DirEntry, FileType, Metadata, ReadDir},
+    fs::{self, FileType, Metadata, ReadDir},
     io::{BufWriter, ErrorKind, IsTerminal, Stdout, Write, stdout},
     iter,
     num::IntErrorKind,
@@ -1971,8 +1971,6 @@ impl PathData {
             Dereference::None => false,
         };
 
-        // Why prefer to check the DirEntry file_type()?  B/c the call is
-        // nearly free compared to a metadata() call on a Path
         let ft: OnceCell<Option<FileType>> = OnceCell::new();
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
@@ -2375,22 +2373,22 @@ fn sort_entries(entries: &mut [PathData], config: &Config) {
     }
 }
 
-fn is_hidden(file_path: &DirEntry) -> bool {
+fn is_hidden(path_data: &PathData) -> bool {
     #[cfg(windows)]
     {
-        let metadata = file_path.metadata().unwrap();
+        let metadata = path_data.metadata().unwrap();
         let attr = metadata.file_attributes();
         (attr & 0x2) > 0
     }
     #[cfg(not(windows))]
     {
-        file_path.file_name().as_encoded_bytes().starts_with(b".")
+        path_data.file_name().as_encoded_bytes().starts_with(b".")
     }
 }
 
-fn should_display(entry: &DirEntry, config: &Config) -> bool {
+fn should_display(path_data: &PathData, config: &Config) -> bool {
     // check if hidden
-    if config.files == Files::Normal && is_hidden(entry) {
+    if config.files == Files::Normal && is_hidden(path_data) {
         return false;
     }
 
@@ -2402,22 +2400,19 @@ fn should_display(entry: &DirEntry, config: &Config) -> bool {
         case_sensitive: true,
     };
 
-    let file_name = entry.file_name();
+    let file_name = path_data.file_name();
     // If the decoding fails, still match best we can
     // FIXME: use OsStrings or Paths once we have a glob crate that supports it:
     // https://github.com/rust-lang/glob/issues/23
     // https://github.com/rust-lang/glob/issues/78
     // https://github.com/BurntSushi/ripgrep/issues/1250
 
-    let file_name = match file_name.to_str() {
-        Some(s) => Cow::Borrowed(s),
-        None => file_name.to_string_lossy(),
-    };
+    let file_name_as_cow = file_name.to_string_lossy();
 
     !config
         .ignore_patterns
         .iter()
-        .any(|p| p.matches_with(&file_name, options))
+        .any(|p| p.matches_with(&file_name_as_cow, options))
 }
 
 fn depth_first_list(
@@ -2491,8 +2486,9 @@ fn depth_first_list(
     for raw_entry in read_dir {
         match raw_entry {
             Ok(dir_entry) => {
-                if should_display(&dir_entry, config) {
-                    buf.push(PathData::new(dir_entry.path(), None, config, false));
+                let path_data = PathData::new(dir_entry.path(), None, config, false);
+                if should_display(&path_data, config) {
+                    buf.push(path_data);
                 }
             }
             Err(err) => {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1976,10 +1976,6 @@ impl PathData {
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
 
-        if !must_dereference {
-            ft.get_or_init(|| opt_dir_entry.and_then(|de| de.file_type().ok()));
-        }
-
         Self {
             md,
             ft,

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -9,11 +9,11 @@
 #[cfg(unix)]
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
-use std::borrow::Cow;
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 #[cfg(windows)]
 use std::os::windows::fs::MetadataExt;
+use std::{borrow::Cow, fs::DirEntry};
 use std::{
     cell::{LazyCell, OnceCell},
     cmp::Reverse,
@@ -1940,13 +1940,14 @@ struct PathData {
 impl PathData {
     fn new(
         p_buf: PathBuf,
-        file_name: Option<OsString>,
+        opt_dir_entry: Option<DirEntry>,
+        opt_file_name: Option<OsString>,
         config: &Config,
         command_line: bool,
     ) -> Self {
         // We cannot use `Path::ends_with` or `Path::Components`, because they remove occurrences of '.'
         // For '..', the filename is None
-        let display_name = if let Some(name) = file_name {
+        let display_name = if let Some(name) = opt_file_name {
             name
         } else if command_line {
             p_buf.as_os_str().to_os_string()
@@ -1974,6 +1975,10 @@ impl PathData {
         let ft: OnceCell<Option<FileType>> = OnceCell::new();
         let md: OnceCell<Option<Metadata>> = OnceCell::new();
         let security_context: OnceCell<Box<str>> = OnceCell::new();
+
+        if !must_dereference {
+            ft.get_or_init(|| opt_dir_entry.and_then(|de| de.file_type().ok()));
+        }
 
         Self {
             md,
@@ -2201,7 +2206,7 @@ pub fn list(locs: Vec<&Path>, config: &Config) -> UResult<()> {
     };
 
     for loc in locs {
-        let path_data = PathData::new(PathBuf::from(loc), None, config, true);
+        let path_data = PathData::new(PathBuf::from(loc), None, None, config, true);
 
         // Getting metadata here is no big deal as it's just the CWD
         // and we really just want to know if the strings exist as files/dirs
@@ -2430,7 +2435,7 @@ fn depth_first_list(
     dired: &mut DiredOutput,
     is_top_level: bool,
 ) -> UResult<()> {
-    let path_data = PathData::new(dir_path, None, config, false);
+    let path_data = PathData::new(dir_path, None, None, config, false);
 
     // Print dir heading - name... 'total' comes after error display
     if state.initial_locs_len > 1 || config.recursive {
@@ -2473,12 +2478,14 @@ fn depth_first_list(
         let v = vec![
             PathData::new(
                 path_data.path().to_path_buf(),
+                None,
                 Some(".".into()),
                 config,
                 false,
             ),
             PathData::new(
                 path_data.path().join(".."),
+                None,
                 Some("..".into()),
                 config,
                 false,
@@ -2493,7 +2500,8 @@ fn depth_first_list(
     for raw_entry in read_dir.into_iter() {
         match raw_entry {
             Ok(dir_entry) => {
-                let path_data = PathData::new(dir_entry.path(), None, config, false);
+                let path_data =
+                    PathData::new(dir_entry.path(), Some(dir_entry), None, config, false);
                 if should_display(&path_data, config) {
                     buf.push(path_data);
                 }
@@ -3438,6 +3446,7 @@ fn display_item_name(
                         Ok(resolved_target) => {
                             let target_data = PathData::new(
                                 resolved_target,
+                                None,
                                 target_path.file_name().map(OsStr::to_os_string),
                                 config,
                                 false,


### PR DESCRIPTION
Here, we were requesting symlink_metadata before proceeding to the color_name fn, and I've also completely eliminated the need to hold onto DirEntrys within the PathData struct.  Statx calls are faster.