### PR TITLE
sort: don't accept leading '+' in numeric (-n) sort

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -668,8 +668,9 @@ impl<'a> Line<'a> {
             );
         }
         if settings.mode == SortMode::Numeric {
-            // exclude inf, nan, scientific notation
-            let line_num_float = (!line.iter().any(u8::is_ascii_alphabetic))
+            // exclude inf, nan, scientific notation, and a leading '+' which
+            // GNU sort -n doesn't accept (only -g does).
+            let line_num_float = (!line.iter().any(|&b| b.is_ascii_alphabetic() || b == b'+'))
                 .then(|| std::str::from_utf8(line).ok())
                 .flatten()
                 .and_then(|s| s.parse::<f64>().ok());

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -419,6 +419,18 @@ fn test_numeric_unsorted_ints() {
 }
 
 #[test]
+fn test_numeric_leading_plus_not_numeric() {
+    // GNU sort -n doesn't accept a leading '+' as a sign, so "+1", "+10", "+2"
+    // should compare lexicographically (i.e., stay in their original order
+    // since sort is stable on equal keys), not numerically.
+    new_ucmd!()
+        .arg("-n")
+        .pipe_in("+1\n+10\n+2\n")
+        .succeeds()
+        .stdout_is("+1\n+10\n+2\n");
+}
+
+#[test]
 fn test_human_block_sizes() {
     test_helper(
         "human_block_sizes",


### PR DESCRIPTION
Rust's `f64` parser happily accepts `+1` as `1.0`, so the whole-line numeric fast path in `sort -n` was treating `+1`, `+10`, `+2` as numbers and sorting them numerically. GNU sort `-n` doesn't accept a leading `+` (only `-g` does), so those lines should compare lexicographically and stay in their original order.

Reproduces on main:

```
$ printf '+1\n+10\n+2\n' | target/debug/sort -n
+1
+2
+10
$ printf '+1\n+10\n+2\n' | /usr/bin/sort -n
+1
+10
+2
```

Fix: exclude inputs containing `+` from the fast path so they fall through to the regular comparator, which already rejects `+` as a sign.

Closes #10315.