### PR TITLE
mkdir: replace libc and unsafe by rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ version = "0.8.0"
 dependencies = [
  "clap",
  "fluent",
+ "rustix",
  "uucore",
 ]
 

--- a/src/uu/mkdir/Cargo.toml
+++ b/src/uu/mkdir/Cargo.toml
@@ -23,6 +23,9 @@ clap = { workspace = true }
 uucore = { workspace = true, features = ["fs", "mode", "fsxattr"] }
 fluent = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["process", "fs"] }
+
 [features]
 selinux = ["uucore/selinux"]
 smack = ["uucore/smack"]

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -252,13 +252,13 @@ fn create_dir(path: &Path, is_parent: bool, config: &Config) -> UResult<()> {
 
 /// RAII guard to restore umask on drop, ensuring cleanup even on panic.
 #[cfg(unix)]
-struct UmaskGuard(uucore::libc::mode_t);
+struct UmaskGuard(rustix::fs::Mode);
 
 #[cfg(unix)]
 impl UmaskGuard {
     /// Set umask to the given value and return a guard that restores the original on drop.
-    fn set(new_mask: uucore::libc::mode_t) -> Self {
-        let old_mask = unsafe { uucore::libc::umask(new_mask) };
+    fn set(new_mask: rustix::fs::Mode) -> Self {
+        let old_mask = rustix::process::umask(new_mask);
         Self(old_mask)
     }
 }
@@ -266,9 +266,7 @@ impl UmaskGuard {
 #[cfg(unix)]
 impl Drop for UmaskGuard {
     fn drop(&mut self) {
-        unsafe {
-            uucore::libc::umask(self.0);
-        }
+        rustix::process::umask(self.0);
     }
 }
 
@@ -283,7 +281,7 @@ fn create_dir_with_mode(path: &Path, mode: u32) -> std::io::Result<()> {
 
     // Temporarily set umask to 0 so the directory is created with the exact mode.
     // The guard restores the original umask on drop, even if we panic.
-    let _guard = UmaskGuard::set(0);
+    let _guard = UmaskGuard::set(rustix::fs::Mode::empty());
 
     std::fs::DirBuilder::new().mode(mode).create(path)
 }


### PR DESCRIPTION
split https://github.com/uutils/coreutils/pull/11548
about -100 bytes, 1 unsafe removal