### PR TITLE
cat: add WASI stub for is_unsafe_overwrite and add to feat_wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ feat_wasm = [
   "base32",
   "base64",
   "basenc",
+  "cat",
   "cut",
   "date",
   "dircolors",

--- a/src/uu/cat/src/platform/mod.rs
+++ b/src/uu/cat/src/platform/mod.rs
@@ -9,6 +9,12 @@ pub use self::unix::is_unsafe_overwrite;
 #[cfg(windows)]
 pub use self::windows::is_unsafe_overwrite;
 
+// WASI: no fstat-based device/inode checks available; assume safe.
+#[cfg(target_os = "wasi")]
+pub fn is_unsafe_overwrite<I, O>(_input: &I, _output: &O) -> bool {
+    false
+}
+
 #[cfg(unix)]
 mod unix;
 


### PR DESCRIPTION
WASI has no fstat-based device/inode checks, so always return false (assume safe) for the overwrite detection.