### PR TITLE
fix(mktemp): preserve `..` literal prefix in template (#12312)

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -291,6 +291,17 @@ impl Params {
                 let prefix = ".".to_string();
 
                 (directory, prefix)
+            } else if prefix_from_template.ends_with("/..") || prefix_from_template == ".." {
+                // `Path::file_name()` returns `None` for a path ending in `..`,
+                // and `Path::parent()` pops the preceding component, so both the
+                // directory and the prefix get mis-computed (e.g. `mktemp /tmp/..XXXXXX`
+                // would return `/tmp/<random>` instead of `/tmp/..<random>`). Strip
+                // the trailing `..` from `prefix_from_template` and use it as the
+                // literal prefix, matching GNU mktemp behavior.
+                let directory = Path::new(&prefix_from_option)
+                    .join(&prefix_from_template[..prefix_from_template.len() - 2]);
+                let prefix = "..".to_string();
+                (directory, prefix)
             } else {
                 let directory = match prefix_path.parent() {
                     None => PathBuf::new(),

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -290,6 +290,17 @@ impl Params {
                 let prefix = ".".to_string();
 
                 (directory, prefix)
+            } else if prefix_from_template.ends_with("/..") || prefix_from_template == ".." {
+                // `Path::file_name()` returns `None` for a path ending in `..`,
+                // and `Path::parent()` pops the preceding component, so both the
+                // directory and the prefix get mis-computed (e.g. `mktemp /tmp/..XXXXXX`
+                // would return `/tmp/<random>` instead of `/tmp/..<random>`). Strip
+                // the trailing `..` from `prefix_from_template` and use it as the
+                // literal prefix, matching GNU mktemp behavior.
+                let directory = Path::new(&prefix_from_option)
+                    .join(&prefix_from_template[..prefix_from_template.len() - 2]);
+                let prefix = "..".to_string();
+                (directory, prefix)
             } else {
                 let directory = match prefix_path.parent() {
                     None => PathBuf::new(),

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -1209,3 +1209,69 @@ fn test_mktemp_hidden_file_single_dot() {
         template_name.len()
     );
 }
+
+#[test]
+#[cfg(unix)]
+fn test_mktemp_dotdot_prefix() {
+    // Regression test for https://github.com/uutils/coreutils/issues/12312
+    //
+    // `mktemp <dir>/..XXXXXX` should produce a file named `..<random>`
+    // inside <dir>, matching GNU mktemp. Previously, `Path::file_name()`
+    // returned `None` for a path ending in `..`, causing the literal `..`
+    // prefix to be dropped from the output filename.
+    let scene = TestScenario::new(util_name!());
+    let dir = tempdir().unwrap();
+    let template = dir.path().join("..XXXXXX");
+
+    let result = scene.ucmd().arg(template.to_str().unwrap()).succeeds();
+
+    let stdout_path = result.stdout_str().trim();
+    let file_name = std::path::Path::new(stdout_path)
+        .file_name()
+        .expect("output path should have a file name")
+        .to_str()
+        .expect("output path should be UTF-8");
+    assert!(
+        file_name.starts_with("..") && file_name.len() == "..XXXXXX".len(),
+        "expected file name to start with '..' and match template length, got {stdout_path}"
+    );
+    // The created file should live in <dir>, not <dir>/.. (the parent).
+    let parent = std::path::Path::new(stdout_path)
+        .parent()
+        .expect("output path should have a parent");
+    let dir_path = dir.path();
+    assert_eq!(
+        parent, dir_path,
+        "expected file to be created in {dir_path:?}, got {parent:?}"
+    );
+    assert!(
+        std::path::Path::new(stdout_path).exists(),
+        "expected mktemp to actually create {stdout_path}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_mktemp_dotdot_prefix_with_tmpdir_flag() {
+    // Same fix should apply when the template is passed via --tmpdir / -p.
+    let scene = TestScenario::new(util_name!());
+    let dir = tempdir().unwrap();
+
+    let result = scene
+        .ucmd()
+        .arg("-p")
+        .arg(dir.path())
+        .arg("..XXXXXX")
+        .succeeds();
+
+    let stdout_path = result.stdout_str().trim();
+    let file_name = std::path::Path::new(stdout_path)
+        .file_name()
+        .expect("output path should have a file name")
+        .to_str()
+        .expect("output path should be UTF-8");
+    assert!(
+        file_name.starts_with(".."),
+        "expected file name to start with '..', got {stdout_path}"
+    );
+}

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -1247,3 +1247,69 @@ fn test_write_error_removes_the_temporary_directory() {
         .collect();
     assert!(leftovers.is_empty(), "left behind: {leftovers:?}");
 }
+
+#[test]
+#[cfg(unix)]
+fn test_mktemp_dotdot_prefix() {
+    // Regression test for https://github.com/uutils/coreutils/issues/12312
+    //
+    // `mktemp <dir>/..XXXXXX` should produce a file named `..<random>`
+    // inside <dir>, matching GNU mktemp. Previously, `Path::file_name()`
+    // returned `None` for a path ending in `..`, causing the literal `..`
+    // prefix to be dropped from the output filename.
+    let scene = TestScenario::new(util_name!());
+    let dir = tempdir().unwrap();
+    let template = dir.path().join("..XXXXXX");
+
+    let result = scene.ucmd().arg(template.to_str().unwrap()).succeeds();
+
+    let stdout_path = result.stdout_str().trim();
+    let file_name = std::path::Path::new(stdout_path)
+        .file_name()
+        .expect("output path should have a file name")
+        .to_str()
+        .expect("output path should be UTF-8");
+    assert!(
+        file_name.starts_with("..") && file_name.len() == "..XXXXXX".len(),
+        "expected file name to start with '..' and match template length, got {stdout_path}"
+    );
+    // The created file should live in <dir>, not <dir>/.. (the parent).
+    let parent = std::path::Path::new(stdout_path)
+        .parent()
+        .expect("output path should have a parent");
+    let dir_path = dir.path();
+    assert_eq!(
+        parent, dir_path,
+        "expected file to be created in {dir_path:?}, got {parent:?}"
+    );
+    assert!(
+        std::path::Path::new(stdout_path).exists(),
+        "expected mktemp to actually create {stdout_path}"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_mktemp_dotdot_prefix_with_tmpdir_flag() {
+    // Same fix should apply when the template is passed via --tmpdir / -p.
+    let scene = TestScenario::new(util_name!());
+    let dir = tempdir().unwrap();
+
+    let result = scene
+        .ucmd()
+        .arg("-p")
+        .arg(dir.path())
+        .arg("..XXXXXX")
+        .succeeds();
+
+    let stdout_path = result.stdout_str().trim();
+    let file_name = std::path::Path::new(stdout_path)
+        .file_name()
+        .expect("output path should have a file name")
+        .to_str()
+        .expect("output path should be UTF-8");
+    assert!(
+        file_name.starts_with(".."),
+        "expected file name to start with '..', got {stdout_path}"
+    );
+}


### PR DESCRIPTION
## Summary

`mktemp /tmp/..XXXXXX` was silently dropping the leading `..`, producing `/tmp/<random>` instead of `/tmp/..<random>`.

```console
# before
$ mktemp /tmp/..XXXXXX
/tmp/fpQ7Y8

# after / GNU mktemp
$ mktemp /tmp/..XXXXXX
/tmp/..cmJm2X
```

## Root cause

The `(directory, prefix)` split in `Params::from` relied on `Path::file_name()` and `Path::parent()` to break up the joined `prefix_path`. `Path::file_name()` returns `None` for any path whose final component is `..` (it is a `ParentDir`, not a regular name), so the prefix fell back to the empty string while `Path::parent()` popped the preceding component — together they erased the `..` from the output filename.

## Fix

Detect a trailing `..` component on `prefix_from_template` and split the directory and prefix from the raw template string before path normalization discards it, mirroring the existing handling for templates ending in `MAIN_SEPARATOR`. Every other template continues through the unchanged code path. This is intentionally a sibling fix to #12311 (which addresses the lone `.` case via the same hook).

## Tests

Added two regression tests in `tests/by-util/test_mktemp.rs`:

- `test_mktemp_dotdot_prefix` — bare `<dir>/..XXXXXX` template: asserts the resulting file name starts with `..`, matches the expected length, lives in `<dir>` (not `<dir>/..`), and actually exists on disk.
- `test_mktemp_dotdot_prefix_with_tmpdir_flag` — same property with `-p <dir> ..XXXXXX`.

Full `cargo test --test tests test_mktemp` is green on macOS (40 passed, 5 linux-only filtered), and `cargo fmt --all -- --check` and `cargo clippy -p uu_mktemp --all-targets -- -D warnings` are clean.

Fixes #12312