### PR TITLE
feat(sum): use larger buffer in bsd_sum and sysv_sum

### DIFF
--- a/src/uu/sum/BENCHMARKING.md
+++ b/src/uu/sum/BENCHMARKING.md
@@ -13,11 +13,11 @@ cargo build --release --package uu_sum
 and then you can time how it long it takes to checksum the file by running
 
 ```shell
-time ./target/release/sum wikidatawiki-20211001-pages-logging.xml
+time ./target/release/sum wikidatawiki-20251220-pages-logging.xml
 ```
 
 For more systematic measurements that include warm-ups, repetitions and comparisons, [Hyperfine](https://github.com/sharkdp/hyperfine) can be helpful. For example, to compare this implementation to the one provided by your distribution run
 
 ```shell
-hyperfine "./target/release/sum wikidatawiki-20211001-pages-logging.xml" "sum wikidatawiki-20211001-pages-logging.xml"
+hyperfine "./target/release/sum wikidatawiki-20251220-pages-logging.xml" "sum wikidatawiki-20251220-pages-logging.xml"
 ```

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -16,8 +16,11 @@ use uucore::translate;
 
 use uucore::{format_usage, show};
 
+// Fixed to 8 KiB (equivalent to `std::sys::io::DEFAULT_BUF_SIZE` on most targets)
+const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+
 fn bsd_sum(mut reader: impl Read) -> std::io::Result<(usize, u16)> {
-    let mut buf = [0; 4096];
+    let mut buf = [0; DEFAULT_BUF_SIZE];
     let mut bytes_read = 0;
     let mut checksum: u16 = 0;
     loop {
@@ -41,7 +44,7 @@ fn bsd_sum(mut reader: impl Read) -> std::io::Result<(usize, u16)> {
 }
 
 fn sysv_sum(mut reader: impl Read) -> std::io::Result<(usize, u16)> {
-    let mut buf = [0; 4096];
+    let mut buf = [0; DEFAULT_BUF_SIZE];
     let mut bytes_read = 0;
     let mut ret = 0u32;
 


### PR DESCRIPTION
Follow-up https://github.com/uutils/coreutils/pull/3741

Increase stack buffer size from 4 KiB to 8 KiB.

```log
$ hyperfine --warmup 1 "time ./target/release/sum wikidatawiki-20251220-pages-logging.xml" "time ./target/release/sum.ref wikidatawiki-20251220-pages-logging.xml"
Benchmark 1: time ./target/release/sum wikidatawiki-20251220-pages-logging.xml
  Time (mean ± σ):     12.819 s ±  0.012 s    [User: 8.082 s, System: 2.085 s]
  Range (min … max):   12.807 s … 12.845 s    10 runs
 
Benchmark 2: time ./target/release/sum.ref wikidatawiki-20251220-pages-logging.xml
  Time (mean ± σ):     13.085 s ±  0.022 s    [User: 8.138 s, System: 2.290 s]
  Range (min … max):   13.065 s … 13.142 s    10 runs
 
Summary
  time ./target/release/sum wikidatawiki-20251220-pages-logging.xml ran
    1.02 ± 0.00 times faster than time ./target/release/sum.ref wikidatawiki-20251220-pages-logging.xml
```