### PR TITLE
tr: drop '[:...:]' wrapper from invalid character class error

### DIFF
--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -547,10 +547,9 @@ impl Sequence {
                         b"space" => Ok(Self::Class(Class::Space)),
                         b"upper" => Ok(Self::Class(Class::Upper)),
                         b"xdigit" => Ok(Self::Class(Class::Xdigit)),
-                        _ => Err(BadSequence::InvalidCharClass(format!(
-                            "[:{}:]",
-                            String::from_utf8_lossy(class_name)
-                        ))),
+                        _ => Err(BadSequence::InvalidCharClass(
+                            String::from_utf8_lossy(class_name).into_owned(),
+                        )),
                     },
                 )
             })

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1240,7 +1240,7 @@ fn check_against_gnu_tr_tests_invalid_cc() {
         .args(&["[:fooclass:]", "x"])
         .pipe_in("")
         .fails()
-        .stderr_is("tr: invalid character class '[:fooclass:]'\n");
+        .stderr_is("tr: invalid character class 'fooclass'\n");
 }
 
 #[test]


### PR DESCRIPTION
should fix  tests/tr/tr.pl