### PR TITLE
dd: introduce fast-stream skip

### DIFF
--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -25,6 +25,7 @@ libc = { workspace = true }
 uucore = { workspace = true, features = [
   "format",
   "parser-size",
+  "pipes",
   "quoting-style",
   "fs",
   "signals",

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -183,11 +183,43 @@ impl Num {
 /// This is more efficient than `io::copy` with `BufReader` because it reads
 /// directly in `buf_size`-sized chunks, matching GNU dd's behavior.
 /// Returns the total number of bytes actually read.
-fn read_and_discard<R: Read>(reader: &mut R, n: u64, buf_size: usize) -> io::Result<u64> {
-    // todo: consider splice()ing to /dev/null on Linux
-    let mut buf = Vec::with_capacity(buf_size);
+fn read_and_discard<
+    #[cfg(any(target_os = "linux", target_os = "android"))] R: Read + AsFd,
+    #[cfg(not(any(target_os = "linux", target_os = "android")))] R: Read,
+>(
+    reader: &mut R,
+    n: u64,
+    buf_size: usize,
+) -> io::Result<u64> {
+    let mut buf = Vec::new(); // vec allocation should be after splice, but needed for tests?
+    buf.try_reserve(buf_size.min(n as usize))?; // try_with_capacity is unstable <https://github.com/rust-lang/rust/issues/91913>
     let mut total = 0u64;
     let mut remaining = n;
+
+    // try fast-discard by zero-copy (FIFO support only currently)
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        use uucore::pipes::KERNEL_DEFAULT_PIPE_SIZE;
+        if buf_size.min(remaining as usize) > KERNEL_DEFAULT_PIPE_SIZE
+            && let Some(null) = uucore::pipes::dev_null()
+        {
+            while remaining > 0 {
+                // no need to increase pipe size of input fd since
+                // - sender with splice probably increased size already
+                // - sender without splice is bottleneck of our wc -c
+                // posix dd does not read more than block size
+                match uucore::pipes::splice(reader, &null, buf_size.min(remaining as usize)) {
+                    Ok(0) => return Ok(total),
+                    Ok(s) => {
+                        total += s as u64;
+                        remaining -= s as u64;
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    }
+
     while remaining > 0 {
         let to_read = cmp::min(remaining, buf_size as u64);
         buf.clear();

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -18,7 +18,7 @@ use std::{
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub const MAX_ROOTLESS_PIPE_SIZE: usize = 1024 * 1024;
 #[cfg(any(target_os = "linux", target_os = "android"))]
-const KERNEL_DEFAULT_PIPE_SIZE: usize = 64 * 1024;
+pub const KERNEL_DEFAULT_PIPE_SIZE: usize = 64 * 1024;
 
 /// return pipe larger than given size
 /// SIZE_REQUIRED should be true if you want to fail when changing pipe size failed


### PR DESCRIPTION
Assuming the situation downloading part of large file e.g.
`curl * | dd skip=* bs=1M`.

```
$ hyperfine "time head -c 1G /dev/zero |dd skip=1GiB bs=1M" "time head -c 1G /dev/zero |target/release/dd skip=1GiB bs=1M"
Benchmark 1: time head -c 1G /dev/zero |dd skip=1GiB bs=1M
  Time (mean ± σ):     407.0 ms ±  14.0 ms    [User: 10.6 ms, System: 788.1 ms]
  Range (min … max):   394.2 ms … 433.5 ms    10 runs
 
Benchmark 2: time head -c 1G /dev/zero |target/release/dd skip=1GiB bs=1M
  Time (mean ± σ):     235.7 ms ±   8.2 ms    [User: 3.2 ms, System: 451.5 ms]
  Range (min … max):   224.2 ms … 248.5 ms    13 runs
 
Summary
  time head -c 1G /dev/zero |target/release/dd skip=1GiB bs=1M ran
    1.73 ± 0.08 times faster than time head -c 1G /dev/zero |dd skip=1GiB bs=1M
```