### PR TITLE
fix(du): use getdents64 on Linux to avoid EOVERFLOW on 32-bit architectures

### DIFF
--- a/src/uucore/src/lib/features/safe_traversal.rs
+++ b/src/uucore/src/lib/features/safe_traversal.rs
@@ -10,7 +10,7 @@
 //
 // spell-checker:ignore CLOEXEC RDONLY TOCTOU closedir dirp fdopendir fstatat openat REMOVEDIR unlinkat smallfile
 // spell-checker:ignore RAII dirfd fchownat fchown FchmodatFlags fchmodat fchmod mkdirat CREAT WRONLY ELOOP ENOTDIR
-// spell-checker:ignore atimensec mtimensec ctimensec opath chmods
+// spell-checker:ignore atimensec mtimensec ctimensec opath chmods EOVERFLOW getdents
 
 #[cfg(test)]
 use std::os::unix::ffi::OsStringExt;
@@ -22,12 +22,19 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::path::{Path, PathBuf};
 
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 use nix::dir::Dir;
 use nix::fcntl::{OFlag, openat};
 use nix::libc;
 use nix::sys::stat::{FchmodatFlags, FileStat, Mode, fchmodat, fstatat, mkdirat};
 use nix::unistd::{Gid, Uid, UnlinkatFlags, fchown, fchownat, unlinkat};
 use os_display::Quotable;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::mem::MaybeUninit;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use rustix::fs::RawDir;
 
 use crate::translate;
 
@@ -108,7 +115,27 @@ impl From<SafeTraversalError> for io::Error {
     }
 }
 
-// Helper function to read directory entries using nix
+// Helper function to read directory entries.
+// On Linux, use [`rustix::fs::RawDir`](https://docs.rs/rustix/latest/rustix/fs/struct.RawDir.html) which calls getdents64 directly,
+// avoiding EOVERFLOW on 32-bit architectures where libc readdir() uses
+// 32-bit d_ino.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn read_dir_entries(fd: &OwnedFd) -> io::Result<Vec<OsString>> {
+    let mut entries = Vec::new();
+    let mut buf = [MaybeUninit::uninit(); 8192];
+    let mut iter = RawDir::new(fd, &mut buf);
+    while let Some(entry_result) = iter.next() {
+        let entry = entry_result.map_err(io::Error::from)?;
+        let name_bytes = entry.file_name().to_bytes();
+        let name_os = OsStr::from_bytes(name_bytes);
+        if name_os != "." && name_os != ".." {
+            entries.push(name_os.to_os_string());
+        }
+    }
+    Ok(entries)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn read_dir_entries(fd: &OwnedFd) -> io::Result<Vec<OsString>> {
     let mut entries = Vec::new();
 


### PR DESCRIPTION
## Summary

- Fix `du` producing "Value too large for defined data type" (EOVERFLOW) on 32-bit Linux (i686) when reading directories
- Replace `nix::dir::Dir` (which calls `libc::readdir()` with 32-bit `d_ino`) with `rustix::fs::RawDir` (which calls `getdents64` syscall with 64-bit `d_ino`/`d_off`) on Linux/Android
- This also fixes all other utilities using `DirFd::read_dir()`: `rm`, `chmod`, `chown`, `install`

## Root Cause

On 32-bit glibc, `libc::readdir()` uses `struct dirent` with 32-bit `d_ino`. Modern filesystems (XFS, Btrfs, ext4+inode64) can return inode numbers exceeding 2^32, causing `EOVERFLOW`.

## Fix

Use `rustix::fs::RawDir` on Linux which calls the `getdents64` syscall directly, always using 64-bit directory entry fields. `rustix` with `fs` feature is already an unconditional dependency of `uucore`, so no new dependencies are needed.

On non-Linux Unix (macOS, BSDs), the existing `nix::dir::Dir` implementation is retained.

## Test 

- [x] `cargo check -p uucore` passes
- [x] `cargo check -p uu_du` passes
- [x] `cargo test -p uu_du` — all tests pass
- [x] `cargo test -p uu_rm` — all tests pass
- [x] `cargo test -p uu_chmod` — all tests pass
- [x] `cargo test -p coreutils -- du` — all 112 du integration tests pass


Closes #11848