### PR TITLE
fix(uucore): use is_dir() instead of exists() for locale path resolution

### DIFF
--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -516,21 +516,21 @@ pub fn setup_localization(p: &str) -> Result<(), LocalizationError> {
 fn resolve_locales_dir_from_exe_dir(exe_dir: &Path, p: &str) -> Option<PathBuf> {
     // 1. <bindir>/locales/<prog>
     let coreutils = exe_dir.join("locales").join(p);
-    if coreutils.exists() {
+    if coreutils.is_dir() {
         return Some(coreutils);
     }
 
     // 2. <prefix>/share/locales/<prog>
     if let Some(prefix) = exe_dir.parent() {
         let fhs = prefix.join("share").join("locales").join(p);
-        if fhs.exists() {
+        if fhs.is_dir() {
             return Some(fhs);
         }
     }
 
     // 3. <bindir>/<prog>   (legacy fall-back)
     let fallback = exe_dir.join(p);
-    if fallback.exists() {
+    if fallback.is_dir() {
         return Some(fallback);
     }
 


### PR DESCRIPTION
## Summary

Fix `resolve_locales_dir_from_exe_dir()` in release builds to use `.is_dir()` instead of `.exists()` when checking for locale directories.

In Debian build environments where individual utility binaries (e.g. `target/release/wc`) exist alongside the multicall `coreutils` binary, `.exists()` incorrectly matches the binary file as a "locale directory". This causes `setup_localization()` to attempt filesystem-based locale loading from the wrong path, resulting in a FluentBundle that lacks utility-specific messages. The `translate!()` macro then returns raw Fluent keys instead of resolved translations.

Fixes the test failure reported in #11023 (comment):
```
assertion `left == right` failed: wc should stop after the first stdout write error:
  "wc: wc-error-failed-to-print-result: No space left on device\n"
  left: 0
  right: 1
```

## Changes

- `src/uucore/src/lib/mods/locale.rs`: Changed 3 occurrences of `.exists()` to `.is_dir()` in `resolve_locales_dir_from_exe_dir()`

