### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1857,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
 
 [[package]]
 name = "linktime-proc-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -396,7 +396,7 @@ clap_complete = "4.4"
 clap_mangen = "0.3"
 compare = "0.1.0"
 crossterm = { version = "0.29.0", default-features = false }
-ctor = "0.12.0"
+ctor = "1.0.0"
 ctrlc = { version = "3.5.2", features = ["termination"] }
 divan = { package = "codspeed-divan-compat", version = "4.4.1" }
 dns-lookup = { version = "3.0.0" }

--- a/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
+++ b/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
@@ -10,7 +10,7 @@ use std::io::{Write, stderr};
 use std::{env, ptr};
 
 // This runs automatically when the library is loaded via LD_PRELOAD
-#[ctor]
+#[ctor(unsafe)]
 fn init() {
     unsafe { __stdbuf() };
 }

--- a/tests/test_util_name.rs
+++ b/tests/test_util_name.rs
@@ -16,9 +16,8 @@ pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_coreutils");
 // Set the environment variable for any tests
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
-    // No need for unsafe here
     unsafe {
         env::set_var("UUTESTS_BINARY_PATH", TESTS_BINARY);
     }

--- a/tests/test_uudoc.rs
+++ b/tests/test_uudoc.rs
@@ -23,9 +23,8 @@ pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_uudoc");
 // Set the environment variable for any tests
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
-    // No need for unsafe here
     unsafe {
         env::set_var("UUTESTS_BINARY_PATH", TESTS_BINARY);
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,7 +8,7 @@ use std::env;
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_coreutils");
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     // Allow overriding the binary path (e.g. to test a WASI binary via wasmtime)
     if env::var("UUTESTS_BINARY_PATH").is_err() {

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -3244,7 +3244,7 @@ mod tests {
 
     // Create a init for the test with a fake value (not needed)
     #[cfg(test)]
-    #[ctor::ctor]
+    #[ctor::ctor(unsafe)]
     fn init() {
         unsafe {
             env::set_var("UUTESTS_BINARY_PATH", "");


### PR DESCRIPTION
This PR bumps `ctor` from `0.12.0` to <del>`0.13.0`</del><del>`1.0.0`</del>`1.0.1` and adapts a few files to a change in `ctor`. 