### PR TITLE
uucore: use 1 MiB pipe size at buf_copy

### DIFF
--- a/src/uucore/src/lib/features/buf_copy/linux.rs
+++ b/src/uucore/src/lib/features/buf_copy/linux.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     error::UResult,
-    pipes::{pipe, splice, splice_exact},
+    pipes::{MAX_ROOTLESS_PIPE_SIZE, pipe, splice, splice_exact},
 };
 
 /// Buffer-based copying utilities for unix (excluding Linux).
@@ -28,7 +28,6 @@ pub trait FdWritable: Write + AsFd + AsRawFd {}
 
 impl<T> FdWritable for T where T: Write + AsFd + AsRawFd {}
 
-const SPLICE_SIZE: usize = 1024 * 128;
 const BUF_SIZE: usize = 1024 * 16;
 
 /// Conversion from a `nix::Error` into our `Error` which implements `UError`.
@@ -94,7 +93,7 @@ where
     let mut bytes: u64 = 0;
 
     loop {
-        match splice(&source, &pipe_wr, SPLICE_SIZE) {
+        match splice(&source, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE) {
             Ok(n) => {
                 if n == 0 {
                     return Ok((bytes, false));


### PR DESCRIPTION
This PR deprecates `const SPLICE_SIZE` and uses maximal pipe size without root.

This is preliminary for improving other progs. We need to fcntl() just once before calling `copy_stream()` to achieve benefit of this PR.

But it seems such utils are `cp` and `install` only and I have no idea where is the suitable place to fcnti() currently.