### PR TITLE
ci: target x86_64-v3 in benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: 0
+      RUSTFLAGS: "-C target-cpu=x86-64-v3"
     strategy:
       matrix:
         type: [simulation, memory]


### PR DESCRIPTION
Ubuntu 26.04 builds packages targeting `x86_64-v3`, so using this target for benchmarks better reflects real-world performance.