### PR TITLE
head/tail: use OPTION rather than FLAG

### DIFF
--- a/src/uu/head/locales/en-US.ftl
+++ b/src/uu/head/locales/en-US.ftl
@@ -2,8 +2,8 @@ head-about = Print the first 10 lines of each FILE to standard output.
   With more than one FILE, precede each with a header giving the file name.
   With no FILE, or when FILE is -, read standard input.
 
-  Mandatory arguments to long flags are mandatory for short flags too.
-head-usage = head [FLAG]... [FILE]...
+  Mandatory arguments to long options are mandatory for short options too.
+head-usage = head [OPTION]... [FILE]...
 
 # Help messages
 head-help-bytes = print the first NUM bytes of each file;

--- a/src/uu/head/locales/fr-FR.ftl
+++ b/src/uu/head/locales/fr-FR.ftl
@@ -3,7 +3,7 @@ head-about = Affiche les 10 premières lignes de chaque FICHIER sur la sortie st
   Sans FICHIER, ou quand FICHIER est -, lit l'entrée standard.
 
   Les arguments obligatoires pour les options longues sont obligatoires pour les options courtes aussi.
-head-usage = head [DRAPEAU]... [FICHIER]...
+head-usage = head [OPTION]... [FICHIER]...
 
 # Messages d'aide
 head-help-bytes = affiche les premiers NUM octets de chaque fichier ;

--- a/src/uu/tail/locales/en-US.ftl
+++ b/src/uu/tail/locales/en-US.ftl
@@ -1,8 +1,9 @@
 tail-about = Print the last 10 lines of each FILE to standard output.
   With more than one FILE, precede each with a header giving the file name.
   With no FILE, or when FILE is -, read standard input.
-  Mandatory arguments to long flags are mandatory for short flags too.
-tail-usage = tail [FLAG]... [FILE]...
+
+  Mandatory arguments to long options are mandatory for short options too.
+tail-usage = tail [OPTION]... [FILE]...
 
 # Help messages
 tail-help-bytes = Number of bytes to print

--- a/src/uu/tail/locales/fr-FR.ftl
+++ b/src/uu/tail/locales/fr-FR.ftl
@@ -1,6 +1,7 @@
 tail-about = Afficher les 10 dernières lignes de chaque FICHIER sur la sortie standard.
   Avec plus d'un FICHIER, précéder chacun d'un en-tête donnant le nom du fichier.
   Sans FICHIER, ou quand FICHIER est -, lire l'entrée standard.
+
   Les arguments obligatoires pour les options longues sont également obligatoires pour les options courtes.
 tail-usage = tail [OPTION]... [FICHIER]...
 


### PR DESCRIPTION
This brings head & tail in par with all the other utils. French translation of tail is already using OPTION.

head and tail now have the same print layout as each other: one empty line before "Mandatory arguments..."

These changes reflect brings the help messages closer to the coreutils version of head and tail.

Ref: #12049 