### PR TITLE
tests/cut: ignore stdin write error on fast-exit delimiter test

### DIFF
--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -291,6 +291,7 @@ fn test_single_quote_pair_as_delimiter_is_invalid() {
     for args in [&["-d", "''", "-f2"][..], &["--delimiter=''", "-f2"][..]] {
         new_ucmd!()
             .args(args)
+            .ignore_stdin_write_error()
             .pipe_in("a''b\n")
             .fails()
             .stderr_contains("cut: the delimiter must be a single character")


### PR DESCRIPTION
test_single_quote_pair_as_delimiter_is_invalid is intermittent on i686: the parent writes "a''b\n" to cut's stdin while cut validates args and exits immediately with "delimiter must be a single character". On a fast child exit, the kernel closes the pipe read-end before the parent's write() runs, so write() returns EPIPE and the pipe_in thread panics.

The race is inherent: draining stdin in cut before exiting on an arg error would hang on terminals and read unbounded data from long pipes, contradicting GNU behavior. Use the test framework's ignore_stdin_write_error() flag, which exists for exactly this "parent writes to child that exits fast" pattern.