### PR TITLE
uucore::pipes: remove pipe and use pipe_with_size(MAX_ROOTLESS_PIPE_SIZE)

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -27,7 +27,7 @@ const FILE_ATTRIBUTE_NORMAL: u32 = 128;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use libc::S_IFIFO;
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, pipe, splice, splice_exact};
+use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, pipe_with_size, splice, splice_exact};
 
 const BUF_SIZE: usize = 64 * 1024;
 
@@ -55,7 +55,7 @@ fn count_bytes_using_splice(fd: &impl AsFd) -> Result<usize, usize> {
         }
     } else {
         // input is not pipe. needs broker to use splice() with additional cost
-        let (pipe_rd, pipe_wr) = pipe().map_err(|_| 0_usize)?;
+        let (pipe_rd, pipe_wr) = pipe_with_size(MAX_ROOTLESS_PIPE_SIZE).map_err(|_| 0_usize)?;
         loop {
             match splice(fd, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE) {
                 Ok(0) => return Ok(byte_count),

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -112,7 +112,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
-    use uucore::pipes::{pipe, splice, tee};
+    use uucore::pipes::{pipe_with_size, splice, tee};
 
     const PAGE_SIZE: usize = 4096;
     let aligned = PAGE_SIZE.is_multiple_of(bytes.len());
@@ -122,12 +122,12 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
     // improve throughput
     let _ = rustix::pipe::fcntl_setpipe_size(&stdout, MAX_ROOTLESS_PIPE_SIZE);
     // don't show any error from fast-path and fallback to write for proper message
-    if let Ok((p_read, mut p_write)) = pipe()
+    if let Ok((p_read, mut p_write)) = pipe_with_size(MAX_ROOTLESS_PIPE_SIZE)
         && p_write.write_all(bytes).is_ok()
     {
         if aligned && tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE).is_ok() {
             while let Ok(1..) = tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE) {}
-        } else if let Ok((broker_read, broker_write)) = pipe() {
+        } else if let Ok((broker_read, broker_write)) = pipe_with_size(MAX_ROOTLESS_PIPE_SIZE) {
             // tee() cannot control offset and write to non-pipe
             'hybrid: while let Ok(mut remain) = tee(&p_read, &broker_write, MAX_ROOTLESS_PIPE_SIZE)
             {

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -40,7 +40,7 @@ pub fn pipe() -> std::io::Result<(File, File)> {
 /// useful to save RAM usage
 #[inline]
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn pipe_with_size(s: usize) -> std::io::Result<(File, File)> {
+pub fn pipe_with_size(s: usize) -> std::io::Result<(File, File)> {
     let (read, write) = rustix::pipe::pipe()?;
     if s > KERNEL_DEFAULT_PIPE_SIZE {
         let _ = fcntl_setpipe_size(&read, s);

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -687,13 +687,13 @@ fn test_output_lossy_utf8() {
 #[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths not visible")]
 fn test_comm_anonymous_pipes() {
     use std::{io::Write, os::fd::AsRawFd, process};
-    use uucore::pipes::{pipe_with_size, MAX_ROOTLESS_PIPE_SIZE};
+    use uucore::pipes::pipe;
 
     let scene = TestScenario::new(util_name!());
 
     // Open two anonymous pipes
-    let (comm1_reader, mut comm1_writer) = pipe_with_size(MAX_ROOTLESS_PIPE_SIZE).unwrap();
-    let (comm2_reader, mut comm2_writer) = pipe_with_size(MAX_ROOTLESS_PIPE_SIZE).unwrap();
+    let (comm1_reader, mut comm1_writer) = pipe().unwrap();
+    let (comm2_reader, mut comm2_writer) = pipe().unwrap();
 
     // comm reads the data in chunks
     // make content large enough, so that at least two chunks are read

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -687,13 +687,13 @@ fn test_output_lossy_utf8() {
 #[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths not visible")]
 fn test_comm_anonymous_pipes() {
     use std::{io::Write, os::fd::AsRawFd, process};
-    use uucore::pipes::pipe;
+    use uucore::pipes::{pipe_with_size, MAX_ROOTLESS_PIPE_SIZE};
 
     let scene = TestScenario::new(util_name!());
 
     // Open two anonymous pipes
-    let (comm1_reader, mut comm1_writer) = pipe().unwrap();
-    let (comm2_reader, mut comm2_writer) = pipe().unwrap();
+    let (comm1_reader, mut comm1_writer) = pipe_with_size(MAX_ROOTLESS_PIPE_SIZE).unwrap();
+    let (comm2_reader, mut comm2_writer) = pipe_with_size(MAX_ROOTLESS_PIPE_SIZE).unwrap();
 
     // comm reads the data in chunks
     // make content large enough, so that at least two chunks are read


### PR DESCRIPTION
Fixes #12271

I have changes to the files using uucore:pipe replacing it with pipe_size_max(MAX_ROOTLESS_PIPE_SIZE). I've made this function public in the pipe.rs file. 