### PR TITLE
uucore: handle SIGRTMIN+N and SIGRTMAX-N notation

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -1148,7 +1148,7 @@ fn list_signal_handling(log: &SignalActionLog) {
             SignalActionKind::Ignore => "IGNORE",
             SignalActionKind::Block => "BLOCK",
         };
-        let signal_name = signal_name_by_value(sig_value).unwrap_or("?");
+        let signal_name = signal_name_by_value(sig_value).unwrap_or("?".to_string());
         eprintln!("{signal_name:<10} ({}): {action}", sig_value as i32);
     }
 }

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) chdir progname subcommand subcommands unsets setenv putenv spawnp SIGSEGV SIGBUS sigaction Sigmask sigprocmask elidable
+// spell-checker:ignore (ToDO) chdir progname subcommand subcommands unsets setenv putenv spawnp SIGSEGV SIGBUS sigaction Sigmask sigprocmask elidable sigset sigaddset sigemptyset
 
 pub mod native_int_str;
 pub mod split_iterator;
@@ -20,10 +20,7 @@ use native_int_str::{
 #[cfg(unix)]
 use nix::libc;
 #[cfg(unix)]
-use nix::sys::signal::{
-    SigHandler::{SigDfl, SigIgn},
-    SigSet, SigmaskHow, Signal, signal, sigprocmask,
-};
+use nix::sys::signal::{SigSet, SigmaskHow, Signal, sigprocmask};
 #[cfg(unix)]
 use nix::unistd::execvp;
 use std::borrow::Cow;
@@ -37,13 +34,18 @@ use std::io;
 use std::io::Write as _;
 use std::io::stderr;
 #[cfg(unix)]
+use std::mem::zeroed;
+#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 
 use uucore::display::{Quotable, print_all_env_vars};
 use uucore::error::{ExitCode, UError, UResult, USimpleError, UUsageError};
 use uucore::line_ending::LineEnding;
 #[cfg(unix)]
-use uucore::signals::{signal_by_name_or_value, signal_name_by_value, signal_number_upper_bound};
+use uucore::signals::{
+    realtime_signal_bounds, signal_by_name_or_value, signal_name_by_value,
+    signal_number_upper_bound,
+};
 use uucore::translate;
 use uucore::{format_usage, show_warning};
 
@@ -295,16 +297,18 @@ fn build_signal_request(
 }
 
 #[cfg(unix)]
-fn signal_from_value(sig_value: usize) -> UResult<Signal> {
-    Signal::try_from(sig_value as i32).map_err(|_| {
-        USimpleError::new(
-            125,
-            translate!(
-                "env-error-invalid-signal",
-                "signal" => sig_value.to_string().quote()
-            ),
-        )
-    })
+fn signal_is_valid(sig: usize) -> bool {
+    if Signal::try_from(sig as i32).is_err() {
+        // nix::sys::signal does not know about real-time signals, so check that
+        // ourselves.
+        if let Some((rtmin, rtmax)) = realtime_signal_bounds() {
+            return sig >= rtmin && sig <= rtmax;
+        }
+
+        return false;
+    }
+
+    true
 }
 
 fn load_config_file(opts: &mut Options) -> UResult<()> {
@@ -1072,15 +1076,16 @@ fn apply_signal_action<F>(
     signal_fn: F,
 ) -> UResult<()>
 where
-    F: Fn(Signal) -> UResult<()>,
+    F: Fn(usize) -> UResult<()>,
 {
     request.for_each_signal(|sig_value, explicit| {
         // On some platforms ALL_SIGNALS may contain values that are not valid in libc.
         // Skip those invalid ones and continue (GNU env also ignores undefined signals).
-        let Ok(sig) = signal_from_value(sig_value) else {
+        if !signal_is_valid(sig_value) {
             return Ok(());
-        };
-        signal_fn(sig)?;
+        }
+
+        signal_fn(sig_value)?;
         log.record(sig_value, action_kind, explicit);
 
         // Set environment variable to communicate to Rust child processes
@@ -1096,9 +1101,14 @@ where
 }
 
 #[cfg(unix)]
-fn ignore_signal(sig: Signal) -> UResult<()> {
+fn ignore_signal(sig: usize) -> UResult<()> {
     // SAFETY: This is safe because we write the handler for each signal only once, and therefore "the current handler is the default", as the documentation requires it.
-    let result = unsafe { signal(sig, SigIgn) };
+    // nix::sys::signal::Signal does not cover real-time signals, so we need to call
+    // libc::signal directly.
+    let result = unsafe {
+        let res = libc::signal(sig as libc::c_int, libc::SIG_IGN);
+        nix::errno::Errno::result(res)
+    };
     if let Err(err) = result {
         return Err(USimpleError::new(
             125,
@@ -1109,8 +1119,13 @@ fn ignore_signal(sig: Signal) -> UResult<()> {
 }
 
 #[cfg(unix)]
-fn reset_signal(sig: Signal) -> UResult<()> {
-    let result = unsafe { signal(sig, SigDfl) };
+fn reset_signal(sig: usize) -> UResult<()> {
+    // nix::sys::signal::Signal does not cover real-time signals, so we need to call
+    // libc::signal directly.
+    let result = unsafe {
+        let res = libc::signal(sig as libc::c_int, libc::SIG_DFL);
+        nix::errno::Errno::result(res)
+    };
     if let Err(err) = result {
         return Err(USimpleError::new(
             125,
@@ -1121,9 +1136,42 @@ fn reset_signal(sig: Signal) -> UResult<()> {
 }
 
 #[cfg(unix)]
-fn block_signal(sig: Signal) -> UResult<()> {
-    let mut set = SigSet::empty();
-    set.add(sig);
+fn sigset_from_signal_value(sig: usize) -> UResult<SigSet> {
+    // nix::sys::signal::Signal does not cover real time signals, so we need to build
+    // sigset_t manually using libc.
+    let mut sigset: libc::sigset_t = unsafe { zeroed() };
+
+    if let Err(err) = unsafe { nix::errno::Errno::result(libc::sigemptyset(&raw mut sigset)) } {
+        return Err(USimpleError::new(
+            125,
+            translate!(
+                "env-error-failed-set-signal-action",
+                "signal" => (sig as i32),
+                "error" => err.desc()
+            ),
+        ));
+    }
+
+    if let Err(err) =
+        unsafe { nix::errno::Errno::result(libc::sigaddset(&raw mut sigset, sig as libc::c_int)) }
+    {
+        return Err(USimpleError::new(
+            125,
+            translate!(
+                "env-error-failed-set-signal-action",
+                "signal" => (sig as i32),
+                "error" => err.desc()
+            ),
+        ));
+    }
+
+    Ok(unsafe { SigSet::from_sigset_t_unchecked(sigset) })
+}
+
+#[cfg(unix)]
+fn block_signal(sig: usize) -> UResult<()> {
+    let set = sigset_from_signal_value(sig)?;
+
     if let Err(err) = sigprocmask(SigmaskHow::SIG_BLOCK, Some(&set), None) {
         return Err(USimpleError::new(
             125,

--- a/src/uucore/src/lib/features/signals.rs
+++ b/src/uucore/src/lib/features/signals.rs
@@ -462,16 +462,18 @@ pub fn signal_name_by_value(signal_value: usize) -> Option<String> {
     })
 }
 
+/// Returns the values of SIGRTMIN and SIGRTMAX if defined on this platform.
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn realtime_signal_bounds() -> Option<(usize, usize)> {
+pub fn realtime_signal_bounds() -> Option<(usize, usize)> {
     let rtmin = libc::SIGRTMIN();
     let rtmax = libc::SIGRTMAX();
 
     (0 < rtmin && rtmin <= rtmax).then_some((rtmin as usize, rtmax as usize))
 }
 
+/// Returns the values of SIGRTMIN and SIGRTMAX if defined on this platform.
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
-fn realtime_signal_bounds() -> Option<(usize, usize)> {
+pub fn realtime_signal_bounds() -> Option<(usize, usize)> {
     None
 }
 

--- a/src/uucore/src/lib/features/signals.rs
+++ b/src/uucore/src/lib/features/signals.rs
@@ -399,9 +399,6 @@ pub fn signal_by_name_or_value(signal_name_or_value: &str) -> Option<usize> {
         if is_signal(value) {
             return Some(value);
         }
-        return realtime_signal_bounds()
-            .filter(|&(rtmin, rtmax)| value >= rtmin && value <= rtmax)
-            .map(|_| value);
     }
     let signal_name = signal_name_upcase.trim_start_matches("SIG");
 
@@ -409,21 +406,60 @@ pub fn signal_by_name_or_value(signal_name_or_value: &str) -> Option<usize> {
         return Some(pos);
     }
 
-    realtime_signal_bounds().and_then(|(rtmin, rtmax)| match signal_name {
-        "RTMIN" => Some(rtmin),
-        "RTMAX" => Some(rtmax),
-        _ => None,
+    realtime_signal_bounds().and_then(|(rtmin, rtmax)| {
+        if signal_name.starts_with("RTMIN+") {
+            if let Ok(n) = signal_name.trim_start_matches("RTMIN+").parse::<usize>() {
+                let value = rtmin + n;
+                return (value >= rtmin && value <= rtmax).then_some(value);
+            }
+        }
+
+        if signal_name.starts_with("RTMAX-") {
+            if let Ok(n) = signal_name.trim_start_matches("RTMAX-").parse::<usize>() {
+                let value = rtmax - n;
+                return (value >= rtmin && value <= rtmax).then_some(value);
+            }
+        }
+
+        match signal_name {
+            "RTMIN" => Some(rtmin),
+            "RTMAX" => Some(rtmax),
+            _ => None,
+        }
     })
 }
 
 /// Returns true if the given number is a valid signal number.
 pub fn is_signal(num: usize) -> bool {
-    num < ALL_SIGNALS.len()
+    if num < ALL_SIGNALS.len() {
+        return true;
+    }
+
+    if let Some((rtmin, rtmax)) = realtime_signal_bounds() {
+        return num >= rtmin && num <= rtmax;
+    }
+
+    false
 }
 
 /// Returns the signal name for a given signal value.
-pub fn signal_name_by_value(signal_value: usize) -> Option<&'static str> {
-    ALL_SIGNALS.get(signal_value).copied()
+pub fn signal_name_by_value(signal_value: usize) -> Option<String> {
+    if let Some(name) = ALL_SIGNALS.get(signal_value).copied() {
+        return Some(name.to_string());
+    }
+
+    realtime_signal_bounds().and_then(|(rtmin, rtmax)| {
+        if signal_value == rtmin {
+            Some("RTMIN".to_string())
+        } else if signal_value == rtmax {
+            Some("RTMAX".to_string())
+        } else if signal_value > rtmin && signal_value < rtmax {
+            let n = signal_value - rtmin;
+            Some(format!("RTMIN+{n}"))
+        } else {
+            None
+        }
+    })
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -449,7 +485,7 @@ pub fn signal_number_upper_bound() -> usize {
 /// Returns the signal name for list-style interfaces.
 pub fn signal_list_name_by_value(signal_value: usize) -> Option<String> {
     if let Some(signal_name) = signal_name_by_value(signal_value) {
-        return Some(signal_name.to_string());
+        return Some(signal_name);
     }
 
     realtime_signal_bounds().and_then(|(rtmin, rtmax)| {
@@ -720,7 +756,7 @@ fn signal_by_long_name() {
 #[test]
 fn name() {
     for (value, signal) in ALL_SIGNALS.iter().enumerate() {
-        assert_eq!(signal_name_by_value(value), Some(*signal));
+        assert_eq!(signal_name_by_value(value), Some(signal.to_string()));
     }
 }
 
@@ -784,11 +820,35 @@ fn linux_realtime_signals_resolve_by_name_or_value() {
 
     // By name
     assert_eq!(signal_by_name_or_value("RTMIN"), Some(rtmin));
+    for i in 1..rtmax - rtmin - 1 {
+        assert_eq!(
+            signal_by_name_or_value(&format!("RTMIN+{i}")),
+            Some(rtmin + i)
+        );
+        assert_eq!(
+            signal_by_name_or_value(&format!("RTMAX-{i}")),
+            Some(rtmax - i)
+        );
+    }
     assert_eq!(signal_by_name_or_value("RTMAX"), Some(rtmax));
     assert_eq!(signal_by_name_or_value("SIGRTMIN"), Some(rtmin));
+    for i in 1..rtmax - rtmin - 1 {
+        assert_eq!(
+            signal_by_name_or_value(&format!("SIGRTMIN+{i}")),
+            Some(rtmin + i)
+        );
+        assert_eq!(
+            signal_by_name_or_value(&format!("SIGRTMAX-{i}")),
+            Some(rtmax - i)
+        );
+    }
     assert_eq!(signal_by_name_or_value("SIGRTMAX"), Some(rtmax));
 
     // By numeric value
     assert_eq!(signal_by_name_or_value(&rtmin.to_string()), Some(rtmin));
+    for i in 1..rtmax - rtmin - 1 {
+        let value = rtmin + i;
+        assert_eq!(signal_by_name_or_value(&value.to_string()), Some(value));
+    }
     assert_eq!(signal_by_name_or_value(&rtmax.to_string()), Some(rtmax));
 }

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -946,6 +946,21 @@ fn test_env_block_signal_flag() {
 }
 
 #[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_env_block_realtime_signal() {
+    new_ucmd!()
+        .env("PATH", PATH)
+        .args(&["--block-signal=SIGRTMIN+7", "true"])
+        .succeeds()
+        .no_stderr();
+    new_ucmd!()
+        .env("PATH", PATH)
+        .args(&["--block-signal=SIGRTMAX-7", "true"])
+        .succeeds()
+        .no_stderr();
+}
+
+#[test]
 #[cfg(unix)]
 fn test_env_list_signal_handling_reports_ignore() {
     let result = new_ucmd!()

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -6,6 +6,8 @@
 use regex::Regex;
 use std::os::unix::process::ExitStatusExt;
 use std::process::{Child, Command};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use uucore::signals::realtime_signal_bounds;
 use uutests::new_ucmd;
 
 // A child process the tests will try to kill.
@@ -538,4 +540,34 @@ fn test_kill_realtime_signal() {
         .arg(format!("{}", target.pid()))
         .succeeds();
     assert_eq!(target.wait_for_signal(), Some(libc::SIGRTMIN()));
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[test]
+fn test_kill_with_rtmax_offset() {
+    let (_, rtmax) = realtime_signal_bounds().unwrap();
+    let sig: i32 = (rtmax as i32) - 7;
+
+    let mut target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("SIGRTMAX-7")
+        .arg(format!("{}", target.pid()))
+        .succeeds();
+    assert_eq!(target.wait_for_signal(), Some(sig));
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[test]
+fn test_kill_with_rtmin_offset() {
+    let (rtmin, _) = realtime_signal_bounds().unwrap();
+    let sig: i32 = (rtmin as i32) + 7;
+
+    let mut target = Target::new();
+    new_ucmd!()
+        .arg("-s")
+        .arg("SIGRTMIN+7")
+        .arg(format!("{}", target.pid()))
+        .succeeds();
+    assert_eq!(target.wait_for_signal(), Some(sig));
 }


### PR DESCRIPTION
On Linux, signals in the range SIGRTMIN..SIGRTMAX are valid in addition to SIGRTMIN and SIGRTMAX themselves. The notation SIGRTMIN+N and SIGRTMAX-N is used to reference signals in that range.

Adapt signal helpers to understand this.

Fixes: #11151