### PR TITLE
date: fix %N modifier handling

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -1060,13 +1060,33 @@ mod tests {
 
     #[test]
     fn test_apply_modifiers_nanoseconds() {
-        assert_eq!(apply_modifiers("123456789", &spec("", None, "N")).unwrap(), "123456789");
-        assert_eq!(apply_modifiers("000000000", &spec("", None, "N")).unwrap(), "000000000");
-        assert_eq!(apply_modifiers("123456789", &spec("", Some(3), "N")).unwrap(), "123");
-        assert_eq!(apply_modifiers("000000000", &spec("_", Some(3), "N")).unwrap(), "0  ");
-        assert_eq!(apply_modifiers("000000000", &spec("-", None, "N")).unwrap(), "000000000");
-        assert_eq!(apply_modifiers("000000000", &spec("-", Some(3), "N")).unwrap(), "000");
+        assert_eq!(
+            apply_modifiers("123456789", &spec("", None, "N")).unwrap(),
+            "123456789"
+        );
+        assert_eq!(
+            apply_modifiers("000000000", &spec("", None, "N")).unwrap(),
+            "000000000"
+        );
+        assert_eq!(
+            apply_modifiers("123456789", &spec("", Some(3), "N")).unwrap(),
+            "123"
+        );
+        assert_eq!(
+            apply_modifiers("000000000", &spec("_", Some(3), "N")).unwrap(),
+            "0  "
+        );
+        assert_eq!(
+            apply_modifiers("000000000", &spec("-", None, "N")).unwrap(),
+            "000000000"
+        );
+        assert_eq!(
+            apply_modifiers("000000000", &spec("-", Some(3), "N")).unwrap(),
+            "000"
+        );
         let err = apply_modifiers("123456789", &spec("", Some(10), "N")).unwrap_err();
-        assert!(matches!(err, FormatError::FieldWidthTooLarge { width, specifier } if width == 10 && specifier == "N"));
+        assert!(
+            matches!(err, FormatError::FieldWidthTooLarge { width, specifier } if width == 10 && specifier == "N")
+        );
     }
 }

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -341,6 +341,40 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
     let flags = parsed.flags;
     let width = parsed.width;
     let specifier = parsed.spec;
+
+    // %N: nanoseconds have unique semantics
+    if specifier.ends_with('N') {
+        let no_pad = flags.contains('-');
+        let underscore = flags.contains('_');
+
+        // - without width: no-op, return full 9 digits
+        if no_pad && width.is_none() {
+            return Ok(value.to_string());
+        }
+
+        let target_width = match width {
+            Some(w) if w > 9 => {
+                return Err(FormatError::FieldWidthTooLarge {
+                    width: w,
+                    specifier: specifier.to_string(),
+                });
+            }
+            Some(w) => w,
+            None => 9,
+        };
+
+        let truncated = &value[..target_width.min(value.len())];
+
+        if underscore {
+            let trimmed = truncated.trim_end_matches('0');
+            let core = if trimmed.is_empty() { "0" } else { trimmed };
+            let padding = target_width.saturating_sub(core.len());
+            return Ok(format!("{core}{}", " ".repeat(padding)));
+        }
+
+        return Ok(truncated.to_string());
+    }
+
     let mut result = value.to_string();
 
     // Determine default pad character based on specifier type
@@ -473,10 +507,6 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             padded.extend(std::iter::repeat_n(pad_char, padding));
             padded.push_str(&result);
             result = padded;
-        }
-    } else if specifier.ends_with('N') {
-        if effective_width <= get_default_width(specifier) && effective_width != 0 {
-            result.truncate(effective_width);
         }
     }
 
@@ -1026,5 +1056,17 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(has_gnu_modifiers(input), *expected, "input = {input:?}");
         }
+    }
+
+    #[test]
+    fn test_apply_modifiers_nanoseconds() {
+        assert_eq!(apply_modifiers("123456789", &spec("", None, "N")).unwrap(), "123456789");
+        assert_eq!(apply_modifiers("000000000", &spec("", None, "N")).unwrap(), "000000000");
+        assert_eq!(apply_modifiers("123456789", &spec("", Some(3), "N")).unwrap(), "123");
+        assert_eq!(apply_modifiers("000000000", &spec("_", Some(3), "N")).unwrap(), "0  ");
+        assert_eq!(apply_modifiers("000000000", &spec("-", None, "N")).unwrap(), "000000000");
+        assert_eq!(apply_modifiers("000000000", &spec("-", Some(3), "N")).unwrap(), "000");
+        let err = apply_modifiers("123456789", &spec("", Some(10), "N")).unwrap_err();
+        assert!(matches!(err, FormatError::FieldWidthTooLarge { width, specifier } if width == 10 && specifier == "N"));
     }
 }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -408,24 +408,6 @@ fn test_date_nano_seconds() {
 }
 
 #[test]
-fn test_date_strftime_n_width_and_flags() {
-    new_ucmd!()
-        .env("LC_ALL", "C")
-        .env("TZ", "UTC")
-        .arg("-d").arg("@0")
-        .arg("+%_3N")
-        .succeeds()
-        .stdout_is("0  \n");
-    new_ucmd!()
-        .env("LC_ALL", "C")
-        .env("TZ", "UTC")
-        .arg("-d").arg("@0")
-        .arg("+%-N")
-        .succeeds()
-        .stdout_is("000000000\n");
-}
-
-#[test]
 fn test_date_format_without_plus() {
     // [+FORMAT]
     new_ucmd!()

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -408,6 +408,24 @@ fn test_date_nano_seconds() {
 }
 
 #[test]
+fn test_date_strftime_n_width_and_flags() {
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .arg("-d").arg("@0")
+        .arg("+%_3N")
+        .succeeds()
+        .stdout_is("0  \n");
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .arg("-d").arg("@0")
+        .arg("+%-N")
+        .succeeds()
+        .stdout_is("000000000\n");
+}
+
+#[test]
 fn test_date_format_without_plus() {
     // [+FORMAT]
     new_ucmd!()

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -408,6 +408,39 @@ fn test_date_nano_seconds() {
 }
 
 #[test]
+fn test_date_nano_seconds_modifiers() {
+    let scene = TestScenario::new(util_name!());
+
+    // (epoch_input, format, expected_output)
+    let cases = [
+        ("@0.123456789", "%N", "123456789"),
+        ("@0.123456789", "%3N", "123"),
+        ("@0.123456789", "%6N", "123456"),
+        ("@0.120000000", "%_3N", "12 "),
+        ("@0.100000000", "%_3N", "1  "),
+        ("@0.000000000", "%_3N", "0  "),
+        ("@0.123000000", "%_6N", "123   "),
+        ("@0.123456789", "%-N", "123456789"),
+        ("@0.123456789", "%-3N", "123"),
+    ];
+
+    for (input, fmt, expected) in cases {
+        scene
+            .ucmd()
+            .args(&["-d", input, &format!("+{fmt}")])
+            .succeeds()
+            .stdout_is(format!("{expected}\n"));
+    }
+
+    // width > 9 is invalid
+    scene
+        .ucmd()
+        .arg("+%10N")
+        .fails()
+        .stderr_contains("is too large for specifier");
+}
+
+#[test]
 fn test_date_format_without_plus() {
     // [+FORMAT]
     new_ucmd!()


### PR DESCRIPTION
Fixes #11658

Fix %N (nanoseconds) strftime modifier handling to match GNU behavior:

- `%_3N` now correctly truncates to 3 digits and right-fills trailing zeros with spaces (e.g., "0  " instead of "0")
- `%-N` now correctly returns all 9 digits when no width is specified (e.g., "000000000" instead of "0")

The fix handles %N's unique semantics: width truncates from the right (not expands), `_` flag right-fills with spaces, and `-` without width is a no-op.

Includes unit tests and integration tests.