### PR TITLE
Fix numfmt accepting scientific notation #11655

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -496,16 +496,7 @@ fn transform_to(
                 round_with_precision(i2, round_method, precision),
             )
         }
-        Some(s) if precision > 0 => {
-            format!(
-                "{i2:.precision$}{unit_separator}{}",
-                DisplayableSuffix(s, opts.to),
-            )
-        }
-        Some(s) if i2.abs() < 10.0 => {
-            format!("{i2:.1}{unit_separator}{}", DisplayableSuffix(s, opts.to))
-        }
-        Some(s) => format!("{i2:.0}{unit_separator}{}", DisplayableSuffix(s, opts.to)),
+        Some(s) => format!("{i2:.precision$}{unit_separator}{}", DisplayableSuffix(s, opts.to)),
     })
 }
 

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -612,6 +612,7 @@ fn format_string(
         options.format.prefix, options.format.suffix
     ))
 }
+
 /// Encodes a byte slice as a string, representing non-UTF-8 bytes and non-printable ASCII
 /// bytes as octal escapes. Valid UTF-8 multi-byte characters pass through unchanged.
 /// Used to safely format invalid input in error messages.

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -488,7 +488,6 @@ fn transform_to(
     unit_separator: &str,
     is_specified: bool,
 ) -> Result<String> {
-
     let (i2, s) = consider_suffix(s, opts.to, round_method, precision)?;
     let i2 = i2 / (opts.to_unit as f64);
     Ok(match s {
@@ -549,7 +548,6 @@ fn format_string(
     };
     let mut is_specified = true;
     let precision = if let Some(p) = options.format.precision {
-
         p
     } else if options.transform.to == Unit::None
         && !source_without_suffix
@@ -557,11 +555,10 @@ fn format_string(
             .last()
             .is_some_and(char::is_alphabetic)
     {
-
         parse_implicit_precision(source_without_suffix)
     } else {
-    is_specified = false;
-    0
+        is_specified = false;
+        0
     };
 
     let number = transform_to(
@@ -570,7 +567,7 @@ fn format_string(
         options.round,
         precision,
         &options.unit_separator,
-        is_specified
+        is_specified,
     )?;
 
     // bring back the suffix before applying padding

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -507,7 +507,7 @@ fn transform_to(
             format!("{i2:.0}{unit_separator}{}", DisplayableSuffix(s, opts.to))
         }
         Some(s) if i2.abs() < 10.0 => {
-            //when there's a single digit before the dot.
+            // when there's a single digit before the dot.
             format!("{i2:.1}{unit_separator}{}", DisplayableSuffix(s, opts.to))
         }
         Some(s) => {

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -486,7 +486,7 @@ fn transform_to(
     round_method: RoundMethod,
     precision: usize,
     unit_separator: &str,
-    is_specified: bool,
+    is_precision_specified: bool,
 ) -> Result<String> {
     let i2 = s / (opts.to_unit as f64);
     let (i2, s) = consider_suffix(i2, opts.to, round_method, precision)?;
@@ -503,7 +503,7 @@ fn transform_to(
                 DisplayableSuffix(s, opts.to),
             )
         }
-        Some(s) if is_specified => {
+        Some(s) if is_precision_specified => {
             format!("{i2:.0}{unit_separator}{}", DisplayableSuffix(s, opts.to))
         }
         Some(s) if i2.abs() < 10.0 => {
@@ -546,7 +546,7 @@ fn format_string(
         Some(suffix) => source.strip_suffix(suffix).unwrap_or(source),
         None => source,
     };
-    let mut is_specified = true;
+    let mut is_precision_specified = true;
     let precision = if let Some(p) = options.format.precision {
         p
     } else if options.transform.to == Unit::None
@@ -557,7 +557,7 @@ fn format_string(
     {
         parse_implicit_precision(source_without_suffix)
     } else {
-        is_specified = false;
+        is_precision_specified = false;
         0
     };
 
@@ -567,7 +567,7 @@ fn format_string(
         options.round,
         precision,
         &options.unit_separator,
-        is_specified,
+        is_precision_specified,
     )?;
 
     // bring back the suffix before applying padding

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -486,7 +486,9 @@ fn transform_to(
     round_method: RoundMethod,
     precision: usize,
     unit_separator: &str,
+    is_specified: bool,
 ) -> Result<String> {
+
     let (i2, s) = consider_suffix(s, opts.to, round_method, precision)?;
     let i2 = i2 / (opts.to_unit as f64);
     Ok(match s {
@@ -496,7 +498,22 @@ fn transform_to(
                 round_with_precision(i2, round_method, precision),
             )
         }
-        Some(s) => format!("{i2:.precision$}{unit_separator}{}", DisplayableSuffix(s, opts.to)),
+        Some(s) if precision > 0 => {
+            format!(
+                "{i2:.precision$}{unit_separator}{}",
+                DisplayableSuffix(s, opts.to),
+            )
+        }
+        Some(s) if is_specified => {
+            format!("{i2:.0}{unit_separator}{}", DisplayableSuffix(s, opts.to))
+        }
+        Some(s) if i2.abs() < 10.0 => {
+            //when there's a single digit before the dot.
+            format!("{i2:.1}{unit_separator}{}", DisplayableSuffix(s, opts.to))
+        }
+        Some(s) => {
+            format!("{i2:.0}{unit_separator}{}", DisplayableSuffix(s, opts.to))
+        }
     })
 }
 
@@ -530,8 +547,9 @@ fn format_string(
         Some(suffix) => source.strip_suffix(suffix).unwrap_or(source),
         None => source,
     };
-
+    let mut is_specified = true;
     let precision = if let Some(p) = options.format.precision {
+
         p
     } else if options.transform.to == Unit::None
         && !source_without_suffix
@@ -539,9 +557,11 @@ fn format_string(
             .last()
             .is_some_and(char::is_alphabetic)
     {
+
         parse_implicit_precision(source_without_suffix)
     } else {
-        0
+    is_specified = false;
+    0
     };
 
     let number = transform_to(
@@ -550,6 +570,7 @@ fn format_string(
         options.round,
         precision,
         &options.unit_separator,
+        is_specified
     )?;
 
     // bring back the suffix before applying padding
@@ -589,7 +610,6 @@ fn format_string(
         options.format.prefix, options.format.suffix
     ))
 }
-
 /// Encodes a byte slice as a string, representing non-UTF-8 bytes and non-printable ASCII
 /// bytes as octal escapes. Valid UTF-8 multi-byte characters pass through unchanged.
 /// Used to safely format invalid input in error messages.

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -47,6 +47,14 @@ fn format_and_write<W: std::io::Write>(
         None => input_line,
     };
 
+    // Return false if the input is in scientific notation.
+    if line.contains(&101) {
+        let _ = writeln!(stderr(), "numfmt: {}",translate!(
+                "numfmt-error-invalid-number",
+                "input" => escape_line(line).quote()));
+        return Ok(false);
+    }
+    
     // In non-abort modes we buffer the formatted output so that on error we
     // can emit the original line instead.
     let buffer_output = !matches!(options.invalid, InvalidModes::Abort);

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -54,7 +54,7 @@ fn format_and_write<W: std::io::Write>(
                 "input" => escape_line(line).quote()));
         return Ok(false);
     }
-    
+
     // In non-abort modes we buffer the formatted output so that on error we
     // can emit the original line instead.
     let buffer_output = !matches!(options.invalid, InvalidModes::Abort);

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1452,7 +1452,6 @@ fn test_to_unit_prefix_selection_issue_11666() {
 // `--format='%.0f'` with `--to=<scale>` still prints one fractional digit;
 // the precision specifier `.0` is ignored.
 #[test]
-#[ignore = "GNU compat: see uutils/coreutils#11667"]
 fn test_format_precision_zero_with_to_scale_issue_11667() {
     new_ucmd!()
         .args(&["--to=iec", "--format=%.0f", "5183776"])


### PR DESCRIPTION
This PR forbids accepting number with scientific notation as argument and may resolve #11655 