### PR TITLE
ls: hide `paths` argument

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -779,6 +779,7 @@ pub fn uu_app() -> Command {
     // Positional arguments
     .arg(
         Arg::new(options::PATHS)
+            .hide(true)
             .action(ArgAction::Append)
             .value_hint(clap::ValueHint::AnyPath)
             .value_parser(ValueParser::os_string()),


### PR DESCRIPTION
When running `ls --help`, we currently show (among many other things):
```
Usage: ls [OPTION]... [FILE]...

Arguments:
  [paths]... 
```
I think it's confusing to list the same twice with different names (`[FILE]...` and `[paths]...`), and so this PR hides the `paths` argument.