### PR TITLE
uucore: remove dead code

### DIFF
--- a/src/uucore/src/lib/mods/io.rs
+++ b/src/uucore/src/lib/mods/io.rs
@@ -43,22 +43,6 @@ impl<T: AsFd> io::Write for RawWriter<T> {
     }
 }
 
-// io::write_all but no buffering (deprecated?)
-#[inline]
-#[cfg(any(unix, target_os = "wasi"))]
-pub fn write_all_raw(output: impl AsFd, buf: &[u8]) -> io::Result<()> {
-    let mut written = 0;
-    let len = buf.len();
-    while written < len {
-        match rustix::io::write(&output, &buf[written..]) {
-            Ok(n) => written += n,
-            Err(e) if e.kind() != io::ErrorKind::Interrupted => return Err(e.into()),
-            _ => {}
-        }
-    }
-    Ok(())
-}
-
 /// abstraction wrapper for native file handle / file descriptor
 // todo: remove clone introducing additional syscall dependency
 pub struct OwnedFileDescriptorOrHandle {


### PR DESCRIPTION
`uucore::io::write_all_raw` is unused in coreutils and external crates.