### PR TITLE
stat: shell-escape control chars in `%N` output (#9925)

### DIFF
--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -25,6 +25,7 @@ uucore = { workspace = true, features = [
   "libc",
   "fs",
   "fsext",
+  "quoting-style",
   "time",
 ] }
 thiserror = { workspace = true }

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -440,12 +440,29 @@ fn print_os_str(s: &OsString, flags: Flags, width: usize, precision: Precision) 
 fn quote_file_name(file_name: &str, quoting_style: &QuotingStyle) -> String {
     match quoting_style {
         QuotingStyle::Locale | QuotingStyle::Shell => {
+            // GNU's `locale` style (and the unreachable-from-env `shell`)
+            // keeps the simple backslash-escape form; see GNU coreutils
+            // test `tests/stat/stat-fmt.sh` which expects `'\''` for a
+            // file named `'`. Control characters are emitted as-is here,
+            // matching GNU behavior in this style.
             let escaped = file_name.replace('\'', r"\'");
             format!("'{escaped}'")
         }
         QuotingStyle::ShellEscapeAlways => {
-            let quote = if file_name.contains('\'') { '"' } else { '\'' };
-            format!("{quote}{file_name}{quote}")
+            // GH #9925: this is the default `%N` style. Delegate to
+            // uucore's shell-escape implementation so control characters
+            // (newlines, tabs, ...) in file names are properly encoded
+            // as `$'\n'`, `$'\t'`, ... matching GNU `stat -c %N`
+            // behavior. uucore picks single-quote wrapping when the name
+            // contains control chars, and double-quote wrapping when it
+            // only contains a literal single quote, matching GNU exactly.
+            use std::ffi::OsStr;
+            uucore::quoting_style::locale_aware_escape_name(
+                OsStr::new(file_name),
+                uucore::quoting_style::QuotingStyle::SHELL_ESCAPE_QUOTE,
+            )
+            .to_string_lossy()
+            .into_owned()
         }
         QuotingStyle::Quote => file_name.to_string(),
     }

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -449,6 +449,34 @@ fn test_quoting_style_locale() {
         .stdout_only("\'\"\'\n");
 }
 
+/// GH #9925: file names containing control characters (newline, tab, ...)
+/// must be encoded with `$'\X'` shell-escape sequences in the `%N` output,
+/// matching GNU `stat`. Before the fix the newline was emitted literally
+/// inside the single quotes.
+#[test]
+fn test_format_n_handles_newline() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.touch("a\nb");
+    ts.ucmd()
+        .args(&["-c", "%N", "a\nb"])
+        .succeeds()
+        .stdout_only("'a'$'\\n''b'\n");
+}
+
+/// Sanity check: a tab character inside a file name should also be encoded
+/// (`$'\t'`), not embedded as a raw byte.
+#[test]
+fn test_format_n_handles_tab() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.touch("a\tb");
+    ts.ucmd()
+        .args(&["-c", "%N", "a\tb"])
+        .succeeds()
+        .stdout_only("'a'$'\\t''b'\n");
+}
+
 #[test]
 fn test_quoting_style_invalid_env() {
     let ts = TestScenario::new(util_name!());


### PR DESCRIPTION
Closes #9925.

## Problem

GNU `stat` encodes control characters in file names using bash
`$'\X'` shell-escape sequences in the `%N` directive:

```
$ touch $'/tmp/test\nnewline'
$ /usr/bin/stat -c '{"name":"%N"}' $'/tmp/test\nnewline'
{"name":"'/tmp/test'$'\n''newline'"}
```

uutils was emitting the newline byte literally between single quotes,
producing invalid shell-quoted output and breaking JSON / log consumers
that parse the result:

```
{"name":"'/tmp/test
newline'"}
```

## Fix

For the default `%N` quoting style (`ShellEscapeAlways`), delegate to
uucore's shell-escape implementation
(`uucore::quoting_style::locale_aware_escape_name`), which already
encodes control characters as `$'\X'` sequences. Same code path that
`ls --quoting-style=shell-escape` uses, so `stat -c %N` output is now
consistent with `ls`.

`QUOTING_STYLE=locale` and `=shell` keep their previous backslash-escape
behavior so that GNU's `tests/stat/stat-fmt.sh` (which asserts `'\''`
for a `'` file under `locale`) still passes.

`Cargo.toml`: enables the `quoting-style` uucore feature for `uu_stat`.

## Tests

Added:
- `test_format_n_handles_newline` — exact GNU output for newline.
- `test_format_n_handles_tab` — tab sanity check.

`test_quoting_style_locale` continues to pass unchanged.

```
$ cargo test --features 'stat' --test tests -- test_stat
test result: ok. 35 passed; 0 failed
```

GNU compatibility: `tests/stat/stat-fmt.sh` continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)