### PR TITLE
tty: Build for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ feat_common_core = [
   "tr",
   "true",
   "truncate",
+  "tty",
   "tsort",
   "unexpand",
   "uniq",
@@ -292,7 +293,6 @@ feat_require_unix_core = [
   "stat",
   "stty",
   "timeout",
-  "tty",
 ]
 # "feat_require_unix_utmpx" == set of utilities requiring unix utmp/utmpx support
 # * ref: <https://wiki.musl-libc.org/faq.html#Q:-Why-is-the-utmp/wtmp-functionality-only-implemented-as-stubs?>
@@ -317,7 +317,6 @@ feat_os_unix_fuchsia = [
   "mkfifo",
   "mknod",
   "nice",
-  "tty",
   "uname",
   "unlink",
 ]

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -27,19 +27,22 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _ = uucore::signals::disable_pipe_errors();
 
     let silent = matches.get_flag(options::SILENT);
+    let is_tty = std::io::stdin().is_terminal();
 
     // If silent, we don't need the name, only whether or not stdin is a tty.
     if silent {
-        return if std::io::stdin().is_terminal() {
-            Ok(())
-        } else {
-            Err(1.into())
-        };
+        return if is_tty { Ok(()) } else { Err(1.into()) };
     }
 
     let mut stdout = std::io::stdout();
-
+    #[cfg(unix)]
     let name = rustix::termios::ttyname(std::io::stdin(), Vec::with_capacity(8));
+    #[cfg(not(unix))] // todo: maximize cygwin compatibility
+    let name = if is_tty {
+        Ok(std::ffi::OsString::from("/dev/tty"))
+    } else {
+        Err(())
+    };
 
     let write_result = if let Ok(name) = name {
         use std::os::unix::ffi::OsStrExt;

--- a/tests/by-util/test_tty.rs
+++ b/tests/by-util/test_tty.rs
@@ -2,12 +2,13 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+#[cfg(unix)]
 use std::fs::File;
-
+#[cfg(unix)]
 use uutests::new_ucmd;
 
 #[test]
-#[cfg(not(windows))]
+#[cfg(unix)]
 fn test_dev_null() {
     new_ucmd!()
         .set_stdin(File::open("/dev/null").unwrap())
@@ -16,7 +17,7 @@ fn test_dev_null() {
 }
 
 #[test]
-#[cfg(not(windows))]
+#[cfg(unix)]
 fn test_dev_null_silent() {
     new_ucmd!()
         .args(&["-s"])
@@ -26,6 +27,7 @@ fn test_dev_null_silent() {
 }
 
 #[test]
+#[cfg(unix)]
 fn test_close_stdin() {
     let mut child = new_ucmd!().run_no_wait();
     child.close_stdin();
@@ -33,6 +35,7 @@ fn test_close_stdin() {
 }
 
 #[test]
+#[cfg(unix)]
 fn test_close_stdin_silent() {
     let mut child = new_ucmd!().arg("-s").run_no_wait();
     child.close_stdin();
@@ -40,6 +43,7 @@ fn test_close_stdin_silent() {
 }
 
 #[test]
+#[cfg(unix)]
 fn test_close_stdin_silent_long() {
     let mut child = new_ucmd!().arg("--silent").run_no_wait();
     child.close_stdin();
@@ -47,6 +51,7 @@ fn test_close_stdin_silent_long() {
 }
 
 #[test]
+#[cfg(unix)]
 fn test_close_stdin_silent_alias() {
     let mut child = new_ucmd!().arg("--quiet").run_no_wait();
     child.close_stdin();
@@ -54,11 +59,13 @@ fn test_close_stdin_silent_alias() {
 }
 
 #[test]
+#[cfg(unix)]
 fn test_wrong_argument() {
     new_ucmd!().args(&["a"]).fails_with_code(2);
 }
 
 #[test]
+#[cfg(unix)]
 fn test_help() {
     new_ucmd!().args(&["--help"]).succeeds();
 }


### PR DESCRIPTION
I believe this is useful on  Windows as thin `is_terminal()` wrapper even output is frozen.