### PR TITLE
Revert "fix(renovate): do not update pinned dependencies"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
 	"extends": [
 		"config:recommended"
-	],
-	"updatePinnedDependencies": false
+	]
 }


### PR DESCRIPTION
Reverts uutils/coreutils#11965 because I didn't expect it to close the action-related updates.