### PR TITLE
head: continue processing files even if one has io error

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -461,8 +461,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
                 print_verbatim(file).unwrap();
                 println!(" <==");
             }
-            head_file(&mut file_handle, options)?;
-            Ok(())
+            head_file(&mut file_handle, options).map(|_| ())
         };
         if let Err(err) = res {
             let name = if file == "-" {
@@ -470,7 +469,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
             } else {
                 file.into()
             };
-            return Err(HeadError::Io { name, err }.into());
+            show!(HeadError::Io { name, err });
         }
         first = false;
     }

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -933,3 +933,21 @@ fn test_do_not_attempt_to_read_a_directory() {
         .fails_with_code(1)
         .stderr_contains("error reading '.'");
 }
+
+// When passed multiple files, process all files even if one fails
+#[cfg(target_os = "linux")]
+#[test]
+fn test_file_after_fail() {
+    let scene = TestScenario::new(util_name!());
+    let fixtures = &scene.fixtures;
+
+    fixtures.write("a", "a");
+
+    scene
+        .ucmd()
+        .args(&["/proc/self/mem", "a"])
+        .fails_with_code(1)
+        .stdout_contains("==> /proc/self/mem <==\n")
+        .stderr_contains("head: error reading '/proc/self/mem'")
+        .stdout_contains("==> a <==\na");
+}

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -937,6 +937,7 @@ fn test_do_not_attempt_to_read_a_directory() {
 // When passed multiple files, process all files even if one fails
 #[cfg(target_os = "linux")]
 #[test]
+#[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/proc) not visible")]
 fn test_file_after_fail() {
     let scene = TestScenario::new(util_name!());
     let fixtures = &scene.fixtures;


### PR DESCRIPTION
Currently head exits with an error when it encounters an I/O error, whereas GNU head continues with the rest of the files provided in the arguments. Closes #11846