### PR TITLE
nohup: create nohup.out with mode 0600

### DIFF
--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -12,6 +12,7 @@ use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout, stdout};
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{Error, ErrorKind, IsTerminal};
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process;
@@ -152,7 +153,15 @@ fn find_stdout() -> UResult<File> {
 }
 
 fn try_open_nohup_file(path: &str) -> std::io::Result<File> {
-    let file = OpenOptions::new().create(true).append(true).open(path)?;
+    // POSIX nohup creates the output file with mode 0600 so that other
+    // users on a shared host can't read whatever the detached job logs.
+    // Setting `.mode()` here only affects newly-created files; if the
+    // file already exists its permissions are left alone.
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(path)?;
 
     show_error!(
         "{}",


### PR DESCRIPTION
Closes #10021.

POSIX nohup creates the output file as owner-only so other local users can't read what the detached job logs. We were leaving the mode at the process umask, so on a host with the typical umask of 022 the file would land at 0644 and anyone could read it.

Pass `.mode(0o600)` on the `OpenOptions`. The mode only applies to newly-created files; if `nohup.out` already exists its permissions are left alone, which matches GNU.

Verified locally:

```
$ umask 022
$ ./target/debug/nohup sh -c 'echo secret'
nohup: ignoring input and appending output to 'nohup.out'
$ ls -l nohup.out
-rw-------  1 me  staff  7 May 16 19:52 nohup.out
```