### PR TITLE
GnuTests: mask an equivalent df test

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -153,7 +153,8 @@ else
         echo "strip t${i}.sh from Makefile and tests/local.mk"
         sed -i -e "s/\$(tf)\/t${i}.sh//g" Makefile tests/local.mk
     done
-
+    # Remove LD_PRELOAD implementation of no-mtab-status-masked-proc. not compatible with our binary
+    sed -i '/tests\/df\/no-mtab-status.sh/ D' Makefile
     # Remove tests checking for --version & --help
     # Not really interesting for us and logs are too big
     sed -i '/tests\/help\/help-version.sh/ D' Makefile


### PR DESCRIPTION
no-mtab-status-masked-proc was submitted by me to avoid LD_PRELOAD.