### PR TITLE
ls,pr: wrap angle-bracket placeholders in backticks to fix mdbook HTML warnings

### DIFF
--- a/src/uu/ls/locales/en-US.ftl
+++ b/src/uu/ls/locales/en-US.ftl
@@ -55,7 +55,7 @@ ls-help-escape-quoting-style = Use escape quoting style. Equivalent to `--quotin
 ls-help-c-quoting-style = Use C quoting style. Equivalent to `--quoting-style=c`
 ls-help-replace-control-chars = Replace control characters with '?' if they are not escaped.
 ls-help-show-control-chars = Show control characters 'as is' if they are not escaped.
-ls-help-show-time-field = Show time in <field>:
+ls-help-show-time-field = Show time in `<field>`:
     access time (-u): atime, access, use;
     change time (-t): ctime, status.
     modification time: mtime, modification.
@@ -71,7 +71,7 @@ ls-help-time-access = If the long listing format (e.g., -l, -o) is being used, p
 ls-help-hide-pattern = do not list implied entries matching shell PATTERN (overridden by -a or -A)
 ls-help-ignore-pattern = do not list implied entries matching shell PATTERN
 ls-help-ignore-backups = Ignore entries which end with ~.
-ls-help-sort-by-field = Sort by <field>: name, none (-U), time (-t), size (-S), extension (-X) or width
+ls-help-sort-by-field = Sort by `<field>`: name, none (-U), time (-t), size (-S), extension (-X) or width
 ls-help-sort-by-size = Sort by file size, largest first.
 ls-help-sort-by-time = Sort by modification time (the 'mtime' in the inode), newest first.
 ls-help-sort-by-version = Natural sort of (version) numbers in the filenames.

--- a/src/uu/ls/locales/fr-FR.ftl
+++ b/src/uu/ls/locales/fr-FR.ftl
@@ -55,7 +55,7 @@ ls-help-escape-quoting-style = Utiliser le style de citation d'échappement. Éq
 ls-help-c-quoting-style = Utiliser le style de citation C. Équivalent à `--quoting-style=c`
 ls-help-replace-control-chars = Remplacer les caractères de contrôle par '?' s'ils ne sont pas échappés.
 ls-help-show-control-chars = Afficher les caractères de contrôle 'tels quels' s'ils ne sont pas échappés.
-ls-help-show-time-field = Afficher l'heure dans <champ> :
+ls-help-show-time-field = Afficher l'heure dans `<champ>` :
     heure d'accès (-u) : atime, access, use ;
     heure de changement (-t) : ctime, status.
     heure de modification : mtime, modification.
@@ -71,7 +71,7 @@ ls-help-time-access = Si le format de liste long (par ex., -l, -o) est utilisé,
 ls-help-hide-pattern = ne pas lister les entrées implicites correspondant au MOTIF shell (surchargé par -a ou -A)
 ls-help-ignore-pattern = ne pas lister les entrées implicites correspondant au MOTIF shell
 ls-help-ignore-backups = Ignorer les entrées qui se terminent par ~.
-ls-help-sort-by-field = Trier par <champ> : name, none (-U), time (-t), size (-S), extension (-X) ou width
+ls-help-sort-by-field = Trier par `<champ>` : name, none (-U), time (-t), size (-S), extension (-X) ou width
 ls-help-sort-by-size = Trier par taille de fichier, le plus grand en premier.
 ls-help-sort-by-time = Trier par heure de modification (le 'mtime' dans l'inode), le plus récent en premier.
 ls-help-sort-by-version = Tri naturel des numéros (de version) dans les noms de fichiers.

--- a/src/uu/pr/locales/en-US.ftl
+++ b/src/uu/pr/locales/en-US.ftl
@@ -16,14 +16,14 @@ pr-help-header =
 pr-help-date-format =
   Use 'date'-style FORMAT for the header date.
 pr-help-double-space =
-  Produce output that is double spaced. An extra <newline>
-                  character is output following every <newline> found in the input.
+  Produce output that is double spaced. An extra `<newline>`
+                  character is output following every `<newline>` found in the input.
 pr-help-number-lines =
   Provide width digit line numbering.  The default for width,
                   if not specified, is 5.  The number occupies the first width column
                   positions of each text column or each line of -m output.  If char
                   (any non-digit character) is given, it is appended to the line number
-                  to separate it from whatever follows.  The default for char is a <tab>.
+                  to separate it from whatever follows.  The default for char is a `<tab>`.
                   Line numbers longer than width columns are truncated.
 pr-help-first-line-number = start counting with NUMBER at 1st line of first page printed
 pr-help-omit-header =
@@ -41,8 +41,8 @@ pr-help-page-length =
                   option were in effect.
 pr-help-no-file-warnings = omit warning when a file cannot be opened
 pr-help-form-feed =
-  Use a <form-feed> for new pages, instead of the default behavior that
-                  uses a sequence of <newline>s.
+  Use a `<form-feed>` for new pages, instead of the default behavior that
+                  uses a sequence of `<newline>`s.
 pr-help-column-width =
   Set the width of the line to width column positions for multiple
                   text-column output only. If the -w option is not specified and the -s option
@@ -67,10 +67,10 @@ pr-help-column =
                   When used with -t, use the minimum number of lines to write the output.
 pr-help-column-char-separator =
   Separate text columns by the single character char instead of by the
-                  appropriate number of <space>s (default for char is the <tab> character).
+                  appropriate number of `<space>`s (default for char is the `<tab>` character).
 pr-help-column-string-separator =
   separate columns by STRING,
-                  without -S: Default separator <TAB> with -J and <space>
+                  without -S: Default separator `<TAB>` with -J and `<space>`
                   otherwise (same as -S\" \"), no effect on column options
 pr-help-merge =
   Merge files. Standard output shall be formatted so the pr utility
@@ -78,7 +78,7 @@ pr-help-merge =
                   into text columns of equal fixed widths, in terms of the number of column
                   positions. Implementations shall support merging of at least nine file operands.
 pr-help-indent =
-  Each line of output shall be preceded by offset <space>s. If the -o
+  Each line of output shall be preceded by offset `<space>`s. If the -o
                   option is not specified, the default offset shall be zero. The space taken is
                   in addition to the output line width (see the -w option below).
 pr-help-join-lines =

--- a/src/uu/pr/locales/fr-FR.ftl
+++ b/src/uu/pr/locales/fr-FR.ftl
@@ -16,15 +16,15 @@ pr-help-header =
 pr-help-date-format =
   Utiliser le FORMAT de style 'date' pour la date dans la ligne d'en-tête.
 pr-help-double-space =
-  Produire une sortie avec double espacement. Un caractère <saut de ligne>
-                  supplémentaire est affiché après chaque <saut de ligne> trouvé dans l'entrée.
+  Produire une sortie avec double espacement. Un caractère `<saut de ligne>`
+                  supplémentaire est affiché après chaque `<saut de ligne>` trouvé dans l'entrée.
 pr-help-number-lines =
   Fournir une numérotation de ligne avec largeur de chiffres. La valeur par défaut
                   pour la largeur, si non spécifiée, est 5. Le numéro occupe les premières
                   largeur positions de colonne de chaque colonne de texte ou de chaque ligne
                   de sortie -m. Si char (tout caractère non numérique) est donné, il est
                   ajouté au numéro de ligne pour le séparer de ce qui suit. La valeur par
-                  défaut pour char est une <tabulation>. Les numéros de ligne plus longs
+                  défaut pour char est une `<tabulation>`. Les numéros de ligne plus longs
                   que largeur colonnes sont tronqués.
 pr-help-first-line-number = commencer le comptage avec NUMÉRO à la 1ère ligne de la première page imprimée
 pr-help-omit-header =
@@ -39,8 +39,8 @@ pr-help-page-length =
                   était en vigueur.
 pr-help-no-file-warnings = omettre l'avertissement lorsqu'un fichier ne peut pas être ouvert
 pr-help-form-feed =
-  Utiliser un <saut de page> pour les nouvelles pages, au lieu du comportement par défaut
-                  qui utilise une séquence de <sauts de ligne>.
+  Utiliser un `<saut de page>` pour les nouvelles pages, au lieu du comportement par défaut
+                  qui utilise une séquence de `<sauts de ligne>`.
 pr-help-column-width =
   Définir la largeur de la ligne à largeur positions de colonne pour la sortie
                   multi-colonnes de texte seulement. Si l'option -w n'est pas spécifiée et
@@ -66,10 +66,10 @@ pr-help-column =
                   utiliser le nombre minimum de lignes pour écrire la sortie.
 pr-help-column-char-separator =
   Séparer les colonnes de texte par le caractère unique char au lieu du nombre
-                  approprié d'<espaces> (par défaut pour char est le caractère de <tabulation>).
+                  approprié d'`<espaces>` (par défaut pour char est le caractère de `<tabulation>`).
 pr-help-column-string-separator =
   séparer les colonnes par CHAÎNE,
-                  sans -S : Séparateur par défaut <TAB> avec -J et <espace>
+                  sans -S : Séparateur par défaut `<TAB>` avec -J et `<espace>`
                   sinon (même que -S\" \"), aucun effet sur les options de colonne
 pr-help-merge =
   Fusionner les fichiers. La sortie standard sera formatée pour que l'utilitaire pr
@@ -77,7 +77,7 @@ pr-help-merge =
                   dans des colonnes de texte de largeurs fixes égales, en termes du nombre de positions
                   de colonne. Les implémentations doivent supporter la fusion d'au moins neuf opérandes de fichier.
 pr-help-indent =
-  Chaque ligne de sortie sera précédée par décalage <espaces>. Si l'option -o
+  Chaque ligne de sortie sera précédée par décalage `<espaces>`. Si l'option -o
                   n'est pas spécifiée, le décalage par défaut sera zéro. L'espace pris est
                   en plus de la largeur de ligne de sortie (voir l'option -w ci-dessous).
 pr-help-join-lines =


### PR DESCRIPTION
mdbook interprets tokens like <field>, <newline>, <tab> etc. as unclosed HTML tags. Wrapping them in backticks renders them as code instead.

see
https://uutils.github.io/coreutils/docs/utils/ls.html
<img width="382" height="216" alt="image" src="https://github.com/user-attachments/assets/e5000a8b-3bc1-4a89-bb33-35f25355bdf6" />
