### PR TITLE
mv: preserve mtime/atime when moving across filesystems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,6 +3831,7 @@ version = "0.8.0"
 dependencies = [
  "clap",
  "codspeed-divan-compat",
+ "filetime",
  "fluent",
  "fs_extra",
  "indicatif",

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/mv.rs"
 
 [dependencies]
 clap = { workspace = true }
+filetime = { workspace = true }
 fs_extra = { workspace = true }
 indicatif = { workspace = true }
 libc = { workspace = true }

--- a/src/uu/mv/locales/en-US.ftl
+++ b/src/uu/mv/locales/en-US.ftl
@@ -37,6 +37,7 @@ mv-error-dangling-symlink = can't determine symlink type, since it is dangling
 mv-error-no-symlink-support = your operating system does not support symlinks
 mv-error-permission-denied = Permission denied
 mv-error-inter-device-move-failed = inter-device move failed: {$from} to {$to}; unable to remove target: {$err}
+mv-error-preserve-times = failed to preserve times for {$path}: {$err}
 
 # Help messages
 mv-help-force = do not prompt before overwriting

--- a/src/uu/mv/locales/fr-FR.ftl
+++ b/src/uu/mv/locales/fr-FR.ftl
@@ -37,6 +37,7 @@ mv-error-dangling-symlink = impossible de déterminer le type de lien symbolique
 mv-error-no-symlink-support = votre système d'exploitation ne prend pas en charge les liens symboliques
 mv-error-permission-denied = Permission refusée
 mv-error-inter-device-move-failed = échec du déplacement inter-périphérique : {$from} vers {$to} ; impossible de supprimer la cible : {$err}
+mv-error-preserve-times = impossible de préserver les horodatages pour {$path} : {$err}
 
 # Messages d'aide
 mv-help-force = ne pas demander avant d'écraser

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -12,6 +12,7 @@ mod hardlink;
 use clap::builder::ValueParser;
 use clap::error::ErrorKind;
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use filetime::FileTime;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
@@ -1153,12 +1154,16 @@ fn copy_file_with_hardlinks_helper(
         make_fifo(to)?;
     } else {
         // Copy a regular file.
+        let source_metadata = fs::symlink_metadata(from)?;
         fs::copy(from, to)?;
         // Copy xattrs, ignoring ENOTSUP errors (filesystem doesn't support xattrs)
         #[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
         {
             let _ = copy_xattrs_if_supported(from, to);
         }
+        // Preserve mtime/atime from the source — `fs::copy` resets them
+        // to "now", and we'll unlink the source shortly.
+        preserve_times(to, &source_metadata);
     }
 
     Ok(())
@@ -1198,6 +1203,11 @@ fn rename_file_fallback(
         }
     }
 
+    // Capture source timestamps before the copy so we can restore them on
+    // the destination — `fs::copy` does not preserve mtime/atime, and once
+    // we delete the source the original times are lost.
+    let source_metadata = fs::symlink_metadata(from)?;
+
     // Regular file copy
     fs::copy(from, to)
         .map_err(|err| io::Error::new(err.kind(), translate!("mv-error-permission-denied")))?;
@@ -1208,9 +1218,38 @@ fn rename_file_fallback(
         let _ = copy_xattrs_if_supported(from, to);
     }
 
+    // Restore the source mtime/atime onto the new file. If the destination
+    // happens to be a symlink, this is a no-op (we already know `to` was
+    // unlinked above for symlinks), so we don't need the symlink variant.
+    preserve_times(to, &source_metadata);
+
     fs::remove_file(from)
         .map_err(|err| io::Error::new(err.kind(), translate!("mv-error-permission-denied")))?;
     Ok(())
+}
+
+/// Copy mtime and atime from `source_metadata` onto `dest`.
+///
+/// `mv` does not document timestamp preservation, but the GNU-compatible
+/// behavior — and the user expectation — is that moving a file across
+/// filesystems should keep its modification and access times. The cross-fs
+/// fallback in `mv` falls back to `fs::copy` + `unlink`, and `fs::copy`
+/// resets the destination's timestamps to "now", so without this restore
+/// the move silently rewrites mtime.
+///
+/// Time-restore failures are logged via the standard error path through
+/// `show!`, but they do not abort the move — the data has already been
+/// copied successfully, and a stricter behavior would surprise users on
+/// filesystems that don't support precise timestamps.
+fn preserve_times(dest: &Path, source_metadata: &fs::Metadata) {
+    let atime = FileTime::from_last_access_time(source_metadata);
+    let mtime = FileTime::from_last_modification_time(source_metadata);
+    if let Err(e) = filetime::set_file_times(dest, atime, mtime) {
+        show!(USimpleError::new(
+            0,
+            translate!("mv-error-preserve-times", "path" => dest.quote(), "err" => e),
+        ));
+    }
 }
 
 /// Copy xattrs from source to destination, ignoring ENOTSUP/EOPNOTSUPP errors.

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -2472,6 +2472,93 @@ mod inter_partition_copying {
         let moved_fifo = other_fs_tempdir.path().join("dir/fifo");
         assert!(moved_fifo.symlink_metadata().unwrap().file_type().is_fifo());
     }
+
+    // Regression test for issue #11738: moving a file across filesystems
+    // should preserve the source's mtime/atime, not reset them to "now".
+    // The cross-fs path falls back to fs::copy + unlink, and fs::copy
+    // does not preserve timestamps, so without an explicit restore the
+    // new file ends up with the move's wall-clock time.
+    #[test]
+    pub(crate) fn test_mv_preserves_timestamps_across_filesystems() {
+        use filetime::FileTime;
+
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+
+        // Create a source file in the current partition with a known
+        // mtime/atime well in the past.
+        at.write("src", "src contents");
+        let past = FileTime::from_unix_time(1_600_000_000, 0);
+        filetime::set_file_times(at.plus("src"), past, past)
+            .expect("Unable to set source mtime/atime");
+
+        // Move it to /dev/shm (a different filesystem) to force the
+        // cross-fs fallback.
+        let other_fs_tempdir =
+            TempDir::new_in("/dev/shm/").expect("Unable to create temp directory");
+
+        scene
+            .ucmd()
+            .arg("src")
+            .arg(other_fs_tempdir.path().to_str().unwrap())
+            .succeeds()
+            .no_output();
+
+        // Source must be gone, destination must exist with the original
+        // contents and — critically — the original mtime/atime.
+        assert!(!at.file_exists("src"));
+
+        let moved = other_fs_tempdir.path().join("src");
+        let metadata = fs::metadata(&moved).expect("Unable to stat moved file");
+        let mtime = FileTime::from_last_modification_time(&metadata);
+        let atime = FileTime::from_last_access_time(&metadata);
+
+        assert_eq!(
+            mtime, past,
+            "mv should preserve mtime across filesystems (got {mtime:?}, expected {past:?})",
+        );
+        assert_eq!(
+            atime, past,
+            "mv should preserve atime across filesystems (got {atime:?}, expected {past:?})",
+        );
+    }
+
+    // Same as above, but for the directory case which goes through a
+    // different code path (`copy_file_with_hardlinks_helper`).
+    #[test]
+    pub(crate) fn test_mv_preserves_timestamps_across_filesystems_dir() {
+        use filetime::FileTime;
+
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+
+        at.mkdir("dir");
+        at.write("dir/file", "contents");
+        let past = FileTime::from_unix_time(1_600_000_000, 0);
+        filetime::set_file_times(at.plus("dir/file"), past, past)
+            .expect("Unable to set source mtime/atime");
+
+        let other_fs_tempdir =
+            TempDir::new_in("/dev/shm/").expect("Unable to create temp directory");
+
+        scene
+            .ucmd()
+            .arg("dir")
+            .arg(other_fs_tempdir.path().to_str().unwrap())
+            .succeeds()
+            .no_output();
+
+        assert!(!at.dir_exists("dir"));
+
+        let moved_file = other_fs_tempdir.path().join("dir/file");
+        let metadata = fs::metadata(&moved_file).expect("Unable to stat moved file");
+        let mtime = FileTime::from_last_modification_time(&metadata);
+
+        assert_eq!(
+            mtime, past,
+            "mv -r should preserve mtime across filesystems (got {mtime:?}, expected {past:?})",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #11738

When `mv` falls back to the cross-fs `fs::copy + unlink` path, `fs::copy` does not preserve the source mtime/atime, so the destination ends up with the move's wall-clock time. Capture the source metadata before copying and restore the timestamps on the destination via `filetime::set_file_times` before unlinking the source. Mirrors the pattern in `cp.rs`.

Fixes both code paths:
- `rename_file_fallback` (single-file move)
- `copy_file_with_hardlinks_helper` (directory recursive case)

Two regression tests added in the existing `inter_partition_copying` mod, using `/dev/shm` to force the cross-fs path.