### PR TITLE
CI/SizeComment: enhance PR commenting logic to update existing comments

### DIFF
--- a/.github/workflows/SizeComment.yml
+++ b/.github/workflows/SizeComment.yml
@@ -58,26 +58,48 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            var fs = require('fs');
+            const fs = require('fs');
             if (!fs.existsSync('./NR') || !fs.existsSync('./result.txt')) {
               core.info("No size comment payload to post.");
               return;
             }
-            var issue_number = Number(fs.readFileSync('./NR'));
+            const issue_number = Number(fs.readFileSync('./NR'));
             if (!issue_number) {
               core.info("No PR number; skipping.");
               return;
             }
-            var content = fs.readFileSync('./result.txt');
-            // Only comment when there is something meaningful to say.
-            // compare_size_results.py only writes the file when there is a
-            // significant change, so an empty/short body is treated as
-            // "nothing to report".
-            if (content.toString().trim().length > 0) {
+            const content = fs.readFileSync('./result.txt').toString();
+
+            const marker = '<!-- size-comment-bot -->';
+            const body = `${marker}\nBinary size comparison:\n\`\`\`\n${content}\n\`\`\``;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              // Only comment when there is something meaningful to say.
+              // compare_size_results.py only writes the file when there is a
+              // significant change, so an empty/short body is treated as
+              // "nothing to report".
+              if (content.trim().length == 0) {
+                return;
+              }
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue_number,
-                body: 'Binary size comparison:\n```\n' + content + '```'
+                ...context.repo,
+                issue_number,
+                body
               });
             }


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/11761#issuecomment-4231812169

### Summary

Update SizeComment workflow to edit a single bot comment instead of creating new ones on each run.

### Key change

- Introduce a hidden marker (`<!-- size-comment-bot -->`) to identify bot-generated comments.
- Only comments with this marker are updated, so this applies to new comments going forward (existing comments remain unchanged).
