### PR TITLE
pre-commit: add Cargo.lock sync check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,13 @@ repos:
         pass_filenames: false
         types: [file, rust]
         language: system
+      - id: cargo-lock-check
+        name: Cargo.lock sync check
+        description: Ensure Cargo.lock and fuzz/Cargo.lock are up-to-date.
+        entry: bash -c 'for dir in . fuzz; do ( cd "$dir" && cargo fetch --locked --quiet ) || { echo "ERROR - $dir/Cargo.lock is out of date. Run -> cd $dir && cargo update"; exit 1; } done'
+        pass_filenames: false
+        files: 'Cargo\.(toml|lock)$'
+        language: system
       - id: cspell
         name: Code spell checker (cspell)
         description: Run cspell to check for spelling errors (if available).


### PR DESCRIPTION
Catch out-of-date Cargo.lock and fuzz/Cargo.lock before push, avoiding CI failures from lock file mismatch.