### PR TITLE
tail: improve throughput for -c +0 by splice()

### DIFF
--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -33,6 +33,9 @@ notify = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["fs", "process"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+uucore = { workspace = true, features = ["pipes"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_System_Threading",

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -575,17 +575,26 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
     Ok(())
 }
 
-fn print_target_section<R>(file: &mut R, limit: Option<u64>) -> UResult<()>
-where
-    R: Read + ?Sized,
-{
-    // Print the target section of the file.
+// Print the target section of the file
+fn print_target_section<
+    #[cfg(any(target_os = "linux", target_os = "android"))] R: Read + rustix::fd::AsFd,
+    #[cfg(not(any(target_os = "linux", target_os = "android")))] R: Read + ?Sized,
+>(
+    file: &mut R,
+    limit: Option<u64>,
+) -> UResult<()> {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     if let Some(limit) = limit {
         let mut reader = file.take(limit);
         io::copy(&mut reader, &mut stdout)?;
     } else {
+        // zero-copy fast-path
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if uucore::pipes::splice_unbounded_broker(file, &mut stdout)? {
+            io::copy(file, &mut stdout)?;
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         io::copy(file, &mut stdout)?;
     }
     Ok(())


### PR DESCRIPTION
Start supporting https://github.com/uutils/coreutils/issues/11607 and https://github.com/uutils/coreutils/issues/11785 .

`tail`'s code path is very complex. So I do them with several PRs.
This PR covers
```
> truncate -s 9PB /tmp/huge
> target/debug/tail -c +0 /tmp/huge|pv>/dev/null
^C.4GiB 0:00:01 [39.4GiB/s]
```