### PR TITLE
id: don't exit 1 when uid/gid name lookup fails in default output

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -638,6 +638,10 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
 
     let mut lock = io::stdout().lock();
 
+    // Name lookup failures in the default output are non-fatal: GNU `id`
+    // happily prints just the numeric id and exits 0. Docker containers
+    // routinely run as uids that don't have a /etc/passwd entry, and exit
+    // 1 here breaks init scripts that probe with `id`.
     write!(
         lock,
         "uid={uid}({})",
@@ -646,7 +650,6 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
                 "{}",
                 translate!("id-error-cannot-find-user-name", "uid" => uid)
             );
-            set_exit_code(1);
             uid.to_string()
         })
     )?;
@@ -658,7 +661,6 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
                 "{}",
                 translate!("id-error-cannot-find-group-name", "gid" => gid)
             );
-            set_exit_code(1);
             gid.to_string()
         })
     )?;
@@ -671,7 +673,6 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
                     "{}",
                     translate!("id-error-cannot-find-user-name", "uid" => euid)
                 );
-                set_exit_code(1);
                 euid.to_string()
             })
         )?;
@@ -686,7 +687,6 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
                     "{}",
                     translate!("id-error-cannot-find-group-name", "gid" => egid)
                 );
-                set_exit_code(1);
                 egid.to_string()
             })
         )?;
@@ -703,7 +703,6 @@ fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {
                         "{}",
                         translate!("id-error-cannot-find-group-name", "gid" => gr)
                     );
-                    set_exit_code(1);
                     gr.to_string()
                 })
             ))


### PR DESCRIPTION
Closes #12246.

In a docker container where the current gid doesn't have an entry in `/etc/passwd`/`/etc/group`, uutils id was printing the fallback numeric value but then exiting 1:

```
$ id
id: cannot find name for group ID 1234
id: cannot find name for group ID 1234
uid=0(root) gid=1234(1234) groups=1234(1234)
$ echo $?
1
```

That breaks init scripts that probe identities with plain `id`. GNU id prints the numeric value and exits 0.

The bug was a `set_exit_code(1)` call in each of the five lookup sites in the default formatter (uid, gid, euid, egid, groups). Failing to resolve a name isn't an error in the no-flag case, only with `-n`/`--name` where the user explicitly asked for a name. The `-n` paths still set exit 1, matching GNU.

I left the `id: cannot find name...` warning in place since it's informational; happy to also drop that if you'd prefer the cleaner GNU output.