### PR TITLE
tail: improve throughput for -c N file

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -576,6 +576,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
 }
 
 // Print the target section of the file
+// use zero-copy on Linux
 fn print_target_section<
     #[cfg(any(target_os = "linux", target_os = "android"))] R: Read + rustix::fd::AsFd,
     #[cfg(not(any(target_os = "linux", target_os = "android")))] R: Read,
@@ -586,10 +587,14 @@ fn print_target_section<
     let stdout = stdout();
     let mut stdout = stdout.lock();
     if let Some(limit) = limit {
-        let mut reader = file.take(limit);
-        io::copy(&mut reader, &mut stdout)?;
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        uucore::pipes::send_n_bytes(file, &mut stdout, limit)?;
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            let mut reader = file.take(limit);
+            io::copy(&mut reader, &mut stdout)?;
+        }
     } else {
-        // zero-copy fast-path
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if uucore::pipes::splice_unbounded_broker(file, &mut stdout)? {
             io::copy(file, &mut stdout)?;


### PR DESCRIPTION
Part of https://github.com/uutils/coreutils/issues/11607 (non-stream)
The code path without + is different.
```
$ target/debug/tail -c 1PB /tmp/huge | pv>/dev/null
^C.9GiB 0:00:01 [39.9GiB/s]
$ tail -c 1PB /tmp/huge | pv>/dev/null
^C02GiB 0:00:01 [2.02GiB/s]
```