### PR TITLE
yes: fix confusing 1.. and comment

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -120,10 +120,10 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
     if let Ok((p_read, mut p_write)) = pipe::<true>(MAX_ROOTLESS_PIPE_SIZE)
         && p_write.write_all(bytes).is_ok()
     {
+        // tee() cannot control offset. Check that output is pipe by tee
         if safe_partial_send && tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE).is_ok() {
-            while let Ok(1..) = tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE) {}
+            while tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE).is_ok() {}
         } else if let Ok((broker_read, broker_write)) = pipe::<true>(MAX_ROOTLESS_PIPE_SIZE) {
-            // tee() cannot control offset and write to non-pipe
             'hybrid: while let Ok(mut remain) = tee(&p_read, &broker_write, MAX_ROOTLESS_PIPE_SIZE)
             {
                 debug_assert!(remain == bytes.len(), "splice() should cleanup pipe");


### PR DESCRIPTION
`yes` never reach to end of file (ENOSPC is not EOF).
Since we don't use busy loop, `let Ok(1..) =` does not reduce CPU workload. We should continue zero-copy when tee was temporarily blocked by stdout by some reason.