### PR TITLE
od: fix string offset to match GNU behaviour

### DIFF
--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -616,6 +616,7 @@ fn extract_strings_from_input(
     let mut current_offset = skip_bytes;
     let mut bytes_read = 0u64;
     let mut buf = [0u8; 1];
+    let mut offset_preloaded = false; //changed this
 
     loop {
         // Check if we've reached the read_bytes limit
@@ -639,16 +640,28 @@ fn extract_strings_from_input(
 
                 // Check if it's a printable character (including space)
                 if (0x20..=0x7E).contains(&byte) {
-                    if current_string.is_empty() {
+                    if current_string.is_empty() && !offset_preloaded { //changed this
                         string_start_offset = current_offset;
                     }
                     current_string.push(byte);
+
+                    offset_preloaded = false; //changed this
                 } else {
                     // Either null terminator or non-printable character
-                    if byte == 0 && current_string.len() >= min_length {
-                        // Null terminator found with valid string
-                        print_string(string_start_offset, &current_string)?;
+                    if byte == 0 {
+                        // Print current string if it's long enough
+                        if current_string.len() >= min_length {
+                            print_string(string_start_offset, &current_string)?;
+                        }
+
+                        // Preload the offset with the null byte position
+                        string_start_offset = current_offset;
+                        offset_preloaded = true;
+                    } else {
+                        // Any other non-printable (like \n) resets the prelod logic, representig the GNU bug
+                        offset_preloaded = false;
                     }
+
                     current_string.clear();
                 }
 

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -659,7 +659,7 @@ fn extract_strings_from_input(
                         string_start_offset = current_offset;
                         offset_preloaded = true;
                     } else {
-                        // Any other non-printable (like \n) resets the prelod logic, representig the GNU bug
+                        // Any other non-printable (like \n) resets the preload logic, representing the GNU bug
                         offset_preloaded = false;
                     }
 

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -640,7 +640,8 @@ fn extract_strings_from_input(
 
                 // Check if it's a printable character (including space)
                 if (0x20..=0x7E).contains(&byte) {
-                    if current_string.is_empty() && !offset_preloaded { //changed this
+                    if current_string.is_empty() && !offset_preloaded {
+                        //changed this
                         string_start_offset = current_offset;
                     }
                     current_string.push(byte);

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -1322,3 +1322,12 @@ fn test_write_error_dev_full() {
         .code_is(1)
         .stderr_contains("No space left on device");
 }
+
+#[test]
+fn test_od_strings_null_offset_regression() {
+    new_ucmd!()
+        .args(&["-S", "3"]) // You can add "-t", "x1" if your code uses it
+        .pipe_in("foo\0bar\0")
+        .succeeds()
+        .stdout_only("0000000 foo\n0000003 bar\n");
+}


### PR DESCRIPTION
this fixes and recreates the same exact bug, foo/0bar works as expected and also foo/0/0bar works as expected. 