### PR TITLE
chmod: report Permission denied instead of No such file when stat fails

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -370,7 +370,23 @@ impl Chmoder {
 
         for filename in files {
             let file = Path::new(filename);
-            if !file.exists() {
+            // `Path::exists()` swallows IO errors and returns false for things
+            // like "the containing directory has mode 000 so I can't stat the
+            // child", which makes us report "No such file or directory" when
+            // GNU chmod reports "Permission denied". Use `try_exists()` and
+            // surface the permission error if there is one.
+            let exists = match file.try_exists() {
+                Ok(b) => b,
+                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                    if !self.quiet {
+                        show!(ChmodError::PermissionDenied(filename.into()));
+                    }
+                    set_exit_code(1);
+                    continue;
+                }
+                Err(_) => true, // Some other IO error, fall through and let the chmod call surface it.
+            };
+            if !exists {
                 if file.is_symlink() {
                     if !self.dereference && !self.recursive {
                         // The file is a symlink and we should not follow it


### PR DESCRIPTION
Closes #9789.

`Path::exists()` returns `false` whenever it can't stat the path — including when the parent directory is unreadable. That makes chmod surface "No such file or directory" in cases where the file is actually there:

```
$ mkdir locked && touch locked/file && chmod 000 locked
$ chmod 000 locked/file                     # GNU
chmod: cannot access 'locked/file': Permission denied
$ ./target/debug/chmod 000 locked/file      # uutils (before this PR)
chmod: cannot access 'locked/file': No such file or directory
```

Swap `exists()` for `try_exists()` and emit the existing `PermissionDenied` variant when the kind matches. Other IO errors fall through and the actual chmod call surfaces its own message.