### PR TITLE
toml: avoid defining tables out-of-order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -495,6 +495,66 @@ uu_base32 = { version = "0.8.0", path = "src/uu/base32" }
 uu_checksum_common = { version = "0.8.0", path = "src/uu/checksum_common" }
 uutests = { version = "0.8.0", package = "uutests", path = "tests/uutests" }
 
+# This is the linting configuration for all crates.
+# In order to use these, all crates have `[lints] workspace = true` section.
+[workspace.lints.rust]
+# Allow "fuzzing" as a "cfg" condition name and "cygwin" as a value for "target_os"
+# https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(fuzzing)',
+  'cfg(target_os, values("cygwin"))',
+  'cfg(wasi_runner)',
+] }
+unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+collapsible_if = { level = "allow", priority = 127 } # remove me
+# The counts were generated with this command:
+#   cargo clippy --all-targets --workspace --message-format=json --quiet \
+#     | jq -r '.message.code.code | select(. != null and startswith("clippy::"))' \
+#     | sort | uniq -c | sort -h -r
+#
+all = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+use_self = "warn"                            # nursery lint
+cargo_common_metadata = "allow"              # 3240
+multiple_crate_versions = "allow"            # 2882
+missing_errors_doc = "allow"                 # 1572
+missing_panics_doc = "allow"                 # 946
+must_use_candidate = "allow"                 # 322
+match_same_arms = "allow"                    # 204
+cast_possible_truncation = "allow"           # 122
+too_many_lines = "allow"                     # 101
+cast_possible_wrap = "allow"                 # 78
+cast_sign_loss = "allow"                     # 70
+struct_excessive_bools = "allow"             # 68
+cast_precision_loss = "allow"                # 52
+cast_lossless = "allow"                      # 35
+ignored_unit_patterns = "allow"              # 21
+similar_names = "allow"                      # 20
+needless_pass_by_value = "allow"             # 16
+float_cmp = "allow"                          # 12
+return_self_not_must_use = "allow"           # 8
+inline_always = "allow"                      # 6
+fn_params_excessive_bools = "allow"          # 6
+used_underscore_items = "allow"              # 2
+should_panic_without_expect = "allow"        # 2
+
+doc_markdown = "allow"
+unused_self = "allow"
+enum_glob_use = "allow"
+unnested_or_patterns = "allow"
+implicit_hasher = "allow"
+doc_link_with_quotes = "allow"
+format_push_string = "allow"
+flat_map_option = "allow"
+from_iter_instead_of_collect = "allow"
+large_types_passed_by_value = "allow"
+
+[workspace.metadata.cargo-shear]
+ignored = ["clap", "fluent", "libstdbuf"]
+
 [dependencies]
 clap.workspace = true
 clap_complete = { workspace = true, optional = true }
@@ -621,17 +681,6 @@ who = { optional = true, version = "0.8.0", package = "uu_who", path = "src/uu/w
 whoami = { optional = true, version = "0.8.0", package = "uu_whoami", path = "src/uu/whoami" }
 yes = { optional = true, version = "0.8.0", package = "uu_yes", path = "src/uu/yes" }
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-rustix.workspace = true
-
-# this breaks clippy linting with: "tests/by-util/test_factor_benches.rs: No such file or directory (os error 2)"
-# factor_benches = { optional = true, version = "0.0.0", package = "uu_factor_benches", path = "tests/benches/factor" }
-
-#
-# * pinned transitive dependencies
-# Not needed for now. Keep as examples:
-#pin_cc = { version="1.0.61, < 1.0.62", package="cc" } ## cc v1.0.62 has compiler errors for MinRustV v1.32.0, requires 1.34 (for `std::str::split_ascii_whitespace()`)
-
 [dev-dependencies]
 ctor.workspace = true
 filetime.workspace = true
@@ -662,6 +711,17 @@ walkdir.workspace = true
 hex-literal = "1.0.0"
 rstest.workspace = true
 rstest_reuse.workspace = true
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+rustix.workspace = true
+
+# this breaks clippy linting with: "tests/by-util/test_factor_benches.rs: No such file or directory (os error 2)"
+# factor_benches = { optional = true, version = "0.0.0", package = "uu_factor_benches", path = "tests/benches/factor" }
+
+#
+# * pinned transitive dependencies
+# Not needed for now. Keep as examples:
+#pin_cc = { version="1.0.61, < 1.0.62", package="cc" } ## cc v1.0.62 has compiler errors for MinRustV v1.32.0, requires 1.34 (for `std::str::split_ascii_whitespace()`)
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true, features = [
@@ -707,63 +767,3 @@ debug = true
 
 [lints]
 workspace = true
-
-# This is the linting configuration for all crates.
-# In order to use these, all crates have `[lints] workspace = true` section.
-[workspace.lints.rust]
-# Allow "fuzzing" as a "cfg" condition name and "cygwin" as a value for "target_os"
-# https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(fuzzing)',
-  'cfg(target_os, values("cygwin"))',
-  'cfg(wasi_runner)',
-] }
-unused_qualifications = "warn"
-
-[workspace.lints.clippy]
-collapsible_if = { level = "allow", priority = 127 } # remove me
-# The counts were generated with this command:
-#   cargo clippy --all-targets --workspace --message-format=json --quiet \
-#     | jq -r '.message.code.code | select(. != null and startswith("clippy::"))' \
-#     | sort | uniq -c | sort -h -r
-#
-all = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-use_self = "warn"                            # nursery lint
-cargo_common_metadata = "allow"              # 3240
-multiple_crate_versions = "allow"            # 2882
-missing_errors_doc = "allow"                 # 1572
-missing_panics_doc = "allow"                 # 946
-must_use_candidate = "allow"                 # 322
-match_same_arms = "allow"                    # 204
-cast_possible_truncation = "allow"           # 122
-too_many_lines = "allow"                     # 101
-cast_possible_wrap = "allow"                 # 78
-cast_sign_loss = "allow"                     # 70
-struct_excessive_bools = "allow"             # 68
-cast_precision_loss = "allow"                # 52
-cast_lossless = "allow"                      # 35
-ignored_unit_patterns = "allow"              # 21
-similar_names = "allow"                      # 20
-needless_pass_by_value = "allow"             # 16
-float_cmp = "allow"                          # 12
-return_self_not_must_use = "allow"           # 8
-inline_always = "allow"                      # 6
-fn_params_excessive_bools = "allow"          # 6
-used_underscore_items = "allow"              # 2
-should_panic_without_expect = "allow"        # 2
-
-doc_markdown = "allow"
-unused_self = "allow"
-enum_glob_use = "allow"
-unnested_or_patterns = "allow"
-implicit_hasher = "allow"
-doc_link_with_quotes = "allow"
-format_push_string = "allow"
-flat_map_option = "allow"
-from_iter_instead_of_collect = "allow"
-large_types_passed_by_value = "allow"
-
-[workspace.metadata.cargo-shear]
-ignored = ["clap", "fluent", "libstdbuf"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,9 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+[package.metadata]
+cargo-fuzz = true
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
@@ -16,9 +19,6 @@ members = ["."]
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
-
-[package.metadata]
-cargo-fuzz = true
 
 # Enable debug symbols in release builds for readable backtraces
 # when fuzzing discovers crashes. This addresses issue #5343.

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -26,14 +26,14 @@ thiserror = { workspace = true }
 uucore = { workspace = true, features = ["fast-inc", "fs", "pipes", "signals"] }
 fluent = { workspace = true }
 
-[target.'cfg(windows)'.dependencies]
-winapi-util = { workspace = true }
-windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
-
 [dev-dependencies]
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[target.'cfg(windows)'.dependencies]
+winapi-util = { workspace = true }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 rustix = { workspace = true }

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -11,6 +11,9 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["uucore_procs"]
+
 [lints]
 workspace = true
 
@@ -37,9 +40,6 @@ windows-sys = { workspace = true, features = [
 [[bin]]
 name = "hostname"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]
 
 [[bench]]
 name = "hostname_bench"

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -11,6 +11,9 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["uucore_procs"]
+
 [lints]
 workspace = true
 
@@ -37,6 +40,3 @@ windows-sys = { workspace = true, features = [
 [[bin]]
 name = "sync"
 path = "src/main.rs"
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["uucore_procs"]

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -28,12 +28,12 @@ thiserror = { workspace = true }
 uucore = { workspace = true, features = ["libc", "parser"] }
 fluent = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }
-
-[dev-dependencies]
-tempfile = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -92,6 +92,9 @@ fluent-syntax = { workspace = true }
 unic-langid = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = [
   "dir",
@@ -104,9 +107,6 @@ nix = { workspace = true, features = [
 ] }
 walkdir = { workspace = true, optional = true }
 xattr = { workspace = true, optional = true }
-
-[dev-dependencies]
-tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { workspace = true, optional = true }


### PR DESCRIPTION
Fix [`Tombi(tables-out-of-order)`](https://tombi-toml.github.io/tombi/docs/configuration/#lint-rules-tables-out-of-order) lint