### PR TITLE
Add CI for cygwin except for date

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,11 +1,11 @@
 name: make
 
 # spell-checker:ignore (abbrev/names) CACHEDIR taiki
-# spell-checker:ignore (env/flags) RUSTDOCFLAGS RUSTFLAGS CARGOFLAGS CLEVEL
+# spell-checker:ignore (env/flags) CHERE RUSTDOCFLAGS RUSTFLAGS CARGOFLAGS CLEVEL
 # spell-checker:ignore (jargon) deps softprops toolchain
 # spell-checker:ignore (people) dawidd
-# spell-checker:ignore (shell/tools) nextest sccache zstd
-# spell-checker:ignore (misc) bindir busytest defconfig DESTDIR manpages multisize runtest testsuite toybox uutils
+# spell-checker:ignore (shell/tools) bsdtar nextest pacman sccache zstd
+# spell-checker:ignore (misc) bindir busytest defconfig DESTDIR manpages multisize noconfirm runtest testsuite toybox uutils
 
 env:
   PROJECT_NAME: coreutils
@@ -93,26 +93,6 @@ jobs:
         disable_search: true
         flags: makefile,${{ matrix.job.os }}
         fail_ci_if_error: false
-    - name: "`make install PROG_PREFIX=uu- PROFILE=release-small COMPLETIONS=n MANPAGES=n LOCALES=n`"
-      shell: bash
-      run: |
-        set -x
-        DESTDIR=/tmp/ make install PROG_PREFIX=uu- PROFILE=release-small COMPLETIONS=n MANPAGES=n LOCALES=n
-        # Check that utils are built with given profile
-        ./target/release-small/true
-        # Check that the progs have prefix
-        test -f /tmp/usr/local/bin/uu-tty
-        test -f /tmp/usr/local/libexec/uu-coreutils/libstdbuf.*
-        # Check that the manpage is not present
-        ! test -f /tmp/usr/local/share/man/man1/uu-whoami.1
-        # Check that the completion is not present
-        ! test -f /tmp/usr/local/share/zsh/site-functions/_uu-install
-        ! test -f /tmp/usr/local/share/bash-completion/completions/uu-head.bash
-        ! test -f /tmp/usr/local/share/fish/vendor_completions.d/uu-cat.fish
-        # don't publish binaries with uu-
-        make uninstall PROG_PREFIX=uu- PROFILE=release-small COMPLETIONS=n MANPAGES=n LOCALES=n
-      env:
-        RUST_BACKTRACE: "1"
     - name: "`make install`"
       shell: bash
       run: |
@@ -292,8 +272,10 @@ jobs:
         DESTDIR=/tmp/ make SKIP_UTILS="stdbuf" install
 
   # keep this job minimal to avoid have many duplicated build with CICD
-  build_makefile-other:
-    name: Build/Makefile
+  build_makefile-windows-cygwin:
+    name: Build MSYS
+    permissions:
+      contents: write # Publish cygwin binary
     runs-on: ${{ matrix.job.os }}
     env:
       CARGO_INCREMENTAL: 0
@@ -316,6 +298,40 @@ jobs:
       run: |
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+    - name: "`(x86_64-pc-cygwin) make install PROG_PREFIX=uu- PROFILE=release-small COMPLETIONS=n MANPAGES=n LOCALES=n`"
+      shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail {0}'
+      run: |
+        set -x
+        pacman -Sy --noconfirm --needed make rust base-devel
+        DESTDIR=/tmp/c make install PROG_PREFIX=uu- PROFILE=release-small COMPLETIONS=n MANPAGES=n LOCALES=n SKIP_UTILS=date # FIXME: build date
+        # Check that utils are built with given profile
+        ./target/release-small/true
+        # Check that the progs have prefix
+        test -f /tmp/c/usr/local/bin/uu-tty
+        test -f /tmp/c/usr/local/libexec/uu-coreutils/libstdbuf.*
+        # Check that the manpage is not present
+        ! test -f /tmp/c/usr/local/share/man/man1/uu-whoami.1
+        # Check that the completion is not present
+        ! test -f /tmp/c/usr/local/share/zsh/site-functions/_uu-install
+        ! test -f /tmp/c/usr/local/share/bash-completion/completions/uu-head.bash
+        ! test -f /tmp/c/usr/local/share/fish/vendor_completions.d/uu-cat.fish
+        # package
+        mv target/release-small/deps/stdbuf.dll -t /tmp/c/usr/local/bin
+        bsdtar -caf x86_64-pc-cygwin.tar.zst -C /tmp/c/usr/local bin
+      env:
+        CHERE_INVOKING: 1
+        RUST_BACKTRACE: "1"
+    - name: Publish
+      uses: softprops/action-gh-release@v3
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      with:
+        tag_name: latest-commit
+        draft: false
+        prerelease: true
+        files: |
+          x86_64-pc-cygwin.tar.zst
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: "`make build`"
       shell: bash
       run: |

--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -263,6 +263,7 @@ pub const BAUD_RATES: &[(&str, BaudRate)] = &[
     ("57600", BaudRate::B57600),
     ("115200", BaudRate::B115200),
     ("230400", BaudRate::B230400),
+    #[cfg(not(target_os = "cygwin"))]
     ("460800", BaudRate::B460800),
     #[cfg(any(target_os = "android", target_os = "linux"))]
     ("500000", BaudRate::B500000),

--- a/src/uucore/src/lib/features/i18n/datetime.rs
+++ b/src/uucore/src/lib/features/i18n/datetime.rs
@@ -169,7 +169,12 @@ pub fn get_locale_months() -> Option<&'static [Vec<u8>; 12]> {
 }
 
 /// Unix implementation using nl_langinfo for exact match with `locale abmon` output.
-#[cfg(all(unix, not(target_os = "android"), not(target_os = "redox")))]
+#[cfg(all(
+    unix,
+    not(target_os = "android"),
+    not(target_os = "cygwin"),
+    not(target_os = "redox")
+))]
 fn get_locale_months_inner() -> Option<[Vec<u8>; 12]> {
     use nix::libc;
     use std::ffi::CStr;
@@ -221,7 +226,12 @@ fn get_locale_months_inner() -> Option<[Vec<u8>; 12]> {
 }
 
 /// Non-Unix fallback using ICU DateTimeFormatter.
-#[cfg(any(not(unix), target_os = "android", target_os = "redox"))]
+#[cfg(any(
+    not(unix),
+    target_os = "android",
+    target_os = "cygwin",
+    target_os = "redox"
+))]
 fn get_locale_months_inner() -> Option<[Vec<u8>; 12]> {
     let (locale, _) = get_time_locale();
     let locale_prefs = locale.clone().into();


### PR DESCRIPTION
We currently build and discard release-small binary just for checking file pathes and prefixes.

Reuse it for Cygwin. Closes https://github.com/uutils/coreutils/issues/11022 .