### PR TITLE
 uucore: add WASI support for FileInformation and io module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ feat_wasm = [
   "shred",
   "shuf",
   "sleep",
+  "sort",
   "sum",
   "tee",
   "true",

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -47,7 +47,7 @@ uucore = { workspace = true, features = [
 fluent = { workspace = true }
 foldhash = { workspace = true }
 
-[target.'cfg(not(target_os = "redox"))'.dependencies]
+[target.'cfg(not(any(target_os = "redox", target_os = "wasi")))'.dependencies]
 ctrlc = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -54,7 +54,7 @@ fn should_install_signal_handler() -> bool {
     open_fds.saturating_add(CTRL_C_FDS + RESERVED_FOR_MERGE) <= limit
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 fn ensure_signal_handler_installed(state: Arc<Mutex<HandlerRegistration>>) -> UResult<()> {
     // This shared state must originate from `HANDLER_STATE` so the handler always sees
     // the current lock/path pair and can clean up the active temp directory on SIGINT.
@@ -104,7 +104,7 @@ fn ensure_signal_handler_installed(state: Arc<Mutex<HandlerRegistration>>) -> UR
     Ok(())
 }
 
-#[cfg(target_os = "redox")]
+#[cfg(any(target_os = "redox", target_os = "wasi"))]
 fn ensure_signal_handler_installed(_state: Arc<Mutex<HandlerRegistration>>) -> UResult<()> {
     Ok(())
 }

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -225,6 +225,7 @@ impl Hash for FileInformation {
         #[cfg(target_os = "wasi")]
         {
             self.0.len().hash(state);
+            self.0.file_type().is_dir().hash(state);
         }
     }
 }

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -28,6 +28,7 @@ use crate::os_str_from_bytes;
 #[cfg(windows)]
 use crate::show_warning;
 
+#[cfg(not(target_os = "wasi"))]
 use std::ffi::OsStr;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -64,13 +65,14 @@ use libc::{
 };
 #[cfg(unix)]
 use std::ffi::{CStr, CString};
+#[cfg(not(target_os = "wasi"))]
 use std::io::Error as IOError;
 #[cfg(unix)]
 use std::mem;
 #[cfg(windows)]
 use std::path::Path;
 use std::time::SystemTime;
-#[cfg(not(windows))]
+#[cfg(unix)]
 use std::time::UNIX_EPOCH;
 use std::{borrow::Cow, ffi::OsString};
 

--- a/src/uucore/src/lib/mods/io.rs
+++ b/src/uucore/src/lib/mods/io.rs
@@ -75,7 +75,14 @@ impl OwnedFileDescriptorOrHandle {
     /// instantiates a corresponding `Stdio`
     #[cfg(not(target_os = "wasi"))]
     pub fn into_stdio(self) -> Stdio {
-        Stdio::from(self.fx)
+        #[cfg(not(target_os = "wasi"))]
+        {
+            Stdio::from(self.fx)
+        }
+        #[cfg(target_os = "wasi")]
+        {
+            Stdio::from(File::from(self.fx))
+        }
     }
 
     /// WASI: Stdio::from(OwnedFd) is not available, convert via File instead.


### PR DESCRIPTION
The ctrlc crate uses platform-specific signal handling unavailable on WASI. Exclude it and skip signal handler installation on WASI, similar to the existing Redox exclusion.