### PR TITLE
date: fix "unused variable" warning

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -706,7 +706,8 @@ fn format_date_with_locale_aware_months(
     date: &Zoned,
     format_string: &str,
     config: &Config<PosixCustom>,
-    skip_localization: bool,
+    #[cfg(feature = "i18n-datetime")] skip_localization: bool,
+    #[cfg(not(feature = "i18n-datetime"))] _skip_localization: bool,
 ) -> Result<String, String> {
     // First check if format string has GNU modifiers (width/flags) and format if present
     // This optimization combines detection and formatting in a single pass


### PR DESCRIPTION
This PR fixes an "unused variable" warning I noticed in the output of the `WASI` workflow. See, for example, https://github.com/uutils/coreutils/actions/runs/23980203236/job/69943304931?pr=11633#step:6:714