### PR TITLE
ln: remove panic in result function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,6 +3768,7 @@ dependencies = [
 name = "uu_ln"
 version = "0.9.0"
 dependencies = [
+ "assert_matches",
  "clap",
  "fluent",
  "rustix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,6 +3763,7 @@ dependencies = [
 name = "uu_ln"
 version = "0.10.0"
 dependencies = [
+ "assert_matches",
  "clap",
  "fluent",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,6 +402,7 @@ version = "0.9.0"
 
 [workspace.dependencies]
 ansi-width = "0.1.0"
+assert_matches = "1.5.0"
 bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"
 bstr = "1.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,6 +416,7 @@ ansi-width = "0.1.0"
 # is what catches it; keep the bound tight enough that only patch releases
 # arrive without one running.
 ariadne = "0.6.0"
+assert_matches = "1.5.0"
 base64-simd = "0.8"
 bigdecimal = "0.4"
 bstr = "1.9.1"

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -22,6 +22,9 @@ uucore = { workspace = true, features = ["backup-control", "fs"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }
 
+[dev-dependencies]
+assert_matches = { workspace = true }
+
 [target.'cfg(target_os = "wasi")'.dependencies]
 rustix = { workspace = true, features = ["fs"] }
 

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -23,6 +23,9 @@ uucore = { workspace = true, features = ["backup-control", "fs"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }
 
+[dev-dependencies]
+assert_matches = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/src/uu/ln/locales/en-US.ftl
+++ b/src/uu/ln/locales/en-US.ftl
@@ -26,6 +26,7 @@ ln-help-verbose = print name of each linked file
 ln-error-target-is-not-directory = target {$target} is not a directory
 ln-error-same-file = {$file1} and {$file2} are the same file
 ln-error-missing-destination = missing destination file operand after {$operand}
+ln-error-missing-operand = missing operand
 ln-error-extra-operand = extra operand {$operand}
   Try '{$program} --help' for more information.
 ln-error-could-not-update = Could not update {$target}: {$error}

--- a/src/uu/ln/locales/fr-FR.ftl
+++ b/src/uu/ln/locales/fr-FR.ftl
@@ -27,6 +27,7 @@ ln-help-verbose = afficher le nom de chaque fichier lié
 ln-error-target-is-not-directory = la cible {$target} n'est pas un répertoire
 ln-error-same-file = {$file1} et {$file2} sont le même fichier
 ln-error-missing-destination = opérande de fichier de destination manquant après {$operand}
+ln-error-missing-operand = opérande manquant
 ln-error-extra-operand = opérande supplémentaire {$operand}
   Essayez « {$program} --help » pour plus d'informations.
 ln-error-could-not-update = Impossible de mettre à jour {$target} : {$error}

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -70,6 +70,9 @@ pub enum LnError {
     #[error("{}", translate!("ln-error-missing-destination", "operand" => _0.quote()))]
     MissingDestination(PathBuf),
 
+    #[error("{}", translate!("ln-error-missing-operand"))]
+    MissingOperand,
+
     #[error("{}", translate!("ln-error-extra-operand", "operand" => _0.quote(), "program" => _1.clone()))]
     ExtraOperand(OsString, String),
 
@@ -271,6 +274,10 @@ pub fn uu_app() -> Command {
 ///
 /// This is made public to allow other apps to use `ln` as a library.
 pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
+    if files.is_empty() {
+        return Err(LnError::MissingOperand);
+    }
+
     // Handle cases where we create links in a directory first.
     if let Some(ref target_path) = settings.target_dir {
         // 4th form: a directory is specified by -t.
@@ -299,7 +306,6 @@ pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
             uucore::execution_phrase().to_string(),
         ));
     }
-    assert!(!files.is_empty());
 
     link(&files[0], &files[1], settings)
 }

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -532,3 +532,67 @@ pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> io::Result
 pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> io::Result<()> {
     rustix::fs::symlink(src.as_ref(), dst.as_ref()).map_err(io::Error::from)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use std::ffi::OsString;
+
+    #[test]
+    fn test_exec_missing_operand() {
+        let settings: Settings = Settings {
+            overwrite: OverwriteMode::NoClobber,
+            backup: BackupMode::None,
+            suffix: OsString::from(""),
+            symbolic: false,
+            relative: false,
+            logical: false,
+            target_dir: None,
+            no_target_dir: false,
+            no_dereference: false,
+            verbose: false,
+        };
+
+        let result = exec(&[], &settings);
+        assert_matches!(result, Err(LnError::MissingOperand));
+    }
+
+    #[test]
+    fn test_exec_missing_destination() {
+        let settings = Settings {
+            overwrite: OverwriteMode::NoClobber,
+            backup: BackupMode::None,
+            suffix: OsString::from(""),
+            symbolic: false,
+            relative: false,
+            logical: false,
+            target_dir: None,
+            no_target_dir: true,
+            no_dereference: false,
+            verbose: false,
+        };
+
+        let result = exec(&["a".into()], &settings);
+        assert_matches!(result, Err(LnError::MissingDestination(path)) if *path == *"a");
+    }
+
+    #[test]
+    fn test_exec_extra_operand() {
+        let settings = Settings {
+            overwrite: OverwriteMode::NoClobber,
+            backup: BackupMode::None,
+            suffix: OsString::from(""),
+            symbolic: false,
+            relative: false,
+            logical: false,
+            target_dir: None,
+            no_target_dir: true,
+            no_dereference: false,
+            verbose: false,
+        };
+
+        let result = exec(&["a".into(), "b".into(), "c".into()], &settings);
+        assert_matches!(result, Err(LnError::ExtraOperand(operand, _)) if operand == "c");
+    }
+}

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -66,6 +66,9 @@ pub enum LnError {
     #[error("{}", translate!("ln-error-missing-destination", "operand" => _0.quote()))]
     MissingDestination(PathBuf),
 
+    #[error("{}", translate!("ln-error-missing-operand"))]
+    MissingOperand,
+
     #[error("{}", translate!("ln-error-extra-operand", "operand" => _0.quote(), "program" => _1.clone()))]
     ExtraOperand(OsString, String),
 
@@ -267,6 +270,10 @@ pub fn uu_app() -> Command {
 ///
 /// This is made public to allow other apps to use `ln` as a library.
 pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
+    if files.is_empty() {
+        return Err(LnError::MissingOperand);
+    }
+
     // Handle cases where we create links in a directory first.
     if let Some(ref target_path) = settings.target_dir {
         // 4th form: a directory is specified by -t.
@@ -295,7 +302,6 @@ pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
             uucore::execution_phrase().to_string(),
         ));
     }
-    assert!(!files.is_empty());
 
     link(&files[0], &files[1], settings)
 }

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -529,3 +529,67 @@ pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> io::Result
 pub fn symlink<P1: AsRef<Path>, P2: AsRef<Path>>(src: P1, dst: P2) -> io::Result<()> {
     rustix::fs::symlink(src.as_ref(), dst.as_ref()).map_err(io::Error::from)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use std::ffi::OsString;
+
+    #[test]
+    fn test_exec_missing_operand() {
+        let settings: Settings = Settings {
+            overwrite: OverwriteMode::NoClobber,
+            backup: BackupMode::None,
+            suffix: OsString::from(""),
+            symbolic: false,
+            relative: false,
+            logical: false,
+            target_dir: None,
+            no_target_dir: false,
+            no_dereference: false,
+            verbose: false,
+        };
+
+        let result = exec(&[], &settings);
+        assert_matches!(result, Err(LnError::MissingOperand));
+    }
+
+    #[test]
+    fn test_exec_missing_destination() {
+        let settings = Settings {
+            overwrite: OverwriteMode::NoClobber,
+            backup: BackupMode::None,
+            suffix: OsString::from(""),
+            symbolic: false,
+            relative: false,
+            logical: false,
+            target_dir: None,
+            no_target_dir: true,
+            no_dereference: false,
+            verbose: false,
+        };
+
+        let result = exec(&["a".into()], &settings);
+        assert_matches!(result, Err(LnError::MissingDestination(path)) if *path == *"a");
+    }
+
+    #[test]
+    fn test_exec_extra_operand() {
+        let settings = Settings {
+            overwrite: OverwriteMode::NoClobber,
+            backup: BackupMode::None,
+            suffix: OsString::from(""),
+            symbolic: false,
+            relative: false,
+            logical: false,
+            target_dir: None,
+            no_target_dir: true,
+            no_dereference: false,
+            verbose: false,
+        };
+
+        let result = exec(&["a".into(), "b".into(), "c".into()], &settings);
+        assert_matches!(result, Err(LnError::ExtraOperand(operand, _)) if operand == "c");
+    }
+}


### PR DESCRIPTION
Avoid panicking in `uu_ln::exec` when called with an empty `files` list.

An empty `files` list cannot occur through normal command-line usage because `clap` requires the necessary operands. However, `exec` is a public API that can be used directly by other Rust projects, where this precondition is not enforced by the CLI argument parser.

This change returns an error instead of panicking when `exec` is called without operands.
