### PR TITLE
wc: avoid pipe() if input is pipe

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -40,24 +40,33 @@ const BUF_SIZE: usize = 256 * 1024;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn count_bytes_using_splice(fd: &impl AsFd) -> Result<usize, usize> {
     let null_file = uucore::pipes::dev_null().ok_or(0_usize)?;
-    // todo: avoid generating broker if input is pipe (fcntl_setpipe_size succeed) and directly splice() to /dev/null to save RAM usage
-    let (pipe_rd, pipe_wr) = pipe().map_err(|_| 0_usize)?;
-
     let mut byte_count = 0;
-    // improve throughput from pipe
-    let _ = rustix::pipe::fcntl_setpipe_size(fd, MAX_ROOTLESS_PIPE_SIZE);
-    loop {
-        match splice(fd, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE) {
-            Ok(0) => break,
-            Ok(res) => {
-                byte_count += res;
-                // Silent the warning as we want to the error message
-                if splice_exact(&pipe_rd, &null_file, res).is_err() {
-                    return Err(byte_count);
-                }
+    if let Ok(res) = splice(fd, &null_file, MAX_ROOTLESS_PIPE_SIZE) {
+        byte_count += res;
+        // no need to increase pipe size of input fd since
+        // - sender with splice probably increased size already
+        // - sender without splice is bottleneck of our wc -c
+        loop {
+            match splice(fd, &null_file, MAX_ROOTLESS_PIPE_SIZE) {
+                Ok(0) => break,
+                Ok(res) => byte_count += res,
+                Err(_) => return Err(byte_count),
             }
-            Err(_) => return Err(byte_count),
         }
+    } else if let Ok((pipe_rd, pipe_wr)) = pipe() {
+        // input is not pipe. needs broker to use splice() with additional cost
+        loop {
+            match splice(fd, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE) {
+                Ok(0) => break,
+                Ok(res) => {
+                    byte_count += res;
+                    splice_exact(&pipe_rd, &null_file, res).map_err(|_| byte_count)?;
+                }
+                Err(_) => return Err(byte_count),
+            }
+        }
+    } else {
+        return Ok(0_usize);
     }
 
     Ok(byte_count)


### PR DESCRIPTION
Avoid unnecessary pipe() call (1 MiB RAM usage). This avoids performance drop on the system opening too many pipes too:
```
$ time cat h| strace -o /dev/null -e inject=pipe:error=ENOENT target/release/wc -c
1000000000
Executed in   51.41 millis    fish           external
   usr time   16.81 millis    1.53 millis   15.27 millis
   sys time   60.23 millis    1.40 millis   58.83 millis

$ time cat h| strace -o /dev/null -e inject=pipe:error=ENOENT wc -c
1000000000
Executed in  258.63 millis    fish           external
   usr time   60.48 millis    0.00 millis   60.48 millis
   sys time  242.36 millis    3.15 millis  239.21 millis
```
(benchmark result is not important at here)