### PR TITLE
shred: handle '-' as stdout

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -626,8 +626,16 @@ fn wipe_file(
     verbose: bool,
     force: bool,
 ) -> UResult<()> {
-    // Get these potential errors out of the way first
+    #[cfg(unix)]
+    let path = if path_str == "-" {
+        Path::new("/dev/fd/1")
+    } else {
+        Path::new(path_str)
+    };
+
+    #[cfg(not(unix))]
     let path = Path::new(path_str);
+
     if !path.exists() {
         return Err(USimpleError::new(
             1,

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -420,3 +420,18 @@ fn test_gnu_shred_passes_different_counts() {
     result.stderr_contains("pass 1/19 (random)");
     result.stderr_contains("pass 19/19 (random)");
 }
+
+#[test]
+#[cfg(unix)]
+fn test_shred_dash_wipes_stdout_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "secret.txt";
+    at.write(file, "secret data");
+
+    ucmd.arg("-n1")
+        .arg("-")
+        .set_stdout(at.make_file(file))
+        .succeeds();
+
+    assert_ne!(at.read(file), "secret data");
+}


### PR DESCRIPTION
Fixes #12288

Resolve `-` to `/dev/fd/1` on Unix systems, allowing shred to operate on whatever stdout is connected to. This matches the UNIX convention used by most coreutils tools.

When stdout is a pipe or terminal, the existing file type validation naturally rejects it with "not a file".
This doesn't match GNU's "invalid file type", but feels out of scope for the issue.
