### PR TITLE
ln: Improve to LnError and make public fns for nushell

### DIFF
--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -28,6 +28,8 @@ use std::path::{Path, PathBuf};
 use uucore::backup_control::{self, BackupMode};
 use uucore::fs::{MissingHandling, ResolveMode, canonicalize};
 
+/// Public visibility allows other apps to integrate with our
+/// `ln` utility by calling `exec` directly with their `Settings`.
 pub struct Settings {
     pub overwrite: OverwriteMode,
     pub backup: BackupMode,
@@ -264,6 +266,9 @@ pub fn uu_app() -> Command {
         )
 }
 
+/// Executes the `ln` utility with the given paths and settings.
+///
+/// This is made public to allow other apps to use `ln` as a library.
 pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
     // Handle cases where we create links in a directory first.
     if let Some(ref target_path) = settings.target_dir {

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -510,7 +510,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
 }
 
 #[cfg(windows)]
-pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> std::io::Result<()> {
+pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> io::Result<()> {
     if src.as_ref().is_dir() {
         symlink_dir(src, dst)
     } else {
@@ -519,9 +519,9 @@ pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> std::io::R
 }
 
 #[cfg(target_os = "wasi")]
-fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(_src: P1, _dst: P2) -> std::io::Result<()> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
+fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(_src: P1, _dst: P2) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
         "symlinks not supported on this platform",
     ))
 }

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -56,10 +56,10 @@ pub enum LnError {
     TargetIsNotADirectory(PathBuf),
 
     #[error("{0}")]
-    IoErr(#[from] UIoError),
+    Io(#[from] UIoError),
 
     #[error("{1}: {0}")]
-    IoErrContext(UIoError, String),
+    IoContext(UIoError, String),
 
     #[error("")]
     SomeLinksFailed,
@@ -86,7 +86,7 @@ pub type LnResult<T> = Result<T, LnError>;
 
 impl From<io::Error> for LnError {
     fn from(err: io::Error) -> Self {
-        Self::IoErr(UIoError::from(err))
+        Self::Io(UIoError::from(err))
     }
 }
 
@@ -424,7 +424,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
         }
         if let Some(ref p) = backup_path {
             fs::rename(dst, p).map_err(|e| {
-                LnError::IoErrContext(
+                LnError::IoContext(
                     UIoError::from(e),
                     translate!("ln-cannot-backup", "file" => dst.quote()),
                 )
@@ -465,7 +465,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
     } else {
         let p = if settings.logical && source.is_symlink() {
             fs::canonicalize(&source).map_err(|e| {
-                LnError::IoErrContext(
+                LnError::IoContext(
                     UIoError::from(e),
                     translate!("ln-failed-to-access", "file" => source.quote()),
                 )
@@ -476,7 +476,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
         match fs::hard_link(&p, dst) {
             Ok(()) => Ok(()),
             Err(_) if p.is_dir() => Err(LnError::FailedToCreateHardLinkDir(source.to_path_buf())),
-            Err(e) => Err(LnError::IoErrContext(
+            Err(e) => Err(LnError::IoContext(
                 UIoError::from(e),
                 translate!(
                     "ln-failed-to-create-hard-link",
@@ -490,7 +490,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
     if let Err(e) = res {
         if let Some(ref p) = backup_path {
             fs::rename(p, dst).map_err(|e| {
-                LnError::IoErrContext(
+                LnError::IoContext(
                     UIoError::from(e),
                     translate!("ln-cannot-backup", "file" => dst.quote()),
                 )

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -6,9 +6,10 @@
 // spell-checker:ignore (ToDO) srcpath targetpath EEXIST
 
 use clap::{Arg, ArgAction, Command};
-use std::io::{Write, stdout};
+use std::io::{self, Write, stdout};
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UError, UResult};
+use uucore::error::{UError, UIoError, UResult};
+
 use uucore::fs::{make_path_relative_to, paths_refer_to_same_file};
 use uucore::translate;
 use uucore::{format_usage, prompt_yes, show_error};
@@ -28,16 +29,16 @@ use uucore::backup_control::{self, BackupMode};
 use uucore::fs::{MissingHandling, ResolveMode, canonicalize};
 
 pub struct Settings {
-    overwrite: OverwriteMode,
-    backup: BackupMode,
-    suffix: OsString,
-    symbolic: bool,
-    relative: bool,
-    logical: bool,
-    target_dir: Option<PathBuf>,
-    no_target_dir: bool,
-    no_dereference: bool,
-    verbose: bool,
+    pub overwrite: OverwriteMode,
+    pub backup: BackupMode,
+    pub suffix: OsString,
+    pub symbolic: bool,
+    pub relative: bool,
+    pub logical: bool,
+    pub target_dir: Option<PathBuf>,
+    pub no_target_dir: bool,
+    pub no_dereference: bool,
+    pub verbose: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -48,9 +49,15 @@ pub enum OverwriteMode {
 }
 
 #[derive(Error, Debug)]
-enum LnError {
+pub enum LnError {
     #[error("{}", translate!("ln-error-target-is-not-directory", "target" => _0.quote()))]
     TargetIsNotADirectory(PathBuf),
+
+    #[error("{0}")]
+    IoErr(#[from] UIoError),
+
+    #[error("{1}: {0}")]
+    IoErrContext(UIoError, String),
 
     #[error("")]
     SomeLinksFailed,
@@ -71,6 +78,13 @@ enum LnError {
 impl UError for LnError {
     fn code(&self) -> i32 {
         1
+    }
+}
+pub type LnResult<T> = Result<T, LnError>;
+
+impl From<io::Error> for LnError {
+    fn from(err: io::Error) -> Self {
+        Self::IoErr(UIoError::from(err))
     }
 }
 
@@ -133,7 +147,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         verbose: matches.get_flag(options::VERBOSE),
     };
 
-    exec(&paths[..], &settings)
+    exec(&paths[..], &settings)?;
+    Ok(())
 }
 
 pub fn uu_app() -> Command {
@@ -249,7 +264,7 @@ pub fn uu_app() -> Command {
         )
 }
 
-fn exec(files: &[PathBuf], settings: &Settings) -> UResult<()> {
+pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
     // Handle cases where we create links in a directory first.
     if let Some(ref target_path) = settings.target_dir {
         // 4th form: a directory is specified by -t.
@@ -270,14 +285,13 @@ fn exec(files: &[PathBuf], settings: &Settings) -> UResult<()> {
     // 1st form. Now there should be only two operands, but if -T is
     // specified we may have a wrong number of operands.
     if files.len() == 1 {
-        return Err(LnError::MissingDestination(files[0].clone()).into());
+        return Err(LnError::MissingDestination(files[0].clone()));
     }
     if files.len() > 2 {
         return Err(LnError::ExtraOperand(
             files[2].clone().into(),
             uucore::execution_phrase().to_string(),
-        )
-        .into());
+        ));
     }
     assert!(!files.is_empty());
 
@@ -285,9 +299,9 @@ fn exec(files: &[PathBuf], settings: &Settings) -> UResult<()> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) -> UResult<()> {
+fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) -> LnResult<()> {
     if !target_dir.is_dir() {
-        return Err(LnError::TargetIsNotADirectory(target_dir.to_owned()).into());
+        return Err(LnError::TargetIsNotADirectory(target_dir.to_owned()));
     }
     // remember the linked destinations for further usage
     let mut linked_destinations: HashSet<PathBuf> = HashSet::with_capacity(files.len());
@@ -369,7 +383,7 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
     if all_successful {
         Ok(())
     } else {
-        Err(LnError::SomeLinksFailed.into())
+        Err(LnError::SomeLinksFailed)
     }
 }
 
@@ -387,7 +401,7 @@ fn relative_path<'a>(src: &'a Path, dst: &Path) -> Cow<'a, Path> {
 }
 
 #[allow(clippy::cognitive_complexity)]
-fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
+fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
     let mut backup_path = None;
     let source: Cow<'_, Path> = if settings.relative {
         relative_path(src, dst)
@@ -400,18 +414,22 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
         if settings.backup == BackupMode::Existing && !settings.symbolic {
             // when ln --backup f f, it should detect that it is the same file
             if paths_refer_to_same_file(src, dst, true) {
-                return Err(LnError::SameFile(src.to_owned(), dst.to_owned()).into());
+                return Err(LnError::SameFile(src.to_owned(), dst.to_owned()));
             }
         }
         if let Some(ref p) = backup_path {
-            fs::rename(dst, p)
-                .map_err_context(|| translate!("ln-cannot-backup", "file" => dst.quote()))?;
+            fs::rename(dst, p).map_err(|e| {
+                LnError::IoErrContext(
+                    UIoError::from(e),
+                    translate!("ln-cannot-backup", "file" => dst.quote()),
+                )
+            })?;
         }
         match settings.overwrite {
             OverwriteMode::NoClobber => {}
             OverwriteMode::Interactive => {
                 if !prompt_yes!("{}", translate!("ln-prompt-replace", "file" => dst.quote())) {
-                    return Err(LnError::SomeLinksFailed.into());
+                    return Err(LnError::SomeLinksFailed);
                 }
 
                 let _ = fs::remove_file(dst);
@@ -428,7 +446,7 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
                         _ => true,
                     };
                     if same_entry {
-                        return Err(LnError::SameFile(src.to_owned(), dst.to_owned()).into());
+                        return Err(LnError::SameFile(src.to_owned(), dst.to_owned()));
                     }
                 }
                 let _ = fs::remove_file(dst);
@@ -441,26 +459,37 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> UResult<()> {
         symlink(&source, dst).map_err(Into::into)
     } else {
         let p = if settings.logical && source.is_symlink() {
-            fs::canonicalize(&source)
-                .map_err_context(|| translate!("ln-failed-to-access", "file" => source.quote()))?
+            fs::canonicalize(&source).map_err(|e| {
+                LnError::IoErrContext(
+                    UIoError::from(e),
+                    translate!("ln-failed-to-access", "file" => source.quote()),
+                )
+            })?
         } else {
             source.to_path_buf()
         };
         match fs::hard_link(&p, dst) {
             Ok(()) => Ok(()),
-            Err(_) if p.is_dir() => {
-                Err(LnError::FailedToCreateHardLinkDir(source.to_path_buf()).into())
-            }
-            Err(e) => Err(e).map_err_context(|| {
-                translate!("ln-failed-to-create-hard-link", "source" => source.quote(), "dest" => dst.quote())
-            }),
+            Err(_) if p.is_dir() => Err(LnError::FailedToCreateHardLinkDir(source.to_path_buf())),
+            Err(e) => Err(LnError::IoErrContext(
+                UIoError::from(e),
+                translate!(
+                    "ln-failed-to-create-hard-link",
+                    "source" => source.quote(),
+                    "dest" => dst.quote()
+                ),
+            )),
         }
     };
 
     if let Err(e) = res {
         if let Some(ref p) = backup_path {
-            fs::rename(p, dst)
-                .map_err_context(|| translate!("ln-cannot-backup", "file" => dst.quote()))?;
+            fs::rename(p, dst).map_err(|e| {
+                LnError::IoErrContext(
+                    UIoError::from(e),
+                    translate!("ln-cannot-backup", "file" => dst.quote()),
+                )
+            })?;
         }
         return Err(e);
     }


### PR DESCRIPTION
PR changes mainly:
* Change return types to `LnError` rather than `Box<dyn Error>` for more consistency with other utilities, and compatibility with usage by 3rd party like nushell. I took heavy inspiration from the `cp` utility.
* Makes `Settings` and `exec` public. Normally we would make the `link()` fn public, but I felt there was so much logic involved there and `link_files_in_dir` that thought `exec` was more appropriate, otherwise more functions would have been needed to be public. 

If you are curious how it looks in `Nushell`,  please check out [branch in progress uln.rs](https://github.com/nushell/nushell/compare/main...dmatos2012:nushell:add-ln#diff-0031b3c22463018faeb33deed2de895bf4825a438b55d56e4633b3d9238cca80).

Let me know feedback and im willing to go back and forth to get something we are all happy with.  

 
> [!NOTE]
> This hasnt been discussed with the team, so feel free to reject the PR, no hard feelings. However, Given the recent changes to `ls` to further help Nushell, I thought it would be further nice to make the changes here to support the new command `ln` for nushell.