### PR TITLE
uucore: gate tests using linux specific syscall & remove unsafe

### DIFF
--- a/src/uucore/src/lib/features/proc_info.rs
+++ b/src/uucore/src/lib/features/proc_info.rs
@@ -478,8 +478,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_thread_ids() {
-        let main_tid = unsafe { libc::gettid() };
+        let main_tid = rustix::thread::gettid();
         std::thread::spawn(move || {
             let mut pid_entry = ProcessInformation::try_new(
                 PathBuf::from_str(&format!("/proc/{}", current_pid())).unwrap(),
@@ -489,7 +490,7 @@ mod tests {
 
             assert!(thread_ids.contains(&(main_tid as usize)));
 
-            let new_thread_tid = unsafe { libc::gettid() };
+            let new_thread_tid = rustix::thread::gettid();
             assert!(thread_ids.contains(&(new_thread_tid as usize)));
         })
         .join()


### PR DESCRIPTION
It seems `gettid` is Linux specific syscall.