### PR TITLE
clippy: warn for large_stack_arrays lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,5 +1,5 @@
 allow-mixed-uninlined-format-args = false
-array-size-threshold = 262144
+array-size-threshold = 65538
 avoid-breaking-exported-api = false
 check-private-items = true
 cognitive-complexity-threshold = 24

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,5 +1,6 @@
+allow-mixed-uninlined-format-args = false
+array-size-threshold = 262144
 avoid-breaking-exported-api = false
 check-private-items = true
 cognitive-complexity-threshold = 24
 missing-docs-in-crate-items = true
-allow-mixed-uninlined-format-args = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -726,9 +726,6 @@ collapsible_if = { level = "allow", priority = 127 } # remove me
 #     | jq -r '.message.code.code | select(. != null and startswith("clippy::"))' \
 #     | sort | uniq -c | sort -h -r
 #
-# TODO:
-#  remove large_stack_arrays when https://github.com/rust-lang/rust-clippy/issues/13774 is fixed
-#
 all = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
@@ -748,7 +745,6 @@ cast_precision_loss = "allow"                # 52
 cast_lossless = "allow"                      # 35
 ignored_unit_patterns = "allow"              # 21
 similar_names = "allow"                      # 20
-large_stack_arrays = "allow"                 # 20
 needless_pass_by_value = "allow"             # 16
 float_cmp = "allow"                          # 12
 items_after_statements = "allow"             # 11

--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -29,7 +29,7 @@ use libc::S_IFIFO;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, pipe, splice, splice_exact};
 
-const BUF_SIZE: usize = 256 * 1024;
+const BUF_SIZE: usize = 64 * 1024;
 
 /// This is a Linux-specific function to count the number of bytes using the
 /// `splice` system call, which is faster than using `read`.


### PR DESCRIPTION
Set `array-size-threshold` to ~64 KiB. This is relatively large, but matches existing usage in some areas.

CodSpeed results are not reliable due to the absence of syscall measurement. In local benchmarks using hyperfine, a ~1% regression was observed: https://github.com/uutils/coreutils/pull/11868#issuecomment-4274238222.

https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#large_stack_arrays
