### PR TITLE
true, false: simplify code

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -13,19 +13,14 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
         return 1;
     };
 
-    let error = if flag == "--help" {
-        uu_app().print_help()
-    } else if flag == "--version" {
+    if let Err(e) = match flag.as_encoded_bytes() {
+        b"--help" => uu_app().print_help(),
         // avoid uu_app for smaller binary size
-        writeln!(std::io::stdout(), "false {}", crate_version!())
-    } else {
-        return 1;
-    };
-
-    if let Err(print_fail) = error
-        && print_fail.kind() != std::io::ErrorKind::BrokenPipe
+        b"--version" => writeln!(std::io::stdout(), "false {}", crate_version!()),
+        _ => return 1,
+    } && e.kind() != std::io::ErrorKind::BrokenPipe
     {
-        let _ = writeln!(std::io::stderr(), "false: {print_fail}");
+        let _ = writeln!(std::io::stderr(), "false: {e}");
     }
     1
 }

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -13,20 +13,15 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
         return 0;
     };
 
-    let error = if flag == "--help" {
-        uu_app().print_help()
-    } else if flag == "--version" {
+    if let Err(e) = match flag.as_encoded_bytes() {
+        b"--help" => uu_app().print_help(),
         // avoid uu_app for smaller binary size
-        writeln!(std::io::stdout(), "true {}", crate_version!())
-    } else {
-        return 0;
-    };
-
-    if let Err(print_fail) = error
-        && print_fail.kind() != std::io::ErrorKind::BrokenPipe
+        b"--version" => writeln!(std::io::stdout(), "true {}", crate_version!()),
+        _ => return 0,
+    } && e.kind() != std::io::ErrorKind::BrokenPipe
     {
         // Try to display this error.
-        let _ = writeln!(std::io::stderr(), "true: {print_fail}");
+        let _ = writeln!(std::io::stderr(), "true: {e}");
         // Mirror GNU options. When failing to print warnings or version flags, then we exit
         // with FAIL. This avoids allocation some error information which may result in yet
         // other types of failure.


### PR DESCRIPTION
cleanup before supporting `>&-`