### PR TITLE
fix(ls): respect sorting when grouping directories; disambiguate size sorting properly

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1480,7 +1480,12 @@ fn sort_entries(entries: &mut [PathData], config: &Config) {
             )
         }),
         Sort::Size => {
-            entries.sort_unstable_by_key(|k| Reverse(k.metadata().map_or(0, Metadata::len)));
+            entries.sort_unstable_by(|a, b| {
+                b.metadata()
+                    .map_or(0, Metadata::len)
+                    .cmp(&a.metadata().map_or(0, Metadata::len))
+                    .then(a.file_name().cmp(b.file_name()))
+            });
         }
         // The default sort in GNU ls is case insensitive
         Sort::Name => entries.sort_unstable_by(|a, b| a.display_name().cmp(b.display_name())),

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1511,7 +1511,7 @@ fn sort_entries(entries: &mut [PathData], config: &Config) {
     }
 
     if config.group_directories_first && config.sort != Sort::None {
-        entries.sort_unstable_by_key(|p| {
+        entries.sort_by_key(|p| {
             let ft = {
                 // We will always try to deref symlinks to group directories, so PathData.md
                 // is not always useful.

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1941,6 +1941,10 @@ fn test_ls_group_directories_first() {
     }
     filenames.sort_unstable();
 
+    for (i, name) in filenames.iter().enumerate() {
+        at.write_bytes(name, "a".repeat(i).as_bytes());
+    }
+
     let dirnames = ["aaa", "bbb", "ccc", "yyy"];
     for dirname in dirnames {
         at.mkdir(dirname);
@@ -1960,6 +1964,21 @@ fn test_ls_group_directories_first() {
             .chain(filenames.into_iter())
             .chain([""].into_iter())
             .collect::<Vec<_>>(),
+    );
+
+    let result = scene
+        .ucmd()
+        .arg("-1")
+        .arg("--group-directories-first")
+        .arg("--sort=size")
+        .succeeds();
+    assert_eq!(
+        result.stdout_str().split('\n').collect::<Vec<_>>(),
+        dirnames
+            .into_iter()
+            .chain(filenames.into_iter().rev())
+            .chain([""].into_iter())
+            .collect::<Vec<_>>()
     );
 
     let result = scene


### PR DESCRIPTION
Fixes #11997.