### PR TITLE
clippy: remove cognitive_complexity lint suppression

### DIFF
--- a/src/bin/coreutils.rs
+++ b/src/bin/coreutils.rs
@@ -49,7 +49,6 @@ Currently defined functions:
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn main() {
     let utils = util_map();
     let mut args = uucore::args_os();

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1019,7 +1019,6 @@ impl Attributes {
 }
 
 impl Options {
-    #[allow(clippy::cognitive_complexity)]
     fn from_matches(matches: &ArgMatches) -> CopyResult<Self> {
         let not_implemented_opts = vec![
             #[cfg(not(any(windows, unix)))]

--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -406,7 +406,6 @@ impl SplitWriter<'_> {
     /// - if no line matched, an [`CsplitError::MatchNotFound`].
     /// - if there are not enough lines to accommodate the offset, an
     ///   [`CsplitError::LineOutOfRange`].
-    #[allow(clippy::cognitive_complexity)]
     fn do_to_match<I>(
         &mut self,
         pattern_as_str: &str,
@@ -723,7 +722,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn input_splitter() {
         let input = vec![
             Ok(String::from("aaa")),
@@ -796,7 +794,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn input_splitter_interrupt_rewind() {
         let input = vec![
             Ok(String::from("aaa")),

--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -209,7 +209,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn up_to_match_pattern() {
         let input = [
             "/test1.*end$/",
@@ -268,7 +267,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn skip_to_match_pattern() {
         let input = [
             "%test1.*end$%",

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -281,7 +281,6 @@ fn parse_military_timezone_with_offset(s: &str) -> Option<(i32, DayDelta)> {
 }
 
 #[uucore::main]
-#[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1325,7 +1325,6 @@ fn finalize<T>(
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-#[allow(clippy::cognitive_complexity)]
 fn make_linux_oflags(oflags: &OFlags) -> Option<libc::c_int> {
     let mut flag = 0;
 

--- a/src/uu/dd/src/numbers.rs
+++ b/src/uu/dd/src/numbers.rs
@@ -89,7 +89,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_to_magnitude_and_suffix_not_powers_of_1024() {
         assert_eq!(to_magnitude_and_suffix(1, SuffixType::Si), "1.0 B");
         assert_eq!(to_magnitude_and_suffix(999, SuffixType::Si), "999 B");

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -338,7 +338,6 @@ impl Parser {
         }
     }
 
-    #[allow(clippy::cognitive_complexity)]
     fn parse_input_flags(&mut self, val: &str) -> Result<(), ParseError> {
         let i = &mut self.iflag;
         for f in val.split(',') {
@@ -370,7 +369,6 @@ impl Parser {
         Ok(())
     }
 
-    #[allow(clippy::cognitive_complexity)]
     fn parse_output_flags(&mut self, val: &str) -> Result<(), ParseError> {
         let o = &mut self.oflag;
         for f in val.split(',') {

--- a/src/uu/dd/src/parseargs/unit_tests.rs
+++ b/src/uu/dd/src/parseargs/unit_tests.rs
@@ -88,7 +88,6 @@ fn test_status_level_none() {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_all_top_level_args_no_leading_dashes() {
     let args = [
         "if=foo.file",

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -277,7 +277,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_to_magnitude_and_suffix_not_powers_of_1024() {
         assert_eq!(to_magnitude_and_suffix(1, SuffixType::Si, true), "1.0B");
         assert_eq!(to_magnitude_and_suffix(999, SuffixType::Si, true), "999B");

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -566,7 +566,6 @@ fn safe_du(
 // Only used on non-Linux platforms
 // Regular traversal using std::fs
 // Used on non-Linux platforms and as fallback for symlinks on Linux
-#[allow(clippy::cognitive_complexity)]
 fn du_regular(
     mut my_stat: Stat,
     options: &TraversalOptions,
@@ -1006,7 +1005,6 @@ fn parse_size_format(matches: &ArgMatches) -> UResult<SizeFormat> {
 }
 
 #[uucore::main]
-#[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 

--- a/src/uu/fmt/src/linebreak.rs
+++ b/src/uu/fmt/src/linebreak.rs
@@ -214,7 +214,6 @@ struct LineBreak<'a> {
     fresh: bool,
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn find_kp_breakpoints<'a, T: Clone + Iterator<Item = &'a WordInfo<'a>>>(
     iter: T,
     args: &BreakArgs<'a>,

--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -393,7 +393,6 @@ impl ParagraphStream<'_> {
 impl Iterator for ParagraphStream<'_> {
     type Item = Result<Paragraph, Vec<u8>>;
 
-    #[allow(clippy::cognitive_complexity)]
     fn next(&mut self) -> Option<Result<Paragraph, Vec<u8>>> {
         // return a NoFormatLine in an Err; it should immediately be output
         let noformat = match self.lines.peek()? {

--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -670,7 +670,6 @@ fn process_pending_chunk<W: Write>(
 ///
 /// If `spaces` is `true`, attempt to break lines at whitespace boundaries.
 #[allow(unused_assignments)]
-#[allow(clippy::cognitive_complexity)]
 fn fold_file<T: Read, W: Write>(
     mut file: BufReader<T>,
     spaces: bool,

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -399,7 +399,6 @@ fn head_file(input: &mut File, options: &HeadOptions) -> io::Result<u64> {
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn uu_head(options: &HeadOptions) -> UResult<()> {
     let mut stdout = io::stdout().lock();
     let mut first = true;
@@ -577,7 +576,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn all_args_test() {
         assert!(options("--silent").unwrap().quiet);
         assert!(options("--quiet").unwrap().quiet);

--- a/src/uu/head/src/parse.rs
+++ b/src/uu/head/src/parse.rs
@@ -144,7 +144,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_parse_numbers_obsolete() {
         assert_eq!(obsolete("-5"), obsolete_result(&["-n", "5"]));
         assert_eq!(obsolete("-100"), obsolete_result(&["-n", "100"]));

--- a/src/uu/head/src/take.rs
+++ b/src/uu/head/src/take.rs
@@ -475,7 +475,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_take_all_lines_buffer() {
         // 3 lines with new-lines and one partial line.
         let input_buffer = "a\nb\nc\ndef";

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -129,7 +129,6 @@ struct State {
 }
 
 #[uucore::main(no_signals)]
-#[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
     let mut lock = io::stdout().lock();

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -591,7 +591,6 @@ fn is_potential_directory_path(path: &Path) -> bool {
 ///
 /// Returns a Result type with the Err variant containing the error message.
 ///
-#[allow(clippy::cognitive_complexity)]
 fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
     // first check that paths contains at least one element
     if paths.is_empty() {

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -303,7 +303,6 @@ pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
     link(&files[0], &files[1], settings)
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) -> LnResult<()> {
     if !target_dir.is_dir() {
         return Err(LnError::TargetIsNotADirectory(target_dir.to_owned()));
@@ -402,7 +401,6 @@ fn relative_path<'a>(src: &'a Path, dst: &Path) -> Cow<'a, Path> {
     src.into()
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
     let mut backup_path = None;
     let source: Cow<'_, Path> = if settings.relative {

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -669,7 +669,6 @@ fn parse_width(width_match: Option<&String>) -> Result<u16, LsError> {
 }
 
 impl Config {
-    #[allow(clippy::cognitive_complexity)]
     pub fn from(options: &clap::ArgMatches) -> UResult<Self> {
         let context = options.get_flag(options::CONTEXT);
         let (mut format, opt) = extract_format(options);

--- a/src/uu/ls/src/display.rs
+++ b/src/uu/ls/src/display.rs
@@ -321,7 +321,6 @@ fn alt_access_indicator(item: &PathData, config: &Config, is_acl_set: bool) -> u
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
 pub fn display_items(
     items: &[PathData],
     config: &Config,
@@ -673,7 +672,6 @@ pub fn display_size(size: u64, config: &Config) -> String {
 ///
 /// Note that non-unicode sequences in symlink targets are dealt with using
 /// [`std::path::Path::to_string_lossy`].
-#[allow(clippy::cognitive_complexity)]
 fn display_item_name(
     path: &PathData,
     config: &Config,
@@ -875,7 +873,6 @@ fn display_item_name(
 /// ```
 /// that decide the maximum possible character count of each field.
 #[allow(clippy::write_literal)]
-#[allow(clippy::cognitive_complexity)]
 fn display_item_long(
     item: &PathData,
     padding: &PaddingCollection,

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -571,7 +571,6 @@ pub fn mv(files: &[OsString], opts: &Options) -> UResult<()> {
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn move_files_into_dir(files: &[PathBuf], target_dir: &Path, options: &Options) -> UResult<()> {
     // remember the moved destinations for further usage
     let mut moved_destinations: FxHashSet<PathBuf> =

--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -11,7 +11,6 @@ use uucore::translate;
 
 // parse_options loads the options into the settings, returning an array of
 // error messages.
-#[allow(clippy::cognitive_complexity)]
 pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) -> Vec<String> {
     // This vector holds error messages encountered.
     let mut errs: Vec<String> = vec![];

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -884,7 +884,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_round_with_precision() {
         let rm = RoundMethod::FromZero;
         assert_eq!(1.0, round_with_precision(0.12345, rm, 0));

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -119,7 +119,6 @@ impl FromStr for FormatOptions {
     // An optional zero (%010f) will zero pad the number.
     // An optional negative value (%-10f) will left align.
     // An optional precision (%.1f) determines the precision of the number.
-    #[allow(clippy::cognitive_complexity)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut iter = s.chars().peekable();
         let mut options = Self::default();
@@ -274,7 +273,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_parse_format_with_invalid_formats() {
         assert!("".parse::<FormatOptions>().is_err());
         assert!("hello".parse::<FormatOptions>().is_err());

--- a/src/uu/od/src/input_decoder.rs
+++ b/src/uu/od/src/input_decoder.rs
@@ -231,7 +231,6 @@ mod tests {
 
     #[test]
     #[allow(clippy::float_cmp)]
-    #[allow(clippy::cognitive_complexity)]
     fn smoke_test() {
         let data = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xff, 0xff];
         let mut input = PeekReader::new(Cursor::new(&data));

--- a/src/uu/od/src/output_info.rs
+++ b/src/uu/od/src/output_info.rs
@@ -234,7 +234,6 @@ fn assert_alignment(
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_calculate_alignment() {
     // For this example `byte_size_block` is 8 and 'print_width_block' is 23:
     // 1777777777777777777777 1777777777777777777777

--- a/src/uu/od/src/parse_formats.rs
+++ b/src/uu/od/src/parse_formats.rs
@@ -110,7 +110,6 @@ fn od_argument_with_option(ch: char) -> bool {
 /// arguments with parameters like -w16 can only appear at the end: -fvoxw16
 /// parameters of -t/--format specify 1 or more formats.
 /// if -- appears on the command line, parsing should stop.
-#[allow(clippy::cognitive_complexity)]
 pub fn parse_format_flags(args: &[String]) -> Result<Vec<ParsedFormatterItemInfo>, String> {
     let mut formats = Vec::new();
 

--- a/src/uu/od/src/parse_inputs.rs
+++ b/src/uu/od/src/parse_inputs.rs
@@ -271,7 +271,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_parse_inputs_with_offset() {
         // offset is found without filename, so stdin will be used.
         assert_eq!(
@@ -414,7 +413,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_parse_offset_operand() {
         assert_eq!(8, parse_offset_operand_str("10").unwrap()); // default octal
         assert_eq!(0, parse_offset_operand_str("0").unwrap());

--- a/src/uu/od/src/parse_nrofbytes.rs
+++ b/src/uu/od/src/parse_nrofbytes.rs
@@ -79,7 +79,6 @@ pub fn parse_number_of_bytes(s: &str) -> Result<u64, ParseSizeError> {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_parse_number_of_bytes() {
     // octal input
     assert_eq!(8, parse_number_of_bytes("010").unwrap());

--- a/src/uu/od/src/peek_reader.rs
+++ b/src/uu/od/src/peek_reader.rs
@@ -187,7 +187,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_peek_read_with_smaller_buffer() {
         let mut sut = PeekReader::new(Cursor::new(&b"abcdefghij"[..]));
 

--- a/src/uu/od/src/prn_char.rs
+++ b/src/uu/od/src/prn_char.rs
@@ -78,7 +78,6 @@ pub fn format_ascii_dump(bytes: &[u8]) -> String {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_format_item_a() {
     assert_eq!(" nul", format_item_a(0x00));
     assert_eq!(" soh", format_item_a(0x01));
@@ -94,7 +93,6 @@ fn test_format_item_a() {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_format_item_c() {
     assert_eq!("  \\0", format_item_c(&[0x00]));
     assert_eq!(" 001", format_item_c(&[0x01]));

--- a/src/uu/od/src/prn_float.rs
+++ b/src/uu/od/src/prn_float.rs
@@ -239,7 +239,6 @@ fn format_long_double(f: f64) -> String {
 
 #[test]
 #[allow(clippy::excessive_precision)]
-#[allow(clippy::cognitive_complexity)]
 fn test_format_f32() {
     assert_eq!(format_f32(1.0), "      1.0000000");
     assert_eq!(format_f32(9.999_999_0), "      9.9999990");
@@ -316,7 +315,6 @@ fn test_format_f32() {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_format_f64() {
     assert_eq!(format_f64(1.0), "      1.0000000000000000");
     assert_eq!(format_f64(10.0), "      10.000000000000000");
@@ -349,7 +347,6 @@ fn test_format_f64() {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_format_f16() {
     assert_eq!(format_f16(f16::from_bits(0x8400u16)), "  -6.1035156e-5");
     assert_eq!(format_f16(f16::from_bits(0x8401u16)), "  -6.1094761e-5");

--- a/src/uu/od/src/prn_int.rs
+++ b/src/uu/od/src/prn_int.rs
@@ -89,7 +89,6 @@ int_writer_signed!(FORMAT_ITEM_DEC32S, 4, 12, format_item_dec_s32, dec!()); // m
 int_writer_signed!(FORMAT_ITEM_DEC64S, 8, 21, format_item_dec_s64, dec!()); // max: -9223372036854775808
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_sign_extend() {
     assert_eq!(
         0xffff_ffff_ffff_ff80u64 as i64,
@@ -180,7 +179,6 @@ fn test_format_item_dec_u() {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_format_item_dec_s() {
     assert_eq!("    0", format_item_dec_s8(0));
     assert_eq!("  127", format_item_dec_s8(0x7f));

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -82,7 +82,6 @@ pub fn uu_app() -> Command {
         )
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn paste(
     filenames: Vec<OsString>,
     serial: bool,

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -504,7 +504,6 @@ fn get_date_format(matches: &ArgMatches) -> String {
     .to_string()
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn build_options(
     matches: &ArgMatches,
     paths: &[&str],
@@ -1293,7 +1292,6 @@ fn write_offset_spaces(out: &mut impl Write, mut n: usize) -> Result<(), std::io
     Ok(())
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn write_columns(
     lines: &[FileLine],
     options: &OutputOptions,

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -114,7 +114,6 @@ struct WordFilter {
 }
 
 impl WordFilter {
-    #[allow(clippy::cognitive_complexity)]
     fn new(matches: &clap::ArgMatches, config: &Config) -> UResult<Self> {
         let (o, oset): (bool, HashSet<String>) = if matches.contains_id(options::ONLY_FILE) {
             let words =

--- a/src/uu/seq/src/numberparse.rs
+++ b/src/uu/seq/src/numberparse.rs
@@ -282,7 +282,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_num_integral_digits() {
         // no decimal, no exponent
         assert_eq!(num_integral_digits("123"), 3);
@@ -323,7 +322,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_num_fractional_digits() {
         // no decimal, no exponent
         assert_eq!(num_fractional_digits("123"), 0);

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -611,7 +611,6 @@ fn create_compatible_sequence(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::cognitive_complexity)]
 fn wipe_file(
     path_str: &OsString,
     n_passes: usize,

--- a/src/uu/sort/src/numeric_str_cmp.rs
+++ b/src/uu/sort/src/numeric_str_cmp.rs
@@ -50,7 +50,6 @@ impl NumInfo {
     /// an empty range (idx..idx) is returned so that idx is the char after the last zero.
     /// If the input is not a number (which has to be treated as zero), the returned empty range
     /// will be 0..0.
-    #[allow(clippy::cognitive_complexity)]
     pub fn parse(num: &[u8], parse_settings: &NumInfoParseSettings) -> (Self, Range<usize>) {
         let mut exponent = -1;
         let mut had_decimal_pt = false;

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1990,7 +1990,6 @@ fn emit_debug_warnings(
 }
 
 #[uucore::main]
-#[allow(clippy::cognitive_complexity)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut settings = GlobalSettings {
         numeric_locale: detect_numeric_locale(),
@@ -2826,7 +2825,6 @@ fn ascii_case_insensitive_cmp(a: &[u8], b: &[u8]) -> Ordering {
 // In contrast to numeric compare, GNU general numeric/FP sort *should* recognize positive signs and
 // scientific notation, so we strip those lines only after the end of the following numeric string.
 // For example, 5e10KFD would be 5e10 or 5x10^10 and +10000HFKJFK would become 10000.
-#[allow(clippy::cognitive_complexity)]
 fn get_leading_gen(inp: &[u8], decimal_pt: u8) -> Range<usize> {
     // check for inf, -inf and nan
     const ALLOWED_PREFIXES: &[&[u8]] = &[b"inf", b"-inf", b"nan"];

--- a/src/uu/split/src/number.rs
+++ b/src/uu/split/src/number.rs
@@ -424,7 +424,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_dynamic_width_number_display_alphabetic() {
         fn num(n: usize) -> Number {
             let mut number = Number::DynamicWidth(DynamicWidthNumber::new(26, 0));
@@ -470,7 +469,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_dynamic_width_number_display_numeric_hexadecimal() {
         fn num(n: usize) -> Number {
             let mut number = Number::DynamicWidth(DynamicWidthNumber::new(16, 0));
@@ -495,7 +493,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_fixed_width_number_increment() {
         let mut n = Number::FixedWidth(FixedWidthNumber::new(3, 2, 0).unwrap());
         assert_eq!(n.digits(), vec![0, 0]);
@@ -519,7 +516,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_fixed_width_number_display_alphabetic() {
         fn num(n: usize) -> Result<Number, Overflow> {
             let mut number = Number::FixedWidth(FixedWidthNumber::new(26, 2, 0).unwrap());

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1316,7 +1316,6 @@ fn line_bytes(settings: &Settings, reader: &mut impl BufRead, chunk_size: usize)
     Ok(())
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn split(settings: &Settings) -> UResult<()> {
     let r_box = if settings.input == "-" {
         Box::new(stdin()) as Box<dyn Read>

--- a/src/uu/split/src/strategy.rs
+++ b/src/uu/split/src/strategy.rs
@@ -308,7 +308,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_number_type_from_error() {
         assert_eq!(
             NumberType::from("xyz").unwrap_err(),

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1470,7 +1470,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_group_num() {
         assert_eq!("12,379,821,234", group_num("12379821234"));
         assert_eq!("21,234", group_num("21234"));

--- a/src/uu/tac/src/tac.rs
+++ b/src/uu/tac/src/tac.rs
@@ -321,7 +321,6 @@ fn translate_regex_flavor(bytes: &[u8]) -> String {
     String::from_utf8(result).expect("produces ASCII bytes")
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn tac(filenames: &[OsString], before: bool, regex: bool, separator: &OsStr) -> UResult<()> {
     // Compile the regular expression pattern if it is provided.
     let maybe_pattern = if regex {

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -292,7 +292,6 @@ impl Observer {
         Ok(())
     }
 
-    #[allow(clippy::cognitive_complexity)]
     fn handle_event(
         &mut self,
         event: &notify::Event,
@@ -478,7 +477,6 @@ impl Observer {
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
 pub fn follow(mut observer: Observer, settings: &Settings) -> UResult<()> {
     if observer.files.no_files_remaining(settings) && !observer.files.only_stdin_remaining() {
         return Err(USimpleError::new(1, translate!("tail-no-files-remaining")));

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -442,7 +442,6 @@ impl PrintState {
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn unexpand_buf(
     buf: &[u8],
     output: &mut BufWriter<Stdout>,

--- a/src/uu/wc/src/utf8/read.rs
+++ b/src/uu/wc/src/utf8/read.rs
@@ -45,7 +45,6 @@ impl<B: BufRead> BufReadDecoder<B> {
     /// This is similar to `Iterator::next`,
     /// except that decoded chunks borrow the decoder (~iterator)
     /// so they need to be handled or copied before the next chunk can start decoding.
-    #[allow(clippy::cognitive_complexity)]
     pub fn next_strict(&mut self) -> Option<Result<&str, BufReadDecoderError<'_>>> {
         enum BytesSource {
             BufRead(usize),

--- a/src/uu/who/src/platform/unix.rs
+++ b/src/uu/who/src/platform/unix.rs
@@ -192,7 +192,6 @@ fn current_tty() -> String {
 }
 
 impl Who {
-    #[allow(clippy::cognitive_complexity)]
     fn exec(&mut self) -> UResult<()> {
         #[cfg(target_os = "linux")]
         let run_level_chk = |record: i16| record == utmpx::RUN_LVL;

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -364,7 +364,6 @@ impl<'a> From<Component<'a>> for OwningComponent {
 /// * [`ResolveMode::Logical`] makes this function resolve '..' components
 ///   before symlinks
 ///
-#[allow(clippy::cognitive_complexity)]
 pub fn canonicalize<P: AsRef<Path>>(
     original: P,
     miss_mode: MissingHandling,
@@ -556,7 +555,6 @@ fn get_file_display(mode: u32) -> char {
 
 // The logic below is more readable written this way.
 #[allow(clippy::if_not_else)]
-#[allow(clippy::cognitive_complexity)]
 /// Display the unix permissions of a file
 pub fn display_permissions_unix(mode: u32, display_file_type: bool) -> String {
     use mode::{

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -288,7 +288,6 @@ impl ChownExecutor {
         Ok(())
     }
 
-    #[allow(clippy::cognitive_complexity)]
     fn traverse<P: AsRef<Path>>(&self, root: P) -> i32 {
         let path = root.as_ref();
         let Some(meta) = self.obtain_meta(path, self.dereference) else {
@@ -589,7 +588,6 @@ impl ChownExecutor {
     }
 
     #[cfg(not(target_os = "linux"))]
-    #[allow(clippy::cognitive_complexity)]
     fn dive_into<P: AsRef<Path>>(&self, root: P) -> i32 {
         let root = root.as_ref();
 
@@ -880,7 +878,6 @@ pub fn configure_symlink_and_recursion(
 /// `parse_gid_uid_and_filter` will be called to obtain the target gid and uid, and the filter,
 /// from `ArgMatches`.
 /// `groups_only` determines whether verbose output will only mention the group.
-#[allow(clippy::cognitive_complexity)]
 pub fn chown_base(
     mut command: Command,
     args: impl crate::Args,


### PR DESCRIPTION
Remove the suppressions, as [`cognitive_complexity`](https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#cognitive_complexity) is now a restriction lint that is allow-by-default.