### PR TITLE
Group CodSpeed benchmark packages

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         type: [simulation, memory]
         group: [text, file, numeric, misc]

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,49 +19,17 @@ concurrency:
 
 jobs:
   benchmarks:
-    name: Run ${{ matrix.type }} benchmarks for ${{ matrix.package }} (CodSpeed)
+    name: Run ${{ matrix.type }} benchmarks for ${{ matrix.group }} packages (CodSpeed)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     env:
       CARGO_INCREMENTAL: 0
     strategy:
+      fail-fast: false
+      max-parallel: 4
       matrix:
         type: [simulation, memory]
-        package: [
-          uu_base64,
-          uu_cksum,
-          uu_cp,
-          uu_cat,
-          uu_cut,
-          uu_dd,
-          uu_df,
-          uu_du,
-          uu_echo,
-          uu_expand,
-          uu_fold,
-          uu_hostname,
-          uu_join,
-          uu_ls,
-          uu_mv,
-          uu_nl,
-          uu_numfmt,
-          uu_rm,
-          uu_seq,
-          uu_shuf,
-          uu_sort,
-          uu_split,
-          uu_tee,
-          uu_timeout,
-          uu_tsort,
-          uu_unexpand,
-          uu_uniq,
-          uu_wc,
-          uu_factor,
-          uu_date,
-          uu_csplit,
-          uu_true,
-          uu_false
-        ]
+        group: [text, file, numeric, misc]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -92,19 +60,43 @@ jobs:
         with:
           tool: cargo-codspeed
 
-      - name: Build benchmarks for ${{ matrix.package }} (${{ matrix.type }})
+      - name: Select benchmark packages
         shell: bash
         run: |
-          echo "Building ${{ matrix.type }} benchmarks for ${{ matrix.package }}"
-          cargo codspeed build -m ${{ matrix.type }} -p ${{ matrix.package }}
+          case "${{ matrix.group }}" in
+            text)
+              packages="uu_cat uu_cut uu_fold uu_join uu_nl uu_sort uu_uniq uu_wc"
+              ;;
+            file)
+              packages="uu_cp uu_dd uu_df uu_du uu_ls uu_mv uu_rm"
+              ;;
+            numeric)
+              packages="uu_cksum uu_numfmt uu_seq uu_factor"
+              ;;
+            misc)
+              packages="uu_base64 uu_echo uu_expand uu_hostname uu_shuf uu_split uu_tee uu_timeout uu_tsort uu_unexpand uu_date uu_csplit uu_true uu_false"
+              ;;
+          esac
 
-      - name: Run ${{ matrix.type }} benchmarks for ${{ matrix.package }}
+          echo "BENCHMARK_PACKAGES=${packages}" >> $GITHUB_ENV
+
+      - name: Build benchmarks for ${{ matrix.group }} packages (${{ matrix.type }})
+        shell: bash
+        run: |
+          for package in ${BENCHMARK_PACKAGES}; do
+            echo "Building ${{ matrix.type }} benchmarks for ${package}"
+            cargo codspeed build -m ${{ matrix.type }} -p "${package}"
+          done
+
+      - name: Run ${{ matrix.type }} benchmarks for ${{ matrix.group }} packages
         uses: CodSpeedHQ/action@v4
         env:
           CODSPEED_LOG: debug
         with:
           mode: ${{ matrix.type }}
           run: |
-            echo "Running ${{ matrix.type }} benchmarks for ${{ matrix.package }}"
-            cargo codspeed run -p ${{ matrix.package }} > /dev/null
+            for package in ${BENCHMARK_PACKAGES}; do
+              echo "Running ${{ matrix.type }} benchmarks for ${package}"
+              cargo codspeed run -p "${package}" > /dev/null
+            done
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
## What changed

- Replace the per-package CodSpeed benchmark matrix with four package groups: text, file, numeric, and misc.
- Run each group's packages sequentially within the same runner for both simulation and memory modes.
- Add fail-fast: false, cap benchmark concurrency with max-parallel: 4, and increase the job timeout to account for grouped runs.

## Why

This reduces duplicated GitHub Actions setup work across CodSpeed benchmark jobs while keeping the same 33 benchmark packages covered.

Closes #12452.
