### PR TITLE
tee: use is_ok at fn write_flush

### DIFF
--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -195,24 +195,19 @@ impl MultiWriter {
 
     fn write_flush(&mut self, buf: &[u8]) -> Result<()> {
         let mut aborted = None;
-        let mut errors = 0;
         let mode = self.output_error_mode;
         self.writers.retain_mut(|writer| {
             let res = (|| {
                 writer.inner.write_all(buf)?;
                 writer.inner.flush()
             })();
-            match res {
-                Ok(()) => true,
-                Err(e) => {
-                    if let Err(e) = process_error(mode, e, writer, &mut errors) {
-                        aborted.get_or_insert(e);
-                    }
-                    false
+            res.map_err(|e| {
+                if let Err(e) = process_error(mode, e, writer, &mut self.ignored_errors) {
+                    aborted.get_or_insert(e);
                 }
-            }
+            })
+            .is_ok()
         });
-        self.ignored_errors += errors;
         aborted.map_or(
             if self.writers.is_empty() {
                 // This error kind will never be raised by the standard


### PR DESCRIPTION
match is difficult to understand