### PR TITLE
uucore: enable `process` feature of `rustix`

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -37,7 +37,7 @@ jiff = { workspace = true, optional = true, features = [
   "tzdb-concatenated",
 ] }
 rustc-hash = { workspace = true }
-rustix = { workspace = true, features = ["fs", "pipe"] }
+rustix = { workspace = true, features = ["fs", "pipe", "process"] }
 time = { workspace = true, optional = true, features = [
   "formatting",
   "local-offset",


### PR DESCRIPTION
This PR enables the `process` feature of `rustix` to fix an "unresolved import" error that currently shows up when running the `pr` tests:
```
$ cargo test --features=pr --no-default-features
   Compiling uucore v0.8.0 (/home/dho/projects/coreutils/src/uucore)
error[E0432]: unresolved import `rustix::process`
   --> src/uucore/src/lib/features/mode.rs:182:21
    |
182 |         use rustix::process::umask;
    |                     ^^^^^^^ could not find `process` in `rustix`
    |
note: found an item that was configured out
   --> /home/dho/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:269:9
    |
267 | #[cfg(feature = "process")]
    |       ------------------- the item is gated behind the `process` feature
```