### PR TITLE
nl: accept negative -v and -i values as separate arguments

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -329,6 +329,7 @@ pub fn uu_app() -> Command {
                 .long(options::LINE_INCREMENT)
                 .help(translate!("nl-help-line-increment"))
                 .value_name("NUMBER")
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(i64)),
         )
         .arg(
@@ -368,6 +369,7 @@ pub fn uu_app() -> Command {
                 .long(options::STARTING_LINE_NUMBER)
                 .help(translate!("nl-help-starting-line-number"))
                 .value_name("NUMBER")
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(i64)),
         )
         .arg(

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -255,6 +255,17 @@ fn test_negative_starting_line_number() {
 }
 
 #[test]
+fn test_negative_starting_line_number_space_separated() {
+    // GNU nl accepts a negative value passed as a separate argument, e.g.
+    // `nl -v -10`. Without `allow_hyphen_values` clap rejected the `-10` token.
+    new_ucmd!()
+        .args(&["-v", "-10"])
+        .pipe_in("test")
+        .succeeds()
+        .stdout_is("   -10\ttest\n");
+}
+
+#[test]
 fn test_invalid_starting_line_number() {
     for arg in ["-vinvalid", "--starting-line-number=invalid"] {
         new_ucmd!()
@@ -296,6 +307,16 @@ fn test_negative_line_increment() {
             .succeeds()
             .stdout_is("     1\ta\n    -9\tb\n   -19\tc\n");
     }
+}
+
+#[test]
+fn test_negative_line_increment_space_separated() {
+    // GNU nl accepts `nl -i -10` with the value as a separate argument.
+    new_ucmd!()
+        .args(&["-i", "-10"])
+        .pipe_in("a\nb\nc")
+        .succeeds()
+        .stdout_is("     1\ta\n    -9\tb\n   -19\tc\n");
 }
 
 #[test]


### PR DESCRIPTION
## Reproduce

```
gh repo fork uutils/coreutils --clone
cd coreutils && cargo build --bin coreutils
LC_ALL=C printf 'a\nb\n' | ./target/debug/coreutils nl -v -5
```

Oracle is GNU coreutils 9.11 (`LC_ALL=C`):

```
LC_ALL=C printf 'a\nb\n' | gnl -v -5
```

## Before (raw)

```
$ printf 'a\nb\n' | ./target/debug/coreutils nl -v -5
error: unexpected argument '-5' found

  tip: to pass '-5' as a value, use '-- -5'

Usage: nl [OPTION]... [FILE]...

For more information, try '--help'.
```

GNU accepts it:

```
$ printf 'a\nb\n' | gnl -v -5
    -5	a
    -4	b
```

The same divergence affects `-i` (`nl -i -2`).

## After (raw)

```
$ printf 'a\nb\n' | ./target/debug/coreutils nl -v -5
    -5	a
    -4	b
```

## How

`-v`/`-i` already used `value_parser!(i64)`, so negative values were intended, and the attached forms (`-v-5`, `--starting-line-number=-5`) already worked. The space-separated form failed because the arguments lacked `allow_hyphen_values`, so clap rejected the `-5` token as an unknown flag. Setting `allow_hyphen_values(true)` on both arguments makes clap consume the negative token as the option value, matching GNU. This mirrors how `head`, `tail`, and `numfmt` already accept negative space-separated values.

Tests added for the space-separated form of both options.
