### PR TITLE
CI: add GNU tests/rm/isatty to intermittent

### DIFF
--- a/.github/workflows/ignore-intermittent.txt
+++ b/.github/workflows/ignore-intermittent.txt
@@ -13,3 +13,4 @@ tests/misc/stdbuf
 tests/misc/usage_vs_getopt
 tests/misc/tee
 tests/tail/follow-name
+tests/rm/isatty


### PR DESCRIPTION
As seen in #11465, among others.