### PR TITLE
Fix: wait_or_timeout process wait wont have 100 ms latency

### DIFF
--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -7,16 +7,17 @@
 // spell-checker:ignore (sys/unix) WIFSIGNALED ESRCH
 // spell-checker:ignore pgrep pwait snice getpgrp
 
-use libc::{gid_t, pid_t, uid_t};
+use libc::{gid_t, pid_t, uid_t, waitpid};
 #[cfg(not(target_os = "redox"))]
 use nix::errno::Errno;
 use nix::sys::signal::{self as nix_signal, SigHandler, Signal};
 use nix::unistd::Pid;
 use std::io;
+use std::os::unix::process::ExitStatusExt;
 use std::process::Child;
 use std::process::ExitStatus;
-use std::sync::atomic;
 use std::sync::atomic::AtomicBool;
+use std::sync::{atomic, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -145,10 +146,22 @@ impl ChildExt for Child {
         // .try_wait() doesn't drop stdin, so we do it manually
         drop(self.stdin.take());
 
+        let (tx, rx) = mpsc::channel();
+
+        let pid = self.id();
+
+        thread::spawn(move || {
+            let mut status = 0;
+
+            unsafe { waitpid(pid as i32, &raw mut status, 0) };
+
+            _ = tx.send(status);
+        });
+
         let start = Instant::now();
         loop {
-            if let Some(status) = self.try_wait()? {
-                return Ok(Some(status));
+            if let Ok(v) = rx.recv_timeout(Duration::from_millis(100)) {
+                return Ok(Some(ExitStatus::from_raw(v)));
             }
 
             if start.elapsed() >= timeout
@@ -156,11 +169,6 @@ impl ChildExt for Child {
             {
                 break;
             }
-
-            // XXX: this is kinda gross, but it's cleaner than starting a thread just to wait
-            //      (which was the previous solution).  We might want to use a different duration
-            //      here as well
-            thread::sleep(Duration::from_millis(100));
         }
 
         Ok(None)


### PR DESCRIPTION
Removes sleep mentioned in #11615 for a timeouted recv on the pipe. Also removes the latency mentioned in #9099 for when the child process finishes (still needs to loop to check the Atomic bool `signaled`)

following is a hyprfine showing the new version vs the old version


```
hyperfine --runs 100 './old_timeout  0.01 echo .' './new_timeout  0.01 echo .'
Benchmark 1: ./old_timeout  0.01 echo .
  Time (mean ± σ):     119.3 ms ±   2.6 ms    [User: 5.9 ms, System: 7.1 ms]
  Range (min … max):   110.7 ms … 122.5 ms    100 runs

Benchmark 2: ./new_timeout  0.01 echo .
  Time (mean ± σ):       3.1 ms ±   1.3 ms    [User: 1.3 ms, System: 1.4 ms]
  Range (min … max):     2.7 ms …  15.4 ms    100 runs

  Warning: Command took less than 5 ms to complete. Note that the results might be inaccurate because hyperfine can not calibrate the shell startup time much more precise than this limit. You can try to use the `-N`/`--shell=none` option to disable the shell completely.
  Warning: The first benchmarking run for this command was significantly slower than the rest (15.4 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

Summary
  ./new_timeout  0.01 echo . ran
   38.11 ± 15.82 times faster than ./old_timeout  0.01 echo .
```