### PR TITLE
pre-commit: update cargo-lock-check to suggest changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: cargo-lock-check
         name: Cargo.lock sync check
         description: Ensure Cargo.lock and fuzz/Cargo.lock are up-to-date.
-        entry: bash -c 'for dir in . fuzz; do ( cd "$dir" && cargo fetch --locked --quiet ) || { echo "ERROR - $dir/Cargo.lock is out of date. Run -> cd $dir && cargo update"; exit 1; } done'
+        entry: bash -c 'for dir in . fuzz; do ( cd "$dir" && cargo fetch --quiet ); done'
         pass_filenames: false
         files: 'Cargo\.(toml|lock)$'
         language: system


### PR DESCRIPTION
Remove `--locked` option to update the lockfiles if necessary (timesaver). Check will still fail due to changed files.