### PR TITLE
process: replace getuid with rustix::process::getuid

### DIFF
--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -43,7 +43,7 @@ pub fn getgid() -> gid_t {
 
 /// `getuid()` returns the real user ID of the calling process.
 pub fn getuid() -> uid_t {
-    nix::unistd::getuid().as_raw()
+    rustix::process::getuid().as_raw()
 }
 
 /// `getpid()` returns the pid of the calling process.


### PR DESCRIPTION
replace nix::unistd::getuid with rustix::process::getuid

closed: #12042 