### PR TITLE
coreutils: fix panic on linux < 6.4 when /proc is not mounted

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -367,6 +367,7 @@ getcwd
 setpipe
 
 # * other
+auxv
 getlimits
 weblate
 algs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,9 +450,8 @@ rstest = "0.26.0"
 rstest_reuse = "0.7.0"
 rustc-hash = "2.1.1"
 rust-ini = "0.21.0"
-# binary name of coreutils can be hijacked by overriding getauxval via LD_PRELOAD
-# So we use param and avoid libc backend
-rustix = { version = "1.1.4", features = ["param"] }
+# raw-backend's linux_execfn is not supported on linux < 6.4 if /proc is not mounted. So use-libc-auxv is needed
+rustix = { version = "1.1.4", features = ["param", "use-libc-auxv"] }
 same-file = "1.0.6"
 self_cell = "1.0.4"
 selinux = "0.6"

--- a/src/common/validation.rs
+++ b/src/common/validation.rs
@@ -74,7 +74,10 @@ fn get_canonical_util_name(util_name: &str) -> &str {
 
 /// Gets the binary path from command line arguments
 /// Panics if the binary path cannot be determined
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(any(
+    not(any(target_os = "linux", target_os = "android")),
+    target_env = "musl"
+))]
 pub fn binary_path(args: &mut impl Iterator<Item = OsString>) -> PathBuf {
     match args.next() {
         Some(ref s) if !s.is_empty() => PathBuf::from(s),
@@ -84,7 +87,10 @@ pub fn binary_path(args: &mut impl Iterator<Item = OsString>) -> PathBuf {
 }
 /// Get actual binary path from kernel, not argv0, to prevent `env -a` from bypassing
 /// AppArmor, SELinux policies on hard-linked binaries
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    not(target_env = "musl")
+))]
 pub fn binary_path(args: &mut impl Iterator<Item = OsString>) -> PathBuf {
     use std::fs::File;
     use std::io::Read;

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -27,7 +27,11 @@ fn init() {
 }
 
 #[test]
-#[cfg(all(feature = "env", any(target_os = "linux", target_os = "android")))]
+#[cfg(all(
+    feature = "env",
+    any(target_os = "linux", target_os = "android"),
+    not(target_env = "musl")
+))]
 fn binary_name_protection() {
     let ts = TestScenario::new("env");
     let bin = ts.bin_path.clone();


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/11975

@Ecordonnier Ubuntu should revert this before building.