### PR TITLE
uudoc: drop legacy FA4 `fa` class from platform icons

### DIFF
--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -495,7 +495,7 @@ impl MDWriter<'_, '_> {
                     .iter()
                     .any(|u| u == self.name)
             {
-                writeln!(self.w, "<i class=\"fa fa-brands fa-{icon}\"></i>")?;
+                writeln!(self.w, "<i class=\"fa-brands fa-{icon}\"></i>")?;
             }
         }
         writeln!(self.w, "</div>")?;


### PR DESCRIPTION
mdbook 0.5's built-in Font Awesome parser sees the leading `fa` class and defaults to type=regular, which fails to find linux/windows/apple (they live under the `brands` family) and emits hundreds of WARN lines per build. Keeping only `fa-brands fa-<icon>` lets the parser resolve the icon correctly.

See https://rust-lang.github.io/mdBook/format/mdbook.html for the mdbook Font Awesome syntax.