### PR TITLE
build: gate SELinux utilities behind selinux

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -935,34 +935,6 @@ jobs:
     - name: Lint with SELinux
       run: lima bash -c "cd work && cargo clippy --all-targets --features 'feat_selinux' --no-default-features -- -D warnings"
 
-  test_selinux_stubs:
-    name: Build/SELinux-Stubs (Non-Linux)
-    needs: [ min_version, deps ]
-    runs-on: ${{ matrix.job.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        job:
-          - { os: macos-latest   , features: feat_os_unix }
-          - { os: windows-latest , features: feat_os_windows }
-
-    steps:
-    - uses: actions/checkout@v7.0.1
-      with:
-        persist-credentials: false
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
-    - name: Build SELinux utilities as stubs
-      run: cargo build -p uu_chcon -p uu_runcon
-    - name: Verify stub binaries exist
-      shell: bash
-      run: |
-        test -f target/debug/chcon || test -f target/debug/chcon.exe
-        test -f target/debug/runcon || test -f target/debug/runcon.exe
-    # check is enough to detect workspace breakage by chcon
-    - name: Verify workspace builds with stubs
-      run: cargo check --features ${{ matrix.job.features }}
-
   test_safe_traversal:
     name: Safe Traversal Security Check
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,7 +346,7 @@ feat_require_unix_utmpx = ["pinky", "uptime", "users", "who"]
 # "feat_require_unix_hostid" == set of utilities requiring gethostid in libc (only some unixes provide)
 feat_require_unix_hostid = ["hostid"]
 # "feat_require_selinux" == set of utilities depending on SELinux.
-feat_require_selinux = ["chcon", "runcon"]
+feat_require_selinux = ["chcon/selinux", "runcon/selinux"]
 ## (alternate/newer/smaller platforms) feature sets
 # "feat_os_unix_fuchsia" == set of utilities which can be built/run on the "Fuchsia" OS (refs: <https://fuchsia.dev>; <https://en.wikipedia.org/wiki/Google_Fuchsia>)
 feat_os_unix_fuchsia = [

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,9 @@ pub fn main() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    let target_os = env::var_os("CARGO_CFG_TARGET_OS").unwrap();
+    let is_feat_selinux = env::var_os("CARGO_FEATURE_FEAT_SELINUX").is_some();
+
     let mut crates = Vec::new();
     for (key, val) in env::vars() {
         if val == "1" && key.starts_with(ENV_FEATURE_PREFIX) {
@@ -44,8 +47,9 @@ pub fn main() {
             // Allow this as we have a bunch of info in the comments
             #[allow(clippy::match_same_arms)]
             match krate.as_ref() {
-                #[cfg(not(any(target_os = "linux", target_os = "android")))]
-                "chcon" | "runcon" => {
+                "chcon" | "runcon"
+                    if !(is_feat_selinux && (target_os == "linux" || target_os == "android")) =>
+                {
                     continue;
                 }
                 "default" | "macos" | "unix" | "windows" | "selinux" | "zip" | "clap_complete"

--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -19,17 +19,34 @@ path = "src/chcon.rs"
 test = false
 doctest = false
 
-# TODO: block fetching crates without feat_selinux
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-clap = { workspace = true }
-uucore = { workspace = true, features = ["entries", "fs", "perms"] }
-selinux = { workspace = true }
-thiserror = { workspace = true }
-libc = { workspace = true }
-fts-sys = { workspace = true }
-rustix = { workspace = true, features = ["fs"] }
-fluent = { workspace = true }
+clap = { workspace = true, optional = true }
+fluent = { workspace = true, optional = true }
+fts-sys = { workspace = true, optional = true }
+libc = { workspace = true, optional = true }
+rustix = { workspace = true, features = ["fs"], optional = true }
+selinux = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+uucore = { workspace = true, features = [
+  "entries",
+  "fs",
+  "perms",
+  "selinux",
+], optional = true }
+
+[features]
+selinux = [
+  "dep:clap",
+  "dep:fluent",
+  "dep:fts-sys",
+  "dep:libc",
+  "dep:rustix",
+  "dep:selinux",
+  "dep:thiserror",
+  "dep:uucore",
+]
 
 [[bin]]
 name = "chcon"
 path = "src/main.rs"
+required-features = ["uucore/selinux"]

--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -5,7 +5,7 @@
 
 // spell-checker:ignore (vars) RFILE RDONLY CLOEXEC fgetfilecon fsetfilecon
 
-#![cfg(any(target_os = "linux", target_os = "android"))]
+#![cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 #![allow(clippy::upper_case_acronyms)]
 
 use clap::builder::ValueParser;

--- a/src/uu/chcon/src/errors.rs
+++ b/src/uu/chcon/src/errors.rs
@@ -3,8 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-#![cfg(any(target_os = "linux", target_os = "android"))]
-
 use std::ffi::OsString;
 use std::fmt::Write;
 use std::io;

--- a/src/uu/chcon/src/fts.rs
+++ b/src/uu/chcon/src/fts.rs
@@ -5,8 +5,6 @@
 
 // spell-checker:ignore (vars) RDONLY CLOEXEC
 
-#![cfg(any(target_os = "linux", target_os = "android"))]
-
 use core::ffi::{CStr, c_int, c_long, c_short};
 use std::ffi::{CString, OsStr};
 use std::marker::PhantomData;

--- a/src/uu/chcon/src/main.rs
+++ b/src/uu/chcon/src/main.rs
@@ -3,17 +3,4 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-//! This package is specific to Android and some Linux distributions. On other
-//! targets, provide a stub main to keep the binary target present and the
-//! workspace buildable. Using item-level cfg avoids excluding the crate
-//! entirely (via #![cfg(...)]), which can break tooling and cross builds that
-//! expect this binary to exist even when it's a no-op off Linux.
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
 uucore::bin!(uu_chcon);
-
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
-fn main() {
-    eprintln!("chcon: SELinux is not supported on this platform");
-    std::process::exit(1);
-}

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -19,15 +19,30 @@ path = "src/runcon.rs"
 test = false
 doctest = false
 
-# TODO: block fetching crates without feat_selinux
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-clap = { workspace = true }
-uucore = { workspace = true, features = ["entries", "fs", "perms", "selinux"] }
-selinux = { workspace = true }
-thiserror = { workspace = true }
-libc = { workspace = true }
-fluent = { workspace = true }
+clap = { workspace = true, optional = true }
+fluent = { workspace = true, optional = true }
+libc = { workspace = true, optional = true }
+selinux = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+uucore = { workspace = true, features = [
+  "entries",
+  "fs",
+  "perms",
+  "selinux",
+], optional = true }
+
+[features]
+selinux = [
+  "dep:clap",
+  "dep:fluent",
+  "dep:libc",
+  "dep:selinux",
+  "dep:thiserror",
+  "dep:uucore",
+]
 
 [[bin]]
 name = "runcon"
 path = "src/main.rs"
+required-features = ["uucore/selinux"]

--- a/src/uu/runcon/src/errors.rs
+++ b/src/uu/runcon/src/errors.rs
@@ -3,8 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-#![cfg(any(target_os = "linux", target_os = "android"))]
-
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter, Write};
 use std::io;

--- a/src/uu/runcon/src/main.rs
+++ b/src/uu/runcon/src/main.rs
@@ -3,17 +3,4 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-//! This package is specific to Android and some Linux distributions. On other
-//! targets, provide a stub main to keep the binary target present and the
-//! workspace buildable. Using item-level cfg avoids excluding the crate
-//! entirely (via #![cfg(...)]), which can break tooling and cross builds that
-//! expect this binary to exist even when it's a no-op off Linux.
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
 uucore::bin!(uu_runcon);
-
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
-fn main() {
-    eprintln!("runcon: SELinux is not supported on this platform");
-    std::process::exit(1);
-}

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -5,7 +5,7 @@
 
 // spell-checker:ignore (vars) RFILE execv execvp
 
-#![cfg(any(target_os = "linux", target_os = "android"))]
+#![cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 
 use clap::builder::ValueParser;
 use uucore::error::{UError, UResult};


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/12320
Contributes to https://github.com/uutils/coreutils/issues/12394
Contributes to https://github.com/uutils/coreutils/issues/4400

## Summary

Avoid building `chcon` and `runcon` binaries when the `selinux` feature is not enabled.

Both utilities depend on SELinux support, so they should not be included in builds that do not enable the corresponding feature. Using Cargo’s `required-features` mechanism makes this dependency explicit at the binary target level and prevents these targets from being built when SELinux support is unavailable.

This also avoids the previous approach of using `compile_error!` to prevent unsupported binaries from being distributed. While that approach catches the problem at compile time, it also makes otherwise valid operations such as `cargo check` fail when the `selinux` feature is disabled.

## Alternatives considered

- **Keep building stub binaries**: This would keep the binaries available but would result in commands that cannot provide their intended functionality, for example on Windows.
- **Use `compile_error!`**: This prevents `chcon` and `runcon` from being compiled without SELinux support, but also causes commands such as `cargo check` to fail for configurations where `selinux` is disabled.
- **Runtime checks**: Checking for SELinux support at runtime would still require building and distributing the binaries, and would not address the fact that the utilities have an unavailable build-time dependency.
- **Use Cargo's `required-features`**: This is the approach taken here. It expresses the dependency at the binary-target level and lets Cargo skip `chcon` and `runcon` entirely when `selinux` is disabled.

## Context

- https://github.com/uutils/coreutils/pull/8795
- https://github.com/uutils/coreutils/pull/10360


