### PR TITLE
ls: fix leading space before first entry when color is enabled

### DIFF
--- a/src/uu/ls/src/display.rs
+++ b/src/uu/ls/src/display.rs
@@ -482,7 +482,10 @@ fn display_grid(
                     // ```
                     // FIXME: the Grid crate only supports &str, so can't display raw bytes
                     buf.clear();
-                    if quoted && !os_str_starts_with(&n, b"'") && !os_str_starts_with(&n, b"\"") {
+                    if quoted
+                        && !os_str_starts_with_skip_ansi(&n, b"'")
+                        && !os_str_starts_with_skip_ansi(&n, b"\"")
+                    {
                         buf.push(b' ');
                     }
                     buf.extend(n.as_encoded_bytes());
@@ -968,7 +971,8 @@ fn display_item_long(
             LazyCell::new(|| ansi_width(&String::from_utf8_lossy(&state.display_buf))),
         );
 
-        let needs_space = quoted && !os_str_starts_with(&item_display.displayed, b"'");
+        let needs_space =
+            quoted && !os_str_starts_with_skip_ansi(&item_display.displayed, b"'");
 
         if config.dired {
             let mut dired_name_len = item_display.dired_name_len;
@@ -1338,6 +1342,24 @@ fn calculate_padding_collection(
 
 fn os_str_starts_with(haystack: &OsStr, needle: &[u8]) -> bool {
     os_str_as_bytes_lossy(haystack).starts_with(needle)
+}
+
+fn os_str_starts_with_skip_ansi(haystack: &OsStr, needle: &[u8]) -> bool {
+    let bytes = os_str_as_bytes_lossy(haystack);
+    let mut i = 0;
+    while i < bytes.len() && bytes[i] == b'\x1b' {
+        i += 1;
+        if i < bytes.len() && bytes[i] == b'[' {
+            i += 1;
+            while i < bytes.len() && bytes[i] != b'm' {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1; // skip 'm'
+            }
+        }
+    }
+    bytes[i..].starts_with(needle)
 }
 
 fn write_os_str<W: Write>(writer: &mut W, string: &OsStr) -> std::io::Result<()> {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -4027,6 +4027,33 @@ fn test_ls_align_unquoted_multiline() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_ls_color_no_leading_space_when_all_quoted() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("aa directory");
+    at.mkdir("bb directory");
+    at.touch("cc file");
+
+    let result = scene
+        .ucmd()
+        .arg("--color=always")
+        .arg("--quoting-style=shell-escape-always")
+        .arg("-T0")
+        .arg("--format=column")
+        .succeeds();
+
+    let stdout = result.stdout_str();
+    for line in stdout.lines() {
+        assert!(
+            !line.starts_with(' '),
+            "Line should not start with a space: {line:?}"
+        );
+    }
+}
+
+#[test]
 fn test_ls_ignore_hide() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
## Summary

- When --color is active and quoting is in use, entry names get wrapped in ANSI escape sequences. The alignment logic that prepends a space to unquoted entries was checking the raw first byte of the name, which is now an ESC character instead of a quote. This caused a spurious leading space on every output line in columnar mode.
- Added a helper that skips over ANSI CSI sequences before checking whether a name starts with a quote character, and used it in both the grid format and long format code paths.
- Added a regression test that asserts no leading space appears when all names are quoted and color is enabled.

Fixes #12432

## Test plan

- Reproduced the bug using the exact steps from the issue (script + perl byte check)
- Verified output now matches GNU coreutils 9.9 byte for byte
- Confirmed the alignment space still works correctly for mixed quoted/unquoted names
- All 165 existing ls tests pass with no regressions
- New test covers the specific scenario from the issue