### PR TITLE
feat(dd): use wasi_ext feature on nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,6 +3485,7 @@ dependencies = [
  "fluent",
  "gcd",
  "libc",
+ "rustc_version",
  "rustix",
  "tempfile",
  "thiserror 2.0.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,6 +3496,7 @@ dependencies = [
  "fluent",
  "gcd",
  "libc",
+ "rustc_version",
  "rustix",
  "tempfile",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,6 +464,7 @@ regex = "1.10.4"
 rlimit = "0.11.0"
 rstest = "0.26.0"
 rstest_reuse = "0.7.0"
+rustc_version = "0.4.1"
 rustc-hash = "2.1.1"
 rust-ini = "0.21.0"
 # raw-backend's linux_execfn is not supported on linux < 6.4 if /proc is not mounted. So use-libc-auxv is needed
@@ -521,6 +522,7 @@ uutests = { version = "0.10.0", path = "tests/uutests" }
 # https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(fuzzing)',
+  'cfg(nightly)',
   'cfg(target_os, values("cygwin"))',
   'cfg(wasi_runner)',
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -479,6 +479,7 @@ regex = "1.10.4"
 rlimit = "0.11.0"
 rstest = "0.26.0"
 rstest_reuse = "0.7.0"
+rustc_version = "0.4.1"
 rustc-hash = "2.1.1"
 rust-ini = "0.21.0"
 # raw-backend's linux_execfn is not supported on linux < 6.4 if /proc is not mounted. So use-libc-auxv is needed
@@ -538,6 +539,7 @@ renamed_and_removed_lints = { level = "allow", priority = -1 }
 # https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(fuzzing)',
+  'cfg(nightly)',
   'cfg(pgo_training)',
   'cfg(target_os, values("cygwin"))',
   'cfg(wasi_runner)',

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -39,6 +39,9 @@ divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
 
+[build-dependencies]
+rustc_version = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/src/uu/dd/build.rs
+++ b/src/uu/dd/build.rs
@@ -1,0 +1,10 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+fn main() {
+    if rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -5,6 +5,8 @@
 
 // spell-checker:ignore fname, ftype, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, behaviour, bmax, bremain, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rremain, rsofar, rstat, sigusr, wlen, wstat oconv canonicalized FADV DONTNEED ESPIPE SPIPE bufferedoutput, SETFL
 
+#![cfg_attr(all(target_os = "wasi", nightly), feature(wasi_ext))]
+
 mod blocks;
 mod bufferedoutput;
 mod conversion_tables;
@@ -27,17 +29,20 @@ use uucore::translate;
 use std::cmp;
 use std::env;
 use std::ffi::OsString;
-#[cfg(unix)]
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
 use std::fs::Metadata;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::fd::AsFd;
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
+use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(unix)]
-use std::os::unix::{
-    fs::FileTypeExt,
-    io::{AsRawFd, FromRawFd},
-};
+use std::os::unix::fs::FileTypeExt;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(all(target_os = "wasi", nightly))]
+use std::os::wasi::fs::FileTypeExt;
 #[cfg(windows)]
 use std::os::windows::{fs::MetadataExt, io::AsHandle};
 use std::path::Path;
@@ -49,9 +54,11 @@ use std::time::{Duration, Instant};
 use clap::{Arg, Command};
 use gcd::Gcd;
 use uucore::display::Quotable;
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
+use uucore::error::set_exit_code;
 use uucore::error::{FromIo, UResult};
 #[cfg(unix)]
-use uucore::error::{USimpleError, set_exit_code};
+use uucore::error::USimpleError;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use uucore::show_if_err;
 use uucore::{format_usage, show_error};
@@ -173,14 +180,14 @@ impl Num {
 /// fine-grained access to reading from stdin.
 enum Source {
     /// Input from stdin.
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, all(target_os = "wasi", nightly))))]
     Stdin(io::Stdin),
 
     /// Input from a file.
     File(File),
 
     /// Input from stdin, opened from its file descriptor.
-    #[cfg(unix)]
+    #[cfg(any(unix, all(target_os = "wasi", nightly)))]
     StdinFile(File),
 
     /// Input from a named pipe, also known as a FIFO.
@@ -196,7 +203,7 @@ impl Source {
     /// the [`File`] parameter. You can use this instead of
     /// `Source::Stdin` to allow reading from stdin without consuming
     /// the entire contents of stdin when this process terminates.
-    #[cfg(unix)]
+    #[cfg(any(unix, all(target_os = "wasi", nightly)))]
     fn stdin_as_file() -> Self {
         let fd = io::stdin().as_raw_fd();
         let f = unsafe { File::from_raw_fd(fd) };
@@ -205,7 +212,7 @@ impl Source {
 
     fn skip(&mut self, n: u64, ibs: usize) -> io::Result<u64> {
         match self {
-            #[cfg(not(unix))]
+            #[cfg(not(any(unix, all(target_os = "wasi", nightly))))]
             Self::Stdin(stdin) => {
                 let m = uucore::io::read_and_discard(stdin, n, ibs)?;
                 if m < n {
@@ -216,7 +223,7 @@ impl Source {
                 }
                 Ok(m)
             }
-            #[cfg(unix)]
+            #[cfg(any(unix, all(target_os = "wasi", nightly)))]
             Self::StdinFile(f) => {
                 if let Ok(Some(len)) = try_get_len_of_block_device(f)
                     && len < n
@@ -295,10 +302,10 @@ impl Source {
 impl Read for Source {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            #[cfg(not(unix))]
+            #[cfg(not(any(unix, all(target_os = "wasi", nightly))))]
             Self::Stdin(stdin) => stdin.read(buf),
             Self::File(f) => f.read(buf),
-            #[cfg(unix)]
+            #[cfg(any(unix, all(target_os = "wasi", nightly)))]
             Self::StdinFile(f) => f.read(buf),
             #[cfg(unix)]
             Self::Fifo(f) => f.read(buf),
@@ -342,9 +349,9 @@ impl<'a> Input<'a> {
                 Source::Stdin(io::stdin())
             }
         };
-        #[cfg(all(not(unix), not(windows)))]
+        #[cfg(all(not(unix), not(windows), not(all(target_os = "wasi", nightly))))]
         let mut src = Source::Stdin(io::stdin());
-        #[cfg(unix)]
+        #[cfg(any(unix, all(target_os = "wasi", nightly)))]
         let mut src = Source::stdin_as_file();
         #[cfg(unix)]
         if let Source::StdinFile(f) = &src
@@ -1454,7 +1461,7 @@ fn is_stdout_redirected_to_seekable_file() -> bool {
 }
 
 /// Try to get the len if it is a block device
-#[cfg(unix)]
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
 fn try_get_len_of_block_device(file: &mut File) -> io::Result<Option<u64>> {
     let ftype = file.metadata()?.file_type();
     if !ftype.is_block_device() {

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -5,6 +5,8 @@
 
 // spell-checker:ignore fname, ftype, tname, fpath, specfile, testfile, unspec, ifile, ofile, outfile, fullblock, urand, fileio, atoe, atoibm, behaviour, bmax, bremain, cflags, creat, ctable, ctty, datastructures, doesnt, etoa, fileout, fname, gnudd, iconvflags, iseek, nocache, noctty, noerror, nofollow, nolinks, nonblock, oconvflags, oseek, outfile, parseargs, rlen, rmax, rremain, rsofar, rstat, sigusr, virtio, wlen, wstat, zram, oconv canonicalized FADV DONTNEED ESPIPE SPIPE bufferedoutput, SETFL
 
+#![cfg_attr(all(target_os = "wasi", nightly), feature(wasi_ext))]
+
 mod blocks;
 mod bufferedoutput;
 mod conversion_tables;
@@ -28,17 +30,18 @@ use uucore::translate;
 use std::cmp;
 use std::env;
 use std::ffi::OsString;
-#[cfg(unix)]
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
 use std::fs::Metadata;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::fs::FileTypeExt;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::fs::OpenOptionsExt;
-#[cfg(unix)]
-use std::os::unix::{
-    fs::FileTypeExt,
-    io::{AsRawFd, FromRawFd},
-};
+#[cfg(all(target_os = "wasi", nightly))]
+use std::os::wasi::fs::FileTypeExt;
 #[cfg(windows)]
 use std::os::windows::{fs::MetadataExt, io::AsHandle};
 use std::path::Path;
@@ -50,9 +53,11 @@ use std::time::{Duration, Instant};
 use clap::{Arg, Command};
 use gcd::Gcd;
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UResult};
 #[cfg(unix)]
-use uucore::error::{USimpleError, set_exit_code};
+use uucore::error::USimpleError;
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
+use uucore::error::set_exit_code;
+use uucore::error::{FromIo, UResult};
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use uucore::show_if_err;
 use uucore::{format_usage, show_error};
@@ -213,14 +218,14 @@ impl AlignedBuf {
 /// fine-grained access to reading from stdin.
 enum Source {
     /// Input from stdin.
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, all(target_os = "wasi", nightly))))]
     Stdin(io::Stdin),
 
     /// Input from a file.
     File(File),
 
     /// Input from stdin, opened from its file descriptor.
-    #[cfg(unix)]
+    #[cfg(any(unix, all(target_os = "wasi", nightly)))]
     StdinFile(File),
 
     /// Input from a named pipe, also known as a FIFO.
@@ -236,7 +241,7 @@ impl Source {
     /// the [`File`] parameter. You can use this instead of
     /// `Source::Stdin` to allow reading from stdin without consuming
     /// the entire contents of stdin when this process terminates.
-    #[cfg(unix)]
+    #[cfg(any(unix, all(target_os = "wasi", nightly)))]
     fn stdin_as_file() -> Self {
         let fd = io::stdin().as_raw_fd();
         let f = unsafe { File::from_raw_fd(fd) };
@@ -245,7 +250,7 @@ impl Source {
 
     fn skip(&mut self, n: u64, ibs: usize) -> io::Result<u64> {
         match self {
-            #[cfg(not(unix))]
+            #[cfg(not(any(unix, all(target_os = "wasi", nightly))))]
             Self::Stdin(stdin) => {
                 let m = uucore::io::read_and_discard(stdin, n, ibs)?;
                 if m < n {
@@ -256,7 +261,7 @@ impl Source {
                 }
                 Ok(m)
             }
-            #[cfg(unix)]
+            #[cfg(any(unix, all(target_os = "wasi", nightly)))]
             Self::StdinFile(f) => {
                 if let Ok(Some(len)) = try_get_len_of_block_device(f)
                     && len < n
@@ -335,10 +340,10 @@ impl Source {
 impl Read for Source {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            #[cfg(not(unix))]
+            #[cfg(not(any(unix, all(target_os = "wasi", nightly))))]
             Self::Stdin(stdin) => stdin.read(buf),
             Self::File(f) => f.read(buf),
-            #[cfg(unix)]
+            #[cfg(any(unix, all(target_os = "wasi", nightly)))]
             Self::StdinFile(f) => f.read(buf),
             #[cfg(unix)]
             Self::Fifo(f) => f.read(buf),
@@ -382,9 +387,9 @@ impl<'a> Input<'a> {
                 Source::Stdin(io::stdin())
             }
         };
-        #[cfg(all(not(unix), not(windows)))]
+        #[cfg(all(not(unix), not(windows), not(all(target_os = "wasi", nightly))))]
         let mut src = Source::Stdin(io::stdin());
-        #[cfg(unix)]
+        #[cfg(any(unix, all(target_os = "wasi", nightly)))]
         let mut src = Source::stdin_as_file();
         #[cfg(unix)]
         if let Source::StdinFile(f) = &src
@@ -1544,7 +1549,7 @@ fn is_stdout_redirected_to_seekable_file() -> bool {
 }
 
 /// Try to get the len if it is a block device
-#[cfg(unix)]
+#[cfg(any(unix, all(target_os = "wasi", nightly)))]
 fn try_get_len_of_block_device(file: &mut File) -> io::Result<Option<u64>> {
     let ftype = file.metadata()?.file_type();
     if !ftype.is_block_device() {


### PR DESCRIPTION
Enable the unstable[`wasi-ext`](https://doc.rust-lang.org/beta/unstable-book/library-features/wasi-ext.html) feature for nightly WASI builds.

* Detect nightly Rust in `build.rs`.
* Set the nightly cfg flag.
* Gate `wasi_ext` behind `nightly` and `target_os = "wasi"`.

Context: https://github.com/uutils/coreutils/pull/12258.