### PR TITLE
Downgrade actions/checkout to v5

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -37,7 +37,7 @@ jobs:
     name: Style/cargo-deny
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: EmbarkStudios/cargo-deny-action@v2
@@ -56,7 +56,7 @@ jobs:
           - { os: macos-latest   , features: "feat_Tier1,feat_require_unix,feat_require_unix_utmpx" }
           - { os: windows-latest , features: feat_os_windows }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: taiki-e/install-action@cargo-udeps
@@ -105,7 +105,7 @@ jobs:
 #          - { os: macos-latest   , features: feat_os_unix }
 #          - { os: windows-latest , features: feat_os_windows }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@master
@@ -168,7 +168,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@master
@@ -255,7 +255,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: "`cargo update` testing"
@@ -280,7 +280,7 @@ jobs:
           - { os: macos-latest   , features: feat_os_unix }
           - { os: windows-latest , features: feat_os_windows }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
@@ -323,7 +323,7 @@ jobs:
           - { os: macos-latest   , features: feat_os_unix }
           - { os: windows-latest , features: feat_os_windows }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@nightly
@@ -390,7 +390,7 @@ jobs:
           - { os: windows-latest , target: x86_64-pc-windows-msvc      , features: feat_os_windows }
           - { os: windows-latest , target: aarch64-pc-windows-msvc     , features: feat_os_windows, use-cross: use-cross , skip-tests: true }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Avoid no space left on device
@@ -713,7 +713,7 @@ jobs:
           # FIXME: Re-enable Code Coverage on windows, which currently fails due to "profiler_builtins". See #6686.
           # - { os: windows-latest , features: windows, toolchain: stable-x86_64-pc-windows-gnu }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: taiki-e/install-action@v2
@@ -832,7 +832,7 @@ jobs:
     needs: [ min_version, deps ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Setup Lima
@@ -873,7 +873,7 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
@@ -895,7 +895,7 @@ jobs:
     needs: [ min_version, deps ]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/CheckScripts.yml
+++ b/.github/workflows/CheckScripts.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Run ShellCheck
@@ -47,7 +47,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Setup shfmt

--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -26,7 +26,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Initialize job variables

--- a/.github/workflows/GnuTests.yml
+++ b/.github/workflows/GnuTests.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
     #### Get the code
     - name: Checkout code (uutils)
-      uses: actions/checkout@v6
+      uses: actions/checkout@v5
       with:
         path: 'uutils'
         persist-credentials: false
@@ -182,7 +182,7 @@ jobs:
     steps:
     #### Get the code
     - name: Checkout code (uutils)
-      uses: actions/checkout@v6
+      uses: actions/checkout@v5
       with:
         path: 'uutils'
         persist-credentials: false
@@ -293,7 +293,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout code (uutils)
-      uses: actions/checkout@v6
+      uses: actions/checkout@v5
       with:
         path: 'uutils'
         persist-credentials: false
@@ -349,7 +349,7 @@ jobs:
 
         outputs TEST_SUMMARY_FILE AGGREGATED_SUMMARY_FILE
     - name: Checkout code (uutils)
-      uses: actions/checkout@v6
+      uses: actions/checkout@v5
       with:
         path: 'uutils'
         persist-credentials: false

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -75,7 +75,7 @@ jobs:
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Collect information about runner

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: rustsec/audit-check@v2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
       matrix:
         type: [simulation, memory]
         package: [

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 12
       matrix:
         type: [simulation, memory]
         package: [

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,6 +25,8 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
     strategy:
+      fail-fast: false
+      max-parallel: 8
       matrix:
         type: [simulation, memory]
         package: [

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,51 +19,17 @@ concurrency:
 
 jobs:
   benchmarks:
-    name: Run ${{ matrix.type }} benchmarks for ${{ matrix.package }} (CodSpeed)
+    name: Run ${{ matrix.type }} benchmarks for ${{ matrix.group }} group (CodSpeed)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: 0
     strategy:
       fail-fast: false
-      max-parallel: 12
+      max-parallel: 4
       matrix:
         type: [simulation, memory]
-        package: [
-          uu_base64,
-          uu_cksum,
-          uu_cp,
-          uu_cat,
-          uu_cut,
-          uu_dd,
-          uu_df,
-          uu_du,
-          uu_echo,
-          uu_expand,
-          uu_fold,
-          uu_hostname,
-          uu_join,
-          uu_ls,
-          uu_mv,
-          uu_nl,
-          uu_numfmt,
-          uu_rm,
-          uu_seq,
-          uu_shuf,
-          uu_sort,
-          uu_split,
-          uu_tee,
-          uu_timeout,
-          uu_tsort,
-          uu_unexpand,
-          uu_uniq,
-          uu_wc,
-          uu_factor,
-          uu_date,
-          uu_csplit,
-          uu_true,
-          uu_false
-        ]
+        group: [text, file, numeric, misc]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -94,19 +60,44 @@ jobs:
         with:
           tool: cargo-codspeed
 
-      - name: Build benchmarks for ${{ matrix.package }} (${{ matrix.type }})
+      - name: Select benchmark packages
+        id: packages
         shell: bash
         run: |
-          echo "Building ${{ matrix.type }} benchmarks for ${{ matrix.package }}"
-          cargo codspeed build -m ${{ matrix.type }} -p ${{ matrix.package }}
+          case "${{ matrix.group }}" in
+            text)
+              packages="uu_cat uu_cut uu_fold uu_join uu_nl uu_sort uu_uniq uu_wc"
+              ;;
+            file)
+              packages="uu_cp uu_dd uu_df uu_du uu_ls uu_mv uu_rm"
+              ;;
+            numeric)
+              packages="uu_cksum uu_numfmt uu_seq uu_factor"
+              ;;
+            misc)
+              packages="uu_base64 uu_echo uu_expand uu_hostname uu_shuf uu_split uu_tee uu_timeout uu_tsort uu_unexpand uu_date uu_csplit uu_true uu_false"
+              ;;
+          esac
 
-      - name: Run ${{ matrix.type }} benchmarks for ${{ matrix.package }}
+          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+
+      - name: Build benchmarks for ${{ matrix.group }} group (${{ matrix.type }})
+        shell: bash
+        run: |
+          for package in ${{ steps.packages.outputs.packages }}; do
+            echo "Building ${{ matrix.type }} benchmarks for ${package}"
+            cargo codspeed build -m ${{ matrix.type }} -p "${package}"
+          done
+
+      - name: Run ${{ matrix.type }} benchmarks for ${{ matrix.group }} group
         uses: CodSpeedHQ/action@v4
         env:
           CODSPEED_LOG: debug
         with:
           mode: ${{ matrix.type }}
           run: |
-            echo "Running ${{ matrix.type }} benchmarks for ${{ matrix.package }}"
-            cargo codspeed run -p ${{ matrix.package }} > /dev/null
+            for package in ${{ steps.packages.outputs.packages }}; do
+              echo "Running ${{ matrix.type }} benchmarks for ${package}"
+              cargo codspeed run -p "${package}" > /dev/null
+            done
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
           uu_false
         ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,7 +33,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Initialize workflow variables
@@ -76,7 +76,7 @@ jobs:
           - { os: windows-latest , features: feat_os_windows }
           - { os: ubuntu-latest  , features: feat_wasm , target: wasm32-wasip1 }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@master
@@ -154,7 +154,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Initialize workflow variables
@@ -192,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Run test in devcontainer

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -31,7 +31,7 @@ jobs:
         job:
           - { os: ubuntu-24.04 , features: unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Prepare, build and test
@@ -121,7 +121,7 @@ jobs:
     env:
       mem: 4096
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Avoid no space left on device (Ubuntu runner)

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build and test uufuzz examples
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Build uufuzz library
@@ -54,7 +54,7 @@ jobs:
     name: Build the fuzzers
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Install `cargo-fuzz`
@@ -100,7 +100,7 @@ jobs:
           - { name: fuzz_dirname, should_pass: true }
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Install `cargo-fuzz`
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Download all stats

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -34,7 +34,7 @@ jobs:
           - { os: macos-latest   , features: "feat_os_unix" }
           - { os: windows-latest , features: "feat_os_windows" }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: taiki-e/install-action@nextest
@@ -85,7 +85,7 @@ jobs:
     name: L10n/Fluent Syntax Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Setup Python
@@ -137,7 +137,7 @@ jobs:
     name: L10n/Clap Error Localization Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -300,7 +300,7 @@ jobs:
     name: L10n/French Integration Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -411,7 +411,7 @@ jobs:
           - { os: ubuntu-latest  , features: "feat_os_unix" }
           - { os: macos-latest   , features: "feat_os_unix" }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -564,7 +564,7 @@ jobs:
           - { os: ubuntu-latest  , features: "feat_os_unix" }
           - { os: macos-latest   , features: "feat_os_unix" }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -898,7 +898,7 @@ jobs:
     name: L10n/Locale Support Verification
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -1130,7 +1130,7 @@ jobs:
     name: L10n/Embedded Locale Regression Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -1156,7 +1156,7 @@ jobs:
     name: L10n/Locale Embedding - Cat Utility
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -1187,7 +1187,7 @@ jobs:
     name: L10n/Locale Embedding - Ls Utility
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -1218,7 +1218,7 @@ jobs:
     name: L10n/Locale Embedding - Multicall Binary
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -1251,7 +1251,7 @@ jobs:
     name: L10n/Locale Embedding - Cargo Install
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -43,7 +43,7 @@ jobs:
         job:
           - { os: ubuntu-latest , features: feat_os_unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: taiki-e/install-action@nextest
@@ -285,7 +285,7 @@ jobs:
         job:
           - { os: windows-latest , features: feat_os_windows }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -356,7 +356,7 @@ jobs:
       run: |
         ## VARs setup
         echo "TEST_SUMMARY_FILE=busybox-result.json" >> $GITHUB_OUTPUT
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2
@@ -442,7 +442,7 @@ jobs:
         outputs() { step_id="${{ github.action }}"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo "${var}=${!var}" >> $GITHUB_OUTPUT; done; }
         TEST_SUMMARY_FILE="toybox-result.json"
         outputs TEST_SUMMARY_FILE
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/manpage-lint.yml
+++ b/.github/workflows/manpage-lint.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -31,7 +31,7 @@ jobs:
         job:
           - { features: unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Prepare, build and test
@@ -131,7 +131,7 @@ jobs:
         job:
           - { features: unix }
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Prepare, build and test

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -21,7 +21,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/wsl2.yml
+++ b/.github/workflows/wsl2.yml
@@ -27,7 +27,7 @@ jobs:
         job:
           - { os: windows-latest, distribution: Ubuntu-24.04, features: feat_os_unix}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Install WSL2


### PR DESCRIPTION
## What changed

Downgraded every GitHub Actions workflow use of actions/checkout from v6 to v5.

## Why

actions/checkout@v6 can fail during checkout before any project code runs with this error:

fatal: could not read Username for `https://github.com:` terminal prompts disabled

This follows the workaround discussed in #12446 while preserving the existing persist-credentials: false setting.

## Impact

Workflow checkout behavior returns to the prior stable action version while keeping credentials from being persisted in the local git config.

## Validation

- Confirmed no actions/checkout@v6 references remain under .github
- Confirmed all checkout references under .github now use actions/checkout@v5

Fixes #12446