### PR TITLE
date: width prefix in %N format specifier is ignored ( %3N, %6N always output full 9 nanosecond digits) #12001

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -474,8 +474,16 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             padded.push_str(&result);
             result = padded;
         }
+    } else {
+        if specifier.chars().last() == Some('N') {
+            if effective_width <= get_default_width(specifier) {
+                for _ in 0..result.len() - effective_width {
+                    result.pop();
+                }
+            }
+        }
     }
-
+    
     Ok(result)
 }
 

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -476,9 +476,7 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
         }
     } else if specifier.ends_with('N') {
         if effective_width <= get_default_width(specifier) {
-            for _ in 0..result.len() - effective_width {
-                result.pop();
-            }
+            result.truncate(3);
         }
     }
 

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -476,7 +476,7 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
         }
     } else if specifier.ends_with('N') {
         if effective_width <= get_default_width(specifier) {
-            result.truncate(3);
+            result.truncate(effective_width);
         }
     }
 

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -474,12 +474,10 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             padded.push_str(&result);
             result = padded;
         }
-    } else {
-        if specifier.chars().last() == Some('N') {
-            if effective_width <= get_default_width(specifier) {
-                for _ in 0..result.len() - effective_width {
-                    result.pop();
-                }
+    } else if specifier.ends_with('N') {
+        if effective_width <= get_default_width(specifier) {
+            for _ in 0..result.len() - effective_width {
+                result.pop();
             }
         }
     }

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -483,7 +483,7 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             }
         }
     }
-    
+
     Ok(result)
 }
 

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -475,7 +475,7 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             result = padded;
         }
     } else if specifier.ends_with('N') {
-        if effective_width <= get_default_width(specifier) {
+        if effective_width <= get_default_width(specifier) && effective_width != 0 {
             result.truncate(effective_width);
         }
     }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -3007,3 +3007,12 @@ fn test_korean_time_zone() {
         .succeeds()
         .stdout_is("2026-01-15 01:00:00 UTC\n");
 }
+
+// https://github.com/uutils/coreutils/issues/12001
+// date: width prefix in %N format specifier is ignored ( %3N, %6N always output full 9 nanosecond digits) #12001
+#[test]
+fn test_nanoseconds_width_prefix_ignored_issue12001() {
+    let result = new_ucmd!().arg("+%3N").succeeds();
+    // compare to 4 because of \n
+    assert_eq!(result.stdout().len(), 4);
+}


### PR DESCRIPTION
this PR closes #12001.
the %N format specifier was ignored when the default width value was greater than the specified one.