### PR TITLE
dd: catch OOM

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1166,10 +1166,6 @@ fn dd_copy(mut i: Input, o: Output) -> io::Result<()> {
         );
     }
 
-    // Create a common buffer with a capacity of the block size.
-    // This is the max size needed.
-    let mut buf = vec![BUF_INIT_BYTE; bsize];
-
     // Spawn a timer thread to provide a scheduled signal indicating when we
     // should send an update of our progress to the reporting thread.
     //
@@ -1200,6 +1196,11 @@ fn dd_copy(mut i: Input, o: Output) -> io::Result<()> {
     } else {
         BlockWriter::Unbuffered(o)
     };
+
+    // Create a common empty buffer with a capacity of the block size.
+    // This is the max size needed.
+    let mut buf = Vec::new();
+    buf.try_reserve(bsize)?; // try_with_capacity is unstable https://github.com/rust-lang/rust/issues/91913
 
     // The main read/write loop.
     //
@@ -1366,6 +1367,7 @@ fn read_helper(i: &mut Input, buf: &mut Vec<u8>, bsize: usize) -> io::Result<Rea
     // ------------------------------------------------------------------
     // Read
     // Resize the buffer to the bsize. Any garbage data in the buffer is overwritten or truncated, so there is no need to fill with BUF_INIT_BYTE first.
+    // resizing buf cause serious performance drop https://github.com/uutils/coreutils/issues/11544
     buf.resize(bsize, BUF_INIT_BYTE);
 
     let mut rstat = match i.settings.iconv.sync {

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -116,6 +116,14 @@ fn help() {
 }
 
 #[test]
+fn test_out_of_memory() {
+    new_ucmd!()
+        .arg("bs=1PB")
+        .fails_with_code(1)
+        .stderr_contains("memory"); //todo: improve error message at all platforms
+}
+
+#[test]
 fn test_stdin_stdout() {
     let input = build_ascii_block(521);
     let output = String::from_utf8(input.clone()).unwrap();


### PR DESCRIPTION
- Closes https://github.com/uutils/coreutils/issues/11436
- Declare buffer before we use it (preliminary to avoid 0-filling)