### PR TITLE
Cargo.toml: unpin `notify`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,7 +430,7 @@ memchr = "2.7.2"
 memmap2 = "0.9.4"
 nix = { version = "0.31.2", default-features = false }
 nom = "8.0.0"
-notify = { version = "=8.2.0", features = ["macos_kqueue"] }
+notify = { version = "8.2.0", features = ["macos_kqueue"] }
 num-bigint = "0.4.4"
 num-prime = "0.5.0"
 num-traits = "0.2.19"


### PR DESCRIPTION
This PR unpins `notify` as we use the most recent version and I don't know why we pinned it.