### PR TITLE
du: Allow command-line argument that appears more than once

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -1456,7 +1456,7 @@ pub fn uu_app() -> Command {
                 .long(options::EXCLUDE)
                 .value_name("PATTERN")
                 .help(translate!("du-help-exclude"))
-                .action(ArgAction::Append)
+                .action(ArgAction::Append),
         )
         .arg(
             Arg::new(options::EXCLUDE_FROM)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -1289,6 +1289,7 @@ pub fn uu_app() -> Command {
                 .long(options::ALL)
                 .help(translate!("du-help-all"))
                 .conflicts_with(options::SUMMARIZE)
+                .overrides_with(options::ALL)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -1288,75 +1288,86 @@ pub fn uu_app() -> Command {
                 .short('a')
                 .long(options::ALL)
                 .help(translate!("du-help-all"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::ALL),
         )
         .arg(
             Arg::new(options::APPARENT_SIZE)
                 .short('A')
                 .long(options::APPARENT_SIZE)
                 .help(translate!("du-help-apparent-size"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::APPARENT_SIZE),
         )
         .arg(
             Arg::new(options::BLOCK_SIZE)
                 .short('B')
                 .long(options::BLOCK_SIZE)
                 .value_name("SIZE")
-                .help(translate!("du-help-block-size")),
+                .help(translate!("du-help-block-size"))
+                .overrides_with(options::BLOCK_SIZE),
         )
         .arg(
             Arg::new(options::BYTES)
                 .short('b')
                 .long("bytes")
                 .help(translate!("du-help-bytes"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::BYTES),
         )
         .arg(
             Arg::new(options::TOTAL)
                 .long("total")
                 .short('c')
                 .help(translate!("du-help-total"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::TOTAL),
         )
         .arg(
             Arg::new(options::MAX_DEPTH)
                 .short('d')
                 .long("max-depth")
                 .value_name("N")
-                .help(translate!("du-help-max-depth")),
+                .help(translate!("du-help-max-depth"))
+                .overrides_with(options::MAX_DEPTH),
         )
         .arg(
             Arg::new(options::HUMAN_READABLE)
                 .long("human-readable")
                 .short('h')
                 .help(translate!("du-help-human-readable"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::HUMAN_READABLE),
         )
         .arg(
             Arg::new(options::INODES)
                 .long(options::INODES)
                 .help(translate!("du-help-inodes"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::INODES),
         )
         .arg(
             Arg::new(options::BLOCK_SIZE_1K)
                 .short('k')
                 .help(translate!("du-help-block-size-1k"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::BLOCK_SIZE_1K),
         )
         .arg(
             Arg::new(options::COUNT_LINKS)
                 .short('l')
                 .long("count-links")
                 .help(translate!("du-help-count-links"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::COUNT_LINKS),
         )
         .arg(
             Arg::new(options::DEREFERENCE)
                 .short('L')
                 .long(options::DEREFERENCE)
                 .help(translate!("du-help-dereference"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::DEREFERENCE),
         )
         .arg(
             Arg::new(options::DEREFERENCE_ARGS)
@@ -1364,55 +1375,62 @@ pub fn uu_app() -> Command {
                 .visible_short_alias('H')
                 .long(options::DEREFERENCE_ARGS)
                 .help(translate!("du-help-dereference-args"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::DEREFERENCE_ARGS),
         )
         .arg(
             Arg::new(options::NO_DEREFERENCE)
                 .short('P')
                 .long(options::NO_DEREFERENCE)
                 .help(translate!("du-help-no-dereference"))
-                .overrides_with(options::DEREFERENCE)
+                .overrides_with(options::NO_DEREFERENCE)
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new(options::BLOCK_SIZE_1M)
                 .short('m')
                 .help(translate!("du-help-block-size-1m"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::BLOCK_SIZE_1M),
         )
         .arg(
             Arg::new(options::NULL)
                 .short('0')
                 .long("null")
                 .help(translate!("du-help-null"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::NULL),
         )
         .arg(
             Arg::new(options::SEPARATE_DIRS)
                 .short('S')
                 .long("separate-dirs")
                 .help(translate!("du-help-separate-dirs"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::SEPARATE_DIRS),
         )
         .arg(
             Arg::new(options::SUMMARIZE)
                 .short('s')
                 .long("summarize")
                 .help(translate!("du-help-summarize"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::SUMMARIZE),
         )
         .arg(
             Arg::new(options::SI)
                 .long(options::SI)
                 .help(translate!("du-help-si"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::SI),
         )
         .arg(
             Arg::new(options::ONE_FILE_SYSTEM)
                 .short('x')
                 .long(options::ONE_FILE_SYSTEM)
                 .help(translate!("du-help-one-file-system"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::ONE_FILE_SYSTEM),
         )
         .arg(
             Arg::new(options::THRESHOLD)
@@ -1421,14 +1439,16 @@ pub fn uu_app() -> Command {
                 .value_name("SIZE")
                 .num_args(1)
                 .allow_hyphen_values(true)
-                .help(translate!("du-help-threshold")),
+                .help(translate!("du-help-threshold"))
+                .overrides_with(options::THRESHOLD),
         )
         .arg(
             Arg::new(options::VERBOSE)
                 .short('v')
                 .long("verbose")
                 .help(translate!("du-help-verbose"))
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::SetTrue)
+                .overrides_with(options::VERBOSE),
         )
         .arg(
             Arg::new(options::EXCLUDE)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -1457,7 +1457,6 @@ pub fn uu_app() -> Command {
                 .value_name("PATTERN")
                 .help(translate!("du-help-exclude"))
                 .action(ArgAction::Append)
-                .overrides_with(options::EXCLUDE),
         )
         .arg(
             Arg::new(options::EXCLUDE_FROM)
@@ -1496,7 +1495,7 @@ pub fn uu_app() -> Command {
                 .long(options::TIME_STYLE)
                 .value_name("STYLE")
                 .help(translate!("du-help-time-style"))
-                .overrides_with(options::TIME),
+                .overrides_with(options::TIME_STYLE),
         )
         .arg(
             Arg::new(options::FILE)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -1384,6 +1384,7 @@ pub fn uu_app() -> Command {
                 .long(options::NO_DEREFERENCE)
                 .help(translate!("du-help-no-dereference"))
                 .overrides_with(options::DEREFERENCE)
+                .overrides_with(options::NO_DEREFERENCE)
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -1455,7 +1456,8 @@ pub fn uu_app() -> Command {
                 .long(options::EXCLUDE)
                 .value_name("PATTERN")
                 .help(translate!("du-help-exclude"))
-                .action(ArgAction::Append),
+                .action(ArgAction::Append)
+                .overrides_with(options::EXCLUDE),
         )
         .arg(
             Arg::new(options::EXCLUDE_FROM)
@@ -1486,13 +1488,15 @@ pub fn uu_app() -> Command {
                     PossibleValue::new("ctime").alias("status"),
                     PossibleValue::new("creation").alias("birth"),
                 ]))
-                .help(translate!("du-help-time")),
+                .help(translate!("du-help-time"))
+                .overrides_with(options::TIME),
         )
         .arg(
             Arg::new(options::TIME_STYLE)
                 .long(options::TIME_STYLE)
                 .value_name("STYLE")
-                .help(translate!("du-help-time-style")),
+                .help(translate!("du-help-time-style"))
+                .overrides_with(options::TIME),
         )
         .arg(
             Arg::new(options::FILE)

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -1383,7 +1383,7 @@ pub fn uu_app() -> Command {
                 .short('P')
                 .long(options::NO_DEREFERENCE)
                 .help(translate!("du-help-no-dereference"))
-                .overrides_with(options::NO_DEREFERENCE)
+                .overrides_with(options::DEREFERENCE)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2271,3 +2271,318 @@ fn test_overriding_block_size_arg_with_invalid_value_still_errors() {
         .fails_with_code(1)
         .stderr_contains("invalid --block-size argument 'abc'");
 }
+
+#[test]
+fn test_du_repeated_h() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-h", "-h"])
+        .succeeds()
+        .stdout_only("44K\t.\n");
+}
+
+#[test]
+fn test_du_repeated_a() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-a", "-a"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_apparent_size() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-A", "-A"])
+        .succeeds()
+        .stdout_only("6\t.\n");
+}
+
+#[test]
+fn test_du_repeated_block_size() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-B", "100", "-B", "100"])
+        .succeeds()
+        .stdout_only("451\t.\n");
+}
+
+#[test]
+fn test_du_repeated_b() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-b", "-b"])
+        .succeeds()
+        .stdout_only("5148\t.\n");
+}
+
+#[test]
+fn test_du_repeated_c() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-c", "-c"])
+        .succeeds()
+        .stdout_only("44\t.\n44\ttotal\n");
+}
+
+#[test]
+fn test_du_repeated_d() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-d", "2", "-d", "2"])
+        .succeeds()
+        .stdout_only("16\t./subdir/deeper\n16\t./subdir/links\n36\t./subdir\n44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_inodes() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "--inodes", "--inodes"])
+        .succeeds()
+        .stdout_only("11\t.\n");
+}
+
+#[test]
+fn test_du_repeated_k() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-k", "-k"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_l() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-l", "-l"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_dereference() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-L", "-L"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_dereference_args() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-D", "-D"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_no_dereference() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-P", "-P"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_m() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-m", "-m"])
+        .succeeds()
+        .stdout_only("1\t.\n");
+}
+
+#[test]
+fn test_du_repeated_0() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-0", "-0"])
+        .succeeds()
+        .stdout_only("44\t.\0");
+}
+
+#[test]
+fn test_du_repeated_separate_dirs() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-S", "-S"])
+        .succeeds()
+        .stdout_only("8\t.\n");
+}
+
+#[test]
+fn test_du_repeated_s() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-s"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_si() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "--si", "--si"])
+        .succeeds()
+        .stdout_only("46k\t.\n");
+}
+
+#[test]
+fn test_du_repeated_x() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-x", "-x"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_t() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-t", "100", "-t", "100"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_v() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "-v", "-v"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_exclude() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.ucmd()
+        .args(&["-s", "--exclude", "a*", "--exclude", "a*"])
+        .succeeds()
+        .stdout_only("44\t.\n");
+}
+
+#[test]
+fn test_du_repeated_exclude_from() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.write(&format!("./somefile"), "*a");
+
+    ts.ucmd()
+        .args(&["-s", "-X", "somefile", "-X", "somefile"])
+        .succeeds()
+        .stdout_only("48\t.\n");
+}
+
+#[test]
+fn test_du_repeated_files0_from() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.write(&format!("./somefile"), "file2");
+    at.write(&format!("./file2"), "a*");
+
+    ts.ucmd()
+        .args(&["-s", "--files0-from", "somefile", "--files0-from", "somefile"])
+        .succeeds()
+        .stdout_only("4\tfile2\n");
+}
+
+#[test]
+fn test_du_repeated_time() {
+    let ts = TestScenario::new(util_name!());
+
+    // du --time formats the timestamp according to the local timezone. We set the TZ
+    // environment variable to UTC in the commands below to ensure consistent outputs
+    // and test results regardless of the timezone of the machine this test runs in.
+
+    ts.ccmd("touch")
+        .env("TZ", "UTC")
+        .arg("-a")
+        .arg("-t")
+        .arg("201505150000")
+        .arg("date_test")
+        .succeeds();
+
+    ts.ccmd("touch")
+        .env("TZ", "UTC")
+        .arg("-m")
+        .arg("-t")
+        .arg("201606160000")
+        .arg("date_test")
+        .succeeds();
+
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("date_test")
+        .arg("--time")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\t2016-06-16 00:00\tdate_test\n");
+}
+
+#[test]
+fn test_du_repeated_time_style() {
+    let ts = TestScenario::new(util_name!());
+
+    // du --time formats the timestamp according to the local timezone. We set the TZ
+    // environment variable to UTC in the commands below to ensure consistent outputs
+    // and test results regardless of the timezone of the machine this test runs in.
+
+    ts.ccmd("touch")
+        .env("TZ", "UTC")
+        .arg("-a")
+        .arg("-t")
+        .arg("201505150000")
+        .arg("date_test")
+        .succeeds();
+
+    ts.ccmd("touch")
+        .env("TZ", "UTC")
+        .arg("-m")
+        .arg("-t")
+        .arg("201606160000")
+        .arg("date_test")
+        .succeeds();
+
+    // full-iso
+    let result = ts
+        .ucmd()
+        .env("TZ", "UTC")
+        .arg("--time")
+        .arg("--time-style=full-iso")
+        .arg("date_test")
+        .succeeds();
+    result.stdout_only("0\tdate_test\n");
+}

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2486,8 +2486,8 @@ fn test_du_repeated_v() {
 fn test_du_repeated_files0_from() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
-    at.write(&"./somefile".to_string(), "file2");
-    at.write(&"./file2".to_string(), "a*");
+    at.write("./somefile", "file2");
+    at.write("./file2", "a*");
 
     ts.ucmd()
         .args(&[

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2486,8 +2486,8 @@ fn test_du_repeated_v() {
 fn test_du_repeated_files0_from() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
-    at.write(&format!("./somefile"), "file2");
-    at.write(&format!("./file2"), "a*");
+    at.write(&"./somefile".to_string(), "file2");
+    at.write(&"./file2".to_string(), "a*");
 
     ts.ucmd()
         .args(&[

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2274,23 +2274,17 @@ fn test_overriding_block_size_arg_with_invalid_value_still_errors() {
 
 #[test]
 fn test_du_repeated_h() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-h", "-h"]).succeeds();
+    new_ucmd!().args(&["-s", "-h", "-h"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_a() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-a", "-a"]).succeeds();
+    new_ucmd!().args(&["-a", "-a"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_apparent_size() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd()
+    new_ucmd!()
         .args(&["-s", "-A", "-A"])
         .succeeds()
         .stdout_only("6\t.\n");
@@ -2298,16 +2292,12 @@ fn test_du_repeated_apparent_size() {
 
 #[test]
 fn test_du_repeated_block_size() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-B", "100", "-B", "100"]).succeeds();
+    new_ucmd!().args(&["-s", "-B", "100", "-B", "100"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_b() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd()
+    new_ucmd!()
         .args(&["-s", "-b", "-b"])
         .succeeds()
         .stdout_only("5148\t.\n");
@@ -2315,23 +2305,17 @@ fn test_du_repeated_b() {
 
 #[test]
 fn test_du_repeated_c() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-c", "-c"]).succeeds();
+    new_ucmd!().args(&["-s", "-c", "-c"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_d() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-d", "2", "-d", "2"]).succeeds();
+    new_ucmd!().args(&["-d", "2", "-d", "2"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_inodes() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd()
+    new_ucmd!()
         .args(&["-s", "--inodes", "--inodes"])
         .succeeds()
         .stdout_only("11\t.\n");
@@ -2339,44 +2323,32 @@ fn test_du_repeated_inodes() {
 
 #[test]
 fn test_du_repeated_k() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-k", "-k"]).succeeds();
+    new_ucmd!().args(&["-s", "-k", "-k"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_l() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-l", "-l"]).succeeds();
+    new_ucmd!().args(&["-s", "-l", "-l"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_dereference() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-L", "-L"]).succeeds();
+    new_ucmd!().args(&["-s", "-L", "-L"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_dereference_args() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-D", "-D"]).succeeds();
+    new_ucmd!().args(&["-s", "-D", "-D"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_no_dereference() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-P", "-P"]).succeeds();
+    new_ucmd!().args(&["-s", "-P", "-P"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_m() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd()
+    new_ucmd!()
         .args(&["-s", "-m", "-m"])
         .succeeds()
         .stdout_only("1\t.\n");
@@ -2384,59 +2356,50 @@ fn test_du_repeated_m() {
 
 #[test]
 fn test_du_repeated_0() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-0", "-0"]).succeeds();
+    new_ucmd!().args(&["-s", "-0", "-0"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_separate_dirs() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-S", "-S"]).succeeds();
+    new_ucmd!().args(&["-s", "-S", "-S"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_s() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-s"]).succeeds();
+    new_ucmd!().args(&["-s", "-s"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_si() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "--si", "--si"]).succeeds();
+    new_ucmd!().args(&["-s", "--si", "--si"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_x() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-x", "-x"]).succeeds();
+    new_ucmd!().args(&["-s", "-x", "-x"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_t() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-t", "100", "-t", "100"]).succeeds();
+    new_ucmd!().args(&["-s", "-t", "100", "-t", "100"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_v() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd().args(&["-s", "-v", "-v"]).succeeds();
+    new_ucmd!().args(&["-s", "-v", "-v"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_files0_from() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
-    at.write("./somefile", "file2");
-    at.write("./file2", "a*");
+
+    // Set up the data for use with command 'du' and argument '--files0-from'.
+    // File 'somefile' has to contain a list of NUL-terminated directory and
+    // file names.
+    at.mkdir("dir");
+    at.write("dir/file2", "xyz");
+    at.write("./somefile", "dir\0");
 
     ts.ucmd()
         .args(&[
@@ -2450,6 +2413,7 @@ fn test_du_repeated_files0_from() {
 }
 
 #[test]
+#[cfg(feature = "touch")]
 fn test_du_repeated_time() {
     let ts = TestScenario::new(util_name!());
 
@@ -2485,6 +2449,7 @@ fn test_du_repeated_time() {
 }
 
 #[test]
+#[cfg(feature = "touch")]
 fn test_du_repeated_time_style() {
     let ts = TestScenario::new(util_name!());
 
@@ -2513,6 +2478,7 @@ fn test_du_repeated_time_style() {
         .ucmd()
         .env("TZ", "UTC")
         .arg("--time")
+        .arg("--time-style=full-iso")
         .arg("--time-style=full-iso")
         .arg("date_test")
         .succeeds();

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2298,8 +2298,8 @@ fn test_du_repeated_apparent_size() {
 #[test]
 fn test_du_repeated_block_size() {
     new_ucmd!()
-    .args(&["-s", "-B", "100", "-B", "100"])
-    .succeeds();
+        .args(&["-s", "-B", "100", "-B", "100"])
+        .succeeds();
 }
 
 #[test]
@@ -2389,8 +2389,8 @@ fn test_du_repeated_x() {
 #[test]
 fn test_du_repeated_t() {
     new_ucmd!()
-    .args(&["-s", "-t", "100", "-t", "100"])
-    .succeeds();
+        .args(&["-s", "-t", "100", "-t", "100"])
+        .succeeds();
 }
 
 #[test]

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2483,28 +2483,6 @@ fn test_du_repeated_v() {
 }
 
 #[test]
-fn test_du_repeated_exclude() {
-    let ts = TestScenario::new(util_name!());
-
-    ts.ucmd()
-        .args(&["-s", "--exclude", "a*", "--exclude", "a*"])
-        .succeeds()
-        .stdout_only("44\t.\n");
-}
-
-#[test]
-fn test_du_repeated_exclude_from() {
-    let ts = TestScenario::new(util_name!());
-    let at = &ts.fixtures;
-    at.write(&format!("./somefile"), "*a");
-
-    ts.ucmd()
-        .args(&["-s", "-X", "somefile", "-X", "somefile"])
-        .succeeds()
-        .stdout_only("48\t.\n");
-}
-
-#[test]
 fn test_du_repeated_files0_from() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -2590,5 +2568,5 @@ fn test_du_repeated_time_style() {
         .arg("--time-style=full-iso")
         .arg("date_test")
         .succeeds();
-    result.stdout_only("0\tdate_test\n");
+    result.stdout_only("0\t2016-06-16 00:00:00.000000000 +0000\tdate_test\n");
 }

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2446,8 +2446,7 @@ fn test_du_repeated_files0_from() {
             "--files0-from",
             "somefile",
         ])
-        .succeeds()
-        .stdout_only("4\tfile2\n");
+        .succeeds();
 }
 
 #[test]

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2276,18 +2276,14 @@ fn test_overriding_block_size_arg_with_invalid_value_still_errors() {
 fn test_du_repeated_h() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-h", "-h"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-h", "-h"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_a() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-a", "-a"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-a", "-a"]).succeeds();
 }
 
 #[test]
@@ -2304,9 +2300,7 @@ fn test_du_repeated_apparent_size() {
 fn test_du_repeated_block_size() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-B", "100", "-B", "100"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-B", "100", "-B", "100"]).succeeds();
 }
 
 #[test]
@@ -2323,18 +2317,14 @@ fn test_du_repeated_b() {
 fn test_du_repeated_c() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-c", "-c"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-c", "-c"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_d() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-d", "2", "-d", "2"])
-        .succeeds();
+    ts.ucmd().args(&["-d", "2", "-d", "2"]).succeeds();
 }
 
 #[test]
@@ -2351,45 +2341,35 @@ fn test_du_repeated_inodes() {
 fn test_du_repeated_k() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-k", "-k"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-k", "-k"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_l() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-l", "-l"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-l", "-l"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_dereference() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-L", "-L"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-L", "-L"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_dereference_args() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-D", "-D"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-D", "-D"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_no_dereference() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-P", "-P"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-P", "-P"]).succeeds();
 }
 
 #[test]
@@ -2406,63 +2386,49 @@ fn test_du_repeated_m() {
 fn test_du_repeated_0() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-0", "-0"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-0", "-0"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_separate_dirs() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-S", "-S"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-S", "-S"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_s() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-s"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-s"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_si() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "--si", "--si"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "--si", "--si"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_x() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-x", "-x"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-x", "-x"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_t() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-t", "100", "-t", "100"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-t", "100", "-t", "100"]).succeeds();
 }
 
 #[test]
 fn test_du_repeated_v() {
     let ts = TestScenario::new(util_name!());
 
-    ts.ucmd()
-        .args(&["-s", "-v", "-v"])
-        .succeeds();
+    ts.ucmd().args(&["-s", "-v", "-v"]).succeeds();
 }
 
 #[test]

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2278,8 +2278,7 @@ fn test_du_repeated_h() {
 
     ts.ucmd()
         .args(&["-s", "-h", "-h"])
-        .succeeds()
-        .stdout_only("44K\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2288,8 +2287,7 @@ fn test_du_repeated_a() {
 
     ts.ucmd()
         .args(&["-s", "-a", "-a"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2308,8 +2306,7 @@ fn test_du_repeated_block_size() {
 
     ts.ucmd()
         .args(&["-s", "-B", "100", "-B", "100"])
-        .succeeds()
-        .stdout_only("451\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2328,8 +2325,7 @@ fn test_du_repeated_c() {
 
     ts.ucmd()
         .args(&["-s", "-c", "-c"])
-        .succeeds()
-        .stdout_only("44\t.\n44\ttotal\n");
+        .succeeds();
 }
 
 #[test]
@@ -2338,8 +2334,7 @@ fn test_du_repeated_d() {
 
     ts.ucmd()
         .args(&["-d", "2", "-d", "2"])
-        .succeeds()
-        .stdout_only("16\t./subdir/deeper\n16\t./subdir/links\n36\t./subdir\n44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2358,8 +2353,7 @@ fn test_du_repeated_k() {
 
     ts.ucmd()
         .args(&["-s", "-k", "-k"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2368,8 +2362,7 @@ fn test_du_repeated_l() {
 
     ts.ucmd()
         .args(&["-s", "-l", "-l"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2378,8 +2371,7 @@ fn test_du_repeated_dereference() {
 
     ts.ucmd()
         .args(&["-s", "-L", "-L"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2388,8 +2380,7 @@ fn test_du_repeated_dereference_args() {
 
     ts.ucmd()
         .args(&["-s", "-D", "-D"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2398,8 +2389,7 @@ fn test_du_repeated_no_dereference() {
 
     ts.ucmd()
         .args(&["-s", "-P", "-P"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2418,8 +2408,7 @@ fn test_du_repeated_0() {
 
     ts.ucmd()
         .args(&["-s", "-0", "-0"])
-        .succeeds()
-        .stdout_only("44\t.\0");
+        .succeeds();
 }
 
 #[test]
@@ -2428,8 +2417,7 @@ fn test_du_repeated_separate_dirs() {
 
     ts.ucmd()
         .args(&["-s", "-S", "-S"])
-        .succeeds()
-        .stdout_only("8\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2438,8 +2426,7 @@ fn test_du_repeated_s() {
 
     ts.ucmd()
         .args(&["-s", "-s"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2448,8 +2435,7 @@ fn test_du_repeated_si() {
 
     ts.ucmd()
         .args(&["-s", "--si", "--si"])
-        .succeeds()
-        .stdout_only("46k\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2458,8 +2444,7 @@ fn test_du_repeated_x() {
 
     ts.ucmd()
         .args(&["-s", "-x", "-x"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2468,8 +2453,7 @@ fn test_du_repeated_t() {
 
     ts.ucmd()
         .args(&["-s", "-t", "100", "-t", "100"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]
@@ -2478,8 +2462,7 @@ fn test_du_repeated_v() {
 
     ts.ucmd()
         .args(&["-s", "-v", "-v"])
-        .succeeds()
-        .stdout_only("44\t.\n");
+        .succeeds();
 }
 
 #[test]

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2512,7 +2512,13 @@ fn test_du_repeated_files0_from() {
     at.write(&format!("./file2"), "a*");
 
     ts.ucmd()
-        .args(&["-s", "--files0-from", "somefile", "--files0-from", "somefile"])
+        .args(&[
+            "-s",
+            "--files0-from",
+            "somefile",
+            "--files0-from",
+            "somefile",
+        ])
         .succeeds()
         .stdout_only("4\tfile2\n");
 }

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2297,7 +2297,9 @@ fn test_du_repeated_apparent_size() {
 
 #[test]
 fn test_du_repeated_block_size() {
-    new_ucmd!().args(&["-s", "-B", "100", "-B", "100"]).succeeds();
+    new_ucmd!()
+    .args(&["-s", "-B", "100", "-B", "100"])
+    .succeeds();
 }
 
 #[test]
@@ -2386,7 +2388,9 @@ fn test_du_repeated_x() {
 
 #[test]
 fn test_du_repeated_t() {
-    new_ucmd!().args(&["-s", "-t", "100", "-t", "100"]).succeeds();
+    new_ucmd!()
+    .args(&["-s", "-t", "100", "-t", "100"])
+    .succeeds();
 }
 
 #[test]


### PR DESCRIPTION
Fix for [1173](https://github.com/uutils/coreutils/issues/11783): du: error: the argument '--human-readable' cannot be used multiple times (but works in GNU).

- For du command, accept a repeated command-line argument wherever it makes sense.
