### PR TITLE
deps: remove unused rust crate fluent-bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,7 +4509,6 @@ dependencies = [
  "dns-lookup",
  "dunce",
  "fluent",
- "fluent-bundle",
  "fluent-syntax",
  "glob",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,6 @@ digest = "0.10.7"
 
 # Fluent dependencies
 fluent = "0.17.0"
-fluent-bundle = "0.16.0"
 unic-langid = "0.9.6"
 fluent-syntax = "0.12.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2115,7 +2115,6 @@ dependencies = [
  "digest 0.10.7",
  "dunce",
  "fluent",
- "fluent-bundle",
  "fluent-syntax",
  "glob",
  "hex",

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -91,7 +91,6 @@ jiff-icu = { workspace = true, optional = true }
 fluent = { workspace = true }
 fluent-syntax = { workspace = true }
 unic-langid = { workspace = true }
-fluent-bundle = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
`fluent-bundle` is not used as a direct dependency

found using [cargo-shear](https://crates.io/crates/cargo-shear)