### PR TITLE
csplit: fix panic on out-of-range pattern numbers

### DIFF
--- a/src/uu/csplit/src/patterns.rs
+++ b/src/uu/csplit/src/patterns.rs
@@ -120,7 +120,11 @@ fn extract_patterns(args: &[&str]) -> Result<Vec<Pattern>, CsplitError> {
                         // skip the next item
                         iter.next();
                         if let Some(times) = r.name("TIMES") {
-                            ExecutePattern::Times(times.as_str().parse::<usize>().unwrap() + 1)
+                            let n: usize = times
+                                .as_str()
+                                .parse()
+                                .map_err(|_| CsplitError::InvalidPattern(next_item.to_owned()))?;
+                            ExecutePattern::Times(n.saturating_add(1))
                         } else {
                             ExecutePattern::Always
                         }
@@ -133,7 +137,10 @@ fn extract_patterns(args: &[&str]) -> Result<Vec<Pattern>, CsplitError> {
         if let Some(captures) = to_match_reg.captures(arg) {
             let offset = match captures.name("OFFSET") {
                 None => 0,
-                Some(m) => m.as_str().parse().unwrap(),
+                Some(m) => m
+                    .as_str()
+                    .parse()
+                    .map_err(|_| CsplitError::LineOutOfRange(arg.to_owned()))?,
             };
             if let Some(up_to_match) = captures.name("UPTO") {
                 let pattern = Regex::new(up_to_match.as_str())

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -1582,3 +1582,35 @@ fn test_write_error_dev_full_keep_files() {
     assert!(at.file_exists("xx00"));
     assert_eq!(at.read("xx00"), "1\n");
 }
+
+#[test]
+fn test_repeat_count_overflow() {
+    // Repro for #12495: a `{N}` repetition count whose digits exceed usize::MAX
+    // used to panic on `parse::<usize>().unwrap()`. It must now fail cleanly.
+    // We use a different error message than GNU.
+    new_ucmd!()
+        .args(&["numbers50.txt", "10", "{99999999999999999999999999999999}"])
+        .fails_with_code(1)
+        .stderr_contains("invalid pattern");
+}
+
+#[test]
+fn test_repeat_count_saturates_at_usize_max() {
+    // Repro for #12495: `{usize::MAX}` overflowed the `+ 1` (panic in debug,
+    // silent wrap to 0 in release). The count now saturates, so the repetition
+    // runs and fails when it walks past the end of input, matching GNU.
+    new_ucmd!()
+        .args(&["numbers50.txt", "10", "{18446744073709551615}"])
+        .fails_with_code(1)
+        .stderr_is("csplit: '10': line number out of range on repetition 5\n");
+}
+
+#[test]
+fn test_match_offset_overflow() {
+    // Repro for #12495: a `/regex/OFF` offset outside i32 range used to panic on
+    // `parse().unwrap()`. It must now fail cleanly, matching GNU's message.
+    new_ucmd!()
+        .args(&["numbers50.txt", "/9$/-2147483649"])
+        .fails_with_code(1)
+        .stderr_is("csplit: '/9$/-2147483649': line number out of range\n");
+}

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -1585,9 +1585,8 @@ fn test_write_error_dev_full_keep_files() {
 
 #[test]
 fn test_repeat_count_overflow() {
-    // Repro for #12495: a `{N}` repetition count whose digits exceed usize::MAX
-    // used to panic on `parse::<usize>().unwrap()`. It must now fail cleanly.
-    // We use a different error message than GNU.
+    // Repro for #12495: a `{N}` count above usize::MAX used to panic on
+    // `parse::<usize>().unwrap()`; it must now fail cleanly.
     new_ucmd!()
         .args(&["numbers50.txt", "10", "{99999999999999999999999999999999}"])
         .fails_with_code(1)
@@ -1596,19 +1595,19 @@ fn test_repeat_count_overflow() {
 
 #[test]
 fn test_repeat_count_saturates_at_usize_max() {
-    // Repro for #12495: `{usize::MAX}` overflowed the `+ 1` (panic in debug,
-    // silent wrap to 0 in release). The count now saturates, so the repetition
-    // runs and fails when it walks past the end of input, matching GNU.
+    // Repro for #12495: the `+ 1` on a usize::MAX count used to overflow.
+    // usize::MAX is formatted so the count parses on 32- and 64-bit alike.
+    let max = usize::MAX;
     new_ucmd!()
-        .args(&["numbers50.txt", "10", "{18446744073709551615}"])
+        .args(&["numbers50.txt", "10", &format!("{{{max}}}")])
         .fails_with_code(1)
         .stderr_is("csplit: '10': line number out of range on repetition 5\n");
 }
 
 #[test]
 fn test_match_offset_overflow() {
-    // Repro for #12495: a `/regex/OFF` offset outside i32 range used to panic on
-    // `parse().unwrap()`. It must now fail cleanly, matching GNU's message.
+    // Repro for #12495: a `/regex/OFF` offset outside i32 range used to panic
+    // on `parse().unwrap()`; it must now fail cleanly.
     new_ucmd!()
         .args(&["numbers50.txt", "/9$/-2147483649"])
         .fails_with_code(1)


### PR DESCRIPTION
Fixes #12495.

`get_patterns()` unwrapped `str::parse()` on two user-supplied pattern numbers, so out-of-range values aborted with a panic instead of a clean error:

```console
$ csplit - 1 '{99999999999999999999999999999999}'   # parse::<usize> Err -> panic
$ csplit - '/x/-2147483649'                          # parse::<i32> Err  -> panic
```

Both now return a `CsplitError` (exit 1):

- **`{N}` count**: parsed into `usize`, then `saturating_add(1)` so a huge-but-valid count flows into the repetition logic and fails with `line number out of range on repetition K` (matching GNU) instead of being rejected up front. This also fixes the silent wrap to `Times(0)` that release builds produced for `{usize::MAX}`.
- **`/regex/OFF` offset**: parse error maps to `LineOutOfRange`, matching GNU's `line number out of range`.

Verified output matches GNU coreutils 8.30 on these and adjacent inputs. Regression tests added in `tests/by-util/test_csplit.rs`.