### PR TITLE
sync: fix exit code when fcntl failed & 2>/dev/full abort

### DIFF
--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -68,10 +68,13 @@ mod platform {
         // Reset O_NONBLOCK flag if it was set (matches GNU behavior)
         // This is non-critical, so we log errors but don't fail
         if let Err(e) = fcntl(&f, FcntlArg::F_SETFL(OFlag::empty())) {
-            eprintln!(
+            use std::io::{Write, stderr};
+            let _ = writeln!(
+                stderr(),
                 "sync: {}",
                 translate!("sync-warning-fcntl-failed", "file" => path, "error" => e.to_string())
             );
+            uucore::error::set_exit_code(1);
         }
         Ok(f)
     }


### PR DESCRIPTION
Closes #11507