### PR TITLE
chore: remove duplicate words in six comments

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -524,7 +524,7 @@ fn process_file(
         Err(Error::from_io1(s, &file_full_name, r))
     };
 
-    // SAFETY: If `entry.fts_statp` is not null, then is is assumed to be valid.
+    // SAFETY: If `entry.fts_statp` is not null, then it is assumed to be valid.
     let file_dev_ino: DeviceAndINode = if let Some(st) = entry.stat() {
         st.try_into()?
     } else {

--- a/src/uu/od/src/output_info.rs
+++ b/src/uu/od/src/output_info.rs
@@ -112,7 +112,7 @@ impl OutputInfo {
     ///
     /// This function calculates the required spacing for a single line, given the size
     /// of a block, and the width of a block. The size of a block is the largest type
-    /// and the width is width of the the type which needs the most space to print that
+    /// and the width is the width of the type which needs the most space to print that
     /// number of bytes. So both numbers might refer to different types. All widths
     /// include a space at the front. For example the width of a 8-bit hexadecimal,
     /// is 3 characters, for example " FF".

--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -110,7 +110,7 @@ impl Suffix {
     ///   `-a N` or `--suffix-length=N`
     /// - OFF if suffix length is auto pre-calculated (auto-width)
     ///
-    /// Suffix auto-width: Determine if the the output file names suffix length should be automatically pre-calculated
+    /// Suffix auto-width: Determine if the output file names suffix length should be automatically pre-calculated
     /// based on number of files that need to written into, having number of files known upfront
     /// Suffix length auto pre-calculation rules:
     /// - Pre-calculate new suffix length when `-n`/`--number` option (N, K/N, l/N, l/K/N, r/N, r/K/N)

--- a/src/uu/tail/src/paths.rs
+++ b/src/uu/tail/src/paths.rs
@@ -225,7 +225,7 @@ impl PathExtTail for Path {
         !matches!(self.parent(), Some(parent) if parent.is_dir())
     }
 
-    /// Return true if `path` is is a file type that can be tailed
+    /// Return true if `path` is a file type that can be tailed
     fn is_tailable(&self) -> bool {
         path_is_tailable(self)
     }

--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -468,7 +468,7 @@ impl LineInfo {
     /// to populate the fields of the struct.
     /// However, there is a catch to handle regarding the handling of `cached_line_format`.
     /// In case of non-algo-based format, if `cached_line_format` is Some, it must take the priority
-    /// over the detected format. Otherwise, we must set it the the detected format.
+    /// over the detected format. Otherwise, we must set it to the detected format.
     /// This specific behavior is emphasized by the test
     /// `test_md5sum::test_check_md5sum_only_one_space`.
     fn parse(s: impl AsRef<OsStr>, cached_line_format: &mut Option<LineFormat>) -> Option<Self> {

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -413,7 +413,7 @@ pub fn format_nusers(n: usize) -> String {
     )
 }
 
-/// Get the number of users currently logged in in a human-readable format
+/// Get the number of users currently logged in, in a human-readable format
 ///
 /// # Returns
 ///


### PR DESCRIPTION
## Summary

All comment / doc-comment changes.

| File | Line | Fix |
|---|---|---|
| `src/uucore/src/lib/features/checksum/validate.rs` | 471 | "must set it the the detected" → "must set it to the detected" (also adds the missing "to") |
| `src/uucore/src/lib/features/uptime.rs` | 416 | "logged in in a human-readable format" → "logged in, in a human-readable format" |
| `src/uu/od/src/output_info.rs` | 115 | "the width is width of the the type" → "the width is the width of the type" |
| `src/uu/split/src/filenames.rs` | 113 | "Determine if the the output file names" → "Determine if the output file names" |
| `src/uu/tail/src/paths.rs` | 228 | "if \`path\` is is a file type" → "if \`path\` is a file type" |
| `src/uu/chcon/src/chcon.rs` | 527 | "then is is assumed to be valid" → "then it is assumed to be valid" |