### PR TITLE
fix(sort): explicitly clean up temp directory in TmpDirWrapper::Drop

### DIFF
--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -180,6 +180,15 @@ impl Drop for TmpDirWrapper {
             guard.lock = None;
             guard.path = None;
         }
+        drop(guard);
+
+        // Explicitly attempt cleanup before TempDir's Drop runs silently.
+        // TempDir::drop uses `let _ = remove_dir_all()` which silently
+        // ignores errors, potentially leaking the directory.
+        #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
+        if let Some(ref temp_dir) = self.temp_dir {
+            let _ = remove_tmp_dir(temp_dir.path());
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `TmpDirWrapper::Drop` now explicitly calls `remove_tmp_dir()` before the inner `TempDir::Drop` runs
- Previously, `Drop` only cleared handler state, relying entirely on `TempDir::Drop` which silently ignores errors via `let _ = remove_dir_all()`
- This caused `/tmp/uutils_sortXXXX` directories to leak, eventually filling `/tmp` and triggering "disk quota exceeded" errors

## Root Cause

The cleanup chain was:
1. `TmpDirWrapper::Drop` → clears handler state only (no directory cleanup)
2. `TempDir::Drop` → calls `remove_dir_all()` but silently swallows errors with `let _ =`

When `TempDir::Drop` failed (e.g., due to open file handles during error paths), the directory was permanently leaked with no retry or logging.



Closes: #11728
