### PR TITLE
docs: update clippy section in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,8 +65,6 @@ Your git commits will then automatically be checked. If a check fails, an error
 message will explain why, and your commit will be canceled. You can then make
 the suggested changes, and run `git commit ...` again.
 
-**NOTE: On MacOS** the pre-commit hooks are currently broken. There are workarounds involving switching to unstable nightly Rust and components.
-
 ### clippy
 
 ```shell

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,12 +70,8 @@ the suggested changes, and run `git commit ...` again.
 ### clippy
 
 ```shell
-cargo clippy --all-targets --all-features
+cargo clippy --workspace --all-targets --all-features
 ```
-
-The `msrv` key in the clippy configuration file `clippy.toml` is used to disable
-lints pertaining to newer features by specifying the minimum supported Rust
-version (MSRV).
 
 ### rustfmt
 


### PR DESCRIPTION
- remove note about pre-commit hook being broken on macOS
- update clippy command to include `--workspace`, matching `pre-commit`
- remove outdated paragraph about `msrv` in `clippy.toml`