### PR TITLE
date: fix the strftime O and E modifier leaks #11656 (new)

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -99,7 +99,12 @@ fn parse_format_spec(s: &str) -> Option<ParsedSpec<'_>> {
 
     // Flags: any of [_0^#+-], zero or more.
     let flags_start = pos;
-    while pos < bytes.len() && matches!(bytes[pos], b'_' | b'0' | b'^' | b'#' | b'+' | b'-') {
+    while pos < bytes.len()
+        && matches!(
+            bytes[pos],
+            b'_' | b'0' | b'^' | b'#' | b'+' | b'-' | b'O' | b'E'
+        )
+    {
         pos += 1;
     }
     let flags = &s[flags_start..pos];
@@ -223,7 +228,49 @@ fn format_with_modifiers(
                 base_format.clear();
                 base_format.push('%');
                 base_format.push_str(parsed.spec);
-                let formatted = broken_down.to_string_with_config(config, &base_format)?;
+                let mut formatted = String::new();
+                // If modifier is 'E' or 'O',
+                // check if specifier is allowed to work with the modifier.
+                if parsed.flags == "E" {
+                    // Modifier applies to the ‘%c’, ‘%C’, ‘%x’, ‘%X’,
+                    // ‘%y’ and ‘%Y’ conversion specifiers.
+                    if matches!(parsed.spec, "c" | "C" | "x" | "X" | "y" | "Y") {
+                        formatted.push_str(
+                            broken_down
+                                .to_string_with_config(config, &base_format)?
+                                .as_str(),
+                        );
+                    } else {
+                        // Use unformatted string to display
+                        // if specifier does not work with modifier 'E'.
+                        formatted.push('%');
+                        formatted.push_str(parsed.flags);
+                        formatted.push_str(parsed.spec);
+                    }
+                } else if parsed.flags == "O" {
+                    // Modifier 'O' applies only to numeric conversion specifiers.
+                    if matches!(parsed.spec, "a" | "A" | "c" | "D" | "F" | "x" | "X") {
+                        // Use unformatted string to display
+                        // if specifier does not work with modifier 'O'.
+                        formatted.push('%');
+                        formatted.push_str(parsed.flags);
+                        formatted.push_str(parsed.spec);
+                    } else {
+                        // All other specifiers work with modifier 'O'.
+                        formatted.push_str(
+                            broken_down
+                                .to_string_with_config(config, &base_format)?
+                                .as_str(),
+                        );
+                    }
+                } else {
+                    // If modifier is not 'E' either 'O', format the string with config.
+                    formatted.push_str(
+                        broken_down
+                            .to_string_with_config(config, &base_format)?
+                            .as_str(),
+                    );
+                }
 
                 if !parsed.flags.is_empty() || parsed.width.is_some() {
                     let modified = apply_modifiers(&formatted, &parsed)?;

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1968,7 +1968,7 @@ fn test_date_strftime_flag_on_composite() {
 #[ignore = "https://github.com/uutils/coreutils/issues/11656 — GNU date strips the `O` strftime modifier in C locale (e.g. `%Om` -> `%m`); uutils leaks it as literal `%om`."]
 fn test_date_strftime_o_modifier() {
     // In C locale the `O` modifier is a no-op (alternative numeric symbols).
-    // GNU renders `%Om` as `06` for June; uutils renders it as the literal `%Om`.
+    // GNU renders `%Om` as `06` for June.
     new_ucmd!()
         .env("LC_ALL", "C")
         .env("TZ", "UTC")
@@ -1977,6 +1977,20 @@ fn test_date_strftime_o_modifier() {
         .arg("+%Om-%Oy-%Ol")
         .succeeds()
         .stdout_is("06-24-12\n");
+}
+
+#[test]
+fn test_date_strftime_e_modifier() {
+    // In C locale the `E` modifier is a no-op (alternative era).
+    // GNU renders `%Ex` as `06/15/24` for 2024-06-15.
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .arg("-d")
+        .arg("2024-06-15")
+        .arg("+%EC-%Ey-%Ex")
+        .succeeds()
+        .stdout_is("20-24-06/15/24\n");
 }
 
 #[test]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -1965,7 +1965,6 @@ fn test_date_strftime_flag_on_composite() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11656 — GNU date strips the `O` strftime modifier in C locale (e.g. `%Om` -> `%m`); uutils leaks it as literal `%om`."]
 fn test_date_strftime_o_modifier() {
     // In C locale the `O` modifier is a no-op (alternative numeric symbols).
     // GNU renders `%Om` as `06` for June.
@@ -1980,6 +1979,21 @@ fn test_date_strftime_o_modifier() {
 }
 
 #[test]
+fn test_date_strftime_invalid_o_modifier() {
+    // In C locale the `O` modifier is a no-op (alternative numeric symbols).
+    // Modifier 'O' applies only to numeric conversion specifiers.
+    // `%Oa-%OA-%Oc` should be ignored.
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .arg("-d")
+        .arg("2024-06-15")
+        .arg("+%Oa-%OA-%Oc")
+        .succeeds()
+        .stdout_is("%Oa-%OA-%Oc\n");
+}
+
+#[test]
 fn test_date_strftime_e_modifier() {
     // In C locale the `E` modifier is a no-op (alternative era).
     // GNU renders `%Ex` as `06/15/24` for 2024-06-15.
@@ -1991,6 +2005,22 @@ fn test_date_strftime_e_modifier() {
         .arg("+%EC-%Ey-%Ex")
         .succeeds()
         .stdout_is("20-24-06/15/24\n");
+}
+
+#[test]
+fn test_date_strftime_invalid_e_modifier() {
+    // In C locale the `E` modifier is a no-op (alternative era).
+    // This modifier applies to the
+    // '%c', '%C', '%x', '%X', '%y' and '%Y' conversion specifiers.
+    // `%Ea-%Em-%El` should be ignored.
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .arg("-d")
+        .arg("2024-06-15")
+        .arg("+%Ea-%Em-%El")
+        .succeeds()
+        .stdout_is("%Ea-%Em-%El\n");
 }
 
 #[test]


### PR DESCRIPTION
This is a new PR to a broken old PR #11714 and trying to address issue #11656.
This PR fixes date: strftime with O and E modifiers. Fixes #11656 

## Changes

- `coreutils/src/uu/date/src/format_modifiers.rs:105`, in bytes matching, added `O` and `E` bytes match.
- add tests for `O` and `E` modifiers with valid specifier and invalid specifiers according `gnu date` behaviours in the [documentation](https://www.gnu.org/software/coreutils/manual/html_node/Padding-and-other-flags.html)

## Limitations

Currently block the `BrokenDownTime` calling `to_string_with_config` if modifier `E` or `O` combines with invalid specifiers. It pre-checks if modifier is `O` or `E`, then skip formatting if modifier is `E` and specifier is not in '%c', '%C', '%x', '%X', '%y' and '%Y', or if modifier is `O` and specifier is in '%a', '%A', '%c', '%D', '%F', '%x' and '%X'. While `Jiff` does not support modifier `E` and `O`, this check is to be done outside of `Jiff`.

## Build requirements

Rust stable

## Testing

Tested with `make test`