### PR TITLE
numfmt: fix rounding for small scaled values

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -592,10 +592,15 @@ fn transform_to(
         }
     };
     Ok(match s {
-        None => localize(format!(
+        None if opts.to == Unit::None => localize(format!(
             "{:.precision$}",
             round_with_precision(i2, round_method, precision),
         )),
+        None if is_precision_specified => {
+            let i2 = round_with_precision(i2, round_method, 0);
+            localize(format!("{i2:.precision$}"))
+        }
+        None => localize(format!("{i2:.0}")),
         Some(s) if precision > 0 => localize(format!(
             "{i2:.precision$}{unit_separator}{}",
             DisplayableSuffix(s, opts.to),

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -2,7 +2,8 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (paths) gnutest ronna quetta
+
+// spell-checker:ignore (paths) gnutest ronna quetta unitless
 
 use uutests::new_ucmd;
 
@@ -634,6 +635,16 @@ fn test_round() {
 }
 
 #[test]
+fn test_to_unitless_small_values_use_display_rounding() {
+    new_ucmd!()
+        .args(&[
+            "--to=si", "--", "0.4", "0.5", "0.6", "1.4", "3.14", "-0.4", "-0.5", "-0.6", "-1.4",
+        ])
+        .succeeds()
+        .stdout_only("0\n0\n1\n1\n3\n-0\n-0\n-1\n-1\n");
+}
+
+#[test]
 fn test_round_with_to_unit() {
     for (method, exp) in [
         ("from-zero", ["6", "-6", "5.9", "-5.9", "5.86", "-5.86"]),
@@ -657,6 +668,24 @@ fn test_round_with_to_unit() {
             .succeeds()
             .stdout_only(exp.join("\n") + "\n");
     }
+}
+
+#[test]
+fn test_to_unit_with_unitless_small_value_uses_display_rounding() {
+    new_ucmd!()
+        .args(&["--to=iec", "--to-unit=689", "701"])
+        .succeeds()
+        .stdout_only("1\n");
+
+    new_ucmd!()
+        .args(&["--to=si", "--to-unit=689", "701"])
+        .succeeds()
+        .stdout_only("1\n");
+
+    new_ucmd!()
+        .args(&["--to=none", "--to-unit=689", "701"])
+        .succeeds()
+        .stdout_only("2\n");
 }
 
 #[test]
@@ -1022,6 +1051,19 @@ fn test_format_with_precision_and_to_arg() {
             .succeeds()
             .stdout_is(format!("{expected}\n"));
     }
+}
+
+#[test]
+fn test_format_with_precision_and_unitless_to_arg() {
+    new_ucmd!()
+        .args(&["--to=si", "--format=%.1f", "3.14"])
+        .succeeds()
+        .stdout_is("4.0\n");
+
+    new_ucmd!()
+        .args(&["--to=si", "--format=%.1f", "--round=down", "3.14"])
+        .succeeds()
+        .stdout_is("3.0\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes rounding for small scaled values when `numfmt --to=si/iec/iec-i` does not select a suffix.

In this case GNU `numfmt` appears to use display formatting rounding for the scaled value, while uutils was applying the configured rounding method directly. This caused cases like `--to=si 0.4` and `--to=iec --to-unit=689 701` to round away from GNU behavior.

## Changes

- Keep the existing `--to=none` rounding path unchanged.
- Adjust the suffix-less `--to=si/iec/iec-i` path to match GNU display rounding behavior.
- Add regression tests for small scaled values, `--to-unit`, and `--format` precision.

## Test plan

- `cargo fmt`
- `cargo test -p uu_numfmt`
- `cargo test --test tests test_numfmt::test_to_unitless_small_values_use_display_rounding`
- `cargo test --test tests test_numfmt::test_to_unit_with_unitless_small_value_uses_display_rounding`
- `cargo test --test tests test_numfmt::test_format_with_precision_and_unitless_to_arg`

Fixes #11938 