### PR TITLE
install: handle piped stdin when target exists

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -946,10 +946,13 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
 ///
 fn copy_file(from: &Path, to: &Path) -> UResult<()> {
     use std::os::unix::fs::OpenOptionsExt;
-    if let Ok(to_abs) = to.canonicalize()
-        && from.canonicalize()? == to_abs
-    {
-        return Err(InstallError::SameFile(from.to_path_buf(), to.to_path_buf()).into());
+    let mut handle = File::open(from)?;
+
+    if let Ok(to_meta) = metadata(to) {
+        let from_meta = handle.metadata()?;
+        if from_meta.dev() == to_meta.dev() && from_meta.ino() == to_meta.ino() {
+            return Err(InstallError::SameFile(from.to_path_buf(), to.to_path_buf()).into());
+        }
     }
 
     if to.is_dir() && !from.is_dir() {
@@ -970,7 +973,6 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
         );
     }
 
-    let mut handle = File::open(from)?;
     // create_new provides TOCTOU protection
     let mut dest = OpenOptions::new()
         .write(true)

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -950,6 +950,8 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
 
     if let Ok(to_meta) = metadata(to) {
         let from_meta = handle.metadata()?;
+        // Refuse to replace the source file with itself; otherwise removing
+        // the destination below would delete the opened input before copying.
         if from_meta.dev() == to_meta.dev() && from_meta.ino() == to_meta.ino() {
             return Err(InstallError::SameFile(from.to_path_buf(), to.to_path_buf()).into());
         }

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2112,6 +2112,7 @@ fn test_install_from_stdin() {
     let (at, mut ucmd) = at_and_ucmd!();
     let target = "target";
     let test_string = "Hello, World!\n";
+    let updated_string = "Updated content\n";
 
     ucmd.arg("/dev/fd/0")
         .arg(target)
@@ -2120,6 +2121,14 @@ fn test_install_from_stdin() {
 
     assert!(at.file_exists(target));
     assert_eq!(at.read(target), test_string);
+
+    new_ucmd!()
+        .arg("/dev/fd/0")
+        .arg(at.plus(target))
+        .pipe_in(updated_string)
+        .succeeds();
+
+    assert_eq!(at.read(target), updated_string);
 }
 
 #[test]

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -242,7 +242,7 @@ fn test_mkfifo_permission_unchanged_when_failed() {
         .arg("-m")
         .arg("666")
         .fails()
-        .stderr_is(err_msg.as_str());
+        .stderr_contains(err_msg.as_str());
     let metadata = std::fs::metadata(at.subdir.join(file_name)).unwrap();
     let permissions = display_permissions(&metadata, true);
     let expected = "-rw-------";


### PR DESCRIPTION
Fixes #12407.

This updates the copy path to compare the opened source file metadata with the destination instead of canonicalizing the source path. That keeps openable special paths such as `/dev/fd/0` working when the destination already exists while preserving same-file detection.

Tests:
- `cargo fmt --check`
- `cargo test --features install --no-default-features test_install::test_install_from_stdin -- --nocapture`
- `cargo test --features install --no-default-features test_install:: -- --nocapture`
- `cargo test -p uu_install`
- `cargo clippy --features install --no-default-features --all-targets -- -D warnings`