### PR TITLE
chore: restrict Android cfg too 64-bit to match `linux_execfn`

### DIFF
--- a/src/common/validation.rs
+++ b/src/common/validation.rs
@@ -75,7 +75,10 @@ fn get_canonical_util_name(util_name: &str) -> &str {
 /// Gets the binary path from command line arguments
 /// Panics if the binary path cannot be determined
 #[cfg(any(
-    not(any(target_os = "linux", target_os = "android")),
+    not(any(
+        target_os = "linux",
+        all(target_os = "android", target_pointer_width = "64")
+    )),
     target_env = "musl"
 ))]
 pub fn binary_path(args: &mut impl Iterator<Item = OsString>) -> PathBuf {
@@ -88,7 +91,10 @@ pub fn binary_path(args: &mut impl Iterator<Item = OsString>) -> PathBuf {
 /// Get actual binary path from kernel, not argv0, to prevent `env -a` from bypassing
 /// AppArmor, SELinux policies on hard-linked binaries
 #[cfg(all(
-    any(target_os = "linux", target_os = "android"),
+    any(
+        target_os = "linux",
+        all(target_os = "android", target_pointer_width = "64")
+    ),
     not(target_env = "musl")
 ))]
 pub fn binary_path(args: &mut impl Iterator<Item = OsString>) -> PathBuf {


### PR DESCRIPTION
`linux_execfn` cfg requirements to only support Linux and 64-bit Android targets


```rs
#[cfg(any(
    all(target_os = "android", target_pointer_width = "64"),
    target_os = "linux",
))]
#[inline]
pub(crate) fn linux_execfn() -> &'static CStr {
    if let Some(libc_getauxval) = getauxval.get() {
        unsafe { CStr::from_ptr(libc_getauxval(c::AT_EXECFN).cast()) }
    } else {
        cstr!("")
    }
}

```