### PR TITLE
fix df m flag and missing suffix

### DIFF
--- a/src/uu/df/locales/en-US.ftl
+++ b/src/uu/df/locales/en-US.ftl
@@ -17,6 +17,7 @@ df-help-total = produce a grand total
 df-help-human-readable = print sizes in human readable format (e.g., 1K 234M 2G)
 df-help-si = likewise, but use powers of 1000 not 1024
 df-help-inodes = list inode information instead of block usage
+df-help-mega = like --block-size=1M
 df-help-kilo = like --block-size=1K
 df-help-local = limit listing to local file systems
 df-help-no-sync = do not invoke sync before getting usage info (default)

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -176,16 +176,21 @@ pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSi
         } else {
             Err(ParseSizeError::ParseFailure(format!("{}", s.quote())))
         }
+    } else if matches.get_flag("mega") {
+        Ok(BlockSize::Bytes(1024 * 1024))
+    } else if matches.get_flag("kilo") {
+        Ok(BlockSize::Bytes(1024))
     } else if matches.get_flag(OPT_PORTABILITY) {
         Ok(BlockSize::default())
     } else if let Some(bytes) =
         parse_block_size::block_size_from_env(&["DF_BLOCK_SIZE", "BLOCK_SIZE", "BLOCKSIZE"]).found()
     {
-        Ok(BlockSize::Bytes(bytes))
+        Ok(BlockSize::Bytes(bytes)) 
     } else {
         Ok(BlockSize::default())
     }
 }
+
 
 impl fmt::Display for BlockSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -185,7 +185,7 @@ pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSi
     } else if let Some(bytes) =
         parse_block_size::block_size_from_env(&["DF_BLOCK_SIZE", "BLOCK_SIZE", "BLOCKSIZE"]).found()
     {
-        Ok(BlockSize::Bytes(bytes)) 
+        Ok(BlockSize::Bytes(bytes))
     } else {
         Ok(BlockSize::default())
     }

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -131,19 +131,21 @@ pub(crate) enum BlockSize {
     ///
     /// The number must be positive.
     Bytes(u64),
+    /// for when we need to display suffix along with blocksize
+    PrefixedBytes(u64, String),
 }
 
 impl BlockSize {
     /// Returns the associated value
     pub(crate) fn as_u64(&self) -> u64 {
         match *self {
-            Self::Bytes(n) => n,
+            Self::Bytes(n) | Self::PrefixedBytes(n, _) => n,
         }
     }
 
     pub(crate) fn to_header(&self) -> String {
         match self {
-            Self::Bytes(n) => {
+            Self::Bytes(n) | Self::PrefixedBytes(n, _) => {
                 if n % 1024 == 0 && n % 1000 != 0 {
                     to_magnitude_and_suffix(*n as u128, SuffixType::Iec, false)
                 } else {
@@ -166,7 +168,11 @@ pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSi
         let bytes = parse_size_u64(s)?;
 
         if bytes > 0 {
-            Ok(BlockSize::Bytes(bytes))
+            if s.chars().all(char::is_alphabetic) {
+                Ok(BlockSize::PrefixedBytes(bytes, s.clone()))
+            } else {
+                Ok(BlockSize::Bytes(bytes))
+            }
         } else {
             Err(ParseSizeError::ParseFailure(format!("{}", s.quote())))
         }
@@ -184,7 +190,7 @@ pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSi
 impl fmt::Display for BlockSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Bytes(n) => {
+            Self::Bytes(n) | Self::PrefixedBytes(n, _) => {
                 let s = if n % 1024 == 0 && n % 1000 != 0 {
                     to_magnitude_and_suffix(*n as u128, SuffixType::Iec, true)
                 } else {

--- a/src/uu/df/src/blocks.rs
+++ b/src/uu/df/src/blocks.rs
@@ -191,7 +191,6 @@ pub(crate) fn read_block_size(matches: &ArgMatches) -> Result<BlockSize, ParseSi
     }
 }
 
-
 impl fmt::Display for BlockSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -38,6 +38,7 @@ static OPT_TOTAL: &str = "total";
 static OPT_HUMAN_READABLE_BINARY: &str = "human-readable-binary";
 static OPT_HUMAN_READABLE_DECIMAL: &str = "human-readable-decimal";
 static OPT_INODES: &str = "inodes";
+static OPT_MEGA: &str = "mega";
 static OPT_KILO: &str = "kilo";
 static OPT_LOCAL: &str = "local";
 static OPT_NO_SYNC: &str = "no-sync";
@@ -517,7 +518,7 @@ pub fn uu_app() -> Command {
                 .short('B')
                 .long("block-size")
                 .value_name("SIZE")
-                .overrides_with_all([OPT_KILO, OPT_BLOCKSIZE])
+                .overrides_with_all([OPT_KILO, OPT_BLOCKSIZE, OPT_MEGA])
                 .help(translate!("df-help-block-size")),
         )
         .arg(
@@ -552,10 +553,17 @@ pub fn uu_app() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new(OPT_MEGA)
+                .short('m')
+                .help(translate!("df-help-mega"))
+                .overrides_with_all([OPT_BLOCKSIZE, OPT_KILO, OPT_MEGA])
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new(OPT_KILO)
                 .short('k')
                 .help(translate!("df-help-kilo"))
-                .overrides_with_all([OPT_BLOCKSIZE, OPT_KILO])
+                .overrides_with_all([OPT_BLOCKSIZE, OPT_KILO, OPT_MEGA])
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -215,10 +215,7 @@ impl BytesCell {
     fn new(bytes: u64, block_size: &BlockSize) -> Self {
         Self {
             bytes,
-            scaled: {
-                let BlockSize::Bytes(d) = block_size;
-                (bytes as f64 / *d as f64).ceil() as u64
-            },
+            scaled: (bytes as f64 / block_size.as_u64() as f64).ceil() as u64,
         }
     }
 }
@@ -308,14 +305,21 @@ impl<'a> RowFormatter<'a> {
         let size = bytes_column.scaled;
         let s = if let Some(h) = self.options.human_readable {
             let size = if self.is_total_row {
-                let BlockSize::Bytes(d) = self.options.block_size;
+                let d = self.options.block_size.as_u64();
                 d * size
             } else {
                 bytes_column.bytes
             };
             to_magnitude_and_suffix(size.into(), SuffixType::HumanReadable(h), true)
-        } else {
-            size.to_string()
+        }else {
+            match &self.options.block_size {
+                /// if it has a suffix, append it to the size (but not on the 'total' row)
+                BlockSize::PrefixedBytes(_, suffix) if !self.is_total_row => {
+                    format!("{}{}", size, suffix)
+                }
+                /// else, just print the raw number as before
+                _ => size.to_string(),
+            }
         };
         Cell::from_ascii_string(s)
     }
@@ -327,7 +331,14 @@ impl<'a> RowFormatter<'a> {
         let s = if let Some(h) = self.options.human_readable {
             to_magnitude_and_suffix(size, SuffixType::HumanReadable(h), true)
         } else {
-            size.to_string()
+            match &self.options.block_size {
+                /// if it has a suffix, append it to the size (but not on the 'total' row)
+                BlockSize::PrefixedBytes(_, suffix) if !self.is_total_row => {
+                    format!("{}{}", size, suffix)
+                }
+                /// else, just print the raw number as before
+                _ => size.to_string(),
+            }
         };
         Cell::from_ascii_string(s)
     }

--- a/src/uu/df/src/table.rs
+++ b/src/uu/df/src/table.rs
@@ -311,13 +311,13 @@ impl<'a> RowFormatter<'a> {
                 bytes_column.bytes
             };
             to_magnitude_and_suffix(size.into(), SuffixType::HumanReadable(h), true)
-        }else {
+        } else {
             match &self.options.block_size {
-                /// if it has a suffix, append it to the size (but not on the 'total' row)
+                // if it has a suffix, append it to the size (but not on the 'total' row)
                 BlockSize::PrefixedBytes(_, suffix) if !self.is_total_row => {
-                    format!("{}{}", size, suffix)
+                    format!("{size}{suffix}")
                 }
-                /// else, just print the raw number as before
+                // else, just print the raw number as before
                 _ => size.to_string(),
             }
         };
@@ -332,11 +332,11 @@ impl<'a> RowFormatter<'a> {
             to_magnitude_and_suffix(size, SuffixType::HumanReadable(h), true)
         } else {
             match &self.options.block_size {
-                /// if it has a suffix, append it to the size (but not on the 'total' row)
+                // if it has a suffix, append it to the size (but not on the 'total' row)
                 BlockSize::PrefixedBytes(_, suffix) if !self.is_total_row => {
-                    format!("{}{}", size, suffix)
+                    format!("{size}{suffix}")
                 }
-                /// else, just print the raw number as before
+                // else, just print the raw number as before
                 _ => size.to_string(),
             }
         };

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -1150,3 +1150,40 @@ fn test_df_masked_proc_fallback() {
         }
     }
 }
+
+#[test]
+fn test_df_m_flag() {
+    new_ucmd!()
+        .arg("-m")
+        .succeeds()
+        .stdout_contains("1M-blocks");
+}
+
+#[test]
+fn test_blocksize_output_suffix() {
+    fn get_size_value(args: &[&str]) -> String {
+        let output = new_ucmd!()
+            .args(args)
+            .arg("--output=size")
+            .arg(".")
+            .succeeds()
+            .stdout_str_lossy();
+        output.lines().nth(1).unwrap().trim().to_string()
+    }
+
+    let val_m = get_size_value(&["-BM"]);
+    assert!(val_m.ends_with('M'), "Expected suffix 'M', got: {}", val_m);
+
+    let val_k = get_size_value(&["-BK"]);
+    assert!(val_k.ends_with('K'), "Expected suffix 'K', got: {}", val_k);
+
+    let val_mega = get_size_value(&["-m"]);
+    assert!(!val_mega.ends_with('M'), "Expected NO suffix 'M' for -m, got: {}", val_mega);
+
+    let val_kilo = get_size_value(&["-k"]);
+    assert!(!val_kilo.ends_with('K'), "Expected NO suffix 'K' for -k, got: {}", val_kilo);
+
+    let val_numeric = get_size_value(&["-B", "1048576"]);
+    assert!(!val_numeric.ends_with('M'), "Expected NO suffix 'M' for numeric blocks, got: {}", val_numeric);
+}
+

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -1172,18 +1172,26 @@ fn test_blocksize_output_suffix() {
     }
 
     let val_m = get_size_value(&["-BM"]);
-    assert!(val_m.ends_with('M'), "Expected suffix 'M', got: {}", val_m);
+    assert!(val_m.ends_with('M'), "Expected suffix 'M', got: {val_m}");
 
     let val_k = get_size_value(&["-BK"]);
-    assert!(val_k.ends_with('K'), "Expected suffix 'K', got: {}", val_k);
+    assert!(val_k.ends_with('K'), "Expected suffix 'K', got: {val_k}");
 
     let val_mega = get_size_value(&["-m"]);
-    assert!(!val_mega.ends_with('M'), "Expected NO suffix 'M' for -m, got: {}", val_mega);
+    assert!(
+        !val_mega.ends_with('M'),
+        "Expected NO suffix 'M' for -m, got: {val_mega}"
+    );
 
     let val_kilo = get_size_value(&["-k"]);
-    assert!(!val_kilo.ends_with('K'), "Expected NO suffix 'K' for -k, got: {}", val_kilo);
+    assert!(
+        !val_kilo.ends_with('K'),
+        "Expected NO suffix 'K' for -k, got: {val_kilo}"
+    );
 
     let val_numeric = get_size_value(&["-B", "1048576"]);
-    assert!(!val_numeric.ends_with('M'), "Expected NO suffix 'M' for numeric blocks, got: {}", val_numeric);
+    assert!(
+        !val_numeric.ends_with('M'),
+        "Expected NO suffix 'M' for numeric blocks, got: {val_numeric}"
+    );
 }
-


### PR DESCRIPTION
The df utility was missing the -m flag. And when running 'df -BM' it produces just raw numbers, without any suffix like GNU's df does.
Closes #11565