### PR TITLE
numfmt: --format width accounting diverges from GNU for multi-byte --suffix #11937 fix

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -620,7 +620,7 @@ fn transform_to(
 /// Right-aligns when `right_align` is true, left-aligns otherwise.
 /// Unlike `format!("{:>width$}")`, this handles widths larger than 65535.
 fn pad_string(s: &str, width: usize, fill: char, right_align: bool) -> String {
-    let len = s.len();
+    let len = s.chars().count();
     if len >= width {
         return s.to_string();
     }

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1549,3 +1549,13 @@ fn test_si_format_precision_no_cap() {
         .succeeds()
         .stdout_is("1.23457M\n");
 }
+
+// https://github.com/uutils/coreutils/issues/11937
+// numfmt: --format width accounting diverges from GNU for multi-byte --suffix
+#[test]
+fn test_multibyte_suffix_issue11937() {
+    new_ucmd!()
+        .args(&["--suffix=€", "--format=%10.2f", "692"])
+        .succeeds()
+        .stdout_is("   692.00€\n");
+}


### PR DESCRIPTION
This PR closes #11937.
Previously, uutils numfmt treated non-ascii characters as a few characters (equal to the bytes' count), there character counts were considered when using width in the precision flag.
for example 🔗 was treated as f0 9f 94 97 (4 characters). It will now treat it as a single character, just as GNU numfmt does.