### PR TITLE
wc: optimize -c when reading from stdin regular file

### DIFF
--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -62,7 +62,8 @@ fn try_get_stdin_size() -> Option<usize> {
 
         let file_type = rustix::fs::FileType::from_raw_mode(stat.st_mode);
 
-        if file_type == rustix::fs::FileType::RegularFile && stat.st_size > 0 {
+        if file_type == rustix::fs::FileType::RegularFile && stat.st_size > 0 && stat.st_nlink == 1
+        {
             return Some(stat.st_size as usize);
         }
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -58,7 +58,7 @@ fn try_get_stdin_size() -> Option<usize> {
             return None;
         };
         let file_type = rustix::fs::FileType::from_raw_mode(stat.st_mode);
-        if file_type == rustix::fs::FileType::RegularFile && stat.st_size > 0 && stat.st_blocks > 0
+        if file_type == rustix::fs::FileType::RegularFile
         {
             return Some(stat.st_size as usize);
         }

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -58,8 +58,7 @@ fn try_get_stdin_size() -> Option<usize> {
             return None;
         };
         let file_type = rustix::fs::FileType::from_raw_mode(stat.st_mode);
-        if file_type == rustix::fs::FileType::RegularFile
-        {
+        if file_type == rustix::fs::FileType::RegularFile {
             return Some(stat.st_size as usize);
         }
         None

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -60,9 +60,12 @@ fn try_get_stdin_size() -> Option<usize> {
             return None;
         };
 
-        if rustix::fs::FileType::from_raw_mode(stat.st_mode) == rustix::fs::FileType::RegularFile {
+        let file_type = rustix::fs::FileType::from_raw_mode(stat.st_mode);
+
+        if file_type == rustix::fs::FileType::RegularFile && stat.st_size > 0 {
             return Some(stat.st_size as usize);
         }
+
         None
     }
     #[cfg(not(unix))]

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -23,7 +23,6 @@ use std::{
 };
 
 use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser};
-use rustix::fd::AsFd;
 use thiserror::Error;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
@@ -52,6 +51,8 @@ const MINIMUM_WIDTH: usize = 7;
 fn try_get_stdin_size() -> Option<usize> {
     #[cfg(unix)]
     {
+        use rustix::fd::AsFd;
+
         let stdin = io::stdin();
         let fd = stdin.as_fd();
 

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -18,6 +18,7 @@ use std::{
     fs::{self, File},
     io::{self, Write, stderr},
     iter,
+    os::fd::AsFd,
     path::{Path, PathBuf},
     sync::LazyLock,
 };
@@ -46,6 +47,26 @@ use crate::{
 /// The minimum character width for formatting counts when reading from stdin.
 const MINIMUM_WIDTH: usize = 7;
 
+/// Returns the byte size of stdin if it is a regular file (e.g. `wc -c < file`).
+/// Returns `None` for pipes, terminals, sockets, etc. so we fall back to normal counting.
+fn try_get_stding_size() -> Option<usize> {
+    #[cfg(unix)]
+    {
+        let stdin = io::stdin();
+        let fd = stdin.as_fd();
+
+        let Ok(stat) = rustix::fs::fstat(fd) else { return  None};
+
+        if rustix::fs::FileType::from_raw_mode(stat.st_mode) == rustix::fs::FileType::RegularFile {
+            return Some(stat.st_size as usize);
+        }
+        None
+    }
+    #[cfg(not(unix))]
+    {
+        None // TODO: Implement Windows support 
+    }
+}
 struct Settings<'a> {
     show_bytes: bool,
     show_chars: bool,
@@ -483,6 +504,16 @@ fn word_count_from_reader<T: WordCountable>(
 
         // show_bytes
         (true, false, false, false, false) => {
+            // Fast path: if stdin is a regular file, get size from metadata (no reading needed)
+            if let Some(bytes) = try_get_stding_size() {
+                return (
+                    WordCount {
+                        bytes,
+                        ..WordCount::default()
+                    },
+                    None,
+                );
+            }
             // Fast path when only show_bytes is true.
             let (bytes, error) = count_bytes_fast(&mut reader);
             (

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -52,31 +52,21 @@ fn try_get_stdin_size() -> Option<usize> {
     #[cfg(unix)]
     {
         use rustix::fd::AsFd;
-
         let stdin = io::stdin();
         let fd = stdin.as_fd();
-
         let Ok(stat) = rustix::fs::fstat(fd) else {
             return None;
         };
-
-        if rustix::fs::FileType::from_raw_mode(stat.st_mode) != rustix::fs::FileType::RegularFile {
-            return None;
+        let file_type = rustix::fs::FileType::from_raw_mode(stat.st_mode);
+        if file_type == rustix::fs::FileType::RegularFile && stat.st_size > 0 && stat.st_blocks > 0
+        {
+            return Some(stat.st_size as usize);
         }
-
-        let Ok(fs) = rustix::fs::fstatfs(fd) else {
-            return None;
-        };
-
-        if fs.f_type == rustix::fs::PROC_SUPER_MAGIC {
-            return None;
-        }
-
-        Some(stat.st_size as usize)
+        None
     }
     #[cfg(not(unix))]
     {
-        None // TODO: Implement Windows support
+        None
     }
 }
 struct Settings<'a> {

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -18,12 +18,12 @@ use std::{
     fs::{self, File},
     io::{self, Write, stderr},
     iter,
-    os::fd::AsFd,
     path::{Path, PathBuf},
     sync::LazyLock,
 };
 
 use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser};
+use rustix::fd::AsFd;
 use thiserror::Error;
 use unicode_width::UnicodeWidthChar;
 use utf8::{BufReadDecoder, BufReadDecoderError};
@@ -49,7 +49,7 @@ const MINIMUM_WIDTH: usize = 7;
 
 /// Returns the byte size of stdin if it is a regular file (e.g. `wc -c < file`).
 /// Returns `None` for pipes, terminals, sockets, etc. so we fall back to normal counting.
-fn try_get_stding_size() -> Option<usize> {
+fn try_get_stdin_size() -> Option<usize> {
     #[cfg(unix)]
     {
         let stdin = io::stdin();
@@ -507,7 +507,7 @@ fn word_count_from_reader<T: WordCountable>(
         // show_bytes
         (true, false, false, false, false) => {
             // Fast path: if stdin is a regular file, get size from metadata (no reading needed)
-            if let Some(bytes) = try_get_stding_size() {
+            if let Some(bytes) = try_get_stdin_size() {
                 return (
                     WordCount {
                         bytes,

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -55,7 +55,9 @@ fn try_get_stding_size() -> Option<usize> {
         let stdin = io::stdin();
         let fd = stdin.as_fd();
 
-        let Ok(stat) = rustix::fs::fstat(fd) else { return  None};
+        let Ok(stat) = rustix::fs::fstat(fd) else {
+            return None;
+        };
 
         if rustix::fs::FileType::from_raw_mode(stat.st_mode) == rustix::fs::FileType::RegularFile {
             return Some(stat.st_size as usize);

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -64,7 +64,7 @@ fn try_get_stding_size() -> Option<usize> {
     }
     #[cfg(not(unix))]
     {
-        None // TODO: Implement Windows support 
+        None // TODO: Implement Windows support
     }
 }
 struct Settings<'a> {

--- a/src/uu/wc/src/wc.rs
+++ b/src/uu/wc/src/wc.rs
@@ -60,14 +60,19 @@ fn try_get_stdin_size() -> Option<usize> {
             return None;
         };
 
-        let file_type = rustix::fs::FileType::from_raw_mode(stat.st_mode);
-
-        if file_type == rustix::fs::FileType::RegularFile && stat.st_size > 0 && stat.st_nlink == 1
-        {
-            return Some(stat.st_size as usize);
+        if rustix::fs::FileType::from_raw_mode(stat.st_mode) != rustix::fs::FileType::RegularFile {
+            return None;
         }
 
-        None
+        let Ok(fs) = rustix::fs::fstatfs(fd) else {
+            return None;
+        };
+
+        if fs.f_type == rustix::fs::PROC_SUPER_MAGIC {
+            return None;
+        }
+
+        Some(stat.st_size as usize)
     }
     #[cfg(not(unix))]
     {

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -860,7 +860,6 @@ fn wc_w_words_with_emoji_separator() {
         .stdout_contains("3");
 }
 
-
 #[test]
 fn test_invalid_byte_sequence_word_count() {
     // wc should count invalid byte sequences as words

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -860,18 +860,6 @@ fn wc_w_words_with_emoji_separator() {
         .stdout_contains("3");
 }
 
-#[test]
-fn test_wc_bytes_from_stdin_file_size_optimization() {
-    // This tests the metadata fast path (`fstat` on stdin) when only `-c` is used.
-    // It should be extremely fast even for large inputs because it doesn't read the data.
-    let large_input = "a".repeat(50_000_000); // 50 MB
-
-    new_ucmd!()
-        .arg("-c")
-        .pipe_in(large_input)
-        .succeeds()
-        .stdout_is("50000000\n");
-}
 
 #[test]
 fn test_invalid_byte_sequence_word_count() {

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -861,6 +861,19 @@ fn wc_w_words_with_emoji_separator() {
 }
 
 #[test]
+fn test_wc_bytes_from_stdin_file_size_optimization() {
+    // This tests the metadata fast path (`fstat` on stdin) when only `-c` is used.
+    // It should be extremely fast even for large inputs because it doesn't read the data.
+    let large_input = "a".repeat(50_000_000); // 50 MB
+
+    new_ucmd!()
+        .arg("-c")
+        .pipe_in(large_input)
+        .succeeds()
+        .stdout_is("50000000\n");
+}
+
+#[test]
 fn test_invalid_byte_sequence_word_count() {
     // wc should count invalid byte sequences as words
     // Input: "a \xff b\n" should produce: 1 line, 3 words, 6 bytes


### PR DESCRIPTION
fixes #11610

This PR adds the missing metadata optimization for `wc -c` (and `--bytes`) when input comes from stdin redirection (`wc -c < file`).

GNU coreutils uses `fstat()` to get the file size directly in this case, avoiding reading the entire file. uutils previously always read the data, making it very slow on large files.

### Changes
- Added `try_get_stdin_size()` helper using `rustix::fs::fstat` (Unix)
- Integrated it into the existing fast path for bytes-only mode
- Added test for the optimization
- Falls back safely for pipes, terminals, character devices, etc.


also didnt really know windows so i just added todo to windows implementation