### PR TITLE
vscode: update rust-analyzer check command to use clippy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.import": [
         "./.vscode/cSpell.json"
-    ]
+    ],
+    "rust-analyzer.check.command": "clippy"
 }


### PR DESCRIPTION
Surfaces clippy lints to vscode.

cc: @sylvestre