### PR TITLE
date: fix strftime flags and widths on %N (nanoseconds)

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -264,7 +264,7 @@ fn strip_default_padding(value: &str) -> String {
 /// than minimum field width, and the digit zeros are significant content,
 /// not padding.
 fn is_nanosecond_specifier(specifier: &str) -> bool {
-    specifier.chars().last() == Some('N')
+    specifier.ends_with('N')
 }
 
 /// Apply modifiers specifically for the `%N` (nanoseconds) specifier.
@@ -286,7 +286,7 @@ fn apply_nanosecond_modifiers(
     pad_char: char,
     width: usize,
     explicit_width: bool,
-) -> Result<String, FormatError> {
+) -> String {
     let default_width = 9;
     let precision = if explicit_width { width } else { default_width };
 
@@ -318,7 +318,7 @@ fn apply_nanosecond_modifiers(
     // Otherwise (default '0' padding or no flags): result already has the
     // right number of zero-padded digits from the truncation/extension above.
 
-    Ok(result)
+    result
 }
 
 /// Apply width and flag modifiers to a formatted value.
@@ -411,7 +411,7 @@ fn apply_modifiers(
     // (number of fractional digits), not minimum field width, and the
     // digit zeros are significant content rather than padding.
     if is_nanosecond_specifier(specifier) {
-        return apply_nanosecond_modifiers(&result, no_pad, underscore_flag, pad_char, width, explicit_width);
+        return Ok(apply_nanosecond_modifiers(&result, no_pad, underscore_flag, pad_char, width, explicit_width));
     }
 
     // If no_pad flag is active, suppress all padding and return

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -259,6 +259,68 @@ fn strip_default_padding(value: &str) -> String {
     value.to_string()
 }
 
+/// Returns true if the specifier is `%N` (nanoseconds), which needs special
+/// treatment: width controls precision (number of fractional digits) rather
+/// than minimum field width, and the digit zeros are significant content,
+/// not padding.
+fn is_nanosecond_specifier(specifier: &str) -> bool {
+    specifier.chars().last() == Some('N')
+}
+
+/// Apply modifiers specifically for the `%N` (nanoseconds) specifier.
+///
+/// Unlike other numeric specifiers, `%N` treats width as precision
+/// (number of fractional-second digits) and its zeros are significant
+/// content, not padding.
+///
+/// GNU behaviour:
+/// - `%N`   → all 9 digits (e.g. "000000000")
+/// - `%-N`  → all 9 digits unchanged (zeros are content, not padding)
+/// - `%3N`  → first 3 digits, zero-padded on the right (e.g. "000")
+/// - `%_3N` → first 3 digits, trailing zeros replaced with spaces (e.g. "0  ")
+/// - `%_N`  → all 9 digits, trailing zeros replaced with spaces
+fn apply_nanosecond_modifiers(
+    value: &str,
+    no_pad: bool,
+    underscore_flag: bool,
+    pad_char: char,
+    width: usize,
+    explicit_width: bool,
+) -> Result<String, FormatError> {
+    let default_width = 9;
+    let precision = if explicit_width { width } else { default_width };
+
+    // Truncate or extend to the requested precision
+    let mut result: String = if precision <= value.len() {
+        value[..precision].to_string()
+    } else {
+        // Extend with trailing zeros to requested precision
+        let mut s = value.to_string();
+        s.extend(std::iter::repeat_n('0', precision - value.len()));
+        s
+    };
+
+    if no_pad {
+        // `-` flag on %N: the zeros in nanoseconds are significant content,
+        // not padding, so return the digits unchanged.
+    } else if underscore_flag || pad_char == ' ' {
+        // `_` flag: replace trailing zeros with spaces
+        let trimmed = result.trim_end_matches('0');
+        let content_len = if trimmed.is_empty() { 1 } else { trimmed.len() };
+        let trailing_spaces = precision - content_len;
+        if trimmed.is_empty() {
+            result = "0".to_string();
+        } else {
+            result = trimmed.to_string();
+        }
+        result.extend(std::iter::repeat_n(' ', trailing_spaces));
+    }
+    // Otherwise (default '0' padding or no flags): result already has the
+    // right number of zero-padded digits from the truncation/extension above.
+
+    Ok(result)
+}
+
 /// Apply width and flag modifiers to a formatted value.
 ///
 /// The `specifier` parameter is the format specifier (e.g., "d", "B", "Y")
@@ -343,6 +405,13 @@ fn apply_modifiers(
         {
             result = result.to_uppercase();
         }
+    }
+
+    // Special handling for %N (nanoseconds): width controls precision
+    // (number of fractional digits), not minimum field width, and the
+    // digit zeros are significant content rather than padding.
+    if is_nanosecond_specifier(specifier) {
+        return apply_nanosecond_modifiers(&result, no_pad, underscore_flag, pad_char, width, explicit_width);
     }
 
     // If no_pad flag is active, suppress all padding and return
@@ -795,5 +864,73 @@ mod tests {
             result, "19",
             "GNU: %_C should produce '19', not '  19' (default width is 2, not 4)"
         );
+    }
+
+    #[test]
+    fn test_nanosecond_width_and_flags() {
+        // %N: nanoseconds at epoch 0 → "000000000" (9 digits, all zeros)
+        use jiff::Timestamp;
+
+        let ts = Timestamp::from_second(0).unwrap();
+        let date = ts.to_zoned(TimeZone::UTC);
+        let config = get_config();
+
+        // %N without modifiers: full 9-digit nanoseconds
+        let result = format_with_modifiers(&date, "%N", &config).unwrap();
+        assert_eq!(result, "000000000");
+
+        // %-N: no-pad flag should NOT strip zeros (they are content)
+        let result = format_with_modifiers(&date, "%-N", &config).unwrap();
+        assert_eq!(result, "000000000", "GNU: %-N at @0 should be '000000000'");
+
+        // %_3N: space-pad, width 3 → truncate to 3 digits, trailing zeros → spaces
+        let result = format_with_modifiers(&date, "%_3N", &config).unwrap();
+        assert_eq!(result, "0  ", "GNU: %_3N at @0 should be '0  '");
+
+        // %3N: width 3 → truncate to 3 digits
+        let result = format_with_modifiers(&date, "%3N", &config).unwrap();
+        assert_eq!(result, "000", "GNU: %3N at @0 should be '000'");
+
+        // %_N: space-pad without width → 9 digits, trailing zeros → spaces
+        let result = format_with_modifiers(&date, "%_N", &config).unwrap();
+        assert_eq!(result, "0        ", "GNU: %_N at @0 should be '0' + 8 spaces");
+    }
+
+    #[test]
+    fn test_nanosecond_with_nonzero_nanos() {
+        use jiff::Timestamp;
+
+        // 1.123456789 seconds since epoch → nanoseconds = 123456789
+        let ts = Timestamp::new(1, 123_456_789).unwrap();
+        let date = ts.to_zoned(TimeZone::UTC);
+        let config = get_config();
+
+        // %N: full 9-digit nanoseconds
+        let result = format_with_modifiers(&date, "%N", &config).unwrap();
+        assert_eq!(result, "123456789");
+
+        // %3N: first 3 digits
+        let result = format_with_modifiers(&date, "%3N", &config).unwrap();
+        assert_eq!(result, "123");
+
+        // %-N: no-pad, all 9 digits shown
+        let result = format_with_modifiers(&date, "%-N", &config).unwrap();
+        assert_eq!(result, "123456789");
+
+        // %_3N: first 3 digits, trailing zeros → spaces (no trailing zeros here)
+        let result = format_with_modifiers(&date, "%_3N", &config).unwrap();
+        assert_eq!(result, "123");
+
+        // Test with trailing zeros: 1.120000000
+        let ts2 = Timestamp::new(1, 120_000_000).unwrap();
+        let date2 = ts2.to_zoned(TimeZone::UTC);
+
+        // %_N: trailing zeros become spaces
+        let result = format_with_modifiers(&date2, "%_N", &config).unwrap();
+        assert_eq!(result, "12       ");
+
+        // %_3N: first 3 digits "120", trailing zero becomes space
+        let result = format_with_modifiers(&date2, "%_3N", &config).unwrap();
+        assert_eq!(result, "12 ");
     }
 }

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -349,6 +349,68 @@ fn strip_default_padding(value: &str) -> String {
     value.to_string()
 }
 
+/// Returns true if the specifier is `%N` (nanoseconds), which needs special
+/// treatment: width controls precision (number of fractional digits) rather
+/// than minimum field width, and the digit zeros are significant content,
+/// not padding.
+fn is_nanosecond_specifier(specifier: &str) -> bool {
+    specifier.chars().last() == Some('N')
+}
+
+/// Apply modifiers specifically for the `%N` (nanoseconds) specifier.
+///
+/// Unlike other numeric specifiers, `%N` treats width as precision
+/// (number of fractional-second digits) and its zeros are significant
+/// content, not padding.
+///
+/// GNU behaviour:
+/// - `%N`   → all 9 digits (e.g. "000000000")
+/// - `%-N`  → all 9 digits unchanged (zeros are content, not padding)
+/// - `%3N`  → first 3 digits, zero-padded on the right (e.g. "000")
+/// - `%_3N` → first 3 digits, trailing zeros replaced with spaces (e.g. "0  ")
+/// - `%_N`  → all 9 digits, trailing zeros replaced with spaces
+fn apply_nanosecond_modifiers(
+    value: &str,
+    no_pad: bool,
+    underscore_flag: bool,
+    pad_char: char,
+    width: usize,
+    explicit_width: bool,
+) -> Result<String, FormatError> {
+    let default_width = 9;
+    let precision = if explicit_width { width } else { default_width };
+
+    // Truncate or extend to the requested precision
+    let mut result: String = if precision <= value.len() {
+        value[..precision].to_string()
+    } else {
+        // Extend with trailing zeros to requested precision
+        let mut s = value.to_string();
+        s.extend(std::iter::repeat_n('0', precision - value.len()));
+        s
+    };
+
+    if no_pad {
+        // `-` flag on %N: the zeros in nanoseconds are significant content,
+        // not padding, so return the digits unchanged.
+    } else if underscore_flag || pad_char == ' ' {
+        // `_` flag: replace trailing zeros with spaces
+        let trimmed = result.trim_end_matches('0');
+        let content_len = if trimmed.is_empty() { 1 } else { trimmed.len() };
+        let trailing_spaces = precision - content_len;
+        if trimmed.is_empty() {
+            result = "0".to_string();
+        } else {
+            result = trimmed.to_string();
+        }
+        result.extend(std::iter::repeat_n(' ', trailing_spaces));
+    }
+    // Otherwise (default '0' padding or no flags): result already has the
+    // right number of zero-padded digits from the truncation/extension above.
+
+    Ok(result)
+}
+
 /// Apply width and flag modifiers to a formatted value.
 ///
 /// The specifier inside `parsed` (e.g., "d", "B", "Y") determines the default
@@ -425,6 +487,13 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
         {
             result = result.to_uppercase();
         }
+    }
+
+    // Special handling for %N (nanoseconds): width controls precision
+    // (number of fractional digits), not minimum field width, and the
+    // digit zeros are significant content rather than padding.
+    if is_nanosecond_specifier(specifier) {
+        return apply_nanosecond_modifiers(&result, no_pad, underscore_flag, pad_char, width, explicit_width);
     }
 
     // If no_pad flag is active, suppress all padding and return
@@ -1072,5 +1141,73 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(has_gnu_modifiers(input), *expected, "input = {input:?}");
         }
+    }
+
+    #[test]
+    fn test_nanosecond_width_and_flags() {
+        // %N: nanoseconds at epoch 0 → "000000000" (9 digits, all zeros)
+        use jiff::Timestamp;
+
+        let ts = Timestamp::from_second(0).unwrap();
+        let date = ts.to_zoned(TimeZone::UTC);
+        let config = get_config();
+
+        // %N without modifiers: full 9-digit nanoseconds
+        let result = format_with_modifiers(&date, "%N", &config).unwrap();
+        assert_eq!(result, "000000000");
+
+        // %-N: no-pad flag should NOT strip zeros (they are content)
+        let result = format_with_modifiers(&date, "%-N", &config).unwrap();
+        assert_eq!(result, "000000000", "GNU: %-N at @0 should be '000000000'");
+
+        // %_3N: space-pad, width 3 → truncate to 3 digits, trailing zeros → spaces
+        let result = format_with_modifiers(&date, "%_3N", &config).unwrap();
+        assert_eq!(result, "0  ", "GNU: %_3N at @0 should be '0  '");
+
+        // %3N: width 3 → truncate to 3 digits
+        let result = format_with_modifiers(&date, "%3N", &config).unwrap();
+        assert_eq!(result, "000", "GNU: %3N at @0 should be '000'");
+
+        // %_N: space-pad without width → 9 digits, trailing zeros → spaces
+        let result = format_with_modifiers(&date, "%_N", &config).unwrap();
+        assert_eq!(result, "0        ", "GNU: %_N at @0 should be '0' + 8 spaces");
+    }
+
+    #[test]
+    fn test_nanosecond_with_nonzero_nanos() {
+        use jiff::Timestamp;
+
+        // 1.123456789 seconds since epoch → nanoseconds = 123456789
+        let ts = Timestamp::new(1, 123_456_789).unwrap();
+        let date = ts.to_zoned(TimeZone::UTC);
+        let config = get_config();
+
+        // %N: full 9-digit nanoseconds
+        let result = format_with_modifiers(&date, "%N", &config).unwrap();
+        assert_eq!(result, "123456789");
+
+        // %3N: first 3 digits
+        let result = format_with_modifiers(&date, "%3N", &config).unwrap();
+        assert_eq!(result, "123");
+
+        // %-N: no-pad, all 9 digits shown
+        let result = format_with_modifiers(&date, "%-N", &config).unwrap();
+        assert_eq!(result, "123456789");
+
+        // %_3N: first 3 digits, trailing zeros → spaces (no trailing zeros here)
+        let result = format_with_modifiers(&date, "%_3N", &config).unwrap();
+        assert_eq!(result, "123");
+
+        // Test with trailing zeros: 1.120000000
+        let ts2 = Timestamp::new(1, 120_000_000).unwrap();
+        let date2 = ts2.to_zoned(TimeZone::UTC);
+
+        // %_N: trailing zeros become spaces
+        let result = format_with_modifiers(&date2, "%_N", &config).unwrap();
+        assert_eq!(result, "12       ");
+
+        // %_3N: first 3 digits "120", trailing zero becomes space
+        let result = format_with_modifiers(&date2, "%_3N", &config).unwrap();
+        assert_eq!(result, "12 ");
     }
 }

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -354,7 +354,7 @@ fn strip_default_padding(value: &str) -> String {
 /// than minimum field width, and the digit zeros are significant content,
 /// not padding.
 fn is_nanosecond_specifier(specifier: &str) -> bool {
-    specifier.chars().last() == Some('N')
+    specifier.ends_with('N')
 }
 
 /// Apply modifiers specifically for the `%N` (nanoseconds) specifier.
@@ -374,11 +374,10 @@ fn apply_nanosecond_modifiers(
     no_pad: bool,
     underscore_flag: bool,
     pad_char: char,
-    width: usize,
-    explicit_width: bool,
-) -> Result<String, FormatError> {
+    width: Option<usize>,
+) -> String {
     let default_width = 9;
-    let precision = if explicit_width { width } else { default_width };
+    let precision = width.unwrap_or(default_width);
 
     // Truncate or extend to the requested precision
     let mut result: String = if precision <= value.len() {
@@ -408,7 +407,7 @@ fn apply_nanosecond_modifiers(
     // Otherwise (default '0' padding or no flags): result already has the
     // right number of zero-padded digits from the truncation/extension above.
 
-    Ok(result)
+    result
 }
 
 /// Apply width and flag modifiers to a formatted value.
@@ -493,7 +492,13 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
     // (number of fractional digits), not minimum field width, and the
     // digit zeros are significant content rather than padding.
     if is_nanosecond_specifier(specifier) {
-        return apply_nanosecond_modifiers(&result, no_pad, underscore_flag, pad_char, width, explicit_width);
+        return Ok(apply_nanosecond_modifiers(
+            &result,
+            no_pad,
+            underscore_flag,
+            pad_char,
+            width,
+        ));
     }
 
     // If no_pad flag is active, suppress all padding and return
@@ -1170,7 +1175,10 @@ mod tests {
 
         // %_N: space-pad without width → 9 digits, trailing zeros → spaces
         let result = format_with_modifiers(&date, "%_N", &config).unwrap();
-        assert_eq!(result, "0        ", "GNU: %_N at @0 should be '0' + 8 spaces");
+        assert_eq!(
+            result, "0        ",
+            "GNU: %_N at @0 should be '0' + 8 spaces"
+        );
     }
 
     #[test]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1926,7 +1926,6 @@ fn test_date_strftime_case_flag_on_alt_ampm() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11658 — GNU date applies flags/widths to `%N` (nanoseconds); uutils ignores/mishandles them."]
 fn test_date_strftime_n_width_and_flags() {
     // `%_3N` should space-pad nanoseconds to width 3. GNU outputs `0  `; uutils outputs `0`.
     new_ucmd!()

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2027,7 +2027,6 @@ fn test_date_strftime_case_flag_on_alt_ampm() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11658 — GNU date applies flags/widths to `%N` (nanoseconds); uutils ignores/mishandles them."]
 fn test_date_strftime_n_width_and_flags() {
     // `%_3N` should space-pad nanoseconds to width 3. GNU outputs `0  `; uutils outputs `0`.
     new_ucmd!()


### PR DESCRIPTION
## Summary

Fixes #11658

GNU `date` treats `%N` width as **precision** (number of fractional-second digits) and its zeros as significant content, not padding. Previously uutils ignored or mishandled flags/widths on `%N`:

- `%-N` at `@0` produced `0` instead of `000000000`
- `%_3N` at `@0` produced `0` instead of `0  `
- `%3N` at `@0` produced `0` instead of `000`

### Changes

- Added `apply_nanosecond_modifiers()` in `format_modifiers.rs` with special handling for `%N`:
  - `%-N`: preserve all digits unchanged (zeros are content, not padding)
  - `%3N`: truncate to first 3 fractional digits
  - `%_3N`: truncate to 3 digits, replace trailing zeros with spaces
  - `%_N`: full 9 digits, trailing zeros replaced with spaces
- Added unit tests for nanosecond modifier handling (zero and non-zero nanos)
- Un-ignored the existing integration test `test_date_strftime_n_width_and_flags`

## Test plan

- [x] All 23 `format_modifiers` unit tests pass (including 2 new nanosecond tests)
- [x] All 129 `test_date` integration tests pass (previously ignored test now runs)
- [x] Verified: `%-N` at `@0` → `000000000`
- [x] Verified: `%_3N` at `@0` → `0  ` (0 + two spaces)
- [x] Verified: `%3N` at `@0` → `000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)