### PR TITLE
fix: refine feature checks for SELinux and SMACK support

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -331,7 +331,7 @@ fn create_single_dir(path: &Path, is_parent: bool, config: &Config) -> UResult<(
             }
 
             // Apply SELinux context if requested
-            #[cfg(feature = "selinux")]
+            #[cfg(all(feature = "selinux", any(target_os = "android", target_os = "linux")))]
             if config.set_security_context && uucore::selinux::is_selinux_enabled() {
                 if let Err(e) = uucore::selinux::set_selinux_security_context(path, config.context)
                 {
@@ -341,7 +341,7 @@ fn create_single_dir(path: &Path, is_parent: bool, config: &Config) -> UResult<(
             }
 
             // Apply SMACK context if requested
-            #[cfg(feature = "smack")]
+            #[cfg(all(feature = "smack", target_os = "linux"))]
             if config.set_security_context {
                 uucore::smack::set_smack_label_and_cleanup(path, config.context, |p| {
                     std::fs::remove_dir(p)

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -83,7 +83,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
 
         // Apply SMACK context if requested
-        #[cfg(feature = "smack")]
+        #[cfg(all(feature = "smack", target_os = "linux"))]
         {
             let set_security_context = matches.get_flag(options::SECURITY_CONTEXT);
             let context = matches.get_one::<String>(options::CONTEXT);

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -57,11 +57,17 @@ struct Config {
     dev: u64,
 
     /// Set security context (SELinux/SMACK).
-    #[cfg(any(feature = "selinux", feature = "smack"))]
+    #[cfg(any(
+        all(feature = "selinux", any(target_os = "android", target_os = "linux")),
+        all(feature = "smack", target_os = "linux"),
+    ))]
     set_security_context: bool,
 
     /// Specific security context (SELinux/SMACK).
-    #[cfg(any(feature = "selinux", feature = "smack"))]
+    #[cfg(any(
+        all(feature = "selinux", any(target_os = "android", target_os = "linux")),
+        all(feature = "smack", target_os = "linux"),
+    ))]
     context: Option<String>,
 }
 
@@ -96,7 +102,7 @@ fn mknod(file_name: &str, config: Config) -> i32 {
     }
 
     // Apply SELinux context if requested
-    #[cfg(feature = "selinux")]
+    #[cfg(all(feature = "selinux", any(target_os = "android", target_os = "linux")))]
     if config.set_security_context {
         use std::io::Write as _;
 
@@ -112,7 +118,7 @@ fn mknod(file_name: &str, config: Config) -> i32 {
     }
 
     // Apply SMACK context if requested
-    #[cfg(feature = "smack")]
+    #[cfg(all(feature = "smack", target_os = "linux"))]
     if config.set_security_context {
         use std::io::Write as _;
 
@@ -150,9 +156,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .expect("Missing argument 'NAME'");
 
     // Extract the security context related flags and options
-    #[cfg(any(feature = "selinux", feature = "smack"))]
+    #[cfg(any(
+        all(feature = "selinux", any(target_os = "android", target_os = "linux")),
+        all(feature = "smack", target_os = "linux"),
+    ))]
     let set_security_context = matches.get_flag(options::SECURITY_CONTEXT);
-    #[cfg(any(feature = "selinux", feature = "smack"))]
+    #[cfg(any(
+        all(feature = "selinux", any(target_os = "android", target_os = "linux")),
+        all(feature = "smack", target_os = "linux"),
+    ))]
     let context = matches.get_one::<String>(options::CONTEXT).cloned();
 
     let dev = match (
@@ -181,9 +193,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         file_type: file_type.clone(),
         use_umask,
         dev,
-        #[cfg(any(feature = "selinux", feature = "smack"))]
+        #[cfg(any(
+            all(feature = "selinux", any(target_os = "android", target_os = "linux")),
+            all(feature = "smack", target_os = "linux"),
+        ))]
         set_security_context: set_security_context || context.is_some(),
-        #[cfg(any(feature = "selinux", feature = "smack"))]
+        #[cfg(any(
+            all(feature = "selinux", any(target_os = "android", target_os = "linux")),
+            all(feature = "smack", target_os = "linux"),
+        ))]
         context,
     };
 

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -85,7 +85,7 @@ pub mod hardware;
 pub mod selinux;
 #[cfg(all(unix, not(target_os = "fuchsia"), feature = "signals"))]
 pub mod signals;
-#[cfg(all(target_os = "linux", feature = "smack"))]
+#[cfg(all(feature = "smack", target_os = "linux"))]
 pub mod smack;
 #[cfg(feature = "feat_systemd_logind")]
 pub mod systemd_logind;

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -125,7 +125,7 @@ pub use crate::features::fsxattr;
 #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 pub use crate::features::selinux;
 
-#[cfg(all(target_os = "linux", feature = "smack"))]
+#[cfg(all(feature = "smack", target_os = "linux"))]
 pub use crate::features::smack;
 
 //## core functions


### PR DESCRIPTION
Resolve build failures on non-Linux platforms when `selinux` or `smack` features are enabled. The cfg attribute was missing `target_os` check, causing pre-commit hook failures.