### PR TITLE
cp: fix fail-perm GNU test adaptation

### DIFF
--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -194,8 +194,8 @@ sed -i "s|--coreutils-prog=||g" tests/misc/coreutils.sh
 sed -i "s|grep '^#define HAVE_CAP 1' \$CONFIG_HEADER > /dev/null|true|"  tests/ls/capability.sh
 
 # our messages are better
-sed -i "s|cannot stat 'symlink': Permission denied|not writing through dangling symlink 'symlink'|" tests/cp/fail-perm.sh
-sed -i "s|cp: target directory 'symlink': Permission denied|cp: 'symlink' is not a directory|" tests/cp/fail-perm.sh
+sed -i "s|cp: cannot stat 'symlink': .*|cp: not writing through dangling symlink 'symlink'|" tests/cp/fail-perm.sh
+sed -i "s|cp: target directory 'symlink': .*|cp: 'symlink' is not a directory|" tests/cp/fail-perm.sh
 
 # Our message is a bit better
 sed -i "s|cannot create regular file 'no-such/': Not a directory|'no-such/' is not a directory|" tests/mv/trailing-slash.sh


### PR DESCRIPTION
GNU 9.11 changed `tests/cp/fail-perm.sh` to use `$EACCES` in the expected diagnostics, so our existing replacement no longer matched.

This updates the existing replacement to match the full diagnostic line instead.