### PR TITLE
wasi: fix warnings

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1896,12 +1896,13 @@ pub(crate) fn copy_attributes(
 fn symlink_file(
     source: &Path,
     dest: &Path,
-    symlinked_files: &mut HashSet<FileInformation>,
+    #[cfg(not(target_os = "wasi"))] symlinked_files: &mut HashSet<FileInformation>,
+    #[cfg(target_os = "wasi")] _symlinked_files: &mut HashSet<FileInformation>,
 ) -> CopyResult<()> {
     #[cfg(target_os = "wasi")]
     {
         return Err(CpError::IoErrContext(
-            std::io::Error::new(std::io::ErrorKind::Unsupported, "symlinks not supported"),
+            io::Error::new(io::ErrorKind::Unsupported, "symlinks not supported"),
             translate!("cp-error-cannot-create-symlink",
                        "dest" => get_filename(dest).unwrap_or("?").quote(),
                        "source" => get_filename(source).unwrap_or("?").quote()),
@@ -1930,10 +1931,13 @@ fn symlink_file(
             )
         })?;
     }
-    if let Ok(file_info) = FileInformation::from_path(dest, false) {
-        symlinked_files.insert(file_info);
+    #[cfg(not(target_os = "wasi"))]
+    {
+        if let Ok(file_info) = FileInformation::from_path(dest, false) {
+            symlinked_files.insert(file_info);
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 fn context_for(src: &Path, dest: &Path) -> String {

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -929,7 +929,7 @@ fn rename_symlink_fallback(from: &Path, to: &Path) -> io::Result<()> {
 }
 
 #[cfg(target_os = "wasi")]
-fn rename_symlink_fallback(from: &Path, to: &Path) -> io::Result<()> {
+fn rename_symlink_fallback(_from: &Path, _to: &Path) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Other,
         translate!("mv-error-no-symlink-support"),

--- a/src/uu/wc/src/countable.rs
+++ b/src/uu/wc/src/countable.rs
@@ -24,6 +24,7 @@ pub trait WordCountable: AsFd + AsRawFd + Read {
 pub trait WordCountable: Read {
     type Buffered: BufRead;
     fn buffered(self) -> Self::Buffered;
+    #[cfg(not(target_os = "wasi"))]
     fn inner_file(&mut self) -> Option<&mut File>;
 }
 
@@ -40,6 +41,8 @@ impl WordCountable for StdinLock<'_> {
     fn buffered(self) -> Self::Buffered {
         self
     }
+
+    #[cfg(not(target_os = "wasi"))]
     fn inner_file(&mut self) -> Option<&mut File> {
         None
     }
@@ -62,6 +65,7 @@ impl WordCountable for File {
         BufReader::new(self)
     }
 
+    #[cfg(not(target_os = "wasi"))]
     fn inner_file(&mut self) -> Option<&mut File> {
         Some(self)
     }


### PR DESCRIPTION
This PR fixes some warnings that show up in the wasi job. See, for example, https://github.com/uutils/coreutils/actions/runs/23898299309/job/69688858252?pr=11598#step:18:209

Update: I didn't fix the warnings in `fsext.rs` because they are fixed in https://github.com/uutils/coreutils/pull/11568