### PR TITLE
dd: don't silently swallow truncate failures

### DIFF
--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1067,17 +1067,20 @@ impl BlockWriter<'_> {
     }
 
     /// Truncate the file to the final cursor location.
-    fn truncate(&mut self) {
-        // Calling `set_len()` may result in an error (for example,
-        // when calling it on `/dev/null`), but we don't want to
-        // terminate the process when that happens. Instead, we
-        // suppress the error by calling `Result::ok()`. This matches
-        // the behavior of GNU `dd` when given the command-line
-        // argument `of=/dev/null`.
-        match self {
-            Self::Unbuffered(o) => o.truncate().ok(),
-            Self::Buffered(o) => o.truncate().ok(),
+    fn truncate(&mut self) -> io::Result<()> {
+        let result = match self {
+            Self::Unbuffered(o) => o.truncate(),
+            Self::Buffered(o) => o.truncate(),
         };
+        // ftruncate returns EINVAL when the destination isn't a regular
+        // file (e.g. `of=/dev/null`), which GNU dd silently ignores.
+        // Anything else (ENOSPC, EROFS, ...) is a real failure we need
+        // to surface so the user doesn't end up with stale data.
+        match result {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::InvalidInput => Ok(()),
+            Err(err) => Err(err),
+        }
     }
 
     fn write_blocks(&mut self, buf: &[u8]) -> io::Result<WriteStat> {
@@ -1308,7 +1311,7 @@ fn finalize<T>(
 
     // Truncate the file to the final cursor location.
     if truncate {
-        output.truncate();
+        output.truncate()?;
     }
 
     // Print the final read/write statistics.

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -1072,10 +1072,11 @@ impl BlockWriter<'_> {
             Self::Unbuffered(o) => o.truncate(),
             Self::Buffered(o) => o.truncate(),
         };
-        // ftruncate returns EINVAL when the destination isn't a regular
-        // file (e.g. `of=/dev/null`), which GNU dd silently ignores.
-        // Anything else (ENOSPC, EROFS, ...) is a real failure we need
-        // to surface so the user doesn't end up with stale data.
+        // set_len() returns InvalidInput (EINVAL) when the destination
+        // isn't a regular file (e.g. `of=/dev/null`), which GNU dd
+        // silently ignores. Anything else (ENOSPC, EROFS, ...) is a real
+        // failure we need to surface so the user doesn't end up with
+        // stale data.
         match result {
             Ok(()) => Ok(()),
             Err(err) if err.kind() == io::ErrorKind::InvalidInput => Ok(()),

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1201,6 +1201,20 @@ fn test_outfile_dev_null() {
     new_ucmd!().arg("of=/dev/null").succeeds().no_stdout();
 }
 
+/// Regression test for the truncate path: writing data to /dev/null must
+/// still succeed even though set_len() returns InvalidInput on
+/// non-regular files. The fix narrows the error swallow to InvalidInput,
+/// so this case must remain green.
+#[cfg(unix)]
+#[test]
+fn test_outfile_dev_null_with_input() {
+    new_ucmd!()
+        .arg("of=/dev/null")
+        .pipe_in("some data\n")
+        .succeeds()
+        .no_stdout();
+}
+
 #[test]
 fn test_block_sync() {
     new_ucmd!()


### PR DESCRIPTION
Closes #9745.

`Output::truncate` was suppressing every error from `set_len()` by calling `.ok()`, which the comment justified by pointing at `of=/dev/null` (where `ftruncate` returns EINVAL). That also hid real failures like ENOSPC and EROFS, so dd would exit 0 while leaving stale tail bytes in the output file.

Narrow the swallow to InvalidInput (which is what `set_len` returns on non-regular files) and propagate everything else. `of=/dev/null` still works, real I/O errors now surface.

```
$ echo hello | ./target/debug/dd of=/dev/null
0+1 records in
0+1 records out
6 bytes copied, 0.000155542 s, 6.0 kB/s
```