### PR TITLE
pre-commit: update rust-clippy and cargo-lock-check to run without accessing the network

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,14 +39,14 @@ repos:
       - id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit.
-        entry: cargo +stable clippy --workspace --all-targets --all-features -- -D warnings
+        entry: cargo +stable clippy --frozen --workspace --all-targets --all-features -- -D warnings
         pass_filenames: false
         types: [file, rust]
         language: system
       - id: cargo-lock-check
         name: Cargo.lock sync check
         description: Ensure Cargo.lock and fuzz/Cargo.lock are up-to-date.
-        entry: bash -c 'for dir in . fuzz; do ( cd "$dir" && cargo fetch --locked --quiet ) || { echo "ERROR - $dir/Cargo.lock is out of date. Run -> cd $dir && cargo update"; exit 1; } done'
+        entry: bash -c 'for dir in . fuzz; do ( cd "$dir" && cargo fetch --frozen --quiet ) || { echo "ERROR - $dir/Cargo.lock is out of date. Run -> cd $dir && cargo update"; exit 1; } done'
         pass_filenames: false
         files: 'Cargo\.(toml|lock)$'
         language: system


### PR DESCRIPTION
This allows committing without network access and should reduce the time taken for the hook.