### PR TITLE
tsort: handle stdout write errors without panicking

### DIFF
--- a/src/uu/tsort/locales/en-US.ftl
+++ b/src/uu/tsort/locales/en-US.ftl
@@ -9,3 +9,5 @@ tsort-error-loop = input contains a loop:
 tsort-error-extra-operand = extra operand { $operand }
   Try '{ $util } --help' for more information.
 tsort-error-at-least-one-input = at least one input
+tsort-error-read = read error: { $error }
+tsort-error-write = write error: { $error }

--- a/src/uu/tsort/locales/fr-FR.ftl
+++ b/src/uu/tsort/locales/fr-FR.ftl
@@ -9,3 +9,5 @@ tsort-error-loop = l'entrée contient une boucle :
 tsort-error-extra-operand = opérande supplémentaire { $operand }
   Essayez '{ $util } --help' pour plus d'informations.
 tsort-error-at-least-one-input = au moins une entrée
+tsort-error-read = erreur de lecture : { $error }
+tsort-error-write = erreur d'écriture : { $error }

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -10,12 +10,12 @@ use std::collections::VecDeque;
 use std::collections::hash_map::Entry;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, Write};
 use string_interner::StringInterner;
 use string_interner::backend::BucketBackend;
 use thiserror::Error;
 use uucore::display::Quotable;
-use uucore::error::{UError, UResult, USimpleError};
+use uucore::error::{UError, UResult, USimpleError, strip_errno};
 use uucore::{format_usage, show, translate};
 
 // short types for switching interning behavior on the fly.
@@ -102,7 +102,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         process_input(reader, &mut g)?;
     }
 
-    g.run_tsort();
+    g.run_tsort()?;
     Ok(())
 }
 
@@ -148,9 +148,13 @@ enum TsortError {
     #[error("{input}: {message}", input = .0, message = translate!("tsort-error-loop"))]
     Loop(String),
 
-    /// Wrapper for bubbling up IO errors
-    #[error("{0}")]
-    IO(#[from] io::Error),
+    /// Read error.
+    #[error("{}", translate!("tsort-error-read", "error" => strip_errno(.0)))]
+    Read(io::Error),
+
+    /// Write error.
+    #[error("{}", translate!("tsort-error-write", "error" => strip_errno(.0)))]
+    Write(io::Error),
 }
 
 // Auxiliary struct, just for printing loop nodes via show! macro
@@ -173,7 +177,7 @@ fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), TsortEr
             if e.kind() == io::ErrorKind::IsADirectory {
                 TsortError::IsDir(graph.name())
             } else {
-                e.into()
+                TsortError::Read(e)
             }
         })?;
         for token in line.split_whitespace() {
@@ -276,7 +280,7 @@ impl Graph {
     }
 
     /// Implementation of algorithm T from TAOCP (Don. Knuth), vol. 1.
-    fn run_tsort(&mut self) {
+    fn run_tsort(&mut self) -> Result<(), TsortError> {
         let mut independent_nodes_queue: VecDeque<Sym> = self
             .nodes
             .iter()
@@ -289,6 +293,10 @@ impl Graph {
             })
             .collect();
 
+        let stdout = io::stdout();
+        let mut handle = stdout.lock();
+        let mut res: io::Result<()> = Ok(());
+
         // Sort by resolved string for deterministic output
         independent_nodes_queue
             .make_contiguous()
@@ -296,7 +304,12 @@ impl Graph {
 
         while !self.nodes.is_empty() {
             let v = self.find_next_node(&mut independent_nodes_queue);
-            println!("{}", self.get_node_name(v));
+
+            // Attempt write but continue regardless on error
+            if res.is_ok() {
+                res = writeln!(handle, "{}", self.get_node_name(v));
+            }
+
             if let Some(node_to_process) = self.nodes.remove(&v) {
                 for successor_name in node_to_process.successor_tokens.into_iter().rev() {
                     // we reverse to match GNU tsort order
@@ -311,6 +324,8 @@ impl Graph {
                 }
             }
         }
+
+        res.map_err(TsortError::Write)
     }
     pub fn indegree(&self, sym: Sym) -> Option<usize> {
         self.nodes.get(&sym).map(|data| data.predecessor_count)


### PR DESCRIPTION
Fixes #12006

Avoid a panic in tsort when stdout is unwritable (for example, redirected to /dev/full). Previously an unchecked println! was used which could panic on write errors. Replaced that with a writeln! wrapped in error handling so the program continues generating cycle diagnostics even if writing to stdout fails.

Cycle diagnostics are still always written to stderr; any write errors are recorded and cause the program to exit with status 1 after processing completes.

Tested with `/etc/pacman.conf` and `printf "a b\nb a\n" | tsort > /dev/full` in both cases.