### PR TITLE
sort: fix infinite loop on --files0-from read error

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2042,7 +2042,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         // sort errors with "cannot open: [...]" instead of "cannot read: [...]" here
         let reader = open_with_open_failed_error(&files0_from)?;
         let buf_reader = BufReader::new(reader);
-        for (line_num, line) in buf_reader.split(b'\0').flatten().enumerate() {
+        for (line_num, line_res) in buf_reader.split(b'\0').enumerate() {
+            let line = line_res.map_err(|error| SortError::ReadFailed {
+                path: files0_from.clone(),
+                error,
+            })?;
             let f = std::str::from_utf8(&line)
                 .expect("Could not parse string from zero terminated input.");
             match f {

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1569,6 +1569,15 @@ fn test_files0_from_empty() {
         .stderr_only("sort: no input from 'file'\n");
 }
 
+#[test]
+#[cfg(unix)]
+fn test_files0_read_error() {
+    new_ucmd!()
+        .args(&["--files0-from", "."])
+        .fails_with_code(2)
+        .stderr_only("sort: cannot read: .: Is a directory\n");
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 // Test for GNU tests/sort/sort-files0-from.pl "empty-non-regular"


### PR DESCRIPTION
If the read from the `--files0-from` file results in a permanent error, we end up in an infinite loop.

Clippy will detect this in the future, see https://github.com/rust-lang/rust-clippy/pull/16763.