### PR TITLE
fix(sort): always install SIGINT handler to ensure temp dir cleanup

### DIFF
--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -18,7 +18,7 @@ use uucore::error::UResult;
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 use uucore::{error::USimpleError, show_error, translate};
 
-use crate::{SortError, current_open_fd_count, fd_soft_limit};
+use crate::SortError;
 
 /// A wrapper around [`TempDir`] that may only exist once in a process.
 ///
@@ -43,16 +43,6 @@ struct HandlerRegistration {
 // SIGINT handler operate on the same lock/path snapshot.
 static HANDLER_STATE: LazyLock<Arc<Mutex<HandlerRegistration>>> =
     LazyLock::new(|| Arc::new(Mutex::new(HandlerRegistration::default())));
-
-fn should_install_signal_handler() -> bool {
-    const CTRL_C_FDS: usize = 2;
-    const RESERVED_FOR_MERGE: usize = 3; // temp output + minimum inputs
-    let Some(limit) = fd_soft_limit() else {
-        return true;
-    };
-    let open_fds = current_open_fd_count().unwrap_or(3);
-    open_fds.saturating_add(CTRL_C_FDS + RESERVED_FOR_MERGE) <= limit
-}
 
 #[cfg(not(any(target_os = "redox", target_os = "wasi")))]
 fn ensure_signal_handler_installed(state: Arc<Mutex<HandlerRegistration>>) -> UResult<()> {
@@ -140,9 +130,10 @@ impl TmpDirWrapper {
             guard.path = Some(path);
         }
 
-        if should_install_signal_handler() {
-            ensure_signal_handler_installed(state)?;
-        }
+        // Always attempt to install the signal handler so that Ctrl+C
+        // triggers cleanup. Failure is non-fatal: sort still works,
+        // just without SIGINT-triggered temp directory removal.
+        let _ = ensure_signal_handler_installed(state);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

The `should_install_signal_handler()` check added in `87c332c72` skipped SIGINT handler installation on systems with many open FDs, meaning Ctrl+C left `/tmp/uutils_sortXXXX` directories behind with **no cleanup at all**.

Now the handler is always attempted; `ctrlc::set_handler` failing naturally is sufficient. Failure is treated as non-fatal.

## Root Cause

| Scenario | Before this fix | After |
|---|---|---|
| Ctrl+C (high FDs) | **No handler installed → no cleanup** | Handler always attempted |
| Ctrl+C (normal) | `remove_tmp_dir` → `exit(2)` | Same (already worked) |
| Normal exit | `TempDir::Drop` | Same (no change) |

On Ubuntu 26.04 and systems with many open FDs, the SIGINT handler was never installed, so every interrupted `sort` leaked its temp directory.

## Test 

- [x] `cargo check -p uu_sort` passes
- [x] `cargo test -p uu_sort` — all 28 tests pass

Closes: #11728
We will also address the PR below and close the issue.
https://github.com/uutils/coreutils/pull/11888