### PR TITLE
du: fix error from `needless_borrow` lint on FreeBSD

### DIFF
--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -532,7 +532,7 @@ fn test_du_soft_link() {
         // FreeBSD may have different block allocations depending on filesystem
         // Accept both common sizes
         let valid_sizes = ["12\tsubdir/links\n", "16\tsubdir/links\n"];
-        assert_valid_size(&s, &valid_sizes);
+        assert_valid_size(s, &valid_sizes);
     }
 
     #[cfg(all(


### PR DESCRIPTION
Fixes #11788 