### PR TITLE
wc: improve wc -c perf with unextended pipe input (Linux only)

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -29,11 +29,9 @@ const FILE_ATTRIBUTE_NORMAL: u32 = 128;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use libc::S_IFIFO;
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use uucore::pipes::{pipe, splice, splice_exact};
+use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, pipe, splice, splice_exact};
 
 const BUF_SIZE: usize = 256 * 1024;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-const SPLICE_SIZE: usize = 128 * 1024;
 
 /// This is a Linux-specific function to count the number of bytes using the
 /// `splice` system call, which is faster than using `read`.
@@ -55,11 +53,14 @@ fn count_bytes_using_splice(fd: &impl AsFd) -> Result<usize, usize> {
         // Bit of an edge case, but it has been known to happen
         return Err(0);
     }
+    // todo: avoid generating broker if input is pipe (fcntl_setpipe_size succeed) and directly splice() to /dev/null to save RAM usage
     let (pipe_rd, pipe_wr) = pipe().map_err(|_| 0_usize)?;
 
     let mut byte_count = 0;
+    // improve throughput from pipe
+    let _ = rustix::pipe::fcntl_setpipe_size(fd, MAX_ROOTLESS_PIPE_SIZE);
     loop {
-        match splice(fd, &pipe_wr, SPLICE_SIZE) {
+        match splice(fd, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE) {
             Ok(0) => break,
             Ok(res) => {
                 byte_count += res;


### PR DESCRIPTION
```
$ truncate -s 32GB huge
$ time cat huge|wc -c
Executed in    1.31 secs    fish           external
   usr time    0.64 secs    0.53 millis    0.63 secs
   sys time    1.53 secs    2.95 millis    1.52 secs
$ time cat huge|target/release/wc -c
Executed in  388.34 millis    fish           external
   usr time   39.03 millis    0.64 millis   38.39 millis
   sys time  657.96 millis    2.98 millis  654.98 millis
```
Depends on https://github.com/uutils/coreutils/pull/11551 for smaller diff.