### PR TITLE
ci: pin ubuntu runner to 24.04 in workflows

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   cargo-deny:
     name: Style/cargo-deny
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -52,7 +52,7 @@ jobs:
         job:
           # note: `cargo-udeps` panics when processing stdbuf/libstdbuf ("uu_stdbuf_libstdbuf"); either b/c of the 'cpp' crate or 'libstdbuf' itself
           #   ... b/c of the panic, a more limited feature set is tested (though only excluding `stdbuf`)
-          - { os: ubuntu-latest  , features: "feat_Tier1,feat_require_unix,feat_require_unix_utmpx" }
+          - { os: ubuntu-24.04  , features: "feat_Tier1,feat_require_unix,feat_require_unix_utmpx" }
           - { os: macos-latest   , features: "feat_Tier1,feat_require_unix,feat_require_unix_utmpx" }
           - { os: windows-latest , features: feat_os_windows }
     steps:
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: feat_os_unix }
+          - { os: ubuntu-24.04  , features: feat_os_unix }
 # for now, don't build it on mac & windows because the doc is only published from linux
 # + it needs a bunch of duplication for build
 # and I don't want to add a doc step in the regular build to avoid long builds
@@ -166,7 +166,7 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: ubuntu-latest , features: feat_os_unix }
+          - { os: ubuntu-24.04 , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -253,7 +253,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest , features: feat_os_unix }
+          - { os: ubuntu-24.04 , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -276,7 +276,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: feat_os_unix }
+          - { os: ubuntu-24.04  , features: feat_os_unix }
           - { os: macos-latest   , features: feat_os_unix }
           - { os: windows-latest , features: feat_os_windows }
     steps:
@@ -319,7 +319,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: feat_os_unix }
+          - { os: ubuntu-24.04  , features: feat_os_unix }
           - { os: macos-latest   , features: feat_os_unix }
           - { os: windows-latest , features: feat_os_windows }
     steps:
@@ -368,19 +368,19 @@ jobs:
       matrix:
         job:
           # - { os , target , default-features,  features , use-cross , toolchain, skip-tests, workspace-tests, skip-package, skip-publish }
-          - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross , skip-tests: true }
+          - { os: ubuntu-24.04  , target: arm-unknown-linux-gnueabihf , features: feat_os_unix_gnueabihf , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-24.04-arm  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf }
-          - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
-          - { os: ubuntu-latest  , target: riscv64gc-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
-          # - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
-          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,test_risky_names", use-cross: use-cross, skip-publish: true }
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: x86_64-unknown-netbsd, features: "feat_os_unix", use-cross: use-cross , skip-tests: true , check-only: true }
-          - { os: ubuntu-latest  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true , check-only: true }
-          - { os: ubuntu-latest  , target: wasm32-wasip1, default-features: false, features: feat_wasm, skip-tests: true }
+          - { os: ubuntu-24.04  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
+          - { os: ubuntu-24.04  , target: riscv64gc-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
+          # - { os: ubuntu-24.04  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
+          - { os: ubuntu-24.04  , target: i686-unknown-linux-gnu      , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
+          - { os: ubuntu-24.04  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl , use-cross: use-cross }
+          - { os: ubuntu-24.04  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,test_risky_names", use-cross: use-cross, skip-publish: true }
+          - { os: ubuntu-24.04  , target: x86_64-unknown-linux-gnu    , features: "feat_os_unix,uudoc"   , use-cross: no, workspace-tests: true }
+          - { os: ubuntu-24.04  , target: x86_64-unknown-linux-musl   , features: feat_os_unix_musl , use-cross: use-cross }
+          - { os: ubuntu-24.04  , target: x86_64-unknown-netbsd, features: "feat_os_unix", use-cross: use-cross , skip-tests: true , check-only: true }
+          - { os: ubuntu-24.04  , target: x86_64-unknown-redox        , features: feat_os_unix_redox     , use-cross: redoxer , skip-tests: true , check-only: true }
+          - { os: ubuntu-24.04  , target: wasm32-wasip1, default-features: false, features: feat_wasm, skip-tests: true }
           - { os: macos-latest   , target: aarch64-apple-darwin        , features: feat_os_unix, workspace-tests: true } # M1 CPU
           # PR #7964: chcon should not break build without the feature. cargo check is enough to detect it.
           - { os: macos-latest   , target: aarch64-apple-darwin        , workspace-tests: true, check-only: true } # M1 CPU
@@ -710,7 +710,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: unix }
+          - { os: ubuntu-24.04  , features: unix }
           # FIXME: Re-enable macos code coverage
           # - { os: macos-latest   , features: macos }
           # FIXME: Re-enable Code Coverage on windows, which currently fails due to "profiler_builtins". See #6686.
@@ -770,7 +770,7 @@ jobs:
         esac
 
         case '${{ matrix.job.os }}' in
-          ubuntu-latest)
+          ubuntu-24.04)
             # selinux and systemd headers needed to build tests
             # acl: setfacl for coverage profile-trace dir default ACL (umask 0777 tests)
             sudo apt-get -y update
@@ -841,8 +841,8 @@ jobs:
       matrix:
         job:
           # Linux: exercises both vendored (static) and OPENSSL_NO_VENDOR=1
-          # (dynamic against system libcrypto). ubuntu-latest ships libssl-dev.
-          - { os: ubuntu-latest, features: feat_os_unix, dynamic: true }
+          # (dynamic against system libcrypto). ubuntu-24.04 ships libssl-dev.
+          - { os: ubuntu-24.04, features: feat_os_unix, dynamic: true }
           # macOS: vendored only — system libcrypto needs OPENSSL_DIR
           # pointing at Homebrew, which isn't worth wiring up for a smoke test.
           - { os: macos-latest, features: feat_os_unix, dynamic: false }
@@ -879,7 +879,7 @@ jobs:
     # Confirm the vendored build is actually statically linked. If this
     # regresses, the `vendored` feature has stopped doing its job.
     - name: Verify static linkage (vendored)
-      if: matrix.job.os == 'ubuntu-latest'
+      if: matrix.job.os == 'ubuntu-24.04'
       shell: bash
       run: |
         cargo build --release --features "${{ matrix.job.features }},openssl" --bin coreutils
@@ -904,7 +904,7 @@ jobs:
   test_selinux:
     name: Build/SELinux
     needs: [ min_version, deps ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -965,7 +965,7 @@ jobs:
 
   test_safe_traversal:
     name: Safe Traversal Security Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ min_version, deps ]
 
     steps:
@@ -983,7 +983,7 @@ jobs:
 
   test_toctou:
     name: TOCTOU Security Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ min_version, deps ]
 
     steps:

--- a/.github/workflows/CheckScripts.yml
+++ b/.github/workflows/CheckScripts.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   shell_check:
     name: ShellScript/Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   shell_fmt:
     name: ShellScript/Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: ubuntu-latest , features: feat_os_unix }
+          - { os: ubuntu-24.04 , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v7.0.1
       with:

--- a/.github/workflows/GnuComment.yml
+++ b/.github/workflows/GnuComment.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read  #  to list workflow runs artifacts
       pull-requests: write  #  to comment on pr
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: >
       github.event.workflow_run.event == 'pull_request'
     steps:

--- a/.github/workflows/SizeComment.yml
+++ b/.github/workflows/SizeComment.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read  #  to list workflow runs artifacts
       pull-requests: write  #  to comment on pr
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: >
       github.event.workflow_run.event == 'pull_request'
     steps:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # , macos-latest
+        os: [ubuntu-24.04] # , macos-latest
         cores: [4] # , 6
         ram: [4096]
         api-level: [28]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   benchmarks:
     name: Run ${{ matrix.type }} benchmarks for ${{ matrix.package }} (CodSpeed)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/check-toml.yml
+++ b/.github/workflows/check-toml.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest , features: feat_os_unix }
+          - { os: ubuntu-24.04 , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -71,10 +71,10 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: all             , workspace: true }
+          - { os: ubuntu-24.04  , features: all             , workspace: true }
           - { os: macos-latest   , features: all             , workspace: true }
           - { os: windows-latest , features: feat_os_windows }
-          - { os: ubuntu-latest  , features: feat_wasm , target: wasm32-wasip1 }
+          - { os: ubuntu-24.04  , features: feat_wasm , target: wasm32-wasip1 }
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -152,7 +152,7 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: ubuntu-latest , features: feat_os_unix }
+          - { os: ubuntu-24.04 , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -189,7 +189,7 @@ jobs:
 
   python:
     name: Style/Python
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v7.0.1
@@ -213,7 +213,7 @@ jobs:
 
   pre_commit:
     name: Pre-commit hooks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test:
     name: Verify devcontainer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
     - uses: actions/checkout@v7.0.1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   check-doc:
     name: Verify uudoc generates correct documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   uufuzz-examples:
     name: Build and test uufuzz examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -52,7 +52,7 @@ jobs:
 
   fuzz-build:
     name: Build the fuzzers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -72,7 +72,7 @@ jobs:
   fuzz-run:
     needs: fuzz-build
     name: Fuzz (${{ matrix.group.name }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       RUN_FOR: 60
@@ -202,7 +202,7 @@ jobs:
   fuzz-summary:
     needs: fuzz-run
     name: Fuzzing Summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: "feat_os_unix" }
+          - { os: ubuntu-24.04  , features: "feat_os_unix" }
           - { os: macos-latest   , features: "feat_os_unix" }
           - { os: windows-latest , features: "feat_os_windows" }
     steps:
@@ -83,7 +83,7 @@ jobs:
 
   l10n_fluent_syntax:
     name: L10n/Fluent Syntax Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -131,7 +131,7 @@ jobs:
 
   l10n_clap_error_localization:
     name: L10n/Clap Error Localization Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -294,7 +294,7 @@ jobs:
 
   l10n_french_integration:
     name: L10n/French Integration Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -404,7 +404,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: "feat_os_unix" }
+          - { os: ubuntu-24.04  , features: "feat_os_unix" }
           - { os: macos-latest   , features: "feat_os_unix" }
     steps:
     - uses: actions/checkout@v7.0.1
@@ -557,7 +557,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , features: "feat_os_unix" }
+          - { os: ubuntu-24.04  , features: "feat_os_unix" }
           - { os: macos-latest   , features: "feat_os_unix" }
     steps:
     - uses: actions/checkout@v7.0.1
@@ -627,7 +627,7 @@ jobs:
         fi
 
         # Test French localization with make-installed binary (Ubuntu only)
-        if [ "${{ matrix.job.os }}" = "ubuntu-latest" ]; then
+        if [ "${{ matrix.job.os }}" = "ubuntu-24.04" ]; then
           echo "Testing French localization with make-installed binary..."
 
           # Set French locale
@@ -892,7 +892,7 @@ jobs:
 
   l10n_locale_support_verification:
     name: L10n/Locale Support Verification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -1124,7 +1124,7 @@ jobs:
 
   l10n_embedded_locale_regression_test:
     name: L10n/Embedded Locale Regression Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -1150,7 +1150,7 @@ jobs:
 
   l10n_locale_embedding_cat:
     name: L10n/Locale Embedding - Cat Utility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -1181,7 +1181,7 @@ jobs:
 
   l10n_locale_embedding_ls:
     name: L10n/Locale Embedding - Ls Utility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -1212,7 +1212,7 @@ jobs:
 
   l10n_locale_embedding_multicall:
     name: L10n/Locale Embedding - Multicall Binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -1245,7 +1245,7 @@ jobs:
 
   l10n_locale_embedding_cargo_install:
     name: L10n/Locale Embedding - Cargo Install
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest , features: feat_os_unix }
+          - { os: ubuntu-24.04 , features: feat_os_unix }
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -365,7 +365,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest }
+          - { os: ubuntu-24.04 }
     steps:
     - name: Initialize workflow variables
       id: vars
@@ -449,7 +449,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest }
+          - { os: ubuntu-24.04 }
     steps:
     - name: Initialize workflow variables
       id: vars

--- a/.github/workflows/manpage-lint.yml
+++ b/.github/workflows/manpage-lint.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   manpage-lint:
     name: Validate manpages with mandoc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         locale: [en_US.UTF-8, fr_FR.UTF-8]

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   style:
     name: Style and Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -123,7 +123,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test_wasi:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7.0.1
       with:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We provide prebuilt binaries, manpages, and shell completions from main branch a
 The latest stable tag https://github.com/uutils/coreutils/releases/latest also exists for reproducible products and packagers.
 Bug reporters should use binary from latest commit.
 
-Minimal compatible glibc version is same with ubuntu-latest runner. Use `coreutils-*-musl` if `coreutils-*-gnu` is not compatible with your system.
+Minimal compatible glibc version is same with ubuntu-24.04 runner. Use `coreutils-*-musl` if `coreutils-*-gnu` is not compatible with your system.
 
 </div>
 

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -2973,7 +2973,7 @@ pub fn host_name_for(util_name: &str) -> Cow<'_, str> {
     util_name.into()
 }
 
-// Choose same coreutils version with ubuntu-latest runner: https://github.com/actions/runner-images/tree/main/images/ubuntu
+// Choose same coreutils version with ubuntu-24.04 runner: https://github.com/actions/runner-images/tree/main/images/ubuntu
 const VERSION_MIN: &str = "9.4"; // minimum Version for the reference `coreutil` in `$PATH`
 
 const UUTILS_WARNING: &str = "uutils-tests-warning";


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/12005

Pin the Ubuntu GitHub Actions runner version to avoid unintentionally introducing a dependency on the kernel and glibc version shipped with Ubuntu 26.04 when `ubuntu-latest` is updated. This ensures that future runner upgrades remain explicit and deliberate decisions.