### PR TITLE
yes: no hang with fcntl failure

### DIFF
--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 clap = { workspace = true }
 itertools = { workspace = true }
 fluent = { workspace = true }
-rustix = { workspace = true, features = ["pipe"] }
+rustix = { workspace = true, features = ["stdio", "pipe"] }
 uucore = { workspace = true, features = ["pipes"] }
 
 [[bin]]

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -112,22 +112,24 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
-    use uucore::pipes::{pipe, splice, tee};
+    use uucore::io::RawWriter;
+    use uucore::pipes::{pipe_exact, splice, tee};
 
     const PAGE_SIZE: usize = 4096;
     let aligned = PAGE_SIZE.is_multiple_of(bytes.len());
     repeat_content_to_capacity(&mut bytes);
     let bytes = bytes.as_slice();
-    let mut stdout = io::stdout(); // no need to lock with zero-copy
+    let stdout = rustix::stdio::stdout();
     // improve throughput
-    let _ = rustix::pipe::fcntl_setpipe_size(&stdout, MAX_ROOTLESS_PIPE_SIZE);
+    let _ = rustix::pipe::fcntl_setpipe_size(stdout, MAX_ROOTLESS_PIPE_SIZE);
     // don't show any error from fast-path and fallback to write for proper message
-    if let Ok((p_read, mut p_write)) = pipe()
+    // todo: zero-copy with default pipe size is logically possible when fcntl failed
+    if let Ok((p_read, mut p_write)) = pipe_exact(MAX_ROOTLESS_PIPE_SIZE)
         && p_write.write_all(bytes).is_ok()
     {
         if aligned && tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE).is_ok() {
             while let Ok(1..) = tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE) {}
-        } else if let Ok((broker_read, broker_write)) = pipe() {
+        } else if let Ok((broker_read, broker_write)) = pipe_exact(MAX_ROOTLESS_PIPE_SIZE) {
             // tee() cannot control offset and write to non-pipe
             'hybrid: while let Ok(mut remain) = tee(&p_read, &broker_write, MAX_ROOTLESS_PIPE_SIZE)
             {
@@ -137,7 +139,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
                         remain -= s;
                     } else {
                         // avoid output breakage with reduced remain even if it would not happen
-                        stdout.write_all(&bytes[bytes.len() - remain..])?;
+                        RawWriter(stdout).write_all(&bytes[bytes.len() - remain..])?;
                         break 'hybrid;
                     }
                 }
@@ -145,7 +147,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
         }
     }
     // fallback
-    let mut stdout = stdout.lock();
+    let mut stdout = RawWriter(stdout);
     loop {
         stdout.write_all(bytes)?;
     }

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -8,9 +8,8 @@
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use rustix::pipe::{SpliceFlags, fcntl_setpipe_size};
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use std::fs::File;
-#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::{
+    fs::File,
     io::{Read, Write},
     os::fd::AsFd,
     sync::OnceLock,
@@ -35,15 +34,31 @@ pub fn pipe() -> std::io::Result<(File, File)> {
     Ok((File::from(read), File::from(write)))
 }
 
-/// return pipe larger than given size and kernel's default size
+/// try to return pipe larger than given size
 ///
 /// useful to save RAM usage
 #[inline]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn pipe_with_size(s: usize) -> std::io::Result<(File, File)> {
     let (read, write) = rustix::pipe::pipe()?;
+    // avoid unnecessary syscall
     if s > KERNEL_DEFAULT_PIPE_SIZE {
         let _ = fcntl_setpipe_size(&read, s);
+    }
+
+    Ok((File::from(read), File::from(write)))
+}
+
+// used only from yes currently. We might use this for dd...
+/// return pipe larger than given size
+///
+/// use this if writing size to pipe should not hang
+#[inline]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn pipe_exact(s: usize) -> std::io::Result<(File, File)> {
+    let (read, write) = rustix::pipe::pipe()?;
+    if s > KERNEL_DEFAULT_PIPE_SIZE {
+        fcntl_setpipe_size(&read, s)?;
     }
 
     Ok((File::from(read), File::from(write)))


### PR DESCRIPTION
Don't hang with `strace -o /dev/null -e inject=fcntl:error=ENOSYS yes` by checking pipe size. The error does not appear on the daily usage. But it should be avoided. ~It was accidentally avoided by incorrect assumption for stdout.~

This bypasses `File::from` of `uucore::pipes::pipe`. So use `RawWriter` to allow using `write_all`.

Checking pipe size is not required for other splice(2)ing utils.