### PR TITLE
ls: properly release parent nodes in DFS

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1246,6 +1246,7 @@ pub fn list_with_output<O: LsOutput>(
             &mut entries,
         )?;
         listed_ancestors.remove(&inode);
+        debug_assert!(listed_ancestors.is_empty());
     }
 
     output.finalize(config)?;

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) somegroup nlink tabsize dired subdired dtype colorterm stringly
-// spell-checker:ignore nohash strtime clocale
+// spell-checker:ignore nohash strtime clocale inode
 
 use clap::{
     Arg, ArgAction, Command,
@@ -1235,10 +1235,8 @@ pub fn list_with_output<O: LsOutput>(
         }
 
         let mut listed_ancestors = FxHashSet::default();
-        listed_ancestors.insert(FileInformation::from_path(
-            path_data.path(),
-            path_data.must_dereference,
-        )?);
+        let inode = FileInformation::from_path(path_data.path(), path_data.must_dereference)?;
+        listed_ancestors.insert(inode.clone());
         enter_directory(
             path_data,
             read_dir,
@@ -1247,6 +1245,7 @@ pub fn list_with_output<O: LsOutput>(
             output,
             &mut entries,
         )?;
+        listed_ancestors.remove(&inode);
     }
 
     output.finalize(config)?;
@@ -1367,6 +1366,7 @@ fn enter_directory<O: LsOutput>(
         path: PathBuf,
         command_line: bool,
         is_first: bool,
+        inode: FileInformation,
     }
 
     let mut stack = Vec::new();
@@ -1374,6 +1374,7 @@ fn enter_directory<O: LsOutput>(
         path: path_data.path().to_path_buf(),
         command_line: path_data.command_line,
         is_first: true,
+        inode: FileInformation::from_path(path_data.path(), path_data.must_dereference)?,
     });
     let mut initial_read_dir = Some(read_dir);
 
@@ -1423,33 +1424,30 @@ fn enter_directory<O: LsOutput>(
                 let child_must_dereference = child.must_dereference;
                 let child_command_line = child.command_line;
 
-                match fs::read_dir(&child_path) {
-                    Err(err) => {
+                if let Err(err) = fs::read_dir(&child_path) {
+                    output.flush()?;
+                    show!(LsError::IOErrorContext(
+                        child_path.clone(),
+                        err,
+                        child_command_line,
+                    ));
+                } else {
+                    let inode = FileInformation::from_path(&child_path, child_must_dereference)?;
+                    if listed_ancestors.insert(inode.clone()) {
+                        stack.push(StackEntry {
+                            path: child_path,
+                            command_line: child_command_line,
+                            is_first: false,
+                            inode,
+                        });
+                    } else {
                         output.flush()?;
-                        show!(LsError::IOErrorContext(
-                            child_path.clone(),
-                            err,
-                            child_command_line,
-                        ));
-                    }
-                    Ok(_) => {
-                        if listed_ancestors.insert(FileInformation::from_path(
-                            &child_path,
-                            child_must_dereference,
-                        )?) {
-                            stack.push(StackEntry {
-                                path: child_path,
-                                command_line: child_command_line,
-                                is_first: false,
-                            });
-                        } else {
-                            output.flush()?;
-                            show!(LsError::AlreadyListedError(child_path));
-                        }
+                        show!(LsError::AlreadyListedError(child_path));
                     }
                 }
             }
         }
+        listed_ancestors.remove(&entry.inode);
     }
 
     Ok(())

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1257,6 +1257,7 @@ pub fn list_with_output<O: LsOutput>(
             path_data,
             read_dir,
             config,
+            inode.as_ref(),
             &mut listed_ancestors,
             output,
             &mut entries,
@@ -1378,6 +1379,7 @@ fn enter_directory<O: LsOutput>(
     path_data: &PathData,
     read_dir: ReadDir,
     config: &Config,
+    inode: Option<&FileInformation>,
     listed_ancestors: &mut FxHashSet<FileInformation>,
     output: &mut O,
     entries: &mut Vec<PathData>,
@@ -1386,7 +1388,7 @@ fn enter_directory<O: LsOutput>(
         path: PathBuf,
         command_line: bool,
         is_first: bool,
-        inode: FileInformation,
+        inode: Option<FileInformation>,
     }
 
     let mut stack = Vec::new();
@@ -1394,7 +1396,7 @@ fn enter_directory<O: LsOutput>(
         path: path_data.path().to_path_buf(),
         command_line: path_data.command_line,
         is_first: true,
-        inode: FileInformation::from_path(path_data.path(), path_data.must_dereference)?,
+        inode: inode.cloned(),
     });
     let mut initial_read_dir = Some(read_dir);
 
@@ -1458,7 +1460,7 @@ fn enter_directory<O: LsOutput>(
                             path: child_path,
                             command_line: child_command_line,
                             is_first: false,
-                            inode,
+                            inode: Some(inode),
                         });
                     } else {
                         output.flush()?;
@@ -1467,7 +1469,9 @@ fn enter_directory<O: LsOutput>(
                 }
             }
         }
-        listed_ancestors.remove(&entry.inode);
+        if let Some(ref inode) = entry.inode {
+            listed_ancestors.remove(inode);
+        }
     }
 
     Ok(())

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1427,6 +1427,11 @@ fn enter_directory<O: LsOutput>(
                         err,
                         entry.command_line,
                     ));
+                    // Release the inode. To be made a proper drop guard when
+                    // the [`std::mem::DropGuard`] API hits stable in our MSRV.
+                    if let Some(ref inode) = entry.inode {
+                        listed_ancestors.remove(inode);
+                    }
                     continue;
                 }
                 Ok(rd) => rd,

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1391,16 +1391,31 @@ fn enter_directory<O: LsOutput>(
         inode: Option<FileInformation>,
     }
 
+    /// Controls inode freeing precisely in the loop, so we correctly thread
+    /// cycle detection and inode discarding. Does away with many headaches.
+    enum StackItem {
+        Enter(StackEntry),
+        Exit(FileInformation),
+    }
+
     let mut stack = Vec::new();
-    let mut current = Some(StackEntry {
+    let mut current = Some(StackItem::Enter(StackEntry {
         path: path_data.path().to_path_buf(),
         command_line: path_data.command_line,
         is_first: true,
         inode: inode.cloned(),
-    });
+    }));
     let mut initial_read_dir = Some(read_dir);
 
     while let Some(entry) = current.take().or_else(|| stack.pop()) {
+        let entry = match entry {
+            StackItem::Exit(inode) => {
+                listed_ancestors.remove(&inode);
+                continue;
+            }
+            StackItem::Enter(entry) => entry,
+        };
+
         let path_data = PathData::new(
             entry.path.as_path().into(),
             None,
@@ -1427,8 +1442,7 @@ fn enter_directory<O: LsOutput>(
                         err,
                         entry.command_line,
                     ));
-                    // Release the inode. To be made a proper drop guard when
-                    // the [`std::mem::DropGuard`] API hits stable in our MSRV.
+                    // Force-free the inode if we encounter an error.
                     if let Some(ref inode) = entry.inode {
                         listed_ancestors.remove(inode);
                     }
@@ -1440,6 +1454,12 @@ fn enter_directory<O: LsOutput>(
 
         collect_directory_entries(entries, &path_data, config, output, &mut current_read_dir)?;
         write_directory_entries(entries, config, output)?;
+
+        // Sets the inode to be removed after all children and descendants have
+        // been processed. The exit marker sits under the children in the stack.
+        if let Some(ref inode) = entry.inode {
+            stack.push(StackItem::Exit(inode.clone()));
+        }
 
         if config.recursive {
             for child in entries
@@ -1461,21 +1481,18 @@ fn enter_directory<O: LsOutput>(
                 } else {
                     let inode = FileInformation::from_path(&child_path, child_must_dereference)?;
                     if listed_ancestors.insert(inode.clone()) {
-                        stack.push(StackEntry {
+                        stack.push(StackItem::Enter(StackEntry {
                             path: child_path,
                             command_line: child_command_line,
                             is_first: false,
                             inode: Some(inode),
-                        });
+                        }));
                     } else {
                         output.flush()?;
                         show!(LsError::AlreadyListedError(child_path));
                     }
                 }
             }
-        }
-        if let Some(ref inode) = entry.inode {
-            listed_ancestors.remove(inode);
         }
     }
 

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1245,10 +1245,11 @@ pub fn list_with_output<O: LsOutput>(
         // Only recursion can revisit a directory, so only then is it worth a
         // stat to remember this one; without -R the set is never consulted.
         let mut listed_ancestors = FxHashSet::default();
-        let inode = if config.recursive {
-            let inode = FileInformation::from_path(path_data.path(), path_data.must_dereference)?;
-            listed_ancestors.insert(inode.clone());
-            Some(inode)
+        let id = if config.recursive {
+            let info = FileInformation::from_path(path_data.path(), path_data.must_dereference)?;
+            let id = DirId::new(&info);
+            listed_ancestors.insert(id);
+            Some(id)
         } else {
             None
         };
@@ -1257,15 +1258,12 @@ pub fn list_with_output<O: LsOutput>(
             path_data,
             read_dir,
             config,
-            inode.as_ref(),
+            id,
             &mut listed_ancestors,
             output,
             &mut entries,
         )?;
 
-        if let Some(ref inode) = inode {
-            listed_ancestors.remove(inode);
-        }
         debug_assert!(listed_ancestors.is_empty());
     }
 
@@ -1371,6 +1369,19 @@ fn write_directory_entries<O: LsOutput>(
     }
 }
 
+/// Wrapper for `(dev, inode)`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+struct DirId(u64, u64);
+
+impl DirId {
+    fn new(info: &FileInformation) -> Self {
+        #[cfg(any(unix, target_os = "wasi"))]
+        return Self(info.dev(), info.inode());
+        #[cfg(windows)]
+        return Self(info.dev(), info.file_index());
+    }
+}
+
 /// Recursively traverse directories using an explicit stack.
 ///
 /// This avoids deep recursive call chains while preserving GNU-style
@@ -1379,8 +1390,8 @@ fn enter_directory<O: LsOutput>(
     path_data: &PathData,
     read_dir: ReadDir,
     config: &Config,
-    inode: Option<&FileInformation>,
-    listed_ancestors: &mut FxHashSet<FileInformation>,
+    id: Option<DirId>,
+    listed_ancestors: &mut FxHashSet<DirId>,
     output: &mut O,
     entries: &mut Vec<PathData>,
 ) -> UResult<()> {
@@ -1388,14 +1399,14 @@ fn enter_directory<O: LsOutput>(
         path: PathBuf,
         command_line: bool,
         is_first: bool,
-        inode: Option<FileInformation>,
+        id: DirId,
     }
 
     /// Controls inode freeing precisely in the loop, so we correctly thread
     /// cycle detection and inode discarding. Does away with many headaches.
     enum StackItem {
         Enter(StackEntry),
-        Exit(FileInformation),
+        Exit(DirId),
     }
 
     let mut stack = Vec::new();
@@ -1403,24 +1414,21 @@ fn enter_directory<O: LsOutput>(
         path: path_data.path().to_path_buf(),
         command_line: path_data.command_line,
         is_first: true,
-        inode: inode.cloned(),
+        id: id.unwrap_or_default(),
     }));
     let mut initial_read_dir = Some(read_dir);
 
     while let Some(entry) = current.take().or_else(|| stack.pop()) {
         let entry = match entry {
-            StackItem::Exit(inode) => {
-                listed_ancestors.remove(&inode);
+            StackItem::Exit(id) => {
+                listed_ancestors.remove(&id);
                 continue;
             }
             StackItem::Enter(entry) => entry,
         };
 
         // Check for duplicates at entry time, so we can reliably track cycles.
-        if !entry.is_first
-            && let Some(ref inode) = entry.inode
-            && !listed_ancestors.insert(inode.clone())
-        {
+        if !entry.is_first && !listed_ancestors.insert(entry.id) {
             output.flush()?;
             show!(LsError::AlreadyListedError(entry.path.clone()));
             continue;
@@ -1453,9 +1461,7 @@ fn enter_directory<O: LsOutput>(
                         entry.command_line,
                     ));
                     // Force-free the inode if we encounter an error.
-                    if let Some(ref inode) = entry.inode {
-                        listed_ancestors.remove(inode);
-                    }
+                    listed_ancestors.remove(&entry.id);
                     continue;
                 }
                 Ok(rd) => rd,
@@ -1467,9 +1473,7 @@ fn enter_directory<O: LsOutput>(
 
         // Sets the inode to be removed after all children and descendants have
         // been processed. The exit marker sits under the children in the stack.
-        if let Some(ref inode) = entry.inode {
-            stack.push(StackItem::Exit(inode.clone()));
-        }
+        stack.push(StackItem::Exit(entry.id));
 
         if config.recursive {
             for child in entries
@@ -1492,12 +1496,23 @@ fn enter_directory<O: LsOutput>(
                     continue;
                 }
 
-                let inode = FileInformation::from_path(&child_path, child_must_dereference)?;
+                let info = match FileInformation::from_path(&child_path, child_must_dereference) {
+                    Ok(info) => info,
+                    Err(err) => {
+                        output.flush()?;
+                        show!(LsError::IOErrorContext(
+                            child_path.clone(),
+                            err,
+                            child_command_line,
+                        ));
+                        continue;
+                    }
+                };
                 stack.push(StackItem::Enter(StackEntry {
                     path: child_path,
                     command_line: child_command_line,
                     is_first: false,
-                    inode: Some(inode),
+                    id: DirId::new(&info),
                 }));
             }
         }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1434,6 +1434,9 @@ fn enter_directory<O: LsOutput>(
             continue;
         }
 
+        // Register clean-up now.
+        stack.push(StackItem::Exit(entry.id));
+
         let path_data = PathData::new(
             entry.path.as_path().into(),
             None,
@@ -1460,8 +1463,6 @@ fn enter_directory<O: LsOutput>(
                         err,
                         entry.command_line,
                     ));
-                    // Force-free the inode if we encounter an error.
-                    listed_ancestors.remove(&entry.id);
                     continue;
                 }
                 Ok(rd) => rd,
@@ -1470,10 +1471,6 @@ fn enter_directory<O: LsOutput>(
 
         collect_directory_entries(entries, &path_data, config, output, &mut current_read_dir)?;
         write_directory_entries(entries, config, output)?;
-
-        // Sets the inode to be removed after all children and descendants have
-        // been processed. The exit marker sits under the children in the stack.
-        stack.push(StackItem::Exit(entry.id));
 
         if config.recursive {
             for child in entries

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) somegroup nlink tabsize dired subdired dtype colorterm stringly
-// spell-checker:ignore nohash strtime clocale
+// spell-checker:ignore nohash strtime clocale inode
 
 use clap::{
     Arg, ArgAction, Command,
@@ -1245,12 +1245,14 @@ pub fn list_with_output<O: LsOutput>(
         // Only recursion can revisit a directory, so only then is it worth a
         // stat to remember this one; without -R the set is never consulted.
         let mut listed_ancestors = FxHashSet::default();
-        if config.recursive {
-            listed_ancestors.insert(FileInformation::from_path(
-                path_data.path(),
-                path_data.must_dereference,
-            )?);
-        }
+        let inode = if config.recursive {
+            let inode = FileInformation::from_path(path_data.path(), path_data.must_dereference)?;
+            listed_ancestors.insert(inode.clone());
+            Some(inode)
+        } else {
+            None
+        };
+
         enter_directory(
             path_data,
             read_dir,
@@ -1259,6 +1261,10 @@ pub fn list_with_output<O: LsOutput>(
             output,
             &mut entries,
         )?;
+
+        if let Some(ref inode) = inode {
+            listed_ancestors.remove(inode);
+        }
     }
 
     output.finalize(config)?;
@@ -1379,6 +1385,7 @@ fn enter_directory<O: LsOutput>(
         path: PathBuf,
         command_line: bool,
         is_first: bool,
+        inode: FileInformation,
     }
 
     let mut stack = Vec::new();
@@ -1386,6 +1393,7 @@ fn enter_directory<O: LsOutput>(
         path: path_data.path().to_path_buf(),
         command_line: path_data.command_line,
         is_first: true,
+        inode: FileInformation::from_path(path_data.path(), path_data.must_dereference)?,
     });
     let mut initial_read_dir = Some(read_dir);
 
@@ -1435,33 +1443,30 @@ fn enter_directory<O: LsOutput>(
                 let child_must_dereference = child.must_dereference;
                 let child_command_line = child.command_line;
 
-                match fs::read_dir(&child_path) {
-                    Err(err) => {
+                if let Err(err) = fs::read_dir(&child_path) {
+                    output.flush()?;
+                    show!(LsError::IOErrorContext(
+                        child_path.clone(),
+                        err,
+                        child_command_line,
+                    ));
+                } else {
+                    let inode = FileInformation::from_path(&child_path, child_must_dereference)?;
+                    if listed_ancestors.insert(inode.clone()) {
+                        stack.push(StackEntry {
+                            path: child_path,
+                            command_line: child_command_line,
+                            is_first: false,
+                            inode,
+                        });
+                    } else {
                         output.flush()?;
-                        show!(LsError::IOErrorContext(
-                            child_path.clone(),
-                            err,
-                            child_command_line,
-                        ));
-                    }
-                    Ok(_) => {
-                        if listed_ancestors.insert(FileInformation::from_path(
-                            &child_path,
-                            child_must_dereference,
-                        )?) {
-                            stack.push(StackEntry {
-                                path: child_path,
-                                command_line: child_command_line,
-                                is_first: false,
-                            });
-                        } else {
-                            output.flush()?;
-                            show!(LsError::AlreadyListedError(child_path));
-                        }
+                        show!(LsError::AlreadyListedError(child_path));
                     }
                 }
             }
         }
+        listed_ancestors.remove(&entry.inode);
     }
 
     Ok(())

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1265,6 +1265,7 @@ pub fn list_with_output<O: LsOutput>(
         if let Some(ref inode) = inode {
             listed_ancestors.remove(inode);
         }
+        debug_assert!(listed_ancestors.is_empty());
     }
 
     output.finalize(config)?;

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1416,6 +1416,16 @@ fn enter_directory<O: LsOutput>(
             StackItem::Enter(entry) => entry,
         };
 
+        // Check for duplicates at entry time, so we can reliably track cycles.
+        if !entry.is_first
+            && let Some(ref inode) = entry.inode
+            && !listed_ancestors.insert(inode.clone())
+        {
+            output.flush()?;
+            show!(LsError::AlreadyListedError(entry.path.clone()));
+            continue;
+        }
+
         let path_data = PathData::new(
             entry.path.as_path().into(),
             None,
@@ -1471,6 +1481,7 @@ fn enter_directory<O: LsOutput>(
                 let child_must_dereference = child.must_dereference;
                 let child_command_line = child.command_line;
 
+                // Try to read_dir now to eagerly report errors, matching GNU.
                 if let Err(err) = fs::read_dir(&child_path) {
                     output.flush()?;
                     show!(LsError::IOErrorContext(
@@ -1478,20 +1489,16 @@ fn enter_directory<O: LsOutput>(
                         err,
                         child_command_line,
                     ));
-                } else {
-                    let inode = FileInformation::from_path(&child_path, child_must_dereference)?;
-                    if listed_ancestors.insert(inode.clone()) {
-                        stack.push(StackItem::Enter(StackEntry {
-                            path: child_path,
-                            command_line: child_command_line,
-                            is_first: false,
-                            inode: Some(inode),
-                        }));
-                    } else {
-                        output.flush()?;
-                        show!(LsError::AlreadyListedError(child_path));
-                    }
+                    continue;
                 }
+
+                let inode = FileInformation::from_path(&child_path, child_must_dereference)?;
+                stack.push(StackItem::Enter(StackEntry {
+                    path: child_path,
+                    command_line: child_command_line,
+                    is_first: false,
+                    inode: Some(inode),
+                }));
             }
         }
     }

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -178,6 +178,13 @@ impl FileInformation {
         #[allow(clippy::useless_conversion)]
         return self.0.st_ino.into();
     }
+
+    pub fn dev(&self) -> u64 {
+        #[cfg(any(unix, target_os = "wasi"))]
+        return self.0.st_dev as _;
+        #[cfg(windows)]
+        return self.0.dwVolumeSerialNumber as _;
+    }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7807,9 +7807,8 @@ fn test_ls_dereference_cross_branch_alias_after_first_branch_completes() {
 
     let result = ucmd.args(&["-RL", "top"]).succeeds();
     result
-        .stdout_contains("target:")
-        .stdout_contains("link:")
-        .stdout_contains("file")
+        .stdout_contains("target:\nfile")
+        .stdout_contains("link:\nfile")
         .no_stderr();
 }
 
@@ -7824,8 +7823,7 @@ fn test_ls_dereference_sibling_alias_not_already_listed() {
 
     let result = ucmd.args(&["-RL", "top"]).succeeds();
     result
-        .stdout_contains("real:")
-        .stdout_contains("link:")
-        .stdout_contains("file")
+        .stdout_contains("real:\nfile")
+        .stdout_contains("link:\nfile")
         .no_stderr();
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7795,3 +7795,37 @@ fn test_ls_dereference_looped_symlinks_recursive_nested() {
         .fails_with_code(2)
         .stderr_contains("not listing already-listed directory");
 }
+
+#[test]
+fn test_ls_dereference_cross_branch_alias_after_first_branch_completes() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir_all("top/a/target");
+    at.touch("top/a/target/file");
+    at.mkdir_all("top/b");
+    at.relative_symlink_dir("../a/target", "top/b/link");
+
+    let result = ucmd.args(&["-RL", "top"]).succeeds();
+    result
+        .stdout_contains("target:")
+        .stdout_contains("link:")
+        .stdout_contains("file")
+        .no_stderr();
+}
+
+#[test]
+fn test_ls_dereference_sibling_alias_not_already_listed() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("top");
+    at.mkdir("top/real");
+    at.touch("top/real/file");
+    at.relative_symlink_dir("real", "top/link");
+
+    let result = ucmd.args(&["-RL", "top"]).succeeds();
+    result
+        .stdout_contains("real:")
+        .stdout_contains("link:")
+        .stdout_contains("file")
+        .no_stderr();
+}

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7782,3 +7782,16 @@ ls: invalid --block-size argument '1fb'
             .stderr_is("ls: invalid --block-size argument '1fb'\n");
     }
 }
+
+#[test]
+fn test_ls_dereference_looped_symlinks_recursive_nested() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir("loop");
+    at.mkdir("loop/a");
+    at.relative_symlink_dir("..", "loop/a/back");
+
+    ucmd.args(&["-RL", "loop"])
+        .fails_with_code(2)
+        .stderr_contains("not listing already-listed directory");
+}


### PR DESCRIPTION
Fixes a regression introduced in #11386 (sorry) where DFS nodes did not properly free the recorded inodes of the parent directories. This caused critical errors in some instances of recursive hard links, and made memory usage increase with a combinatorical explosion.