### PR TITLE
fix(sort): reject leading '+' in numeric (-n) sort

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -668,10 +668,11 @@ impl<'a> Line<'a> {
             );
         }
         if settings.mode == SortMode::Numeric {
-            // exclude inf, nan, scientific notation
+            // exclude inf, nan, scientific notation; GNU -n does not treat '+' as a sign
             let line_num_float = (!line.iter().any(u8::is_ascii_alphabetic))
                 .then(|| std::str::from_utf8(line).ok())
                 .flatten()
+                .filter(|s| !s.trim_ascii_start().starts_with('+'))
                 .and_then(|s| s.parse::<f64>().ok());
             line_data.line_num_floats.push(line_num_float);
         }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -297,6 +297,16 @@ fn test_numeric_with_trailing_invalid_chars() {
 }
 
 #[test]
+fn test_numeric_sort_rejects_leading_plus_sign() {
+    // GNU sort -n does not treat '+' as a number sign; lines sort lexicographically.
+    new_ucmd!()
+        .arg("-n")
+        .pipe_in("+1\n+10\n+2\n")
+        .succeeds()
+        .stdout_is("+1\n+10\n+2\n");
+}
+
+#[test]
 fn test_check_zero_terminated_failure() {
     new_ucmd!()
         .arg("-z")


### PR DESCRIPTION
## Summary
- GNU `sort -n` does not treat `+` as a number sign
- Skip `f64` fast-path parsing when a line begins with `+` after whitespace

Fixes #10315

## Test plan
- [x] `test_numeric_sort_rejects_leading_plus_sign`