### PR TITLE
uucore: add missing feature of rustix

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -37,7 +37,7 @@ jiff = { workspace = true, optional = true, features = [
   "tzdb-concatenated",
 ] }
 rustc-hash = { workspace = true }
-rustix = { workspace = true, features = ["pipe"] }
+rustix = { workspace = true, features = ["fs", "pipe"] }
 time = { workspace = true, optional = true, features = [
   "formatting",
   "local-offset",


### PR DESCRIPTION
```
error[E0433]: failed to resolve: could not find `fs` in `rustix`
   --> src/uucore/src/lib/features/pipes.rs:80:24
    |
 80 |     let stat = rustix::fs::fstat(&null).ok()?;
    |                        ^^ could not find `fs` in `rustix`
    |
note: found an item that was configured out
   --> /tmp/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:226:9
    |
224 | #[cfg(feature = "fs")]
    |       -------------- the item is gated behind the `fs` feature
225 | #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
226 | pub mod fs;
    |         ^^
note: found an item that was configured out
   --> /tmp/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:336:16
    |
327 |       any(
    |  ________-
328 | |         feature = "param",
329 | |         feature = "runtime",
330 | |         feature = "thread",
331 | |         feature = "time",
332 | |         target_arch = "x86",
333 | |     )
    | |_____- the item is gated here
...
336 |   pub(crate) mod fs;
    |                  ^^

error[E0433]: failed to resolve: could not find `fs` in `rustix`
   --> src/uucore/src/lib/features/pipes.rs:82:17
    |
 82 |     if (rustix::fs::major(dev), rustix::fs::minor(dev)) == (1, 3) {
    |                 ^^ could not find `fs` in `rustix`
    |
note: found an item that was configured out
   --> /tmp/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:226:9
    |
224 | #[cfg(feature = "fs")]
    |       -------------- the item is gated behind the `fs` feature
225 | #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
226 | pub mod fs;
    |         ^^
note: found an item that was configured out
   --> /tmp/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:336:16
    |
327 |       any(
    |  ________-
328 | |         feature = "param",
329 | |         feature = "runtime",
330 | |         feature = "thread",
331 | |         feature = "time",
332 | |         target_arch = "x86",
333 | |     )
    | |_____- the item is gated here
...
336 |   pub(crate) mod fs;
    |                  ^^

error[E0433]: failed to resolve: could not find `fs` in `rustix`
   --> src/uucore/src/lib/features/pipes.rs:82:41
    |
 82 |     if (rustix::fs::major(dev), rustix::fs::minor(dev)) == (1, 3) {
    |                                         ^^ could not find `fs` in `rustix`
    |
note: found an item that was configured out
   --> /tmp/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:226:9
    |
224 | #[cfg(feature = "fs")]
    |       -------------- the item is gated behind the `fs` feature
225 | #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
226 | pub mod fs;
    |         ^^
note: found an item that was configured out
   --> /tmp/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:336:16
    |
327 |       any(
    |  ________-
328 | |         feature = "param",
329 | |         feature = "runtime",
330 | |         feature = "thread",
331 | |         feature = "time",
332 | |         target_arch = "x86",
333 | |     )
    | |_____- the item is gated here
...
336 |   pub(crate) mod fs;
    |                  ^^
```