### PR TITLE
Fix clippy CI

### DIFF
--- a/src/uucore/build.rs
+++ b/src/uucore/build.rs
@@ -350,9 +350,7 @@ fn embed_locale_file(
 /// Check if we are cross-compiling for WASI (build.rs runs on the host,
 /// so `#[cfg(target_os = "wasi")]` does not work here).
 fn is_wasi_target() -> bool {
-    env::var("CARGO_CFG_TARGET_OS")
-        .map(|os| os == "wasi")
-        .unwrap_or(false)
+    env::var("CARGO_CFG_TARGET_OS").is_ok_and(|os| os == "wasi")
 }
 
 /// For WASI/WASM builds, embed ALL available .ftl files in a locale

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -435,12 +435,11 @@ pub fn canonicalize<P: AsRef<Path>>(
                 }
                 result.pop();
             }
-            Err(e) => {
-                if miss_mode == MissingHandling::Existing
-                    || (miss_mode == MissingHandling::Normal && !parts.is_empty())
-                {
-                    return Err(e);
-                }
+            Err(e)
+                if (miss_mode == MissingHandling::Existing
+                    || (miss_mode == MissingHandling::Normal && !parts.is_empty())) =>
+            {
+                return Err(e);
             }
             _ => {}
         }


### PR DESCRIPTION
```
error: called `map(<f>).unwrap_or(false)` on a `Result` value
     --> src/uucore/build.rs:353:5
      |
  353 | /     env::var("CARGO_CFG_TARGET_OS")
  354 | |         .map(|os| os == "wasi")
  355 | |         .unwrap_or(false)
      | |_________________________^
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#map_unwrap_or
      = note: `-D clippy::map-unwrap-or` implied by `-D warnings`
      = help: to override `-D warnings` add `#[allow(clippy::map_unwrap_or)]`
  help: use `is_ok_and(<f>)` instead
      |
  354 -         .map(|os| os == "wasi")
  355 -         .unwrap_or(false)
  354 +         .is_ok_and(|os| os == "wasi")
```