### PR TITLE
date: honor narrow width on wide default strftime fields #11660

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -356,9 +356,9 @@ fn apply_modifiers(
         width
     };
 
-    // Handle width smaller than result: strip default padding to fit
+    // When the requested width is narrower than the default formatted width, GNU first removes default padding and then reapplies the requested width.
     if effective_width > 0 && effective_width < result.len() {
-        return Ok(strip_default_padding(&result));
+        result = strip_default_padding(&result);
     }
 
     // Strip default padding when switching pad characters on numeric fields

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1827,7 +1827,6 @@ fn test_date_parenthesis_comment() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11660 — GNU date pads to the requested width when it is narrower than the default (e.g. `%02j` on day-1 -> `01`); uutils strips leading zeros to `1`."]
 fn test_date_strftime_narrow_width_on_wide_default() {
     // `%j` has a default width of 3. Requesting `%02j` on day 1 should yield `01`.
     // uutils currently yields `1`.


### PR DESCRIPTION
Fixes #11660 

For specifiers with a wider default width like `%j`, uutils stripped default padding when the requested width was smaller, but returned too early.
This change strips the default padding first and then continues through the existing width-padding logic, matching GNU behavior.

The test now passes after the change:
<img width="731" height="186" alt="image" src="https://github.com/user-attachments/assets/26d12821-19fa-4e46-9b48-b2dfbb64c4a7" />
