### PR TITLE
forbid scientific notation in numfmt #11655

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -48,11 +48,16 @@ fn format_and_write<W: std::io::Write>(
     };
 
     // Return false if the input is in scientific notation
-    if line.contains(&101) && line[line.len() - 1] != 69 && line.contains(&69) && line[line.len() - 1] != 101 && line[0] >= 48 && line[0] <= 57 {
-        let err = NumfmtError::FormattingError(String::from_utf8_lossy(line).to_string());
-        let _ = writeln!(stderr(), "numfmt: invalid number: '{err}'");
-
-        return Ok(false);
+    if let Some(pos) = line.iter().position(|&b| b == b'E' || b == b'e') {
+        if pos < line.len() - 1 {
+            if line[pos + 1] >= 48 && line[pos + 1] <= 57 {
+                let errormsg = format!(
+                    "invalid suffix in input: '{}'",
+                    NumfmtError::FormattingError(String::from_utf8_lossy(line).to_string())
+                );
+                return Err(Box::new(NumfmtError::FormattingError(errormsg)));
+            }
+        }
     }
 
     // In non-abort modes we buffer the formatted output so that on error we

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -50,7 +50,7 @@ fn format_and_write<W: std::io::Write>(
     // Return false if the input is in scientific notation
     if let Some(pos) = line.iter().position(|&b| b == b'E' || b == b'e') {
         if pos < line.len() - 1 {
-            if line[pos + 1] >= 48 && line[pos + 1] <= 57 {
+            if line[pos + 1].is_ascii_digit() {
                 let err = format!(
                     "invalid suffix in input: '{}'",
                     NumfmtError::FormattingError(String::from_utf8_lossy(line).to_string())

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -47,6 +47,14 @@ fn format_and_write<W: std::io::Write>(
         None => input_line,
     };
 
+    // Return false if the input is in scientific notation
+    if line.contains(&101) && line[line.len() - 1] != 69 && line.contains(&69) && line[line.len() - 1] != 101 && line[0] >= 48 && line[0] <= 57 {
+        let err = NumfmtError::FormattingError(String::from_utf8_lossy(line).to_string());
+        let _ = writeln!(stderr(), "numfmt: invalid number: '{err}'");
+
+        return Ok(false);
+    }
+    
     // In non-abort modes we buffer the formatted output so that on error we
     // can emit the original line instead.
     let buffer_output = !matches!(options.invalid, InvalidModes::Abort);

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -53,7 +53,7 @@ fn format_and_write<W: std::io::Write>(
             if line[pos + 1].is_ascii_digit() {
                 let err = format!(
                     "invalid suffix in input: '{}'",
-                    NumfmtError::FormattingError(String::from_utf8_lossy(line).to_string())
+                    String::from_utf8_lossy(line)
                 );
                 return Err(Box::new(NumfmtError::FormattingError(err)));
             }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -51,11 +51,11 @@ fn format_and_write<W: std::io::Write>(
     if let Some(pos) = line.iter().position(|&b| b == b'E' || b == b'e') {
         if pos < line.len() - 1 {
             if line[pos + 1] >= 48 && line[pos + 1] <= 57 {
-                let errormsg = format!(
+                let err = format!(
                     "invalid suffix in input: '{}'",
                     NumfmtError::FormattingError(String::from_utf8_lossy(line).to_string())
                 );
-                return Err(Box::new(NumfmtError::FormattingError(errormsg)));
+                return Err(Box::new(NumfmtError::FormattingError(err)));
             }
         }
     }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -54,7 +54,7 @@ fn format_and_write<W: std::io::Write>(
 
         return Ok(false);
     }
-    
+
     // In non-abort modes we buffer the formatted output so that on error we
     // can emit the original line instead.
     let buffer_output = !matches!(options.invalid, InvalidModes::Abort);

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1405,7 +1405,6 @@ fn test_large_integer_precision_loss_issue_11654() {
 // uutils accepts scientific notation (`1e9`, `5e-3`, ...); GNU rejects it
 // as "invalid suffix in input".
 #[test]
-#[ignore = "GNU compat: see uutils/coreutils#11655"]
 fn test_scientific_notation_rejected_by_gnu_issue_11655() {
     new_ucmd!()
         .arg("1e9")


### PR DESCRIPTION
This PR forbids scientific notation in input of numfmt and should resolve #11655.
Passes all checks with cargo test .
Thanks!