### PR TITLE
wc: dedup code with uucore::pipes::splice_unbounded

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -39,23 +39,19 @@ const BUF_SIZE: usize = 64 * 1024;
 #[inline]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn count_bytes_using_splice(fd: &impl AsFd) -> Result<usize, usize> {
-    let null_file = uucore::pipes::dev_null().ok_or(0_usize)?;
-    let mut byte_count = 0;
-    if let Ok(res) = splice(fd, &null_file, MAX_ROOTLESS_PIPE_SIZE) {
-        byte_count += res;
+    let mut null_file = uucore::pipes::dev_null().ok_or(0_usize)?;
+    if let Ok(first_count) = splice(fd, &null_file, MAX_ROOTLESS_PIPE_SIZE) {
         // no need to increase pipe size of input fd since
         // - sender with splice probably increased size already
         // - sender without splice is bottleneck of our wc -c
-        loop {
-            match splice(fd, &null_file, MAX_ROOTLESS_PIPE_SIZE) {
-                Ok(0) => return Ok(byte_count),
-                Ok(res) => byte_count += res,
-                Err(_) => return Err(byte_count),
-            }
+        match uucore::pipes::splice_unbounded(fd, &mut null_file) {
+            Ok(n) => Ok(n + first_count),
+            Err(n) => Err(n + first_count),
         }
     } else {
         // input is not pipe. needs broker to use splice() with additional cost
         let (pipe_rd, pipe_wr) = pipe::<false>(MAX_ROOTLESS_PIPE_SIZE).map_err(|_| 0_usize)?;
+        let mut byte_count = 0;
         loop {
             match splice(fd, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE).map_err(|_| byte_count)? {
                 0 => return Ok(byte_count),

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -80,22 +80,25 @@ pub fn might_fuse(source: &impl AsFd) -> bool {
 }
 
 /// splice all of source to dest
-/// return true if we need read/write fallback
-/// fails if one of in/output should be pipe
-#[inline]
+/// return bytes splice sent even error was returned
+///
+/// if it failed, one of in/output is probably not a pipe
+#[inline] // try to remove unused byte count
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn splice_unbounded(source: &impl AsFd, dest: &mut impl AsFd) -> std::io::Result<bool> {
+pub fn splice_unbounded(source: &impl AsFd, dest: &mut impl AsFd) -> Result<usize, usize> {
     // improve throughput
     // todo: avoid fcntl overhead for small input, but don't fcntl inside of the loop
+    // todo: cache fcntl call
     // no need to increase pipe size of input fd since
     // - sender with splice probably increased size already
     // - sender without splice is bottleneck
     let _ = fcntl_setpipe_size(&mut *dest, MAX_ROOTLESS_PIPE_SIZE);
+    let mut sent = 0;
     loop {
         match splice(&source, &dest, MAX_ROOTLESS_PIPE_SIZE) {
-            Ok(1..) => {}
-            Ok(0) => return Ok(false),
-            Err(_) => return Ok(true),
+            Ok(0) => return Ok(sent),
+            Ok(n) => sent += n,
+            Err(_) => return Err(sent),
         }
     }
 }
@@ -159,7 +162,7 @@ where
 {
     // use splice to check that input or output is pipe which is efficient
     let fallback = match splice(&source, dest, MAX_ROOTLESS_PIPE_SIZE) {
-        Ok(_) => splice_unbounded(source, dest)?,
+        Ok(_) => splice_unbounded(source, dest).is_err(),
         _ => splice_unbounded_broker(source, dest)?,
     };
     Ok(fallback)


### PR DESCRIPTION
- replace bool of `splice_unbounded` by bytes sent. I'm not sure if I do same things for `_broker`. But I believe this is enough to Close https://github.com/uutils/coreutils/pull/12365 .
- reuse `splice_unbounded` to dedup code. 