### PR TITLE
date: width prefix in %N format specifier fix

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -33,8 +33,8 @@
 //! - `%^B`: Month name in uppercase (JUNE)
 //! - `%+4C`: Century with sign, padded to 4 characters (+019)
 
-use jiff::fmt::strtime::{BrokenDownTime, Config, PosixCustom};
 use jiff::Zoned;
+use jiff::fmt::strtime::{BrokenDownTime, Config, PosixCustom};
 use std::fmt;
 use uucore::translate;
 
@@ -654,12 +654,12 @@ mod tests {
         let date = make_test_date(1999, 6, 1, 0);
         let config = get_config();
         let result = format_with_modifiers(&date, "%N", &config).unwrap();
-        // %N wihtout width should return 9 digits
+        // %N without width should return 9 digits
         assert_eq!(result.len(), 9);
     }
 
     #[test]
-    fn test_n_specifier_tuncates_from_right() {
+    fn test_n_specifier_truncates_from_right() {
         let date = make_test_date(1999, 6, 1, 0);
         let config = get_config();
         let result = format_with_modifiers(&date, "%3N", &config).unwrap();

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -33,8 +33,8 @@
 //! - `%^B`: Month name in uppercase (JUNE)
 //! - `%+4C`: Century with sign, padded to 4 characters (+019)
 
-use jiff::Zoned;
 use jiff::fmt::strtime::{BrokenDownTime, Config, PosixCustom};
+use jiff::Zoned;
 use std::fmt;
 use uucore::translate;
 
@@ -75,8 +75,7 @@ struct ParsedSpec<'a> {
     /// Flag characters from `[_0^#+-]`.
     flags: &'a str,
     /// Explicit width, if present. `None` means no width was specified.
-    /// A value that overflows `usize` is represented as `Some(usize::MAX)` so
-    /// the downstream allocation check surfaces it as `FieldWidthTooLarge`.
+    /// Width overflows are handled naturally by usize parsing.
     width: Option<usize>,
     /// The specifier itself, including any leading colons (e.g. `Y`, `:z`, `::z`).
     spec: &'a str,
@@ -341,7 +340,11 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
     let flags = parsed.flags;
     let width = parsed.width;
     let specifier = parsed.spec;
-    let mut result = value.to_string();
+    let mut result = if specifier.ends_with('N') {
+        value.trim_end_matches(' ').to_string()
+    } else {
+        value.to_string()
+    };
 
     // Determine default pad character based on specifier type
     // Determine default pad character based on specifier type.
@@ -411,6 +414,14 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
 
     // If no_pad flag is active, suppress all padding and return
     if no_pad {
+        if specifier.ends_with('N') {
+            let trimmed = result.trim_end();
+            if let Some(w) = width {
+                let truncated: String = trimmed.chars().take(w).collect();
+                return Ok(truncated);
+            }
+            return Ok(trimmed.to_string());
+        }
         return Ok(strip_default_padding(&result));
     }
 
@@ -453,6 +464,15 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
         }
     }
 
+    if specifier.ends_with('N') && effective_width != 0 {
+        result.truncate(effective_width);
+        result.extend(std::iter::repeat_n(
+            '0',
+            effective_width.saturating_sub(result.len()),
+        ));
+        return Ok(result);
+    }
+
     // Apply width padding
     if effective_width > result.len() {
         let padding = effective_width - result.len();
@@ -473,10 +493,6 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             padded.extend(std::iter::repeat_n(pad_char, padding));
             padded.push_str(&result);
             result = padded;
-        }
-    } else if specifier.ends_with('N') {
-        if effective_width <= get_default_width(specifier) && effective_width != 0 {
-            result.truncate(effective_width);
         }
     }
 
@@ -631,6 +647,51 @@ mod tests {
         // %1d: width 1 < "01".len() → strip zero padding → "1"
         let result = format_with_modifiers(&date, "%1d", &config).unwrap();
         assert_eq!(result, "1");
+    }
+
+    #[test]
+    fn test_n_specifier_no_flag_full_width() {
+        let date = make_test_date(1999, 6, 1, 0);
+        let config = get_config();
+        let result = format_with_modifiers(&date, "%N", &config).unwrap();
+        // %N wihtout width should return 9 digits
+        assert_eq!(result.len(), 9);
+    }
+
+    #[test]
+    fn test_n_specifier_tuncates_from_right() {
+        let date = make_test_date(1999, 6, 1, 0);
+        let config = get_config();
+        let result = format_with_modifiers(&date, "%3N", &config).unwrap();
+        // %kN should produce the first k digits
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_n_specifier_flag() {
+        let date = make_test_date(1999, 6, 1, 0);
+        let config = get_config();
+        let result = format_with_modifiers(&date, "%-3N", &config).unwrap();
+        // %-kN should produce the first k digits from the right
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_large_width() {
+        let date = make_test_date(1999, 6, 1, 0);
+        let config = get_config();
+        let result = format_with_modifiers(&date, "%20N", &config).unwrap();
+        // %kN (k >= 9) produces the output with (k - 9) trailing zeros
+        assert_eq!(result.len(), 20);
+    }
+
+    #[test]
+    fn test_large_width_flag() {
+        let date = make_test_date(1999, 6, 1, 0);
+        let config = get_config();
+        let result = format_with_modifiers(&date, "%-20N", &config).unwrap();
+        // %-kN (k >= 9) returns the 9 digits of the nanosecond value
+        assert_eq!(result.len(), 9);
     }
 
     #[test]
@@ -988,6 +1049,7 @@ mod tests {
 
         for (input, expected) in cases {
             let actual = parse_format_spec(input).map(|p| (p.flags, p.width, p.spec, p.len));
+
             assert_eq!(actual, *expected, "input = {input:?}");
         }
     }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -3012,3 +3012,24 @@ fn test_nanoseconds_width_prefix_ignored_issue12001() {
     // compare to 4 because of \n
     assert_eq!(result.stdout().len(), 4);
 }
+
+// date: width prefix in %N format specifier fix #12098
+#[test]
+fn test_date_n_flag() {
+    let cases = [
+        ("%N", "123456789\n"),
+        ("%3N", "123\n"),
+        ("%-3N", "123\n"),
+        ("%20N", "12345678900000000000\n"),
+        ("%-20N", "123456789\n"),
+    ];
+
+    for (fmt, expected) in cases {
+        new_ucmd!()
+            .arg("-d")
+            .arg("@0.123456789")
+            .arg(format!("+{fmt}"))
+            .succeeds()
+            .stdout_is(expected);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/11658

Corrects width handling and flag behavior for %N format specifier to match GNU coreutils:

 - Truncates nanoseconds from the right when width is specified
 - '-' flag properly suppresses padding and ignores width
 - Full 9 digits returned when no width specified
 - Effectively handles huge widths
 
After fixes:
>>> cargo run date +%-2N
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.90s
     Running `target/debug/coreutils date '+%-2N'`
99

Before fix:
>>> date +%-2N
928353556