### PR TITLE
head: strip os error suffix from stdout write error message

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -162,7 +162,7 @@ impl HeadOptions {
 fn wrap_in_stdout_error(err: io::Error) -> io::Error {
     io::Error::new(
         err.kind(),
-        translate!("head-error-writing-stdout", "err" => err),
+        translate!("head-error-writing-stdout", "err" => uucore::error::strip_errno(&err)),
     )
 }
 

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -896,7 +896,7 @@ fn test_write_to_dev_full() {
                 .pipe_in_fixture(INPUT)
                 .set_stdout(dev_full)
                 .fails()
-                .stderr_contains("error writing 'standard output': No space left on device");
+                .stderr_is("head: error writing 'standard output': No space left on device\n");
         }
     }
 }


### PR DESCRIPTION
should fix 
tests/head/head