### PR TITLE
ls: use locale-aware collation for name sort

### DIFF
--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -36,6 +36,7 @@ uucore = { workspace = true, features = [
   "fs",
   "fsext",
   "fsxattr",
+  "i18n-collator",
   "parser-size",
   "parser-glob",
   "quoting-style",

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -35,6 +35,7 @@ uucore = { workspace = true, features = [
   "fs",
   "fsext",
   "fsxattr",
+  "i18n-collator",
   "parser-size",
   "parser-glob",
   "quoting-style",

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -119,6 +119,8 @@ impl UError for LsError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result_with_exit_code(uu_app(), args, 2)?;
 
+    uucore::i18n::collator::init_locale_collation();
+
     let config = Config::from(&matches)?;
 
     let locs = matches
@@ -1456,7 +1458,18 @@ fn sort_entries(entries: &mut [PathData], config: &Config) {
             entries.sort_unstable_by_key(|k| Reverse(k.metadata().map_or(0, Metadata::len)));
         }
         // The default sort in GNU ls is case insensitive
-        Sort::Name => entries.sort_unstable_by(|a, b| a.display_name().cmp(b.display_name())),
+        Sort::Name => {
+            if uucore::i18n::collator::should_use_locale_collation() {
+                entries.sort_unstable_by(|a, b| {
+                    uucore::i18n::collator::locale_cmp(
+                        os_str_as_bytes_lossy(a.display_name()).as_ref(),
+                        os_str_as_bytes_lossy(b.display_name()).as_ref(),
+                    )
+                });
+            } else {
+                entries.sort_unstable_by(|a, b| a.display_name().cmp(b.display_name()));
+            }
+        }
         Sort::Version => entries.sort_unstable_by(|a, b| {
             version_cmp(
                 os_str_as_bytes_lossy(a.path().as_os_str()).as_ref(),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -119,6 +119,8 @@ impl UError for LsError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result_with_exit_code(uu_app(), args, 2)?;
 
+    uucore::i18n::collator::init_locale_collation();
+
     let config = Config::from(&matches)?;
 
     let locs = matches
@@ -1489,7 +1491,18 @@ fn sort_entries(entries: &mut [PathData], config: &Config) {
             });
         }
         // The default sort in GNU ls is case insensitive
-        Sort::Name => entries.sort_unstable_by(|a, b| a.display_name().cmp(b.display_name())),
+        Sort::Name => {
+            if uucore::i18n::collator::should_use_locale_collation() {
+                entries.sort_unstable_by(|a, b| {
+                    uucore::i18n::collator::locale_cmp(
+                        os_str_as_bytes_lossy(a.display_name()).as_ref(),
+                        os_str_as_bytes_lossy(b.display_name()).as_ref(),
+                    )
+                });
+            } else {
+                entries.sort_unstable_by(|a, b| a.display_name().cmp(b.display_name()));
+            }
+        }
         Sort::Version => entries.sort_unstable_by(|a, b| {
             version_cmp(
                 os_str_as_bytes_lossy(a.file_name()).as_ref(),

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2045,6 +2045,26 @@ fn test_ls_sort_name() {
         .stdout_is(".a\n.b\na\nb\n");
 }
 
+// https://github.com/uutils/coreutils/issues/11831
+// In a UTF-8 locale, GNU ls places "." and ".." before names starting with
+// punctuation such as '#' due to locale-aware collation.
+#[test]
+fn test_ls_sort_dot_first_utf8_locale() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("#asdf");
+    at.touch("bar");
+    at.touch("foo");
+
+    scene
+        .ucmd()
+        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
+        .arg("-1a")
+        .succeeds()
+        .stdout_is(".\n..\n#asdf\nbar\nfoo\n");
+}
+
 #[test]
 fn test_ls_sort_width() {
     let scene = TestScenario::new(util_name!());

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2110,6 +2110,26 @@ fn test_ls_sort_name() {
         .stdout_is(".a\n.b\na\nb\n");
 }
 
+// https://github.com/uutils/coreutils/issues/11831
+// In a UTF-8 locale, GNU ls places "." and ".." before names starting with
+// punctuation such as '#' due to locale-aware collation.
+#[test]
+fn test_ls_sort_dot_first_utf8_locale() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("#asdf");
+    at.touch("bar");
+    at.touch("foo");
+
+    scene
+        .ucmd()
+        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
+        .arg("-1a")
+        .succeeds()
+        .stdout_is(".\n..\n#asdf\nbar\nfoo\n");
+}
+
 #[test]
 fn test_ls_sort_width() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
GNU ls uses strcoll() so in UTF-8 locales punctuation is reordered (e.g. '.' sorts before '#'), placing '.' and '..' first in `ls -a` output. uutils was always doing a byte-wise compare, diverging from GNU in non-C locales.

Wire up uucore's ICU collator for Sort::Name, gated on should_use_locale_collation() so C/POSIX locales keep the existing zero-overhead byte compare path.

Fixes #11831