### PR TITLE
refactor: add TeeState enum

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -10,7 +10,7 @@ use std::ffi::OsString;
 use std::io::{self, Write};
 use uucore::error::{UResult, USimpleError, strip_errno};
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use uucore::pipes::MAX_ROOTLESS_PIPE_SIZE;
+use uucore::pipes::{MAX_ROOTLESS_PIPE_SIZE, TeeState};
 use uucore::{format_usage, translate};
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -113,6 +113,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
     let safe_partial_send = rustix::pipe::PIPE_BUF.is_multiple_of(bytes.len());
     repeat_content_to_capacity(&mut bytes);
     let bytes = bytes.as_slice();
+    debug_assert!(!bytes.is_empty());
     let stdout = rustix::stdio::stdout();
     // improve throughput
     let _ = rustix::pipe::fcntl_setpipe_size(stdout, MAX_ROOTLESS_PIPE_SIZE);
@@ -120,11 +121,12 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
     if let Ok((p_read, mut p_write)) = pipe::<true>(MAX_ROOTLESS_PIPE_SIZE)
         && p_write.write_all(bytes).is_ok()
     {
-        if safe_partial_send && tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE).is_ok() {
-            while let Ok(1..) = tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE) {}
+        if safe_partial_send {
+            while let TeeState::Ended(_) = tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE) {}
         } else if let Ok((broker_read, broker_write)) = pipe::<true>(MAX_ROOTLESS_PIPE_SIZE) {
             // tee() cannot control offset and write to non-pipe
-            'hybrid: while let Ok(mut remain) = tee(&p_read, &broker_write, MAX_ROOTLESS_PIPE_SIZE)
+            'hybrid: while let TeeState::Ended(mut remain) =
+                tee(&p_read, &broker_write, MAX_ROOTLESS_PIPE_SIZE)
             {
                 debug_assert!(remain == bytes.len(), "splice() should cleanup pipe");
                 while remain > 0 {

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -267,9 +267,18 @@ pub fn dev_null() -> Option<File> {
     ((rustix::fs::major(dev), rustix::fs::minor(dev)) == (1, 3)).then_some(null)
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub enum TeeState {
+    Ended(usize),
+    Fallback(usize),
+}
+
 // Less noisy wrapper around tee syscall
 #[inline]
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn tee(source: &impl AsFd, target: &impl AsFd, len: usize) -> rustix::io::Result<usize> {
-    rustix::pipe::tee(source, target, len, SpliceFlags::empty())
+pub fn tee(source: &impl AsFd, target: &impl AsFd, len: usize) -> TeeState {
+    match rustix::pipe::tee(source, target, len, SpliceFlags::empty()) {
+        Ok(n @ 1..) => TeeState::Ended(n),
+        _ => TeeState::Fallback(0),
+    }
 }


### PR DESCRIPTION
Context: https://github.com/uutils/coreutils/pull/12419

Previously, `pipes::tee` returned a `rustix::io::Result`, which does not align with the intended abstraction boundary. Since the `Err` variant was always discarded at the call sites, the implementation can be simplified by using an enum instead.