### PR TITLE
date: fix %#P case-swap on lowercase am/pm #11659

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -337,7 +337,10 @@ fn apply_modifiers(
             .all(|c| !c.is_alphabetic() || c.is_uppercase())
         {
             result = result.to_lowercase();
-        } else {
+        } else if !result
+            .chars()
+            .all(|c| !c.is_alphabetic() || c.is_lowercase())
+        {
             result = result.to_uppercase();
         }
     }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1888,7 +1888,6 @@ fn test_date_input_trailing_tz_abbrev_rezones() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11659 — GNU date treats the `#` case-swap flag as no-op on `%P` (already-lowercase alt); uutils uppercases it to `PM`."]
 fn test_date_strftime_case_flag_on_alt_ampm() {
     // `%P` is GNU's lowercase am/pm. `%#P` should stay lowercase in GNU; uutils flips to `PM`.
     new_ucmd!()


### PR DESCRIPTION
Fixes #11659 

`%P` already returns lowercase am/pm. The current `#` handling uppercases any non-uppercase value, so `%#P` becomes `PM`. GNU keeps `%#P` as `pm`. Adjusted the case-swap logic to leave already-lowercased alt-specifier unchanged.

The test_date_strftime_case_flag_on_alt_ampm() test case now passes.
<img width="671" height="258" alt="image" src="https://github.com/user-attachments/assets/bd3cf133-8694-4824-88b5-7a62fa7e5baa" />
