### PR TITLE
df: replace nix by rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,7 +3461,7 @@ dependencies = [
  "clap",
  "codspeed-divan-compat",
  "fluent",
- "nix",
+ "rustix",
  "tempfile",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = { workspace = true }
 fluent = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true, features = ["fs"] }
+rustix = { workspace = true, features = ["fs"] }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -301,7 +301,7 @@ fn get_all_filesystems(opt: &Options) -> UResult<Vec<Filesystem>> {
     // Run a sync call before any operation if so instructed.
     if opt.sync {
         #[cfg(not(any(windows, target_os = "redox")))]
-        nix::unistd::sync();
+        rustix::fs::sync();
     }
 
     let mut mounts = vec![];


### PR DESCRIPTION
split https://github.com/uutils/coreutils/pull/11548
reduced binary size about 50 bytes (ofcause we still have nix at uucore).