### PR TITLE
readme: remove incorrect "not"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We provide prebuilt binaries, manpages, and shell completions from main branch a
 The latest stable tag https://github.com/uutils/coreutils/releases/latest also exists for reproducible products and packagers.
 Bug reporters should use binary from latest commit.
 
-Minimal compatible glibc version is same with ubuntu-latest runner. Use `coreutils-*-musl` if `coreutils-*-musl` is not compatible with your system.
+Minimal compatible glibc version is same with ubuntu-latest runner. Use `coreutils-*-musl` if `coreutils-*-musl` is compatible with your system.
 
 </div>
 


### PR DESCRIPTION
With a recent commit the following sentence was added to the readme:

> Use `coreutils-*-musl` if `coreutils-*-musl` is not compatible with your system.

The sentence doesn't make sense. This PR removes the "not". However, it's also possible that the "not" is correct and the second `coreutils-*-musl` is incorrect.