### PR TITLE
more: swap -f and -l short flags to match GNU/util-linux

### DIFF
--- a/src/uu/more/locales/en-US.ftl
+++ b/src/uu/more/locales/en-US.ftl
@@ -12,9 +12,9 @@ more-error-unknown-key = Unknown key: '{$key}'. Press 'h' for instructions. (uni
 
 # Help messages
 more-help-silent = Display help instead of ringing bell when an illegal key is pressed
-more-help-logical = Do not pause after any line containing a ^L (form feed)
+more-help-logical = Count logical lines, rather than screen lines
 more-help-exit-on-eof = Exit on End-Of-File
-more-help-no-pause = Count logical lines, rather than screen lines
+more-help-no-pause = Do not pause after any line containing a ^L (form feed)
 more-help-print-over = Do not scroll, clear screen and display text
 more-help-clean-print = Do not scroll, display text and clean line ends
 more-help-squeeze = Squeeze multiple blank lines into one

--- a/src/uu/more/locales/fr-FR.ftl
+++ b/src/uu/more/locales/fr-FR.ftl
@@ -12,9 +12,9 @@ more-error-unknown-key = Touche inconnue : '{$key}'. Appuyez sur 'h' pour les in
 
 # Messages d'aide
 more-help-silent = Afficher l'aide au lieu de sonner la cloche lorsqu'une touche illégale est pressée
-more-help-logical = Ne pas faire de pause après une ligne contenant un ^L (saut de page)
+more-help-logical = Compter les lignes logiques plutôt que les lignes d'écran
 more-help-exit-on-eof = Quitter à la fin du fichier
-more-help-no-pause = Compter les lignes logiques plutôt que les lignes d'écran
+more-help-no-pause = Ne pas faire de pause après une ligne contenant un ^L (saut de page)
 more-help-print-over = Ne pas défiler, effacer l'écran et afficher le texte
 more-help-clean-print = Ne pas défiler, afficher le texte et nettoyer les fins de ligne
 more-help-squeeze = Compresser plusieurs lignes vides en une seule

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -221,7 +221,7 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::LOGICAL)
-                .short('l')
+                .short('f')
                 .long(options::LOGICAL)
                 .action(ArgAction::SetTrue)
                 .help(translate!("more-help-logical")),
@@ -235,7 +235,7 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::NO_PAUSE)
-                .short('f')
+                .short('l')
                 .long(options::NO_PAUSE)
                 .action(ArgAction::SetTrue)
                 .help(translate!("more-help-no-pause")),

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -79,6 +79,10 @@ fn test_valid_arg() {
         &["--from-line", "0"],
         &["-P", "something"],
         &["--pattern", "-1"],
+        &["-f"],
+        &["--logical"],
+        &["-l"],
+        &["--no-pause"],
     ];
     for args in args_list {
         test_alive(args);


### PR DESCRIPTION
The clap definition had `-l` mapped to `--logical` and `-f` mapped to `--no-pause`, which is the reverse of util-linux `more`. The help strings were also describing the wrong long option, so the only thing that was internally consistent was the long names.

util-linux `more`:

```
-f, --logical   Count logical lines, rather than screen lines
-l, --no-pause  Suppress pausing after form feed (^L)
```

Swapped the short flags and the en-US/fr-FR help strings. Both options are still no-ops (the struct fields are still prefixed with `_` and marked `not implemented`), but at least the CLI surface is right now and `--help` doesn't describe the wrong behavior.

For #2320.