### PR TITLE
Remove authors from Cargo metadata (per RFC 3052)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/uutils/coreutils"
 edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true
@@ -376,7 +375,6 @@ members = [
 ]
 
 [workspace.package]
-authors = ["uutils developers"]
 categories = ["command-line-utilities"]
 edition = "2024"
 rust-version = "1.88.0"

--- a/fuzz/uufuzz/Cargo.toml
+++ b/fuzz/uufuzz/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "uufuzz"
-authors = ["uutils developers"]
 description = "uutils ~ 'core' uutils fuzzing library"
 repository = "https://github.com/uutils/coreutils/tree/main/fuzz/uufuzz"
 version = "0.8.0"

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_arch"
 description = "arch ~ (uutils) display machine architecture"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/arch"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/b2sum/Cargo.toml
+++ b/src/uu/b2sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_b2sum"
 description = "b2sum ~ (uutils) Print or check the BLAKE2b checksums"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/b2sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_base32"
 description = "base32 ~ (uutils) decode/encode input (base32-encoding)"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/base32"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/base64/Cargo.toml
+++ b/src/uu/base64/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_base64"
 description = "base64 ~ (uutils) decode/encode input (base64-encoding)"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/base64"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/basename/Cargo.toml
+++ b/src/uu/basename/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_basename"
 description = "basename ~ (uutils) display PATHNAME with leading directory components removed"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/basename"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/basenc/Cargo.toml
+++ b/src/uu/basenc/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_basenc"
 description = "basenc ~ (uutils) decode/encode input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/basenc"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_cat"
 description = "cat ~ (uutils) concatenate and display input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cat"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -4,7 +4,6 @@ description = "chcon ~ (uutils) change file security context"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chcon"
 keywords = ["coreutils", "uutils", "cli", "utility"]
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 categories.workspace = true

--- a/src/uu/checksum_common/Cargo.toml
+++ b/src/uu/checksum_common/Cargo.toml
@@ -2,7 +2,6 @@
 name = "uu_checksum_common"
 description = "Base for checksum utils"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_chgrp"
 description = "chgrp ~ (uutils) change the group ownership of FILE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chgrp"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_chmod"
 description = "chmod ~ (uutils) change mode of FILE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chmod"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/chown/Cargo.toml
+++ b/src/uu/chown/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_chown"
 description = "chown ~ (uutils) change the ownership of FILE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chown"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/chroot/Cargo.toml
+++ b/src/uu/chroot/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_chroot"
 description = "chroot ~ (uutils) run COMMAND under a new root directory"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/chroot"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_cksum"
 description = "cksum ~ (uutils) display CRC and size of input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cksum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/comm/Cargo.toml
+++ b/src/uu/comm/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_comm"
 description = "comm ~ (uutils) compare sorted inputs"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/comm"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_cp"
 description = "cp ~ (uutils) copy SOURCE to DESTINATION"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cp"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/csplit/Cargo.toml
+++ b/src/uu/csplit/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_csplit"
 description = "csplit ~ (uutils) Output pieces of FILE separated by PATTERN(s) to files 'xx00', 'xx01', ..., and output byte counts of each piece to standard output"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ls"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_cut"
 description = "cut ~ (uutils) display byte/field columns of input lines"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/cut"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -4,7 +4,6 @@ name = "uu_date"
 description = "date ~ (uutils) display or set the current time"
 repository = "https://github.com/uutils/coreutils/tree/main/src/date"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_dd"
 description = "dd ~ (uutils) copy and convert files"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/dd"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_df"
 description = "df ~ (uutils) display file system information"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/df"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/dir/Cargo.toml
+++ b/src/uu/dir/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_dir"
 description = "shortcut to ls -C -b"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ls"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/dircolors/Cargo.toml
+++ b/src/uu/dircolors/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_dircolors"
 description = "dircolors ~ (uutils) display commands to set LS_COLORS"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/dircolors"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/dirname/Cargo.toml
+++ b/src/uu/dirname/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_dirname"
 description = "dirname ~ (uutils) display parent directory of PATHNAME"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/dirname"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_du"
 description = "du ~ (uutils) display disk usage"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/du"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_echo"
 description = "echo ~ (uutils) display TEXT"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/echo"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_env"
 description = "env ~ (uutils) set each NAME to VALUE in the environment and run COMMAND"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/env"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_expand"
 description = "expand ~ (uutils) convert input tabs to spaces"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/expand"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_expr"
 description = "expr ~ (uutils) display the value of EXPRESSION"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/expr"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_factor"
 description = "factor ~ (uutils) display the prime factors of each NUMBER"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/false/Cargo.toml
+++ b/src/uu/false/Cargo.toml
@@ -4,7 +4,6 @@ name = "uu_false"
 description = "false ~ (uutils) do nothing and fail"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/false"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/fmt/Cargo.toml
+++ b/src/uu/fmt/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_fmt"
 description = "fmt ~ (uutils) reformat each paragraph of input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/fmt"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/fold/Cargo.toml
+++ b/src/uu/fold/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_fold"
 description = "fold ~ (uutils) wrap each line of input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/fold"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/groups/Cargo.toml
+++ b/src/uu/groups/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_groups"
 description = "groups ~ (uutils) display group memberships for USERNAME"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/groups"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/head/Cargo.toml
+++ b/src/uu/head/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_head"
 description = "head ~ (uutils) display the first lines of input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/head"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/hostid/Cargo.toml
+++ b/src/uu/hostid/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_hostid"
 description = "hostid ~ (uutils) display the numeric identifier of the current host"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/hostid"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_hostname"
 description = "hostname ~ (uutils) display or set the host name of the current host"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/hostname"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/id/Cargo.toml
+++ b/src/uu/id/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_id"
 description = "id ~ (uutils) display user and group information for USER"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/id"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_install"
 description = "install ~ (uutils) copy files from SOURCE to DESTINATION (with specified attributes)"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/install"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/join/Cargo.toml
+++ b/src/uu/join/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_join"
 description = "join ~ (uutils) merge lines from inputs with matching join fields"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/join"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/kill/Cargo.toml
+++ b/src/uu/kill/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_kill"
 description = "kill ~ (uutils) send a signal to a process"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/kill"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/link/Cargo.toml
+++ b/src/uu/link/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_link"
 description = "link ~ (uutils) create a hard (file system) link to FILE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/link"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_ln"
 description = "ln ~ (uutils) create a (file system) link to TARGET"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ln"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/logname/Cargo.toml
+++ b/src/uu/logname/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_logname"
 description = "logname ~ (uutils) display the login name of the current user"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/logname"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -5,7 +5,6 @@ name = "uu_ls"
 description = "ls ~ (uutils) display directory contents"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ls"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/md5sum/Cargo.toml
+++ b/src/uu/md5sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_md5sum"
 description = "md5sum ~ (uutils) Print or check the MD5 checksums"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/md5sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/mkdir/Cargo.toml
+++ b/src/uu/mkdir/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_mkdir"
 description = "mkdir ~ (uutils) create DIRECTORY"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mkdir"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/mkfifo/Cargo.toml
+++ b/src/uu/mkfifo/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_mkfifo"
 description = "mkfifo ~ (uutils) create FIFOs (named pipes)"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mkfifo"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/mknod/Cargo.toml
+++ b/src/uu/mknod/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_mknod"
 description = "mknod ~ (uutils) create special file NAME of TYPE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mknod"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_mktemp"
 description = "mktemp ~ (uutils) create and display a temporary file or directory from TEMPLATE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mktemp"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_more"
 description = "more ~ (uutils) input perusal filter"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/more"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_mv"
 description = "mv ~ (uutils) move (rename) SOURCE to DESTINATION"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/mv"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_nice"
 description = "nice ~ (uutils) run PROGRAM with modified scheduling priority"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nice"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/nl/Cargo.toml
+++ b/src/uu/nl/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_nl"
 description = "nl ~ (uutils) display input with added line numbers"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nl"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_nohup"
 description = "nohup ~ (uutils) run COMMAND, ignoring hangup signals"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nohup"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/nproc/Cargo.toml
+++ b/src/uu/nproc/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_nproc"
 description = "nproc ~ (uutils) display the number of processing units available"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/nproc"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/numfmt/Cargo.toml
+++ b/src/uu/numfmt/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_numfmt"
 description = "numfmt ~ (uutils) reformat NUMBER"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/numfmt"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_od"
 description = "od ~ (uutils) display formatted representation of input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/od"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/paste/Cargo.toml
+++ b/src/uu/paste/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_paste"
 description = "paste ~ (uutils) merge lines from inputs"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/paste"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/pathchk/Cargo.toml
+++ b/src/uu/pathchk/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_pathchk"
 description = "pathchk ~ (uutils) diagnose invalid or non-portable PATHNAME"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pathchk"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/pinky/Cargo.toml
+++ b/src/uu/pinky/Cargo.toml
@@ -5,7 +5,6 @@ name = "uu_pinky"
 description = "pinky ~ (uutils) display user information"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pinky"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_pr"
 description = "pr ~ (uutils) convert text files for printing"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pr"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/printenv/Cargo.toml
+++ b/src/uu/printenv/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_printenv"
 description = "printenv ~ (uutils) display value of environment VAR"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/printenv"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_printf"
 description = "printf ~ (uutils) FORMAT and display ARGUMENTS"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/printf"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/ptx/Cargo.toml
+++ b/src/uu/ptx/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_ptx"
 description = "ptx ~ (uutils) display a permuted index of input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ptx"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/pwd/Cargo.toml
+++ b/src/uu/pwd/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_pwd"
 description = "pwd ~ (uutils) display current working directory"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/pwd"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/readlink/Cargo.toml
+++ b/src/uu/readlink/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_readlink"
 description = "readlink ~ (uutils) display resolved path of PATHNAME"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/readlink"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/realpath/Cargo.toml
+++ b/src/uu/realpath/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_realpath"
 description = "realpath ~ (uutils) display resolved absolute path of PATHNAME"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/realpath"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_rm"
 description = "rm ~ (uutils) remove PATHNAME"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/rm"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/rmdir/Cargo.toml
+++ b/src/uu/rmdir/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_rmdir"
 description = "rmdir ~ (uutils) remove empty DIRECTORY"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/rmdir"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_runcon"
 description = "runcon ~ (uutils) run command with specified security context"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/runcon"
 keywords = ["coreutils", "uutils", "cli", "utility"]
-authors.workspace = true
 categories.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -4,7 +4,6 @@ name = "uu_seq"
 description = "seq ~ (uutils) display a sequence of numbers"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/seq"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sha1sum/Cargo.toml
+++ b/src/uu/sha1sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sha1sum"
 description = "sha1sum ~ (uutils) Print or check the SHA1 checksums"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sha1sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sha224sum/Cargo.toml
+++ b/src/uu/sha224sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sha224sum"
 description = "sha224sum ~ (uutils) Print or check the SHA224 checksums"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sha224sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sha256sum/Cargo.toml
+++ b/src/uu/sha256sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sha256sum"
 description = "sha256sum ~ (uutils) Print or check the SHA256 checksums"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sha256sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sha384sum/Cargo.toml
+++ b/src/uu/sha384sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sha384sum"
 description = "sha384sum ~ (uutils) Print or check the SHA384 checksums"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sha384sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sha512sum/Cargo.toml
+++ b/src/uu/sha512sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sha512sum"
 description = "sha512sum ~ (uutils) Print or check the SHA512 checksums"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sha512sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/shred/Cargo.toml
+++ b/src/uu/shred/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_shred"
 description = "shred ~ (uutils) hide former FILE contents with repeated overwrites"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/shred"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_shuf"
 description = "shuf ~ (uutils) display random permutations of input lines"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/shuf"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sleep"
 description = "sleep ~ (uutils) pause for DURATION"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sleep"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -5,7 +5,6 @@ name = "uu_sort"
 description = "sort ~ (uutils) sort input lines"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sort"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_split"
 description = "split ~ (uutils) split input into output files"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/split"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_stat"
 description = "stat ~ (uutils) display FILE status"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/stat"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/stdbuf/Cargo.toml
+++ b/src/uu/stdbuf/Cargo.toml
@@ -4,7 +4,6 @@ name = "uu_stdbuf"
 description = "stdbuf ~ (uutils) run COMMAND with modified standard stream buffering"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/stdbuf"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/stdbuf/src/libstdbuf/Cargo.toml
+++ b/src/uu/stdbuf/src/libstdbuf/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_stdbuf_libstdbuf"
 description = "stdbuf/libstdbuf ~ (uutils); dynamic library required for stdbuf"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/stdbuf"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/stty/Cargo.toml
+++ b/src/uu/stty/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_stty"
 description = "stty ~ (uutils) print or change terminal characteristics"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/stty"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sum"
 description = "sum ~ (uutils) display checksum and block counts for input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sum"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_sync"
 description = "sync ~ (uutils) synchronize cache writes to storage"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/sync"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -5,7 +5,6 @@ name = "uu_tac"
 description = "tac ~ (uutils) concatenate and display input lines in reverse order"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tac"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -4,7 +4,6 @@ name = "uu_tail"
 description = "tail ~ (uutils) display the last lines of input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tail"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_tee"
 description = "tee ~ (uutils) display input and copy to FILE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tee"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_test"
 description = "test ~ (uutils) evaluate comparison and file type expressions"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/test"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_timeout"
 description = "timeout ~ (uutils) run COMMAND with a DURATION time limit"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/timeout"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -4,7 +4,6 @@ name = "uu_touch"
 description = "touch ~ (uutils) change FILE timestamps"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/touch"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/tr/Cargo.toml
+++ b/src/uu/tr/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_tr"
 description = "tr ~ (uutils) translate characters within input and display"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tr"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/true/Cargo.toml
+++ b/src/uu/true/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_true"
 description = "true ~ (uutils) do nothing and succeed"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/true"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/truncate/Cargo.toml
+++ b/src/uu/truncate/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_truncate"
 description = "truncate ~ (uutils) truncate (or extend) FILE to SIZE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/truncate"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/tsort/Cargo.toml
+++ b/src/uu/tsort/Cargo.toml
@@ -4,7 +4,6 @@ name = "uu_tsort"
 description = "tsort ~ (uutils) topologically sort input (partially ordered) pairs"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tsort"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_tty"
 description = "tty ~ (uutils) display the name of the terminal connected to standard input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/tty"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/uname/Cargo.toml
+++ b/src/uu/uname/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_uname"
 description = "uname ~ (uutils) display system information"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/uname"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/unexpand/Cargo.toml
+++ b/src/uu/unexpand/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_unexpand"
 description = "unexpand ~ (uutils) convert input spaces to tabs"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/unexpand"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_uniq"
 description = "uniq ~ (uutils) filter identical adjacent lines from input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/uniq"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/unlink/Cargo.toml
+++ b/src/uu/unlink/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_unlink"
 description = "unlink ~ (uutils) remove a (file system) link to FILE"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/unlink"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -5,7 +5,6 @@ name = "uu_uptime"
 description = "uptime ~ (uutils) display dynamic system information"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/uptime"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/users/Cargo.toml
+++ b/src/uu/users/Cargo.toml
@@ -5,7 +5,6 @@ name = "uu_users"
 description = "users ~ (uutils) display names of currently logged-in users"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/users"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/vdir/Cargo.toml
+++ b/src/uu/vdir/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_vdir"
 description = "shortcut to ls -l -b"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/ls"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_wc"
 description = "wc ~ (uutils) display newline, word, and byte counts for input"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/wc"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -6,7 +6,6 @@ name = "uu_who"
 description = "who ~ (uutils) display information about currently logged-in users"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/who"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_whoami"
 description = "whoami ~ (uutils) display user name of current effective user ID"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/whoami"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -3,7 +3,6 @@ name = "uu_yes"
 description = "yes ~ (uutils) repeatedly display a line with STRING (or 'y')"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uu/yes"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -4,7 +4,6 @@
 name = "uucore"
 description = "uutils ~ 'core' uutils code library (cross-platform)"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uucore"
-authors.workspace = true
 categories.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/src/uucore_procs/Cargo.toml
+++ b/src/uucore_procs/Cargo.toml
@@ -4,7 +4,6 @@ description = "uutils ~ 'uucore' proc-macros"
 repository = "https://github.com/uutils/coreutils/tree/main/src/uucore_procs"
 keywords = ["cross-platform", "proc-macros", "uucore", "uutils"]
 # categories = ["os"]
-authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/tests/uutests/Cargo.toml
+++ b/tests/uutests/Cargo.toml
@@ -4,7 +4,6 @@
 name = "uutests"
 description = "uutils ~ 'core' uutils test library (cross-platform)"
 repository = "https://github.com/uutils/coreutils/tree/main/tests/uutests"
-authors.workspace = true
 categories.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
The `authors` field has been deprecated since https://github.com/rust-lang/cargo/pull/15068.