### PR TITLE
df: always show all mounts on the same device

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -249,50 +249,6 @@ fn is_included(mi: &MountInfo, opt: &Options) -> bool {
     true
 }
 
-/// Whether the mount info in `m2` should be prioritized over `m1`.
-///
-/// The "lt" in the function name is in analogy to the
-/// [`std::cmp::PartialOrd::lt`].
-fn mount_info_lt(m1: &MountInfo, m2: &MountInfo) -> bool {
-    // let "real" devices with '/' in the name win.
-    if m1.dev_name.starts_with('/') && !m2.dev_name.starts_with('/') {
-        return false;
-    }
-
-    let m1_nearer_root = m1.mount_dir.len() < m2.mount_dir.len();
-    // With bind mounts, prefer items nearer the root of the source
-    let m2_below_root = !m1.mount_root.is_empty()
-        && !m2.mount_root.is_empty()
-        && m1.mount_root.len() > m2.mount_root.len();
-    // let points towards the root of the device win.
-    if m1_nearer_root && !m2_below_root {
-        return false;
-    }
-
-    // let an entry over-mounted on a new device win, but only when
-    // matching an existing mnt point, to avoid problematic
-    // replacement when given inaccurate mount lists, seen with some
-    // chroot environments for example.
-    if m1.dev_name != m2.dev_name && m1.mount_dir == m2.mount_dir {
-        return false;
-    }
-
-    true
-}
-
-/// Whether to prioritize given mount info over all others on the same device.
-///
-/// This function decides whether the mount info `mi` is better than
-/// all others in `previous` that mount the same device as `mi`.
-fn is_best(previous: &[MountInfo], mi: &MountInfo) -> bool {
-    for seen in previous {
-        if seen.dev_id == mi.dev_id && mount_info_lt(mi, seen) {
-            return false;
-        }
-    }
-    true
-}
-
 /// Get all currently mounted filesystems.
 ///
 /// `opt` excludes certain filesystems from consideration and allows for the synchronization of filesystems before running; see
@@ -306,12 +262,7 @@ fn get_all_filesystems(opt: &Options) -> UResult<Vec<Filesystem>> {
 
     let mut mounts = vec![];
     for mut mi in read_fs_list()? {
-        // TODO The running time of the `is_best()` function is linear
-        // in the length of `result`. That makes the running time of
-        // this loop quadratic in the length of `vmi`. This could be
-        // improved by a more efficient implementation of `is_best()`,
-        // but `vmi` is probably not very long in practice.
-        if is_included(&mi, opt) && is_best(&mounts, &mi) {
+        if is_included(&mi, opt) {
             let dev_path: &Path = Path::new(&mi.dev_name);
             // Only check is_symlink() for absolute paths. For non-absolute paths
             // like "tmpfs", "sysfs", etc., is_symlink() would resolve relative to


### PR DESCRIPTION
Given the following mounts:

```
/ # cat /proc/self/mountinfo
101 34 0:69 / /dev rw,noexec,relatime shared:709 - tmpfs tmpfs rw,size=1024k
803 101 0:77 / /dev/shm rw,nosuid,nodev,noexec,relatime shared:724 - tmpfs tmpfs rw
818 101 0:82 / /dev/pts rw,relatime shared:739 - devpts devpts rw,mode=600,ptmxmode=666
833 34 0:26 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
848 34 0:27 / /sys rw,nosuid,nodev,noexec,relatime shared:6 - sysfs sysfs rw
863 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_apk_aarch64 /var/cache/apk rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
878 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_appstream/aarch64/edge /mnt/appstream-data rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
893 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_ccache_aarch64 /mnt/pmbootstrap/ccache rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
908 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_distfiles /var/cache/distfiles rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
923 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_git /mnt/pmbootstrap/git rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
938 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_go /mnt/pmbootstrap/go rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
953 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_rust /mnt/pmbootstrap/rust rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
968 34 259:2 /home/aelin/.local/var/pmbootstrap/config_abuild /mnt/pmbootstrap/abuild-config rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
983 34 259:2 /home/aelin/.local/var/pmbootstrap/config_apk_keys /etc/apk/keys rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
998 34 259:2 /home/aelin/.local/var/pmbootstrap/cache_sccache /mnt/pmbootstrap/sccache rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
1013 34 259:2 /home/aelin/.local/var/pmbootstrap/images_netboot /mnt/pmbootstrap/netboot rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
1028 34 259:2 /home/aelin/.local/var/pmbootstrap/packages /mnt/pmbootstrap/packages rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw
```

GNU coreutils will display all of them (minus `/dev/pts`, `/proc` and `/sys`, but uutils also skips those):

```
/ # df
Filesystem           1K-blocks      Used Available Use% Mounted on
tmpfs                     1024         0      1024   0% /dev
tmpfs                  7771112         0   7771112   0% /dev/shm
/dev/nvme0n1p2       490150872 159980088 305199060  34% /var/cache/apk
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/appstream-data
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/ccache
/dev/nvme0n1p2       490150872 159980088 305199060  34% /var/cache/distfiles
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/git
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/go
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/rust
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/abuild-config
/dev/nvme0n1p2       490150872 159980088 305199060  34% /etc/apk/keys
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/sccache
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/netboot
/dev/nvme0n1p2       490150872 159980088 305199060  34% /mnt/pmbootstrap/packages
```

while uutils would only show some of these entries:

```
/ # /tmp/coreutils df
Filesystem     1K-blocks      Used Available Use% Mounted on
tmpfs               1024         0      1024   0% /dev
tmpfs            7771112         0   7771112   0% /dev/shm
/dev/nvme0n1p2 490150872 156467712 308711436  34% /var/cache/apk
/dev/nvme0n1p2 490150872 156467712 308711436  34% /etc/apk/keys
```

That's because they were being skipped due to not being found the "best" mount info entries. I'm not sure why this logic even existed, please feel free to point me at cases where this is necessary. From what I can tell running the test suite locally, simply not skipping entries like this does not break any of the testsuite.

With these changes:

```
/ # /tmp/coreutils df
Filesystem     1K-blocks      Used Available Use% Mounted on
tmpfs               1024         0      1024   0% /dev
tmpfs            7771112         0   7771112   0% /dev/shm
/dev/nvme0n1p2 490150872 159980420 305198728  35% /var/cache/apk
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/appstream-data
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/ccache
/dev/nvme0n1p2 490150872 159980420 305198728  35% /var/cache/distfiles
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/git
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/go
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/rust
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/abuild-config
/dev/nvme0n1p2 490150872 159980420 305198728  35% /etc/apk/keys
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/sccache
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/netboot
/dev/nvme0n1p2 490150872 159980420 305198728  35% /mnt/pmbootstrap/packages
```