### PR TITLE
mktemp: ensure that "-q XX" shows error msg

### DIFF
--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -698,6 +698,14 @@ fn test_too_few_xs_suffix_directory() {
 }
 
 #[test]
+fn test_too_few_xs_quiet() {
+    new_ucmd!()
+        .args(&["-q", "aXX"])
+        .fails()
+        .stderr_only("mktemp: too few X's in template 'aXX'\n");
+}
+
+#[test]
 fn test_too_many_arguments() {
     new_ucmd!()
         .args(&["-q", "a", "b"])


### PR DESCRIPTION
This PR adds a test to ensure that an error message is shown when using `-q` and too few Xs in the template.

I noticed the lack of such a test in https://github.com/uutils/coreutils/pull/12490 where our test suite didn't catch a bug whereas the GNU test suite did.