### PR TITLE
nl: continue if a file can't be opened

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -254,9 +254,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 );
                 set_exit_code(1);
             } else {
-                let reader = File::open(path).map_err_context(|| file.maybe_quote().to_string())?;
-                let mut buffer = BufReader::new(reader);
-                nl(&mut buffer, &mut stats, &settings)?;
+                match File::open(path) {
+                    Ok(reader) => {
+                        let mut buffer = BufReader::new(reader);
+                        nl(&mut buffer, &mut stats, &settings)?;
+                    }
+                    Err(e) => {
+                        show_error!("{}", e.map_err_context(|| file.maybe_quote().to_string()));
+                        set_exit_code(1);
+                    }
+                }
             }
         }
     }

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 //
 // spell-checker:ignore binvalid finvalid hinvalid iinvalid linvalid nabcabc nabcabcabc ninvalid vinvalid winvalid dabc näää févr
+
 use uutests::{at_and_ucmd, new_ucmd, util::TestScenario, util_name};
 
 #[test]
@@ -412,6 +413,19 @@ fn test_default_body_numbering_multiple_files_and_stdin() {
         .pipe_in("b")
         .succeeds()
         .stdout_is("     1\ta\n     2\tb\n     3\tc\n");
+}
+
+#[test]
+fn test_default_body_numbering_multiple_files_with_non_existing_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("a.txt", "a");
+    at.write("b.txt", "b");
+
+    ucmd.args(&["a.txt", "non_existing", "b.txt"])
+        .fails_with_code(1)
+        .stdout_is("     1\ta\n     2\tb\n")
+        .stderr_is("nl: non_existing: No such file or directory\n");
 }
 
 #[test]


### PR DESCRIPTION
Currently, we stop processing the specified files if one can't be opened whereas GNU `nl` keeps processing.

This PR fixes the issue. It should make the [multiple-files.sh](https://github.com/coreutils/coreutils/blob/master/tests/nl/multiple-files.sh) GNU test pass.