### PR TITLE
sort:Optimize sort collation for long lines

### DIFF
--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -24,8 +24,20 @@ use crate::{
 };
 
 const ALLOC_CHUNK_SIZE: usize = 64 * 1024;
+const COLLATION_KEY_SKIPPED: usize = 1usize << (usize::BITS - 1);
+const COLLATION_KEY_OFFSET_MASK: usize = !COLLATION_KEY_SKIPPED;
 const MAX_TOKEN_BUFFER_BYTES: usize = 4 * 1024 * 1024;
 const MAX_TOKEN_BUFFER_ELEMS: usize = MAX_TOKEN_BUFFER_BYTES / size_of::<Range<usize>>();
+
+#[inline]
+fn collation_key_end(entry: usize) -> usize {
+    entry & COLLATION_KEY_OFFSET_MASK
+}
+
+#[inline]
+fn is_collation_key_skipped(entry: usize) -> bool {
+    entry & COLLATION_KEY_SKIPPED != 0
+}
 
 self_cell!(
     /// The chunk that is passed around between threads.
@@ -55,20 +67,42 @@ pub struct LineData<'a> {
     pub line_num_floats: Vec<Option<f64>>,
     /// Arena buffer holding all collation sort keys concatenated.
     pub collation_key_buffer: Vec<u8>,
-    /// End offsets into `collation_key_buffer` for each line's sort key.
+    /// End offsets into `collation_key_buffer`; the high bit marks lines that use lazy collation.
     pub collation_key_ends: Vec<usize>,
 }
 
 impl LineData<'_> {
     /// Get the collation sort key for a line at the given index.
-    pub fn collation_key(&self, index: usize) -> &[u8] {
+    pub fn collation_key(&self, index: usize) -> Option<&[u8]> {
+        let entry = self.collation_key_ends[index];
+        if is_collation_key_skipped(entry) {
+            return None;
+        }
         let start = if index == 0 {
             0
         } else {
-            self.collation_key_ends[index - 1]
+            collation_key_end(self.collation_key_ends[index - 1])
         };
-        let end = self.collation_key_ends[index];
-        &self.collation_key_buffer[start..end]
+        let end = collation_key_end(entry);
+        Some(&self.collation_key_buffer[start..end])
+    }
+
+    /// Record that the current end of `collation_key_buffer` terminates the
+    /// precomputed collation key of the line being appended.
+    #[inline]
+    pub fn push_collation_key_end(&mut self) {
+        let end = self.collation_key_buffer.len();
+        debug_assert_eq!(end & COLLATION_KEY_SKIPPED, 0);
+        self.collation_key_ends.push(end);
+    }
+
+    /// Record a line whose collation key was not precomputed; `collation_key`
+    /// returns `None` for it so it is compared lazily via the locale collator.
+    #[inline]
+    pub fn push_skipped_collation_key(&mut self) {
+        let end = self.collation_key_buffer.len();
+        debug_assert_eq!(end & COLLATION_KEY_SKIPPED, 0);
+        self.collation_key_ends.push(end | COLLATION_KEY_SKIPPED);
     }
 }
 
@@ -313,6 +347,9 @@ fn parse_lines<'a>(
     }
     if settings.mode == SortMode::Numeric {
         line_data.line_num_floats.reserve(estimated);
+    }
+    if settings.precomputed.fast_locale_collation {
+        line_data.collation_key_ends.reserve(estimated);
     }
     let mut start = 0usize;
     let mut index = 0usize;

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -132,6 +132,11 @@ const POSITIVE: &u8 = &b'+';
 const MIN_AUTOMATIC_BUF_SIZE: usize = 512 * 1024; // 512 KiB
 const FALLBACK_AUTOMATIC_BUF_SIZE: usize = 32 * 1024 * 1024; // 32 MiB
 const MAX_AUTOMATIC_BUF_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
+// Longest line for which an ICU collation key is precomputed. Keys are a
+// small multiple of the line length, so for lines beyond this cap the cost
+// of materializing and storing multi-MiB keys outweighs the per-comparison
+// savings; such lines fall back to lazy `locale_cmp` (see `Line::create`).
+const MAX_PRECOMPUTED_COLLATION_KEY_LINE_LEN: usize = u16::MAX as usize;
 
 #[derive(Debug, Error)]
 pub enum SortError {
@@ -639,10 +644,12 @@ impl<'a> Line<'a> {
     ) -> Self {
         #[cfg(feature = "i18n-collator")]
         if settings.precomputed.fast_locale_collation {
-            compute_sort_key_utf8(line, &mut line_data.collation_key_buffer);
-            line_data
-                .collation_key_ends
-                .push(line_data.collation_key_buffer.len());
+            if line.len() <= MAX_PRECOMPUTED_COLLATION_KEY_LINE_LEN {
+                compute_sort_key_utf8(line, &mut line_data.collation_key_buffer);
+                line_data.push_collation_key_end();
+            } else {
+                line_data.push_skipped_collation_key();
+            }
             return Self { line, index };
         }
 
@@ -2637,9 +2644,13 @@ fn compare_by<'a>(
 
     #[cfg(feature = "i18n-collator")]
     if global_settings.precomputed.fast_locale_collation {
-        let a_key = a_line_data.collation_key(a.index);
-        let b_key = b_line_data.collation_key(b.index);
-        let mut cmp = a_key.cmp(b_key);
+        let mut cmp = match (
+            a_line_data.collation_key(a.index),
+            b_line_data.collation_key(b.index),
+        ) {
+            (Some(a_key), Some(b_key)) => a_key.cmp(b_key),
+            _ => locale_cmp(a.line, b.line),
+        };
         // If collation keys are equal, fall back to lexicographic comparison
         // This can be the case for inputs like `01` and `0_1`, which have equal keys
         if cmp == Ordering::Equal {

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -3086,4 +3086,50 @@ fn test_sort_locale_punctuation() {
     }
 }
 
+#[test]
+fn test_locale_collation_long_lines() {
+    // Lines longer than 64 KiB skip collation-key precomputation and are
+    // compared lazily with the locale collator (issue #12138). Interleave
+    // long and short lines so lazy lines are compared against precomputed
+    // ones, and precomputed lines follow lazy ones (validating that key
+    // offsets stay correct after a skipped entry).
+    const LONG: usize = 70_000; // > MAX_PRECOMPUTED_COLLATION_KEY_LINE_LEN
+
+    let long_e_acute = "é".repeat(LONG / 2); // 2 bytes per char => above the cap
+    let long_upper_a = "A".repeat(LONG);
+    let long_lower_a = "a".repeat(LONG);
+    let input = format!("f\n{long_upper_a}\nb\n{long_lower_a}\n{long_e_acute}\na\n");
+    // Locale order: a < aa… < AA… < b < éé… < f.
+    // Byte order would instead yield AA… < a < aa… < b < f < éé….
+    let expected = format!("a\n{long_lower_a}\n{long_upper_a}\nb\n{long_e_acute}\nf\n");
+
+    new_ucmd!()
+        .env("LC_ALL", "en_US.UTF-8")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
+fn test_locale_collation_long_line_boundary() {
+    // Lines of exactly 65,535 bytes still get a precomputed collation key,
+    // while 65,536-byte lines take the lazy path. Both paths must agree on
+    // locale-aware order: shorter prefixes first, lowercase before uppercase
+    // within the same length.
+    const AT_CAP: usize = 65_535; // == MAX_PRECOMPUTED_COLLATION_KEY_LINE_LEN
+
+    let lower_at = "a".repeat(AT_CAP);
+    let upper_at = "A".repeat(AT_CAP);
+    let lower_over = "a".repeat(AT_CAP + 1);
+    let upper_over = "A".repeat(AT_CAP + 1);
+    let input = format!("{upper_over}\n{lower_at}\n{upper_at}\n{lower_over}\n");
+    let expected = format!("{lower_at}\n{upper_at}\n{lower_over}\n{upper_over}\n");
+
+    new_ucmd!()
+        .env("LC_ALL", "en_US.UTF-8")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(expected);
+}
+
 /* spell-checker: enable */


### PR DESCRIPTION
## What changed

- Avoid precomputing ICU collation sort keys for lines larger than 65,535 bytes.
- Store optional collation key ranges so very long lines can fall back to lazy locale comparison during sorting.

## Why

Fixes #12138. In UTF-8 locales, `sort` precomputed ICU collation keys for every input line. For inputs with a small number of very large lines, such as 26 lines of 200 MiB each, the cost of generating and storing multi-GiB collation keys dominated runtime.

## Impact

Small and normal-sized lines keep the existing precomputed-key fast path. Very long lines skip the expensive key materialization and use `locale_cmp` when compared.

## Validation

- `cargo check -p uu_sort`
- `cargo test -p uu_sort`
- `cargo test -p coreutils --test tests test_sort::test_default_unsorted_ints -- --exact`
- Compared output against GNU sort with `cmp` for 52 MiB and 130 MiB reproducer inputs.
- Hyperfine on the issue-sized 5.1 GiB input with `LC_ALL=en_US.UTF-8 --parallel 1 --buffer-size 8G`:
  - uutils release: 5.054 s
  - GNU gsort 9.11: 33.685 s
