### PR TITLE
df: don't show entries previously considered best

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -327,6 +327,9 @@ fn get_all_filesystems(opt: &Options) -> UResult<Vec<Filesystem>> {
                 }
             }
 
+            // Remove any entries previously considered the best for this device
+            mounts.retain(|m| m.dev_id != mi.dev_id);
+
             mounts.push(mi);
         }
     }

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -309,6 +309,9 @@ fn get_all_filesystems(opt: &Options) -> UResult<Vec<Filesystem>> {
                 mi.dev_name = canonicalized_symlink.to_string_lossy().to_string();
             }
 
+            // Remove any entries previously considered the best for this device
+            mounts.retain(|m| m.dev_id != mi.dev_id);
+
             mounts.push(mi);
         }
     }


### PR DESCRIPTION
We would go over all the mountpoints and only display those considered the "best" for a device. However, if we found a new "best" entry for a device, we would still display the entry previously considered "best". Fix this by removing all previous entries for the same device before adding a new one.

Previously with the following mounts:

```
/ # cat /proc/mounts
tmpfs /dev tmpfs rw,noexec,relatime,size=1024k 0 0
tmpfs /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime 0 0
devpts /dev/pts devpts rw,relatime,mode=600,ptmxmode=666 0 0
proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
/dev/nvme0n1p2 /var/cache/apk ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/appstream-data ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/ccache ext4 rw,relatime 0 0
/dev/nvme0n1p2 /var/cache/distfiles ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/git ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/go ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/rust ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/abuild-config ext4 rw,relatime 0 0
/dev/nvme0n1p2 /etc/apk/keys ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/sccache ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/netboot ext4 rw,relatime 0 0
/dev/nvme0n1p2 /mnt/pmbootstrap/packages ext4 rw,relatime 0 0
```

`/var/cache/apk` is the first entry that was seen and it was considered best, and it remains the best entry until `/etc/apk/keys` is encountered, which is considered the new best entry. Currently, this would result in both being printed:

```
/ # /tmp/coreutils df
Filesystem     1K-blocks      Used Available Use% Mounted on
tmpfs               1024         0      1024   0% /dev
tmpfs            7771112         0   7771112   0% /dev/shm
/dev/nvme0n1p2 490150872 162018872 303160276  35% /var/cache/apk
/dev/nvme0n1p2 490150872 162018872 303160276  35% /etc/apk/keys
```

After this change, finding a new best would get rid of any entry previously considered best, resulting in

```
/ # /tmp/coreutils df
Filesystem     1K-blocks      Used Available Use% Mounted on
tmpfs               1024         0      1024   0% /dev
tmpfs            7771112         0   7771112   0% /dev/shm
/dev/nvme0n1p2 490150872 162141416 303037732  35% /etc/apk/keys
```

which matches GNU coreutils:

```
/ # df
Filesystem     1K-blocks      Used Available Use% Mounted on
tmpfs               1024         0      1024   0% /dev
tmpfs            7771112         0   7771112   0% /dev/shm
/dev/nvme0n1p2 490150872 161206736 303972412  35% /etc/apk/keys
```