### PR TITLE
cat: improve fallback when splice failed, dedup a code

### DIFF
--- a/src/uu/cat/src/splice.rs
+++ b/src/uu/cat/src/splice.rs
@@ -4,12 +4,9 @@
 // file that was distributed with this source code.
 use super::{CatResult, FdReadable, InputHandle};
 
-use rustix::io::{read, write};
 use std::os::{fd::AsFd, unix::io::AsRawFd};
 
-use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, might_fuse, pipe, splice, splice_exact};
-
-const BUF_SIZE: usize = 1024 * 16;
+use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, copy_exact, might_fuse, pipe, splice, splice_exact};
 
 /// This function is called from `write_fast()` on Linux and Android. The
 /// function `splice()` is used to move data between two file descriptors
@@ -56,25 +53,4 @@ pub(super) fn write_fast_using_splice<R: FdReadable, S: AsRawFd + AsFd>(
     } else {
         Ok(true)
     }
-}
-
-/// Move exactly `num_bytes` bytes from `read_fd` to `write_fd`.
-///
-/// Panics if not enough bytes can be read.
-fn copy_exact(read_fd: &impl AsFd, write_fd: &impl AsFd, num_bytes: usize) -> std::io::Result<()> {
-    let mut left = num_bytes;
-    let mut buf = [0; BUF_SIZE];
-    while left > 0 {
-        let n = read(read_fd, &mut buf)?;
-        assert_ne!(n, 0, "unexpected end of pipe");
-        let mut written = 0;
-        while written < n {
-            match write(write_fd, &buf[written..n])? {
-                0 => unreachable!("fd should be writable"),
-                w => written += w,
-            }
-        }
-        left -= n;
-    }
-    Ok(())
 }

--- a/src/uucore/src/lib/features/buf_copy.rs
+++ b/src/uucore/src/lib/features/buf_copy.rs
@@ -56,13 +56,13 @@ mod tests {
     fn test_copy_exact() {
         let (mut pipe_read, mut pipe_write) = pipes::pipe().unwrap();
         let data = b"Hello, world!";
+        let data_len = data.len();
         let n = pipe_write.write(data).unwrap();
-        assert_eq!(n, data.len());
-        let mut buf = [0; 1024];
-        let n = copy_exact(&pipe_read, &pipe_write, data.len()).unwrap();
-        let n2 = pipe_read.read(&mut buf).unwrap();
-        assert_eq!(n, n2);
-        assert_eq!(&buf[..n], data);
+        assert_eq!(n, data_len);
+        let mut buf = [0; 64];
+        let _ = pipes::copy_exact(&pipe_read, &pipe_write, data_len);
+        let _ = pipe_read.read(&mut buf).unwrap();
+        assert_eq!(&buf[..data_len], data);
     }
 
     #[test]

--- a/src/uucore/src/lib/features/buf_copy/linux.rs
+++ b/src/uucore/src/lib/features/buf_copy/linux.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     error::UResult,
-    pipes::{pipe, splice, splice_exact},
+    pipes::{copy_exact, pipe, splice, splice_exact},
 };
 
 /// Buffer-based copying utilities for unix (excluding Linux).
@@ -29,7 +29,6 @@ pub trait FdWritable: Write + AsFd + AsRawFd {}
 impl<T> FdWritable for T where T: Write + AsFd + AsRawFd {}
 
 const SPLICE_SIZE: usize = 1024 * 128;
-const BUF_SIZE: usize = 1024 * 16;
 
 /// Conversion from a `rustix::io::Errno` into our `Error` which implements `UError`.
 impl From<rustix::io::Errno> for Error {
@@ -116,29 +115,4 @@ where
             }
         }
     }
-}
-
-/// Move exactly `num_bytes` bytes from `read_fd` to `write_fd` using the `read`
-/// and `write` calls.
-#[cfg(any(target_os = "linux", target_os = "android"))]
-pub(crate) fn copy_exact(
-    read_fd: &impl AsFd,
-    write_fd: &impl AsFd,
-    num_bytes: usize,
-) -> std::io::Result<usize> {
-    let mut left = num_bytes;
-    let mut buf = [0; BUF_SIZE];
-    let mut total_written = 0;
-    while left > 0 {
-        let n_read = rustix::io::read(read_fd, &mut buf)?;
-        assert_ne!(n_read, 0, "unexpected end of pipe");
-        let mut written = 0;
-        while written < n_read {
-            let n = rustix::io::write(write_fd, &buf[written..n_read])?;
-            written += n;
-        }
-        total_written += written;
-        left -= n_read;
-    }
-    Ok(total_written)
 }

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -62,6 +62,32 @@ pub fn splice_exact(source: &impl AsFd, target: &impl AsFd, len: usize) -> std::
     Ok(())
 }
 
+/// Move exactly `left` bytes from `pipe_fd` to `write_fd`.
+/// write_all-like operation with rustix's raw-syscall without io::copy's internal splice call
+/// used to move content of pipe if splice from broker pipe failed
+/// Panics if not enough bytes can be read (e.g. wrong size was given)
+#[inline]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn copy_exact(pipe_fd: &impl AsFd, write_fd: &impl AsFd, left: usize) -> std::io::Result<()> {
+    debug_assert!(
+        left <= MAX_ROOTLESS_PIPE_SIZE,
+        "use this function with pipe input"
+    );
+    let mut buf = vec![0; left];
+    let mut left = left;
+    while left > 0 {
+        let n = rustix::io::read(pipe_fd, &mut buf)?;
+        debug_assert!(n > 0, "incorrect size of content of pipe was given");
+        let mut written = 0;
+        while written < n {
+            written += rustix::io::write(write_fd, &buf[written..n])?;
+        }
+        left -= n;
+    }
+    debug_assert!(left == 0, "incorrect size of content of pipe was given");
+    Ok(())
+}
+
 /// check that source is FUSE
 /// we fallback to read() at FUSE <https://github.com/uutils/coreutils/issues/9609>
 #[inline]


### PR DESCRIPTION
- dedup a code with buf_copy
- drop BUF_SIZE
- use same buf size with pipe at write fallback when splice from broker pipe failed. (this failure would not happen generally. So using 1 MiB should not be problem)
- directly use rustix::io to make its meaning clear (raw syscall usage)
- remove assertion from release binary