### PR TITLE
fix(true/false): print Usage line before about in --help (fixes #10279)

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -30,10 +30,17 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     1
 }
 
+/// GNU coreutils prints the usage line before the about text for `true`/`false`.
+const HELP_TEMPLATE: &str = "\
+Usage: false [ignored command line arguments]\n\n\
+{about-with-newline}\
+{options}\
+";
+
 pub fn uu_app() -> Command {
     Command::new("false")
         .version(crate_version!())
-        .help_template(uucore::localized_help_template("false"))
+        .help_template(HELP_TEMPLATE)
         .about(translate!("false-about"))
         // We provide our own help and version options, to ensure maximum compatibility with GNU.
         .disable_help_flag(true)

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -35,10 +35,17 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     0
 }
 
+/// GNU coreutils prints the usage line before the about text for `true`/`false`.
+const HELP_TEMPLATE: &str = "\
+Usage: true [ignored command line arguments]\n\n\
+{about-with-newline}\
+{options}\
+";
+
 pub fn uu_app() -> Command {
     Command::new("true")
         .version(crate_version!())
-        .help_template(uucore::localized_help_template("true"))
+        .help_template(HELP_TEMPLATE)
         .about(translate!("true-about"))
         // We provide our own help and version options, to ensure maximum compatibility with GNU.
         .disable_help_flag(true)


### PR DESCRIPTION
## Summary
- Use a custom help template for `true` and `false` so `--help` starts with a `Usage:` line, matching GNU coreutils.

## Test plan
- [ ] `cargo run -p uu_false -- --help | head -1` shows `Usage: false ...`
- [ ] `cargo run -p uu_true -- --help | head -1` shows `Usage: true ...`

Fixes #10279