### PR TITLE
buf_copy: define FdReadable and FdWritable traits

### DIFF
--- a/src/uucore/src/lib/features/buf_copy/linux.rs
+++ b/src/uucore/src/lib/features/buf_copy/linux.rs
@@ -4,7 +4,18 @@
 // file that was distributed with this source code.
 
 //! Buffer-based copying implementation for Linux and Android.
-use std::os::fd::AsFd;
+
+/// A readable file descriptor.
+pub trait FdReadable: std::io::Read + std::os::fd::AsFd {}
+
+impl FdReadable for std::fs::File {}
+impl FdReadable for std::io::PipeReader {}
+
+/// A writable file descriptor.
+pub trait FdWritable: std::io::Write + std::os::fd::AsFd {}
+
+impl FdWritable for std::fs::File {}
+impl FdWritable for std::io::PipeWriter {}
 
 /// Copy data from `Read` implementor `source` into a `Write` implementor
 /// `dest`. This works by reading a chunk of data from `source` and writing the
@@ -17,16 +28,17 @@ use std::os::fd::AsFd;
 /// # Arguments
 /// * `source` - `Read` implementor to copy data from.
 /// * `dest` - `Write` implementor to copy data to.
-pub fn copy_stream(
-    src: &mut (impl std::io::Read + AsFd),
-    dest: &mut impl AsFd,
-) -> crate::error::UResult<()> {
+pub fn copy_stream<R, W>(src: &mut R, dest: &mut W) -> crate::error::UResult<()>
+where
+    R: FdReadable,
+    W: FdWritable,
+{
     // If we're on Linux or Android, try to use the splice() system call
     // for faster writing. If it works, we're done.
     if crate::pipes::splice_unbounded_auto(src, dest)? {
         // If the splice() call failed, fall back on writing "without buffering", or order of output would be wrong
         // unrelated for cp /dev/stdin since cp does not have multiple input? <https://github.com/uutils/coreutils/issues/5186>
-        std::io::copy(src, &mut crate::io::RawWriter(dest))?;
+        std::io::copy(src, dest)?;
     }
     Ok(())
 }


### PR DESCRIPTION
- replace direct trait use with `FdReadable` and `FdWritable` traits for improved abstraction
- avoid blanket trait implementations to ensure only valid types (files or pipes) are used
- no need to use `RawWriter` since `File` and `PipeWriter` are unbuffered
