### PR TITLE
uucore: simplify splice()

### DIFF
--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -41,15 +41,8 @@ pub fn pipe() -> std::io::Result<(File, File)> {
 /// this is still very efficient.
 #[inline]
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn splice(source: &impl AsFd, target: &impl AsFd, len: usize) -> std::io::Result<usize> {
-    Ok(rustix::pipe::splice(
-        source,
-        None,
-        target,
-        None,
-        len,
-        SpliceFlags::empty(),
-    )?)
+pub fn splice(source: &impl AsFd, target: &impl AsFd, len: usize) -> rustix::io::Result<usize> {
+    rustix::pipe::splice(source, None, target, None, len, SpliceFlags::empty())
 }
 
 /// Splice wrapper which fully finishes the write.


### PR DESCRIPTION
Remove Ok(..)? . We don't show splice()'s error and always take from  write()' fallback since `>/dev/full` shows incorrect EINVAL. 