### PR TITLE
tests(env): increase signal delivery delay to fix flaky macOS CI

### DIFF
--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -52,6 +52,10 @@ impl Target {
             .spawn()
             .expect("failed to send signal")
             .wait();
+        // macOS CI needs a longer delay for process teardown after signal delivery
+        #[cfg(target_os = "macos")]
+        self.child.delay(500);
+        #[cfg(not(target_os = "macos"))]
         self.child.delay(100);
     }
     fn is_alive(&mut self) -> bool {


### PR DESCRIPTION
The `test_env_arg_ignore_signal_valid_signals` test was intermittently failing on macOS CI runners because 100ms was not always enough for the process to terminate after receiving a fatal signal (SIGUSR1).

Increase the delay from 100ms to 500ms in `Target::send_signal()` to match the existing 500ms startup delay in `Target::new()`.

Fixes flaky failure seen in: https://github.com/uutils/coreutils/actions/runs/24442074142/job/71409227191