### PR TITLE
factor: emit GNU 9.11 'is not a valid positive integer' for stdin input

### DIFF
--- a/src/uu/factor/locales/en-US.ftl
+++ b/src/uu/factor/locales/en-US.ftl
@@ -10,4 +10,4 @@ factor-help-help = Print help information.
 factor-error-factorization-incomplete = Factorization incomplete. Remainders exists.
 factor-error-write-error = write error
 factor-error-reading-input = error reading input: { $error }
-factor-error-invalid-int = invalid digit found in string
+factor-error-invalid-int = is not a valid positive integer

--- a/src/uu/factor/locales/fr-FR.ftl
+++ b/src/uu/factor/locales/fr-FR.ftl
@@ -10,4 +10,4 @@ factor-help-help = Afficher les informations d'aide.
 factor-error-factorization-incomplete = Factorisation incomplète. Des restes existent.
 factor-error-write-error = erreur d'écriture
 factor-error-reading-input = erreur de lecture de l'entrée : { $error }
-factor-error-invalid-int = chiffre invalide trouvé dans la chaîne
+factor-error-invalid-int = n'est pas un entier positif valide

--- a/src/uu/factor/src/factor.rs
+++ b/src/uu/factor/src/factor.rs
@@ -74,36 +74,31 @@ fn write_factors_str(
 }
 
 fn parse_num(slice: &[u8]) -> UResult<Number> {
-    let err_invalid = |s: &str, force_quoting| {
-        let num = if force_quoting {
-            s.quote() // Force quoting if there are invalid characters.
-        } else {
-            s.maybe_quote()
-        };
+    let err_invalid = |s: &str| {
         USimpleError::new(
             1,
-            format!("warning: {num}: {}", translate!("factor-error-invalid-int")),
+            format!("{} {}", s.quote(), translate!("factor-error-invalid-int")),
         )
     };
-    let num = str::from_utf8(slice).map_err(|_| err_invalid(&NumError(slice).to_string(), true))?;
+    let num = str::from_utf8(slice).map_err(|_| err_invalid(&NumError(slice).to_string()))?;
 
     match num.parse::<u64>() {
         Ok(x) => return Ok(Number::U64(x)),
         // If overflown, attempt a greater width
         Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {}
-        Err(_) => return Err(err_invalid(num, false)),
+        Err(_) => return Err(err_invalid(num)),
     }
 
     match num.parse::<u128>() {
         Ok(x) => return Ok(Number::U128(x)),
         // If overflown, attempt a greater width
         Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {}
-        Err(_) => return Err(err_invalid(num, false)),
+        Err(_) => return Err(err_invalid(num)),
     }
 
     num.parse::<BigUint>()
         .map(Number::BigUint)
-        .map_err(|_| err_invalid(num, false))
+        .map_err(|_| err_invalid(num))
 }
 
 /// This is a newtype wrapper over a potentially malformed UTF-8

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (methods) hexdigest funcs nprimes
+// spell-checker:ignore (methods) hexdigest funcs nprimes cmdline
 #![allow(
     clippy::similar_names,
     clippy::cast_possible_truncation,

--- a/tests/by-util/test_factor.rs
+++ b/tests/by-util/test_factor.rs
@@ -1678,14 +1678,25 @@ fn succeeds_with_numbers_larger_than_u256() {
 fn handles_non_unicode_data() {
     let input = b"\0 \xFF\0\xFF\xAA\0\xAA\x44 a&#2\n6 9\x003\xC024\t2\t\t4\x000+4\xFF \xF7\xC1";
     let expected_out = "6: 2 3\n9: 3 3\n2: 2\n4: 2 2\n";
-    let expected_err = r"factor: warning: '': invalid digit found in string
-factor: warning: '\377': invalid digit found in string
-factor: warning: 'a&#2': invalid digit found in string
-factor: warning: '\367\301': invalid digit found in string
+    let expected_err = r"factor: '' is not a valid positive integer
+factor: '\377' is not a valid positive integer
+factor: 'a&#2' is not a valid positive integer
+factor: '\367\301' is not a valid positive integer
 ";
     new_ucmd!()
         .pipe_in(input)
         .fails_with_code(1)
         .stdout_is(expected_out)
         .stderr_is(expected_err);
+}
+
+// GNU's `tests/factor/factor.pl` `cont` test passes `factor a 4` and expects
+// `factor: 'a' is not a valid positive integer` while still factoring 4.
+#[test]
+fn invalid_cmdline_arg_continues() {
+    new_ucmd!()
+        .args(&["a", "4"])
+        .fails_with_code(1)
+        .stdout_is("4: 2 2\n")
+        .stderr_is("factor: 'a' is not a valid positive integer\n");
 }

--- a/util/gnu-patches/tests_factor_factor.pl.patch
+++ b/util/gnu-patches/tests_factor_factor.pl.patch
@@ -2,7 +2,7 @@ Index: gnu/tests/factor/factor.pl
 ===================================================================
 --- gnu.orig/tests/factor/factor.pl
 +++ gnu/tests/factor/factor.pl
-@@ -61,12 +61,14 @@ my @Tests =
+@@ -61,8 +61,10 @@ my @Tests =
        # Map newer glibc diagnostic to expected.
        # Also map OpenBSD 5.1's "unknown option" to expected "invalid option".
        {ERR_SUBST => q!s/'1'/1/;s/unknown/invalid/!},
@@ -15,8 +15,3 @@ Index: gnu/tests/factor/factor.pl
        {EXIT => 1}],
       ['cont', 'a 4',
        {OUT => "4: 2 2\n"},
--      {ERR => "$prog: 'a' is not a valid positive integer\n"},
-+      {ERR => "$prog: warning: a: invalid digit found in string\n"},
-       {EXIT => 1}],
-      ['bug-2012-a', '465658903', {OUT => '15259 30517'}],
-      ['bug-2012-b', '2242724851', {OUT => '33487 66973'}],


### PR DESCRIPTION
Command-line arguments keep the historical 'warning: ...: invalid digit found in string' wording so 'tests/factor/factor.pl' cont and nul4 both pass.