### PR TITLE
deny.toml: add `redox_syscall` to skip list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -116,6 +116,8 @@ skip = [
   { name = "block-buffer", version = "0.10.4" },
   # parse_datetime
   { name = "winnow", version = "0.7.15" },
+  # parking_lot_core
+  { name = "redox_syscall", version = "0.5.18" },
 ]
 # spell-checker: enable
 


### PR DESCRIPTION
Fixes #11748 