### PR TITLE
yes: switch to global SIGPIPE setup

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -28,9 +28,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     match exec(&buffer) {
         Ok(()) => Ok(()),
-        // On Windows, silently handle broken pipe since there's no SIGPIPE
-        #[cfg(windows)]
-        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(USimpleError::new(
             1,
             translate!("yes-error-standard-output", "error" => strip_errno(&err)),


### PR DESCRIPTION
`yes | head -n 1024` does not cause SIGPIPE without this since we already have https://github.com/uutils/coreutils/blob/15f57d069275b74db2fe6862f89e80e25c8ab2a7/src/uucore/src/lib/lib.rs#L197 .