### PR TITLE
yes: move import to the other imports

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -9,13 +9,12 @@ use clap::{Arg, ArgAction, Command, builder::ValueParser};
 use std::ffi::OsString;
 use std::io::{self, Write};
 use uucore::error::{UResult, USimpleError, strip_errno};
-use uucore::format_usage;
-use uucore::translate;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use uucore::pipes::MAX_ROOTLESS_PIPE_SIZE;
+use uucore::{format_usage, translate};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const PAGE_SIZE: usize = 4096;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use uucore::pipes::MAX_ROOTLESS_PIPE_SIZE;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const BUF_SIZE: usize = MAX_ROOTLESS_PIPE_SIZE;
 // it's possible that using a smaller or larger buffer might provide better performance
@@ -116,6 +115,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
     use uucore::pipes::{pipe, splice, tee};
+
     let aligned = PAGE_SIZE.is_multiple_of(bytes.len());
     repeat_content_to_capacity(&mut bytes);
     let bytes = bytes.as_slice();


### PR DESCRIPTION
This PR moves an import, currently sandwiched between `const`s, to the other imports. And adds an empty line to separate imports from the code.