### PR TITLE
tail: replace unsafe libc::kill by rustix

### DIFF
--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -31,7 +31,7 @@ libc = { workspace = true }
 notify = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["fs"] }
+rustix = { workspace = true, features = ["fs", "process"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/src/uu/tail/src/platform/unix.rs
+++ b/src/uu/tail/src/platform/unix.rs
@@ -4,11 +4,11 @@
 // file that was distributed with this source code.
 
 // spell-checker:ignore (ToDO) stdlib, ISCHR, GETFD
-// spell-checker:ignore (options) EPERM, ENOSYS
+// spell-checker:ignore (options) EPERM, ENOSYS, NOSYS
 
-use std::io::Error;
+use rustix::process::{Pid as RustixPid, test_kill_process};
 
-pub type Pid = libc::pid_t;
+pub type Pid = i32;
 
 pub struct ProcessChecker {
     pid: Pid,
@@ -20,7 +20,14 @@ impl ProcessChecker {
     }
 
     pub fn is_dead(&self) -> bool {
-        unsafe { libc::kill(self.pid, 0) != 0 && get_errno() != libc::EPERM }
+        let Some(pid) = RustixPid::from_raw(self.pid) else {
+            return true;
+        };
+        match test_kill_process(pid) {
+            Ok(()) => false,
+            Err(rustix::io::Errno::PERM) => false,
+            Err(_) => true,
+        }
     }
 }
 
@@ -29,12 +36,14 @@ impl Drop for ProcessChecker {
 }
 
 pub fn supports_pid_checks(pid: Pid) -> bool {
-    unsafe { !(libc::kill(pid, 0) != 0 && get_errno() == libc::ENOSYS) }
-}
-
-#[inline]
-fn get_errno() -> i32 {
-    Error::last_os_error().raw_os_error().unwrap()
+    let Some(pid) = RustixPid::from_raw(pid) else {
+        return false;
+    };
+    match test_kill_process(pid) {
+        Ok(()) => true,
+        Err(rustix::io::Errno::NOSYS) => false,
+        Err(_) => true,
+    }
 }
 
 //pub fn stdin_is_bad_fd() -> bool {


### PR DESCRIPTION
## Summary

- Replace `unsafe { libc::kill(pid, 0) }` calls with the safe `rustix::process::test_kill_process` API
- Remove the `get_errno` helper and `std::io::Error` import, using `match` on `rustix::io::Errno` variants instead
- Add `process` feature to the existing `rustix` dependency in `uu_tail/Cargo.toml`

This eliminates **all `unsafe` blocks** from `src/uu/tail/src/platform/unix.rs`.

