### PR TITLE
shred /dev/null should be infinite loop 

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -635,10 +635,13 @@ fn wipe_file(
         ));
     }
     if !path.is_file() {
-        return Err(USimpleError::new(
-            1,
-            translate!("shred-not-a-file", "file" => path.maybe_quote()),
-        ));
+        if path.is_dir() {
+            return Err(USimpleError::new(
+                1,
+                translate!("shred-not-a-file", "file" => path.maybe_quote()),
+            ));
+        }
+        // Special files loop.
     }
 
     let metadata =


### PR DESCRIPTION
Fixes #12283 

Allows special files to naturally loop indefinitely, matching GNU shred. I have added explicit directory check following existence validation to prevent errors on special files.