### PR TITLE
cat: improve splice fast-path

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -369,6 +369,7 @@ weblate
 algs
 wasm
 wasip
+SETPIPE
 
 # * stty terminal flags
 brkint

--- a/src/uu/cat/src/splice.rs
+++ b/src/uu/cat/src/splice.rs
@@ -7,9 +7,8 @@ use super::{CatResult, FdReadable, InputHandle};
 use nix::unistd;
 use std::os::{fd::AsFd, unix::io::AsRawFd};
 
-use uucore::pipes::{pipe, splice, splice_exact};
+use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, pipe, splice, splice_exact};
 
-const SPLICE_SIZE: usize = 1024 * 128;
 const BUF_SIZE: usize = 1024 * 16;
 
 /// This function is called from `write_fast()` on Linux and Android. The
@@ -24,10 +23,16 @@ pub(super) fn write_fast_using_splice<R: FdReadable, S: AsRawFd + AsFd>(
     handle: &InputHandle<R>,
     write_fd: &S,
 ) -> CatResult<bool> {
+    use nix::fcntl::{FcntlArg, fcntl};
     let (pipe_rd, pipe_wr) = pipe()?;
+    // improve performance
+    let _ = fcntl(
+        write_fd,
+        FcntlArg::F_SETPIPE_SZ(MAX_ROOTLESS_PIPE_SIZE as i32),
+    );
 
     loop {
-        match splice(&handle.reader, &pipe_wr, SPLICE_SIZE) {
+        match splice(&handle.reader, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE) {
             Ok(n) => {
                 if n == 0 {
                     return Ok(false);

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -5,12 +5,14 @@
 
 //! Thin pipe-related wrappers around functions from the `nix` crate.
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use nix::fcntl::{FcntlArg, SpliceFFlags, fcntl};
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::fs::File;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::AsFd;
-
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use nix::fcntl::SpliceFFlags;
+pub const MAX_ROOTLESS_PIPE_SIZE: usize = 1024 * 1024;
 
 pub use nix::{Error, Result};
 
@@ -18,8 +20,13 @@ pub use nix::{Error, Result};
 ///
 /// Returns two `File` objects: everything written to the second can be read
 /// from the first.
+/// This is used only for resolving the limitation for splice: one of a input or output should be pipe
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn pipe() -> Result<(File, File)> {
     let (read, write) = nix::unistd::pipe()?;
+    // improve performance for splice
+    let _ = fcntl(&read, FcntlArg::F_SETPIPE_SZ(MAX_ROOTLESS_PIPE_SIZE as i32));
+
     Ok((File::from(read), File::from(write)))
 }
 


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/11516
```
$ yes-gf421d0112 | cat-p | pv >/dev/null
^C.4GiB 0:00:04 [23.1GiB/s]
$ yes-gf421d0112 | cat | pv >/dev/null
^C.6GiB 0:00:05 [6.33GiB/s]
```