### PR TITLE
tail:Fix tail -f sparse file growth handling

### DIFF
--- a/src/uu/tail/src/follow/files.rs
+++ b/src/uu/tail/src/follow/files.rs
@@ -6,13 +6,13 @@
 // spell-checker:ignore tailable stdlib (stdlib)
 
 use crate::args::Settings;
-use crate::chunks::BytesChunkBuffer;
+use crate::chunks::BytesChunk;
 use crate::paths::{HeaderPrinter, PathExtTail};
 use crate::text;
 use std::collections::HashMap;
 use std::collections::hash_map::Keys;
 use std::fs::{File, Metadata};
-use std::io::{BufRead, BufReader, BufWriter, Write, stdout};
+use std::io::{self, BufRead, BufReader, BufWriter, Write, stdout};
 use std::path::{Path, PathBuf};
 use uucore::error::UResult;
 
@@ -136,20 +136,32 @@ impl FileHandling {
 
     /// Read new data from `path` and print it to stdout
     pub fn tail_file(&mut self, path: &Path, verbose: bool) -> UResult<bool> {
-        let mut chunks = BytesChunkBuffer::new(u64::MAX);
-        if let Some(reader) = self.get_mut(path).reader.as_mut() {
-            chunks.fill(reader)?;
-        }
-        if chunks.has_data() {
+        let Some(mut reader) = self.get_mut(path).reader.take() else {
+            return Ok(false);
+        };
+
+        let result = (|| -> UResult<bool> {
+            let mut chunk = BytesChunk::new();
+            if chunk.fill(&mut reader)?.is_none() {
+                return Ok(false);
+            }
+
             if self.needs_header(path, verbose) {
                 let display_name = self.get(path).display_name.clone();
                 self.header_printer.print(display_name.as_str());
             }
 
             let mut writer = BufWriter::new(stdout().lock());
-            chunks.write(&mut writer)?;
+            writer.write_all(chunk.get_buffer())?;
+            io::copy(&mut reader, &mut writer)?;
             writer.flush()?;
 
+            Ok(true)
+        })();
+
+        self.get_mut(path).reader = Some(reader);
+
+        if result? {
             self.last.replace(path.to_owned());
             self.update_metadata(path, None);
             Ok(true)

--- a/src/uu/tail/src/follow/files.rs
+++ b/src/uu/tail/src/follow/files.rs
@@ -140,24 +140,7 @@ impl FileHandling {
             return Ok(false);
         };
 
-        let result = (|| -> UResult<bool> {
-            let mut chunk = BytesChunk::new();
-            if chunk.fill(&mut reader)?.is_none() {
-                return Ok(false);
-            }
-
-            if self.needs_header(path, verbose) {
-                let display_name = self.get(path).display_name.clone();
-                self.header_printer.print(display_name.as_str());
-            }
-
-            let mut writer = BufWriter::new(stdout().lock());
-            writer.write_all(chunk.get_buffer())?;
-            io::copy(&mut reader, &mut writer)?;
-            writer.flush()?;
-
-            Ok(true)
-        })();
+        let result = self.print_new_data(path, verbose, &mut reader);
 
         self.get_mut(path).reader = Some(reader);
 
@@ -168,6 +151,30 @@ impl FileHandling {
         } else {
             Ok(false)
         }
+    }
+
+    fn print_new_data(
+        &mut self,
+        path: &Path,
+        verbose: bool,
+        reader: &mut impl BufRead,
+    ) -> UResult<bool> {
+        let mut chunk = BytesChunk::new();
+        if chunk.fill(&mut *reader)?.is_none() {
+            return Ok(false);
+        }
+
+        if self.needs_header(path, verbose) {
+            let display_name = self.get(path).display_name.clone();
+            self.header_printer.print(display_name.as_str());
+        }
+
+        let mut writer = BufWriter::new(stdout().lock());
+        writer.write_all(chunk.get_buffer())?;
+        io::copy(&mut *reader, &mut writer)?;
+        writer.flush()?;
+
+        Ok(true)
     }
 
     /// Decide if printing `path` needs a header based on when it was last printed

--- a/src/uu/tail/src/follow/files.rs
+++ b/src/uu/tail/src/follow/files.rs
@@ -160,7 +160,7 @@ impl FileHandling {
         reader: &mut impl BufRead,
     ) -> UResult<bool> {
         let mut chunk = BytesChunk::new();
-        if chunk.fill(&mut *reader)?.is_none() {
+        if chunk.fill(reader)?.is_none() {
             return Ok(false);
         }
 

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -265,7 +265,7 @@ fn test_follow_sparse_file_growth_under_memory_limit() {
     let mut child = ucmd
         .limit(Resource::AS, AS_LIMIT, AS_LIMIT)
         .set_stdout(Stdio::null())
-        .args([
+        .args(&[
             "-n0",
             "-f",
             "--use-polling",

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -248,6 +248,46 @@ fn test_n0_with_follow() {
     child.kill();
 }
 
+#[test]
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+fn test_follow_sparse_file_growth_under_memory_limit() {
+    use rlimit::Resource;
+
+    // The old follow implementation buffered the entire newly readable range. Keep the address
+    // space smaller than the sparse range so that implementation aborts instead of streaming it.
+    const AS_LIMIT: u64 = 200 * 1024 * 1024;
+    const SPARSE_FILE_SIZE: u64 = 512 * 1024 * 1024;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    let test_file = "sparse";
+    at.touch(test_file);
+
+    let mut child = ucmd
+        .limit(Resource::AS, AS_LIMIT, AS_LIMIT)
+        .set_stdout(Stdio::null())
+        .args([
+            "-n0",
+            "-f",
+            "--use-polling",
+            "--sleep-interval=0.1",
+            test_file,
+        ])
+        .run_no_wait();
+    child.make_assertion_with_delay(500).is_alive();
+
+    File::options()
+        .write(true)
+        .open(at.plus(test_file))
+        .unwrap()
+        .set_len(SPARSE_FILE_SIZE)
+        .unwrap();
+
+    child
+        .make_assertion_with_delay(2 * DEFAULT_SLEEP_INTERVAL_MILLIS)
+        .is_alive();
+    child.kill();
+}
+
 // TODO: Add similar test for windows
 #[test]
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Fixes tail -f behavior when a followed sparse file grows by a very large amount, such as via truncate -s 1P.

The follow path previously used BytesChunkBuffer::new(u64::MAX), which consumed all newly readable bytes into memory before printing. For sparse file holes, those bytes are read as NULs, so a large logical size increase could cause tail to consume excessive memory and get killed.

This changes follow-mode output to read one chunk to detect whether new data exists and preserve header behavior, then stream the remaining data directly to stdout with io::copy.

Fixes #12015.

## Validation

- cargo fmt --check
- cargo check -p uu_tail
- cargo test -p uu_tail
- cargo build -p coreutils
- cargo test --test tests test_n0_with_follow --features tail
- Manual sparse growth check with tail -n0 -f --use-polling and truncate -s 1P