### PR TITLE
factor: add benchmark coverage

### DIFF
--- a/src/uu/factor/benches/factor_bench.rs
+++ b/src/uu/factor/benches/factor_bench.rs
@@ -3,23 +3,36 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore funcs
+// spell-checker:ignore funcs semiprime
 
 use divan::{Bencher, black_box};
 use uu_factor::uumain;
 use uucore::benchmark::run_util_function;
 
-/// Benchmark multiple u64 digits
+/// Benchmark multiple u64 digits.
 #[divan::bench(args = [(2)])]
 fn factor_multiple_u64s(bencher: Bencher, start_num: u64) {
-    bencher
-        // this is a range of 5000 different u128 integers
-        .with_inputs(|| (start_num, start_num + 2500))
-        .bench_values(|(start_u64, end_u64)| {
-            for u64_digit in start_u64..=end_u64 {
-                black_box(run_util_function(uumain, &[&u64_digit.to_string()]));
-            }
-        });
+    bencher.bench(|| {
+        for n in start_num..=start_num + 2500 {
+            black_box(run_util_function(uumain, &[&n.to_string()]));
+        }
+    });
+}
+
+/// Benchmark a large u64 prime.
+#[divan::bench]
+fn factor_large_u64_prime(bencher: Bencher) {
+    bencher.bench(|| {
+        black_box(run_util_function(uumain, &["18446744073709551557"]));
+    });
+}
+
+/// Benchmark a 64-bit semiprime made from two 32-bit primes.
+#[divan::bench]
+fn factor_64bit_semiprime(bencher: Bencher) {
+    bencher.bench(|| {
+        black_box(run_util_function(uumain, &["18446743979220271189"]));
+    });
 }
 
 fn main() {


### PR DESCRIPTION
expands `factor` Divan bench with internal factorization cases and e2e CLI cases

Covers: small ranges, semiprimes, large primes, u128-sized composites, and PR timing inputs

https://github.com/uutils/coreutils/pull/9587
