### PR TITLE
dd: support wasm32-wasip1

### DIFF
--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -37,7 +37,7 @@ jobs:
         CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
       run: |
         # Get all utilities and exclude ones that don't compile for wasm32-wasip1
-        EXCLUDE="dd|df|du|env|expr|mktemp|more|tac|test"
+        EXCLUDE="df|du|env|expr|mktemp|more|tac|test"
         UTILS=$(./util/show-utils.sh | tr ' ' '\n' | grep -vE "^($EXCLUDE)$" | sed 's/^/-p uu_/' | tr '\n' ' ')
         cargo test --target wasm32-wasip1 --no-default-features $UTILS
     - name: Run integration tests via wasmtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,7 @@ feat_wasm = [
   "csplit",
   "cut",
   "date",
+  "dd",
   "dir",
   "dircolors",
   "dirname",

--- a/src/uu/dd/src/conversion_tables.rs
+++ b/src/uu/dd/src/conversion_tables.rs
@@ -17,7 +17,10 @@ pub fn build_lcase_table() -> ConversionTable {
     // Initialize locale from environment if not already done
     // SAFETY: setlocale is called with a valid C string and is used to initialize
     // the locale for character conversion functions
-    unsafe { libc::setlocale(libc::LC_CTYPE, c"".as_ptr()) };
+    #[cfg(not(target_os = "wasi"))]
+    unsafe {
+        libc::setlocale(libc::LC_CTYPE, c"".as_ptr())
+    };
 
     let mut table = [0u8; 256];
     for (i, item) in table.iter_mut().enumerate() {
@@ -34,7 +37,10 @@ pub fn build_ucase_table() -> ConversionTable {
     // Initialize locale from environment if not already done
     // SAFETY: setlocale is called with a valid C string and is used to initialize
     // the locale for character conversion functions
-    unsafe { libc::setlocale(libc::LC_CTYPE, c"".as_ptr()) };
+    #[cfg(not(target_os = "wasi"))]
+    unsafe {
+        libc::setlocale(libc::LC_CTYPE, c"".as_ptr())
+    };
 
     let mut table = [0u8; 256];
     for (i, item) in table.iter_mut().enumerate() {

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -359,7 +359,7 @@ struct Input<'a> {
 impl<'a> Input<'a> {
     /// Instantiate this struct with stdin as a source.
     fn new_stdin(settings: &'a Settings) -> UResult<Self> {
-        #[cfg(not(unix))]
+        #[cfg(windows)]
         let mut src = {
             let f = File::from(io::stdin().as_handle().try_clone_to_owned()?);
             let is_file = if let Ok(metadata) = f.metadata() {
@@ -378,6 +378,8 @@ impl<'a> Input<'a> {
                 Source::Stdin(io::stdin())
             }
         };
+        #[cfg(all(not(unix), not(windows)))]
+        let mut src = Source::Stdin(io::stdin());
         #[cfg(unix)]
         let mut src = Source::stdin_as_file();
         #[cfg(unix)]


### PR DESCRIPTION
Closes #12211 

adds `dd` to `feat_wasm`. wasi-libc has no `LC_CTYPE` so gated that, and the windows stdin detection was leaking into wasi so scoped it under `cfg(windows)`. unit tests pass under wasmtime. runtime still panics on `thread::spawn` though, separate issue. happy to open a follow-up issue for the thread::spawn runtime problem if that'd be useful
