### PR TITLE
uucore: pipes.rs replace != with >

### DIFF
--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -56,7 +56,7 @@ pub fn splice(source: &impl AsFd, target: &impl AsFd, len: usize) -> std::io::Re
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn splice_exact(source: &impl AsFd, target: &impl AsFd, len: usize) -> std::io::Result<()> {
     let mut left = len;
-    while left != 0 {
+    while left > 0 {
         let written = splice(source, target, left)?;
         debug_assert_ne!(written, 0, "unexpected end of data");
         left -= written;


### PR DESCRIPTION
!= is too strict. ~Might cause infinite loop if external crate has a bug.~