### PR TITLE
CI/GnuComment: enhance PR commenting logic to update existing comments

### DIFF
--- a/.github/workflows/GnuComment.yml
+++ b/.github/workflows/GnuComment.yml
@@ -49,14 +49,37 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            var fs = require('fs');
-            var issue_number = Number(fs.readFileSync('./NR'));
-            var content = fs.readFileSync('./result.txt');
-            if (content.toString().trim().length > 7) { // 7 because we have backquote + \n
+            const fs = require('fs');
+            const issue_number = Number(fs.readFileSync('./NR'));
+            const content = fs.readFileSync('./result.txt').toString();
+
+            if (content.trim().length <= 7) { // 7 because we have backquote + \n
+              return;
+            }
+
+            const marker = '<!-- gnu-comment-bot -->';
+            const body = `${marker}\nGNU testsuite comparison:\n\`\`\`\n${content}\n\`\`\``;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue_number,
-                body: 'GNU testsuite comparison:\n```\n' + content + '```'
+                ...context.repo,
+                issue_number,
+                body
               });
             }

--- a/.github/workflows/GnuComment.yml
+++ b/.github/workflows/GnuComment.yml
@@ -53,10 +53,6 @@ jobs:
             const issue_number = Number(fs.readFileSync('./NR'));
             const content = fs.readFileSync('./result.txt').toString();
 
-            if (content.trim().length <= 7) { // 7 because we have backquote + \n
-              return;
-            }
-
             const marker = '<!-- gnu-comment-bot -->';
             const body = `${marker}\nGNU testsuite comparison:\n\`\`\`\n${content}\n\`\`\``;
 
@@ -77,6 +73,9 @@ jobs:
                 body
               });
             } else {
+              if (content.trim().length <= 7) { // 7 because we have backquote + \n
+                return;
+              }
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number,


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/11761

### Summary

Update GNU testsuite comment workflow to edit a single bot comment instead of creating new ones on each run.

### Key change
- Introduce a hidden marker (`<!-- gnu-comment-bot -->`) to identify bot-generated comments.
- Only comments with this marker are updated, so this applies to new comments going forward (existing comments remain unchanged).

