### PR TITLE
uu_install should overwrite files like GNU coreutils #11532

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -926,6 +926,21 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
     Ok(())
 }
 
+// checks if a path is symlink to a device e.g /dev/stdin
+fn is_path_device(path: &Path) -> bool {
+    #[cfg(unix)]
+    use std::os::unix::fs::FileTypeExt;
+    {
+        if let Ok(metadata) = metadata(path) {
+            let file_type = metadata.file_type();
+            if file_type.is_fifo() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Copy a file from one path to another. Handles the certain cases of special
 /// files (e.g character specials).
 ///
@@ -940,12 +955,13 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
 ///
 fn copy_file(from: &Path, to: &Path) -> UResult<()> {
     use std::os::unix::fs::OpenOptionsExt;
-    if let Ok(to_abs) = to.canonicalize()
-        && from.canonicalize()? == to_abs
-    {
-        return Err(InstallError::SameFile(from.to_path_buf(), to.to_path_buf()).into());
+    if !is_path_device(from) && !is_path_device(to) {
+        if let Ok(to_abs) = to.canonicalize()
+            && from.canonicalize()? == to_abs
+        {
+            return Err(InstallError::SameFile(from.to_path_buf(), to.to_path_buf()).into());
+        }
     }
-
     if to.is_dir() && !from.is_dir() {
         return Err(InstallError::OverrideDirectoryFailed(
             to.to_path_buf().clone(),

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -928,7 +928,7 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
 
 // checks if a path is fifo e.g /dev/stdin
 fn is_path_fifo(path: &Path) -> bool {
-    #[cfg(any(target_os = "android", unix))]
+    #[cfg(unix)]
     use std::os::unix::fs::FileTypeExt;
     {
         if let Ok(metadata) = metadata(path) {

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -926,8 +926,8 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
     Ok(())
 }
 
-// checks if a path is symlink to a device e.g /dev/stdin
-fn is_path_device(path: &Path) -> bool {
+// checks if a path is fifo e.g /dev/stdin
+fn is_path_fifo(path: &Path) -> bool {
     #[cfg(unix)]
     use std::os::unix::fs::FileTypeExt;
     {
@@ -955,7 +955,7 @@ fn is_path_device(path: &Path) -> bool {
 ///
 fn copy_file(from: &Path, to: &Path) -> UResult<()> {
     use std::os::unix::fs::OpenOptionsExt;
-    if !is_path_device(from) && !is_path_device(to) {
+    if !is_path_fifo(from) && !is_path_fifo(to) {
         if let Ok(to_abs) = to.canonicalize()
             && from.canonicalize()? == to_abs
         {

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -928,7 +928,7 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
 
 // checks if a path is fifo e.g /dev/stdin
 fn is_path_fifo(path: &Path) -> bool {
-    #[cfg(unix)]
+    #[cfg(any(target_os = "android", unix))]
     use std::os::unix::fs::FileTypeExt;
     {
         if let Ok(metadata) = metadata(path) {

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2658,3 +2658,17 @@ fn test_install_d_symlink_race_condition_concurrent() {
         "Intermediate directory should be a real directory, not a symlink"
     );
 }
+
+#[test]
+#[cfg(unix)]
+fn test_install_device_path() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    let file = "existing-file-to-be-overwritten.txt";
+    at.touch(file);
+    scene
+        .ucmd()
+        .args(&["-m644", "/dev/stdin", "existing-file-to-be-overwritten.txt"])
+        .pipe_in("some stuff\n")
+        .succeeds();
+}

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2661,7 +2661,7 @@ fn test_install_d_symlink_race_condition_concurrent() {
 
 #[test]
 #[cfg(unix)]
-fn test_install_device_path() {
+fn test_install_fifo_path() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     let file = "existing-file-to-be-overwritten.txt";


### PR DESCRIPTION
This PR resolves #11532.
Canonicalize didn't work with a fifo file types, in that case, /dev/stdin was a device path that is a symlink to /proc/self/fd/0