### PR TITLE
tr: add ASCII range translation fast path

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -670,6 +670,14 @@ impl ChunkProcessor for DeleteOperation {
 #[derive(Debug)]
 pub struct TranslateOperation {
     pub(crate) translation_table: [u8; 256],
+    pub(crate) ascii_range: Option<AsciiRangeTranslate>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AsciiRangeTranslate {
+    pub(crate) start: u8,
+    pub(crate) end: u8,
+    pub(crate) delta: u8,
 }
 
 impl TranslateOperation {
@@ -686,14 +694,58 @@ impl TranslateOperation {
                 translation_table[from as usize] = to;
             }
 
-            Ok(Self { translation_table })
+            Ok(Self {
+                ascii_range: detect_ascii_range_translate(&translation_table),
+                translation_table,
+            })
         } else if set1.is_empty() && set2.is_empty() {
             // Identity mapping for empty sets
-            Ok(Self { translation_table })
+            Ok(Self {
+                ascii_range: None,
+                translation_table,
+            })
         } else {
             Err(BadSequence::EmptySet2WhenNotTruncatingSet1)
         }
     }
+}
+
+fn detect_ascii_range_translate(table: &[u8; 256]) -> Option<AsciiRangeTranslate> {
+    let mut range: Option<AsciiRangeTranslate> = None;
+    let mut changed_count = 0usize;
+    let mut finished_range = false;
+
+    for (from, &to) in table.iter().enumerate() {
+        let from = from as u8;
+        if to == from {
+            if range.is_some() {
+                finished_range = true;
+            }
+            continue;
+        }
+
+        if from > 0x7f || finished_range {
+            return None;
+        }
+
+        let delta = to.wrapping_sub(from);
+        match &mut range {
+            Some(range) if range.delta == delta => {
+                range.end = from;
+            }
+            Some(_) => return None,
+            None => {
+                range = Some(AsciiRangeTranslate {
+                    start: from,
+                    end: from,
+                    delta,
+                });
+            }
+        }
+        changed_count += 1;
+    }
+
+    (changed_count > 1).then_some(range?)
 }
 
 impl SymbolTranslator for TranslateOperation {
@@ -704,7 +756,7 @@ impl SymbolTranslator for TranslateOperation {
 
 impl ChunkProcessor for TranslateOperation {
     fn process_chunk(&self, input: &[u8], output: &mut Vec<u8>) {
-        use crate::simd::{find_single_change, process_single_char_replace};
+        use crate::simd::{find_single_change, process_single_char_replace, translate_ascii_range};
 
         // Check if this is a simple single-character translation
         if let Some((source, target)) =
@@ -712,6 +764,8 @@ impl ChunkProcessor for TranslateOperation {
         {
             // Use SIMD-optimized single character replacement
             process_single_char_replace(input, output, source, target);
+        } else if let Some(range) = self.ascii_range {
+            translate_ascii_range(input, output, range);
         } else {
             // Standard translation using table lookup
             output.extend(input.iter().map(|&b| self.translation_table[b as usize]));

--- a/src/uu/tr/src/simd.rs
+++ b/src/uu/tr/src/simd.rs
@@ -3,6 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+// spell-checker:ignore (intrinsics) blendv cmpgt loadu storeu
+
 //! I/O processing infrastructure for tr operations with SIMD optimizations
 
 use crate::operation::{AsciiRangeTranslate, ChunkProcessor};

--- a/src/uu/tr/src/simd.rs
+++ b/src/uu/tr/src/simd.rs
@@ -5,7 +5,7 @@
 
 //! I/O processing infrastructure for tr operations with SIMD optimizations
 
-use crate::operation::ChunkProcessor;
+use crate::operation::{AsciiRangeTranslate, ChunkProcessor};
 use std::io::{BufRead, Write};
 use uucore::error::{FromIo, UResult};
 use uucore::translate;
@@ -57,6 +57,89 @@ pub fn process_single_delete(input: &[u8], output: &mut Vec<u8>, delete_char: u8
         output.extend(input.iter().filter(|&&b| b != delete_char).copied());
     }
     // If count == input.len(), all deleted, output nothing
+}
+
+/// Translate a contiguous ASCII byte range by a constant wrapping delta.
+#[inline]
+pub(crate) fn translate_ascii_range(
+    input: &[u8],
+    output: &mut Vec<u8>,
+    range: AsciiRangeTranslate,
+) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if input.len() >= 32 && std::is_x86_feature_detected!("avx2") {
+        unsafe {
+            translate_ascii_range_avx2(input, output, range);
+        }
+        return;
+    }
+
+    translate_ascii_range_scalar(input, output, range);
+}
+
+#[inline]
+fn translate_ascii_range_scalar(input: &[u8], output: &mut Vec<u8>, range: AsciiRangeTranslate) {
+    output.extend(input.iter().map(|&byte| {
+        if (range.start..=range.end).contains(&byte) {
+            byte.wrapping_add(range.delta)
+        } else {
+            byte
+        }
+    }));
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+/// # Safety
+///
+/// Callers must only call this function when AVX2 is available on the current CPU.
+unsafe fn translate_ascii_range_avx2(
+    input: &[u8],
+    output: &mut Vec<u8>,
+    range: AsciiRangeTranslate,
+) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::{
+        _mm256_add_epi8, _mm256_and_si256, _mm256_blendv_epi8, _mm256_cmpgt_epi8,
+        _mm256_loadu_si256, _mm256_set1_epi8, _mm256_storeu_si256, _mm256_xor_si256,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::{
+        _mm256_add_epi8, _mm256_and_si256, _mm256_blendv_epi8, _mm256_cmpgt_epi8,
+        _mm256_loadu_si256, _mm256_set1_epi8, _mm256_storeu_si256, _mm256_xor_si256,
+    };
+
+    let start_len = output.len();
+    output.resize(start_len + input.len(), 0);
+
+    let start_minus_one = (range.start.wrapping_sub(1)) as i8;
+    let start = _mm256_set1_epi8(start_minus_one);
+    let end = _mm256_set1_epi8(range.end as i8);
+    let delta = _mm256_set1_epi8(range.delta as i8);
+    let all_bits = _mm256_set1_epi8(-1);
+
+    let mut offset = 0usize;
+    while offset + 32 <= input.len() {
+        let bytes = unsafe { _mm256_loadu_si256(input.as_ptr().add(offset).cast()) };
+        let greater_equal_start = _mm256_cmpgt_epi8(bytes, start);
+        let greater_than_end = _mm256_cmpgt_epi8(bytes, end);
+        let less_equal_end = _mm256_xor_si256(greater_than_end, all_bits);
+        let in_range = _mm256_and_si256(greater_equal_start, less_equal_end);
+        let translated = _mm256_add_epi8(bytes, delta);
+        let blended = _mm256_blendv_epi8(bytes, translated, in_range);
+        unsafe {
+            _mm256_storeu_si256(output.as_mut_ptr().add(start_len + offset).cast(), blended);
+        }
+        offset += 32;
+    }
+
+    for (index, &byte) in input[offset..].iter().enumerate() {
+        output[start_len + offset + index] = if (range.start..=range.end).contains(&byte) {
+            byte.wrapping_add(range.delta)
+        } else {
+            byte
+        };
+    }
 }
 
 /// Unified I/O processing for all operations

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -47,6 +47,69 @@ fn test_to_upper() {
 }
 
 #[test]
+fn test_ascii_range_translate_alignment_boundaries() {
+    let mut cases = vec![
+        Vec::new(),
+        b"a".to_vec(),
+        (0..31).map(|i| b'a' + (i % 26) as u8).collect(),
+        (0..32).map(|i| b'a' + (i % 26) as u8).collect(),
+        (0..33).map(|i| b'a' + (i % 26) as u8).collect(),
+        b"zZ!\xc3\xa9a".to_vec(),
+    ];
+    cases.push((0u8..=255).collect());
+
+    #[cfg(unix)]
+    let gnu_tr = ["tr", "gtr"].into_iter().find(|candidate| {
+        std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| {
+                output.status.success()
+                    && String::from_utf8_lossy(&output.stdout).contains("(GNU coreutils)")
+            })
+    });
+
+    for input in cases {
+        let expected: Vec<u8> = input
+            .iter()
+            .map(|&byte| {
+                if byte.is_ascii_lowercase() {
+                    byte.to_ascii_uppercase()
+                } else {
+                    byte
+                }
+            })
+            .collect();
+
+        new_ucmd!()
+            .args(&["a-z", "A-Z"])
+            .pipe_in(input.clone())
+            .succeeds()
+            .stdout_is_bytes(&expected)
+            .no_stderr();
+
+        #[cfg(unix)]
+        if let Some(gnu_tr) = gnu_tr {
+            use std::io::Write as _;
+
+            let mut child = std::process::Command::new(gnu_tr)
+                .args(["a-z", "A-Z"])
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .unwrap();
+            child.stdin.as_mut().unwrap().write_all(&input).unwrap();
+            let output = child.wait_with_output().unwrap();
+
+            assert!(output.status.success());
+            assert_eq!(output.stdout, expected);
+            assert!(output.stderr.is_empty());
+        }
+    }
+}
+
+#[test]
 fn test_small_set2() {
     new_ucmd!()
         .args(&["0-9", "X"])


### PR DESCRIPTION
## What

Adds a narrow fast path for bytewise ASCII range translations such as:

```bash
tr 'a-z' 'A-Z'
```

The change detects translation tables that modify one contiguous ASCII range by a constant wrapping delta, then processes that range with an AVX2 range compare plus masked add on x86/x86_64 hosts that support AVX2. Other translations continue to use the existing single-byte or table-lookup paths, and non-AVX2 hosts use the scalar fallback.

## Why

Before this change, `tr 'a-z' 'A-Z'` mapped every byte through a scalar 256-byte translation table. This is a common case, and it can be handled more directly by checking whether each byte falls within the translated ASCII range and adding the fixed delta.

## Measurements

Environment:

- CPU: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
- OS: Linux x86_64
- Rust: `rustc 1.92.0`
- Candidate branch: `perf/P002`
- Baseline commit: `4b5a2af7a916910bfeaf46b298a963d8a038565a`
- `hyperfine` was not installed, so this used `/usr/bin/time`, 2 warmups, and 12 measured runs.

Input was `corpus/large_text.txt` repeated 16 times, 1,342,178,256 bytes total.

```bash
/usr/bin/time -f '%e %M' ./runs/P002-rerun/bin/tr-baseline 'a-z' 'A-Z' < runs/P002-rerun/input/large_text_x16.txt > /dev/null
/usr/bin/time -f '%e %M' ./runs/P002-rerun/bin/tr-p002 'a-z' 'A-Z' < runs/P002-rerun/input/large_text_x16.txt > /dev/null
/usr/bin/time -f '%e %M' /usr/bin/tr 'a-z' 'A-Z' < runs/P002-rerun/input/large_text_x16.txt > /dev/null
```

| implementation | mean wall time | stddev | throughput |
|---|---:|---:|---:|
| uutils baseline | 1.068 s | 0.129 s | 1198.1 MiB/s |
| uutils candidate | 0.421 s | 0.029 s | 3041.6 MiB/s |
| GNU tr | 1.251 s | 0.209 s | 1023.3 MiB/s |

The candidate is 2.54x faster than the uutils baseline on this workload, a 60.6% wall-time reduction. The earlier 80 MiB pipeline benchmark also showed a 53.8% reduction, from 0.065 s to 0.030 s.

## Correctness

For the 1.3 GB input, baseline uutils, candidate uutils, and GNU `tr` produced the same transformed output SHA256:

```text
6f2d6cb371ca0b423a90a5690ee7f6dac0be6a7d889f308ff5b15f2957e853db
```

## Tests

```bash
cargo test --release --test tests -- --nocapture --test-threads=1 test_tr::test_ascii_range_translate_alignment_boundaries
cargo clippy --release -p uu_tr -- -D warnings
cargo fmt --check --package uu_tr
```

The regression test covers 0, 1, 31, 32, and 33 byte inputs around the AVX2 lane width, all byte values, and a UTF-8/non-ASCII boundary case, with GNU parity when GNU `tr` is available.

## Caveats

The speedup is from the AVX2 path on this x86_64 host. Non-AVX2 targets use the scalar fallback and should be behavior-preserving, but I did not benchmark those targets here.
