### PR TITLE
fix(date): treat composite strftime specifiers as atomic

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -198,29 +198,11 @@ fn is_atomic_composite_specifier(specifier: &str) -> bool {
 /// This includes text specifiers and numeric specifiers like %e and %k
 /// that use blank-padding by default in GNU date.
 fn is_space_padded_specifier(specifier: &str) -> bool {
-    matches!(
-        specifier.chars().last(),
-        Some(
-            'A' | 'a'
-                | 'B'
-                | 'b'
-                | 'h'
-                | 'Z'
-                | 'p'
-                | 'P'
-                | 'e'
-                | 'k'
-                | 'l'
-                | 'D'
-                | 'F'
-                | 'T'
-                | 'r'
-                | 'R'
-                | 'c'
-                | 'x'
-                | 'X'
+    is_atomic_composite_specifier(specifier)
+        || matches!(
+            specifier.chars().last(),
+            Some('A' | 'a' | 'B' | 'b' | 'h' | 'Z' | 'p' | 'P' | 'e' | 'k' | 'l')
         )
-    )
 }
 
 /// Returns the default width for a specifier.

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -183,13 +183,43 @@ fn is_text_specifier(specifier: &str) -> bool {
     )
 }
 
+/// Returns true if the specifier is a composite strftime format.
+///
+/// GNU date applies flags/width to the rendered composite output as a whole,
+/// instead of propagating modifiers to inner sub-fields.
+fn is_atomic_composite_specifier(specifier: &str) -> bool {
+    matches!(
+        specifier.chars().last(),
+        Some('D' | 'F' | 'T' | 'r' | 'R' | 'c' | 'x' | 'X')
+    )
+}
+
 /// Returns true if the specifier defaults to space padding.
 /// This includes text specifiers and numeric specifiers like %e and %k
 /// that use blank-padding by default in GNU date.
 fn is_space_padded_specifier(specifier: &str) -> bool {
     matches!(
         specifier.chars().last(),
-        Some('A' | 'a' | 'B' | 'b' | 'h' | 'Z' | 'p' | 'P' | 'e' | 'k' | 'l')
+        Some(
+            'A' | 'a'
+                | 'B'
+                | 'b'
+                | 'h'
+                | 'Z'
+                | 'p'
+                | 'P'
+                | 'e'
+                | 'k'
+                | 'l'
+                | 'D'
+                | 'F'
+                | 'T'
+                | 'r'
+                | 'R'
+                | 'c'
+                | 'x'
+                | 'X'
+        )
     )
 }
 
@@ -276,6 +306,7 @@ fn apply_modifiers(
     explicit_width: bool,
 ) -> Result<String, FormatError> {
     let mut result = value.to_string();
+    let is_atomic_composite = is_atomic_composite_specifier(specifier);
 
     // Determine default pad character based on specifier type
     // Determine default pad character based on specifier type.
@@ -347,6 +378,9 @@ fn apply_modifiers(
 
     // If no_pad flag is active, suppress all padding and return
     if no_pad {
+        if is_atomic_composite {
+            return Ok(result);
+        }
         return Ok(strip_default_padding(&result));
     }
 
@@ -360,12 +394,12 @@ fn apply_modifiers(
     };
 
     // When the requested width is narrower than the default formatted width, GNU first removes default padding and then reapplies the requested width.
-    if effective_width > 0 && effective_width < result.len() {
+    if !is_atomic_composite && effective_width > 0 && effective_width < result.len() {
         result = strip_default_padding(&result);
     }
 
     // Strip default padding when switching pad characters on numeric fields
-    if !is_text_specifier(specifier) && result.len() >= 2 {
+    if !is_atomic_composite && !is_text_specifier(specifier) && result.len() >= 2 {
         if pad_char == ' ' && result.starts_with('0') {
             // Switching to space padding: strip leading zeros
             result = strip_default_padding(&result);
@@ -379,7 +413,7 @@ fn apply_modifiers(
     // GNU behavior: + only adds sign if:
     // 1. An explicit width is provided, OR
     // 2. The value exceeds the default width for that specifier (e.g., year > 4 digits)
-    if force_sign && !result.starts_with('+') && !result.starts_with('-') {
+    if force_sign && !is_atomic_composite && !result.starts_with('+') && !result.starts_with('-') {
         if result.chars().next().is_some_and(|c| c.is_ascii_digit()) {
             let default_w = get_default_width(specifier);
             // Add sign only if explicit width provided OR result exceeds default width

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1982,7 +1982,6 @@ fn test_date_strftime_composite_modifiers_are_atomic() {
         ("+%10R", "     03:04\n"),
         ("+%10x", "  06/15/24\n"),
         ("+%10X", "  03:04:05\n"),
-        ("+%+10D", "0006/15/24\n"),
     ];
 
     for (format, expected) in test_cases {
@@ -1995,6 +1994,20 @@ fn test_date_strftime_composite_modifiers_are_atomic() {
             .succeeds()
             .stdout_is(expected);
     }
+}
+
+#[test]
+fn test_date_strftime_plus_width_on_composite() {
+    // GNU applies %+10D to the full composite output with zero padding,
+    // and does not inject a leading sign into the composite string.
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .arg("-d")
+        .arg("2024-06-15 03:04:05")
+        .arg("+%+10D")
+        .succeeds()
+        .stdout_is("0006/15/24\n");
 }
 
 #[test]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1967,11 +1967,14 @@ fn test_date_strftime_flag_on_composite() {
 fn test_date_strftime_composite_modifiers_are_atomic() {
     let test_cases = [
         ("+%-D", "06/15/24\n"),
+        ("+%^D", "06/15/24\n"),
         ("+%-F", "2024-06-15\n"),
         ("+%-T", "03:04:05\n"),
         ("+%-r", "03:04:05 AM\n"),
         ("+%-R", "03:04\n"),
         ("+%-c", "Sat Jun 15 03:04:05 2024\n"),
+        ("+%^c", "SAT JUN 15 03:04:05 2024\n"),
+        ("+%#c", "SAT JUN 15 03:04:05 2024\n"),
         ("+%-x", "06/15/24\n"),
         ("+%-X", "03:04:05\n"),
         ("+%_D", "06/15/24\n"),

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1950,7 +1950,6 @@ fn test_date_strftime_n_width_and_flags() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11657 — GNU date treats composite strftime specifiers (%D, %F, %T, ...) as atomic; flags like `-` should not propagate to sub-fields."]
 fn test_date_strftime_flag_on_composite() {
     // GNU `%-D` keeps `06/15/24` (flag ignored on composite).
     // uutils applies `-` to inner `%m`, producing `6/15/24`.
@@ -1962,6 +1961,40 @@ fn test_date_strftime_flag_on_composite() {
         .arg("+%-D")
         .succeeds()
         .stdout_is("06/15/24\n");
+}
+
+#[test]
+fn test_date_strftime_composite_modifiers_are_atomic() {
+    let test_cases = [
+        ("+%-D", "06/15/24\n"),
+        ("+%-F", "2024-06-15\n"),
+        ("+%-T", "03:04:05\n"),
+        ("+%-r", "03:04:05 AM\n"),
+        ("+%-R", "03:04\n"),
+        ("+%-c", "Sat Jun 15 03:04:05 2024\n"),
+        ("+%-x", "06/15/24\n"),
+        ("+%-X", "03:04:05\n"),
+        ("+%_D", "06/15/24\n"),
+        ("+%10D", "  06/15/24\n"),
+        ("+%010D", "0006/15/24\n"),
+        ("+%-10D", "06/15/24\n"),
+        ("+%10T", "  03:04:05\n"),
+        ("+%10R", "     03:04\n"),
+        ("+%10x", "  06/15/24\n"),
+        ("+%10X", "  03:04:05\n"),
+        ("+%+10D", "0006/15/24\n"),
+    ];
+
+    for (format, expected) in test_cases {
+        new_ucmd!()
+            .env("LC_ALL", "C")
+            .env("TZ", "UTC")
+            .arg("-d")
+            .arg("2024-06-15 03:04:05")
+            .arg(format)
+            .succeeds()
+            .stdout_is(expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #11657

## Summary

GNU `date` treats composite `strftime` directives (such as `%D`, `%F`, `%T`, `%r`, `%R`, `%c`, `%x`, `%X`) as **atomic units**. Formatting modifiers should apply to the full rendered result, not propagate into inner sub-fields.

Previously, uutils expanded composite directives (e.g. `%D → %m/%d/%y`) and applied modifiers to each inner specifier, leading to incorrect output such as:
+%-D → 6/15/24

where GNU correctly produces:
+%-D → 06/15/24

## Fix

The fix is implemented in `src/date/format/format_modifiers.rs`:

- Added composite directive detection to identify `%D`, `%F`, `%T`, `%r`, `%R`, `%c`, `%x`, `%X`
- Updated modifier handling logic to treat composite outputs as atomic values
- Prevented modifier propagation (e.g. `-`, `0`, width adjustments) into expanded sub-fields
- Preserved width and padding behavior at the top level

## Tests

Changes in `tests/by-util/test_date.rs`:

- Enabled the regression test provided in this issue
- Added additional coverage for composite directives
- Added a dedicated `%+10D` test to verify width and padding behavior