### PR TITLE
cat: avoid unnecessary alloc on Linux

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -490,11 +490,13 @@ fn write_fast<R: FdReadable>(handle: &mut InputHandle<R>) -> CatResult<()> {
     }
     // If we're not on Linux or Android, or the splice() call failed,
     // fall back on slower writing.
+    write_slow(handle, stdout)
+}
+
+#[cfg_attr(any(target_os = "linux", target_os = "android"), inline(never))] // splice fast-path does not require this allocation
+#[cfg_attr(not(any(target_os = "linux", target_os = "android")), inline)]
+fn write_slow<R: FdReadable>(handle: &mut InputHandle<R>, stdout: io::Stdout) -> CatResult<()> {
     let mut stdout_lock = stdout.lock();
-    // stack allocation is overhead when splice succeed
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    let mut buf = vec![0; 1024 * 64];
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     let mut buf = [0; 1024 * 64];
     loop {
         match handle.reader.read(&mut buf) {


### PR DESCRIPTION
Split a code path which is rarely called to a different function instead of using vec! like https://github.com/uutils/coreutils/pull/11675 .