### PR TITLE
install: keep post-copy finalization bound to created file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,7 +3684,7 @@ dependencies = [
  "file_diff",
  "filetime",
  "fluent",
- "nix",
+ "rustix",
  "selinux",
  "thiserror 2.0.18",
  "uucore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,6 +3684,7 @@ dependencies = [
  "file_diff",
  "filetime",
  "fluent",
+ "nix",
  "selinux",
  "thiserror 2.0.18",
  "uucore",

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -34,6 +34,9 @@ uucore = { workspace = true, default-features = true, features = [
 ] }
 fluent = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["fs", "user"] }
+
 [features]
 selinux = ["dep:selinux", "uucore/selinux"]
 

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -35,7 +35,7 @@ uucore = { workspace = true, default-features = true, features = [
 fluent = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true, features = ["fs", "user"] }
+rustix = { workspace = true, features = ["fs"] }
 
 [features]
 selinux = ["dep:selinux", "uucore/selinux"]

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -47,9 +47,9 @@ use uucore::{format_usage, show, show_error, show_if_err};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(unix)]
-use std::os::unix::prelude::OsStrExt;
-#[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
+#[cfg(unix)]
+use std::os::unix::prelude::OsStrExt;
 
 const DEFAULT_MODE: u32 = 0o755;
 const DEFAULT_STRIP_PROGRAM: &str = "strip";
@@ -1037,7 +1037,7 @@ fn strip_file(to: &Path, b: &Behavior) -> UResult<()> {
 fn fd_operation_path(fd: &File) -> PathBuf {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
-        return PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+        PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()))
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -1071,7 +1071,10 @@ fn strip_file_fd(to: &Path, file: &File, b: &Behavior) -> UResult<()> {
     let strip_file = File::from(strip_fd);
     let strip_arg = fd_operation_path(&strip_file);
 
-    match process::Command::new(&b.strip_program).arg(&strip_arg).status() {
+    match process::Command::new(&b.strip_program)
+        .arg(&strip_arg)
+        .status()
+    {
         Ok(status) => {
             if !status.success() {
                 discard_installed_path_if_unchanged(to, file);
@@ -1124,8 +1127,12 @@ fn chown_optional_user_group_fd(file: &File, path: &Path, b: &Behavior) -> UResu
         return Ok(());
     };
 
-    fchown(file, owner_id.map(Uid::from_raw), group_id.map(Gid::from_raw))
-        .map_err(|e| InstallError::ChownFailed(path.to_path_buf(), e.to_string()))?;
+    fchown(
+        file,
+        owner_id.map(Uid::from_raw),
+        group_id.map(Gid::from_raw),
+    )
+    .map_err(|e| InstallError::ChownFailed(path.to_path_buf(), e.to_string()))?;
 
     Ok(())
 }

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -13,7 +13,9 @@ use file_diff::diff;
 use filetime::set_file_times;
 use filetime::{FileTime, set_file_handle_times};
 #[cfg(unix)]
-use nix::unistd::{Gid, Uid, dup, fchown};
+use rustix::fs::{Gid, Uid, fchown};
+#[cfg(unix)]
+use rustix::io::dup;
 #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 use selinux::SecurityContext;
 use std::ffi::OsString;

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -9,7 +9,11 @@ mod mode;
 
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use file_diff::diff;
-use filetime::{FileTime, set_file_times};
+#[cfg(not(unix))]
+use filetime::set_file_times;
+use filetime::{FileTime, set_file_handle_times};
+#[cfg(unix)]
+use nix::unistd::{Gid, Uid, dup, fchown};
 #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 use selinux::SecurityContext;
 use std::ffi::OsString;
@@ -39,9 +43,11 @@ use uucore::translate;
 use uucore::{format_usage, show, show_error, show_if_err};
 
 #[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
+use std::os::fd::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::prelude::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 const DEFAULT_MODE: u32 = 0o755;
 const DEFAULT_STRIP_PROGRAM: &str = "strip";
@@ -764,9 +770,9 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
                     );
                 }
 
-                copy_file_safe(source, parent_fd, filename.as_os_str())?;
+                let dest = copy_file_safe(source, parent_fd, filename.as_os_str())?;
 
-                finalize_installed_file(source, &target, b, backup_path)
+                finalize_installed_file(source, &target, b, backup_path, &dest)
             } else {
                 copy(source, &target, b)
             }
@@ -905,7 +911,11 @@ fn perform_backup(to: &Path, b: &Behavior) -> UResult<Option<PathBuf>> {
 /// - `copy_file_safe` uses fd-based `DirFd::open_file_at()` (openat syscall)
 /// - `copy_file` uses path-based `OpenOptions::new().create_new().open()`
 #[cfg(unix)]
-fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsStr) -> UResult<()> {
+fn copy_file_safe(
+    from: &Path,
+    to_parent_fd: &DirFd,
+    to_filename: &std::ffi::OsStr,
+) -> UResult<File> {
     let from_meta = metadata(from)?;
 
     // Check if source and destination are the same file
@@ -923,7 +933,7 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
     let mut dst = to_parent_fd.open_file_at(to_filename)?;
     copy_stream(&mut src, &mut dst)?;
 
-    Ok(())
+    Ok(dst)
 }
 
 /// Copy a file from one path to another. Handles the certain cases of special
@@ -938,7 +948,7 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
 ///
 /// Returns an empty Result or an error in case of failure.
 ///
-fn copy_file(from: &Path, to: &Path) -> UResult<()> {
+fn copy_file(from: &Path, to: &Path) -> UResult<File> {
     use std::os::unix::fs::OpenOptionsExt;
     if let Ok(to_abs) = to.canonicalize()
         && from.canonicalize()? == to_abs
@@ -976,9 +986,10 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
         InstallError::InstallFailed(from.to_path_buf(), to.to_path_buf(), err.to_string())
     })?;
 
-    Ok(())
+    Ok(dest)
 }
 
+#[cfg(not(unix))]
 /// Strip a file using an external program.
 ///
 /// # Parameters
@@ -1020,6 +1031,64 @@ fn strip_file(to: &Path, b: &Behavior) -> UResult<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn fd_operation_path(fd: &File) -> PathBuf {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        return PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()));
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        PathBuf::from(format!("/dev/fd/{}", fd.as_raw_fd()))
+    }
+}
+
+#[cfg(unix)]
+fn path_matches_open_file(path: &Path, file: &File) -> UResult<bool> {
+    let file_meta = file.metadata().map_err(InstallError::MetadataFailed)?;
+    let path_meta = match metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(InstallError::MetadataFailed(e).into()),
+    };
+
+    Ok(file_meta.dev() == path_meta.dev() && file_meta.ino() == path_meta.ino())
+}
+
+#[cfg(unix)]
+fn discard_installed_path_if_unchanged(path: &Path, file: &File) {
+    if path_matches_open_file(path, file).unwrap_or(false) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+#[cfg(unix)]
+fn strip_file_fd(to: &Path, file: &File, b: &Behavior) -> UResult<()> {
+    let strip_fd = dup(file).map_err(|e| InstallError::StripProgramFailed(e.to_string()))?;
+    let strip_file = File::from(strip_fd);
+    let strip_arg = fd_operation_path(&strip_file);
+
+    match process::Command::new(&b.strip_program).arg(&strip_arg).status() {
+        Ok(status) => {
+            if !status.success() {
+                discard_installed_path_if_unchanged(to, file);
+                return Err(InstallError::StripProgramFailed(
+                    translate!("install-error-strip-abnormal", "code" => status.code().unwrap()),
+                )
+                .into());
+            }
+        }
+        Err(e) => {
+            discard_installed_path_if_unchanged(to, file);
+            return Err(InstallError::StripProgramFailed(e.to_string()).into());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
 /// Set ownership and permissions on the destination file.
 ///
 /// # Parameters
@@ -1045,6 +1114,33 @@ fn set_ownership_and_permissions(to: &Path, b: &Behavior) -> UResult<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn chown_optional_user_group_fd(file: &File, path: &Path, b: &Behavior) -> UResult<()> {
+    let (owner_id, group_id) = if b.owner_id.is_some() || b.group_id.is_some() {
+        (b.owner_id, b.group_id)
+    } else {
+        return Ok(());
+    };
+
+    fchown(file, owner_id.map(Uid::from_raw), group_id.map(Gid::from_raw))
+        .map_err(|e| InstallError::ChownFailed(path.to_path_buf(), e.to_string()))?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_ownership_and_permissions_fd(file: &File, to: &Path, b: &Behavior) -> UResult<()> {
+    file.set_permissions(fs::Permissions::from_mode(b.mode()))
+        .map_err(|_| InstallError::ChmodFailed(to.to_path_buf()))?;
+
+    if b.privileged {
+        chown_optional_user_group_fd(file, to, b)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
 /// Preserve timestamps on the destination file.
 ///
 /// # Parameters
@@ -1072,7 +1168,91 @@ fn preserve_timestamps(from: &Path, to: &Path) -> UResult<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn preserve_timestamps_fd(from: &Path, file: &File) -> UResult<()> {
+    let meta = match metadata(from) {
+        Ok(meta) => meta,
+        Err(e) => return Err(InstallError::MetadataFailed(e).into()),
+    };
+
+    let modified_time = FileTime::from_last_modification_time(&meta);
+    let accessed_time = FileTime::from_last_access_time(&meta);
+
+    if let Err(e) = set_file_handle_times(file, Some(accessed_time), Some(modified_time)) {
+        show_error!("{e}");
+    }
+    Ok(())
+}
+
 /// Apply post-copy operations: strip, ownership, permissions, timestamps, SELinux, and verbose output.
+#[cfg(unix)]
+fn finalize_installed_file(
+    from: &Path,
+    to: &Path,
+    b: &Behavior,
+    backup_path: Option<PathBuf>,
+    file: &File,
+) -> UResult<()> {
+    if b.strip {
+        strip_file_fd(to, file, b)?;
+    }
+
+    set_ownership_and_permissions_fd(file, to, b)?;
+
+    if b.preserve_timestamps {
+        preserve_timestamps_fd(from, file)?;
+    }
+
+    #[cfg(all(feature = "selinux", target_os = "linux"))]
+    if b.privileged {
+        if b.preserve_context {
+            let context = get_selinux_security_context(from, false)
+                .map_err(|e| InstallError::SelinuxContextFailed(e.to_string()))?;
+            if !context.is_empty() {
+                set_selinux_security_context(&fd_operation_path(file), Some(&context))
+                    .map_err(|e| InstallError::SelinuxContextFailed(e.to_string()))?;
+            }
+        } else if b.default_context {
+            match get_default_context_for_path(to) {
+                Ok(Some(default_ctx)) => {
+                    set_selinux_security_context(&fd_operation_path(file), Some(&default_ctx))
+                        .map_err(|e| InstallError::SelinuxContextFailed(e.to_string()))?
+                }
+                Ok(None) | Err(_) => set_selinux_default_context(to)
+                    .map_err(|e| InstallError::SelinuxContextFailed(e.to_string()))?,
+            }
+        } else if b.context.is_some() {
+            let context = get_context_for_selinux(b);
+            set_selinux_security_context(&fd_operation_path(file), context)
+                .map_err(|e| InstallError::SelinuxContextFailed(e.to_string()))?;
+        }
+    }
+
+    if !path_matches_open_file(to, file)? {
+        return Err(InstallError::InstallFailed(
+            from.to_path_buf(),
+            to.to_path_buf(),
+            String::from("destination path changed during installation"),
+        )
+        .into());
+    }
+
+    if b.verbose {
+        write!(stdout(), "{} -> {}", from.quote(), to.quote())?;
+        match backup_path {
+            Some(path) => writeln!(
+                stdout(),
+                " {}",
+                translate!("install-verbose-backup", "backup" => path.quote())
+            )?,
+            None => writeln!(stdout())?,
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
 fn finalize_installed_file(
     from: &Path,
     to: &Path,
@@ -1140,9 +1320,16 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> UResult<()> {
     // Declare the path here as we may need it for the verbose output below.
     let backup_path = perform_backup(to, b)?;
 
-    copy_file(from, to)?;
+    let dest = copy_file(from, to)?;
 
-    finalize_installed_file(from, to, b, backup_path)
+    #[cfg(unix)]
+    {
+        finalize_installed_file(from, to, b, backup_path, &dest)
+    }
+    #[cfg(not(unix))]
+    {
+        finalize_installed_file(from, to, b, backup_path)
+    }
 }
 
 #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]

--- a/src/uucore/src/lib/features/safe_traversal.rs
+++ b/src/uucore/src/lib/features/safe_traversal.rs
@@ -337,12 +337,16 @@ impl DirFd {
         Ok(())
     }
 
-    /// Open a file for writing relative to this directory
-    /// Creates the file if it doesn't exist, truncates if it does
+    /// Open a newly-created file for writing relative to this directory.
+    /// Fails if the final path component already exists or is a symlink.
     pub fn open_file_at(&self, name: &OsStr) -> io::Result<fs::File> {
         let name_cstr =
             CString::new(name.as_bytes()).map_err(|_| SafeTraversalError::PathContainsNull)?;
-        let flags = OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_TRUNC | OFlag::O_CLOEXEC;
+        let flags = OFlag::O_CREAT
+            | OFlag::O_EXCL
+            | OFlag::O_NOFOLLOW
+            | OFlag::O_WRONLY
+            | OFlag::O_CLOEXEC;
         let mode = Mode::from_bits_truncate(0o666); // Default file permissions
 
         let fd: OwnedFd = openat(self.fd.as_fd(), name_cstr.as_c_str(), flags, mode)

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -823,7 +823,10 @@ fn test_install_and_strip_with_program_hyphen() {
 
     let at = &scene.fixtures;
     let content = r#"#!/bin/sh
-    printf -- '%s\n' "$1" | grep '^[^-]'
+    case "$1" in
+      /proc/self/fd/*|/dev/fd/*) printf './proc-self-fd\n' ;;
+      *) printf -- '%s\n' "$1" ;;
+    esac | grep '^[^-]'
     "#;
     at.write("no-hyphen", content);
     scene.ccmd("chmod").arg("+x").arg("no-hyphen").succeeds();
@@ -839,7 +842,11 @@ fn test_install_and_strip_with_program_hyphen() {
         .arg("-dest")
         .succeeds()
         .no_stderr()
-        .stdout_is("./-dest\n");
+        .stdout_is(if cfg!(unix) {
+            "./proc-self-fd\n"
+        } else {
+            "./-dest\n"
+        });
 
     scene
         .ucmd()
@@ -851,7 +858,56 @@ fn test_install_and_strip_with_program_hyphen() {
         .arg("./-dest")
         .succeeds()
         .no_stderr()
-        .stdout_is("./-dest\n");
+        .stdout_is(if cfg!(unix) {
+            "./proc-self-fd\n"
+        } else {
+            "./-dest\n"
+        });
+}
+
+#[cfg(all(unix, feature = "chmod"))]
+#[test]
+fn test_install_strip_program_symlink_swap_does_not_touch_victim() {
+    use std::os::unix::fs::symlink;
+    use std::time::Duration;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("src", "ORIGINAL-SOURCE");
+    at.write("victim", "VICTIM");
+    at.write(
+        "fake-strip.sh",
+        "#!/bin/sh\nsleep 0.2\nprintf 'PWNED-BY-STRIP' > \"$1\"\n",
+    );
+    scene.ccmd("chmod").arg("+x").arg("fake-strip.sh").succeeds();
+
+    let dest_path = at.plus("dest");
+    let victim_path = at.plus("victim");
+    let swapper = std::thread::spawn(move || {
+        for _ in 0..20_000 {
+            if fs::symlink_metadata(&dest_path).is_ok() {
+                let _ = fs::remove_file(&dest_path);
+                symlink("victim", &dest_path).unwrap();
+                return;
+            }
+            sleep(Duration::from_micros(50));
+        }
+        panic!("destination was never created");
+    });
+
+    scene
+        .ucmd()
+        .arg("-s")
+        .arg("--strip-program")
+        .arg("./fake-strip.sh")
+        .arg("src")
+        .arg("dest")
+        .fails()
+        .stderr_contains("destination path changed during installation");
+
+    swapper.join().unwrap();
+    assert_eq!(fs::read_to_string(victim_path).unwrap(), "VICTIM");
 }
 
 #[cfg(all(unix, feature = "chmod"))]


### PR DESCRIPTION
Fixes #12062.

This keeps `install` bound to the file it actually created instead of reopening the destination by pathname during post-copy finalization.

What changed:
- add `O_NOFOLLOW | O_EXCL` to fd-based destination creation
- keep the destination file open through finalization
- run `--strip-program`, `chmod`, `chown`, and timestamp updates against that file handle
- fail if the destination pathname no longer resolves to the same file before success
- add a regression test for the symlink-swap `--strip-program` case

Validation:
- `cargo +1.93.0-x86_64-unknown-linux-gnu build -p uu_install --bin install`
- `cargo +1.93.0-x86_64-unknown-linux-gnu test --test tests --features 'install chmod' test_install::test_install_and_strip_with_program_hyphen -- --exact --nocapture`
- `cargo +1.93.0-x86_64-unknown-linux-gnu test --test tests --features 'install chmod' test_install::test_install_strip_program_symlink_swap_does_not_touch_victim -- --exact --nocapture`