### PR TITLE
yes: don't mix buffered write and zero-copy

### DIFF
--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -22,8 +22,8 @@ doctest = false
 clap = { workspace = true }
 itertools = { workspace = true }
 fluent = { workspace = true }
-rustix = { workspace = true, features = ["pipe"] }
-uucore = { workspace = true, features = ["pipes"] }
+rustix = { workspace = true, features = ["stdio", "pipe"] }
+uucore = { workspace = true, features = ["fs", "pipes"] }
 
 [[bin]]
 name = "yes"

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -107,15 +107,16 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
+    use uucore::io::RawWriter;
     use uucore::pipes::{pipe, splice, tee};
 
     const PAGE_SIZE: usize = 4096;
     let aligned = PAGE_SIZE.is_multiple_of(bytes.len());
     repeat_content_to_capacity(&mut bytes);
     let bytes = bytes.as_slice();
-    let mut stdout = io::stdout(); // no need to lock with zero-copy
+    let stdout = rustix::stdio::stdout();
     // improve throughput
-    let _ = rustix::pipe::fcntl_setpipe_size(&stdout, MAX_ROOTLESS_PIPE_SIZE);
+    let _ = rustix::pipe::fcntl_setpipe_size(stdout, MAX_ROOTLESS_PIPE_SIZE);
     // don't show any error from fast-path and fallback to write for proper message
     if let Ok((p_read, mut p_write)) = pipe()
         && p_write.write_all(bytes).is_ok()
@@ -132,7 +133,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
                         remain -= s;
                     } else {
                         // avoid output breakage with reduced remain even if it would not happen
-                        stdout.write_all(&bytes[bytes.len() - remain..])?;
+                        RawWriter(stdout).write_all(&bytes[bytes.len() - remain..])?;
                         break 'hybrid;
                     }
                 }
@@ -140,7 +141,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
         }
     }
     // fallback
-    let mut stdout = stdout.lock();
+    let mut stdout = RawWriter(stdout);
     loop {
         stdout.write_all(bytes)?;
     }


### PR DESCRIPTION
No need to double buffering.
Buffered write after zero-copy does not cause any breakage. But it is a risk of changing order of outputs when tried to improve fallback in the future (I'm planning to do that) by mixing them.