### PR TITLE
wasi: clean up core platform abstractions

### DIFF
--- a/src/uu/env/src/native_int_str.rs
+++ b/src/uu/env/src/native_int_str.rs
@@ -13,8 +13,10 @@
 // this conversion needs to be done only once in the beginning and at the end.
 
 use std::ffi::OsString;
-#[cfg(not(target_os = "windows"))]
+#[cfg(unix)]
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::ffi::{OsStrExt, OsStringExt};
 #[cfg(target_os = "windows")]
 use std::os::windows::prelude::*;
 use std::{borrow::Cow, ffi::OsStr};

--- a/src/uu/tail/src/platform/mod.rs
+++ b/src/uu/tail/src/platform/mod.rs
@@ -19,21 +19,6 @@ pub use self::windows::{Pid, ProcessChecker, supports_pid_checks};
 pub type Pid = u64;
 
 #[cfg(target_os = "wasi")]
-#[allow(dead_code)]
-pub struct ProcessChecker;
-
-#[cfg(target_os = "wasi")]
-#[allow(dead_code)]
-impl ProcessChecker {
-    pub fn new(_pid: Pid) -> Self {
-        Self
-    }
-    pub fn is_dead(&self) -> bool {
-        true
-    }
-}
-
-#[cfg(target_os = "wasi")]
 pub fn supports_pid_checks(_pid: Pid) -> bool {
     false
 }

--- a/src/uu/tail/src/platform/mod.rs
+++ b/src/uu/tail/src/platform/mod.rs
@@ -19,6 +19,21 @@ pub use self::windows::{Pid, ProcessChecker, supports_pid_checks};
 pub type Pid = u64;
 
 #[cfg(target_os = "wasi")]
+#[allow(dead_code)]
+pub struct ProcessChecker;
+
+#[cfg(target_os = "wasi")]
+#[allow(dead_code)]
+impl ProcessChecker {
+    pub fn new(_pid: Pid) -> Self {
+        Self
+    }
+    pub fn is_dead(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(target_os = "wasi")]
 pub fn supports_pid_checks(_pid: Pid) -> bool {
     false
 }

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -18,7 +18,7 @@ use std::fs::read_dir;
 use std::hash::Hash;
 use std::io::Stdin;
 use std::io::{Error, ErrorKind, Result as IOResult};
-#[cfg(any(unix, all(target_os = "wasi", target_env = "p2")))]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::AsFd;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -52,15 +52,13 @@ macro_rules! has {
 /// Information to uniquely identify a file
 #[derive(Clone)]
 pub struct FileInformation(
-    #[cfg(unix)] rustix::fs::Stat,
+    #[cfg(any(unix, target_os = "wasi"))] rustix::fs::Stat,
     #[cfg(windows)] winapi_util::file::Information,
-    // WASI does not have nix::sys::stat, so we store std::fs::Metadata instead.
-    #[cfg(target_os = "wasi")] fs::Metadata,
 );
 
 impl FileInformation {
     /// Get information from a currently open file
-    #[cfg(unix)]
+    #[cfg(any(unix, target_os = "wasi"))]
     pub fn from_file(file: &impl AsFd) -> IOResult<Self> {
         let stat = rustix::fs::fstat(file)?;
         Ok(Self(stat))
@@ -78,7 +76,7 @@ impl FileInformation {
     /// If `path` points to a symlink and `dereference` is true, information about
     /// the link's target will be returned.
     pub fn from_path(path: impl AsRef<Path>, dereference: bool) -> IOResult<Self> {
-        #[cfg(unix)]
+        #[cfg(any(unix, target_os = "wasi"))]
         {
             let stat = if dereference {
                 rustix::fs::stat(path.as_ref())
@@ -102,20 +100,10 @@ impl FileInformation {
             let file = open_options.read(true).open(path.as_ref())?;
             Self::from_file(&file)
         }
-        // WASI: use std::fs::metadata / symlink_metadata since nix is not available
-        #[cfg(target_os = "wasi")]
-        {
-            let metadata = if dereference {
-                fs::metadata(path.as_ref())
-            } else {
-                fs::symlink_metadata(path.as_ref())
-            };
-            Ok(Self(metadata?))
-        }
     }
 
     pub fn file_size(&self) -> u64 {
-        #[cfg(unix)]
+        #[cfg(any(unix, target_os = "wasi"))]
         {
             assert!(self.0.st_size >= 0, "File size is negative");
             self.0.st_size.try_into().unwrap()
@@ -123,10 +111,6 @@ impl FileInformation {
         #[cfg(target_os = "windows")]
         {
             self.0.file_size()
-        }
-        #[cfg(target_os = "wasi")]
-        {
-            self.0.len()
         }
     }
 
@@ -154,6 +138,8 @@ impl FileInformation {
             target_pointer_width = "64"
         ))]
         return self.0.st_nlink;
+        #[cfg(target_os = "wasi")]
+        return self.0.st_nlink;
         #[cfg(all(
             unix,
             any(
@@ -178,12 +164,9 @@ impl FileInformation {
         return self.0.st_nlink.try_into().unwrap();
         #[cfg(windows)]
         return self.0.number_of_links();
-        // WASI: nlink is not available in std::fs::Metadata, return 1
-        #[cfg(target_os = "wasi")]
-        return 1;
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, target_os = "wasi"))]
     pub fn inode(&self) -> u64 {
         #[cfg(all(not(any(target_os = "netbsd")), target_pointer_width = "64"))]
         return self.0.st_ino;
@@ -193,19 +176,10 @@ impl FileInformation {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 impl PartialEq for FileInformation {
     fn eq(&self, other: &Self) -> bool {
         self.0.st_dev == other.0.st_dev && self.0.st_ino == other.0.st_ino
-    }
-}
-
-// WASI: compare by file type and size as a basic heuristic since
-// device/inode numbers are not available through std::fs::Metadata.
-#[cfg(target_os = "wasi")]
-impl PartialEq for FileInformation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.file_type() == other.0.file_type() && self.0.len() == other.0.len()
     }
 }
 
@@ -221,7 +195,7 @@ impl Eq for FileInformation {}
 
 impl Hash for FileInformation {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        #[cfg(unix)]
+        #[cfg(any(unix, target_os = "wasi"))]
         {
             self.0.st_dev.hash(state);
             self.0.st_ino.hash(state);
@@ -230,11 +204,6 @@ impl Hash for FileInformation {
         {
             self.0.volume_serial_number().hash(state);
             self.0.file_index().hash(state);
-        }
-        #[cfg(target_os = "wasi")]
-        {
-            self.0.len().hash(state);
-            self.0.file_type().is_dir().hash(state);
         }
     }
 }

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -430,7 +430,6 @@ fn mount_dev_id(mount_dir: &OsStr) -> String {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 use crate::error::UResult;
 #[cfg(any(
     target_os = "freebsd",
@@ -461,7 +460,7 @@ use std::ptr;
 use std::slice;
 
 /// Read file system list.
-#[cfg(not(target_os = "wasi"))]
+#[cfg_attr(target_os = "wasi", allow(clippy::unnecessary_wraps))]
 pub fn read_fs_list() -> UResult<Vec<MountInfo>> {
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "cygwin"))]
     {
@@ -542,18 +541,12 @@ pub fn read_fs_list() -> UResult<Vec<MountInfo>> {
         target_os = "redox",
         target_os = "illumos",
         target_os = "solaris",
+        target_os = "wasi"
     ))]
     {
         // No method to read mounts on these platforms
         Ok(Vec::new())
     }
-}
-
-/// Read file system list.
-#[cfg(target_os = "wasi")]
-pub fn read_fs_list() -> Vec<MountInfo> {
-    // No method to read mounts on WASI
-    Vec::new()
 }
 
 #[derive(Debug, Clone)]

--- a/src/uucore/src/lib/mods/io.rs
+++ b/src/uucore/src/lib/mods/io.rs
@@ -99,14 +99,7 @@ impl OwnedFileDescriptorOrHandle {
     /// instantiates a corresponding `Stdio`
     #[cfg(not(target_os = "wasi"))]
     pub fn into_stdio(self) -> Stdio {
-        #[cfg(not(target_os = "wasi"))]
-        {
-            Stdio::from(self.fx)
-        }
-        #[cfg(target_os = "wasi")]
-        {
-            Stdio::from(File::from(self.fx))
-        }
+        Stdio::from(self.fx)
     }
 
     /// WASI: Stdio::from(OwnedFd) is not available, convert via File instead.

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -455,17 +455,12 @@ fn test_sorted() {
     let at = &scene.fixtures;
     at.write("comm1", "1\n3");
     at.write("comm2", "3\n2");
-    let cmd = scene.ucmd().args(&["comm1", "comm2"]).run();
-    // WASI's strcoll (C locale only) may not detect unsorted input,
-    // but the comparison output is still correct.
-    if std::env::var("UUTESTS_WASM_RUNNER").is_ok() {
-        cmd.success().stdout_is("1\n\t\t3\n\t2\n");
-    } else {
-        cmd.failure()
-            .code_is(1)
-            .stdout_is("1\n\t\t3\n\t2\n")
-            .stderr_is("comm: file 2 is not in sorted order\ncomm: input is not in sorted order\n");
-    }
+    scene
+        .ucmd()
+        .args(&["comm1", "comm2"])
+        .fails_with_code(1)
+        .stdout_is("1\n\t\t3\n\t2\n")
+        .stderr_is("comm: file 2 is not in sorted order\ncomm: input is not in sorted order\n");
 }
 
 #[test]
@@ -492,19 +487,16 @@ fn test_both_inputs_out_of_order() {
     at.write("file_a", "3\n1\n0\n");
     at.write("file_b", "3\n2\n0\n");
 
-    let cmd = scene.ucmd().args(&["file_a", "file_b"]).run();
-    if std::env::var("UUTESTS_WASM_RUNNER").is_ok() {
-        cmd.success().stdout_is("\t\t3\n1\n0\n\t2\n\t0\n");
-    } else {
-        cmd.failure()
-            .code_is(1)
-            .stdout_is("\t\t3\n1\n0\n\t2\n\t0\n")
-            .stderr_is(
-                "comm: file 1 is not in sorted order\n\
-                 comm: file 2 is not in sorted order\n\
-                 comm: input is not in sorted order\n",
-            );
-    }
+    scene
+        .ucmd()
+        .args(&["file_a", "file_b"])
+        .fails_with_code(1)
+        .stdout_is("\t\t3\n1\n0\n\t2\n\t0\n")
+        .stderr_is(
+            "comm: file 1 is not in sorted order\n\
+             comm: file 2 is not in sorted order\n\
+             comm: input is not in sorted order\n",
+        );
 }
 
 #[test]
@@ -514,19 +506,16 @@ fn test_both_inputs_out_of_order_last_pair() {
     at.write("file_a", "3\n1\n");
     at.write("file_b", "3\n2\n");
 
-    let cmd = scene.ucmd().args(&["file_a", "file_b"]).run();
-    if std::env::var("UUTESTS_WASM_RUNNER").is_ok() {
-        cmd.success().stdout_is("\t\t3\n1\n\t2\n");
-    } else {
-        cmd.failure()
-            .code_is(1)
-            .stdout_is("\t\t3\n1\n\t2\n")
-            .stderr_is(
-                "comm: file 1 is not in sorted order\n\
-                 comm: file 2 is not in sorted order\n\
-                 comm: input is not in sorted order\n",
-            );
-    }
+    scene
+        .ucmd()
+        .args(&["file_a", "file_b"])
+        .fails_with_code(1)
+        .stdout_is("\t\t3\n1\n\t2\n")
+        .stderr_is(
+            "comm: file 1 is not in sorted order\n\
+             comm: file 2 is not in sorted order\n\
+             comm: input is not in sorted order\n",
+        );
 }
 
 #[test]

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -229,16 +229,19 @@ fn test_zero_bytes_with_suffix() {
     new_ucmd!()
         .args(&["--bytes=0K"])
         .pipe_in("qwerty")
+        .ignore_stdin_write_error()
         .succeeds()
         .no_output();
     new_ucmd!()
         .args(&["--bytes=00K"])
         .pipe_in("qwerty")
+        .ignore_stdin_write_error()
         .succeeds()
         .no_output();
     new_ucmd!()
         .args(&["--bytes=+0K"])
         .pipe_in("qwerty")
+        .ignore_stdin_write_error()
         .succeeds()
         .no_output();
 }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -210,11 +210,13 @@ fn test_zero_bytes_with_suffix() {
     ts.ucmd()
         .args(&["-c0K"])
         .pipe_in("qwerty")
+        .ignore_stdin_write_error()
         .succeeds()
         .no_output();
     ts.ucmd()
         .args(&["-c00K"])
         .pipe_in("qwerty")
+        .ignore_stdin_write_error()
         .succeeds()
         .no_output();
     ts.ucmd()


### PR DESCRIPTION
This is the first PR split out from the larger WASI changes in #11712.

## Changes

- Use `rustix::fs::Stat` for WASI `FileInformation` so same-file checks use device/inode identity instead of a file-type/size heuristic.
- Make `read_fs_list()` return `UResult<Vec<MountInfo>>` on WASI, matching other platforms while still returning an empty mount list.
- Use the WASI-specific `OsStrExt`/`OsStringExt` imports in `env`.
- Add inert WASI `tail` process-check stubs so the shared follow code compiles while `--pid` remains unsupported.
- Remove an unreachable nested cfg branch from non-WASI `OwnedFileDescriptorOrHandle::into_stdio()`.
- Update WASI comm tests for corrected same-file detection.