### PR TITLE
sort: fix warnings about unused stuff on Redox

### DIFF
--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -2,18 +2,21 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
+#[cfg(not(target_os = "redox"))]
+use std::path::Path;
+#[cfg(not(target_os = "redox"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     fs::File,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, LazyLock, Mutex},
 };
 
 use tempfile::TempDir;
-use uucore::{
-    error::{UResult, USimpleError},
-    show_error, translate,
-};
+use uucore::error::UResult;
+#[cfg(not(target_os = "redox"))]
+use uucore::{error::USimpleError, show_error, translate};
 
 use crate::{SortError, current_open_fd_count, fd_soft_limit};
 
@@ -181,6 +184,7 @@ impl Drop for TmpDirWrapper {
 
 /// Remove the directory at `path` by deleting its child files and then itself.
 /// Errors while deleting child files are ignored.
+#[cfg(not(target_os = "redox"))]
 fn remove_tmp_dir(path: &Path) -> std::io::Result<()> {
     if let Ok(read_dir) = std::fs::read_dir(path) {
         for file in read_dir.flatten() {


### PR DESCRIPTION
This PR fixes some warnings about unused imports and an unused function on Redox. See, for example, https://github.com/uutils/coreutils/actions/runs/23742274684/job/69162751126?pr=11495#step:17:282:
```
warning: unused imports: `AtomicBool` and `Ordering`
 --> src/uu/sort/src/tmp_dir.rs:5:25
  |
5 | use std::sync::atomic::{AtomicBool, Ordering};
  |                         ^^^^^^^^^^  ^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused imports: `USimpleError`, `show_error`, and `translate`
  --> src/uu/sort/src/tmp_dir.rs:14:22
   |
14 |     error::{UResult, USimpleError},
   |                      ^^^^^^^^^^^^
15 |     show_error, translate,
   |     ^^^^^^^^^^  ^^^^^^^^^

warning: function `remove_tmp_dir` is never used
   --> src/uu/sort/src/tmp_dir.rs:184:4
    |
184 | fn remove_tmp_dir(path: &Path) -> std::io::Result<()> {
```