### PR TITLE
mktemp: fix hidden file creation with dot prefix

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -281,6 +281,16 @@ impl Params {
             let prefix_str = prefix_path.to_string_lossy();
             if prefix_str.ends_with(MAIN_SEPARATOR) {
                 (prefix_path, String::new())
+            } else if prefix_from_template.ends_with("/.") || prefix_from_template == "." {
+                // Path normalizes trailing '.' away, making both parent() and file_name()
+                // return wrong results for hidden files like /tmp/.XXXXXXXX.
+                // Use prefix_from_template directly instead.
+                let directory = Path::new(&prefix_from_option)
+                    .join(&prefix_from_template[..prefix_from_template.len() - 1]); // strip trailing '.'
+
+                let prefix = ".".to_string();
+
+                (directory, prefix)
             } else {
                 let directory = match prefix_path.parent() {
                     None => PathBuf::new(),

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -1172,3 +1172,32 @@ fn test_non_utf8_tmpdir_directory_creation() {
     // but we can verify the command succeeds
     ucmd.arg("-d").arg("-p").arg(at.plus(dir_name)).succeeds();
 }
+
+#[test]
+#[cfg(unix)]
+fn test_mktemp_hidden_file_single_dot() {
+    let scene = TestScenario::new(util_name!());
+    let dir = tempdir().unwrap();
+    let template_name = ".XXXXXX";
+    let template = dir.path().join(template_name);
+
+    let result = scene.ucmd().arg(template.to_str().unwrap()).succeeds();
+
+    let path = result.stdout_str().trim();
+    let filename = std::path::Path::new(path)
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    assert!(
+        filename.starts_with('.'),
+        "expected hidden file, got {path}"
+    );
+    assert_eq!(
+        filename.len(),
+        template_name.len(),
+        "expected filename of length {}, got {filename}",
+        template_name.len()
+    );
+}


### PR DESCRIPTION
Fixes #12299

`mktemp /tmp/.XXXXXXXX` was failing with "Permission denied" because `Path::file_name()` treats a trailing `.` as the current directory, resolving it to the parent component name instead. This caused both the directory and prefix to be computed incorrectly.

Fixed by detecting when `prefix_from_template` ends in a lone `.` and extracting the directory and prefix directly from the raw string, before Path normalization can discard the dot.