### PR TITLE
deps: unpin selinux rust crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -457,7 +457,7 @@ rust-ini = "0.21.0"
 rustix = { version = "1.1.4", features = ["param"] }
 same-file = "1.0.6"
 self_cell = "1.0.4"
-selinux = "=0.6.1"
+selinux = "0.6"
 string-interner = "0.19.0"
 tempfile = "3.15.0"
 terminal_size = "0.4.0"


### PR DESCRIPTION
The `selinux` crate was previously pinned in https://github.com/uutils/coreutils/pull/8502 because of an MSRV issue. Now that the crate specifies a `rust-version` in its `Cargo.toml`, pinning is no longer required.

Reference: https://codeberg.org/koutheir/selinux/pulls/4