### PR TITLE
ci: add workflow to check TOML files

### DIFF
--- a/.github/workflows/check-toml.yml
+++ b/.github/workflows/check-toml.yml
@@ -1,0 +1,30 @@
+name: Check TOML files
+
+# spell-checker:ignore (people) taiki-e
+# spell-checker:ignore (misc) taplo tombi
+
+on:
+  push:
+    paths:
+      - "**.toml"
+  pull_request:
+    paths:
+      - "**.toml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Tombi
+        uses: tombi-toml/setup-tombi@v1
+      - name: Install taplo-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
+      - name: Lint TOML files
+        run: tombi lint --error-on-warnings
+      - name: Format TOML files
+        run: taplo fmt --check --diff

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -187,23 +187,6 @@ jobs:
         S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress .) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/^(.*):([0-9]+):([0-9]+) - Unknown word \(([^)]+)\).*$/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \`cspell\`: Unknown word '\4' (file:'\1', line:\2)/p" ; fault=true ; true ; }
         if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
-  toml_format:
-    name: Style/toml
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Install taplo-cli
-        uses: taiki-e/install-action@v2
-        with:
-          tool: taplo-cli
-
-      - name: Check
-        run: taplo fmt --check --diff
-
   python:
     name: Style/Python
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a dedicated CI workflow to check TOML files so style issues are reported automatically and formatting stays consistent across the repository.

Uses `taplo` for formatting and `tombi` for linting.