### PR TITLE
build: exclude chcon and runcon from util_map for non-Linux targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,10 @@ pub fn main() {
             // Allow this as we have a bunch of info in the comments
             #[allow(clippy::match_same_arms)]
             match krate.as_ref() {
+                #[cfg(not(any(target_os = "linux", target_os = "android")))]
+                "chcon" | "runcon" => {
+                    continue;
+                }
                 "default" | "macos" | "unix" | "windows" | "selinux" | "zip" | "clap_complete"
                 | "clap_mangen" | "fluent_syntax" => continue, // common/standard feature names
                 "nightly" | "test_unimplemented" | "expensive_tests" | "test_risky_names" => {


### PR DESCRIPTION
Contributes to https://github.com/uutils/coreutils/issues/11019